### PR TITLE
feat(#302): operator-customisable k3s pod + service CIDRs in install wizard

### DIFF
--- a/appliance/mkosi.extra/etc/rancher/k3s/config.yaml
+++ b/appliance/mkosi.extra/etc/rancher/k3s/config.yaml
@@ -15,13 +15,18 @@
 # rejects loopback IPs ("may not be in the loopback range") — coredns
 # / local-path / helm-controller all fail to reach the cluster IP.
 #
-# External reach is gated by nftables: tcp/6443 is only accepted from
-# the pod CIDR (10.42.0.0/16) on the input chain; all other origins
-# fall through to the default-drop policy. #272 Phase 7b widens this on
-# control-plane nodes: when the control plane promotes peers, it hands
-# each member the peer node IPs and the supervisor renders an nftables
-# drop-in opening the k3s server ports (6443 apiserver, 2379/2380 etcd,
-# 10250 kubelet) to those peers — see firewall_renderer._K3S_PEER_PORTS_TCP.
+# Network-layer posture: tcp/6443, 2379/2380, 10250 are OPEN on the
+# LAN-facing INPUT chain (see /etc/nftables.conf "k3s-ha" rule). k3s
+# itself token+mTLS protects the apiserver and requires client certs
+# for etcd — LAN exposure on a single-tenant appliance is acceptable.
+# #272 Phase 7b's per-peer drop-ins under /etc/nftables.d/ are kept
+# as defence-in-depth + documentation of the active peer set.
+#
+# Pod + service CIDRs are operator-chosen at install time (issue
+# #302); see /etc/rancher/k3s/config.yaml.d/spatium-cidrs.yaml for
+# the values in effect. Defaults are k3s upstream (10.42.0.0/16 pods,
+# 10.43.0.0/16 services); the install wizard customises them when
+# the operator's LAN already uses one of those ranges.
 https-listen-port: 6443
 
 # #272 Phase 7 — embedded etcd from first boot. ``cluster-init: true``

--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -106,6 +106,15 @@ NET_PREFIX="24"
 NET_GATEWAY=""
 NET_DNS="1.1.1.1 1.0.0.1"
 TIMEZONE="UTC"
+# Issue #302 — k3s pod + service CIDRs. Defaults match k3s upstream
+# defaults exactly so operators on a clean LAN don't have to touch
+# them. Customisable in ``ask_k3s_cidrs`` for installs where the LAN
+# already uses one of these ranges (Flannel ``host-gw`` writes routes
+# directly; an overlapping pod CIDR masks the LAN). The cluster-dns
+# IP is derived as ``<service_cidr_base>.0.10`` — k3s/kube-dns
+# convention.
+K3S_POD_CIDR="10.42.0.0/16"
+K3S_SERVICE_CIDR="10.43.0.0/16"
 # Default ROLE = appliance (the role screen frames it as "Additional
 # node"). #272 UX fix: operators don't read the body text, and a
 # misclick / blind Enter on "control plane" silently spins up a SECOND
@@ -513,6 +522,135 @@ ask_timezone() {
     fi
 }
 
+# Issue #302 — operator-customisable k3s pod + service CIDRs.
+#
+# k3s defaults (10.42.0.0/16 pods, 10.43.0.0/16 services) collide
+# with several common LAN ranges in the wild (Flannel docs example,
+# some VPN/overlay setups, branch SD-WAN). Defaults pre-filled so
+# clean-LAN operators just press Enter through this step; overrides
+# kick in for operators whose LAN already uses one of these ranges.
+#
+# Validation runs server-side via Python's ``ipaddress`` because bash
+# regex CIDR validation is awful and we want overlap detection
+# (between pod / service / operator's static-IP subnet) for free.
+ask_k3s_cidrs() {
+    log "Step: ask_k3s_cidrs"
+    while true; do
+        local pod
+        pod=$(whiptail --backtitle "$BACKTITLE" --title "k3s pod network" \
+            --cancel-button "Back" \
+            --inputbox "Pod CIDR — internal range Flannel uses for per-pod IPs. Default works for most LANs; change only if your network already uses 10.42.x.x.\n\nIPv4 CIDR (e.g. 10.42.0.0/16):" \
+            14 70 "$K3S_POD_CIDR" 3>&1 1>&2 2>&3) \
+            || return 1
+        local svc
+        svc=$(whiptail --backtitle "$BACKTITLE" --title "k3s service network" \
+            --cancel-button "Back" \
+            --inputbox "Service CIDR — internal range k8s uses for service ClusterIPs (incl. cluster DNS). Must not overlap with the pod CIDR or your LAN.\n\nIPv4 CIDR (e.g. 10.43.0.0/16):" \
+            14 70 "$K3S_SERVICE_CIDR" 3>&1 1>&2 2>&3) \
+            || return 1
+        if _validate_k3s_cidrs "$pod" "$svc"; then
+            K3S_POD_CIDR="$pod"
+            K3S_SERVICE_CIDR="$svc"
+            return 0
+        fi
+        # _validate_k3s_cidrs already showed the operator a msgbox
+        # with the reason — loop back to the pod CIDR prompt with the
+        # operator's just-typed values pre-filled so they don't lose
+        # them. Set the running defaults to what they typed so the
+        # next prompt-iteration's inputbox shows those values.
+        K3S_POD_CIDR="$pod"
+        K3S_SERVICE_CIDR="$svc"
+    done
+}
+
+# Helper: validate the two CIDRs typed by ask_k3s_cidrs. Returns 0 on
+# success; on fail, shows a whiptail msgbox describing the problem +
+# returns 1 so the caller re-prompts.
+_validate_k3s_cidrs() {
+    local pod="$1" svc="$2"
+    # Hand off to Python — ``ipaddress`` does parsing, prefix-len
+    # checking, and overlap detection in three idiomatic lines. The
+    # bash regex alternative would be 30 lines + still wrong on edge
+    # cases. We pass the operator's static-IP subnet (if static
+    # mode) so we can refuse pod/svc CIDRs that would mask the LAN.
+    local static_subnet=""
+    if [ "$NET_MODE" = "static" ] && [ -n "$NET_IP" ] && [ -n "$NET_PREFIX" ]; then
+        static_subnet="$NET_IP/$NET_PREFIX"
+    fi
+    local err
+    err=$(python3 - "$pod" "$svc" "$static_subnet" <<'PY' 2>&1
+import ipaddress
+import sys
+pod_s, svc_s, static_s = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    pod = ipaddress.ip_network(pod_s, strict=False)
+except ValueError as exc:
+    print(f"Pod CIDR is not a valid IPv4 network: {exc}")
+    sys.exit(1)
+try:
+    svc = ipaddress.ip_network(svc_s, strict=False)
+except ValueError as exc:
+    print(f"Service CIDR is not a valid IPv4 network: {exc}")
+    sys.exit(1)
+if pod.version != 4 or svc.version != 4:
+    print("Only IPv4 CIDRs are supported.")
+    sys.exit(1)
+# /22 is the upper bound — k3s allocates /24 per node out of the pod
+# CIDR (max ~64 nodes from /22) and /16 service CIDRs are k3s
+# convention. Tighter than /22 silently breaks at scale + once-
+# allocated CIDRs can't be expanded without a reinstall.
+if pod.prefixlen > 22:
+    print(f"Pod CIDR prefix {pod.prefixlen} is too small. Use /22 or wider (e.g. /16).")
+    sys.exit(1)
+if svc.prefixlen > 22:
+    print(f"Service CIDR prefix {svc.prefixlen} is too small. Use /22 or wider (e.g. /16).")
+    sys.exit(1)
+if pod.overlaps(svc):
+    print(f"Pod CIDR {pod} overlaps with service CIDR {svc}. They must be disjoint.")
+    sys.exit(1)
+if static_s:
+    try:
+        lan = ipaddress.ip_interface(static_s).network
+    except ValueError:
+        # Bad static-IP shape elsewhere in the wizard — let that
+        # surface there, not here.
+        sys.exit(0)
+    if pod.overlaps(lan):
+        print(
+            f"Pod CIDR {pod} overlaps with the LAN subnet {lan} you "
+            f"just configured. Flannel's host-gw backend would mask "
+            f"the LAN. Pick a non-overlapping range."
+        )
+        sys.exit(1)
+    if svc.overlaps(lan):
+        print(
+            f"Service CIDR {svc} overlaps with the LAN subnet {lan}. "
+            f"Pick a non-overlapping range."
+        )
+        sys.exit(1)
+PY
+)
+    if [ -z "$err" ]; then
+        return 0
+    fi
+    whiptail --backtitle "$BACKTITLE" --title "k3s networking — invalid" \
+        --msgbox "$err\n\nPress OK to fix." 14 72 || true
+    return 1
+}
+
+# Helper: compute the cluster-dns IP from the chosen service CIDR.
+# k3s + kube-dns convention is ``<service_cidr_base>.10`` (e.g. the
+# 10.43.0.0/16 default gives 10.43.0.10). Outputs the address only;
+# called by do_install when writing the k3s config drop-in.
+_cluster_dns_ip_from_svc_cidr() {
+    python3 - "$1" <<'PY'
+import ipaddress
+import sys
+net = ipaddress.ip_network(sys.argv[1], strict=False)
+print(str(net.network_address + 10))
+PY
+}
+
 confirm() {
     log "Step: confirm"
     local role_label
@@ -538,8 +676,14 @@ confirm() {
     if [ "$NET_MODE" = "static" ]; then
         s+=" ($NET_INTERFACE: $NET_IP/$NET_PREFIX via $NET_GATEWAY)"
     fi
-    s+="\nTimezone:    $TIMEZONE\n\n"
-    s+="WARNING: $TARGET_DISK will be ERASED. There is no undo.\n\n"
+    s+="\nTimezone:    $TIMEZONE\n"
+    # Only show the k3s CIDR row when the operator overrode either
+    # default — keeps the confirm screen short for the common case.
+    if [ "$K3S_POD_CIDR" != "10.42.0.0/16" ] || [ "$K3S_SERVICE_CIDR" != "10.43.0.0/16" ]; then
+        s+="K3s pod CIDR: $K3S_POD_CIDR\n"
+        s+="K3s svc CIDR: $K3S_SERVICE_CIDR\n"
+    fi
+    s+="\nWARNING: $TARGET_DISK will be ERASED. There is no undo.\n\n"
     s+="Proceed with installation?"
     whiptail --backtitle "$BACKTITLE" --title "Confirm" \
         --no-button "Back" \
@@ -961,9 +1105,42 @@ node-label:
 EOF
             chmod 0644 "$MOUNT/etc/rancher/k3s/config.yaml.d/spatium-roles.yaml"
         fi
-        # ROLE=appliance leaves the drop-in absent; the supervisor
-        # applies role-* labels dynamically via the heartbeat-driven
-        # role-assignment flow.
+        # ROLE=appliance leaves the role-label drop-in absent; the
+        # supervisor applies role-* labels dynamically via the
+        # heartbeat-driven role-assignment flow.
+
+        # Issue #302 — k3s pod + service CIDR drop-in. ALWAYS written,
+        # even on defaults, so the values are explicit on disk + a
+        # future operator editing /etc/rancher/k3s/config.yaml.d/
+        # spatium-cidrs.yaml sees what's in effect (instead of having
+        # to grep the upstream k3s default elsewhere). Drop-in form
+        # rather than editing the main config.yaml so the in-tree
+        # config.yaml stays operator-readable + the install-time
+        # choices are isolated in their own file.
+        #
+        # cluster-dns is derived from the service CIDR base + 10 —
+        # k3s + kube-dns convention. The coredns Deployment binds to
+        # this IP at startup; changing it post-install requires a
+        # coredns restart and is documented as "reinstall" today.
+        local cluster_dns_ip
+        cluster_dns_ip=$(_cluster_dns_ip_from_svc_cidr "$K3S_SERVICE_CIDR")
+        cat > "$MOUNT/etc/rancher/k3s/config.yaml.d/spatium-cidrs.yaml" <<EOF
+# Auto-generated by spatium-install (issue #302) — operator-chosen
+# k3s pod + service CIDRs from the install wizard. Values default to
+# k3s upstream defaults (10.42.0.0/16 / 10.43.0.0/16) unless the
+# operator overrode them on an installation where the LAN collided.
+#
+# These CANNOT be changed in-place — k3s does not support live CIDR
+# migration. Reinstall is required to change them (the partition
+# layout permits keeping /var across reinstalls; data + Postgres
+# state on the persistent volume survive).
+cluster-cidr: $K3S_POD_CIDR
+service-cidr: $K3S_SERVICE_CIDR
+cluster-dns: $cluster_dns_ip
+EOF
+        chmod 0644 "$MOUNT/etc/rancher/k3s/config.yaml.d/spatium-cidrs.yaml"
+        log "k3s CIDRs: pod=$K3S_POD_CIDR svc=$K3S_SERVICE_CIDR dns=$cluster_dns_ip"
+
         cat > "$MOUNT/etc/hosts" <<EOF
 127.0.0.1 localhost
 127.0.1.1 $HOSTNAME
@@ -1459,14 +1636,20 @@ main() {
                 if ask_network; then step="ask_timezone"; else step="ask_user_password"; fi
                 ;;
             ask_timezone)
-                if ask_timezone; then step="ask_application_config"; else step="ask_network"; fi
+                if ask_timezone; then step="ask_k3s_cidrs"; else step="ask_network"; fi
+                ;;
+            ask_k3s_cidrs)
+                # Issue #302 — operator picks (or accepts the defaults
+                # for) the k3s pod + service CIDRs. Forward → application
+                # role config; back → timezone.
+                if ask_k3s_cidrs; then step="ask_application_config"; else step="ask_timezone"; fi
                 ;;
             ask_application_config)
                 # Returns 0 immediately when ROLE != application — so
                 # forward navigation moves straight to confirm and
                 # backward navigation from confirm walks through here
                 # without showing any whiptail screen.
-                if ask_application_config; then step="confirm"; else step="ask_timezone"; fi
+                if ask_application_config; then step="confirm"; else step="ask_k3s_cidrs"; fi
                 ;;
             confirm)
                 if confirm; then step="do_install"; else step="ask_application_config"; fi

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -555,6 +555,33 @@ trigger: tag push (CalVer)
 > `spatiumddi-firstboot` runs after collecting answers has
 > changed.
 
