### PR TITLE
Security hardening: address Copilot code-review findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,15 @@ SECRET_KEY=change-me-to-a-random-32-char-string
 # rotating SECRET_KEY would invalidate every encrypted column).
 CREDENTIAL_ENCRYPTION_KEY=
 
+# CORS allowed origins — comma-separated. Default "*" serves a wildcard
+# WITHOUT credentials (the API authenticates via the Bearer Authorization
+# header, not cookies, so cross-origin credentials aren't needed). Pin to
+# your frontend origin(s) in production to lock the API down, e.g.
+#   CORS_ORIGINS=https://ddi.example.com,https://ipam.example.com
+# (the appliance serves the UI + API same-origin via nginx, so the default
+# is fine there).
+CORS_ORIGINS=*
+
 # Pre-shared key shared by every BIND9 / PowerDNS DNS agent container.
 # Required only if you run the DNS profile (or any standalone DNS agent).
 #   Generate:  openssl rand -hex 32

--- a/backend/app/api/v1/auth/router.py
+++ b/backend/app/api/v1/auth/router.py
@@ -40,7 +40,9 @@ from app.core.auth.user_sync import (
     ExternalSyncRejected,
     sync_external_user,
 )
+from app.core.auth_throttle import login_rate_limited, mfa_challenge_consume
 from app.core.demo_mode import forbid_in_demo_mode
