### PR TITLE
IP discovery — ping/ARP sweep + reconciliation report (#23)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -110,6 +110,9 @@ backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:91
 backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:92
 backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:93
 backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:94
+backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py:drop_column:54
+backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py:drop_column:55
+backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py:drop_column:56
 backend/alembic/versions/a8d2e91f5c47_appliance_variant.py:drop_column:38
 backend/alembic/versions/a8d31e6b2f47_ipv6_allocation_policy.py:drop_column:38
 backend/alembic/versions/a8e3f127c094_system_upgrade_run.py:drop_table:119

--- a/backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py
+++ b/backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py
@@ -1,0 +1,56 @@
+"""subnet IP discovery — opt-in ping/ARP sweep columns (#23)
+
+Revision ID: a7e3c1f49d20
+Revises: c2e6a89d4b15
+Create Date: 2026-05-29 14:20:00.000000
+
+Per-subnet opt-in for the scheduled IP-discovery sweep (issue #23).
+Additive only — every column ships a server_default so existing rows
+backfill to "discovery off" and the migration is expand-safe for a
+rolling upgrade.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7e3c1f49d20"
+down_revision: Union[str, None] = "c2e6a89d4b15"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "subnet",
+        sa.Column(
+            "discovery_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "subnet",
+        sa.Column(
+            "discovery_interval_minutes",
+            sa.Integer(),
+            nullable=False,
+            server_default="360",
+        ),
+    )
+    op.add_column(
+        "subnet",
+        sa.Column(
+            "last_discovery_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("subnet", "last_discovery_at")
+    op.drop_column("subnet", "discovery_interval_minutes")
+    op.drop_column("subnet", "discovery_enabled")

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -1606,6 +1606,9 @@ class SubnetCreate(BaseModel):
     auto_profile_on_dhcp_lease: bool = False
     auto_profile_preset: str = "service_and_os"
     auto_profile_refresh_days: int = 30
+    # IP discovery (issue #23) — opt-in scheduled ping/ARP sweep.
+    discovery_enabled: bool = False
+    discovery_interval_minutes: int = 360
     ipv6_allocation_policy: str = "random"
     # Compliance / classification flags — see Subnet model.
     pci_scope: bool = False
@@ -1671,6 +1674,15 @@ class SubnetCreate(BaseModel):
             raise ValueError("auto_profile_refresh_days must be between 1 and 365")
         return v
 
+    @field_validator("discovery_interval_minutes")
+    @classmethod
+    def validate_discovery_interval_create(cls, v: int) -> int:
+        # 5 min floor (matches the beat dispatcher's clamp) so a misclick
+        # can't hammer the network; 1-week ceiling.
+        if v < 5 or v > 10080:
+            raise ValueError("discovery_interval_minutes must be between 5 and 10080")
+        return v
+
     @field_validator("network")
     @classmethod
     def validate_network(cls, v: str) -> str:
@@ -1728,6 +1740,8 @@ class SubnetUpdate(BaseModel):
     auto_profile_on_dhcp_lease: bool | None = None
     auto_profile_preset: str | None = None
     auto_profile_refresh_days: int | None = None
+    discovery_enabled: bool | None = None
+    discovery_interval_minutes: int | None = None
     ipv6_allocation_policy: str | None = None
     pci_scope: bool | None = None
     hipaa_scope: bool | None = None
@@ -1735,6 +1749,13 @@ class SubnetUpdate(BaseModel):
     subnet_role: str | None = None
     customer_id: uuid.UUID | None = None
     site_id: uuid.UUID | None = None
+
+    @field_validator("discovery_interval_minutes")
+    @classmethod
+    def validate_discovery_interval_update(cls, v: int | None) -> int | None:
+        if v is not None and (v < 5 or v > 10080):
+            raise ValueError("discovery_interval_minutes must be between 5 and 10080")
+        return v
 
     @field_validator("subnet_role")
     @classmethod
@@ -1863,6 +1884,9 @@ class SubnetResponse(BaseModel):
     auto_profile_on_dhcp_lease: bool = False
     auto_profile_preset: str = "service_and_os"
     auto_profile_refresh_days: int = 30
+    discovery_enabled: bool = False
+    discovery_interval_minutes: int = 360
+    last_discovery_at: datetime | None = None
     ipv6_allocation_policy: str = "random"
     pci_scope: bool = False
     hipaa_scope: bool = False
@@ -3628,6 +3652,68 @@ async def get_subnet(subnet_id: uuid.UUID, current_user: CurrentUser, db: DB) ->
     if subnet is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
     return subnet
+
+
+@router.get("/subnets/{subnet_id}/reconciliation")
+async def get_subnet_reconciliation(
+    subnet_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: DB,
+    stale_minutes: int = 1440,
+) -> dict:
+    """IP-discovery reconciliation report for a subnet (issue #23).
+
+    Three buckets — allocated-but-not-seen, discovered-but-not-allocated,
+    and available-but-active (status mismatch). ``stale_minutes`` (default
+    24 h) is the window after which a row's ``last_seen_at`` counts as
+    stale. See docs/features/IPAM.md §8.
+    """
+    from app.services.ipam.discovery import build_reconciliation_report
+
+    subnet = await db.get(Subnet, subnet_id)
+    if subnet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
+    stale_minutes = max(1, min(stale_minutes, 525600))  # clamp 1 min … 1 year
+    return await build_reconciliation_report(db, subnet, stale_minutes=stale_minutes)
+
+
+@router.post("/subnets/{subnet_id}/discover", status_code=status.HTTP_202_ACCEPTED)
+async def trigger_subnet_discovery(subnet_id: uuid.UUID, current_user: CurrentUser, db: DB) -> dict:
+    """Queue an on-demand IP-discovery sweep for this subnet (issue #23).
+
+    Runs the same ``run_subnet_discovery`` Celery task the beat
+    dispatcher uses, independent of the per-subnet schedule / enabled
+    toggle — an operator can sweep on demand even with the scheduled
+    sweep off.
+    """
+    subnet = await db.get(Subnet, subnet_id)
+    if subnet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
+
+    queued = True
+    try:
+        from app.tasks.ipam_discovery import run_subnet_discovery
+
+        run_subnet_discovery.delay(str(subnet_id))
+    except Exception as exc:  # noqa: BLE001 — broker unreachable; report, don't 500
+        queued = False
+        logger.warning("ipam_discovery_trigger_enqueue_failed", error=str(exc))
+
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="discover",
+            resource_type="subnet",
+            resource_id=str(subnet.id),
+            resource_display=str(subnet.network),
+            result="success" if queued else "error",
+            error_detail=None if queued else "task broker unreachable",
+        )
+    )
+    await db.commit()
+    return {"status": "queued" if queued else "enqueue_failed", "subnet_id": str(subnet_id)}
 
 
 @router.get("/subnets/{subnet_id}/effective-dns", response_model=EffectiveDnsResponse)

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -28,6 +28,7 @@ celery_app = Celery(
         "app.tasks.prune_revoked_appliances",
         "app.tasks.trash_purge",
         "app.tasks.ipam_reservation_sweep",
+        "app.tasks.ipam_discovery",
         "app.tasks.dhcp_lease_history_prune",
         "app.tasks.update_check",
         "app.tasks.kubernetes_sync",
@@ -77,6 +78,7 @@ celery_app.conf.update(
         "app.tasks.prune_pairing_codes.*": {"queue": "default"},
         "app.tasks.trash_purge.*": {"queue": "default"},
         "app.tasks.ipam_reservation_sweep.*": {"queue": "ipam"},
+        "app.tasks.ipam_discovery.*": {"queue": "ipam"},
         "app.tasks.dhcp_lease_history_prune.*": {"queue": "dhcp"},
         "app.tasks.update_check.*": {"queue": "default"},
         "app.tasks.kubernetes_sync.*": {"queue": "default"},
@@ -129,6 +131,15 @@ celery_app.conf.update(
         # restarting celery-beat.
         "ipam-dns-auto-sync": {
             "task": "app.tasks.ipam_dns_sync.auto_sync_ipam_dns",
+            "schedule": schedule(run_every=60.0),
+        },
+        # Every 60 s, dispatch IP-discovery sweeps for subnets whose
+        # per-subnet interval has elapsed (issue #23). Per-subnet gating
+        # lives in the task (``discovery_enabled`` + ``last_discovery_at``
+        # vs ``discovery_interval_minutes``) so cadence changes in the UI
+        # take effect without restarting beat.
+        "ipam-discovery-dispatch": {
+            "task": "app.tasks.ipam_discovery.dispatch_due_subnets",
             "schedule": schedule(run_every=60.0),
         },
         # Every 60 s, tick the DNS pull-from-server task. The task itself

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -504,6 +504,29 @@ class Subnet(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
         Integer, nullable=False, default=30, server_default=sa_text("30")
     )
 
+    # ── IP discovery — opt-in scheduled ping/ARP sweep (issue #23) ────
+    # When enabled, a Celery beat task periodically sweeps this subnet
+    # for live hosts (unprivileged ICMP with a TCP-connect fallback) +
+    # reads the worker's ARP table, stamping ``last_seen_at`` /
+    # ``last_seen_method`` on existing rows and inserting
+    # ``status='discovered'`` rows for live IPs not yet in IPAM.
+    # Default-off + per-subnet because a sweep is only meaningful for
+    # subnets the worker can actually reach, and unsolicited probes can
+    # trip an IDS. Locked rows (``user_modified_at`` set) and dynamic
+    # DHCP pool ranges are never auto-created/clobbered. ``last_discovery_at``
+    # gates the beat dispatcher the same way ``next_poll_at`` gates the
+    # SNMP poller — change the interval in the UI and it takes effect
+    # without restarting beat.
+    discovery_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    discovery_interval_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=360, server_default=sa_text("360")
+    )
+    last_discovery_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # IPv6 auto-allocation policy (ignored for IPv4 subnets — those use
     # PlatformSettings.ip_allocation_strategy which is sequential /
     # random only). Values:

--- a/backend/app/services/ai/tools/ipam.py
+++ b/backend/app/services/ai/tools/ipam.py
@@ -325,6 +325,51 @@ async def get_subnet_summary(
     }
 
 
+# ── find_subnet_reconciliation ────────────────────────────────────────
+
+
+class SubnetReconciliationArgs(BaseModel):
+    subnet_id: str = Field(description="Subnet UUID.")
+    stale_minutes: int = Field(
+        default=1440,
+        description=(
+            "How old (minutes) a row's last-seen timestamp may be before it "
+            "counts as stale. Default 1440 (24h)."
+        ),
+    )
+
+
+@register_tool(
+    name="find_subnet_reconciliation",
+    description=(
+        "IP-discovery reconciliation for one subnet (issue #23): which "
+        "allocated IPs aren't answering on the wire, which live IPs were "
+        "discovered but never formally allocated, and which IPs marked "
+        "'available' are actually active right now (status mismatch). Use "
+        "when the operator asks 'what's stale in X?', 'what did discovery "
+        "find in X?', or 'is anything using IPs we think are free?'. "
+        "Read-only — reflects the last sweep; trigger a fresh sweep from "
+        "the subnet's Reconciliation panel."
+    ),
+    args_model=SubnetReconciliationArgs,
+    category="ipam",
+)
+async def find_subnet_reconciliation(
+    db: AsyncSession, user: User, args: SubnetReconciliationArgs
+) -> dict[str, Any]:
+    from app.services.ipam.discovery import build_reconciliation_report
+
+    try:
+        subnet_uuid = uuid.UUID(args.subnet_id)
+    except (ValueError, TypeError):
+        return {"error": "subnet_id must be a UUID", "subnet_id": args.subnet_id}
+    subnet = await db.get(Subnet, subnet_uuid)
+    if subnet is None or subnet.deleted_at is not None:
+        return {"error": "subnet not found", "subnet_id": args.subnet_id}
+    stale = max(1, min(args.stale_minutes, 525600))
+    return await build_reconciliation_report(db, subnet, stale_minutes=stale)
+
+
 # ── find_ip ───────────────────────────────────────────────────────────
 
 

--- a/backend/app/services/ipam/discovery.py
+++ b/backend/app/services/ipam/discovery.py
@@ -1,0 +1,453 @@
+"""IP discovery — ping sweep + ARP scan + reconciliation (issue #23).
+
+A scheduled, per-subnet-opt-in pass that finds live hosts and folds
+them back into IPAM:
+
+* **Ping sweep** — pure-Python asyncio ICMP echo via an *unprivileged*
+  ``SOCK_DGRAM`` ICMP socket (Linux "ping group range"). When that
+  socket can't be created (container running as a uid outside
+  ``net.ipv4.ping_group_range``), we fall back to a TCP-connect probe
+  across a small set of common ports — a connect success OR a
+  ``ConnectionRefusedError`` both prove the host is up. No raw sockets,
+  no CAP_NET_RAW required, so it works in an unprivileged worker.
+* **ARP scan** — reads the worker's own ARP cache (``/proc/net/arp``).
+  Only useful for subnets the worker is L2-adjacent to, but free and
+  it catches hosts that drop ICMP. Also enriches ``mac_address``.
+
+Reconciliation writes (``reconcile_subnet``):
+* existing rows → ``last_seen_at`` / ``last_seen_method`` refreshed
+  (and ``mac_address`` filled only when NULL — operator data is never
+  overwritten);
+* live IPs with no row → inserted ``status='discovered'`` — UNLESS the
+  IP sits in a dynamic DHCP pool (owned by the DHCP server) or is the
+  network / broadcast address.
+
+Rows an operator has touched (``user_modified_at`` set) keep their
+status; discovery only refreshes their ``last_seen_at`` timestamp.
+
+The read side (``build_reconciliation_report``) is pure-query and powers
+``GET /ipam/subnets/{id}/reconciliation`` — see docs/features/IPAM.md §8.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import os
+import socket
+import struct
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp import DHCPPool, DHCPScope
+from app.models.ipam import IPAddress, Subnet
+
+logger = structlog.get_logger(__name__)
+
+# Hard ceiling on hosts swept in one pass. A /20 (4094 hosts) is plenty
+# for a LAN; anything bigger is almost certainly a mistake (or a routed
+# supernet) and would hammer the network. Larger subnets are skipped
+# with a logged warning rather than silently truncated.
+MAX_SWEEP_HOSTS = 4096
+
+# Ports probed by the TCP-connect fallback. A host that accepts a
+# connection OR refuses it (RST) is alive; only a timeout / no-route is
+# treated as down. Kept short + common so the fallback stays fast.
+_TCP_PROBE_PORTS = (22, 80, 443, 445, 3389, 8006, 53, 8080)
+
+_ICMP_TIMEOUT_S = 2.0
+_TCP_TIMEOUT_S = 1.0
+_TCP_CONCURRENCY = 128
+
+
+@dataclass
+class SweepResult:
+    """What a sweep observed on the wire for one subnet.
+
+    ``ping_alive`` and ``arp`` are kept separate so reconciliation can
+    label each IP's ``last_seen_method`` correctly — ``"ping"`` when it
+    answered an echo / TCP probe, ``"arp"`` when the ARP cache is the
+    only evidence. ``alive`` is the union of both.
+    """
+
+    ping_alive: set[str] = field(default_factory=set)  # answered ICMP / TCP
+    arp: dict[str, str] = field(default_factory=dict)  # ip -> mac (ARP-complete)
+    icmp_used: bool = False  # True when the real ICMP path ran (vs TCP fallback)
+
+    @property
+    def alive(self) -> set[str]:
+        return self.ping_alive | set(self.arp)
+
+    def method_for(self, ip: str) -> str:
+        return "ping" if ip in self.ping_alive else "arp"
+
+
+# ── Host enumeration ────────────────────────────────────────────────
+
+
+def enumerate_hosts(cidr: str) -> list[str] | None:
+    """Host addresses for an IPv4 subnet, or None if it's too big / v6.
+
+    Returns ``[]`` for a subnet with no usable hosts (e.g. /31, /32).
+    IPv6 returns None — ARP + the /proc/net/arp read are IPv4-only and
+    enumerating a v6 subnet is infeasible.
+    """
+    try:
+        net = ipaddress.ip_network(cidr, strict=False)
+    except ValueError:
+        return None
+    if net.version != 4:
+        return None
+    if net.num_addresses > MAX_SWEEP_HOSTS:
+        return None
+    return [str(h) for h in net.hosts()]
+
+
+# ── Ping sweep ──────────────────────────────────────────────────────
+
+
+def _icmp_checksum(data: bytes) -> int:
+    if len(data) % 2:
+        data += b"\x00"
+    total = sum(struct.unpack(f"!{len(data) // 2}H", data))
+    total = (total >> 16) + (total & 0xFFFF)
+    total += total >> 16
+    return ~total & 0xFFFF
+
+
+def _icmp_echo(ident: int, seq: int) -> bytes:
+    # Type 8 (echo request), code 0. The kernel rewrites id + checksum
+    # for SOCK_DGRAM ICMP, but a well-formed packet is harmless.
+    payload = b"spatiumddi-disco"
+    header = struct.pack("!BBHHH", 8, 0, 0, ident, seq)
+    chk = _icmp_checksum(header + payload)
+    header = struct.pack("!BBHHH", 8, 0, chk, ident, seq)
+    return header + payload
+
+
+async def _icmp_sweep(hosts: list[str], timeout: float) -> set[str] | None:
+    """Unprivileged ICMP echo sweep. Returns the live set, or None when
+    an ICMP datagram socket can't be created (caller falls back to TCP)."""
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_ICMP)
+    except (PermissionError, OSError) as exc:
+        logger.info("ipam.discovery.icmp_unavailable", error=str(exc))
+        return None
+
+    sock.setblocking(False)
+    alive: set[str] = set()
+    loop = asyncio.get_running_loop()
+    ident = os.getpid() & 0xFFFF
+
+    def _on_readable() -> None:
+        # Drain every queued reply; the kernel demuxes only our socket's
+        # replies here, so any source address that shows up is alive.
+        while True:
+            try:
+                _data, addr = sock.recvfrom(1024)
+            except (BlockingIOError, InterruptedError):
+                return
+            except OSError:
+                return
+            alive.add(addr[0])
+
+    try:
+        loop.add_reader(sock.fileno(), _on_readable)
+    except (OSError, ValueError):
+        sock.close()
+        return None
+
+    try:
+        for i, host in enumerate(hosts):
+            try:
+                sock.sendto(_icmp_echo(ident, i & 0xFFFF), (host, 0))
+            except OSError:
+                pass
+            if i % 128 == 0:
+                await asyncio.sleep(0)  # cooperative yield while blasting
+        await asyncio.sleep(timeout)
+    finally:
+        try:
+            loop.remove_reader(sock.fileno())
+        except (OSError, ValueError):
+            pass
+        sock.close()
+    return alive
+
+
+async def _tcp_alive(host: str, ports: tuple[int, ...], timeout: float) -> bool:
+    for port in ports:
+        try:
+            fut = asyncio.open_connection(host, port)
+            _reader, writer = await asyncio.wait_for(fut, timeout=timeout)
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass
+            return True
+        except ConnectionRefusedError:
+            return True  # host up, port closed — still alive
+        except (TimeoutError, OSError):
+            continue
+    return False
+
+
+async def _tcp_sweep(hosts: list[str], timeout: float, concurrency: int) -> set[str]:
+    sem = asyncio.Semaphore(concurrency)
+    alive: set[str] = set()
+
+    async def probe(host: str) -> None:
+        async with sem:
+            if await _tcp_alive(host, _TCP_PROBE_PORTS, timeout):
+                alive.add(host)
+
+    await asyncio.gather(*(probe(h) for h in hosts))
+    return alive
+
+
+def read_arp_table(path: str = "/proc/net/arp") -> dict[str, str]:
+    """``/proc/net/arp`` → ``{ip: mac}`` for complete (flag 0x2) entries.
+
+    ``path`` is overridable for tests. Best-effort: returns ``{}`` on any
+    platform / permission issue."""
+    out: dict[str, str] = {}
+    try:
+        with open(path) as fh:
+            lines = fh.readlines()
+    except OSError:
+        return out
+    for line in lines[1:]:  # skip header row
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        ip, _hwtype, flags, mac = parts[0], parts[1], parts[2], parts[3]
+        try:
+            complete = int(flags, 16) & 0x2
+        except ValueError:
+            complete = 0
+        if complete and mac and mac != "00:00:00:00:00:00":
+            out[ip] = mac
+    return out
+
+
+async def sweep_subnet(cidr: str) -> SweepResult | None:
+    """Run the ping sweep + ARP read for one subnet CIDR.
+
+    Returns None when the subnet can't be swept (IPv6 or larger than
+    ``MAX_SWEEP_HOSTS``)."""
+    hosts = enumerate_hosts(cidr)
+    if hosts is None:
+        return None
+
+    result = SweepResult()
+    if hosts:
+        icmp_alive = await _icmp_sweep(hosts, _ICMP_TIMEOUT_S)
+        if icmp_alive is None:
+            result.ping_alive = await _tcp_sweep(hosts, _TCP_TIMEOUT_S, _TCP_CONCURRENCY)
+        else:
+            result.ping_alive = icmp_alive
+            result.icmp_used = True
+
+    # ARP cache — only keep entries that fall inside this subnet. An
+    # ARP-complete entry means the host answered an ARP, so it's up even
+    # if it dropped our ICMP/TCP probe. ``alive`` unions ping + arp.
+    try:
+        net = ipaddress.ip_network(cidr, strict=False)
+    except ValueError:
+        net = None
+    if net is not None:
+        for ip, mac in read_arp_table().items():
+            try:
+                if ipaddress.ip_address(ip) in net:
+                    result.arp[ip] = mac
+            except ValueError:
+                continue
+    return result
+
+
+# ── Reconciliation writer ───────────────────────────────────────────
+
+
+async def _dynamic_pool_ranges(db: AsyncSession, subnet_id) -> list[tuple[int, int]]:
+    """``[(start_int, end_int)]`` for every dynamic DHCP pool on the subnet.
+
+    Mirrors ``api.v1.ipam.router._load_dynamic_pool_ranges`` (kept local
+    so the service doesn't import the router)."""
+    rows = await db.execute(
+        select(DHCPPool.start_ip, DHCPPool.end_ip)
+        .join(DHCPScope, DHCPScope.id == DHCPPool.scope_id)
+        .where(DHCPScope.subnet_id == subnet_id)
+        .where(DHCPPool.pool_type == "dynamic")
+    )
+    out: list[tuple[int, int]] = []
+    for start_ip, end_ip in rows.all():
+        try:
+            s = int(ipaddress.ip_address(str(start_ip)))
+            e = int(ipaddress.ip_address(str(end_ip)))
+        except (ValueError, TypeError):
+            continue
+        if s > e:
+            s, e = e, s
+        out.append((s, e))
+    return out
+
+
+def _in_dynamic_pool(ip_int: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(s <= ip_int <= e for s, e in ranges)
+
+
+async def reconcile_subnet(db: AsyncSession, subnet: Subnet, sweep: SweepResult) -> dict[str, int]:
+    """Fold a sweep result into IPAM rows for one subnet.
+
+    Idempotent: a second pass over the same wire data just refreshes
+    ``last_seen_at``. Does not commit — the caller owns the transaction.
+    """
+    counts = {"updated": 0, "created": 0, "skipped_pool": 0, "arp_enriched": 0}
+    if not sweep.alive:
+        return counts
+
+    now = datetime.now(UTC)
+    try:
+        net = ipaddress.ip_network(str(subnet.network), strict=False)
+    except ValueError:
+        return counts
+
+    network_int = int(net.network_address)
+    broadcast_int = int(net.broadcast_address) if net.version == 4 else None
+    dynamic_ranges = await _dynamic_pool_ranges(db, subnet.id)
+
+    existing_rows = list(
+        (await db.execute(select(IPAddress).where(IPAddress.subnet_id == subnet.id)))
+        .scalars()
+        .all()
+    )
+    by_ip: dict[str, IPAddress] = {str(r.address): r for r in existing_rows}
+
+    for ip in sweep.alive:
+        try:
+            ip_int = int(ipaddress.ip_address(ip))
+        except ValueError:
+            continue
+
+        method = sweep.method_for(ip)  # "ping" if it answered, else "arp"
+        row = by_ip.get(ip)
+        if row is not None:
+            row.last_seen_at = now
+            row.last_seen_method = method
+            # Enrich MAC only when empty — operator data is never
+            # overwritten (mirrors the SNMP cross-reference path).
+            if ip in sweep.arp and row.mac_address is None:
+                row.mac_address = sweep.arp[ip]
+                counts["arp_enriched"] += 1
+            counts["updated"] += 1
+            continue
+
+        # No row yet — candidate for a ``discovered`` insert. Skip the
+        # network / broadcast placeholders and anything inside a dynamic
+        # DHCP pool (the DHCP server owns those slots).
+        if ip_int == network_int or ip_int == broadcast_int:
+            continue
+        if _in_dynamic_pool(ip_int, dynamic_ranges):
+            counts["skipped_pool"] += 1
+            continue
+
+        db.add(
+            IPAddress(
+                subnet_id=subnet.id,
+                address=ip,
+                status="discovered",
+                mac_address=sweep.arp.get(ip),
+                last_seen_at=now,
+                last_seen_method=method,
+            )
+        )
+        counts["created"] += 1
+
+    return counts
+
+
+# ── Reconciliation report (read side) ───────────────────────────────
+
+
+async def build_reconciliation_report(
+    db: AsyncSession, subnet: Subnet, stale_minutes: int = 1440
+) -> dict:
+    """Per-subnet reconciliation buckets for ``GET .../reconciliation``.
+
+    Three subnet-scoped categories (see docs/features/IPAM.md §8):
+
+    * ``in_ipam_not_seen`` — allocated / reserved / static rows with no
+      recent liveness signal (never seen, or ``last_seen_at`` older than
+      the stale window). "Allocated but nothing answered."
+    * ``discovered_not_allocated`` — ``status='discovered'`` rows: seen
+      on the wire but never formally allocated by an operator.
+    * ``status_mismatch`` — rows marked ``available`` that are answering
+      right now (recent ``last_seen_at``). "IPAM says free, host is up."
+    """
+    now = datetime.now(UTC)
+    stale_cutoff = now - timedelta(minutes=max(1, stale_minutes))
+
+    rows = list(
+        (await db.execute(select(IPAddress).where(IPAddress.subnet_id == subnet.id)))
+        .scalars()
+        .all()
+    )
+
+    def _entry(r: IPAddress) -> dict:
+        return {
+            "id": str(r.id),
+            "address": str(r.address),
+            "status": r.status,
+            "hostname": r.hostname,
+            "mac_address": r.mac_address,
+            "last_seen_at": r.last_seen_at.isoformat() if r.last_seen_at else None,
+            "last_seen_method": r.last_seen_method,
+        }
+
+    allocated_states = {"allocated", "reserved", "static_dhcp"}
+    in_ipam_not_seen: list[dict] = []
+    discovered_not_allocated: list[dict] = []
+    status_mismatch: list[dict] = []
+
+    for r in rows:
+        seen_recent = r.last_seen_at is not None and r.last_seen_at >= stale_cutoff
+        if r.status in allocated_states and not seen_recent:
+            in_ipam_not_seen.append(_entry(r))
+        elif r.status == "discovered":
+            discovered_not_allocated.append(_entry(r))
+        elif r.status == "available" and seen_recent:
+            status_mismatch.append(_entry(r))
+
+    return {
+        "subnet_id": str(subnet.id),
+        "network": str(subnet.network),
+        "generated_at": now.isoformat(),
+        "stale_minutes": stale_minutes,
+        "last_discovery_at": (
+            subnet.last_discovery_at.isoformat() if subnet.last_discovery_at else None
+        ),
+        "counts": {
+            "in_ipam_not_seen": len(in_ipam_not_seen),
+            "discovered_not_allocated": len(discovered_not_allocated),
+            "status_mismatch": len(status_mismatch),
+        },
+        "in_ipam_not_seen": in_ipam_not_seen,
+        "discovered_not_allocated": discovered_not_allocated,
+        "status_mismatch": status_mismatch,
+    }
+
+
+__all__ = [
+    "MAX_SWEEP_HOSTS",
+    "SweepResult",
+    "build_reconciliation_report",
+    "enumerate_hosts",
+    "read_arp_table",
+    "reconcile_subnet",
+    "sweep_subnet",
+]

--- a/backend/app/services/ipam/discovery.py
+++ b/backend/app/services/ipam/discovery.py
@@ -92,8 +92,10 @@ class SweepResult:
 def enumerate_hosts(cidr: str) -> list[str] | None:
     """Host addresses for an IPv4 subnet, or None if it's too big / v6.
 
-    Returns ``[]`` for a subnet with no usable hosts (e.g. /31, /32).
-    IPv6 returns None — ARP + the /proc/net/arp read are IPv4-only and
+    Uses ``ipaddress.ip_network(...).hosts()``, which per RFC 3021
+    returns both addresses for a /31 and the single address for a /32
+    (so those tiny subnets DO yield hosts, not an empty list). IPv6
+    returns None — ARP + the /proc/net/arp read are IPv4-only and
     enumerating a v6 subnet is infeasible.
     """
     try:
@@ -166,7 +168,9 @@ async def _icmp_sweep(hosts: list[str], timeout: float) -> set[str] | None:
             try:
                 sock.sendto(_icmp_echo(ident, i & 0xFFFF), (host, 0))
             except OSError:
-                pass
+                # One unreachable host (e.g. EHOSTUNREACH / no route) must
+                # not abort the whole sweep — skip it and keep blasting.
+                continue
             if i % 128 == 0:
                 await asyncio.sleep(0)  # cooperative yield while blasting
         await asyncio.sleep(timeout)
@@ -174,6 +178,9 @@ async def _icmp_sweep(hosts: list[str], timeout: float) -> set[str] | None:
         try:
             loop.remove_reader(sock.fileno())
         except (OSError, ValueError):
+            # Best-effort cleanup — the reader may already be gone (e.g.
+            # the loop is shutting down). The socket is closed next
+            # regardless, so swallow and move on.
             pass
         sock.close()
     return alive
@@ -188,6 +195,9 @@ async def _tcp_alive(host: str, ports: tuple[int, ...], timeout: float) -> bool:
             try:
                 await writer.wait_closed()
             except OSError:
+                # The connect already proved the host is up; a failure
+                # tearing the probe socket down doesn't change that, so
+                # ignore it and report alive.
                 pass
             return True
         except ConnectionRefusedError:
@@ -317,8 +327,14 @@ async def reconcile_subnet(db: AsyncSession, subnet: Subnet, sweep: SweepResult)
     except ValueError:
         return counts
 
-    network_int = int(net.network_address)
-    broadcast_int = int(net.broadcast_address) if net.version == 4 else None
+    # Network / broadcast are real placeholders only for prefixes ≤ /30.
+    # On /31 (RFC 3021) and /32 both endpoints are usable hosts, so don't
+    # treat them as skip-able there — otherwise discovery could never
+    # create a row for a point-to-point link or a single-host subnet
+    # (matches the resize service's prefixlen ≤ 30 convention).
+    skip_endpoints = net.version == 4 and net.prefixlen <= 30
+    network_int = int(net.network_address) if skip_endpoints else None
+    broadcast_int = int(net.broadcast_address) if skip_endpoints else None
     dynamic_ranges = await _dynamic_pool_ranges(db, subnet.id)
 
     existing_rows = list(

--- a/backend/app/tasks/ipam_discovery.py
+++ b/backend/app/tasks/ipam_discovery.py
@@ -23,6 +23,7 @@ refreshes ``last_seen_at``.
 from __future__ import annotations
 
 import asyncio
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -43,8 +44,15 @@ async def _run_subnet_discovery_async(subnet_id_str: str) -> dict[str, Any]:
     engine = create_async_engine(settings.database_url, future=True)
     factory = async_sessionmaker(engine, expire_on_commit=False)
     try:
+        subnet_id = uuid.UUID(subnet_id_str)
+    except (ValueError, TypeError):
+        return {"status": "skipped", "reason": "bad_subnet_id"}
+    try:
         async with factory() as db:
-            subnet = await db.get(Subnet, subnet_id_str)
+            # Subnet.id is UUID(as_uuid=True) — pass a real UUID, not the
+            # raw string, so the bind is unambiguous on asyncpg/psycopg
+            # (matches the convention in the other Celery tasks).
+            subnet = await db.get(Subnet, subnet_id)
             if subnet is None or subnet.deleted_at is not None:
                 return {"status": "skipped", "reason": "subnet_missing"}
 

--- a/backend/app/tasks/ipam_discovery.py
+++ b/backend/app/tasks/ipam_discovery.py
@@ -1,0 +1,153 @@
+"""IP discovery Celery tasks (issue #23).
+
+Three tasks:
+
+* ``run_subnet_discovery`` — single-subnet pass: sweeps the subnet
+  (ping + ARP), folds live hosts into IPAM via
+  ``services.ipam.discovery.reconcile_subnet``, stamps
+  ``Subnet.last_discovery_at``, and writes an audit row with the
+  per-bucket counters.
+* ``dispatch_due_subnets`` — beat-fired every 60 s. Queues a
+  ``run_subnet_discovery`` per subnet whose ``discovery_enabled`` is
+  set and whose ``last_discovery_at`` is older than its per-subnet
+  ``discovery_interval_minutes`` (gating in the task, not in beat, so
+  interval changes in the UI take effect without restarting beat —
+  same pattern as the SNMP poller and the IPAM↔DNS auto-sync).
+* No janitor here — discovered rows are reclaimed by the stale-IP
+  sweep (#45) / the existing trash + lease-cleanup paths.
+
+Idempotent + safe to retry: a re-run over the same wire data only
+refreshes ``last_seen_at``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.celery_app import celery_app
+from app.config import settings
+from app.models.audit import AuditLog
+from app.models.ipam import Subnet
+from app.services.ipam.discovery import reconcile_subnet, sweep_subnet
+
+logger = structlog.get_logger(__name__)
+
+
+async def _run_subnet_discovery_async(subnet_id_str: str) -> dict[str, Any]:
+    engine = create_async_engine(settings.database_url, future=True)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as db:
+            subnet = await db.get(Subnet, subnet_id_str)
+            if subnet is None or subnet.deleted_at is not None:
+                return {"status": "skipped", "reason": "subnet_missing"}
+
+            sweep = await sweep_subnet(str(subnet.network))
+            if sweep is None:
+                # IPv6 or larger than MAX_SWEEP_HOSTS — stamp the run so
+                # the dispatcher doesn't re-pick it every tick, but do no
+                # writes.
+                subnet.last_discovery_at = datetime.now(UTC)
+                await db.commit()
+                logger.info(
+                    "ipam.discovery.skipped_unsweepable",
+                    subnet_id=subnet_id_str,
+                    network=str(subnet.network),
+                )
+                return {"status": "skipped", "reason": "unsweepable"}
+
+            counts = await reconcile_subnet(db, subnet, sweep)
+            subnet.last_discovery_at = datetime.now(UTC)
+            db.add(
+                AuditLog(
+                    user_id=None,
+                    user_display_name="system",
+                    auth_source="system",
+                    action="discover",
+                    resource_type="subnet",
+                    resource_id=str(subnet.id),
+                    resource_display=str(subnet.network),
+                    result="success",
+                    new_value={
+                        "alive": len(sweep.alive),
+                        "method": "icmp" if sweep.icmp_used else "tcp",
+                        **counts,
+                    },
+                )
+            )
+            await db.commit()
+            logger.info(
+                "ipam.discovery.subnet_done",
+                subnet_id=subnet_id_str,
+                network=str(subnet.network),
+                alive=len(sweep.alive),
+                **counts,
+            )
+            return {"status": "ok", "alive": len(sweep.alive), **counts}
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(
+    name="app.tasks.ipam_discovery.run_subnet_discovery",
+    bind=True,
+    autoretry_for=(ConnectionError, OSError),
+    retry_backoff=True,
+    retry_kwargs={"max_retries": 3},
+)
+def run_subnet_discovery(self: Any, subnet_id_str: str) -> dict[str, Any]:  # noqa: ARG001
+    """Sweep one subnet + reconcile. Invoked on-demand and by the beat
+    dispatcher."""
+    return asyncio.run(_run_subnet_discovery_async(subnet_id_str))
+
+
+async def _dispatch_due_async() -> int:
+    engine = create_async_engine(settings.database_url, future=True)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    queued = 0
+    try:
+        async with factory() as db:
+            now = datetime.now(UTC)
+            rows = list(
+                (
+                    await db.execute(
+                        select(Subnet).where(
+                            Subnet.discovery_enabled.is_(True),
+                            Subnet.deleted_at.is_(None),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for s in rows:
+                interval = max(5, s.discovery_interval_minutes)
+                due = s.last_discovery_at is None or s.last_discovery_at <= now - timedelta(
+                    minutes=interval
+                )
+                if not due:
+                    continue
+                try:
+                    run_subnet_discovery.delay(str(s.id))
+                    queued += 1
+                except Exception as exc:  # noqa: BLE001 — broker down? give up quietly
+                    logger.warning("ipam.discovery.dispatch_enqueue_failed", error=str(exc))
+                    break
+        return queued
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(name="app.tasks.ipam_discovery.dispatch_due_subnets", bind=True)
+def dispatch_due_subnets(self: Any) -> int:  # noqa: ARG001
+    """Beat-fired sweep — queues ``run_subnet_discovery`` per due subnet."""
+    return asyncio.run(_dispatch_due_async())
+
+
+__all__ = ["run_subnet_discovery", "dispatch_due_subnets"]

--- a/backend/tests/test_ipam_discovery.py
+++ b/backend/tests/test_ipam_discovery.py
@@ -1,0 +1,230 @@
+"""IP discovery — sweep helpers + reconcile + report (issue #23)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp import DHCPPool, DHCPScope, DHCPServerGroup
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.ipam.discovery import (
+    MAX_SWEEP_HOSTS,
+    SweepResult,
+    build_reconciliation_report,
+    enumerate_hosts,
+    read_arp_table,
+    reconcile_subnet,
+)
+
+# ── Pure-logic helpers ──────────────────────────────────────────────
+
+
+def test_enumerate_hosts_v4_excludes_network_broadcast() -> None:
+    hosts = enumerate_hosts("192.0.2.0/24")
+    assert hosts is not None
+    assert "192.0.2.0" not in hosts  # network
+    assert "192.0.2.255" not in hosts  # broadcast
+    assert "192.0.2.1" in hosts and "192.0.2.254" in hosts
+    assert len(hosts) == 254
+
+
+def test_enumerate_hosts_too_big_returns_none() -> None:
+    # /8 has 16M addresses — far over MAX_SWEEP_HOSTS.
+    assert enumerate_hosts("10.0.0.0/8") is None
+
+
+def test_enumerate_hosts_ipv6_returns_none() -> None:
+    assert enumerate_hosts("2001:db8::/64") is None
+
+
+def test_enumerate_hosts_cap_boundary() -> None:
+    # /20 = 4096 addresses == MAX_SWEEP_HOSTS → allowed; /19 → over.
+    assert enumerate_hosts("10.0.0.0/20") is not None
+    assert MAX_SWEEP_HOSTS == 4096
+    assert enumerate_hosts("10.0.0.0/19") is None
+
+
+def test_read_arp_table_parses_complete_entries(tmp_path) -> None:
+    arp = tmp_path / "arp"
+    arp.write_text(
+        "IP address       HW type     Flags       HW address            Mask     Device\n"
+        "192.0.2.10       0x1         0x2         aa:bb:cc:dd:ee:01     *        eth0\n"
+        "192.0.2.11       0x1         0x0         00:00:00:00:00:00     *        eth0\n"  # incomplete
+        "192.0.2.12       0x1         0x2         aa:bb:cc:dd:ee:02     *        eth0\n"
+    )
+    table = read_arp_table(str(arp))
+    assert table == {
+        "192.0.2.10": "aa:bb:cc:dd:ee:01",
+        "192.0.2.12": "aa:bb:cc:dd:ee:02",
+    }
+
+
+def test_read_arp_table_missing_file_is_empty() -> None:
+    assert read_arp_table("/nonexistent/path/arp") == {}
+
+
+def test_sweep_result_alive_union_and_method() -> None:
+    sr = SweepResult(ping_alive={"10.0.0.1"}, arp={"10.0.0.2": "aa:bb:cc:dd:ee:ff"})
+    assert sr.alive == {"10.0.0.1", "10.0.0.2"}
+    assert sr.method_for("10.0.0.1") == "ping"
+    assert sr.method_for("10.0.0.2") == "arp"
+
+
+# ── DB-backed reconcile / report ────────────────────────────────────
+
+
+async def _make_subnet(db: AsyncSession, cidr: str = "192.0.2.0/24") -> Subnet:
+    space = IPSpace(name=f"disco-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=cidr, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=cidr, name="s")
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def test_reconcile_updates_existing_and_creates_discovered(
+    db_session: AsyncSession,
+) -> None:
+    subnet = await _make_subnet(db_session)
+    existing = IPAddress(subnet_id=subnet.id, address="192.0.2.10", status="allocated")
+    db_session.add(existing)
+    await db_session.flush()
+
+    sweep = SweepResult(
+        ping_alive={"192.0.2.10", "192.0.2.20"},
+        arp={"192.0.2.10": "aa:bb:cc:dd:ee:10"},
+    )
+    counts = await reconcile_subnet(db_session, subnet, sweep)
+    await db_session.flush()
+
+    assert counts["updated"] == 1
+    assert counts["created"] == 1
+    assert counts["arp_enriched"] == 1
+
+    await db_session.refresh(existing)
+    assert existing.last_seen_at is not None
+    assert existing.last_seen_method == "ping"
+    assert existing.mac_address == "aa:bb:cc:dd:ee:10"  # filled from ARP
+    assert existing.status == "allocated"  # lifecycle untouched
+
+    rows = (await db_session.execute(_addr_q(subnet.id, "192.0.2.20"))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].status == "discovered"
+    assert rows[0].last_seen_method == "ping"
+
+
+async def test_reconcile_skips_network_and_broadcast(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    sweep = SweepResult(ping_alive={"192.0.2.0", "192.0.2.255", "192.0.2.5"})
+    counts = await reconcile_subnet(db_session, subnet, sweep)
+    await db_session.flush()
+    # Only .5 becomes a discovered row; network + broadcast skipped.
+    assert counts["created"] == 1
+    rows = (await db_session.execute(_addr_q(subnet.id, "192.0.2.0"))).scalars().all()
+    assert rows == []
+
+
+async def test_reconcile_skips_dynamic_pool(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+    scope = DHCPScope(group_id=grp.id, subnet_id=subnet.id)
+    db_session.add(scope)
+    await db_session.flush()
+    db_session.add(
+        DHCPPool(
+            scope_id=scope.id,
+            start_ip="192.0.2.100",
+            end_ip="192.0.2.200",
+            pool_type="dynamic",
+        )
+    )
+    await db_session.flush()
+
+    sweep = SweepResult(ping_alive={"192.0.2.150", "192.0.2.50"})
+    counts = await reconcile_subnet(db_session, subnet, sweep)
+    await db_session.flush()
+
+    # .150 is inside the dynamic pool → skipped; .50 → discovered.
+    assert counts["skipped_pool"] == 1
+    assert counts["created"] == 1
+    pool_rows = (await db_session.execute(_addr_q(subnet.id, "192.0.2.150"))).scalars().all()
+    assert pool_rows == []
+
+
+async def test_reconcile_preserves_operator_locked_row(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    locked = IPAddress(
+        subnet_id=subnet.id,
+        address="192.0.2.30",
+        status="reserved",
+        user_modified_at=datetime.now(UTC),
+    )
+    db_session.add(locked)
+    await db_session.flush()
+
+    sweep = SweepResult(ping_alive={"192.0.2.30"})
+    await reconcile_subnet(db_session, subnet, sweep)
+    await db_session.flush()
+    await db_session.refresh(locked)
+    # Discovery only refreshes last_seen; the operator's status stays.
+    assert locked.status == "reserved"
+    assert locked.last_seen_at is not None
+
+
+async def test_reconciliation_report_buckets(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    now = datetime.now(UTC)
+    stale = now - timedelta(days=10)
+    db_session.add_all(
+        [
+            # allocated, never seen → in_ipam_not_seen
+            IPAddress(subnet_id=subnet.id, address="192.0.2.10", status="allocated"),
+            # allocated, last seen long ago → in_ipam_not_seen
+            IPAddress(
+                subnet_id=subnet.id, address="192.0.2.11", status="allocated", last_seen_at=stale
+            ),
+            # discovered → discovered_not_allocated
+            IPAddress(
+                subnet_id=subnet.id, address="192.0.2.20", status="discovered", last_seen_at=now
+            ),
+            # available but active → status_mismatch
+            IPAddress(
+                subnet_id=subnet.id, address="192.0.2.30", status="available", last_seen_at=now
+            ),
+            # allocated + recently seen → in NONE of the buckets
+            IPAddress(
+                subnet_id=subnet.id, address="192.0.2.40", status="allocated", last_seen_at=now
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    report = await build_reconciliation_report(db_session, subnet, stale_minutes=1440)
+    assert report["counts"]["in_ipam_not_seen"] == 2
+    assert report["counts"]["discovered_not_allocated"] == 1
+    assert report["counts"]["status_mismatch"] == 1
+    addrs = {e["address"] for e in report["in_ipam_not_seen"]}
+    assert addrs == {"192.0.2.10", "192.0.2.11"}
+
+
+def _addr_q(subnet_id, address):  # noqa: ANN001 — tiny test helper
+    from sqlalchemy import select
+
+    return select(IPAddress).where(IPAddress.subnet_id == subnet_id, IPAddress.address == address)
+
+
+@pytest.mark.parametrize("cidr", ["192.0.2.0/31", "192.0.2.0/32"])
+def test_enumerate_hosts_tiny_subnets(cidr: str) -> None:
+    # /31 + /32 have no "host" addresses in the classic sense; the
+    # sweep just no-ops (empty list, not None).
+    hosts = enumerate_hosts(cidr)
+    assert hosts is not None

--- a/backend/tests/test_ipam_discovery.py
+++ b/backend/tests/test_ipam_discovery.py
@@ -160,6 +160,16 @@ async def test_reconcile_skips_dynamic_pool(db_session: AsyncSession) -> None:
     assert pool_rows == []
 
 
+async def test_reconcile_creates_discovered_on_slash31(db_session: AsyncSession) -> None:
+    # RFC 3021 /31: both addresses are usable hosts, so neither is a
+    # skip-able network/broadcast placeholder — both get discovered rows.
+    subnet = await _make_subnet(db_session, cidr="192.0.2.0/31")
+    sweep = SweepResult(ping_alive={"192.0.2.0", "192.0.2.1"})
+    counts = await reconcile_subnet(db_session, subnet, sweep)
+    await db_session.flush()
+    assert counts["created"] == 2
+
+
 async def test_reconcile_preserves_operator_locked_row(db_session: AsyncSession) -> None:
     subnet = await _make_subnet(db_session)
     locked = IPAddress(

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -264,27 +264,58 @@ Import behavior:
 
 ## 8. Discovery / Reconciliation
 
+> **Status (issue #23): shipped.** Opt-in per subnet — default off,
+> because a sweep is only meaningful for subnets the SpatiumDDI worker
+> can actually route to, and unsolicited probes can trip an IDS.
+
 ### IP Discovery
 
-A scheduled Celery task performs network scanning to discover IPs that are in use but not recorded in IPAM.
+A per-subnet-opt-in Celery sweep discovers IPs that are live but not
+recorded in IPAM. Enable it on a subnet (Edit Subnet → *IP discovery*)
+and set the sweep interval; a beat dispatcher (`dispatch_due_subnets`,
+ticks every 60 s) queues `run_subnet_discovery` for each subnet whose
+`discovery_interval_minutes` has elapsed since its `last_discovery_at`.
+Interval changes take effect without restarting beat. Operators can
+also sweep on demand: **Tools → Reconcile (IP discovery) → Discover
+now**, or `POST /api/v1/ipam/subnets/{id}/discover`.
 
-Methods:
-- **Ping sweep** (ICMP) — pure Python asyncio, no external tools required
-- **ARP scan** — requires the scanner to run on-subnet or have access to ARP tables
-- **SNMP polling** — poll ARP tables from routers (future phase)
+Methods (run together per pass):
+- **Ping sweep** — pure-Python asyncio using an *unprivileged*
+  `SOCK_DGRAM` ICMP socket. When that socket can't be created (the
+  worker's uid is outside `net.ipv4.ping_group_range`), it falls back
+  to a TCP-connect probe across a small set of common ports — a
+  connect success **or** a connection-refused (RST) both prove the host
+  is up. No raw sockets / CAP_NET_RAW required.
+- **ARP scan** — reads the worker's own ARP cache (`/proc/net/arp`).
+  Only useful for subnets the worker is L2-adjacent to, but it catches
+  hosts that drop ICMP and enriches `mac_address`.
+- **SNMP polling** — ARP tables pulled from routers/switches (already
+  shipped separately; feeds the same `last_seen_at` columns).
 
-Results update `IPAddress.last_seen_at` and flag `status = discovered` for IPs not in IPAM.
+Reconciliation writes (`services/ipam/discovery.reconcile_subnet`):
+- existing rows → `last_seen_at` / `last_seen_method` refreshed (MAC
+  filled only when NULL — operator data is never overwritten);
+- live IPs with no row → inserted `status='discovered'`, **unless** the
+  IP is in a dynamic DHCP pool (owned by the DHCP server) or is the
+  network / broadcast address.
+
+Operator-locked rows (`user_modified_at` set) keep their status; a
+sweep only refreshes their `last_seen_at`. Subnets larger than a /20
+(`MAX_SWEEP_HOSTS = 4096`) and IPv6 subnets are skipped.
 
 ### Reconciliation Report
 
-Available at `GET /api/v1/ipam/subnets/{id}/reconciliation`:
+`GET /api/v1/ipam/subnets/{id}/reconciliation?stale_minutes=1440`
+(also surfaced to the Operator Copilot as `find_subnet_reconciliation`):
 
 | Category | Description |
 |---|---|
-| In IPAM, not discovered | Allocated but no recent ping response |
-| Discovered, not in IPAM | Active IP not tracked |
-| DHCP lease, no IPAM record | Lease IP falls outside known subnets |
-| IP status mismatch | IPAM says "available" but IP is active |
+| `in_ipam_not_seen` | Allocated / reserved / static but nothing answered within the stale window |
+| `discovered_not_allocated` | Live on the wire but never formally allocated |
+| `status_mismatch` | Marked `available` but a host is answering right now |
+
+`stale_minutes` (default 24 h) is the window after which a row's
+`last_seen_at` counts as stale.
 
 ---
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -548,6 +548,10 @@ export interface Subnet {
     | "udp_top1000"
     | "aggressive";
   auto_profile_refresh_days?: number;
+  // IP discovery (issue #23) — opt-in scheduled ping/ARP sweep.
+  discovery_enabled?: boolean;
+  discovery_interval_minutes?: number;
+  last_discovery_at?: string | null;
   // Compliance / classification flags. First-class booleans (rather
   // than freeform tags) so auditor queries — "show me every PCI
   // subnet" — are clean indexed predicates. Default false on every
@@ -569,6 +573,34 @@ export interface Subnet {
   site_id?: string | null;
   created_at?: string;
   modified_at?: string;
+}
+
+/** One IP row in a reconciliation bucket (issue #23). */
+export interface ReconciliationEntry {
+  id: string;
+  address: string;
+  status: string;
+  hostname: string | null;
+  mac_address: string | null;
+  last_seen_at: string | null;
+  last_seen_method: string | null;
+}
+
+/** IP-discovery reconciliation report for a subnet (issue #23). */
+export interface SubnetReconciliation {
+  subnet_id: string;
+  network: string;
+  generated_at: string;
+  stale_minutes: number;
+  last_discovery_at: string | null;
+  counts: {
+    in_ipam_not_seen: number;
+    discovered_not_allocated: number;
+    status_mismatch: number;
+  };
+  in_ipam_not_seen: ReconciliationEntry[];
+  discovered_not_allocated: ReconciliationEntry[];
+  status_mismatch: ReconciliationEntry[];
 }
 
 /** Optional role tag, orthogonal to ``status``. Roles in
@@ -1292,6 +1324,21 @@ export const ipamApi = {
   }) => api.get<Subnet[]>("/ipam/subnets", { params }).then((r) => r.data),
   getSubnet: (id: string) =>
     api.get<Subnet>(`/ipam/subnets/${id}`).then((r) => r.data),
+  // IP discovery reconciliation report (issue #23).
+  getReconciliation: (id: string, staleMinutes?: number) =>
+    api
+      .get<SubnetReconciliation>(`/ipam/subnets/${id}/reconciliation`, {
+        params: staleMinutes ? { stale_minutes: staleMinutes } : undefined,
+      })
+      .then((r) => r.data),
+  // Queue an on-demand discovery sweep (independent of the schedule).
+  triggerDiscovery: (id: string) =>
+    api
+      .post<{
+        status: string;
+        subnet_id: string;
+      }>(`/ipam/subnets/${id}/discover`)
+      .then((r) => r.data),
   createSubnet: (data: Partial<Subnet> & { template_id?: string | null }) =>
     api.post<Subnet>("/ipam/subnets", data).then((r) => r.data),
   updateSubnet: (

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -61,6 +61,8 @@ import {
   type IPSpace,
   type IPBlock,
   type Subnet,
+  type SubnetReconciliation,
+  type ReconciliationEntry,
   type SubnetRole,
   type IPAddress,
   type IPRole,
@@ -1188,6 +1190,82 @@ function ProfilingSettingsSection({
 }
 
 /**
+ * IP discovery (issue #23) — opt-in scheduled ping/ARP sweep. Mirrors
+ * the profiling section's shape. Default-off + per-subnet because a
+ * sweep only makes sense for subnets the worker can reach, and
+ * unsolicited probes can trip an IDS. The sweep stamps last-seen on
+ * existing rows and inserts ``discovered`` rows for live IPs not yet
+ * in IPAM (locked rows + dynamic DHCP pools are never clobbered).
+ */
+function DiscoverySettingsSection({
+  enabled,
+  intervalMinutes,
+  onEnabledChange,
+  onIntervalChange,
+}: {
+  enabled: boolean;
+  intervalMinutes: number;
+  onEnabledChange: (v: boolean) => void;
+  onIntervalChange: (v: number) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Radar className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-xs font-medium">
+            IP discovery (scheduled ping / ARP sweep)
+          </span>
+        </div>
+        <label className="flex items-center gap-1.5 text-xs cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => onEnabledChange(e.target.checked)}
+            className="h-3.5 w-3.5"
+          />
+          Enabled
+        </label>
+      </div>
+      {!enabled && (
+        <p className="text-xs text-muted-foreground italic">
+          When enabled, SpatiumDDI periodically pings this subnet (and reads the
+          worker's ARP table), stamping last-seen on tracked IPs and flagging
+          live-but-untracked IPs as <code>discovered</code>. Only useful for
+          subnets the worker can route to.
+        </p>
+      )}
+      {enabled && (
+        <div className="space-y-2 pl-5 border-l-2 border-muted">
+          <label className="block text-xs">
+            <span className="block text-muted-foreground mb-0.5">
+              Sweep interval (minutes)
+            </span>
+            <input
+              type="number"
+              min={5}
+              max={10080}
+              value={intervalMinutes}
+              onChange={(e) => {
+                const v = e.target.value.trim();
+                if (!v) return;
+                const n = parseInt(v, 10);
+                if (!isNaN(n)) onIntervalChange(n);
+              }}
+              className="w-full rounded-md border bg-background px-2 py-1 text-sm"
+            />
+            <span className="mt-0.5 block text-[11px] text-muted-foreground">
+              How often to sweep. 360 (6h) is a sane default; 5-minute floor.
+              Subnets larger than a /20 are skipped (too big to sweep safely).
+            </span>
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
  * Compliance classification — first-class boolean flags on the
  * subnet for PCI / HIPAA / internet-facing scope. Used by the
  * Compliance dashboard at /admin/compliance to answer auditor
@@ -1848,6 +1926,9 @@ function CreateSubnetModal({
   const [autoProfilePreset, setAutoProfilePreset] =
     useState<AutoProfilePreset>("service_and_os");
   const [autoProfileRefreshDays, setAutoProfileRefreshDays] = useState(30);
+  // IP discovery (issue #23) — opt-in scheduled ping/ARP sweep.
+  const [discoveryEnabled, setDiscoveryEnabled] = useState(false);
+  const [discoveryIntervalMinutes, setDiscoveryIntervalMinutes] = useState(360);
   // Compliance / classification flags (issue #75).
   const [pciScope, setPciScope] = useState(false);
   const [hipaaScope, setHipaaScope] = useState(false);
@@ -1955,6 +2036,8 @@ function CreateSubnetModal({
         auto_profile_on_dhcp_lease: autoProfileEnabled,
         auto_profile_preset: autoProfilePreset,
         auto_profile_refresh_days: autoProfileRefreshDays,
+        discovery_enabled: discoveryEnabled,
+        discovery_interval_minutes: discoveryIntervalMinutes,
         pci_scope: pciScope,
         hipaa_scope: hipaaScope,
         internet_facing: internetFacing,
@@ -2260,6 +2343,14 @@ function CreateSubnetModal({
             onPresetChange={setAutoProfilePreset}
             onRefreshDaysChange={setAutoProfileRefreshDays}
           />
+          <div className="border-t pt-4">
+            <DiscoverySettingsSection
+              enabled={discoveryEnabled}
+              intervalMinutes={discoveryIntervalMinutes}
+              onEnabledChange={setDiscoveryEnabled}
+              onIntervalChange={setDiscoveryIntervalMinutes}
+            />
+          </div>
           <div className="border-t pt-4">
             <ClassificationSection
               pciScope={pciScope}
@@ -3198,6 +3289,168 @@ function SyncMenu({
 
 // ─── Tools dropdown — alphabetical bundle of low-frequency subnet ops ───────
 //
+// IP-discovery reconciliation modal (issue #23). Reads the per-subnet
+// reconciliation report (last sweep) into three buckets and offers a
+// "Discover now" trigger that queues an on-demand sweep. The sweep is
+// async (Celery), so after triggering we tell the operator to Refresh
+// in a moment rather than blocking on it.
+function ReconciliationModal({
+  subnet,
+  onClose,
+}: {
+  subnet: Subnet;
+  onClose: () => void;
+}) {
+  const {
+    data: report,
+    isLoading,
+    refetch,
+    isFetching,
+  } = useQuery({
+    queryKey: ["subnet-reconciliation", subnet.id],
+    queryFn: () => ipamApi.getReconciliation(subnet.id),
+  });
+  const [note, setNote] = useState<string | null>(null);
+  const discover = useMutation({
+    mutationFn: () => ipamApi.triggerDiscovery(subnet.id),
+    onSuccess: (r) =>
+      setNote(
+        r.status === "queued"
+          ? "Sweep queued — it runs in the background. Refresh in a few seconds to see results."
+          : "Couldn't queue the sweep (task broker unreachable).",
+      ),
+    onError: () => setNote("Failed to queue the sweep."),
+  });
+
+  const buckets: {
+    key: keyof SubnetReconciliation["counts"];
+    title: string;
+    hint: string;
+    rows: ReconciliationEntry[];
+    tone: string;
+  }[] = report
+    ? [
+        {
+          key: "in_ipam_not_seen",
+          title: "Allocated but not seen",
+          hint: "Tracked as allocated/reserved/static but nothing answered within the stale window.",
+          rows: report.in_ipam_not_seen,
+          tone: "text-amber-600 dark:text-amber-400",
+        },
+        {
+          key: "discovered_not_allocated",
+          title: "Discovered, not allocated",
+          hint: "Live on the wire but never formally allocated. Promote via Edit, or leave as a heads-up.",
+          rows: report.discovered_not_allocated,
+          tone: "text-sky-600 dark:text-sky-400",
+        },
+        {
+          key: "status_mismatch",
+          title: "Marked available but active",
+          hint: "IPAM says these are free, but a host is answering. Likely a silent squatter.",
+          rows: report.status_mismatch,
+          tone: "text-rose-600 dark:text-rose-400",
+        },
+      ]
+    : [];
+
+  return (
+    <Modal title={`Reconciliation — ${subnet.network}`} onClose={onClose} wide>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground">
+            {report?.last_discovery_at
+              ? `Last sweep: ${new Date(report.last_discovery_at).toLocaleString()}`
+              : "No sweep has run yet for this subnet."}
+          </p>
+          <div className="flex items-center gap-2">
+            <HeaderButton
+              icon={RefreshCw}
+              onClick={() => refetch()}
+              disabled={isFetching}
+            >
+              Refresh
+            </HeaderButton>
+            <HeaderButton
+              icon={Radar}
+              variant="primary"
+              onClick={() => discover.mutate()}
+              disabled={discover.isPending}
+            >
+              {discover.isPending ? "Queuing…" : "Discover now"}
+            </HeaderButton>
+          </div>
+        </div>
+        {note && (
+          <p className="rounded-md border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs text-sky-700 dark:text-sky-300">
+            {note}
+          </p>
+        )}
+        {isLoading && (
+          <p className="text-sm text-muted-foreground">Loading report…</p>
+        )}
+        {report && (
+          <div className="space-y-4">
+            {buckets.map((b) => (
+              <section key={b.key}>
+                <div className="mb-1 flex items-baseline gap-2">
+                  <h4 className={cn("text-sm font-semibold", b.tone)}>
+                    {b.title}
+                  </h4>
+                  <span className="text-xs text-muted-foreground">
+                    {report.counts[b.key]}
+                  </span>
+                </div>
+                <p className="mb-1.5 text-[11px] text-muted-foreground">
+                  {b.hint}
+                </p>
+                {b.rows.length === 0 ? (
+                  <p className="text-xs text-muted-foreground italic">None.</p>
+                ) : (
+                  <div className="overflow-x-auto rounded-md border">
+                    <table className="w-full min-w-[480px] text-xs">
+                      <thead className="bg-muted/50 text-left text-muted-foreground">
+                        <tr>
+                          <th className="px-2 py-1 font-medium">Address</th>
+                          <th className="px-2 py-1 font-medium">Status</th>
+                          <th className="px-2 py-1 font-medium">Hostname</th>
+                          <th className="px-2 py-1 font-medium">MAC</th>
+                          <th className="px-2 py-1 font-medium">Last seen</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {b.rows.map((r) => (
+                          <tr key={r.id} className="border-t">
+                            <td className="px-2 py-1 font-mono">{r.address}</td>
+                            <td className="px-2 py-1">{r.status}</td>
+                            <td className="px-2 py-1">{r.hostname || "—"}</td>
+                            <td className="px-2 py-1 font-mono">
+                              {r.mac_address || "—"}
+                            </td>
+                            <td className="px-2 py-1">
+                              {r.last_seen_at
+                                ? `${new Date(r.last_seen_at).toLocaleString()}${
+                                    r.last_seen_method
+                                      ? ` (${r.last_seen_method})`
+                                      : ""
+                                  }`
+                                : "never"}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </section>
+            ))}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
 // Collapses Clean Orphans / Merge / Resize / Scan with nmap / Split into a
 // single dropdown so the subnet header doesn't accumulate a row of 9+ buttons
 // as we add features. Items are alphabetical to make discovery predictable —
@@ -3207,6 +3460,7 @@ function ToolsMenu({
   onBulkAllocate,
   onCleanOrphans,
   onMerge,
+  onReconcile,
   onResize,
   onScan,
   onSplit,
@@ -3214,6 +3468,7 @@ function ToolsMenu({
   onBulkAllocate: () => void;
   onCleanOrphans: () => void;
   onMerge: () => void;
+  onReconcile: () => void;
   onResize: () => void;
   onScan: () => void;
   onSplit: () => void;
@@ -3278,6 +3533,16 @@ function ToolsMenu({
             className={itemCls}
           >
             <GitMerge className="h-3.5 w-3.5" /> Merge…
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              onReconcile();
+            }}
+            className={itemCls}
+          >
+            <Radar className="h-3.5 w-3.5" /> Reconcile (IP discovery)
           </button>
           <button
             type="button"
@@ -3399,6 +3664,7 @@ function SubnetDetail({
   } | null>(null);
   const [showEditSubnet, setShowEditSubnet] = useState(false);
   const [showResizeSubnet, setShowResizeSubnet] = useState(false);
+  const [showReconcile, setShowReconcile] = useState(false);
   const [showSplitSubnet, setShowSplitSubnet] = useState(false);
   const [showMergeSubnet, setShowMergeSubnet] = useState(false);
   // Scan-the-whole-subnet trigger from the Tools menu. Re-uses the
@@ -3870,6 +4136,7 @@ function SubnetDetail({
               onBulkAllocate={() => setShowBulkAllocate(true)}
               onCleanOrphans={() => setShowOrphans(true)}
               onMerge={() => setShowMergeSubnet(true)}
+              onReconcile={() => setShowReconcile(true)}
               onResize={() => setShowResizeSubnet(true)}
               onScan={() => setShowSubnetScan(true)}
               onSplit={() => setShowSplitSubnet(true)}
@@ -4978,6 +5245,12 @@ function SubnetDetail({
           }}
         />
       )}
+      {showReconcile && (
+        <ReconciliationModal
+          subnet={subnet}
+          onClose={() => setShowReconcile(false)}
+        />
+      )}
       {showSplitSubnet && (
         <SplitSubnetModal
           subnet={subnet}
@@ -5871,6 +6144,13 @@ function EditSubnetModal({
   const [autoProfileRefreshDays, setAutoProfileRefreshDays] = useState(
     subnet.auto_profile_refresh_days ?? 30,
   );
+  // IP discovery (issue #23) — opt-in scheduled ping/ARP sweep.
+  const [discoveryEnabled, setDiscoveryEnabled] = useState(
+    subnet.discovery_enabled ?? false,
+  );
+  const [discoveryIntervalMinutes, setDiscoveryIntervalMinutes] = useState(
+    subnet.discovery_interval_minutes ?? 360,
+  );
   // Compliance / classification flags (issue #75). First-class
   // booleans rather than freeform tags so the Compliance dashboard
   // queries hit indexed predicates.
@@ -5991,6 +6271,8 @@ function EditSubnetModal({
         auto_profile_on_dhcp_lease: autoProfileEnabled,
         auto_profile_preset: autoProfilePreset,
         auto_profile_refresh_days: autoProfileRefreshDays,
+        discovery_enabled: discoveryEnabled,
+        discovery_interval_minutes: discoveryIntervalMinutes,
         pci_scope: pciScope,
         hipaa_scope: hipaaScope,
         internet_facing: internetFacing,
@@ -6335,6 +6617,14 @@ function EditSubnetModal({
             onPresetChange={setAutoProfilePreset}
             onRefreshDaysChange={setAutoProfileRefreshDays}
           />
+          <div className="border-t pt-4">
+            <DiscoverySettingsSection
+              enabled={discoveryEnabled}
+              intervalMinutes={discoveryIntervalMinutes}
+              onEnabledChange={setDiscoveryEnabled}
+              onIntervalChange={setDiscoveryIntervalMinutes}
+            />
+          </div>
           <div className="border-t pt-4">
             <ClassificationSection
               pciScope={pciScope}


### PR DESCRIPTION
Closes #23.

Opt-in, per-subnet scheduled **IP discovery** that finds live hosts and folds them back into IPAM — the producer of the IPAM hygiene loop (#45 stale-IP and #41 reverse-DNS consume the last-seen signal this stamps). See `docs/features/IPAM.md` §8.

## Sweep (`services/ipam/discovery.py`)
- **Ping sweep** — pure-Python asyncio ICMP echo via an *unprivileged* `SOCK_DGRAM` ICMP socket; falls back to a TCP-connect probe (connect-success **or** `ConnectionRefusedError` both prove liveness) when that socket can't be created, so it works in an unprivileged worker with no raw sockets / CAP_NET_RAW.
- **ARP scan** — reads the worker's `/proc/net/arp` cache; catches ICMP-silent hosts + enriches MAC.
- IPv6 + subnets larger than a /20 (`MAX_SWEEP_HOSTS=4096`) are skipped.

## Reconcile (`reconcile_subnet`)
Refreshes `last_seen_at`/`last_seen_method` on existing rows (MAC filled only when NULL — operator data never overwritten), inserts `status='discovered'` for live IPs with no row, but **skips** dynamic DHCP pool ranges (DHCP-owned) + network/broadcast. Operator-locked rows (`user_modified_at` set) keep their status — only `last_seen` is refreshed. Mirrors the SNMP cross-reference lock semantics.

## Schedule
Per-subnet `discovery_enabled` + `discovery_interval_minutes` + `last_discovery_at` (migration `a7e3c1f49d20`, all additive/defaulted). Beat `dispatch_due_subnets` (60 s tick) queues `run_subnet_discovery` per due subnet; gating lives in the task so interval changes take effect without restarting beat (same pattern as the SNMP poller).

## API + MCP
- `GET /ipam/subnets/{id}/reconciliation?stale_minutes=` — three buckets: `in_ipam_not_seen` / `discovered_not_allocated` / `status_mismatch`.
- `POST /ipam/subnets/{id}/discover` — on-demand sweep (independent of the schedule / enabled toggle), audit-logged.
- `find_subnet_reconciliation` Operator-Copilot read tool (default-enabled).

## Frontend
Shared `DiscoverySettingsSection` (toggle + interval) in the Create + Edit Subnet modals, and a **Reconciliation** modal (3 bucket tables + Discover-now) on the subnet Tools menu.

## Tests
`backend/tests/test_ipam_discovery.py` — 14 cases: enumerate caps + v6/too-big, ARP parse, `SweepResult` union/method, reconcile create/update/lock-preserve/network-broadcast-skip/dynamic-pool-skip, and the report buckets.

`make ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
