### PR TITLE
Remove dead Releases-tab Apply on k3s appliance; point to Fleet OS upgrades (#294)

### DIFF
--- a/backend/app/api/v1/appliance/releases.py
+++ b/backend/app/api/v1/appliance/releases.py
@@ -1,13 +1,17 @@
 """SpatiumDDI release management — Phase 4c.
 
-Mounted at ``/api/v1/appliance/releases``. Three endpoints:
-    GET    /                 — list available releases + installed + log tail
-    POST   /apply            — schedule an upgrade to the given tag (202)
-    GET    /log              — tail the host-side update log (polled by UI)
+Mounted at ``/api/v1/appliance/releases``. Read-only:
+    GET / — list available releases + currently-installed version.
 
-The actual upgrade runs as a host-side oneshot driven by a systemd
-Path unit watching ``/var/lib/spatiumddi/release-pending``; see
-``app/services/appliance/releases.py`` for the rationale.
+#294 — the old ``POST /apply`` + ``GET /log`` endpoints were removed.
+They drove a pre-#183 docker-compose update (a trigger file watched by
+a host-side ``spatiumddi-update.path`` unit running
+``docker-compose pull && up -d``), which does nothing on the k3s
+appliance — no compose stack, no such unit. OS upgrades on the
+appliance go through the A/B slot image flow (``slot.py`` /
+``services/appliance/slot.py``, surfaced on the Fleet tab); docker/k8s
+control planes run the manual ``docker compose`` / ``helm upgrade``
+commands the UI shows.
 """
 
 from __future__ import annotations
@@ -15,17 +19,12 @@ from __future__ import annotations
 from datetime import datetime
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 
-from app.api.deps import DB, CurrentUser
 from app.core.permissions import require_permission
-from app.models.audit import AuditLog
 from app.services.appliance.releases import (
     get_installed_version,
-    get_update_log_tail,
-    is_apply_in_flight,
-    schedule_apply,
 )
 from app.services.appliance.releases import (
     list_releases as svc_list_releases,
@@ -48,17 +47,7 @@ class ReleaseInfo(BaseModel):
 
 class ReleasesResponse(BaseModel):
     installed_version: str
-    apply_in_flight: bool
     releases: list[ReleaseInfo]
-    update_log_tail: str
-
-
-class ApplyRequest(BaseModel):
-    tag: str = Field(min_length=1, max_length=80)
-
-
-class ApplyResponse(BaseModel):
-    scheduled: str
 
 
 @router.get(
@@ -71,7 +60,6 @@ async def list_releases() -> ReleasesResponse:
     rels = await svc_list_releases()
     return ReleasesResponse(
         installed_version=get_installed_version(),
-        apply_in_flight=is_apply_in_flight(),
         releases=[
             ReleaseInfo(
                 tag=r.tag,
@@ -84,58 +72,4 @@ async def list_releases() -> ReleasesResponse:
             )
             for r in rels
         ],
-        update_log_tail=get_update_log_tail(),
     )
-
-
-@router.post(
-    "/apply",
-    response_model=ApplyResponse,
-    status_code=status.HTTP_202_ACCEPTED,
-    dependencies=[Depends(require_permission("admin", "appliance"))],
-    summary="Schedule an upgrade to the named tag",
-)
-async def apply_release(
-    body: ApplyRequest,
-    db: DB,
-    user: CurrentUser,
-) -> ApplyResponse:
-    if is_apply_in_flight():
-        raise HTTPException(
-            status.HTTP_409_CONFLICT,
-            "an upgrade is already in flight — wait for it to finish",
-        )
-    try:
-        schedule_apply(body.tag)
-    except RuntimeError as exc:
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc))
-
-    db.add(
-        AuditLog(
-            user_id=user.id,
-            user_display_name=user.display_name,
-            auth_source=user.auth_source,
-            action="apply_release",
-            resource_type="appliance",
-            resource_id="release",
-            resource_display=body.tag,
-            new_value={"tag": body.tag},
-            result="success",
-        )
-    )
-    await db.commit()
-    logger.info("appliance_release_apply_requested", tag=body.tag, user=user.username)
-    return ApplyResponse(scheduled=body.tag)
-
-
-@router.get(
-    "/log",
-    response_model=dict,
-    dependencies=[Depends(require_permission("read", "appliance"))],
-    summary="Tail of the host-side update log",
-)
-async def get_log() -> dict:
-    return {
-        "apply_in_flight": is_apply_in_flight(),
-        "log_tail": get_update_log_tail(),
-    }

--- a/backend/app/services/appliance/releases.py
+++ b/backend/app/services/appliance/releases.py
@@ -1,18 +1,18 @@
-"""GitHub release listing + scheduled-apply trigger (Phase 4c).
+"""GitHub release listing (Phase 4c).
 
-The api container can't run ``docker-compose pull && up -d`` directly
-on the host — and even if it could, it can't gracefully recreate
-itself mid-request. Two-process design:
+Lists published SpatiumDDI releases from the GitHub API and reports the
+currently-installed version, so the Releases tab can show "what's
+available" + "what you're running". Read-only.
 
-* This module: lists releases from the GitHub API + writes a trigger
-  file (``/var/lib/spatiumddi/release-pending``) with the requested
-  tag. The endpoint returns 202 Accepted and exits the request.
-* Host-side ``/usr/local/bin/spatiumddi-update`` runs as a systemd
-  oneshot driven by a Path unit watching the trigger file. It edits
-  ``SPATIUMDDI_VERSION`` in ``/etc/spatiumddi/.env``, runs
-  ``docker-compose pull && docker-compose up -d``, then renames the
-  trigger so it doesn't re-fire. Log goes to
-  ``/var/log/spatiumddi/update.log`` for the UI to tail.
+#294 — the old one-click "apply" half of this module (a trigger file
+watched by a host-side ``spatiumddi-update.path`` unit running
+``docker-compose pull && up -d``) was removed: it's a pre-#183
+docker-compose-era mechanism that does nothing on the k3s appliance
+(no compose stack, no such unit). OS upgrades on the appliance go
+through the A/B slot image flow (``services/appliance/slot.py``,
+surfaced on the Fleet tab); docker/k8s control planes use the
+operator-run ``docker compose`` / ``helm upgrade`` commands shown in
+the UI's manual-upgrade modal.
 
 Cache: GitHub release listings are public + rate-limited (60 req/h
 unauthenticated). 60-second in-memory cache keeps the page snappy
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
 
 import httpx
 import structlog
