### PR TITLE
fix: thread VERSION env into api/worker/beat on the helm path (closes #274)

### DIFF
--- a/charts/spatiumddi/templates/_helpers.tpl
+++ b/charts/spatiumddi/templates/_helpers.tpl
@@ -182,6 +182,19 @@ Common env block for api / worker / beat. Only $(POSTGRES_PASSWORD) and
 $(REDIS_PASSWORD) reference secrets; everything else is inline.
 */}}
 {{- define "spatiumddi.commonEnv" -}}
+{{/* Issue #274 — running version, surfaced by the api as
+     ``settings.version`` and rendered in the sidebar's lower-
+     left "v…" chip. Mirrors the docker-compose ``VERSION:
+     ${SPATIUMDDI_VERSION:-dev}`` wiring on the helm path.
+     Precedence: operator-pinned ``image.tag`` wins (e.g. for a
+     manual rollback) → chart-packaged ``.Chart.AppVersion`` (the
+     CalVer tag the release workflow stamps via
+     ``helm package --app-version``) → falls through to the
+     api's own ``"dev"`` fallback in ``app/config.py``. Same
+     resolution chain as the existing ``spatiumddi.image``
+     helper so the env value tracks the running image tag. */}}
+- name: VERSION
+  value: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
## Summary

Closes #274. Every k3s / appliance install has been showing
`vdev` in the sidebar version chip regardless of which release
ISO it came from. Root cause is one missing line in the umbrella
chart's common-env helper: docker-compose threads
`VERSION: \${SPATIUMDDI_VERSION:-dev}` to api / worker / beat, but
the helm chart never did, so the api falls back to the literal
`"dev"` default in \`backend/app/config.py:62\`. Frontend renders
`"v" + "dev"` → `vdev`.

## The fix

One env entry in \`charts/spatiumddi/templates/_helpers.tpl\` →
\`spatiumddi.commonEnv\`:

\`\`\`yaml
- name: VERSION
  value: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
\`\`\`

Same resolution chain as the existing \`spatiumddi.image\`
helper — operator-pinned \`image.tag\` (manual rollback) wins
over chart-packaged \`.Chart.AppVersion\` (the CalVer tag the
release workflow stamps via \`helm package --app-version\`).
On an unpackaged chart, falls through to the \`0.0.0-dev\`
placeholder in \`Chart.yaml\`.

## Verified

\`\`\`
$ helm template charts/spatiumddi | grep -A1 'name: VERSION'
            - name: VERSION
              value: \"0.0.0-dev\"

$ helm template charts/spatiumddi --set image.tag=2026.05.18-1 | grep -A1 'name: VERSION'
            - name: VERSION
              value: \"2026.05.18-1\"

$ helm lint charts/spatiumddi
1 chart(s) linted, 0 chart(s) failed
\`\`\`

## Test plan

- [x] \`helm template\` no-override → \`VERSION=\"0.0.0-dev\"\`
- [x] \`helm template --set image.tag=<tag>\` → \`VERSION=\"<tag>\"\`
- [x] \`helm lint charts/spatiumddi\` clean
- [x] \`make ci\` — backend + frontend lint + build all clean
- [ ] Cut next release; install ISO; verify sidebar reads
      \`v<CalVer>\`

## Existing installs

Existing 2026.05.17-6 / 2026.05.18-1 appliances pick this up via
slot upgrade (the helm chart re-applies on every boot, and on the
next chart roll-out the api Deployment gets the new env). No
operator action required.

Closes #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)