+from app.core.request_meta import clean_user_agent
 from app.core.security import (
     create_access_token,
     create_mfa_challenge_token,
@@ -192,7 +194,7 @@ async def _issue_tokens(db: DB, request: Request, user: User, auth_source: str) 
         user_id=user.id,
         refresh_token_hash=refresh_hash,
         source_ip=_client_ip(request),
-        user_agent=request.headers.get("user-agent"),
+        user_agent=clean_user_agent(request.headers.get("user-agent")),
         auth_source=auth_source,
         created_at=now,
         last_seen_at=now,
@@ -207,7 +209,7 @@ async def _issue_tokens(db: DB, request: Request, user: User, auth_source: str) 
             user_display_name=user.display_name,
             auth_source=auth_source,
             source_ip=_client_ip(request),
-            user_agent=request.headers.get("user-agent"),
+            user_agent=clean_user_agent(request.headers.get("user-agent")),
             action="login",
             resource_type="user",
             resource_id=str(user.id),
@@ -270,7 +272,7 @@ async def _audit_login_failure(
             user_display_name=user.display_name if user else (username or "<unknown>"),
             auth_source=auth_source,
             source_ip=_client_ip(request),
-            user_agent=request.headers.get("user-agent"),
+            user_agent=clean_user_agent(request.headers.get("user-agent")),
             action="login",
             resource_type="user",
             resource_id=str(user.id) if user else "",
@@ -289,7 +291,7 @@ async def _audit_login_failure(
                 user_display_name=user.display_name,
                 auth_source=auth_source,
                 source_ip=_client_ip(request),
-                user_agent=request.headers.get("user-agent"),
+                user_agent=clean_user_agent(request.headers.get("user-agent")),
                 action="account.locked",
                 resource_type="user",
                 resource_id=str(user.id),
@@ -379,7 +381,7 @@ async def _try_external_password_login(
                     user_display_name=username,
                     auth_source=provider.name,
                     source_ip=_client_ip(request),
-                    user_agent=request.headers.get("user-agent"),
+                    user_agent=clean_user_agent(request.headers.get("user-agent")),
                     action="login",
                     resource_type="auth_provider",
                     resource_id=str(provider.id),
@@ -397,7 +399,7 @@ async def _try_external_password_login(
                     user_display_name=username,
                     auth_source=provider.name,
                     source_ip=_client_ip(request),
-                    user_agent=request.headers.get("user-agent"),
+                    user_agent=clean_user_agent(request.headers.get("user-agent")),
                     action="login",
                     resource_type="auth_provider",
                     resource_id=str(provider.id),
@@ -436,6 +438,15 @@ async def _try_external_password_login(
 
 @router.post("/login", response_model=LoginResponse)
 async def login(body: LoginRequest, request: Request, db: DB) -> LoginResponse:
+    # Per-IP rate limit (#4) — complements the per-account lockout, which
+    # only engages once a valid username is hit. Fails open if Redis is
+    # down. 429 with a generic message (no account-existence leak).
+    if await login_rate_limited(_client_ip(request)):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many login attempts. Try again shortly.",
+        )
+
     result = await db.execute(select(User).where(User.username == body.username))
     user = result.scalar_one_or_none()
 
@@ -524,6 +535,14 @@ async def login_mfa(body: MfaLoginRequest, request: Request, db: DB) -> LoginRes
     only against a successful TOTP/recovery code, so an attacker who
     captures the challenge token still needs the second factor.
     """
+    # Same per-IP budget as /login (#4) — the MFA step is the other half
+    # of the credential surface.
+    if await login_rate_limited(_client_ip(request)):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many login attempts. Try again shortly.",
+        )
+
     if (body.code and body.recovery_code) or (not body.code and not body.recovery_code):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -582,7 +601,7 @@ async def login_mfa(body: MfaLoginRequest, request: Request, db: DB) -> LoginRes
                         user_display_name=user.display_name,
                         auth_source="local",
                         source_ip=_client_ip(request),
-                        user_agent=request.headers.get("user-agent"),
+                        user_agent=clean_user_agent(request.headers.get("user-agent")),
                         action="mfa.recovery_used",
                         resource_type="user",
                         resource_id=str(user.id),
@@ -597,6 +616,21 @@ async def login_mfa(body: MfaLoginRequest, request: Request, db: DB) -> LoginRes
     if not matched:
         await _audit_login_failure(db, request, user.username, reason="mfa_code_invalid", user=user)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid MFA code")
+
+    # Single-use guard (#7): claim the challenge jti now that the factor
+    # matched. A wrong code above never reaches here, so a legit user can
+    # still retry a fat-fingered code with the same challenge — but once a
+    # valid code is accepted, the challenge can't be replayed (the
+    # attacker who captured challenge+code loses the race / gets rejected).
+    # Fails open if Redis is down (reverts to the prior stateless behavior).
+    if not await mfa_challenge_consume(payload.get("jti")):
+        await _audit_login_failure(
+            db, request, user.username, reason="mfa_challenge_replayed", user=user
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="MFA challenge already used",
+        )
 
     # ── Success — issue real tokens ────────────────────────────────────────
     tokens = await _issue_tokens(db, request, user, auth_source="local")
@@ -897,7 +931,7 @@ async def mfa_enroll_verify(
             user_display_name=current_user.display_name,
             auth_source="local",
             source_ip=_client_ip(request),
-            user_agent=request.headers.get("user-agent"),
+            user_agent=clean_user_agent(request.headers.get("user-agent")),
             action="mfa.enabled",
             resource_type="user",
             resource_id=str(current_user.id),
@@ -940,7 +974,7 @@ async def mfa_disable(
             user_display_name=current_user.display_name,
             auth_source="local",
             source_ip=_client_ip(request),
-            user_agent=request.headers.get("user-agent"),
+            user_agent=clean_user_agent(request.headers.get("user-agent")),
             action="mfa.disabled",
             resource_type="user",
             resource_id=str(current_user.id),
@@ -986,7 +1020,7 @@ async def mfa_regenerate_recovery_codes(
             user_display_name=current_user.display_name,
             auth_source="local",
             source_ip=_client_ip(request),
-            user_agent=request.headers.get("user-agent"),
+            user_agent=clean_user_agent(request.headers.get("user-agent")),
             action="mfa.recovery_regenerated",
             resource_type="user",
             resource_id=str(current_user.id),
@@ -1240,7 +1274,7 @@ async def oidc_callback(
                 user_display_name="<unknown>",
                 auth_source=provider.name,
                 source_ip=_client_ip(request),
-                user_agent=request.headers.get("user-agent"),
+                user_agent=clean_user_agent(request.headers.get("user-agent")),
                 action="login",
                 resource_type="auth_provider",
                 resource_id=str(provider.id),
@@ -1315,7 +1349,7 @@ async def saml_callback(
                 user_display_name="<unknown>",
                 auth_source=provider.name,
                 source_ip=_client_ip(request),
-                user_agent=request.headers.get("user-agent"),
+                user_agent=clean_user_agent(request.headers.get("user-agent")),
                 action="login",
                 resource_type="auth_provider",
                 resource_id=str(provider.id),

--- a/backend/app/api/v1/users/router.py
+++ b/backend/app/api/v1/users/router.py
@@ -1,5 +1,6 @@
 """User management endpoints (superadmin only)."""
 
+import re
 import uuid
 from datetime import UTC, datetime
 
@@ -80,6 +81,23 @@ class UserResponse(BaseModel):
         return data
 
 
+# Pragmatic email shape check for local-user create/edit (#14). Not full
+# RFC 5322 — just enough to reject the malformed values that confuse
+# outbound mail (password reset, alerts): one ``@``, a non-empty local
+# part, and a dotted domain with no whitespace. External-auth-synced
+# users bypass this surface (they're provisioned by user_sync, not this
+# API), so a sloppy LDAP attr can still land — but operator-entered
+# locals are validated here.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _validate_email(v: str) -> str:
+    v = v.strip()
+    if not _EMAIL_RE.match(v):
+        raise ValueError("Invalid email address")
+    return v
+
+
 class CreateUserRequest(BaseModel):
     username: str
     email: str
@@ -103,6 +121,11 @@ class CreateUserRequest(BaseModel):
             raise ValueError("Username cannot be empty")
         return v
 
+    @field_validator("email")
+    @classmethod
+    def email_valid(cls, v: str) -> str:
+        return _validate_email(v)
+
 
 class UpdateUserRequest(BaseModel):
     display_name: str | None = None
@@ -110,6 +133,11 @@ class UpdateUserRequest(BaseModel):
     is_active: bool | None = None
     is_superadmin: bool | None = None
     force_password_change: bool | None = None
+
+    @field_validator("email")
+    @classmethod
+    def email_valid(cls, v: str | None) -> str | None:
+        return None if v is None else _validate_email(v)
 
 
 class ResetPasswordRequest(BaseModel):

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,6 +37,18 @@ class Settings(BaseSettings):
     refresh_token_expire_days: int = 7
     credential_encryption_key: str = ""
 
+    # CORS — comma-separated allowed origins (e.g.
+    # "https://ddi.example.com,https://ipam.example.com"). Default "*"
+    # keeps dev / same-origin appliance deployments working out of the
+    # box. When left as "*" we serve a wildcard WITHOUT
+    # ``allow_credentials`` (the API authenticates via the Bearer
+    # Authorization header, not cookies, so cross-origin credentials
+    # aren't needed) — that avoids the dangerous "reflect any origin +
+    # allow credentials" combo Starlette produces for ``["*"]`` +
+    # ``allow_credentials=True``. Set explicit origins to lock the API
+    # down to your frontend(s); credentials are then enabled for them.
+    cors_origins: str = "*"
+
     # External auth providers (LDAP / OIDC / SAML) are configured via the GUI at
     # /admin/auth-providers — see backend/app/models/auth_provider.py. Secrets are
     # encrypted with the Fernet helper in app.core.crypto using
@@ -144,6 +156,16 @@ class Settings(BaseSettings):
     # TLS context. Matches the compose service name on the appliance.
     appliance_frontend_container: str = "spatiumddi-frontend"
 
+    @property
+    def cors_origins_list(self) -> list[str]:
+        """``cors_origins`` parsed into a list. ``"*"`` (the default)
+        yields ``["*"]``; a comma-separated value yields the trimmed,
+        non-empty entries."""
+        raw = self.cors_origins.strip()
+        if raw == "*" or not raw:
+            return ["*"]
+        return [o.strip() for o in raw.split(",") if o.strip()]
+
     @model_validator(mode="after")
     def _check_secret_key_default(self) -> "Settings":
         # The sentinel JWT-signing key in ``.env.example`` MUST NOT
@@ -156,14 +178,19 @@ class Settings(BaseSettings):
                     "STRICT_SECRET_KEY=true. Generate a real key with "
                     "`openssl rand -hex 32` and set SECRET_KEY in .env."
                 )
-            print(
-                "WARNING: SECRET_KEY is still the .env.example sentinel. "
-                "Set SECRET_KEY=<openssl rand -hex 32> in .env. "
-                "Enable STRICT_SECRET_KEY=true in non-dev deployments to "
-                "make this a hard error.",
-                file=sys.stderr,
-                flush=True,
-            )
+            # Skip the stderr spam under pytest — Settings() is built at
+            # import time, so the sentinel (which every test DB uses) would
+            # print on every collection. ``pytest`` is always in
+            # sys.modules by the time the app imports during a test run.
+            if "pytest" not in sys.modules:
+                print(
+                    "WARNING: SECRET_KEY is still the .env.example sentinel. "
+                    "Set SECRET_KEY=<openssl rand -hex 32> in .env. "
+                    "Enable STRICT_SECRET_KEY=true in non-dev deployments to "
+                    "make this a hard error.",
+                    file=sys.stderr,
+                    flush=True,
+                )
         return self
 
 

--- a/backend/app/core/auth_throttle.py
+++ b/backend/app/core/auth_throttle.py
@@ -1,0 +1,81 @@
+"""Redis-backed throttles for the auth surface.
+
+Two complements to the per-account lockout (#71):
+
+* ``login_rate_limited`` — a per-source-IP attempt budget on
+  ``/auth/login`` + ``/auth/login/mfa`` (#4). Account lockout needs a
+  *valid username* to engage, so an attacker spraying usernames gets one
+  free guess each before lockout triggers; an IP budget caps that.
+* ``mfa_challenge_consume`` — single-use consumption of an MFA challenge
+  ``jti`` so a captured (challenge + TOTP) pair can't be replayed inside
+  the 5-minute token TTL (#7).
+
+Both **fail open** when Redis is unreachable: the per-account lockout +
+the always-required second factor remain the hard backstops, so a Redis
+outage degrades these to no-ops rather than locking everyone out.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from app.config import settings
+from app.core.redis_client import make_async_redis
+
+logger = structlog.get_logger(__name__)
+
+# 30 attempts / 60 s / IP. Generous enough that a NAT'd office or a
+# password-manager retry storm won't trip it, tight enough to throttle
+# scripted username spraying.
+_LOGIN_RL_MAX = 30
+_LOGIN_RL_WINDOW_SECONDS = 60
+
+# Matches create_mfa_challenge_token's _MFA_TOKEN_TTL_MINUTES (5 min) —
+# once the challenge JWT expires the used-marker is moot.
+_MFA_USED_TTL_SECONDS = 5 * 60
+
+
+async def login_rate_limited(ip: str | None) -> bool:
+    """Increment the per-IP login counter and return True once it exceeds
+    the window budget. Fails open (False) when ``ip`` is unknown or Redis
+    is unavailable."""
+    if not ip:
+        return False
+    key = f"login_rl:{ip}"
+    try:
+        r = make_async_redis(settings.redis_url, socket_connect_timeout=2)
+        try:
+            count = await r.incr(key)
+            if count == 1:
+                await r.expire(key, _LOGIN_RL_WINDOW_SECONDS)
+            return int(count) > _LOGIN_RL_MAX
+        finally:
+            await r.aclose()
+    except Exception as exc:  # noqa: BLE001 — throttle must never break login
+        logger.warning("login_rate_limit_redis_unavailable", error=str(exc))
+        return False
+
+
+async def mfa_challenge_consume(jti: str | None) -> bool:
+    """Atomically claim an MFA challenge ``jti``. Returns True if this is
+    the first claim (caller may proceed), False if it was already consumed
+    (replay / race — caller must reject).
+
+    Fails open (True) when ``jti`` is missing (legacy token) or Redis is
+    unavailable, preserving the prior stateless behaviour rather than
+    blocking a legitimate MFA login during a Redis outage."""
+    if not jti:
+        return True
+    key = f"mfa_challenge:{jti}:used"
+    try:
+        r = make_async_redis(settings.redis_url, socket_connect_timeout=2)
+        try:
+            # SET key 1 EX ttl NX — returns truthy only when the key did
+            # not already exist, i.e. this is the first (winning) claim.
+            ok = await r.set(key, "1", ex=_MFA_USED_TTL_SECONDS, nx=True)
+            return bool(ok)
+        finally:
+            await r.aclose()
+    except Exception as exc:  # noqa: BLE001 — never block MFA on a Redis blip
+        logger.warning("mfa_replay_guard_redis_unavailable", error=str(exc))
+        return True

--- a/backend/app/core/crypto.py
+++ b/backend/app/core/crypto.py
@@ -12,11 +12,15 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import sys
 from functools import lru_cache
 
+import structlog
 from cryptography.fernet import Fernet, InvalidToken
 
 from app.config import settings
+
+logger = structlog.get_logger(__name__)
 
 
 @lru_cache(maxsize=1)
@@ -25,11 +29,27 @@ def _fernet() -> Fernet:
     if raw:
         try:
             return Fernet(raw.encode())
-        except (ValueError, Exception):
-            # Explicit key is malformed — fall through to derived key so the
-            # service still runs. Admins should set a valid Fernet key generated
-            # via `Fernet.generate_key()`.
-            pass
+        except Exception as exc:  # noqa: BLE001 — Fernet raises bare ValueError/binascii
+            # Explicit key is malformed. Falling through to the derived key
+            # would encrypt with a DIFFERENT key than the operator intended,
+            # silently orphaning every secret written with the (broken) key.
+            # Make it loud — and a hard error under STRICT_SECRET_KEY so a
+            # production boot can't quietly mis-key its secrets.
+            msg = (
+                "CREDENTIAL_ENCRYPTION_KEY is set but not a valid Fernet key "
+                f"({exc!r}). Generate one with `Fernet.generate_key()`."
+            )
+            if settings.strict_secret_key:
+                raise ValueError(msg) from exc
+            logger.error("credential_encryption_key_invalid", error=str(exc))
+            print(f"WARNING: {msg} Falling back to a SECRET_KEY-derived key.", file=sys.stderr)
+    else:
+        # No explicit key — secrets are encrypted with a key DERIVED from
+        # SECRET_KEY. That couples the two: rotating SECRET_KEY without
+        # re-encrypting rows makes every stored LDAP/OIDC/SAML secret +
+        # backup-target credential unreadable. Note it once at startup.
+        if "pytest" not in sys.modules:
+            logger.info("credential_encryption_key_derived_from_secret_key")
     digest = hashlib.sha256(settings.secret_key.encode()).digest()
     return Fernet(base64.urlsafe_b64encode(digest))
 

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -33,6 +33,7 @@ from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import CurrentUser, get_db
+from app.core.request_meta import clean_user_agent
 from app.models.audit import AuditLog
 from app.models.auth import User
 
@@ -165,7 +166,7 @@ async def _record_denial(
                 user_display_name=user.display_name,
                 auth_source=getattr(user, "auth_source", "local") or "local",
                 source_ip=request.client.host if request.client else None,
-                user_agent=request.headers.get("user-agent"),
+                user_agent=clean_user_agent(request.headers.get("user-agent")),
                 action=action,
                 resource_type=resource_type,
                 resource_id=resource_id or "",

--- a/backend/app/core/request_meta.py
+++ b/backend/app/core/request_meta.py
@@ -1,0 +1,35 @@
+"""Helpers for safely capturing request metadata (client IP, user agent)
+into audit-log + session rows.
+
+The User-Agent header is fully attacker-controlled, so anything derived
+from it that lands in a log or DB row must be sanitised first — otherwise
+a crafted UA can inject control characters / newlines for log forging or
+break downstream rendering (#9).
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import Request
+
+# Strip C0 controls + DEL. Newlines/tabs in particular enable log forging
+# when the value is later written to a text log.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+# Matches the user_agent / audit columns (String(500)). Truncate well
+# inside that so a multi-byte tail can't overflow the column.
+_MAX_USER_AGENT_LEN = 500
+
+
+def clean_user_agent(raw: str | None) -> str | None:
+    """Strip control characters and clamp the User-Agent to the column
+    width. Returns ``None`` for missing / empty-after-cleaning input."""
+    if not raw:
+        return None
+    cleaned = _CONTROL_CHARS.sub("", raw).strip()
+    return cleaned[:_MAX_USER_AGENT_LEN] or None
+
+
+def client_ip(request: Request) -> str | None:
+    return request.client.host if request.client else None

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import secrets
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -76,7 +77,15 @@ _MFA_TOKEN_TTL_MINUTES = 5
 
 def create_mfa_challenge_token(user_id: str) -> str:
     expire = datetime.now(UTC) + timedelta(minutes=_MFA_TOKEN_TTL_MINUTES)
-    payload: dict[str, Any] = {"sub": user_id, "exp": expire, "type": "mfa"}
+    # ``jti`` lets the redeem path mark the challenge single-use in Redis
+    # so a captured (challenge + TOTP) pair can't be replayed within the
+    # TTL (#7).
+    payload: dict[str, Any] = {
+        "sub": user_id,
+        "exp": expire,
+        "type": "mfa",
+        "jti": uuid.uuid4().hex,
+    }
     return jwt.encode(payload, settings.secret_key, algorithm=ALGORITHM)
 
 

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -83,10 +83,16 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 async def task_session() -> AsyncGenerator[AsyncSession, None]:
     """Per-Celery-task DB session — fresh engine, fresh loop binding."""
 
+    # A task needs exactly one connection; bound the pool to 1 (no
+    # overflow) so a burst of N concurrent scheduled tasks opens N
+    # connections, not N×(pool_size+max_overflow). The engine is disposed
+    # in the finally below, releasing that connection at task end (#15).
     task_engine = create_async_engine(
         settings.database_url,
         future=True,
         json_serializer=_json_serializer,
+        pool_size=1,
+        max_overflow=0,
     )
     factory = async_sessionmaker(task_engine, class_=AsyncSession, expire_on_commit=False)
     try:
@@ -208,6 +214,14 @@ def _filter_soft_deleted(execute_state: Any) -> None:
     for model in _get_soft_delete_models():
         if not _statement_references(statement, model):
             continue
+        # NOTE: no late-binding-closure bug here. ``model`` (the outer
+        # loop var) is NOT captured by the lambda — it's passed to
+        # ``with_loader_criteria`` as the entity to scope to, and
+        # SQLAlchemy invokes the lambda with THAT entity as ``cls`` at
+        # query-build time. So each criterion correctly targets its own
+        # model. Do NOT "fix" this by referencing ``model`` inside the
+        # lambda — that WOULD introduce the classic late-binding bug
+        # (every criterion would see the last loop value).
         statement = statement.options(
             with_loader_criteria(
                 model,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -418,10 +418,19 @@ def create_app() -> FastAPI:
     if settings.prometheus_metrics_enabled:
         app.add_middleware(PrometheusMiddleware)
 
+    # CORS — origins come from ``CORS_ORIGINS`` (comma-separated; default
+    # "*"). With a wildcard we MUST NOT enable credentials: Starlette
+    # would otherwise reflect the request Origin back with
+    # Access-Control-Allow-Credentials: true, effectively trusting every
+    # site. The API authenticates via the Bearer Authorization header
+    # (not cookies), so wildcard-without-credentials is correct + safe.
+    # When the operator pins explicit origins we enable credentials for
+    # them (future cookie-based flows / withCredentials fetches).
+    _cors_origins = settings.cors_origins_list
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
+        allow_origins=_cors_origins,
+        allow_credentials=_cors_origins != ["*"],
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/backend/app/services/backup/archive.py
+++ b/backend/app/services/backup/archive.py
@@ -89,6 +89,23 @@ def _pg_env_from_url(url: str) -> tuple[dict[str, str], str]:
     return env, dbname
 
 
+# Env vars pg_dump / psql / pg_restore legitimately need: PATH to find the
+# binary, plus locale/timezone for correct output. Everything else in the
+# parent process env (OPENAI_API_KEY, fingerbank keys, …) is deliberately
+# NOT inherited by the subprocess (#10).
+_SUBPROCESS_ENV_ALLOW = ("PATH", "HOME", "LANG", "LC_", "TZ", "TMPDIR")
+
+
+def _pg_subprocess_env(pg_env: dict[str, str]) -> dict[str, str]:
+    """A minimal environment for a Postgres CLI subprocess: an allowlisted
+    slice of the parent env plus the PG* connection vars. Avoids leaking
+    unrelated parent-process secrets into pg_dump/psql via ``/proc/<pid>/
+    environ``."""
+    base = {k: v for k, v in os.environ.items() if k.startswith(_SUBPROCESS_ENV_ALLOW)}
+    base.update(pg_env)
+    return base
+
+
 # ── Archive building ───────────────────────────────────────────────────
 
 
@@ -117,7 +134,7 @@ async def _run_pg_dump(out_path: Path, *, snapshot_id: str | None = None) -> Non
     completes so the live DB never observes the NULLed state.
     """
     pg_env, _dbname = _pg_env_from_url(str(settings.database_url))
-    full_env = {**os.environ, **pg_env}
+    full_env = _pg_subprocess_env(pg_env)
     cmd = [
         "pg_dump",
         "--format=custom",
@@ -225,7 +242,7 @@ async def _run_pg_dump_plain(out_path: Path) -> None:
     is the simplest correct alternative.
     """
     pg_env, _dbname = _pg_env_from_url(str(settings.database_url))
-    full_env = {**os.environ, **pg_env}
+    full_env = _pg_subprocess_env(pg_env)
     cmd = [
         "pg_dump",
         "--format=plain",

--- a/backend/app/services/backup/targets/ftp.py
+++ b/backend/app/services/backup/targets/ftp.py
@@ -168,6 +168,11 @@ class FtpDestination(BackupDestination):
             if not verify:
                 ctx.check_hostname = False
                 ctx.verify_mode = ssl.CERT_NONE
+                # Operator opted out of TLS verification for this backup
+                # target. Surface it whenever we connect so the insecure
+                # posture is visible in the centralized logs (#5); the
+                # who/when of enabling it lives in the target's audit row.
+                logger.warning("ftp_tls_verification_disabled", host=config.get("host"), mode=mode)
 
         try:
             if mode == "ftps_implicit":

--- a/backend/app/services/mfa.py
+++ b/backend/app/services/mfa.py
@@ -38,12 +38,12 @@ from app.core.crypto import decrypt_dict, decrypt_str, encrypt_dict, encrypt_str
 _RECOVERY_CODE_COUNT: Final[int] = 10
 
 # Recovery-code alphabet — base32 minus the visually ambiguous
-# characters. 29 letters + digits.
+# characters (no I/O/0/1). 24 letters + 6 digits = 30 chars.
 _RECOVERY_ALPHABET: Final[str] = "ABCDEFGHJKLMNPQRSTUVWXYZ234567"
 
 # Code length per chunk + chunks per code. 4-4 split with a hyphen
 # so the operator can read it off paper without losing place. Total
-# entropy = 8 chars × log2(29) ≈ 38.8 bits per code; brute-forcing
+# entropy = 8 chars × log2(30) ≈ 39.3 bits per code; brute-forcing
 # even one is impractical against the rate-limited verify endpoint.
 _RECOVERY_CHUNK_LEN: Final[int] = 4
 _RECOVERY_CHUNK_COUNT: Final[int] = 2

--- a/backend/app/services/proxmox/client.py
+++ b/backend/app/services/proxmox/client.py
@@ -294,6 +294,11 @@ class ProxmoxClient:
         verify: Any
         if not self._verify_tls:
             verify = False
+            # Operator opted out of TLS verification for this endpoint.
+            # Surface it on every connect so the insecure posture is
+            # visible in the centralized logs (#5); the who/when of
+            # enabling it lives in the integration-target audit row.
+            logger.warning("proxmox_tls_verification_disabled", endpoint=self._base)
         elif self._ca_bundle_pem:
             verify = ssl.create_default_context(cadata=self._ca_bundle_pem)
         else:

--- a/backend/app/services/unifi/client.py
+++ b/backend/app/services/unifi/client.py
@@ -251,6 +251,13 @@ class UnifiClient:
         if self._cfg.auth_kind == "api_key" and self._cfg.api_key:
             headers["X-API-Key"] = self._cfg.api_key
 
+        if verify is False:
+            # Operator opted out of TLS verification for this controller.
+            # Surface it on every connect so the insecure posture is
+            # visible in the centralized logs (#5); the who/when of
+            # enabling it lives in the integration-target audit row.
+            logger.warning("unifi_tls_verification_disabled", endpoint=base)
+
         self._client = httpx.AsyncClient(
             base_url=base,
             headers=headers,

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -1,0 +1,64 @@
+"""Unit coverage for the security-hardening fixes from the Copilot review.
+
+Pure / deterministic surfaces only — the Redis-backed throttles
+(login_rate_limited, mfa_challenge_consume) fail open and are exercised
+here only on their no-Redis / no-jti fallback paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.api.v1.users.router import CreateUserRequest
+from app.config import Settings
+from app.core.auth_throttle import mfa_challenge_consume
+from app.core.request_meta import clean_user_agent
+
+
+# ── #9 User-Agent sanitisation ──────────────────────────────────────────
+def test_clean_user_agent_strips_control_chars() -> None:
+    assert clean_user_agent("Mozilla/5.0\r\nInjected: evil") == "Mozilla/5.0Injected: evil"
+
+
+def test_clean_user_agent_truncates() -> None:
+    out = clean_user_agent("A" * 900)
+    assert out is not None and len(out) == 500
+
+
+def test_clean_user_agent_empty_is_none() -> None:
+    assert clean_user_agent(None) is None
+    assert clean_user_agent("   ") is None
+    assert clean_user_agent("\x00\x01") is None
+
+
+# ── #1 CORS origins parsing ─────────────────────────────────────────────
+def test_cors_origins_default_wildcard() -> None:
+    assert Settings(cors_origins="*").cors_origins_list == ["*"]
+    assert Settings(cors_origins="").cors_origins_list == ["*"]
+
+
+def test_cors_origins_explicit_list() -> None:
+    s = Settings(cors_origins="https://a.example.com, https://b.example.com ,")
+    assert s.cors_origins_list == ["https://a.example.com", "https://b.example.com"]
+
+
+# ── #14 email validation ────────────────────────────────────────────────
+@pytest.mark.parametrize("good", ["a@b.co", "ops.team@ddi.example.com"])
+def test_create_user_accepts_valid_email(good: str) -> None:
+    req = CreateUserRequest(username="u", email=good, display_name="U", password="longenough")
+    assert req.email == good
+
+
+@pytest.mark.parametrize("bad", ["not-an-email", "a@b", "@b.co", "a b@c.co", "a@@b.co"])
+def test_create_user_rejects_bad_email(bad: str) -> None:
+    with pytest.raises(ValueError):
+        CreateUserRequest(username="u", email=bad, display_name="U", password="longenough")
+
+
+# ── #7 MFA replay guard fail-open ───────────────────────────────────────
+@pytest.mark.asyncio
+async def test_mfa_consume_missing_jti_allows() -> None:
+    # A legacy challenge token without a jti can't be tracked — allow it
+    # (preserves the prior stateless behaviour rather than locking out).
+    assert await mfa_challenge_consume(None) is True
+    assert await mfa_challenge_consume("") is True

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -37,6 +37,13 @@ function createClient(): AxiosInstance {
   //   2. If refresh fails, we must reject every queued request too
   //      — not just the current one. Otherwise any concurrent
   //      requests that were already queued hang forever.
+  // NOTE: isRefreshing + refreshQueue are closure-local to this
+  // createClient() call. That's correct here because createClient() is
+  // invoked exactly once and the single instance is exported as `api`
+  // below — so there is one shared refresh lock + queue process-wide. If
+  // this module were ever evaluated twice (e.g. a test that re-imports a
+  // fresh copy), each copy would get its own lock and two concurrent 401s
+  // could trigger two parallel refreshes. Keep createClient() a singleton.
   let isRefreshing = false;
   let refreshQueue: Array<{
     resolve: (token: string) => void;


### PR DESCRIPTION
Addresses the high/medium/low findings from a Copilot security review of the codebase. Scoped to everything **except** the two architectural items (deferred to their own PRs): migrating refresh tokens to httpOnly cookies (#2) and narrowing the startup-seed `except Exception` blocks (#11).

## High
- **#1 Wildcard CORS w/ credentials** — origins now come from `CORS_ORIGINS` (comma-separated, default `*`). A wildcard no longer enables credentials: Starlette would otherwise reflect the request Origin back with `Access-Control-Allow-Credentials: true`, trusting every site. The API authenticates via the Bearer header (not cookies), so wildcard-without-credentials is correct + safe; pinning explicit origins re-enables credentials for them. Documented in `.env.example`.
- **#3/#8 Silent Fernet fallback** — a malformed `CREDENTIAL_ENCRYPTION_KEY` no longer silently derives a *different* key from `SECRET_KEY` (which would orphan every secret written with the broken key). It logs an error + stderr warning and hard-fails under `STRICT_SECRET_KEY`. The redundant `except (ValueError, Exception)` is fixed; the implicit derive-from-`SECRET_KEY` coupling is noted once at startup.
- **#4 No login rate limit** — per-source-IP budget (30/60s) on `/auth/login` + `/auth/login/mfa` via a new Redis-backed `app.core.auth_throttle`. Complements the per-account lockout (which needs a valid username to engage). Fails open if Redis is down.
- **#5 SSL verify disabled silently** — proxmox / unifi / ftp clients log a WARNING whenever the operator-enabled `tls_insecure` path disables verification, so the insecure posture is visible in the centralized logs (the who/when of *enabling* it stays in the integration-target audit row). The AI `tls_cert_check` path is intentionally untouched — it's a diagnostic cert inspector (its whole job is reading expired/self-signed certs), not a credential-bearing data connection.

## Medium
- **#7 MFA challenge replay** — the challenge token carries a `jti`; `/login/mfa` claims it single-use in Redis on a successful factor match, so a captured (challenge + TOTP) pair can't be replayed inside the 5-min TTL. A wrong code doesn't burn the challenge; fails open without Redis.
- **#9 Unsanitised User-Agent** — stripped of control chars + truncated before it lands in session / audit rows (`app.core.request_meta.clean_user_agent`), closing a log-forging vector.
- **#10 pg_dump inherits full env** — Postgres CLI subprocesses now run with a minimal allowlisted env (`PATH`/`HOME`/`LANG`/`LC_*`/`TZ`/`TMPDIR` + `PG*`) instead of the whole parent `os.environ`, so unrelated secrets aren't inherited via `/proc`.
- **#14 No email validation** — API-layer format check on local user create/update.
- **#15 Unbounded task_session pool** — per-task engine bounded to `pool_size=1, max_overflow=0`.
- **#12 Sentinel warning at import** — silenced under pytest so it doesn't spam CI.

## Low / code quality
- **#6** comment clarifying the soft-delete `with_loader_criteria` lambda is **not** a late-binding bug (and must not be "fixed" into one).
- **#13** recovery-code alphabet comment + entropy corrected (30 chars, `log2(30) ≈ 39.3` bits).
- **#16** comment that `createClient()` must stay a singleton for the shared refresh lock.

## Tests
13 new unit tests (`test_security_hardening.py`) over CORS parsing, UA sanitisation, email validation, and the MFA replay fail-open path. Existing auth/MFA/login suite (15 tests) still green. `make ci` clean; ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)