### PR TITLE
BIND9 DNSSEC — inline-signing, policies, DS export, rollover (#49)

### DIFF
--- a/agent/dns/images/bind9/entrypoint.sh
+++ b/agent/dns/images/bind9/entrypoint.sh
@@ -10,8 +10,11 @@ set -eu
 # spatium (see start_daemon — no `-u` flag), so the directory needs
 # to be owned by that user before the daemon can open the file. The
 # log file itself is created by named on first query.
-mkdir -p /var/lib/spatium-dns-agent /var/cache/bind /var/log/named
-chown -R spatium:spatium /var/lib/spatium-dns-agent /var/log/named || true
+# /var/cache/bind/keys is the DNSSEC key-directory (issue #49): BIND9
+# auto-generates + rotates the inline-signing private keys there, so it
+# must exist and be writable by the unprivileged named (spatium) user.
+mkdir -p /var/lib/spatium-dns-agent /var/cache/bind/keys /var/log/named
+chown -R spatium:spatium /var/lib/spatium-dns-agent /var/log/named /var/cache/bind || true
 
 # Agent-controlled rndc credentials. The alpine bind package's
 # /etc/bind/rndc.key lives in a directory `spatium` can't traverse,

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -720,6 +720,9 @@ class Bind9Driver(DriverBase):
                 f"nsupdate returned rcode={rcode} "
                 f"(zone={zone} op={op['op']} name={name} type={rtype})"
             )
+        # Explicit None so the record-op path matches the dict|None return
+        # type the DNSSEC branches use (no implicit fall-through).
+        return None
 
     # ── DNSSEC (issue #49) ──────────────────────────────────────────────────
 

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -38,6 +39,7 @@ options {{
     recursion {recursion};
     allow-query {{ {allow_query}; }};
     dnssec-validation {dnssec};
+    key-directory "/var/cache/bind/keys";
     check-integrity no;
 {forwarders}{response_policy}
 }};
@@ -66,6 +68,111 @@ logging {
     category query-errors { queries_channel; };
 };
 """
+
+
+def _lifetime(days: int) -> str:
+    """BIND ``lifetime`` token — 0 ⇒ unlimited, else ``<days>d``."""
+    return "unlimited" if not days else f"{int(days)}d"
+
+
+# DNSSEC algorithm name → IANA number (issue #49). Used when parsing
+# ``rndc dnssec -status`` output, which prints the algorithm by name.
+_DNSSEC_ALGO_NUM: dict[str, int] = {
+    "RSASHA256": 8,
+    "RSASHA512": 10,
+    "ECDSAP256SHA256": 13,
+    "ECDSAP384SHA384": 14,
+    "ED25519": 15,
+    "ED448": 16,
+}
+
+
+def _parse_dnssec_status(text: str) -> list[dict[str, Any]]:
+    """Parse ``rndc dnssec -status <zone>`` into per-key state dicts.
+
+    The header line ``key: <tag> (<ALGO>), <KSK|ZSK|CSK>`` is stable across
+    BIND versions; the per-key body varies, so we derive a coarse state
+    ("active" once the key is signing, else "published") + keep the raw
+    timing lines. Pure + version-tolerant so it's unit-testable.
+    """
+    keys: list[dict[str, Any]] = []
+    cur: dict[str, Any] | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        m = re.match(r"key:\s+(\d+)\s+\(([^)]+)\),\s+(KSK|ZSK|CSK)", line)
+        if m:
+            if cur is not None:
+                keys.append(cur)
+            cur = {
+                "key_tag": int(m.group(1)),
+                "algorithm": _DNSSEC_ALGO_NUM.get(m.group(2).upper(), 0),
+                "key_type": m.group(3).lower(),
+                "state": "published",
+                "ds_records": [],
+                "timing": {},
+            }
+            continue
+        if cur is None:
+            continue
+        low = line.lower()
+        if ("key signing:" in low or "zone signing:" in low) and "yes" in low:
+            cur["state"] = "active"
+        mt = re.match(
+            r"(published|active|retire|remove|key signing|zone signing):\s*(.+)", low
+        )
+        if mt:
+            cur["timing"][mt.group(1).replace(" ", "_")] = mt.group(2).strip()
+    if cur is not None:
+        keys.append(cur)
+    return keys
+
+
+def _keyfile_is_ksk(path: str) -> bool:
+    """True if a BIND ``K*.key`` file holds a KSK (DNSKEY flags SEP bit set)."""
+    try:
+        with open(path) as f:
+            for line in f:
+                s = line.strip()
+                if not s or s.startswith(";"):
+                    continue
+                m = re.search(r"\bDNSKEY\s+(\d+)\s", s)
+                if m:
+                    return bool(int(m.group(1)) & 1)  # SEP bit ⇒ KSK
+    except OSError:
+        return False
+    return False
+
+
+def _render_dnssec_policies(policies: list[dict[str, Any]]) -> str:
+    """Render top-level ``dnssec-policy "<name>" { ... };`` blocks (issue #49).
+
+    BIND's built-in ``default`` policy is never shipped here (zones that use
+    it reference it by name without a definition). Each entry is a dict from
+    the ConfigBundle: name / algorithm / ksk_lifetime_days / zsk_lifetime_days
+    / nsec3 + nsec3_iterations / nsec3_salt_length / nsec3_optout.
+    """
+    out = ""
+    for p in policies:
+        name = p.get("name")
+        if not name or name == "default":
+            continue
+        algo = p.get("algorithm") or "ecdsap256sha256"
+        block = (
+            f'dnssec-policy "{name}" {{\n'
+            "    keys {\n"
+            f"        ksk lifetime {_lifetime(p.get('ksk_lifetime_days', 0))} algorithm {algo};\n"
+            f"        zsk lifetime {_lifetime(p.get('zsk_lifetime_days', 90))} algorithm {algo};\n"
+            "    };\n"
+        )
+        if p.get("nsec3"):
+            optout = "yes" if p.get("nsec3_optout") else "no"
+            block += (
+                f"    nsec3param iterations {int(p.get('nsec3_iterations', 0))} "
+                f"optout {optout} salt-length {int(p.get('nsec3_salt_length', 0))};\n"
+            )
+        block += "};\n"
+        out += block
+    return out
 
 
 class Bind9Driver(DriverBase):
@@ -155,6 +262,12 @@ class Bind9Driver(DriverBase):
                 "};\n"
             )
 
+        # DNSSEC signing policies (issue #49). Custom policies referenced by
+        # a signed zone render as top-level ``dnssec-policy { ... }`` blocks;
+        # BIND's built-in "default" needs none. The key-directory above is
+        # where BIND auto-generates + rotates the private keys.
+        conf += _render_dnssec_policies(bundle.get("dnssec_policies") or [])
+
         def _zone_stanza(zone: dict[str, Any], file_prefix: str) -> str:
             """Build one ``zone "..." { ... };`` and write its zone file.
 
@@ -186,11 +299,18 @@ class Bind9Driver(DriverBase):
             allow_update = (
                 f'allow-update {{ key "{tsig_key_name}"; }}; ' if tsig_key_name else ""
             )
+            # DNSSEC inline-signing (issue #49): primary zones with signing on
+            # reference a dnssec-policy + enable inline-signing; BIND
+            # auto-generates keys in key-directory + signs on load.
+            dnssec_clause = ""
+            if zone_type in {"primary", "master"} and zone.get("dnssec_enabled"):
+                pol = zone.get("dnssec_policy_name") or "default"
+                dnssec_clause = f'dnssec-policy "{pol}"; inline-signing yes; '
             if zone_type in {"primary", "master"}:
                 self._write_zone_file(new_dir / rel_zfile, zone)
             return (
                 f'zone "{zname}" {{ type {bind_type}; file "{abs_zfile}"; '
-                f"{allow_update}}};\n"
+                f"{allow_update}{dnssec_clause}}};\n"
             )
 
         def _rpz_stanza(bl: dict[str, Any], file_prefix: str) -> str:
@@ -506,7 +626,17 @@ class Bind9Driver(DriverBase):
 
     # ── Record ops (RFC 2136 over loopback) ─────────────────────────────────
 
-    def apply_record_op(self, op: dict[str, Any]) -> None:
+    def apply_record_op(self, op: dict[str, Any]) -> dict[str, Any] | None:
+        # DNSSEC ops (issue #49). BIND9 signs from the rendered config
+        # (inline-signing), so sign/unsign need no per-op action here — the
+        # zone's dnssec_enabled flip already reshaped the bundle + triggered a
+        # reload. A manual rollover is the one thing that needs an rndc call.
+        op_kind = op.get("op")
+        if op_kind == "dnssec_rollover":
+            return self._dnssec_rollover(op)
+        if op_kind in ("dnssec_sign", "dnssec_unsign"):
+            return None
+
         if dns is None:
             raise RuntimeError("dnspython not installed — cannot apply record ops")
         zone = op["zone_name"].rstrip(".") + "."
@@ -590,6 +720,106 @@ class Bind9Driver(DriverBase):
                 f"nsupdate returned rcode={rcode} "
                 f"(zone={zone} op={op['op']} name={name} type={rtype})"
             )
+
+    # ── DNSSEC (issue #49) ──────────────────────────────────────────────────
+
+    def _rndc_base(self) -> list[str]:
+        cmd = ["rndc"]
+        agent_conf = self.state_dir / "rndc.conf"
+        if agent_conf.exists():
+            cmd += ["-c", str(agent_conf)]
+        return cmd
+
+    def collect_dnssec_state(self, bundle: dict[str, Any]) -> list[dict[str, Any]]:
+        """For every signed primary zone, read its DS rrset + per-key state
+        and return report entries for ``POST /dns/agents/dnssec-state``.
+
+        BIND owns the private keys (inline-signing); this is a read-only
+        mirror via ``rndc dnssec -status`` + ``dnssec-dsfromkey``. Best
+        effort — a zone still mid-key-generation just reports empty DS, and
+        the next sync picks it up.
+        """
+        out: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for z in bundle.get("zones", []):
+            if not z.get("dnssec_enabled"):
+                continue
+            ztype = z.get("type", "primary")
+            if ztype not in {"primary", "master"}:
+                continue
+            zname = (z.get("name") or "").rstrip(".")
+            if not zname or zname in seen:
+                continue
+            seen.add(zname)
+            try:
+                out.append(self._zone_dnssec_state(zname))
+            except Exception as e:  # noqa: BLE001 — never let one zone block the rest
+                log.warning("dnssec_state_collect_failed", zone=zname, error=str(e))
+        return out
+
+    def _zone_dnssec_state(self, zone: str) -> dict[str, Any]:
+        keys: list[dict[str, Any]] = []
+        ds_records: list[str] = []
+        if shutil.which("rndc"):
+            res = subprocess.run(
+                [*self._rndc_base(), "dnssec", "-status", zone],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if res.returncode == 0:
+                keys = _parse_dnssec_status(res.stdout)
+        # DS rrset(s) from the KSK public-key files BIND wrote into the
+        # key-directory. The CDS records BIND publishes are an alternative,
+        # but dnssec-dsfromkey is deterministic + version-stable.
+        key_dir = "/var/cache/bind/keys"
+        if shutil.which("dnssec-dsfromkey") and os.path.isdir(key_dir):
+            for fn in sorted(os.listdir(key_dir)):
+                if not fn.endswith(".key") or not fn.startswith(f"K{zone}.+"):
+                    continue
+                path = os.path.join(key_dir, fn)
+                try:
+                    if not _keyfile_is_ksk(path):
+                        continue
+                    dres = subprocess.run(
+                        ["dnssec-dsfromkey", "-2", path],
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    for ln in dres.stdout.splitlines():
+                        ln = ln.strip()
+                        if ln and " DS " in ln:
+                            ds_records.append(ln)
+                except Exception as e:  # noqa: BLE001
+                    log.warning("dsfromkey_failed", zone=zone, file=fn, error=str(e))
+        # Attach DS to the KSK key entries so the per-key UI can show them.
+        for k in keys:
+            if k.get("key_type") in ("ksk", "csk"):
+                k["ds_records"] = ds_records
+        return {"zone_name": zone + ".", "ds_records": ds_records, "keys": keys}
+
+    def _dnssec_rollover(self, op: dict[str, Any]) -> dict[str, Any] | None:
+        """Force a key rollover for the zone (``rndc dnssec -rollover``).
+
+        The op record carries the ``key_tag`` to roll. After triggering, we
+        re-read the zone's state so the control plane reflects the new key
+        set on the next heartbeat.
+        """
+        zone = op["zone_name"].rstrip(".")
+        rec = op.get("record") or {}
+        key_tag = rec.get("key_tag")
+        if not shutil.which("rndc"):
+            raise RuntimeError("rndc not available — cannot roll DNSSEC key")
+        cmd = [*self._rndc_base(), "dnssec", "-rollover", "-key", str(key_tag), zone]
+        res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if res.returncode != 0:
+            raise RuntimeError(f"rndc dnssec -rollover failed: {res.stderr.strip()}")
+        log.info("dnssec_rollover_triggered", zone=zone, key_tag=key_tag)
+        try:
+            return {"dnssec_state": self._zone_dnssec_state(zone)}
+        except Exception:  # noqa: BLE001
+            return None
 
     # ── Lifecycle ───────────────────────────────────────────────────────────
 

--- a/agent/dns/spatium_dns_agent/sync.py
+++ b/agent/dns/spatium_dns_agent/sync.py
@@ -44,7 +44,9 @@ def _touch_ready_marker(state_dir: Path) -> None:
 
 
 class SyncLoop:
-    def __init__(self, cfg: AgentConfig, token_ref: list[str], driver: DriverBase, heartbeat: Any):
+    def __init__(
+        self, cfg: AgentConfig, token_ref: list[str], driver: DriverBase, heartbeat: Any
+    ):
         self.cfg = cfg
         self.token_ref = token_ref
         self.driver = driver
@@ -102,7 +104,9 @@ class SyncLoop:
         elif self.cfg.tls_ca_path:
             verify = self.cfg.tls_ca_path
         # server holds for ~30s, give client a bit more
-        return httpx.Client(base_url=self.cfg.control_plane_url, verify=verify, timeout=60.0)
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url, verify=verify, timeout=60.0
+        )
 
     def _poll_once(self) -> None:
         headers = {"Authorization": f"Bearer {self.token_ref[0]}"}
@@ -129,6 +133,7 @@ class SyncLoop:
                 reason="token_invalid" if resp.status_code == 401 else "server_missing",
             )
             from .cache import save_token
+
             save_token(self.cfg.state_dir, "")
             self._stop.set()
             return
