### PR TITLE
DHCPv6 stateful / stateless / SLAAC mode (#52)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -368,6 +368,9 @@ backend/alembic/versions/e4b9f07d25a1_dhcp_group_centric_refactor.py:drop_constr
 backend/alembic/versions/e4b9f07d25a1_dhcp_group_centric_refactor.py:drop_constraint_fk:450
 backend/alembic/versions/e4b9f07d25a1_dhcp_group_centric_refactor.py:drop_constraint_fk:488
 backend/alembic/versions/e4b9f07d25a1_dhcp_group_centric_refactor.py:drop_table:349
+backend/alembic/versions/e4c1a8f63b29_dhcp_scope_v6_mode.py:drop_column:59
+backend/alembic/versions/e4c1a8f63b29_dhcp_scope_v6_mode.py:drop_column:60
+backend/alembic/versions/e4c1a8f63b29_dhcp_scope_v6_mode.py:drop_column:61
 backend/alembic/versions/e4d8c2a91f7b_phone_profiles.py:drop_table:100
 backend/alembic/versions/e4d8c2a91f7b_phone_profiles.py:drop_table:98
 backend/alembic/versions/e5a18c40729b_ai_tool_catalog.py:drop_column:47

--- a/backend/alembic/versions/e4c1a8f63b29_dhcp_scope_v6_mode.py
+++ b/backend/alembic/versions/e4c1a8f63b29_dhcp_scope_v6_mode.py
@@ -1,0 +1,61 @@
+"""dhcp scope — DHCPv6 address mode + RA flags (#52)
+
+Revision ID: e4c1a8f63b29
+Revises: d7a3f2b9c1e4
+Create Date: 2026-05-29 20:30:00.000000
+
+Adds the DHCPv6 operating-mode discriminator to ``dhcp_scope`` (issue
+#52). ``v6_address_mode`` is only meaningful for ipv6 scopes — it drives
+how Kea renders the subnet6 (stateful = address pools; stateless =
+options only; slaac = no DHCP address service). ``ra_managed_flag`` /
+``ra_other_flag`` record the intended Router-Advertisement M/O flags
+(operator applies these on their router; SpatiumDDI's Kea agent doesn't
+send RAs). Additive only — every column ships a server_default so
+existing v4 + v6 scopes backfill to "stateful" (current behaviour).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e4c1a8f63b29"
+down_revision: Union[str, None] = "d7a3f2b9c1e4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "dhcp_scope",
+        sa.Column(
+            "v6_address_mode",
+            sa.String(length=12),
+            nullable=False,
+            server_default="stateful",
+        ),
+    )
+    op.add_column(
+        "dhcp_scope",
+        sa.Column(
+            "ra_managed_flag",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "dhcp_scope",
+        sa.Column(
+            "ra_other_flag",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("dhcp_scope", "ra_other_flag")
+    op.drop_column("dhcp_scope", "ra_managed_flag")
+    op.drop_column("dhcp_scope", "v6_address_mode")

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -33,6 +33,8 @@ router = APIRouter(tags=["dhcp"], dependencies=[Depends(require_resource_permiss
 
 VALID_HOSTNAME_POLICIES = {"client", "server_name", "derived", "none"}
 VALID_SYNC_MODES = {"disabled", "on_lease", "on_static_only", "ipam", "learned"}
+# DHCPv6 operating modes (issue #52). Only meaningful for ipv6 scopes.
+VALID_V6_MODES = {"stateful", "stateless", "slaac"}
 
 _CODE_TO_NAME: dict[int, str] = {
     2: "time-offset",
@@ -94,6 +96,10 @@ class ScopeCreate(BaseModel):
     ddns_hostname_policy: str | None = "client"
     hostname_to_ipam_sync: str = "on_static_only"
     hostname_sync_mode: str | None = None
+    # DHCPv6 operating mode (issue #52) — ignored for v4 scopes.
+    v6_address_mode: str = "stateful"
+    ra_managed_flag: bool = True
+    ra_other_flag: bool = True
     tags: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("ddns_hostname_policy")
@@ -105,6 +111,15 @@ class ScopeCreate(BaseModel):
             raise ValueError(
                 f"ddns_hostname_policy must be one of {sorted(VALID_HOSTNAME_POLICIES)}"
             )
+        return v
+
+    @field_validator("v6_address_mode")
+    @classmethod
+    def _v6mode(cls, v: str | None) -> str:
+        if v in (None, ""):
+            return "stateful"
+        if v not in VALID_V6_MODES:
+            raise ValueError(f"v6_address_mode must be one of {sorted(VALID_V6_MODES)}")
         return v
 
 
@@ -132,7 +147,20 @@ class ScopeUpdate(BaseModel):
     # treats null + missing identically by default. We need this to
     # support detaching a previously-bound profile.
     clear_pxe_profile: bool | None = None
+    # DHCPv6 operating mode (issue #52) — ignored for v4 scopes.
+    v6_address_mode: str | None = None
+    ra_managed_flag: bool | None = None
+    ra_other_flag: bool | None = None
     tags: dict[str, Any] | None = None
+
+    @field_validator("v6_address_mode")
+    @classmethod
+    def _v6mode(cls, v: str | None) -> str | None:
+        if v in (None, ""):
+            return None
+        if v not in VALID_V6_MODES:
+            raise ValueError(f"v6_address_mode must be one of {sorted(VALID_V6_MODES)}")
+        return v
 
 
 _NAME_TO_CODE = {v: k for k, v in _CODE_TO_NAME.items()}
@@ -154,6 +182,9 @@ class ScopeResponse(BaseModel):
     ddns_domain_override: str | None = None
     hostname_sync_mode: str
     address_family: str = "ipv4"
+    v6_address_mode: str = "stateful"
+    ra_managed_flag: bool = True
+    ra_other_flag: bool = True
     last_pushed_at: datetime | None
     tags: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
@@ -184,6 +215,9 @@ def _scope_to_response(scope: DHCPScope) -> ScopeResponse:
         ddns_domain_override=None,
         hostname_sync_mode=scope.hostname_to_ipam_sync,
         address_family=getattr(scope, "address_family", "ipv4") or "ipv4",
+        v6_address_mode=getattr(scope, "v6_address_mode", "stateful") or "stateful",
+        ra_managed_flag=getattr(scope, "ra_managed_flag", True),
+        ra_other_flag=getattr(scope, "ra_other_flag", True),
         last_pushed_at=scope.last_pushed_at,
         tags=scope.tags or {},
         created_at=scope.created_at,
@@ -277,6 +311,9 @@ async def create_scope(
         ddns_hostname_policy=body.ddns_hostname_policy or "client",
         hostname_to_ipam_sync=sync_mode,
         address_family=address_family,
+        v6_address_mode=body.v6_address_mode,
+        ra_managed_flag=body.ra_managed_flag,
+        ra_other_flag=body.ra_other_flag,
     )
     db.add(scope)
     await db.flush()

--- a/backend/app/drivers/dhcp/base.py
+++ b/backend/app/drivers/dhcp/base.py
@@ -153,6 +153,11 @@ class ScopeDef:
     # "ipv4" → Dhcp4 rendering, "ipv6" → Dhcp6 rendering. Defaults to "ipv4"
     # so legacy bundles (before address_family existed) keep working.
     address_family: str = "ipv4"
+    # DHCPv6 operating mode (issue #52) — "stateful" | "stateless" | "slaac".
+    # Only consulted when ``address_family == "ipv6"``; drives whether the
+    # Kea driver renders address pools and/or option-data for the subnet6.
+    # Defaults to "stateful" so v4 scopes + pre-#52 bundles render unchanged.
+    v6_address_mode: str = "stateful"
 
 
 @dataclass(frozen=True)

--- a/backend/app/drivers/dhcp/kea.py
+++ b/backend/app/drivers/dhcp/kea.py
@@ -157,20 +157,39 @@ def _render_reservation(s: StaticAssignmentDef, *, address_family: str = "ipv4")
 
 def _render_scope(scope: ScopeDef) -> dict[str, Any]:
     af = scope.address_family  # "ipv4" | "ipv6"
-    dynamic_pools = [p for p in scope.pools if p.pool_type == "dynamic"]
-    subnet_key = "subnet"  # Kea names the CIDR field "subnet" for both families
-    pools_key = "pools" if af != "ipv6" else "pools"  # same in both
+    # DHCPv6 operating mode (issue #52) gates what Kea serves for a v6
+    # subnet6. v4 always serves both addresses + options (mode is ignored).
+    #   stateful  → address pools + option-data
+    #   stateless → no pools, option-data only (Information-Request)
+    #   slaac     → no pools, no option-data (the router's RA does it all)
+    mode = getattr(scope, "v6_address_mode", "stateful") or "stateful"
+    if af == "ipv6":
+        serve_addresses = mode == "stateful"
+        serve_options = mode in ("stateful", "stateless")
+    else:
+        serve_addresses = True
+        serve_options = True
+
+    dynamic_pools = [p for p in scope.pools if p.pool_type == "dynamic"] if serve_addresses else []
     out: dict[str, Any] = {
-        subnet_key: scope.subnet_cidr,
-        pools_key: [_render_pool(p, address_family=af) for p in dynamic_pools],
-        "reservations": [_render_reservation(s, address_family=af) for s in scope.statics],
+        # Kea names the CIDR field "subnet" and the pool list "pools" in
+        # both Dhcp4 and Dhcp6 modes.
+        "subnet": scope.subnet_cidr,
+        "pools": [_render_pool(p, address_family=af) for p in dynamic_pools],
+        # A pure-SLAAC subnet has no DHCP role, so host reservations (which
+        # assign addresses / host-specific options) are dropped too.
+        "reservations": (
+            [_render_reservation(s, address_family=af) for s in scope.statics]
+            if (serve_addresses or serve_options)
+            else []
+        ),
         "valid-lifetime": scope.lease_time,
     }
     if scope.min_lease_time is not None:
         out["min-valid-lifetime"] = scope.min_lease_time
     if scope.max_lease_time is not None:
         out["max-valid-lifetime"] = scope.max_lease_time
-    if scope.options:
+    if scope.options and serve_options:
         out["option-data"] = _render_option_data(scope.options, address_family=af)
     return out
 

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -277,6 +277,31 @@ class DHCPScope(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
         String(4), nullable=False, default="ipv4", server_default="ipv4"
     )
 
+    # ── DHCPv6 operating mode (issue #52) ───────────────────────────
+    # Only meaningful for ``address_family == "ipv6"`` scopes; v4 ignores
+    # it. Drives how the Kea driver renders the subnet6:
+    #   * "stateful"  — Kea hands out addresses from the pools (IA_NA) and
+    #                   serves option data. RA M-flag=1, O-flag=1.
+    #   * "stateless" — no address pools; Kea serves only option data
+    #                   (DNS / domain-search) via Information-Request.
+    #                   Clients SLAAC their address from the router's RA.
+    #                   RA M-flag=0, O-flag=1.
+    #   * "slaac"     — no DHCPv6 address service at all; the router's RA
+    #                   does everything. RA M-flag=0, O-flag=0.
+    # ``ra_managed_flag`` / ``ra_other_flag`` capture the intended RA M/O
+    # flags — these are operator intent applied on the *router* (SpatiumDDI's
+    # Kea agent doesn't emit Router Advertisements), surfaced in the UI as
+    # "what to set upstream". They don't affect the rendered Kea config.
+    v6_address_mode: Mapped[str] = mapped_column(
+        String(12), nullable=False, default="stateful", server_default="stateful"
+    )
+    ra_managed_flag: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    ra_other_flag: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+
     lease_time: Mapped[int] = mapped_column(Integer, nullable=False, default=86400)
     min_lease_time: Mapped[int | None] = mapped_column(Integer, nullable=True)
     max_lease_time: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/services/ai/tools/dhcp.py
+++ b/backend/app/services/ai/tools/dhcp.py
@@ -103,6 +103,7 @@ async def list_dhcp_scopes(
             "subnet": str(s.subnet),
             "name": s.name,
             "address_family": s.address_family,
+            "v6_address_mode": getattr(s, "v6_address_mode", "stateful"),
         }
         for s in rows
     ]

--- a/backend/app/services/dhcp/config_bundle.py
+++ b/backend/app/services/dhcp/config_bundle.py
@@ -215,6 +215,7 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
                 ddns_hostname_policy=sc.ddns_hostname_policy,
                 is_active=sc.is_active,
                 address_family=getattr(sc, "address_family", "ipv4") or "ipv4",
+                v6_address_mode=getattr(sc, "v6_address_mode", "stateful") or "stateful",
             )
         )
 

--- a/backend/tests/test_dhcp_v6_mode.py
+++ b/backend/tests/test_dhcp_v6_mode.py
@@ -1,0 +1,194 @@
+"""DHCPv6 stateful / stateless / SLAAC mode — Kea render + scope API (#52)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.drivers.dhcp.base import (
+    ConfigBundle,
+    PoolDef,
+    ScopeDef,
+    ServerOptionsDef,
+    StaticAssignmentDef,
+)
+from app.drivers.dhcp.kea import KeaDriver
+from app.models.auth import User
+from app.models.dhcp import DHCPScope, DHCPServerGroup
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+V6_CIDR = "2001:db8:52::/64"
+
+
+def _v6_scope(mode: str) -> ScopeDef:
+    return ScopeDef(
+        subnet_cidr=V6_CIDR,
+        address_family="ipv6",
+        v6_address_mode=mode,
+        lease_time=3600,
+        options={"dns-servers": ["2001:db8::53"]},
+        pools=(PoolDef(start_ip="2001:db8:52::100", end_ip="2001:db8:52::1ff"),),
+        statics=(
+            StaticAssignmentDef(ip_address="2001:db8:52::5", mac_address="aa:bb:cc:dd:ee:ff"),
+        ),
+    )
+
+
+def _bundle(scope: ScopeDef) -> ConfigBundle:
+    return ConfigBundle(
+        server_id="00000000-0000-0000-0000-000000000000",
+        server_name="kea6-test",
+        driver="kea",
+        roles=(),
+        options=ServerOptionsDef(options={}, lease_time=3600),
+        scopes=(scope,),
+        client_classes=(),
+        generated_at=datetime.now(UTC),
+    )
+
+
+def _render_subnet6(mode: str) -> dict:
+    cfg = json.loads(KeaDriver().render_config(_bundle(_v6_scope(mode))))
+    return cfg["Dhcp6"]["subnet6"][0]
+
+
+# ── Kea render by mode ──────────────────────────────────────────────────
+
+
+def test_stateful_renders_pools_and_options() -> None:
+    s = _render_subnet6("stateful")
+    assert len(s["pools"]) == 1  # address pool present
+    assert "option-data" in s  # options served
+    assert len(s["reservations"]) == 1
+
+
+def test_stateless_drops_pools_keeps_options() -> None:
+    s = _render_subnet6("stateless")
+    assert s["pools"] == []  # no address assignment
+    assert "option-data" in s  # but options still served (Information-Request)
+    assert len(s["reservations"]) == 1
+
+
+def test_slaac_drops_pools_and_options() -> None:
+    s = _render_subnet6("slaac")
+    assert s["pools"] == []
+    assert "option-data" not in s  # router's RA does everything
+    assert s["reservations"] == []  # no DHCP role at all
+
+
+def test_v4_scope_ignores_mode() -> None:
+    # A v4 scope with a (meaningless) non-stateful mode still serves pools.
+    sc = ScopeDef(
+        subnet_cidr="192.0.2.0/24",
+        address_family="ipv4",
+        v6_address_mode="slaac",
+        pools=(PoolDef(start_ip="192.0.2.10", end_ip="192.0.2.50"),),
+        options={"routers": ["192.0.2.1"]},
+    )
+    cfg = json.loads(KeaDriver().render_config(_bundle(sc)))
+    sub = cfg["Dhcp4"]["subnet4"][0]
+    assert len(sub["pools"]) == 1
+    assert "option-data" in sub
+
+
+def test_v6_mode_shifts_etag() -> None:
+    # Changing the v6 mode must change the bundle ETag so agents re-pull.
+    assert (
+        _bundle(_v6_scope("stateful")).compute_etag()
+        != _bundle(_v6_scope("stateless")).compute_etag()
+    )
+
+
+# ── Scope API ───────────────────────────────────────────────────────────
+
+
+async def _make_user(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _v6_subnet_and_group(db: AsyncSession) -> tuple[Subnet, DHCPServerGroup]:
+    space = IPSpace(name=f"v6-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=V6_CIDR, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=V6_CIDR, name="s")
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, grp])
+    await db.flush()
+    return subnet, grp
+
+
+async def test_scope_api_persists_v6_mode(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _make_user(db_session)
+    subnet, grp = await _v6_subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet.id}/dhcp-scopes",
+        headers=h,
+        json={
+            "group_id": str(grp.id),
+            "name": "v6-scope",
+            "v6_address_mode": "stateless",
+            "ra_managed_flag": False,
+            "ra_other_flag": True,
+        },
+    )
+    assert r.status_code in (200, 201), r.text
+    body = r.json()
+    assert body["address_family"] == "ipv6"
+    assert body["v6_address_mode"] == "stateless"
+    assert body["ra_managed_flag"] is False
+    assert body["ra_other_flag"] is True
+
+    scope_id = body["id"]
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{scope_id}",
+        headers=h,
+        json={"v6_address_mode": "slaac"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["v6_address_mode"] == "slaac"
+
+    scope = await db_session.get(DHCPScope, uuid.UUID(scope_id))
+    await db_session.refresh(scope)
+    assert scope.v6_address_mode == "slaac"
+
+
+async def test_scope_api_rejects_bad_mode(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _make_user(db_session)
+    subnet, grp = await _v6_subnet_and_group(db_session)
+    await db_session.commit()
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet.id}/dhcp-scopes",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"group_id": str(grp.id), "name": "bad", "v6_address_mode": "bogus"},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.parametrize("mode", ["stateful", "stateless", "slaac"])
+def test_all_modes_render_valid_subnet(mode: str) -> None:
+    # Every mode must produce a syntactically present subnet6 entry with the
+    # CIDR + lifetime, regardless of pools/options.
+    s = _render_subnet6(mode)
+    assert s["subnet"] == V6_CIDR
+    assert s["valid-lifetime"] == 3600

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -78,8 +78,32 @@ DHCPScope
   }
   ddns_enabled: bool
   ddns_hostname_policy: enum(client_provided, client_or_generated, always_generate, disabled)
