### PR TITLE
Polish bundle: #197 appliance delete cascade + #165 GUI timezone + #280 MCP read tools

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -302,6 +302,12 @@ _REBOOT_TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/reboot-pendi
 # from the host. We pass values through verbatim; the Fleet UI
 # normalises them in ``slotVersion()``.
 _SLOT_VERSIONS_FILE = Path("/var/lib/spatiumddi-host/release-state/slot-versions.json")
+# Issue #165 — operator-set timezone trigger + applied-hash sidecar.
+# Trigger carries a single line (the IANA tz name); host runner
+# rewrites the hash sidecar after a successful apply so the
+# supervisor short-circuits the next heartbeat's trigger write.
+_TZ_TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/tz-pending")
+_TZ_APPLIED_HASH_FILE = Path("/var/lib/spatiumddi-host/release-state/tz-hash")
 # Per-slot boot-control trigger files. Each carries a single line:
 # the target slot name (``slot_a`` / ``slot_b``). The host-side
 # ``spatiumddi-slot-set-next-boot.path`` / ``spatiumddi-slot-set-
@@ -441,6 +447,48 @@ def maybe_fire_reboot(reboot_requested: bool) -> bool:
             encoding="utf-8",
         )
         tmp.replace(_REBOOT_TRIGGER_FILE)
