### PR TITLE
Fix for Useless comparison test

### DIFF
--- a/frontend/src/pages/dhcp/CreateScopeModal.tsx
+++ b/frontend/src/pages/dhcp/CreateScopeModal.tsx
@@ -25,7 +25,7 @@ function suggestRange(
   if (parts.length !== 4 || parts.some((n) => isNaN(n))) return null;
   const netInt =
     ((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) >>> 0;
-  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  const mask = (0xffffffff << (32 - prefix)) >>> 0;
   const base = (netInt & mask) >>> 0;
   const hostBits = 32 - prefix;
   const total = hostBits >= 32 ? 0 : 1 << hostBits;


### PR DESCRIPTION
To fix this without changing functionality, remove the unreachable `prefix === 0` branch and compute the mask directly from the validated prefix range.

Best single change in `frontend/src/pages/dhcp/CreateScopeModal.tsx`:
- In `suggestRange`, replace:
  - `const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;`
- With:
  - `const mask = (0xffffffff << (32 - prefix)) >>> 0;`

Why this is correct:
- `prefix` is guaranteed to be between 8 and 30 before this line.
- So `32 - prefix` is in `[2, 24]`, a safe shift distance.
- Computed result is identical for all reachable inputs.
- No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._