### PR TITLE
Fix for Useless comparison test

### DIFF
--- a/frontend/src/pages/dhcp/CreateScopeModal.tsx
+++ b/frontend/src/pages/dhcp/CreateScopeModal.tsx
@@ -28,7 +28,7 @@ function suggestRange(
   const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
   const base = (netInt & mask) >>> 0;
   const hostBits = 32 - prefix;
-  const total = hostBits >= 32 ? 0 : 1 << hostBits;
+  const total = 1 << hostBits;
   if (total < 16) return null;
   const startInt = (base + 10) >>> 0;
   const endInt = (base + total - 2) >>> 0;


### PR DESCRIPTION
To fix this without changing behavior, remove the unreachable branch and compute `total` directly from `hostBits`, which is guaranteed to be between 2 and 24 at that point.

Best change (single-file, minimal behavior impact):
- In `frontend/src/pages/dhcp/CreateScopeModal.tsx`, inside `suggestRange`, replace:
  - `const total = hostBits >= 32 ? 0 : 1 << hostBits;`
- With:
  - `const total = 1 << hostBits;`

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._