### PR TITLE
Fix for Unused import

### DIFF
--- a/agent/dhcp/spatium_dhcp_agent/sync.py
+++ b/agent/dhcp/spatium_dhcp_agent/sync.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import json
 import threading
-import time
 from typing import Any
 
 import httpx


### PR DESCRIPTION
The correct fix is to remove the unused `time` import from `agent/dhcp/spatium_dhcp_agent/sync.py` while leaving behavior unchanged.

Best single fix:
- In the import section near lines 21–24, delete `import time`.
- No other code changes are required.
- No new methods, definitions, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._