+> **#302 update — k3s CIDR step in the wizard.** The interactive
+> installer (`spatium-install`) now asks for the k3s pod + service
+> CIDRs between the timezone step and the role-config step. Both
+> default to the k3s upstream defaults (`10.42.0.0/16` pods,
+> `10.43.0.0/16` services); operators on a clean LAN just press
+> Enter through both prompts.
+>
+> Operators whose LAN already uses one of these ranges (Flannel
+> docs example uses `10.42.0.0/24`; some VPN/SD-WAN deployments use
+> `10.42.x` or `10.43.x` for branch routing) can override them. The
+> wizard validates that:
+>
+> - Both CIDRs are syntactically valid IPv4 networks.
+> - Prefixes are wide enough (≤ /22 — k3s allocates a /24 per node
+>   out of the pod CIDR, plus headroom for service ClusterIPs).
+> - Pod CIDR and service CIDR are disjoint.
+> - On static-IP installs, neither CIDR overlaps with the LAN
+>   subnet the operator just configured (Flannel's `host-gw`
+>   backend writes routes that would mask the LAN otherwise).
+>
+> The chosen values land in
+> `/etc/rancher/k3s/config.yaml.d/spatium-cidrs.yaml` (always
+> written, even on defaults, so the active values are visible on
+> disk). **In-place change is NOT supported** — k3s requires a
+> reinstall to change `cluster-cidr` / `service-cidr`. The
+> partition layout permits keeping `/var` across reinstalls.
+
 ### Phase 1 (pre-#183, replaced): headless via cloud-init NoCloud
 
 Phase 1 ships with `cloud-init` enabled and the NoCloud datasource


