### PR TITLE
Fix for Empty except

### DIFF
--- a/agent/dhcp/spatium_dhcp_agent/cache.py
+++ b/agent/dhcp/spatium_dhcp_agent/cache.py
@@ -60,6 +60,8 @@ def save_token(state_dir: Path, token: str) -> None:
     try:
         os.chmod(tmp, 0o600)
     except (PermissionError, FileNotFoundError):
+        # Best-effort only: chmod may fail due to mount ownership/permissions,
+        # or tmp may disappear under concurrent saves.
         pass
     try:
         tmp.replace(path)

--- a/agent/dhcp/spatium_dhcp_agent/cache.py
+++ b/agent/dhcp/spatium_dhcp_agent/cache.py
@@ -62,6 +62,8 @@ def save_token(state_dir: Path, token: str) -> None:
     except (PermissionError, FileNotFoundError):
         # Best-effort only: chmod may fail due to mount ownership/permissions,
         # or tmp may disappear under concurrent saves.
+        # Best-effort only: chmod may fail due to mount ownership/permissions,
+        # or tmp may disappear under concurrent saves.
         pass
     try:
         tmp.replace(path)


### PR DESCRIPTION
Add an explanatory comment inside the `except (PermissionError, FileNotFoundError):` block in `agent/dhcp/spatium_dhcp_agent/cache.py` (around lines 60–63), while preserving the existing `pass` and behavior.

Best fix without changing functionality:
- Keep the same exceptions and control flow.
- Document why it is safe to ignore these exceptions:
  - `PermissionError`: ownership/permissions may prevent chmod in some deployments.
  - `FileNotFoundError`: temp file may have disappeared due to a race/concurrent operation.
- No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._