@@ -183,6 +188,19 @@ class SyncLoop:
             # roll back the apply (we already serve the new config).
             self._report_zone_state(bundle)
 
+            # DNSSEC (issue #49): BIND9 signs inline from the rendered
+            # config, so after a structural reload we read each signed
+            # zone's DS + per-key state and report it. PowerDNS reports via
+            # the op path below instead (so its driver has no collector).
+            collect = getattr(self.driver, "collect_dnssec_state", None)
+            if collect is not None:
+                try:
+                    bind_states = collect(bundle)
+                    if bind_states:
+                        self._report_dnssec_state(bind_states)
+                except Exception:
+                    log.exception("dnssec_collect_failed")
+
             # Push the on-disk rendered config snapshot so the Server
             # Detail modal's Config tab can show "what's actually live
             # right now" — operators no longer need to SSH in to verify.
@@ -198,9 +216,15 @@ class SyncLoop:
         for op in bundle.get("pending_record_ops", []):
             try:
                 result = self.driver.apply_record_op(op)
-                self.heartbeat.pending_acks.append({"op_id": op["op_id"], "result": "ok"})
-                log.info("record_op_applied", op_id=op["op_id"], op=op.get("op"),
-                         zone=op.get("zone_name"))
+                self.heartbeat.pending_acks.append(
+                    {"op_id": op["op_id"], "result": "ok"}
+                )
+                log.info(
+                    "record_op_applied",
+                    op_id=op["op_id"],
+                    op=op.get("op"),
+                    zone=op.get("zone_name"),
+                )
                 # PowerDNS DNSSEC ops return the DS rrset so we can ship
                 # it back to the control plane in one batched POST below.
                 if isinstance(result, dict) and "dnssec_state" in result:

