### PR TITLE
Fix 18 low-severity audit findings: api + worker + supervisor + dns/dhcp agents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,12 @@ POSTGRES_PASSWORD=changeme
 # JWT signing key. Must be at least 32 chars in production.
 #   Generate:  openssl rand -hex 32
 #   Or:        python3 -c "import secrets; print(secrets.token_hex(32))"
+# The control plane emits a loud stderr warning every boot while the
+# default sentinel is in place. Set STRICT_SECRET_KEY=true below to
+# turn that warning into a hard boot failure once you have generated
+# a real key — recommended for any non-dev deployment.
 SECRET_KEY=change-me-to-a-random-32-char-string
+# STRICT_SECRET_KEY=true
 
 # Fernet key for at-rest encryption of stored secrets (auth_provider configs,
 # integration credentials, AI provider API keys, backup-target passwords).

--- a/agent/dhcp/spatium_dhcp_agent/bootstrap.py
+++ b/agent/dhcp/spatium_dhcp_agent/bootstrap.py
@@ -34,12 +34,11 @@ def _fingerprint(agent_id: str) -> str:
 
 
 def _client(cfg: AgentConfig) -> httpx.Client:
-    verify: bool | str = True
-    if cfg.insecure_skip_tls_verify:
-        verify = False
-    elif cfg.tls_ca_path:
-        verify = cfg.tls_ca_path
-    return httpx.Client(base_url=cfg.control_plane_url, verify=verify, timeout=30.0)
+    return httpx.Client(
+        base_url=cfg.control_plane_url,
+        verify=cfg.httpx_verify(),
+        timeout=30.0,
+    )
 
 
 def register(cfg: AgentConfig) -> tuple[str, str, dict]:

--- a/agent/dhcp/spatium_dhcp_agent/config.py
+++ b/agent/dhcp/spatium_dhcp_agent/config.py
@@ -46,6 +46,19 @@ class AgentConfig:
     heartbeat_interval: float = 30.0
     longpoll_timeout: float = 30.0
 
+    def httpx_verify(self) -> bool | str:
+        """Resolve the ``verify=`` argument for ``httpx.Client`` calls.
+
+        Issue #266 — was previously duplicated across 9 modules. Single
+        source of truth: ``insecure_skip_tls_verify`` (dev-only override)
+        wins over a custom CA bundle; the default is full verification.
+        """
+        if self.insecure_skip_tls_verify:
+            return False
+        if self.tls_ca_path:
+            return self.tls_ca_path
+        return True
+
     @classmethod
     def from_env(cls) -> "AgentConfig":
         cp = os.environ.get("SPATIUM_API_URL", "").rstrip("/")

--- a/agent/dhcp/spatium_dhcp_agent/dhcp_fingerprint.py
+++ b/agent/dhcp/spatium_dhcp_agent/dhcp_fingerprint.py
@@ -221,12 +221,10 @@ class DhcpFingerprintShipper:
         self._last_flush = time.monotonic()
 
     def stop(self) -> None:
+        # ``run()`` owns the sniffer lifecycle and stops the scapy
+        # AsyncSniffer in its shutdown block. Calling ``_sniffer.stop()``
+        # from here too is harmless (idempotent) but dead — issue #261.
         self._stop.set()
-        if self._sniffer is not None:
-            try:
-                self._sniffer.stop()
-            except Exception:  # noqa: BLE001 — scapy can raise oddly on stop
-                pass
 
     def _on_packet(self, packet: Any) -> None:
         try:
@@ -280,12 +278,11 @@ class DhcpFingerprintShipper:
         return True
 
     def _cp_client(self) -> httpx.Client:
-        verify: bool | str = True
-        if self.cfg.insecure_skip_tls_verify:
-            verify = False
-        elif self.cfg.tls_ca_path:
-            verify = self.cfg.tls_ca_path
-        return httpx.Client(base_url=self.cfg.control_plane_url, verify=verify, timeout=15.0)
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=15.0,
+        )
 
     def _drain(self) -> list[FingerprintObservation]:
         with self._lock:

--- a/agent/dhcp/spatium_dhcp_agent/ha_status.py
+++ b/agent/dhcp/spatium_dhcp_agent/ha_status.py
@@ -87,13 +87,10 @@ class HAStatusPoller:
         self._stop.set()
 
     def _client(self) -> httpx.Client:
-        verify: bool | str = True
-        if self.cfg.insecure_skip_tls_verify:
-            verify = False
-        elif self.cfg.tls_ca_path:
-            verify = self.cfg.tls_ca_path
         return httpx.Client(
-            base_url=self.cfg.control_plane_url, verify=verify, timeout=10.0
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=10.0,
         )
 
     def _poll_kea(self) -> tuple[str | None, dict[str, Any] | None]:

--- a/agent/dhcp/spatium_dhcp_agent/heartbeat.py
+++ b/agent/dhcp/spatium_dhcp_agent/heartbeat.py
@@ -30,20 +30,17 @@ class HeartbeatClient:
         self._stop.set()
 
     def _client(self) -> httpx.Client:
