### PR TITLE
Release 2026.05.17-4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,13 +344,14 @@ jobs:
           BAKE_SOURCE: ghcr
         run: |
           set -euo pipefail
-          echo "→ Pulling every image at ${SPATIUMDDI_VERSION} + baking docker-overlay.img"
+          echo "→ Pulling every image at ${SPATIUMDDI_VERSION} + baking per-image tarballs"
           chmod +x appliance/scripts/bake-images.sh
-          # #170 Phase E1 — bake-images.sh runs a sandboxed docker:dind
-          # to populate /var/lib/docker, then mkfs.ext4 + rsync into
-          # a per-slot overlay image. The runner needs nested-docker +
-          # loop-mount privileges; GitHub-hosted ubuntu-latest runners
-          # have both. ``sudo`` is required for the loop-mount step.
+          # Post-#183 bake script writes per-image zst tarballs to
+          # ``appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/``
+          # which k3s auto-imports at startup. The pre-#183 path that
+          # built a single ``docker-overlay.img`` overlay file via a
+          # docker:dind sandbox is gone (no docker on the appliance
+          # post-Phase-7).
           # ``sudo -E`` preserves SPATIUMDDI_VERSION + BAKE_SOURCE
           # from the job env. Without ``-E``, sudo strips them and
           # bake-images.sh falls back to its ``SPATIUMDDI_VERSION=dev``
@@ -364,10 +365,10 @@ jobs:
           # ghcr.io/spatiumddi/* images are private; without this redirect
           # root would docker-pull anonymously and 401 on every image.
           sudo DOCKER_CONFIG="$HOME/.docker" -E appliance/scripts/bake-images.sh
