### PR TITLE
proxmox: #177 match VNet → IPAM subnets by CIDR (no more duplicate vnet:VLAN40)

### DIFF
--- a/backend/app/services/proxmox/reconcile.py
+++ b/backend/app/services/proxmox/reconcile.py
@@ -99,6 +99,11 @@ class ReconcileSummary:
     subnets_created: int = 0
     subnets_updated: int = 0
     subnets_deleted: int = 0
+    # Issue #177: counted when a pre-existing operator-owned subnet at
+    # an exact-CIDR match was reused instead of creating a duplicate.
+    # Surfaces in the per-run audit blob so operators can see when their
+    # own rows took the path Proxmox would otherwise have created.
+    subnets_matched: int = 0
     addresses_created: int = 0
     addresses_updated: int = 0
     addresses_deleted: int = 0
@@ -506,8 +511,38 @@ async def _apply_blocks_and_subnets(
         existing_networks[supernet] = parent
         summary.blocks_created += 1
 
-    res = await db.execute(select(Subnet).where(Subnet.proxmox_node_id == node.id))
-    current_subnets = {str(s.network): s for s in res.scalars().all()}
+    # Issue #177: match by CIDR across the whole space. Loading only
+    # ``proxmox_node_id == node.id`` rows meant a manually-created or
+    # different-integration subnet at the same CIDR was invisible to
+    # us, and we'd spawn a duplicate ``vnet:<name>`` twin on every
+    # reconcile. We now classify every subnet in the space into:
+    #   * node-owned       — drives the update + delete paths below
+    #   * operator-owned   — reused as-is (no claim, no overwrite) so
+    #                        the operator's curated row survives untouched
+    #   * foreign          — owned by another integration; we warn and
+    #                        skip without creating a duplicate
+    all_subnet_rows = (
+        (await db.execute(select(Subnet).where(Subnet.space_id == node.ipam_space_id)))
+        .scalars()
+        .all()
+    )
+    current_subnets: dict[str, Subnet] = {}
+    operator_subnets: dict[str, Subnet] = {}
+    foreign_subnets: dict[str, Subnet] = {}
+    for s in all_subnet_rows:
+        net_key = str(s.network)
+        if s.proxmox_node_id == node.id:
+            current_subnets[net_key] = s
+        elif (
+            s.proxmox_node_id is None
+            and s.kubernetes_cluster_id is None
+            and s.docker_host_id is None
+            and s.tailscale_tenant_id is None
+            and s.unifi_controller_id is None
+        ):
+            operator_subnets[net_key] = s
+        else:
+            foreign_subnets[net_key] = s
 
     desired_map = {d.network: d for d in desired_subnets}
     used_wrapper_cidrs: set[str] = set()
@@ -537,6 +572,25 @@ async def _apply_blocks_and_subnets(
         summary.subnets_deleted += 1
 
     for net_str, d in desired_map.items():
+        # Issue #177: an operator subnet at this exact CIDR wins. We
+        # reuse it without claiming ownership or rewriting any of its
+        # fields — operator-curated rows survive reconciles untouched.
+        # IP addresses still mirror into it via ``_find_subnet_for_ip``
+        # in the addresses apply pass.
+        if net_str in operator_subnets:
+            summary.subnets_matched += 1
+            continue
+
+        # Another integration (Kubernetes / Docker / Tailscale / UniFi)
+        # already owns this CIDR. We don't duplicate it and we don't
+        # try to wrest it away — the operator should resolve the
+        # cross-integration overlap deliberately.
+        if net_str in foreign_subnets:
+            summary.warnings.append(
+                f"subnet {net_str} already exists, owned by another integration; not creating duplicate"
+            )
+            continue
+
         parent_block = _find_enclosing_operator_block(blocks, d.network, node.id)
 
         if parent_block is None:
@@ -1079,6 +1133,7 @@ async def reconcile_node(db: AsyncSession, node: ProxmoxNode) -> ReconcileSummar
                     "created": summary.subnets_created,
                     "updated": summary.subnets_updated,
                     "deleted": summary.subnets_deleted,
+                    "matched": summary.subnets_matched,
                 },
                 "addresses": {
                     "created": summary.addresses_created,

--- a/backend/app/tasks/proxmox_sync.py
+++ b/backend/app/tasks/proxmox_sync.py
@@ -113,6 +113,7 @@ async def _run_one(node_id: str) -> dict[str, Any]:
                 "subnets_created": summary.subnets_created,
                 "subnets_updated": summary.subnets_updated,
                 "subnets_deleted": summary.subnets_deleted,
+                "subnets_matched": summary.subnets_matched,
                 "addresses_created": summary.addresses_created,
                 "addresses_updated": summary.addresses_updated,
                 "addresses_deleted": summary.addresses_deleted,

--- a/backend/tests/test_proxmox_reconcile.py
+++ b/backend/tests/test_proxmox_reconcile.py
@@ -436,6 +436,243 @@ async def test_rfc1918_supernet_auto_created(db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
+async def test_match_by_cidr_reuses_operator_subnet(
+    db_session: AsyncSession,
+) -> None:
+    """Issue #177: a pre-existing operator subnet at the exact CIDR
+    that Proxmox would otherwise auto-create must be reused — not
+    duplicated. The operator's name / description / block linkage are
+    preserved, ownership stays NULL, and addresses still mirror into
+    the reused subnet.
+    """
+    space = await _make_space(db_session)
+    parent = await _make_block(db_session, space, "10.0.0.0/8")
+    node = await _make_node(db_session, space)
+    # Operator pre-creates 10.1.40.0/24 with their own naming.
+    operator_sub = Subnet(
+        space_id=space.id,
+        block_id=parent.id,
+        network="10.1.40.0/24",
+        name="lab-vlan40",
+        description="manually curated",
+        gateway="10.1.40.1",
+        total_ips=254,
+    )
+    db_session.add(operator_sub)
+    await db_session.commit()
+
+    # Proxmox advertises VLAN40 as an SDN VNet at the same CIDR; PVE's
+    # host has a vmbr0 on 192.168.0.0/24 that's unrelated.
+    vm = _ProxmoxGuest(
+        node="pve01",
+        vmid=100,
+        name="vm-100",
+        kind="qemu",
+        status="running",
+        agent_enabled=True,
+        nics=[
+            _ProxmoxNicDef(
+                slot="net0",
+                mac="BC:24:11:E8:4A:3F",
+                bridge="VLAN40",
+                vlan_tag=None,
+                static_cidr=None,
+            )
+        ],
+        runtime_ips_by_mac={"bc:24:11:e8:4a:3f": ["10.1.40.50"]},
+    )
+    fake = _FakeClient(
+        networks={
+            "pve01": [
+                _ProxmoxNetworkIface(
+                    node="pve01",
+                    iface="vmbr0",
+                    iface_type="bridge",
+                    cidr="192.168.0.10/24",
+                    active=True,
+                )
+            ]
+        },
+        sdn_subnets=[
+            _ProxmoxSDNSubnet(
+                vnet="VLAN40",
+                zone="dc1",
+                cidr="10.1.40.0/24",
+                gateway="10.1.40.1",
+                snat=False,
+                alias=None,
+            )
+        ],
+        qemu={"pve01": [vm]},
+    )
+    with _patch_client(fake):
+        summary = await reconcile_node(db_session, node)
+
+    assert summary.ok, summary.error
+    assert summary.subnets_matched == 1
+
+    # Exactly one subnet at 10.1.40.0/24 — no duplicate.
+    rows = (
+        (
+            await db_session.execute(
+                select(Subnet).where(Subnet.space_id == space.id, Subnet.network == "10.1.40.0/24")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    only = rows[0]
+    # Operator's row untouched: ownership stays NULL, name + description
+    # + gateway + block linkage preserved.
+    assert only.id == operator_sub.id
+    assert only.proxmox_node_id is None
+    assert only.name == "lab-vlan40"
+    assert only.description == "manually curated"
+    assert str(only.gateway) == "10.1.40.1"
+    assert only.block_id == parent.id
+
+    # The VM's IP still lands in the reused subnet.
+    ip = (
+        await db_session.execute(
+            select(IPAddress).where(
+                IPAddress.proxmox_node_id == node.id,
+                IPAddress.status == "proxmox-vm",
+            )
+        )
+    ).scalar_one()
+    assert str(ip.address) == "10.1.40.50"
+    assert ip.subnet_id == operator_sub.id
+
+
+@pytest.mark.asyncio
+async def test_match_by_cidr_is_idempotent(
+    db_session: AsyncSession,
+) -> None:
+    """Two consecutive reconciles against an operator subnet match
+    must report ``subnets_matched=1`` each time and never create the
+    duplicate row, even though the first pass left the operator
+    subnet unowned (so the node-owned query still returns nothing
+    on pass two).
+    """
+    space = await _make_space(db_session)
+    parent = await _make_block(db_session, space, "10.0.0.0/8")
+    node = await _make_node(db_session, space)
+    operator_sub = Subnet(
+        space_id=space.id,
+        block_id=parent.id,
+        network="10.1.40.0/24",
+        name="lab-vlan40",
+        total_ips=254,
+    )
+    db_session.add(operator_sub)
+    await db_session.commit()
+
+    fake = _FakeClient(
+        sdn_subnets=[
+            _ProxmoxSDNSubnet(
+                vnet="VLAN40",
+                zone="dc1",
+                cidr="10.1.40.0/24",
+                gateway=None,
+                snat=False,
+                alias=None,
+            )
+        ],
+    )
+    with _patch_client(fake):
+        first = await reconcile_node(db_session, node)
+    with _patch_client(fake):
+        second = await reconcile_node(db_session, node)
+
+    assert first.ok and second.ok
+    assert first.subnets_matched == 1
+    assert second.subnets_matched == 1
+    assert first.subnets_created == 0
+    assert second.subnets_created == 0
+
+    rows = (
+        (
+            await db_session.execute(
+                select(Subnet).where(Subnet.space_id == space.id, Subnet.network == "10.1.40.0/24")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_match_by_cidr_skips_foreign_integration_subnet(
+    db_session: AsyncSession,
+) -> None:
+    """A subnet owned by a different integration (e.g. Kubernetes
+    pod CIDR) at the desired CIDR must NOT be duplicated. A warning
+    surfaces in ``summary.warnings`` so the operator can resolve the
+    overlap deliberately.
+    """
+    from app.models.kubernetes import KubernetesCluster  # noqa: PLC0415
+
+    space = await _make_space(db_session)
+    block = await _make_block(db_session, space, "10.0.0.0/8")
+    node = await _make_node(db_session, space)
+    # Stand up a fake k8s cluster + a pod-CIDR subnet at 10.1.40.0/24.
+    cluster = KubernetesCluster(
+        name="k8s-test",
+        api_server_url="https://k8s.example.test",
+        ipam_space_id=space.id,
+        token_encrypted=b"",
+    )
+    db_session.add(cluster)
+    await db_session.flush()
+    foreign_sub = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network="10.1.40.0/24",
+        name="pod-cidr",
+        total_ips=254,
+        kubernetes_cluster_id=cluster.id,
+        kubernetes_semantics=True,
+    )
+    db_session.add(foreign_sub)
+    await db_session.commit()
+
+    fake = _FakeClient(
+        sdn_subnets=[
+            _ProxmoxSDNSubnet(
+                vnet="VLAN40",
+                zone="dc1",
+                cidr="10.1.40.0/24",
+                gateway=None,
+                snat=False,
+                alias=None,
+            )
+        ],
+    )
+    with _patch_client(fake):
+        summary = await reconcile_node(db_session, node)
+
+    assert summary.ok
+    assert summary.subnets_created == 0
+    assert summary.subnets_matched == 0
+    assert any("another integration" in w for w in summary.warnings)
+
+    # Exactly one subnet at the CIDR — the original foreign one.
+    rows = (
+        (
+            await db_session.execute(
+                select(Subnet).where(Subnet.space_id == space.id, Subnet.network == "10.1.40.0/24")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].kubernetes_cluster_id == cluster.id
+
+
+@pytest.mark.asyncio
 async def test_vm_nic_with_runtime_ip_creates_proxmox_vm_row(
     db_session: AsyncSession,
 ) -> None:


### PR DESCRIPTION
Closes #177.

## Summary

- The Proxmox reconciler was loading only ``Subnet.proxmox_node_id == node.id`` when computing the create/update/delete diff, so an operator-curated (or other-integration-owned) subnet at the same CIDR was invisible and a duplicate ``vnet:<name>`` twin got spawned on every reconcile pass. The issue reporter saw their existing ``10.1.40.0/24`` ride alongside a fresh ``vnet:VLAN40`` row at the same CIDR.
- Reconciler now loads every subnet in the IPAM space and classifies into **node-owned** (drives update/delete, unchanged), **operator-owned** (no integration FK), and **foreign-integration**. When a desired CIDR matches an operator row we reuse it as-is — no ownership claim, no field overwrite, no wrapper parent block. Foreign-integration overlaps surface as warnings instead of duplicates.
- New ``subnets_matched`` counter on ``ReconcileSummary`` exposes the reuse in the audit blob + ``sync_node_now`` task result so operators can see when their own rows took the path Proxmox would otherwise have created.

## Test plan

- [x] New unit test ``test_match_by_cidr_reuses_operator_subnet`` — operator pre-creates ``10.1.40.0/24``, Proxmox reports it as an SDN VNet with a VM at ``.50``; exactly one subnet exists after reconcile, the operator's name/description/gateway/block linkage are preserved, ownership stays NULL, and the VM IP lands in the reused subnet.
- [x] New unit test ``test_match_by_cidr_is_idempotent`` — two consecutive reconciles both report ``subnets_matched=1``, never create the duplicate.
- [x] New unit test ``test_match_by_cidr_skips_foreign_integration_subnet`` — Kubernetes-owned subnet at the desired CIDR triggers a warning and zero subnet creations.
- [x] Full proxmox reconciler suite (24 tests) — green.
- [x] Full backend suite (607 tests) — green.
- [x] ``make ci`` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)