### PR TITLE
DNS Views — end-to-end split-horizon rendering (#24)

### DIFF
--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -94,9 +94,7 @@ class Bind9Driver(DriverBase):
             dnssec = "no"
         fwd_block = ""
         if forwarders:
-            fwd_block = "    forwarders {{ {fs}; }};\n".format(
-                fs="; ".join(forwarders)
-            )
+            fwd_block = "    forwarders {{ {fs}; }};\n".format(fs="; ".join(forwarders))
 
         tsig_keys = bundle.get("tsig_keys") or []
         tsig_key_name = tsig_keys[0]["name"] if tsig_keys else None
@@ -104,11 +102,20 @@ class Bind9Driver(DriverBase):
             'include "/var/lib/spatium-dns-agent/tsig/ddns.key";\n' if tsig_keys else ""
         )
 
+        # Split-horizon (issue #24): when the group defines views, every
+        # zone — and every RPZ/response-policy — lives INSIDE a
+        # ``view { match-clients … }`` block. BIND9 forbids mixing
+        # top-level zones with views, so the global response-policy below
+        # is only emitted in the no-views path; with views it's rendered
+        # per-view further down.
+        views = bundle.get("views") or []
+        has_views = bool(views)
+
         # Response-policy block needs to list every RPZ zone we're about to
         # declare, otherwise BIND9 won't consult them on lookups.
         blocklists = bundle.get("blocklists") or []
         response_policy_block = ""
-        if blocklists:
+        if blocklists and not has_views:
             zones_list = "; ".join(
                 f'zone "{bl["rpz_zone_name"].rstrip(".")}"' for bl in blocklists
             )
@@ -120,9 +127,7 @@ class Bind9Driver(DriverBase):
                 f"    response-policy {{ {zones_list}; }} break-dnssec yes;\n"
             )
 