### PR DESCRIPTION
Closes #302.

## What this changes

Two new prompts in the interactive `spatium-install` wizard, between the **Timezone** and **Application config** steps:

```
… → Network → Timezone
                 ↓
       ┌─ k3s pod network ─────┐
       │ Pod CIDR  [10.42.0.0/16]
       └───────────────────────┘
                 ↓
       ┌─ k3s service network ─┐
       │ Svc CIDR  [10.43.0.0/16]
       └───────────────────────┘
                 ↓
            Application config → Confirm → Install
```

**Defaults match k3s upstream exactly.** Operators on a clean LAN press Enter through both — the one-click flow is preserved. Operators on a colliding LAN (Flannel's docs example uses `10.42.0.0/24`; some VPN / SD-WAN deployments carve `10.42.x` or `10.43.x` for branch routing; some Docker setups grab `10.43.x` for bridges) override them.

The pain this avoids: Flannel's `host-gw` backend writes Linux routes directly. An overlapping pod CIDR masks the LAN — the appliance suddenly can't reach LAN hosts in that range. The install completes cleanly + the failure only surfaces at first network reach, which is rough to diagnose.

## Validation

Python's `ipaddress` does the heavy lifting (bash CIDR regex is awful + we need overlap detection for free):

- Each CIDR is a syntactically valid IPv4 network.
- Each prefix length is ≤ /22 — k3s allocates /24 per node out of the pod CIDR. Tighter than /22 silently breaks at scale and can't be expanded without a reinstall.
- Pod CIDR and service CIDR are disjoint.
- On static-IP installs, neither CIDR overlaps with the LAN subnet the operator just configured. DHCP mode skips this check — we don't know the lease subnet at install time.

Failure surfaces as a named whiptail msgbox (`Pod CIDR 10.42.0.0/16 overlaps with the LAN subnet 10.42.5.0/24 you just configured`), then re-prompts with the operator's just-typed values pre-filled so they don't lose them.

## On-disk

Always writes `/etc/rancher/k3s/config.yaml.d/spatium-cidrs.yaml` (even on defaults) so the active values are visible on disk:

```yaml
cluster-cidr: <chosen-pod-cidr>
service-cidr: <chosen-service-cidr>
cluster-dns:  <service_cidr_base + 10>
```

`cluster-dns` is derived `<service_cidr_base + 10>` — k3s + kube-dns convention. coredns binds to this IP at startup; post-install changes require a reinstall (documented).

Drop-in form rather than editing the main `config.yaml` so the in-tree file stays operator-readable + the install-time choices stay isolated in their own file.

## Misc

- Fixes a **stale comment** in the base `config.yaml` that claimed nftables gates `tcp/6443` on the pod CIDR. It doesn't — the `k3s-ha` rule accepts from any source (k3s's own token+mTLS is the actual posture). Replaced with an accurate description + a cross-reference to the new drop-in.
- New section in `docs/deployment/APPLIANCE.md` § 4 covering the new step + the validation rules + the "no in-place change" invariant.

