### PR TITLE
release.yml: install helm via azure/setup-helm v3.20.2 (baltocdn.com unreachable)

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.14.0
+          version: v3.20.2
 
       - name: Create kind cluster
         uses: helm/kind-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: azure/setup-helm@v4
         with:
-          version: v3.14.0
+          version: v3.20.2
       - name: Log in to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" \
@@ -336,19 +336,20 @@ jobs:
           } > appliance/mkosi.extra/etc/spatiumddi/appliance-release
           echo "→ Stamped appliance-release:"
           cat appliance/mkosi.extra/etc/spatiumddi/appliance-release
-      - name: Install zstd + helm
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y zstd
-          # helm comes from its own apt repo (Debian/Ubuntu don't carry
-          # current helm). bake-chart.sh shells out to ``helm package``
-          # so it must be on PATH before the chart-bake steps.
-          curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-          sudo apt-get update
-          sudo apt-get install -y helm
-          helm version
+      - name: Install zstd
+        run: sudo apt-get update && sudo apt-get install -y zstd
+      - name: Install helm
+        # Use the upstream-published azure/setup-helm action — it
+        # downloads the helm static binary from get.helm.sh (which
+        # resolves via the GitHub Releases CDN; reachable from the
+        # Azure runner). The Helm-stable apt repo at baltocdn.com is
+        # NOT reachable from GitHub Actions runners ("Could not resolve
+        # host: baltocdn.com" — Azure runner network policy).
+        # bake-chart.sh shells out to ``helm package`` so helm must be
+        # on PATH before the chart-bake step.
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.20.2
       - name: Fetch k3s binary + airgap tarball
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,36 @@ the formatter handles the rest.
 
 ## Unreleased
 
+## 2026.05.17-6 — 2026-05-17
+
+Fifth hotfix on the 2026.05.17 chain. 2026.05.17-5 tried to
+``apt-get install helm`` from ``baltocdn.com``'s Helm-stable repo
+but the Azure-hosted GitHub Actions runner's network policy doesn't
+resolve baltocdn.com (``curl: (6) Could not resolve host:
+baltocdn.com``), so the bake step never landed. Swapped to the
+upstream ``azure/setup-helm@v4`` action which downloads the helm
+static binary directly from ``get.helm.sh`` — same channel
+get-helm-3 ships from, reachable from Azure runners (GitHub
+Releases CDN). Took the opportunity to bump every helm-action pin
+in the repo (release.yml's chart-publish job + agent-e2e.yml were
+both on the long-stale v3.14.0) to the current latest v3.20.2 so
+all three CI surfaces stay aligned.
+
+### Fixed
+
+- **Release workflow's helm install couldn't reach baltocdn.com.**
+  Replaced the apt-repo recipe in ``build-appliance-iso`` with
+  ``azure/setup-helm@v4`` pinned to ``v3.20.2`` — same channel
+  ``get-helm-3`` ships from, reachable from Azure runners.
+
+### Changed
+
+- **All ``azure/setup-helm`` pins bumped to v3.20.2.**
+  ``release.yml``'s Publish-Helm-chart job and ``agent-e2e.yml``'s
+  kind-cluster job were both on v3.14.0; aligned with the new
+  ``build-appliance-iso`` job's pin so the three CI surfaces
+  don't drift.
+
 ## 2026.05.17-5 — 2026-05-17
 
 Fourth hotfix on the 2026.05.17 chain. The previous four cuts all


### PR DESCRIPTION
## Summary

2026.05.17-5's ``build-appliance-iso`` job failed at the new
"Install zstd + helm" step with:

```
curl: (6) Could not resolve host: baltocdn.com
```

The Azure-hosted GitHub Actions runner's network policy doesn't
resolve baltocdn.com (where the Helm-stable apt repo lives), so
the apt-repo recipe never ran. The k3s + chart bakes therefore
never ran either, and the slot rootfs would have shipped without
helm-baked charts again.

## Changes

- ``.github/workflows/release.yml`` — ``build-appliance-iso`` job:
  - Re-split zstd install back into its own step
  - Replace apt-repo helm install with ``azure/setup-helm@v4``
    pinned to ``v3.20.2`` (uses ``get.helm.sh``, reachable from
    Azure runners — same channel ``get-helm-3`` ships from)
- Bump the two existing ``azure/setup-helm@v4`` pins
  (release.yml's chart-publish job + agent-e2e.yml) from the
  stale v3.14.0 to v3.20.2 so all three CI surfaces stay aligned
- ``CHANGELOG.md`` — 2026.05.17-6 release entry

## Local verification

Mirrored the workflow's bake steps locally before pushing:

```
$ bash appliance/scripts/fetch-k3s.sh
✓ k3s v1.35.4+k3s1 baked into mkosi.extra/
  k3s binary: 75M, airgap tarball: 173M
$ bash appliance/scripts/bake-chart.sh
✓ Chart baked → .../charts/spatiumddi-appliance.tgz (12K)
$ CHART_NAME=spatiumddi bash appliance/scripts/bake-chart.sh
✓ Chart baked → .../charts/spatiumddi.tgz (22K)
```

Confirmed v3.20.2 exists at ``get.helm.sh`` (HTTP 200) — what
``azure/setup-helm`` actually downloads from.

## Test plan

- [x] Local fetch-k3s + double bake-chart all produce expected
  artifacts (k3s binary 75M, airgap 173M, both chart tgz)
- [ ] CI workflow's appliance-ISO job completes green
- [ ] Booted 2026.05.17-6 appliance has k3s.service active +
  firstboot reaches /health/live 200 + spatium-console renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)