### PR TITLE
Fix for Unused import

### DIFF
--- a/agent/dns/tests/conftest.py
+++ b/agent/dns/tests/conftest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 from typing import Iterator
 


### PR DESCRIPTION
The best fix is to delete the unused `import tempfile` line from `agent/dns/tests/conftest.py`.

- General approach: remove imports that are not referenced.
- Specific change: in `agent/dns/tests/conftest.py`, remove line 5 (`import tempfile`).
- No other code changes, methods, or definitions are required.
- No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._