### PR TITLE
appliance: bake k3s + helm charts into release ISO + spatium-console NameError fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,8 +336,43 @@ jobs:
           } > appliance/mkosi.extra/etc/spatiumddi/appliance-release
           echo "→ Stamped appliance-release:"
           cat appliance/mkosi.extra/etc/spatiumddi/appliance-release
-      - name: Install zstd
-        run: sudo apt-get update && sudo apt-get install -y zstd
+      - name: Install zstd + helm
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y zstd
+          # helm comes from its own apt repo (Debian/Ubuntu don't carry
+          # current helm). bake-chart.sh shells out to ``helm package``
+          # so it must be on PATH before the chart-bake steps.
+          curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+          sudo apt-get update
+          sudo apt-get install -y helm
+          helm version
+      - name: Fetch k3s binary + airgap tarball
+        run: |
+          set -euo pipefail
+          # Issue #183 — without this step the slot rootfs ships zero
+          # k3s, ``/usr/local/bin/k3s`` is missing on every appliance,
+          # ``k3s.service`` crash-loops, firstboot wedges forever at
+          # "Waiting for k3s /readyz". Mirrors what
+          # ``make appliance-fetch-k3s`` does locally.
+          chmod +x appliance/scripts/fetch-k3s.sh
+          appliance/scripts/fetch-k3s.sh
+          ls -lh appliance/mkosi.extra/usr/local/bin/k3s
+          ls -lh appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/k3s-airgap-images-*.tar.zst
+      - name: Bake helm charts (appliance + control)
+        run: |
+          set -euo pipefail
+          # Issue #183 — without these steps the slot rootfs ships an
+          # empty /usr/lib/spatiumddi/charts/ directory; firstboot's
+          # WARN "missing — control plane won't auto-deploy" fires and
+          # the appliance never installs anything via the HelmChart CR.
+          # Mirrors ``make appliance-bake-chart appliance-bake-control-chart``.
+          chmod +x appliance/scripts/bake-chart.sh
+          appliance/scripts/bake-chart.sh
+          CHART_NAME=spatiumddi appliance/scripts/bake-chart.sh
+          ls -lh appliance/mkosi.extra/usr/lib/spatiumddi/charts/*.tgz
       - name: Bake container images into rootfs overlay
         env:
           SPATIUMDDI_VERSION: ${{ needs.meta.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,53 @@ the formatter handles the rest.
 
 ## Unreleased
 
+## 2026.05.17-5 — 2026-05-17
+
+Fourth hotfix on the 2026.05.17 chain. The previous four cuts all
+produced a green release artifact and uploaded an appliance ISO, but
+once the ISO was booted on a fresh VM (192.168.0.199) it became
+clear the slot rootfs was missing two artifacts that #194's k3s
+migration introduced: the k3s static binary at `/usr/local/bin/k3s`
+and the helm charts at `/usr/lib/spatiumddi/charts/{spatiumddi.tgz,
+spatiumddi-appliance.tgz}`. `k3s.service` crash-looped at restart
+counter 43, firstboot wedged forever at "Waiting for k3s /readyz",
+no api pod ever came up, no web UI ever served. The local `make
+appliance-baked-iso` chain runs `appliance-fetch-k3s` +
+`appliance-bake-chart` + `appliance-bake-control-chart` before mkosi
+— the release workflow's `build-appliance-iso` job inlines its own
+steps and never picked them up after #194 added them. Bundled with a
+separate `NameError` regression in `spatium-console` that crash-
+looped the F-key console dashboard at first frame (restart counter
+18 on 192.168.0.199).
+
+### Fixed
+
+- **Release workflow missing k3s + chart bake steps.** Added three
+  steps to `.github/workflows/release.yml`'s
+  `build-appliance-iso` job ahead of the mkosi build:
+  apt-install `helm` from the Helm stable repo (Debian's archive
+  doesn't carry a current helm), run `appliance/scripts/fetch-k3s
+  .sh` to download the pinned k3s static binary + airgap images
+  tarball + LICENSE into `mkosi.extra/`, run `appliance/scripts/
+  bake-chart.sh` (appliance chart) and `CHART_NAME=spatiumddi
+  appliance/scripts/bake-chart.sh` (umbrella control chart) to
+  package both helm charts into `mkosi.extra/usr/lib/spatiumddi/
+  charts/`. Mirrors `make appliance-fetch-k3s appliance-bake-chart
+  appliance-bake-control-chart` from the local
+  `appliance-baked-iso` chain. Without this the slot rootfs has no
+  k3s and no charts; the booted appliance is completely non-
+  functional. Caught when 192.168.0.199 came up from the
+  2026.05.17-4 ISO with k3s.service crash-looping and firstboot
+  warning "/usr/lib/spatiumddi/charts/spatiumddi.tgz missing —
+  control plane won't auto-deploy".
+- **`spatium-console` `NameError: name 'rows' is not defined`** at
+  `disk_summary` L619. #194 dropped the docker-overlay skip-prefix
+  block and accidentally also dropped the `rows: list[tuple[str,
+  float, float, float]] = []` initialization line. The function
+  appended to an undefined name on its first iteration → the
+  service crash-looped at restart counter 18 within seconds of
+  boot. Restored the initialization.
+
 ## 2026.05.17-4 — 2026-05-17
 
 Third hotfix in the chain. With #201 + #203 the bake script + sudo

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -594,6 +594,7 @@ def disk_summary() -> list[tuple[str, float, float, float]]:
         "binfmt_misc", "autofs", "nsfs", "hugetlbfs", "fuse.gvfsd-fuse",
     }
     skip_mounts = {"/boot/efi"}
+    rows: list[tuple[str, float, float, float]] = []
     # Dedupe by device — bind mounts (e.g. /home → /var/home, /root →
     # /var/root per #170 Phase 8a) report the SAME underlying device
     # as the parent, just at a different mountpoint. Listing them all


### PR DESCRIPTION
## Summary

Two critical fixes for the 2026.05.17 release chain. The -1 → -4
release ISOs all built green and uploaded artifacts but the booted
appliance (verified on 192.168.0.199 from the 2026.05.17-4 ISO)
was non-functional:

- ``/usr/local/bin/k3s`` missing → ``k3s.service`` crash-looped
  (restart counter 43 within minutes)
- ``/usr/lib/spatiumddi/charts/`` empty → firstboot logged
  ``WARN: /usr/lib/spatiumddi/charts/spatiumddi.tgz missing —
  control plane won't auto-deploy``
- Firstboot wedged forever at ``Waiting for k3s /readyz``
- ``spatium-console`` crashed at first frame with
  ``NameError: name 'rows' is not defined`` (restart counter 18)

Root cause #1: the local ``make appliance-baked-iso`` chain runs
``appliance-fetch-k3s`` + ``appliance-bake-chart`` +
``appliance-bake-control-chart`` ahead of mkosi to land the k3s
static binary + airgap tarball + both helm charts into
``mkosi.extra/`` so the slot rootfs ships them. The release
workflow's ``build-appliance-iso`` job inlines its own steps and
never picked these up after #194 added them — net result, the
release ISO ships container images but no k3s and no charts.

Root cause #2: #194's ``disk_summary()`` rewrite dropped the
docker-overlay skip-prefix block and accidentally also dropped the
``rows: list[tuple[str, float, float, float]] = []``
initialization line at the top of the function body.

## Changes

- ``.github/workflows/release.yml`` — three new steps before mkosi
  build:
  - Install ``helm`` from the Helm stable apt repo (Debian's
    archive doesn't carry a current helm)
  - Run ``appliance/scripts/fetch-k3s.sh`` to download pinned k3s
    ``v1.35.4+k3s1`` static binary + airgap images tarball +
    LICENSE into ``mkosi.extra/``
  - Run ``appliance/scripts/bake-chart.sh`` for both the per-role
    appliance chart + ``CHART_NAME=spatiumddi`` for the umbrella
    control chart
  - ``ls -lh`` after each step so a future regression is
    immediately obvious in the workflow log
- ``appliance/mkosi.extra/usr/local/bin/spatium-console`` —
  restored the ``rows: list[tuple[str, float, float, float]] = []``
  initialization line in ``disk_summary()``
- ``CHANGELOG.md`` — 2026.05.17-5 release entry

## Test plan

- [x] ``git diff --stat`` shows only the three intended files
- [ ] Workflow run on merge attaches a working appliance ISO
  (post-bake ``ls -lh`` lines show k3s binary + both chart
  tarballs)
- [ ] 192.168.0.199 rebooted onto the new ISO comes up with
  ``k3s.service`` active, firstboot reaching
  ``http://127.0.0.1/health/live`` 200, web UI reachable
- [ ] ``spatium-console`` no longer crash-loops on tty1

🤖 Generated with [Claude Code](https://claude.com/claude-code)