### PR TITLE
deps: bump kube-state-metrics 2.18.0 + node-exporter 1.11.1 + nginx 1.30.1 + redis 8.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:7-alpine
+        image: redis:8.6-alpine
         ports:
           - 6379:6379
         options: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,33 @@ the formatter handles the rest.
 
 ## Unreleased
 
+### Changed
+
+- **Bumped four bundled images.** kube-state-metrics
+  ``v2.13.0`` → ``v2.18.0``, prometheus node-exporter ``v1.8.2``
+  → ``v1.11.1``, nginx ``1.27-alpine`` → ``1.30.1-alpine``
+  (agent-landing + frontend runtime), redis ``7-alpine`` →
+  ``8.6-alpine``. All four are in-place safe — three are
+  stateless (metrics scrapers + nginx web server, no on-disk
+  state to migrate), and Redis 8 reads RDB / AOF files written
+  by Redis 5+ so the existing ``redis_data`` volume mounts
+  cleanly on first start. Updated in lockstep across
+  ``appliance/scripts/bake-images.sh``,
+  ``charts/spatiumddi/values.yaml``,
+  ``charts/spatiumddi-appliance/values.yaml``,
+  ``docker-compose.yml``, ``docker-compose.dev.yml``,
+  ``frontend/Dockerfile``, ``k8s/ha/redis-sentinel.yaml``,
+  ``.github/workflows/ci.yml`` (test redis container), and the
+  matching doc comments in ``charts/spatiumddi/Chart.yaml`` +
+  ``charts/spatiumddi-appliance/templates/agent-landing.yaml`` +
+  ``docs/deployment/APPLIANCE.md``. Postgres stays on
+  ``16-alpine`` pending a dedicated PR — PG18 refuses to start
+  against a PG16 data directory, so we need an upfront
+  ``pg_upgrade`` migration sidecar before we bump (and the
+  ``postgresql-client-16`` pin in ``backend/Dockerfile`` needs
+  to move in lockstep with the server major to keep
+  ``pg_dump`` / ``pg_restore`` matched).
+
 ## 2026.05.17-6 — 2026-05-17
 
 Fifth hotfix on the 2026.05.17 chain. 2026.05.17-5 tried to

--- a/appliance/scripts/bake-images.sh
+++ b/appliance/scripts/bake-images.sh
@@ -65,17 +65,19 @@ IMAGES=(
 # ``charts/spatiumddi-appliance/values.yaml`` ``observability.*``
 # image refs.
 OBSERVABILITY_IMAGES=(
-    "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.13.0"
-    "quay.io/prometheus/node-exporter:v1.8.2"
+    "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0"
+    "quay.io/prometheus/node-exporter:v1.11.1"
     # Agent landing page — always-on nginx serving the rendered
     # /var/lib/spatiumddi/agent-landing/index.html on :80. Pinned to
-    # 1.27-alpine matching values.yaml's ``agentLanding.image.tag``.
-    "nginx:1.27-alpine"
+    # 1.30.1-alpine matching values.yaml's ``agentLanding.image.tag``.
+    "nginx:1.30.1-alpine"
     # Phase 11 (#183) — datastores for the AIO + Core control plane.
     # Tags follow the umbrella chart's ``postgresql.image.tag`` and
-    # ``redis.image.tag`` defaults.
+    # ``redis.image.tag`` defaults. Postgres stays on 16-alpine
+    # pending a dedicated PR with pg_upgrade migration tooling —
+    # PG18 refuses to start against a PG16 data directory.
     "postgres:16-alpine"
-    "redis:7-alpine"
+    "redis:8.6-alpine"
 )
 
 if ! command -v docker >/dev/null 2>&1; then

--- a/charts/spatiumddi-appliance/templates/agent-landing.yaml
+++ b/charts/spatiumddi-appliance/templates/agent-landing.yaml
@@ -13,7 +13,7 @@
        k3s; no LoadBalancer to fall back on (klipper-lb is disabled),
        so hostNetwork is the simplest path.
 
-       Image: stock ``nginx:1.27-alpine``, preloaded into containerd
+       Image: stock ``nginx:1.30.1-alpine``, preloaded into containerd
        at bake time alongside the SpatiumDDI service images. */}}
 {{- if .Values.agentLanding.enabled }}
 apiVersion: apps/v1

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -99,7 +99,7 @@ observability:
     enabled: false
     image:
       repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-      tag: v2.13.0
+      tag: v2.18.0
     # Resource cap — appliance VMs are typically 2-4 GB; KSM has a
     # bounded memory profile but a runaway pod shouldn't dent the
     # service pods' headroom.
@@ -117,7 +117,7 @@ observability:
     enabled: false
     image:
       repository: quay.io/prometheus/node-exporter
-      tag: v1.8.2
+      tag: v1.11.1
     resources:
       requests:
         cpu: 10m
@@ -164,6 +164,6 @@ agentLanding:
   enabled: true
   image:
     repository: nginx
