### PR TITLE
Reverse-DNS auto-population (#41)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -313,6 +313,10 @@ backend/alembic/versions/d6e1a4b9f082_add_dns_auto_sync_settings.py:drop_column:
 backend/alembic/versions/d6e1a4b9f082_add_dns_auto_sync_settings.py:drop_column:63
 backend/alembic/versions/d72a36e159c4_ai_prompts.py:drop_table:102
 backend/alembic/versions/d7a2b6e9f134_add_address_family_to_dhcp_scope.py:drop_column:44
+backend/alembic/versions/d7a3f2b9c1e4_platform_settings_reverse_dns.py:drop_column:65
+backend/alembic/versions/d7a3f2b9c1e4_platform_settings_reverse_dns.py:drop_column:66
+backend/alembic/versions/d7a3f2b9c1e4_platform_settings_reverse_dns.py:drop_column:67
+backend/alembic/versions/d7a3f2b9c1e4_platform_settings_reverse_dns.py:drop_column:68
 backend/alembic/versions/d7e5b8c91a3f_dhcp_failover_channel.py:drop_column:145
 backend/alembic/versions/d7e5b8c91a3f_dhcp_failover_channel.py:drop_column:146
 backend/alembic/versions/d7e5b8c91a3f_dhcp_failover_channel.py:drop_table:148

--- a/backend/alembic/versions/d7a3f2b9c1e4_platform_settings_reverse_dns.py
+++ b/backend/alembic/versions/d7a3f2b9c1e4_platform_settings_reverse_dns.py
@@ -1,0 +1,68 @@
+"""platform settings — reverse-DNS auto-population (#41)
+
+Revision ID: d7a3f2b9c1e4
+Revises: a7e3c1f49d20
+Create Date: 2026-05-29 19:30:00.000000
+
+Adds the four ``reverse_dns_*`` columns that drive the scheduled
+reverse-DNS (PTR) auto-population sweep (issue #41). Additive only —
+every column ships a server_default so existing rows backfill to
+"reverse-DNS off" and the migration is expand-safe for a rolling
+upgrade. ``reverse_dns_resolvers`` is a JSONB list of resolver IPs
+(NULL / empty = use the worker's system resolvers).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "d7a3f2b9c1e4"
+down_revision: Union[str, None] = "a7e3c1f49d20"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "reverse_dns_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "reverse_dns_interval_minutes",
+            sa.Integer(),
+            nullable=False,
+            server_default="360",
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "reverse_dns_resolvers",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "reverse_dns_last_run_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_settings", "reverse_dns_last_run_at")
+    op.drop_column("platform_settings", "reverse_dns_resolvers")
+    op.drop_column("platform_settings", "reverse_dns_interval_minutes")
+    op.drop_column("platform_settings", "reverse_dns_enabled")

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -67,6 +67,10 @@ class SettingsResponse(BaseModel):
     dns_auto_sync_interval_minutes: int
     dns_auto_sync_delete_stale: bool
     dns_auto_sync_last_run_at: datetime | None
+    reverse_dns_enabled: bool
+    reverse_dns_interval_minutes: int
+    reverse_dns_resolvers: list[str] | None
+    reverse_dns_last_run_at: datetime | None
     dns_pull_from_server_enabled: bool
     dns_pull_from_server_interval_minutes: int
     dns_pull_from_server_last_run_at: datetime | None
@@ -320,6 +324,9 @@ class SettingsUpdate(BaseModel):
     dns_auto_sync_enabled: bool | None = None
     dns_auto_sync_interval_minutes: int | None = None
     dns_auto_sync_delete_stale: bool | None = None
+    reverse_dns_enabled: bool | None = None
+    reverse_dns_interval_minutes: int | None = None
+    reverse_dns_resolvers: list[str] | None = None
     dns_pull_from_server_enabled: bool | None = None
     dns_pull_from_server_interval_minutes: int | None = None
     dhcp_pull_leases_enabled: bool | None = None
@@ -464,6 +471,7 @@ class SettingsUpdate(BaseModel):
     @field_validator(
         "dns_auto_sync_interval_minutes",
         "dns_pull_from_server_interval_minutes",
+        "reverse_dns_interval_minutes",
         "oui_update_interval_hours",
     )
     @classmethod
@@ -471,6 +479,25 @@ class SettingsUpdate(BaseModel):
         if v is not None and v < 1:
             raise ValueError("Must be >= 1")
         return v
+
+    @field_validator("reverse_dns_resolvers")
+    @classmethod
+    def validate_resolvers(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        import ipaddress
+
+        cleaned: list[str] = []
+        for entry in v:
+            host = (entry or "").strip()
+            if not host:
+                continue
+            try:
+                ipaddress.ip_address(host)
+            except ValueError as exc:
+                raise ValueError(f"Invalid resolver IP: {entry!r}") from exc
+            cleaned.append(host)
+        return cleaned
 
     @field_validator("asn_whois_interval_hours", "rpki_roa_refresh_interval_hours")
     @classmethod
@@ -762,6 +789,54 @@ async def update_settings(
     await db.refresh(settings)
     logger.info("platform_settings_updated", user=current_user.username, changes=changes)
     return settings
+
+
+class ReverseDnsRunResponse(BaseModel):
+    status: str  # "queued" | "enqueue_failed"
+    task_id: str | None = None
+
+
+@router.post("/reverse-dns/run", response_model=ReverseDnsRunResponse)
+async def trigger_reverse_dns_run(current_user: CurrentUser, db: DB) -> ReverseDnsRunResponse:
+    """Queue an on-demand reverse-DNS sweep (issue #41).
+
+    Runs the same ``sweep_reverse_dns`` task the beat dispatcher uses, with
+    ``force=True`` so it bypasses the enabled-gate + per-run interval — an
+    operator can sweep on demand even with the scheduled sweep off.
+    """
+    forbid_in_demo_mode("Reverse-DNS sweep is disabled")
+    if not user_has_permission(current_user, "write", "settings"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied: need 'write' on 'settings'",
+        )
+
+    from app.models.audit import AuditLog
+
+    task_id: str | None = None
+    try:
+        from app.tasks.reverse_dns import sweep_reverse_dns
+
+        result = sweep_reverse_dns.delay(force=True)
+        task_id = result.id
+    except Exception as exc:  # noqa: BLE001 — broker unreachable; report, don't 500
+        logger.warning("reverse_dns_trigger_enqueue_failed", error=str(exc))
+
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="reverse-dns",
+            resource_type="platform",
+            resource_id="1",
+            resource_display="reverse-dns-run",
+            result="success" if task_id else "error",
+            error_detail=None if task_id else "task broker unreachable",
+        )
+    )
+    await db.commit()
+    return ReverseDnsRunResponse(status="queued" if task_id else "enqueue_failed", task_id=task_id)
 
 
 # ── OUI vendor database ───────────────────────────────────────────────────────

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -29,6 +29,7 @@ celery_app = Celery(
         "app.tasks.trash_purge",
         "app.tasks.ipam_reservation_sweep",
         "app.tasks.ipam_discovery",
+        "app.tasks.reverse_dns",
         "app.tasks.dhcp_lease_history_prune",
         "app.tasks.update_check",
         "app.tasks.kubernetes_sync",
@@ -79,6 +80,7 @@ celery_app.conf.update(
         "app.tasks.trash_purge.*": {"queue": "default"},
         "app.tasks.ipam_reservation_sweep.*": {"queue": "ipam"},
         "app.tasks.ipam_discovery.*": {"queue": "ipam"},
+        "app.tasks.reverse_dns.*": {"queue": "ipam"},
         "app.tasks.dhcp_lease_history_prune.*": {"queue": "dhcp"},
         "app.tasks.update_check.*": {"queue": "default"},
         "app.tasks.kubernetes_sync.*": {"queue": "default"},
@@ -140,6 +142,14 @@ celery_app.conf.update(
         # take effect without restarting beat.
         "ipam-discovery-dispatch": {
             "task": "app.tasks.ipam_discovery.dispatch_due_subnets",
+            "schedule": schedule(run_every=60.0),
+        },
+        # Every 60 s, tick the reverse-DNS (PTR) auto-population sweep
+        # (issue #41). The task gates on ``PlatformSettings.reverse_dns_enabled``
+        # and the per-run interval, so cadence changes in the UI take effect
+        # without restarting celery-beat.
+        "reverse-dns-sweep": {
+            "task": "app.tasks.reverse_dns.sweep_reverse_dns",
             "schedule": schedule(run_every=60.0),
         },
         # Every 60 s, tick the DNS pull-from-server task. The task itself

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -144,6 +144,24 @@ class PlatformSettings(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # Reverse-DNS (PTR) auto-population — issue #41. Beat fires every 60s;
+    # the task gates on ``reverse_dns_enabled`` + the per-run interval so
+    # cadence changes in the UI take effect without restarting beat. The
+    # sweep fills ``IPAddress.hostname`` (short label) + ``description``
+    # (full PTR FQDN, only when description is empty) for operator-owned
+    # rows whose hostname is NULL. ``reverse_dns_resolvers`` is a list of
+    # resolver IPs to query; NULL / empty = the worker's system resolvers.
+    reverse_dns_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    reverse_dns_interval_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=360, server_default="360"
+    )
+    reverse_dns_resolvers: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
+    reverse_dns_last_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # Scheduled "pull from authoritative server" (AXFR → additive import).
     # Complements the IPAM→DNS push direction above; together they keep
     # SpatiumDDI's DB in sync with both its own intent (IPAM) and the live

--- a/backend/app/services/ipam/reverse_dns.py
+++ b/backend/app/services/ipam/reverse_dns.py
@@ -32,13 +32,10 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.ipam import IPAddress
-
-logger = structlog.get_logger(__name__)
 
 # Statuses worth a PTR lookup — real allocations / sightings an operator
 # would want named. ``dhcp`` (lease mirror) is excluded via

--- a/backend/app/services/ipam/reverse_dns.py
+++ b/backend/app/services/ipam/reverse_dns.py
@@ -1,0 +1,175 @@
+"""Reverse-DNS (PTR) auto-population (issue #41).
+
+A scheduled, platform-opt-in sweep that fills ``IPAddress.hostname`` for
+operator-owned rows that have none, by issuing a PTR lookup against the
+configured resolvers (or the worker's system resolvers when none are
+configured).
+
+For each resolved row:
+  * ``hostname`` ← the short, leftmost label of the PTR FQDN
+    (``server01`` from ``server01.corp.example.com``);
+  * ``description`` ← the full PTR FQDN, **only when description is
+    currently empty** so an operator's note is never clobbered. (The
+    issue asks for the FQDN in ``description``; we deliberately keep the
+    dedicated ``fqdn`` column out of it — that field is owned by the
+    forward-DNS sync, which derives it from the assigned zone.)
+
+Skipped:
+  * rows whose hostname is authoritative from an upstream integration —
+    any row carrying an integration provenance FK
+    (docker / kubernetes / proxmox / tailscale / unifi) or
+    ``auto_from_lease`` (a DHCP lease mirror);
+  * unallocated / placeholder rows — only ``allocated`` / ``reserved`` /
+    ``static_dhcp`` / ``discovered`` statuses are resolved.
+
+The sweep only ever touches rows where ``hostname IS NULL`` so it never
+overwrites an existing name; once filled, a row drops out of the next
+sweep's candidate set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.ipam import IPAddress
+
+logger = structlog.get_logger(__name__)
+
+# Statuses worth a PTR lookup — real allocations / sightings an operator
+# would want named. ``dhcp`` (lease mirror) is excluded via
+# ``auto_from_lease``; integration statuses are excluded via the
+# provenance-FK guard in the query below.
+REVERSE_DNS_CANDIDATE_STATUSES: frozenset[str] = frozenset(
+    {"allocated", "reserved", "static_dhcp", "discovered"}
+)
+
+# Per-run safety caps — keep the sweep gentle on the resolver and bounded
+# in wall-clock so a single beat tick can't run away.
+DEFAULT_LIMIT = 256
+DEFAULT_CONCURRENCY = 16
+QUERY_TIMEOUT_SECONDS = 3.0
+
+
+def short_label(fqdn: str) -> str:
+    """Leftmost DNS label of a (possibly trailing-dot) FQDN."""
+    return fqdn.rstrip(".").split(".", 1)[0]
+
+
+def _build_resolver(resolvers: list[str] | None) -> Any:
+    """An async dnspython resolver, optionally pinned to ``resolvers``.
+
+    Returns None if dnspython can't be imported — defensive only; it's a
+    hard dependency, but a missing import must never crash the worker.
+    """
+    try:
+        import dns.asyncresolver  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    # configure=False skips reading /etc/resolv.conf when we're pinning an
+    # explicit resolver list.
+    r = dns.asyncresolver.Resolver(configure=not resolvers)
+    if resolvers:
+        r.nameservers = list(resolvers)
+    r.lifetime = QUERY_TIMEOUT_SECONDS
+    r.timeout = QUERY_TIMEOUT_SECONDS
+    return r
+
+
+async def resolve_ptr(ip: str, resolver: Any) -> str | None:
+    """Return the PTR FQDN for ``ip`` (trailing dot stripped), or None."""
+    try:
+        import dns.reversename  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        rev = dns.reversename.from_address(ip)
+        answer = await resolver.resolve(rev, "PTR")
+    except Exception:  # noqa: BLE001 — NXDOMAIN / timeout / no-answer / bad IP
+        return None
+    for rdata in answer:
+        name = rdata.to_text().rstrip(".")
+        if name:
+            return name
+    return None
+
+
+async def populate_reverse_dns(
+    db: AsyncSession,
+    *,
+    resolvers: list[str] | None = None,
+    limit: int = DEFAULT_LIMIT,
+    concurrency: int = DEFAULT_CONCURRENCY,
+) -> dict[str, int]:
+    """Resolve + fill hostname/description for hostname-NULL candidate rows.
+
+    Returns counts: ``scanned`` / ``resolved`` / ``updated`` / ``no_ptr``.
+    The caller owns the transaction (commit + audit).
+    """
+    resolver = _build_resolver(resolvers)
+    if resolver is None:
+        return {"scanned": 0, "resolved": 0, "updated": 0, "no_ptr": 0}
+
+    stmt = (
+        select(IPAddress)
+        .where(
+            IPAddress.hostname.is_(None),
+            IPAddress.auto_from_lease.is_(False),
+            IPAddress.status.in_(REVERSE_DNS_CANDIDATE_STATUSES),
+            IPAddress.docker_host_id.is_(None),
+            IPAddress.kubernetes_cluster_id.is_(None),
+            IPAddress.proxmox_node_id.is_(None),
+            IPAddress.tailscale_tenant_id.is_(None),
+            IPAddress.unifi_controller_id.is_(None),
+        )
+        .order_by(IPAddress.created_at.asc())
+        .limit(max(1, min(limit, 5000)))
+    )
+    rows = list((await db.execute(stmt)).scalars().all())
+    if not rows:
+        return {"scanned": 0, "resolved": 0, "updated": 0, "no_ptr": 0}
+
+    sem = asyncio.Semaphore(max(1, concurrency))
+
+    async def _lookup(ip_row: IPAddress) -> tuple[IPAddress, str | None]:
+        async with sem:
+            return ip_row, await resolve_ptr(str(ip_row.address), resolver)
+
+    results = await asyncio.gather(*[_lookup(r) for r in rows])
+
+    resolved = 0
+    updated = 0
+    for ip_row, raw in results:
+        if not raw:
+            continue
+        fqdn = raw.rstrip(".")  # normalize even if the resolver kept the dot
+        if not fqdn:
+            continue
+        resolved += 1
+        # Re-check NULL in case a concurrent writer filled it mid-sweep.
+        if ip_row.hostname:
+            continue
+        ip_row.hostname = short_label(fqdn)
+        # Never clobber an operator note — only write the FQDN when blank.
+        if not (ip_row.description or "").strip():
+            ip_row.description = fqdn
+        updated += 1
+
+    return {
+        "scanned": len(rows),
+        "resolved": resolved,
+        "updated": updated,
+        "no_ptr": len(rows) - resolved,
+    }
+
+
+__all__ = [
+    "REVERSE_DNS_CANDIDATE_STATUSES",
+    "populate_reverse_dns",
+    "resolve_ptr",
+    "short_label",
+]

--- a/backend/app/tasks/reverse_dns.py
+++ b/backend/app/tasks/reverse_dns.py
@@ -55,19 +55,22 @@ async def _run_sweep(force: bool = False) -> dict[str, Any]:
             counts = await populate_reverse_dns(db, resolvers=ps.reverse_dns_resolvers or None)
             ps.reverse_dns_last_run_at = now
 
-            if counts["updated"]:
-                db.add(
-                    AuditLog(
-                        user_display_name="<system>",
-                        auth_source="system",
-                        action="reverse-dns",
-                        resource_type="platform",
-                        resource_id=str(_SINGLETON_ID),
-                        resource_display="reverse-dns-sweep",
-                        result="success",
-                        new_value={"forced": force, **counts},
-                    )
+            # One summary row per actual sweep — the enabled-gate + interval
+            # early-returns above mean we only reach here on a real run (not
+            # every 60s tick), so this matches the documented contract
+            # without spamming the audit log.
+            db.add(
+                AuditLog(
+                    user_display_name="<system>",
+                    auth_source="system",
+                    action="reverse-dns",
+                    resource_type="platform",
+                    resource_id=str(_SINGLETON_ID),
+                    resource_display="reverse-dns-sweep",
+                    result="success",
+                    new_value={"forced": force, **counts},
                 )
+            )
             await db.commit()
 
             logger.info("reverse_dns_sweep_completed", forced=force, **counts)

--- a/backend/app/tasks/reverse_dns.py
+++ b/backend/app/tasks/reverse_dns.py
@@ -1,0 +1,87 @@
+"""Reverse-DNS (PTR) auto-population task (issue #41).
+
+Fired every 60 s by Celery Beat. A fast no-op when
+``PlatformSettings.reverse_dns_enabled`` is False or the configured
+interval hasn't elapsed — keeping the beat schedule static while letting
+the operator change cadence from the UI. The on-demand "Run now" endpoint
+calls the same task with ``force=True`` to bypass both gates.
+
+The heavy lifting lives in ``services.ipam.reverse_dns.populate_reverse_dns``;
+this module owns the platform-settings gate, the resolver list, the
+``last_run_at`` stamp, and a single summary audit row per run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.celery_app import celery_app
+from app.config import settings
+from app.models.audit import AuditLog
+from app.models.settings import PlatformSettings
+
+logger = structlog.get_logger(__name__)
+
+_SINGLETON_ID = 1
+
+
+async def _run_sweep(force: bool = False) -> dict[str, Any]:
+    from app.services.ipam.reverse_dns import populate_reverse_dns  # noqa: PLC0415
+
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            ps = await db.get(PlatformSettings, _SINGLETON_ID)
+            if ps is None or (not force and not ps.reverse_dns_enabled):
+                return {"status": "disabled"}
+
+            now = datetime.now(UTC)
+            if not force and ps.reverse_dns_last_run_at is not None:
+                interval = timedelta(minutes=max(1, ps.reverse_dns_interval_minutes))
+                elapsed = now - ps.reverse_dns_last_run_at
+                if elapsed < interval:
+                    return {
+                        "status": "skipped",
+                        "reason": "interval_not_elapsed",
+                        "wait_seconds": int((interval - elapsed).total_seconds()),
+                    }
+
+            counts = await populate_reverse_dns(db, resolvers=ps.reverse_dns_resolvers or None)
+            ps.reverse_dns_last_run_at = now
+
+            if counts["updated"]:
+                db.add(
+                    AuditLog(
+                        user_display_name="<system>",
+                        auth_source="system",
+                        action="reverse-dns",
+                        resource_type="platform",
+                        resource_id=str(_SINGLETON_ID),
+                        resource_display="reverse-dns-sweep",
+                        result="success",
+                        new_value={"forced": force, **counts},
+                    )
+                )
+            await db.commit()
+
+            logger.info("reverse_dns_sweep_completed", forced=force, **counts)
+            return {"status": "ran", **counts}
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(name="app.tasks.reverse_dns.sweep_reverse_dns", bind=True)
+def sweep_reverse_dns(self: object, force: bool = False) -> dict[str, Any]:  # type: ignore[type-arg]
+    """Beat entrypoint (fires every 60 s) + on-demand entrypoint
+    (``force=True`` bypasses the enabled-gate and the interval)."""
+    try:
+        return asyncio.run(_run_sweep(force=force))
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("reverse_dns_sweep_failed", error=str(exc))
+        raise

--- a/backend/tests/test_reverse_dns.py
+++ b/backend/tests/test_reverse_dns.py
@@ -149,6 +149,41 @@ async def test_populate_skips_integration_and_lease_and_noncandidate(
     assert good.hostname == "disco"
 
 
+async def test_populate_skips_row_with_integration_fk(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A candidate-status row (allocated) that carries an integration
+    # provenance FK must be excluded by the FK guard — its hostname is
+    # authoritative from the upstream reconciler.
+    from app.models.docker import DockerHost
+
+    subnet = await _make_subnet(db_session)
+    host = DockerHost(
+        name=f"dh-{uuid.uuid4().hex[:6]}",
+        endpoint="tcp://1.2.3.4:2375",
+        ipam_space_id=subnet.space_id,
+    )
+    db_session.add(host)
+    await db_session.flush()
+    row = IPAddress(
+        subnet_id=subnet.id,
+        address="192.0.2.40",
+        status="allocated",
+        docker_host_id=host.id,
+    )
+    db_session.add(row)
+    await db_session.flush()
+
+    monkeypatch.setattr(
+        reverse_dns, "resolve_ptr", _fake_ptr({"192.0.2.40": "claimed.example.com"})
+    )
+    counts = await populate_reverse_dns(db_session, resolvers=RESOLVERS)
+    await db_session.flush()
+    assert counts["scanned"] == 0  # FK guard excluded it from the candidate query
+    await db_session.refresh(row)
+    assert row.hostname is None
+
+
 async def test_populate_no_ptr_leaves_row_untouched(
     db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_reverse_dns.py
+++ b/backend/tests/test_reverse_dns.py
@@ -1,0 +1,201 @@
+"""Reverse-DNS (PTR) auto-population (issue #41)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.ipam import reverse_dns
+from app.services.ipam.reverse_dns import populate_reverse_dns, short_label
+
+RESOLVERS = ["192.0.2.53"]  # pinned → _build_resolver skips /etc/resolv.conf
+
+
+async def _make_user(db: AsyncSession) -> tuple[User, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_subnet(db: AsyncSession, cidr: str = "192.0.2.0/24") -> Subnet:
+    space = IPSpace(name=f"rdns-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=cidr, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=cidr, name="s")
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+# ── Pure helper ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "fqdn,expected",
+    [
+        ("server01.corp.example.com.", "server01"),
+        ("server01.corp.example.com", "server01"),
+        ("host", "host"),
+        ("a.b", "a"),
+    ],
+)
+def test_short_label(fqdn: str, expected: str) -> None:
+    assert short_label(fqdn) == expected
+
+
+# ── populate_reverse_dns ────────────────────────────────────────────────
+
+
+def _fake_ptr(mapping: dict[str, str]):
+    async def _resolve(ip: str, resolver: object) -> str | None:  # noqa: ARG001
+        return mapping.get(ip)
+
+    return _resolve
+
+
+async def test_populate_fills_hostname_and_description(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subnet = await _make_subnet(db_session)
+    row = IPAddress(subnet_id=subnet.id, address="192.0.2.10", status="allocated")
+    db_session.add(row)
+    await db_session.flush()
+
+    monkeypatch.setattr(
+        reverse_dns, "resolve_ptr", _fake_ptr({"192.0.2.10": "server01.corp.example.com."})
+    )
+    counts = await populate_reverse_dns(db_session, resolvers=RESOLVERS)
+    await db_session.flush()
+
+    assert counts == {"scanned": 1, "resolved": 1, "updated": 1, "no_ptr": 0}
+    await db_session.refresh(row)
+    assert row.hostname == "server01"
+    assert row.description == "server01.corp.example.com"
+
+
+async def test_populate_preserves_operator_description(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subnet = await _make_subnet(db_session)
+    row = IPAddress(
+        subnet_id=subnet.id, address="192.0.2.11", status="allocated", description="my note"
+    )
+    db_session.add(row)
+    await db_session.flush()
+
+    monkeypatch.setattr(reverse_dns, "resolve_ptr", _fake_ptr({"192.0.2.11": "host.example.com"}))
+    await populate_reverse_dns(db_session, resolvers=RESOLVERS)
+    await db_session.flush()
+    await db_session.refresh(row)
+    assert row.hostname == "host"
+    assert row.description == "my note"  # not clobbered
+
+
+async def test_populate_skips_integration_and_lease_and_noncandidate(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subnet = await _make_subnet(db_session)
+    cluster_owned = IPAddress(
+        subnet_id=subnet.id,
+        address="192.0.2.20",
+        status="kubernetes-node",
+        kubernetes_cluster_id=None,  # set below
+    )
+    lease = IPAddress(
+        subnet_id=subnet.id, address="192.0.2.21", status="dhcp", auto_from_lease=True
+    )
+    available = IPAddress(subnet_id=subnet.id, address="192.0.2.22", status="available")
+    good = IPAddress(subnet_id=subnet.id, address="192.0.2.23", status="discovered")
+    db_session.add_all([cluster_owned, lease, available, good])
+    await db_session.flush()
+
+    monkeypatch.setattr(
+        reverse_dns,
+        "resolve_ptr",
+        _fake_ptr(
+            {
+                "192.0.2.20": "k8s.example.com",
+                "192.0.2.21": "lease.example.com",
+                "192.0.2.22": "free.example.com",
+                "192.0.2.23": "disco.example.com",
+            }
+        ),
+    )
+    counts = await populate_reverse_dns(db_session, resolvers=RESOLVERS)
+    await db_session.flush()
+
+    # Only the `discovered` row is a candidate (no provenance FK, not a
+    # lease, real status). The k8s/lease/available rows are all skipped.
+    assert counts["scanned"] == 1
+    assert counts["updated"] == 1
+    await db_session.refresh(good)
+    assert good.hostname == "disco"
+
+
+async def test_populate_no_ptr_leaves_row_untouched(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subnet = await _make_subnet(db_session)
+    row = IPAddress(subnet_id=subnet.id, address="192.0.2.30", status="allocated")
+    db_session.add(row)
+    await db_session.flush()
+
+    monkeypatch.setattr(reverse_dns, "resolve_ptr", _fake_ptr({}))  # NXDOMAIN everywhere
+    counts = await populate_reverse_dns(db_session, resolvers=RESOLVERS)
+    await db_session.flush()
+    assert counts == {"scanned": 1, "resolved": 0, "updated": 0, "no_ptr": 1}
+    await db_session.refresh(row)
+    assert row.hostname is None
+
+
+# ── On-demand run endpoint ──────────────────────────────────────────────
+
+
+async def test_run_endpoint_queues_and_audits(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.models.audit import AuditLog
+    from app.tasks import reverse_dns as task_mod
+
+    _, token = await _make_user(db_session)
+    await db_session.commit()
+
+    class _Result:
+        id = "fake-task-id"
+
+    monkeypatch.setattr(task_mod.sweep_reverse_dns, "delay", lambda *a, **k: _Result())
+
+    r = await client.post(
+        "/api/v1/settings/reverse-dns/run", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "queued"
+    assert r.json()["task_id"] == "fake-task-id"
+
+    audit = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(AuditLog.resource_display == "reverse-dns-run")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audit) == 1

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -354,6 +354,34 @@ IPs older than `threshold_days` (default 90). It reads the same signal
 but excludes never-seen rows so the passive feed stays high-confidence;
 operators chase the full list, including never-seen, from the report.
 
+### Reverse-DNS auto-population (issue #41)
+
+A scheduled, platform-opt-in sweep that names IP rows from reverse DNS.
+The reverse-DNS beat task (every 60 s, gated on `reverse_dns_enabled` +
+`reverse_dns_interval_minutes`) finds rows where `hostname IS NULL`,
+issues a PTR lookup against the configured resolvers, and fills:
+
+- `hostname` ← the **short, leftmost label** of the PTR FQDN
+  (`server01` from `server01.corp.example.com`);
+- `description` ← the **full PTR FQDN**, but **only when the description
+  is currently empty** so an operator's note is never clobbered. (The
+  dedicated `fqdn` column is intentionally left to the forward-DNS sync,
+  which derives it from the assigned zone.)
+
+Candidate rows are `allocated` / `reserved` / `static_dhcp` /
+`discovered` only. Rows whose hostname is authoritative from an upstream
+integration are skipped — anything carrying an integration provenance FK
+(Docker / Kubernetes / Proxmox / Tailscale / UniFi) or `auto_from_lease`
+(a DHCP lease mirror). `discovered` rows *are* included because
+ping/ARP/nmap discovery (#23) never provides a hostname. The sweep only
+ever touches `hostname IS NULL` rows, so it never overwrites a name.
+
+Configured under **Settings → IPAM → Reverse DNS (PTR)**: enable toggle,
+sweep interval, and a comma-separated resolver list (blank = the
+worker's system resolvers). A **Run now** button queues an on-demand
+sweep (`POST /api/v1/settings/reverse-dns/run`) that bypasses the
+enabled-gate + interval. Each sweep writes one summary audit row.
+
 ---
 
 ## 9. Utilization Tracking

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2800,6 +2800,11 @@ export interface PlatformSettings {
   dns_auto_sync_interval_minutes: number;
   dns_auto_sync_delete_stale: boolean;
   dns_auto_sync_last_run_at: string | null;
+  // Reverse-DNS (PTR) auto-population — issue #41.
+  reverse_dns_enabled: boolean;
+  reverse_dns_interval_minutes: number;
+  reverse_dns_resolvers: string[] | null;
+  reverse_dns_last_run_at: string | null;
   dns_pull_from_server_enabled: boolean;
   dns_pull_from_server_interval_minutes: number;
   dns_pull_from_server_last_run_at: string | null;
@@ -3054,6 +3059,15 @@ export const settingsApi = {
   getDefaults: () =>
     api
       .get<Partial<PlatformSettings>>("/settings/defaults")
+      .then((r) => r.data),
+  /** Issue #41 — queue an on-demand reverse-DNS (PTR) sweep, bypassing
+   *  the enabled-gate + interval. */
+  runReverseDns: () =>
+    api
+      .post<{
+        status: string;
+        task_id: string | null;
+      }>("/settings/reverse-dns/run")
       .then((r) => r.data),
   /** Issue #153 — reveal the configured SNMP v2c community after a
    *  password re-verify. Superadmin + local-auth only; every reveal

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -51,6 +51,7 @@ type SectionId =
   | "branding"
   | "dns"
   | "dns-auto-sync"
+  | "reverse-dns"
   | "dns-pull-from-server"
   | "dhcp"
   | "dhcp-lease-sync"
@@ -114,6 +115,11 @@ const SECTION_FIELDS: Record<SectionId, (keyof PlatformSettings)[]> = {
     "dns_auto_sync_enabled",
     "dns_auto_sync_interval_minutes",
     "dns_auto_sync_delete_stale",
+  ],
+  "reverse-dns": [
+    "reverse_dns_enabled",
+    "reverse_dns_interval_minutes",
+    "reverse_dns_resolvers",
   ],
   "dns-pull-from-server": [
     "dns_pull_from_server_enabled",
@@ -811,6 +817,24 @@ const SECTIONS: SectionDef[] = [
     ],
   },
   {
+    id: "reverse-dns",
+    title: "Reverse DNS (PTR)",
+    group: "IPAM",
+    description:
+      "Periodically PTR-resolve IP rows that have no hostname and fill in the name from reverse DNS. Hostname gets the short label; the full FQDN goes in the description (only when it's blank). Skips integration-owned rows whose name is authoritative upstream. Opt-in — off by default.",
+    keywords: [
+      "reverse",
+      "ptr",
+      "dns",
+      "hostname",
+      "resolve",
+      "lookup",
+      "auto",
+      "populate",
+      "rdns",
+    ],
+  },
+  {
     id: "dns-pull-from-server",
     title: "Zone ↔ Server Reconciliation",
     group: "DNS",
@@ -969,6 +993,21 @@ export function SettingsPage() {
       setForm({});
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+    },
+  });
+
+  // Issue #41 — on-demand reverse-DNS sweep ("Run now"). Independent of
+  // the save flow; reports a transient queued/failed status.
+  const [rdnsRun, setRdnsRun] = useState<"idle" | "queued" | "error">("idle");
+  const runReverseDns = useMutation({
+    mutationFn: () => settingsApi.runReverseDns(),
+    onSuccess: (res) => {
+      setRdnsRun(res.status === "queued" ? "queued" : "error");
+      setTimeout(() => setRdnsRun("idle"), 4000);
+    },
+    onError: () => {
+      setRdnsRun("error");
+      setTimeout(() => setRdnsRun("idle"), 4000);
     },
   });
 
@@ -1321,6 +1360,95 @@ export function SettingsPage() {
                         ).toLocaleString()
                       : "never"}
                   </span>
+                </Field>
+              </>
+            )}
+
+            {activeId === "reverse-dns" && (
+              <>
+                <Field
+                  label="Enable Reverse-DNS"
+                  description="Periodically PTR-resolve IP rows with no hostname and fill the name from reverse DNS. Only allocated / reserved / static_dhcp / discovered rows are resolved; integration-owned rows (Docker / Kubernetes / Proxmox / Tailscale / UniFi / DHCP leases) are skipped since their name is authoritative upstream."
+                >
+                  <Toggle
+                    checked={!!values.reverse_dns_enabled}
+                    onChange={(v) => set("reverse_dns_enabled", v)}
+                    disabled={!isSuperadmin}
+                  />
+                </Field>
+                <Field
+                  label="Sweep Interval"
+                  description="How often the reverse-DNS sweep runs."
+                >
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      min={1}
+                      value={values.reverse_dns_interval_minutes ?? 360}
+                      onChange={(e) =>
+                        set(
+                          "reverse_dns_interval_minutes",
+                          Number(e.target.value),
+                        )
+                      }
+                      disabled={!isSuperadmin || !values.reverse_dns_enabled}
+                      className={cn(inputCls, "w-24")}
+                    />
+                    <span className="text-xs text-muted-foreground">min</span>
+                  </div>
+                </Field>
+                <Field
+                  label="Resolvers"
+                  description="Comma-separated resolver IPs to query for PTR records. Leave blank to use the worker's system resolvers."
+                >
+                  <input
+                    type="text"
+                    value={(values.reverse_dns_resolvers ?? []).join(", ")}
+                    onChange={(e) =>
+                      set(
+                        "reverse_dns_resolvers",
+                        e.target.value
+                          .split(",")
+                          .map((s) => s.trim())
+                          .filter(Boolean),
+                      )
+                    }
+                    placeholder="10.0.0.53, 1.1.1.1 (blank = system)"
+                    disabled={!isSuperadmin || !values.reverse_dns_enabled}
+                    className={inputCls}
+                  />
+                </Field>
+                <Field
+                  label="Last Run"
+                  description="Timestamp of the most recent reverse-DNS sweep."
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="rounded bg-muted px-2 py-1 text-xs font-mono text-muted-foreground">
+                      {values.reverse_dns_last_run_at
+                        ? new Date(
+                            values.reverse_dns_last_run_at,
+                          ).toLocaleString()
+                        : "never"}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => runReverseDns.mutate()}
+                      disabled={!isSuperadmin || runReverseDns.isPending}
+                      className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+                    >
+                      {runReverseDns.isPending ? "Queuing…" : "Run now"}
+                    </button>
+                    {rdnsRun === "queued" && (
+                      <span className="text-xs text-emerald-600 dark:text-emerald-400">
+                        Sweep queued
+                      </span>
+                    )}
+                    {rdnsRun === "error" && (
+                      <span className="text-xs text-destructive">
+                        Could not queue — broker unreachable?
+                      </span>
+                    )}
+                  </div>
                 </Field>
               </>
             )}


### PR DESCRIPTION
Closes #41.

A scheduled, platform-opt-in sweep that names IP rows from reverse DNS — the discovery/hygiene companion to #23 (IP discovery) and #45 (stale-IP report).

## Backend
- **`services/ipam/reverse_dns.py`** — PTR-resolves rows where `hostname IS NULL` against the configured resolvers (dnspython `asyncresolver`, bounded concurrency + per-run cap). Fills `hostname` with the short leftmost label (`server01` from `server01.corp.example.com`) and `description` with the full FQDN — **only when description is blank**, so an operator note is never clobbered.
  - Candidate statuses: `allocated` / `reserved` / `static_dhcp` / `discovered`.
  - Skipped: rows carrying an integration provenance FK (Docker / Kubernetes / Proxmox / Tailscale / UniFi) or `auto_from_lease` (DHCP lease mirror) — their name is authoritative upstream. `discovered` **is** included because ping/ARP/nmap discovery (#23) never sets a hostname.
  - Only ever touches `hostname IS NULL`, so it never overwrites a name.
- **`tasks/reverse_dns.py`** — beat task every 60 s, gated on `reverse_dns_enabled` + `reverse_dns_interval_minutes` (UI cadence changes need no beat restart); writes one summary audit row per run. `force=True` powers the on-demand `POST /api/v1/settings/reverse-dns/run` (bypasses the enabled-gate + interval).
- **PlatformSettings** — `reverse_dns_enabled` / `_interval_minutes` / `_resolvers` (JSONB; blank = the worker's system resolvers) / `_last_run_at`. Migration `d7a3f2b9c1e4`, additive (server_defaults); downgrade drops baselined in the migration-shape linter.
- Settings API exposes + validates the fields (each resolver entry checked via `ipaddress.ip_address`).

## Frontend
- **Settings → IPAM → Reverse DNS (PTR)**: enable toggle, sweep interval, comma-separated resolver list, last-run timestamp + **Run now** button.

## Deviation from the issue
The issue says the FQDN goes in `description`; I honour that (clobber-guarded) rather than the dedicated `fqdn` column, because `fqdn` is owned by the forward-DNS sync (derived from the IP's assigned zone) and writing PTR data there would conflict.

## Verification
- `make ci` — ruff/black/mypy + frontend lint/format/typecheck/build all pass.
- 9 new tests in `backend/tests/test_reverse_dns.py` (short-label, hostname+description fill, operator-description preserved, integration/lease/non-candidate skip, no-PTR no-op, on-demand endpoint queues + audits) — all pass.
- Schema-check + health tests pass; migration applied cleanly to the dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)