### PR TITLE
CGNAT (RFC 6598) awareness — badge + New-Subnet hint (#42)

### DIFF
--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -1829,6 +1829,12 @@ class SubnetResponse(BaseModel):
     # ranges (issue #126 Phase 2). Operator-readable; not
     # operator-settable.
     kind: str = "unicast"
+    # Auto-derived (issue #42): True when ``network`` sits inside
+    # CGNAT space (RFC 6598, ``100.64.0.0/10``). Operator-readable,
+    # NOT operator-settable — computed from the CIDR, no column. Drives
+    # the "CGNAT" badge so operators don't mistake carrier-grade NAT /
+    # Tailscale-overlay space for a normal on-prem LAN.
+    is_cgnat: bool = False
     vlan_id: int | None
     vxlan_id: int | None
     vlan_ref_id: uuid.UUID | None = None
@@ -1874,6 +1880,16 @@ class SubnetResponse(BaseModel):
     @classmethod
     def coerce_inet(cls, v: Any) -> Any:
         return str(v) if v is not None else v
+
+    @model_validator(mode="after")
+    def _derive_is_cgnat(self) -> "SubnetResponse":
+        # Computed from the (already-coerced) network CIDR regardless of
+        # input shape, so the ``_attach_vlan`` dict path and the plain
+        # ORM path both get a correct value. See issue #42.
+        from app.services.ipam.classify import is_cgnat_cidr
+
+        self.is_cgnat = is_cgnat_cidr(self.network)
+        return self
 
     @model_validator(mode="before")
     @classmethod

--- a/backend/app/services/ipam/classify.py
+++ b/backend/app/services/ipam/classify.py
@@ -17,10 +17,13 @@ from typing import Final
 # non-private — but for split-horizon-publishing safety it's the same
 # class as RFC 1918: not routed on the public internet, so publishing
 # it through a public-facing resolver is a misconfiguration.
-_CGNAT_V4: Final = ipaddress.ip_network("100.64.0.0/10")
+# Constructed via the concrete IPv4Network (not ``ip_network``, which
+# infers the IPv4|IPv6 union) so ``subnet_of`` in ``is_cgnat_cidr``
+# type-checks against a definite IPv4Network arg.
+_CGNAT_V4: Final = ipaddress.IPv4Network("100.64.0.0/10")
 
 # Unique-Local Addresses (RFC 4193). Not on the public internet.
-_ULA_V6: Final = ipaddress.ip_network("fc00::/7")
+_ULA_V6: Final = ipaddress.IPv6Network("fc00::/7")
 
 
 def is_private_ip(value: str) -> bool:
@@ -52,4 +55,30 @@ def is_private_ip(value: str) -> bool:
     return False
 
 
-__all__ = ["is_private_ip"]
+def is_cgnat_cidr(value: str) -> bool:
+    """Return True when a network (CIDR) sits inside CGNAT space
+    (RFC 6598, ``100.64.0.0/10``).
+
+    Operator-facing classification only (issue #42): drives the
+    "CGNAT" subnet badge + the New-Subnet advisory hint. CGNAT is the
+    one reserved IPv4 range that's actively *allocated* by overlays
+    (Tailscale carves ``100.64.0.0/10`` per-tenant), so operators who
+    reach for it as a normal on-prem LAN hit silent overlap pain —
+    surfacing it is a footgun-preventer.
+
+    A leaf subnet is "CGNAT" when its whole CIDR is contained in
+    ``100.64.0.0/10``. Supernets that merely *overlap* (e.g. a
+    hypothetical ``100.0.0.0/8``) are not flagged — real managed
+    subnets are leaves well inside the range. IPv6 always returns
+    False (CGNAT is an IPv4-only concept).
+    """
+    try:
+        net = ipaddress.ip_network(value, strict=False)
+    except ValueError:
+        return False
+    if not isinstance(net, ipaddress.IPv4Network):
+        return False
+    return net.subnet_of(_CGNAT_V4)
+
+
+__all__ = ["is_private_ip", "is_cgnat_cidr"]

--- a/backend/tests/test_cgnat_classify.py
+++ b/backend/tests/test_cgnat_classify.py
@@ -1,0 +1,85 @@
+"""CGNAT (RFC 6598) awareness — issue #42.
+
+Operator-facing classification only: a "CGNAT" badge + New-Subnet
+hint driven off a computed property. These tests pin the classifier
+edge cases and the ``SubnetResponse`` derivation (no DB — the field
+is computed from the network CIDR, not a column).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.ipam.classify import is_cgnat_cidr
+
+
+@pytest.mark.parametrize(
+    "cidr,expected",
+    [
+        # Inside 100.64.0.0/10 (100.64.0.0 – 100.127.255.255).
+        ("100.64.0.0/10", True),  # the range itself
+        ("100.64.5.0/24", True),  # typical leaf
+        ("100.127.255.0/24", True),  # top of the range
+        ("100.100.100.100/32", True),  # single host
+        ("100.96.0.0/12", True),  # mid-range block
+        # Outside.
+        ("100.63.255.0/24", False),  # one below the range
+        ("100.128.0.0/24", False),  # one above the range
+        ("10.0.1.0/24", False),  # RFC 1918
+        ("192.168.1.0/24", False),  # RFC 1918
+        ("100.0.0.0/8", False),  # supernet that merely overlaps — not flagged
+        ("8.8.8.0/24", False),  # public
+        # IPv6 is never CGNAT.
+        ("2001:db8::/64", False),
+        ("fc00::/7", False),
+        # Malformed input degrades to False, never raises.
+        ("not-a-cidr", False),
+        ("", False),
+        # A bare IP coerces to /32 (strict=False); 100.64.0.0/32 is
+        # still inside CGNAT, so this is correctly True. SubnetResponse
+        # always carries a real CIDR, so this is just edge robustness.
+        ("100.64.0.0", True),
+    ],
+)
+def test_is_cgnat_cidr(cidr: str, expected: bool) -> None:
+    assert is_cgnat_cidr(cidr) is expected
+
+
+def _subnet_response(network: str):
+    from app.api.v1.ipam.router import SubnetResponse
+
+    return SubnetResponse(
+        id=uuid.uuid4(),
+        space_id=uuid.uuid4(),
+        block_id=uuid.uuid4(),
+        network=network,
+        name="t",
+        description="",
+        vlan_id=None,
+        vxlan_id=None,
+        gateway=None,
+        status="active",
+        utilization_percent=0.0,
+        total_ips=0,
+        allocated_ips=0,
+        dns_servers=None,
+        domain_name=None,
+        tags={},
+        custom_fields={},
+        dns_group_ids=None,
+        dns_zone_id=None,
+        dns_additional_zone_ids=None,
+        dns_inherit_settings=True,
+        created_at=datetime.now(UTC),
+        modified_at=datetime.now(UTC),
+    )
+
+
+def test_subnet_response_derives_cgnat_flag() -> None:
+    assert _subnet_response("100.64.10.0/24").is_cgnat is True
+    assert _subnet_response("10.0.1.0/24").is_cgnat is False
+    # IPv6 subnet — never CGNAT, must not raise on the derivation.
+    assert _subnet_response("2001:db8:1::/64").is_cgnat is False

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -492,6 +492,11 @@ export interface Subnet {
    *     groups are managed under /multicast/groups instead.
    */
   kind?: string;
+  // Auto-derived server-side (issue #42): true when ``network`` sits
+  // inside CGNAT space (RFC 6598, 100.64.0.0/10). Read-only — drives
+  // the "CGNAT" badge. Carrier-grade NAT space that overlays like
+  // Tailscale allocate, so it's worth flagging vs a normal LAN.
+  is_cgnat?: boolean;
   vlan_id: number | null;
   vxlan_id: number | null;
   vlan_ref_id?: string | null;

--- a/frontend/src/lib/cidr.ts
+++ b/frontend/src/lib/cidr.ts
@@ -49,11 +49,18 @@ export function cidrContains(parent: string, child: string): boolean {
  * 100.64.0.0/10). Mirrors the backend ``is_cgnat_cidr`` so the
  * New-Subnet modal can warn the operator live as they type, before
  * the server round-trip (issue #42). IPv6 / malformed input → false.
+ *
+ * A bare IPv4 with no prefix is coerced to /32 to match the backend
+ * (which parses with ``strict=False``), so e.g. ``100.64.5.5`` warns
+ * just like ``100.64.5.5/32`` does. Leading/trailing whitespace is
+ * trimmed for the same reason.
  */
 export function isCgnatCidr(cidr: string): boolean {
-  const c = parseCidr(cidr);
+  const trimmed = cidr.trim();
+  const normalized = trimmed.includes("/") ? trimmed : `${trimmed}/32`;
+  const c = parseCidr(normalized);
   if (!c) return false; // not a valid IPv4 CIDR (incl. any IPv6 input)
-  return cidrContains("100.64.0.0/10", cidr);
+  return cidrContains("100.64.0.0/10", normalized);
 }
 
 /**

--- a/frontend/src/lib/cidr.ts
+++ b/frontend/src/lib/cidr.ts
@@ -45,6 +45,18 @@ export function cidrContains(parent: string, child: string): boolean {
 }
 
 /**
+ * Return true when an IPv4 CIDR sits inside CGNAT space (RFC 6598,
+ * 100.64.0.0/10). Mirrors the backend ``is_cgnat_cidr`` so the
+ * New-Subnet modal can warn the operator live as they type, before
+ * the server round-trip (issue #42). IPv6 / malformed input → false.
+ */
+export function isCgnatCidr(cidr: string): boolean {
+  const c = parseCidr(cidr);
+  if (!c) return false; // not a valid IPv4 CIDR (incl. any IPv6 input)
+  return cidrContains("100.64.0.0/10", cidr);
+}
+
+/**
  * Convert a bare IP address (no prefix) to a BigInt for numeric ordering.
  * Works for both IPv4 ("10.0.0.0") and IPv6 ("2001:db8::1"). Returns 0n
  * for malformed input — callers should only feed strings that came from

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -119,7 +119,7 @@ import {
   MergeSubnetSiblingPicker,
   SplitSubnetModal,
 } from "./SubnetOpsModals";
-import { cidrContains, compareNetwork } from "@/lib/cidr";
+import { cidrContains, compareNetwork, isCgnatCidr } from "@/lib/cidr";
 import { FreeSpaceBand } from "@/components/ipam/FreeSpaceBand";
 import { PlanAllocationModal } from "@/components/ipam/PlanAllocationModal";
 import { AggregationCandidatesBadge } from "@/components/ipam/AggregationSuggestions";
@@ -2040,6 +2040,14 @@ function CreateSubnetModal({
               placeholder="e.g. 10.0.1.0/24 or 2001:db8:1::/64"
               autoFocus
             />
+            {isCgnatCidr(network) && (
+              <p className="mt-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300">
+                This is RFC 6598 carrier-grade NAT space (100.64.0.0/10).
+                Overlays like Tailscale allocate it per-tenant — double-check
+                before using it for a normal on-prem LAN, or you may hit silent
+                overlap with an overlay route.
+              </p>
+            )}
           </Field>
         ) : (
           <div className="space-y-2">
@@ -3911,6 +3919,14 @@ function SubnetDetail({
               title="Multicast subnet — addresses are stream identities, managed under /network/multicast"
             >
               multicast
+            </span>
+          )}
+          {subnet.is_cgnat && (
+            <span
+              className="inline-flex items-center rounded px-2 py-0.5 text-[11px] font-medium uppercase tracking-wider bg-amber-100 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400"
+              title="CGNAT space (RFC 6598, 100.64.0.0/10) — carrier-grade NAT, also the range overlays like Tailscale allocate. Not publicly routable; double-check before using for a normal on-prem LAN."
+            >
+              CGNAT
             </span>
           )}
           {subnet.name && (


### PR DESCRIPTION
Closes #42.

Operator-facing framing only — no allocation behaviour changes, no migration. `100.64.0.0/10` is the one reserved IPv4 range overlays actively *allocate* (Tailscale carves it per-tenant), so operators who reach for it as a normal on-prem LAN hit silent overlap with overlay routes. Surfacing it is a footgun-preventer.

**Backend**
- `is_cgnat_cidr(cidr)` in `services/ipam/classify.py` — True when a CIDR is fully contained in `100.64.0.0/10` (leaf subnets are well inside; an overlapping supernet is not flagged). IPv6 always False.
- `SubnetResponse.is_cgnat` — derived in a `mode="after"` validator from the network CIDR, so both the ORM and vlan-enriched dict paths get a correct value. Read-only; no column.
- CGNAT was already treated as private by `is_private_ip` (the #25 split-horizon guard), so it's already excluded from public-facing-resolver exposure — the "exclude from public-space reporting" half needs no code change.

**Frontend**
- `isCgnatCidr` in `lib/cidr.ts` mirrors the backend so the New-Subnet modal warns live as the operator types.
- Amber **CGNAT** badge on the subnet detail identity row (next to the multicast badge).
- Amber advisory hint under the New-Subnet manual-CIDR field for RFC 6598 space.

**Tests** — `backend/tests/test_cgnat_classify.py` (17 cases): classifier edge cases (range boundaries, supernet-overlap, IPv6, bare-IP→/32, malformed) + the `SubnetResponse` derivation.

`make ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