-        logging_block = (
-            _QUERY_LOG_BLOCK if bool(opts.get("query_log_enabled")) else ""
-        )
+        logging_block = _QUERY_LOG_BLOCK if bool(opts.get("query_log_enabled")) else ""
         conf = NAMED_CONF_SKELETON.format(
             recursion=recursion,
             allow_query=allow_query,
@@ -144,99 +149,155 @@ class Bind9Driver(DriverBase):
         if rndc_key_path.exists():
             conf += (
                 f'include "{rndc_key_path}";\n'
-                'controls {\n'
-                '    inet 127.0.0.1 port 953 allow { 127.0.0.1; } '
+                "controls {\n"
+                "    inet 127.0.0.1 port 953 allow { 127.0.0.1; } "
                 'keys { "spatium-rndc"; };\n'
-                '};\n'
+                "};\n"
             )
 
-        for zone in bundle.get("zones", []):
+        def _zone_stanza(zone: dict[str, Any], file_prefix: str) -> str:
+            """Build one ``zone "..." { ... };`` and write its zone file.
+
+            ``file_prefix`` namespaces the on-disk file (e.g.
+            ``"internal/"``) so the SAME zone name served from multiple
+            views doesn't clobber files (issue #24). Returns "" for a
+            zone that shouldn't be emitted (forward zone w/o upstreams).
+            """
             zname = zone.get("name") or ""
             if not zname:
-                continue
+                return ""
             zone_type = zone.get("type", "primary")
-            # Forward zones: BIND9 doesn't expect a file or allow-update — just
-            # a forwarders block. Skip the per-zone file write entirely.
+            # Forward zones: just a forwarders block, no file / allow-update.
             if zone_type == "forward":
                 fwds = [str(f) for f in (zone.get("forwarders") or []) if f]
                 if not fwds:
-                    # Forward zone with no upstreams is invalid — skip rather
-                    # than emit a malformed stanza.
-                    continue
-                forward_only = bool(zone.get("forward_only", True))
-                policy = "only" if forward_only else "first"
-                conf += (
-                    f'zone "{zname}" {{ type forward; '
-                    f"forward {policy}; "
+                    return ""
+                policy = "only" if bool(zone.get("forward_only", True)) else "first"
+                return (
+                    f'zone "{zname}" {{ type forward; forward {policy}; '
                     f'forwarders {{ {"; ".join(fwds)}; }}; }};\n'
                 )
-                continue
-            # Relative path used inside the rendered tree; absolute path
-            # written into named.conf so BIND9 doesn't resolve against its
-            # `directory` (which is /var/cache/bind, not our rendered tree).
-            rel_zfile = f"zones/{zname.rstrip('.')}.db"
-            current_dir = self.state_dir / self.rendered_dir_name
-            abs_zfile = current_dir / rel_zfile
+            # Relative path inside the rendered tree; absolute path written
+            # into named.conf so BIND9 doesn't resolve against its
+            # `directory` (/var/cache/bind, not our rendered tree).
+            rel_zfile = f"zones/{file_prefix}{zname.rstrip('.')}.db"
+            abs_zfile = self.state_dir / self.rendered_dir_name / rel_zfile
             bind_type = "master" if zone_type in {"primary", "master"} else "slave"
             allow_update = (
                 f'allow-update {{ key "{tsig_key_name}"; }}; ' if tsig_key_name else ""
             )
-            conf += (
-                f'zone "{zname}" {{ type {bind_type}; file "{abs_zfile}"; '
-                f'{allow_update}}};\n'
-            )
             if zone_type in {"primary", "master"}:
                 self._write_zone_file(new_dir / rel_zfile, zone)
-
-        # BIND9 catalog zone (RFC 9432). When the group has catalog zones
-        # enabled, the producer (is_primary=True) renders a master catalog
-        # zone whose contents describe every primary zone in the group.
-        # Consumers get a single `catalog-zones` directive in options{};
-        # BIND9 auto-pulls the catalog and creates each member zone as a
-        # secondary served from the producer.
-        catalog = bundle.get("catalog") or None
-        if catalog and catalog.get("mode") == "producer":
-            cname = catalog["zone_name"]
-            rel = f"zones/{cname.rstrip('.')}.db"
-            abs_zfile = self.state_dir / self.rendered_dir_name / rel
-            conf += (
-                f'zone "{cname}" {{ type master; file "{abs_zfile}"; '
-                f"allow-transfer {{ any; }}; notify yes; }};\n"
+            return (
+                f'zone "{zname}" {{ type {bind_type}; file "{abs_zfile}"; '
+                f"{allow_update}}};\n"
             )
-            self._write_catalog_zone_file(new_dir / rel, catalog)
-        elif catalog and catalog.get("mode") == "consumer":
-            cname = catalog["zone_name"]
-            producer_addr = (catalog.get("producer_addr") or "").strip()
-            if producer_addr:
-                # `catalog-zones` lives inside options{}; inject just before
-                # the closing brace of the options block we already rendered
-                # via NAMED_CONF_SKELETON. ``in-memory yes`` keeps the
-                # member zones cached in RAM so we don't litter the
-                # rendered tree with per-member files.
-                injection = (
-                    f"    catalog-zones {{ "
-                    f'zone "{cname}" default-masters {{ {producer_addr}; }} '
-                    f"in-memory yes; }};"
-                )
-                target = "    check-integrity no;"
-                if target in conf and injection not in conf:
-                    conf = conf.replace(target, target + "\n" + injection, 1)
 
-        # RPZ zones for blocklists. Each blocklist becomes a master zone named
-        # after its rpz_zone_name. Entries are rendered as CNAME records:
-        # - nxdomain     → CNAME .                  (synthesize NXDOMAIN)
-        # - sinkhole     → CNAME rpz-drop.          (drop silently)
-        # - redirect     → CNAME <target>.          (CNAME to target)
-        # Exceptions (allow-list) are CNAME rpz-passthru.  (explicit bypass)
-        for bl in blocklists:
+        def _rpz_stanza(bl: dict[str, Any], file_prefix: str) -> str:
+            """Build an RPZ ``zone "..." { ... };`` and write its file.
+
+            Entries render as CNAME records: nxdomain → CNAME .,
+            sinkhole → CNAME rpz-drop., redirect → CNAME <target>.,
+            exceptions → CNAME rpz-passthru.
+            """
             zname = bl["rpz_zone_name"]
-            rel = f"zones/{zname.rstrip('.')}.db"
+            rel = f"zones/{file_prefix}{zname.rstrip('.')}.db"
             abs_zfile = self.state_dir / self.rendered_dir_name / rel
-            conf += (
+            self._write_rpz_zone_file(new_dir / rel, bl)
+            return (
                 f'zone "{zname}" {{ type master; file "{abs_zfile}"; '
                 f"allow-query {{ localhost; }}; }};\n"
             )
-            self._write_rpz_zone_file(new_dir / rel, bl)
+
+        def _indent(text: str, spaces: int = 4) -> str:
+            pad = " " * spaces
+            return "".join(
+                (pad + ln if ln.strip() else ln)
+                for ln in text.splitlines(keepends=True)
+            )
+
+        if has_views:
+            # Split-horizon (issue #24): every zone + RPZ lives inside its
+            # view block. Group-level blocklists (view_name=None) replicate
+            # into EVERY view; per-view blocklists land only in their own
+            # view. Files are namespaced per view (zones/<view>/...) so
+            # identical zone names across views don't collide. Views are
+            # already ordered low→high by the control plane for first-match
+            # precedence.
+            global_bls = [bl for bl in blocklists if bl.get("view_name") is None]
+            for view in views:
+                vname = view.get("name") or ""
+                if not vname:
+                    continue
+                match_clients = "; ".join(
+                    str(c) for c in (view.get("match_clients") or ["any"])
+                )
+                recursion_v = "yes" if view.get("recursion", True) else "no"
+                view_bls = [
+                    bl for bl in blocklists if bl.get("view_name") == vname
+                ] + global_bls
+                body = ""
+                if view_bls:
+                    zlist = "; ".join(
+                        f'zone "{bl["rpz_zone_name"].rstrip(".")}"' for bl in view_bls
+                    )
+                    body += f"response-policy {{ {zlist}; }} break-dnssec yes;\n"
+                for zone in bundle.get("zones", []):
+                    if zone.get("view_name") != vname:
+                        continue
+                    body += _zone_stanza(zone, f"{vname}/")
+                for bl in view_bls:
+                    body += _rpz_stanza(bl, f"{vname}/")
+                md = view.get("match_destinations") or []
+                md_line = (
+                    f"    match-destinations {{ {'; '.join(str(m) for m in md)}; }};\n"
+                    if md
+                    else ""
+                )
+                conf += (
+                    f'view "{vname}" {{\n'
+                    f"    match-clients {{ {match_clients}; }};\n"
+                    f"{md_line}"
+                    f"    recursion {recursion_v};\n"
+                    f"{_indent(body)}"
+                    f"}};\n"
+                )
+        else:
+            for zone in bundle.get("zones", []):
+                conf += _zone_stanza(zone, "")
+
+            # BIND9 catalog zone (RFC 9432) — flat path only. Catalog + views
+            # is an unsupported combo in this cut (views render their own
+            # per-view zones); the producer/consumer wiring assumes top-level
+            # zones, which BIND9 forbids alongside views.
+            catalog = bundle.get("catalog") or None
+            if catalog and catalog.get("mode") == "producer":
+                cname = catalog["zone_name"]
+                rel = f"zones/{cname.rstrip('.')}.db"
+                abs_zfile = self.state_dir / self.rendered_dir_name / rel
+                conf += (
+                    f'zone "{cname}" {{ type master; file "{abs_zfile}"; '
+                    f"allow-transfer {{ any; }}; notify yes; }};\n"
+                )
+                self._write_catalog_zone_file(new_dir / rel, catalog)
+            elif catalog and catalog.get("mode") == "consumer":
+                cname = catalog["zone_name"]
+                producer_addr = (catalog.get("producer_addr") or "").strip()
+                if producer_addr:
+                    # `catalog-zones` lives inside options{}; inject before
+                    # the closing brace of the options block. ``in-memory
+                    # yes`` keeps member zones in RAM (no per-member files).
+                    injection = (
+                        f"    catalog-zones {{ "
+                        f'zone "{cname}" default-masters {{ {producer_addr}; }} '
+                        f"in-memory yes; }};"
+                    )
+                    target = "    check-integrity no;"
+                    if target in conf and injection not in conf:
+                        conf = conf.replace(target, target + "\n" + injection, 1)
+
+            for bl in blocklists:
+                conf += _rpz_stanza(bl, "")
 
         (new_dir / "named.conf").write_text(conf)
 
@@ -299,11 +360,14 @@ class Bind9Driver(DriverBase):
             # RFC 9432 §4.1: hash is SHA-1 of the *wire-format* zone
             # name (each label prefixed with its length byte, root null
             # byte at the end).
-            wire = b"".join(
-                bytes([len(label)]) + label.encode("ascii")
-                for label in text.split(".")
-                if label
-            ) + b"\x00"
+            wire = (
+                b"".join(
+                    bytes([len(label)]) + label.encode("ascii")
+                    for label in text.split(".")
+                    if label
+                )
+                + b"\x00"
+            )
             digest = hashlib.sha1(wire).hexdigest()
             text_with_dot = text + "." if text else "."
             lines.append(f"{digest}.zones IN PTR {text_with_dot}")
@@ -430,7 +494,9 @@ class Bind9Driver(DriverBase):
             res = subprocess.run(cmd, capture_output=True, text=True, check=False)
             rndc_ok = res.returncode == 0
             if not rndc_ok:
-                log.warning("rndc_failed_falling_back_to_sighup", stderr=res.stderr.strip())
+                log.warning(
+                    "rndc_failed_falling_back_to_sighup", stderr=res.stderr.strip()
+                )
         if not rndc_ok and self.daemon_pid:
             try:
                 os.kill(self.daemon_pid, signal.SIGHUP)
@@ -459,6 +525,7 @@ class Bind9Driver(DriverBase):
             # Very small parser — supports the one-line key we render above.
             content = tsig_path.read_text()
             import re
+
             m = re.search(r'key\s+"([^"]+)".*?secret\s+"([^"]+)"', content, re.DOTALL)
             if m:
                 keyring = dns.tsigkeyring.from_text({m.group(1): m.group(2)})
@@ -540,9 +607,7 @@ class Bind9Driver(DriverBase):
         # running unprivileged as ``spatium`` (entrypoint dropped privs
         # via su-exec), so don't pass ``-u`` — named would try to
         # setgid() to a different user and fail.
-        self.daemon_pid = subprocess.Popen(
-            ["named", "-f", "-c", str(conf_path)]
-        ).pid
+        self.daemon_pid = subprocess.Popen(["named", "-f", "-c", str(conf_path)]).pid
         log.info("named_started", pid=self.daemon_pid)
 
     def daemon_running(self) -> bool:

--- a/agent/dns/tests/test_views_render.py
+++ b/agent/dns/tests/test_views_render.py
@@ -1,0 +1,237 @@
+"""DNS Views — split-horizon BIND9 rendering on the agent (issue #24).
+
+The agent receives a long-poll bundle whose zones are pre-expanded
+per view (each zone copy tagged with ``view_name`` and carrying only
+that view's records) and renders ``named.conf`` with one ``view { … }``
+block per view, plus per-view zone files so an identical zone name in
+two views doesn't clobber files.
+
+These tests exercise ``Bind9Driver.render`` against hand-built bundles
+shaped exactly like ``app.services.dns.agent_config.build_config_bundle``
+emits.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from spatium_dns_agent.drivers.bind9 import Bind9Driver
+
+
+def _zone(name: str, view_name: str | None, records: list[dict]) -> dict:
+    return {
+        "id": name,
+        "name": name,
+        "type": "primary",
+        "ttl": 3600,
+        "forwarders": [],
+        "forward_only": True,
+        "view_name": view_name,
+        "records": records,
+    }
+
+
+def _split_horizon_bundle() -> dict:
+    # Same zone "example.com." served two ways: internal clients see the
+    # RFC 1918 address, external clients see the public one; the MX is
+    # shared (view_name folded to NULL on the control plane → present in
+    # both view copies).
+    internal_recs = [
+        {
+            "name": "www",
+            "type": "A",
+            "ttl": 300,
+            "value": "10.0.0.1",
+            "priority": None,
+            "weight": None,
+            "port": None,
+        },
+        {
+            "name": "@",
+            "type": "MX",
+            "ttl": 3600,
+            "value": "mail.example.com.",
+            "priority": 10,
+            "weight": None,
+            "port": None,
+        },
+    ]
+    external_recs = [
+        {
+            "name": "www",
+            "type": "A",
+            "ttl": 300,
+            "value": "203.0.113.10",
+            "priority": None,
+            "weight": None,
+            "port": None,
+        },
+        {
+            "name": "@",
+            "type": "MX",
+            "ttl": 3600,
+            "value": "mail.example.com.",
+            "priority": 10,
+            "weight": None,
+            "port": None,
+        },
+    ]
+    return {
+        "options": {"recursion_enabled": True, "allow_query": ["any"]},
+        "views": [
+            {
+                "id": "v1",
+                "name": "internal",
+                "match_clients": ["10.0.0.0/8"],
+                "match_destinations": [],
+                "recursion": True,
+                "order": 0,
+            },
+            {
+                "id": "v2",
+                "name": "external",
+                "match_clients": ["any"],
+                "match_destinations": [],
+                "recursion": False,
+                "order": 1,
+            },
+        ],
+        "zones": [
+            _zone("example.com.", "internal", internal_recs),
+            _zone("example.com.", "external", external_recs),
+        ],
+        "tsig_keys": [],
+        "blocklists": [],
+    }
+
+
+def test_render_wraps_zones_in_view_blocks(tmp_path: Path) -> None:
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(_split_horizon_bundle())
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+
+    # One view block per view, with the right match-clients + recursion.
+    assert 'view "internal" {' in conf
+    assert 'view "external" {' in conf
+    assert "match-clients { 10.0.0.0/8; };" in conf
+    # internal recursion yes, external recursion no. Internal (order 0)
+    # is emitted before external (order 1), so the internal block is the
+    # text between the two view headers.
+    internal_block = conf.split('view "internal" {', 1)[1].split(
+        'view "external" {', 1
+    )[0]
+    external_block = conf.split('view "external" {', 1)[1]
+    assert "recursion yes;" in internal_block
+    assert "recursion no;" in external_block
+
+    # The zone appears inside BOTH view blocks, each pointing at a
+    # per-view zone file (no clobber).
+    assert "zones/internal/example.com.db" in conf
+    assert "zones/external/example.com.db" in conf
+
+
+def test_per_view_zone_files_hold_view_scoped_records(tmp_path: Path) -> None:
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(_split_horizon_bundle())
+    zdir = tmp_path / "rendered.new" / "zones"
+
+    internal_zone = (zdir / "internal" / "example.com.db").read_text()
+    external_zone = (zdir / "external" / "example.com.db").read_text()
+
+    # Split horizon: the same name resolves differently per view.
+    assert "www 300 IN A 10.0.0.1" in internal_zone
+    assert "10.0.0.1" not in external_zone
+    assert "www 300 IN A 203.0.113.10" in external_zone
+    assert "203.0.113.10" not in internal_zone
+    # Shared record present in both.
+    assert "mail.example.com." in internal_zone
+    assert "mail.example.com." in external_zone
+
+
+def test_no_views_keeps_flat_render(tmp_path: Path) -> None:
+    # Backward-compat: a bundle with no views renders flat (no view {}
+    # blocks, zone file at zones/<name>.db).
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(
+        {
+            "options": {"recursion_enabled": True, "allow_query": ["any"]},
+            "views": [],
+            "zones": [
+                _zone(
+                    "flat.example.",
+                    None,
+                    [
+                        {
+                            "name": "a",
+                            "type": "A",
+                            "ttl": 300,
+                            "value": "192.0.2.1",
+                            "priority": None,
+                            "weight": None,
+                            "port": None,
+                        }
+                    ],
+                )
+            ],
+            "tsig_keys": [],
+            "blocklists": [],
+        }
+    )
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+    assert 'view "' not in conf
+    assert 'zone "flat.example." {' in conf
+    assert (tmp_path / "rendered.new" / "zones" / "flat.example.db").exists()
+
+
+def test_global_zone_renders_into_every_view(tmp_path: Path) -> None:
+    # A zone with view_name set per the control-plane "global zone →
+    # every view" expansion: here we simulate it by emitting the same
+    # zone for both views with identical records.
+    recs = [
+        {
+            "name": "shared",
+            "type": "A",
+            "ttl": 300,
+            "value": "198.51.100.5",
+            "priority": None,
+            "weight": None,
+            "port": None,
+        }
+    ]
+    bundle = {
+        "options": {"recursion_enabled": True, "allow_query": ["any"]},
+        "views": [
+            {
+                "id": "v1",
+                "name": "internal",
+                "match_clients": ["10.0.0.0/8"],
+                "match_destinations": [],
+                "recursion": True,
+                "order": 0,
+            },
+            {
+                "id": "v2",
+                "name": "external",
+                "match_clients": ["any"],
+                "match_destinations": [],
+                "recursion": True,
+                "order": 1,
+            },
+        ],
+        "zones": [
+            _zone("global.example.", "internal", recs),
+            _zone("global.example.", "external", recs),
+        ],
+        "tsig_keys": [],
+        "blocklists": [],
+    }
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(bundle)
+    zdir = tmp_path / "rendered.new" / "zones"
+    assert (zdir / "internal" / "global.example.db").exists()
+    assert (zdir / "external" / "global.example.db").exists()
+    for v in ("internal", "external"):
+        assert (
+            "shared 300 IN A 198.51.100.5"
+            in (zdir / v / "global.example.db").read_text()
+        )

--- a/backend/app/drivers/dns/base.py
+++ b/backend/app/drivers/dns/base.py
@@ -141,6 +141,12 @@ class EffectiveBlocklistData:
     rpz_zone_name: str  # e.g. "spatium-blocklist.rpz."
     entries: tuple[BlocklistEntry, ...]
     exceptions: frozenset[str]
+    # Issue #24 — which view this RPZ belongs to. ``None`` = group-level
+    # (global; rendered into every view, or top-level when no views
+    # exist). When views exist, RPZ zones + the response-policy directive
+    # must live INSIDE the owning view block — BIND9 forbids top-level
+    # ``zone {}`` alongside ``view {}``.
+    view_name: str | None = None
 
 
 @dataclass
@@ -179,6 +185,7 @@ class ConfigBundle:
             "blocklists": [
                 {
                     "rpz_zone_name": b.rpz_zone_name,
+                    "view_name": b.view_name,
                     "entries": [asdict(e) for e in b.entries],
                     "exceptions": sorted(b.exceptions),
                 }

--- a/backend/app/drivers/dns/bind9.py
+++ b/backend/app/drivers/dns/bind9.py
@@ -113,7 +113,10 @@ class BIND9Driver(DNSDriver):
             server_name = bundle.server_name
             generated_at = bundle.generated_at.isoformat() if bundle.generated_at else ""
 
-        zone_stanzas = {z.name: self.render_zone_config(z) for z in zones}
+        # Key by (view_name, name): under split-horizon (issue #24) the same
+        # zone name appears once per view, so a name-only key would collapse
+        # the copies and drop all but one view's stanza from the preview.
+        zone_stanzas = {(z.view_name, z.name): self.render_zone_config(z) for z in zones}
 
         return tmpl.render(
             server_id=str(server_id),

--- a/backend/app/drivers/dns/templates/bind9/named.conf.j2
+++ b/backend/app/drivers/dns/templates/bind9/named.conf.j2
@@ -81,14 +81,14 @@ view "{{ view.name }}" {
     recursion {{ "yes" if view.recursion else "no" }};
 {%- for zone in zones %}
 {%- if zone.view_name == view.name %}
-{{ zone_stanzas[zone.name] | indent(4, true) }}
+{{ zone_stanzas[(zone.view_name, zone.name)] | indent(4, true) }}
 {%- endif %}
 {%- endfor %}
 };
 {% endfor %}
 {%- else %}
 {%- for zone in zones %}
-{{ zone_stanzas[zone.name] }}
+{{ zone_stanzas[(zone.view_name, zone.name)] }}
 {%- endfor %}
 {%- endif %}
 

--- a/backend/app/drivers/dns/templates/bind9/named.conf.j2
+++ b/backend/app/drivers/dns/templates/bind9/named.conf.j2
@@ -73,16 +73,27 @@ key "{{ key.name }}" {
 
 {%- if views %}
 {%- for view in views %}
+{# Per-view RPZ (issue #24): each view owns its blocklist + the
+   response-policy directive. ``view_name == none`` is a group-level
+   blocklist that applies to EVERY view; BIND9 forbids top-level
+   ``zone {}`` alongside views, so RPZ can't be hoisted out. #}
+{%- set view_bls = blocklists | selectattr("view_name", "in", [view.name, none]) | list %}
 view "{{ view.name }}" {
     match-clients { {% for c in view.match_clients %}{{ c }}; {% endfor %}};
     {%- if view.match_destinations %}
     match-destinations { {% for c in view.match_destinations %}{{ c }}; {% endfor %}};
     {%- endif %}
     recursion {{ "yes" if view.recursion else "no" }};
+    {%- if view_bls %}
+    response-policy { {% for bl in view_bls %}zone "{{ bl.rpz_zone_name }}"; {% endfor %}} break-dnssec yes;
+    {%- endif %}
 {%- for zone in zones %}
 {%- if zone.view_name == view.name %}
 {{ zone_stanzas[(zone.view_name, zone.name)] | indent(4, true) }}
 {%- endif %}
+{%- endfor %}
+{%- for bl in view_bls %}
+    zone "{{ bl.rpz_zone_name }}" { type primary; file "/var/cache/bind/rpz/{{ view.name }}/{{ bl.rpz_zone_name }}db"; allow-query { none; }; };
 {%- endfor %}
 };
 {% endfor %}
@@ -90,8 +101,6 @@ view "{{ view.name }}" {
 {%- for zone in zones %}
 {{ zone_stanzas[(zone.view_name, zone.name)] }}
 {%- endfor %}
-{%- endif %}
-
 {%- for bl in blocklists %}
 zone "{{ bl.rpz_zone_name }}" {
     type primary;
@@ -99,3 +108,4 @@ zone "{{ bl.rpz_zone_name }}" {
     allow-query { none; };
 };
 {%- endfor %}
+{%- endif %}

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -97,6 +97,12 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     # Views
     views_res = await db.execute(select(DNSView).where(DNSView.group_id == server.group_id))
     views = views_res.scalars().all()
+    # Split-horizon (issue #24). When the group defines views, every zone is
+    # rendered INSIDE a ``view { match-clients … }`` block and records are
+    # scoped per view (``DNSRecord.view_id``; NULL = shared across all
+    # views). Lower ``order`` first → BIND first-match precedence.
+    has_views = bool(views)
+    ordered_views = sorted(views, key=lambda v: (v.order, v.name))
 
     # ACLs
     acls_res = await db.execute(
@@ -110,9 +116,20 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     zones_res = await db.execute(select(DNSZone).where(DNSZone.group_id == server.group_id))
     zones = zones_res.scalars().all()
 
+    def _rec_dict(r: DNSRecord) -> dict[str, Any]:
+        return {
+            "name": r.name,
+            "type": r.record_type,
+            "ttl": r.ttl,
+            "value": r.value,
+            "priority": r.priority,
+            "weight": r.weight,
+            "port": r.port,
+        }
+
     zone_payload: list[dict[str, Any]] = []
     for z in zones:
-        zp: dict[str, Any] = {
+        base_zp: dict[str, Any] = {
             "id": str(z.id),
             "name": getattr(z, "name", None) or getattr(z, "fqdn", None),
             "type": getattr(z, "zone_type", "primary"),
@@ -125,20 +142,41 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         # historically gated this, but agents need records to render zone
         # files for serving — primary/secondary distinction matters for
         # accepting RFC 2136 updates, not for which server gets the data.
-        rec_res = await db.execute(select(DNSRecord).where(DNSRecord.zone_id == z.id))
-        zp["records"] = [
-            {
-                "name": r.name,
-                "type": r.record_type,
-                "ttl": r.ttl,
-                "value": r.value,
-                "priority": r.priority,
-                "weight": r.weight,
-                "port": r.port,
-            }
-            for r in rec_res.scalars().all()
-        ]
-        zone_payload.append(zp)
+        rec_rows = list(
+            (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == z.id))).scalars().all()
+        )
+
+        if not has_views:
+            # Flat render — one zone copy, all records, no view (today's path).
+            zone_payload.append(
+                {**base_zp, "view_name": None, "records": [_rec_dict(r) for r in rec_rows]}
+            )
+            continue
+
+        # Split-horizon expansion (issue #24). The zone materialises in
+        # every view it has content for: each view referenced by a scoped
+        # record PLUS the zone's own pinned ``view_id``. With no explicit
+        # scoping the zone is "global" — rendered into EVERY view with all
+        # records (also fixes the prior gap where a view-group zone with no
+        # ``view_id`` rendered in no view at all). Per view, the record set
+        # is (scoped-to-this-view) ∪ (shared, i.e. ``view_id IS NULL``).
+        record_view_ids = {r.view_id for r in rec_rows if r.view_id is not None}
+        zone_view_ids = {z.view_id} if z.view_id is not None else set()
+        target_view_ids = record_view_ids | zone_view_ids
+        emit_views = (
+            [v for v in ordered_views if v.id in target_view_ids]
+            if target_view_ids
+            else list(ordered_views)
+        )
+        for v in emit_views:
+            recs = (
+                [r for r in rec_rows if r.view_id == v.id or r.view_id is None]
+                if target_view_ids
+                else rec_rows
+            )
+            zone_payload.append(
+                {**base_zp, "view_name": v.name, "records": [_rec_dict(r) for r in recs]}
+            )
 
     # Pending record ops — every agent-based server in the group
     # gets its own queue (one op row per server per record change,
@@ -158,8 +196,33 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     # Issue #182: pause pending-op dispatch when the server is in
     # operator-set maintenance mode. Ops accumulate in ``state=pending``
     # and ship as soon as the operator resumes — no work is lost.
+    ops_to_dispatch: list[DNSRecordOp] = []
     if server.maintenance_mode:
-        ops_to_dispatch: list[DNSRecordOp] = []
+        pass
+    elif has_views:
+        # Split-horizon: the incremental RFC 2136 path can't target a
+        # specific view (an nsupdate to loopback lands in whichever view
+        # matches 127.0.0.1, not necessarily the record's view). Records
+        # are folded into the structural fingerprint below so every record
+        # change triggers a full, view-correct re-render instead. Retire any
+        # queued ops as ``applied`` — the bundle the agent is about to render
+        # already reflects them — so they don't pile up in ``pending``.
+        stale_ops = (
+            (
+                await db.execute(
+                    select(DNSRecordOp).where(
+                        DNSRecordOp.server_id == server.id,
+                        DNSRecordOp.state.in_(("pending", "in_flight")),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for op in stale_ops:
+            op.state = "applied"
+        if stale_ops:
+            await db.flush()
     else:
         op_res = await db.execute(
             select(DNSRecordOp)
@@ -233,9 +296,14 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         {
             "id": str(v.id),
             "name": v.name,
-            "match_clients": getattr(v, "match_clients", []),
+            "match_clients": getattr(v, "match_clients", []) or ["any"],
+            "match_destinations": getattr(v, "match_destinations", []) or [],
+            "recursion": bool(getattr(v, "recursion", True)),
+            "order": getattr(v, "order", 0),
         }
-        for v in views
+        # Ordered low→high so the rendered view blocks honour BIND's
+        # first-match-wins precedence (issue #24).
+        for v in ordered_views
     ]
     acls_block = [{"id": str(a.id), "name": a.name} for a in acls]
 
@@ -300,6 +368,10 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
                         "rpz_zone_name": f"spatium-blocklist-{v.name}.rpz.",
                         "entries": _entries_payload(eff_v.entries),
                         "exceptions": sorted(eff_v.exceptions),
+                        # Issue #24 — when views exist, RPZ zones + the
+                        # response-policy directive must live INSIDE the
+                        # owning view block, not at global options scope.
+                        "view_name": v.name,
                     }
                 )
     eff_g = await build_effective_for_group(db, server.group_id)
@@ -309,6 +381,10 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
                 "rpz_zone_name": "spatium-blocklist.rpz.",
                 "entries": _entries_payload(eff_g.entries),
                 "exceptions": sorted(eff_g.exceptions),
+                # Group-level blocklist. With views, it applies to EVERY
+                # view (rendered into each); with no views it's the single
+                # global RPZ as before. ``view_name=None`` marks it global.
+                "view_name": None,
             }
         )
 
@@ -384,7 +460,15 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         "views": views_block,
         "acls": acls_block,
         "tsig_keys": tsig_keys,
-        "zones_structural": [{k: v for k, v in z.items() if k != "records"} for z in zone_payload],
+        # Records are normally excluded so a record-only change rides the
+        # incremental RFC 2136 path without a full reload. But under
+        # split-horizon (issue #24) the incremental path can't target a
+        # view, so records are folded in here — any record/view change then
+        # shifts the structural etag and triggers a full, view-correct
+        # re-render. ``view_name`` is always retained either way.
+        "zones_structural": [
+            {k: val for k, val in z.items() if (k != "records" or has_views)} for z in zone_payload
+        ],
         # Blocklists affect named.conf (response-policy block) + RPZ zone
         # files, so a change MUST trigger a daemon reload.
         "blocklists": blocklists_payload,

--- a/backend/app/services/dns/config_bundle.py
+++ b/backend/app/services/dns/config_bundle.py
@@ -49,9 +49,12 @@ def _tuple_or_none(v: list | None) -> tuple[str, ...] | None:
     return tuple(str(x) for x in v)
 
 
-def _to_blocklist_data(eff: EffectiveBlocklist, rpz_name: str) -> EffectiveBlocklistData:
+def _to_blocklist_data(
+    eff: EffectiveBlocklist, rpz_name: str, view_name: str | None = None
+) -> EffectiveBlocklistData:
     return EffectiveBlocklistData(
         rpz_zone_name=rpz_name,
+        view_name=view_name,
         entries=tuple(
             BlocklistEntry(
                 domain=e.domain,
@@ -249,7 +252,9 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         for v in view_rows:
             eff = await build_effective_for_view(db, v.id)
             if eff.entries:
-                blocklists.append(_to_blocklist_data(eff, f"spatium-blocklist-{v.name}.rpz."))
+                blocklists.append(
+                    _to_blocklist_data(eff, f"spatium-blocklist-{v.name}.rpz.", view_name=v.name)
+                )
     else:
         eff = await build_effective_for_group(db, server.group_id)
         if eff.entries:

--- a/backend/app/services/dns/config_bundle.py
+++ b/backend/app/services/dns/config_bundle.py
@@ -10,7 +10,6 @@ module and the driver layer share the exact same definition. See
 
 from __future__ import annotations
 
-import uuid
 from datetime import UTC, datetime
 
 from sqlalchemy import select
@@ -31,6 +30,7 @@ from app.drivers.dns.base import (
 )
 from app.models.dns import (
     DNSAcl,
+    DNSRecord,
     DNSServer,
     DNSServerOptions,
     DNSView,
@@ -151,7 +151,6 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         )
         for v in view_rows
     )
-    view_by_id: dict[uuid.UUID, DNSView] = {v.id: v for v in view_rows}
 
     # Zones + records
     zone_rows = (
@@ -166,44 +165,83 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         .all()
     )
 
+    # Stable view ordering — lower ``order`` first, matching BIND's
+    # first-match-wins view semantics so the rendered named.conf view
+    # blocks land in the right precedence.
+    ordered_views = sorted(view_rows, key=lambda v: (v.order, v.name))
+    has_views = bool(view_rows)
+
+    def _record_data(r: DNSRecord) -> RecordData:
+        return RecordData(
+            name=r.name,
+            record_type=r.record_type,
+            value=r.value,
+            ttl=r.ttl,
+            priority=r.priority,
+            weight=r.weight,
+            port=r.port,
+        )
+
+    def _zone_data(z: DNSZone, records: tuple[RecordData, ...], view_name: str | None) -> ZoneData:
+        return ZoneData(
+            name=z.name,
+            zone_type=z.zone_type,
+            kind=z.kind,
+            ttl=z.ttl,
+            refresh=z.refresh,
+            retry=z.retry,
+            expire=z.expire,
+            minimum=z.minimum,
+            primary_ns=z.primary_ns or "",
+            admin_email=z.admin_email or "",
+            serial=z.last_serial or 0,
+            records=records,
+            allow_query=_tuple_or_none(z.allow_query),
+            allow_transfer=_tuple_or_none(z.allow_transfer),
+            also_notify=_tuple_or_none(z.also_notify),
+            notify_enabled=z.notify_enabled,
+            view_name=view_name,
+            forwarders=tuple(z.forwarders or ()),
+            forward_only=bool(z.forward_only),
+        )
+
     zones: list[ZoneData] = []
     for z in zone_rows:
-        records = tuple(
-            RecordData(
-                name=r.name,
-                record_type=r.record_type,
-                value=r.value,
-                ttl=r.ttl,
-                priority=r.priority,
-                weight=r.weight,
-                port=r.port,
-            )
-            for r in z.records
-        )
-        view_name = view_by_id[z.view_id].name if z.view_id in view_by_id else None
-        zones.append(
-            ZoneData(
-                name=z.name,
-                zone_type=z.zone_type,
-                kind=z.kind,
-                ttl=z.ttl,
-                refresh=z.refresh,
-                retry=z.retry,
-                expire=z.expire,
-                minimum=z.minimum,
-                primary_ns=z.primary_ns or "",
-                admin_email=z.admin_email or "",
-                serial=z.last_serial or 0,
-                records=records,
-                allow_query=_tuple_or_none(z.allow_query),
-                allow_transfer=_tuple_or_none(z.allow_transfer),
-                also_notify=_tuple_or_none(z.also_notify),
-                notify_enabled=z.notify_enabled,
-                view_name=view_name,
-                forwarders=tuple(z.forwarders or ()),
-                forward_only=bool(z.forward_only),
-            )
-        )
+        all_records = list(z.records)
+
+        if not has_views:
+            # No views in the group — flat render with every record
+            # (the historical behaviour, byte-for-byte).
+            zones.append(_zone_data(z, tuple(_record_data(r) for r in all_records), None))
+            continue
+
+        # Split-horizon (issue #24). A record with ``view_id IS NULL`` is
+        # SHARED across every view it appears in; a record scoped to view X
+        # renders only in X. The zone must materialise in every view it has
+        # content for:
+        #   * each view referenced by a scoped record, plus
+        #   * the zone's own ``view_id`` (its pinned/home view), if any.
+        # When the zone has NO explicit scoping at all, it's a "global"
+        # zone — render it into EVERY view (visible everywhere) with all
+        # records. This also fixes the latent gap where a view-group zone
+        # with no ``view_id`` previously rendered in NO view at all.
+        record_view_ids = {r.view_id for r in all_records if r.view_id is not None}
+        zone_view_ids = {z.view_id} if z.view_id is not None else set()
+        target_view_ids = record_view_ids | zone_view_ids
+
+        if target_view_ids:
+            emit_views = [v for v in ordered_views if v.id in target_view_ids]
+        else:
+            emit_views = list(ordered_views)
+
+        for v in emit_views:
+            if target_view_ids:
+                recs = tuple(
+                    _record_data(r) for r in all_records if r.view_id == v.id or r.view_id is None
+                )
+            else:
+                recs = tuple(_record_data(r) for r in all_records)
+            zones.append(_zone_data(z, recs, v.name))
 
     # Blocklists: one RPZ zone per view if views present, plus group-level.
     blocklists: list[EffectiveBlocklistData] = []

--- a/backend/tests/test_dns_driver.py
+++ b/backend/tests/test_dns_driver.py
@@ -19,6 +19,7 @@ from app.drivers.dns.base import (
     ServerOptions,
     TrustAnchorData,
     TsigKey,
+    ViewData,
     ZoneData,
 )
 from app.drivers.dns.bind9 import BIND9Driver
@@ -168,6 +169,69 @@ def test_render_server_config_includes_acl_and_forwarders(bundle: ConfigBundle) 
     assert 'zone "example.com."' in out
     # No view wrapping when views=()
     assert 'view "' not in out
+
+
+def test_render_server_config_split_horizon_views() -> None:
+    """Issue #24: the same zone name materialises once per view (with
+    each view's filtered records pre-expanded by the bundle builder),
+    and the driver wraps each copy in its own ``view { … }`` block —
+    the stanza dict is keyed by (view_name, name) so the copies don't
+    collapse."""
+
+    def _z(view_name: str) -> ZoneData:
+        return ZoneData(
+            name="example.com.",
+            zone_type="primary",
+            kind="forward",
+            ttl=3600,
+            refresh=86400,
+            retry=7200,
+            expire=3600000,
+            minimum=3600,
+            primary_ns="ns1.example.com.",
+            admin_email="hostmaster.example.com.",
+            serial=2026041401,
+            records=(),
+            view_name=view_name,
+        )
+
+    b = ConfigBundle(
+        server_id=str(uuid.uuid4()),
+        server_name="ns1",
+        driver="bind9",
+        roles=("authoritative",),
+        options=ServerOptions(),
+        acls=(),
+        views=(
+            ViewData(
+                name="internal",
+                match_clients=("10.0.0.0/8",),
+                match_destinations=(),
+                recursion=True,
+                order=0,
+            ),
+            ViewData(
+                name="external",
+                match_clients=("any",),
+                match_destinations=(),
+                recursion=False,
+                order=1,
+            ),
+        ),
+        zones=(_z("internal"), _z("external")),
+        tsig_keys=(),
+        blocklists=(),
+        generated_at=datetime(2026, 4, 14, 12, 0, tzinfo=UTC),
+    )
+    out = BIND9Driver().render_server_config(
+        SimpleNamespace(id=b.server_id, name=b.server_name), b.options, bundle=b
+    )
+    assert 'view "internal" {' in out
+    assert 'view "external" {' in out
+    assert "match-clients { 10.0.0.0/8; };" in out
+    # The zone stanza appears inside BOTH view blocks (keyed by
+    # (view_name, name), so neither copy is dropped).
+    assert out.count('zone "example.com."') == 2
 
 
 # ── RPZ rendering ─────────────────────────────────────────────────────────

--- a/backend/tests/test_dns_driver.py
+++ b/backend/tests/test_dns_driver.py
@@ -234,6 +234,62 @@ def test_render_server_config_split_horizon_views() -> None:
     assert out.count('zone "example.com."') == 2
 
 
+def test_render_server_config_views_put_rpz_inside_view() -> None:
+    """Issue #24 (review): with views present, RPZ zones + the
+    response-policy directive must render INSIDE the owning view block,
+    never at the top level — BIND9 rejects top-level ``zone {}``
+    alongside ``view {}``. A ``view_name=None`` blocklist is group-level
+    and replicates into every view."""
+    b = ConfigBundle(
+        server_id=str(uuid.uuid4()),
+        server_name="ns1",
+        driver="bind9",
+        roles=("authoritative",),
+        options=ServerOptions(),
+        acls=(),
+        views=(
+            ViewData(
+                name="internal",
+                match_clients=("10.0.0.0/8",),
+                match_destinations=(),
+                recursion=True,
+                order=0,
+            ),
+        ),
+        zones=(),
+        tsig_keys=(),
+        blocklists=(
+            EffectiveBlocklistData(
+                rpz_zone_name="spatium-blocklist-internal.rpz.",
+                entries=(
+                    BlocklistEntry(
+                        domain="ads.example.com",
+                        action="block",
+                        block_mode="nxdomain",
+                        sinkhole_ip=None,
+                        target=None,
+                        is_wildcard=False,
+                    ),
+                ),
+                exceptions=frozenset(),
+                view_name="internal",
+            ),
+        ),
+        generated_at=datetime(2026, 4, 14, 12, 0, tzinfo=UTC),
+    )
+    out = BIND9Driver().render_server_config(
+        SimpleNamespace(id=b.server_id, name=b.server_name), b.options, bundle=b
+    )
+    # The RPZ zone declaration + response-policy live inside the view
+    # block, not at top level. Slice from the view header onward.
+    view_block = out.split('view "internal" {', 1)[1]
+    assert "response-policy {" in view_block
+    assert 'zone "spatium-blocklist-internal.rpz.";' in view_block
+    # And the RPZ zone is NOT declared before the view block opens.
+    preamble = out.split('view "internal" {', 1)[0]
+    assert 'zone "spatium-blocklist-internal.rpz." {' not in preamble
+
+
 # ── RPZ rendering ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #24.

The storage (`DNSView` + `DNSZone.view_id` + `DNSRecord.view_id`), CRUD API (`view_id` flows through create/update/list), and the record-form view picker all already shipped. The remaining gap was purely **rendering**: the agent ignored `views` entirely and rendered a flat zone list, so a zone could only ever live in one place and per-record view scoping was dropped on the floor. This wires the full split-horizon render. **BIND9 path only** — PowerDNS keeps its existing 422 view-gate.

**Per-view expansion** (both bundle builders — `agent_config.py` is the live agent path, `config_bundle.py` the driver preview/validate path):
- A record with `view_id IS NULL` is **shared** across every view; a record scoped to view X renders only in X.
- A zone materialises in every view it has content for: each view referenced by a scoped record **plus** its own pinned `view_id`.
- A zone with no explicit scoping is "global" — rendered into every view (also fixes the latent gap where a view-group zone with no `view_id` previously rendered in **no** view at all).
- No views in the group → flat render, byte-for-byte as before.

**Agent BIND9 driver**
- Emits one `view "<name>" { match-clients …; recursion …; }` block per view (ordered low→high for BIND first-match), zone stanzas + RPZ inside.
- Per-view zone files (`zones/<view>/<name>.db`) so the same zone name in two views doesn't clobber.
- RPZ/response-policy moves into each view block when views exist (BIND forbids top-level zones alongside views); group-level blocklists replicate into every view. Catalog zones stay flat-path-only (catalog + views unsupported this cut).

**Re-render correctness** — when views exist, records are folded into the structural fingerprint (incremental RFC 2136 can't target a view), and queued ops are retired as `applied`.

**Control-plane preview** — `zone_stanzas` re-keyed by `(view_name, name)` so duplicate zone names across views aren't collapsed.

**Tests** — `agent/dns/tests/test_views_render.py` (4 cases: view blocks render; per-view zone files hold the view-scoped record set; shared records in both; no-views flat; global zone in every view) + a control-plane split-horizon render test in `test_dns_driver.py`.

`make ci` clean; agent ruff/black/tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
