### PR TITLE
Fix multi-node DNS/DHCP on control-plane HA: in-cluster URL, persistent cache, RollingUpdate (#292)

### DIFF
--- a/charts/spatiumddi-appliance/templates/dhcp-kea.yaml
+++ b/charts/spatiumddi-appliance/templates/dhcp-kea.yaml
@@ -61,11 +61,15 @@ spec:
           env:
             # Kea entrypoint env contract (agent/dhcp/images/kea/
             # entrypoint.sh): SPATIUM_API_URL + SPATIUM_AGENT_KEY +
-            # AGENT_GROUP. The chart values are named after the
-            # SpatiumDDI control plane (controlPlaneUrl / agentKey /
-            # serverGroupName); translate at the env boundary.
+            # AGENT_GROUP.
+            # #292 — co-located DaemonSet agent reaches the control plane
+            # via the in-cluster API Service over plain HTTP. The external
+            # operator-facing URL (dhcpKea.controlPlaneUrl) carries the
+            # appliance's self-signed cert, which the agent can't verify
+            # → registration fails with CERTIFICATE_VERIFY_FAILED. See
+            # dns-bind9.yaml for the full rationale.
             - name: SPATIUM_API_URL
-              value: {{ .Values.dhcpKea.controlPlaneUrl | quote }}
+              value: {{ .Values.dhcpKea.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
             - name: SPATIUM_AGENT_KEY
               value: {{ .Values.dhcpKea.agentKey | quote }}
             - name: AGENT_GROUP
@@ -90,25 +94,28 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 30
           volumeMounts:
+            # #292 — persistent agent config-bundle cache (#5): on a pod
+            # restart during a control-plane outage this is the only thing
+            # that lets Kea keep serving leases from last-known-good
+            # config. Was never mounted before (ephemeral container layer).
+            - name: agent-state
+              mountPath: /var/lib/spatium-dhcp-agent
             - name: leases
               mountPath: /var/lib/kea
+      # #292 — per-node hostPath (not shared PVC, not emptyDir). The
+      # shared local-path PVC pinned its PV to one node → other DaemonSet
+      # pods Pending; emptyDir would drop leases + the #5 cache on
+      # restart. hostPath keeps each node's leases + cache durable on the
+      # persistent /var partition. See dns-bind9.yaml for the full note.
       volumes:
+        - name: agent-state
+          hostPath:
+            path: /var/lib/spatiumddi/agents/dhcp-kea/state
+            type: DirectoryOrCreate
         - name: leases
-          persistentVolumeClaim:
-            claimName: dhcp-kea-leases
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: dhcp-kea-leases
-  labels:
-    {{- include "spatiumddi-appliance.labels" . | nindent 4 }}
-spec:
-  accessModes: [ReadWriteOnce]
-  storageClassName: local-path
-  resources:
-    requests:
-      storage: {{ .Values.dhcpKea.persistence.leases.size }}
+          hostPath:
+            path: /var/lib/spatiumddi/agents/dhcp-kea/leases
+            type: DirectoryOrCreate
 {{- if .Values.dhcpKea.relayVIP }}
 ---
 # #272 Phase 5 — DHCP relay-VIP. An ADDITIONAL LoadBalancer Service so a

--- a/charts/spatiumddi-appliance/templates/dns-bind9.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-bind9.yaml
@@ -22,12 +22,21 @@ metadata:
 spec:
   # DaemonSet so ``DESIRED`` is computed from matching nodes — no
   # Pending pod when the per-role label isn't on the node. Same
-  # shape as dhcp-kea. Use OnDelete update strategy so a chart
-  # upgrade doesn't roll-replace mid-flight (single-instance
-  # stateful workload + hostNetwork:53; operator can `kubectl
-  # delete pod` to trigger the upgrade explicitly).
+  # shape as dhcp-kea.
+  #
+  # #292 — RollingUpdate, NOT OnDelete. OnDelete strands a pod on its
+  # creation-time spec: the supervisor first renders this DaemonSet
+  # before CONTROL_PLANE_URL is known (empty), the pod crashloops, and
+  # OnDelete never recreates it when the URL is later populated — it
+  # crashloops forever until manually deleted. RollingUpdate auto-rolls
+  # on any template/env change. maxUnavailable:1 means one node at a
+  # time: the old hostNetwork:53 pod terminates (releasing the port)
+  # before the new one binds, and the cluster's other DNS nodes keep
+  # serving during the brief per-node gap.
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: dns-bind9
@@ -59,8 +68,17 @@ spec:
           image: {{ include "spatiumddi-appliance.imageRef" (dict "global" .Values.global "repository" .Values.dnsBind9.image.repository) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
+            # #292 — co-located DaemonSet agents reach the control plane
+            # via the in-cluster API Service over plain HTTP. The external
+            # operator-facing URL (dnsBind9.controlPlaneUrl) carries the
+            # appliance's self-signed cert, which the agent can't verify
+            # → registration fails with CERTIFICATE_VERIFY_FAILED. Intra-
+            # cluster traffic needs no TLS, so point at the api Service
+            # directly (same repoint as the #272 supervisor heartbeat).
+            # ``inClusterApiUrl`` overrides the default if a deployment
+            # uses a non-standard control-release name/namespace.
             - name: CONTROL_PLANE_URL
-              value: {{ .Values.dnsBind9.controlPlaneUrl | quote }}
+              value: {{ .Values.dnsBind9.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
             - name: DNS_AGENT_KEY
               value: {{ .Values.dnsBind9.agentKey | quote }}
             - name: AGENT_GROUP
@@ -89,17 +107,30 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
           volumeMounts:
-            - name: data
-              mountPath: /var/named/data
-            - name: keys
-              mountPath: /var/named/keys
+            # #292 — the agent's state dir (AGENT_STATE_DIR) is the ONLY
+            # thing that needs persisting. named runs with
+            # ``-c /var/lib/spatium-dns-agent/rendered/named.conf`` and
+            # every path it references (rendered zones, tsig + rndc keys,
+            # the cached ConfigBundle under config/) lives here. The old
+            # /var/named/{data,keys} PVC mounts were never written to —
+            # confirmed empty on a live install — so they're dropped.
+            # MUST be persistent: on a pod restart during a control-plane
+            # outage this cache is the only thing that lets named keep
+            # serving from last-known-good config (non-negotiable #5).
+            - name: agent-state
+              mountPath: /var/lib/spatium-dns-agent
+      # #292 — per-node hostPath, NOT a shared RWO PVC and NOT emptyDir:
+      #   * A single local-path PVC pins its PV to one node, so the other
+      #     DaemonSet pods can't bind it → Pending forever.
+      #   * emptyDir is wiped on pod restart → loses the #5 cache.
+      # hostPath gives each node its own durable dir on the persistent
+      # /var partition (survives restart + reboot + slot upgrade).
+      # Containers run as root, so kubelet-created dirs are writable.
       volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: dns-bind9-data
-        - name: keys
-          persistentVolumeClaim:
-            claimName: dns-bind9-keys
+        - name: agent-state
+          hostPath:
+            path: /var/lib/spatiumddi/agents/dns-bind9/state
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service
@@ -129,30 +160,4 @@ spec:
     - name: dns-tcp
       port: 53
       protocol: TCP
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: dns-bind9-data
-  labels:
-    {{- include "spatiumddi-appliance.labels" . | nindent 4 }}
-spec:
-  accessModes: [ReadWriteOnce]
-  storageClassName: local-path
-  resources:
-    requests:
-      storage: {{ .Values.dnsBind9.persistence.data.size }}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: dns-bind9-keys
-  labels:
-    {{- include "spatiumddi-appliance.labels" . | nindent 4 }}
-spec:
-  accessModes: [ReadWriteOnce]
-  storageClassName: local-path
-  resources:
-    requests:
-      storage: {{ .Values.dnsBind9.persistence.keys.size }}
 {{- end }}

--- a/charts/spatiumddi-appliance/templates/dns-powerdns.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-powerdns.yaml
@@ -17,8 +17,13 @@ spec:
   # DaemonSet for symmetry with dns-bind9 + dhcp-kea — DESIRED=0
   # when the node lacks ``spatium.io/role-dns-powerdns=true``, so
   # ``kubectl get pods`` stays silent on unscheduled roles.
+  # #292 — RollingUpdate (not OnDelete): OnDelete strands a pod on its
+  # creation-time spec when CONTROL_PLANE_URL is populated after first
+  # render. See dns-bind9.yaml for the full rationale.
   updateStrategy:
-    type: OnDelete
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: dns-powerdns
@@ -44,8 +49,10 @@ spec:
           image: {{ include "spatiumddi-appliance.imageRef" (dict "global" .Values.global "repository" .Values.dnsPowerdns.image.repository) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
+            # #292 — in-cluster API Service over HTTP; see dns-bind9.yaml
+            # (the external URL's self-signed cert fails agent registration).
             - name: CONTROL_PLANE_URL
-              value: {{ .Values.dnsPowerdns.controlPlaneUrl | quote }}
+              value: {{ .Values.dnsPowerdns.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
             - name: DNS_AGENT_KEY
               value: {{ .Values.dnsPowerdns.agentKey | quote }}
             - name: AGENT_GROUP
@@ -71,12 +78,23 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
           volumeMounts:
+            # #292 — persistent agent config-bundle cache (#5); see
+            # dns-bind9.yaml.
+            - name: agent-state
+              mountPath: /var/lib/spatium-dns-agent
             - name: data
               mountPath: /var/lib/powerdns
+      # #292 — per-node hostPath (not shared PVC, not emptyDir); see
+      # dns-bind9.yaml for the rationale.
       volumes:
+        - name: agent-state
+          hostPath:
+            path: /var/lib/spatiumddi/agents/dns-powerdns/state
+            type: DirectoryOrCreate
         - name: data
-          persistentVolumeClaim:
-            claimName: dns-powerdns-data
+          hostPath:
+            path: /var/lib/spatiumddi/agents/dns-powerdns/data
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service
@@ -106,17 +124,4 @@ spec:
     - name: dns-tcp
       port: 53
       protocol: TCP
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: dns-powerdns-data
-  labels:
-    {{- include "spatiumddi-appliance.labels" . | nindent 4 }}
-spec:
-  accessModes: [ReadWriteOnce]
-  storageClassName: local-path
-  resources:
-    requests:
-      storage: {{ .Values.dnsPowerdns.persistence.data.size }}
 {{- end }}

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -38,16 +38,30 @@ dnsBind9:
     repository: ghcr.io/spatiumddi/dns-bind9
   # Pass-through to the agent via env. The supervisor fills these in
   # when assigning the DNS role.
+  # NOTE (#292): controlPlaneUrl is the EXTERNAL operator-facing URL
+  # (self-signed cert) — no longer used by the co-located DaemonSet
+  # agent, which registers against the in-cluster Service instead. Kept
+  # for the standalone docker-compose agent path.
   controlPlaneUrl: ""
+  # #292 — in-cluster API Service URL the co-located DaemonSet agent
+  # registers against (plain HTTP — no TLS to verify intra-cluster, so
+  # the appliance's self-signed cert is a non-issue). Empty → defaults
+  # to http://spatium-control-spatiumddi-api.<release-namespace>.svc:8000
+  # (the appliance's fixed spatium-control release). Override only for a
+  # non-standard control-release name/namespace.
+  inClusterApiUrl: ""
   agentKey: ""
   serverGroupName: ""
-  # hostPath bind mounts for persistent state. local-path-provisioner
-  # binds these to /var/lib/rancher/k3s/storage/<pvc>/ on the host.
-  persistence:
-    data:
-      size: 1Gi
-    keys:
-      size: 256Mi
+  # #292 — per-node state lives on a hostPath dir at
+  # /var/lib/spatiumddi/agents/dns-bind9/state, mounted at the agent's
+  # /var/lib/spatium-dns-agent. That dir holds the cached ConfigBundle +
+  # the rendered named.conf/zones + tsig/rndc keys — everything named
+  # serves from — so the node keeps serving from last-known-good config
+  # when the control plane is unreachable (#5). NOT a shared RWO PVC (it
+  # pins to one node → other DaemonSet pods Pending) and NOT emptyDir
+  # (wiped on restart → loses the cache). The old /var/named/{data,keys}
+  # mounts were dropped — bind9 never wrote to them. No size knob —
+  # hostPath grows with /var.
 
 # DNS — PowerDNS backend. Same shape as dnsBind9.
 dnsPowerdns:
@@ -55,11 +69,9 @@ dnsPowerdns:
   image:
     repository: ghcr.io/spatiumddi/dns-powerdns
   controlPlaneUrl: ""
+  inClusterApiUrl: ""  # #292 — see dnsBind9.inClusterApiUrl
   agentKey: ""
   serverGroupName: ""
-  persistence:
-    data:
-      size: 1Gi
 
 # DHCP — Kea backend. DaemonSet (single node) with ``hostNetwork:
 # true`` + ``CAP_NET_BIND_SERVICE`` so Kea sees DHCP-discover
@@ -70,15 +82,15 @@ dhcpKea:
   image:
     repository: ghcr.io/spatiumddi/dhcp-kea
   controlPlaneUrl: ""
+  inClusterApiUrl: ""  # #292 — see dnsBind9.inClusterApiUrl
   agentKey: ""
   serverGroupName: ""
   # ``host`` = listen on the host's NIC (the default + only mode
   # that lets DHCP broadcasts reach Kea). ``bridged`` would require
   # a relay-agent on every subnet — defer to Phase 5.
   networkMode: host
-  persistence:
-    leases:
-      size: 512Mi
+  # #292 — per-node hostPath state under /var/lib/spatiumddi/agents/
+  # dhcp-kea/ (agent cache + Kea leases), NOT a PVC. See dnsBind9.
   # #272 Phase 5 — DHCP relay-VIP (default off). When set, an ADDITIONAL
   # LoadBalancer Service (``dhcp-kea-relay``) requests this IP from the
   # MetalLB pool so a DHCP relay's ``forward-to`` target can outlive a


### PR DESCRIPTION
Closes #292

Enabling the DNS / DHCP roles across a **multi-node control-plane HA cluster** (#272) left the agent DaemonSets broken three ways. None surface on a single-node appliance — they're specific to the co-located DNS/DHCP DaemonSets running across 3/5/7 control-plane nodes, which the `2026.05.22-1` release first enabled. **Chart-only — no agent/image change.** All diagnosed + validated live on the 3-node test cluster.

## The three bugs

1. **Agents pointed at the external node IP + self-signed cert** → registration failed (`CERTIFICATE_VERIFY_FAILED`). These DaemonSets are co-located in the control-plane cluster, so point them at the **in-cluster API Service over plain HTTP** (`http://spatium-control-spatiumddi-api.<ns>.svc:8000`) — no TLS to verify intra-cluster. Same repoint as the #272 supervisor heartbeat. New `inClusterApiUrl` value (defaulted in-template) overrides for non-standard control-release names.

2. **Shared RWO `local-path` PVCs on a DaemonSet** → the PV pins to one node, so the other nodes' pods stuck `Pending` (PV node-affinity). A DaemonSet has no `volumeClaimTemplate` (unlike the Postgres/Redis StatefulSets), so use **per-node `hostPath`**. Also drops the orphan `dns-powerdns-data` PVC that sat `Pending` whenever PowerDNS was rendered-but-unscheduled.

3. **`dns-bind9` / `dns-powerdns` used `updateStrategy: OnDelete`** → a pod gets stranded on its creation-time spec: the supervisor first renders the DS before `CONTROL_PLANE_URL` is known, the pod crashloops, and OnDelete never recreates it once the URL lands. Switch to `RollingUpdate` (`maxUnavailable: 1`; the old `hostNetwork:53` pod releases the port before the new one binds). `dhcp-kea` already defaulted to RollingUpdate.

## The core: persist the config cache (non-negotiable #5)

The agents render everything under their state dir (verified live: named runs `-c /var/lib/spatium-dns-agent/rendered/named.conf`; the cached ConfigBundle + rendered zones + keys all live there) — but **that dir was never mounted**, so it sat on the ephemeral container layer. A pod restart during a control-plane outage lost the last-known-good config and the agent couldn't serve. Per-node `hostPath` on `/var` now persists it (survives restart + reboot + slot upgrade):

| Service | Persisted hostPath | Holds |
|---|---|---|
| dns-bind9 | `/var/lib/spatium-dns-agent` | cache + rendered flat zones + keys (the old empty `/var/named/{data,keys}` mounts dropped) |
| dns-powerdns | `/var/lib/spatium-dns-agent` + `/var/lib/powerdns` | cache + the LMDB zone DB |
| dhcp-kea | `/var/lib/spatium-dhcp-agent` + `/var/lib/kea` | cache + Kea leases |

## Validation

- `helm lint` + render clean (0 PVCs, 2 RollingUpdate, per-node hostPath).
- **Pushed to the live 3-node cluster via the real HelmChart path** (chartContent update → helm-controller re-apply, agent key preserved): `dns-bind9` 3/3 + `dhcp-kea` 3/3 Ready across all nodes, agents register over the internal Service, and the rendered config + cached bundle land on each node's `/var/lib/spatiumddi/agents/.../state` on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)