-    tag: 1.27-alpine
+    tag: 1.30.1-alpine
   hostMounts:
     htmlDir: /var/lib/spatiumddi/agent-landing

--- a/charts/spatiumddi/Chart.yaml
+++ b/charts/spatiumddi/Chart.yaml
@@ -22,7 +22,7 @@ maintainers:
   - name: SpatiumDDI Contributors
 # No subchart dependencies. Postgres + Redis ship as plain
 # StatefulSet + Service templates owned by this chart, using the
-# official ``postgres:16-alpine`` and ``redis:7-alpine`` images
+# official ``postgres:16-alpine`` and ``redis:8.6-alpine`` images
 # (the same ones docker-compose.yml uses). The bundled subcharts
 # previously came from the Bitnami chart family, but Bitnami pruned
 # the ``bitnami/*`` Docker Hub namespace in late 2025 in favour of

--- a/charts/spatiumddi/templates/redis.yaml
+++ b/charts/spatiumddi/templates/redis.yaml
@@ -3,7 +3,7 @@
 {{- $secretName := printf "%s-redis" (include "spatiumddi.fullname" .) -}}
 # ─────────────────────────────────────────────────────────────────────────────
 # In-chart Redis — single-node StatefulSet using the official
-# ``redis:7-alpine`` image. Sized for a small lab / single-VM
+# ``redis:8.6-alpine`` image. Sized for a small lab / single-VM
 # deployment. Real production HA installs should set
 # ``redis.enabled=false`` and point ``externalRedis`` at a
 # Redis Sentinel cluster (see k8s/ha/redis-sentinel.yaml).

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -10,7 +10,7 @@
 #   ingress               Frontend ingress
 #   postgresql            In-chart Postgres StatefulSet using postgres:16-alpine
 #                         (matches docker-compose.yml). BYO via externalDatabase.
-#   redis                 In-chart Redis StatefulSet using redis:7-alpine.
+#   redis                 In-chart Redis StatefulSet using redis:8.6-alpine.
 #                         BYO via externalRedis.
 #   dnsAgents             Optional BIND9 agent StatefulSets (one per DNSServer row)
 #   dhcpAgents            Optional Kea agent StatefulSets (one per DHCPServer row)
@@ -231,14 +231,14 @@ externalDatabase:
 
 # ── Redis ────────────────────────────────────────────────────────────────────
 # In-chart single-node Redis StatefulSet using the official
-# ``redis:7-alpine`` image (matches docker-compose.yml). For HA
+# ``redis:8.6-alpine`` image (matches docker-compose.yml). For HA
 # production set ``redis.enabled=false`` and point ``externalRedis`` at
 # a Redis Sentinel cluster (see k8s/ha/redis-sentinel.yaml).
 redis:
   enabled: true
   image:
     repository: redis
-    tag: "7-alpine"
+    tag: "8.6-alpine"
     pullPolicy: IfNotPresent
   # Cap and eviction policy match docker-compose.yml's redis-server
   # CLI flags. Bump if your install needs a larger cache.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,7 +42,7 @@ services:
 
   # ── Redis ───────────────────────────────────────────────────────────────────
   redis:
-    image: redis:7-alpine
+    image: redis:8.6-alpine
     restart: unless-stopped
     networks:
       - spatiumddi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   # ── Redis ───────────────────────────────────────────────────────────────────
   redis:
-    image: redis:7-alpine
+    image: redis:8.6-alpine
     restart: unless-stopped
     networks:
       - spatiumddi

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -45,7 +45,7 @@ mkosi bakes everything the appliance needs to come up fully air-gapped:
 
 - **k3s static binary** (~70 MB) at `/usr/local/bin/k3s`; `kubectl` / `crictl` / `ctr` symlink to it.
 - **k3s airgap images** (CoreDNS / local-path / pause / metrics-server) as zst-compressed tarballs at `/var/lib/rancher/k3s/agent/images/*.tar.zst`. k3s auto-imports them into containerd at boot.
-- **SpatiumDDI container images** as zst tarballs at `/usr/lib/spatiumddi/images/`. firstboot imports them into k3s containerd via `ctr -n k8s.io images import`. Includes api / frontend / worker / beat / migrate / dns-bind9 / dns-powerdns / dhcp-kea / supervisor / nginx + postgres:16-alpine + redis:7-alpine for AIO / Core variants.
+- **SpatiumDDI container images** as zst tarballs at `/usr/lib/spatiumddi/images/`. firstboot imports them into k3s containerd via `ctr -n k8s.io images import`. Includes api / frontend / worker / beat / migrate / dns-bind9 / dns-powerdns / dhcp-kea / supervisor / nginx + postgres:16-alpine + redis:8.6-alpine for AIO / Core variants.
 - **Helm chart tarballs** at `/usr/lib/spatiumddi/charts/`. The appliance chart drives Application installs; the umbrella chart drives AIO + Core. Built at release time + signed.
 - **bash-completion + `k` alias** for kubectl — operator SSHing in for triage drops straight into a usable shell.
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,7 +26,7 @@ RUN npm run build
 
 
 # ── Stage 2: serve via nginx ──────────────────────────────────────────────────
