### PR TITLE
fix(auth,ui): unify superadmin gates (#190) + surface backend error detail (#186)

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -160,29 +160,34 @@ async def get_current_user(
 
 
 def require_superadmin(current_user: Annotated[User, Depends(get_current_user)]) -> User:
-    """Admit users who are either
-    (a) the legacy ``User.is_superadmin=True`` (seeded ``admin`` / anyone
-        explicitly flagged), OR
-    (b) granted a Wave-C RBAC wildcard permission (`action=*`,
-        `resource_type=*`) via a group → role, i.e. the built-in ``Superadmin``
-        role or a custom clone of it.
+    """FastAPI dependency: 403 unless the user is an *effective* superadmin.
 
-    Without (b), users provisioned via LDAP / OIDC / SAML and mapped to the
-    ``Superadmins`` internal group could pass RBAC-gated checks but still get
-    403 on ``SuperAdmin``-gated endpoints (users / groups / roles / auth
-    providers / settings) — a split-brain between the legacy flag and the
-    RBAC model. This unifies them.
+    Delegates to :func:`app.core.permissions.is_effective_superadmin`, which
+    admits both:
+
+    * the legacy ``User.is_superadmin=True`` (seeded ``admin`` / anyone
+      explicitly flagged), and
+    * group → role grants of the ``{action: "*", resource_type: "*"}``
+      wildcard permission (built-in ``Superadmin`` role or any clone of it).
+
+    Without the wildcard path, users provisioned via LDAP / OIDC / SAML and
+    mapped to a Superadmin-role group pass every ``require_permission`` gate
+    but get 403 on ``SuperAdmin``-only endpoints — a split-brain between the
+    legacy flag and the RBAC model. The helper unifies them; this dependency
+    is just the gate-style wrapper for routes that pre-Depend.
+
+    Endpoints that already have a hand-rolled ``_require_superadmin`` helper
+    should call ``is_effective_superadmin(user)`` directly from inside the
+    handler — same check, same behaviour.
     """
-    if current_user.is_superadmin:
-        return current_user
     # Lazy import: `app.core.permissions` imports ``CurrentUser`` / ``get_db``
     # from this module at top-level, so an eager import here triggers a
     # circular-import crash at uvicorn startup. Local import side-steps it
     # because by the time this function is called the module graph is fully
     # initialised.
-    from app.core.permissions import user_has_permission
+    from app.core.permissions import is_effective_superadmin
 
-    if user_has_permission(current_user, "*", "*"):
+    if is_effective_superadmin(current_user):
         return current_user
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Superadmin required")
 

--- a/backend/app/api/v1/alerts/router.py
+++ b/backend/app/api/v1/alerts/router.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import delete, select
 
 from app.api.deps import DB, CurrentUser
+from app.core.permissions import is_effective_superadmin
 from app.models.alerts import AlertEvent, AlertRule
 from app.models.audit import AuditLog
 from app.services import alerts as alert_service
@@ -251,8 +252,8 @@ class EvaluateResponse(BaseModel):
 # ── Rules ──────────────────────────────────────────────────────────────────
 
 
-def _require_superadmin(current_user: object) -> None:
-    if not getattr(current_user, "is_superadmin", False):
+def _require_superadmin(current_user: CurrentUser) -> None:
+    if not is_effective_superadmin(current_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Superadmin required to manage alert rules",

--- a/backend/app/api/v1/appliance/pairing.py
+++ b/backend/app/api/v1/appliance/pairing.py
@@ -54,7 +54,7 @@ from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
 from app.core.crypto import decrypt_str, encrypt_str
-from app.core.permissions import require_permission
+from app.core.permissions import is_effective_superadmin, require_permission
 from app.core.security import verify_password
 from app.models.appliance import PairingClaim, PairingCode
 from app.models.audit import AuditLog
@@ -177,7 +177,7 @@ class PairingCodeRevealResponse(BaseModel):
 
 
 def _require_superadmin(user: CurrentUser) -> None:
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
             "Pairing-code management is restricted to superadmins.",

--- a/backend/app/api/v1/appliance/slot_images.py
+++ b/backend/app/api/v1/appliance/slot_images.py
@@ -57,7 +57,7 @@ from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
 from app.config import settings
-from app.core.permissions import require_permission
+from app.core.permissions import is_effective_superadmin, require_permission
 from app.models.appliance import ApplianceSlotImage
 from app.models.audit import AuditLog
 
@@ -87,7 +87,7 @@ _CHUNK_BYTES = 4 * 1024 * 1024
 
 
 def _require_superadmin(user: CurrentUser) -> None:
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
             "Slot-image management is restricted to superadmins.",

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -56,7 +56,7 @@ from sqlalchemy import func as sa_func
 from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
-from app.core.permissions import require_permission
+from app.core.permissions import is_effective_superadmin, require_permission
 from app.models.appliance import (
     APPLIANCE_STATE_APPROVED,
     APPLIANCE_STATE_PENDING_APPROVAL,
@@ -1164,7 +1164,7 @@ class ApplianceList(BaseModel):
 
 
 def _require_superadmin(user: CurrentUser) -> None:
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
             "Appliance approval is restricted to superadmins.",

--- a/backend/app/api/v1/backup/router.py
+++ b/backend/app/api/v1/backup/router.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel
 
 from app.api.deps import DB, CurrentUser
 from app.config import settings
+from app.core.permissions import is_effective_superadmin
 from app.models.audit import AuditLog
 from app.services.backup import (
     BackupArchiveError,
@@ -52,8 +53,8 @@ logger = structlog.get_logger(__name__)
 _MAX_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024
 
 
-def _require_superadmin(current_user: object) -> None:
-    if not getattr(current_user, "is_superadmin", False):
+def _require_superadmin(current_user: CurrentUser) -> None:
+    if not is_effective_superadmin(current_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Backup + restore is restricted to superadmin",
@@ -69,7 +70,7 @@ async def list_backup_sections(current_user: CurrentUser) -> dict[str, Any]:
     the upcoming selective-backup + selective-restore checkboxes —
     operators tick which sections to include / apply.
     """
-    if not getattr(current_user, "is_superadmin", False):
+    if not is_effective_superadmin(current_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Backup is restricted to superadmin",

--- a/backend/app/api/v1/backup/targets.py
+++ b/backend/app/api/v1/backup/targets.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import attributes
 from app.api.deps import DB, CurrentUser
 from app.core.crypto import encrypt_str
 from app.core.demo_mode import forbid_in_demo_mode
+from app.core.permissions import is_effective_superadmin
 from app.models.audit import AuditLog
 from app.models.backup import BackupTarget
 from app.services.backup.runner import run_backup_for_target
@@ -58,8 +59,8 @@ def _valid_kinds() -> set[str]:
     return set(DESTINATIONS)
 
 
-def _require_superadmin(current_user: object) -> None:
-    if not getattr(current_user, "is_superadmin", False):
+def _require_superadmin(current_user: CurrentUser) -> None:
+    if not is_effective_superadmin(current_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Backup targets are restricted to superadmin",

--- a/backend/app/api/v1/diagnostics/router.py
+++ b/backend/app/api/v1/diagnostics/router.py
@@ -18,13 +18,15 @@ from pydantic import BaseModel, Field
 from sqlalchemy import desc, func, select
 
 from app.api.deps import DB, CurrentUser
+from app.core.permissions import is_effective_superadmin
+from app.models.auth import User
 from app.models.diagnostics import InternalError
 
 router = APIRouter()
 
 
-def _require_superadmin(user_obj: object) -> None:
-    if not getattr(user_obj, "is_superadmin", False):
+def _require_superadmin(user_obj: User) -> None:
+    if not is_effective_superadmin(user_obj):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Diagnostics surface is restricted to superadmin",

--- a/backend/app/api/v1/system/factory_reset.py
+++ b/backend/app/api/v1/system/factory_reset.py
@@ -27,6 +27,7 @@ from sqlalchemy import select
 from app.api.deps import DB, CurrentUser
 from app.config import settings
 from app.core.demo_mode import forbid_in_demo_mode
+from app.core.permissions import is_effective_superadmin
 from app.models.backup import BackupTarget
 from app.services.factory_reset import (
     FACTORY_SECTIONS,
@@ -45,8 +46,8 @@ router = APIRouter()
 logger = structlog.get_logger(__name__)
 
 
-def _require_superadmin(current_user: object) -> None:
-    if not getattr(current_user, "is_superadmin", False):
+def _require_superadmin(current_user: CurrentUser) -> None:
+    if not is_effective_superadmin(current_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Factory reset is restricted to superadmin",

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -87,6 +87,34 @@ def _resource_id_matches(granted: str | None, requested: str | None) -> bool:
     return str(granted) == str(requested)
 
 
+def is_effective_superadmin(user: User) -> bool:
+    """Whether the user is a superadmin for gate-style checks.
+
+    Two paths qualify:
+
+    * **Legacy column** — ``User.is_superadmin=True`` set directly on the
+      row (seeded ``admin`` account, anyone explicitly flagged in
+      ``users/router.py``'s admin form).
+    * **RBAC wildcard** — the user belongs to a group whose role carries
+      a ``{action: "*", resource_type: "*"}`` permission (the built-in
+      ``Superadmin`` role + any custom clone of it).
+
+    Without the RBAC path, users provisioned via LDAP / OIDC / SAML and
+    mapped into a Superadmin-role group pass every ``require_permission``
+    gate but get 403 on the per-endpoint local ``_require_superadmin``
+    helpers — closes that split-brain (issue #190).
+
+    This is intentionally separate from :func:`user_has_permission`:
+    inactive users are admitted here when the legacy flag is set so a
+    disabled superadmin can still reach the diagnostic surfaces an
+    operator might need during incident triage. Per-permission checks
+    still gate on ``user.is_active``.
+    """
+    if getattr(user, "is_superadmin", False):
+        return True
+    return user_has_permission(user, "*", "*")
+
+
 def user_has_permission(
     user: User,
     action: str,

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -9,7 +9,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.permissions import user_has_permission
+from app.core.permissions import is_effective_superadmin, user_has_permission
 from app.core.security import create_access_token, hash_password
 from app.models.auth import Group, Role, User
 
@@ -74,6 +74,55 @@ def test_superadmin_short_circuits() -> None:
     # No roles at all
     assert user_has_permission(u, "write", "subnet") is True
     assert user_has_permission(u, "delete", "any_made_up_type") is True
+
+
+# ── is_effective_superadmin (issue #190) ──────────────────────────────────────
+
+
+def test_effective_superadmin_legacy_flag() -> None:
+    """User with the legacy ``is_superadmin`` column set is admitted."""
+    u = _user(superadmin=True)
+    assert is_effective_superadmin(u) is True
+
+
+def test_effective_superadmin_via_wildcard_permission() -> None:
+    """OIDC / LDAP user mapped into a group with the built-in Superadmin
+    role gets the same admission as a legacy ``is_superadmin=True``.
+
+    This is the bug #190 closes: pre-fix, per-endpoint local
+    ``_require_superadmin`` helpers ignored this path entirely.
+    """
+    u = _user(superadmin=False)
+    u.groups = [_group([_role([{"action": "*", "resource_type": "*"}])])]
+    assert is_effective_superadmin(u) is True
+
+
+def test_effective_superadmin_denied_without_either_path() -> None:
+    """No legacy flag, no wildcard permission → denied."""
+    u = _user(superadmin=False)
+    u.groups = [_group([_role([{"action": "read", "resource_type": "*"}])])]
+    assert is_effective_superadmin(u) is False
+
+
+def test_effective_superadmin_denied_with_no_groups() -> None:
+    u = _user(superadmin=False)
+    assert is_effective_superadmin(u) is False
+
+
+def test_effective_superadmin_legacy_flag_overrides_inactive() -> None:
+    """A disabled legacy superadmin can still pass the gate — matches the
+    docstring on :func:`is_effective_superadmin` ("disabled superadmin can
+    still reach diagnostic surfaces during incident triage"). The
+    wildcard-permission path still gates on ``is_active``.
+    """
+    u = _user(superadmin=True, is_active=False)
+    assert is_effective_superadmin(u) is True
+
+
+def test_effective_superadmin_wildcard_path_respects_inactive() -> None:
+    u = _user(superadmin=False, is_active=False)
+    u.groups = [_group([_role([{"action": "*", "resource_type": "*"}])])]
+    assert is_effective_superadmin(u) is False
 
 
 def test_inactive_user_denied_even_with_wildcard() -> None:

--- a/frontend/src/components/AgentBootstrapKeysSection.tsx
+++ b/frontend/src/components/AgentBootstrapKeysSection.tsx
@@ -13,6 +13,7 @@ import {
 import {
   agentBootstrapKeysApi,
   type AgentBootstrapKeysReveal,
+  formatApiError,
 } from "@/lib/api";
 
 /**
@@ -103,7 +104,7 @@ export function AgentBootstrapKeysSection() {
           {reveal.isError && (
             <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
               <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span>{(reveal.error as Error).message}</span>
+              <span>{formatApiError(reveal.error)}</span>
             </div>
           )}
           <button

--- a/frontend/src/components/SNMPSection.tsx
+++ b/frontend/src/components/SNMPSection.tsx
@@ -9,6 +9,7 @@ import {
   type SnmpAuthProtocol,
   type SnmpPrivProtocol,
   type SnmpVersion,
+  formatApiError,
 } from "@/lib/api";
 import { Toggle } from "@/components/ui/toggle";
 import { cn } from "@/lib/utils";
@@ -191,7 +192,7 @@ function CommunityField({
         )}
         {revealMutation.isError && (
           <span className="text-xs text-destructive">
-            {(revealMutation.error as Error).message}
+            {formatApiError(revealMutation.error)}
           </span>
         )}
 

--- a/frontend/src/components/ipam/PlanAllocationModal.tsx
+++ b/frontend/src/components/ipam/PlanAllocationModal.tsx
@@ -7,6 +7,7 @@ import {
   type IPBlock,
   type PlanAllocationResponse,
   type PlanRequestItem,
+  formatApiError,
 } from "@/lib/api";
 
 interface RowDraft {
@@ -169,7 +170,7 @@ export function PlanAllocationModal({
         )}
         {planMut.isError && (
           <p className="text-xs text-destructive">
-            {(planMut.error as Error).message}
+            {formatApiError(planMut.error)}
           </p>
         )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -127,17 +127,22 @@ export const api = createClient();
 
 /**
  * Normalise whatever shape an API error arrives in into a single string
- * suitable for React children.
+ * suitable for React children (issue #31) and operator-readable toasts
+ * / inline form errors (issue #186).
  *
  * FastAPI returns three common shapes:
  *   - 4xx HTTPException:   `{"detail": "some message"}`
  *   - 422 validation:      `{"detail": [{"type", "loc", "msg", "input", "ctx"}, ...]}`
  *   - Unhandled 500:       `{"detail": "Internal Server Error"}` or no body
  *
- * Passing the raw `detail` into `setError(...)` was crashing React with
- * error #31 ("Objects are not valid as a React child") when a 422 hit a
- * code path that assumed it was always a string. Use this helper instead
- * of a naive `err.response?.data?.detail ?? "Error"`.
+ * Use this **everywhere** an error gets rendered — including
+ * ``{(mutation.error as Error).message}``-style sites. Axios's default
+ * ``.message`` is just ``"Request failed with status code N"`` which
+ * hides the backend's actual detail; this helper pulls the right field
+ * for each shape. Original use case was issue #31 (avoid React error
+ * "Objects are not valid as a React child" when the 422 path returned
+ * an array); issue #186 extended adoption across every error-render
+ * site in the app.
  */
 export function formatApiError(err: unknown, fallback = "Error"): string {
   const anyErr = err as {

--- a/frontend/src/pages/admin/DNSImportPage.tsx
+++ b/frontend/src/pages/admin/DNSImportPage.tsx
@@ -25,6 +25,7 @@ import {
   type DNSImportZoneConflict,
   type PowerDNSConnectionInfo,
   type WindowsDNSServerOption,
+  formatApiError,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { HeaderButton } from "@/components/ui/header-button";
@@ -205,7 +206,7 @@ function BindTab() {
     onError: (err: unknown) => {
       const detail =
         (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? (err as Error).message;
+          ?.detail ?? formatApiError(err);
       setState((s) => ({ ...s, phase: "select", error: detail }));
     },
   });
@@ -226,7 +227,7 @@ function BindTab() {
     onError: (err: unknown) => {
       const detail =
         (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? (err as Error).message;
+          ?.detail ?? formatApiError(err);
       setState((s) => ({ ...s, phase: "ready", error: detail }));
     },
   });
@@ -371,7 +372,7 @@ function WindowsDNSTab() {
     onError: (err: unknown) => {
       const detail =
         (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? (err as Error).message;
+          ?.detail ?? formatApiError(err);
       setState((s) => ({ ...s, phase: "select", error: detail }));
     },
   });
@@ -392,7 +393,7 @@ function WindowsDNSTab() {
     onError: (err: unknown) => {
       const detail =
         (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? (err as Error).message;
+          ?.detail ?? formatApiError(err);
       setState((s) => ({ ...s, phase: "ready", error: detail }));
     },
   });
@@ -657,7 +658,7 @@ function PowerDNSTab() {
     onError: (err: unknown) => {
       const detail =
         (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? (err as Error).message;
+          ?.detail ?? formatApiError(err);
       setState((s) => ({ ...s, testInfo: null, error: detail }));
     },
   });
@@ -693,7 +694,7 @@ function PowerDNSTab() {
     onError: (err: unknown) => {
       const detail =
         (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? (err as Error).message;
+          ?.detail ?? formatApiError(err);
       setState((s) => ({ ...s, phase: "select", error: detail }));
     },
   });
@@ -714,7 +715,7 @@ function PowerDNSTab() {
     onError: (err: unknown) => {
       const detail =
         (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? (err as Error).message;
+          ?.detail ?? formatApiError(err);
       setState((s) => ({ ...s, phase: "ready", error: detail }));
     },
   });

--- a/frontend/src/pages/admin/DiagnosticsErrorsPage.tsx
+++ b/frontend/src/pages/admin/DiagnosticsErrorsPage.tsx
@@ -16,6 +16,7 @@ import {
   diagnosticsApi,
   type InternalErrorDetail,
   type InternalErrorListItem,
+  formatApiError,
 } from "@/lib/api";
 import { copyToClipboard } from "@/lib/clipboard";
 
@@ -195,7 +196,7 @@ export function DiagnosticsErrorsPage() {
           <div className="p-6 text-sm text-destructive">
             Failed to load errors.
             {(listQ.error as Error)?.message
-              ? ` ${(listQ.error as Error).message}`
+              ? ` ${formatApiError(listQ.error)}`
               : ""}
           </div>
         ) : errors.length === 0 ? (

--- a/frontend/src/pages/appliance/CertificatesTab.tsx
+++ b/frontend/src/pages/appliance/CertificatesTab.tsx
@@ -18,6 +18,7 @@ import {
   type ApplianceCertificate,
   type CSRKeyType,
   type CertificateSource,
+  formatApiError,
 } from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
@@ -113,7 +114,7 @@ export function CertificatesTab() {
 
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-          Failed to load certificates: {(error as Error).message}
+          Failed to load certificates: {formatApiError(error)}
         </div>
       )}
 

--- a/frontend/src/pages/appliance/ContainersTab.tsx
+++ b/frontend/src/pages/appliance/ContainersTab.tsx
@@ -17,6 +17,7 @@ import {
   streamApplianceContainerLogs,
   type ApplianceContainer,
   type ContainerAction,
+  formatApiError,
 } from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
 
@@ -84,7 +85,7 @@ export function ContainersTab() {
 
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-          {(error as Error).message}
+          {formatApiError(error)}
         </div>
       )}
 

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -30,6 +30,7 @@ import {
   type ApplianceState,
   type SlotImage,
   type SupervisorCapabilities,
+  formatApiError,
 } from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
@@ -549,7 +550,7 @@ export function FleetTab() {
 
               {error ? (
                 <div className="rounded-md border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-700 dark:text-rose-300">
-                  Failed to load appliances: {(error as Error).message}
+                  Failed to load appliances: {formatApiError(error)}
                 </div>
               ) : isLoading ? (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -1556,7 +1557,7 @@ function ApplianceClusterHealthSection({ row }: { row: ApplianceRow }) {
         </button>
         {restartBind9.error && (
           <span className="text-[11px] text-rose-700 dark:text-rose-300">
-            {(restartBind9.error as Error).message}
+            {formatApiError(restartBind9.error)}
           </span>
         )}
         {restartBind9.isSuccess && (
@@ -1723,7 +1724,7 @@ function PodLogsModal({
           </button>
           {logsQuery.error && (
             <span className="text-[11px] text-rose-700 dark:text-rose-300">
-              {(logsQuery.error as Error).message}
+              {formatApiError(logsQuery.error)}
             </span>
           )}
         </div>
@@ -1822,7 +1823,7 @@ function KubeapiCidrEditorModal({
         />
         {save.error && (
           <p className="text-xs text-rose-700 dark:text-rose-300">
-            {(save.error as Error).message}
+            {formatApiError(save.error)}
           </p>
         )}
         <div className="flex items-center justify-end gap-2">
@@ -1928,7 +1929,7 @@ function RevealKubeconfigModal({
             </div>
             {reveal.error && (
               <p className="text-xs text-rose-700 dark:text-rose-300">
-                {(reveal.error as Error).message}
+                {formatApiError(reveal.error)}
               </p>
             )}
           </>
@@ -2258,7 +2259,7 @@ function ApplianceRoleAssignmentSection({
         )}
         {save.error && (
           <span className="text-xs text-rose-700 dark:text-rose-300">
-            {(save.error as Error).message}
+            {formatApiError(save.error)}
           </span>
         )}
       </div>
@@ -2772,7 +2773,7 @@ function ApplianceOsUpgradeSection({ row }: { row: ApplianceRow }) {
             </button>
             {scheduleUpgrade.error && (
               <span className="text-xs text-rose-700 dark:text-rose-300">
-                {(scheduleUpgrade.error as Error).message}
+                {formatApiError(scheduleUpgrade.error)}
               </span>
             )}
           </div>
@@ -2804,7 +2805,7 @@ function ApplianceOsUpgradeSection({ row }: { row: ApplianceRow }) {
           </button>
           {reboot.error && (
             <span className="text-xs text-rose-700 dark:text-rose-300">
-              {(reboot.error as Error).message}
+              {formatApiError(reboot.error)}
             </span>
           )}
         </div>
@@ -2972,7 +2973,7 @@ function SlotImageManager() {
           )}
           {upload.error && (
             <span className="text-rose-700 dark:text-rose-300">
-              {(upload.error as Error).message}
+              {formatApiError(upload.error)}
             </span>
           )}
         </div>

--- a/frontend/src/pages/appliance/LogsTab.tsx
+++ b/frontend/src/pages/appliance/LogsTab.tsx
@@ -15,6 +15,7 @@ import {
 import {
   applianceDiagnosticsApi,
   type ApplianceSelfTestReport,
+  formatApiError,
 } from "@/lib/api";
 
 /**
@@ -91,7 +92,7 @@ function SelfTestCard() {
       {run.isError && (
         <div className="mt-3 flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
           <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-          <span>{(run.error as Error).message}</span>
+          <span>{formatApiError(run.error)}</span>
         </div>
       )}
 
@@ -213,7 +214,7 @@ function LogViewerCard() {
         {tail.isLoading
           ? "Loading…"
           : tail.isError
-            ? `(error: ${(tail.error as Error).message})`
+            ? `(error: ${formatApiError(tail.error)})`
             : tail.data?.tail || "(empty)"}
       </pre>
     </section>

--- a/frontend/src/pages/appliance/NetworkTab.tsx
+++ b/frontend/src/pages/appliance/NetworkTab.tsx
@@ -8,7 +8,7 @@ import {
   Server,
 } from "lucide-react";
 
-import { applianceSystemApi } from "@/lib/api";
+import { applianceSystemApi, formatApiError } from "@/lib/api";
 
 /**
  * Phase 4f — Network & Host info (read-mostly MVP).
@@ -60,7 +60,7 @@ export function NetworkTab() {
 
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-          {(error as Error).message}
+          {formatApiError(error)}
         </div>
       )}
 

--- a/frontend/src/pages/appliance/PairingTab.tsx
+++ b/frontend/src/pages/appliance/PairingTab.tsx
@@ -19,6 +19,7 @@ import {
   authApi,
   type PairingCodeCreated,
   type PairingCodeRow,
+  formatApiError,
 } from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
@@ -514,7 +515,7 @@ function GenerateCodeModal({
 
           {mutation.error && (
             <div className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
-              {String((mutation.error as Error).message ?? mutation.error)}
+              {formatApiError(mutation.error)}
             </div>
           )}
 
@@ -702,7 +703,7 @@ function RevealModal({
           </label>
           {mutation.error && (
             <div className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
-              {String((mutation.error as Error).message ?? mutation.error)}
+              {formatApiError(mutation.error)}
             </div>
           )}
           <div className="flex justify-end gap-2">

--- a/frontend/src/pages/appliance/ReleasesTab.tsx
+++ b/frontend/src/pages/appliance/ReleasesTab.tsx
@@ -11,7 +11,11 @@ import {
   RefreshCw,
 } from "lucide-react";
 
-import { applianceReleasesApi, type ApplianceRelease } from "@/lib/api";
+import {
+  applianceReleasesApi,
+  type ApplianceRelease,
+  formatApiError,
+} from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
 
 // Number of most-recent releases rendered as full cards. Anything older
@@ -91,7 +95,7 @@ export function ReleasesTab({
 
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-          Failed to load releases: {(error as Error).message}
+          Failed to load releases: {formatApiError(error)}
         </div>
       )}
 
@@ -156,7 +160,7 @@ export function ReleasesTab({
           onClose={() => !apply.isPending && setConfirmTarget(null)}
           onConfirm={() => apply.mutate(confirmTarget.tag)}
           submitting={apply.isPending}
-          error={apply.isError ? (apply.error as Error).message : null}
+          error={apply.isError ? formatApiError(apply.error) : null}
         />
       )}
     </div>

--- a/frontend/src/pages/appliance/SetupWizardPage.tsx
+++ b/frontend/src/pages/appliance/SetupWizardPage.tsx
@@ -15,6 +15,7 @@ import {
   applianceSystemApi,
   applianceTlsApi,
   versionApi,
+  formatApiError,
 } from "@/lib/api";
 
 /**
@@ -146,7 +147,7 @@ export function SetupWizardPage() {
       {finish.isError && (
         <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
           <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>{(finish.error as Error).message}</span>
+          <span>{formatApiError(finish.error)}</span>
         </div>
       )}
 

--- a/frontend/src/pages/appliance/SlotUpgradeCard.tsx
+++ b/frontend/src/pages/appliance/SlotUpgradeCard.tsx
@@ -19,6 +19,7 @@ import {
   applianceSystemApi,
   type ApplianceSlot,
   type ApplianceSlotStatus,
+  formatApiError,
 } from "@/lib/api";
 
 /**
@@ -224,7 +225,7 @@ export function SlotUpgradeCard() {
 
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-          Failed to load slot status: {(error as Error).message}
+          Failed to load slot status: {formatApiError(error)}
         </div>
       )}
 
@@ -337,8 +338,8 @@ export function SlotUpgradeCard() {
             {releasesError && (
               <p className="text-[11px] text-destructive">
                 Couldn’t load the GitHub releases list (
-                {(releasesError as Error).message}). Switch to custom URL to
-                apply manually.
+                {formatApiError(releasesError)}). Switch to custom URL to apply
+                manually.
               </p>
             )}
           </>
@@ -512,9 +513,7 @@ export function SlotUpgradeCard() {
               reboot that lands back on the current slot.
             </p>
             {apply.isError && (
-              <p className="text-destructive">
-                {(apply.error as Error).message}
-              </p>
+              <p className="text-destructive">{formatApiError(apply.error)}</p>
             )}
           </div>
         }
@@ -553,7 +552,7 @@ export function SlotUpgradeCard() {
             </p>
             {rollback.isError && (
               <p className="text-destructive">
-                {(rollback.error as Error).message}
+                {formatApiError(rollback.error)}
               </p>
             )}
           </div>
@@ -588,9 +587,7 @@ export function SlotUpgradeCard() {
                 : "No slot change pending — this just reboots the current slot."}
             </p>
             {reboot.isError && (
-              <p className="text-destructive">
-                {(reboot.error as Error).message}
-              </p>
+              <p className="text-destructive">{formatApiError(reboot.error)}</p>
             )}
           </div>
         }

--- a/frontend/src/pages/dhcp/CreateServerModal.tsx
+++ b/frontend/src/pages/dhcp/CreateServerModal.tsx
@@ -4,6 +4,7 @@ import {
   dhcpApi,
   type DHCPServer,
   type WindowsDHCPCredentials,
+  formatApiError,
 } from "@/lib/api";
 import { Modal, Field, Btns, inputCls, errMsg } from "./_shared";
 
@@ -151,7 +152,7 @@ export function CreateServerModal({
           try {
             mut.mutate();
           } catch (err) {
-            setError((err as Error).message);
+            setError(formatApiError(err));
           }
         }}
         className="space-y-3"

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -32,6 +32,7 @@ import {
   type DHCPClientClass,
   type DHCPOptionTemplate,
   type DHCPLease,
+  formatApiError,
 } from "@/lib/api";
 import { useSessionState } from "@/lib/useSessionState";
 import { copyToClipboard } from "@/lib/clipboard";
@@ -2365,7 +2366,7 @@ export function DHCPPage() {
     deleteGroupMut.error &&
     (((deleteGroupMut.error as { response?: { data?: { detail?: string } } })
       ?.response?.data?.detail as string | undefined) ??
-      (deleteGroupMut.error as Error).message);
+      formatApiError(deleteGroupMut.error));
   const deleteServerMut = useMutation({
     mutationFn: (id: string) => dhcpApi.deleteServer(id),
     onSuccess: (_, id) => {

--- a/frontend/src/pages/dns/BlocklistCatalogModal.tsx
+++ b/frontend/src/pages/dns/BlocklistCatalogModal.tsx
@@ -13,6 +13,7 @@ import {
   dnsBlocklistApi,
   type BlocklistCatalogSource,
   type DNSBlockList,
+  formatApiError,
 } from "@/lib/api";
 
 /**
@@ -131,7 +132,7 @@ export function BlocklistCatalogModal({ onClose }: { onClose: () => void }) {
 
         {subscribeMut.isError && (
           <p className="text-xs text-destructive">
-            {(subscribeMut.error as Error).message}
+            {formatApiError(subscribeMut.error)}
           </p>
         )}
 

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -7394,7 +7394,7 @@ export function DNSPage() {
     deleteGroup.error &&
     (((deleteGroup.error as { response?: { data?: { detail?: string } } })
       ?.response?.data?.detail as string | undefined) ??
-      (deleteGroup.error as Error).message);
+      formatApiError(deleteGroup.error));
 
   function toggleGroup(id: string) {
     setExpandedGroups((prev) => {

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -73,6 +73,7 @@ import {
   type MacHistoryEntry,
   type NATMapping,
   type NetworkContextEntry,
+  formatApiError,
 } from "@/lib/api";
 import { copyToClipboard } from "@/lib/clipboard";
 import { cn, swatchTintCls, zebraBodyCls } from "@/lib/utils";
@@ -5344,7 +5345,7 @@ function DnsSyncModal({
           )}
           {error && (
             <p className="text-sm text-destructive">
-              Failed to load preview. {(error as Error).message}
+              Failed to load preview. {formatApiError(error)}
             </p>
           )}
           {data && (

--- a/frontend/src/pages/ipam/SubnetPlannerListPage.tsx
+++ b/frontend/src/pages/ipam/SubnetPlannerListPage.tsx
@@ -7,6 +7,7 @@ import {
   type IPBlock,
   type IPSpace,
   type SubnetPlanRead,
+  formatApiError,
 } from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
 import { newNodeId } from "@/lib/uuid";
@@ -331,7 +332,7 @@ function NewPlanModal({ onClose }: { onClose: () => void }) {
         </div>
         {createMut.isError && (
           <p className="text-xs text-destructive">
-            {(createMut.error as Error).message}
+            {formatApiError(createMut.error)}
           </p>
         )}
         <div className="flex justify-end gap-2 pt-2">


### PR DESCRIPTION
## Summary

Two operator-facing fixes that both close issues filed by tristanbob:

- **#190** — OIDC users in a Superadmin-role group get 403 on Diagnostics, Backup, Slot-images, Pairing-codes, Alerts, Factory-reset (eight surfaces in total). Eight per-endpoint local `_require_superadmin` helpers each open-coded `user.is_superadmin == True`, missing the RBAC wildcard path the canonical `require_superadmin` in `deps.py` already handles.
- **#186** — Backend returns `{"detail": "No DNS_AGENT_KEY configured ..."}` but the UI renders `"Request failed with status code 409"` because every error-site uses `(error as Error).message` instead of pulling the real detail. 40 sites across 20 files affected.

Both are one-file root-cause issues with a wide blast radius — a single helper used inconsistently. Each commit centralises the helper, then sweeps every call site.

## Commits

### `27f34ed` — auth: #190 unify per-endpoint superadmin gates

- New `is_effective_superadmin(user)` in `app/core/permissions.py`: True when `user.is_superadmin == True` **OR** the user holds a `{action: "*", resource_type: "*"}` permission via group → role (built-in Superadmin role or any clone).
- Eight hand-rolled `_require_superadmin` helpers delegate to it: diagnostics, appliance pairing / slot_images / supervisor, alerts, backup / backup-targets, factory-reset. Error messages + audit-log shapes unchanged.
- Canonical `app/api/deps.require_superadmin` dependency also delegates (drops duplicated inline logic).
- The legacy-flag path keeps admitting inactive superadmins (incident-triage carve-out documented on the helper); the wildcard-permission path still requires `user.is_active`.

6 new unit tests in `tests/test_permissions.py`:
- Legacy flag path
- Wildcard via group → role (the #190 closure)
- Both paths denied with no flag + no wildcard
- No groups case
- Inactive + legacy flag → admitted (documented carve-out)
- Inactive + wildcard → denied (per `user_has_permission` semantics)

### `a829e80` — ui: #186 surface backend error detail at every render site

- `formatApiError(err)` already exists in `lib/api.ts` from issue #31 ("Objects are not valid as a React child" on 422 list-shaped detail) — it handles every FastAPI shape. The bug was that 40 render sites never used it.
- Sweep: 40 × `(X as Error).message` → `formatApiError(X)` across 20 files, plus 2 × `String((mutation.error as Error).message ?? mutation.error)` in PairingTab.tsx (the literal screenshot case) collapsed to `formatApiError(mutation.error)`.
- `formatApiError` docstring updated to cite #186 alongside #31 so it's recognisable as the canonical helper, not a one-off.

Verified against the screenshot's exact 409 shape, a FastAPI 422 validation list, status-only error, plain `Error`, `null`, `undefined`, raw string — 8/8 cases return the expected operator-readable string.

## Verification

- `make ci` clean end-to-end (backend ruff/black/mypy + 13/13 permission tests + frontend eslint/prettier/tsc/vite build).
- CI-version-toolchain check passed (ruff 0.15.13 / black 26.5.0 / mypy 2.1.0).

## Test plan

- [ ] Log in as an OIDC user assigned to a group with the built-in Superadmin role; verify `/admin/diagnostics/errors` loads without 403 (previously: 403 even though the sidebar entry was visible).
- [ ] Same user opens **Appliance → Pairing** and clicks **New pairing code** on a control plane with no `DNS_AGENT_KEY` set; verify the error banner reads "No DNS_AGENT_KEY configured on the control plane..." instead of just "409".
- [ ] Trigger a 422 (e.g. submit pairing-code form with `expires_in_minutes: 999999`); verify the inline error shows the field path + message (`"expires_in_minutes: ensure this value is less than or equal to N"`) instead of `"422"`.
- [ ] As a non-superadmin user with no wildcard permission, verify all 8 affected endpoints still return 403 with their existing detail message.

Closes #186
Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)
