### PR TITLE
Sites tree view + Move + sibling-code fix (#279); domains RDAP-on-create (#278)

### DIFF
--- a/backend/alembic/versions/a1c7e9f32b84_site_code_partial_unique.py
+++ b/backend/alembic/versions/a1c7e9f32b84_site_code_partial_unique.py
@@ -1,0 +1,56 @@
+"""site code uniqueness: partial index on non-NULL code (#279 bug)
+
+The ``ix_site_parent_code_unique`` index was created over
+``(parent_site_id, code)`` with ``NULLS NOT DISTINCT`` so two top-level
+sites (NULL parent) can't share a code. But that flag also makes the
+optional ``code`` column's NULLs (and empty strings) compare equal, so a
+second code-less sibling — including the common case of a second
+top-level site created with no code — 409'd with "a sibling site with
+this code already exists" despite having no code.
+
+Fix: make the unique index partial (``WHERE code IS NOT NULL``) so
+code-less rows are excluded from it entirely; real codes stay unique per
+parent with NULL parents sharing one namespace. Existing empty/whitespace
+codes are normalised to NULL first (create/update now do the same).
+
+Revision ID: a1c7e9f32b84
+Revises: f3b8d24a1c70
+Create Date: 2026-05-22
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "a1c7e9f32b84"
+down_revision = "f3b8d24a1c70"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_site_parent_code_unique", table_name="site")
+    # Normalise existing empty/whitespace codes to NULL so they fall out
+    # of the partial index (and match the API's new "" → NULL coercion).
+    op.execute("UPDATE site SET code = NULL WHERE btrim(code) = ''")
+    op.create_index(
+        "ix_site_parent_code_unique",
+        "site",
+        ["parent_site_id", "code"],
+        unique=True,
+        postgresql_nulls_not_distinct=True,
+        postgresql_where=sa.text("code IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_site_parent_code_unique", table_name="site")
+    op.create_index(
+        "ix_site_parent_code_unique",
+        "site",
+        ["parent_site_id", "code"],
+        unique=True,
+        postgresql_nulls_not_distinct=True,
+    )

--- a/backend/app/api/v1/asns/router.py
+++ b/backend/app/api/v1/asns/router.py
@@ -20,6 +20,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Literal
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import String, func, or_, select
@@ -30,6 +31,8 @@ from app.core.permissions import require_resource_permission
 from app.models.asn import ASN, ASNRpkiRoa, BGPCommunity, BGPPeering
 from app.services.asns.classifier import REGISTRIES, classify_asn
 from app.services.tags import apply_tag_filter
+
+logger = structlog.get_logger(__name__)
 
 # Router-level permission gate — covers GET (read), POST/PUT (write),
 # DELETE on every endpoint mounted below.
@@ -232,6 +235,20 @@ async def create_asn(body: ASNCreate, db: DB, user: CurrentUser) -> ASNRead:
     )
     await db.commit()
     await db.refresh(row)
+
+    # #278 follow-up — kick a one-shot RDAP (+ RPKI for public ASNs)
+    # refresh so the row is populated within seconds instead of sitting at
+    # whois_state "n/a" until the next refresh_due_asns beat tick. Private
+    # ASNs short-circuit inside the task (no RDAP/ROAs issued for them).
+    # Fire-and-forget: a broker hiccup must not fail the 201 — the
+    # scheduled sweep still picks the row up (next_check_at IS NULL).
+    try:
+        from app.tasks.asn_whois_refresh import refresh_one_asn_by_id
+
+        refresh_one_asn_by_id.delay(str(row.id))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("asn_whois_refresh_dispatch_failed", asn=row.number, error=str(exc))
+
     return ASNRead.model_validate(row)
 
 

--- a/backend/app/api/v1/domains/router.py
+++ b/backend/app/api/v1/domains/router.py
@@ -327,6 +327,19 @@ async def create_domain(body: DomainCreate, db: DB, current_user: CurrentUser) -
     )
     await db.commit()
     await db.refresh(d)
+
+    # #278 — kick a one-shot RDAP refresh so the row is populated within
+    # seconds instead of sitting empty until the next refresh_due_domains
+    # beat tick (up to domain_whois_interval_hours away). Fire-and-forget:
+    # a broker hiccup must not fail the 201 — the scheduled sweep still
+    # picks the row up (it orders next_check_at IS NULL first).
+    try:
+        from app.tasks.domain_whois_refresh import refresh_one_domain_by_id
+
+        refresh_one_domain_by_id.delay(str(d.id))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("domain_whois_refresh_dispatch_failed", domain=d.name, error=str(exc))
+
     return _to_read(d)
 
 

--- a/backend/app/api/v1/ownership/sites.py
+++ b/backend/app/api/v1/ownership/sites.py
@@ -32,6 +32,19 @@ router = APIRouter(
 SiteKind = Literal["datacenter", "branch", "pop", "colo", "cloud_region", "customer_premise"]
 
 
+# An empty / whitespace ``code`` means "no code", which must be stored
+# as NULL — not ``""``. The sibling-uniqueness index treats NULL parents
+# as equal (so top-level codes are unique), and that flag would make two
+# empty-string codes collide too; normalising to NULL keeps the index's
+# ``WHERE code IS NOT NULL`` predicate excluding code-less siblings so
+# any number of them can coexist. Shared by create + update.
+def _normalize_code(v: str | None) -> str | None:
+    if v is None:
+        return None
+    v = v.strip()
+    return v or None
+
+
 class SiteCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     code: str | None = Field(default=None, max_length=64)
@@ -48,6 +61,11 @@ class SiteCreate(BaseModel):
             raise ValueError(f"kind must be one of {sorted(SITE_KINDS)}")
         return v
 
+    @field_validator("code")
+    @classmethod
+    def _v_code(cls, v: str | None) -> str | None:
+        return _normalize_code(v)
+
 
 class SiteUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
@@ -57,6 +75,11 @@ class SiteUpdate(BaseModel):
     parent_site_id: uuid.UUID | None = None
     notes: str | None = None
     tags: dict[str, Any] | None = None
+
+    @field_validator("code")
+    @classmethod
+    def _v_code(cls, v: str | None) -> str | None:
+        return _normalize_code(v)
 
 
 class SiteRead(BaseModel):

--- a/backend/app/models/ownership.py
+++ b/backend/app/models/ownership.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy import ForeignKey, Index, String, Text, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -101,14 +101,25 @@ class Site(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __table_args__ = (
         # Operator code is unique per parent for sub-site disambiguation
         # (e.g. two campuses with floors named ``F1``). NULL parents
-        # share one global namespace; ``NULLS NOT DISTINCT`` so two
-        # top-level sites can't share a code.
+        # share one global namespace; ``NULLS NOT DISTINCT`` makes the
+        # NULL parent_site_id values compare equal so two top-level sites
+        # can't share a *code*. But ``code`` itself is optional, and that
+        # same NULLS-NOT-DISTINCT flag also makes empty codes collide —
+        # so a second code-less sibling (top-level or otherwise) would
+        # 409 with "a sibling site with this code already exists" even
+        # though it has no code at all. The partial ``WHERE code IS NOT
+        # NULL`` predicate excludes code-less rows from the index, so any
+        # number of siblings may have no code while real codes stay
+        # unique per parent. (create/update normalise ``""`` → NULL so
+        # an empty input field is treated as "no code", not a code of
+        # "".) Requires PG 15+ for NULLS NOT DISTINCT.
         Index(
             "ix_site_parent_code_unique",
             "parent_site_id",
             "code",
             unique=True,
             postgresql_nulls_not_distinct=True,
+            postgresql_where=text("code IS NOT NULL"),
         ),
         Index("ix_site_kind", "kind"),
         Index("ix_site_region", "region"),

--- a/backend/app/tasks/asn_whois_refresh.py
+++ b/backend/app/tasks/asn_whois_refresh.py
@@ -32,6 +32,7 @@ Idempotent — re-running before any row is due is a no-op.
 from __future__ import annotations
 
 import asyncio
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -260,4 +261,101 @@ def refresh_due_asns(self: object) -> dict[str, Any]:  # type: ignore[type-arg]
         raise
 
 
-__all__ = ["refresh_due_asns"]
+async def _refresh_one_by_id_async(asn_id: str) -> dict[str, Any]:
+    """RDAP (+ RPKI for public ASNs) refresh a single ASN by id.
+
+    Reuses the same per-row services the beat sweeps + manual endpoints
+    use — the whois state machine here, plus rpki_roa_refresh's per-row
+    reconciler for public rows. Private rows skip both RDAP and RPKI
+    (RIRs issue neither for private AS numbers); ``_refresh_one_asn``
+    still stamps ``whois_last_checked_at`` so the UI poll converges.
+    """
+    async with task_session() as db:
+        row = await db.get(ASN, uuid.UUID(asn_id))
+        if row is None:
+            return {"status": "missing", "asn_id": asn_id}
+
+        ps = await db.get(PlatformSettings, _SINGLETON_ID)
+        whois_interval = 24
+        rpki_interval = 4
+        rpki_source = "cloudflare"
+        if ps is not None:
+            whois_interval = max(1, min(168, int(ps.asn_whois_interval_hours or 24)))
+            rpki_interval = max(1, min(168, int(ps.rpki_roa_refresh_interval_hours or 4)))
+            candidate = (ps.rpki_roa_source or "cloudflare").lower()
+            if candidate in {"cloudflare", "ripe"}:
+                rpki_source = candidate
+
+        now = datetime.now(UTC)
+
+        try:
+            summary = await _refresh_one_asn(db, row, whois_interval, now)
+        except Exception as exc:  # noqa: BLE001 — one bad lookup mustn't crash the worker
+            logger.warning("asn_whois_refresh_one_failed", asn=row.number, error=str(exc))
+            row.whois_last_checked_at = now  # record the attempt so the sweep paces itself
+            await db.commit()
+            return {"status": "error", "asn": row.number, "error": str(exc)}
+
+        if summary.get("transitioned"):
+            db.add(
+                AuditLog(
+                    user_display_name="<system>",
+                    auth_source="system",
+                    action="whois_state_transition",
+                    resource_type="asn",
+                    resource_id=str(row.id),
+                    resource_display=f"AS{row.number}",
+                    result="success",
+                    changed_fields=["whois_state"],
+                    old_value={"whois_state": summary.get("old_state")},
+                    new_value={
+                        "whois_state": summary.get("new_state"),
+                        "old_holder": summary.get("old_holder"),
+                        "new_holder": summary.get("new_holder"),
+                    },
+                )
+            )
+
+        # RPKI ROAs — public ASNs only (RIRs don't issue ROAs for private
+        # AS numbers). Best-effort: an RPKI failure shouldn't undo the
+        # whois refresh we just committed conceptually in the same txn.
+        rpki_result: str | None = None
+        if row.kind == "public":
+            from app.tasks.rpki_roa_refresh import _refresh_one_asn as _refresh_one_asn_rpki
+
+            try:
+                await _refresh_one_asn_rpki(db, row, rpki_source, rpki_interval, now)
+                rpki_result = "ok"
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("asn_rpki_refresh_one_failed", asn=row.number, error=str(exc))
+                rpki_result = "error"
+
+        await db.commit()
+
+        logger.info(
+            "asn_whois_refresh_one_completed",
+            asn=row.number,
+            whois_result=summary.get("result"),
+            rpki_result=rpki_result,
+        )
+        return {
+            "status": "ran",
+            "asn": row.number,
+            "whois_result": summary.get("result"),
+            "rpki_result": rpki_result,
+        }
+
+
+@celery_app.task(name="app.tasks.asn_whois_refresh.refresh_one_asn_by_id", bind=True)
+def refresh_one_asn_by_id(self: object, asn_id: str) -> dict[str, Any]:  # type: ignore[type-arg]
+    """One-shot whois (+ RPKI) refresh for a single ASN, dispatched right
+    after create_asn (#278 follow-up) so a public AS is populated within
+    seconds instead of sitting at ``n/a`` until the next beat tick."""
+    try:
+        return asyncio.run(_refresh_one_by_id_async(asn_id))
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("asn_whois_refresh_one_failed", asn_id=asn_id, error=str(exc))
+        raise
+
+
+__all__ = ["refresh_due_asns", "refresh_one_asn_by_id"]

--- a/backend/app/tasks/domain_whois_refresh.py
+++ b/backend/app/tasks/domain_whois_refresh.py
@@ -25,6 +25,7 @@ the row that triggered them; the rest of the sweep proceeds.
 from __future__ import annotations
 
 import asyncio
+import uuid
 from datetime import UTC, datetime
 from typing import Any
 
@@ -211,6 +212,77 @@ def refresh_due_domains(self: object) -> dict[str, Any]:  # type: ignore[type-ar
         return asyncio.run(_refresh_due_async())
     except Exception as exc:  # noqa: BLE001
         logger.exception("domain_whois_refresh_failed", error=str(exc))
+        raise
+
+
+async def _refresh_one_by_id_async(domain_id: str) -> dict[str, Any]:
+    """RDAP-refresh a single domain by id, in its own session.
+
+    Shares the exact ``refresh_one_domain`` service the beat sweep + the
+    manual endpoint use — no duplicated refresh logic. Writes a per-row
+    audit entry only on a meaningful change (the same gate the sweep
+    uses), so a freshly-created domain that RDAP can't resolve doesn't
+    add a noise row on top of the ``create`` audit already written.
+    """
+    async with task_session() as db:
+        d = await db.get(Domain, uuid.UUID(domain_id))
+        if d is None:
+            # Created then deleted before the task ran — nothing to do.
+            return {"status": "missing", "domain_id": domain_id}
+
+        ps = await db.get(PlatformSettings, _SINGLETON_ID)
+        interval_hours = _clamp_interval(ps.domain_whois_interval_hours if ps is not None else None)
+        now = datetime.now(UTC)
+
+        try:
+            result = await refresh_one_domain(d, interval_hours=interval_hours, now=now)
+        except Exception as exc:  # noqa: BLE001 — one bad lookup shouldn't crash the worker
+            logger.warning("domain_whois_refresh_one_failed", domain=d.name, error=str(exc))
+            d.whois_last_checked_at = now  # record the attempt so the beat sweep paces itself
+            await db.commit()
+            return {"status": "error", "domain": d.name, "error": str(exc)}
+
+        if result.any_meaningful_change:
+            db.add(
+                AuditLog(
+                    user_display_name="<system>",
+                    auth_source="system",
+                    action="refresh_whois",
+                    resource_type="domain",
+                    resource_id=str(d.id),
+                    resource_display=d.name,
+                    result="success",
+                    new_value=build_refresh_audit_payload(d, result),
+                )
+            )
+        await db.commit()
+
+        logger.info(
+            "domain_whois_refresh_one_completed",
+            domain=d.name,
+            rdap_reachable=result.rdap_reachable,
+            state_changed=result.state_changed,
+        )
+        return {
+            "status": "ran",
+            "domain": d.name,
+            "rdap_reachable": result.rdap_reachable,
+            "state_changed": result.state_changed,
+        }
+
+
+@celery_app.task(name="app.tasks.domain_whois_refresh.refresh_one_domain_by_id", bind=True)
+def refresh_one_domain_by_id(self: object, domain_id: str) -> dict[str, Any]:  # type: ignore[type-arg]
+    """One-shot RDAP refresh for a single domain, dispatched right after
+    ``create_domain`` (#278) so the row is populated within seconds
+    instead of sitting empty until the next ``refresh_due_domains`` beat
+    tick (up to ``domain_whois_interval_hours`` away). Thin wrapper around
+    the shared ``refresh_one_domain`` service.
+    """
+    try:
+        return asyncio.run(_refresh_one_by_id_async(domain_id))
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("domain_whois_refresh_one_failed", domain_id=domain_id, error=str(exc))
         raise
 
 

--- a/backend/tests/test_asn_create_refresh.py
+++ b/backend/tests/test_asn_create_refresh.py
@@ -1,0 +1,71 @@
+"""#278 follow-up — creating an ASN dispatches a one-shot whois/RPKI refresh.
+
+So a freshly-added public AS is populated within seconds instead of
+sitting at whois_state "n/a" until the next refresh_due_asns beat tick.
+Fire-and-forget: a broker error must not fail the 201.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+
+
+async def _admin(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+@pytest.mark.asyncio
+async def test_create_dispatches_refresh(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.tasks.asn_whois_refresh as task_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        task_mod.refresh_one_asn_by_id, "delay", lambda asn_id: calls.append(asn_id)
+    )
+
+    h = await _admin(db_session)
+    r = await client.post("/api/v1/asns", json={"number": 64512}, headers=h)
+    assert r.status_code == 201, r.text
+    assert calls == [r.json()["id"]]
+
+
+@pytest.mark.asyncio
+async def test_create_succeeds_when_dispatch_raises(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.tasks.asn_whois_refresh as task_mod
+
+    def _boom(asn_id: str) -> None:
+        raise RuntimeError("broker unreachable")
+
+    monkeypatch.setattr(task_mod.refresh_one_asn_by_id, "delay", _boom)
+
+    h = await _admin(db_session)
+    r = await client.post("/api/v1/asns", json={"number": 64513}, headers=h)
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_one_by_id_missing_asn_is_noop() -> None:
+    import app.tasks.asn_whois_refresh as task_mod
+
+    out = await task_mod._refresh_one_by_id_async(str(uuid.uuid4()))
+    assert out["status"] == "missing"

--- a/backend/tests/test_domain_create_refresh.py
+++ b/backend/tests/test_domain_create_refresh.py
@@ -1,0 +1,74 @@
+"""#278 — creating a domain dispatches a one-shot WHOIS refresh.
+
+So a freshly-added domain is populated within seconds instead of sitting
+empty until the next ``refresh_due_domains`` beat tick. The dispatch is
+fire-and-forget: a broker error must not fail the 201.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+
+
+async def _admin(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+@pytest.mark.asyncio
+async def test_create_dispatches_refresh(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.tasks.domain_whois_refresh as task_mod
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        task_mod.refresh_one_domain_by_id, "delay", lambda domain_id: calls.append(domain_id)
+    )
+
+    h = await _admin(db_session)
+    r = await client.post("/api/v1/domains", json={"name": "example.com"}, headers=h)
+    assert r.status_code == 201, r.text
+    assert calls == [r.json()["id"]]
+
+
+@pytest.mark.asyncio
+async def test_create_succeeds_when_dispatch_raises(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broker outage on .delay() must not fail the create — the
+    scheduled sweep still picks the row up (next_check_at IS NULL first)."""
+    import app.tasks.domain_whois_refresh as task_mod
+
+    def _boom(domain_id: str) -> None:
+        raise RuntimeError("broker unreachable")
+
+    monkeypatch.setattr(task_mod.refresh_one_domain_by_id, "delay", _boom)
+
+    h = await _admin(db_session)
+    r = await client.post("/api/v1/domains", json={"name": "resilient.com"}, headers=h)
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_one_by_id_missing_domain_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The one-shot task tolerates a domain deleted before it ran."""
+    from app.tasks.domain_whois_refresh import _refresh_one_by_id_async
+
+    out = await _refresh_one_by_id_async(str(uuid.uuid4()))
+    assert out["status"] == "missing"

--- a/backend/tests/test_domain_create_refresh.py
+++ b/backend/tests/test_domain_create_refresh.py
@@ -66,9 +66,9 @@ async def test_create_succeeds_when_dispatch_raises(
 
 
 @pytest.mark.asyncio
-async def test_refresh_one_by_id_missing_domain_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_refresh_one_by_id_missing_domain_is_noop() -> None:
     """The one-shot task tolerates a domain deleted before it ran."""
-    from app.tasks.domain_whois_refresh import _refresh_one_by_id_async
+    import app.tasks.domain_whois_refresh as task_mod
 
-    out = await _refresh_one_by_id_async(str(uuid.uuid4()))
+    out = await task_mod._refresh_one_by_id_async(str(uuid.uuid4()))
     assert out["status"] == "missing"

--- a/backend/tests/test_sites_code_uniqueness.py
+++ b/backend/tests/test_sites_code_uniqueness.py
@@ -1,0 +1,95 @@
+"""Sites: sibling-code uniqueness must not block code-less siblings (#279 bug).
+
+The unique index over ``(parent_site_id, code)`` uses ``NULLS NOT
+DISTINCT`` so two top-level sites can't share a *code*. The bug: that
+flag also made the optional ``code`` column's NULLs/empties compare
+equal, so a second code-less top-level site 409'd with "a sibling site
+with this code already exists" despite having no code. The fix makes the
+index partial (``WHERE code IS NOT NULL``) and normalises ``""`` → NULL.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+
+
+async def _admin(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+@pytest.mark.asyncio
+async def test_two_codeless_top_level_sites_allowed(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The reported bug: a second top-level site with no code must work."""
+    h = await _admin(db_session)
+    r1 = await client.post("/api/v1/sites", json={"name": "HQ"}, headers=h)
+    assert r1.status_code == 201, r1.text
+    r2 = await client.post("/api/v1/sites", json={"name": "Branch"}, headers=h)
+    assert r2.status_code == 201, r2.text
+
+
+@pytest.mark.asyncio
+async def test_empty_string_code_normalised_to_null(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An empty/whitespace code is stored as NULL, and two such siblings
+    don't collide."""
+    h = await _admin(db_session)
+    r1 = await client.post("/api/v1/sites", json={"name": "A", "code": "   "}, headers=h)
+    assert r1.status_code == 201, r1.text
+    assert r1.json()["code"] is None
+    r2 = await client.post("/api/v1/sites", json={"name": "B", "code": ""}, headers=h)
+    assert r2.status_code == 201, r2.text
+    assert r2.json()["code"] is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_nonnull_top_level_code_still_blocked(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Real codes stay unique among top-level sites — the intended rule."""
+    h = await _admin(db_session)
+    r1 = await client.post("/api/v1/sites", json={"name": "East", "code": "DC-1"}, headers=h)
+    assert r1.status_code == 201, r1.text
+    r2 = await client.post("/api/v1/sites", json={"name": "West", "code": "DC-1"}, headers=h)
+    assert r2.status_code == 409, r2.text
+
+
+@pytest.mark.asyncio
+async def test_same_code_under_different_parents_allowed(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``F1`` under campus A and ``F1`` under campus B don't collide."""
+    h = await _admin(db_session)
+    a = await client.post("/api/v1/sites", json={"name": "Campus A"}, headers=h)
+    b = await client.post("/api/v1/sites", json={"name": "Campus B"}, headers=h)
+    a_id, b_id = a.json()["id"], b.json()["id"]
+    fa = await client.post(
+        "/api/v1/sites",
+        json={"name": "Floor 1", "code": "F1", "parent_site_id": a_id},
+        headers=h,
+    )
+    assert fa.status_code == 201, fa.text
+    fb = await client.post(
+        "/api/v1/sites",
+        json={"name": "Floor 1", "code": "F1", "parent_site_id": b_id},
+        headers=h,
+    )
+    assert fb.status_code == 201, fb.text

--- a/frontend/src/pages/admin/DomainsPage.tsx
+++ b/frontend/src/pages/admin/DomainsPage.tsx
@@ -320,6 +320,15 @@ export function DomainsPage() {
   const { data, isLoading, refetch, isFetching } = useQuery({
     queryKey: ["domains", listParams],
     queryFn: () => domainsApi.list(listParams),
+    // #278 — a freshly-created domain's RDAP data lands a few seconds
+    // later via the one-shot worker task. ``whois_last_checked_at`` is
+    // null until that first lookup records an attempt (success OR
+    // unreachable), so poll while any row is still un-checked and stop
+    // once they've all reported — no manual Refresh needed.
+    refetchInterval: (query) => {
+      const rows = query.state.data?.items ?? [];
+      return rows.some((d) => d.whois_last_checked_at == null) ? 3000 : false;
+    },
   });
 
   const items = useMemo(() => data?.items ?? [], [data]);

--- a/frontend/src/pages/network/AsnsPage.tsx
+++ b/frontend/src/pages/network/AsnsPage.tsx
@@ -330,6 +330,15 @@ export function AsnsPage() {
   const { data, isFetching } = useQuery({
     queryKey: ["asns", queryParams],
     queryFn: () => asnsApi.list(queryParams),
+    // #278 follow-up — a freshly-created ASN's RDAP/RPKI data lands a few
+    // seconds later via the one-shot worker task. ``whois_last_checked_at``
+    // is null until that first lookup records an attempt (it's stamped for
+    // private rows too), so poll while any row is still un-checked and stop
+    // once they've all reported — no manual Refresh needed.
+    refetchInterval: (query) => {
+      const rows = query.state.data?.items ?? [];
+      return rows.some((a) => a.whois_last_checked_at == null) ? 3000 : false;
+    },
   });
   const asns = data?.items ?? [];
   const total = data?.total ?? 0;

--- a/frontend/src/pages/network/SitesPage.tsx
+++ b/frontend/src/pages/network/SitesPage.tsx
@@ -692,9 +692,11 @@ export function SitesPage() {
   const [moving, setMoving] = useState<SiteRead | null>(null);
   const [showNew, setShowNew] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Tree is the primary view per #279 (hierarchy at a glance + drag-to-
+  // reparent); the flat table stays one click away via the toggle.
   const [view, setView] = useSessionState<"table" | "tree">(
     "sites.view",
-    "table",
+    "tree",
   );
   const [confirm, setConfirm] = useState<{
     title: string;

--- a/frontend/src/pages/network/SitesPage.tsx
+++ b/frontend/src/pages/network/SitesPage.tsx
@@ -1,6 +1,27 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  useDroppable,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  ChevronRight,
+  CornerLeftUp,
+  GripVertical,
+  ListTree,
+  Move,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Table as TableIcon,
+  Trash2,
+} from "lucide-react";
 import {
   sitesApi,
   type SiteCreate,
@@ -9,12 +30,37 @@ import {
   type SiteUpdate,
 } from "@/lib/api";
 import { cn, zebraBodyCls } from "@/lib/utils";
+import { useSessionState } from "@/lib/useSessionState";
 import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { HeaderButton } from "@/components/ui/header-button";
 
 const inputCls =
   "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+// A site can never be re-parented under itself or any of its own
+// descendants (that would form a cycle). Returns the blocked set: the
+// root site id + every transitive child. Shared by the editor parent
+// picker, the Move modal, and the tree drag-and-drop drop-target gate
+// (issue #279 — the backend enforces the same rule in _validate_parent).
+function descendantSet(sites: SiteRead[], rootId: string): Set<string> {
+  const blocked = new Set<string>([rootId]);
+  let added = true;
+  while (added) {
+    added = false;
+    for (const s of sites) {
+      if (
+        !blocked.has(s.id) &&
+        s.parent_site_id &&
+        blocked.has(s.parent_site_id)
+      ) {
+        blocked.add(s.id);
+        added = true;
+      }
+    }
+  }
+  return blocked;
+}
 
 const KINDS: SiteKind[] = [
   "datacenter",
@@ -53,25 +99,10 @@ function SiteEditorModal({
   const [error, setError] = useState<string | null>(null);
 
   // Self + descendants are illegal parent picks (would form a cycle).
-  const cycleBlockedIds = useMemo(() => {
-    if (!existing) return new Set<string>();
-    const blocked = new Set<string>([existing.id]);
-    let added = true;
-    while (added) {
-      added = false;
-      for (const s of sites) {
-        if (
-          !blocked.has(s.id) &&
-          s.parent_site_id &&
-          blocked.has(s.parent_site_id)
-        ) {
-          blocked.add(s.id);
-          added = true;
-        }
-      }
-    }
-    return blocked;
-  }, [existing, sites]);
+  const cycleBlockedIds = useMemo(
+    () => (existing ? descendantSet(sites, existing.id) : new Set<string>()),
+    [existing, sites],
+  );
 
   const mut = useMutation({
     mutationFn: async () => {
@@ -221,13 +252,450 @@ function SiteEditorModal({
   );
 }
 
+// ── Move modal ──────────────────────────────────────────────────────
+// Keyboard / touch-friendly re-parent (issue #279 Option B): a search
+// box over the valid parent sites (self + descendants excluded via the
+// shared descendantSet) plus a "Make top-level" action. Complements the
+// tree's drag-and-drop for large trees where precise drops are fiddly.
+function MoveSiteModal({
+  site,
+  sites,
+  onClose,
+}: {
+  site: SiteRead;
+  sites: SiteRead[];
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [q, setQ] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const blocked = useMemo(
+    () => descendantSet(sites, site.id),
+    [sites, site.id],
+  );
+  const options = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    return sites
+      .filter((s) => !blocked.has(s.id))
+      .filter(
+        (s) =>
+          !needle ||
+          s.name.toLowerCase().includes(needle) ||
+          (s.code ?? "").toLowerCase().includes(needle),
+      )
+      .sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, {
+          numeric: true,
+          sensitivity: "base",
+        }),
+      );
+  }, [sites, blocked, q]);
+
+  const currentParentName = site.parent_site_id
+    ? (sites.find((s) => s.id === site.parent_site_id)?.name ?? "—")
+    : null;
+
+  const mut = useMutation({
+    mutationFn: (parentId: string | null) =>
+      sitesApi.update(site.id, { parent_site_id: parentId }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["sites"] });
+      onClose();
+    },
+    onError: (e: unknown) => {
+      const err = e as {
+        message?: string;
+        response?: { data?: { detail?: string } };
+      };
+      setError(err?.response?.data?.detail ?? err?.message ?? "Move failed");
+    },
+  });
+
+  return (
+    <Modal onClose={onClose} title={`Move “${site.name}”`}>
+      <div className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Current parent:{" "}
+          <span className="font-medium text-foreground">
+            {currentParentName ?? "top-level (no parent)"}
+          </span>
+        </p>
+        <button
+          type="button"
+          disabled={!site.parent_site_id || mut.isPending}
+          onClick={() => mut.mutate(null)}
+          className="flex w-full items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted disabled:opacity-40"
+        >
+          <CornerLeftUp className="h-4 w-4" />
+          Make top-level (no parent)
+        </button>
+        <input
+          className={inputCls}
+          placeholder="Search sites by name / code…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          autoFocus
+        />
+        <div className="max-h-64 divide-y overflow-y-auto rounded-md border">
+          {options.length === 0 && (
+            <p className="px-3 py-4 text-center text-sm text-muted-foreground">
+              No eligible parent sites.
+            </p>
+          )}
+          {options.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              disabled={mut.isPending || s.id === site.parent_site_id}
+              onClick={() => mut.mutate(s.id)}
+              className={cn(
+                "flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-muted disabled:opacity-40",
+                s.id === site.parent_site_id && "bg-muted/50",
+              )}
+            >
+              <span className="break-words font-medium">{s.name}</span>
+              <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+                {s.code ? `${s.code} · ` : ""}
+                {KIND_LABELS[s.kind]}
+                {s.id === site.parent_site_id ? " · current" : ""}
+              </span>
+            </button>
+          ))}
+        </div>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+    </Modal>
+  );
+}
+
+// ── Tree view ───────────────────────────────────────────────────────
+const ROOT_DROP_ID = "__site_root__";
+
+function RootDropZone({ active }: { active: boolean }) {
+  const { setNodeRef, isOver } = useDroppable({ id: ROOT_DROP_ID });
+  if (!active) return null;
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "mb-2 rounded-md border border-dashed px-3 py-2 text-center text-xs text-muted-foreground transition-colors",
+        isOver
+          ? "border-primary bg-primary/10 text-primary"
+          : "border-muted-foreground/40",
+      )}
+    >
+      Drop here to make top-level
+    </div>
+  );
+}
+
+function SiteTreeRow({
+  site,
+  depth,
+  childrenByParent,
+  expanded,
+  toggleExpand,
+  activeId,
+  blockedForActive,
+  onEdit,
+  onMove,
+  onDelete,
+}: {
+  site: SiteRead;
+  depth: number;
+  childrenByParent: Map<string | null, SiteRead[]>;
+  expanded: Set<string>;
+  toggleExpand: (id: string) => void;
+  activeId: string | null;
+  blockedForActive: Set<string>;
+  onEdit: (s: SiteRead) => void;
+  onMove: (s: SiteRead) => void;
+  onDelete: (s: SiteRead) => void;
+}) {
+  const kids = childrenByParent.get(site.id) ?? [];
+  const hasKids = kids.length > 0;
+  const isExpanded = expanded.has(site.id);
+  // While a drag is in flight, the dragged site + its descendants can't
+  // accept the drop (cycle) — disable + dim them.
+  const isBlocked = activeId !== null && blockedForActive.has(site.id);
+  const isSelf = activeId === site.id;
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef: dragRef,
+    isDragging,
+  } = useDraggable({ id: site.id });
+  const { setNodeRef: dropRef, isOver } = useDroppable({
+    id: site.id,
+    disabled: isBlocked,
+  });
+  const setRefs = (node: HTMLElement | null) => {
+    dragRef(node);
+    dropRef(node);
+  };
+
+  return (
+    <>
+      <div
+        ref={setRefs}
+        style={{ paddingLeft: depth * 20 + 8 }}
+        className={cn(
+          "flex items-center gap-1.5 py-1.5 pr-2 transition-colors",
+          isOver &&
+            !isBlocked &&
+            "bg-primary/10 ring-1 ring-inset ring-primary/40",
+          isBlocked && "opacity-40",
+          isDragging && "opacity-50",
+        )}
+      >
+        <button
+          ref={dragRef}
+          {...listeners}
+          {...attributes}
+          title="Drag to re-parent"
+          className="cursor-grab rounded p-0.5 text-muted-foreground/60 hover:bg-muted hover:text-foreground active:cursor-grabbing"
+        >
+          <GripVertical className="h-3.5 w-3.5" />
+        </button>
+        {hasKids ? (
+          <button
+            type="button"
+            onClick={() => toggleExpand(site.id)}
+            className="rounded p-0.5 hover:bg-muted"
+            title={isExpanded ? "Collapse" : "Expand"}
+          >
+            <ChevronRight
+              className={cn(
+                "h-3.5 w-3.5 transition-transform",
+                isExpanded && "rotate-90",
+              )}
+            />
+          </button>
+        ) : (
+          <span className="inline-block w-[18px]" />
+        )}
+        <span className="break-words font-medium">{site.name}</span>
+        {site.code && (
+          <span className="rounded border px-1 py-0.5 text-[10px] text-muted-foreground tabular-nums">
+            {site.code}
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground">
+          {KIND_LABELS[site.kind]}
+        </span>
+        {site.region && (
+          <span className="text-xs text-muted-foreground/70">
+            · {site.region}
+          </span>
+        )}
+        <div className="ml-auto flex items-center">
+          <button
+            type="button"
+            title="Move"
+            onClick={() => onMove(site)}
+            className="rounded p-1 hover:bg-muted"
+          >
+            <Move className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            title="Edit"
+            onClick={() => onEdit(site)}
+            className="ml-1 rounded p-1 hover:bg-muted"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            title="Delete"
+            onClick={() => onDelete(site)}
+            className="ml-1 rounded p-1 text-destructive hover:bg-destructive/10"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+      {hasKids &&
+        isExpanded &&
+        !isSelf &&
+        kids.map((k) => (
+          <SiteTreeRow
+            key={k.id}
+            site={k}
+            depth={depth + 1}
+            childrenByParent={childrenByParent}
+            expanded={expanded}
+            toggleExpand={toggleExpand}
+            activeId={activeId}
+            blockedForActive={blockedForActive}
+            onEdit={onEdit}
+            onMove={onMove}
+            onDelete={onDelete}
+          />
+        ))}
+    </>
+  );
+}
+
+function SiteTreeView({
+  sites,
+  onEdit,
+  onMove,
+  onDelete,
+}: {
+  sites: SiteRead[];
+  onEdit: (s: SiteRead) => void;
+  onMove: (s: SiteRead) => void;
+  onDelete: (s: SiteRead) => void;
+}) {
+  const qc = useQueryClient();
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // Expand everything by default so the hierarchy is visible at a glance;
+  // operators collapse what they don't care about.
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
+
+  const childrenByParent = useMemo(() => {
+    const ids = new Set(sites.map((s) => s.id));
+    const m = new Map<string | null, SiteRead[]>();
+    for (const s of sites) {
+      // A parent_site_id pointing outside the current list (e.g. filtered
+      // out) is treated as a root so the row never vanishes.
+      const key =
+        s.parent_site_id && ids.has(s.parent_site_id) ? s.parent_site_id : null;
+      const arr = m.get(key) ?? [];
+      arr.push(s);
+      m.set(key, arr);
+    }
+    for (const arr of m.values()) {
+      arr.sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, {
+          numeric: true,
+          sensitivity: "base",
+        }),
+      );
+    }
+    return m;
+  }, [sites]);
+
+  const blockedForActive = useMemo(
+    () => (activeId ? descendantSet(sites, activeId) : new Set<string>()),
+    [activeId, sites],
+  );
+  const expanded = useMemo(() => {
+    // expanded = everything except the collapsed set.
+    const all = new Set(sites.map((s) => s.id));
+    for (const id of collapsed) all.delete(id);
+    return all;
+  }, [sites, collapsed]);
+
+  const reparent = useMutation({
+    mutationFn: ({ id, parentId }: { id: string; parentId: string | null }) =>
+      sitesApi.update(id, { parent_site_id: parentId }),
+    onError: (e: unknown) => {
+      const err = e as {
+        message?: string;
+        response?: { data?: { detail?: string } };
+      };
+      setError(err?.response?.data?.detail ?? err?.message ?? "Move failed");
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ["sites"] }),
+  });
+
+  function toggleExpand(id: string) {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function handleDragStart(e: DragStartEvent) {
+    setError(null);
+    setActiveId(String(e.active.id));
+  }
+
+  function handleDragEnd(e: DragEndEvent) {
+    const draggedId = String(e.active.id);
+    setActiveId(null);
+    if (!e.over) return;
+    const overId = String(e.over.id);
+    const newParent = overId === ROOT_DROP_ID ? null : overId;
+    const dragged = sites.find((s) => s.id === draggedId);
+    if (!dragged) return;
+    if ((dragged.parent_site_id ?? null) === newParent) return; // no-op drop
+    // Cycle guard mirrors the backend's _validate_parent.
+    if (newParent && descendantSet(sites, draggedId).has(newParent)) return;
+    reparent.mutate({ id: draggedId, parentId: newParent });
+  }
+
+  const roots = childrenByParent.get(null) ?? [];
+
+  return (
+    <div className="space-y-2">
+      {error && (
+        <p className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+      <p className="text-xs text-muted-foreground">
+        Drag the <GripVertical className="inline h-3 w-3" /> handle onto another
+        site to re-parent, or use the <Move className="inline h-3 w-3" /> Move
+        button. Drop on the zone above to make a site top-level.
+      </p>
+      <DndContext
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => setActiveId(null)}
+      >
+        <RootDropZone active={activeId !== null} />
+        <div className="divide-y rounded-lg border text-sm">
+          {roots.length === 0 ? (
+            <p className="px-3 py-6 text-center text-muted-foreground">
+              No sites yet — click “New site” to add one.
+            </p>
+          ) : (
+            roots.map((s) => (
+              <SiteTreeRow
+                key={s.id}
+                site={s}
+                depth={0}
+                childrenByParent={childrenByParent}
+                expanded={expanded}
+                toggleExpand={toggleExpand}
+                activeId={activeId}
+                blockedForActive={blockedForActive}
+                onEdit={onEdit}
+                onMove={onMove}
+                onDelete={onDelete}
+              />
+            ))
+          )}
+        </div>
+      </DndContext>
+    </div>
+  );
+}
+
 export function SitesPage() {
   const qc = useQueryClient();
   const [search, setSearch] = useState("");
   const [kindFilter, setKindFilter] = useState<SiteKind | "">("");
   const [editing, setEditing] = useState<SiteRead | null>(null);
+  const [moving, setMoving] = useState<SiteRead | null>(null);
   const [showNew, setShowNew] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [view, setView] = useSessionState<"table" | "tree">(
+    "sites.view",
+    "table",
+  );
   const [confirm, setConfirm] = useState<{
     title: string;
     message: string;
@@ -295,6 +763,15 @@ export function SitesPage() {
     }
   }
 
+  function askDelete(s: SiteRead) {
+    setConfirm({
+      title: "Delete site",
+      message: `Delete site "${s.name}"?`,
+      confirmLabel: "Delete",
+      onConfirm: () => removeOne.mutate(s.id),
+    });
+  }
+
   return (
     <div className="h-full overflow-auto p-6">
       <div className="space-y-4">
@@ -308,6 +785,36 @@ export function SitesPage() {
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
+            <div className="inline-flex overflow-hidden rounded-md border text-sm">
+              <button
+                type="button"
+                onClick={() => setView("table")}
+                className={cn(
+                  "inline-flex items-center gap-1.5 px-2.5 py-1.5",
+                  view === "table"
+                    ? "bg-muted font-medium"
+                    : "text-muted-foreground hover:bg-muted/50",
+                )}
+                title="Flat table"
+              >
+                <TableIcon className="h-3.5 w-3.5" />
+                Table
+              </button>
+              <button
+                type="button"
+                onClick={() => setView("tree")}
+                className={cn(
+                  "inline-flex items-center gap-1.5 border-l px-2.5 py-1.5",
+                  view === "tree"
+                    ? "bg-muted font-medium"
+                    : "text-muted-foreground hover:bg-muted/50",
+                )}
+                title="Hierarchy tree (drag to re-parent)"
+              >
+                <ListTree className="h-3.5 w-3.5" />
+                Tree
+              </button>
+            </div>
             <HeaderButton
               icon={RefreshCw}
               onClick={() => query.refetch()}
@@ -325,28 +832,30 @@ export function SitesPage() {
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
-          <input
-            className={cn(inputCls, "max-w-xs")}
-            placeholder="Search name / code / region…"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-          <select
-            className={cn(inputCls, "max-w-[180px]")}
-            value={kindFilter}
-            onChange={(e) => setKindFilter(e.target.value as SiteKind | "")}
-          >
-            <option value="">All kinds</option>
-            {KINDS.map((k) => (
-              <option key={k} value={k}>
-                {KIND_LABELS[k]}
-              </option>
-            ))}
-          </select>
-        </div>
+        {view === "table" && (
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              className={cn(inputCls, "max-w-xs")}
+              placeholder="Search name / code / region…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <select
+              className={cn(inputCls, "max-w-[180px]")}
+              value={kindFilter}
+              onChange={(e) => setKindFilter(e.target.value as SiteKind | "")}
+            >
+              <option value="">All kinds</option>
+              {KINDS.map((k) => (
+                <option key={k} value={k}>
+                  {KIND_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
-        {selectedIds.size > 0 && (
+        {view === "table" && selectedIds.size > 0 && (
           <div className="flex items-center justify-between rounded-md border bg-muted/50 px-3 py-2 text-sm">
             <span>{selectedIds.size} selected</span>
             <HeaderButton
@@ -368,103 +877,119 @@ export function SitesPage() {
           </div>
         )}
 
-        <div className="overflow-x-auto rounded-lg border">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
-              <tr>
-                <th className="w-8 px-3 py-2">
-                  <input
-                    type="checkbox"
-                    checked={allChecked}
-                    onChange={toggleAll}
-                    aria-label="Select all"
-                  />
-                </th>
-                <th className="px-3 py-2 text-left">Name</th>
-                <th className="px-3 py-2 text-left">Code</th>
-                <th className="px-3 py-2 text-left">Kind</th>
-                <th className="px-3 py-2 text-left">Region</th>
-                <th className="px-3 py-2 text-left">Parent</th>
-                <th className="w-24 px-3 py-2 text-right">Actions</th>
-              </tr>
-            </thead>
-            <tbody className={zebraBodyCls}>
-              {query.isLoading && (
+        {view === "tree" ? (
+          allSitesQuery.isLoading ? (
+            <div className="rounded-lg border px-3 py-6 text-center text-sm text-muted-foreground">
+              Loading…
+            </div>
+          ) : (
+            <SiteTreeView
+              sites={allSites}
+              onEdit={(s) => setEditing(s)}
+              onMove={(s) => setMoving(s)}
+              onDelete={askDelete}
+            />
+          )
+        ) : (
+          <div className="overflow-x-auto rounded-lg border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
                 <tr>
-                  <td
-                    className="px-3 py-6 text-center text-muted-foreground"
-                    colSpan={7}
-                  >
-                    Loading…
-                  </td>
-                </tr>
-              )}
-              {!query.isLoading && items.length === 0 && (
-                <tr>
-                  <td
-                    className="px-3 py-6 text-center text-muted-foreground"
-                    colSpan={7}
-                  >
-                    No sites yet — click "New site" to add one.
-                  </td>
-                </tr>
-              )}
-              {items.map((s) => (
-                <tr key={s.id} className="border-t">
-                  <td className="px-3 py-2 align-top">
+                  <th className="w-8 px-3 py-2">
                     <input
                       type="checkbox"
-                      checked={selectedIds.has(s.id)}
-                      onChange={() => toggle(s.id)}
+                      checked={allChecked}
+                      onChange={toggleAll}
+                      aria-label="Select all"
                     />
-                  </td>
-                  <td className="px-3 py-2 align-top break-words font-medium">
-                    {s.name}
-                  </td>
-                  <td className="px-3 py-2 align-top break-all text-muted-foreground tabular-nums">
-                    {s.code ?? "—"}
-                  </td>
-                  <td className="px-3 py-2 align-top text-muted-foreground">
-                    {KIND_LABELS[s.kind]}
-                  </td>
-                  <td className="px-3 py-2 align-top break-words text-muted-foreground">
-                    {s.region ?? "—"}
-                  </td>
-                  <td className="px-3 py-2 align-top break-words text-muted-foreground">
-                    {s.parent_site_id
-                      ? (siteName.get(s.parent_site_id) ?? "—")
-                      : "—"}
-                  </td>
-                  <td className="px-3 py-2 align-top text-right">
-                    <button
-                      type="button"
-                      title="Edit"
-                      onClick={() => setEditing(s)}
-                      className="rounded p-1 hover:bg-muted"
-                    >
-                      <Pencil className="h-3.5 w-3.5" />
-                    </button>
-                    <button
-                      type="button"
-                      title="Delete"
-                      onClick={() => {
-                        setConfirm({
-                          title: "Delete site",
-                          message: `Delete site "${s.name}"?`,
-                          confirmLabel: "Delete",
-                          onConfirm: () => removeOne.mutate(s.id),
-                        });
-                      }}
-                      className="ml-1 rounded p-1 text-destructive hover:bg-destructive/10"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
-                  </td>
+                  </th>
+                  <th className="px-3 py-2 text-left">Name</th>
+                  <th className="px-3 py-2 text-left">Code</th>
+                  <th className="px-3 py-2 text-left">Kind</th>
+                  <th className="px-3 py-2 text-left">Region</th>
+                  <th className="px-3 py-2 text-left">Parent</th>
+                  <th className="w-24 px-3 py-2 text-right">Actions</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody className={zebraBodyCls}>
+                {query.isLoading && (
+                  <tr>
+                    <td
+                      className="px-3 py-6 text-center text-muted-foreground"
+                      colSpan={7}
+                    >
+                      Loading…
+                    </td>
+                  </tr>
+                )}
+                {!query.isLoading && items.length === 0 && (
+                  <tr>
+                    <td
+                      className="px-3 py-6 text-center text-muted-foreground"
+                      colSpan={7}
+                    >
+                      No sites yet — click "New site" to add one.
+                    </td>
+                  </tr>
+                )}
+                {items.map((s) => (
+                  <tr key={s.id} className="border-t">
+                    <td className="px-3 py-2 align-top">
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.has(s.id)}
+                        onChange={() => toggle(s.id)}
+                      />
+                    </td>
+                    <td className="px-3 py-2 align-top break-words font-medium">
+                      {s.name}
+                    </td>
+                    <td className="px-3 py-2 align-top break-all text-muted-foreground tabular-nums">
+                      {s.code ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 align-top text-muted-foreground">
+                      {KIND_LABELS[s.kind]}
+                    </td>
+                    <td className="px-3 py-2 align-top break-words text-muted-foreground">
+                      {s.region ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 align-top break-words text-muted-foreground">
+                      {s.parent_site_id
+                        ? (siteName.get(s.parent_site_id) ?? "—")
+                        : "—"}
+                    </td>
+                    <td className="px-3 py-2 align-top text-right">
+                      <button
+                        type="button"
+                        title="Move"
+                        onClick={() => setMoving(s)}
+                        className="rounded p-1 hover:bg-muted"
+                      >
+                        <Move className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        title="Edit"
+                        onClick={() => setEditing(s)}
+                        className="ml-1 rounded p-1 hover:bg-muted"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        title="Delete"
+                        onClick={() => askDelete(s)}
+                        className="ml-1 rounded p-1 text-destructive hover:bg-destructive/10"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
 
         {showNew && (
           <SiteEditorModal
@@ -478,6 +1003,13 @@ export function SitesPage() {
             existing={editing}
             sites={allSites}
             onClose={() => setEditing(null)}
+          />
+        )}
+        {moving && (
+          <MoveSiteModal
+            site={moving}
+            sites={allSites}
+            onClose={() => setMoving(null)}
           />
         )}
         <ConfirmModal


### PR DESCRIPTION
Closes #278
Closes #279

## #279 — Sites hierarchy management + a sibling-code bug

### Bug (found in testing): a second code-less top-level site 409'd
Creating a second top-level site failed with *"A sibling site with this code already exists"* even when neither had a code. The `(parent_site_id, code)` unique index used `NULLS NOT DISTINCT` to keep top-level codes unique — but that flag applies to **both** columns, so two rows with `(NULL parent, NULL/empty code)` compared equal and collided.

- Index is now **partial** (`WHERE code IS NOT NULL`): code-less rows are excluded entirely (any number of code-less siblings allowed), real codes stay unique per parent.
- Empty/whitespace `code` is normalised to `NULL` in create/update.
- Migration drops + recreates the index and normalises existing `""` codes.
- 4 regression tests.

### Feature: tree view + drag-and-drop + Move button
- **Table | Tree** view toggle (persisted in sessionStorage).
- **Tree view**: indented hierarchy with expand/collapse; drag the handle onto another site to re-parent, or drop on the root zone to make it top-level. Cycle-blocked targets (self + descendants) are disabled + dimmed mid-drag (mirrors the backend `_validate_parent`). Uses `@dnd-kit` (already a dep).
- **Move button** (both views): searchable parent picker excluding self + descendants, plus "Make top-level" — the keyboard/touch-friendly path for large trees.
- Extracted the cycle-block walk into a shared `descendantSet()` helper used by the editor picker, the Move modal, and the drop gate.
- No backend change — `PUT /sites/{id}` already accepts `parent_site_id` + validates cycles.

## #278 — Domains: RDAP refresh immediately on create
A new domain sat empty (`whois_state: unknown`) until the next `refresh_due_domains` beat tick — up to `domain_whois_interval_hours` (24h default) away.

- New one-shot `refresh_one_domain_by_id` Celery task — a thin wrapper around the existing `refresh_one_domain` service (no duplicated RDAP logic) — dispatched fire-and-forget after `create_domain` commits.
- A broker error is caught + logged so it never fails the `201`; the scheduled sweep still picks the row up (`next_check_at IS NULL` ordered first).
- 3 tests (dispatch happens, create survives a `.delay()` failure, task no-ops on a deleted domain).

## Validation
- 7 new backend tests pass in-container; `make ci` green (backend lint+types, frontend lint+build); ruff/black/mypy clean; migration applies cleanly against the dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)