-FROM nginx:1.27-alpine AS runtime
+FROM nginx:1.30.1-alpine AS runtime
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 # Issue #176: the API upstream + DNS resolver are now templated so the

--- a/k8s/ha/redis-sentinel.yaml
+++ b/k8s/ha/redis-sentinel.yaml
@@ -50,7 +50,7 @@ spec:
       initContainers:
         # Set replica-of on non-primary pods
         - name: init-redis
-          image: redis:7-alpine
+          image: redis:8.6-alpine
           command:
             - sh
             - -c
@@ -69,7 +69,7 @@ spec:
               mountPath: /data
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: redis:8.6-alpine
           command: ["redis-server", "/data/redis.conf"]
           ports:
             - containerPort: 6379
@@ -90,7 +90,7 @@ spec:
               memory: 512Mi
 
         - name: sentinel
-          image: redis:7-alpine
+          image: redis:8.6-alpine
           command: ["redis-sentinel", "/data/sentinel.conf"]
           ports:
             - containerPort: 26379


### PR DESCRIPTION
## Summary

Four in-place-safe image bumps across every surface the appliance
ISO touches (slot bake, helm chart values, docker-compose, k8s
manifests, CI test redis):

| Image | Was | Now | Type |
|---|---|---|---|
| kube-state-metrics | ``v2.13.0`` | ``v2.18.0`` | Stateless |
| node-exporter | ``v1.8.2`` | ``v1.11.1`` | Stateless |
| nginx | ``1.27-alpine`` | ``1.30.1-alpine`` | Stateless |
| redis | ``7-alpine`` | ``8.6-alpine`` | Major, in-place |

## Why these four are safe to ship now

- **kube-state-metrics + node-exporter** are pure ``/metrics``
  scrapers. No on-disk state. Drop-in replacement.
- **nginx** runs as the frontend runtime + the appliance
  agent-landing pod. Stateless; both render templated config at
  start. No 1.27 → 1.30 breaking change applies to our usage.
- **Redis 8** reads RDB and AOF files written by Redis 5+, so
  the existing ``redis_data`` volume mounts cleanly on first
  start. The ``--maxmemory`` / ``--maxmemory-policy`` CLI flags
  and the celery broker / kombu wire protocol are all unchanged.
  Note Redis 8 re-licensed under AGPLv3 + SSPL (still open
  source, but worth flagging for downstream packagers).

## Why postgres is NOT in this PR

Postgres 16 → 18 is a hard breaking change for every existing
appliance. PG18 refuses to start against a data directory whose
``PG_VERSION`` says ``16`` — every fielded install would lose its
database on slot upgrade. The right move is its own PR with:

1. ``pg_upgrade`` migration sidecar (init container carrying
   PG16 + PG18 binaries) that detects the version mismatch on
   the PVC and runs the upgrade before the main postgres pod
   starts.
2. Lockstep bump of ``postgresql-client-16`` to ``-18`` in
   ``backend/Dockerfile`` (pg_dump/pg_restore major must match
   the server major — same lockstep note already in the
   Dockerfile).
3. ``k8s/ha/postgres-cluster.yaml`` CNPG ``imageName`` bump from
   ``cloudnative-pg/postgresql:16`` to ``:18``.
4. Backup-system regression test against PG18 dumps.

Tracked separately so this PR doesn't strand existing operators.

## Files touched

```
.github/workflows/ci.yml                                  (redis test image)
appliance/scripts/bake-images.sh                          (all 4 tags)
charts/spatiumddi-appliance/templates/agent-landing.yaml  (comment)
charts/spatiumddi-appliance/values.yaml                   (ksm + node-exp + nginx tags)
charts/spatiumddi/Chart.yaml                              (comment)
charts/spatiumddi/templates/redis.yaml                    (comment)
charts/spatiumddi/values.yaml                             (redis tag + header doc)
docker-compose.dev.yml                                    (redis)
docker-compose.yml                                        (redis)
docs/deployment/APPLIANCE.md                              (operator-doc image list)
frontend/Dockerfile                                       (nginx runtime)
k8s/ha/redis-sentinel.yaml                                (3 redis refs)
CHANGELOG.md                                              (Unreleased entry)
```

## Test plan

- [x] ``helm lint charts/spatiumddi`` clean
- [x] ``helm lint charts/spatiumddi-appliance`` clean
- [x] No stale ``redis:7`` / ``nginx:1.27`` / ``kube-state...v2.13`` /
      ``node-exporter:...v1.8.2`` references remain (grep clean
      across yml / yaml / sh / md / Dockerfile)
- [ ] CI green (backend tests run against the new redis:8.6-alpine)
- [ ] Next release ISO's appliance boots; agent-landing renders;
      observability pods (when enabled) come up
- [ ] Celery worker connects to redis 8.6 without protocol surprises

🤖 Generated with [Claude Code](https://claude.com/claude-code)