-        verify: bool | str = True
-        if self.cfg.insecure_skip_tls_verify:
-            verify = False
-        elif self.cfg.tls_ca_path:
-            verify = self.cfg.tls_ca_path
-        return httpx.Client(base_url=self.cfg.control_plane_url, verify=verify, timeout=15.0)
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=15.0,
+        )
 
     def send_once(self) -> None:
         # Drain queued op acks (queued by SyncLoop when bundle includes pending_ops).
-        acks = getattr(self, "pending_acks", None)
         ops_ack: list[dict] = []
-        if acks is not None:
-            while acks:
-                ops_ack.append(acks.pop(0))
+        while self.pending_acks:
+            ops_ack.append(self.pending_acks.pop(0))
         body: dict[str, Any] = {
             "agent_version": __version__,
             "pid": os.getpid(),

--- a/agent/dhcp/spatium_dhcp_agent/leases.py
+++ b/agent/dhcp/spatium_dhcp_agent/leases.py
@@ -83,12 +83,11 @@ class LeaseWatcher:
         self._stop.set()
 
     def _client(self) -> httpx.Client:
-        verify: bool | str = True
-        if self.cfg.insecure_skip_tls_verify:
-            verify = False
-        elif self.cfg.tls_ca_path:
-            verify = self.cfg.tls_ca_path
-        return httpx.Client(base_url=self.cfg.control_plane_url, verify=verify, timeout=15.0)
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=15.0,
+        )
 
     def _flush(self) -> None:
         if not self._pending:

--- a/agent/dhcp/spatium_dhcp_agent/log_shipper.py
+++ b/agent/dhcp/spatium_dhcp_agent/log_shipper.py
@@ -52,12 +52,11 @@ class LogShipper:
         self._stop.set()
 
     def _cp_client(self) -> httpx.Client:
-        verify: bool | str = True
-        if self.cfg.insecure_skip_tls_verify:
-            verify = False
-        elif self.cfg.tls_ca_path:
-            verify = self.cfg.tls_ca_path
-        return httpx.Client(base_url=self.cfg.control_plane_url, verify=verify, timeout=15.0)
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=15.0,
+        )
 
     def _open(self) -> bool:
         try:

--- a/agent/dhcp/spatium_dhcp_agent/metrics.py
+++ b/agent/dhcp/spatium_dhcp_agent/metrics.py
@@ -9,18 +9,25 @@ the bucket and seed the next snapshot fresh — better to drop one
 bucket than emit a spurious negative-turned-positive spike when the
 new counters climb back up.
 
-Kea statistic names we care about (v4-only for MVP — DHCPv6 stats
-have the same shape under ``pkt6-*`` names and can be added with a
-one-line map once v6 scopes are in wide use):
+Kea statistic names we care about. The eight column names on
+``dhcp_metric_sample`` were v4-shaped originally and now do double
+duty for v6 by mapping each v6 message to the v4 column with the
+closest role-equivalent semantics (SOLICIT≈DISCOVER, ADVERTISE≈
+OFFER, REPLY≈ACK, INFORMATION-REQUEST≈INFORM, RENEW+REBIND fold
+into ``request``). Issue #264 — both stacks share one row per
+server so operators running v6 finally get per-bucket numbers
+without a schema migration.
 