@@ -33,12 +32,6 @@ from app.config import settings
 logger = structlog.get_logger(__name__)
 
 _GITHUB_API = "https://api.github.com"
-# Paths inside the api container — bind-mounted to the host's
-# /var/lib/spatiumddi/release-state/ and /var/log/spatiumddi/ via
-# the appliance docker-compose. The host's spatiumddi-update.path
-# unit watches the same trigger file on its side.
-_TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/release-pending")
-_UPDATE_LOG = Path("/var/log/spatiumddi-host/update.log")
 _CACHE_TTL_SECONDS = 60
 
 
@@ -111,43 +104,3 @@ async def list_releases() -> list[Release]:
         )
     _CACHE["releases"] = (now, releases)
     return releases
-
-
-def schedule_apply(tag: str) -> None:
-    """Drop the trigger file the host-side updater watches.
-
-    Atomic via ``.new`` sibling + replace so the Path unit doesn't
-    fire on a half-written file. Raises if the trigger dir isn't
-    writable (e.g. dev environment without the appliance volume).
-    """
-    if not settings.appliance_mode:
-        raise RuntimeError("release apply is only supported on the SpatiumDDI OS appliance")
-    _TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-    tmp = _TRIGGER_FILE.with_suffix(".new")
-    tmp.write_text(f"{tag.strip()}\n", encoding="utf-8")
-    tmp.replace(_TRIGGER_FILE)
-    logger.info("appliance_release_scheduled", tag=tag)
-
-
-def get_update_log_tail(lines: int = 80) -> str:
-    """Return the last ``lines`` lines of /var/log/spatiumddi/update.log.
-
-    The UI polls this while an apply is in flight to show progress.
-    Empty string when the file doesn't exist (no apply has ever run).
-    """
-    if not _UPDATE_LOG.exists():
-        return ""
-    try:
-        text = _UPDATE_LOG.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return ""
-    return "\n".join(text.splitlines()[-lines:])
-
-
-def is_apply_in_flight() -> bool:
-    """True when a trigger file is present (host hasn't processed it yet).
-
-    The host's update runner renames the file to ``.done`` once it's
-    finished, so its presence is the "still working" signal.
-    """
-    return _TRIGGER_FILE.exists()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7024,26 +7024,17 @@ export interface ApplianceRelease {
 
 export interface ApplianceReleasesResponse {
   installed_version: string;
-  apply_in_flight: boolean;
   releases: ApplianceRelease[];
-  update_log_tail: string;
 }
 
+// #294 — read-only. The old one-click `apply` (+ `log` poll) drove a
+// docker-compose-era host updater that does nothing on the k3s
+// appliance; OS upgrades go through the A/B slot flow (Fleet tab) and
+// docker/k8s use the manual-command modal in the UI.
 export const applianceReleasesApi = {
   list: () =>
     api
       .get<ApplianceReleasesResponse>("/appliance/releases")
-      .then((r) => r.data),
-  apply: (tag: string) =>
-    api
-      .post<{ scheduled: string }>("/appliance/releases/apply", { tag })
-      .then((r) => r.data),
-  log: () =>
-    api
-      .get<{
-        apply_in_flight: boolean;
-        log_tail: string;
-      }>("/appliance/releases/log")
       .then((r) => r.data),
 };
 

--- a/frontend/src/pages/appliance/AppliancePage.tsx
+++ b/frontend/src/pages/appliance/AppliancePage.tsx
@@ -246,7 +246,10 @@ export function AppliancePage() {
             isApplianceHost={isApplianceHost}
           />
         ) : effectiveTab === "releases" ? (
-          <ReleasesTab applianceMode={isApplianceHost} />
+          <ReleasesTab
+            applianceMode={isApplianceHost}
+            onNavigateTab={(t) => setTab(t as Tab)}
+          />
         ) : effectiveTab === "containers" ? (
           <ContainersTab />
         ) : effectiveTab === "logs" ? (

--- a/frontend/src/pages/appliance/ReleasesTab.tsx
+++ b/frontend/src/pages/appliance/ReleasesTab.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
-  AlertCircle,
   Box,
   CheckCircle2,
   ChevronRight,
   Download,
   ExternalLink,
-  Loader2,
+  Info,
   RefreshCw,
 } from "lucide-react";
 
@@ -24,49 +23,34 @@ import { Modal } from "@/components/ui/modal";
 const FULL_CARDS = 3;
 
 /**
- * Phase 4c — Release management.
+ * Phase 4c — Release listing (read-only).
  *
- * Lists recent GitHub releases (top 25, 60 s cached server-side),
- * shows the currently-installed version, and lets the operator
- * one-click an upgrade. The actual `docker-compose pull && up -d`
- * runs on the host via a systemd Path unit so the api container can
- * recreate itself cleanly mid-upgrade.
+ * Lists recent GitHub releases (top 25, 60 s cached server-side) and
+ * shows the currently-installed version.
  *
- * While an upgrade is in flight, the apply buttons are disabled and
- * a "Update log" card auto-tails /var/log/spatiumddi/update.log via
- * a 3-second poll. Once /api/v1/version reports a different version
- * the upgrade is complete (poll interval bumps back down).
- *
- * Apply is gated on ``applianceMode`` — the host-side systemd Path
- * unit (``spatiumddi-update.path``) only exists on a SpatiumDDI OS
- * appliance. On docker / k8s control planes, Apply is replaced with a
- * "manual upgrade" command modal carrying the appropriate
- * ``docker compose pull`` / ``helm upgrade`` invocation.
+ * #294 — there is no one-click "Apply" here anymore. It used to write a
+ * trigger file watched by a host-side ``spatiumddi-update.path`` unit
+ * running ``docker-compose pull && up -d`` — a pre-#183 mechanism that
+ * does nothing on the k3s appliance (no compose stack, no such unit).
+ * OS upgrades on the appliance go through the A/B slot image flow on the
+ * **Fleet** tab; docker / k8s control planes run the manual
+ * ``docker compose`` / ``helm upgrade`` command shown in the per-release
+ * "Manual…" modal. So this tab is informational: "what's available" +
+ * "what you're running".
  */
 export function ReleasesTab({
   applianceMode = false,
+  onNavigateTab,
 }: {
   applianceMode?: boolean;
+  // Lets the appliance-mode banner deep-link to the Fleet tab where OS
+  // slot upgrades actually live.
+  onNavigateTab?: (tab: string) => void;
 }) {
-  const qc = useQueryClient();
-  const [confirmTarget, setConfirmTarget] = useState<ApplianceRelease | null>(
-    null,
-  );
-
   const { data, isLoading, error } = useQuery({
     queryKey: ["appliance", "releases"],
     queryFn: applianceReleasesApi.list,
-    // Poll faster while an apply is in flight so the log + the
-    // is_installed marker on each card update without manual refresh.
-    refetchInterval: (q) => (q.state.data?.apply_in_flight ? 3_000 : 60_000),
-  });
-
-  const apply = useMutation({
-    mutationFn: applianceReleasesApi.apply,
-    onSuccess: () => {
-      setConfirmTarget(null);
-      qc.invalidateQueries({ queryKey: ["appliance", "releases"] });
-    },
+    refetchInterval: 60_000,
   });
 
   return (
@@ -78,11 +62,9 @@ export function ReleasesTab({
             SpatiumDDI Releases
           </h2>
           <p className="mt-1 text-xs text-muted-foreground">
-            Updates pull new container images from{" "}
+            Published releases from{" "}
             <code className="rounded bg-muted px-1">ghcr.io/spatiumddi</code>{" "}
-            and recycle the stack via a host-side systemd unit so the api can
-            replace itself cleanly. The web UI reconnects automatically once the
-            new version is healthy.
+            and the version this control plane is running.
           </p>
         </div>
         <div className="shrink-0 rounded-md border bg-muted px-2 py-1.5 text-xs">
@@ -93,42 +75,39 @@ export function ReleasesTab({
         </div>
       </div>
 
-      {error && (
-        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-          Failed to load releases: {formatApiError(error)}
-        </div>
-      )}
-
-      {data?.apply_in_flight && (
-        <div className="rounded-md border border-amber-500/50 bg-amber-500/10 p-3">
-          <div className="flex items-start gap-2">
-            <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-amber-600 dark:text-amber-400" />
-            <div className="flex-1 text-xs">
-              <p className="font-medium text-amber-700 dark:text-amber-400">
-                Upgrade in flight — pulling images + recycling the stack
+      {/* #294 — on the appliance, OS upgrades are NOT applied from here;
+          they go through the A/B slot image flow on the Fleet tab. This
+          list is read-only. */}
+      {applianceMode && (
+        <div className="rounded-md border border-sky-500/40 bg-sky-500/10 p-3">
+          <div className="flex items-start gap-2 text-xs">
+            <Info className="mt-0.5 h-4 w-4 shrink-0 text-sky-600 dark:text-sky-400" />
+            <div className="flex-1">
+              <p className="font-medium text-sky-700 dark:text-sky-300">
+                This list is informational
               </p>
-              <p className="mt-0.5 text-amber-700/80 dark:text-amber-400/80">
-                The api container will recycle itself; this page may go blank
-                for ~30 s and come back on the new version. Don't close the
-                browser tab.
+              <p className="mt-0.5 text-sky-700/80 dark:text-sky-300/80">
+                OS upgrades on the appliance are applied as atomic A/B slot
+                images from the Fleet tab — not from here.
               </p>
+              {onNavigateTab && (
+                <button
+                  type="button"
+                  onClick={() => onNavigateTab("fleet")}
+                  className="mt-1.5 inline-flex items-center gap-1 rounded-md border border-sky-500/50 bg-background px-2 py-1 text-xs font-medium text-sky-700 hover:bg-sky-500/10 dark:text-sky-300"
+                >
+                  Go to Fleet → OS upgrades
+                </button>
+              )}
             </div>
           </div>
         </div>
       )}
 
-      {(data?.update_log_tail ?? "").length > 0 && (
-        <details
-          className="rounded-md border bg-card"
-          open={data?.apply_in_flight}
-        >
-          <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-muted-foreground hover:bg-muted/50">
-            Update log (tail) — last apply
-          </summary>
-          <pre className="overflow-auto border-t bg-muted/30 px-3 py-2 font-mono text-[11px] leading-tight">
-            {data?.update_log_tail}
-          </pre>
-        </details>
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          Failed to load releases: {formatApiError(error)}
+        </div>
       )}
 
       {isLoading ? (
@@ -145,23 +124,7 @@ export function ReleasesTab({
           </p>
         </div>
       ) : (
-        <ReleasesList
-          releases={data.releases}
-          applyInFlight={data.apply_in_flight}
-          applianceMode={applianceMode}
-          onApply={(rel) => setConfirmTarget(rel)}
-        />
-      )}
-
-      {confirmTarget && (
-        <ApplyConfirmModal
-          release={confirmTarget}
-          installed={data?.installed_version ?? "—"}
-          onClose={() => !apply.isPending && setConfirmTarget(null)}
-          onConfirm={() => apply.mutate(confirmTarget.tag)}
-          submitting={apply.isPending}
-          error={apply.isError ? formatApiError(apply.error) : null}
-        />
+        <ReleasesList releases={data.releases} applianceMode={applianceMode} />
       )}
     </div>
   );
@@ -169,14 +132,10 @@ export function ReleasesTab({
 
 function ReleasesList({
   releases,
-  applyInFlight,
   applianceMode,
-  onApply,
 }: {
   releases: ApplianceRelease[];
-  applyInFlight: boolean;
   applianceMode: boolean;
-  onApply: (rel: ApplianceRelease) => void;
 }) {
   // Always render the top ``FULL_CARDS`` as full-detail cards. The
   // remainder collapses behind a disclosure to keep the page scannable
@@ -196,16 +155,11 @@ function ReleasesList({
         <ReleaseCard
           key={rel.tag}
           release={rel}
-          disabled={applyInFlight}
           applianceMode={applianceMode}
-          onApply={() => onApply(rel)}
         />
       ))}
       {older.length > 0 && (
-        <details
-          className="group rounded-lg border bg-card"
-          open={applyInFlight}
-        >
+        <details className="group rounded-lg border bg-card">
           <summary className="flex cursor-pointer items-center gap-2 px-4 py-2.5 text-sm hover:bg-muted/50">
             <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
             <span className="font-medium">
@@ -223,9 +177,7 @@ function ReleasesList({
               <CompactReleaseRow
                 key={rel.tag}
                 release={rel}
-                disabled={applyInFlight}
                 applianceMode={applianceMode}
-                onApply={() => onApply(rel)}
               />
             ))}
           </div>
@@ -241,14 +193,10 @@ function ReleasesList({
 // release's notes preview.
 function CompactReleaseRow({
   release,
-  disabled,
   applianceMode,
-  onApply,
 }: {
   release: ApplianceRelease;
-  disabled: boolean;
   applianceMode: boolean;
-  onApply: () => void;
 }) {
   const [manualOpen, setManualOpen] = useState(false);
   return (
@@ -278,19 +226,9 @@ function CompactReleaseRow({
         >
           <ExternalLink className="h-3 w-3" />
         </a>
-        {release.is_installed ? (
-          <span className="shrink-0 text-xs text-muted-foreground">Active</span>
-        ) : applianceMode ? (
-          <button
-            type="button"
-            onClick={onApply}
-            disabled={disabled}
-            className="inline-flex shrink-0 items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <Download className="h-3 w-3" />
-            Apply
-          </button>
-        ) : (
+        {/* No per-release apply on the appliance (OS upgrades live on the
+            Fleet tab). docker / k8s control planes get the manual command. */}
+        {!applianceMode && !release.is_installed && (
           <button
             type="button"
             onClick={() => setManualOpen(true)}
@@ -324,14 +262,10 @@ function CompactReleaseRow({
 
 function ReleaseCard({
   release,
-  disabled,
   applianceMode,
-  onApply,
 }: {
   release: ApplianceRelease;
-  disabled: boolean;
   applianceMode: boolean;
-  onApply: () => void;
 }) {
   const [manualOpen, setManualOpen] = useState(false);
   return (
@@ -384,17 +318,7 @@ function ReleaseCard({
         <div className="shrink-0">
           {release.is_installed ? (
             <span className="text-xs text-muted-foreground">Active</span>
-          ) : applianceMode ? (
-            <button
-              type="button"
-              onClick={onApply}
-              disabled={disabled}
-              className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <Download className="h-3 w-3" />
-              Apply
-            </button>
-          ) : (
+          ) : !applianceMode ? (
             <button
               type="button"
               onClick={() => setManualOpen(true)}
@@ -404,7 +328,7 @@ function ReleaseCard({
               <Download className="h-3 w-3" />
               Manual…
             </button>
-          )}
+          ) : null}
         </div>
       </div>
       {manualOpen && (
@@ -417,11 +341,9 @@ function ReleaseCard({
   );
 }
 
-// Replaces the Apply button on docker / k8s control planes. The
-// host-side systemd Path unit that the appliance flow relies on
-// (``spatiumddi-update.path``) doesn't exist here, so a one-click
-// apply isn't possible. Operator copies a command + runs it against
-// the deployment they manage.
+// Shown on docker / k8s control planes (no host-side update mechanism,
+// and no A/B slot flow either). The operator copies a command + runs it
+// against the deployment they manage.
 function ManualApplyModal({
   tag,
   onClose,
@@ -445,9 +367,8 @@ function ManualApplyModal({
     <Modal title={`Manual upgrade — ${tag}`} onClose={onClose} wide>
       <div className="space-y-3 text-sm">
         <p className="text-muted-foreground">
-          This control plane runs on docker / kubernetes — there's no host-side
-          update unit to trigger a one-click apply. Pick the deploy shape that
-          matches your install, copy the command, and run it on the
+          This control plane runs on docker / kubernetes — pick the deploy shape
+          that matches your install, copy the command, and run it on the
           control-plane host.
         </p>
         <div>
@@ -495,79 +416,6 @@ function ManualApplyModal({
             className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
           >
             Close
-          </button>
-        </div>
-      </div>
-    </Modal>
-  );
-}
-
-function ApplyConfirmModal({
-  release,
-  installed,
-  onClose,
-  onConfirm,
-  submitting,
-  error,
-}: {
-  release: ApplianceRelease;
-  installed: string;
-  onClose: () => void;
-  onConfirm: () => void;
-  submitting: boolean;
-  error: string | null;
-}) {
-  return (
-    <Modal title="Apply release" onClose={onClose} wide>
-      <div className="space-y-3 text-sm">
-        <p>
-          Upgrade the appliance stack from{" "}
-          <code className="rounded bg-muted px-1 py-0.5 font-mono">
-            {installed}
-          </code>{" "}
-          to{" "}
-          <code className="rounded bg-muted px-1 py-0.5 font-mono">
-            {release.tag}
-          </code>
-          ?
-        </p>
-        <p className="text-xs text-muted-foreground">
-          The host will pull the new image set and recycle every container.
-          Expect a ~30 second blackout while the api container restarts. DNS and
-          DHCP service continue serving from cache during the recycle.
-        </p>
-        {release.is_prerelease && (
-          <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-2 text-xs">
-            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
-            <span className="text-amber-700 dark:text-amber-400">
-              This release is marked as pre-release on GitHub. Not recommended
-              for production appliances.
-            </span>
-          </div>
-        )}
-        {error && (
-          <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
-            <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        )}
-        <div className="flex justify-end gap-2 pt-2">
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={submitting}
-            className="rounded-md border bg-background px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={submitting}
-            className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-          >
-            <Download className="h-3.5 w-3.5" />
-            {submitting ? "Scheduling…" : `Apply ${release.tag}`}
           </button>
         </div>
       </div>


### PR DESCRIPTION
Closes #294

The **Appliance → Releases** tab showed a one-click **Apply** button per release on the OS appliance that **did nothing**. It wrote a trigger file watched by a host-side `spatiumddi-update.path` systemd unit running `docker-compose pull && up -d` — a **pre-#183 docker-compose-era** mechanism. After the k3s migration the appliance has no compose stack and ships no such unit (it ships `spatiumddi-slot-upgrade.path` instead), so the trigger file was written and nothing watched it. The stale code comment even claimed the opposite.

The one-click apply was dead **everywhere**: appliances upgrade via the A/B slot image flow (Fleet tab), docker/k8s control planes already use the copy-paste manual modal. So it's removed end-to-end.

### Changes
- **Frontend**: Releases tab is now read-only. Appliance mode shows an informational banner with a **"Go to Fleet → OS upgrades"** deep link; docker/k8s keep the per-release **Manual…** command modal. Dropped the apply mutation, ApplyConfirmModal, the apply-in-flight banner, and the update-log tail.
- **API client**: dropped `applianceReleasesApi.apply` + `.log` and the `apply_in_flight` / `update_log_tail` response fields.
- **Backend**: dropped `POST /appliance/releases/apply` + `GET /log` and the docker-compose update machinery in `services/appliance/releases.py` (`schedule_apply` / `is_apply_in_flight` / `get_update_log_tail` + the trigger/log paths). The read-only list endpoint stays. The `slot.py` A/B-upgrade path is untouched (it has its own `schedule_apply`).

### Validation
- `helm`/lint N/A; backend ruff/black/mypy clean, frontend eslint/tsc/build clean, no tests reference the removed endpoint.
- **Deployed live to the 3-node cluster** (frontend image imported on each node + rolled): Releases tab now shows the read-only list + the Fleet banner; the dead Apply button + old confirm modal are gone. (Frontend-only deploy — the new UI only calls `GET /releases`, fully compatible with the running backend; the endpoint removal lands with the next release.)

Found while testing #272 multi-node HA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)