### PR TITLE
Fix for Unused import

### DIFF
--- a/agent/dns/spatium_dns_agent/heartbeat.py
+++ b/agent/dns/spatium_dns_agent/heartbeat.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import random
 import threading
-import time
 from typing import Any
 
 import httpx


### PR DESCRIPTION
The best fix is to remove the unused `import time` statement from `agent/dns/spatium_dns_agent/heartbeat.py` without changing any runtime logic.

Specifically:
- Edit the import block at the top of the file.
- Delete only `import time`.
- Keep all other imports unchanged.

No new methods, definitions, or third-party dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._