-    pkt4-discover-received    → discover
-    pkt4-offer-sent           → offer
-    pkt4-request-received     → request
-    pkt4-ack-sent             → ack
-    pkt4-nak-sent             → nak
-    pkt4-decline-received     → decline
-    pkt4-release-received     → release
-    pkt4-inform-received      → inform
+    pkt4-discover-received                pkt6-solicit-received        → discover
+    pkt4-offer-sent                       pkt6-advertise-sent          → offer
+    pkt4-request-received                 pkt6-request-received
+                                          pkt6-renew-received
+                                          pkt6-rebind-received         → request
+    pkt4-ack-sent                         pkt6-reply-sent              → ack
+    pkt4-nak-sent                                                      → nak
+    pkt4-decline-received                 pkt6-decline-received        → decline
+    pkt4-release-received                 pkt6-release-received        → release
+    pkt4-inform-received                  pkt6-information-request-received → inform
 """
 
 from __future__ import annotations
@@ -39,6 +46,9 @@ from .kea_ctrl import KeaCtrlError, send_command
 log = structlog.get_logger(__name__)
 
 # Map Kea's statistic names to the column names on dhcp_metric_sample.
+# Multiple v6 message types fold into a single v4-shaped column when
+# their roles align — see the module docstring for the mapping
+# rationale (issue #264).
 _STAT_MAP = {
     "pkt4-discover-received": "discover",
     "pkt4-offer-sent": "offer",
@@ -48,7 +58,21 @@ _STAT_MAP = {
     "pkt4-decline-received": "decline",
     "pkt4-release-received": "release",
     "pkt4-inform-received": "inform",
+    "pkt6-solicit-received": "discover",
+    "pkt6-advertise-sent": "offer",
+    "pkt6-request-received": "request",
+    "pkt6-renew-received": "request",
+    "pkt6-rebind-received": "request",
+    "pkt6-reply-sent": "ack",
+    "pkt6-decline-received": "decline",
+    "pkt6-release-received": "release",
+    "pkt6-information-request-received": "inform",
 }
+
+# Column names — the unique set of values from ``_STAT_MAP``, used by
+# ``_compute_delta`` so a multi-stat → single-column mapping doesn't
+# re-diff the same column twice.
+_METRIC_COLUMNS = sorted(set(_STAT_MAP.values()))
 
 
 def _extract_counter(series: Any) -> int | None:
@@ -73,13 +97,19 @@ def _extract_counter(series: Any) -> int | None:
 
 
 def _parse_snapshot(resp: dict[str, Any]) -> dict[str, int]:
-    """``statistic-get-all`` → flat ``{column: current_counter}`` dict."""
+    """``statistic-get-all`` → flat ``{column: current_counter}`` dict.
+
+    Multiple stat names can map to the same column (e.g. ``pkt6-
+    renew-received`` + ``pkt6-rebind-received`` both feed ``request``);
+    in that case we sum the counters so the column carries the
+    full per-role activity.
+    """
     args = resp.get("arguments") or {}
     out: dict[str, int] = {}
     for stat_name, col in _STAT_MAP.items():
         v = _extract_counter(args.get(stat_name))
         if v is not None:
-            out[col] = v
+            out[col] = out.get(col, 0) + v
     return out
 
 
@@ -96,12 +126,11 @@ class MetricsPoller:
         self._stop.set()
 
     def _client(self) -> httpx.Client:
-        verify: bool | str = True
-        if self.cfg.insecure_skip_tls_verify:
-            verify = False
-        elif self.cfg.tls_ca_path:
-            verify = self.cfg.tls_ca_path
-        return httpx.Client(base_url=self.cfg.control_plane_url, verify=verify, timeout=15.0)
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=15.0,
+        )
 
     def _poll_kea(self) -> dict[str, int] | None:
         try:
@@ -123,7 +152,7 @@ class MetricsPoller:
             return None  # first bucket — no baseline
         delta: dict[str, int] = {}
         reset = False
-        for col in _STAT_MAP.values():
+        for col in _METRIC_COLUMNS:
             d = current.get(col, 0) - prev.get(col, 0)
             if d < 0:
                 reset = True

--- a/agent/dhcp/spatium_dhcp_agent/peer_resolve.py
+++ b/agent/dhcp/spatium_dhcp_agent/peer_resolve.py
@@ -49,15 +49,27 @@ class PeerResolveWatcher:
 
     def __init__(
         self,
-        apply_fn: Callable[..., None],
+        apply_fn: Callable[..., None] | None = None,
         *,
         check_interval: float = CHECK_INTERVAL,
     ):
+        # ``apply_fn`` may be deferred so the supervisor can construct
+        # the watcher before the SyncLoop (which the apply_fn closes
+        # over) exists — see ``set_apply_fn`` (issue #265).
         self._apply_fn = apply_fn
         self._check_interval = check_interval
         self._stop = threading.Event()
         self._lock = threading.Lock()
         self._bundle: dict[str, Any] | None = None
+
+    def set_apply_fn(self, apply_fn: Callable[..., None]) -> None:
+        """Arm the watcher with the SyncLoop's bundle-apply callback.
+
+        Called by the supervisor after the SyncLoop is constructed so
+        the watcher's apply path can never fire against a partially-
+        wired chain (issue #265).
+        """
+        self._apply_fn = apply_fn
         # Maps hostname → last resolved IP. We only reload when the
         # resolution changes, not on every tick.
         self._resolved: dict[str, str] = {}
@@ -124,6 +136,12 @@ class PeerResolveWatcher:
             return
         for host, old_ip, new_ip in changed:
             log.info("ha_peer_ip_changed", host=host, old=old_ip, new=new_ip)
+        if self._apply_fn is None:
+            # Supervisor hasn't armed the watcher yet — log and bail.
+            # Caller will pick the change up on the next tick once the
+            # SyncLoop wires in via ``set_apply_fn``.
+            log.warning("ha_peer_reresolve_no_apply_fn", changes=len(changed))
+            return
         try:
             self._apply_fn(bundle, reload_kea=True)
             log.info("ha_peer_reresolve_reloaded", changes=len(changed))

--- a/agent/dhcp/spatium_dhcp_agent/supervisor.py
+++ b/agent/dhcp/spatium_dhcp_agent/supervisor.py
@@ -36,18 +36,19 @@ def run(cfg: AgentConfig) -> int:
 
     heartbeat = HeartbeatClient(cfg, token_ref)
     ha_poller = HAStatusPoller(cfg, token_ref)
-    # Placeholder watcher — we need the syncer to exist before we can
-    # give the watcher its apply callback. Construct both and wire.
-    syncer_holder: list[SyncLoop] = []
-    peer_watcher = PeerResolveWatcher(
-        apply_fn=lambda bundle, reload_kea=True: syncer_holder[0]._apply_bundle(
-            bundle, reload_kea=reload_kea
-        )
-    )
+    # Construct the watcher first (SyncLoop needs the reference in its
+    # ``__init__``), then arm it once the SyncLoop exists. Issue #265 —
+    # the old ``syncer_holder[0]`` closure could fire against an empty
+    # list if anything in SyncLoop ever invoked the apply path during
+    # construction; the explicit ``set_apply_fn`` setter rules that
+    # footgun out at compile time.
+    peer_watcher = PeerResolveWatcher()
     syncer = SyncLoop(
         cfg, token_ref, heartbeat, ha_poller=ha_poller, peer_watcher=peer_watcher
     )
-    syncer_holder.append(syncer)
+    peer_watcher.set_apply_fn(
+        lambda bundle, reload_kea=True: syncer._apply_bundle(bundle, reload_kea=reload_kea)
+    )
     leases = LeaseWatcher(cfg, token_ref, heartbeat)
     metrics = MetricsPoller(cfg, token_ref)
     log_shipper = LogShipper(cfg, token_ref)

--- a/agent/dhcp/spatium_dhcp_agent/sync.py
+++ b/agent/dhcp/spatium_dhcp_agent/sync.py
@@ -26,7 +26,7 @@ from typing import Any
 import httpx
 import structlog
 
-from .cache import load_config, save_config, save_rendered_kea
+from .cache import load_config, save_config, save_rendered_kea, save_token
 from .config import AgentConfig
 from .kea_ctrl import KeaCtrlError, config_reload
 from .render_kea import render as render_kea
@@ -99,15 +99,10 @@ class SyncLoop:
         self._stop.set()
 
     def _client(self) -> httpx.Client:
-        verify: bool | str = True
-        if self.cfg.insecure_skip_tls_verify:
-            verify = False
-        elif self.cfg.tls_ca_path:
-            verify = self.cfg.tls_ca_path
         # server holds for ~longpoll_timeout seconds, give client a bit more
         return httpx.Client(
             base_url=self.cfg.control_plane_url,
-            verify=verify,
+            verify=self.cfg.httpx_verify(),
             timeout=self.cfg.longpoll_timeout + 15.0,
         )
 
@@ -245,8 +240,6 @@ class SyncLoop:
                 status=resp.status_code,
                 reason="token_invalid" if resp.status_code == 401 else "server_missing",
             )
-            from .cache import save_token
-
             save_token(self.cfg.state_dir, "")
             self._stop.set()
             return

--- a/agent/dns/spatium_dns_agent/config.py
+++ b/agent/dns/spatium_dns_agent/config.py
@@ -17,7 +17,7 @@ class AgentConfig:
     # supervisor's ``role-compose.env``.
     dns_agent_key: str
     server_name: str
-    driver: str  # bind9 (only supported backend)
+    driver: str  # bind9 | powerdns (see supervisor.py for the registry)
     roles: list[str]
     group_name: str | None
     tls_ca_path: str | None

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -8,10 +8,12 @@ TSIG key carried in the config bundle.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import shutil
 import signal
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
@@ -277,9 +279,6 @@ class Bind9Driver(DriverBase):
         renders on bundle change, so each render really is a different
         membership state and consumers will always pull.
         """
-        import hashlib
-        import time
-
         path.parent.mkdir(parents=True, exist_ok=True)
         cname = (catalog.get("zone_name") or "").strip()
         if not cname:
@@ -323,7 +322,7 @@ class Bind9Driver(DriverBase):
             f"$TTL {ttl}",
             f"@ IN SOA ns1.{name} admin.{name} ( {serial} 3600 600 86400 300 )",
             f"@ IN NS ns1.{name}",
-            f"ns1 IN A 127.0.0.1",
+            "ns1 IN A 127.0.0.1",
         ]
         for rec in zone.get("records", []) or []:
             rec_ttl = rec.get("ttl") or ttl