-          echo "→ Baked overlay image:"
-          ls -lh appliance/mkosi.extra/usr/lib/spatiumddi/docker-overlay.img
-          echo "→ Manifest:"
-          cat appliance/mkosi.extra/usr/lib/spatiumddi/docker-overlay.manifest
+          echo "→ Baked image tarballs:"
+          ls -lh appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/*.tar.zst
+          echo "→ Total size:"
+          du -sh appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/
       - name: Build raw image (mkosi)
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,28 @@ the formatter handles the rest.
 
 ## Unreleased
 
+## 2026.05.17-4 — 2026-05-17
+
+Third hotfix in the chain. With #201 + #203 the bake script + sudo
+env-passthrough were fixed and the bake itself succeeded on the
+2026.05.17-3 release-workflow run: 11 images, 382 MB written into
+the rootfs overlay. But the workflow's post-bake verification then
+errored at `ls: cannot access 'appliance/mkosi.extra/usr/lib/spatiumddi/docker-overlay.img':
+No such file or directory`. The path is from the pre-#183 era when
+`bake-images.sh` ran a docker-in-docker sandbox to populate
+`/var/lib/docker` and rsynced it into a per-slot overlay image; the
+post-#183 path writes per-image `.tar.zst` tarballs to
+`var/lib/rancher/k3s/agent/images/` for k3s's containerd to auto-
+import at startup. The bake step's verification was never updated
+to match. Fixed.
+
+### Fixed
+
+- **`build-appliance-iso` post-bake verification looked for a
+  pre-#183 docker-overlay.img.** Replaced with an `ls -lh` +
+  `du -sh` against the post-#183 tarball directory the bake script
+  actually populates.
+
 ## 2026.05.17-3 — 2026-05-17
 
 Second hotfix on top of -2. The release-workflow's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,24 @@ to match. Fixed.
   `du -sh` against the post-#183 tarball directory the bake script
   actually populates.
 
+### Changed
+
+- **Appliance operator-facing docs caught up to k3s.**
+  `appliance/README.md` and `appliance/cloud-init/README.md` still
+  described the pre-#183 first-boot flow (`docker compose pull && up
+  -d`) + referenced the now-gone `mkosi.extra/usr/local/share/
+  spatiumddi/docker-compose.yml` artifact. Rewritten to describe the
+  k3s flow: firstboot renders a variant-specific HelmChart manifest
+  into `/var/lib/rancher/k3s/server/manifests/`; k3s containerd
+  auto-imports the per-image tarballs at `/var/lib/rancher/k3s/
+  agent/images/*.tar.zst` so a fresh boot never reaches out to
+  ghcr.io; helm-controller installs the chart tarball baked at
+  `/usr/lib/spatiumddi/charts/`.
+- **`spatium-console` skipped the loop-mounted `/var/lib/spatiumddi/
+  docker-overlay/` mount in the disk panel** — dead skip rule from
+  the docker-overlay era (the path doesn't exist post-#183). Rule +
+  the two comment blocks that referenced it removed.
+
 ## 2026.05.17-3 — 2026-05-17
 
 Second hotfix on top of -2. The release-workflow's

--- a/appliance/README.md
+++ b/appliance/README.md
@@ -118,8 +118,10 @@ At runtime, **live-boot** (baked into the appliance's initrd by
 `mkosi.conf` Packages=) detects the boot medium, loop-mounts
 `/live/filesystem.squashfs` from the ISO, and overlays it with a
 tmpfs so writes work in RAM. The `spatiumddi-firstboot` service
-then runs the same way as on the qcow2 (docker compose up, wait for
-`/health/live`).
+then runs the same way as on the qcow2: writes the variant-specific
+HelmChart manifest into `/var/lib/rancher/k3s/server/manifests/`,
+starts k3s, and polls `/health/live` until the api pod reports
+ready.
 
 Verify the boot records with `xorriso -indev <iso> -report_el_torito plain`.
 
@@ -175,7 +177,7 @@ appliance/
 │       │   ├── spatiumddi-firstboot        # boot-time orchestrator
 │       │   └── spatiumddi-stack-status     # operator status command
 │       └── share/spatiumddi/
-│           └── docker-compose.yml          # all-in-one stack
+│           └── (k3s manifest templates rendered by firstboot)
 ├── builder/
 │   ├── Dockerfile           # the appliance-builder image (mkosi + qemu-img + xorriso + ...)
 │   └── .dockerignore
@@ -189,13 +191,23 @@ appliance/
 
 ## Customising the stack
 
-Compose file: `mkosi.extra/usr/local/share/spatiumddi/docker-compose.yml`.
-Track tag-for-tag with the top-level `docker-compose.yml`; appliance
-deltas should stay surgical (no profile clutter, no docker-volume
-opt-ins, no host-socket mounts).
+The appliance is k3s-driven post-#183. `spatiumddi-firstboot` renders
+one of three variant-specific HelmChart manifests (Application /
+All-in-One / Core-only) into `/var/lib/rancher/k3s/server/manifests/`
+on every boot and k3s's helm-controller installs the chart tarball
+baked at `/usr/lib/spatiumddi/charts/`. Chart values are filled in
+from `/etc/spatiumddi/.env` (secrets + agent keys + control-plane
+URL + appliance role).
 
-To pin a release tag instead of `:latest`, drop a
-`/etc/spatiumddi/release` file via cloud-init `write_files` — see
+To customise an existing install:
+- Operator-pasted overrides live in `/etc/spatiumddi/` (preserved
+  across slot swaps via the `/etc` overlay → `/var/persist/etc`).
+- Per-role firewall extras land in `appliance.firewall_extra` on the
+  control plane — rendered by the supervisor into
+  `/etc/nftables.d/spatium-role.nft`.
+
+To pin a release tag, drop a `/etc/spatiumddi/release` file via
+cloud-init `write_files` — see
 [cloud-init/README.md](cloud-init/README.md).
 
 ## What this MVP does NOT do (yet)
@@ -209,10 +221,8 @@ Tracked in [#134](https://github.com/spatiumddi/spatiumddi/issues/134):
 
 Other gaps Phase 1 surfaces but doesn't close:
 - No SBOM / GPG signing on the produced qcow2
-- No `make appliance` CI workflow yet (the builder-image publish
-  workflow ships, but there's no nightly/per-tag artifact build)
 - Stack health waits on `/health/live` only — does not verify DNS /
   DHCP agents finished registration
-- No host-level Prometheus exporters baked in
-- Debian's `docker-compose` (Python v1) — switch to upstream Docker
-  CE + `docker compose` plugin in Phase 1.x
+- No host-level Prometheus exporters baked in (the `observability`
+  Helm chart values flag enables kube-state-metrics + node-exporter
+  on-demand; both images are baked into the slot)

--- a/appliance/cloud-init/README.md
+++ b/appliance/cloud-init/README.md
@@ -51,10 +51,19 @@ hdiutil makehybrid -o cidata.iso -hfs -joliet -iso \
 2. The `spatiumddi-firstboot.service` systemd unit starts after
    `cloud-final.service` and:
    - generates `/etc/spatiumddi/.env` (POSTGRES_PASSWORD, SECRET_KEY,
-     CREDENTIAL_ENCRYPTION_KEY, DNS_AGENT_KEY, DHCP_AGENT_KEY) on
-     first run only — preserved across reboots
-   - `docker compose pull` (first run) + `docker compose up -d`
-   - polls `http://127.0.0.1:8000/health/live` until ready (5 min cap)
+     CREDENTIAL_ENCRYPTION_KEY, DNS_AGENT_KEY, DHCP_AGENT_KEY,
+     BOOTSTRAP_PAIRING_CODE on Application installs) on first run
+     only — preserved across reboots via the `/etc` overlay →
+     `/var/persist/etc` path
+   - renders the variant-specific HelmChart manifest into
+     `/var/lib/rancher/k3s/server/manifests/spatium-bootstrap.yaml`;
+     k3s's helm-controller auto-installs the chart tarball baked at
+     `/usr/lib/spatiumddi/charts/`
+   - starts `k3s.service`; containerd auto-imports the per-image
+     tarballs at `/var/lib/rancher/k3s/agent/images/*.tar.zst` so a
+     fresh boot never reaches out to ghcr.io
+   - polls `http://127.0.0.1:8000/health/live` until the api pod
+     reports ready (5 min cap)
 3. Web UI is reachable at `http://<appliance-ip>/`. Default login
    `admin` / `admin` (forces password change on first login).
 

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -594,14 +594,6 @@ def disk_summary() -> list[tuple[str, float, float, float]]:
         "binfmt_misc", "autofs", "nsfs", "hugetlbfs", "fuse.gvfsd-fuse",
     }
     skip_mounts = {"/boot/efi"}
-    # Skip the loop-mounted baked-image overlay — it's an internal
-    # implementation detail (Phase 8 firstboot loop-mounts the
-    # /usr/lib/spatiumddi/docker-overlay.img read-only as a lower
-    # layer for the docker storage driver). The operator-visible
-    # storage signal is /, /var, and ESP; the overlay's capacity
-    # doesn't change once the image is laid down at boot.
-    skip_mount_prefixes = ("/var/lib/spatiumddi/docker-overlay/",)
-    rows: list[tuple[str, float, float, float]] = []
     # Dedupe by device — bind mounts (e.g. /home → /var/home, /root →
     # /var/root per #170 Phase 8a) report the SAME underlying device
     # as the parent, just at a different mountpoint. Listing them all
@@ -616,8 +608,6 @@ def disk_summary() -> list[tuple[str, float, float, float]]:
         if part.fstype in skip_fstypes:
             continue
         if part.mountpoint in skip_mounts:
-            continue
-        if any(part.mountpoint.startswith(p) for p in skip_mount_prefixes):
             continue
         if part.device in seen_devices:
             continue
@@ -1148,9 +1138,9 @@ def render_header(state: "DashboardState", mono_t: float) -> Panel:
 
     # Vitals line — uptime / cpu / ram / load / disks all on one row.
     # Previously disks were on a separate ``line5`` but with the bind-
-    # mount dedupe + docker-overlay skip there are typically only 2-3
-    # mount entries, easily fitting alongside the vitals on the same
-    # row on any 80+ col TTY. Saves one vertical row on the dashboard.
+    # mount dedupe there are typically only 2-3 mount entries, easily
+    # fitting alongside the vitals on the same row on any 80+ col TTY.
+    # Saves one vertical row on the dashboard.
     vitals = Text()
     vitals.append("Up ", style="dim"); vitals.append(uptime_str(), style="bold")
     vitals.append("   CPU ", style="dim"); vitals.append(f"{cpu:.0f}%", style="bold")


### PR DESCRIPTION
## Summary

Third hotfix on top of 2026.05.17-3, plus a sweep of remaining pre-#183 docker remnants in operator-facing docs + dead skip rules.

### The release-blocking fix

With #201 + #203 in place, the 2026.05.17-3 release-workflow's `build-appliance-iso` step finally **succeeded at baking** — 11 images, 382 MB written into the rootfs overlay. The job still failed because the workflow's post-bake verification step looked for a pre-#183 file:

```
→ Baked overlay image:
ls: cannot access 'appliance/mkosi.extra/usr/lib/spatiumddi/docker-overlay.img': No such file or directory
##[error]Process completed with exit code 2.
```

That path is from the pre-#183 docker-in-docker overlay-image era. The post-#183 bake script writes per-image `.tar.zst` tarballs to `var/lib/rancher/k3s/agent/images/` (k3s containerd auto-imports at startup). The workflow's verification step was never updated to match.

Replaced the broken `ls` + `cat` with `ls -lh ... /*.tar.zst` + `du -sh` against the actual path.

### Bundled cleanup (per the audit before cutting -4)

Three other categories of pre-#183 docker remnants that don't affect the build but ship with the appliance and operators read them:

- **`appliance/README.md`** — still described the docker-compose first-boot flow + referenced the now-gone `mkosi.extra/usr/local/share/spatiumddi/docker-compose.yml` artifact + a Debian docker-compose-package switch caveat. Rewritten to describe the k3s + HelmChart flow.
- **`appliance/cloud-init/README.md`** — "docker compose pull + docker compose up -d" was the wrong first-boot sequence post-#183. Replaced with the actual k3s manifest-write + helm-install + `/health/live` poll path.
- **`spatium-console` disk panel** — dead skip rule for `/var/lib/spatiumddi/docker-overlay/` (a path that doesn't exist post-#183). Rule + two comment blocks removed.

The release pipeline itself is now structurally clean — no other docker remnants will bite. (Verified: the only `docker compose` references left in the repo's build/release surface are in the dev-container Makefile targets, which is correct — the dev environment IS docker-based; only the appliance dropped docker.)

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: cut 2026.05.17-4. Verify `build-appliance-iso` completes end-to-end (bake already proven to work at 2026.05.17-3; this is the verification-step + doc-cleanup landing).
- [ ] Verify the GitHub release page for 2026.05.17-4 has both `.iso` + `.raw.xz` assets (plus their `.sha256` sidecars).