## Test plan

- `bash -n` clean on the modified installer. ✅
- 7 black-box validation tests (defaults / non-colliding static / pod-overlaps-LAN / invalid CIDR / pod-svc overlap / custom override / cluster-dns derivation). All pass. ✅
- **End-to-end wizard test** — needs a fresh ISO build + install on a test VM. TBD; will validate after this PR lands on a feature freeze.

## Confirm-screen behaviour

The "K3s pod CIDR" / "K3s svc CIDR" rows only render on the confirm screen when the operator overrode at least one default — keeps it short for the common case:

```
# default flow (unchanged from before)
Role:        Control plane …
Hostname:    appliance-1
Timezone:    UTC

WARNING: /dev/sda will be ERASED …
```

```
# override flow (new)
Role:        Control plane …
Hostname:    appliance-1
Timezone:    UTC
K3s pod CIDR: 172.30.0.0/16
K3s svc CIDR: 172.31.0.0/16

WARNING: /dev/sda will be ERASED …
```

## Out of scope / deferred

- In-UI CIDR change post-install — k3s doesn't support live `cluster-cidr` / `service-cidr` migration. Reinstall is required (the partition layout permits keeping `/var` across reinstalls, so data + Postgres state survive).
- Auto-suggest a non-colliding range based on the discovered LAN — could land later; the validate-no-overlap check covers the dangerous case.
- Multi-node join CIDR negotiation — joiners inherit the seed's CIDRs transparently. No second prompt on the join wizard.
- IPv6 dual-stack service CIDR — single-stack v4 only for now; dual-stack is a bigger lift across CNPG / frontend nginx / chart API_UPSTREAM resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