@@ -364,7 +363,7 @@ class Bind9Driver(DriverBase):
         zname = bl["rpz_zone_name"]
         lines = [
             "$TTL 60",
-            f"@ IN SOA localhost. root.localhost. ( 1 3600 600 86400 60 )",
+            "@ IN SOA localhost. root.localhost. ( 1 3600 600 86400 60 )",
             "@ IN NS localhost.",
         ]
         for e in bl.get("entries") or []:

--- a/agent/dns/spatium_dns_agent/drivers/powerdns.py
+++ b/agent/dns/spatium_dns_agent/drivers/powerdns.py
@@ -25,6 +25,7 @@ the first ship.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import secrets
@@ -106,9 +107,6 @@ def _render_catalog_zone_payload(catalog: dict[str, Any]) -> dict[str, Any]:
     entries so the existing reconciler creates / patches it through
     the same code path.
     """
-    import hashlib
-    import time
-
     zname = (catalog.get("zone_name") or "").rstrip(".") + "."
     if not zname or zname == ".":
         return {"name": "invalid.", "kind": "Native", "rrsets": []}

--- a/agent/supervisor/pyproject.toml
+++ b/agent/supervisor/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8", "ruff>=0.4", "mypy>=1.10"]
+dev = ["pytest>=8", "ruff>=0.4", "mypy>=1.10", "types-PyYAML>=6.0"]
 
 [project.scripts]
 spatium-supervisor = "spatium_supervisor.__main__:main"

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -34,7 +34,6 @@ the supervisor.
 from __future__ import annotations
 
 import hashlib
-import subprocess
 import time
 import uuid
 from pathlib import Path
@@ -43,7 +42,7 @@ from typing import Any
 import httpx
 import structlog
 
-from . import appliance_state, approval_state
+from . import appliance_state, approval_state, watchdog
 from .cert_auth import build_auth_headers, load_cert, save_cert
 from .config import SupervisorConfig
 from .firewall_renderer import FirewallProfile, render_drop_in
@@ -53,10 +52,6 @@ from .role_orchestrator import (
     probe_port_conflicts,
     render_env_file,
 )
-from . import watchdog
-
-log = structlog.get_logger(__name__)
-
 # Issue #183 Phase 7 — k3s-only lifecycle. The pre-Phase-7 dispatcher
 # (compose vs k3s on ``detect_runtime()``) is gone with the rest of
 # docker; this is the only path now.
@@ -65,6 +60,8 @@ from .service_lifecycle import (
     reconcile_node_labels,
     tear_down_supervised_services,
 )
+
+log = structlog.get_logger(__name__)
 
 # #170 Wave C2 — role-driven compose env file. Written under the
 # supervisor's state-dir so it survives slot swaps; the operator's

--- a/agent/supervisor/spatium_supervisor/watchdog.py
+++ b/agent/supervisor/spatium_supervisor/watchdog.py
@@ -86,10 +86,14 @@ class ServiceHealth:
     container_id: str | None
 
 
-# Process-local history of (status, monotonic-first-seen). Survives
-# heartbeat ticks within one supervisor process; resets on restart
-# (acceptable — first watchdog tick after restart re-observes).
-_status_history: dict[str, tuple[str, float]] = {}
+# Process-local history of (status, monotonic-first-seen,
+# wall-first-seen). Wall timestamp is persisted alongside the
+# monotonic anchor so a backward host-clock adjustment between two
+# probes can't reconstruct a ``since`` that lands in the past
+# relative to itself (issue #244). Survives heartbeat ticks within
+# one supervisor process; resets on restart (acceptable — first
+# watchdog tick after restart re-observes).
+_status_history: dict[str, tuple[str, float, float]] = {}
 
 
 def read_assigned_profiles(env_file: Path) -> list[str]:
@@ -172,10 +176,10 @@ def _check_health_k3s(
         for svc, role in desired_services.items():
             prev = _status_history.get(svc)
             if prev is None or prev[0] != "missing":
-                _status_history[svc] = ("missing", now_mono)
+                _status_history[svc] = ("missing", now_mono, now_wall)
                 since_wall = now_wall
             else:
-                since_wall = now_wall - (now_mono - prev[1])
+                since_wall = prev[2]
             out[svc] = {
                 "role": role,
                 "status": "missing",
@@ -209,10 +213,10 @@ def _check_health_k3s(
 
         prev = _status_history.get(svc)
         if prev is None or prev[0] != status:
-            _status_history[svc] = (status, now_mono)
+            _status_history[svc] = (status, now_mono, now_wall)
             since_wall = now_wall
         else:
-            since_wall = now_wall - (now_mono - prev[1])
+            since_wall = prev[2]
 
         out[svc] = {
             "role": role,

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,9 +1,10 @@
 """Health probe endpoints consumed by Docker/Kubernetes."""
 
 import asyncio
+from collections.abc import Awaitable
 from datetime import UTC, datetime
 from time import monotonic
-from typing import Any
+from typing import Any, cast
 
 import structlog
 from fastapi import APIRouter
@@ -49,7 +50,7 @@ async def readiness() -> JSONResponse:
         from app.config import settings
 
         r = aioredis.from_url(settings.redis_url, socket_connect_timeout=2)
-        await r.ping()
+        await cast(Awaitable[bool], r.ping())
         await r.aclose()
         checks["redis"] = "ok"
     except Exception as exc:
@@ -107,7 +108,7 @@ async def platform_health() -> JSONResponse:
         from app.config import settings
 
         r = aioredis.from_url(settings.redis_url, socket_connect_timeout=2)
-        await r.ping()
+        await cast(Awaitable[bool], r.ping())
         await r.aclose()
         components.append(
             {

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -309,7 +309,7 @@ async def agent_config_longpoll(
         response.headers["X-Spatium-Pending-Approval"] = "1"
         return {"pending_approval": True, "etag": None}
 
-    deadline = asyncio.get_event_loop().time() + LONGPOLL_TIMEOUT_SECONDS
+    deadline = asyncio.get_running_loop().time() + LONGPOLL_TIMEOUT_SECONDS
     while True:
         bundle = await build_config_bundle(db, server)
         # Issue #153 — fold the rendered snmpd.conf hash into the ETag
@@ -471,7 +471,7 @@ async def agent_config_longpoll(
                 # spatiumddi-chrony-reload.path applies + reloads.
                 "ntp_settings": ntp_block,
             }
-        if asyncio.get_event_loop().time() >= deadline:
+        if asyncio.get_running_loop().time() >= deadline:
             return Response(status_code=304, headers={"ETag": etag})
         await asyncio.sleep(LONGPOLL_POLL_INTERVAL)
 

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -313,7 +313,7 @@ async def agent_config_longpoll(
         response.headers["X-Spatium-Pending-Approval"] = "1"
         return {"pending_approval": True, "etag": None}
 
-    deadline = asyncio.get_event_loop().time() + LONGPOLL_TIMEOUT_SECONDS
+    deadline = asyncio.get_running_loop().time() + LONGPOLL_TIMEOUT_SECONDS
     while True:
         bundle = await build_config_bundle(db, server)
         etag = bundle["etag"]
@@ -324,7 +324,7 @@ async def agent_config_longpoll(
             await db.commit()
             response.headers["ETag"] = etag
             return bundle
-        if asyncio.get_event_loop().time() >= deadline:
+        if asyncio.get_running_loop().time() >= deadline:
             response.status_code = 304
             response.headers["ETag"] = etag
             return Response(status_code=304, headers={"ETag": etag})

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,15 @@
+import sys
+
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Sentinel default for ``secret_key``. Production deployments MUST
+# override this via the ``SECRET_KEY`` env var (or ``.env``) — the
+# model validator below emits a loud stderr warning whenever the
+# sentinel is in use, and hard-fails the boot when
+# ``STRICT_SECRET_KEY=true`` is set (recommended for any non-dev
+# deployment).
+_SECRET_KEY_DEV_SENTINEL = "change-me-to-a-random-32-char-string"
 
 
 class Settings(BaseSettings):
@@ -13,7 +24,7 @@ class Settings(BaseSettings):
     redis_url: str = "redis://redis:6379/0"
 
     # Security
-    secret_key: str = "change-me-to-a-random-32-char-string"
+    secret_key: str = _SECRET_KEY_DEV_SENTINEL
     access_token_expire_minutes: int = 15
     refresh_token_expire_days: int = 7
     credential_encryption_key: str = ""
@@ -65,6 +76,14 @@ class Settings(BaseSettings):
     # so forks can point their update check at their own repo.
     github_repo: str = "spatiumddi/spatiumddi"
 
+    # When ``True`` (recommended for any non-dev deployment), the boot
+    # fails fast if ``SECRET_KEY`` is still set to the .env.example
+    # sentinel. Default ``False`` so a fresh ``cp .env.example .env``
+    # first-time setup boots and the operator can log in to fix it,
+    # but every boot with the sentinel still emits a loud stderr
+    # warning regardless of this flag. See #216.
+    strict_secret_key: bool = False
+
     # Demo mode — locks down abusable mutation surfaces (nmap, AI
     # provider creates, webhook targets, integration targets,
     # outbound mail/audit/backup, factory reset, password change)
@@ -107,6 +126,28 @@ class Settings(BaseSettings):
     # SIGHUP to when a new cert is activated, so nginx reloads its
     # TLS context. Matches the compose service name on the appliance.
     appliance_frontend_container: str = "spatiumddi-frontend"
+
+    @model_validator(mode="after")
+    def _check_secret_key_default(self) -> "Settings":
+        # The sentinel JWT-signing key in ``.env.example`` MUST NOT
+        # reach a production deploy. Emit a loud warning every boot;
+        # hard-fail when ``STRICT_SECRET_KEY=true`` is set.
+        if self.secret_key == _SECRET_KEY_DEV_SENTINEL:
+            if self.strict_secret_key:
+                raise ValueError(
+                    "SECRET_KEY is still set to the .env.example default and "
+                    "STRICT_SECRET_KEY=true. Generate a real key with "
+                    "`openssl rand -hex 32` and set SECRET_KEY in .env."
+                )
+            print(
+                "WARNING: SECRET_KEY is still the .env.example sentinel. "
+                "Set SECRET_KEY=<openssl rand -hex 32> in .env. "
+                "Enable STRICT_SECRET_KEY=true in non-dev deployments to "
+                "make this a hard error.",
+                file=sys.stderr,
+                flush=True,
+            )
+        return self
 
 
 settings = Settings()

--- a/backend/app/services/acme.py
+++ b/backend/app/services/acme.py
@@ -328,8 +328,8 @@ async def wait_for_op_applied(
     which writes ``state=applied`` on the row. Polling is simple,
     correct, and usually converges in <5 seconds on a healthy pair.
     """
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
         async with AsyncSessionLocal() as fresh_db:
             row = await fresh_db.get(DNSRecordOp, op_id)
             if row is None:
