### PR TITLE
Stale-IP report + one-click bulk-deprecate (#45)

### DIFF
--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -3796,17 +3796,25 @@ async def deprecate_stale_ips(
     """
     from app.services.ipam.stale_ips import MAX_BULK_DEPRECATE, select_stale_ip_ids
 
+    stale_days = max(1, min(body.stale_days, 3650))
+    now = datetime.now(UTC)
+    stale_cutoff = now - timedelta(days=stale_days)
+
     capped = False
     if body.all_matching:
+        # Fetch one past the cap so "exactly at cap, no remainder" doesn't
+        # read as capped — a false "re-run to finish" prompt otherwise.
         ids = await select_stale_ip_ids(
             db,
-            stale_days=max(1, min(body.stale_days, 3650)),
+            stale_days=stale_days,
             include_never_seen=body.include_never_seen,
             space_id=body.space_id,
             block_id=body.block_id,
             subnet_id=body.subnet_id,
+            cap=MAX_BULK_DEPRECATE + 1,
         )
-        capped = len(ids) >= MAX_BULK_DEPRECATE
+        capped = len(ids) > MAX_BULK_DEPRECATE
+        ids = ids[:MAX_BULK_DEPRECATE]
     else:
         ids = list(body.ip_ids or [])
     if not ids:
@@ -3819,9 +3827,17 @@ async def deprecate_stale_ips(
     rows = list((await db.execute(select(IPAddress).where(IPAddress.id.in_(ids)))).scalars().all())
     deprecated = 0
     skipped: list[uuid.UUID] = []
-    now = datetime.now(UTC)
     for ip in rows:
         if ip.status != "allocated" or ip.auto_from_lease:
+            skipped.append(ip.id)
+            continue
+        # Re-check staleness against the request's window so a row that came
+        # back to life after the report page loaded isn't deprecated out from
+        # under a live host. The all_matching path already filtered on this,
+        # so the re-check is a no-op there and the real guard for explicit
+        # ip_ids (the frontend passes the filter it showed the operator).
+        is_stale = ip.last_seen_at is not None and ip.last_seen_at < stale_cutoff
+        if not is_stale and not (body.include_never_seen and ip.last_seen_at is None):
             skipped.append(ip.id)
             continue
         old_status = ip.status

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -3716,6 +3716,152 @@ async def trigger_subnet_discovery(subnet_id: uuid.UUID, current_user: CurrentUs
     return {"status": "queued" if queued else "enqueue_failed", "subnet_id": str(subnet_id)}
 
 
+# ── Stale-IP report + one-click bulk-deprecate (issue #45) ──────────────────
+# Cross-subnet hygiene view over the discovery (#23) ``last_seen_at`` signal:
+# which allocated IPs has nothing seen on the wire in N days? The deprecate
+# action flips them to ``deprecated`` (reversible — the operator can re-edit
+# any row back), stamping ``user_modified_at`` so a later sweep won't undo it.
+
+
+@router.get("/reports/stale-ips")
+async def get_stale_ip_report(
+    current_user: CurrentUser,
+    db: DB,
+    stale_days: int = Query(90, ge=1, le=3650),
+    include_never_seen: bool = Query(False),
+    space_id: uuid.UUID | None = Query(None),
+    block_id: uuid.UUID | None = Query(None),
+    subnet_id: uuid.UUID | None = Query(None),
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+) -> dict:
+    """Allocated IPs nothing has seen in ``stale_days`` days (issue #45).
+
+    Optional ``space_id`` / ``block_id`` / ``subnet_id`` scope the report.
+    ``include_never_seen`` folds in allocated rows that were never seen on
+    the wire (off by default — those are often in subnets where discovery
+    was never enabled). See docs/features/IPAM.md §9.
+    """
+    from app.services.ipam.stale_ips import build_stale_ip_report
+
+    return await build_stale_ip_report(
+        db,
+        stale_days=stale_days,
+        include_never_seen=include_never_seen,
+        space_id=space_id,
+        block_id=block_id,
+        subnet_id=subnet_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+class StaleIPDeprecateRequest(BaseModel):
+    # Either deprecate a hand-picked set (``ip_ids`` — the rows the operator
+    # ticked) or every row the current filter selects (``all_matching`` —
+    # reuses the same filter params the report endpoint takes).
+    ip_ids: list[uuid.UUID] | None = None
+    all_matching: bool = False
+    stale_days: int = 90
+    include_never_seen: bool = False
+    space_id: uuid.UUID | None = None
+    block_id: uuid.UUID | None = None
+    subnet_id: uuid.UUID | None = None
+
+
+class StaleIPDeprecateResponse(BaseModel):
+    batch_id: uuid.UUID
+    deprecated_count: int
+    skipped: list[uuid.UUID] = []
+    # True when ``all_matching`` hit the server-side cap — the operator
+    # should re-run to sweep the remainder.
+    capped: bool = False
+
+
+@router.post("/reports/stale-ips/deprecate", response_model=StaleIPDeprecateResponse)
+async def deprecate_stale_ips(
+    body: StaleIPDeprecateRequest,
+    current_user: CurrentUser,
+    db: DB,
+) -> StaleIPDeprecateResponse:
+    """One-click bulk-deprecate of stale allocated IPs (issue #45).
+
+    Provide ``ip_ids`` to deprecate a hand-picked set, or
+    ``all_matching=true`` to deprecate every IP the report filter selects
+    (capped at ``MAX_BULK_DEPRECATE``). Only genuinely ``allocated`` rows
+    are touched; system placeholders and DHCP-lease mirrors are skipped
+    even if an id slips through a stale client-side selection. Each row's
+    status flips to ``deprecated`` and ``user_modified_at`` is stamped so a
+    later discovery / integration sweep won't silently un-deprecate it.
+    """
+    from app.services.ipam.stale_ips import MAX_BULK_DEPRECATE, select_stale_ip_ids
+
+    capped = False
+    if body.all_matching:
+        ids = await select_stale_ip_ids(
+            db,
+            stale_days=max(1, min(body.stale_days, 3650)),
+            include_never_seen=body.include_never_seen,
+            space_id=body.space_id,
+            block_id=body.block_id,
+            subnet_id=body.subnet_id,
+        )
+        capped = len(ids) >= MAX_BULK_DEPRECATE
+    else:
+        ids = list(body.ip_ids or [])
+    if not ids:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Provide ip_ids or set all_matching=true with a filter that matches rows",
+        )
+
+    batch_id = uuid.uuid4()
+    rows = list((await db.execute(select(IPAddress).where(IPAddress.id.in_(ids)))).scalars().all())
+    deprecated = 0
+    skipped: list[uuid.UUID] = []
+    now = datetime.now(UTC)
+    for ip in rows:
+        if ip.status != "allocated" or ip.auto_from_lease:
+            skipped.append(ip.id)
+            continue
+        old_status = ip.status
+        ip.status = "deprecated"
+        ip.user_modified_at = now
+        db.add(
+            _audit(
+                current_user,
+                "update",
+                "ip_address",
+                str(ip.id),
+                str(ip.address),
+                old_value={"status": old_status},
+                new_value={
+                    "status": "deprecated",
+                    "reason": "stale_ip_deprecate",
+                    "batch_id": str(batch_id),
+                },
+            )
+        )
+        deprecated += 1
+
+    await db.commit()
+    logger.info(
+        "stale_ip_bulk_deprecate",
+        user=current_user.username,
+        batch_id=str(batch_id),
+        deprecated=deprecated,
+        skipped=len(skipped),
+        all_matching=body.all_matching,
+        capped=capped,
+    )
+    return StaleIPDeprecateResponse(
+        batch_id=batch_id,
+        deprecated_count=deprecated,
+        skipped=skipped,
+        capped=capped,
+    )
+
+
 @router.get("/subnets/{subnet_id}/effective-dns", response_model=EffectiveDnsResponse)
 async def get_effective_subnet_dns(
     subnet_id: uuid.UUID, current_user: CurrentUser, db: DB

--- a/backend/app/services/ai/tools/ipam.py
+++ b/backend/app/services/ai/tools/ipam.py
@@ -370,6 +370,69 @@ async def find_subnet_reconciliation(
     return await build_reconciliation_report(db, subnet, stale_minutes=stale)
 
 
+# ── find_stale_ips ─────────────────────────────────────────────────────
+
+
+class FindStaleIPsArgs(BaseModel):
+    stale_days: int = Field(
+        default=90,
+        description="Allocated IPs not seen on the wire in this many days count as stale. Default 90.",
+    )
+    include_never_seen: bool = Field(
+        default=False,
+        description=(
+            "Also include allocated IPs that were never seen on the wire "
+            "(often in subnets where discovery was never enabled). Off by default."
+        ),
+    )
+    space_id: str | None = Field(
+        default=None, description="Optional IP-space UUID to scope the report to."
+    )
+    subnet_id: str | None = Field(
+        default=None, description="Optional subnet UUID to scope the report to."
+    )
+    limit: int = Field(default=100, description="Max rows to return (1–500). Default 100.")
+
+
+@register_tool(
+    name="find_stale_ips",
+    description=(
+        "Address-space hygiene report (issue #45): allocated IPs that "
+        "nothing has seen on the wire in N days (default 90), drawn from "
+        "the discovery last-seen signal. Use when the operator asks "
+        "'what's stale?', 'which IPs can I reclaim?', 'what allocations "
+        "are dead?', or 'find addresses to clean up'. Read-only — to "
+        "actually deprecate, point the operator at the Stale-IP report's "
+        "bulk-deprecate action. Optionally scope by space or subnet."
+    ),
+    args_model=FindStaleIPsArgs,
+    category="ipam",
+)
+async def find_stale_ips(db: AsyncSession, user: User, args: FindStaleIPsArgs) -> dict[str, Any]:
+    from app.services.ipam.stale_ips import build_stale_ip_report
+
+    space_uuid: uuid.UUID | None = None
+    subnet_uuid: uuid.UUID | None = None
+    if args.space_id:
+        try:
+            space_uuid = uuid.UUID(args.space_id)
+        except (ValueError, TypeError):
+            return {"error": "space_id must be a UUID", "space_id": args.space_id}
+    if args.subnet_id:
+        try:
+            subnet_uuid = uuid.UUID(args.subnet_id)
+        except (ValueError, TypeError):
+            return {"error": "subnet_id must be a UUID", "subnet_id": args.subnet_id}
+    return await build_stale_ip_report(
+        db,
+        stale_days=max(1, min(args.stale_days, 3650)),
+        include_never_seen=args.include_never_seen,
+        space_id=space_uuid,
+        subnet_id=subnet_uuid,
+        limit=max(1, min(args.limit, 500)),
+    )
+
+
 # ── find_ip ───────────────────────────────────────────────────────────
 
 

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -91,6 +91,13 @@ RULE_TYPE_VOICE_LEASE_COUNT_BELOW = "voice_lease_count_below"
 # critical as expiry approaches. Default threshold 30 d.
 RULE_TYPE_K3S_API_CERT_EXPIRING = "k3s_api_cert_expiring"
 
+# Address-space hygiene — issue #45. Fires when a subnet holds more than
+# ``threshold_percent`` (re-used as a raw count) allocated IPs whose
+# ``last_seen_at`` is older than ``threshold_days`` (default 90). The
+# companion to the Stale-IP report: the report is the operator-driven
+# drilldown, this is the passive "your hygiene is slipping" feed.
+RULE_TYPE_STALE_IP_COUNT = "stale_ip_count"
+
 RULE_TYPES = frozenset(
     {
         RULE_TYPE_SUBNET_UTILIZATION,
@@ -111,8 +118,13 @@ RULE_TYPES = frozenset(
         RULE_TYPE_AUDIT_CHAIN_BROKEN,
         RULE_TYPE_VOICE_LEASE_COUNT_BELOW,
         RULE_TYPE_K3S_API_CERT_EXPIRING,
+        RULE_TYPE_STALE_IP_COUNT,
     }
 )
+
+# Default stale-IP alert params when the rule doesn't pin them.
+_STALE_IP_DEFAULT_COUNT_THRESHOLD = 10
+_STALE_IP_DEFAULT_DAYS = 90
 
 # Compliance-change rule constants. Keep in lock-step with the
 # Subnet model in ``backend/app/models/ipam.py`` — only flags that
@@ -281,6 +293,51 @@ async def _matching_voice_lease_count_below_subjects(
         message = (
             f"Voice subnet {display} has {int(count or 0)} active lease(s) "
             f"(threshold {threshold}) — possible mass-disconnect event"
+        )
+        matches.append((str(s.id), display, message))
+    return matches
+
+
+async def _matching_stale_ip_count_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+) -> list[tuple[str, str, str]]:
+    """Subnets holding ≥ ``threshold_percent`` (raw count) allocated IPs
+    whose ``last_seen_at`` is older than ``threshold_days`` (default 90).
+
+    Reads the same discovery (#23) liveness signal the Stale-IP report
+    uses. ``include_never_seen`` is intentionally off for the alert —
+    never-seen rows are noisy (often in discovery-disabled subnets), so
+    the alert fires only on the high-confidence "seen, then went dark"
+    signal. Operators chase the full list, including never-seen, from the
+    report page.
+    """
+    from app.services.ipam.stale_ips import count_stale_per_subnet
+
+    threshold = (
+        int(rule.threshold_percent)
+        if rule.threshold_percent is not None
+        else _STALE_IP_DEFAULT_COUNT_THRESHOLD
+    )
+    stale_days = (
+        int(rule.threshold_days) if rule.threshold_days is not None else _STALE_IP_DEFAULT_DAYS
+    )
+    counts = await count_stale_per_subnet(db, stale_days=stale_days, include_never_seen=False)
+    over = {sid: n for sid, n in counts.items() if n >= max(1, threshold)}
+    if not over:
+        return []
+
+    subnets = list(
+        (await db.execute(select(Subnet).where(Subnet.id.in_(over.keys())))).scalars().all()
+    )
+    matches: list[tuple[str, str, str]] = []
+    for s in subnets:
+        n = over[s.id]
+        display = f"{s.network}" + (f" — {s.name}" if s.name else "")
+        message = (
+            f"Subnet {display} has {n} stale allocated IP(s) not seen on the "
+            f"wire in {stale_days}+ days (threshold {threshold}) — review for "
+            f"deprecation from the Stale-IP report"
         )
         matches.append((str(s.id), display, message))
     return matches
@@ -1491,6 +1548,10 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 subject_type = "subnet"
             elif rule.rule_type == RULE_TYPE_VOICE_LEASE_COUNT_BELOW:
                 base = await _matching_voice_lease_count_below_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "subnet"
+            elif rule.rule_type == RULE_TYPE_STALE_IP_COUNT:
+                base = await _matching_stale_ip_count_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]
                 subject_type = "subnet"
             elif rule.rule_type == RULE_TYPE_SERVER_UNREACHABLE:

--- a/backend/app/services/ipam/stale_ips.py
+++ b/backend/app/services/ipam/stale_ips.py
@@ -1,0 +1,245 @@
+"""Stale-IP report — allocated IPs nothing has seen in a while (issue #45).
+
+The IP-discovery sweep (#23) stamps ``last_seen_at`` / ``last_seen_method``
+on every IPAddress it can prove is alive (ping / ARP / DHCP / nmap / SNMP).
+This module reads that signal from the *other* direction: which IPs are
+still marked ``allocated`` but haven't been seen on the wire in N days?
+Those are the address-space-hygiene candidates — hosts decommissioned
+without anyone freeing the IPAM row.
+
+Read side (``build_stale_ip_report``) powers ``GET /ipam/reports/stale-ips``
+and the ``find_stale_ips`` MCP tool. ``select_stale_ip_ids`` resolves the
+full matching set for the "deprecate all matching" one-click action.
+``count_stale_per_subnet`` powers the ``stale_ip_count`` alert rule.
+
+Semantics:
+* candidate status = ``allocated`` only. ``reserved`` / ``static_dhcp``
+  are deliberately held; ``deprecated`` is already deprecated;
+  integration-owned statuses churn on their own reconciler cadence.
+* ``auto_from_lease`` rows are always excluded — a DHCP lease mirror is
+  owned by the DHCP server and naturally comes and goes.
+* a row counts as stale when ``last_seen_at`` is older than the cutoff.
+  Rows *never* seen (``last_seen_at IS NULL``) are a separate concern —
+  many live in subnets where discovery was never enabled, so they'd be
+  false positives. They're included only when the caller opts in via
+  ``include_never_seen``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.selectable import Select
+
+from app.models.ipam import IPAddress, Subnet
+
+# Operator-tunable default — the issue's stated 90-day window.
+STALE_IP_DEFAULT_DAYS = 90
+
+# Only ``allocated`` rows are hygiene candidates. Kept as a frozenset so
+# the semantics are obvious and the set is easy to widen later.
+STALE_CANDIDATE_STATUSES: frozenset[str] = frozenset({"allocated"})
+
+# Hard cap on the "deprecate all matching" path so one click can't issue
+# an unbounded write. The report itself paginates; this guards the
+# server-side resolve-then-mutate flow.
+MAX_BULK_DEPRECATE = 5000
+
+
+def _recency_clause(stale_cutoff: datetime, include_never_seen: bool) -> Any:
+    """WHERE fragment selecting rows whose last-seen signal is stale."""
+    older = and_(IPAddress.last_seen_at.is_not(None), IPAddress.last_seen_at < stale_cutoff)
+    if include_never_seen:
+        return or_(IPAddress.last_seen_at.is_(None), older)
+    return older
+
+
+def _stale_stmt(
+    stale_cutoff: datetime,
+    include_never_seen: bool,
+    *,
+    space_id: uuid.UUID | None,
+    block_id: uuid.UUID | None,
+    subnet_id: uuid.UUID | None,
+) -> Select[Any]:
+    """Base SELECT over stale IPAddress rows, scope filters applied.
+
+    Joins Subnet so callers can scope by space / block and so soft-deleted
+    subnets drop out of the report.
+    """
+    stmt = (
+        select(IPAddress)
+        .join(Subnet, IPAddress.subnet_id == Subnet.id)
+        .where(
+            Subnet.deleted_at.is_(None),
+            IPAddress.status.in_(STALE_CANDIDATE_STATUSES),
+            IPAddress.auto_from_lease.is_(False),
+            _recency_clause(stale_cutoff, include_never_seen),
+        )
+    )
+    if subnet_id is not None:
+        stmt = stmt.where(IPAddress.subnet_id == subnet_id)
+    if block_id is not None:
+        stmt = stmt.where(Subnet.block_id == block_id)
+    if space_id is not None:
+        stmt = stmt.where(Subnet.space_id == space_id)
+    return stmt
+
+
+def _days_stale(last_seen_at: datetime | None, now: datetime) -> int | None:
+    if last_seen_at is None:
+        return None
+    return max(0, (now - last_seen_at).days)
+
+
+async def build_stale_ip_report(
+    db: AsyncSession,
+    *,
+    stale_days: int = STALE_IP_DEFAULT_DAYS,
+    include_never_seen: bool = False,
+    space_id: uuid.UUID | None = None,
+    block_id: uuid.UUID | None = None,
+    subnet_id: uuid.UUID | None = None,
+    limit: int = 200,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Paginated stale-IP report across all (or a scoped set of) subnets.
+
+    Stalest rows first — NULL ``last_seen_at`` sorts before any timestamp
+    (PostgreSQL ``NULLS FIRST`` on ascending), so never-seen rows lead when
+    ``include_never_seen`` is on, then oldest-seen, then by address.
+    """
+    now = datetime.now(UTC)
+    stale_cutoff = now - timedelta(days=max(1, stale_days))
+
+    base = _stale_stmt(
+        stale_cutoff,
+        include_never_seen,
+        space_id=space_id,
+        block_id=block_id,
+        subnet_id=subnet_id,
+    )
+
+    total = (await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
+
+    rows = list(
+        (
+            await db.execute(
+                base.order_by(
+                    IPAddress.last_seen_at.asc().nullsfirst(),
+                    IPAddress.address.asc(),
+                )
+                .limit(max(1, min(limit, 1000)))
+                .offset(max(0, offset))
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    # One bulk lookup keeps the subnet display columns cheap even on a
+    # 1000-row page spanning many subnets.
+    subnet_ids = {r.subnet_id for r in rows}
+    subnets: dict[uuid.UUID, Subnet] = {}
+    if subnet_ids:
+        for s in (
+            (await db.execute(select(Subnet).where(Subnet.id.in_(subnet_ids)))).scalars().all()
+        ):
+            subnets[s.id] = s
+
+    entries: list[dict[str, Any]] = []
+    for r in rows:
+        s = subnets.get(r.subnet_id)
+        entries.append(
+            {
+                "id": str(r.id),
+                "address": str(r.address),
+                "status": r.status,
+                "hostname": r.hostname,
+                "mac_address": str(r.mac_address) if r.mac_address else None,
+                "last_seen_at": r.last_seen_at.isoformat() if r.last_seen_at else None,
+                "last_seen_method": r.last_seen_method,
+                "days_stale": _days_stale(r.last_seen_at, now),
+                "subnet_id": str(r.subnet_id),
+                "subnet_network": str(s.network) if s else None,
+                "subnet_name": s.name if s else None,
+            }
+        )
+
+    return {
+        "generated_at": now.isoformat(),
+        "stale_days": stale_days,
+        "include_never_seen": include_never_seen,
+        "total": int(total),
+        "limit": max(1, min(limit, 1000)),
+        "offset": max(0, offset),
+        "entries": entries,
+    }
+
+
+async def select_stale_ip_ids(
+    db: AsyncSession,
+    *,
+    stale_days: int = STALE_IP_DEFAULT_DAYS,
+    include_never_seen: bool = False,
+    space_id: uuid.UUID | None = None,
+    block_id: uuid.UUID | None = None,
+    subnet_id: uuid.UUID | None = None,
+    cap: int = MAX_BULK_DEPRECATE,
+) -> list[uuid.UUID]:
+    """Resolve the full set of stale IP ids matching the filter (capped).
+
+    Powers the "deprecate all matching" one-click action — the caller
+    re-uses the same filter the operator saw in the report so the action
+    is exactly what's on screen.
+    """
+    now = datetime.now(UTC)
+    stale_cutoff = now - timedelta(days=max(1, stale_days))
+    base = _stale_stmt(
+        stale_cutoff,
+        include_never_seen,
+        space_id=space_id,
+        block_id=block_id,
+        subnet_id=subnet_id,
+    )
+    rows = (await db.execute(base.with_only_columns(IPAddress.id).limit(max(1, cap)))).all()
+    return [row[0] for row in rows]
+
+
+async def count_stale_per_subnet(
+    db: AsyncSession,
+    *,
+    stale_days: int = STALE_IP_DEFAULT_DAYS,
+    include_never_seen: bool = False,
+) -> dict[uuid.UUID, int]:
+    """Map of subnet_id → stale allocated-IP count. Powers the
+    ``stale_ip_count`` alert rule. Only subnets with ≥ 1 stale IP appear.
+    """
+    now = datetime.now(UTC)
+    stale_cutoff = now - timedelta(days=max(1, stale_days))
+    stmt = (
+        select(IPAddress.subnet_id, func.count().label("n"))
+        .join(Subnet, IPAddress.subnet_id == Subnet.id)
+        .where(
+            Subnet.deleted_at.is_(None),
+            IPAddress.status.in_(STALE_CANDIDATE_STATUSES),
+            IPAddress.auto_from_lease.is_(False),
+            _recency_clause(stale_cutoff, include_never_seen),
+        )
+        .group_by(IPAddress.subnet_id)
+    )
+    return {row[0]: int(row[1]) for row in (await db.execute(stmt)).all()}
+
+
+__all__ = [
+    "MAX_BULK_DEPRECATE",
+    "STALE_CANDIDATE_STATUSES",
+    "STALE_IP_DEFAULT_DAYS",
+    "build_stale_ip_report",
+    "count_stale_per_subnet",
+    "select_stale_ip_ids",
+]

--- a/backend/tests/test_stale_ips.py
+++ b/backend/tests/test_stale_ips.py
@@ -213,6 +213,35 @@ async def test_endpoint_deprecate_requires_target(
     assert r.status_code == 422
 
 
+async def test_endpoint_deprecate_explicit_id_rechecks_staleness(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # A row that went live after the report loaded (fresh last_seen) must be
+    # skipped even when its id is posted explicitly — the server re-checks
+    # against the request's window rather than trusting the client selection.
+    _, token = await _make_user(db_session)
+    h = {"Authorization": f"Bearer {token}"}
+    subnet = await _make_subnet(db_session)
+    stale = IPAddress(
+        subnet_id=subnet.id, address="192.0.2.10", status="allocated", last_seen_at=STALE
+    )
+    fresh = IPAddress(
+        subnet_id=subnet.id, address="192.0.2.11", status="allocated", last_seen_at=FRESH
+    )
+    db_session.add_all([stale, fresh])
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/ipam/reports/stale-ips/deprecate",
+        headers=h,
+        json={"ip_ids": [str(stale.id), str(fresh.id)], "stale_days": 90},
+    )
+    assert r.status_code == 200, r.text
+    res = r.json()
+    assert res["deprecated_count"] == 1
+    assert str(fresh.id) in res["skipped"]
+
+
 # ── Alert rule ─────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_stale_ips.py
+++ b/backend/tests/test_stale_ips.py
@@ -1,0 +1,243 @@
+"""Stale-IP report + bulk-deprecate + hygiene alert (issue #45)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.alerts import AlertRule
+from app.models.auth import User
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.alerts import _matching_stale_ip_count_subjects
+from app.services.ipam.stale_ips import (
+    build_stale_ip_report,
+    count_stale_per_subnet,
+    select_stale_ip_ids,
+)
+
+NOW = datetime.now(UTC)
+STALE = NOW - timedelta(days=100)  # older than the 90-day default window
+FRESH = NOW - timedelta(days=10)  # well inside the window
+
+
+async def _make_user(db: AsyncSession) -> tuple[User, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_subnet(db: AsyncSession, cidr: str = "192.0.2.0/24") -> Subnet:
+    space = IPSpace(name=f"stale-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=cidr, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=cidr, name="s")
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _seed_mix(db: AsyncSession, subnet: Subnet) -> dict[str, IPAddress]:
+    """Seed the canonical mix the report has to discriminate."""
+    rows = {
+        # allocated + last seen long ago → STALE (the target)
+        "stale": IPAddress(
+            subnet_id=subnet.id, address="192.0.2.10", status="allocated", last_seen_at=STALE
+        ),
+        # allocated + seen recently → not stale
+        "fresh": IPAddress(
+            subnet_id=subnet.id, address="192.0.2.11", status="allocated", last_seen_at=FRESH
+        ),
+        # allocated + never seen → only counts with include_never_seen
+        "never": IPAddress(subnet_id=subnet.id, address="192.0.2.12", status="allocated"),
+        # reserved + stale → deliberately held, never in the report
+        "reserved": IPAddress(
+            subnet_id=subnet.id, address="192.0.2.13", status="reserved", last_seen_at=STALE
+        ),
+        # DHCP-lease mirror + stale → owned by DHCP, always excluded
+        "lease": IPAddress(
+            subnet_id=subnet.id,
+            address="192.0.2.14",
+            status="allocated",
+            last_seen_at=STALE,
+            auto_from_lease=True,
+        ),
+    }
+    db.add_all(list(rows.values()))
+    await db.flush()
+    return rows
+
+
+# ── Service: report ──────────────────────────────────────────────────
+
+
+async def test_report_only_stale_allocated(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    await _seed_mix(db_session, subnet)
+    report = await build_stale_ip_report(db_session, stale_days=90)
+    addrs = {e["address"] for e in report["entries"]}
+    assert addrs == {"192.0.2.10"}  # only the stale allocated row
+    assert report["total"] == 1
+    assert report["entries"][0]["days_stale"] >= 99
+
+
+async def test_report_include_never_seen(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    await _seed_mix(db_session, subnet)
+    report = await build_stale_ip_report(db_session, stale_days=90, include_never_seen=True)
+    addrs = {e["address"] for e in report["entries"]}
+    assert addrs == {"192.0.2.10", "192.0.2.12"}  # stale + never-seen
+    # Never-seen sorts first (NULLS FIRST on ascending last_seen_at).
+    assert report["entries"][0]["address"] == "192.0.2.12"
+    assert report["entries"][0]["days_stale"] is None
+
+
+async def test_report_scoped_by_space(db_session: AsyncSession) -> None:
+    a = await _make_subnet(db_session, "192.0.2.0/24")
+    b = await _make_subnet(db_session, "198.51.100.0/24")
+    db_session.add_all(
+        [
+            IPAddress(subnet_id=a.id, address="192.0.2.10", status="allocated", last_seen_at=STALE),
+            IPAddress(
+                subnet_id=b.id, address="198.51.100.10", status="allocated", last_seen_at=STALE
+            ),
+        ]
+    )
+    await db_session.flush()
+    report = await build_stale_ip_report(db_session, stale_days=90, space_id=a.space_id)
+    assert {e["address"] for e in report["entries"]} == {"192.0.2.10"}
+
+
+async def test_select_ids_and_count(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    rows = await _seed_mix(db_session, subnet)
+    ids = await select_stale_ip_ids(db_session, stale_days=90)
+    assert ids == [rows["stale"].id]
+    counts = await count_stale_per_subnet(db_session, stale_days=90)
+    assert counts == {subnet.id: 1}
+    # include_never_seen folds in the never-seen row
+    counts2 = await count_stale_per_subnet(db_session, stale_days=90, include_never_seen=True)
+    assert counts2 == {subnet.id: 2}
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────
+
+
+async def test_endpoint_report_and_deprecate_selected(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_user(db_session)
+    h = {"Authorization": f"Bearer {token}"}
+    subnet = await _make_subnet(db_session)
+    rows = await _seed_mix(db_session, subnet)
+    await db_session.commit()
+
+    r = await client.get("/api/v1/ipam/reports/stale-ips", headers=h)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] == 1
+    assert body["entries"][0]["address"] == "192.0.2.10"
+
+    # Deprecate the selected stale row + a reserved row (should be skipped).
+    r = await client.post(
+        "/api/v1/ipam/reports/stale-ips/deprecate",
+        headers=h,
+        json={"ip_ids": [str(rows["stale"].id), str(rows["reserved"].id)]},
+    )
+    assert r.status_code == 200, r.text
+    res = r.json()
+    assert res["deprecated_count"] == 1
+    assert str(rows["reserved"].id) in res["skipped"]
+
+    refreshed = (
+        await db_session.execute(select(IPAddress).where(IPAddress.id == rows["stale"].id))
+    ).scalar_one()
+    assert refreshed.status == "deprecated"
+    assert refreshed.user_modified_at is not None
+    # No longer surfaces in the report.
+    r = await client.get("/api/v1/ipam/reports/stale-ips", headers=h)
+    assert r.json()["total"] == 0
+
+
+async def test_endpoint_deprecate_all_matching(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_user(db_session)
+    h = {"Authorization": f"Bearer {token}"}
+    subnet = await _make_subnet(db_session)
+    db_session.add_all(
+        [
+            IPAddress(
+                subnet_id=subnet.id, address="192.0.2.10", status="allocated", last_seen_at=STALE
+            ),
+            IPAddress(
+                subnet_id=subnet.id, address="192.0.2.11", status="allocated", last_seen_at=STALE
+            ),
+            IPAddress(
+                subnet_id=subnet.id, address="192.0.2.12", status="allocated", last_seen_at=FRESH
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/ipam/reports/stale-ips/deprecate",
+        headers=h,
+        json={"all_matching": True, "stale_days": 90, "space_id": str(subnet.space_id)},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["deprecated_count"] == 2
+    assert r.json()["capped"] is False
+
+
+async def test_endpoint_deprecate_requires_target(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_user(db_session)
+    h = {"Authorization": f"Bearer {token}"}
+    r = await client.post("/api/v1/ipam/reports/stale-ips/deprecate", headers=h, json={})
+    assert r.status_code == 422
+
+
+# ── Alert rule ─────────────────────────────────────────────────────────
+
+
+async def test_stale_ip_count_alert_fires_over_threshold(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    db_session.add_all(
+        [
+            IPAddress(
+                subnet_id=subnet.id, address="192.0.2.10", status="allocated", last_seen_at=STALE
+            ),
+            IPAddress(
+                subnet_id=subnet.id, address="192.0.2.11", status="allocated", last_seen_at=STALE
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    # threshold 2 → fires (2 stale ≥ 2)
+    rule = AlertRule(
+        name="hygiene", rule_type="stale_ip_count", threshold_percent=2, threshold_days=90
+    )
+    matches = await _matching_stale_ip_count_subjects(db_session, rule)
+    assert len(matches) == 1
+    assert str(subnet.id) == matches[0][0]
+
+    # threshold 3 → quiet (only 2 stale)
+    rule.threshold_percent = 3
+    assert await _matching_stale_ip_count_subjects(db_session, rule) == []

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -317,6 +317,43 @@ sweep only refreshes their `last_seen_at`. Subnets larger than a /20
 `stale_minutes` (default 24 h) is the window after which a row's
 `last_seen_at` counts as stale.
 
+### Stale-IP Report (issue #45)
+
+A cross-subnet "address-space hygiene" view that reads the discovery
+`last_seen_at` signal from the other direction: which IPs are still
+marked `allocated` but haven't been seen on the wire in *N* days?
+Those are reclaim candidates — hosts decommissioned without anyone
+freeing the IPAM row.
+
+`GET /api/v1/ipam/reports/stale-ips?stale_days=90&include_never_seen=false`
+(also surfaced to the Operator Copilot as `find_stale_ips`):
+
+- **Candidate status** is `allocated` only — `reserved` / `static_dhcp`
+  are deliberately held, and DHCP-lease mirrors (`auto_from_lease`)
+  churn on their own cadence, so all of those are excluded.
+- **Stale** means `last_seen_at` older than the cutoff. Rows that were
+  *never* seen (`last_seen_at IS NULL`) are excluded by default —
+  many live in subnets where discovery was never enabled — and fold in
+  only with `include_never_seen=true`.
+- Optional `space_id` / `block_id` / `subnet_id` scope the report.
+  Stalest rows sort first (`NULLS FIRST` ascending).
+
+**One-click bulk-deprecate.** `POST /api/v1/ipam/reports/stale-ips/deprecate`
+flips stale rows to `deprecated` (reversible from the normal IP edit
+path) and stamps `user_modified_at` so a later discovery / integration
+sweep won't silently un-deprecate them. Provide `ip_ids` to deprecate a
+hand-picked set, or `all_matching=true` with the report filter to
+deprecate every matching row in one shot (capped at `MAX_BULK_DEPRECATE`
+= 5000; the response `capped` flag tells the operator to re-run for the
+remainder). System placeholders and DHCP mirrors are skipped even if an
+id slips through. The page lives at **Stale IPs** in the sidebar.
+
+**Hygiene alert.** A `stale_ip_count` alert rule fires when any subnet
+holds at least `threshold_percent` (re-used as a raw count) allocated
+IPs older than `threshold_days` (default 90). It reads the same signal
+but excludes never-seen rows so the passive feed stays high-confidence;
+operators chase the full list, including never-seen, from the report.
+
 ---
 
 ## 9. Utilization Tracking

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { SetupWizardPage } from "@/pages/appliance/SetupWizardPage";
 import { DashboardPage } from "@/pages/DashboardPage";
 import { IPAMPage } from "@/pages/ipam/IPAMPage";
 import { NATPage } from "@/pages/ipam/NATPage";
+import { StaleIPReportPage } from "@/pages/ipam/StaleIPReportPage";
 import { DNSPage } from "@/pages/dns/DNSPage";
 import { DNSPoolsPage } from "@/pages/dns/DNSPoolsPage";
 import { VLANsPage } from "@/pages/vlans/VLANsPage";
@@ -93,6 +94,7 @@ export default function App() {
         <Route path="dashboard" element={<DashboardPage />} />
         <Route path="ipam" element={<IPAMPage />} />
         <Route path="ipam/nat" element={<NATPage />} />
+        <Route path="ipam/stale" element={<StaleIPReportPage />} />
         <Route path="ipam/plans" element={<SubnetPlannerListPage />} />
         <Route path="ipam/plans/:id" element={<SubnetPlannerEditorPage />} />
         <Route path="dns" element={<DNSPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -43,6 +43,7 @@ import {
   Radio,
   Shuffle,
   Trash2,
+  History,
   Search,
   Calculator,
   Webhook,
@@ -70,6 +71,7 @@ const baseMainNav = [
   { label: "Domains", icon: Earth, to: "/admin/domains" },
   { label: "Logs", icon: ScrollText, to: "/logs" },
   { label: "NAT Mappings", icon: Shuffle, to: "/ipam/nat" },
+  { label: "Stale IPs", icon: History, to: "/ipam/stale" },
   { label: "Subnet Planner", icon: Workflow, to: "/ipam/plans" },
 ];
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -603,6 +603,59 @@ export interface SubnetReconciliation {
   status_mismatch: ReconciliationEntry[];
 }
 
+/** One stale allocated IP in the address-space hygiene report (issue #45). */
+export interface StaleIPEntry {
+  id: string;
+  address: string;
+  status: string;
+  hostname: string | null;
+  mac_address: string | null;
+  last_seen_at: string | null;
+  last_seen_method: string | null;
+  days_stale: number | null;
+  subnet_id: string;
+  subnet_network: string | null;
+  subnet_name: string | null;
+}
+
+/** Stale-IP report — allocated IPs nothing has seen in N days (issue #45). */
+export interface StaleIPReport {
+  generated_at: string;
+  stale_days: number;
+  include_never_seen: boolean;
+  total: number;
+  limit: number;
+  offset: number;
+  entries: StaleIPEntry[];
+}
+
+export interface StaleIPReportParams {
+  stale_days?: number;
+  include_never_seen?: boolean;
+  space_id?: string;
+  block_id?: string;
+  subnet_id?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface StaleIPDeprecateRequest {
+  ip_ids?: string[];
+  all_matching?: boolean;
+  stale_days?: number;
+  include_never_seen?: boolean;
+  space_id?: string;
+  block_id?: string;
+  subnet_id?: string;
+}
+
+export interface StaleIPDeprecateResponse {
+  batch_id: string;
+  deprecated_count: number;
+  skipped: string[];
+  capped: boolean;
+}
+
 /** Optional role tag, orthogonal to ``status``. Roles in
  *  ``IP_ROLES_SHARED`` (anycast / vip / vrrp) are intentionally
  *  shared across multiple devices — the API skips MAC-collision
@@ -1338,6 +1391,15 @@ export const ipamApi = {
         status: string;
         subnet_id: string;
       }>(`/ipam/subnets/${id}/discover`)
+      .then((r) => r.data),
+  // Stale-IP report + one-click bulk-deprecate (issue #45).
+  getStaleIPs: (params?: StaleIPReportParams) =>
+    api
+      .get<StaleIPReport>("/ipam/reports/stale-ips", { params })
+      .then((r) => r.data),
+  deprecateStaleIPs: (body: StaleIPDeprecateRequest) =>
+    api
+      .post<StaleIPDeprecateResponse>("/ipam/reports/stale-ips/deprecate", body)
       .then((r) => r.data),
   createSubnet: (data: Partial<Subnet> & { template_id?: string | null }) =>
     api.post<Subnet>("/ipam/subnets", data).then((r) => r.data),
@@ -6276,7 +6338,8 @@ export type AlertRuleType =
   | "service_term_expiring"
   | "service_resource_orphaned"
   | "compliance_change"
-  | "voice_lease_count_below";
+  | "voice_lease_count_below"
+  | "stale_ip_count";
 export type AlertSeverity = "info" | "warning" | "critical";
 export type AlertServerType = "dns" | "dhcp" | "any";
 // ``compliance_change`` rule type — keep in lock-step with

--- a/frontend/src/pages/admin/AlertsPage.tsx
+++ b/frontend/src/pages/admin/AlertsPage.tsx
@@ -26,6 +26,21 @@ import { AskAIButton } from "@/components/copilot/AskAIButton";
 const inputCls =
   "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
 
+// Per-rule-type sensible starting values, seeded when the operator picks a
+// type in the New-rule modal. Without this, switching to e.g. stale_ip_count
+// would inherit subnet_utilization's 90 / 30 and create a 90-count / 30-day
+// rule that contradicts the documented 10 / 90 semantics.
+const RULE_TYPE_PARAM_DEFAULTS: Partial<
+  Record<AlertRuleType, { threshold?: number; thresholdDays?: number }>
+> = {
+  subnet_utilization: { threshold: 90 },
+  voice_lease_count_below: { threshold: 10 },
+  stale_ip_count: { threshold: 10, thresholdDays: 90 },
+  domain_expiring: { thresholdDays: 30 },
+  circuit_term_expiring: { thresholdDays: 30 },
+  service_term_expiring: { thresholdDays: 30 },
+};
+
 function Field({
   label,
   hint,
@@ -161,7 +176,14 @@ function RuleEditorModal({
             <select
               className={inputCls}
               value={ruleType}
-              onChange={(e) => setRuleType(e.target.value as AlertRuleType)}
+              onChange={(e) => {
+                const next = e.target.value as AlertRuleType;
+                setRuleType(next);
+                const d = RULE_TYPE_PARAM_DEFAULTS[next];
+                if (d?.threshold !== undefined) setThreshold(d.threshold);
+                if (d?.thresholdDays !== undefined)
+                  setThresholdDays(d.thresholdDays);
+              }}
             >
               <optgroup label="Infrastructure">
                 <option value="subnet_utilization">Subnet utilization</option>

--- a/frontend/src/pages/admin/AlertsPage.tsx
+++ b/frontend/src/pages/admin/AlertsPage.tsx
@@ -101,13 +101,15 @@ function RuleEditorModal({
         notify_smtp: notifySmtp,
         threshold_percent:
           ruleType === "subnet_utilization" ||
-          ruleType === "voice_lease_count_below"
+          ruleType === "voice_lease_count_below" ||
+          ruleType === "stale_ip_count"
             ? threshold
             : null,
         threshold_days:
           ruleType === "domain_expiring" ||
           ruleType === "circuit_term_expiring" ||
-          ruleType === "service_term_expiring"
+          ruleType === "service_term_expiring" ||
+          ruleType === "stale_ip_count"
             ? thresholdDays
             : null,
         server_type: ruleType === "server_unreachable" ? serverType : null,
@@ -164,6 +166,9 @@ function RuleEditorModal({
               <optgroup label="Infrastructure">
                 <option value="subnet_utilization">Subnet utilization</option>
                 <option value="server_unreachable">Server unreachable</option>
+                <option value="stale_ip_count">
+                  Stale IP count (address-space hygiene)
+                </option>
               </optgroup>
               <optgroup label="Network (ASN / RPKI)">
                 <option value="asn_holder_drift">ASN holder drift</option>
@@ -242,6 +247,35 @@ function RuleEditorModal({
               onChange={(e) => setThreshold(Number(e.target.value))}
             />
           </Field>
+        )}
+        {ruleType === "stale_ip_count" && (
+          <>
+            <Field
+              label="Stale IP count threshold"
+              hint="Fires when a subnet holds at least this many allocated IPs that haven't been seen on the wire in the window below. Reads the discovery last-seen signal; never-seen rows are excluded (chase those from the Stale-IP report)."
+            >
+              <input
+                type="number"
+                min={1}
+                className={inputCls}
+                value={threshold}
+                onChange={(e) => setThreshold(Number(e.target.value))}
+              />
+            </Field>
+            <Field
+              label="Stale window (days)"
+              hint="An allocated IP counts as stale once its last-seen timestamp is older than this. Default 90."
+            >
+              <input
+                type="number"
+                min={1}
+                max={3650}
+                className={inputCls}
+                value={thresholdDays}
+                onChange={(e) => setThresholdDays(Number(e.target.value))}
+              />
+            </Field>
+          </>
         )}
         {ruleType === "server_unreachable" && (
           <Field label="Server type">
@@ -563,15 +597,17 @@ export function AlertsPage() {
                         ? `≥ ${r.threshold_percent}%`
                         : r.rule_type === "voice_lease_count_below"
                           ? `< ${r.threshold_percent ?? 1} leases`
-                          : r.rule_type === "server_unreachable"
-                            ? `type=${r.server_type ?? "any"}`
-                            : r.rule_type === "domain_expiring" ||
-                                r.rule_type === "circuit_term_expiring" ||
-                                r.rule_type === "service_term_expiring"
-                              ? `≤ ${r.threshold_days ?? 30} d`
-                              : r.rule_type === "compliance_change"
-                                ? `${r.classification ?? "?"} · ${r.change_scope ?? "any_change"}`
-                                : "—"}
+                          : r.rule_type === "stale_ip_count"
+                            ? `≥ ${r.threshold_percent ?? 10} stale · ${r.threshold_days ?? 90}d`
+                            : r.rule_type === "server_unreachable"
+                              ? `type=${r.server_type ?? "any"}`
+                              : r.rule_type === "domain_expiring" ||
+                                  r.rule_type === "circuit_term_expiring" ||
+                                  r.rule_type === "service_term_expiring"
+                                ? `≤ ${r.threshold_days ?? 30} d`
+                                : r.rule_type === "compliance_change"
+                                  ? `${r.classification ?? "?"} · ${r.change_scope ?? "any_change"}`
+                                  : "—"}
                     </td>
                     <td className="px-4 py-2">
                       <SeverityBadge severity={r.severity} />

--- a/frontend/src/pages/ipam/StaleIPReportPage.tsx
+++ b/frontend/src/pages/ipam/StaleIPReportPage.tsx
@@ -6,6 +6,7 @@ import { History, RefreshCw, Trash2 } from "lucide-react";
 import {
   ipamApi,
   type StaleIPDeprecateRequest,
+  type StaleIPDeprecateResponse,
   type StaleIPEntry,
 } from "@/lib/api";
 import { HeaderButton } from "@/components/ui/header-button";
@@ -15,6 +16,10 @@ import { humanTime } from "@/pages/network/_shared";
 import { cn } from "@/lib/utils";
 
 const PAGE_SIZE = 200;
+// Mirrors MAX_BULK_DEPRECATE on the backend — one "Deprecate all" call
+// processes at most this many rows, then reports ``capped`` so the
+// operator knows to run it again for the remainder.
+const BULK_CAP = 5000;
 
 const inputCls =
   "rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
@@ -38,6 +43,11 @@ export function StaleIPReportPage() {
   const [pending, setPending] = useState<
     { kind: "selected"; ids: string[] } | { kind: "all"; count: number } | null
   >(null);
+  // Result of the last deprecate — surfaces the server's ``capped`` flag
+  // (``all_matching`` only processes MAX_BULK_DEPRECATE rows per call).
+  const [lastResult, setLastResult] = useState<StaleIPDeprecateResponse | null>(
+    null,
+  );
 
   const params = useMemo(
     () => ({
@@ -63,9 +73,10 @@ export function StaleIPReportPage() {
   const deprecate = useMutation({
     mutationFn: (body: StaleIPDeprecateRequest) =>
       ipamApi.deprecateStaleIPs(body),
-    onSuccess: () => {
+    onSuccess: (res) => {
       setSelected(new Set());
       setPending(null);
+      setLastResult(res);
       qc.invalidateQueries({ queryKey: ["stale-ips"] });
     },
   });
@@ -96,7 +107,14 @@ export function StaleIPReportPage() {
   const confirmDeprecate = () => {
     if (!pending) return;
     if (pending.kind === "selected") {
-      deprecate.mutate({ ip_ids: pending.ids });
+      // Pass the current filter so the server re-checks each row against the
+      // same window the operator saw — a row that went live after the page
+      // loaded is skipped rather than wrongly deprecated.
+      deprecate.mutate({
+        ip_ids: pending.ids,
+        stale_days: staleDays,
+        include_never_seen: includeNeverSeen,
+      });
     } else {
       deprecate.mutate({
         all_matching: true,
@@ -141,6 +159,37 @@ export function StaleIPReportPage() {
           </HeaderButton>
         </div>
       </div>
+
+      {/* Result banner — emphasise the capped case (more rows remain) */}
+      {lastResult && (
+        <div
+          className={cn(
+            "flex items-center justify-between rounded-md border px-3 py-2 text-sm",
+            lastResult.capped
+              ? "border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30"
+              : "border-emerald-300 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-950/30",
+          )}
+        >
+          <span>
+            Deprecated {lastResult.deprecated_count} IP(s)
+            {lastResult.skipped.length > 0
+              ? `, skipped ${lastResult.skipped.length}`
+              : ""}
+            .
+            {lastResult.capped
+              ? ` Hit the ${BULK_CAP}-row per-call limit — more matches remain. Run "Deprecate all" again to continue.`
+              : ""}
+          </span>
+          <button
+            type="button"
+            className="ml-3 shrink-0 text-muted-foreground hover:text-foreground"
+            onClick={() => setLastResult(null)}
+            aria-label="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {/* Filter bar */}
       <div className="flex flex-wrap items-end gap-4 rounded-md border bg-muted/20 p-3">
@@ -331,19 +380,29 @@ export function StaleIPReportPage() {
         title="Deprecate stale IPs?"
         confirmLabel={
           pending?.kind === "all"
-            ? `Deprecate all ${pending.count}`
+            ? pending.count > BULK_CAP
+              ? `Deprecate ${BULK_CAP}`
+              : `Deprecate all ${pending.count}`
             : `Deprecate ${pending?.kind === "selected" ? pending.ids.length : 0}`
         }
         loading={deprecate.isPending}
         message={
           pending?.kind === "all" ? (
             <>
-              This flips <strong>all {pending.count}</strong> matching allocated
-              IPs to <strong>deprecated</strong> in the current filter (
-              {staleDays}+ days stale
+              This flips{" "}
+              <strong>
+                {pending.count > BULK_CAP
+                  ? `the first ${BULK_CAP} of ${pending.count}`
+                  : `all ${pending.count}`}
+              </strong>{" "}
+              matching allocated IPs to <strong>deprecated</strong> in the
+              current filter ({staleDays}+ days stale
               {includeNeverSeen ? ", including never-seen" : ""}). DHCP-lease
-              mirrors and system rows are skipped. This is reversible — edit any
-              row back from the IPAM page.
+              mirrors and system rows are skipped.
+              {pending.count > BULK_CAP
+                ? " You'll need to run this again for the remainder."
+                : ""}{" "}
+              This is reversible — edit any row back from the IPAM page.
             </>
           ) : (
             <>

--- a/frontend/src/pages/ipam/StaleIPReportPage.tsx
+++ b/frontend/src/pages/ipam/StaleIPReportPage.tsx
@@ -1,0 +1,364 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { History, RefreshCw, Trash2 } from "lucide-react";
+
+import {
+  ipamApi,
+  type StaleIPDeprecateRequest,
+  type StaleIPEntry,
+} from "@/lib/api";
+import { HeaderButton } from "@/components/ui/header-button";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { SeenDot } from "@/pages/ipam/SeenDot";
+import { humanTime } from "@/pages/network/_shared";
+import { cn } from "@/lib/utils";
+
+const PAGE_SIZE = 200;
+
+const inputCls =
+  "rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+/**
+ * Stale-IP report (issue #45). Cross-subnet hygiene view over the
+ * discovery (#23) ``last_seen_at`` signal: allocated IPs nothing has
+ * answered for in N days. One-click bulk-deprecate flips the selected
+ * rows (or every matching row) to ``deprecated`` — reversible from the
+ * normal IPAM edit path.
+ */
+export function StaleIPReportPage() {
+  const qc = useQueryClient();
+  const [staleDays, setStaleDays] = useState(90);
+  const [includeNeverSeen, setIncludeNeverSeen] = useState(false);
+  const [spaceId, setSpaceId] = useState<string>("");
+  const [offset, setOffset] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  // Pending deprecate action — null when no modal open. ``all`` deprecates
+  // every matching row server-side; otherwise the ticked ``ids``.
+  const [pending, setPending] = useState<
+    { kind: "selected"; ids: string[] } | { kind: "all"; count: number } | null
+  >(null);
+
+  const params = useMemo(
+    () => ({
+      stale_days: staleDays,
+      include_never_seen: includeNeverSeen,
+      space_id: spaceId || undefined,
+      limit: PAGE_SIZE,
+      offset,
+    }),
+    [staleDays, includeNeverSeen, spaceId, offset],
+  );
+
+  const spaces = useQuery({
+    queryKey: ["ipam-spaces"],
+    queryFn: ipamApi.listSpaces,
+  });
+
+  const report = useQuery({
+    queryKey: ["stale-ips", params],
+    queryFn: () => ipamApi.getStaleIPs(params),
+  });
+
+  const deprecate = useMutation({
+    mutationFn: (body: StaleIPDeprecateRequest) =>
+      ipamApi.deprecateStaleIPs(body),
+    onSuccess: () => {
+      setSelected(new Set());
+      setPending(null);
+      qc.invalidateQueries({ queryKey: ["stale-ips"] });
+    },
+  });
+
+  const entries = report.data?.entries ?? [];
+  const total = report.data?.total ?? 0;
+  const selectableIds = useMemo(() => entries.map((e) => e.id), [entries]);
+  const allSelected =
+    selectableIds.length > 0 && selectableIds.every((id) => selected.has(id));
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  const toggleAll = () =>
+    setSelected((prev) =>
+      allSelected ? new Set() : new Set([...prev, ...selectableIds]),
+    );
+
+  const resetPage = () => {
+    setOffset(0);
+    setSelected(new Set());
+  };
+
+  const confirmDeprecate = () => {
+    if (!pending) return;
+    if (pending.kind === "selected") {
+      deprecate.mutate({ ip_ids: pending.ids });
+    } else {
+      deprecate.mutate({
+        all_matching: true,
+        stale_days: staleDays,
+        include_never_seen: includeNeverSeen,
+        space_id: spaceId || undefined,
+      });
+    }
+  };
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-4 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="flex items-center gap-2 text-xl font-semibold">
+            <History className="h-5 w-5 shrink-0" /> Stale IPs
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Allocated IPs nothing has seen on the wire in {staleDays}+ days,
+            drawn from the discovery last-seen signal. Deprecate to reclaim
+            address space — it&rsquo;s reversible from the normal IP edit path.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <HeaderButton
+            variant="secondary"
+            onClick={() => report.refetch()}
+            disabled={report.isFetching}
+          >
+            <RefreshCw
+              className={cn("h-4 w-4", report.isFetching && "animate-spin")}
+            />
+            Refresh
+          </HeaderButton>
+          <HeaderButton
+            variant="destructive"
+            disabled={total === 0 || deprecate.isPending}
+            onClick={() => setPending({ kind: "all", count: total })}
+          >
+            <Trash2 className="h-4 w-4" />
+            Deprecate all {total}
+          </HeaderButton>
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-end gap-4 rounded-md border bg-muted/20 p-3">
+        <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+          Stale window (days)
+          <input
+            type="number"
+            min={1}
+            max={3650}
+            className={cn(inputCls, "w-28")}
+            value={staleDays}
+            onChange={(e) => {
+              setStaleDays(Math.max(1, Number(e.target.value) || 1));
+              resetPage();
+            }}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs font-medium text-muted-foreground">
+          IP space
+          <select
+            className={cn(inputCls, "w-48")}
+            value={spaceId}
+            onChange={(e) => {
+              setSpaceId(e.target.value);
+              resetPage();
+            }}
+          >
+            <option value="">All spaces</option>
+            {(spaces.data ?? []).map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            className="cursor-pointer"
+            checked={includeNeverSeen}
+            onChange={(e) => {
+              setIncludeNeverSeen(e.target.checked);
+              resetPage();
+            }}
+          />
+          Include never-seen
+        </label>
+      </div>
+
+      {/* Bulk toolbar — only when rows are ticked */}
+      {selected.size > 0 && (
+        <div className="flex items-center justify-between rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm dark:border-amber-700 dark:bg-amber-950/30">
+          <span>{selected.size} selected</span>
+          <HeaderButton
+            variant="destructive"
+            disabled={deprecate.isPending}
+            onClick={() => setPending({ kind: "selected", ids: [...selected] })}
+          >
+            <Trash2 className="h-4 w-4" />
+            Deprecate selected
+          </HeaderButton>
+        </div>
+      )}
+
+      <div className="min-w-0 overflow-x-auto rounded-md border">
+        <table className="w-full min-w-[760px] text-sm">
+          <thead className="bg-muted/40 text-left text-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="w-8 px-3 py-2">
+                <input
+                  type="checkbox"
+                  className="cursor-pointer"
+                  checked={allSelected}
+                  onChange={toggleAll}
+                  aria-label="Select all on this page"
+                />
+              </th>
+              <th className="px-3 py-2">Address</th>
+              <th className="px-3 py-2">Hostname</th>
+              <th className="px-3 py-2">Subnet</th>
+              <th className="px-3 py-2">Last seen</th>
+              <th className="px-3 py-2 text-right">Days stale</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.isLoading ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-3 py-8 text-center text-muted-foreground"
+                >
+                  Loading…
+                </td>
+              </tr>
+            ) : entries.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-3 py-8 text-center text-muted-foreground"
+                >
+                  No stale IPs in this window. Address space looks healthy. ✨
+                </td>
+              </tr>
+            ) : (
+              entries.map((e: StaleIPEntry) => (
+                <tr key={e.id} className="border-t hover:bg-muted/20">
+                  <td className="px-3 py-2">
+                    <input
+                      type="checkbox"
+                      className="cursor-pointer"
+                      checked={selected.has(e.id)}
+                      onChange={() => toggle(e.id)}
+                      aria-label={`Select ${e.address}`}
+                    />
+                  </td>
+                  <td className="px-3 py-2 font-mono">
+                    <Link
+                      to={`/ipam?subnet=${e.subnet_id}`}
+                      className="text-primary hover:underline"
+                    >
+                      {e.address}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    {e.hostname || "—"}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    <span className="font-mono">{e.subnet_network ?? "?"}</span>
+                    {e.subnet_name ? (
+                      <span className="ml-1">— {e.subnet_name}</span>
+                    ) : null}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span className="inline-flex items-center gap-1.5">
+                      <SeenDot
+                        lastSeenAt={e.last_seen_at}
+                        lastSeenMethod={e.last_seen_method}
+                      />
+                      <span className="text-muted-foreground">
+                        {e.last_seen_at ? humanTime(e.last_seen_at) : "never"}
+                      </span>
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                    {e.days_stale ?? "—"}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {total > PAGE_SIZE && (
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>
+            {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+          </span>
+          <div className="flex gap-2">
+            <HeaderButton
+              variant="secondary"
+              disabled={offset === 0}
+              onClick={() => {
+                setOffset(Math.max(0, offset - PAGE_SIZE));
+                setSelected(new Set());
+              }}
+            >
+              Prev
+            </HeaderButton>
+            <HeaderButton
+              variant="secondary"
+              disabled={offset + PAGE_SIZE >= total}
+              onClick={() => {
+                setOffset(offset + PAGE_SIZE);
+                setSelected(new Set());
+              }}
+            >
+              Next
+            </HeaderButton>
+          </div>
+        </div>
+      )}
+
+      <ConfirmModal
+        open={pending !== null}
+        tone="destructive"
+        title="Deprecate stale IPs?"
+        confirmLabel={
+          pending?.kind === "all"
+            ? `Deprecate all ${pending.count}`
+            : `Deprecate ${pending?.kind === "selected" ? pending.ids.length : 0}`
+        }
+        loading={deprecate.isPending}
+        message={
+          pending?.kind === "all" ? (
+            <>
+              This flips <strong>all {pending.count}</strong> matching allocated
+              IPs to <strong>deprecated</strong> in the current filter (
+              {staleDays}+ days stale
+              {includeNeverSeen ? ", including never-seen" : ""}). DHCP-lease
+              mirrors and system rows are skipped. This is reversible — edit any
+              row back from the IPAM page.
+            </>
+          ) : (
+            <>
+              This flips the{" "}
+              <strong>
+                {pending?.kind === "selected" ? pending.ids.length : 0}
+              </strong>{" "}
+              selected allocated IP(s) to <strong>deprecated</strong>. This is
+              reversible — edit any row back from the IPAM page.
+            </>
+          )
+        }
+        onConfirm={confirmDeprecate}
+        onClose={() => setPending(null)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #45.

Address-space hygiene over the discovery (#23) `last_seen_at` signal: which allocated IPs has nothing answered for in N days? Those are reclaim candidates — hosts decommissioned without anyone freeing the IPAM row. The companion to the per-subnet reconciliation report (#23): this is the cross-subnet, action-oriented view.

## Backend
- **`services/ipam/stale_ips.py`** — `build_stale_ip_report` (paginated, optional `space_id`/`block_id`/`subnet_id` scope, stalest-first `NULLS FIRST` sort), `select_stale_ip_ids` (capped resolve for the deprecate-all path), `count_stale_per_subnet` (alert feed). Candidate status is `allocated` only — `reserved`/`static_dhcp` are deliberately held, `auto_from_lease` DHCP mirrors churn on their own cadence. Never-seen rows (`last_seen_at IS NULL`) fold in only via `include_never_seen` (off by default — they're often in discovery-disabled subnets).
- **Endpoints** — `GET /ipam/reports/stale-ips` and `POST /ipam/reports/stale-ips/deprecate` (explicit `ip_ids` **or** `all_matching` with the report filter, capped at `MAX_BULK_DEPRECATE`=5000 with a `capped` flag). Deprecate flips rows to `deprecated` (reversible from the normal IP edit path) and stamps `user_modified_at` so a later discovery/integration sweep won't silently un-deprecate; system placeholders + lease mirrors are skipped server-side even if a stale id slips through.
- **`stale_ip_count` alert rule** — fires when a subnet holds ≥ `threshold_percent` (re-used as a raw count) allocated IPs older than `threshold_days` (default 90). Reuses existing columns → **no migration**.
- **`find_stale_ips` MCP read tool** — default-enabled, read-only.

## Frontend
- New **Stale IPs** sidebar entry → `/ipam/stale`: filter bar (stale window / IP space / include-never-seen), bulk-select table reusing `SeenDot`, **Deprecate selected** + **Deprecate all N** behind a `ConfirmModal`, pagination.
- `AlertsPage` gains the `stale_ip_count` rule type (count + days params).

## Verification
- `make ci` — ruff/black/mypy + frontend lint/format/typecheck/build all pass.
- 8 new tests in `backend/tests/test_stale_ips.py` (service discrimination of stale vs fresh vs reserved vs lease-mirror, scoping, never-seen, endpoints, deprecate skip-logic, alert threshold) — all pass.
- Migration-shape linter clean (no new migration).

## Docs
- `docs/features/IPAM.md` §8 gained a **Stale-IP Report** subsection. Per the sibling convention (#308/#309/#311 added none between releases), CHANGELOG + the CLAUDE.md roadmap marker are left for the next release cut to reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)