### PR TITLE
Fix for Empty except

### DIFF
--- a/agent/dhcp/spatium_dhcp_agent/cache.py
+++ b/agent/dhcp/spatium_dhcp_agent/cache.py
@@ -41,6 +41,7 @@ def load_or_create_agent_id(state_dir: Path) -> str:
     try:
         os.chmod(path, 0o600)
     except PermissionError:
+        # Volume-mount owner may differ; best-effort only.
         pass
     return aid
 

--- a/agent/dhcp/spatium_dhcp_agent/cache.py
+++ b/agent/dhcp/spatium_dhcp_agent/cache.py
@@ -42,6 +42,7 @@ def load_or_create_agent_id(state_dir: Path) -> str:
         os.chmod(path, 0o600)
     except PermissionError:
         # Volume-mount owner may differ; best-effort only.
+        # Volume-mount owner may differ; best-effort only.
         pass
     return aid
 


### PR DESCRIPTION
To fix this without changing functionality, keep the `except PermissionError:` handler but add an explanatory comment above `pass`, matching the style already used elsewhere in the file (`ensure_layout`). This satisfies CodeQL by documenting intentional exception swallowing and preserves current runtime behavior.

Edit only `agent/dhcp/spatium_dhcp_agent/cache.py`, in `load_or_create_agent_id`, around lines 41–44:

- Keep `except PermissionError:`
- Add a brief reason comment (e.g., ownership/volume mount may prevent chmod; permission tightening is best-effort)
- Keep `pass`

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._