### PR TITLE
Release 2026.05.17-3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,7 +351,19 @@ jobs:
           # a per-slot overlay image. The runner needs nested-docker +
           # loop-mount privileges; GitHub-hosted ubuntu-latest runners
           # have both. ``sudo`` is required for the loop-mount step.
-          sudo appliance/scripts/bake-images.sh
+          # ``sudo -E`` preserves SPATIUMDDI_VERSION + BAKE_SOURCE
+          # from the job env. Without ``-E``, sudo strips them and
+          # bake-images.sh falls back to its ``SPATIUMDDI_VERSION=dev``
+          # / ``BAKE_SOURCE=local`` defaults — which then fails on the
+          # runner with "no local image found" because no :dev tags
+          # exist (the release runner pulls from ghcr, not local).
+          #
+          # ``DOCKER_CONFIG=$HOME/.docker`` re-points root's docker CLI
+          # at the runner-user's ``~/.docker/config.json`` where the
+          # docker/login-action step above stamped the GHCR creds. Our
+          # ghcr.io/spatiumddi/* images are private; without this redirect
+          # root would docker-pull anonymously and 401 on every image.
+          sudo DOCKER_CONFIG="$HOME/.docker" -E appliance/scripts/bake-images.sh
           echo "→ Baked overlay image:"
           ls -lh appliance/mkosi.extra/usr/lib/spatiumddi/docker-overlay.img
           echo "→ Manifest:"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,43 @@ the formatter handles the rest.
 
 ## Unreleased
 
+## 2026.05.17-3 — 2026-05-17
+
+Second hotfix on top of -2. The release-workflow's
+`build-appliance-iso` job failed again — different bug. The
+workflow's `Bake container images into rootfs overlay` step runs
+`sudo appliance/scripts/bake-images.sh` (sudo is required for the
+later loop-mount of the docker-overlay.img), but `sudo` strips the
+environment by default — so `SPATIUMDDI_VERSION=2026.05.17-2` and
+`BAKE_SOURCE=ghcr` (set on the job's `env:` block) never reached
+the script. The script fell back to its `SPATIUMDDI_VERSION=dev` +
+`BAKE_SOURCE=local` defaults, then errored at
+`ERROR: no local image found for ghcr.io/spatiumddi/spatium-supervisor`
+because there's no `:dev`-tagged image on a GitHub-hosted runner.
+
+Fix is one line: `sudo -E` instead of bare `sudo` so the env passes
+through. Plus a preemptive `DOCKER_CONFIG=$HOME/.docker` to point
+root's docker CLI at the runner-user's `~/.docker/config.json`
+where the workflow's `docker/login-action` step stamped the GHCR
+credentials — our `ghcr.io/spatiumddi/*` container images are
+private, so without this redirect the `docker pull` calls inside
+the script would 401 anonymously even after the env-var fix.
+
+Same story as -2: container images + Helm chart are already published
+from the -1 / -2 cuts; this release only re-runs the workflow against
+the env-passthrough fix so the appliance ISO + slot raw.xz finally
+land on a GitHub release page. No operator action needed on existing
+docker-compose or Kubernetes installs.
+
+### Fixed
+
+- **Release-workflow `Bake container images` step lost
+  `SPATIUMDDI_VERSION` + `BAKE_SOURCE` through `sudo`.** Changed
+  `sudo appliance/scripts/bake-images.sh` to `sudo
+  DOCKER_CONFIG="$HOME/.docker" -E appliance/scripts/bake-images.sh`
+  so the env passes through and root inherits the runner-user's
+  GHCR auth.
+
 ## 2026.05.17-2 — 2026-05-17
 
 Same-day hotfix for the 2026.05.17-1 release pipeline. The


### PR DESCRIPTION
## Summary

Second hotfix on top of 2026.05.17-2. The previous fix (#201) cleared the ghost-image entries from `bake-images.sh`, but the `build-appliance-iso` job for 2026.05.17-2 failed *again* with a different bug — `sudo` was stripping the workflow's env vars (`SPATIUMDDI_VERSION`, `BAKE_SOURCE`), so the script fell back to its `:-dev` / `:-local` defaults and errored on missing local images.

Two-part fix in `.github/workflows/release.yml`:

1. **`sudo -E`** instead of bare `sudo` — preserves `SPATIUMDDI_VERSION` + `BAKE_SOURCE` through the privilege jump.
2. **`DOCKER_CONFIG=$HOME/.docker`** — points root's docker CLI at the runner-user's `~/.docker/config.json` where the `docker/login-action` step stamped the GHCR credentials. Our `ghcr.io/spatiumddi/*` images are private, so without this redirect `docker pull` would 401 anonymously when running as root.

## Evidence from the failing log

```
→ Pulling every image at 2026.05.17-2 + baking docker-overlay.img
→ SPATIUMDDI_VERSION = dev (stamped at .../spatiumddi-version)   ← should be 2026.05.17-2
ERROR: no local image found for ghcr.io/spatiumddi/spatium-supervisor
```

The `SPATIUMDDI_VERSION = dev` line is the script's own line 91 echo — it's reading the value sudo gave it (the default), not the value the workflow set on the job env. Same for `BAKE_SOURCE` — the local-mode error fires when it should have been in ghcr mode.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: cut tag 2026.05.17-3; verify `build-appliance-iso` completes; verify the GitHub release page has `spatiumddi-appliance-amd64.iso` + `spatiumddi-appliance-slot-amd64.raw.xz` + their `.sha256` sidecars
