### PR TITLE
Fix for Unused import

### DIFF
--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -11,7 +11,6 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import (
-    BigInteger,
     Boolean,
     DateTime,
     ForeignKey,


### PR DESCRIPTION
To fix this, remove the unused `BigInteger` symbol from the `from sqlalchemy import (...)` import block in `backend/app/models/dhcp.py`.

Best single fix without changing functionality:
- Edit only the import list at the top of `backend/app/models/dhcp.py`.
- Delete `BigInteger,` from the multi-line `sqlalchemy` import block.
- Keep all other imports and formatting unchanged.

No new methods, definitions, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._