@@ -356,10 +356,10 @@ async def wait_for_ops_applied(
     """
     if not op_ids:
         return {}
-    deadline = asyncio.get_event_loop().time() + timeout
+    deadline = asyncio.get_running_loop().time() + timeout
     remaining = set(op_ids)
     result: dict[uuid.UUID, str] = {}
-    while remaining and asyncio.get_event_loop().time() < deadline:
+    while remaining and asyncio.get_running_loop().time() < deadline:
         async with AsyncSessionLocal() as fresh_db:
             rows = (
                 (

--- a/backend/app/tasks/alerts.py
+++ b/backend/app/tasks/alerts.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 
 import structlog
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.celery_app import celery_app
 from app.db import task_session
@@ -20,8 +21,18 @@ from app.services import alerts as alert_service
 logger = structlog.get_logger(__name__)
 
 
-@celery_app.task(name="app.tasks.alerts.evaluate_alerts")
-def evaluate_alerts() -> dict[str, int]:
+@celery_app.task(
+    name="app.tasks.alerts.evaluate_alerts",
+    bind=True,
+    # Issue #222 — autoretry on transient DB / network classes so a
+    # missed tick doesn't have to wait for the next 60 s beat firing.
+    autoretry_for=(SQLAlchemyError, ConnectionError, OSError),
+    retry_backoff=True,
+    retry_backoff_max=30,
+    retry_jitter=True,
+    max_retries=3,
+)
+def evaluate_alerts(self: object) -> dict[str, int]:  # type: ignore[type-arg]
     return asyncio.run(_run())
 
 

--- a/backend/app/tasks/audit_chain_verify.py
+++ b/backend/app/tasks/audit_chain_verify.py
@@ -20,6 +20,7 @@ from datetime import UTC, datetime
 import structlog
 from celery import shared_task
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.db import task_session
 from app.models.alerts import AlertEvent, AlertRule
@@ -126,8 +127,19 @@ async def _async_verify_and_alert() -> dict:
         return {"ok": False, "rows_checked": result.rows_checked, "broken": len(result.breaks)}
 
 
-@shared_task(name="app.tasks.audit_chain_verify.verify_audit_chain")
-def verify_audit_chain() -> dict:
+@shared_task(
+    name="app.tasks.audit_chain_verify.verify_audit_chain",
+    bind=True,
+    # Issue #222 — autoretry on transient DB / network classes so a
+    # nightly verifier hit by a DB blip doesn't have to wait a full
+    # 24 h for the next beat firing.
+    autoretry_for=(SQLAlchemyError, ConnectionError, OSError),
+    retry_backoff=True,
+    retry_backoff_max=300,
+    retry_jitter=True,
+    max_retries=3,
+)
+def verify_audit_chain(self: object) -> dict:  # type: ignore[type-arg]
     """Celery entry point. Runs nightly via beat; idempotent on its
     own — re-runs are cheap and self-resolving when the break clears."""
     return asyncio.run(_async_verify_and_alert())

--- a/backend/app/tasks/conformity.py
+++ b/backend/app/tasks/conformity.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 
 import structlog
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.celery_app import celery_app
 from app.db import task_session
@@ -20,8 +21,18 @@ from app.services.conformity import evaluate_due_policies
 logger = structlog.get_logger(__name__)
 
 
-@celery_app.task(name="app.tasks.conformity.evaluate_conformity")
-def evaluate_conformity() -> dict[str, int]:
+@celery_app.task(
+    name="app.tasks.conformity.evaluate_conformity",
+    bind=True,
+    # Issue #222 — autoretry on transient DB / network classes so a
+    # missed tick doesn't have to wait for the next 60 s beat firing.
+    autoretry_for=(SQLAlchemyError, ConnectionError, OSError),
+    retry_backoff=True,
+    retry_backoff_max=30,
+    retry_jitter=True,
+    max_retries=3,
+)
+def evaluate_conformity(self: object) -> dict[str, int]:  # type: ignore[type-arg]
     return asyncio.run(_run())
 
 

--- a/backend/app/tasks/event_outbox.py
+++ b/backend/app/tasks/event_outbox.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 
 import structlog
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -22,8 +23,19 @@ from app.services.event_delivery import process_due_outbox
 logger = structlog.get_logger(__name__)
 
 
-@celery_app.task(name="app.tasks.event_outbox.process_event_outbox")
-def process_event_outbox() -> dict[str, object]:
+@celery_app.task(
+    name="app.tasks.event_outbox.process_event_outbox",
+    bind=True,
+    # Issue #221 — autoretry on DB connection drops so a transient
+    # outage doesn't cost a beat tick. Backoff caps at 30 s so a
+    # retry storm never overlaps the next 10 s beat firing.
+    autoretry_for=(SQLAlchemyError, ConnectionError, OSError),
+    retry_backoff=True,
+    retry_backoff_max=30,
+    retry_jitter=True,
+    max_retries=3,
+)
+def process_event_outbox(self: object) -> dict[str, object]:  # type: ignore[type-arg]
     """Tick the event outbox worker.
 
     Uses a fresh ``NullPool`` engine per tick. Celery's prefork worker
@@ -45,6 +57,9 @@ def process_event_outbox() -> dict[str, object]:
 
     try:
         return dict(asyncio.run(_run()))
+    except (SQLAlchemyError, ConnectionError, OSError):
+        # Let Celery autoretry these — re-raise unchanged.
+        raise
     except Exception as exc:  # noqa: BLE001
         logger.exception("event_outbox_tick_failed", error=str(exc))
         return {"claimed": 0, "delivered": 0, "failed": 0, "dead": 0, "error": str(exc)}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -63,6 +63,8 @@ dev = [
     "ruff>=0.8.0",
     "black>=24.10.0",
     "mypy>=1.13.0",
+    "types-croniter>=3.0.0",
+    "types-paramiko>=3.4.0",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

Closes the 18 open low-severity findings from the `mzac-bug-check`
audit (5 thematic commits, one per component). All are cosmetic /
hygiene / preventative-footgun fixes — no behaviour changes a user
would notice. Same one-PR-per-component-commit pattern as #268 and
#269.

### api (#211 #214 #215 #216)

- `health.py` — `cast(Awaitable[bool], r.ping())` so redis-py's
  union return type narrows for mypy.
- 8 call-sites — `asyncio.get_event_loop().time()` → `asyncio.
  get_running_loop().time()` (deprecated in 3.12 with no running loop).
- `backend/pyproject.toml` — `types-croniter` + `types-paramiko` in
  dev extras.
- `config.py` — new `STRICT_SECRET_KEY=true` toggle that hard-fails
  the boot when `SECRET_KEY` is still the `.env.example` sentinel.
  Loud stderr warning every boot regardless. `.env.example`
  documents the toggle.

### worker (#221 #222)

Four beat-fired tasks were re-raising on transient DB/network
failures with no retry policy. Added `bind=True` +
`autoretry_for=(SQLAlchemyError, ConnectionError, OSError)` +
exponential backoff to `event_outbox`, `conformity`, `alerts`, and
`audit_chain_verify`. Non-transient exceptions still surface
through `logger.exception` unchanged.

### supervisor (#243 #244 #245)

- `heartbeat.py` — drop unused `import subprocess` (Phase 7
  remnant); re-order `from .service_lifecycle import ...` to the
  import block (E402).
- `watchdog.py` — persist wall-clock timestamp alongside the
  monotonic anchor in `_status_history`. Old reconstruction
  `since_wall = now_wall - (now_mono - prev[1])` could land in the
  past relative to itself after a backward host-clock adjustment.
- `agent/supervisor/pyproject.toml` — `types-PyYAML` in dev extras.

### dns-agent (#254 #255 #256)

- BIND9 + PowerDNS `_render_catalog_zone_payload` / `_write_catalog
  _zone_file` — hoist in-function `import hashlib` / `import time` to
  module top.
- `bind9.py` — drop `f` prefix on two placeholder-less strings (ruff
  F541).
- `config.py` — fix stale `# bind9 (only supported backend)`
  comment; PowerDNS shipped in #127.

### dhcp-agent (#261 #262 #263 #264 #265 #266)

- `dhcp_fingerprint.py` — remove duplicate `_sniffer.stop()` call
  (run() owns sniffer cleanup).
- `heartbeat.py` — drop dead `getattr(self, "pending_acks", None)`
  defensive check; `__init__` always sets the attr.
- `sync.py` — hoist `from .cache import save_token` from the
  401/404 rebootstrap branch to the module top.
- `metrics.py` — add the long-deferred DHCPv6 stat map. Multiple v6
  message types fold into v4-shaped columns by closest role
  semantics. `_METRIC_COLUMNS` constant prevents double-diffing on
  many-to-one mappings.
- `peer_resolve.py` + `supervisor.py` — `PeerResolveWatcher`
  accepts a deferred `apply_fn` and exposes `set_apply_fn()`, so the
  supervisor can construct the watcher first and arm it once
  SyncLoop exists. Drops the `syncer_holder[0]` closure footgun.
- `config.py` + 8 callers — hoist the `verify=` resolution into
  `AgentConfig.httpx_verify()`. Was duplicated verbatim across 8
  modules.

## Test plan

- [x] `make ci` — backend ruff + black + mypy + frontend lint + format
      + typecheck + build all clean
- [x] `pytest tests/test_health.py tests/test_audit_forward.py` —
      19 pass (touches the modules with the most direct impact)
- [ ] Smoke-test the dev container after rebuild — `make dev` + log
      in + confirm the new SECRET_KEY-sentinel warning fires on
      stderr

Closes #211, Closes #214, Closes #215, Closes #216, Closes #221, Closes #222, Closes #243, Closes #244, Closes #245, Closes #254, Closes #255, Closes #256, Closes #261, Closes #262, Closes #263, Closes #264, Closes #265, Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)