### PR TITLE
fix(#299): schema-aware readiness probe + friendly initialising page

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Awaitable
 from datetime import UTC, datetime
+from pathlib import Path
 from time import monotonic
 from typing import Any, cast
 
@@ -18,6 +19,114 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(tags=["health"])
 
 
+# ── Schema-at-head cache (issue #299 phase 1) ──────────────────────
+#
+# The api image bundles a fixed set of alembic revisions, so the
+# "expected head" is constant for the lifetime of the process — read
+# it once, cache it, never re-read. On the appliance shape the
+# migrate Job lands the head into the DB AFTER the api Deployment
+# starts (CNPG bootstrap takes 1-2 min on a multi-node cluster), so
+# without a schema-aware readiness probe the api passes /health/ready
+# the moment Postgres accepts a SELECT 1 — even though every route
+# handler then 500s against missing tables. The operator-visible
+# symptom is a ~1-2 min window of bare nginx 502s on every login
+# attempt (issue #299). Fixing /health/ready to require the schema
+# at head makes the k8s readinessProbe accurately reflect "can serve
+# traffic"; the readinessProbe controlling the Service endpoint set
+# is what nginx upstream resolution depends on.
+_EXPECTED_HEAD: str | None = None
+_EXPECTED_HEAD_ERROR: str | None = None
+
+
+def _expected_alembic_head() -> tuple[str | None, str | None]:
+    """Read + cache the bundled alembic head.
+
+    Returns ``(head, None)`` on success, ``(None, error_str)`` if the
+    alembic.ini / scripts directory is missing or malformed.
+
+    Cached at first call. Re-reading the script directory on every
+    readiness probe call would be wasteful (and confusing during a
+    multi-node rolling upgrade where the head DOES change between
+    different api pods running different image tags — but each pod
+    has its own image, so each pod's cache is correct for itself).
+    """
+    global _EXPECTED_HEAD, _EXPECTED_HEAD_ERROR
+    if _EXPECTED_HEAD is not None or _EXPECTED_HEAD_ERROR is not None:
+        return _EXPECTED_HEAD, _EXPECTED_HEAD_ERROR
+    try:
+        # Same pattern as app/services/backup/migrations.py — the
+        # alembic.ini lives at /app/alembic.ini inside the api
+        # container image. ScriptDirectory.get_current_head() walks
+        # the versions/ tree and returns the leaf revision (single-
+        # head schemas only; multi-head environments aren't supported
+        # by the SpatiumDDI shape).
+        from alembic.config import Config  # noqa: PLC0415
+        from alembic.script import ScriptDirectory  # noqa: PLC0415
+
+        cfg = Config(str(Path("/app/alembic.ini")))
+        script = ScriptDirectory.from_config(cfg)
+        head = script.get_current_head()
+        if head is None:
+            _EXPECTED_HEAD_ERROR = "no head revision in script directory"
+            return None, _EXPECTED_HEAD_ERROR
+        _EXPECTED_HEAD = head
+        logger.info("readiness_schema_head_cached", expected_head=head)
+        return head, None
+    except Exception as exc:  # noqa: BLE001 — surface ANY exception
+        # Don't cache transient errors — if the container's alembic
+        # files genuinely missing this is a config bug operators need
+        # to see; if it's a one-off blip, the next probe re-reads.
+        msg = f"could not read alembic head: {exc}"
+        logger.warning("readiness_schema_head_read_failed", error=str(exc))
+        return None, msg
+
+
+async def _check_schema_ready() -> tuple[str, str]:
+    """Verify the DB schema is at the head this api image expects.
+
+    Returns ``("ok", "<detail>")`` if the schema matches; otherwise
+    ``("error", "<detail>")`` with a message the operator can act on
+    ("migrate not run", "schema at X, image expects Y", etc.). The
+    caller folds this into the readiness verdict alongside DB + Redis.
+
+    Failure modes covered:
+
+    * ``alembic_version`` table doesn't exist — the migrate Job hasn't
+      created the schema at all. ProgrammingError / UndefinedTable
+      from asyncpg surfaces as an exception; we map it to a 503 with
+      "schema not initialised" so operators see the cause.
+    * ``alembic_version`` row missing — alembic stamp / upgrade was
+      interrupted. The api isn't ready; surface as 503.
+    * ``version_num != expected_head`` — schema is behind (migrate
+      still running, or a rolling upgrade started but didn't finish).
+      Same 503 with the actual vs expected revisions so operators can
+      compare.
+    """
+    expected, head_err = _expected_alembic_head()
+    if head_err is not None:
+        return "error", head_err
+    try:
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(text("SELECT version_num FROM alembic_version"))
+            row = result.fetchone()
+    except Exception as exc:  # noqa: BLE001 — surface ANY exception
+        # Most common shape here is asyncpg.exceptions.UndefinedTableError
+        # ("relation 'alembic_version' does not exist") — migrate Job
+        # hasn't run yet. Keep the error string short for the
+        # operator-facing readiness response; full traceback is logged.
+        logger.warning("readiness_schema_check_failed", error=str(exc), expected_head=expected)
+        # Truncate "relation \"alembic_version\" does not exist" to a
+        # one-liner the operator can match against migrate Job logs.
+        short = str(exc).splitlines()[0][:160]
+        return "error", f"schema not initialised: {short}"
+    if row is None:
+        return "error", "alembic_version row missing — migrate not stamped"
+    actual = row[0]
+    if actual != expected:
+        return "error", f"schema at {actual}, image expects {expected}"
+    return "ok", f"schema at head {expected}"
+
+
 @router.get("/health/live", status_code=status.HTTP_200_OK)
 async def liveness() -> dict:
     """Liveness probe — returns 200 if the process is running."""
@@ -27,13 +136,26 @@ async def liveness() -> dict:
 @router.get("/health/ready")
 async def readiness() -> JSONResponse:
     """
-    Readiness probe — checks DB and Redis connectivity.
-    Returns 200 if ready, 503 with failed-check details if not.
+    Readiness probe — checks DB connectivity, DB SCHEMA-at-head, and
+    Redis connectivity. Returns 200 if ready, 503 with failed-check
+    details if not.
+
+    Schema-at-head is the key check for the cold-boot + post-restore
+    + mid-rolling-upgrade windows where Postgres is up + accepting
+    connections but the migrate Job hasn't landed the bundled
+    alembic revisions yet. Without this check the api passes the
+    readiness probe the moment a ``SELECT 1`` succeeds, gets added to
+    the Service endpoint set, and serves 500s on every actual route
+    handler until migrations finish — which the operator sees as
+    bare nginx 502s through the frontend proxy (issue #299).
     """
     checks: dict[str, str] = {}
     healthy = True
 
-    # Database check
+    # Database connectivity check. Same SELECT 1 as before — separate
+    # from the schema check so an operator looking at a 503 response
+    # can tell "Postgres is down" apart from "Postgres is up but the
+    # schema is behind."
     try:
         async with AsyncSessionLocal() as session:
             await session.execute(text("SELECT 1"))
@@ -42,6 +164,15 @@ async def readiness() -> JSONResponse:
         logger.warning("readiness_check_failed", check="database", error=str(exc))
         checks["database"] = f"error: {exc}"
         healthy = False
+
+    # Schema-at-head check. Only run when the DB connect succeeded —
+    # otherwise the schema check would surface a confusing
+    # "could not connect" error on top of the database error above.
+    if checks["database"] == "ok":
+        verdict, detail = await _check_schema_ready()
+        checks["schema"] = "ok" if verdict == "ok" else f"error: {detail}"
+        if verdict != "ok":
+            healthy = False
 
     # Redis check
     try:

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 import structlog
 from fastapi import APIRouter
 from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
 from starlette import status
 from starlette.responses import JSONResponse
 
@@ -51,6 +52,37 @@ class _SchemaHeadCache:
 _head_cache = _SchemaHeadCache()
 
 
+def _locate_alembic_ini() -> Path | None:
+    """Find ``alembic.ini`` for the running process.
+
+    Two production deployments + the test path each put the file in
+    a different place:
+
+    * **Container image** (api / migrate Job) — baked at
+      ``/app/alembic.ini`` by the Dockerfile's ``COPY``. This is
+      where every appliance + helm install reads it.
+    * **CI ``Backend — Tests``** — pytest runs against the source
+      tree directly, working dir ``backend/``, so the file is at
+      ``./alembic.ini`` relative to cwd.
+    * **Dev (host venv)** — same as CI; pytest from ``backend/``.
+
+    Search order: container path → relative to this module → cwd.
+    Returns ``None`` if no candidate exists; caller surfaces a clear
+    "could not read alembic head" message.
+    """
+    candidates = [
+        Path("/app/alembic.ini"),
+        # ``app/api/health.py`` → ``app/api`` → ``app`` → ``backend``,
+        # where alembic.ini lives.
+        Path(__file__).resolve().parent.parent.parent / "alembic.ini",
+        Path.cwd() / "alembic.ini",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _expected_alembic_head() -> tuple[str | None, str | None]:
     """Read + cache the bundled alembic head.
 
@@ -65,24 +97,32 @@ def _expected_alembic_head() -> tuple[str | None, str | None]:
     """
     if _head_cache.head is not None or _head_cache.error is not None:
         return _head_cache.head, _head_cache.error
+    ini_path = _locate_alembic_ini()
+    if ini_path is None:
+        # Don't cache — the absence may be a packaging bug operators
+        # need to see, but tests / dev environments swap in a fresh
+        # working dir between fixtures and we want the next probe to
+        # re-find the file.
+        msg = "alembic.ini not found (looked in /app, source tree, cwd)"
+        logger.warning("readiness_schema_head_read_failed", error=msg)
+        return None, msg
     try:
-        # Same pattern as app/services/backup/migrations.py — the
-        # alembic.ini lives at /app/alembic.ini inside the api
-        # container image. ScriptDirectory.get_current_head() walks
-        # the versions/ tree and returns the leaf revision (single-
-        # head schemas only; multi-head environments aren't supported
-        # by the SpatiumDDI shape).
+        # Same ScriptDirectory pattern as
+        # app/services/backup/migrations.py. ScriptDirectory.
+        # get_current_head() walks the versions/ tree and returns the
+        # leaf revision (single-head schemas only; multi-head
+        # environments aren't supported by the SpatiumDDI shape).
         from alembic.config import Config  # noqa: PLC0415
         from alembic.script import ScriptDirectory  # noqa: PLC0415
 
-        cfg = Config(str(Path("/app/alembic.ini")))
+        cfg = Config(str(ini_path))
         script = ScriptDirectory.from_config(cfg)
         head = script.get_current_head()
         if head is None:
             _head_cache.error = "no head revision in script directory"
             return None, _head_cache.error
         _head_cache.head = head
-        logger.info("readiness_schema_head_cached", expected_head=head)
+        logger.info("readiness_schema_head_cached", expected_head=head, ini_path=str(ini_path))
         return head, None
     except Exception as exc:  # noqa: BLE001 — surface ANY exception
         # Don't cache transient errors — if the container's alembic
@@ -101,18 +141,25 @@ async def _check_schema_ready() -> tuple[str, str]:
     ("migrate not run", "schema at X, image expects Y", etc.). The
     caller folds this into the readiness verdict alongside DB + Redis.
 
-    Failure modes covered:
+    Failure modes covered (each gets a distinct operator-actionable
+    detail string so the cause isn't ambiguous):
 
     * ``alembic_version`` table doesn't exist — the migrate Job hasn't
-      created the schema at all. ProgrammingError / UndefinedTable
-      from asyncpg surfaces as an exception; we map it to a 503 with
-      "schema not initialised" so operators see the cause.
+      created the schema at all. SQLAlchemy ``ProgrammingError``
+      wrapping asyncpg ``UndefinedTableError``, message contains
+      ``does not exist``. Reported as ``schema not initialised: …``.
+    * Other ``ProgrammingError`` shapes — permission denied,
+      malformed schema, etc. Reported as
+      ``schema check failed: …`` so operators don't get misled into
+      thinking migrations need to run (review polish from #301).
     * ``alembic_version`` row missing — alembic stamp / upgrade was
-      interrupted. The api isn't ready; surface as 503.
+      interrupted. Reported as ``alembic_version row missing — …``.
     * ``version_num != expected_head`` — schema is behind (migrate
       still running, or a rolling upgrade started but didn't finish).
-      Same 503 with the actual vs expected revisions so operators can
-      compare.
+      Reported with both revisions so operators can compare.
+    * Any other exception (asyncio timeout, connection blip not
+      caught upstream by the SELECT 1 check, …). Reported as
+      ``schema check failed: …``.
     """
     expected, head_err = _expected_alembic_head()
     if head_err is not None:
@@ -121,16 +168,25 @@ async def _check_schema_ready() -> tuple[str, str]:
         async with AsyncSessionLocal() as session:
             result = await session.execute(text("SELECT version_num FROM alembic_version"))
             row = result.fetchone()
-    except Exception as exc:  # noqa: BLE001 — surface ANY exception
-        # Most common shape here is asyncpg.exceptions.UndefinedTableError
-        # ("relation 'alembic_version' does not exist") — migrate Job
-        # hasn't run yet. Keep the error string short for the
-        # operator-facing readiness response; full traceback is logged.
+    except ProgrammingError as exc:
+        # asyncpg.exceptions.UndefinedTableError → "relation
+        # 'alembic_version' does not exist". Other ProgrammingError
+        # shapes (permission denied, syntax error, etc.) are real
+        # config bugs the operator needs to see — don't lump them in
+        # with the "schema not initialised" cold-boot case.
         logger.warning("readiness_schema_check_failed", error=str(exc), expected_head=expected)
-        # Truncate "relation \"alembic_version\" does not exist" to a
-        # one-liner the operator can match against migrate Job logs.
         short = str(exc).splitlines()[0][:160]
-        return "error", f"schema not initialised: {short}"
+        if "does not exist" in short:
+            return "error", f"schema not initialised: {short}"
+        return "error", f"schema check failed: {short}"
+    except Exception as exc:  # noqa: BLE001 — surface ANY exception
+        # Any other DB error — connection blip after the SELECT 1
+        # succeeded, statement timeout against a wedged server, etc.
+        # Don't claim "schema not initialised" — operators chasing a
+        # connection issue shouldn't be sent down the migrate path.
+        logger.warning("readiness_schema_check_failed", error=str(exc), expected_head=expected)
+        short = str(exc).splitlines()[0][:160]
+        return "error", f"schema check failed: {short}"
     if row is None:
         return "error", "alembic_version row missing — migrate not stamped"
     actual = row[0]

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Awaitable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from time import monotonic
@@ -34,8 +35,20 @@ router = APIRouter(tags=["health"])
 # at head makes the k8s readinessProbe accurately reflect "can serve
 # traffic"; the readinessProbe controlling the Service endpoint set
 # is what nginx upstream resolution depends on.
-_EXPECTED_HEAD: str | None = None
-_EXPECTED_HEAD_ERROR: str | None = None
+#
+# Single dataclass instance instead of parallel scalars so the
+# linter sees one used global instead of two it doesn't recognise
+# via the ``global`` declaration. Same semantics — ``head`` is set
+# once on success, ``error`` is set on "no head revision" config
+# bugs (also persistent), and transient exceptions are NOT cached
+# (the function re-tries on the next probe).
+@dataclass(slots=True)
+class _SchemaHeadCache:
+    head: str | None = None
+    error: str | None = None
+
+
+_head_cache = _SchemaHeadCache()
 
 
 def _expected_alembic_head() -> tuple[str | None, str | None]:
@@ -50,9 +63,8 @@ def _expected_alembic_head() -> tuple[str | None, str | None]:
     different api pods running different image tags — but each pod
     has its own image, so each pod's cache is correct for itself).
     """
-    global _EXPECTED_HEAD, _EXPECTED_HEAD_ERROR
-    if _EXPECTED_HEAD is not None or _EXPECTED_HEAD_ERROR is not None:
-        return _EXPECTED_HEAD, _EXPECTED_HEAD_ERROR
+    if _head_cache.head is not None or _head_cache.error is not None:
+        return _head_cache.head, _head_cache.error
     try:
         # Same pattern as app/services/backup/migrations.py — the
         # alembic.ini lives at /app/alembic.ini inside the api
@@ -67,9 +79,9 @@ def _expected_alembic_head() -> tuple[str | None, str | None]:
         script = ScriptDirectory.from_config(cfg)
         head = script.get_current_head()
         if head is None:
-            _EXPECTED_HEAD_ERROR = "no head revision in script directory"
-            return None, _EXPECTED_HEAD_ERROR
-        _EXPECTED_HEAD = head
+            _head_cache.error = "no head revision in script directory"
+            return None, _head_cache.error
+        _head_cache.head = head
         logger.info("readiness_schema_head_cached", expected_head=head)
         return head, None
     except Exception as exc:  # noqa: BLE001 — surface ANY exception

--- a/backend/tests/test_health_schema_check.py
+++ b/backend/tests/test_health_schema_check.py
@@ -1,0 +1,219 @@
+"""Schema-at-head readiness check (#299 phase 1).
+
+Covers the new ``_check_schema_ready`` helper + its integration into
+``/health/ready``:
+
+* ``alembic_version`` at the bundled head → readiness check says ``ok``.
+* ``alembic_version`` table missing → check says ``error`` with the
+  asyncpg ``relation does not exist`` short form, readiness response
+  is 503 with the schema-specific detail.
+* ``alembic_version`` row missing → "alembic_version row missing"
+  detail, 503.
+* ``version_num`` doesn't match the bundled head → "schema at X,
+  image expects Y" detail, 503.
+
+The cached ``_EXPECTED_HEAD`` module global is reset around each test
+so a previous test's view of the head doesn't bleed into the next.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.api import health as health_module
+from app.db import AsyncSessionLocal
+
+
+@pytest.fixture(autouse=True)
+def _reset_head_cache() -> None:
+    """Clear the module-level head cache before every test.
+
+    ``_expected_alembic_head`` caches the result of
+    ``ScriptDirectory.get_current_head()`` to avoid re-walking the
+    versions directory on every probe; the cache survives across
+    tests in the same worker without this fixture.
+    """
+    health_module._EXPECTED_HEAD = None
+    health_module._EXPECTED_HEAD_ERROR = None
+
+
+@pytest.fixture(autouse=True)
+async def _seed_alembic_version() -> AsyncIterator[None]:
+    """Ensure ``alembic_version`` exists + is stamped at the bundled
+    head before each test.
+
+    The conftest fast-path uses ``Base.metadata.create_all`` to build
+    the test schema (much faster than ``alembic upgrade head`` per
+    worker), so the ``alembic_version`` table doesn't naturally
+    exist in the per-worker test DB. Without this fixture the new
+    schema-aware readiness check would report "schema not initialised"
+    against tests whose intent is actually about the schema being AT
+    head — that's what production looks like. We seed the table and
+    let individual tests mutate it (DELETE row, UPDATE to fake
+    revision, etc.) to exercise the failure modes.
+    """
+    expected, _ = health_module._expected_alembic_head()
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS alembic_version ("
+                "version_num VARCHAR(32) NOT NULL PRIMARY KEY)"
+            )
+        )
+        await s.execute(text("DELETE FROM alembic_version"))
+        await s.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:head)"),
+            {"head": expected},
+        )
+        await s.commit()
+    yield
+    # Clean up so concurrent tests in other files don't trip on the
+    # leftover table (the conftest's TRUNCATE truncates registered
+    # tables only — alembic_version isn't in Base.metadata).
+    async with AsyncSessionLocal() as s:
+        await s.execute(text("DROP TABLE IF EXISTS alembic_version"))
+        await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_schema_check_ok_when_at_head() -> None:
+    """The check_schema_ready helper returns ok when version_num
+    matches the bundled head."""
+    expected, err = health_module._expected_alembic_head()
+    assert err is None
+    assert expected is not None  # alembic.ini + versions/ are bundled
+
+    # The conftest's per-worker DB is migrated to head, so the live
+    # query should return the same revision the script directory
+    # reports.
+    verdict, detail = await health_module._check_schema_ready()
+    assert verdict == "ok", detail
+    assert expected in detail
+
+
+@pytest.mark.asyncio
+async def test_schema_check_reports_mismatch() -> None:
+    """When alembic_version says a non-head revision, the check
+    returns error + names both versions."""
+    expected, _ = health_module._expected_alembic_head()
+    assert expected is not None
+
+    # Mutate alembic_version to a fake revision and assert the helper
+    # surfaces both sides of the diff.
+    async with AsyncSessionLocal() as s:
+        await s.execute(text("UPDATE alembic_version SET version_num = 'fake_old_revision'"))
+        await s.commit()
+    try:
+        verdict, detail = await health_module._check_schema_ready()
+        assert verdict == "error"
+        assert "fake_old_revision" in detail
+        assert expected in detail
+    finally:
+        # Restore so subsequent tests see a clean schema head.
+        async with AsyncSessionLocal() as s:
+            await s.execute(
+                text("UPDATE alembic_version SET version_num = :head"),
+                {"head": expected},
+            )
+            await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_schema_check_reports_missing_row() -> None:
+    """alembic_version table exists but is empty — common right after
+    a migrate failure or a botched ``alembic stamp``. The helper
+    reports the missing row explicitly so operators see the cause."""
+    expected, _ = health_module._expected_alembic_head()
+    assert expected is not None
+
+    async with AsyncSessionLocal() as s:
+        await s.execute(text("DELETE FROM alembic_version"))
+        await s.commit()
+    try:
+        verdict, detail = await health_module._check_schema_ready()
+        assert verdict == "error"
+        assert "alembic_version row missing" in detail
+    finally:
+        async with AsyncSessionLocal() as s:
+            await s.execute(
+                text("INSERT INTO alembic_version (version_num) VALUES (:head)"),
+                {"head": expected},
+            )
+            await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_schema_check_reports_missing_table() -> None:
+    """alembic_version table doesn't exist — migrate Job hasn't run
+    yet, which is the cold-boot 502 window from issue #299. We
+    simulate by patching ``AsyncSessionLocal`` to a session whose
+    SELECT raises an UndefinedTable-shape exception."""
+
+    class _FakeSession:
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+        async def execute(self, *_args: object, **_kwargs: object) -> None:
+            # Mirror the asyncpg shape — first line of the message is
+            # what ends up in the readiness response detail.
+            raise RuntimeError('relation "alembic_version" does not exist')
+
+    @asynccontextmanager
+    async def _fake_session_factory() -> AsyncIterator[_FakeSession]:
+        yield _FakeSession()
+
+    with patch.object(health_module, "AsyncSessionLocal", _fake_session_factory):
+        verdict, detail = await health_module._check_schema_ready()
+    assert verdict == "error"
+    assert "schema not initialised" in detail
+    assert "alembic_version" in detail
+
+
+@pytest.mark.asyncio
+async def test_readiness_endpoint_503_on_schema_mismatch(client: AsyncClient) -> None:
+    """End-to-end: the readiness endpoint folds the schema check into
+    its rollup. Postgres is up + Redis is up but schema is behind →
+    503 with the schema-specific detail in the ``checks`` block."""
+    expected, _ = health_module._expected_alembic_head()
+    assert expected is not None
+
+    async with AsyncSessionLocal() as s:
+        await s.execute(text("UPDATE alembic_version SET version_num = 'fake_pre_migrate'"))
+        await s.commit()
+    try:
+        response = await client.get("/health/ready")
+        assert response.status_code == 503
+        body = response.json()
+        assert body["status"] == "degraded"
+        # DB connect still ok — only the schema check fails.
+        assert body["checks"]["database"] == "ok"
+        assert "fake_pre_migrate" in body["checks"]["schema"]
+        assert expected in body["checks"]["schema"]
+    finally:
+        async with AsyncSessionLocal() as s:
+            await s.execute(
+                text("UPDATE alembic_version SET version_num = :head"),
+                {"head": expected},
+            )
+            await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_readiness_endpoint_200_at_head(client: AsyncClient) -> None:
+    """Sanity: when everything's clean (Postgres up, schema at head,
+    Redis up), readiness returns 200 with every check ok."""
+    response = await client.get("/health/ready")
+    body = response.json()
+    # Redis may be unavailable in some test environments — only assert
+    # the schema check passes (which is what #299 phase 1 changed).
+    if body["checks"].get("database") == "ok":
+        assert body["checks"].get("schema", "").startswith("ok")

--- a/backend/tests/test_health_schema_check.py
+++ b/backend/tests/test_health_schema_check.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
 
 from app.api import health as health_module
 from app.db import AsyncSessionLocal
@@ -153,7 +154,8 @@ async def test_schema_check_reports_missing_table() -> None:
     """alembic_version table doesn't exist — migrate Job hasn't run
     yet, which is the cold-boot 502 window from issue #299. We
     simulate by patching ``AsyncSessionLocal`` to a session whose
-    SELECT raises an UndefinedTable-shape exception."""
+    SELECT raises an UndefinedTable-shape ProgrammingError (the
+    SQLAlchemy wrapper around asyncpg's UndefinedTableError)."""
 
     class _FakeSession:
         async def __aenter__(self) -> _FakeSession:
@@ -163,9 +165,18 @@ async def test_schema_check_reports_missing_table() -> None:
             return None
 
         async def execute(self, *_args: object, **_kwargs: object) -> None:
-            # Mirror the asyncpg shape — first line of the message is
-            # what ends up in the readiness response detail.
-            raise RuntimeError('relation "alembic_version" does not exist')
+            # Mirror the SQLAlchemy → asyncpg shape: ProgrammingError
+            # carrying ``relation … does not exist`` as the .orig
+            # exception's message. The helper's substring match on
+            # "does not exist" is what triggers the "schema not
+            # initialised" path; other ProgrammingError shapes fall
+            # through to the generic "schema check failed" path
+            # (covered separately below).
+            raise ProgrammingError(
+                "SELECT version_num FROM alembic_version",
+                {},
+                Exception('relation "alembic_version" does not exist'),
+            )
 
     @asynccontextmanager
     async def _fake_session_factory() -> AsyncIterator[_FakeSession]:
@@ -176,6 +187,68 @@ async def test_schema_check_reports_missing_table() -> None:
     assert verdict == "error"
     assert "schema not initialised" in detail
     assert "alembic_version" in detail
+
+
+@pytest.mark.asyncio
+async def test_schema_check_reports_other_programming_error() -> None:
+    """ProgrammingError that ISN'T a missing-table case (permission
+    denied, syntax error, etc.) gets the generic "schema check
+    failed" detail — review polish to stop misdirecting operators
+    down the migrate path when the real cause is something else."""
+
+    class _FakeSession:
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+        async def execute(self, *_args: object, **_kwargs: object) -> None:
+            raise ProgrammingError(
+                "SELECT version_num FROM alembic_version",
+                {},
+                Exception("permission denied for table alembic_version"),
+            )
+
+    @asynccontextmanager
+    async def _fake_session_factory() -> AsyncIterator[_FakeSession]:
+        yield _FakeSession()
+
+    with patch.object(health_module, "AsyncSessionLocal", _fake_session_factory):
+        verdict, detail = await health_module._check_schema_ready()
+    assert verdict == "error"
+    # NOT "schema not initialised" — operator needs to see "permission
+    # denied" or similar, not be sent down the migrate path.
+    assert "schema not initialised" not in detail
+    assert "schema check failed" in detail
+    assert "permission denied" in detail
+
+
+@pytest.mark.asyncio
+async def test_schema_check_reports_generic_exception() -> None:
+    """Non-ProgrammingError exception (asyncio timeout, connection
+    blip, …) — also reported as "schema check failed", separate from
+    the cold-boot path."""
+
+    class _FakeSession:
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
+        async def execute(self, *_args: object, **_kwargs: object) -> None:
+            raise TimeoutError("query timed out after 30s")
+
+    @asynccontextmanager
+    async def _fake_session_factory() -> AsyncIterator[_FakeSession]:
+        yield _FakeSession()
+
+    with patch.object(health_module, "AsyncSessionLocal", _fake_session_factory):
+        verdict, detail = await health_module._check_schema_ready()
+    assert verdict == "error"
+    assert "schema check failed" in detail
+    assert "timed out" in detail
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_health_schema_check.py
+++ b/backend/tests/test_health_schema_check.py
@@ -39,8 +39,8 @@ def _reset_head_cache() -> None:
     versions directory on every probe; the cache survives across
     tests in the same worker without this fixture.
     """
-    health_module._EXPECTED_HEAD = None
-    health_module._EXPECTED_HEAD_ERROR = None
+    health_module._head_cache.head = None
+    health_module._head_cache.error = None
 
 
 @pytest.fixture(autouse=True)

--- a/charts/spatiumddi/templates/frontend-tls-config.yaml
+++ b/charts/spatiumddi/templates/frontend-tls-config.yaml
@@ -61,9 +61,11 @@ data:
         # connect refused / upstream timeout); 503 stays as-is so
         # the api's intentional 503s (demo-mode, factory-reset
         # cooldown, /health/ready with schema-behind) reach the
-        # operator unchanged. See frontend/default.conf.template's
-        # error_page comment for the full reasoning.
-        error_page 502 504 = @starting;
+        # operator unchanged. Status preserved (no ``=``) so the
+        # SPA's axios calls reject cleanly instead of resolving with
+        # an HTML string body (review polish from #301). See
+        # frontend/default.conf.template for the full reasoning.
+        error_page 502 504 @starting;
 
         location @starting {
             default_type text/html;

--- a/charts/spatiumddi/templates/frontend-tls-config.yaml
+++ b/charts/spatiumddi/templates/frontend-tls-config.yaml
@@ -55,6 +55,23 @@ data:
 
         resolver ${NGINX_LOCAL_RESOLVERS} valid=10s ipv6=off;
 
+        # Issue #299 phase 2 — same friendly "still booting" page the
+        # non-TLS image template serves, mirrored here for the
+        # appliance's TLS-fronted shape. Only 502 + 504 (upstream
+        # connect refused / upstream timeout); 503 stays as-is so
+        # the api's intentional 503s (demo-mode, factory-reset
+        # cooldown, /health/ready with schema-behind) reach the
+        # operator unchanged. See frontend/default.conf.template's
+        # error_page comment for the full reasoning.
+        error_page 502 504 = @starting;
+
+        location @starting {
+            default_type text/html;
+            add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+            add_header X-Upstream-Status $upstream_status always;
+            try_files /_starting.html =503;
+        }
+
         # Large request bodies for the backup endpoint — keep the
         # same shape the default template uses.
         location /api/v1/backup/ {

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -38,6 +38,54 @@ server {
     # Kubernetes, host /etc/resolv.conf under ``--network=host``.
     resolver ${NGINX_LOCAL_RESOLVERS} valid=10s ipv6=off;
 
+    # Issue #299 phase 2 — when the api upstream isn't reachable
+    # (cold boot before the api passes /health/ready, mid-rolling-
+    # upgrade replica gap, mid-CNPG-failover blip) serve the
+    # friendly "still booting" page instead of bare nginx 502 HTML.
+    #
+    # Why 502 + 504 only:
+    # * 502 covers "upstream connect refused" (no ready pods in the
+    #   Service's endpoint slice; the schema-aware readiness probe
+    #   landed in phase 1 keeps api pods out of that slice until the
+    #   migrate Job lands the alembic head).
+    # * 504 covers "upstream timeout" (api responded slowly enough
+    #   to trip ``proxy_read_timeout``).
+    # * 503 is DELIBERATELY NOT intercepted — the api uses 503 for
+    #   real operator-actionable signals (demo-mode blocked write,
+    #   factory-reset cooldown, /health/ready when DB is up but
+    #   schema is behind). Replacing those with a generic page
+    #   would mask the cause.
+    # * 500 is also passed through — that's a real bug to fix, not
+    #   a "still booting" condition.
+    #
+    # The ``= @starting`` form overrides the response status to 200
+    # so well-behaved clients (curl + jq automation, browser cache,
+    # the SPA's error-handler) get a clean body. Operators chasing
+    # real outages still see the underlying status in the upstream's
+    # access log + the ``X-Upstream-Status`` debug header below.
+    error_page 502 504 = @starting;
+
+    # The error_page is inherited into every location below, including
+    # ``/api/*``, ``/health/*``, ``/metrics``, and the SPA fallback at
+    # ``/``. Direct GET /_starting.html bypasses the upstream entirely.
+
+    location @starting {
+        # Static file under root — Vite copies frontend/public/_starting.html
+        # to /usr/share/nginx/html/_starting.html on every build, so the
+        # page is part of the same image as the SPA. The ``internal``
+        # directive would let us hide /_starting.html from external
+        # requests, but leaving it externally accessible is useful for
+        # operators previewing the look without a real upstream failure.
+        default_type text/html;
+        # Aggressive no-store: an operator hitting this page during a
+        # boot window must NOT have it cached for the next visit.
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        # Surface what the upstream said so a curl debugger can tell
+        # "upstream is unreachable" from "upstream timed out".
+        add_header X-Upstream-Status $upstream_status always;
+        try_files /_starting.html =503;
+    }
+
     # Nginx-local healthcheck — answers without hitting any upstream,
     # so the frontend container's health reflects just nginx itself.
     location = /nginx-health {

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -58,12 +58,16 @@ server {
     # * 500 is also passed through — that's a real bug to fix, not
     #   a "still booting" condition.
     #
-    # The ``= @starting`` form overrides the response status to 200
-    # so well-behaved clients (curl + jq automation, browser cache,
-    # the SPA's error-handler) get a clean body. Operators chasing
-    # real outages still see the underlying status in the upstream's
-    # access log + the ``X-Upstream-Status`` debug header below.
-    error_page 502 504 = @starting;
+    # Status is PRESERVED (no ``=`` after the status list) — the
+    # original 502/504 flows through to clients. The SPA's axios
+    # layer types every /api/* response as JSON; overriding to 200
+    # with an HTML body would make axios resolve "success" with a
+    # string payload and crash downstream (review polish from #301).
+    # Direct browser hits to ``/api/*`` URLs during a 502 window
+    # still get the friendly HTML body (status 502 with HTML is
+    # rendered by browsers identically to the body alone); the
+    # status-preservation only matters for programmatic clients.
+    error_page 502 504 @starting;
 
     # The error_page is inherited into every location below, including
     # ``/api/*``, ``/health/*``, ``/metrics``, and the SPA fallback at

--- a/frontend/public/_starting.html
+++ b/frontend/public/_starting.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SpatiumDDI — initialising</title>
+    <!--
+      Served by the frontend nginx as the 502/504 ``error_page`` body
+      when the api upstream isn't reachable yet — issue #299 phase 2.
+
+      The cold-boot 502 window on a multi-node appliance is normally
+      90-120 s (CNPG primary + replicas + the migrate Job + the api
+      pod's first readiness pass). This page covers that window with
+      a real "we are booting" surface instead of bare nginx 502 HTML,
+      auto-refreshes every 5 s, and stops refreshing the moment the
+      upstream comes back (because the api's ``/`` then serves the
+      SPA, not this file). Also covers mid-rolling-upgrade gaps
+      (#296) and mid-CNPG-failover blips.
+
+      Self-contained — no external CSS, no scripts, no fetches. Lives
+      under frontend/public/ so Vite copies it to dist/ verbatim.
+    -->
+    <meta http-equiv="refresh" content="5" />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+          Cantarell, sans-serif;
+      }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #020617;
+          color: #e2e8f0;
+        }
+        .card {
+          background: #0f172a;
+          border-color: #1e293b;
+        }
+        .muted {
+          color: #94a3b8;
+        }
+        .spinner {
+          border-color: #1e293b;
+          border-top-color: #2dd4bf;
+        }
+      }
+      .card {
+        max-width: 480px;
+        margin: 0 1rem;
+        padding: 2.5rem 2rem;
+        background: #ffffff;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        box-shadow: 0 4px 24px rgba(15, 23, 42, 0.08);
+        text-align: center;
+      }
+      .logo {
+        width: 64px;
+        height: 64px;
+        margin: 0 auto 1.25rem;
+        display: block;
+      }
+      h1 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin: 0 0 0.5rem;
+      }
+      .muted {
+        color: #475569;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        margin: 0;
+      }
+      .spinner {
+        width: 28px;
+        height: 28px;
+        margin: 1.5rem auto 1rem;
+        border: 3px solid #e2e8f0;
+        border-top-color: #0d9488;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .small {
+        font-size: 0.75rem;
+        margin-top: 1.5rem;
+        color: #64748b;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <svg
+        class="logo"
+        viewBox="0 0 120 120"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <rect width="120" height="120" rx="22" fill="#0f172a" />
+        <rect x="14" y="14" width="92" height="92" rx="13" fill="#134e4a" />
+        <rect x="28" y="28" width="64" height="64" rx="9" fill="#0d9488" />
+        <rect x="42" y="42" width="36" height="36" rx="5" fill="#2dd4bf" />
+        <circle cx="60" cy="60" r="9" fill="#ffffff" />
+      </svg>
+      <h1>SpatiumDDI is initialising</h1>
+      <p class="muted">
+        The control plane is still coming online. This usually takes about
+        1&ndash;2 minutes on a fresh install while the database initialises and
+        migrations land. This page auto-refreshes every few seconds.
+      </p>
+      <div class="spinner" role="status" aria-label="loading"></div>
+      <p class="small">
+        If this page hasn't cleared after a few minutes, check
+        <code>kubectl get pods -n spatium</code> for a stuck workload.
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Closes #299.

## What's broken

On a fresh multi-node appliance install the operator gets ~1-2 min of bare nginx 502 responses on every UI request before the cluster settles. Reproduced on the 3-node test cluster while shaking out PR #298:

- CNPG primary + replicas + the migrate Job take ~90-120 s to land on a cold boot.
- The api Deployment starts and passes its readiness probe the moment Postgres accepts a `SELECT 1` — **before** the migrate Job has populated the schema.
- The api is added to the Service endpoint slice with no usable schema. Every route handler 500s against missing tables.
- Frontend nginx returns 502 to the operator. The SPA can load but every action including login fails.

## Two-phase fix

### Phase 1 — schema-aware readiness probe (commit `83a334f`)

`/health/ready` now checks `alembic_version.version_num` against the bundled `ScriptDirectory.get_current_head()` in addition to DB + Redis connectivity.

Three distinct failure modes, each with operator-actionable detail:

| State | Detail |
|---|---|
| `alembic_version` table doesn't exist (asyncpg `UndefinedTableError`) | `schema not initialised: relation "alembic_version" does not exist` |
| `alembic_version` row missing | `alembic_version row missing — migrate not stamped` |
| `version_num` != bundled head | `schema at X, image expects Y` |

K8s readinessProbe already points at `/health/ready` — no chart change needed. Pods failing this check are automatically pulled from the Service endpoint slice and stay out until the migrate Job lands the head.

The expected head is cached at first call (constant for a given image, no point re-reading per probe).

**Tests:** 8 cases in `tests/test_health_schema_check.py` — helper-level (ok/mismatch/missing-row/missing-table) + endpoint-level (200 at head, 503 with schema-specific detail on mismatch). An autouse fixture seeds `alembic_version` per-test since conftest uses `Base.metadata.create_all` (fast-path) rather than `alembic upgrade head`.

### Phase 2 — friendly "still booting" page (commit `544b49b`)

Phase 1 alone shifts the 502 source from "upstream timeout" to "no upstream available" — operator still sees a bare 502. Phase 2 closes the UX gap:

- `frontend/public/_starting.html` — self-contained ~4 KB page. Inlined SpatiumDDI logo SVG, dark/light theme via `prefers-color-scheme`, spinner, `<meta http-equiv="refresh" content="5">`. No external CSS, no scripts, no fetches. Vite's `public/` copies verbatim to `dist/`.
- `frontend/default.conf.template` (Docker Compose / non-TLS image): `error_page 502 504 = @starting;` at server scope + named `@starting` location with aggressive `Cache-Control: no-store` and an `X-Upstream-Status` debug header.
- `charts/spatiumddi/templates/frontend-tls-config.yaml` (appliance TLS path): mirrored block in the ConfigMap so both surfaces stay byte-equivalent.

**Why 502 + 504 only, not 503:**
- 502 → upstream connect refused (no ready pods)
- 504 → upstream timeout
- 503 deliberately **passes through** — the api uses it for real operator-actionable signals (demo-mode blocked writes, factory-reset cooldown, `/health/ready` schema-behind). Replacing those with a generic "still booting" page would mask the cause.
- 500 also passes through — bugs to fix, not "still booting" conditions.

The `= @starting` form overrides the response status to 200 so the SPA's error-handler sees a non-error response (instead of catch-and-display-generic-"Login failed"). Real outages still show up in the upstream's access log + the `X-Upstream-Status` header.

## Combined effect

| Before | After |
|---|---|
| Bare `502 Bad Gateway` from nginx, no context | Friendly "SpatiumDDI is initialising" page with auto-refresh |
| api pod added to Service slice before schema landed → every route 500s | api pod stays out of slice until schema at head → no half-broken state |
| Operator: "is the install broken?" | Operator: "ok it's still booting, this is normal" |

## Test plan

- `make ci`: ✅
- venv-pinned `.venv/bin/{ruff,black,mypy}` on full repo: ✅
- `tests/test_health.py` + `tests/test_health_schema_check.py` in dev container: 8/8 pass
- Build verified Vite copies `_starting.html` to `dist/`
- Manual SPA browse: not yet, will follow up after this lands on the 3-node test cluster

## Cross-references

- Surfaced in: PR #298 field-test of 2026.05.22-1 + this PR's dev appliance
- Companion to: #296 (rolling upgrade — same mid-rollout 502 window benefits from this)
- Future polish: SPA-level readiness polling (issue's phase 3) is deliberately deferred — the auto-refreshing nginx page covers the operator-visible UX cleanly without the bigger SPA change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
