### PR TITLE
Hotfix: drop nonexistent images from appliance bake script

### DIFF
--- a/appliance/scripts/bake-images.sh
+++ b/appliance/scripts/bake-images.sh
@@ -42,12 +42,17 @@ IMAGES=(
     # install variants. Application-role appliances don't run these
     # pods, but baking them keeps the slot consistent across all
     # three variants (no "I built a Core but my image set was for
-    # Application" gotcha) — disk cost ~1 GB extra on the slot.
+    # Application" gotcha) — disk cost ~250 MB extra on the slot.
+    #
+    # NOTE — only ``spatiumddi-api`` + ``spatiumddi-frontend`` are
+    # separately-built images. The umbrella chart's worker / beat /
+    # migrate Deployments + Jobs all run the SAME spatiumddi-api
+    # image with different ``command:`` overrides (verified across
+    # docker-compose.yml + charts/spatiumddi/templates/{api,worker,
+    # beat,migrate}.yaml). Don't add ``spatiumddi-worker`` /
+    # ``-beat`` / ``-migrate`` here — they don't exist in ghcr.
     "ghcr.io/spatiumddi/spatiumddi-api"
     "ghcr.io/spatiumddi/spatiumddi-frontend"
-    "ghcr.io/spatiumddi/spatiumddi-worker"
-    "ghcr.io/spatiumddi/spatiumddi-beat"
-    "ghcr.io/spatiumddi/spatiumddi-migrate"
 )
 
 # Issue #183 Phase 8 — 3rd-party observability images. Tagged with


### PR DESCRIPTION
## Summary

The release-workflow run for 2026.05.17-1 ([run 25994841755](https://github.com/spatiumddi/spatiumddi/actions/runs/25994841755)) failed its `build-appliance-iso` step at 14s with exit code 3 — `bake-images.sh` tried to `docker pull` three images that don't exist:

- `ghcr.io/spatiumddi/spatiumddi-worker`
- `ghcr.io/spatiumddi/spatiumddi-beat`
- `ghcr.io/spatiumddi/spatiumddi-migrate`

The umbrella chart's worker / beat / migrate Deployments + Jobs all share the **`spatiumddi-api`** image with different `command:` overrides (confirmed in `docker-compose.yml` + `charts/spatiumddi/templates/{api,worker,beat,migrate}.yaml`). There's no separate Dockerfile, no `build-worker` / `build-beat` / `build-migrate` job in the release workflow, no ghcr tag pushed for them. They were added to `bake-images.sh` in #183 Phase 11 wave 1 (commit `a6bc553`) by mistake — never actually existed.

## Fix

One-file change: remove the three nonexistent entries from `bake-images.sh`'s `IMAGES` array. The two real control-plane-bundled images (`spatiumddi-api` + `spatiumddi-frontend`) stay.

Disk savings on the slot rootfs: ~250 MB (down from the previous wave 1 estimate of ~1 GB because the three ghost entries were the bulk of that estimate).

## Next steps after merge

Cut **2026.05.17-2** from `main` with just this fix so the appliance ISO + slot raw.xz assets land on the release page. 2026.05.17-1's container images + Helm chart are already published and operational for docker-compose + Kubernetes installs; only the appliance-ISO path is affected.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: cut tag 2026.05.17-2; verify the `build-appliance-iso` job completes; verify the release page has both `.iso` and `.raw.xz` assets