+  address_family: enum(ipv4, ipv6)   -- inferred from the bound subnet's CIDR
+  v6_address_mode: enum(stateful, stateless, slaac)  -- v6 only (issue #52)
+  ra_managed_flag: bool              -- intended RA M-flag (router-side intent)
+  ra_other_flag: bool                -- intended RA O-flag (router-side intent)
   last_pushed_at: timestamp
 ```
+
+#### DHCPv6 operating mode (issue #52)
+
+For IPv6 scopes, `v6_address_mode` chooses how clients on the subnet get
+their address, and drives what the Kea driver renders into the `subnet6`:
+
+| Mode | Kea `subnet6` render | RA flags (set on the router) | Client behaviour |
+|---|---|---|---|
+| `stateful` | address `pools` + `option-data` + reservations | M=1, O=1 | DHCPv6 hands out the address (IA_NA) and options |
+| `stateless` | **no pools**, `option-data` only + reservations | M=0, O=1 | Client SLAACs its address from the RA prefix, asks DHCPv6 (Information-Request) for DNS / domain-search |
+| `slaac` | bare subnet — **no pools, no options, no reservations** | M=0, O=0 | The router's RA does everything; DHCPv6 is not involved |
+
+The `ra_managed_flag` (M) / `ra_other_flag` (O) columns record the
+intended Router-Advertisement flags. **SpatiumDDI's Kea agent does not
+send RAs** — these are operator intent surfaced in the scope modal
+("set these on your router / radvd"), auto-suggested from the chosen
+mode (and freely overridable). The mode picker only appears on IPv6
+scopes; v4 scopes ignore these columns and always serve addresses +
+options. Changing the mode shifts the agent ConfigBundle ETag, so the
+Kea agent re-pulls and re-renders.
 
 ### DHCPPool Model (Dynamic Ranges)
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5389,6 +5389,14 @@ export interface DHCPScope {
   hostname_sync_mode: string;
   // "ipv4" → Kea Dhcp4; "ipv6" → Kea Dhcp6. Inferred from subnet CIDR.
   address_family?: "ipv4" | "ipv6";
+  // DHCPv6 operating mode (issue #52). Only meaningful for ipv6 scopes.
+  // "stateful" = DHCP hands out addresses; "stateless" = options only
+  // (clients SLAAC their address); "slaac" = no DHCP address service.
+  // ra_managed_flag / ra_other_flag are the intended Router-Advertisement
+  // M/O flags — configured on the upstream router, not pushed by Kea.
+  v6_address_mode?: "stateful" | "stateless" | "slaac";
+  ra_managed_flag?: boolean;
+  ra_other_flag?: boolean;
   options: DHCPOption[];
   // PXE / iPXE profile binding (issue #51). Null = no PXE on this
   // scope. Bound profile renders one Kea client-class per arch-match

--- a/frontend/src/pages/dhcp/CreateScopeModal.tsx
+++ b/frontend/src/pages/dhcp/CreateScopeModal.tsx
@@ -85,6 +85,12 @@ export function CreateScopeModal({
     scope?.hostname_sync_mode ?? "ipam",
   );
   const [options, setOptions] = useState<DHCPOption[]>(scope?.options ?? []);
+  // DHCPv6 mode (issue #52) — only surfaced/sent for IPv6 scopes.
+  const [v6Mode, setV6Mode] = useState<"stateful" | "stateless" | "slaac">(
+    scope?.v6_address_mode ?? "stateful",
+  );
+  const [raManaged, setRaManaged] = useState(scope?.ra_managed_flag ?? true);
+  const [raOther, setRaOther] = useState(scope?.ra_other_flag ?? true);
   // Initial pool — only used when creating; edits happen in the Pools tab.
   const [poolStart, setPoolStart] = useState("");
   const [poolEnd, setPoolEnd] = useState("");
@@ -147,6 +153,25 @@ export function CreateScopeModal({
     queryFn: () => ipamApi.getSubnet(subnetId),
     enabled: !editing && !!subnetId,
   });
+
+  // Is this an IPv6 scope? On edit we trust the stored family; on create
+  // we sniff the selected subnet's CIDR (": " ⇒ v6). Drives the DHCPv6
+  // mode section + whether the initial-pool block applies.
+  const selectedNetwork =
+    subnetDetail?.network ??
+    pinnedSubnet?.network ??
+    subnets.find((s) => s.id === subnetId)?.network ??
+    null;
+  const isV6 = editing
+    ? scope?.address_family === "ipv6"
+    : !!selectedNetwork && selectedNetwork.includes(":");
+  // When the operator picks a v6 mode, seed the recommended RA M/O flags
+  // (they can still override). stateful → M+O, stateless → O, slaac → none.
+  function applyV6Mode(m: "stateful" | "stateless" | "slaac") {
+    setV6Mode(m);
+    setRaManaged(m === "stateful");
+    setRaOther(m !== "slaac");
+  }
 
   const [prefilled, setPrefilled] = useState(false);
   useEffect(() => {
@@ -219,6 +244,12 @@ export function CreateScopeModal({
         hostname_sync_mode: hostnameSync,
         options,
       };
+      // DHCPv6 mode + RA flags only apply to v6 scopes (issue #52).
+      if (isV6) {
+        data.v6_address_mode = v6Mode;
+        data.ra_managed_flag = raManaged;
+        data.ra_other_flag = raOther;
+      }
       // PXE binding (issue #51). The backend distinguishes "no
       // change" from "explicit detach" via ``clear_pxe_profile``;
       // pass it true when the operator picked "(none)" on an
@@ -413,7 +444,71 @@ export function CreateScopeModal({
           </Field>
         </div>
 
-        {!editing && (
+        {isV6 && (
+          <div className="space-y-3 rounded-md border p-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold">DHCPv6 mode</h3>
+              <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                IPv6 scope
+              </span>
+            </div>
+            <Field
+              label="Address assignment"
+              hint="How clients on this subnet obtain their IPv6 address."
+            >
+              <select
+                className={inputCls}
+                value={v6Mode}
+                onChange={(e) =>
+                  applyV6Mode(
+                    e.target.value as "stateful" | "stateless" | "slaac",
+                  )
+                }
+              >
+                <option value="stateful">
+                  Stateful — Kea assigns addresses from the pool
+                </option>
+                <option value="stateless">
+                  Stateless — clients SLAAC their address; Kea serves options
+                  (DNS, etc.)
+                </option>
+                <option value="slaac">
+                  SLAAC only — the router&apos;s RA does everything; no DHCPv6
+                </option>
+              </select>
+            </Field>
+            <div className="rounded border bg-muted/20 p-2 text-[11px] text-muted-foreground">
+              Set these Router Advertisement flags on your{" "}
+              <strong>router</strong> (radvd / gateway) — SpatiumDDI&apos;s Kea
+              agent doesn&apos;t send RAs. These are recorded as intent and
+              auto-suggested from the mode above.
+              <div className="mt-2 flex flex-wrap gap-x-5 gap-y-1 text-foreground">
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={raManaged}
+                    onChange={(e) => setRaManaged(e.target.checked)}
+                  />
+                  <span>
+                    <strong>M</strong> (Managed) — use DHCPv6 for addresses
+                  </span>
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={raOther}
+                    onChange={(e) => setRaOther(e.target.checked)}
+                  />
+                  <span>
+                    <strong>O</strong> (Other) — use DHCPv6 for other config
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!editing && !(isV6 && v6Mode !== "stateful") && (
           <div className="rounded-md border bg-muted/30 p-3">
             <div className="mb-2 flex items-baseline justify-between">
               <span className="text-sm font-medium">Initial pool</span>


### PR DESCRIPTION
Closes #52.

The Kea Dhcp6 backend already existed (address-family toggle from Wave D); the missing piece was an operator-friendly way to choose the v6 operating mode — and to have that choice actually shape the rendered config. This adds both.

## Backend
- **`DHCPScope.v6_address_mode`** — `stateful` | `stateless` | `slaac` — plus `ra_managed_flag` / `ra_other_flag` (intended Router-Advertisement M/O flags). Migration `e4c1a8f63b29`, additive (server_defaults → existing scopes backfill to `stateful` = current behaviour); downgrade drops baselined in the migration-shape linter. Only meaningful for ipv6 scopes.
- **Kea driver renders the `subnet6` by mode** (the substantive part):
  | Mode | `subnet6` render | RA flags (router) |
  |---|---|---|
  | `stateful` | address `pools` + `option-data` + reservations | M=1, O=1 |
  | `stateless` | **no pools**, `option-data` only + reservations | M=0, O=1 |
  | `slaac` | bare subnet — no pools / options / reservations | M=0, O=0 |
  v4 scopes ignore the mode (always serve addresses + options). The mode flows through `ScopeDef`, so the agent ConfigBundle **ETag shifts on a mode change** and the Kea agent re-pulls + re-renders.
- Scope create / update / response carry the three fields, validated against `{stateful, stateless, slaac}`; the `list_dhcp_scopes` MCP tool surfaces the mode.

## Frontend
- **CreateScopeModal** gains a **DHCPv6 mode** section (shown only on IPv6 scopes): an address-assignment picker + RA **M**/**O** flag checkboxes that auto-suggest from the chosen mode and stay overridable. The initial-pool block is hidden for `stateless` / `slaac` (no DHCP-assigned addresses there).

## Design note
The RA M/O flags are recorded as **operator intent applied on the upstream router** — SpatiumDDI's Kea agent does **not** emit Router Advertisements (Kea is a DHCP server, not a router / radvd). The UI frames them as "set these on your router," and they deliberately don't affect the rendered Kea config (only `v6_address_mode` does).

## Verification
- `make ci` — ruff/black/mypy + frontend lint/format/typecheck/build all pass.
- 10 new tests in `backend/tests/test_dhcp_v6_mode.py` — Kea render per mode (pools/options/reservations presence), v4-ignores-mode, ETag shift on mode change, scope API persist + bad-mode 422 — all pass.
- Migration applied cleanly to the dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)