--- a/agent/dns/tests/test_dnssec_render.py
+++ b/agent/dns/tests/test_dnssec_render.py
@@ -1,0 +1,121 @@
+"""BIND9 agent DNSSEC rendering + status parsing (issue #49).
+
+Exercises ``Bind9Driver.render`` against bundles shaped like
+``app.services.dns.agent_config.build_config_bundle`` emits — a signed
+zone gets ``dnssec-policy`` + ``inline-signing yes`` in its stanza and a
+referenced custom policy renders a top-level ``dnssec-policy { … }``
+block. Also covers the pure ``rndc dnssec -status`` parser + the KSK
+keyfile classifier.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from spatium_dns_agent.drivers.bind9 import (
+    Bind9Driver,
+    _keyfile_is_ksk,
+    _parse_dnssec_status,
+    _render_dnssec_policies,
+)
+
+
+def _zone(
+    name: str, *, dnssec_enabled: bool = False, policy: str | None = None
+) -> dict:
+    return {
+        "id": name,
+        "name": name,
+        "type": "primary",
+        "ttl": 3600,
+        "forwarders": [],
+        "forward_only": True,
+        "view_name": None,
+        "records": [],
+        "dnssec_enabled": dnssec_enabled,
+        "dnssec_policy_name": policy,
+    }
+
+
+def test_signed_zone_default_policy(tmp_path: Path) -> None:
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render({"options": {}, "zones": [_zone("ex.com.", dnssec_enabled=True)]})
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+    assert 'dnssec-policy "default";' in conf
+    assert "inline-signing yes;" in conf
+    assert 'key-directory "/var/cache/bind/keys";' in conf
+
+
+def test_unsigned_zone_no_signing(tmp_path: Path) -> None:
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render({"options": {}, "zones": [_zone("ex.com.", dnssec_enabled=False)]})
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+    assert "inline-signing" not in conf
+    # The bare ``dnssec-policy "name";`` zone clause is absent; key-directory
+    # is always present (harmless when no zone is signed).
+    assert 'dnssec-policy "' not in conf
+
+
+def test_custom_policy_block_rendered(tmp_path: Path) -> None:
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(
+        {
+            "options": {},
+            "zones": [_zone("ex.com.", dnssec_enabled=True, policy="strong")],
+            "dnssec_policies": [
+                {
+                    "name": "strong",
+                    "algorithm": "ed25519",
+                    "ksk_lifetime_days": 0,
+                    "zsk_lifetime_days": 30,
+                    "nsec3": True,
+                    "nsec3_iterations": 0,
+                    "nsec3_salt_length": 0,
+                    "nsec3_optout": False,
+                }
+            ],
+        }
+    )
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+    assert 'dnssec-policy "strong" {' in conf
+    assert "zsk lifetime 30d algorithm ed25519;" in conf
+    assert "nsec3param iterations 0 optout no salt-length 0;" in conf
+    assert 'dnssec-policy "strong";' in conf
+
+
+def test_render_dnssec_policies_skips_default() -> None:
+    out = _render_dnssec_policies([{"name": "default", "algorithm": "ecdsap256sha256"}])
+    assert out == ""
+
+
+def test_parse_dnssec_status() -> None:
+    sample = """\
+dnssec-policy: default
+current time: Thu May 29 21:00:00 2026
+
+key: 12345 (ECDSAP256SHA256), KSK
+  published:      yes - since Thu May 29 20:00:00 2026
+  key signing:    yes - since Thu May 29 20:00:00 2026
+
+key: 23456 (ECDSAP256SHA256), ZSK
+  published:      yes - since Thu May 29 20:00:00 2026
+  zone signing:   no
+"""
+    keys = _parse_dnssec_status(sample)
+    assert len(keys) == 2
+    ksk = next(k for k in keys if k["key_type"] == "ksk")
+    zsk = next(k for k in keys if k["key_type"] == "zsk")
+    assert ksk["key_tag"] == 12345
+    assert ksk["algorithm"] == 13
+    assert ksk["state"] == "active"  # "key signing: yes"
+    assert zsk["key_tag"] == 23456
+    assert zsk["state"] == "published"  # "zone signing: no"
+
+
+def test_keyfile_is_ksk(tmp_path: Path) -> None:
+    ksk = tmp_path / "Kex.com.+013+12345.key"
+    ksk.write_text("; comment\nex.com. IN DNSKEY 257 3 13 AAAA...\n")
+    zsk = tmp_path / "Kex.com.+013+23456.key"
+    zsk.write_text("ex.com. IN DNSKEY 256 3 13 BBBB...\n")
+    assert _keyfile_is_ksk(str(ksk)) is True
+    assert _keyfile_is_ksk(str(zsk)) is False

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -436,6 +436,10 @@ backend/alembic/versions/f1c9a4d2b8e6_ip_role_reserved_mac_history.py:drop_table
 backend/alembic/versions/f1e7a3c92b40_multicast_groups.py:drop_table:230
 backend/alembic/versions/f1e7a3c92b40_multicast_groups.py:drop_table:233
 backend/alembic/versions/f1e7a3c92b40_multicast_groups.py:drop_table:241
+backend/alembic/versions/f2b6d4a91c37_dnssec_bind9.py:drop_column:115
+backend/alembic/versions/f2b6d4a91c37_dnssec_bind9.py:drop_constraint_fk:114
+backend/alembic/versions/f2b6d4a91c37_dnssec_bind9.py:drop_table:117
+backend/alembic/versions/f2b6d4a91c37_dnssec_bind9.py:drop_table:119
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:132
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:133
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:134

--- a/backend/alembic/versions/f2b6d4a91c37_dnssec_bind9.py
+++ b/backend/alembic/versions/f2b6d4a91c37_dnssec_bind9.py
@@ -1,0 +1,119 @@
+"""DNSSEC — BIND9 dnssec-policy + key state (#49)
+
+Revision ID: f2b6d4a91c37
+Revises: e4c1a8f63b29
+Create Date: 2026-05-29 21:30:00.000000
+
+Adds the BIND9 DNSSEC tables (issue #49):
+
+* ``dnssec_policy`` — reusable ``dnssec-policy`` definitions (algorithm /
+  NSEC3 params / KSK+ZSK lifetimes). Seeds one built-in ``default`` row.
+* ``dnssec_key`` — public per-zone key state reported by the agent (key
+  tag / type / state / DS rrset). No private material.
+* ``dns_zone.dnssec_policy_id`` — FK (SET NULL) pinning a zone's policy.
+
+Additive — all server-defaulted; the seed is idempotent on re-run.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f2b6d4a91c37"
+down_revision: Union[str, None] = "e4c1a8f63b29"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Stable UUID for the seeded built-in "default" policy so re-runs + cross-
+# install backups stay consistent.
+_DEFAULT_POLICY_ID = "0000002d-0049-4000-8000-000000000001"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dnssec_policy",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("is_builtin", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "algorithm", sa.String(length=20), nullable=False, server_default="ecdsap256sha256"
+        ),
+        sa.Column("ksk_lifetime_days", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("zsk_lifetime_days", sa.Integer(), nullable=False, server_default="90"),
+        sa.Column("nsec3", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("nsec3_iterations", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("nsec3_salt_length", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("nsec3_optout", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("name", name="uq_dnssec_policy_name"),
+    )
+    op.create_index("ix_dnssec_policy_name", "dnssec_policy", ["name"])
+
+    op.create_table(
+        "dnssec_key",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("zone_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("key_tag", sa.Integer(), nullable=False),
+        sa.Column("key_type", sa.String(length=4), nullable=False),
+        sa.Column("algorithm", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("state", sa.String(length=16), nullable=False, server_default="unknown"),
+        sa.Column("ds_records", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("timing", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "reported_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["zone_id"], ["dns_zone.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_dnssec_key_zone", "dnssec_key", ["zone_id"])
+
+    op.add_column(
+        "dns_zone",
+        sa.Column("dnssec_policy_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_dns_zone_dnssec_policy",
+        "dns_zone",
+        "dnssec_policy",
+        ["dnssec_policy_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # Seed the built-in "default" policy (idempotent). Cast the bound id to
+    # uuid — the column is UUID, and a plain bind param arrives as VARCHAR.
+    op.execute(
+        sa.text(
+            "INSERT INTO dnssec_policy "
+            "(id, name, description, is_builtin, algorithm, "
+            "ksk_lifetime_days, zsk_lifetime_days, "
+            "nsec3, nsec3_iterations, nsec3_salt_length, nsec3_optout) "
+            "VALUES (CAST(:id AS uuid), 'default', "
+            "'BIND9 built-in default policy: ECDSAP256SHA256, NSEC, "
+            "unlimited KSK + 90-day auto-rolled ZSK.', "
+            "true, 'ecdsap256sha256', 0, 90, false, 0, 0, false) "
+            "ON CONFLICT (name) DO NOTHING"
+        ).bindparams(id=_DEFAULT_POLICY_ID)
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_dns_zone_dnssec_policy", "dns_zone", type_="foreignkey")
+    op.drop_column("dns_zone", "dnssec_policy_id")
+    op.drop_index("ix_dnssec_key_zone", table_name="dnssec_key")
+    op.drop_table("dnssec_key")
+    op.drop_index("ix_dnssec_policy_name", table_name="dnssec_policy")
+    op.drop_table("dnssec_policy")

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -272,7 +272,11 @@ async def agent_register(
             resource_type="dns_server",
             resource_id=str(server.id),
             resource_display=body.hostname,
-            new_value={"driver": body.driver, "version": body.version, "roles": body.roles},
+            new_value={
+                "driver": body.driver,
+                "version": body.version,
+                "roles": body.roles,
+            },
             result="success",
         )
     )
@@ -633,10 +637,11 @@ async def agent_dnssec_state(
         zone.dnssec_ds_records = entry.ds_records or None
         zone.dnssec_synced_at = now
         # Per-key state (issue #49) — replace the zone's DNSKey rows wholesale
-        # so the table always mirrors the agent's latest ``rndc dnssec
-        # -status``. Only BIND9 agents send ``keys``; PowerDNS leaves it empty
-        # (and we leave any existing rows untouched in that case).
-        if entry.keys:
+        # so the table mirrors the agent's latest ``rndc dnssec -status``.
+        # ``keys`` PRESENT (even empty) replaces — so an unsign that reports
+        # ``keys: []`` clears stale rows. ``keys`` OMITTED (PowerDNS agents)
+        # leaves existing rows untouched.
+        if "keys" in entry.model_fields_set:
             await db.execute(sa_delete(DNSKey).where(DNSKey.zone_id == zone.id))
             for k in entry.keys:
                 db.add(

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -16,11 +16,13 @@ import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from jose import JWTError
 from pydantic import BaseModel
+from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
 
 from app.api.deps import DB
 from app.models.audit import AuditLog
 from app.models.dns import (
+    DNSKey,
     DNSRecordOp,
     DNSServer,
     DNSServerGroup,
@@ -551,16 +553,30 @@ async def agent_zone_state(
     return {"updated": updated}
 
 
+class DNSKeyReport(BaseModel):
+    """One DNSSEC key's public state (issue #49 — BIND9 ``rndc dnssec
+    -status``). No private material; BIND owns + rotates the keys."""
+
+    key_tag: int
+    key_type: str = "zsk"  # ksk | zsk | csk
+    algorithm: int = 0
+    state: str = "unknown"
+    ds_records: list[str] = []
+    timing: dict[str, Any] = {}
+
+
 class DNSSECStateReport(BaseModel):
     """One zone's DNSSEC state, posted by the agent after signing.
 
-    The DS rrset strings come straight from PowerDNS's
-    ``GET /zones/{z}/cryptokeys`` response — operator copies them
-    into the parent registrar verbatim. Empty list = unsigned.
+    ``ds_records`` is the zone-level DS rrset the operator copies into the
+    parent registrar verbatim (empty = unsigned). ``keys`` is the optional
+    per-key breakdown BIND9 agents report from ``rndc dnssec -status``
+    (issue #49); PowerDNS agents omit it.
     """
 
     zone_name: str
     ds_records: list[str]
+    keys: list[DNSKeyReport] = []
 
 
 class DNSSECStateBatch(BaseModel):
@@ -616,6 +632,25 @@ async def agent_dnssec_state(
             continue
         zone.dnssec_ds_records = entry.ds_records or None
         zone.dnssec_synced_at = now
+        # Per-key state (issue #49) — replace the zone's DNSKey rows wholesale
+        # so the table always mirrors the agent's latest ``rndc dnssec
+        # -status``. Only BIND9 agents send ``keys``; PowerDNS leaves it empty
+        # (and we leave any existing rows untouched in that case).
+        if entry.keys:
+            await db.execute(sa_delete(DNSKey).where(DNSKey.zone_id == zone.id))
+            for k in entry.keys:
+                db.add(
+                    DNSKey(
+                        zone_id=zone.id,
+                        key_tag=k.key_tag,
+                        key_type=k.key_type,
+                        algorithm=k.algorithm,
+                        state=k.state,
+                        ds_records=k.ds_records or None,
+                        timing=k.timing or None,
+                        reported_at=now,
+                    )
+                )
         updated += 1
 
     await db.commit()

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -13,6 +13,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import delete as sa_delete
 from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
@@ -908,7 +909,9 @@ async def list_servers(group_id: uuid.UUID, db: DB, _: CurrentUser) -> list[Serv
 
 
 @router.post(
-    "/groups/{group_id}/servers", response_model=ServerResponse, status_code=status.HTTP_201_CREATED
+    "/groups/{group_id}/servers",
+    response_model=ServerResponse,
+    status_code=status.HTTP_201_CREATED,
 )
 async def create_server(
     group_id: uuid.UUID, body: ServerCreate, db: DB, current_user: SuperAdmin
@@ -919,7 +922,8 @@ async def create_server(
     )
     if existing.scalar_one_or_none():
         raise HTTPException(
-            status_code=409, detail="A server with that name already exists in this group"
+            status_code=409,
+            detail="A server with that name already exists in this group",
         )
 
     data = body.model_dump(exclude={"api_key", "windows_credentials"})
@@ -978,7 +982,11 @@ async def create_server(
 
 @router.put("/groups/{group_id}/servers/{server_id}", response_model=ServerResponse)
 async def update_server(
-    group_id: uuid.UUID, server_id: uuid.UUID, body: ServerUpdate, db: DB, current_user: SuperAdmin
+    group_id: uuid.UUID,
+    server_id: uuid.UUID,
+    body: ServerUpdate,
+    db: DB,
+    current_user: SuperAdmin,
 ) -> ServerResponse:
     server = await _require_server(group_id, server_id, db)
     changes = body.model_dump(exclude_none=True, exclude={"api_key", "windows_credentials"})
@@ -1860,7 +1868,9 @@ async def update_options(
 
 
 @router.post(
-    "/groups/{group_id}/options/trust-anchors", response_model=TrustAnchorResponse, status_code=201
+    "/groups/{group_id}/options/trust-anchors",
+    response_model=TrustAnchorResponse,
+    status_code=201,
 )
 async def add_trust_anchor(
     group_id: uuid.UUID, body: TrustAnchorCreate, db: DB, current_user: SuperAdmin
@@ -1968,7 +1978,11 @@ async def create_acl(
 
 @router.put("/groups/{group_id}/acls/{acl_id}", response_model=AclResponse)
 async def update_acl(
-    group_id: uuid.UUID, acl_id: uuid.UUID, body: AclUpdate, db: DB, current_user: SuperAdmin
+    group_id: uuid.UUID,
+    acl_id: uuid.UUID,
+    body: AclUpdate,
+    db: DB,
+    current_user: SuperAdmin,
 ) -> DNSAcl:
     acl = await _require_acl(group_id, acl_id, db)
     changes = body.model_dump(exclude_none=True, exclude={"entries"})
@@ -2169,7 +2183,8 @@ async def create_tsig_key(
     )
     if existing.scalar_one_or_none():
         raise HTTPException(
-            status_code=409, detail="A TSIG key with that name already exists in this group"
+            status_code=409,
+            detail="A TSIG key with that name already exists in this group",
         )
 
     plaintext = body.secret.strip() if body.secret else _generate_tsig_secret(body.algorithm)
@@ -2357,7 +2372,11 @@ async def create_view(
 
 @router.put("/groups/{group_id}/views/{view_id}", response_model=ViewResponse)
 async def update_view(
-    group_id: uuid.UUID, view_id: uuid.UUID, body: ViewUpdate, db: DB, current_user: SuperAdmin
+    group_id: uuid.UUID,
+    view_id: uuid.UUID,
+    body: ViewUpdate,
+    db: DB,
+    current_user: SuperAdmin,
 ) -> DNSView:
     view = await _require_view(group_id, view_id, db)
     changes = body.model_dump(exclude_none=True)
@@ -2436,7 +2455,8 @@ async def create_zone(
     )
     if existing.scalar_one_or_none():
         raise HTTPException(
-            status_code=409, detail="A zone with that name already exists in this group/view"
+            status_code=409,
+            detail="A zone with that name already exists in this group/view",
         )
 
     zone = DNSZone(group_id=group_id, **body.model_dump())
@@ -2898,7 +2918,11 @@ async def get_server_rndc_status(
 
 @router.put("/groups/{group_id}/zones/{zone_id}", response_model=ZoneResponse)
 async def update_zone(
-    group_id: uuid.UUID, zone_id: uuid.UUID, body: ZoneUpdate, db: DB, current_user: SuperAdmin
+    group_id: uuid.UUID,
+    zone_id: uuid.UUID,
+    body: ZoneUpdate,
+    db: DB,
+    current_user: SuperAdmin,
 ) -> DNSZone:
     zone = await _require_zone(group_id, zone_id, db)
     _reject_if_synthesised_zone(zone, "edit")
@@ -3015,6 +3039,7 @@ async def create_dnssec_policy(
         raise HTTPException(status_code=409, detail=f"Policy '{body.name}' already exists")
     pol = DNSSECPolicy(**body.model_dump())
     db.add(pol)
+    await db.flush()  # populate pol.id so the audit row can correlate
     db.add(
         AuditLog(
             user_id=current_user.id,
@@ -3022,13 +3047,12 @@ async def create_dnssec_policy(
             auth_source=current_user.auth_source,
             action="create",
             resource_type="dnssec_policy",
-            resource_id="",
+            resource_id=str(pol.id),
             resource_display=body.name,
             new_value=body.model_dump(),
             result="success",
         )
     )
-    await db.flush()
     await db.commit()
     await db.refresh(pol)
     return pol
@@ -3125,7 +3149,7 @@ async def get_zone_dnssec_info(
         "zone_id": str(zone.id),
         "zone_name": zone.name,
         "dnssec_enabled": zone.dnssec_enabled,
-        "dnssec_policy_id": str(zone.dnssec_policy_id) if zone.dnssec_policy_id else None,
+        "dnssec_policy_id": (str(zone.dnssec_policy_id) if zone.dnssec_policy_id else None),
         "dnssec_ds_records": zone.dnssec_ds_records or [],
         "dnssec_synced_at": (zone.dnssec_synced_at.isoformat() if zone.dnssec_synced_at else None),
         "keys": [
@@ -3174,11 +3198,17 @@ async def sign_zone_dnssec(
     _reject_if_synthesised_zone(zone, "DNSSEC-sign")
     await _check_driver_gated_operation("dnssec_sign", group_id, db)
     zone.dnssec_enabled = True
-    if body is not None and body.policy_id is not None:
-        pol = await db.get(DNSSECPolicy, body.policy_id)
-        if pol is None:
-            raise HTTPException(status_code=404, detail="DNSSEC policy not found")
-        zone.dnssec_policy_id = body.policy_id
+    # Policy semantics: field present + value → set; field present + null →
+    # reset to BIND's built-in ``default``; field omitted → leave unchanged
+    # (so a re-sign that doesn't touch the picker keeps the current policy).
+    if body is not None and "policy_id" in body.model_fields_set:
+        if body.policy_id is None:
+            zone.dnssec_policy_id = None
+        else:
+            pol = await db.get(DNSSECPolicy, body.policy_id)
+            if pol is None:
+                raise HTTPException(status_code=404, detail="DNSSEC policy not found")
+            zone.dnssec_policy_id = body.policy_id
     await enqueue_record_op(
         db,
         zone,
@@ -3221,6 +3251,10 @@ async def unsign_zone_dnssec(
     _reject_if_synthesised_zone(zone, "DNSSEC-unsign")
     await _check_driver_gated_operation("dnssec_unsign", group_id, db)
     zone.dnssec_enabled = False
+    # Clear cached DS + per-key state now — the BIND9 agent only reports
+    # signed zones, so it won't send a keys=[] report to clear these.
+    zone.dnssec_ds_records = None
+    await db.execute(sa_delete(DNSKey).where(DNSKey.zone_id == zone.id))
     await enqueue_record_op(
         db,
         zone,
@@ -3428,7 +3462,8 @@ async def create_zone_from_template(
     )
     if existing.scalar_one_or_none():
         raise HTTPException(
-            status_code=409, detail="A zone with that name already exists in this group/view"
+            status_code=409,
+            detail="A zone with that name already exists in this group/view",
         )
 
     zone = DNSZone(
@@ -3785,10 +3820,16 @@ async def list_records(
 
 
 @router.post(
-    "/groups/{group_id}/zones/{zone_id}/records", response_model=RecordResponse, status_code=201
+    "/groups/{group_id}/zones/{zone_id}/records",
+    response_model=RecordResponse,
+    status_code=201,
 )
 async def create_record(
-    group_id: uuid.UUID, zone_id: uuid.UUID, body: RecordCreate, db: DB, current_user: CurrentUser
+    group_id: uuid.UUID,
+    zone_id: uuid.UUID,
+    body: RecordCreate,
+    db: DB,
+    current_user: CurrentUser,
 ) -> DNSRecord:
     zone = await _require_zone(group_id, zone_id, db)
     _reject_if_synthesised_zone(zone, "add records to")
@@ -3836,7 +3877,10 @@ async def create_record(
     return record
 
 
-@router.put("/groups/{group_id}/zones/{zone_id}/records/{record_id}", response_model=RecordResponse)
+@router.put(
+    "/groups/{group_id}/zones/{zone_id}/records/{record_id}",
+    response_model=RecordResponse,
+)
 async def update_record(
     group_id: uuid.UUID,
     zone_id: uuid.UUID,

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -24,9 +24,12 @@ from app.drivers.dns import is_agentless
 from app.drivers.dns.windows import test_winrm_credentials
 from app.models.audit import AuditLog
 from app.models.dns import (
+    DNSSEC_ALGORITHMS,
     DNSAcl,
     DNSAclEntry,
+    DNSKey,
     DNSRecord,
+    DNSSECPolicy,
     DNSServer,
     DNSServerGroup,
     DNSServerOptions,
@@ -112,8 +115,13 @@ _DRIVER_GATED_RECORD_TYPES: dict[str, frozenset[str]] = {
 # online via REST and BIND9 needs the manual ``dnssec-keygen``
 # dance that's #49's umbrella scope.
 _DRIVER_GATED_OPERATIONS: dict[str, frozenset[str]] = {
-    "dnssec_sign": frozenset({"powerdns"}),
-    "dnssec_unsign": frozenset({"powerdns"}),
+    # Both PowerDNS (online signing) and BIND9 (inline-signing via
+    # dnssec-policy, issue #49) support sign/unsign. Windows DNS does not.
+    "dnssec_sign": frozenset({"powerdns", "bind9"}),
+    "dnssec_unsign": frozenset({"powerdns", "bind9"}),
+    # Manual key rollover is BIND9-only (rndc dnssec -rollover); PowerDNS
+    # rolls on its own schedule + Windows DNS isn't supported.
+    "dnssec_rollover": frozenset({"bind9"}),
 }
 VALID_FORWARD_POLICIES = {"first", "only"}
 VALID_DNSSEC = {"auto", "yes", "no"}
@@ -618,6 +626,8 @@ class ZoneUpdate(BaseModel):
     primary_ns: str | None = None
     admin_email: str | None = None
     dnssec_enabled: bool | None = None
+    # DNSSEC signing policy (issue #49). null ⇒ BIND built-in "default".
+    dnssec_policy_id: uuid.UUID | None = None
     color: str | None = None
     linked_subnet_id: uuid.UUID | None = None
     domain_id: uuid.UUID | None = None
@@ -673,6 +683,7 @@ class ZoneResponse(BaseModel):
     linked_subnet_id: uuid.UUID | None
     domain_id: uuid.UUID | None = None
     dnssec_enabled: bool
+    dnssec_policy_id: uuid.UUID | None = None
     color: str | None
     last_serial: int
     last_pushed_at: datetime | None
@@ -2897,6 +2908,10 @@ async def update_zone(
     # None in the incoming payload — exclude_none would otherwise drop it.
     if "color" in body.model_fields_set and body.color is None:
         changes["color"] = None
+    # Same NULL-is-meaningful treatment for the DNSSEC policy (issue #49):
+    # explicit null ⇒ fall back to BIND's built-in "default" policy.
+    if "dnssec_policy_id" in body.model_fields_set and body.dnssec_policy_id is None:
+        changes["dnssec_policy_id"] = None
     for k, v in changes.items():
         setattr(zone, k, v)
     db.add(
@@ -2917,6 +2932,168 @@ async def update_zone(
     return zone
 
 
+# ── DNSSEC policies (issue #49) ─────────────────────────────────────────────
+
+
+class DNSSECPolicyCreate(BaseModel):
+    name: str
+    description: str = ""
+    algorithm: str = "ecdsap256sha256"
+    ksk_lifetime_days: int = 0
+    zsk_lifetime_days: int = 90
+    nsec3: bool = False
+    nsec3_iterations: int = 0
+    nsec3_salt_length: int = 0
+    nsec3_optout: bool = False
+
+    @field_validator("algorithm")
+    @classmethod
+    def _algo(cls, v: str) -> str:
+        if v not in DNSSEC_ALGORITHMS:
+            raise ValueError(f"algorithm must be one of {sorted(DNSSEC_ALGORITHMS)}")
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def _name(cls, v: str) -> str:
+        v = (v or "").strip()
+        if not v or not re.fullmatch(r"[A-Za-z0-9_-]{1,64}", v):
+            raise ValueError("name must be 1-64 chars of [A-Za-z0-9_-]")
+        return v
+
+
+class DNSSECPolicyUpdate(BaseModel):
+    description: str | None = None
+    algorithm: str | None = None
+    ksk_lifetime_days: int | None = None
+    zsk_lifetime_days: int | None = None
+    nsec3: bool | None = None
+    nsec3_iterations: int | None = None
+    nsec3_salt_length: int | None = None
+    nsec3_optout: bool | None = None
+
+    @field_validator("algorithm")
+    @classmethod
+    def _algo(cls, v: str | None) -> str | None:
+        if v is not None and v not in DNSSEC_ALGORITHMS:
+            raise ValueError(f"algorithm must be one of {sorted(DNSSEC_ALGORITHMS)}")
+        return v
+
+
+class DNSSECPolicyResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str
+    is_builtin: bool
+    algorithm: str
+    ksk_lifetime_days: int
+    zsk_lifetime_days: int
+    nsec3: bool
+    nsec3_iterations: int
+    nsec3_salt_length: int
+    nsec3_optout: bool
+    created_at: datetime
+    modified_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+@router.get("/dnssec-policies", response_model=list[DNSSECPolicyResponse])
+async def list_dnssec_policies(db: DB, _: CurrentUser) -> list[DNSSECPolicy]:
+    rows = (await db.execute(select(DNSSECPolicy).order_by(DNSSECPolicy.name))).scalars().all()
+    return list(rows)
+
+
+@router.post("/dnssec-policies", response_model=DNSSECPolicyResponse, status_code=201)
+async def create_dnssec_policy(
+    body: DNSSECPolicyCreate, db: DB, current_user: SuperAdmin
+) -> DNSSECPolicy:
+    existing = (
+        await db.execute(select(DNSSECPolicy).where(DNSSECPolicy.name == body.name))
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise HTTPException(status_code=409, detail=f"Policy '{body.name}' already exists")
+    pol = DNSSECPolicy(**body.model_dump())
+    db.add(pol)
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="create",
+            resource_type="dnssec_policy",
+            resource_id="",
+            resource_display=body.name,
+            new_value=body.model_dump(),
+            result="success",
+        )
+    )
+    await db.flush()
+    await db.commit()
+    await db.refresh(pol)
+    return pol
+
+
+@router.put("/dnssec-policies/{policy_id}", response_model=DNSSECPolicyResponse)
+async def update_dnssec_policy(
+    policy_id: uuid.UUID, body: DNSSECPolicyUpdate, db: DB, current_user: SuperAdmin
+) -> DNSSECPolicy:
+    pol = await db.get(DNSSECPolicy, policy_id)
+    if pol is None:
+        raise HTTPException(status_code=404, detail="Policy not found")
+    if pol.is_builtin:
+        raise HTTPException(status_code=422, detail="Built-in policies cannot be edited")
+    changes = body.model_dump(exclude_none=True)
+    for k, v in changes.items():
+        setattr(pol, k, v)
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="update",
+            resource_type="dnssec_policy",
+            resource_id=str(pol.id),
+            resource_display=pol.name,
+            new_value=changes,
+            result="success",
+        )
+    )
+    await db.commit()
+    await db.refresh(pol)
+    return pol
+
+
+@router.delete("/dnssec-policies/{policy_id}", status_code=204)
+async def delete_dnssec_policy(policy_id: uuid.UUID, db: DB, current_user: SuperAdmin) -> None:
+    pol = await db.get(DNSSECPolicy, policy_id)
+    if pol is None:
+        raise HTTPException(status_code=404, detail="Policy not found")
+    if pol.is_builtin:
+        raise HTTPException(status_code=422, detail="Built-in policies cannot be deleted")
+    # Zones referencing it fall back to the built-in default (FK SET NULL).
+    in_use = (
+        await db.execute(
+            select(func.count()).select_from(DNSZone).where(DNSZone.dnssec_policy_id == policy_id)
+        )
+    ).scalar_one()
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="delete",
+            resource_type="dnssec_policy",
+            resource_id=str(pol.id),
+            resource_display=pol.name,
+            new_value={"zones_reset_to_default": int(in_use)},
+            result="success",
+        )
+    )
+    await db.delete(pol)
+    await db.commit()
+
+
 @router.get("/groups/{group_id}/zones/{zone_id}/dnssec/info")
 async def get_zone_dnssec_info(
     group_id: uuid.UUID,
@@ -2933,13 +3110,43 @@ async def get_zone_dnssec_info(
     sync cycle (typically <30s after the operator clicks Sign).
     """
     zone = await _require_zone(group_id, zone_id, db)
+    keys = (
+        (
+            await db.execute(
+                select(DNSKey)
+                .where(DNSKey.zone_id == zone.id)
+                .order_by(DNSKey.key_type, DNSKey.key_tag)
+            )
+        )
+        .scalars()
+        .all()
+    )
     return {
         "zone_id": str(zone.id),
         "zone_name": zone.name,
         "dnssec_enabled": zone.dnssec_enabled,
+        "dnssec_policy_id": str(zone.dnssec_policy_id) if zone.dnssec_policy_id else None,
         "dnssec_ds_records": zone.dnssec_ds_records or [],
         "dnssec_synced_at": (zone.dnssec_synced_at.isoformat() if zone.dnssec_synced_at else None),
+        "keys": [
+            {
+                "key_tag": k.key_tag,
+                "key_type": k.key_type,
+                "algorithm": k.algorithm,
+                "state": k.state,
+                "ds_records": k.ds_records or [],
+                "timing": k.timing or {},
+                "reported_at": k.reported_at.isoformat() if k.reported_at else None,
+            }
+            for k in keys
+        ],
     }
+
+
+class DNSSECSignRequest(BaseModel):
+    # Optional signing policy. null ⇒ BIND9 built-in "default". Ignored by
+    # the PowerDNS path (online signing uses its own defaults).
+    policy_id: uuid.UUID | None = None
 
 
 @router.post("/groups/{group_id}/zones/{zone_id}/dnssec/sign", response_model=ZoneResponse)
@@ -2948,21 +3155,30 @@ async def sign_zone_dnssec(
     zone_id: uuid.UUID,
     db: DB,
     current_user: SuperAdmin,
+    body: DNSSECSignRequest | None = None,
 ) -> DNSZone:
-    """Trigger PowerDNS online DNSSEC signing for the zone (issue #127, Phase 3c).
+    """Enable DNSSEC signing for the zone (PowerDNS online signing #127 /
+    BIND9 inline-signing #49).
 
-    Driver-aware — refuses if any server in the zone's group is non-PowerDNS
-    (BIND9's manual ``dnssec-keygen`` flow is the #49 umbrella). The agent
-    picks up the enqueued ``dnssec_sign`` op on its next long-poll, generates
-    KSK + ZSK via ``POST /zones/{z}/cryptokeys``, sets ``PRESIGNED`` zone
-    metadata, and rectifies. The zone's ``dnssec_enabled`` flag flips to
-    True synchronously so the UI reflects intent immediately; actual
-    signed-state confirmation lands when the agent reports back.
+    Driver-aware (``_check_driver_gated_operation``): allowed on PowerDNS +
+    BIND9 groups, refused on Windows DNS. For BIND9 the signing is
+    config-driven — flipping ``dnssec_enabled`` (+ optional ``policy_id``)
+    reshapes the agent ConfigBundle, the agent re-renders the zone with
+    ``dnssec-policy`` + ``inline-signing yes``, BIND auto-generates keys and
+    signs, then reports DS + per-key state back. The enqueued op is a no-op
+    on BIND9 (PowerDNS consumes it to drive its REST sign). The
+    ``dnssec_enabled`` flag flips synchronously so the UI reflects intent
+    immediately.
     """
     zone = await _require_zone(group_id, zone_id, db)
     _reject_if_synthesised_zone(zone, "DNSSEC-sign")
     await _check_driver_gated_operation("dnssec_sign", group_id, db)
     zone.dnssec_enabled = True
+    if body is not None and body.policy_id is not None:
+        pol = await db.get(DNSSECPolicy, body.policy_id)
+        if pol is None:
+            raise HTTPException(status_code=404, detail="DNSSEC policy not found")
+        zone.dnssec_policy_id = body.policy_id
     await enqueue_record_op(
         db,
         zone,
@@ -3026,6 +3242,53 @@ async def unsign_zone_dnssec(
     await db.commit()
     await db.refresh(zone)
     return zone
+
+
+class DNSSECRolloverRequest(BaseModel):
+    key_tag: int
+
+
+@router.post("/groups/{group_id}/zones/{zone_id}/dnssec/rollover")
+async def rollover_zone_dnssec_key(
+    group_id: uuid.UUID,
+    zone_id: uuid.UUID,
+    body: DNSSECRolloverRequest,
+    db: DB,
+    current_user: SuperAdmin,
+) -> dict[str, Any]:
+    """Force a manual KSK/ZSK rollover for a signed BIND9 zone (issue #49).
+
+    BIND9-only (``rndc dnssec -rollover``); PowerDNS rolls on its own
+    schedule and Windows DNS isn't supported. Enqueues a ``dnssec_rollover``
+    op carrying the key tag; the agent runs the rollover and reports the new
+    key set back on its next sync. The zone must already be signed.
+    """
+    zone = await _require_zone(group_id, zone_id, db)
+    _reject_if_synthesised_zone(zone, "DNSSEC-rollover")
+    if not zone.dnssec_enabled:
+        raise HTTPException(status_code=409, detail="Zone is not DNSSEC-signed")
+    await _check_driver_gated_operation("dnssec_rollover", group_id, db)
+    await enqueue_record_op(
+        db,
+        zone,
+        "dnssec_rollover",
+        {"name": "@", "type": "DNSSEC_OP", "key_tag": body.key_tag},
+    )
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="dnssec_rollover",
+            resource_type="dns_zone",
+            resource_id=str(zone.id),
+            resource_display=zone.name,
+            new_value={"key_tag": body.key_tag},
+            result="success",
+        )
+    )
+    await db.commit()
+    return {"status": "queued", "zone_id": str(zone.id), "key_tag": body.key_tag}
 
 
 @router.delete("/groups/{group_id}/zones/{zone_id}", status_code=204)

--- a/backend/app/drivers/dns/base.py
+++ b/backend/app/drivers/dns/base.py
@@ -61,6 +61,29 @@ class ZoneData:
     # (false — the resolver may fall back to recursion if all forwarders fail).
     forwarders: tuple[str, ...] = ()
     forward_only: bool = True
+    # DNSSEC inline-signing (issue #49). When ``dnssec_enabled`` the BIND9
+    # driver renders ``dnssec-policy "<dnssec_policy_name>"; inline-signing
+    # yes;`` into the zone stanza and BIND auto-signs. ``dnssec_policy_name``
+    # is None ⇒ BIND's built-in ``default`` policy. Only consulted for
+    # primary zones; PowerDNS ignores both (online-signing is op-driven).
+    dnssec_enabled: bool = False
+    dnssec_policy_name: str | None = None
+
+
+@dataclass(frozen=True)
+class DNSSECPolicyData:
+    """A BIND9 ``dnssec-policy`` definition shipped in the ConfigBundle
+    so the agent can render the matching ``dnssec-policy { ... };`` block
+    (issue #49). ``default`` is BIND's built-in and is never shipped."""
+
+    name: str
+    algorithm: str = "ecdsap256sha256"
+    ksk_lifetime_days: int = 0
+    zsk_lifetime_days: int = 90
+    nsec3: bool = False
+    nsec3_iterations: int = 0
+    nsec3_salt_length: int = 0
+    nsec3_optout: bool = False
 
 
 @dataclass(frozen=True)
@@ -169,6 +192,9 @@ class ConfigBundle:
     blocklists: tuple[EffectiveBlocklistData, ...]
     generated_at: datetime
     etag: str = ""
+    # DNSSEC signing policies referenced by signed zones (issue #49).
+    # Defaulted so existing constructors keep working.
+    dnssec_policies: tuple[DNSSECPolicyData, ...] = ()
 
     def compute_etag(self) -> str:
         """Compute a stable SHA-256 of the bundle contents (excluding the etag/timestamp)."""
@@ -191,6 +217,7 @@ class ConfigBundle:
                 }
                 for b in self.blocklists
             ],
+            "dnssec_policies": [asdict(p) for p in self.dnssec_policies],
         }
         blob = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
         return "sha256:" + hashlib.sha256(blob).hexdigest()

--- a/backend/app/drivers/dns/bind9.py
+++ b/backend/app/drivers/dns/bind9.py
@@ -100,6 +100,7 @@ class BIND9Driver(DNSDriver):
             acls: tuple[Any, ...] = ()
             tsig_keys: tuple[Any, ...] = ()
             blocklists: tuple[EffectiveBlocklistData, ...] = ()
+            dnssec_policies: tuple[Any, ...] = ()
             server_id = getattr(server, "id", "")
             server_name = getattr(server, "name", "")
             generated_at = ""
@@ -109,6 +110,7 @@ class BIND9Driver(DNSDriver):
             acls = bundle.acls
             tsig_keys = bundle.tsig_keys
             blocklists = bundle.blocklists
+            dnssec_policies = bundle.dnssec_policies
             server_id = bundle.server_id
             server_name = bundle.server_name
             generated_at = bundle.generated_at.isoformat() if bundle.generated_at else ""
@@ -128,6 +130,7 @@ class BIND9Driver(DNSDriver):
             zones=zones,
             tsig_keys=tsig_keys,
             blocklists=blocklists,
+            dnssec_policies=dnssec_policies,
             zone_stanzas=zone_stanzas,
         )
 

--- a/backend/app/drivers/dns/templates/bind9/named.conf.j2
+++ b/backend/app/drivers/dns/templates/bind9/named.conf.j2
@@ -34,6 +34,20 @@ options {
     {%- endif %}
 };
 
+{#- DNSSEC signing policies (issue #49). Custom policies referenced by a
+    signed zone; BIND's built-in "default" needs no block. #}
+{%- for p in dnssec_policies %}
+dnssec-policy "{{ p.name }}" {
+    keys {
+        ksk lifetime {{ "unlimited" if p.ksk_lifetime_days == 0 else (p.ksk_lifetime_days|string ~ "d") }} algorithm {{ p.algorithm }};
+        zsk lifetime {{ "unlimited" if p.zsk_lifetime_days == 0 else (p.zsk_lifetime_days|string ~ "d") }} algorithm {{ p.algorithm }};
+    };
+    {%- if p.nsec3 %}
+    nsec3param iterations {{ p.nsec3_iterations }} optout {{ "yes" if p.nsec3_optout else "no" }} salt-length {{ p.nsec3_salt_length }};
+    {%- endif %}
+};
+{% endfor %}
+
 {%- if options.query_log_enabled %}
 logging {
     channel queries_channel {

--- a/backend/app/drivers/dns/templates/bind9/zone.stanza.j2
+++ b/backend/app/drivers/dns/templates/bind9/zone.stanza.j2
@@ -8,6 +8,10 @@ zone "{{ zone.name }}" {
 zone "{{ zone.name }}" {
     type {{ "master" if zone.zone_type == "primary" else zone.zone_type }};
     file "/var/cache/bind/zones/{{ zone.name }}db";
+    {%- if zone.dnssec_enabled and zone.zone_type == "primary" %}
+    dnssec-policy "{{ zone.dnssec_policy_name or "default" }}";
+    inline-signing yes;
+    {%- endif %}
     {%- if zone.allow_query %}
     allow-query { {% for a in zone.allow_query %}{{ a }}; {% endfor %}};
     {%- endif %}

--- a/backend/app/models/dns.py
+++ b/backend/app/models/dns.py
@@ -621,6 +621,17 @@ class DNSZone(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     dnssec_synced_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # BIND9 DNSSEC signing policy (issue #49). NULL while signing is off, or
+    # when signing with BIND's built-in ``default`` policy. Set to a
+    # ``DNSSECPolicy`` row to sign with a custom algorithm / NSEC3 / key
+    # lifetimes. SET NULL on policy delete so the zone falls back to the
+    # built-in default rather than orphaning. Only consulted by the BIND9
+    # driver; PowerDNS uses its own online-signing defaults.
+    dnssec_policy_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dnssec_policy.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     last_serial: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     last_pushed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
@@ -1030,3 +1041,126 @@ class DNSBlockListException(UUIDPrimaryKeyMixin, Base):
     )
 
     blocklist: Mapped["DNSBlockList"] = relationship("DNSBlockList", back_populates="exceptions")
+
+
+# ── DNSSEC (issue #49) ──────────────────────────────────────────────────────
+#
+# BIND9 9.16+ inline signing via ``dnssec-policy``. BIND owns the private
+# key material and rotates keys automatically per the policy; SpatiumDDI
+# only stores the *public* state (DS rrsets + per-key status) the agent
+# reports back, so there is no private-key custody here. A ``DNSSECPolicy``
+# maps 1:1 to a BIND ``dnssec-policy { ... }`` block; a zone references one
+# via ``DNSZone.dnssec_policy_id`` (NULL ⇒ BIND's built-in ``default``).
+
+# Algorithms we expose in the policy editor → BIND dnssec-policy ``algorithm``
+# token. ECDSAP256SHA256 is the modern default (small keys, fast, broad
+# resolver support). The map is also the API validator's allow-list.
+DNSSEC_ALGORITHMS: frozenset[str] = frozenset(
+    {
+        "ecdsap256sha256",
+        "ecdsap384sha384",
+        "ed25519",
+        "ed448",
+        "rsasha256",
+        "rsasha512",
+    }
+)
+
+# Per-key lifecycle states BIND reports via ``rndc dnssec -status`` (the
+# RFC 7583 key-timing "states"). Stored verbatim on DNSKey.state.
+DNSKEY_STATES: frozenset[str] = frozenset(
+    {"generated", "published", "rumoured", "active", "omnipresent", "retired", "removed", "unknown"}
+)
+
+
+class DNSSECPolicy(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A reusable BIND9 ``dnssec-policy`` definition (issue #49).
+
+    Renders to a ``dnssec-policy "<name>" { ... };`` block in named.conf.
+    Lifetimes are in days; 0 = unlimited (BIND ``lifetime unlimited``),
+    which is the normal choice for a KSK (rolled manually via the parent
+    DS update) paired with an auto-rolled ZSK.
+    """
+
+    __tablename__ = "dnssec_policy"
+    __table_args__ = (UniqueConstraint("name", name="uq_dnssec_policy_name"),)
+
+    name: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    # Built-in seeds (e.g. "default") can't be deleted or renamed.
+    is_builtin: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+
+    algorithm: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="ecdsap256sha256", server_default="ecdsap256sha256"
+    )
+    # KSK / ZSK lifetimes in days (0 = unlimited). For ECDSA the key size is
+    # fixed by the algorithm, so no explicit bits field is needed.
+    ksk_lifetime_days: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    zsk_lifetime_days: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=90, server_default="90"
+    )
+
+    # NSEC3 (opt-in). When false the zone uses plain NSEC. iterations 0 +
+    # salt-length 0 is the modern best-practice NSEC3 config (RFC 9276).
+    nsec3: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    nsec3_iterations: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    nsec3_salt_length: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    nsec3_optout: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+
+    zones: Mapped[list["DNSZone"]] = relationship(
+        "DNSZone",
+        primaryjoin="DNSSECPolicy.id == foreign(DNSZone.dnssec_policy_id)",
+        viewonly=True,
+    )
+
+
+class DNSKey(UUIDPrimaryKeyMixin, Base):
+    """Public DNSSEC key state for one zone, reported by the agent.
+
+    Populated from ``rndc dnssec -status <zone>`` (per-key states + timing)
+    plus ``dnssec-dsfromkey`` for the KSK DS rrset. **No private key
+    material** — BIND holds and rotates the private keys; these rows are a
+    read-only mirror for the operator's "is it signed / what do I give the
+    registrar / where is the rollover" view. Replaced wholesale per zone on
+    each agent report.
+    """
+
+    __tablename__ = "dnssec_key"
+    __table_args__ = (Index("ix_dnssec_key_zone", "zone_id"),)
+
+    zone_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dns_zone.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # DNSKEY key tag (RFC 4034 §5.1.4) — the operator-visible key id.
+    key_tag: Mapped[int] = mapped_column(Integer, nullable=False)
+    # "ksk" | "zsk" | "csk" (combined signing key).
+    key_type: Mapped[str] = mapped_column(String(4), nullable=False)
+    # DNSSEC algorithm number (e.g. 13 for ECDSAP256SHA256).
+    algorithm: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # RFC 7583 lifecycle state (see ``DNSKEY_STATES``).
+    state: Mapped[str] = mapped_column(String(16), nullable=False, default="unknown")
+    # DS rrset string(s) for a KSK/CSK (empty for a ZSK). Operator pastes
+    # these into the parent registrar.
+    ds_records: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    # ISO-8601 timing hints from ``rndc dnssec -status`` (published / active
+    # / retire / remove). Free-form so we don't chase BIND's exact phrasing.
+    timing: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    reported_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    zone: Mapped["DNSZone"] = relationship("DNSZone")

--- a/backend/app/services/ai/tools/dns.py
+++ b/backend/app/services/ai/tools/dns.py
@@ -652,16 +652,72 @@ class FindZoneDNSSECInfoArgs(BaseModel):
 async def find_zone_dnssec_info(
     db: AsyncSession, user: User, args: FindZoneDNSSECInfoArgs
 ) -> dict[str, Any]:
+    from app.models.dns import DNSKey  # noqa: PLC0415
+
     zone = await db.get(DNSZone, args.zone_id)
     if zone is None:
         return {"error": "DNS zone not found", "zone_id": str(args.zone_id)}
+    keys = (await db.execute(select(DNSKey).where(DNSKey.zone_id == zone.id))).scalars().all()
     return {
         "zone_id": str(zone.id),
         "name": zone.name,
         "dnssec_enabled": zone.dnssec_enabled,
+        "dnssec_policy_id": str(zone.dnssec_policy_id) if zone.dnssec_policy_id else None,
         "dnssec_ds_records": zone.dnssec_ds_records,
         "dnssec_synced_at": (zone.dnssec_synced_at.isoformat() if zone.dnssec_synced_at else None),
         "last_serial": zone.last_serial,
+        "keys": [
+            {
+                "key_tag": k.key_tag,
+                "key_type": k.key_type,
+                "algorithm": k.algorithm,
+                "state": k.state,
+                "ds_records": k.ds_records or [],
+            }
+            for k in keys
+        ],
+    }
+
+
+class ListDNSSECPoliciesArgs(BaseModel):
+    pass
+
+
+@register_tool(
+    name="list_dnssec_policies",
+    description=(
+        "List the DNSSEC signing policies operators can attach to BIND9 "
+        "zones (issue #49): name, algorithm, NSEC3 settings, and KSK/ZSK "
+        "lifetimes. The built-in 'default' policy always exists. Use this "
+        "to answer 'what DNSSEC policies are available?' or 'what algorithm "
+        "does policy X use?'. Read-only."
+    ),
+    args_model=ListDNSSECPoliciesArgs,
+    category="dns",
+    module="dns",
+)
+async def list_dnssec_policies(
+    db: AsyncSession, user: User, args: ListDNSSECPoliciesArgs
+) -> dict[str, Any]:
+    from app.models.dns import DNSSECPolicy  # noqa: PLC0415
+
+    rows = (await db.execute(select(DNSSECPolicy).order_by(DNSSECPolicy.name))).scalars().all()
+    return {
+        "policies": [
+            {
+                "id": str(p.id),
+                "name": p.name,
+                "is_builtin": p.is_builtin,
+                "algorithm": p.algorithm,
+                "ksk_lifetime_days": p.ksk_lifetime_days,
+                "zsk_lifetime_days": p.zsk_lifetime_days,
+                "nsec3": p.nsec3,
+                "nsec3_iterations": p.nsec3_iterations,
+                "nsec3_salt_length": p.nsec3_salt_length,
+                "nsec3_optout": p.nsec3_optout,
+            }
+            for p in rows
+        ]
     }
 
 

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -24,6 +24,7 @@ from app.models.dns import (
     DNSAcl,
     DNSRecord,
     DNSRecordOp,
+    DNSSECPolicy,
     DNSServer,
     DNSServerGroup,
     DNSServerOptions,
@@ -127,6 +128,20 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             "port": r.port,
         }
 
+    # DNSSEC policies (issue #49) — resolve each signed zone's policy name +
+    # ship the referenced custom policy definitions so the BIND9 agent can
+    # render ``dnssec-policy { ... }`` blocks + per-zone inline-signing. The
+    # built-in "default" carries no block (BIND ships it).
+    dnssec_policy_rows = list((await db.execute(select(DNSSECPolicy))).scalars().all())
+    dnssec_policies_by_id = {p.id: p for p in dnssec_policy_rows}
+
+    def _zone_policy_name(z: DNSZone) -> str | None:
+        pid = getattr(z, "dnssec_policy_id", None)
+        if not getattr(z, "dnssec_enabled", False) or pid is None:
+            return None
+        pol = dnssec_policies_by_id.get(pid)
+        return pol.name if pol is not None else None
+
     zone_payload: list[dict[str, Any]] = []
     for z in zones:
         base_zp: dict[str, Any] = {
@@ -137,6 +152,10 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             # Forward-zone-only fields (ignored by the agent for other types).
             "forwarders": list(getattr(z, "forwarders", []) or []),
             "forward_only": bool(getattr(z, "forward_only", True)),
+            # DNSSEC inline-signing (issue #49). policy_name None ⇒ BIND
+            # built-in "default".
+            "dnssec_enabled": bool(getattr(z, "dnssec_enabled", False)),
+            "dnssec_policy_name": _zone_policy_name(z),
         }
         # Ship records to every server in the group. The is_primary flag
         # historically gated this, but agents need records to render zone
@@ -434,6 +453,27 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         }
     )
 
+    # Ship only the custom policies referenced by a signed zone (the agent
+    # renders one ``dnssec-policy { ... }`` block per entry; "default" is
+    # BIND's own and needs none).
+    _referenced_policy_names = {
+        _zone_policy_name(z) for z in zones if getattr(z, "dnssec_enabled", False)
+    }
+    dnssec_policies_block = [
+        {
+            "name": p.name,
+            "algorithm": p.algorithm,
+            "ksk_lifetime_days": p.ksk_lifetime_days,
+            "zsk_lifetime_days": p.zsk_lifetime_days,
+            "nsec3": p.nsec3,
+            "nsec3_iterations": p.nsec3_iterations,
+            "nsec3_salt_length": p.nsec3_salt_length,
+            "nsec3_optout": p.nsec3_optout,
+        }
+        for p in dnssec_policy_rows
+        if p.name != "default" and p.name in _referenced_policy_names
+    ]
+
     bundle_body: dict[str, Any] = {
         "server_id": str(server.id),
         "driver": server.driver,
@@ -449,6 +489,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         "fleet_upgrade": fleet_upgrade_block,
         "snmp_settings": snmp_block,
         "ntp_settings": ntp_block,
+        "dnssec_policies": dnssec_policies_block,
     }
 
     # Structural fingerprint excludes records and pending ops so record-only
@@ -469,6 +510,9 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         "zones_structural": [
             {k: val for k, val in z.items() if (k != "records" or has_views)} for z in zone_payload
         ],
+        # DNSSEC signing intent / policy params rewrite named.conf, so a
+        # change must trigger a full reload (issue #49).
+        "dnssec_policies": dnssec_policies_block,
         # Blocklists affect named.conf (response-policy block) + RPZ zone
         # files, so a change MUST trigger a daemon reload.
         "blocklists": blocklists_payload,

--- a/backend/app/services/dns/config_bundle.py
+++ b/backend/app/services/dns/config_bundle.py
@@ -20,6 +20,7 @@ from app.drivers.dns.base import (
     AclData,
     BlocklistEntry,
     ConfigBundle,
+    DNSSECPolicyData,
     EffectiveBlocklistData,
     RecordData,
     ServerOptions,
@@ -30,7 +31,9 @@ from app.drivers.dns.base import (
 )
 from app.models.dns import (
     DNSAcl,
+    DNSKey,  # noqa: F401 — registers the mapper so DNSZone.dnssec relationship resolves
     DNSRecord,
+    DNSSECPolicy,
     DNSServer,
     DNSServerOptions,
     DNSView,
@@ -185,6 +188,18 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             port=r.port,
         )
 
+    # DNSSEC policies (issue #49) — resolve each signed zone's policy name
+    # and ship the referenced custom policy definitions so the agent can
+    # render the matching ``dnssec-policy { ... }`` blocks. The built-in
+    # "default" needs no block (BIND ships it), so it's never collected.
+    policies_by_id = {p.id: p for p in (await db.execute(select(DNSSECPolicy))).scalars().all()}
+
+    def _zone_policy_name(z: DNSZone) -> str | None:
+        if not z.dnssec_enabled or z.dnssec_policy_id is None:
+            return None
+        pol = policies_by_id.get(z.dnssec_policy_id)
+        return pol.name if pol is not None else None
+
     def _zone_data(z: DNSZone, records: tuple[RecordData, ...], view_name: str | None) -> ZoneData:
         return ZoneData(
             name=z.name,
@@ -206,6 +221,8 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             view_name=view_name,
             forwarders=tuple(z.forwarders or ()),
             forward_only=bool(z.forward_only),
+            dnssec_enabled=bool(z.dnssec_enabled),
+            dnssec_policy_name=_zone_policy_name(z),
         )
 
     zones: list[ZoneData] = []
@@ -268,6 +285,26 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     if tsig_name and tsig_secret:
         tsig_keys = (TsigKey(name=tsig_name, algorithm=tsig_algo, secret=tsig_secret),)
 
+    # Collect the custom (non-"default") policies referenced by signed zones
+    # so the agent has a ``dnssec-policy { ... }`` block to render for each.
+    referenced_policy_ids = {
+        z.dnssec_policy_id for z in zone_rows if z.dnssec_enabled and z.dnssec_policy_id is not None
+    }
+    dnssec_policies = tuple(
+        DNSSECPolicyData(
+            name=p.name,
+            algorithm=p.algorithm,
+            ksk_lifetime_days=p.ksk_lifetime_days,
+            zsk_lifetime_days=p.zsk_lifetime_days,
+            nsec3=p.nsec3,
+            nsec3_iterations=p.nsec3_iterations,
+            nsec3_salt_length=p.nsec3_salt_length,
+            nsec3_optout=p.nsec3_optout,
+        )
+        for pid in referenced_policy_ids
+        if (p := policies_by_id.get(pid)) is not None and p.name != "default"
+    )
+
     bundle = ConfigBundle(
         server_id=str(server.id),
         server_name=server.name,
@@ -280,6 +317,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         tsig_keys=tsig_keys,
         blocklists=tuple(blocklists),
         generated_at=datetime.now(UTC),
+        dnssec_policies=dnssec_policies,
     )
     bundle.etag = bundle.compute_etag()
     return bundle

--- a/backend/app/services/dns/config_bundle.py
+++ b/backend/app/services/dns/config_bundle.py
@@ -31,7 +31,6 @@ from app.drivers.dns.base import (
 )
 from app.models.dns import (
     DNSAcl,
-    DNSKey,  # noqa: F401 — registers the mapper so DNSZone.dnssec relationship resolves
     DNSRecord,
     DNSSECPolicy,
     DNSServer,

--- a/backend/tests/test_dnssec_bind9.py
+++ b/backend/tests/test_dnssec_bind9.py
@@ -1,0 +1,225 @@
+"""BIND9 DNSSEC — render + policy CRUD + driver gate (issue #49)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.drivers.dns.base import ConfigBundle, DNSSECPolicyData, ServerOptions, ZoneData
+from app.drivers.dns.bind9 import BIND9Driver
+from app.models.auth import User
+from app.models.dns import DNSSECPolicy, DNSServer, DNSServerGroup, DNSZone
+
+
+def _zone(*, dnssec_enabled: bool = False, policy: str | None = None) -> ZoneData:
+    return ZoneData(
+        name="example.com.",
+        zone_type="primary",
+        kind="forward",
+        ttl=3600,
+        refresh=3600,
+        retry=600,
+        expire=604800,
+        minimum=300,
+        primary_ns="ns1.example.com.",
+        admin_email="admin.example.com.",
+        serial=1,
+        dnssec_enabled=dnssec_enabled,
+        dnssec_policy_name=policy,
+    )
+
+
+def _bundle(zone: ZoneData, policies: tuple[DNSSECPolicyData, ...] = ()) -> ConfigBundle:
+    return ConfigBundle(
+        server_id=str(uuid.uuid4()),
+        server_name="ns1",
+        driver="bind9",
+        roles=("authoritative",),
+        options=ServerOptions(),
+        acls=(),
+        views=(),
+        zones=(zone,),
+        tsig_keys=(),
+        blocklists=(),
+        generated_at=datetime(2026, 5, 29, 12, 0, tzinfo=UTC),
+        dnssec_policies=policies,
+    )
+
+
+# ── Control-plane render ────────────────────────────────────────────────
+
+
+def test_unsigned_zone_has_no_dnssec_policy() -> None:
+    out = BIND9Driver().render_server_config(None, ServerOptions(), bundle=_bundle(_zone()))
+    assert "dnssec-policy" not in out
+    assert "inline-signing" not in out
+
+
+def test_signed_zone_default_policy() -> None:
+    out = BIND9Driver().render_server_config(
+        None, ServerOptions(), bundle=_bundle(_zone(dnssec_enabled=True))
+    )
+    assert 'dnssec-policy "default";' in out
+    assert "inline-signing yes;" in out
+    # No custom policy block — "default" is BIND's built-in.
+    assert 'dnssec-policy "default" {' not in out
+
+
+def test_signed_zone_custom_policy_renders_block() -> None:
+    pol = DNSSECPolicyData(
+        name="strong",
+        algorithm="ed25519",
+        ksk_lifetime_days=0,
+        zsk_lifetime_days=30,
+        nsec3=True,
+        nsec3_iterations=0,
+        nsec3_salt_length=0,
+        nsec3_optout=False,
+    )
+    out = BIND9Driver().render_server_config(
+        None,
+        ServerOptions(),
+        bundle=_bundle(_zone(dnssec_enabled=True, policy="strong"), policies=(pol,)),
+    )
+    # Top-level policy block + zone reference.
+    assert 'dnssec-policy "strong" {' in out
+    assert "ksk lifetime unlimited algorithm ed25519;" in out
+    assert "zsk lifetime 30d algorithm ed25519;" in out
+    assert "nsec3param iterations 0 optout no salt-length 0;" in out
+    assert 'dnssec-policy "strong";' in out
+    assert "inline-signing yes;" in out
+
+
+def test_dnssec_enable_shifts_bundle_etag() -> None:
+    a = _bundle(_zone(dnssec_enabled=False)).compute_etag()
+    b = _bundle(_zone(dnssec_enabled=True)).compute_etag()
+    assert a != b
+
+
+# ── Policy CRUD + driver gate ───────────────────────────────────────────
+
+
+async def _admin(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def test_default_policy_seeded_and_crud(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _admin(db_session)
+    # The real DB gets the built-in "default" from the migration seed; the
+    # test DB is create_all (no seed), so insert it directly to exercise the
+    # built-in-protection logic.
+    db_session.add(DNSSECPolicy(name="default", is_builtin=True))
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    r = await client.get("/api/v1/dns/dnssec-policies", headers=h)
+    assert r.status_code == 200, r.text
+    names = {p["name"]: p for p in r.json()}
+    assert "default" in names and names["default"]["is_builtin"] is True
+
+    # Create a custom policy.
+    r = await client.post(
+        "/api/v1/dns/dnssec-policies",
+        headers=h,
+        json={"name": "nsec3-ec", "algorithm": "ecdsap256sha256", "nsec3": True},
+    )
+    assert r.status_code == 201, r.text
+    pid = r.json()["id"]
+
+    # Bad algorithm → 422.
+    r = await client.post(
+        "/api/v1/dns/dnssec-policies",
+        headers=h,
+        json={"name": "bad", "algorithm": "md5"},
+    )
+    assert r.status_code == 422
+
+    # Built-in can't be deleted.
+    r = await client.delete(f"/api/v1/dns/dnssec-policies/{names['default']['id']}", headers=h)
+    assert r.status_code == 422
+
+    # Custom delete works.
+    r = await client.delete(f"/api/v1/dns/dnssec-policies/{pid}", headers=h)
+    assert r.status_code == 204
+
+
+async def _group_with_driver(db: AsyncSession, driver: str) -> DNSServerGroup:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    db.add(
+        DNSServer(group_id=grp.id, name=f"s-{uuid.uuid4().hex[:6]}", driver=driver, host="1.2.3.4")
+    )
+    await db.flush()
+    return grp
+
+
+async def _zone_row(db: AsyncSession, grp: DNSServerGroup) -> DNSZone:
+    z = DNSZone(
+        group_id=grp.id,
+        name=f"z{uuid.uuid4().hex[:6]}.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.",
+        admin_email="admin.example.",
+    )
+    db.add(z)
+    await db.flush()
+    return z
+
+
+async def test_sign_allowed_on_bind9_group(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _admin(db_session)
+    grp = await _group_with_driver(db_session, "bind9")
+    zone = await _zone_row(db_session, grp)
+    await db_session.commit()
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/dnssec/sign",
+        headers={"Authorization": f"Bearer {token}"},
+        json={},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["dnssec_enabled"] is True
+
+
+async def test_sign_rejected_on_windows_group(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _admin(db_session)
+    grp = await _group_with_driver(db_session, "windows_dns")
+    zone = await _zone_row(db_session, grp)
+    await db_session.commit()
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/dnssec/sign",
+        headers={"Authorization": f"Bearer {token}"},
+        json={},
+    )
+    assert r.status_code == 422
+
+
+async def test_rollover_requires_signed_zone(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _admin(db_session)
+    grp = await _group_with_driver(db_session, "bind9")
+    zone = await _zone_row(db_session, grp)  # unsigned
+    await db_session.commit()
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/dnssec/rollover",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"key_tag": 12345},
+    )
+    assert r.status_code == 409

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -154,6 +154,37 @@ class BIND9DriverConfig:
     rndc_port: int = 953
 ```
 
+### 2.5 DNSSEC — inline-signing (issue #49)
+
+BIND9 9.16+ `dnssec-policy` inline-signing. **BIND owns + auto-rotates the
+private keys**; the control plane stores only public state. The flow is
+config-driven, not op-driven (unlike PowerDNS's REST sign):
+
+1. **Control plane.** A signed zone (`DNSZone.dnssec_enabled`) carries an
+   optional `dnssec_policy_id` → a `DNSSECPolicy` row (algorithm / NSEC3 /
+   KSK+ZSK lifetimes). The bundle assembler stamps `dnssec_enabled` +
+   `dnssec_policy_name` onto each zone and ships referenced custom policies
+   in `dnssec_policies` (the built-in `default` carries no block). Both flow
+   into the structural ETag, so a sign/policy change triggers a re-render.
+2. **Agent render.** `named.conf` gets `key-directory "/var/cache/bind/keys"`,
+   a top-level `dnssec-policy "<name>" { keys { ksk … ; zsk … ; }; nsec3param … ; };`
+   per custom policy, and each signed primary zone's stanza gets
+   `dnssec-policy "<name>"; inline-signing yes;`. BIND auto-generates keys in
+   the key-directory and signs on load.
+3. **DS + key-state report.** After a reload the agent's `collect_dnssec_state`
+   runs `rndc dnssec -status <zone>` (parsed by the version-tolerant
+   `_parse_dnssec_status`) + `dnssec-dsfromkey` over the KSK key files, and
+   POSTs the DS rrset + per-key state to `/dns/agents/dnssec-state`. The
+   control plane mirrors it into `DNSZone.dnssec_ds_records` + `DNSKey` rows
+   (replace-per-zone) for the operator's DS-export + key-status view.
+4. **Manual rollover.** `POST .../dnssec/rollover` enqueues a
+   `dnssec_rollover` op (key tag); the agent runs
+   `rndc dnssec -rollover -key <tag> <zone>` and re-reports. Sign/unsign ops
+   are no-ops on the BIND9 agent (the config render drives signing).
+
+Gating: `_DRIVER_GATED_OPERATIONS` allows `dnssec_sign`/`dnssec_unsign` on
+`{powerdns, bind9}` and `dnssec_rollover` on `{bind9}`.
+
 ---
 
 ## 3. Windows DNS Driver

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -29,7 +29,7 @@ SpatiumDDI ships three authoritative DNS drivers. Pick **per server group** — 
 | Zone CRUD wire protocol | rndc addzone / delzone | REST API | WinRM (Path B only) |
 | ALIAS records (CNAME at apex) | — | ✅ | — |
 | LUA records (computed responses) | — | ✅ | — |
-| Online DNSSEC signing | manual | ✅ one-toggle | manual |
+| Online DNSSEC signing | ✅ inline-signing (#49) | ✅ one-toggle | manual |
 | Catalog zones (RFC 9432) — producer | ✅ | ✅ | — |
 | Catalog zones (RFC 9432) — consumer | ✅ | — (waits for pdns 4.10+) | — |
 | First-class views / split-horizon | ✅ | tag-based, not surfaced as views in UI | — (replication scope) |
@@ -174,6 +174,41 @@ DNSTrustAnchor
 - **BIND9:** `dnssec-validation auto|yes|no;` in `options {}` or per-view; trust anchors go in `managed-keys {}` or `trust-anchors {}`
 - The root DNSSEC trust anchor (ICANN KSK) is pre-loaded automatically when `dnssec_validation: auto`
 - UI shows DNSSEC chain validation status for each zone
+
+> **Validation vs. signing.** The setting above controls whether the
+> server *validates* answers as a resolver. *Signing* your own zones is a
+> separate feature — see §3.3a (BIND9) / §0 (PowerDNS).
+
+### 3.3a Zone signing — BIND9 inline-signing (issue #49)
+
+BIND9 9.16+ `dnssec-policy` inline-signing. A **DNSSECPolicy** maps 1:1
+to a BIND `dnssec-policy "<name>" { ... };` block — algorithm, NSEC3
+params, KSK/ZSK lifetimes — and a zone references one. **BIND owns and
+auto-rotates the private keys** (the modern, recommended model); SpatiumDDI
+stores only the *public* state it reports back (DS rrset + per-key status),
+so there is no private-key custody.
+
+- **Policies** are managed at **DNS → DNSSEC Policies** (`/dns/dnssec-policies`).
+  A built-in `default` policy (ECDSAP256SHA256, NSEC, unlimited KSK +
+  90-day auto-rolled ZSK) is seeded and read-only.
+- **Sign a zone** from its DNSSEC card (`POST .../dnssec/sign` with an
+  optional `policy_id` — null ⇒ `default`). Signing is **config-driven**:
+  flipping `dnssec_enabled` (+ policy) reshapes the agent ConfigBundle, the
+  agent renders `dnssec-policy "<name>"; inline-signing yes;` into the zone
+  stanza (and a top-level `dnssec-policy { }` block for custom policies),
+  BIND auto-generates keys in `key-directory` and signs.
+- **DS export.** After signing the agent runs `rndc dnssec -status` +
+  `dnssec-dsfromkey` and reports the DS rrset + per-key state back via
+  `POST /dns/agents/dnssec-state`; the card surfaces the DS records to
+  paste at the parent registrar, plus a per-key table (tag / type / state).
+- **Manual rollover.** The card's per-key **Roll** button
+  (`POST .../dnssec/rollover`) enqueues a `dnssec_rollover` op; the agent
+  runs `rndc dnssec -rollover -key <tag>`. Routine rollover is automatic
+  per the policy — this is the "roll now" escape hatch.
+- **Driver gating.** Sign/unsign are allowed on BIND9 + PowerDNS groups,
+  rollover on BIND9 only; Windows DNS is refused (422). NSEC3 follows
+  RFC 9276 (iterations 0 + salt-length 0 recommended) — the policy editor
+  warns when iterations > 0.
 
 ### 3.4 GSS-TSIG
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { DashboardPage } from "@/pages/DashboardPage";
 import { IPAMPage } from "@/pages/ipam/IPAMPage";
 import { NATPage } from "@/pages/ipam/NATPage";
 import { StaleIPReportPage } from "@/pages/ipam/StaleIPReportPage";
+import { DNSSECPoliciesPage } from "@/pages/dns/DNSSECPoliciesPage";
 import { DNSPage } from "@/pages/dns/DNSPage";
 import { DNSPoolsPage } from "@/pages/dns/DNSPoolsPage";
 import { VLANsPage } from "@/pages/vlans/VLANsPage";
@@ -99,6 +100,7 @@ export default function App() {
         <Route path="ipam/plans/:id" element={<SubnetPlannerEditorPage />} />
         <Route path="dns" element={<DNSPage />} />
         <Route path="dns/pools" element={<DNSPoolsPage />} />
+        <Route path="dns/dnssec-policies" element={<DNSSECPoliciesPage />} />
         {/* Network section — Devices / VLANs / VRFs / ASNs. The old top-
             level /network and /vlans paths redirect here so existing
             bookmarks keep working. See issue #84. */}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -68,6 +68,7 @@ const baseMainNav = [
   { label: "DHCP", icon: Server, to: "/dhcp" },
   { label: "DNS", icon: Globe, to: "/dns", end: true },
   { label: "DNS Pools", icon: Workflow, to: "/dns/pools" },
+  { label: "DNSSEC Policies", icon: KeyRound, to: "/dns/dnssec-policies" },
   { label: "Domains", icon: Earth, to: "/admin/domains" },
   { label: "Logs", icon: ScrollText, to: "/logs" },
   { label: "NAT Mappings", icon: Shuffle, to: "/ipam/nat" },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4590,11 +4590,14 @@ export const dnsApi = {
     api
       .get<ZoneDnssecInfo>(`/dns/groups/${groupId}/zones/${zoneId}/dnssec/info`)
       .then((r) => r.data),
+  // policyId undefined ⇒ omit (backend leaves the zone's policy unchanged);
+  // null ⇒ reset to built-in default; a UUID ⇒ set that policy.
   signZoneDnssec: (groupId: string, zoneId: string, policyId?: string | null) =>
     api
-      .post<DNSZone>(`/dns/groups/${groupId}/zones/${zoneId}/dnssec/sign`, {
-        policy_id: policyId ?? null,
-      })
+      .post<DNSZone>(
+        `/dns/groups/${groupId}/zones/${zoneId}/dnssec/sign`,
+        policyId === undefined ? {} : { policy_id: policyId },
+      )
       .then((r) => r.data),
   unsignZoneDnssec: (groupId: string, zoneId: string) =>
     api

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4117,6 +4117,7 @@ export interface DNSZone {
   linked_subnet_id: string | null;
   domain_id?: string | null;
   dnssec_enabled: boolean;
+  dnssec_policy_id?: string | null;
   dnssec_ds_records: string[] | null;
   dnssec_synced_at: string | null;
   color: string | null;
@@ -4319,6 +4320,45 @@ export interface PropagationCheckResult {
   record_type: string;
   queried_at_ms: number;
   results: PropagationResolverResult[];
+}
+
+/** One DNSSEC key's public state (issue #49). No private material. */
+export interface DNSKeyState {
+  key_tag: number;
+  key_type: "ksk" | "zsk" | "csk";
+  algorithm: number;
+  state: string;
+  ds_records: string[];
+  timing?: Record<string, string>;
+  reported_at?: string | null;
+}
+
+/** Zone DNSSEC posture for the zone-edit DNSSEC card. */
+export interface ZoneDnssecInfo {
+  zone_id: string;
+  zone_name: string;
+  dnssec_enabled: boolean;
+  dnssec_policy_id: string | null;
+  dnssec_ds_records: string[];
+  dnssec_synced_at: string | null;
+  keys: DNSKeyState[];
+}
+
+/** A reusable BIND9 dnssec-policy definition (issue #49). */
+export interface DNSSECPolicy {
+  id: string;
+  name: string;
+  description: string;
+  is_builtin: boolean;
+  algorithm: string;
+  ksk_lifetime_days: number;
+  zsk_lifetime_days: number;
+  nsec3: boolean;
+  nsec3_iterations: number;
+  nsec3_salt_length: number;
+  nsec3_optout: boolean;
+  created_at: string;
+  modified_at: string;
 }
 
 export const dnsApi = {
@@ -4544,25 +4584,42 @@ export const dnsApi = {
       )
       .then((r) => r.data),
 
-  // PowerDNS online DNSSEC (issue #127, Phase 3c)
+  // DNSSEC — PowerDNS online signing (#127) + BIND9 inline-signing (#49)
+  // (types declared above `dnsApi`; see DNSKeyState / ZoneDnssecInfo / DNSSECPolicy)
   getZoneDnssecInfo: (groupId: string, zoneId: string) =>
     api
-      .get<{
-        zone_id: string;
-        zone_name: string;
-        dnssec_enabled: boolean;
-        dnssec_ds_records: string[];
-        dnssec_synced_at: string | null;
-      }>(`/dns/groups/${groupId}/zones/${zoneId}/dnssec/info`)
+      .get<ZoneDnssecInfo>(`/dns/groups/${groupId}/zones/${zoneId}/dnssec/info`)
       .then((r) => r.data),
-  signZoneDnssec: (groupId: string, zoneId: string) =>
+  signZoneDnssec: (groupId: string, zoneId: string, policyId?: string | null) =>
     api
-      .post<DNSZone>(`/dns/groups/${groupId}/zones/${zoneId}/dnssec/sign`)
+      .post<DNSZone>(`/dns/groups/${groupId}/zones/${zoneId}/dnssec/sign`, {
+        policy_id: policyId ?? null,
+      })
       .then((r) => r.data),
   unsignZoneDnssec: (groupId: string, zoneId: string) =>
     api
       .post<DNSZone>(`/dns/groups/${groupId}/zones/${zoneId}/dnssec/unsign`)
       .then((r) => r.data),
+  rolloverZoneDnssecKey: (groupId: string, zoneId: string, keyTag: number) =>
+    api
+      .post<{
+        status: string;
+        zone_id: string;
+        key_tag: number;
+      }>(`/dns/groups/${groupId}/zones/${zoneId}/dnssec/rollover`, {
+        key_tag: keyTag,
+      })
+      .then((r) => r.data),
+  // DNSSEC policies (issue #49)
+  listDnssecPolicies: () =>
+    api.get<DNSSECPolicy[]>("/dns/dnssec-policies").then((r) => r.data),
+  createDnssecPolicy: (data: Partial<DNSSECPolicy>) =>
+    api.post<DNSSECPolicy>("/dns/dnssec-policies", data).then((r) => r.data),
+  updateDnssecPolicy: (id: string, data: Partial<DNSSECPolicy>) =>
+    api
+      .put<DNSSECPolicy>(`/dns/dnssec-policies/${id}`, data)
+      .then((r) => r.data),
+  deleteDnssecPolicy: (id: string) => api.delete(`/dns/dnssec-policies/${id}`),
 
   // Delegation wizard
   getDelegationPreview: (groupId: string, zoneId: string) =>

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -1258,6 +1258,11 @@ function DnssecCard({
     queryKey: ["dns-dnssec-policies"],
     queryFn: () => dnsApi.listDnssecPolicies(),
   });
+  // Seed the picker from the zone's stored policy so it reflects what's
+  // actually applied (rather than always showing "default policy").
+  useEffect(() => {
+    if (info.data?.dnssec_policy_id) setPolicyId(info.data.dnssec_policy_id);
+  }, [info.data?.dnssec_policy_id]);
 
   const invalidate = () => {
     qc.invalidateQueries({
@@ -1266,8 +1271,11 @@ function DnssecCard({
     qc.invalidateQueries({ queryKey: ["dns-zones", groupId] });
   };
 
+  // policy: a UUID / null sets-or-resets the policy (fresh sign);
+  // ``undefined`` omits it so a re-sign keeps the zone's current policy.
   const signMut = useMutation({
-    mutationFn: () => dnsApi.signZoneDnssec(groupId, zoneId, policyId || null),
+    mutationFn: (policy: string | null | undefined) =>
+      dnsApi.signZoneDnssec(groupId, zoneId, policy),
     onSuccess: () => {
       setError(null);
       invalidate();
@@ -1348,9 +1356,9 @@ function DnssecCard({
               <button
                 type="button"
                 disabled={busy}
-                onClick={() => signMut.mutate()}
+                onClick={() => signMut.mutate(undefined)}
                 className="rounded border px-2 py-1 text-xs hover:bg-accent disabled:opacity-50"
-                title="Re-run sign / re-apply policy"
+                title="Re-run sign (keeps the current policy)"
               >
                 {signMut.isPending ? "Re-signing…" : "Re-sign"}
               </button>
@@ -1384,7 +1392,7 @@ function DnssecCard({
               <button
                 type="button"
                 disabled={busy}
-                onClick={() => signMut.mutate()}
+                onClick={() => signMut.mutate(policyId || null)}
                 className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
               >
                 {signMut.isPending ? "Signing…" : "Sign zone"}

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -1244,6 +1244,7 @@ function DnssecCard({
   const qc = useQueryClient();
   const [error, setError] = useState<string | null>(null);
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
+  const [policyId, setPolicyId] = useState<string>("");
 
   const info = useQuery({
     queryKey: ["dns-zone-dnssec-info", groupId, zoneId],
@@ -1251,15 +1252,25 @@ function DnssecCard({
     refetchOnWindowFocus: true,
     refetchInterval: initiallyEnabled ? 10_000 : false,
   });
+  // DNSSEC policies (issue #49) — operator picks one when signing a BIND9
+  // zone; null/empty ⇒ BIND built-in "default".
+  const policies = useQuery({
+    queryKey: ["dns-dnssec-policies"],
+    queryFn: () => dnsApi.listDnssecPolicies(),
+  });
+
+  const invalidate = () => {
+    qc.invalidateQueries({
+      queryKey: ["dns-zone-dnssec-info", groupId, zoneId],
+    });
+    qc.invalidateQueries({ queryKey: ["dns-zones", groupId] });
+  };
 
   const signMut = useMutation({
-    mutationFn: () => dnsApi.signZoneDnssec(groupId, zoneId),
+    mutationFn: () => dnsApi.signZoneDnssec(groupId, zoneId, policyId || null),
     onSuccess: () => {
       setError(null);
-      qc.invalidateQueries({
-        queryKey: ["dns-zone-dnssec-info", groupId, zoneId],
-      });
-      qc.invalidateQueries({ queryKey: ["dns-zones", groupId] });
+      invalidate();
     },
     onError: (e: ApiError) => setError(formatApiError(e, "Sign failed")),
   });
@@ -1267,18 +1278,26 @@ function DnssecCard({
     mutationFn: () => dnsApi.unsignZoneDnssec(groupId, zoneId),
     onSuccess: () => {
       setError(null);
-      qc.invalidateQueries({
-        queryKey: ["dns-zone-dnssec-info", groupId, zoneId],
-      });
-      qc.invalidateQueries({ queryKey: ["dns-zones", groupId] });
+      invalidate();
     },
     onError: (e: ApiError) => setError(formatApiError(e, "Unsign failed")),
+  });
+  const rolloverMut = useMutation({
+    mutationFn: (keyTag: number) =>
+      dnsApi.rolloverZoneDnssecKey(groupId, zoneId, keyTag),
+    onSuccess: () => {
+      setError(null);
+      invalidate();
+    },
+    onError: (e: ApiError) => setError(formatApiError(e, "Rollover failed")),
   });
 
   const enabled = info.data?.dnssec_enabled ?? initiallyEnabled;
   const dsRecords = info.data?.dnssec_ds_records ?? [];
   const syncedAt = info.data?.dnssec_synced_at ?? null;
-  const busy = signMut.isPending || unsignMut.isPending;
+  const keys = info.data?.keys ?? [];
+  const busy =
+    signMut.isPending || unsignMut.isPending || rolloverMut.isPending;
 
   function copyDs(idx: number, value: string) {
     navigator.clipboard.writeText(value).then(
@@ -1318,12 +1337,12 @@ function DnssecCard({
               <>
                 Zone is <span className="font-medium">unsigned</span>. Sign to
                 generate KSK + ZSK and publish DS records to the parent
-                registrar. PowerDNS-only.
+                registrar. BIND9 (inline-signing) + PowerDNS.
               </>
             )}
           </div>
         </div>
-        <div className="flex shrink-0 gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           {enabled ? (
             <>
               <button
@@ -1331,7 +1350,7 @@ function DnssecCard({
                 disabled={busy}
                 onClick={() => signMut.mutate()}
                 className="rounded border px-2 py-1 text-xs hover:bg-accent disabled:opacity-50"
-                title="Re-run sign — pdns regenerates keys + rectifies"
+                title="Re-run sign / re-apply policy"
               >
                 {signMut.isPending ? "Re-signing…" : "Re-sign"}
               </button>
@@ -1345,14 +1364,32 @@ function DnssecCard({
               </button>
             </>
           ) : (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => signMut.mutate()}
-              className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
-            >
-              {signMut.isPending ? "Signing…" : "Sign zone"}
-            </button>
+            <>
+              <select
+                value={policyId}
+                onChange={(e) => setPolicyId(e.target.value)}
+                className="rounded border bg-background px-2 py-1 text-xs"
+                title="DNSSEC signing policy (BIND9)"
+              >
+                <option value="">default policy</option>
+                {(policies.data ?? [])
+                  .filter((p) => p.name !== "default")
+                  .map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name} ({p.algorithm}
+                      {p.nsec3 ? ", NSEC3" : ""})
+                    </option>
+                  ))}
+              </select>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => signMut.mutate()}
+                className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+              >
+                {signMut.isPending ? "Signing…" : "Sign zone"}
+              </button>
+            </>
           )}
         </div>
       </div>
@@ -1360,6 +1397,46 @@ function DnssecCard({
       {error && (
         <div className="rounded border border-destructive/40 bg-destructive/10 px-2 py-1.5 text-xs text-destructive">
           {error}
+        </div>
+      )}
+
+      {enabled && keys.length > 0 && (
+        <div>
+          <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Keys
+          </div>
+          <table className="w-full text-[11px]">
+            <thead className="text-left text-muted-foreground">
+              <tr>
+                <th className="py-0.5 pr-2">Tag</th>
+                <th className="py-0.5 pr-2">Type</th>
+                <th className="py-0.5 pr-2">Algo</th>
+                <th className="py-0.5 pr-2">State</th>
+                <th className="py-0.5" />
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => (
+                <tr key={`${k.key_type}-${k.key_tag}`} className="border-t">
+                  <td className="py-0.5 pr-2 font-mono">{k.key_tag}</td>
+                  <td className="py-0.5 pr-2 uppercase">{k.key_type}</td>
+                  <td className="py-0.5 pr-2">{k.algorithm}</td>
+                  <td className="py-0.5 pr-2">{k.state}</td>
+                  <td className="py-0.5 text-right">
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => rolloverMut.mutate(k.key_tag)}
+                      className="rounded border px-1.5 py-0.5 text-[10px] hover:bg-accent disabled:opacity-50"
+                      title="Force a key rollover (BIND9 rndc dnssec -rollover)"
+                    >
+                      Roll
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
 
@@ -1396,8 +1473,9 @@ function DnssecCard({
             </ul>
           )}
           <div className="mt-2 text-[11px] text-muted-foreground">
-            Multiple algorithms are normal — publish them all. PowerDNS rotates
-            keys automatically; this list refreshes after each rollover.
+            Multiple algorithms are normal — publish them all. Keys rotate
+            automatically per the policy (BIND9) or pdns schedule; this list
+            refreshes after each rollover.
           </div>
         </div>
       )}

--- a/frontend/src/pages/dns/DNSSECPoliciesPage.tsx
+++ b/frontend/src/pages/dns/DNSSECPoliciesPage.tsx
@@ -1,0 +1,353 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { KeyRound, Pencil, Plus, Trash2 } from "lucide-react";
+
+import { dnsApi, type DNSSECPolicy } from "@/lib/api";
+import { HeaderButton } from "@/components/ui/header-button";
+import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { cn } from "@/lib/utils";
+
+const ALGORITHMS = [
+  "ecdsap256sha256",
+  "ecdsap384sha384",
+  "ed25519",
+  "ed448",
+  "rsasha256",
+  "rsasha512",
+];
+
+const inputCls =
+  "w-full rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+/**
+ * DNSSEC policy management (issue #49). A policy maps 1:1 to a BIND9
+ * ``dnssec-policy`` block — algorithm, NSEC3 params, KSK/ZSK lifetimes —
+ * and is attached to a zone from the zone's DNSSEC card. The built-in
+ * "default" policy is read-only.
+ */
+export function DNSSECPoliciesPage() {
+  const qc = useQueryClient();
+  const [editing, setEditing] = useState<DNSSECPolicy | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [toDelete, setToDelete] = useState<DNSSECPolicy | null>(null);
+
+  const policies = useQuery({
+    queryKey: ["dns-dnssec-policies"],
+    queryFn: () => dnsApi.listDnssecPolicies(),
+  });
+
+  const del = useMutation({
+    mutationFn: (id: string) => dnsApi.deleteDnssecPolicy(id),
+    onSuccess: () => {
+      setToDelete(null);
+      qc.invalidateQueries({ queryKey: ["dns-dnssec-policies"] });
+    },
+  });
+
+  const rows = policies.data ?? [];
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-4 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="flex items-center gap-2 text-xl font-semibold">
+            <KeyRound className="h-5 w-5 shrink-0" /> DNSSEC Policies
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Reusable BIND9 signing policies (algorithm, NSEC3, KSK/ZSK
+            lifetimes). Attach one to a zone from its DNSSEC card; leave a zone
+            on <code>default</code> for BIND&rsquo;s built-in policy.
+          </p>
+        </div>
+        <HeaderButton variant="primary" onClick={() => setCreating(true)}>
+          <Plus className="h-4 w-4" /> New policy
+        </HeaderButton>
+      </div>
+
+      <div className="min-w-0 overflow-x-auto rounded-md border">
+        <table className="w-full min-w-[720px] text-sm">
+          <thead className="bg-muted/40 text-left text-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2">Name</th>
+              <th className="px-3 py-2">Algorithm</th>
+              <th className="px-3 py-2">NSEC3</th>
+              <th className="px-3 py-2">KSK life</th>
+              <th className="px-3 py-2">ZSK life</th>
+              <th className="px-3 py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-3 py-8 text-center text-muted-foreground"
+                >
+                  {policies.isLoading ? "Loading…" : "No policies."}
+                </td>
+              </tr>
+            ) : (
+              rows.map((p) => (
+                <tr key={p.id} className="border-t hover:bg-muted/20">
+                  <td className="px-3 py-2 font-medium">
+                    {p.name}
+                    {p.is_builtin && (
+                      <span className="ml-2 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
+                        built-in
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs">{p.algorithm}</td>
+                  <td className="px-3 py-2">
+                    {p.nsec3 ? `iter ${p.nsec3_iterations}` : "—"}
+                  </td>
+                  <td className="px-3 py-2 tabular-nums">
+                    {p.ksk_lifetime_days === 0
+                      ? "unlimited"
+                      : `${p.ksk_lifetime_days}d`}
+                  </td>
+                  <td className="px-3 py-2 tabular-nums">
+                    {p.zsk_lifetime_days === 0
+                      ? "unlimited"
+                      : `${p.zsk_lifetime_days}d`}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {!p.is_builtin && (
+                      <span className="inline-flex gap-1">
+                        <button
+                          type="button"
+                          onClick={() => setEditing(p)}
+                          className="rounded border p-1 hover:bg-accent"
+                          title="Edit"
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setToDelete(p)}
+                          className="rounded border border-destructive/40 p-1 text-destructive hover:bg-destructive/10"
+                          title="Delete"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {(creating || editing) && (
+        <PolicyModal
+          existing={editing}
+          onClose={() => {
+            setCreating(false);
+            setEditing(null);
+          }}
+        />
+      )}
+
+      <ConfirmModal
+        open={toDelete !== null}
+        tone="destructive"
+        title="Delete DNSSEC policy?"
+        confirmLabel="Delete"
+        loading={del.isPending}
+        message={
+          <>
+            Delete <strong>{toDelete?.name}</strong>? Zones using it fall back
+            to BIND&rsquo;s built-in <code>default</code> policy on the next
+            config sync.
+          </>
+        }
+        onConfirm={() => toDelete && del.mutate(toDelete.id)}
+        onClose={() => setToDelete(null)}
+      />
+    </div>
+  );
+}
+
+function PolicyModal({
+  existing,
+  onClose,
+}: {
+  existing: DNSSECPolicy | null;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [name, setName] = useState(existing?.name ?? "");
+  const [description, setDescription] = useState(existing?.description ?? "");
+  const [algorithm, setAlgorithm] = useState(
+    existing?.algorithm ?? "ecdsap256sha256",
+  );
+  const [kskLife, setKskLife] = useState(existing?.ksk_lifetime_days ?? 0);
+  const [zskLife, setZskLife] = useState(existing?.zsk_lifetime_days ?? 90);
+  const [nsec3, setNsec3] = useState(existing?.nsec3 ?? false);
+  const [iterations, setIterations] = useState(existing?.nsec3_iterations ?? 0);
+  const [saltLen, setSaltLen] = useState(existing?.nsec3_salt_length ?? 0);
+  const [optout, setOptout] = useState(existing?.nsec3_optout ?? false);
+  const [error, setError] = useState<string | null>(null);
+
+  const mut = useMutation({
+    mutationFn: () => {
+      const body: Partial<DNSSECPolicy> = {
+        description,
+        algorithm,
+        ksk_lifetime_days: kskLife,
+        zsk_lifetime_days: zskLife,
+        nsec3,
+        nsec3_iterations: iterations,
+        nsec3_salt_length: saltLen,
+        nsec3_optout: optout,
+      };
+      if (existing) return dnsApi.updateDnssecPolicy(existing.id, body);
+      return dnsApi.createDnssecPolicy({ ...body, name });
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dns-dnssec-policies"] });
+      onClose();
+    },
+    onError: (e: unknown) => {
+      const err = e as { response?: { data?: { detail?: string } } };
+      setError(err?.response?.data?.detail ?? "Save failed");
+    },
+  });
+
+  return (
+    <Modal
+      title={existing ? "Edit DNSSEC policy" : "New DNSSEC policy"}
+      onClose={onClose}
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mut.mutate();
+        }}
+        className="space-y-3"
+      >
+        {!existing && (
+          <label className="block text-xs font-medium text-muted-foreground">
+            Name
+            <input
+              className={cn(inputCls, "mt-1")}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. nsec3-ecdsa"
+              required
+            />
+          </label>
+        )}
+        <label className="block text-xs font-medium text-muted-foreground">
+          Description
+          <input
+            className={cn(inputCls, "mt-1")}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </label>
+        <label className="block text-xs font-medium text-muted-foreground">
+          Algorithm
+          <select
+            className={cn(inputCls, "mt-1")}
+            value={algorithm}
+            onChange={(e) => setAlgorithm(e.target.value)}
+          >
+            {ALGORITHMS.map((a) => (
+              <option key={a} value={a}>
+                {a}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="block text-xs font-medium text-muted-foreground">
+            KSK lifetime (days, 0 = unlimited)
+            <input
+              type="number"
+              min={0}
+              className={cn(inputCls, "mt-1")}
+              value={kskLife}
+              onChange={(e) => setKskLife(Number(e.target.value))}
+            />
+          </label>
+          <label className="block text-xs font-medium text-muted-foreground">
+            ZSK lifetime (days, 0 = unlimited)
+            <input
+              type="number"
+              min={0}
+              className={cn(inputCls, "mt-1")}
+              value={zskLife}
+              onChange={(e) => setZskLife(Number(e.target.value))}
+            />
+          </label>
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={nsec3}
+            onChange={(e) => setNsec3(e.target.checked)}
+          />
+          NSEC3 (instead of NSEC)
+        </label>
+        {nsec3 && (
+          <div className="grid grid-cols-3 gap-3 pl-6">
+            <label className="block text-xs font-medium text-muted-foreground">
+              Iterations
+              <input
+                type="number"
+                min={0}
+                className={cn(inputCls, "mt-1")}
+                value={iterations}
+                onChange={(e) => setIterations(Number(e.target.value))}
+              />
+            </label>
+            <label className="block text-xs font-medium text-muted-foreground">
+              Salt length
+              <input
+                type="number"
+                min={0}
+                className={cn(inputCls, "mt-1")}
+                value={saltLen}
+                onChange={(e) => setSaltLen(Number(e.target.value))}
+              />
+            </label>
+            <label className="flex items-end gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={optout}
+                onChange={(e) => setOptout(e.target.checked)}
+              />
+              Opt-out
+            </label>
+          </div>
+        )}
+        {nsec3 && iterations > 0 && (
+          <p className="text-[11px] text-amber-600 dark:text-amber-400">
+            RFC 9276 recommends iterations 0 + salt length 0 for NSEC3.
+          </p>
+        )}
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mut.isPending}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {mut.isPending ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}


### PR DESCRIPTION
Closes #49.

Closes the BIND9 side of DNSSEC, reusing the PowerDNS DS-export scaffolding (#127). **BIND9 9.16+ inline-signing via `dnssec-policy`**: BIND owns and auto-rotates the private keys; SpatiumDDI stores only the *public* state (DS rrset + per-key status) the agent reports back — no private-key custody.

## Data model
- **`DNSSECPolicy`** — reusable `dnssec-policy` definition (algorithm / NSEC3 params / KSK+ZSK lifetimes). The migration seeds a read-only built-in `default` (ECDSAP256SHA256, NSEC, unlimited KSK + 90-day auto-rolled ZSK).
- **`DNSKey`** — public per-zone key state (tag / type / state / DS rrset), replace-per-zone from the agent report. **No private material.**
- **`DNSZone.dnssec_policy_id`** — FK (SET NULL; null ⇒ built-in `default`).

## Config-driven signing (the core)
- ConfigBundle ships `dnssec_policies` + per-zone `dnssec_enabled` / `dnssec_policy_name` (both the `config_bundle` dataclass path and the `agent_config` dict path). It flows into the structural ETag, so a sign/policy change re-renders.
- Control-plane **and agent** BIND9 renderers emit top-level `dnssec-policy "<name>" { keys { … }; nsec3param … ; };` blocks + per-signed-zone `dnssec-policy "<name>"; inline-signing yes;` + a `key-directory`. BIND auto-generates keys and signs on load.
- After a reload the agent's `collect_dnssec_state` runs `rndc dnssec -status` (version-tolerant `_parse_dnssec_status`) + `dnssec-dsfromkey` over the KSK key files and reports DS + per-key state via the existing `POST /dns/agents/dnssec-state` (extended with `keys`).

## API + UI
- DNSSEC policy CRUD at `/dns/dnssec-policies` (built-ins can't be edited/deleted; algorithm validated). Driver gate (`_DRIVER_GATED_OPERATIONS`) opened to `bind9` for sign/unsign, `bind9`-only for rollover; Windows DNS refused (422).
- `dnssec/sign` accepts an optional `policy_id`; new `dnssec/rollover` enqueues a `dnssec_rollover` op (`rndc dnssec -rollover -key <tag>`); the info endpoint + `find_zone_dnssec_info` MCP tool return per-key state; new `list_dnssec_policies` MCP read tool.
- Frontend: a **DNSSEC Policies** management page (`/dns/dnssec-policies`) + the zone DNSSEC card gains a policy picker (on sign), a per-key table (tag / type / state), and per-key **Roll** buttons.

## Scope / key model
Per the scoping decision: **everything in one PR** with **BIND-managed keys** — manual KSK/ZSK rollover is the "roll now" escape hatch; routine rollover is automatic per the policy. NSEC3 follows RFC 9276 (the policy editor warns when iterations > 0).

## Verification
- `make ci` — ruff/black/mypy + frontend lint/format/typecheck/build all pass.
- 8 backend tests (`test_dnssec_bind9.py`: control-plane render per policy, ETag shift, policy CRUD + built-in protection + bad-algorithm 422, sign allowed on bind9 / rejected on windows, rollover requires signed zone) + 6 agent tests (`test_dnssec_render.py`: agent named.conf render, custom-policy block, `_parse_dnssec_status`, `_keyfile_is_ksk`). Migration applied cleanly to the dev DB; downgrade drops baselined.

## Caveats (flagged honestly)
1. The **agent runtime** signing path (key-directory generation, `rndc dnssec -status` / `dnssec-dsfromkey` extraction) needs a live BIND9 to fully validate — unit tests cover the rendered `named.conf` + the pure parsers; the kind-based agent e2e boots the agent. A manual validation pass on a test appliance is warranted before relying on it in production.
2. The change spans the **DNS agent image**, so the full effect lands once that image is rebuilt/redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)