### PR TITLE
Fix for Unused import

### DIFF
--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, field_validator


### PR DESCRIPTION
Remove the unused `UTC` symbol from the `datetime` import in `backend/app/api/v1/dhcp/servers.py`.

Best fix without changing functionality:
- In the import section at the top of the file, change:
  - `from datetime import UTC, datetime`
  - to `from datetime import datetime`
- No other code changes are required, because `UTC` is not referenced anywhere in the shown file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._