### PR TITLE
Fix for Unused import

### DIFF
--- a/agent/dns/tests/test_acceptance.py
+++ b/agent/dns/tests/test_acceptance.py
@@ -8,8 +8,6 @@ Tests that require a live kind cluster / docker daemon are marked
 
 from __future__ import annotations
 
-import json
-
 import pytest
 
 from spatium_dns_agent.cache import (


### PR DESCRIPTION
Remove the unused `json` import from `agent/dns/tests/test_acceptance.py`.

Best fix without changing behavior:
- Delete line 11 (`import json`).
- Keep all other imports and test logic unchanged.

No additional methods, definitions, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._