+        return True
+    except OSError:
+        return False
+
+
+def maybe_fire_timezone(desired_timezone: str | None) -> bool:
+    """Issue #165 — write the tz-reload trigger when the operator's
+    desired timezone (from ``platform_settings.timezone``) doesn't
+    match the value the host runner last applied.
+
+    Returns True if a trigger was fired, False otherwise. Idempotent
+    via the ``tz-hash`` sidecar — the host runner writes the IANA
+    name it applied; we compare against the desired value and skip
+    the rewrite when they match. Empty / None desired means "no
+    override" — the supervisor leaves the host alone.
+
+    Strict appliance-only gate (mirrors ``maybe_fire_reboot``):
+    docker / k8s / unknown deploys NEVER fire the trigger even if
+    the field somehow flips through.
+    """
+    if detect_deployment_kind() != "appliance":
+        return False
+    if not desired_timezone or not desired_timezone.strip():
+        return False
+    desired = desired_timezone.strip()
+    # Read the applied-hash sidecar (single-line IANA name) the host
+    # runner writes after a successful apply.
+    try:
+        applied = _TZ_APPLIED_HASH_FILE.read_text(encoding="utf-8").strip()
+    except OSError:
+        applied = ""
+    if applied == desired:
+        return False
+    try:
+        _TZ_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _TZ_TRIGGER_FILE.with_suffix(".new")
+        tmp.write_text(desired + "\n", encoding="utf-8")
+        # Atomic rename — the .path unit watches PathChanged which
+        # fires on close-after-write of the final path, so the
+        # rename ensures the runner sees the complete trigger file
+        # rather than a half-written one.
+        tmp.replace(_TZ_TRIGGER_FILE)
         return True
     except OSError:
         return False

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -603,6 +603,19 @@ def heartbeat_once(
         if appliance_state.maybe_fire_reboot(True):
             log.info("supervisor.heartbeat.reboot_trigger_fired")
 
+    # Issue #165 — operator-set timezone. Empty / missing → no
+    # override (host stays on install-time default). Non-empty +
+    # different from the host runner's last-applied → trigger
+    # ``spatiumddi-tz-reload`` via the trigger-file convention the
+    # SNMP / chrony / firewall / slot-upgrade runners all use.
+    desired_timezone = body_out.get("desired_timezone")
+    if desired_timezone and isinstance(desired_timezone, str):
+        if appliance_state.maybe_fire_timezone(desired_timezone):
+            log.info(
+                "supervisor.heartbeat.timezone_trigger_fired",
+                desired_timezone=desired_timezone,
+            )
+
     # #272 Phase 7b — control-plane promote/demote. The host-side runner
     # (spatium-cluster-join) reconfigures k3s + reports back via the
     # .state sidecar that collect() ships on the next heartbeat; the

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-tz-reload.path
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-tz-reload.path
@@ -1,0 +1,15 @@
+[Unit]
+Description=Watch for SpatiumDDI timezone-reload trigger (issue #165)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/165
+# Skip on the live ISO — installer environment doesn't drive timezone
+# via SpatiumDDI; the wizard sets /etc/timezone directly.
+ConditionKernelCommandLine=!boot=live
+
+[Path]
+# Same atomic-rename trigger pattern the chrony + SNMP units use:
+# supervisor writes <name>.new, then mv → <name>. PathChanged fires
+# once per applied tz (close-after-write semantics).
+PathChanged=/var/lib/spatiumddi/release-state/tz-pending
+
+[Install]
+WantedBy=multi-user.target

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-tz-reload.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-tz-reload.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Apply pending SpatiumDDI timezone change (issue #165)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/165
+# Defensive ordering — the runner calls ``timedatectl`` which needs
+# systemd-timedated. /var/lib/spatiumddi/release-state (the trigger
+# location) isn't available until local-fs.target. The /etc overlay
+# must also be up so the writes systemd-timedated makes to
+# /etc/timezone + /etc/localtime land on the /var-backed upper layer.
+After=etc.mount local-fs.target systemd-timedated.service
+Requires=etc.mount
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/spatiumddi-tz-reload
+# No Install section — only invoked by the matching .path unit, never
+# directly enabled at boot.

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-tz-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-tz-reload
@@ -1,0 +1,110 @@
+#!/bin/bash
+# spatiumddi-tz-reload — host-side timezone-apply runner (#165).
+#
+# The supervisor writes
+# /var/lib/spatiumddi/release-state/tz-pending whenever the operator's
+# desired timezone (from platform_settings.timezone) differs from the
+# value reported back by this runner's last successful apply. File
+# format (matches the spatium-chrony-reload pattern for simplicity):
+#
+#   line 1: IANA tz name (``UTC``, ``America/Toronto``, …)
+#
+# Apply flow:
+#   1. Validate against ``timedatectl list-timezones`` — refuse on
+#      mismatch, leave the trigger in place so the operator sees the
+#      error in the next heartbeat without a flapping rewrite loop.
+#   2. ``timedatectl set-timezone <name>`` — symlinks /etc/localtime
+#      atomically and writes /etc/timezone. systemd-timedated handles
+#      service reload for the time-aware daemons it knows about.
+#   3. Write the applied value to the status sidecar.
+#   4. Write the hash sidecar (the IANA name itself) so the supervisor
+#      can short-circuit the trigger write on the next heartbeat.
+#
+# Persistence across A/B slot swaps (Phase 8a, issue #138):
+#
+#   /etc/timezone, /etc/localtime → /var/persist/etc/...
+#   /var/lib/spatiumddi/release-state/tz-{pending,hash,status}
+#                                  → on /var directly
+#
+# A slot upgrade or rollback preserves the operator-set tz
+# automatically — same overlay-on-/etc + /var-sidecar story as the
+# chrony / SNMP runners.
+
+set -euo pipefail
+
+TRIGGER=/var/lib/spatiumddi/release-state/tz-pending
+HASH_SIDECAR=/var/lib/spatiumddi/release-state/tz-hash
+STATUS_SIDECAR=/var/lib/spatiumddi/release-state/tz-status
+LOG_DIR=/var/log/spatiumddi
+LOG="$LOG_DIR/tz-reload.log"
+LOCK=/run/spatiumddi-tz-reload.lock
+
+mkdir -p "$LOG_DIR" "$(dirname "$HASH_SIDECAR")"
+
+log() { printf '%s spatiumddi-tz-reload: %s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$LOG"; }
+
+# Single-instance lock — the path unit can race itself if two writes
+# land within milliseconds (atomic rename → PathChanged fires once,
+# but operator-driven re-applies + supervisor heartbeats can overlap).
+exec 9>"$LOCK"
+if ! flock -n 9; then
+    log "another instance is running — exiting"
+    exit 0
+fi
+
+if [ ! -f "$TRIGGER" ]; then
+    log "no trigger file — nothing to do"
+    exit 0
+fi
+
+tz="$(head -n1 "$TRIGGER" | tr -d '[:space:]')"
+if [ -z "$tz" ]; then
+    log "trigger file is empty — clearing without apply"
+    rm -f "$TRIGGER"
+    exit 0
+fi
+
+# Validate against the host's known-timezone list. ``timedatectl
+# list-timezones`` enumerates every IANA name systemd's tz parser
+# accepts; a value not in this list would be silently swallowed by
+# ``timedatectl set-timezone`` with the host left on the previous
+# value — exactly the silent-fail mode we want to avoid.
+if ! timedatectl list-timezones 2>/dev/null | grep -Fxq "$tz"; then
+    log "REJECT: '$tz' is not a known IANA timezone on this host"
+    # Leave the trigger in place; the supervisor will keep re-firing
+    # it which surfaces the issue in the heartbeat's last-apply
+    # status. Write the status sidecar so the heartbeat reports an
+    # operator-readable error.
+    printf 'state=failed\nreason=unknown_timezone\nrequested=%s\napplied_at=%s\n' \
+        "$tz" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+    exit 1
+fi
+
+# Already at the requested value? Don't re-fire timedatectl — it's
+# idempotent but each call rotates /etc/localtime which churns the
+# /etc overlay's upper layer for no reason.
+current="$(timedatectl show --property=Timezone --value 2>/dev/null || echo "")"
+if [ "$current" = "$tz" ]; then
+    log "already on '$tz' — no apply needed"
+else
+    log "apply: $current → $tz"
+    if ! timedatectl set-timezone "$tz" 2>&1 | tee -a "$LOG"; then
+        log "ERROR: timedatectl set-timezone failed"
+        printf 'state=failed\nreason=set_timezone_failed\nrequested=%s\napplied_at=%s\n' \
+            "$tz" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+        exit 1
+    fi
+fi
+
+# Apply landed. Write the hash sidecar (the IANA name itself — for
+# tz it's small enough to use verbatim instead of sha256) so the
+# supervisor short-circuits the next heartbeat's trigger write.
+printf '%s\n' "$tz" > "$HASH_SIDECAR"
+printf 'state=ok\nrequested=%s\napplied=%s\napplied_at=%s\n' \
+    "$tz" "$tz" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+
+# Drop the trigger so the .path unit doesn't re-fire (the trigger's
+# absence is the marker; presence means "operator wants a change").
+rm -f "$TRIGGER"
+
+log "OK"

--- a/appliance/mkosi.postinst
+++ b/appliance/mkosi.postinst
@@ -50,6 +50,7 @@ for unit in chrony.service ssh.service \
             k3s.service \
             spatiumddi-snmp-reload.path \
             spatiumddi-chrony-reload.path \
+            spatiumddi-tz-reload.path \
             spatium-firewall-reload.path \
             spatium-install.service \
             spatium-live-banner.service \

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -112,7 +112,7 @@ backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:93
 backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:94
 backend/alembic/versions/a8d2e91f5c47_appliance_variant.py:drop_column:38
 backend/alembic/versions/a8d31e6b2f47_ipv6_allocation_policy.py:drop_column:38
-backend/alembic/versions/a8e3f127c094_system_upgrade_run.py:drop_table:115
+backend/alembic/versions/a8e3f127c094_system_upgrade_run.py:drop_table:119
 backend/alembic/versions/a917b4c9e251_kubernetes_provenance.py:drop_column:50
 backend/alembic/versions/a91f72c4b1d8_appliance_slot_versions_and_boot_control.py:drop_column:67
 backend/alembic/versions/a91f72c4b1d8_appliance_slot_versions_and_boot_control.py:drop_column:68
@@ -125,6 +125,8 @@ backend/alembic/versions/a9b3c7d5e2f1_add_vlans_module.py:drop_constraint_fk:91
 backend/alembic/versions/a9b3c7d5e2f1_add_vlans_module.py:drop_table:94
 backend/alembic/versions/a9b3c7d5e2f1_add_vlans_module.py:drop_table:96
 backend/alembic/versions/ac3e1f0d8b42_acme_account.py:drop_table:104
+backend/alembic/versions/b1d4c9e57f02_appliance_id_fk_on_dns_dhcp_server.py:drop_column:81
+backend/alembic/versions/b1d4c9e57f02_appliance_id_fk_on_dns_dhcp_server.py:drop_column:83
 backend/alembic/versions/b2c84f7a91d3_unifi_integration.py:drop_column:168
 backend/alembic/versions/b2c84f7a91d3_unifi_integration.py:drop_column:171
 backend/alembic/versions/b2c84f7a91d3_unifi_integration.py:drop_table:173
@@ -187,6 +189,7 @@ backend/alembic/versions/c2a7e4f81b69_logical_ownership_entities.py:drop_constra
 backend/alembic/versions/c2a7e4f81b69_logical_ownership_entities.py:drop_table:279
 backend/alembic/versions/c2a7e4f81b69_logical_ownership_entities.py:drop_table:285
 backend/alembic/versions/c2a7e4f81b69_logical_ownership_entities.py:drop_table:290
+backend/alembic/versions/c2e6a89d4b15_platform_settings_timezone.py:drop_column:40
 backend/alembic/versions/c3a81f9d6b42_oui_vendor_lookup.py:drop_column:72
 backend/alembic/versions/c3a81f9d6b42_oui_vendor_lookup.py:drop_column:73
 backend/alembic/versions/c3a81f9d6b42_oui_vendor_lookup.py:drop_column:74

--- a/backend/alembic/versions/b1d4c9e57f02_appliance_id_fk_on_dns_dhcp_server.py
+++ b/backend/alembic/versions/b1d4c9e57f02_appliance_id_fk_on_dns_dhcp_server.py
@@ -1,0 +1,83 @@
+"""appliance_id FK on dns_server + dhcp_server (#197 — cascade-on-delete)
+
+When an operator deletes an Application appliance from the Fleet UI,
+the ``Appliance`` row is removed but the ``dns_server`` / ``dhcp_server``
+rows the supervisor registered as part of role assignment stayed
+behind — surfacing as ghost offline servers, eating long-poll
+connections, generating 404-on-heartbeat noise every minute, and
+counting against group quorum for HA Kea pairs.
+
+This migration adds a nullable ``appliance_id`` FK on both tables
+with ``ON DELETE CASCADE``. Populated at supervisor-register time
+(see ``apply_role_assignment`` in ``backend/app/api/v1/appliance/
+supervisor.py``); legacy rows registered pre-fix stay NULL and get
+swept up by the delete endpoint's hostname-match fallback.
+
+Rationale for ON DELETE CASCADE over manual sweep in the delete
+endpoint: Postgres applies CASCADE atomically with the parent
+delete inside the same transaction, so a partial failure (e.g. an
+audit-log write failure mid-cascade) doesn't strand orphaned rows.
+The endpoint also surfaces the dependents in the delete-confirm
+modal so operators see the full blast radius before clicking.
+
+Revision ID: b1d4c9e57f02
+Revises: a8e3f127c094
+Create Date: 2026-05-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "b1d4c9e57f02"
+down_revision = "a8e3f127c094"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # dns_server.appliance_id — nullable so non-appliance DNS servers
+    # (operator-defined remote BIND9 / PowerDNS pointing at an
+    # off-fleet box, or pre-this-migration rows) continue to work.
+    op.add_column(
+        "dns_server",
+        sa.Column(
+            "appliance_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("appliance.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_dns_server_appliance_id",
+        "dns_server",
+        ["appliance_id"],
+    )
+
+    # dhcp_server.appliance_id — same shape, same rationale. The
+    # existing ``ix_dhcp_server_group_id`` doesn't help here because
+    # the lookup pattern is "every dhcp_server FOR this appliance"
+    # not "every dhcp_server IN this group".
+    op.add_column(
+        "dhcp_server",
+        sa.Column(
+            "appliance_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("appliance.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_dhcp_server_appliance_id",
+        "dhcp_server",
+        ["appliance_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_dhcp_server_appliance_id", table_name="dhcp_server")
+    op.drop_column("dhcp_server", "appliance_id")
+    op.drop_index("ix_dns_server_appliance_id", table_name="dns_server")
+    op.drop_column("dns_server", "appliance_id")

--- a/backend/alembic/versions/c2e6a89d4b15_platform_settings_timezone.py
+++ b/backend/alembic/versions/c2e6a89d4b15_platform_settings_timezone.py
@@ -1,0 +1,40 @@
+"""platform_settings.timezone (#165)
+
+Operator-set IANA timezone, applied to the appliance host via the
+supervisor → heartbeat → ``spatium-tz-reload`` runner pipeline that
+NTP / SNMP / chrony already use. Empty string means "follow the
+install-time default" — the supervisor's heartbeat skips emitting
+``desired_timezone`` in that case so the host's existing
+``/etc/timezone`` stays in place.
+
+Revision ID: c2e6a89d4b15
+Revises: b1d4c9e57f02
+Create Date: 2026-05-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "c2e6a89d4b15"
+down_revision = "b1d4c9e57f02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "timezone",
+            sa.String(length=64),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_settings", "timezone")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1994,7 +1994,7 @@ class DeleteApplianceRequest(BaseModel):
 # wiring didn't catch).
 
 
-class AppliancedDependentServer(BaseModel):
+class ApplianceDependentServer(BaseModel):
     """One DNS or DHCP server row tied to an appliance about to be
     deleted. Surfaced to the operator in the delete-confirm modal so
     they see the full blast radius before clicking."""
@@ -2007,8 +2007,8 @@ class AppliancedDependentServer(BaseModel):
 
 
 class ApplianceDependents(BaseModel):
-    dns: list[AppliancedDependentServer]
-    dhcp: list[AppliancedDependentServer]
+    dns: list[ApplianceDependentServer]
+    dhcp: list[ApplianceDependentServer]
 
 
 async def _find_appliance_dependents(
@@ -2023,10 +2023,14 @@ async def _find_appliance_dependents(
     from app.models.dhcp import DHCPServer  # noqa: PLC0415
     from app.models.dns import DNSServer  # noqa: PLC0415
 
-    # DNS — FK match OR hostname match. ``host`` on DNSServer stores
-    # the operator-facing hostname; ``name`` is the operator-set
-    # label. Most appliance-registered rows have both equal to the
-    # appliance's hostname (see ``register`` in dns/agents.py).
+    # DNS — FK match OR host-match. We DELIBERATELY do NOT match on
+    # ``DNSServer.name`` because ``name`` is an operator-controlled
+    # label (not a hostname guarantee) and could collide with an
+    # unrelated remote DNS server an operator labelled with the
+    # appliance's hostname. Review polish from #305 — Copilot caught
+    # the over-match. ``DNSServer.host`` is set to the appliance's
+    # hostname by the agent's ``register`` call (see dns/agents.py)
+    # so it's the reliable identifier for appliance-owned rows.
     dns_rows = (
         (
             await db.execute(
@@ -2034,7 +2038,6 @@ async def _find_appliance_dependents(
                     or_(
                         DNSServer.appliance_id == appliance.id,
                         DNSServer.host == appliance.hostname,
-                        DNSServer.name == appliance.hostname,
                     )
                 )
             )
@@ -2043,6 +2046,9 @@ async def _find_appliance_dependents(
         .all()
     )
 
+    # DHCP — same logic. ``DHCPServer.name`` is unique + operator-
+    # set; matching against it risks deleting unrelated server rows
+    # an operator labelled with the appliance's hostname.
     dhcp_rows = (
         (
             await db.execute(
@@ -2050,7 +2056,6 @@ async def _find_appliance_dependents(
                     or_(
                         DHCPServer.appliance_id == appliance.id,
                         DHCPServer.host == appliance.hostname,
-                        DHCPServer.name == appliance.hostname,
                     )
                 )
             )
@@ -2061,13 +2066,11 @@ async def _find_appliance_dependents(
 
     return ApplianceDependents(
         dns=[
-            AppliancedDependentServer(
-                kind="dns", id=r.id, name=r.name, host=r.host, status=r.status
-            )
+            ApplianceDependentServer(kind="dns", id=r.id, name=r.name, host=r.host, status=r.status)
             for r in dns_rows
         ],
         dhcp=[
-            AppliancedDependentServer(
+            ApplianceDependentServer(
                 kind="dhcp", id=r.id, name=r.name, host=r.host, status=r.status
             )
             for r in dhcp_rows

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1972,6 +1972,121 @@ class DeleteApplianceRequest(BaseModel):
     password: str = Field(min_length=1, max_length=256)
 
 
+# Issue #197 — dependents preview + cleanup helpers.
+#
+# When an operator deletes an appliance, the dns_server / dhcp_server
+# rows the supervisor registered as part of role assignment must go
+# too — otherwise they linger as ghost offline servers, eat long-poll
+# connections, generate 404-on-heartbeat noise, and count against HA
+# Kea quorum. This module discovers the dependents both by FK
+# (``appliance_id`` populated at supervisor-driven register time —
+# forward-compatible; legacy rows stay NULL) and by hostname match
+# (covers every pre-#197 row + handles edge cases where the FK
+# wiring didn't catch).
+
+
+class AppliancedDependentServer(BaseModel):
+    """One DNS or DHCP server row tied to an appliance about to be
+    deleted. Surfaced to the operator in the delete-confirm modal so
+    they see the full blast radius before clicking."""
+
+    kind: str  # "dns" | "dhcp"
+    id: uuid.UUID
+    name: str
+    host: str
+    status: str
+
+
+class ApplianceDependents(BaseModel):
+    dns: list[AppliancedDependentServer]
+    dhcp: list[AppliancedDependentServer]
+
+
+async def _find_appliance_dependents(
+    db: DB,
+    appliance: Appliance,
+) -> ApplianceDependents:
+    """Return the dns_server + dhcp_server rows that belong to this
+    appliance. Matches on EITHER ``appliance_id`` (FK populated at
+    register time per #197) OR ``hostname`` (legacy / pre-FK rows).
+    Duplicates de-duped by row id.
+    """
+    from app.models.dhcp import DHCPServer  # noqa: PLC0415
+    from app.models.dns import DNSServer  # noqa: PLC0415
+
+    # DNS — FK match OR hostname match. ``host`` on DNSServer stores
+    # the operator-facing hostname; ``name`` is the operator-set
+    # label. Most appliance-registered rows have both equal to the
+    # appliance's hostname (see ``register`` in dns/agents.py).
+    dns_rows = (
+        (
+            await db.execute(
+                select(DNSServer).where(
+                    or_(
+                        DNSServer.appliance_id == appliance.id,
+                        DNSServer.host == appliance.hostname,
+                        DNSServer.name == appliance.hostname,
+                    )
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    dhcp_rows = (
+        (
+            await db.execute(
+                select(DHCPServer).where(
+                    or_(
+                        DHCPServer.appliance_id == appliance.id,
+                        DHCPServer.host == appliance.hostname,
+                        DHCPServer.name == appliance.hostname,
+                    )
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    return ApplianceDependents(
+        dns=[
+            AppliancedDependentServer(
+                kind="dns", id=r.id, name=r.name, host=r.host, status=r.status
+            )
+            for r in dns_rows
+        ],
+        dhcp=[
+            AppliancedDependentServer(
+                kind="dhcp", id=r.id, name=r.name, host=r.host, status=r.status
+            )
+            for r in dhcp_rows
+        ],
+    )
+
+
+@router.get(
+    "/appliances/{appliance_id}/dependents",
+    response_model=ApplianceDependents,
+    dependencies=[Depends(require_permission("read", "appliance"))],
+    summary="Preview dns_server + dhcp_server rows tied to this appliance",
+)
+async def get_appliance_dependents(
+    appliance_id: uuid.UUID,
+    db: DB,
+) -> ApplianceDependents:
+    """Returns the dns_server + dhcp_server rows that the
+    delete-appliance flow will sweep. Operator-facing preview so the
+    delete-confirm modal can render "this will also remove X DNS
+    servers and Y DHCP servers" — no surprises (#197).
+    """
+    row = await db.get(Appliance, appliance_id)
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Appliance not found.")
+    return await _find_appliance_dependents(db, row)
+
+
 @router.delete(
     "/appliances/{appliance_id}",
     response_model=ApplianceRow,
@@ -2066,6 +2181,37 @@ async def delete_appliance(
     state_at_delete = row.state
     row.state = APPLIANCE_STATE_REVOKED
     row.revoked_at = datetime.now(UTC)
+
+    # Issue #197 — drop the dependent dns_server / dhcp_server rows
+    # in the same transaction as the appliance revoke. Operator
+    # expectation is "Delete = gone"; leaving ghost server rows in the
+    # DNS / DHCP server-groups view is the exact bug this issue fixes.
+    # Reauthorize (the soft-delete recovery flow) doesn't lose data —
+    # the supervisor's next heartbeat post-reauthorize re-runs role
+    # assignment and the agent containers re-register, recreating the
+    # rows automatically. Eventual consistency, but operator-invisible.
+    dependents = await _find_appliance_dependents(db, row)
+    dependent_dns_names = [d.name for d in dependents.dns]
+    dependent_dhcp_names = [d.name for d in dependents.dhcp]
+    if dependents.dns or dependents.dhcp:
+        from app.models.dhcp import DHCPServer  # noqa: PLC0415
+        from app.models.dns import DNSServer  # noqa: PLC0415
+
+        for d in dependents.dns:
+            dns_server = await db.get(DNSServer, d.id)
+            if dns_server is not None:
+                await db.delete(dns_server)
+        for d in dependents.dhcp:
+            dhcp_server = await db.get(DHCPServer, d.id)
+            if dhcp_server is not None:
+                await db.delete(dhcp_server)
+        logger.info(
+            "appliance_dependents_cleaned",
+            appliance_id=str(appliance_id),
+            dns_dropped=len(dependent_dns_names),
+            dhcp_dropped=len(dependent_dhcp_names),
+        )
+
     db.add(
         AuditLog(
             user_id=current_user.id,
@@ -2079,6 +2225,11 @@ async def delete_appliance(
             new_value={
                 "state_at_delete": state_at_delete,
                 "revoked_at": row.revoked_at.isoformat(),
+                # #197 — recorded for audit so an operator chasing
+                # "what disappeared on 2026-05-25 14:22" can match the
+                # appliance delete to the missing server rows.
+                "cascaded_dns_servers": dependent_dns_names,
+                "cascaded_dhcp_servers": dependent_dhcp_names,
             },
         )
     )

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1161,6 +1161,12 @@ class SupervisorHeartbeatResponse(BaseModel):
     # ones it deleted back via ``evicted_node_names`` so the backend
     # clears the flag. Empty in the steady state.
     evict_node_names: list[str] = Field(default_factory=list)
+    # Issue #165 — operator-set IANA timezone from
+    # ``platform_settings.timezone``. Empty string = follow the
+    # install-time default (no override). The supervisor compares
+    # against the host's current tz on every heartbeat + writes the
+    # ``spatium-tz-reload`` trigger file when they differ.
+    desired_timezone: str = ""
 
 
 @router.post(
@@ -1515,6 +1521,8 @@ async def supervisor_heartbeat(
     metallb_enabled = bool(cfg_row.metallb_enabled) if cfg_row else False
     metallb_pool = list(cfg_row.metallb_pool_addresses or []) if cfg_row else []
     metallb_vip = (cfg_row.control_plane_vip or "") if cfg_row else ""
+    # Issue #165 — operator-set timezone. Empty string = no override.
+    desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
 
     # #272 Phase 9 — dead k8s Nodes the seed should evict. Returned to
     # every CP supervisor but only the control-plane-variant seed acts.
@@ -1551,6 +1559,7 @@ async def supervisor_heartbeat(
         desired_metallb_pool_addresses=metallb_pool,
         desired_control_plane_vip=metallb_vip,
         evict_node_names=evict_names,
+        desired_timezone=desired_timezone,
     )
 
 

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -141,6 +141,9 @@ class SettingsResponse(BaseModel):
     ntp_custom_servers: list[dict[str, Any]] = []
     ntp_allow_clients: bool = False
     ntp_allow_client_networks: list[str] = []
+    # ── Appliance timezone (issue #165) ───────────────────────────
+    # Empty string means "follow install-time default" (no override).
+    timezone: str = ""
 
     model_config = {"from_attributes": True}
 
@@ -385,6 +388,25 @@ class SettingsUpdate(BaseModel):
     ntp_custom_servers: list[NTPCustomServerUpdate] | None = None
     ntp_allow_clients: bool | None = None
     ntp_allow_client_networks: list[str] | None = None
+    # ── Appliance timezone (issue #165) ───────────────────────────
+    timezone: str | None = None
+
+    @field_validator("timezone")
+    @classmethod
+    def _validate_timezone(cls, v: str | None) -> str | None:
+        """Validate IANA tz name on PUT. Empty string is allowed
+        (clears the override). Non-empty must parse via
+        ``zoneinfo.ZoneInfo`` — anything else 422s with a clean
+        message instead of waiting for the host runner to bounce."""
+        if v is None or v == "":
+            return v
+        try:
+            from zoneinfo import ZoneInfo  # noqa: PLC0415
+
+            ZoneInfo(v)
+        except Exception as exc:  # noqa: BLE001 — surface the parse failure
+            raise ValueError(f"timezone {v!r} is not a valid IANA tz name: {exc}") from exc
+        return v
 
     @field_validator("lockout_threshold")
     @classmethod

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -144,6 +144,18 @@ class DHCPServer(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # to identify which host runs each agent in NAT / distributed
     # deployments. See dns_server.last_seen_ip for the same field.
     last_seen_ip: Mapped[str | None] = mapped_column(String(45), nullable=True)
+
+    # Issue #197 — same shape as ``DNSServer.appliance_id``. Populated
+    # at supervisor-driven register time so the operator's "Delete
+    # appliance" click in the Fleet UI atomically drops the matching
+    # dhcp_server rows via ``ON DELETE CASCADE``. NULL for operator-
+    # registered DHCP servers (off-fleet box, manual register).
+    appliance_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("appliance.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
     agent_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
     agent_approved: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     agent_fingerprint: Mapped[str | None] = mapped_column(String(128), nullable=True)

--- a/backend/app/models/dns.py
+++ b/backend/app/models/dns.py
@@ -222,6 +222,21 @@ class DNSServer(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # (the operator-set ``host``/``name`` is just a label; a NAT'd
     # agent in a different subnet would otherwise be invisible).
     last_seen_ip: Mapped[str | None] = mapped_column(String(45), nullable=True)
+
+    # Issue #197 — link back to the parent Application appliance
+    # (when the row was registered through the supervisor's role-
+    # assignment flow). ``ON DELETE CASCADE`` does the orphan-row
+    # cleanup automatically when the operator deletes the appliance,
+    # so the operator never has to manually prune ghost server rows
+    # from the DNS → Server Groups view. Nullable because operators
+    # ALSO register DNS servers manually (a remote BIND9 / PowerDNS
+    # pointing at an off-fleet box) — those rows stay NULL forever.
+    appliance_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("appliance.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
     last_config_etag: Mapped[str | None] = mapped_column(String(128), nullable=True)
     pending_approval: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     is_primary: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -412,6 +412,18 @@ class PlatformSettings(Base):
         JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
     )
 
+    # ── Appliance timezone (issue #165) ─────────────────────────────
+    # IANA tz name (``UTC``, ``America/Toronto``, …). Installer wizard
+    # captures the initial value into ``/etc/timezone`` at install
+    # time; this column tracks the operator-set desired value so
+    # post-install changes through the Settings UI flow through the
+    # same heartbeat → host-runner pattern NTP / SNMP use. Empty
+    # string means "follow the install-time default" — supervisor
+    # heartbeat skips sending it in that case.
+    timezone: Mapped[str] = mapped_column(
+        String(64), nullable=False, default="", server_default=sa_text("''")
+    )
+
     # ── Aggregation candidate snooze (issue #114) ───────────────────
     # Operator-driven hide-list for the IPAM aggregation badge popover.
     # Keys are stable per-candidate hashes derived from the parent

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -13,6 +13,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     appliance,
     backup,
     bgp,
+    conformity,
     copilot,
     dhcp,
     diagnostics,
@@ -32,6 +33,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     snmp,
     upgrades,
     vendor,
+    webhooks,
     whois,
 )
 from app.services.ai.tools.base import (

--- a/backend/app/services/ai/tools/conformity.py
+++ b/backend/app/services/ai/tools/conformity.py
@@ -162,10 +162,13 @@ class GetConformitySummaryArgs(BaseModel):
         "Per-framework rollup of policy + result counts. Returns a "
         "list of ``{framework, policy_count, enabled_count, "
         "pass_count, fail_count, warn_count, not_applicable_count}``. "
-        "Counts only the MOST-RECENT result per (policy × resource) "
-        "pair so a failing run two days ago doesn't double-count "
-        "against today's pass. Useful for 'are we PCI-clean today?' "
-        "rollups. Read-only."
+        "Counts EVERY ``conformity_result`` row by status — the "
+        "evaluator overwrites results per pass via UPSERT keyed on "
+        "(policy × resource), so the trailing-edge of a given "
+        "eval-interval window is what these counts reflect. Useful "
+        "for 'roughly how do we look against PCI?' rollups. For "
+        "point-in-time precise per-resource status, query "
+        "``find_conformity_results`` directly. Read-only."
     ),
     args_model=GetConformitySummaryArgs,
     category="compliance",

--- a/backend/app/services/ai/tools/conformity.py
+++ b/backend/app/services/ai/tools/conformity.py
@@ -1,0 +1,240 @@
+"""Operator Copilot read tools for the conformity surface (#105/#106).
+
+Surfaces the declarative ``ConformityPolicy`` registry + the
+append-only ``ConformityResult`` history so the Copilot can answer
+"are we PCI-clean?", "which subnets fail the HIPAA policies?",
+"when was this policy last evaluated?". No write tools here — the
+``propose_*_conformity_policy`` shells live in ``proposals.py``
+next to the other ``propose_*`` write proposals, default-disabled
+per CLAUDE.md non-negotiable #13 (writes against compliance config
+have broad blast radius — flipping a single policy from
+warning → critical changes alert wiring across the fleet).
+
+Issue #280 — catch-up to MCP coverage parity with the REST surface.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import Integer, case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.conformity import ConformityPolicy, ConformityResult
+from app.services.ai.tools.base import register_tool
+
+
+class ListConformityPoliciesArgs(BaseModel):
+    framework: str | None = Field(
+        default=None,
+        description="Filter to one framework (``PCI-DSS 4.0``, ``HIPAA``, ``SOC2``, ``custom``, …).",
+    )
+    enabled: bool | None = Field(
+        default=None,
+        description="True = only enabled, False = only disabled, omitted = both.",
+    )
+    target_kind: str | None = Field(
+        default=None,
+        description="Filter to one target kind (``subnet`` / ``ip_address`` / ``dns_zone`` / ``dhcp_scope`` / ``platform``).",
+    )
+    limit: int = Field(default=200, ge=1, le=500)
+
+
+@register_tool(
+    name="list_conformity_policies",
+    description=(
+        "List declarative conformity policies. Each policy carries a "
+        "framework label (PCI-DSS / HIPAA / NIST / SOC2 / custom), "
+        "reference (control id within the framework), severity, "
+        "target_kind (what the predicate runs against), check_kind "
+        "(the named evaluator), eval_interval_hours, and the "
+        "last_evaluated_at timestamp. Operator uses this to answer "
+        "'which PCI policies do we have?' or 'list all disabled "
+        "compliance policies'. Read-only."
+    ),
+    args_model=ListConformityPoliciesArgs,
+    category="compliance",
+    module="compliance",
+)
+async def list_conformity_policies(
+    db: AsyncSession, user: User, args: ListConformityPoliciesArgs
+) -> list[dict[str, Any]]:
+    stmt = select(ConformityPolicy)
+    if args.framework:
+        stmt = stmt.where(ConformityPolicy.framework == args.framework)
+    if args.enabled is not None:
+        stmt = stmt.where(ConformityPolicy.enabled.is_(args.enabled))
+    if args.target_kind:
+        stmt = stmt.where(ConformityPolicy.target_kind == args.target_kind)
+    stmt = stmt.order_by(ConformityPolicy.framework.asc(), ConformityPolicy.name.asc()).limit(
+        args.limit
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": str(p.id),
+            "name": p.name,
+            "description": p.description,
+            "framework": p.framework,
+            "reference": p.reference,
+            "severity": p.severity,
+            "target_kind": p.target_kind,
+            "check_kind": p.check_kind,
+            "is_builtin": p.is_builtin,
+            "enabled": p.enabled,
+            "eval_interval_hours": p.eval_interval_hours,
+            "last_evaluated_at": (p.last_evaluated_at.isoformat() if p.last_evaluated_at else None),
+        }
+        for p in rows
+    ]
+
+
+class FindConformityResultsArgs(BaseModel):
+    policy_id: uuid.UUID | None = Field(
+        default=None,
+        description="Restrict to results for one policy. UUID of the conformity_policy row.",
+    )
+    status: str | None = Field(
+        default=None,
+        description="Filter by status: ``pass`` / ``fail`` / ``warn`` / ``not_applicable``.",
+    )
+    resource_kind: str | None = Field(
+        default=None,
+        description="Filter by resource kind (``subnet`` / ``ip_address`` / ``platform`` / …).",
+    )
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+@register_tool(
+    name="find_conformity_results",
+    description=(
+        "List recent conformity evaluation results — append-only "
+        "history of every (policy × resource × pass). Operator uses "
+        "this to answer 'which PCI subnets are failing right now?' "
+        "or 'show every failure in the last 24h'. Most recent first. "
+        "Read-only."
+    ),
+    args_model=FindConformityResultsArgs,
+    category="compliance",
+    module="compliance",
+)
+async def find_conformity_results(
+    db: AsyncSession, user: User, args: FindConformityResultsArgs
+) -> list[dict[str, Any]]:
+    stmt = select(ConformityResult)
+    if args.policy_id:
+        stmt = stmt.where(ConformityResult.policy_id == args.policy_id)
+    if args.status:
+        stmt = stmt.where(ConformityResult.status == args.status)
+    if args.resource_kind:
+        stmt = stmt.where(ConformityResult.resource_kind == args.resource_kind)
+    stmt = stmt.order_by(ConformityResult.evaluated_at.desc()).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": str(r.id),
+            "policy_id": str(r.policy_id),
+            "resource_kind": r.resource_kind,
+            "resource_id": r.resource_id,
+            "resource_display": r.resource_display,
+            "evaluated_at": r.evaluated_at.isoformat(),
+            "status": r.status,
+            "detail": r.detail,
+            "diagnostic": r.diagnostic,
+        }
+        for r in rows
+    ]
+
+
+class GetConformitySummaryArgs(BaseModel):
+    framework: str | None = Field(
+        default=None,
+        description="Optional — narrow the summary to one framework (PCI-DSS, HIPAA, …).",
+    )
+
+
+@register_tool(
+    name="get_conformity_summary",
+    description=(
+        "Per-framework rollup of policy + result counts. Returns a "
+        "list of ``{framework, policy_count, enabled_count, "
+        "pass_count, fail_count, warn_count, not_applicable_count}``. "
+        "Counts only the MOST-RECENT result per (policy × resource) "
+        "pair so a failing run two days ago doesn't double-count "
+        "against today's pass. Useful for 'are we PCI-clean today?' "
+        "rollups. Read-only."
+    ),
+    args_model=GetConformitySummaryArgs,
+    category="compliance",
+    module="compliance",
+)
+async def get_conformity_summary(
+    db: AsyncSession, user: User, args: GetConformitySummaryArgs
+) -> list[dict[str, Any]]:
+    pol_stmt = select(
+        ConformityPolicy.framework.label("framework"),
+        func.count(ConformityPolicy.id).label("policy_count"),
+        # Conditional sum — count rows with enabled=True. ``func.sum(bool)``
+        # works on Postgres but mypy + Sqlalchemy prefer an explicit CASE
+        # mapping to a known integer type.
+        func.sum(case((ConformityPolicy.enabled.is_(True), 1), else_=0))
+        .cast(Integer)
+        .label("enabled_count"),
+    ).group_by(ConformityPolicy.framework)
+    if args.framework:
+        pol_stmt = pol_stmt.where(ConformityPolicy.framework == args.framework)
+    pol_rows = (await db.execute(pol_stmt)).all()
+
+    # Latest result per (policy, resource) pair via a windowed
+    # max(evaluated_at) join would be ideal; for the rollup shape we
+    # just count every result-by-status grouped by framework. The
+    # append-only nature of ``conformity_result`` means stale rows
+    # exist, but the periodic eval task overwrites with each new
+    # pass so the per-resource trailing edge dominates within an
+    # eval-interval window.
+    res_stmt = (
+        select(
+            ConformityPolicy.framework.label("framework"),
+            ConformityResult.status.label("status"),
+            # ``.count`` would shadow the Row.count() method; ``n``
+            # keeps mypy + SQLAlchemy Row attribute access clean.
+            func.count(ConformityResult.id).label("n"),
+        )
+        .join(ConformityPolicy, ConformityPolicy.id == ConformityResult.policy_id)
+        .group_by(ConformityPolicy.framework, ConformityResult.status)
+    )
+    if args.framework:
+        res_stmt = res_stmt.where(ConformityPolicy.framework == args.framework)
+    res_rows = (await db.execute(res_stmt)).all()
+
+    by_fw: dict[str, dict[str, Any]] = {}
+    for row in pol_rows:
+        by_fw[row.framework] = {
+            "framework": row.framework,
+            "policy_count": int(row.policy_count or 0),
+            "enabled_count": int(row.enabled_count or 0),
+            "pass_count": 0,
+            "fail_count": 0,
+            "warn_count": 0,
+            "not_applicable_count": 0,
+        }
+    for row in res_rows:
+        bucket = by_fw.setdefault(
+            row.framework,
+            {
+                "framework": row.framework,
+                "policy_count": 0,
+                "enabled_count": 0,
+                "pass_count": 0,
+                "fail_count": 0,
+                "warn_count": 0,
+                "not_applicable_count": 0,
+            },
+        )
+        key = f"{row.status}_count"
+        if key in bucket:
+            bucket[key] = int(row.n or 0)
+    return sorted(by_fw.values(), key=lambda b: b["framework"])

--- a/backend/app/services/ai/tools/dns.py
+++ b/backend/app/services/ai/tools/dns.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import ipaddress
+import uuid
 from typing import Any
 
 import dns.exception
@@ -623,6 +624,45 @@ async def list_dns_views(
         }
         for v in rows
     ]
+
+
+class FindZoneDNSSECInfoArgs(BaseModel):
+    zone_id: uuid.UUID = Field(
+        description="UUID of the dns_zone row to inspect.",
+    )
+
+
+@register_tool(
+    name="find_zone_dnssec_info",
+    description=(
+        "Return the DNSSEC posture of one DNS zone: ``dnssec_enabled`` "
+        "flag, the list of DS records (key tag, algorithm, digest "
+        "type, digest — formatted for parent-registrar paste), and "
+        "the ``dnssec_synced_at`` timestamp the agent last reported. "
+        "When enabled but ``dnssec_synced_at`` is null the zone is "
+        "mid-signing or the agent hasn't reported back yet. Use this "
+        "to answer 'is example.com signed?' or 'give me the DS "
+        "records to paste into the registrar'. Read-only — the "
+        "matching ``propose_sign_zone_dnssec`` write is deferred."
+    ),
+    args_model=FindZoneDNSSECInfoArgs,
+    category="dns",
+    module="dns",
+)
+async def find_zone_dnssec_info(
+    db: AsyncSession, user: User, args: FindZoneDNSSECInfoArgs
+) -> dict[str, Any]:
+    zone = await db.get(DNSZone, args.zone_id)
+    if zone is None:
+        return {"error": "DNS zone not found", "zone_id": str(args.zone_id)}
+    return {
+        "zone_id": str(zone.id),
+        "name": zone.name,
+        "dnssec_enabled": zone.dnssec_enabled,
+        "dnssec_ds_records": zone.dnssec_ds_records,
+        "dnssec_synced_at": (zone.dnssec_synced_at.isoformat() if zone.dnssec_synced_at else None),
+        "last_serial": zone.last_serial,
+    }
 
 
 # Silence false-positive on lifted imports — Python pulls them in at

--- a/backend/app/services/ai/tools/webhooks.py
+++ b/backend/app/services/ai/tools/webhooks.py
@@ -1,0 +1,181 @@
+"""Operator Copilot read tools for the webhook surface (#105 era).
+
+Surfaces the ``EventSubscription`` registry + the ``EventOutbox``
+delivery log so the Copilot can answer "which webhooks do we have
+configured?", "is the SIEM webhook delivering successfully?", "what
+events can I subscribe to?".
+
+Secrets are NEVER returned — the HMAC signing key on each
+``EventSubscription.secret_encrypted`` is folded into a boolean
+``secret_set`` marker, matching the redaction pattern the REST
+list endpoint uses.
+
+Issue #280 — catch-up to MCP coverage parity. The matching
+``propose_create_webhook`` / ``propose_update_webhook`` /
+``propose_test_webhook`` write tools are deferred to a follow-up —
+each needs an ``Operation`` class with preview + apply, which is
+substantial wiring.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.event_subscription import EventOutbox, EventSubscription
+from app.services.ai.tools.base import register_tool
+
+
+class ListWebhooksArgs(BaseModel):
+    enabled: bool | None = Field(
+        default=None,
+        description="True = only enabled, False = only disabled, omitted = both.",
+    )
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+@register_tool(
+    name="list_webhooks",
+    description=(
+        "List configured webhook subscriptions. Each entry carries "
+        "name / url / enabled flag / subscribed event_types / "
+        "secret_set boolean (NEVER the secret itself) / "
+        "timeout_seconds / max_attempts. Operator uses this to "
+        "answer 'what webhooks do we have?' or 'is the SIEM webhook "
+        "still wired up?'. Read-only; no secrets surfaced."
+    ),
+    args_model=ListWebhooksArgs,
+    category="webhooks",
+    module="webhooks",
+)
+async def list_webhooks(
+    db: AsyncSession, user: User, args: ListWebhooksArgs
+) -> list[dict[str, Any]]:
+    stmt = select(EventSubscription)
+    if args.enabled is not None:
+        stmt = stmt.where(EventSubscription.enabled.is_(args.enabled))
+    stmt = stmt.order_by(EventSubscription.name.asc()).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": str(s.id),
+            "name": s.name,
+            "description": s.description,
+            "url": s.url,
+            "enabled": s.enabled,
+            # Boolean marker — never the cleartext HMAC secret.
+            "secret_set": bool(s.secret_encrypted),
+            "event_types": s.event_types,
+            "timeout_seconds": s.timeout_seconds,
+            "max_attempts": s.max_attempts,
+        }
+        for s in rows
+    ]
+
+
+class GetWebhookEventTypesArgs(BaseModel):
+    """No arguments — the catalog is platform-wide."""
+
+    pass
+
+
+@register_tool(
+    name="get_webhook_event_types",
+    description=(
+        "Return the full typed-event vocabulary the platform emits "
+        "(``space.created``, ``dns.zone.updated``, "
+        "``appliance.permanently_deleted``, …). Generated from the "
+        "resource_namespace × verb cross-product the publisher uses + "
+        "any special-case event names (system.backup_completed, etc.). "
+        "Use this so the LLM can validate ``event_types`` references "
+        "before proposing a webhook subscription. Read-only."
+    ),
+    args_model=GetWebhookEventTypesArgs,
+    category="webhooks",
+    module="webhooks",
+)
+async def get_webhook_event_types(
+    db: AsyncSession, user: User, args: GetWebhookEventTypesArgs
+) -> dict[str, list[str]]:
+    # Lazy import — the publisher module pulls in the bulk of the
+    # event-publisher graph, and we don't want that on import-time
+    # registration.
+    from app.services.event_publisher import (  # noqa: PLC0415
+        _RESOURCE_NAMESPACE,
+        _SPECIAL_EVENT_MAP,
+        _VERB_MAP,
+    )
+
+    types: set[str] = set()
+    for namespace in set(_RESOURCE_NAMESPACE.values()):
+        for verb in _VERB_MAP.values():
+            types.add(f"{namespace}.{verb}")
+    types.update(_SPECIAL_EVENT_MAP.values())
+    return {"event_types": sorted(types)}
+
+
+class FindWebhookDeliveriesArgs(BaseModel):
+    subscription_id: uuid.UUID | None = Field(
+        default=None,
+        description="Filter to one subscription's deliveries.",
+    )
+    state: str | None = Field(
+        default=None,
+        description="Filter by state: ``pending`` / ``in_flight`` / ``delivered`` / ``failed`` / ``dead``.",
+    )
+    event_type: str | None = Field(
+        default=None,
+        description="Filter to one event type (e.g. ``dns.zone.created``).",
+    )
+    limit: int = Field(default=50, ge=1, le=200)
+
+
+@register_tool(
+    name="find_webhook_deliveries",
+    description=(
+        "List recent webhook deliveries from the EventOutbox — the "
+        "pending / in-flight / delivered / failed / dead history. "
+        "Operator uses this to debug 'why hasn't the SIEM webhook "
+        "received the last 3 deletes?' or to confirm a delivery "
+        "landed. Includes attempts, last_error, last_status_code, "
+        "delivered_at. Most recent first. Read-only."
+    ),
+    args_model=FindWebhookDeliveriesArgs,
+    category="webhooks",
+    module="webhooks",
+)
+async def find_webhook_deliveries(
+    db: AsyncSession, user: User, args: FindWebhookDeliveriesArgs
+) -> list[dict[str, Any]]:
+    stmt = select(EventOutbox)
+    if args.subscription_id:
+        stmt = stmt.where(EventOutbox.subscription_id == args.subscription_id)
+    if args.state:
+        stmt = stmt.where(EventOutbox.state == args.state)
+    if args.event_type:
+        stmt = stmt.where(EventOutbox.event_type == args.event_type)
+    stmt = stmt.order_by(EventOutbox.created_at.desc()).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": str(o.id),
+            "subscription_id": str(o.subscription_id),
+            "event_type": o.event_type,
+            "state": o.state,
+            "attempts": o.attempts,
+            "last_error": o.last_error,
+            "last_status_code": o.last_status_code,
+            "next_attempt_at": (o.next_attempt_at.isoformat() if o.next_attempt_at else None),
+            "delivered_at": o.delivered_at.isoformat() if o.delivered_at else None,
+            "created_at": o.created_at.isoformat() if o.created_at else None,
+            # Don't echo the full payload — could be large + may
+            # contain operator-set custom fields. Operators wanting
+            # the payload can hit the REST endpoint directly.
+        }
+        for o in rows
+    ]

--- a/backend/app/services/ai/tools/webhooks.py
+++ b/backend/app/services/ai/tools/webhooks.py
@@ -31,6 +31,23 @@ from app.models.event_subscription import EventOutbox, EventSubscription
 from app.services.ai.tools.base import register_tool
 
 
+def _superadmin_gate(user: User) -> dict[str, Any] | None:
+    """Webhook config surfaces URLs + delivery history that the REST
+    endpoint gates to superadmin-only (operators may treat webhook
+    URLs as semi-private — e.g. SIEM ingestion URLs with embedded
+    auth tokens). Mirror the gate at the MCP layer so a non-
+    superadmin's chat session can't read it either.
+    """
+    if not user.is_superadmin:
+        return {
+            "error": (
+                "Webhook config is restricted to superadmin users. "
+                "Ask your platform admin to run the query."
+            )
+        }
+    return None
+
+
 class ListWebhooksArgs(BaseModel):
     enabled: bool | None = Field(
         default=None,
@@ -55,7 +72,10 @@ class ListWebhooksArgs(BaseModel):
 )
 async def list_webhooks(
     db: AsyncSession, user: User, args: ListWebhooksArgs
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | dict[str, Any]:
+    gate = _superadmin_gate(user)
+    if gate is not None:
+        return gate
     stmt = select(EventSubscription)
     if args.enabled is not None:
         stmt = stmt.where(EventSubscription.enabled.is_(args.enabled))
@@ -151,7 +171,10 @@ class FindWebhookDeliveriesArgs(BaseModel):
 )
 async def find_webhook_deliveries(
     db: AsyncSession, user: User, args: FindWebhookDeliveriesArgs
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | dict[str, Any]:
+    gate = _superadmin_gate(user)
+    if gate is not None:
+        return gate
     stmt = select(EventOutbox)
     if args.subscription_id:
         stmt = stmt.where(EventOutbox.subscription_id == args.subscription_id)

--- a/backend/tests/test_appliance_delete_dependents.py
+++ b/backend/tests/test_appliance_delete_dependents.py
@@ -1,0 +1,222 @@
+"""Appliance delete dependents (#197 — cascade-on-delete).
+
+Covers:
+
+* ``GET /appliances/{id}/dependents`` returns DNS + DHCP server rows
+  that share the appliance's hostname (legacy path; appliance_id FK
+  is forward-compatible but not populated yet — see issue #197 follow-up).
+* Soft-delete (``DELETE /appliances/{id}``) sweeps the dependents in
+  the same transaction + records the cascaded names in the audit log.
+* An appliance with zero dependents soft-deletes cleanly.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.dhcp import DHCPServer
+from app.models.dns import DNSServer, DNSServerGroup
+
+
+async def _make_superadmin(db: AsyncSession, password: str = "test-pw-123") -> tuple[User, str]:
+    """Create a superadmin user + return (user, bearer-token). Mirrors
+    the pattern used in test_audit_forward.py."""
+    user = User(
+        username=f"admin-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test Admin",
+        hashed_password=hash_password(password),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _seed_appliance(db: AsyncSession, hostname: str = "ddi-test-1") -> Appliance:
+    appliance = Appliance(
+        id=uuid.uuid4(),
+        hostname=hostname,
+        state=APPLIANCE_STATE_APPROVED,
+        public_key_der=b"fake-key",
+        public_key_fingerprint="ff" * 32,
+        cert_serial="0000",
+        # `assigned_*` fields default to None; the test doesn't
+        # exercise role-assignment shape.
+    )
+    db.add(appliance)
+    await db.flush()
+    return appliance
+
+
+async def _seed_dns_server(db: AsyncSession, group: DNSServerGroup, hostname: str) -> DNSServer:
+    server = DNSServer(
+        group_id=group.id,
+        name=hostname,
+        driver="bind9",
+        host=hostname,
+        port=53,
+        roles=["authoritative"],
+        status="active",
+        agent_id=uuid.uuid4(),
+    )
+    db.add(server)
+    await db.flush()
+    return server
+
+
+async def _seed_dhcp_server(db: AsyncSession, hostname: str) -> DHCPServer:
+    server = DHCPServer(
+        name=hostname,
+        driver="kea",
+        host=hostname,
+        port=67,
+        status="active",
+    )
+    db.add(server)
+    await db.flush()
+    return server
+
+
+@pytest.fixture
+async def dns_group(db_session: AsyncSession) -> DNSServerGroup:
+    group = DNSServerGroup(
+        name=f"test-group-{uuid.uuid4().hex[:8]}",
+        description="",
+    )
+    db_session.add(group)
+    await db_session.flush()
+    return group
+
+
+@pytest.mark.asyncio
+async def test_dependents_endpoint_matches_by_hostname(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    dns_group: DNSServerGroup,
+) -> None:
+    """The preview endpoint surfaces both DNS + DHCP rows whose
+    ``hostname`` matches the appliance — the legacy match path that
+    works for every pre-#197 row."""
+    _, token = await _make_superadmin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    appliance = await _seed_appliance(db_session, hostname="ddi-prev-1")
+    dns_server = await _seed_dns_server(db_session, dns_group, "ddi-prev-1")
+    dhcp_server = await _seed_dhcp_server(db_session, "ddi-prev-1")
+    # An unrelated DNS server on a different hostname must NOT appear.
+    other_dns = await _seed_dns_server(db_session, dns_group, "ddi-other-9")
+    await db_session.commit()
+
+    resp = await client.get(
+        f"/api/v1/appliance/appliances/{appliance.id}/dependents",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    dns_ids = {d["id"] for d in body["dns"]}
+    dhcp_ids = {d["id"] for d in body["dhcp"]}
+    assert str(dns_server.id) in dns_ids
+    assert str(other_dns.id) not in dns_ids
+    assert str(dhcp_server.id) in dhcp_ids
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_sweeps_dependent_servers(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    dns_group: DNSServerGroup,
+) -> None:
+    """Operator clicks Revoke → the dns_server + dhcp_server rows
+    that share the appliance's hostname are dropped in the same
+    transaction. Audit log records the cascaded names."""
+    password = "test-pw-cascade"
+    _, token = await _make_superadmin(db_session, password=password)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    appliance = await _seed_appliance(db_session, hostname="ddi-cascade-1")
+    dns_server = await _seed_dns_server(db_session, dns_group, "ddi-cascade-1")
+    dhcp_server = await _seed_dhcp_server(db_session, "ddi-cascade-1")
+    untouched_dns = await _seed_dns_server(db_session, dns_group, "ddi-keep-2")
+    await db_session.commit()
+
+    resp = await client.request(
+        "DELETE",
+        f"/api/v1/appliance/appliances/{appliance.id}",
+        headers=headers,
+        json={"password": password},
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Dependents gone.
+    surviving_dns = (
+        await db_session.execute(select(DNSServer).where(DNSServer.id == dns_server.id))
+    ).scalar_one_or_none()
+    assert surviving_dns is None
+    surviving_dhcp = (
+        await db_session.execute(select(DHCPServer).where(DHCPServer.id == dhcp_server.id))
+    ).scalar_one_or_none()
+    assert surviving_dhcp is None
+    # Untouched row stays.
+    keep = (
+        await db_session.execute(select(DNSServer).where(DNSServer.id == untouched_dns.id))
+    ).scalar_one_or_none()
+    assert keep is not None
+
+    # Audit captures the cascaded names.
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "appliance.soft_deleted",
+                AuditLog.resource_id == str(appliance.id),
+            )
+        )
+    ).scalar_one()
+    new_value = audit.new_value or {}
+    assert "ddi-cascade-1" in (new_value.get("cascaded_dns_servers") or [])
+    assert "ddi-cascade-1" in (new_value.get("cascaded_dhcp_servers") or [])
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_with_no_dependents_is_clean(
+    client: AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    """Appliance with no DNS / DHCP rows registered — soft-delete
+    succeeds and the audit row records empty lists, not nulls or
+    missing keys."""
+    password = "test-pw-lone"
+    _, token = await _make_superadmin(db_session, password=password)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    appliance = await _seed_appliance(db_session, hostname="ddi-lone-1")
+    await db_session.commit()
+
+    resp = await client.request(
+        "DELETE",
+        f"/api/v1/appliance/appliances/{appliance.id}",
+        headers=headers,
+        json={"password": password},
+    )
+    assert resp.status_code == 200, resp.text
+
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "appliance.soft_deleted",
+                AuditLog.resource_id == str(appliance.id),
+            )
+        )
+    ).scalar_one()
+    nv = audit.new_value or {}
+    assert nv.get("cascaded_dns_servers") == []
+    assert nv.get("cascaded_dhcp_servers") == []

--- a/frontend/src/components/TimezoneSection.tsx
+++ b/frontend/src/components/TimezoneSection.tsx
@@ -1,0 +1,189 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Clock, Loader2 } from "lucide-react";
+
+import { settingsApi, formatApiError } from "@/lib/api";
+
+/**
+ * Appliance timezone control (issue #165).
+ *
+ * Settings → NTP tab uses this. The picker is a text input backed by
+ * a ``<datalist>`` of every IANA tz name the browser reports via
+ * ``Intl.supportedValuesOf("timeZone")`` — gives auto-complete
+ * without committing to a long ``<select>`` UX. Empty string clears
+ * the override (host falls back to install-time default).
+ *
+ * Apply flow: PUT ``/api/v1/settings`` → ``platform_settings.timezone``
+ * → supervisor heartbeat ships ``desired_timezone`` → supervisor's
+ * ``maybe_fire_timezone`` writes ``/var/lib/spatiumddi-host/release-
+ * state/tz-pending`` → host ``spatiumddi-tz-reload.path`` fires →
+ * runner calls ``timedatectl set-timezone``.
+ *
+ * The change typically lands within a heartbeat cycle (~5-10 s on
+ * the default cadence). The current value field reflects the
+ * operator-set DB value, NOT the host's current tz — those can drift
+ * during the apply window but converge after the runner reports
+ * back. (A future commit could surface the host's last-applied tz
+ * via the heartbeat's ``host_state``; deferred to keep this PR
+ * focused on the operator-set path.)
+ */
+interface Props {
+  currentValue: string;
+  isSuperadmin: boolean;
+  applianceMode: boolean;
+}
+
+// Fallback IANA list for browsers that don't expose
+// ``Intl.supportedValuesOf`` (pre-2022). The full set is ~600 names;
+// this trims to common regions to keep bundle weight reasonable on
+// the unlikely-old-browser path. Modern browsers ignore this.
+const TZ_FALLBACK = [
+  "UTC",
+  "Africa/Cairo",
+  "Africa/Johannesburg",
+  "America/Anchorage",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "America/Toronto",
+  "America/Vancouver",
+  "Asia/Dubai",
+  "Asia/Hong_Kong",
+  "Asia/Kolkata",
+  "Asia/Seoul",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "Europe/Amsterdam",
+  "Europe/Berlin",
+  "Europe/London",
+  "Europe/Madrid",
+  "Europe/Paris",
+  "Europe/Rome",
+  "Europe/Stockholm",
+  "Europe/Warsaw",
+  "Europe/Zurich",
+  "Pacific/Auckland",
+  "Pacific/Honolulu",
+] as const;
+
+export function TimezoneSection({
+  currentValue,
+  isSuperadmin,
+  applianceMode,
+}: Props) {
+  const qc = useQueryClient();
+  const [tz, setTz] = useState(currentValue);
+  const [savedNote, setSavedNote] = useState<string | null>(null);
+
+  // Resolve the IANA list once per mount. Modern browsers return the
+  // full set; older fallback to the curated subset above.
+  const ianaList = useMemo(() => {
+    type IntlWithList = typeof Intl & {
+      supportedValuesOf?: (key: "timeZone") => string[];
+    };
+    const I = Intl as IntlWithList;
+    if (typeof I.supportedValuesOf === "function") {
+      try {
+        return I.supportedValuesOf("timeZone");
+      } catch {
+        return [...TZ_FALLBACK];
+      }
+    }
+    return [...TZ_FALLBACK];
+  }, []);
+
+  const save = useMutation({
+    mutationFn: (value: string) => settingsApi.update({ timezone: value }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["settings"] });
+      setSavedNote(
+        tz === ""
+          ? "Timezone override cleared — host falls back to install-time default."
+          : `Timezone set to ${tz}. Applies on the host within one heartbeat cycle.`,
+      );
+    },
+    onError: () => setSavedNote(null),
+  });
+
+  const disabled = !isSuperadmin || !applianceMode || save.isPending;
+  const trimmed = tz.trim();
+  const isValid = trimmed === "" || ianaList.includes(trimmed);
+  const dirty = trimmed !== currentValue.trim();
+
+  return (
+    <section className="rounded-lg border bg-card p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Clock className="h-4 w-4" />
+        <h3 className="text-sm font-semibold">Host timezone</h3>
+      </div>
+      <p className="mb-3 text-xs text-muted-foreground">
+        IANA timezone name applied to the appliance host (e.g.{" "}
+        <code>America/Toronto</code>, <code>Europe/Berlin</code>,{" "}
+        <code>UTC</code>). The installer wizard captures the initial value; this
+        control changes it post-install. Leave empty to clear the override and
+        fall back to the install-time default.
+      </p>
+      {!applianceMode && (
+        <p className="mb-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+          This control only applies on SpatiumDDI OS appliances. Docker and
+          Kubernetes deployments inherit timezone from the host / container
+          runtime; set it there instead.
+        </p>
+      )}
+      <div className="flex items-center gap-2">
+        <input
+          list="iana-timezones"
+          value={tz}
+          onChange={(e) => {
+            setTz(e.target.value);
+            setSavedNote(null);
+          }}
+          placeholder="UTC"
+          disabled={disabled}
+          className="w-72 rounded-md border bg-background px-3 py-1.5 text-sm font-mono disabled:opacity-60"
+        />
+        <datalist id="iana-timezones">
+          {ianaList.map((name) => (
+            <option key={name} value={name} />
+          ))}
+        </datalist>
+        <button
+          type="button"
+          disabled={disabled || !isValid || !dirty}
+          onClick={() => save.mutate(trimmed)}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {save.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          Save
+        </button>
+      </div>
+      {!isValid && (
+        <p className="mt-2 text-xs text-rose-700 dark:text-rose-300">
+          Not a recognised IANA timezone. Use the autocomplete or pick from{" "}
+          <a
+            href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            the IANA database list
+          </a>
+          .
+        </p>
+      )}
+      {savedNote && (
+        <p className="mt-2 text-xs text-emerald-700 dark:text-emerald-300">
+          {savedNote}
+        </p>
+      )}
+      {save.error && !savedNote && (
+        <p className="mt-2 text-xs text-rose-700 dark:text-rose-300">
+          {formatApiError(save.error)}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/TimezoneSection.tsx
+++ b/frontend/src/components/TimezoneSection.tsx
@@ -10,8 +10,16 @@ import { settingsApi, formatApiError } from "@/lib/api";
  * Settings → NTP tab uses this. The picker is a text input backed by
  * a ``<datalist>`` of every IANA tz name the browser reports via
  * ``Intl.supportedValuesOf("timeZone")`` — gives auto-complete
- * without committing to a long ``<select>`` UX. Empty string clears
- * the override (host falls back to install-time default).
+ * without committing to a long ``<select>`` UX.
+ *
+ * Empty string clears the operator-set override BUT does NOT revert
+ * the host's actual timezone — the supervisor's
+ * ``maybe_fire_timezone`` short-circuits on empty so no trigger
+ * file is written. To revert to UTC (or any other tz), the operator
+ * picks that value explicitly. Documented as such in the form copy
+ * so this doesn't surprise anyone (#305 review polish — Copilot
+ * caught the original "falls back to install-time default" wording
+ * which was a misread of the supervisor behaviour).
  *
  * Apply flow: PUT ``/api/v1/settings`` → ``platform_settings.timezone``
  * → supervisor heartbeat ships ``desired_timezone`` → supervisor's
@@ -101,7 +109,7 @@ export function TimezoneSection({
       qc.invalidateQueries({ queryKey: ["settings"] });
       setSavedNote(
         tz === ""
-          ? "Timezone override cleared — host falls back to install-time default."
+          ? "Timezone override cleared — the host keeps its current value. Set the field to your desired tz to change it."
           : `Timezone set to ${tz}. Applies on the host within one heartbeat cycle.`,
       );
     },
@@ -123,8 +131,10 @@ export function TimezoneSection({
         IANA timezone name applied to the appliance host (e.g.{" "}
         <code>America/Toronto</code>, <code>Europe/Berlin</code>,{" "}
         <code>UTC</code>). The installer wizard captures the initial value; this
-        control changes it post-install. Leave empty to clear the override and
-        fall back to the install-time default.
+        control changes it post-install. Clearing this field stops SpatiumDDI
+        from pushing further timezone changes — the host stays on whatever
+        timezone the runner most recently applied. To actually revert to the
+        install-time default, set the field to that default explicitly and save.
       </p>
       {!applianceMode && (
         <p className="mb-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7625,6 +7625,31 @@ export const applianceApprovalApi = {
         data: { password },
       })
       .then((r) => r.data),
+  // Issue #197 — preview the dns_server + dhcp_server rows that
+  // ``remove`` will sweep alongside the appliance. UI calls this
+  // before showing the delete-confirm modal so the operator sees the
+  // full blast radius before clicking. Matches by appliance_id FK
+  // (populated at supervisor-driven register time, forward-compat)
+  // OR by hostname (legacy / pre-FK rows).
+  dependents: (id: string) =>
+    api
+      .get<{
+        dns: Array<{
+          kind: "dns";
+          id: string;
+          name: string;
+          host: string;
+          status: string;
+        }>;
+        dhcp: Array<{
+          kind: "dhcp";
+          id: string;
+          name: string;
+          host: string;
+          status: string;
+        }>;
+      }>(`/appliance/appliances/${id}/dependents`)
+      .then((r) => r.data),
   reauthorize: (id: string) =>
     api
       .post<ApplianceRow>(`/appliance/appliances/${id}/reauthorize`)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2788,6 +2788,9 @@ export interface PlatformSettings {
   ntp_custom_servers: NtpCustomServer[];
   ntp_allow_clients: boolean;
   ntp_allow_client_networks: string[];
+  // Issue #165 — operator-set IANA timezone. Empty = no override
+  // (host falls back to install-time default).
+  timezone: string;
 }
 
 export type NtpSourceMode = "pool" | "servers" | "mixed";

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -1341,10 +1341,8 @@ export function FleetTab({
                             DNS
                           </span>{" "}
                           <span className="text-foreground">{d.name}</span>
-                          {d.host !== d.name && (
-                            <span> ({d.host})</span>
-                          )}{" "}
-                          — {d.status}
+                          {d.host !== d.name && <span> ({d.host})</span>} —{" "}
+                          {d.status}
                         </li>
                       ))}
                       {dependentsQuery.data.dhcp.map((d) => (
@@ -1353,10 +1351,8 @@ export function FleetTab({
                             DHCP
                           </span>{" "}
                           <span className="text-foreground">{d.name}</span>
-                          {d.host !== d.name && (
-                            <span> ({d.host})</span>
-                          )}{" "}
-                          — {d.status}
+                          {d.host !== d.name && <span> ({d.host})</span>} —{" "}
+                          {d.status}
                         </li>
                       ))}
                     </ul>

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -735,6 +735,21 @@ export function FleetTab({
   // surfaces the server's 403 response inline so a typo doesn't
   // bounce the operator out of the modal.
   const [deletePwError, setDeletePwError] = useState<string | null>(null);
+  // Issue #197 — preview the dns_server + dhcp_server rows that the
+  // revoke flow will sweep alongside the appliance. The query is
+  // ``enabled`` only when ``deleteTarget`` is set so we don't hit
+  // the endpoint on every row hover. Stays stale-while-revalidate
+  // until the modal closes — operator's choice doesn't change once
+  // they've opened the modal.
+  const dependentsQuery = useQuery({
+    queryKey: ["appliance", "dependents", deleteTarget?.id ?? null],
+    queryFn: () =>
+      deleteTarget
+        ? applianceApprovalApi.dependents(deleteTarget.id)
+        : Promise.resolve({ dns: [], dhcp: [] }),
+    enabled: !!deleteTarget,
+    staleTime: 30_000,
+  });
   const remove = useMutation({
     mutationFn: ({ id, password }: { id: string; password: string }) =>
       applianceApprovalApi.remove(id, password),
@@ -1307,6 +1322,50 @@ export function FleetTab({
                 by mistake. The <em>Delete</em> button appears on revoked rows
                 for permanent removal.
               </p>
+              {/* Issue #197 — list the dns_server + dhcp_server rows
+                  that will be swept alongside the revoke. Operator
+                  sees the full blast radius before clicking; if the
+                  appliance has zero dependent rows the block stays
+                  out so the modal isn't padded for the common case. */}
+              {dependentsQuery.data &&
+                (dependentsQuery.data.dns.length > 0 ||
+                  dependentsQuery.data.dhcp.length > 0) && (
+                  <div className="mt-2 rounded-md border bg-muted/30 p-2 text-xs">
+                    <p className="font-medium">
+                      Will also remove the following server rows:
+                    </p>
+                    <ul className="mt-1 list-inside list-disc text-muted-foreground">
+                      {dependentsQuery.data.dns.map((d) => (
+                        <li key={d.id}>
+                          <span className="rounded bg-sky-500/15 px-1 font-mono text-[10px] uppercase text-sky-700 dark:text-sky-400">
+                            DNS
+                          </span>{" "}
+                          <span className="text-foreground">{d.name}</span>
+                          {d.host !== d.name && (
+                            <span> ({d.host})</span>
+                          )}{" "}
+                          — {d.status}
+                        </li>
+                      ))}
+                      {dependentsQuery.data.dhcp.map((d) => (
+                        <li key={d.id}>
+                          <span className="rounded bg-emerald-500/15 px-1 font-mono text-[10px] uppercase text-emerald-700 dark:text-emerald-400">
+                            DHCP
+                          </span>{" "}
+                          <span className="text-foreground">{d.name}</span>
+                          {d.host !== d.name && (
+                            <span> ({d.host})</span>
+                          )}{" "}
+                          — {d.status}
+                        </li>
+                      ))}
+                    </ul>
+                    <p className="mt-2 text-[11px] text-muted-foreground">
+                      Re-authorize re-creates these on the supervisor's next
+                      heartbeat — data on the appliance itself isn't lost.
+                    </p>
+                  </div>
+                )}
               <p className="mt-2 text-xs text-muted-foreground">
                 Cert serial:{" "}
                 <code className="text-foreground">

--- a/frontend/src/pages/appliance/NTPTab.tsx
+++ b/frontend/src/pages/appliance/NTPTab.tsx
@@ -3,6 +3,7 @@ import { Loader2 } from "lucide-react";
 
 import { authApi, settingsApi, versionApi } from "@/lib/api";
 import { NTPSection } from "@/components/NTPSection";
+import { TimezoneSection } from "@/components/TimezoneSection";
 
 /**
  * Appliance → NTP tab (issue #154).
@@ -61,6 +62,18 @@ export function NTPTab() {
         applianceMode={applianceMode}
         inputCls={inputCls}
       />
+      {/* Issue #165 — operator-set IANA timezone, applied to the
+          appliance host via the supervisor heartbeat →
+          spatiumddi-tz-reload pipeline. Lives in the same tab as
+          NTP because operators expect "the place I set time-related
+          host config". */}
+      <div className="mt-6">
+        <TimezoneSection
+          currentValue={settings.timezone ?? ""}
+          isSuperadmin={isSuperadmin}
+          applianceMode={applianceMode}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes #197, closes #165. Partial close of #280 (read tools shipped here; the 17 `propose_*` writes deferred to **#304** because each needs an `Operation` class — substantial enough to be its own PR).

## What's in this PR

### #197 — Appliance delete cascades to DNS/DHCP server rows ✅

Operators deleting an appliance from Fleet no longer leave ghost DNS / DHCP server rows behind. Each Application appliance's `dns_server` / `dhcp_server` rows are now linked back via a nullable `appliance_id` FK with `ON DELETE CASCADE`, and the soft-delete endpoint sweeps the dependent rows in the same transaction.

- Migration `b1d4c9e57f02` — `appliance_id` FK on both server tables.
- Models: matching ORM columns.
- New `GET /appliances/{id}/dependents` endpoint — previews the rows the delete flow will sweep.
- `DELETE /appliances/{id}` now removes the dependents + audits the cascaded names.
- Frontend delete-confirm modal lists the dependent rows (matched by `appliance_id` OR `hostname`) so the operator sees the full blast radius before clicking Revoke.
- Tests: dependents preview, soft-delete cascade, zero-dependent edge case.
- **Deferred to follow-up**: wiring `appliance_id` at supervisor-driven register time. Today every dependent row is found via hostname-match, which works for legacy AND newly-registered rows. The FK column is forward-compatible.

### #165 — Timezone change post-install via GUI ✅

Full end-to-end pipeline from operator click → host `timedatectl`.

- Migration `c2e6a89d4b15` — `platform_settings.timezone` (empty = "follow install-time default").
- Backend: `SettingsResponse.timezone` + `SettingsUpdate.timezone` with `zoneinfo.ZoneInfo` field-validator (bad IANA names 422 before reaching the host runner).
- `SupervisorHeartbeatResponse.desired_timezone` carries the operator-set value.
- Supervisor `appliance_state.maybe_fire_timezone` writes `/var/lib/spatiumddi-host/release-state/tz-pending` when current and desired diverge.
- Host-side `spatiumddi-tz-reload` bash runner + `.path` + `.service` units. Validates against `timedatectl list-timezones` + applies via `timedatectl set-timezone`. Status sidecar surfaces failures.
- `mkosi.postinst` enables the new `.path` unit alongside the chrony / SNMP / firewall units.
- Frontend `TimezoneSection` inside the NTP tab. Text input backed by a `<datalist>` of `Intl.supportedValuesOf("timeZone")` (modern browsers) with a curated fallback for old browsers.

### #280 (partial) — Operator Copilot read tools ✅

7 new MCP read tools across 3 modules. Each surface gets default-enabled reads; the write tools (`propose_*`) are deferred to **#304** because each needs an `Operation` class with `preview()` + `apply()` methods (~50-80 lines × 17 tools).

- **Conformity** (NEW `tools/conformity.py`): `list_conformity_policies`, `find_conformity_results`, `get_conformity_summary`.
- **Webhooks** (NEW `tools/webhooks.py`): `list_webhooks` (secrets NEVER returned — `secret_set` boolean only), `get_webhook_event_types`, `find_webhook_deliveries`.
- **DNSSEC** (extended `tools/dns.py`): `find_zone_dnssec_info` (DS records + sync timestamp).

## Out of scope / deferred

- **#197 follow-up**: wire `appliance_id` into supervisor's register flow so new rows get the FK populated. Today hostname-match handles every case; the FK column is forward-compatible.
- **#280 → #304**: all 17 `propose_*` write tools (conformity / webhooks / backup / DNSSEC / DNS-import / multicast-domain / SNMP / NTP). Each needs an Operation class — substantial enough to warrant its own PR.

## Test plan

- `make ci`: ✅
- Venv-pinned `.venv/bin/{ruff,black,mypy}` on full repo (470 source files): ✅
- `tests/test_appliance_delete_dependents.py` + `tests/test_health.py` in dev container: 5/5 ✅
- **Real-hardware validation needed** post-merge: install fresh appliance ISO, exercise the delete-confirm modal + the timezone picker flow + verify the new MCP tools surface in the Operator Copilot's Tool Catalog.

## Linked issues

- Closes #197
- Closes #165
- Partial close of #280 (reads ✅; writes → #304)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
