### PR TITLE
DHCP configuration importer — Kea / Windows DHCP / ISC dhcpd.conf (#129)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Always read the relevant spec doc(s) before writing code for a feature area.
 | `docs/features/AUTH.md` | Authentication, LDAP/OIDC/SAML, roles, group-scoped permissions, API tokens |
 | `docs/features/ACME.md` | ACME DNS-01 provider — acme-dns-compatible HTTP surface for LE / public-CA cert issuance |
 | `docs/features/INTEGRATIONS.md` | Read-only Kubernetes + Docker mirror integrations; setup, semantics, dashboard surface |
+| `docs/features/MIGRATION.md` | One-shot importers — DNS (BIND9 / Windows DNS / PowerDNS) + DHCP (Kea / Windows DHCP / ISC dhcpd.conf) into native rows; preview → commit, provenance, IPAM linkage |
 | `docs/PERMISSIONS.md` | RBAC permission grammar (`{action, resource_type, resource_id?}`), builtin roles, wildcards |
 | `docs/features/SYSTEM_ADMIN.md` | System config, health dashboard, notifications, backup/restore, service control |
 | `docs/deployment/APPLIANCE.md` | OS appliance build, base OS selection, licensing |

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -249,6 +249,8 @@ backend/alembic/versions/c7e9b3a481f2_appliance_approval_workflow.py:drop_column
 backend/alembic/versions/c7e9b3a481f2_appliance_approval_workflow.py:drop_column:163
 backend/alembic/versions/c7e9b3a481f2_appliance_approval_workflow.py:drop_table:162
 backend/alembic/versions/c7e9d4f81a26_internal_error_table.py:drop_table:125
+backend/alembic/versions/c7f1a3e58b94_dhcp_import_source.py:drop_column:81
+backend/alembic/versions/c7f1a3e58b94_dhcp_import_source.py:drop_column:82
 backend/alembic/versions/c87a3f29d108_appliance_ntp_settings.py:drop_column:85
 backend/alembic/versions/c8a3f1e94d27_user_mfa.py:drop_column:39
 backend/alembic/versions/c8a3f1e94d27_user_mfa.py:drop_column:51

--- a/backend/alembic/versions/c7f1a3e58b94_dhcp_import_source.py
+++ b/backend/alembic/versions/c7f1a3e58b94_dhcp_import_source.py
@@ -1,0 +1,82 @@
+"""dhcp_import: import_source + imported_at on dhcp scope/pool/static/class + dhcp.import module
+
+Revision ID: c7f1a3e58b94
+Revises: f2b6d4a91c37
+Create Date: 2026-05-30 12:00:00.000000
+
+Provenance columns the DHCP configuration importer (issue #129) stamps
+on every row it creates, plus the ``dhcp.import`` feature-module seed so
+the importer surface gates behind a single toggle (mirrors the DNS
+importer's ``b7e2d9a5f314`` migration).
+
+* ``import_source`` — short text, NULL for hand-created rows. Values
+  ``kea | windows_dhcp | isc_dhcp`` map 1:1 to the three sources the
+  importer speaks. Indexed (partial, ``IS NOT NULL``) so "show me
+  everything I imported from last Tuesday's ISC cutover" stays an
+  index scan.
+* ``imported_at`` — wall-clock timestamp of the commit. Lets a re-import
+  of the same source recognise rows a previous run created.
+
+Both columns are nullable + non-default — pre-existing rows stay
+untouched and look "hand-created" to the importer's match logic, which
+is correct: the importer must never claim ownership of rows it didn't
+create. Carried on the four config-bearing DHCP tables the importer
+writes (scope / pool / static assignment / client class); server +
+group rows are not provenance-stamped (the importer reuses existing
+groups, it doesn't mint servers).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c7f1a3e58b94"
+down_revision: Union[str, None] = "f2b6d4a91c37"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLES = (
+    "dhcp_scope",
+    "dhcp_pool",
+    "dhcp_static_assignment",
+    "dhcp_client_class",
+)
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.add_column(
+            table,
+            sa.Column("import_source", sa.String(length=20), nullable=True),
+        )
+        op.add_column(
+            table,
+            sa.Column("imported_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index(
+            f"ix_{table}_import_source",
+            table,
+            ["import_source"],
+            postgresql_where=sa.text("import_source IS NOT NULL"),
+        )
+
+    # ── feature_module seed ────────────────────────────────────────────
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('dhcp.import', TRUE)
+            ON CONFLICT (id) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'dhcp.import'"))
+    for table in _TABLES:
+        op.drop_index(f"ix_{table}_import_source", table_name=table)
+        op.drop_column(table, "imported_at")
+        op.drop_column(table, "import_source")

--- a/backend/app/api/v1/dhcp_import/__init__.py
+++ b/backend/app/api/v1/dhcp_import/__init__.py
@@ -1,0 +1,1 @@
+"""DHCP configuration importer API package (issue #129)."""

--- a/backend/app/api/v1/dhcp_import/router.py
+++ b/backend/app/api/v1/dhcp_import/router.py
@@ -1,0 +1,503 @@
+"""DHCP configuration importer endpoints — preview + commit per source.
+
+Three sources behind one shared canonical IR + commit pipeline:
+
+* ``/dhcp/import/kea/{preview,commit}``  — Kea JSON file upload
+* ``/dhcp/import/windows/{servers,preview,commit}`` — Windows DHCP live pull
+* ``/dhcp/import/isc/{preview,commit}``  — ISC dhcpd.conf file upload
+
+The split between preview (multipart upload / live pull) and commit
+(JSON body carrying the previewed plan) means we don't re-upload /
+re-pull on commit. The operator-edited per-scope conflict actions +
+IPAM linkage choices ride in the commit body, so the server stays
+stateless between the two calls.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+import structlog
+from fastapi import APIRouter, Body, File, Form, HTTPException, UploadFile, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, SuperAdmin
+from app.models.dhcp import DHCPServer
+from app.services.dhcp_import import (
+    CommitResult,
+    IscImportError,
+    KeaImportError,
+    WindowsDHCPImportError,
+    commit_import,
+    detect_conflicts,
+    parse_isc_config,
+    parse_kea_config,
+    parse_windows_dhcp_server,
+)
+from app.services.dhcp_import.canonical import (
+    ConflictAction,
+    ImportedClientClass,
+    ImportedPool,
+    ImportedReservation,
+    ImportedScope,
+    ImportPreview,
+    ScopeConflict,
+)
+
+logger = structlog.get_logger(__name__)
+router = APIRouter()
+
+_MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+
+
+# ── Pydantic IO models ───────────────────────────────────────────────
+
+
+class ImportedReservationOut(BaseModel):
+    ip_address: str
+    mac_address: str
+    hostname: str = ""
+    client_id: str | None = None
+    options: dict = Field(default_factory=dict)
+
+
+class ImportedPoolOut(BaseModel):
+    start_ip: str
+    end_ip: str
+    pool_type: str = "dynamic"
+    name: str = ""
+    class_restriction: str | None = None
+
+
+class ImportedClientClassOut(BaseModel):
+    name: str
+    match_expression: str = ""
+    description: str = ""
+    options: dict = Field(default_factory=dict)
+    supported: bool = True
+    warning: str | None = None
+
+
+class ImportedScopeOut(BaseModel):
+    subnet_cidr: str
+    address_family: str
+    name: str = ""
+    description: str = ""
+    lease_time: int = 86400
+    min_lease_time: int | None = None
+    max_lease_time: int | None = None
+    is_active: bool = True
+    options: dict = Field(default_factory=dict)
+    pools: list[ImportedPoolOut] = Field(default_factory=list)
+    reservations: list[ImportedReservationOut] = Field(default_factory=list)
+    ddns_enabled: bool = False
+    ddns_hostname_policy: str = "client"
+    v6_address_mode: str = "stateful"
+    skipped_options: dict = Field(default_factory=dict)
+    ha_info: str | None = None
+    parse_warnings: list[str] = Field(default_factory=list)
+
+
+class ScopeConflictOut(BaseModel):
+    subnet_cidr: str
+    existing_scope_id: str | None = None
+    existing_subnet_id: str | None = None
+    existing_subnet_name: str | None = None
+    existing_pool_count: int = 0
+    existing_reservation_count: int = 0
+    action: Literal["skip", "overwrite"] = "skip"
+
+
+class PreviewOut(BaseModel):
+    """Preview response shape — also the commit request payload's
+    ``plan`` field, so the UI hands back the same shape it received."""
+
+    source: Literal["kea", "windows_dhcp", "isc_dhcp"]
+    scopes: list[ImportedScopeOut]
+    client_classes: list[ImportedClientClassOut]
+    conflicts: list[ScopeConflictOut]
+    warnings: list[str]
+    unsupported: list[str]
+    total_pools: int
+    total_reservations: int
+    address_family_histogram: dict[str, int]
+
+
+class ConflictDecision(BaseModel):
+    action: Literal["skip", "overwrite"]
+
+
+class CommitIn(BaseModel):
+    target_group_id: uuid.UUID
+    # IPAM linkage: required (both) to auto-create subnets that don't
+    # already exist; omit to link-only (scopes with no matching subnet
+    # fail with an actionable error).
+    ipam_space_id: uuid.UUID | None = None
+    ipam_block_id: uuid.UUID | None = None
+    plan: PreviewOut
+    # Keyed by canonical scope CIDR. Scopes the operator left untouched
+    # default to skip-on-conflict / create-otherwise.
+    conflict_actions: dict[str, ConflictDecision] = Field(default_factory=dict)
+
+
+class WindowsDHCPPreviewIn(BaseModel):
+    server_id: uuid.UUID
+    target_group_id: uuid.UUID
+    ipam_space_id: uuid.UUID | None = None
+
+
+class WindowsDHCPServerOption(BaseModel):
+    id: uuid.UUID
+    name: str
+    host: str
+    group_id: uuid.UUID | None = None
+    group_name: str | None = None
+    has_credentials: bool
+
+
+class CommitScopeOut(BaseModel):
+    subnet_cidr: str
+    action_taken: Literal["created", "overwrote", "skipped", "failed"]
+    scope_id: str | None = None
+    subnet_id: str | None = None
+    subnet_created: bool = False
+    pools_created: int = 0
+    reservations_created: int = 0
+    error: str | None = None
+
+
+class CommitOut(BaseModel):
+    target_group_id: uuid.UUID
+    scopes: list[CommitScopeOut]
+    client_classes_created: int
+    warnings: list[str]
+    total_scopes_created: int
+    total_scopes_overwrote: int
+    total_scopes_skipped: int
+    total_scopes_failed: int
+    total_subnets_created: int
+    total_pools_created: int
+    total_reservations_created: int
+
+
+# ── Conversion helpers (canonical IR ↔ Pydantic) ─────────────────────
+
+
+def _scope_to_pydantic(s: ImportedScope) -> ImportedScopeOut:
+    return ImportedScopeOut(
+        subnet_cidr=s.subnet_cidr,
+        address_family=s.address_family,
+        name=s.name,
+        description=s.description,
+        lease_time=s.lease_time,
+        min_lease_time=s.min_lease_time,
+        max_lease_time=s.max_lease_time,
+        is_active=s.is_active,
+        options=dict(s.options),
+        pools=[ImportedPoolOut(**p.__dict__) for p in s.pools],
+        reservations=[ImportedReservationOut(**r.__dict__) for r in s.reservations],
+        ddns_enabled=s.ddns_enabled,
+        ddns_hostname_policy=s.ddns_hostname_policy,
+        v6_address_mode=s.v6_address_mode,
+        skipped_options=dict(s.skipped_options),
+        ha_info=s.ha_info,
+        parse_warnings=list(s.parse_warnings),
+    )
+
+
+def _preview_to_pydantic(p: ImportPreview) -> PreviewOut:
+    return PreviewOut(
+        source=p.source,
+        scopes=[_scope_to_pydantic(s) for s in p.scopes],
+        client_classes=[ImportedClientClassOut(**c.__dict__) for c in p.client_classes],
+        conflicts=[ScopeConflictOut(**c.__dict__) for c in p.conflicts],
+        warnings=list(p.warnings),
+        unsupported=list(p.unsupported),
+        total_pools=p.total_pools,
+        total_reservations=p.total_reservations,
+        address_family_histogram=dict(p.address_family_histogram),
+    )
+
+
+def _scope_from_pydantic(o: ImportedScopeOut) -> ImportedScope:
+    return ImportedScope(
+        subnet_cidr=o.subnet_cidr,
+        address_family=o.address_family,
+        name=o.name,
+        description=o.description,
+        lease_time=o.lease_time,
+        min_lease_time=o.min_lease_time,
+        max_lease_time=o.max_lease_time,
+        is_active=o.is_active,
+        options=dict(o.options),
+        pools=[ImportedPool(**p.model_dump()) for p in o.pools],
+        reservations=[ImportedReservation(**r.model_dump()) for r in o.reservations],
+        ddns_enabled=o.ddns_enabled,
+        ddns_hostname_policy=o.ddns_hostname_policy,
+        v6_address_mode=o.v6_address_mode,
+        skipped_options=dict(o.skipped_options),
+        ha_info=o.ha_info,
+        parse_warnings=list(o.parse_warnings),
+    )
+
+
+def _preview_from_pydantic(o: PreviewOut) -> ImportPreview:
+    return ImportPreview(
+        source=o.source,
+        scopes=[_scope_from_pydantic(s) for s in o.scopes],
+        client_classes=[ImportedClientClass(**c.model_dump()) for c in o.client_classes],
+        conflicts=[ScopeConflict(**c.model_dump()) for c in o.conflicts],
+        warnings=list(o.warnings),
+        unsupported=list(o.unsupported),
+        total_pools=o.total_pools,
+        total_reservations=o.total_reservations,
+        address_family_histogram=dict(o.address_family_histogram),
+    )
+
+
+def _commit_result_to_pydantic(r: CommitResult) -> CommitOut:
+    return CommitOut(
+        target_group_id=r.target_group_id,
+        scopes=[
+            CommitScopeOut(
+                subnet_cidr=s.subnet_cidr,
+                action_taken=s.action_taken,  # type: ignore[arg-type]
+                scope_id=s.scope_id,
+                subnet_id=s.subnet_id,
+                subnet_created=s.subnet_created,
+                pools_created=s.pools_created,
+                reservations_created=s.reservations_created,
+                error=s.error,
+            )
+            for s in r.scopes
+        ],
+        client_classes_created=r.client_classes_created,
+        warnings=list(r.warnings),
+        total_scopes_created=r.total_scopes_created,
+        total_scopes_overwrote=r.total_scopes_overwrote,
+        total_scopes_skipped=r.total_scopes_skipped,
+        total_scopes_failed=r.total_scopes_failed,
+        total_subnets_created=r.total_subnets_created,
+        total_pools_created=r.total_pools_created,
+        total_reservations_created=r.total_reservations_created,
+    )
+
+
+async def _read_upload(file: UploadFile) -> bytes:
+    data = await file.read()
+    if len(data) > _MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Upload exceeds {_MAX_UPLOAD_BYTES // (1024 * 1024)} MB limit",
+        )
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty upload")
+    return data
+
+
+def _actions(body: CommitIn) -> dict[str, ConflictAction]:
+    return {cidr: decision.action for cidr, decision in body.conflict_actions.items()}
+
+
+async def _run_commit(
+    db: DB, current_user: SuperAdmin, body: CommitIn, *, source: str
+) -> CommitOut:
+    if body.plan.source != source:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Plan source mismatch: endpoint={source} plan={body.plan.source}",
+        )
+    preview = _preview_from_pydantic(body.plan)
+    try:
+        result = await commit_import(
+            db,
+            preview=preview,
+            target_group_id=body.target_group_id,
+            ipam_space_id=body.ipam_space_id,
+            ipam_block_id=body.ipam_block_id,
+            conflict_actions=_actions(body),
+            current_user=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    logger.info(
+        "dhcp_import_commit",
+        source=source,
+        target_group_id=str(body.target_group_id),
+        scopes_created=result.total_scopes_created,
+        scopes_overwrote=result.total_scopes_overwrote,
+        scopes_skipped=result.total_scopes_skipped,
+        scopes_failed=result.total_scopes_failed,
+        subnets_created=result.total_subnets_created,
+        classes_created=result.client_classes_created,
+        user=current_user.display_name,
+    )
+    return _commit_result_to_pydantic(result)
+
+
+async def _attach_conflicts(
+    db: DB,
+    preview: ImportPreview,
+    *,
+    target_group_id: uuid.UUID,
+    ipam_space_id: uuid.UUID | None,
+) -> None:
+    preview.conflicts = await detect_conflicts(
+        db,
+        scope_cidrs=[s.subnet_cidr for s in preview.scopes],
+        target_group_id=target_group_id,
+        ipam_space_id=ipam_space_id,
+    )
+
+
+# ── Kea endpoints ────────────────────────────────────────────────────
+
+
+@router.post("/kea/preview", response_model=PreviewOut)
+async def kea_preview(
+    current_user: SuperAdmin,
+    db: DB,
+    file: UploadFile = File(..., description="Kea kea-dhcp4.conf / kea-dhcp6.conf JSON"),
+    target_group_id: uuid.UUID = Form(...),
+    ipam_space_id: uuid.UUID | None = Form(default=None),
+) -> PreviewOut:
+    """Parse an uploaded Kea config and return the would-create plan +
+    per-scope conflict status. Side-effect-free — no DB writes."""
+    data = await _read_upload(file)
+    try:
+        preview = parse_kea_config(data)
+    except KeaImportError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    await _attach_conflicts(
+        db, preview, target_group_id=target_group_id, ipam_space_id=ipam_space_id
+    )
+    logger.info(
+        "dhcp_import_kea_preview",
+        scopes=len(preview.scopes),
+        pools=preview.total_pools,
+        reservations=preview.total_reservations,
+        conflicts=len(preview.conflicts),
+        user=current_user.display_name,
+    )
+    return _preview_to_pydantic(preview)
+
+
+@router.post("/kea/commit", response_model=CommitOut)
+async def kea_commit(current_user: SuperAdmin, db: DB, body: CommitIn = Body(...)) -> CommitOut:
+    return await _run_commit(db, current_user, body, source="kea")
+
+
+# ── ISC dhcpd.conf endpoints ─────────────────────────────────────────
+
+
+@router.post("/isc/preview", response_model=PreviewOut)
+async def isc_preview(
+    current_user: SuperAdmin,
+    db: DB,
+    file: UploadFile = File(..., description="ISC dhcpd.conf"),
+    target_group_id: uuid.UUID = Form(...),
+    ipam_space_id: uuid.UUID | None = Form(default=None),
+) -> PreviewOut:
+    data = await _read_upload(file)
+    try:
+        preview = parse_isc_config(data)
+    except IscImportError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    await _attach_conflicts(
+        db, preview, target_group_id=target_group_id, ipam_space_id=ipam_space_id
+    )
+    logger.info(
+        "dhcp_import_isc_preview",
+        scopes=len(preview.scopes),
+        pools=preview.total_pools,
+        reservations=preview.total_reservations,
+        conflicts=len(preview.conflicts),
+        user=current_user.display_name,
+    )
+    return _preview_to_pydantic(preview)
+
+
+@router.post("/isc/commit", response_model=CommitOut)
+async def isc_commit(current_user: SuperAdmin, db: DB, body: CommitIn = Body(...)) -> CommitOut:
+    return await _run_commit(db, current_user, body, source="isc_dhcp")
+
+
+# ── Windows DHCP endpoints ───────────────────────────────────────────
+
+
+@router.get("/windows/servers", response_model=list[WindowsDHCPServerOption])
+async def windows_servers(_: SuperAdmin, db: DB) -> list[WindowsDHCPServerOption]:
+    """List every ``driver=windows_dhcp`` server for the UI's picker,
+    with a ``has_credentials`` flag so the UI greys out servers that
+    haven't had WinRM creds configured yet."""
+    rows = (
+        (
+            await db.execute(
+                select(DHCPServer)
+                .where(DHCPServer.driver == "windows_dhcp")
+                .order_by(DHCPServer.name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    out: list[WindowsDHCPServerOption] = []
+    for srv in rows:
+        out.append(
+            WindowsDHCPServerOption(
+                id=srv.id,
+                name=srv.name,
+                host=srv.host or "",
+                group_id=srv.server_group_id,
+                group_name=srv.group.name if srv.group else None,
+                has_credentials=bool(srv.credentials_encrypted),
+            )
+        )
+    return out
+
+
+@router.post("/windows/preview", response_model=PreviewOut)
+async def windows_preview(
+    current_user: SuperAdmin, db: DB, body: WindowsDHCPPreviewIn = Body(...)
+) -> PreviewOut:
+    """Live-pull every IPv4 scope from a Windows DHCP server."""
+    server = (
+        await db.execute(select(DHCPServer).where(DHCPServer.id == body.server_id))
+    ).scalar_one_or_none()
+    if server is None:
+        raise HTTPException(status_code=404, detail=f"DHCP server {body.server_id} not found")
+    if server.driver != "windows_dhcp":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Server {server.name!r} is driver {server.driver!r}; expected windows_dhcp",
+        )
+    if not server.credentials_encrypted:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Server {server.name!r} has no Windows credentials configured. "
+                "Add them via the DHCP server modal before importing."
+            ),
+        )
+    try:
+        preview = await parse_windows_dhcp_server(server)
+    except WindowsDHCPImportError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    await _attach_conflicts(
+        db, preview, target_group_id=body.target_group_id, ipam_space_id=body.ipam_space_id
+    )
+    logger.info(
+        "dhcp_import_windows_preview",
+        server_id=str(body.server_id),
+        scopes=len(preview.scopes),
+        conflicts=len(preview.conflicts),
+        user=current_user.display_name,
+    )
+    return _preview_to_pydantic(preview)
+
+
+@router.post("/windows/commit", response_model=CommitOut)
+async def windows_commit(current_user: SuperAdmin, db: DB, body: CommitIn = Body(...)) -> CommitOut:
+    return await _run_commit(db, current_user, body, source="windows_dhcp")

--- a/backend/app/api/v1/dhcp_import/router.py
+++ b/backend/app/api/v1/dhcp_import/router.py
@@ -107,6 +107,7 @@ class ScopeConflictOut(BaseModel):
     existing_subnet_name: str | None = None
     existing_pool_count: int = 0
     existing_reservation_count: int = 0
+    soft_deleted: bool = False
     action: Literal["skip", "overwrite"] = "skip"
 
 

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -22,6 +22,7 @@ from app.api.v1.conformity import router as conformity_router
 from app.api.v1.custom_fields.router import router as custom_fields_router
 from app.api.v1.dashboards import router as dashboards_router
 from app.api.v1.dhcp import router as dhcp_router
+from app.api.v1.dhcp_import.router import router as dhcp_import_router
 from app.api.v1.diagnostics import router as diagnostics_router
 from app.api.v1.dns.agents import router as dns_agents_router
 from app.api.v1.dns.blocklist_router import router as dns_blocklist_router
@@ -119,6 +120,12 @@ api_v1_router.include_router(
     dependencies=[Depends(require_module("network.customer"))],
 )
 api_v1_router.include_router(dhcp_router, prefix="/dhcp", tags=["dhcp"])
+api_v1_router.include_router(
+    dhcp_import_router,
+    prefix="/dhcp/import",
+    tags=["dhcp-import"],
+    dependencies=[Depends(require_module("dhcp.import"))],
+)
 api_v1_router.include_router(diagnostics_router, prefix="/diagnostics", tags=["diagnostics"])
 api_v1_router.include_router(dns_router, prefix="/dns", tags=["dns"])
 api_v1_router.include_router(dns_agents_router, prefix="/dns", tags=["dns-agents"])

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -336,6 +336,12 @@ class DHCPScope(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
         JSONB, nullable=False, default=dict, server_default=sa_text("'{}'::jsonb")
     )
 
+    # Provenance — set by the DHCP configuration importer (issue #129).
+    # ``import_source`` ∈ {kea, windows_dhcp, isc_dhcp}; NULL for
+    # hand-created scopes. ``imported_at`` is the commit timestamp.
+    import_source: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    imported_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     group: Mapped[DHCPServerGroup] = relationship("DHCPServerGroup", back_populates="scopes")
     pools: Mapped[list[DHCPPool]] = relationship(
         "DHCPPool",
@@ -383,6 +389,10 @@ class DHCPPool(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     lease_time_override: Mapped[int | None] = mapped_column(Integer, nullable=True)
     options_override: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
+    # Provenance — set by the DHCP configuration importer (issue #129).
+    import_source: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    imported_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     scope: Mapped[DHCPScope] = relationship("DHCPScope", back_populates="pools")
 
 
@@ -426,6 +436,10 @@ class DHCPStaticAssignment(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         JSONB, nullable=False, default=dict, server_default=sa_text("'{}'::jsonb")
     )
 
+    # Provenance — set by the DHCP configuration importer (issue #129).
+    import_source: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    imported_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     scope: Mapped[DHCPScope] = relationship("DHCPScope", back_populates="statics")
 
 
@@ -447,6 +461,10 @@ class DHCPClientClass(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     match_expression: Mapped[str] = mapped_column(Text, nullable=False, default="")
     description: Mapped[str] = mapped_column(Text, nullable=False, default="")
     options: Mapped[dict] = mapped_column(JSONB, nullable=False, default=lambda: {})
+
+    # Provenance — set by the DHCP configuration importer (issue #129).
+    import_source: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    imported_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     group: Mapped[DHCPServerGroup] = relationship(
         "DHCPServerGroup", back_populates="client_classes"

--- a/backend/app/services/dhcp_import/__init__.py
+++ b/backend/app/services/dhcp_import/__init__.py
@@ -1,0 +1,52 @@
+"""DHCP configuration importer (issue #129).
+
+Three sources, one canonical IR. Each source module parses the upstream
+config (Kea JSON file, Windows DHCP WinRM live-pull, ISC ``dhcpd.conf``)
+into :class:`ImportPreview`; the shared :func:`commit_import` writes the
+IR to the DB stamping ``import_source`` + ``imported_at`` on every row
+it creates so the provenance is queryable later.
+
+Sister to :mod:`app.services.dns_import` — same preview/commit contract,
+DHCP scopes instead of DNS zones.
+"""
+
+from .canonical import (
+    ConflictAction,
+    ImportedClientClass,
+    ImportedPool,
+    ImportedReservation,
+    ImportedScope,
+    ImportPreview,
+    ImportSource,
+    ScopeConflict,
+)
+from .commit import (
+    CommitResult,
+    CommitScopeResult,
+    commit_import,
+    detect_conflicts,
+)
+from .isc_dhcp_parser import IscImportError, parse_isc_config
+from .kea_parser import KeaImportError, parse_kea_config
+from .windows_dhcp_pull import WindowsDHCPImportError, parse_windows_dhcp_server
+
+__all__ = [
+    "CommitResult",
+    "CommitScopeResult",
+    "ConflictAction",
+    "ImportPreview",
+    "ImportSource",
+    "ImportedClientClass",
+    "ImportedPool",
+    "ImportedReservation",
+    "ImportedScope",
+    "IscImportError",
+    "KeaImportError",
+    "ScopeConflict",
+    "WindowsDHCPImportError",
+    "commit_import",
+    "detect_conflicts",
+    "parse_isc_config",
+    "parse_kea_config",
+    "parse_windows_dhcp_server",
+]

--- a/backend/app/services/dhcp_import/canonical.py
+++ b/backend/app/services/dhcp_import/canonical.py
@@ -1,0 +1,161 @@
+"""Canonical IR shared by all DHCP importers (issue #129).
+
+Every source — Kea JSON file, Windows DHCP WinRM live-pull, ISC
+``dhcpd.conf`` — parses upstream config into the same neutral shape so
+the commit endpoint can stay source-agnostic. The shape is a strict
+subset of what ``DHCPScope`` + ``DHCPPool`` + ``DHCPStaticAssignment``
++ ``DHCPClientClass`` carry: enough to recreate a scope tree faithfully,
+no source-specific extensions. Anything the source carries that we
+can't model lands in ``ImportedScope.parse_warnings`` (per-scope) or
+``ImportPreview.unsupported`` (the "didn't import" panel) so the UI
+surfaces it on the preview.
+
+Mirrors :mod:`app.services.dns_import.canonical` — same two-call
+preview/commit contract, same conflict-action vocabulary, just keyed
+on DHCP scopes instead of DNS zones.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+# Stable enum the importer stamps on every row it creates. Keep in
+# sync with the values the migration writes into ``import_source``.
+ImportSource = Literal["kea", "windows_dhcp", "isc_dhcp"]
+
+# Per-scope conflict resolution. Unlike the DNS importer there is no
+# ``rename`` — a DHCP scope is keyed by its subnet, not a name, and you
+# can't meaningfully rename a subnet. ``skip`` leaves the existing scope
+# alone; ``overwrite`` deletes it (cascading pools + statics) and
+# recreates from the import.
+ConflictAction = Literal["skip", "overwrite"]
+
+
+@dataclass
+class ImportedReservation:
+    """One DHCP reservation (MAC → IP) in the canonical shape.
+
+    Mirrors the columns ``DHCPStaticAssignment`` needs at create-time.
+    ``options`` is a ``{name: value}`` map in SpatiumDDI's canonical
+    option-name vocabulary (see ``drivers/dhcp/base.STANDARD_OPTION_NAMES``).
+    """
+
+    ip_address: str
+    mac_address: str
+    hostname: str = ""
+    client_id: str | None = None
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ImportedPool:
+    """One pool (range) inside a scope.
+
+    ``pool_type`` ∈ {dynamic, excluded, reserved}. ISC ``range``
+    statements + Kea ``pools`` map to ``dynamic``; Windows exclusion
+    ranges + ISC ``deny`` pools map to ``excluded``.
+    """
+
+    start_ip: str
+    end_ip: str
+    pool_type: str = "dynamic"
+    name: str = ""
+    class_restriction: str | None = None
+
+
+@dataclass
+class ImportedClientClass:
+    """One client class — group-scoped on commit.
+
+    ``supported`` is ``False`` when the source's classifier expression
+    can't be faithfully translated to SpatiumDDI's model (ISC's
+    runtime-expression DSL is richer than ours). Unsupported classes
+    are surfaced for manual review and NOT created; supported ones
+    (Kea ``test`` expressions, which are our native shape) are created
+    verbatim.
+    """
+
+    name: str
+    match_expression: str = ""
+    description: str = ""
+    options: dict[str, Any] = field(default_factory=dict)
+    supported: bool = True
+    warning: str | None = None
+
+
+@dataclass
+class ImportedScope:
+    """One DHCP scope in the canonical shape.
+
+    ``subnet_cidr`` is the canonical network (``10.0.0.0/24``).
+    ``address_family`` ∈ {ipv4, ipv6}. ``skipped_options`` records
+    option values the source carried that we dropped (unmapped /
+    unsupported) so the preview can warn without per-option detail.
+    ``ha_info`` carries the source's failover / HA partner identity as
+    an informational string — we don't reconstruct HA topology, the
+    operator does that server-side post-import.
+    """
+
+    subnet_cidr: str
+    address_family: str  # ipv4 | ipv6
+    name: str = ""
+    description: str = ""
+    lease_time: int = 86400
+    min_lease_time: int | None = None
+    max_lease_time: int | None = None
+    is_active: bool = True
+    options: dict[str, Any] = field(default_factory=dict)
+    pools: list[ImportedPool] = field(default_factory=list)
+    reservations: list[ImportedReservation] = field(default_factory=list)
+    ddns_enabled: bool = False
+    ddns_hostname_policy: str = "client"
+    v6_address_mode: str = "stateful"
+    skipped_options: dict[str, Any] = field(default_factory=dict)
+    ha_info: str | None = None
+    parse_warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ScopeConflict:
+    """A scope whose subnet already has a ``DHCPScope`` in the target
+    group, OR whose CIDR matches an existing IPAM subnet.
+
+    ``existing_scope_id`` is set when the target group already serves
+    this subnet — that's the blocking conflict the operator resolves
+    via ``action`` (skip / overwrite). ``existing_subnet_id`` is
+    informational: when set, the commit links the scope to that subnet
+    instead of auto-creating one. When ``existing_scope_id`` is None the
+    row is advisory (no blocking conflict) — it just tells the UI
+    whether the scope will link-or-create its IPAM subnet.
+    """
+
+    subnet_cidr: str
+    existing_scope_id: str | None = None
+    existing_subnet_id: str | None = None
+    existing_subnet_name: str | None = None
+    existing_pool_count: int = 0
+    existing_reservation_count: int = 0
+    action: ConflictAction = "skip"
+
+
+@dataclass
+class ImportPreview:
+    """What ``POST /dhcp/import/{source}/preview`` returns.
+
+    ``scopes`` + ``client_classes`` is the full canonical IR — the
+    commit endpoint re-receives it from the operator (the UI passes it
+    back) so we don't need to store it server-side between the two
+    calls. ``unsupported`` is the "didn't import" panel (hook configs,
+    failover keys, classifier rules we couldn't model).
+    """
+
+    source: ImportSource
+    scopes: list[ImportedScope]
+    client_classes: list[ImportedClientClass]
+    conflicts: list[ScopeConflict]
+    warnings: list[str]
+    unsupported: list[str]
+    total_pools: int
+    total_reservations: int
+    address_family_histogram: dict[str, int]

--- a/backend/app/services/dhcp_import/canonical.py
+++ b/backend/app/services/dhcp_import/canonical.py
@@ -136,6 +136,12 @@ class ScopeConflict:
     existing_subnet_name: str | None = None
     existing_pool_count: int = 0
     existing_reservation_count: int = 0
+    # True when the matched scope is soft-deleted (in Trash). It still
+    # occupies the ``(group_id, subnet_id)`` unique slot, so a plain
+    # create would hit an IntegrityError — surfacing it as a conflict
+    # lets the operator overwrite (hard-delete the trashed row + create
+    # fresh) instead of seeing a cryptic SQL error.
+    soft_deleted: bool = False
     action: ConflictAction = "skip"
 
 

--- a/backend/app/services/dhcp_import/commit.py
+++ b/backend/app/services/dhcp_import/commit.py
@@ -1,0 +1,554 @@
+"""Source-agnostic commit pipeline for the DHCP configuration importer.
+
+Takes a parsed :class:`ImportPreview` plus a per-scope strategy map and
+writes the canonical IR to the DB, stamping ``import_source`` +
+``imported_at`` on every row it creates. The Kea / Windows / ISC source
+modules each emit the same IR; this module is the only place that
+touches the DB so all three sources share IPAM linkage, conflict
+handling, audit logging, and the per-scope savepoint commit pattern.
+
+Per the issue spec, each scope commits independently — a failure on
+scope N doesn't roll back scopes 1..N-1. The commit ledger we return
+carries one row per attempted scope so the operator sees the
+partial-success state cleanly.
+
+IPAM linkage (the DHCP-specific wrinkle the DNS importer doesn't have):
+``DHCPScope.subnet_id`` is mandatory, so every imported scope must bind
+to an IPAM ``Subnet``. For each scope we either **link** to an existing
+subnet whose CIDR matches, or **auto-create** one under the
+operator-chosen IPSpace + IPBlock. A scope with no CIDR match and no
+chosen block fails with a clear, actionable error.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.dhcp import (
+    DHCPClientClass,
+    DHCPPool,
+    DHCPScope,
+    DHCPServerGroup,
+    DHCPStaticAssignment,
+)
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+from .canonical import (
+    ConflictAction,
+    ImportedScope,
+    ImportPreview,
+    ImportSource,
+    ScopeConflict,
+)
+
+
+@dataclass
+class CommitScopeResult:
+    """One scope's outcome from the commit run."""
+
+    subnet_cidr: str
+    action_taken: str  # "created" | "overwrote" | "skipped" | "failed"
+    scope_id: str | None = None
+    subnet_id: str | None = None
+    subnet_created: bool = False
+    pools_created: int = 0
+    reservations_created: int = 0
+    error: str | None = None
+
+
+@dataclass
+class CommitResult:
+    """Return shape from :func:`commit_import`. Mirrored 1:1 by the
+    Pydantic ``CommitOut`` the API endpoint returns."""
+
+    target_group_id: uuid.UUID
+    scopes: list[CommitScopeResult]
+    client_classes_created: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def total_scopes_created(self) -> int:
+        return sum(1 for s in self.scopes if s.action_taken == "created")
+
+    @property
+    def total_scopes_overwrote(self) -> int:
+        return sum(1 for s in self.scopes if s.action_taken == "overwrote")
+
+    @property
+    def total_scopes_skipped(self) -> int:
+        return sum(1 for s in self.scopes if s.action_taken == "skipped")
+
+    @property
+    def total_scopes_failed(self) -> int:
+        return sum(1 for s in self.scopes if s.action_taken == "failed")
+
+    @property
+    def total_subnets_created(self) -> int:
+        return sum(1 for s in self.scopes if s.subnet_created)
+
+    @property
+    def total_pools_created(self) -> int:
+        return sum(s.pools_created for s in self.scopes)
+
+    @property
+    def total_reservations_created(self) -> int:
+        return sum(s.reservations_created for s in self.scopes)
+
+
+def _canonical_cidr(raw: str) -> str:
+    return str(ipaddress.ip_network(raw, strict=False))
+
+
+async def _find_subnet(db: AsyncSession, cidr: str, space_id: uuid.UUID | None) -> Subnet | None:
+    stmt = select(Subnet).where(Subnet.network == cidr, Subnet.deleted_at.is_(None))
+    if space_id is not None:
+        stmt = stmt.where(Subnet.space_id == space_id)
+    return (await db.execute(stmt.limit(1))).scalars().first()
+
+
+async def _existing_scope(
+    db: AsyncSession, group_id: uuid.UUID, subnet_id: uuid.UUID
+) -> DHCPScope | None:
+    stmt = select(DHCPScope).where(
+        DHCPScope.group_id == group_id,
+        DHCPScope.subnet_id == subnet_id,
+        DHCPScope.deleted_at.is_(None),
+    )
+    return (await db.execute(stmt)).scalars().first()
+
+
+async def detect_conflicts(
+    db: AsyncSession,
+    *,
+    scope_cidrs: list[str],
+    target_group_id: uuid.UUID,
+    ipam_space_id: uuid.UUID | None,
+) -> list[ScopeConflict]:
+    """For each parsed scope CIDR, report whether an IPAM subnet already
+    matches (drives link-vs-create) and whether the target group already
+    serves a scope on it (the blocking conflict — skip / overwrite).
+
+    Used by both the preview endpoints (so the UI's per-scope strategy
+    picker has accurate data) and the commit endpoint (so a stale plan
+    still honours the up-to-date conflict state)."""
+    out: list[ScopeConflict] = []
+    for raw in scope_cidrs:
+        try:
+            cidr = _canonical_cidr(raw)
+        except ValueError:
+            continue
+        subnet = await _find_subnet(db, cidr, ipam_space_id)
+        existing_scope_id: str | None = None
+        pool_count = res_count = 0
+        if subnet is not None:
+            scope = await _existing_scope(db, target_group_id, subnet.id)
+            if scope is not None:
+                existing_scope_id = str(scope.id)
+                pool_count = len(scope.pools)
+                res_count = len(scope.statics)
+        # Emit a row when there's anything to tell the operator: an
+        # existing scope (blocking) or an existing subnet (link vs
+        # create). Pure-new scopes don't generate a row.
+        if existing_scope_id is not None or subnet is not None:
+            out.append(
+                ScopeConflict(
+                    subnet_cidr=cidr,
+                    existing_scope_id=existing_scope_id,
+                    existing_subnet_id=str(subnet.id) if subnet else None,
+                    existing_subnet_name=(subnet.name or cidr) if subnet else None,
+                    existing_pool_count=pool_count,
+                    existing_reservation_count=res_count,
+                )
+            )
+    return out
+
+
+async def _create_subnet(
+    db: AsyncSession,
+    *,
+    cidr: str,
+    space_id: uuid.UUID,
+    block_id: uuid.UUID,
+    now: datetime,
+) -> Subnet:
+    """Auto-create an IPAM subnet for an imported scope under the
+    operator-chosen space + block. Validates containment + no overlap;
+    skips the network/broadcast/gateway placeholder rows the manual
+    create path adds (the imported pools + reservations are the real
+    occupancy)."""
+    block = await db.get(IPBlock, block_id)
+    if block is None or block.space_id != space_id or block.deleted_at is not None:
+        raise ValueError("chosen IPAM block is not in the chosen IP space")
+
+    net = ipaddress.ip_network(cidr, strict=False)
+    block_net = ipaddress.ip_network(str(block.network), strict=False)
+    if isinstance(net, ipaddress.IPv4Network) and isinstance(block_net, ipaddress.IPv4Network):
+        contained = net.subnet_of(block_net)
+    elif isinstance(net, ipaddress.IPv6Network) and isinstance(block_net, ipaddress.IPv6Network):
+        contained = net.subnet_of(block_net)
+    else:
+        contained = False
+    if not contained:
+        raise ValueError(f"scope {cidr} is not contained by block {block.network}")
+
+    # Overlap guard — any non-identical subnet in this space whose range
+    # intersects ours blocks the create (operator should link, not
+    # duplicate). An exact match would have been resolved as a link
+    # upstream, so reaching here with an overlap means a partial overlap.
+    existing = (
+        (
+            await db.execute(
+                select(Subnet).where(Subnet.space_id == space_id, Subnet.deleted_at.is_(None))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for other in existing:
+        try:
+            other_net = ipaddress.ip_network(str(other.network), strict=False)
+        except ValueError:
+            continue
+        if other_net.version != net.version:
+            continue
+        if net.overlaps(other_net):
+            raise ValueError(
+                f"scope {cidr} overlaps existing subnet {other.network} in the chosen space — "
+                "link to it or resolve the overlap first"
+            )
+
+    if isinstance(net, ipaddress.IPv6Network):
+        is_multicast = net.subnet_of(ipaddress.IPv6Network("ff00::/8"))
+    else:
+        is_multicast = net.subnet_of(ipaddress.IPv4Network("224.0.0.0/4"))
+
+    subnet = Subnet(
+        space_id=space_id,
+        block_id=block_id,
+        network=cidr,
+        name="",
+        kind="multicast" if is_multicast else "unicast",
+        total_ips=net.num_addresses,
+        utilization_percent=0.0,
+        allocated_ips=0,
+    )
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+def _scope_kwargs(
+    parsed: ImportedScope,
+    *,
+    group_id: uuid.UUID,
+    subnet_id: uuid.UUID,
+    source: ImportSource,
+    now: datetime,
+) -> dict[str, Any]:
+    return dict(
+        group_id=group_id,
+        subnet_id=subnet_id,
+        is_active=parsed.is_active,
+        name=parsed.name or "",
+        description=parsed.description or "",
+        address_family=parsed.address_family,
+        v6_address_mode=parsed.v6_address_mode or "stateful",
+        lease_time=parsed.lease_time,
+        min_lease_time=parsed.min_lease_time,
+        max_lease_time=parsed.max_lease_time,
+        options=dict(parsed.options or {}),
+        ddns_enabled=parsed.ddns_enabled,
+        ddns_hostname_policy=parsed.ddns_hostname_policy or "client",
+        import_source=source,
+        imported_at=now,
+    )
+
+
+async def _commit_one_scope(
+    db: AsyncSession,
+    *,
+    parsed: ImportedScope,
+    target_group_id: uuid.UUID,
+    ipam_space_id: uuid.UUID | None,
+    ipam_block_id: uuid.UUID | None,
+    source: ImportSource,
+    action: ConflictAction,
+    current_user: User,
+    now: datetime,
+) -> CommitScopeResult:
+    """Apply one parsed scope: resolve its IPAM subnet, honour the
+    operator's skip/overwrite choice on an existing scope, then create
+    the scope + pools + reservations. Caller wraps in try/except +
+    rollback so a failed scope doesn't poison the next one."""
+    cidr = _canonical_cidr(parsed.subnet_cidr)
+
+    subnet = await _find_subnet(db, cidr, ipam_space_id)
+    subnet_created = False
+    if subnet is None:
+        if ipam_space_id is None or ipam_block_id is None:
+            return CommitScopeResult(
+                subnet_cidr=cidr,
+                action_taken="failed",
+                error=(
+                    f"No IPAM subnet matches {cidr}. Pick an IP space + block to auto-create the "
+                    "subnet, or create it first and re-run."
+                ),
+            )
+        subnet = await _create_subnet(
+            db, cidr=cidr, space_id=ipam_space_id, block_id=ipam_block_id, now=now
+        )
+        subnet_created = True
+
+    existing = await _existing_scope(db, target_group_id, subnet.id)
+    overwrote = False
+    if existing is not None:
+        if action == "skip":
+            return CommitScopeResult(
+                subnet_cidr=cidr,
+                action_taken="skipped",
+                subnet_id=str(subnet.id),
+                subnet_created=subnet_created,
+            )
+        # overwrite — delete the existing scope (cascades pools + statics)
+        await db.delete(existing)
+        await db.flush()
+        overwrote = True
+
+    scope = DHCPScope(
+        **_scope_kwargs(
+            parsed, group_id=target_group_id, subnet_id=subnet.id, source=source, now=now
+        )
+    )
+    db.add(scope)
+    await db.flush()
+
+    # Link the subnet to the group so IPAM reflects DHCP ownership.
+    subnet.dhcp_server_group_id = target_group_id
+
+    pools_created = 0
+    for p in parsed.pools:
+        db.add(
+            DHCPPool(
+                scope_id=scope.id,
+                name=p.name or "",
+                start_ip=p.start_ip,
+                end_ip=p.end_ip,
+                pool_type=p.pool_type or "dynamic",
+                class_restriction=p.class_restriction,
+                import_source=source,
+                imported_at=now,
+            )
+        )
+        pools_created += 1
+
+    res_created = 0
+    seen_mac: set[str] = set()
+    seen_ip: set[str] = set()
+    for r in parsed.reservations:
+        if r.mac_address in seen_mac or r.ip_address in seen_ip:
+            continue
+        seen_mac.add(r.mac_address)
+        seen_ip.add(r.ip_address)
+        db.add(
+            DHCPStaticAssignment(
+                scope_id=scope.id,
+                ip_address=r.ip_address,
+                mac_address=r.mac_address,
+                hostname=r.hostname or "",
+                client_id=r.client_id,
+                options_override=dict(r.options) if r.options else None,
+                import_source=source,
+                imported_at=now,
+            )
+        )
+        res_created += 1
+
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="update" if overwrote else "create",
+            resource_type="dhcp_scope",
+            resource_id=str(scope.id),
+            resource_display=cidr,
+            result="success",
+            new_value={
+                "import_source": source,
+                "subnet_cidr": cidr,
+                "subnet_created": subnet_created,
+                "pools_created": pools_created,
+                "reservations_created": res_created,
+                "overwrote_existing": overwrote,
+            },
+        )
+    )
+    await db.commit()
+    await db.refresh(scope)
+
+    return CommitScopeResult(
+        subnet_cidr=cidr,
+        action_taken="overwrote" if overwrote else "created",
+        scope_id=str(scope.id),
+        subnet_id=str(subnet.id),
+        subnet_created=subnet_created,
+        pools_created=pools_created,
+        reservations_created=res_created,
+    )
+
+
+async def _commit_client_classes(
+    db: AsyncSession,
+    *,
+    preview: ImportPreview,
+    target_group_id: uuid.UUID,
+    source: ImportSource,
+    now: datetime,
+    current_user: User,
+) -> int:
+    """Create the supported client classes group-wide, skipping any that
+    already exist by name and any flagged unsupported (manual review).
+    Each class commits in its own savepoint."""
+    created = 0
+    for cc in preview.client_classes:
+        if not cc.supported:
+            continue
+        try:
+            existing = (
+                (
+                    await db.execute(
+                        select(DHCPClientClass).where(
+                            DHCPClientClass.group_id == target_group_id,
+                            DHCPClientClass.name == cc.name,
+                        )
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if existing is not None:
+                continue
+            row = DHCPClientClass(
+                group_id=target_group_id,
+                name=cc.name,
+                match_expression=cc.match_expression or "",
+                description=cc.description or "",
+                options=dict(cc.options or {}),
+                import_source=source,
+                imported_at=now,
+            )
+            db.add(row)
+            await db.flush()
+            db.add(
+                AuditLog(
+                    user_id=current_user.id,
+                    user_display_name=current_user.display_name,
+                    auth_source=current_user.auth_source,
+                    action="create",
+                    resource_type="dhcp_client_class",
+                    resource_id=str(row.id),
+                    resource_display=cc.name,
+                    result="success",
+                    new_value={"import_source": source},
+                )
+            )
+            await db.commit()
+            created += 1
+        except Exception:  # noqa: BLE001 — one bad class shouldn't poison the rest
+            await db.rollback()
+    return created
+
+
+async def commit_import(
+    db: AsyncSession,
+    *,
+    preview: ImportPreview,
+    target_group_id: uuid.UUID,
+    ipam_space_id: uuid.UUID | None,
+    ipam_block_id: uuid.UUID | None,
+    conflict_actions: dict[str, ConflictAction],
+    current_user: User,
+) -> CommitResult:
+    """Apply ``preview`` to the DB inside per-scope savepoints.
+
+    ``conflict_actions`` is keyed by the scope's canonical CIDR.
+    Scopes the operator left untouched default to ``skip`` on conflict
+    (don't trample an existing scope) and plain-create otherwise."""
+    grp = (
+        await db.execute(select(DHCPServerGroup).where(DHCPServerGroup.id == target_group_id))
+    ).scalar_one_or_none()
+    if grp is None:
+        raise ValueError(f"Target DHCP server group {target_group_id} does not exist")
+
+    if ipam_space_id is not None:
+        space = await db.get(IPSpace, ipam_space_id)
+        if space is None:
+            raise ValueError(f"IP space {ipam_space_id} does not exist")
+    if ipam_block_id is not None:
+        if ipam_space_id is None:
+            raise ValueError("ipam_block_id requires ipam_space_id")
+        block = await db.get(IPBlock, ipam_block_id)
+        if block is None or block.space_id != ipam_space_id:
+            raise ValueError("IPAM block does not exist in the chosen IP space")
+
+    now = datetime.now(UTC)
+    results: list[CommitScopeResult] = []
+
+    for parsed in preview.scopes:
+        try:
+            cidr = _canonical_cidr(parsed.subnet_cidr)
+        except ValueError:
+            results.append(
+                CommitScopeResult(
+                    subnet_cidr=parsed.subnet_cidr,
+                    action_taken="failed",
+                    error="unparseable subnet CIDR",
+                )
+            )
+            continue
+        action: ConflictAction = conflict_actions.get(cidr, "skip")
+        try:
+            result = await _commit_one_scope(
+                db,
+                parsed=parsed,
+                target_group_id=target_group_id,
+                ipam_space_id=ipam_space_id,
+                ipam_block_id=ipam_block_id,
+                source=preview.source,
+                action=action,
+                current_user=current_user,
+                now=now,
+            )
+        except Exception as exc:  # noqa: BLE001 — operator-facing error capture
+            await db.rollback()
+            result = CommitScopeResult(
+                subnet_cidr=cidr,
+                action_taken="failed",
+                error=str(exc),
+            )
+        results.append(result)
+
+    classes_created = await _commit_client_classes(
+        db,
+        preview=preview,
+        target_group_id=target_group_id,
+        source=preview.source,
+        now=now,
+        current_user=current_user,
+    )
+
+    return CommitResult(
+        target_group_id=target_group_id,
+        scopes=results,
+        client_classes_created=classes_created,
+        warnings=list(preview.warnings),
+    )

--- a/backend/app/services/dhcp_import/commit.py
+++ b/backend/app/services/dhcp_import/commit.py
@@ -116,13 +116,26 @@ async def _find_subnet(db: AsyncSession, cidr: str, space_id: uuid.UUID | None) 
 
 
 async def _existing_scope(
-    db: AsyncSession, group_id: uuid.UUID, subnet_id: uuid.UUID
+    db: AsyncSession,
+    group_id: uuid.UUID,
+    subnet_id: uuid.UUID,
+    *,
+    include_deleted: bool = False,
 ) -> DHCPScope | None:
+    """Find the scope on ``(group_id, subnet_id)``.
+
+    ``include_deleted=True`` bypasses the global soft-delete filter so
+    the importer also catches a *soft-deleted* scope — it still occupies
+    the ``uq_dhcp_scope_group_subnet`` unique slot, so a blind create
+    would raise IntegrityError. Surfacing it lets the operator overwrite
+    (which hard-deletes the trashed row + recreates)."""
     stmt = select(DHCPScope).where(
         DHCPScope.group_id == group_id,
         DHCPScope.subnet_id == subnet_id,
-        DHCPScope.deleted_at.is_(None),
     )
+    if include_deleted:
+        # Disable the global ``deleted_at IS NULL`` filter for this query.
+        stmt = stmt.execution_options(include_deleted=True)
     return (await db.execute(stmt)).scalars().first()
 
 
@@ -149,12 +162,14 @@ async def detect_conflicts(
         subnet = await _find_subnet(db, cidr, ipam_space_id)
         existing_scope_id: str | None = None
         pool_count = res_count = 0
+        soft_deleted = False
         if subnet is not None:
-            scope = await _existing_scope(db, target_group_id, subnet.id)
+            scope = await _existing_scope(db, target_group_id, subnet.id, include_deleted=True)
             if scope is not None:
                 existing_scope_id = str(scope.id)
                 pool_count = len(scope.pools)
                 res_count = len(scope.statics)
+                soft_deleted = scope.deleted_at is not None
         # Emit a row when there's anything to tell the operator: an
         # existing scope (blocking) or an existing subnet (link vs
         # create). Pure-new scopes don't generate a row.
@@ -167,6 +182,7 @@ async def detect_conflicts(
                     existing_subnet_name=(subnet.name or cidr) if subnet else None,
                     existing_pool_count=pool_count,
                     existing_reservation_count=res_count,
+                    soft_deleted=soft_deleted,
                 )
             )
     return out
@@ -308,7 +324,10 @@ async def _commit_one_scope(
         )
         subnet_created = True
 
-    existing = await _existing_scope(db, target_group_id, subnet.id)
+    # include_deleted so a soft-deleted scope (still holding the unique
+    # slot) is handled via skip/overwrite rather than blowing up on the
+    # constraint at flush time.
+    existing = await _existing_scope(db, target_group_id, subnet.id, include_deleted=True)
     overwrote = False
     if existing is not None:
         if action == "skip":
@@ -318,7 +337,9 @@ async def _commit_one_scope(
                 subnet_id=str(subnet.id),
                 subnet_created=subnet_created,
             )
-        # overwrite — delete the existing scope (cascades pools + statics)
+        # overwrite — hard-delete the existing scope (cascades pools +
+        # statics, and purges it from Trash if it was soft-deleted),
+        # freeing the unique slot before the recreate flush.
         await db.delete(existing)
         await db.flush()
         overwrote = True

--- a/backend/app/services/dhcp_import/isc_dhcp_parser.py
+++ b/backend/app/services/dhcp_import/isc_dhcp_parser.py
@@ -1,0 +1,493 @@
+"""ISC dhcpd.conf importer (issue #129 Phase 3).
+
+The hardest source — ISC's ``dhcpd.conf`` is a brace-delimited,
+semicolon-terminated declaration language with no robust open-source
+Python parser, so we own a small tokeniser + recursive-descent walker
+here. We parse the subset that maps to SpatiumDDI's model — ``subnet`` /
+``subnet6`` blocks, ``range`` / ``range6`` / ``pool`` declarations,
+``host`` reservations, scope ``option`` statements, and ``class``
+declarations — and surface everything else (``failover``, ``key``,
+``zone``, ``omapi``, classifier DSL we can't translate) in the
+"didn't import" panel.
+
+Pipeline:
+
+1. Operator uploads ``dhcpd.conf`` (optionally with ``include`` files
+   already inlined — we don't fetch ``include`` targets, we warn).
+2. Tokenise (comment-aware, string-aware) → recursive-descent into a
+   statement tree.
+3. Walk the tree: ``subnet`` → :class:`ImportedScope`, ``range`` →
+   :class:`ImportedPool`, ``host`` → :class:`ImportedReservation`,
+   ``class`` → :class:`ImportedClientClass` (always flagged
+   ``supported=False`` — ISC's runtime-expression DSL doesn't translate
+   to our constrained class model, so classes are surfaced for manual
+   review, never auto-created).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass, field
+from typing import Any
+
+from .canonical import (
+    ImportedClientClass,
+    ImportedPool,
+    ImportedReservation,
+    ImportedScope,
+    ImportPreview,
+)
+from .options import coerce_option_value, isc_option_to_canonical, normalise_mac
+
+MAX_CONFIG_BYTES = 25 * 1024 * 1024
+
+# Top-level / block keywords we recognise as "present but not imported".
+_UNSUPPORTED_KEYWORDS: dict[str, str] = {
+    "failover": "ISC failover peer config is not imported — set HA up at the SpatiumDDI "
+    "server-group level post-import.",
+    "key": "ISC TSIG key declarations are not imported — re-add DDNS keys server-side.",
+    "zone": "ISC DDNS zone declarations are not imported — DDNS is configured per-subnet in "
+    "SpatiumDDI.",
+    "include": "ISC 'include' files are not fetched — inline them before upload or import each "
+    "file separately.",
+    "omapi-port": "ISC OMAPI config is not imported.",
+    "omapi-key": "ISC OMAPI config is not imported.",
+}
+
+
+class IscImportError(ValueError):
+    """Raised when the upload can't be tokenised / parsed at all."""
+
+
+# ── tokeniser ────────────────────────────────────────────────────────
+
+
+@dataclass
+class _Tok:
+    kind: str  # word | str | lbrace | rbrace | semi | comma
+    value: str = ""
+
+
+def _tokenize(text: str) -> list[_Tok]:
+    toks: list[_Tok] = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c in " \t\r\n":
+            i += 1
+            continue
+        if c == "#":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        if c == '"':
+            i += 1
+            buf: list[str] = []
+            while i < n and text[i] != '"':
+                if text[i] == "\\" and i + 1 < n:
+                    buf.append(text[i + 1])
+                    i += 2
+                    continue
+                buf.append(text[i])
+                i += 1
+            i += 1  # closing quote
+            toks.append(_Tok("str", "".join(buf)))
+            continue
+        if c == "{":
+            toks.append(_Tok("lbrace"))
+            i += 1
+            continue
+        if c == "}":
+            toks.append(_Tok("rbrace"))
+            i += 1
+            continue
+        if c == ";":
+            toks.append(_Tok("semi"))
+            i += 1
+            continue
+        if c == ",":
+            toks.append(_Tok("comma"))
+            i += 1
+            continue
+        # bare word — run until whitespace or a structural char
+        start = i
+        while i < n and text[i] not in ' \t\r\n{};,"#':
+            i += 1
+        toks.append(_Tok("word", text[start:i]))
+    return toks
+
+
+# ── statement tree ───────────────────────────────────────────────────
+
+
+@dataclass
+class _Stmt:
+    parts: list[_Tok]  # the head tokens (before { or ;)
+    children: list[_Stmt] | None = field(default=None)
+
+    @property
+    def keyword(self) -> str:
+        return self.parts[0].value.lower() if self.parts and self.parts[0].kind == "word" else ""
+
+
+def _parse_block(toks: list[_Tok], i: int) -> tuple[list[_Stmt], int]:
+    stmts: list[_Stmt] = []
+    cur: list[_Tok] = []
+    n = len(toks)
+    while i < n:
+        t = toks[i]
+        if t.kind == "semi":
+            if cur:
+                stmts.append(_Stmt(parts=cur))
+                cur = []
+            i += 1
+        elif t.kind == "lbrace":
+            children, i = _parse_block(toks, i + 1)
+            stmts.append(_Stmt(parts=cur, children=children))
+            cur = []
+        elif t.kind == "rbrace":
+            if cur:
+                stmts.append(_Stmt(parts=cur))
+                cur = []
+            return stmts, i + 1
+        else:
+            cur.append(t)
+            i += 1
+    if cur:
+        stmts.append(_Stmt(parts=cur))
+    return stmts, i
+
+
+# ── value helpers ────────────────────────────────────────────────────
+
+
+def _value_tokens(parts: list[_Tok], start: int) -> Any:
+    """Collect the value of an ``option name <value>`` style statement
+    from token index ``start`` to the end, splitting on commas into a
+    list. Single value collapses to a scalar."""
+    groups: list[str] = []
+    cur: list[str] = []
+    for t in parts[start:]:
+        if t.kind == "comma":
+            if cur:
+                groups.append(" ".join(cur))
+                cur = []
+            continue
+        cur.append(t.value)
+    if cur:
+        groups.append(" ".join(cur))
+    if not groups:
+        return ""
+    return coerce_option_value(groups)
+
+
+# ── scope / reservation / class walkers ──────────────────────────────
+
+
+def _parse_options_and_leases(
+    body: list[_Stmt],
+) -> tuple[dict[str, Any], int | None, int | None, int | None, list[str]]:
+    """Extract option-data + lease-time params + parse warnings common
+    to subnet / group / shared-network bodies."""
+    options: dict[str, Any] = {}
+    lease_time: int | None = None
+    min_lt: int | None = None
+    max_lt: int | None = None
+    warnings: list[str] = []
+    for st in body:
+        kw = st.keyword
+        if kw == "option" and len(st.parts) >= 2:
+            name = isc_option_to_canonical(st.parts[1].value)
+            options[name] = _value_tokens(st.parts, 2)
+        elif kw == "default-lease-time" and len(st.parts) >= 2:
+            lease_time = _safe_int(st.parts[1].value, lease_time)
+        elif kw == "max-lease-time" and len(st.parts) >= 2:
+            max_lt = _safe_int(st.parts[1].value, max_lt)
+        elif kw == "min-lease-time" and len(st.parts) >= 2:
+            min_lt = _safe_int(st.parts[1].value, min_lt)
+        elif kw == "next-server":
+            warnings.append(
+                "'next-server' (PXE boot server) not auto-imported — wire it via a PXE profile "
+                "(issue #51) post-import."
+            )
+        elif kw == "filename" and len(st.parts) >= 2:
+            options["bootfile-name"] = _value_tokens(st.parts, 1)
+    return options, lease_time, min_lt, max_lt, warnings
+
+
+def _safe_int(value: str, fallback: int | None) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _parse_ranges(body: list[_Stmt]) -> tuple[list[ImportedPool], list[str]]:
+    """Pull ``range`` / ``range6`` statements + ``pool {}`` blocks out of
+    a subnet body."""
+    pools: list[ImportedPool] = []
+    warnings: list[str] = []
+    for st in body:
+        kw = st.keyword
+        if kw in ("range", "range6"):
+            pool = _range_to_pool(st)
+            if pool is not None:
+                pools.append(pool)
+        elif kw == "pool" and st.children is not None:
+            class_restriction = None
+            for sub in st.children:
+                if sub.keyword == "allow" and "members" in [p.value for p in sub.parts]:
+                    # allow members of "class-name";
+                    str_toks = [p.value for p in sub.parts if p.kind == "str"]
+                    if str_toks:
+                        class_restriction = str_toks[0]
+                elif sub.keyword == "deny":
+                    warnings.append(
+                        "ISC pool-level 'deny' rule not imported — SpatiumDDI imports allowed "
+                        "pools only."
+                    )
+            for sub in st.children:
+                if sub.keyword in ("range", "range6"):
+                    pool = _range_to_pool(sub, class_restriction=class_restriction)
+                    if pool is not None:
+                        pools.append(pool)
+    return pools, warnings
+
+
+def _range_to_pool(st: _Stmt, *, class_restriction: str | None = None) -> ImportedPool | None:
+    # range [dynamic-bootp|dynamic|static] <start> [<end>];
+    ips = [
+        p.value
+        for p in st.parts[1:]
+        if p.kind == "word" and p.value.lower() not in ("dynamic-bootp", "dynamic", "static")
+    ]
+    if not ips:
+        return None
+    start_ip = ips[0]
+    end_ip = ips[1] if len(ips) > 1 else ips[0]
+    return ImportedPool(
+        start_ip=start_ip, end_ip=end_ip, pool_type="dynamic", class_restriction=class_restriction
+    )
+
+
+def _parse_host(st: _Stmt) -> tuple[ImportedReservation | None, str | None]:
+    """A ``host name { hardware ethernet MAC; fixed-address IP; }`` block.
+
+    Returns (reservation, fixed_ip) — fixed_ip is used to attach a
+    *global* host to the subnet whose CIDR contains it.
+    """
+    if st.children is None:
+        return None, None
+    mac: str | None = None
+    ip: str | None = None
+    hostname = ""
+    if len(st.parts) >= 2:
+        hostname = st.parts[1].value
+    options: dict[str, Any] = {}
+    for sub in st.children:
+        kw = sub.keyword
+        if kw == "hardware" and len(sub.parts) >= 3:
+            mac = normalise_mac(sub.parts[2].value)
+        elif kw in ("fixed-address", "fixed-address6") and len(sub.parts) >= 2:
+            ip = sub.parts[1].value
+        elif kw == "option" and len(sub.parts) >= 2:
+            options[isc_option_to_canonical(sub.parts[1].value)] = _value_tokens(sub.parts, 2)
+    if mac is None or not ip:
+        return None, None
+    return (
+        ImportedReservation(ip_address=ip, mac_address=mac, hostname=hostname, options=options),
+        ip,
+    )
+
+
+def _subnet_cidr(st: _Stmt) -> str | None:
+    """Resolve the CIDR for a ``subnet <ip> netmask <mask>`` or
+    ``subnet6 <cidr>`` declaration."""
+    kw = st.keyword
+    words = [p.value for p in st.parts if p.kind == "word"]
+    try:
+        if kw == "subnet6" and len(words) >= 2:
+            return str(ipaddress.ip_network(words[1], strict=False))
+        if kw == "subnet" and len(words) >= 4 and words[2].lower() == "netmask":
+            return str(ipaddress.ip_network(f"{words[1]}/{words[3]}", strict=False))
+    except ValueError:
+        return None
+    return None
+
+
+def _build_scope(
+    st: _Stmt,
+    *,
+    inherited_options: dict[str, Any],
+    inherited_lease: int | None,
+) -> tuple[ImportedScope | None, list[ImportedReservation]]:
+    cidr = _subnet_cidr(st)
+    if cidr is None:
+        return None, []
+    body = st.children or []
+    options, lease_time, min_lt, max_lt, opt_warnings = _parse_options_and_leases(body)
+    pools, range_warnings = _parse_ranges(body)
+
+    # host reservations declared directly inside the subnet block
+    inline_res: list[ImportedReservation] = []
+    for sub in body:
+        if sub.keyword == "host":
+            res, _ = _parse_host(sub)
+            if res is not None:
+                inline_res.append(res)
+
+    af = "ipv6" if st.keyword == "subnet6" else "ipv4"
+    merged_options = {**inherited_options, **options}
+    return (
+        ImportedScope(
+            subnet_cidr=cidr,
+            address_family=af,
+            lease_time=lease_time or inherited_lease or 86400,
+            min_lease_time=min_lt,
+            max_lease_time=max_lt,
+            options=merged_options,
+            pools=pools,
+            reservations=inline_res,
+            parse_warnings=sorted(set(opt_warnings + range_warnings)),
+        ),
+        [],
+    )
+
+
+def _build_class(st: _Stmt) -> ImportedClientClass:
+    name = ""
+    str_toks = [p.value for p in st.parts if p.kind == "str"]
+    if str_toks:
+        name = str_toks[0]
+    elif len(st.parts) >= 2:
+        name = st.parts[1].value
+    match_expr = ""
+    for sub in st.children or []:
+        if sub.keyword in ("match", "spawn"):
+            match_expr = " ".join(p.value for p in sub.parts)
+            break
+    return ImportedClientClass(
+        name=name or "unnamed-class",
+        match_expression=match_expr,
+        description="Imported from ISC dhcpd.conf — review the match expression before enabling.",
+        supported=False,
+        warning="ISC classifier DSL doesn't map to SpatiumDDI's client-class model; "
+        "left for manual review.",
+    )
+
+
+# ── top-level walk ───────────────────────────────────────────────────
+
+
+def parse_isc_config(data: bytes) -> ImportPreview:
+    if len(data) > MAX_CONFIG_BYTES:
+        raise IscImportError(f"Upload exceeds {MAX_CONFIG_BYTES // (1024 * 1024)} MB limit")
+    if not data:
+        raise IscImportError("Empty upload")
+    try:
+        text = data.decode("utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        raise IscImportError(f"Could not read upload as text: {exc}") from exc
+
+    toks = _tokenize(text)
+    stmts, _ = _parse_block(toks, 0)
+
+    scopes: list[ImportedScope] = []
+    client_classes: list[ImportedClientClass] = []
+    global_hosts: list[ImportedReservation] = []
+    warnings: list[str] = []
+    unsupported: list[str] = []
+
+    # Global defaults (top-level options + lease times) become the base
+    # every subnet inherits.
+    g_options, g_lease, _, _, g_warn = _parse_options_and_leases(stmts)
+    warnings.extend(g_warn)
+
+    def _walk(container: list[_Stmt], depth_label: str | None) -> None:
+        for st in container:
+            kw = st.keyword
+            if kw in ("subnet", "subnet6"):
+                scope, _ = _build_scope(st, inherited_options=g_options, inherited_lease=g_lease)
+                if scope is not None:
+                    scopes.append(scope)
+                else:
+                    warnings.append("Skipped a subnet declaration with an unparseable CIDR.")
+            elif kw == "shared-network" and st.children is not None:
+                warnings.append(
+                    "'shared-network' grouping flattened — member subnets imported individually."
+                )
+                _walk(st.children, "shared-network")
+            elif kw == "group" and st.children is not None:
+                _walk(st.children, "group")
+            elif kw == "host":
+                res, ip = _parse_host(st)
+                if res is not None:
+                    global_hosts.append(res)
+            elif kw == "class" and st.children is not None:
+                client_classes.append(_build_class(st))
+            elif kw == "subclass":
+                unsupported.append(
+                    "ISC 'subclass' membership rules are not imported (manual review)."
+                )
+            elif kw in _UNSUPPORTED_KEYWORDS:
+                unsupported.append(_UNSUPPORTED_KEYWORDS[kw])
+
+    _walk(stmts, None)
+
+    # Attach global host reservations to the subnet whose CIDR contains
+    # the fixed-address.
+    nets: list[tuple[Any, ImportedScope]] = []
+    for s in scopes:
+        try:
+            nets.append((ipaddress.ip_network(s.subnet_cidr, strict=False), s))
+        except ValueError:
+            continue
+    unattached = 0
+    for host in global_hosts:
+        try:
+            addr = ipaddress.ip_address(host.ip_address)
+        except ValueError:
+            unattached += 1
+            continue
+        placed = False
+        for net, scope in nets:
+            if addr in net:
+                scope.reservations.append(host)
+                placed = True
+                break
+        if not placed:
+            unattached += 1
+    if unattached:
+        warnings.append(
+            f"{unattached} global host reservation(s) couldn't be matched to an imported subnet "
+            "(no containing subnet, or a non-IP fixed-address) — skipped."
+        )
+
+    if not scopes and not client_classes:
+        raise IscImportError("No subnet declarations found — is this an ISC dhcpd.conf?")
+
+    af_hist: dict[str, int] = {}
+    for s in scopes:
+        af_hist[s.address_family] = af_hist.get(s.address_family, 0) + 1
+
+    return ImportPreview(
+        source="isc_dhcp",
+        scopes=scopes,
+        client_classes=client_classes,
+        conflicts=[],
+        warnings=sorted(set(warnings)),
+        unsupported=sorted(set(unsupported)),
+        total_pools=sum(len(s.pools) for s in scopes),
+        total_reservations=sum(len(s.reservations) for s in scopes),
+        address_family_histogram=af_hist,
+    )

--- a/backend/app/services/dhcp_import/isc_dhcp_parser.py
+++ b/backend/app/services/dhcp_import/isc_dhcp_parser.py
@@ -158,7 +158,6 @@ def _parse_block(toks: list[_Tok], i: int) -> tuple[list[_Stmt], int]:
         elif t.kind == "rbrace":
             if cur:
                 stmts.append(_Stmt(parts=cur))
-                cur = []
             return stmts, i + 1
         else:
             cur.append(t)

--- a/backend/app/services/dhcp_import/kea_parser.py
+++ b/backend/app/services/dhcp_import/kea_parser.py
@@ -1,0 +1,370 @@
+"""Kea JSON config importer (issue #129 Phase 1).
+
+The cleanest source — a Kea ``kea-dhcp4.conf`` / ``kea-dhcp6.conf`` is
+exactly the shape SpatiumDDI's own Kea driver renders, just running on
+a *non-managed* daemon. We invert the driver's render path: walk the
+``Dhcp4`` / ``Dhcp6`` structure and emit the canonical IR.
+
+Pipeline:
+
+1. Operator uploads the raw Kea config file (``.conf`` / ``.json``).
+2. We strip Kea's JSON-with-comments extensions (``//`` + ``#`` line
+   comments, ``/* */`` block comments — string-aware so a ``#`` inside
+   an option value survives) and ``json.loads`` the result.
+3. We accept either a wrapped config (top-level ``{"Dhcp4": {...}}``)
+   or a bare ``Dhcp4`` body (``{"subnet4": [...]}``) — operators paste
+   both.
+4. Each ``subnet4`` / ``subnet6`` becomes an :class:`ImportedScope`;
+   ``pools`` → :class:`ImportedPool`, ``reservations`` →
+   :class:`ImportedReservation`, ``option-data`` → canonical options.
+   Top-level ``client-classes`` become :class:`ImportedClientClass`.
+
+We deliberately don't carry hook libraries (HA / host-cache /
+lease-cmds), control-agent config, or the lease database across — those
+are surfaced in the "didn't import" panel; the operator wires HA up
+server-side post-import (SpatiumDDI's HA is implicit at the group level).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+from typing import Any
+
+from .canonical import (
+    ImportedClientClass,
+    ImportedPool,
+    ImportedReservation,
+    ImportedScope,
+    ImportPreview,
+)
+from .options import coerce_option_value, kea_option_to_canonical, normalise_mac
+
+# Hard cap on uploaded config. A Kea config with thousands of
+# reservations is still well under this; 25 MB stops a pathological
+# upload from blowing out memory on parse.
+MAX_CONFIG_BYTES = 25 * 1024 * 1024
+
+# Kea top-level keys we explicitly note as "not imported" when present.
+_UNSUPPORTED_KEYS: dict[str, str] = {
+    "hooks-libraries": "Kea hook libraries (HA / host-cache / lease-cmds) are not imported — "
+    "SpatiumDDI's HA is implicit at the server-group level; configure it post-import.",
+    "control-socket": "Kea control-socket config is not imported (SpatiumDDI's agent owns the "
+    "control channel).",
+    "lease-database": "Kea lease database config is not imported — leases are transient and "
+    "repopulate from the running daemon once a server is attached.",
+    "loggers": "Kea logger config is not imported.",
+}
+
+
+class KeaImportError(ValueError):
+    """Raised when the upload itself can't be parsed as Kea JSON.
+
+    Per-scope issues don't raise this — they land in
+    ``ImportPreview.warnings`` / ``ImportedScope.parse_warnings`` so the
+    operator sees partial success and can fix-and-reupload.
+    """
+
+
+def _strip_jsonc(text: str) -> str:
+    """Strip ``//`` + ``#`` line comments and ``/* */`` block comments,
+    string-aware so a comment marker inside a quoted value survives."""
+    out: list[str] = []
+    i, n = 0, len(text)
+    in_str = False
+    while i < n:
+        c = text[i]
+        if in_str:
+            out.append(c)
+            if c == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if c == '"':
+                in_str = False
+            i += 1
+            continue
+        if c == '"':
+            in_str = True
+            out.append(c)
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c == "#":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def _split_option_value(data: str) -> Any:
+    """Kea ``option-data`` ``data`` is a comma-separated string. Split
+    into a list when multi-valued, keep scalar otherwise — matching how
+    the Kea driver re-joins lists with ``", "``."""
+    if "," in data:
+        parts = [p.strip() for p in data.split(",")]
+        return parts
+    return data.strip()
+
+
+def _parse_option_data(raw: list[dict[str, Any]] | None, *, address_family: str) -> dict[str, Any]:
+    """Translate a Kea ``option-data`` list into a ``{name: value}`` map
+    in SpatiumDDI's canonical vocabulary. ``code``-form options (vendor
+    options with no Kea name) become ``code:NN`` keys — the same shape
+    the Kea driver round-trips."""
+    out: dict[str, Any] = {}
+    for entry in raw or []:
+        if not isinstance(entry, dict):
+            continue
+        data = entry.get("data")
+        if data is None:
+            continue
+        value = _split_option_value(str(data))
+        if entry.get("name"):
+            key = kea_option_to_canonical(str(entry["name"]), address_family=address_family)
+        elif entry.get("code") is not None:
+            key = f"code:{entry['code']}"
+        else:
+            continue
+        out[key] = coerce_option_value(value)
+    return out
+
+
+def _parse_pool(entry: dict[str, Any]) -> ImportedPool | None:
+    """Kea pool: ``{"pool": "10.0.0.10 - 10.0.0.100"}`` or
+    ``{"pool": "10.0.0.0/25"}``."""
+    raw = entry.get("pool")
+    if not raw or not isinstance(raw, str):
+        return None
+    raw = raw.strip()
+    if " - " in raw or " -" in raw or "- " in raw:
+        start, _, end = raw.partition("-")
+        start_ip, end_ip = start.strip(), end.strip()
+    elif "/" in raw:
+        try:
+            net = ipaddress.ip_network(raw, strict=False)
+        except ValueError:
+            return None
+        start_ip, end_ip = str(net[0]), str(net[-1])
+    else:
+        # Single address pool.
+        start_ip = end_ip = raw
+    if not start_ip or not end_ip:
+        return None
+    return ImportedPool(
+        start_ip=start_ip,
+        end_ip=end_ip,
+        pool_type="dynamic",
+        class_restriction=entry.get("client-class"),
+    )
+
+
+def _parse_reservation(entry: dict[str, Any], *, address_family: str) -> ImportedReservation | None:
+    if not isinstance(entry, dict):
+        return None
+    mac = normalise_mac(entry.get("hw-address"))
+    if mac is None:
+        # DUID-only v6 reservations have no MAC — we can't model those
+        # (DHCPStaticAssignment is MAC-keyed). Caller records a warning.
+        return None
+    if address_family == "ipv6":
+        addrs = entry.get("ip-addresses") or []
+        ip = str(addrs[0]) if addrs else None
+    else:
+        ip = entry.get("ip-address")
+    if not ip:
+        return None
+    return ImportedReservation(
+        ip_address=str(ip),
+        mac_address=mac,
+        hostname=str(entry.get("hostname") or ""),
+        client_id=entry.get("client-id"),
+        options=_parse_option_data(entry.get("option-data"), address_family=address_family),
+    )
+
+
+def _parse_subnet(
+    entry: dict[str, Any],
+    *,
+    address_family: str,
+    global_options: dict[str, Any],
+    global_lease_time: int,
+    global_ddns: bool,
+    warnings: list[str],
+) -> ImportedScope | None:
+    cidr = entry.get("subnet")
+    if not cidr or not isinstance(cidr, str):
+        warnings.append("Skipped a subnet with no 'subnet' CIDR field.")
+        return None
+    try:
+        net = ipaddress.ip_network(cidr.strip(), strict=False)
+    except ValueError:
+        warnings.append(f"Skipped subnet {cidr!r} — not a valid CIDR.")
+        return None
+    canonical = str(net)
+
+    parse_warnings: list[str] = []
+    pools: list[ImportedPool] = []
+    for p in entry.get("pools") or []:
+        if isinstance(p, dict):
+            pool = _parse_pool(p)
+            if pool is not None:
+                pools.append(pool)
+
+    reservations: list[ImportedReservation] = []
+    skipped_duid = 0
+    for r in entry.get("reservations") or []:
+        res = _parse_reservation(r, address_family=address_family)
+        if res is not None:
+            reservations.append(res)
+        elif isinstance(r, dict) and not r.get("hw-address"):
+            skipped_duid += 1
+    if skipped_duid:
+        parse_warnings.append(
+            f"{skipped_duid} DUID-only reservation(s) skipped — only MAC-keyed reservations import."
+        )
+
+    # Scope options override global option-data so the imported scope
+    # behaves identically without a separate group-options surface.
+    scope_options = _parse_option_data(entry.get("option-data"), address_family=address_family)
+    options = {**global_options, **scope_options}
+
+    lease_time = int(entry.get("valid-lifetime") or global_lease_time or 86400)
+    min_lt = entry.get("min-valid-lifetime")
+    max_lt = entry.get("max-valid-lifetime")
+    ddns_enabled = bool(entry.get("ddns-send-updates", global_ddns))
+
+    return ImportedScope(
+        subnet_cidr=canonical,
+        address_family=address_family,
+        name=str(entry.get("comment") or ""),
+        lease_time=lease_time,
+        min_lease_time=int(min_lt) if min_lt is not None else None,
+        max_lease_time=int(max_lt) if max_lt is not None else None,
+        is_active=True,
+        options=options,
+        pools=pools,
+        reservations=reservations,
+        ddns_enabled=ddns_enabled,
+        v6_address_mode="stateful",
+        parse_warnings=parse_warnings,
+    )
+
+
+def _parse_client_classes(
+    raw: list[dict[str, Any]] | None, *, address_family: str
+) -> list[ImportedClientClass]:
+    out: list[ImportedClientClass] = []
+    for entry in raw or []:
+        if not isinstance(entry, dict) or not entry.get("name"):
+            continue
+        # Skip the built-in DROP class SpatiumDDI's own MAC-blocklist
+        # renders — re-importing it would be noise.
+        name = str(entry["name"])
+        if name == "DROP":
+            continue
+        out.append(
+            ImportedClientClass(
+                name=name,
+                match_expression=str(entry.get("test") or ""),
+                options=_parse_option_data(entry.get("option-data"), address_family=address_family),
+                supported=True,
+            )
+        )
+    return out
+
+
+def _dhcp_block(obj: dict[str, Any], wrapper: str, subnet_key: str) -> dict[str, Any] | None:
+    """Resolve the Dhcp4 / Dhcp6 body whether the config is wrapped
+    (``{"Dhcp4": {...}}``) or bare (``{"subnet4": [...]}``)."""
+    if wrapper in obj and isinstance(obj[wrapper], dict):
+        return obj[wrapper]
+    if subnet_key in obj:
+        return obj
+    return None
+
+
+def parse_kea_config(data: bytes) -> ImportPreview:
+    """Parse an uploaded Kea config into the canonical import preview."""
+    if len(data) > MAX_CONFIG_BYTES:
+        raise KeaImportError(f"Upload exceeds {MAX_CONFIG_BYTES // (1024 * 1024)} MB limit")
+    if not data:
+        raise KeaImportError("Empty upload")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise KeaImportError(f"File is not UTF-8 text: {exc}") from exc
+
+    try:
+        obj = json.loads(_strip_jsonc(text))
+    except json.JSONDecodeError as exc:
+        raise KeaImportError(f"Not valid Kea JSON (after comment stripping): {exc}") from exc
+    if not isinstance(obj, dict):
+        raise KeaImportError("Top-level Kea config must be a JSON object")
+
+    warnings: list[str] = []
+    unsupported: list[str] = []
+    scopes: list[ImportedScope] = []
+    client_classes: list[ImportedClientClass] = []
+
+    for wrapper, subnet_key, af in (("Dhcp4", "subnet4", "ipv4"), ("Dhcp6", "subnet6", "ipv6")):
+        block = _dhcp_block(obj, wrapper, subnet_key)
+        if block is None:
+            continue
+        global_options = _parse_option_data(block.get("option-data"), address_family=af)
+        global_lease_time = int(block.get("valid-lifetime") or 86400)
+        global_ddns = bool(block.get("ddns-send-updates", False))
+        if global_options:
+            warnings.append(
+                f"{wrapper}: {len(global_options)} global option(s) applied to every "
+                f"imported {af} scope (SpatiumDDI has no group-wide option surface on import)."
+            )
+        for raw_subnet in block.get(subnet_key) or []:
+            if not isinstance(raw_subnet, dict):
+                continue
+            scope = _parse_subnet(
+                raw_subnet,
+                address_family=af,
+                global_options=global_options,
+                global_lease_time=global_lease_time,
+                global_ddns=global_ddns,
+                warnings=warnings,
+            )
+            if scope is not None:
+                scopes.append(scope)
+        client_classes.extend(_parse_client_classes(block.get("client-classes"), address_family=af))
+        for key, note in _UNSUPPORTED_KEYS.items():
+            if key in block:
+                unsupported.append(note)
+
+    if not scopes and not client_classes:
+        raise KeaImportError(
+            "No Dhcp4/Dhcp6 subnets or client-classes found — is this a Kea config file?"
+        )
+
+    af_hist: dict[str, int] = {}
+    for s in scopes:
+        af_hist[s.address_family] = af_hist.get(s.address_family, 0) + 1
+
+    return ImportPreview(
+        source="kea",
+        scopes=scopes,
+        client_classes=client_classes,
+        conflicts=[],  # populated by the router against the target group
+        warnings=warnings,
+        unsupported=sorted(set(unsupported)),
+        total_pools=sum(len(s.pools) for s in scopes),
+        total_reservations=sum(len(s.reservations) for s in scopes),
+        address_family_histogram=af_hist,
+    )

--- a/backend/app/services/dhcp_import/options.py
+++ b/backend/app/services/dhcp_import/options.py
@@ -1,0 +1,103 @@
+"""Shared option-name maps + value helpers for the DHCP importers.
+
+The Kea driver (``drivers/dhcp/kea.py``) and the Windows driver
+(``drivers/dhcp/windows.py``) own the *forward* direction (SpatiumDDI
+canonical option-name → backend wire name / option-id). The importers
+need the *inverse*: backend → canonical. Rather than re-derive it three
+times, the inverse maps live here, built off the same source-of-truth
+constants where practical.
+
+Canonical option names are the keys of
+``drivers.dhcp.base.STANDARD_OPTION_NAMES`` (``routers`` / ``dns-servers``
+/ ``domain-name`` / …). Unknown source option names are kept verbatim
+(so the value round-trips through ``DHCPScope.options`` and the Kea
+driver re-emits it under the same name) and recorded as a warning, never
+silently dropped.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.drivers.dhcp.kea import _KEA_OPTION_NAMES, _KEA_OPTION_NAMES_V6
+
+# ── Kea wire name → SpatiumDDI canonical name ────────────────────────
+#
+# Inverse of the driver's forward maps. A given canonical name (e.g.
+# ``dns-servers``) renders to ``domain-name-servers`` on the wire, so the
+# inverse maps ``domain-name-servers`` back to ``dns-servers``.
+
+_KEA_V4_NAME_TO_CANONICAL: dict[str, str] = {wire: name for name, wire in _KEA_OPTION_NAMES.items()}
+_KEA_V6_NAME_TO_CANONICAL: dict[str, str] = {
+    wire: name for name, wire in _KEA_OPTION_NAMES_V6.items()
+}
+
+
+def kea_option_to_canonical(name: str, *, address_family: str = "ipv4") -> str:
+    """Map a Kea ``option-data`` name back to the SpatiumDDI canonical
+    name, falling back to the name verbatim when unrecognised."""
+    table = _KEA_V6_NAME_TO_CANONICAL if address_family == "ipv6" else _KEA_V4_NAME_TO_CANONICAL
+    return table.get(name, name)
+
+
+# ── ISC dhcpd.conf option name → SpatiumDDI canonical name ───────────
+#
+# ISC uses its own option vocabulary; the common subset maps cleanly.
+# Anything not here is kept verbatim + warned.
+
+_ISC_NAME_TO_CANONICAL: dict[str, str] = {
+    "routers": "routers",
+    "domain-name-servers": "dns-servers",
+    "domain-name": "domain-name",
+    "broadcast-address": "broadcast-address",
+    "ntp-servers": "ntp-servers",
+    "tftp-server-name": "tftp-server-name",
+    "bootfile-name": "bootfile-name",
+    "domain-search": "domain-search",
+    "interface-mtu": "mtu",
+    "time-offset": "time-offset",
+}
+
+
+def isc_option_to_canonical(name: str) -> str:
+    """Map an ISC option name to the SpatiumDDI canonical name, falling
+    back to the name verbatim when unrecognised."""
+    return _ISC_NAME_TO_CANONICAL.get(name, name)
+
+
+# ── MAC normalisation ────────────────────────────────────────────────
+#
+# Postgres MACADDR accepts colon- or dash-separated 6-byte hex. Sources
+# emit a mix (Kea ``aa:bb:..``; ISC ``hardware ethernet aa:bb:..``;
+# Windows ClientId ``aa-bb-..`` sometimes 7-octet with a ``01-`` hw-type
+# prefix). Normalise everything to lower-case colon form.
+
+_MAC_OCTET_RE = re.compile(r"^[0-9a-f]{2}$")
+
+
+def normalise_mac(raw: str | None) -> str | None:
+    """Return ``aa:bb:cc:dd:ee:ff`` (lower) or None if not a valid MAC.
+
+    Strips a leading ``01-``/``01:`` Ethernet hardware-type prefix when
+    the value has 7 octets (Windows ClientId form).
+    """
+    if not raw:
+        return None
+    parts = re.split(r"[-:]", raw.strip().lower())
+    if len(parts) == 7 and parts[0] == "01":
+        parts = parts[1:]
+    if len(parts) != 6:
+        return None
+    if not all(_MAC_OCTET_RE.fullmatch(p) for p in parts):
+        return None
+    return ":".join(parts)
+
+
+def coerce_option_value(value: Any) -> Any:
+    """Normalise a parsed option value into the JSONB shape the scope
+    stores. Single-element lists collapse to scalars for the options
+    the Kea driver treats as scalar; everything else stays as-is."""
+    if isinstance(value, list) and len(value) == 1:
+        return value[0]
+    return value

--- a/backend/app/services/dhcp_import/windows_dhcp_pull.py
+++ b/backend/app/services/dhcp_import/windows_dhcp_pull.py
@@ -1,0 +1,117 @@
+"""Windows DHCP live-pull importer (issue #129 Phase 2).
+
+Reuses the existing :class:`WindowsDHCPReadOnlyDriver` Path A read
+methods — the driver already speaks ``Get-DhcpServerv4Scope`` +
+``Get-DhcpServerv4OptionValue`` + ``Get-DhcpServerv4ExclusionRange`` +
+``Get-DhcpServerv4Reservation`` for the Logs surface and lease sync, so
+the importer just iterates ``get_scopes()`` and reshapes the neutral
+dicts into the canonical IR.
+
+Windows DHCP is IPv4-only in our driver, so every imported scope is
+``ipv4``. Option names already arrive in SpatiumDDI's canonical
+vocabulary (the driver's ``_translate_options`` did the option-id →
+name mapping), so there's no per-option translation here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.drivers.dhcp.windows import WindowsDHCPReadOnlyDriver
+
+from .canonical import (
+    ImportedPool,
+    ImportedReservation,
+    ImportedScope,
+    ImportPreview,
+)
+from .options import normalise_mac
+
+
+class WindowsDHCPImportError(RuntimeError):
+    """Raised when the live pull from the Windows DHCP server fails
+    (WinRM transport, auth, or PowerShell error)."""
+
+
+def _scope_from_dict(raw: dict[str, Any]) -> ImportedScope | None:
+    cidr = raw.get("subnet_cidr")
+    if not cidr:
+        return None
+    pools: list[ImportedPool] = []
+    for p in raw.get("pools") or []:
+        if p.get("start_ip") and p.get("end_ip"):
+            pools.append(
+                ImportedPool(
+                    start_ip=str(p["start_ip"]),
+                    end_ip=str(p["end_ip"]),
+                    pool_type=str(p.get("pool_type") or "dynamic"),
+                )
+            )
+    reservations: list[ImportedReservation] = []
+    for s in raw.get("statics") or []:
+        mac = normalise_mac(s.get("mac_address"))
+        if mac is None or not s.get("ip_address"):
+            continue
+        reservations.append(
+            ImportedReservation(
+                ip_address=str(s["ip_address"]),
+                mac_address=mac,
+                hostname=str(s.get("hostname") or ""),
+                client_id=s.get("client_id"),
+            )
+        )
+    return ImportedScope(
+        subnet_cidr=str(cidr),
+        address_family="ipv4",
+        name=str(raw.get("name") or ""),
+        description=str(raw.get("description") or ""),
+        lease_time=int(raw.get("lease_time") or 86400),
+        is_active=bool(raw.get("is_active", True)),
+        options=dict(raw.get("options") or {}),
+        pools=pools,
+        reservations=reservations,
+    )
+
+
+async def parse_windows_dhcp_server(server: Any) -> ImportPreview:
+    """Live-pull every IPv4 scope from a Windows DHCP server and reshape
+    into the canonical import preview.
+
+    ``server`` is a ``DHCPServer`` row with ``driver == "windows_dhcp"``
+    and WinRM credentials configured. The pull blocks until every scope
+    has been walked.
+    """
+    driver = WindowsDHCPReadOnlyDriver()
+    try:
+        raw_scopes = await driver.get_scopes(server)
+    except Exception as exc:  # noqa: BLE001 — surface any WinRM/PS error
+        raise WindowsDHCPImportError(f"Windows DHCP pull failed: {exc}") from exc
+
+    scopes: list[ImportedScope] = []
+    warnings: list[str] = []
+    for raw in raw_scopes:
+        scope = _scope_from_dict(raw)
+        if scope is not None:
+            scopes.append(scope)
+
+    # Surface raw / unmapped option ids (the driver keeps them as
+    # ``opt-<id>``) so the operator knows they came across opaque.
+    raw_option_scopes = sum(1 for s in scopes if any(k.startswith("opt-") for k in s.options))
+    if raw_option_scopes:
+        warnings.append(
+            f"{raw_option_scopes} scope(s) carry non-standard DHCP options preserved as "
+            "raw 'opt-<id>' values — review them after import."
+        )
+
+    af_hist = {"ipv4": len(scopes)} if scopes else {}
+    return ImportPreview(
+        source="windows_dhcp",
+        scopes=scopes,
+        client_classes=[],  # Windows DHCP classes aren't pulled by Path A
+        conflicts=[],
+        warnings=warnings,
+        unsupported=[],
+        total_pools=sum(len(s.pools) for s in scopes),
+        total_reservations=sum(len(s.reservations) for s in scopes),
+        address_family_histogram=af_hist,
+    )

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -160,6 +160,19 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         group="DNS",
         description="One-shot import from BIND9 / Windows DNS / PowerDNS into SpatiumDDI's native zones + records. Settings → Import → DNS surface; sources gate behind their own credential / file-upload step.",
     ),
+    # DHCP — sister importer to ``dns.import`` (issue #129). One-shot
+    # import of scopes / pools / reservations / classes from Kea JSON /
+    # Windows DHCP live-pull / ISC dhcpd.conf so operators can seed a
+    # sandbox SpatiumDDI from their real DHCP estate. Same default-on
+    # rationale as the DNS importer: no blast radius from the toggle
+    # (endpoints are RBAC-gated separately), operators flip it off to
+    # hide the surface.
+    ModuleSpec(
+        id="dhcp.import",
+        label="DHCP configuration import",
+        group="DHCP",
+        description="One-shot import from Kea / Windows DHCP / ISC dhcpd.conf into SpatiumDDI's native scopes + pools + reservations + classes. Settings → Import → DHCP surface; sources gate behind their own credential / file-upload step.",
+    ),
     # Integrations — read-only mirrors of external orchestrators.
     # Default-disabled: each one needs operator-supplied credentials
     # before it does anything useful, and the kickoff lives behind

--- a/backend/tests/test_dhcp_import.py
+++ b/backend/tests/test_dhcp_import.py
@@ -1,0 +1,516 @@
+"""Tests for the DHCP configuration importer (issue #129).
+
+Two layers:
+
+* **Parser layer** — ``parse_kea_config`` / ``parse_isc_config``
+  against synthetic configs. Pure-Python; no DB dependency.
+* **Commit layer** — preview + commit endpoints exercised through the
+  FastAPI test client with a real Postgres-backed session so the IPAM
+  link/create resolution, per-scope savepoints, provenance stamping,
+  and audit-log rows are covered end-to-end.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.dhcp import (
+    DHCPClientClass,
+    DHCPPool,
+    DHCPScope,
+    DHCPServerGroup,
+    DHCPStaticAssignment,
+)
+from app.models.ipam import IPBlock, IPSpace, Subnet
+from app.services.dhcp_import import (
+    IscImportError,
+    KeaImportError,
+    parse_isc_config,
+    parse_kea_config,
+)
+
+# ── fixtures / helpers ───────────────────────────────────────────────
+
+
+_KEA_CONF = b"""
+{
+  // top of the file
+  "Dhcp4": {
+    "valid-lifetime": 4000,
+    "option-data": [ { "name": "domain-name", "data": "example.org" } ],
+    "subnet4": [
+      {
+        "subnet": "192.0.2.0/24",
+        "pools": [ { "pool": "192.0.2.10 - 192.0.2.100" } ],
+        "option-data": [
+          { "name": "routers", "data": "192.0.2.1" },
+          { "name": "domain-name-servers", "data": "1.1.1.1, 8.8.8.8" }
+        ],
+        "reservations": [
+          { "hw-address": "aa:bb:cc:dd:ee:ff", "ip-address": "192.0.2.5", "hostname": "printer" }
+        ]
+      }
+    ],
+    "client-classes": [ { "name": "voip", "test": "substring(option[60].hex,0,6) == 'Aastra'" } ]
+  }
+}
+"""
+
+_ISC_CONF = b"""
+# global config
+option domain-name "isc.example";
+default-lease-time 600;
+
+subnet 10.5.5.0 netmask 255.255.255.0 {
+  range 10.5.5.10 10.5.5.100;
+  option routers 10.5.5.1;
+  option domain-name-servers 10.5.5.1, 8.8.8.8;
+  max-lease-time 7200;
+}
+
+host laptop {
+  hardware ethernet 01:02:03:04:05:06;
+  fixed-address 10.5.5.50;
+}
+
+class "pxe" {
+  match if substring(option vendor-class-identifier,0,9) = "PXEClient";
+}
+
+failover peer "dhcp-failover" { primary; }
+"""
+
+
+async def _make_admin(db: AsyncSession) -> tuple[User, str]:
+    user = User(
+        username="dhcpimport-admin",
+        email="dhcpimport-admin@example.com",
+        display_name="dhcpimport-admin",
+        hashed_password=hash_password("password123"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_group(db: AsyncSession, name: str = "dhcp-import-grp") -> DHCPServerGroup:
+    g = DHCPServerGroup(name=name)
+    db.add(g)
+    await db.flush()
+    return g
+
+
+async def _make_space(db: AsyncSession, name: str = "import-space") -> IPSpace:
+    sp = IPSpace(name=name, description="")
+    db.add(sp)
+    await db.flush()
+    return sp
+
+
+async def _make_block(db: AsyncSession, space: IPSpace, network: str = "192.0.2.0/24") -> IPBlock:
+    b = IPBlock(space_id=space.id, network=network, name="b")
+    db.add(b)
+    await db.flush()
+    return b
+
+
+async def _make_subnet(db: AsyncSession, space: IPSpace, block: IPBlock, network: str) -> Subnet:
+    s = Subnet(space_id=space.id, block_id=block.id, network=network)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+# ── Parser layer — Kea ───────────────────────────────────────────────
+
+
+def test_kea_basic_scope() -> None:
+    p = parse_kea_config(_KEA_CONF)
+    assert p.source == "kea"
+    assert len(p.scopes) == 1
+    sc = p.scopes[0]
+    assert sc.subnet_cidr == "192.0.2.0/24"
+    assert sc.address_family == "ipv4"
+    assert sc.lease_time == 4000
+    # global domain-name merged + scope routers/dns-servers
+    assert sc.options["domain-name"] == "example.org"
+    assert sc.options["routers"] == "192.0.2.1"
+    assert sc.options["dns-servers"] == ["1.1.1.1", "8.8.8.8"]
+    assert len(sc.pools) == 1
+    assert sc.pools[0].start_ip == "192.0.2.10"
+    assert sc.pools[0].end_ip == "192.0.2.100"
+    assert len(sc.reservations) == 1
+    assert sc.reservations[0].mac_address == "aa:bb:cc:dd:ee:ff"
+    assert sc.reservations[0].ip_address == "192.0.2.5"
+    assert len(p.client_classes) == 1
+    assert p.client_classes[0].name == "voip"
+    assert p.client_classes[0].supported is True
+
+
+def test_kea_bare_dhcp4_body() -> None:
+    """A config that is the bare Dhcp4 body (no wrapper) parses too."""
+    p = parse_kea_config(b'{"subnet4": [{"subnet": "10.0.0.0/8"}]}')
+    assert len(p.scopes) == 1
+    assert p.scopes[0].subnet_cidr == "10.0.0.0/8"
+
+
+def test_kea_v6_subnet() -> None:
+    p = parse_kea_config(
+        b'{"Dhcp6": {"subnet6": [{"subnet": "2001:db8::/64", '
+        b'"pools": [{"pool": "2001:db8::10 - 2001:db8::ff"}]}]}}'
+    )
+    assert len(p.scopes) == 1
+    assert p.scopes[0].address_family == "ipv6"
+    assert p.scopes[0].v6_address_mode == "stateful"
+    assert p.address_family_histogram == {"ipv6": 1}
+
+
+def test_kea_pool_cidr_form() -> None:
+    p = parse_kea_config(
+        b'{"subnet4": [{"subnet": "10.0.0.0/24", "pools": [{"pool": "10.0.0.0/25"}]}]}'
+    )
+    pool = p.scopes[0].pools[0]
+    assert pool.start_ip == "10.0.0.0"
+    assert pool.end_ip == "10.0.0.127"
+
+
+def test_kea_invalid_json_raises() -> None:
+    with pytest.raises(KeaImportError):
+        parse_kea_config(b"this is not json {")
+
+
+def test_kea_no_subnets_raises() -> None:
+    with pytest.raises(KeaImportError):
+        parse_kea_config(b'{"Dhcp4": {"valid-lifetime": 3600}}')
+
+
+# ── Parser layer — ISC ───────────────────────────────────────────────
+
+
+def test_isc_basic_subnet() -> None:
+    p = parse_isc_config(_ISC_CONF)
+    assert p.source == "isc_dhcp"
+    sc = next(s for s in p.scopes if s.subnet_cidr == "10.5.5.0/24")
+    assert sc.lease_time == 600  # inherited global default
+    assert sc.max_lease_time == 7200
+    assert sc.options["domain-name"] == "isc.example"  # inherited global
+    assert sc.options["routers"] == "10.5.5.1"
+    assert sc.options["dns-servers"] == ["10.5.5.1", "8.8.8.8"]
+    assert len(sc.pools) == 1
+    # global host attaches to the containing subnet
+    assert any(r.ip_address == "10.5.5.50" for r in sc.reservations)
+    assert sc.reservations[0].mac_address == "01:02:03:04:05:06"
+
+
+def test_isc_class_unsupported_and_failover_listed() -> None:
+    p = parse_isc_config(_ISC_CONF)
+    assert len(p.client_classes) == 1
+    assert p.client_classes[0].name == "pxe"
+    assert p.client_classes[0].supported is False
+    assert any("failover" in u.lower() for u in p.unsupported)
+
+
+def test_isc_shared_network_flattened() -> None:
+    conf = b"""
+shared-network office {
+  subnet 10.6.6.0 netmask 255.255.255.0 { range 10.6.6.20 10.6.6.40; }
+  subnet 10.7.7.0 netmask 255.255.255.0 { range 10.7.7.20 10.7.7.40; }
+}
+"""
+    p = parse_isc_config(conf)
+    cidrs = {s.subnet_cidr for s in p.scopes}
+    assert cidrs == {"10.6.6.0/24", "10.7.7.0/24"}
+    assert any("shared-network" in w.lower() for w in p.warnings)
+
+
+def test_isc_empty_raises() -> None:
+    with pytest.raises(IscImportError):
+        parse_isc_config(b"authoritative;\n")
+
+
+# ── Commit layer — endpoints ─────────────────────────────────────────
+
+
+async def _kea_preview(client: AsyncClient, token: str, group_id: str, space_id: str | None = None):
+    data = {"target_group_id": group_id}
+    if space_id:
+        data["ipam_space_id"] = space_id
+    resp = await client.post(
+        "/api/v1/dhcp/import/kea/preview",
+        headers={"Authorization": f"Bearer {token}"},
+        files={"file": ("kea.conf", _KEA_CONF, "application/json")},
+        data=data,
+    )
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_kea_preview_endpoint(db_session: AsyncSession, client: AsyncClient) -> None:
+    _, token = await _make_admin(db_session)
+    group = await _make_group(db_session)
+    await db_session.commit()
+
+    resp = await _kea_preview(client, token, str(group.id))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source"] == "kea"
+    assert len(body["scopes"]) == 1
+    assert body["scopes"][0]["subnet_cidr"] == "192.0.2.0/24"
+    assert body["total_pools"] == 1
+    assert body["total_reservations"] == 1
+    assert body["conflicts"] == []  # no IPAM subnet matches yet
+
+
+@pytest.mark.asyncio
+async def test_kea_commit_autocreates_subnet_with_provenance(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, token = await _make_admin(db_session)
+    group = await _make_group(db_session)
+    space = await _make_space(db_session)
+    block = await _make_block(db_session, space, "192.0.2.0/24")
+    await db_session.commit()
+
+    preview = (await _kea_preview(client, token, str(group.id), str(space.id))).json()
+    resp = await client.post(
+        "/api/v1/dhcp/import/kea/commit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "target_group_id": str(group.id),
+            "ipam_space_id": str(space.id),
+            "ipam_block_id": str(block.id),
+            "plan": preview,
+            "conflict_actions": {},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total_scopes_created"] == 1
+    assert body["total_subnets_created"] == 1
+    assert body["total_pools_created"] == 1
+    assert body["total_reservations_created"] == 1
+    assert body["client_classes_created"] == 1
+    assert body["scopes"][0]["action_taken"] == "created"
+
+    # subnet auto-created + linked to the group
+    subnet = (
+        await db_session.execute(select(Subnet).where(Subnet.network == "192.0.2.0/24"))
+    ).scalar_one()
+    assert str(subnet.dhcp_server_group_id) == str(group.id)
+
+    # scope + provenance
+    scope = (
+        (await db_session.execute(select(DHCPScope).where(DHCPScope.subnet_id == subnet.id)))
+        .unique()
+        .scalar_one()
+    )
+    assert scope.import_source == "kea"
+    assert scope.imported_at is not None
+    pool = (
+        await db_session.execute(select(DHCPPool).where(DHCPPool.scope_id == scope.id))
+    ).scalar_one()
+    assert pool.import_source == "kea"
+    static = (
+        await db_session.execute(
+            select(DHCPStaticAssignment).where(DHCPStaticAssignment.scope_id == scope.id)
+        )
+    ).scalar_one()
+    assert static.mac_address == "aa:bb:cc:dd:ee:ff"
+    cc = (
+        await db_session.execute(
+            select(DHCPClientClass).where(DHCPClientClass.group_id == group.id)
+        )
+    ).scalar_one()
+    assert cc.name == "voip"
+    assert cc.import_source == "kea"
+
+    # audit row
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.resource_type == "dhcp_scope", AuditLog.resource_id == str(scope.id)
+            )
+        )
+    ).scalar_one()
+    assert audit.action == "create"
+
+
+@pytest.mark.asyncio
+async def test_kea_commit_links_existing_subnet(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """A scope whose CIDR already matches an IPAM subnet links to it
+    (no auto-create) even in link-only mode (no space/block in body)."""
+    _, token = await _make_admin(db_session)
+    group = await _make_group(db_session)
+    space = await _make_space(db_session)
+    block = await _make_block(db_session, space, "192.0.2.0/24")
+    await _make_subnet(db_session, space, block, "192.0.2.0/24")
+    await db_session.commit()
+
+    preview = (await _kea_preview(client, token, str(group.id))).json()
+    # preview should flag the existing subnet (link, not conflict)
+    assert preview["conflicts"][0]["existing_subnet_id"] is not None
+    assert preview["conflicts"][0]["existing_scope_id"] is None
+
+    resp = await client.post(
+        "/api/v1/dhcp/import/kea/commit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "target_group_id": str(group.id),
+            "plan": preview,
+            "conflict_actions": {},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total_scopes_created"] == 1
+    assert body["total_subnets_created"] == 0  # linked, not created
+
+
+@pytest.mark.asyncio
+async def test_kea_commit_link_only_fails_without_subnet(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """Link-only mode (no space/block) + no matching subnet → the scope
+    fails with an actionable error, not a 500."""
+    _, token = await _make_admin(db_session)
+    group = await _make_group(db_session)
+    await db_session.commit()
+
+    preview = (await _kea_preview(client, token, str(group.id))).json()
+    resp = await client.post(
+        "/api/v1/dhcp/import/kea/commit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"target_group_id": str(group.id), "plan": preview, "conflict_actions": {}},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total_scopes_failed"] == 1
+    assert "No IPAM subnet matches" in body["scopes"][0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_kea_commit_skip_then_overwrite(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, token = await _make_admin(db_session)
+    group = await _make_group(db_session)
+    space = await _make_space(db_session)
+    block = await _make_block(db_session, space, "192.0.2.0/24")
+    subnet = await _make_subnet(db_session, space, block, "192.0.2.0/24")
+    # an existing scope already serves this subnet in the group
+    existing = DHCPScope(group_id=group.id, subnet_id=subnet.id, name="old")
+    db_session.add(existing)
+    await db_session.commit()
+
+    preview = (await _kea_preview(client, token, str(group.id))).json()
+    assert preview["conflicts"][0]["existing_scope_id"] is not None
+
+    # default skip
+    skip_resp = await client.post(
+        "/api/v1/dhcp/import/kea/commit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"target_group_id": str(group.id), "plan": preview, "conflict_actions": {}},
+    )
+    assert skip_resp.status_code == 200
+    assert skip_resp.json()["total_scopes_skipped"] == 1
+
+    # explicit overwrite
+    ow_resp = await client.post(
+        "/api/v1/dhcp/import/kea/commit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "target_group_id": str(group.id),
+            "plan": preview,
+            "conflict_actions": {"192.0.2.0/24": {"action": "overwrite"}},
+        },
+    )
+    assert ow_resp.status_code == 200, ow_resp.text
+    assert ow_resp.json()["total_scopes_overwrote"] == 1
+    # the new scope replaced the old; only one scope on the subnet
+    scopes = (
+        (
+            await db_session.execute(
+                select(DHCPScope).where(
+                    DHCPScope.subnet_id == subnet.id, DHCPScope.deleted_at.is_(None)
+                )
+            )
+        )
+        .unique()
+        .scalars()
+        .all()
+    )
+    assert len(scopes) == 1
+    assert scopes[0].import_source == "kea"
+
+
+@pytest.mark.asyncio
+async def test_isc_preview_and_commit(db_session: AsyncSession, client: AsyncClient) -> None:
+    _, token = await _make_admin(db_session)
+    group = await _make_group(db_session)
+    space = await _make_space(db_session)
+    block = await _make_block(db_session, space, "10.5.5.0/24")
+    await db_session.commit()
+
+    preview_resp = await client.post(
+        "/api/v1/dhcp/import/isc/preview",
+        headers={"Authorization": f"Bearer {token}"},
+        files={"file": ("dhcpd.conf", _ISC_CONF, "text/plain")},
+        data={"target_group_id": str(group.id), "ipam_space_id": str(space.id)},
+    )
+    assert preview_resp.status_code == 200, preview_resp.text
+    preview = preview_resp.json()
+    assert any(s["subnet_cidr"] == "10.5.5.0/24" for s in preview["scopes"])
+
+    commit_resp = await client.post(
+        "/api/v1/dhcp/import/isc/commit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "target_group_id": str(group.id),
+            "ipam_space_id": str(space.id),
+            "ipam_block_id": str(block.id),
+            "plan": preview,
+            "conflict_actions": {},
+        },
+    )
+    assert commit_resp.status_code == 200, commit_resp.text
+    body = commit_resp.json()
+    assert body["total_scopes_created"] == 1
+    # ISC classes are unsupported → never created
+    assert body["client_classes_created"] == 0
+
+
+@pytest.mark.asyncio
+async def test_windows_servers_endpoint_empty(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, token = await _make_admin(db_session)
+    await db_session.commit()
+    resp = await client.get(
+        "/api/v1/dhcp/import/windows/servers",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_commit_source_mismatch_400(db_session: AsyncSession, client: AsyncClient) -> None:
+    _, token = await _make_admin(db_session)
+    group = await _make_group(db_session)
+    await db_session.commit()
+    preview = (await _kea_preview(client, token, str(group.id))).json()
+    resp = await client.post(
+        "/api/v1/dhcp/import/isc/commit",  # wrong endpoint for a kea plan
+        headers={"Authorization": f"Bearer {token}"},
+        json={"target_group_id": str(group.id), "plan": preview, "conflict_actions": {}},
+    )
+    assert resp.status_code == 400

--- a/backend/tests/test_dhcp_import.py
+++ b/backend/tests/test_dhcp_import.py
@@ -453,6 +453,62 @@ async def test_kea_commit_skip_then_overwrite(
 
 
 @pytest.mark.asyncio
+async def test_kea_commit_soft_deleted_scope_overwrite(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """A soft-deleted scope still holds the (group, subnet) unique slot.
+    The importer must flag it as a conflict (in Trash) and let overwrite
+    hard-delete + recreate — not blow up on an IntegrityError."""
+    from datetime import UTC, datetime
+
+    _, token = await _make_admin(db_session)
+    group = await _make_group(db_session)
+    space = await _make_space(db_session)
+    block = await _make_block(db_session, space, "192.0.2.0/24")
+    subnet = await _make_subnet(db_session, space, block, "192.0.2.0/24")
+    trashed = DHCPScope(
+        group_id=group.id,
+        subnet_id=subnet.id,
+        name="trashed",
+        deleted_at=datetime.now(UTC),
+    )
+    db_session.add(trashed)
+    await db_session.commit()
+
+    preview = (await _kea_preview(client, token, str(group.id))).json()
+    conflict = preview["conflicts"][0]
+    assert conflict["existing_scope_id"] is not None
+    assert conflict["soft_deleted"] is True
+
+    resp = await client.post(
+        "/api/v1/dhcp/import/kea/commit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "target_group_id": str(group.id),
+            "plan": preview,
+            "conflict_actions": {"192.0.2.0/24": {"action": "overwrite"}},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total_scopes_overwrote"] == 1
+    # exactly one live scope on the subnet, and the trashed one is purged
+    live = (
+        (
+            await db_session.execute(
+                select(DHCPScope).where(
+                    DHCPScope.subnet_id == subnet.id, DHCPScope.deleted_at.is_(None)
+                )
+            )
+        )
+        .unique()
+        .scalars()
+        .all()
+    )
+    assert len(live) == 1
+    assert live[0].import_source == "kea"
+
+
+@pytest.mark.asyncio
 async def test_isc_preview_and_commit(db_session: AsyncSession, client: AsyncClient) -> None:
     _, token = await _make_admin(db_session)
     group = await _make_group(db_session)

--- a/docs/drivers/DHCP_DRIVERS.md
+++ b/docs/drivers/DHCP_DRIVERS.md
@@ -298,6 +298,67 @@ For WinRM drivers, `pywinrm` errors get caught and re-raised as `DriverConnectio
 
 ---
 
+## 8. Importing existing daemon configs (issue #129)
+
+The **DHCP configuration importer** is separate from the driver
+abstraction: drivers *render + push* config to managed servers; the
+importer *reads* a foreign daemon's config one-shot and writes the
+canonical SpatiumDDI rows. It never touches a live daemon's config
+file. Code lives in `backend/app/services/dhcp_import/`.
+
+**Canonical IR** (`canonical.py`) — every source parses into the same
+neutral shapes: `ImportedScope` (CIDR, address family, lease times,
+options, DDNS), `ImportedPool`, `ImportedReservation`,
+`ImportedClientClass`, rolled into an `ImportPreview`. The shared
+`commit.py` is the only module that touches the DB, so all three
+sources share IPAM linkage, conflict handling, audit logging, and the
+per-scope savepoint pattern.
+
+**Parsers:**
+
+- `kea_parser.py` — strips Kea's JSON-with-comments (`//`, `#`,
+  `/* */`) string-aware, then walks `Dhcp4.subnet4` / `Dhcp6.subnet6`.
+  Inverts the Kea driver's option-name map (`shared/options.py` builds
+  the inverse of `_KEA_OPTION_NAMES` / `_KEA_OPTION_NAMES_V6`). Pools
+  parse both `"a - b"` and CIDR forms; `code:NN` option-data round-trips
+  the same way the driver renders it. DUID-only v6 reservations are
+  skipped (our reservations are MAC-keyed). Top-level `client-classes`
+  import verbatim — Kea `test` expressions are SpatiumDDI's native class
+  shape. `hooks-libraries` / `control-socket` / `lease-database` /
+  `loggers` are listed unsupported.
+- `windows_dhcp_pull.py` — reuses `WindowsDHCPReadOnlyDriver.get_scopes()`
+  (the same Path A read path the Logs surface uses), reshaping its
+  neutral dicts. IPv4 only; option names already arrive canonical.
+- `isc_dhcp_parser.py` — a self-contained tokeniser (comment- +
+  string-aware) → recursive-descent statement tree → walker.
+  `subnet` / `subnet6` → scopes; `range` / `range6` / `pool {}` →
+  pools (with `allow members of "class"` → `class_restriction`);
+  `host` → reservations (global hosts attach to the subnet containing
+  their `fixed-address`); `option` → canonical options;
+  `shared-network` / `group` are flattened. ISC's runtime-expression
+  classifier DSL doesn't map to our model, so `class` declarations are
+  emitted `supported=false` (manual review, never auto-created);
+  `failover` / `key` / `zone` / `include` are listed unsupported.
+
+**IPAM linkage** — `DHCPScope.subnet_id` is mandatory, so each commit
+resolves a `Subnet`: link to an existing one whose CIDR matches, or
+auto-create under the operator-chosen IP space + block (containment +
+non-overlap validated). Link-only mode (no space/block) reports an
+actionable per-scope error for unmatched CIDRs rather than failing the
+whole batch.
+
+**Provenance** — `import_source` (`kea` / `windows_dhcp` / `isc_dhcp`)
++ `imported_at` are stamped on every `dhcp_scope` / `dhcp_pool` /
+`dhcp_static_assignment` / `dhcp_client_class` row the importer creates
+(migration `c7f1a3e58b94`). Endpoints under
+`/api/v1/dhcp/import/{kea,windows,isc}/…` are gated by the `dhcp.import`
+feature module + superadmin RBAC.
+
+See [Migration](../features/MIGRATION.md) for the operator-facing flow
+and the DNS-importer sibling.
+
+---
+
 ## Related docs
 
 - [DHCP Features](../features/DHCP.md) — user-facing: scopes, pools, leases, HA modes.

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -369,6 +369,35 @@ Available from the admin UI: compares IPAM DB state vs. live DHCP server state a
 - Dry-run mode: shows what would be created before committing
 - Conflict resolution: skip / overwrite / error on duplicates
 
+### Migrating from an existing DHCP server (issue #129)
+
+The **DHCP configuration importer** is the one-shot path for loading a
+real DHCP estate into SpatiumDDI without retyping every scope, pool,
+reservation, and option-set. It lives under **DHCP Import** in the
+sidebar (gated by the `dhcp.import` feature module, default-on) and
+covers three sources:
+
+- **Kea** — upload a `kea-dhcp4.conf` / `kea-dhcp6.conf` from a
+  non-managed daemon.
+- **Windows DHCP** — live-pull every IPv4 scope from a registered
+  `windows_dhcp` server over WinRM (reuses the Path A read driver).
+- **ISC DHCP** — upload a `dhcpd.conf` (the importer ships its own
+  tokeniser; ISC is supported as an *import source* only — SpatiumDDI
+  does not run ISC daemons).
+
+The flow is preview → commit: the preview parses the source and shows
+the would-create scopes (with pool / reservation counts, conflicts,
+IPAM linkage, and a "didn't import" panel) before any DB write; commit
+writes each scope in its own savepoint. Every imported row is stamped
+with `import_source` + `imported_at` provenance. Each scope either
+links to an existing IPAM subnet on its CIDR or auto-creates one under
+an operator-chosen IP space + block. **Live leases are never imported**
+— they repopulate from the running daemon once a Kea server is attached
+to the target group.
+
+Full reference: [Migration](MIGRATION.md). Parser internals:
+[DHCP Drivers § Importing existing daemon configs](../drivers/DHCP_DRIVERS.md).
+
 ---
 
 ## 9. DHCP Permissions

--- a/docs/features/MIGRATION.md
+++ b/docs/features/MIGRATION.md
@@ -1,0 +1,160 @@
+# Migration — importing existing DNS + DHCP estates
+
+> **One-shot import, not ongoing sync.** Both importers exist so an
+> operator can load a real DNS / DHCP estate into a sandbox SpatiumDDI
+> without retyping every zone, record, scope, pool, and reservation.
+> Once imported, **SpatiumDDI is the source of truth** for the imported
+> objects. There is no conflict-resolution loop and no scheduled
+> re-pull. Operators who want a running read-only mirror are served by
+> the Windows DNS / Windows DHCP Path A drivers and the integration
+> shelf instead.
+
+Two sibling importers share one design — a per-source parser feeding a
+shared canonical intermediate representation (IR), then a
+source-agnostic two-phase **preview → commit** pipeline. Both live
+behind a togglable feature module so operators who don't need the
+surface can hide it (Settings → Features).
+
+| | DNS importer (#128) | DHCP importer (#129) |
+|---|---|---|
+| Feature module | `dns.import` | `dhcp.import` |
+| Admin surface | DNS Import (sidebar) | DHCP Import (sidebar) |
+| Sources | BIND9 archive · Windows DNS live-pull · PowerDNS REST | Kea JSON file · Windows DHCP live-pull · ISC `dhcpd.conf` |
+| Target | DNS server group (+ optional view) | DHCP server group (+ IPAM linkage) |
+| Provenance columns | `dns_zone` / `dns_record` `import_source` + `imported_at` | `dhcp_scope` / `dhcp_pool` / `dhcp_static_assignment` / `dhcp_client_class` `import_source` + `imported_at` |
+| Conflict actions | skip / overwrite / rename (per zone) | skip / overwrite (per scope) |
+| API prefix | `/api/v1/dns/import/{source}/…` | `/api/v1/dhcp/import/{source}/…` |
+| RBAC | superadmin | superadmin |
+
+The provenance columns are nullable + non-default: pre-existing,
+hand-created rows look "not imported" to the matcher, so a re-import
+never claims ownership of a row it didn't create.
+
+---
+
+## Shared shape
+
+1. **Configure source.** File upload (BIND9 archive, Kea JSON, ISC
+   `dhcpd.conf`) or a connection (a pre-registered Windows server, a
+   PowerDNS REST endpoint). Plus the **target** — which server group
+   the import lands in.
+2. **Preview.** `POST …/{source}/preview` parses the source into the
+   canonical IR and returns the would-create plan plus per-object
+   conflict status. Side-effect-free — no DB writes, no audit rows.
+   The operator can re-upload / re-pull while iterating.
+3. **Commit.** `POST …/{source}/commit` replays the previewed plan
+   (the UI hands the plan back in the request body, so the server stays
+   stateless between the two calls) and writes the IR. Each object
+   commits in **its own savepoint** — a failure on object N never rolls
+   back objects 1..N-1, and the result ledger carries one row per
+   attempted object so partial success is visible.
+
+Anything the source carries that SpatiumDDI can't model surfaces in the
+preview: per-object `parse_warnings`, a top-level `warnings` list, and
+a **"didn't import"** panel (`unsupported`) for whole subsystems we
+deliberately don't translate (DNSSEC keys, Kea hook libraries, ISC
+failover / TSIG keys, classifier DSL).
+
+---
+
+## DNS importer (#128)
+
+Three sources, all reducing to canonical `ImportedZone` + `ImportedRecord`:
+
+- **BIND9 archive** — upload a `.zip` / `.tar(.gz|.bz2|.xz)` containing
+  `named.conf` + the referenced master files. The parser walks every
+  `zone "…" { … }` declaration (including those nested in `view {}`
+  blocks), resolves the `file "…"` directive inside the archive, and
+  parses each master file. ACL / controls / logging / key declarations
+  stay out of scope; DNSSEC records (DNSKEY / RRSIG / NSEC* / DS) are
+  stripped with a warning — re-sign post-import via the zone DNSSEC tab.
+- **Windows DNS live-pull** — pick a registered `windows_dns` server
+  with WinRM credentials; the importer walks `Get-DnsServerZone` +
+  `Get-DnsServerResourceRecord`.
+- **PowerDNS REST** — paste an API URL + key (read once, never
+  persisted); the importer walks `/api/v1/servers/{server}/zones`.
+
+Per-zone conflict actions: **skip** (default — never trample an
+existing zone), **overwrite** (delete + recreate), **rename** (create
+under an operator-typed FQDN).
+
+See `docs/drivers/DNS_DRIVERS.md` for parser internals.
+
+---
+
+## DHCP importer (#129)
+
+Three sources, all reducing to canonical `ImportedScope` +
+`ImportedPool` + `ImportedReservation` + `ImportedClientClass`:
+
+- **Kea JSON** *(Phase 1)* — upload a `kea-dhcp4.conf` /
+  `kea-dhcp6.conf` from a non-managed daemon. Cleanest source: it's
+  exactly the shape SpatiumDDI's own Kea driver renders. The parser
+  strips Kea's JSON-with-comments extensions (string-aware), accepts
+  either a wrapped (`{"Dhcp4": {…}}`) or bare (`{"subnet4": […]}`)
+  body, and maps `subnet4` / `subnet6` → scopes, `pools` → pools,
+  `reservations` → reservations, `option-data` → canonical options,
+  and top-level `client-classes` → client classes (Kea `test`
+  expressions are SpatiumDDI's native class shape, so they import
+  verbatim).
+- **Windows DHCP live-pull** *(Phase 2)* — pick a registered
+  `windows_dhcp` server with WinRM credentials; the importer reuses the
+  Path A read driver (`Get-DhcpServerv4Scope` + option values +
+  exclusion ranges + reservations). IPv4 only.
+- **ISC `dhcpd.conf`** *(Phase 3)* — upload a `dhcpd.conf`. A hand-rolled
+  tokeniser + recursive-descent walker maps `subnet` / `subnet6` →
+  scopes, `range` / `range6` / `pool {}` → pools, `host` → reservations
+  (a global `host` attaches to the subnet whose CIDR contains its
+  `fixed-address`), and scope `option` statements → canonical options.
+  ISC classifier expressions don't translate to SpatiumDDI's
+  constrained class model, so `class` declarations are surfaced for
+  **manual review** (`supported=false`) and never auto-created;
+  `failover` / `key` / `zone` / `include` are listed in the "didn't
+  import" panel.
+
+### IPAM linkage (the DHCP-specific wrinkle)
+
+A `DHCPScope` must bind to an IPAM `Subnet`. For each imported scope the
+commit either:
+
+- **links** to an existing IPAM subnet whose CIDR matches the scope, or
+- **auto-creates** a subnet under the operator-chosen **IP space +
+  block** (containment + non-overlap validated; the network /
+  broadcast / gateway placeholder rows the manual create path adds are
+  skipped — the imported pools + reservations are the real occupancy).
+
+Leave the IP space + block blank for **link-only** mode: scopes with no
+matching subnet report an actionable per-scope error rather than
+silently creating something. The auto-created (or linked) subnet gets
+its `dhcp_server_group_id` set so IPAM reflects DHCP ownership.
+
+Per-scope conflict actions when the target group **already serves a
+scope on the matched subnet**: **skip** (default) or **overwrite**
+(delete the existing scope — cascading its pools + statics — and
+recreate). Client classes are group-scoped and created once, skipping
+any that already exist by name.
+
+### Not imported
+
+- **Live leases** — transient, unrelated to config, and would race with
+  the running daemon. They repopulate from the running daemon once a
+  real Kea server is attached to the target group.
+- **Kea hook libraries** (HA / host-cache / lease-cmds), **ISC
+  failover** — SpatiumDDI's HA is implicit at the server-group level;
+  configure it server-side post-import.
+- **ISC / Kea classifier DSL** beyond the directly-modellable subset,
+  **TSIG / failover keys**, **`include` files** (inline them before
+  upload).
+
+See `docs/drivers/DHCP_DRIVERS.md` § "Importing existing daemon
+configs" for parser internals.
+
+---
+
+## Re-running an import
+
+Both importers are safe to re-run. A second commit of the same source
+re-detects conflicts against the live DB and defaults every conflicting
+object to **skip**, so a fat-fingered "Commit" twice doesn't duplicate
+or trample. To intentionally refresh an imported object, set its
+conflict action to **overwrite** (DNS also offers **rename**).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,7 @@ import { LogsPage } from "@/pages/LogsPage";
 import { UsersPage } from "@/pages/admin/UsersPage";
 import { AuditPage } from "@/pages/admin/AuditPage";
 import { DNSImportPage } from "@/pages/admin/DNSImportPage";
+import { DHCPImportPage } from "@/pages/admin/DHCPImportPage";
 import { BackupPage } from "@/pages/admin/BackupPage";
 import { DiagnosticsErrorsPage } from "@/pages/admin/DiagnosticsErrorsPage";
 import { AIProvidersPage } from "@/pages/admin/AIProvidersPage";
@@ -152,6 +153,7 @@ export default function App() {
         <Route path="admin/roles" element={<RolesPage />} />
         <Route path="admin/audit" element={<AuditPage />} />
         <Route path="admin/dns-import" element={<DNSImportPage />} />
+        <Route path="admin/dhcp-import" element={<DHCPImportPage />} />
         <Route path="admin/backup" element={<BackupPage />} />
         <Route
           path="admin/diagnostics/errors"

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -207,9 +207,16 @@ const adminConfigurationNav = [
     module: "ai.copilot",
   },
   { label: "Custom Fields", icon: Tags, to: "/admin/custom-fields" },
-  // DNS configuration importer (issue #128). Module-gated so
+  // DHCP configuration importer (issue #129). Module-gated so
   // operators who don't need the surface can hide it via Settings →
-  // Features.
+  // Features. Listed before DNS Import to keep this nav alphabetical.
+  {
+    label: "DHCP Import",
+    icon: Upload,
+    to: "/admin/dhcp-import",
+    module: "dhcp.import",
+  },
+  // DNS configuration importer (issue #128) — sister to DHCP Import.
   {
     label: "DNS Import",
     icon: Upload,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5143,6 +5143,7 @@ export interface DHCPImportScopeConflict {
   existing_subnet_name: string | null;
   existing_pool_count: number;
   existing_reservation_count: number;
+  soft_deleted: boolean;
   action: DHCPImportConflictAction;
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5086,6 +5086,174 @@ export interface PowerDNSConnectionInfo {
   url: string;
 }
 
+// ── DHCP configuration importer (issue #129) ────────────────────────
+
+export type DHCPImportSource = "kea" | "windows_dhcp" | "isc_dhcp";
+export type DHCPImportConflictAction = "skip" | "overwrite";
+
+export interface DHCPImportedReservation {
+  ip_address: string;
+  mac_address: string;
+  hostname: string;
+  client_id: string | null;
+  options: Record<string, unknown>;
+}
+
+export interface DHCPImportedPool {
+  start_ip: string;
+  end_ip: string;
+  pool_type: string;
+  name: string;
+  class_restriction: string | null;
+}
+
+export interface DHCPImportedClientClass {
+  name: string;
+  match_expression: string;
+  description: string;
+  options: Record<string, unknown>;
+  supported: boolean;
+  warning: string | null;
+}
+
+export interface DHCPImportedScope {
+  subnet_cidr: string;
+  address_family: string;
+  name: string;
+  description: string;
+  lease_time: number;
+  min_lease_time: number | null;
+  max_lease_time: number | null;
+  is_active: boolean;
+  options: Record<string, unknown>;
+  pools: DHCPImportedPool[];
+  reservations: DHCPImportedReservation[];
+  ddns_enabled: boolean;
+  ddns_hostname_policy: string;
+  v6_address_mode: string;
+  skipped_options: Record<string, unknown>;
+  ha_info: string | null;
+  parse_warnings: string[];
+}
+
+export interface DHCPImportScopeConflict {
+  subnet_cidr: string;
+  existing_scope_id: string | null;
+  existing_subnet_id: string | null;
+  existing_subnet_name: string | null;
+  existing_pool_count: number;
+  existing_reservation_count: number;
+  action: DHCPImportConflictAction;
+}
+
+export interface DHCPImportPreview {
+  source: DHCPImportSource;
+  scopes: DHCPImportedScope[];
+  client_classes: DHCPImportedClientClass[];
+  conflicts: DHCPImportScopeConflict[];
+  warnings: string[];
+  unsupported: string[];
+  total_pools: number;
+  total_reservations: number;
+  address_family_histogram: Record<string, number>;
+}
+
+export interface DHCPImportConflictDecision {
+  action: DHCPImportConflictAction;
+}
+
+export interface DHCPImportCommitScope {
+  subnet_cidr: string;
+  action_taken: "created" | "overwrote" | "skipped" | "failed";
+  scope_id: string | null;
+  subnet_id: string | null;
+  subnet_created: boolean;
+  pools_created: number;
+  reservations_created: number;
+  error: string | null;
+}
+
+export interface DHCPImportCommitResult {
+  target_group_id: string;
+  scopes: DHCPImportCommitScope[];
+  client_classes_created: number;
+  warnings: string[];
+  total_scopes_created: number;
+  total_scopes_overwrote: number;
+  total_scopes_skipped: number;
+  total_scopes_failed: number;
+  total_subnets_created: number;
+  total_pools_created: number;
+  total_reservations_created: number;
+}
+
+export interface WindowsDHCPServerOption {
+  id: string;
+  name: string;
+  host: string;
+  group_id: string | null;
+  group_name: string | null;
+  has_credentials: boolean;
+}
+
+interface DHCPImportCommitBody {
+  target_group_id: string;
+  ipam_space_id?: string | null;
+  ipam_block_id?: string | null;
+  plan: DHCPImportPreview;
+  conflict_actions: Record<string, DHCPImportConflictDecision>;
+}
+
+export const dhcpImportApi = {
+  // Kea — JSON config file upload.
+  keaPreview: (file: File, target_group_id: string, ipam_space_id?: string) => {
+    const fd = new FormData();
+    fd.append("file", file);
+    fd.append("target_group_id", target_group_id);
+    if (ipam_space_id) fd.append("ipam_space_id", ipam_space_id);
+    return api
+      .post<DHCPImportPreview>("/dhcp/import/kea/preview", fd)
+      .then((r) => r.data);
+  },
+  keaCommit: (body: DHCPImportCommitBody) =>
+    api
+      .post<DHCPImportCommitResult>("/dhcp/import/kea/commit", body)
+      .then((r) => r.data),
+
+  // ISC — dhcpd.conf file upload.
+  iscPreview: (file: File, target_group_id: string, ipam_space_id?: string) => {
+    const fd = new FormData();
+    fd.append("file", file);
+    fd.append("target_group_id", target_group_id);
+    if (ipam_space_id) fd.append("ipam_space_id", ipam_space_id);
+    return api
+      .post<DHCPImportPreview>("/dhcp/import/isc/preview", fd)
+      .then((r) => r.data);
+  },
+  iscCommit: (body: DHCPImportCommitBody) =>
+    api
+      .post<DHCPImportCommitResult>("/dhcp/import/isc/commit", body)
+      .then((r) => r.data),
+
+  // Windows DHCP — server-side live pull.
+  windowsServers: () =>
+    api
+      .get<WindowsDHCPServerOption[]>("/dhcp/import/windows/servers")
+      .then((r) => r.data),
+  windowsPreview: (body: {
+    server_id: string;
+    target_group_id: string;
+    ipam_space_id?: string | null;
+  }) =>
+    api
+      .post<DHCPImportPreview>("/dhcp/import/windows/preview", body)
+      .then((r) => r.data),
+  windowsCommit: (body: DHCPImportCommitBody) =>
+    api
+      .post<DHCPImportCommitResult>("/dhcp/import/windows/commit", body)
+      .then((r) => r.data),
+};
+
 export const dnsBlocklistApi = {
   list: () => api.get<DNSBlockList[]>("/dns/blocklists").then((r) => r.data),
   catalog: () =>

--- a/frontend/src/pages/admin/DHCPImportPage.tsx
+++ b/frontend/src/pages/admin/DHCPImportPage.tsx
@@ -37,7 +37,15 @@ interface TabDef {
   description: string;
 }
 
+// Tabs sorted alphabetically by label (ISC DHCP / Kea / Windows DHCP).
 const TABS: TabDef[] = [
+  {
+    id: "isc_dhcp",
+    label: "ISC DHCP",
+    short: "dhcpd.conf",
+    description:
+      "Upload an ISC dhcpd.conf. The importer tokenises subnet / pool / range / host / class declarations and maps the modellable subset. ISC classifier expressions (class match rules) don't translate to SpatiumDDI's class model — they're surfaced for manual review, never auto-created. failover / key / zone / include declarations are listed in the 'didn't import' panel.",
+  },
   {
     id: "kea",
     label: "Kea",
@@ -51,13 +59,6 @@ const TABS: TabDef[] = [
     short: "WinRM live pull",
     description:
       "Live-pull every IPv4 scope from a Windows DHCP server using the same WinRM read driver the Logs surface uses. Pick a registered windows_dhcp server (with credentials configured) and the importer walks Get-DhcpServerv4Scope + option values + exclusions + reservations. IPv4 only.",
-  },
-  {
-    id: "isc_dhcp",
-    label: "ISC DHCP",
-    short: "dhcpd.conf",
-    description:
-      "Upload an ISC dhcpd.conf. The importer tokenises subnet / pool / range / host / class declarations and maps the modellable subset. ISC classifier expressions (class match rules) don't translate to SpatiumDDI's class model — they're surfaced for manual review, never auto-created. failover / key / zone / include declarations are listed in the 'didn't import' panel.",
   },
 ];
 
@@ -646,7 +647,10 @@ function PreviewPanel({
                       {hasScopeConflict ? (
                         <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-400">
                           <AlertTriangle className="h-3 w-3" />
-                          scope exists ({conflict?.existing_pool_count}p/
+                          {conflict?.soft_deleted
+                            ? "scope in Trash"
+                            : "scope exists"}{" "}
+                          ({conflict?.existing_pool_count}p/
                           {conflict?.existing_reservation_count}r)
                         </span>
                       ) : (

--- a/frontend/src/pages/admin/DHCPImportPage.tsx
+++ b/frontend/src/pages/admin/DHCPImportPage.tsx
@@ -1,0 +1,916 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Database,
+  FileUp,
+  Info,
+  Loader2,
+  RotateCcw,
+  Server as ServerIcon,
+  Trash2,
+  Upload,
+} from "lucide-react";
+
+import {
+  dhcpApi,
+  dhcpImportApi,
+  ipamApi,
+  type DHCPImportCommitResult,
+  type DHCPImportConflictDecision,
+  type DHCPImportPreview,
+  type DHCPImportScopeConflict,
+  type DHCPImportSource,
+  type WindowsDHCPServerOption,
+  formatApiError,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { HeaderButton } from "@/components/ui/header-button";
+
+type TabId = DHCPImportSource;
+
+interface TabDef {
+  id: TabId;
+  label: string;
+  short: string;
+  description: string;
+}
+
+const TABS: TabDef[] = [
+  {
+    id: "kea",
+    label: "Kea",
+    short: "kea-dhcp4.conf / kea-dhcp6.conf",
+    description:
+      "Upload a Kea JSON config from a non-managed daemon. The importer strips Kea's comment extensions, walks every Dhcp4 subnet4 / Dhcp6 subnet6 and maps pools, reservations, option-data, and client-classes into the canonical shape. HA / host-cache / lease-cmds hook config is not carried across — set HA up at the SpatiumDDI server-group level post-import.",
+  },
+  {
+    id: "windows_dhcp",
+    label: "Windows DHCP",
+    short: "WinRM live pull",
+    description:
+      "Live-pull every IPv4 scope from a Windows DHCP server using the same WinRM read driver the Logs surface uses. Pick a registered windows_dhcp server (with credentials configured) and the importer walks Get-DhcpServerv4Scope + option values + exclusions + reservations. IPv4 only.",
+  },
+  {
+    id: "isc_dhcp",
+    label: "ISC DHCP",
+    short: "dhcpd.conf",
+    description:
+      "Upload an ISC dhcpd.conf. The importer tokenises subnet / pool / range / host / class declarations and maps the modellable subset. ISC classifier expressions (class match rules) don't translate to SpatiumDDI's class model — they're surfaced for manual review, never auto-created. failover / key / zone / include declarations are listed in the 'didn't import' panel.",
+  },
+];
+
+type Phase = "select" | "previewing" | "ready" | "committing" | "result";
+
+interface ImportState {
+  file: File | null;
+  serverId: string;
+  groupId: string;
+  spaceId: string;
+  blockId: string;
+  preview: DHCPImportPreview | null;
+  decisions: Record<string, DHCPImportConflictDecision>;
+  result: DHCPImportCommitResult | null;
+  phase: Phase;
+  error: string | null;
+}
+
+function emptyState(): ImportState {
+  return {
+    file: null,
+    serverId: "",
+    groupId: "",
+    spaceId: "",
+    blockId: "",
+    preview: null,
+    decisions: {},
+    result: null,
+    phase: "select",
+    error: null,
+  };
+}
+
+export function DHCPImportPage() {
+  const [tab, setTab] = useState<TabId>("kea");
+  const active = TABS.find((t) => t.id === tab) ?? TABS[0];
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-wrap items-center gap-3 border-b p-4">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Upload className="h-5 w-5 flex-shrink-0 text-primary" />
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold">DHCP configuration import</h1>
+            <p className="text-xs text-muted-foreground">
+              One-shot import of scopes + pools + reservations + classes from
+              Kea / Windows DHCP / ISC dhcpd.conf into native SpatiumDDI rows.
+              Once imported, SpatiumDDI is the source of truth — there is no
+              continuous two-way mirror.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="border-b">
+        <div className="flex flex-wrap gap-1 px-4">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              className={cn(
+                "-mb-px flex items-center gap-2 border-b-2 px-3 py-2 text-sm transition-colors",
+                tab === t.id
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <div className="mb-4 rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+          <div className="mb-1 font-medium text-foreground">
+            {active.label} — {active.short}
+          </div>
+          {active.description}
+        </div>
+
+        {tab === "kea" && <ImportTab key="kea" source="kea" />}
+        {tab === "windows_dhcp" && (
+          <ImportTab key="windows_dhcp" source="windows_dhcp" />
+        )}
+        {tab === "isc_dhcp" && <ImportTab key="isc_dhcp" source="isc_dhcp" />}
+      </div>
+    </div>
+  );
+}
+
+// ── one source's flow ────────────────────────────────────────────────
+
+function ImportTab({ source }: { source: DHCPImportSource }) {
+  const [state, setState] = useState<ImportState>(emptyState());
+  const isFileSource = source === "kea" || source === "isc_dhcp";
+
+  const groupsQ = useQuery({
+    queryKey: ["dhcp-groups"],
+    queryFn: () => dhcpApi.listGroups(),
+  });
+  const spacesQ = useQuery({
+    queryKey: ["ipam-spaces"],
+    queryFn: () => ipamApi.listSpaces(),
+  });
+  const blocksQ = useQuery({
+    queryKey: ["ipam-blocks", state.spaceId],
+    queryFn: () =>
+      state.spaceId ? ipamApi.listBlocks(state.spaceId) : Promise.resolve([]),
+    enabled: Boolean(state.spaceId),
+  });
+  const serversQ = useQuery({
+    queryKey: ["dhcp-import-windows-servers"],
+    queryFn: () => dhcpImportApi.windowsServers(),
+    enabled: source === "windows_dhcp",
+  });
+
+  const previewMut = useMutation({
+    mutationFn: () => {
+      if (!state.groupId)
+        throw new Error("Pick a target DHCP server group first");
+      if (isFileSource) {
+        if (!state.file) throw new Error("Choose a config file first");
+        const fn =
+          source === "kea"
+            ? dhcpImportApi.keaPreview
+            : dhcpImportApi.iscPreview;
+        return fn(state.file, state.groupId, state.spaceId || undefined);
+      }
+      if (!state.serverId) throw new Error("Pick a Windows DHCP server first");
+      return dhcpImportApi.windowsPreview({
+        server_id: state.serverId,
+        target_group_id: state.groupId,
+        ipam_space_id: state.spaceId || null,
+      });
+    },
+    onSuccess: (preview) => {
+      const decisions: Record<string, DHCPImportConflictDecision> = {};
+      for (const c of preview.conflicts) {
+        if (c.existing_scope_id)
+          decisions[c.subnet_cidr] = { action: c.action };
+      }
+      setState((s) => ({
+        ...s,
+        preview,
+        decisions,
+        phase: "ready",
+        error: null,
+      }));
+    },
+    onError: (err: unknown) =>
+      setState((s) => ({ ...s, phase: "select", error: extractError(err) })),
+  });
+
+  const commitMut = useMutation({
+    mutationFn: () => {
+      if (!state.preview) throw new Error("Preview first");
+      const body = {
+        target_group_id: state.groupId,
+        ipam_space_id: state.spaceId || null,
+        ipam_block_id: state.blockId || null,
+        plan: state.preview,
+        conflict_actions: state.decisions,
+      };
+      const fn =
+        source === "kea"
+          ? dhcpImportApi.keaCommit
+          : source === "isc_dhcp"
+            ? dhcpImportApi.iscCommit
+            : dhcpImportApi.windowsCommit;
+      return fn(body);
+    },
+    onSuccess: (result) =>
+      setState((s) => ({ ...s, result, phase: "result", error: null })),
+    onError: (err: unknown) =>
+      setState((s) => ({ ...s, phase: "ready", error: extractError(err) })),
+  });
+
+  const conflictByCidr = useMemo(() => {
+    const m = new Map<string, DHCPImportScopeConflict>();
+    for (const c of state.preview?.conflicts ?? []) m.set(c.subnet_cidr, c);
+    return m;
+  }, [state.preview]);
+
+  const reset = () => setState(emptyState());
+
+  return (
+    <div className="space-y-4">
+      {state.error && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <div>{state.error}</div>
+        </div>
+      )}
+
+      {state.phase === "result" && state.result ? (
+        <CommitResultPanel result={state.result} onReset={reset} />
+      ) : (
+        <>
+          <ConfigureForm
+            source={source}
+            state={state}
+            setState={setState}
+            groups={groupsQ.data ?? []}
+            spaces={spacesQ.data ?? []}
+            blocks={blocksQ.data ?? []}
+            servers={serversQ.data ?? []}
+            serversLoading={serversQ.isLoading}
+            onPreview={() => {
+              setState((s) => ({ ...s, phase: "previewing", error: null }));
+              previewMut.mutate();
+            }}
+            previewing={previewMut.isPending}
+          />
+
+          {state.preview && state.phase !== "previewing" && (
+            <PreviewPanel
+              preview={state.preview}
+              decisions={state.decisions}
+              setDecisions={(updater) =>
+                setState((s) => ({ ...s, decisions: updater(s.decisions) }))
+              }
+              conflictByCidr={conflictByCidr}
+              canCreateSubnets={Boolean(state.spaceId && state.blockId)}
+              onCommit={() => {
+                setState((s) => ({ ...s, phase: "committing", error: null }));
+                commitMut.mutate();
+              }}
+              committing={commitMut.isPending}
+              onReset={reset}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function extractError(err: unknown): string {
+  return (
+    (err as { response?: { data?: { detail?: string } } })?.response?.data
+      ?.detail ?? formatApiError(err)
+  );
+}
+
+// ── configure source + target ────────────────────────────────────────
+
+function ConfigureForm({
+  source,
+  state,
+  setState,
+  groups,
+  spaces,
+  blocks,
+  servers,
+  serversLoading,
+  onPreview,
+  previewing,
+}: {
+  source: DHCPImportSource;
+  state: ImportState;
+  setState: React.Dispatch<React.SetStateAction<ImportState>>;
+  groups: { id: string; name: string }[];
+  spaces: { id: string; name: string }[];
+  blocks: { id: string; name: string; network: string }[];
+  servers: WindowsDHCPServerOption[];
+  serversLoading: boolean;
+  onPreview: () => void;
+  previewing: boolean;
+}) {
+  const isFileSource = source === "kea" || source === "isc_dhcp";
+  const accept =
+    source === "kea" ? ".conf,.json,application/json" : ".conf,.txt,text/plain";
+  const sourceReady = isFileSource
+    ? Boolean(state.file)
+    : Boolean(state.serverId);
+  const canPreview = sourceReady && Boolean(state.groupId) && !previewing;
+  const eligibleServers = servers.filter((s) => s.has_credentials);
+
+  return (
+    <div className="rounded-md border bg-muted/20 p-4">
+      <div className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        1. Configure source + target
+      </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* Source */}
+        <div className="space-y-3">
+          {isFileSource ? (
+            <div>
+              <label className="block text-sm font-medium">Config file</label>
+              <p className="mb-2 text-[11px] text-muted-foreground">
+                {source === "kea"
+                  ? "Kea kea-dhcp4.conf / kea-dhcp6.conf (JSON, comments OK). Max 25 MB."
+                  : "ISC dhcpd.conf. Inline any include files first. Max 25 MB."}
+              </p>
+              <label
+                className={cn(
+                  "flex cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed px-4 py-6 text-sm hover:bg-muted",
+                  state.file && "bg-muted/40 text-foreground",
+                )}
+              >
+                <FileUp className="h-4 w-4 text-muted-foreground" />
+                <span>
+                  {state.file
+                    ? `${state.file.name} (${(state.file.size / 1024).toFixed(1)} KB)`
+                    : "Choose file…"}
+                </span>
+                <input
+                  type="file"
+                  accept={accept}
+                  className="sr-only"
+                  onChange={(e) =>
+                    setState((s) => ({
+                      ...s,
+                      file: e.target.files?.[0] ?? null,
+                      preview: null,
+                      phase: "select",
+                      error: null,
+                    }))
+                  }
+                />
+              </label>
+            </div>
+          ) : (
+            <div>
+              <label className="block text-sm font-medium">
+                Windows DHCP server
+              </label>
+              <p className="mb-2 text-[11px] text-muted-foreground">
+                Registered windows_dhcp server with WinRM credentials. Servers
+                without credentials are greyed out.
+              </p>
+              <select
+                value={state.serverId}
+                onChange={(e) =>
+                  setState((s) => ({
+                    ...s,
+                    serverId: e.target.value,
+                    preview: null,
+                    error: null,
+                  }))
+                }
+                disabled={serversLoading}
+                className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                <option value="">
+                  {serversLoading
+                    ? "Loading…"
+                    : eligibleServers.length === 0
+                      ? "— no eligible servers —"
+                      : "— select —"}
+                </option>
+                {servers.map((srv) => (
+                  <option
+                    key={srv.id}
+                    value={srv.id}
+                    disabled={!srv.has_credentials}
+                  >
+                    {srv.name} ({srv.host})
+                    {!srv.has_credentials ? " — no creds" : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium">
+              Target DHCP server group
+            </label>
+            <p className="mb-2 text-[11px] text-muted-foreground">
+              Imported scopes land in this group. Pick one with at least one Kea
+              server so the agent renders them on its next sync.
+            </p>
+            <select
+              value={state.groupId}
+              onChange={(e) =>
+                setState((s) => ({ ...s, groupId: e.target.value }))
+              }
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">— select —</option>
+              {groups.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* IPAM linkage */}
+        <div className="space-y-3">
+          <div className="rounded-md border border-dashed bg-background/40 p-3">
+            <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              <Info className="h-3 w-3" /> IPAM linkage
+            </div>
+            <p className="mb-2 text-[11px] text-muted-foreground">
+              Every DHCP scope binds to an IPAM subnet. The importer links to an
+              existing subnet whose CIDR matches; to auto-create the ones that
+              don't exist yet, pick an IP space + block below. Leave them blank
+              to link-only (unmatched scopes will report an error you can fix
+              and re-run).
+            </p>
+            <label className="block text-sm font-medium">IP space</label>
+            <select
+              value={state.spaceId}
+              onChange={(e) =>
+                setState((s) => ({
+                  ...s,
+                  spaceId: e.target.value,
+                  blockId: "",
+                }))
+              }
+              className="mb-2 w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">— link-only (no auto-create) —</option>
+              {spaces.map((sp) => (
+                <option key={sp.id} value={sp.id}>
+                  {sp.name}
+                </option>
+              ))}
+            </select>
+            {state.spaceId && (
+              <>
+                <label className="block text-sm font-medium">
+                  Parent block (for new subnets)
+                </label>
+                <select
+                  value={state.blockId}
+                  onChange={(e) =>
+                    setState((s) => ({ ...s, blockId: e.target.value }))
+                  }
+                  className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                >
+                  <option value="">— select a block —</option>
+                  {blocks.map((b) => (
+                    <option key={b.id} value={b.id}>
+                      {b.name || b.network} ({b.network})
+                    </option>
+                  ))}
+                </select>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 flex justify-end gap-2">
+        <HeaderButton
+          variant="primary"
+          icon={previewing ? Loader2 : isFileSource ? Upload : ServerIcon}
+          iconClassName={previewing ? "animate-spin" : undefined}
+          onClick={onPreview}
+          disabled={!canPreview}
+        >
+          {previewing
+            ? isFileSource
+              ? "Parsing…"
+              : "Pulling scopes…"
+            : "Preview import"}
+        </HeaderButton>
+      </div>
+    </div>
+  );
+}
+
+// ── preview + commit ──────────────────────────────────────────────────
+
+function PreviewPanel({
+  preview,
+  decisions,
+  setDecisions,
+  conflictByCidr,
+  canCreateSubnets,
+  onCommit,
+  committing,
+  onReset,
+}: {
+  preview: DHCPImportPreview;
+  decisions: Record<string, DHCPImportConflictDecision>;
+  setDecisions: (
+    updater: (
+      prev: Record<string, DHCPImportConflictDecision>,
+    ) => Record<string, DHCPImportConflictDecision>,
+  ) => void;
+  conflictByCidr: Map<string, DHCPImportScopeConflict>;
+  canCreateSubnets: boolean;
+  onCommit: () => void;
+  committing: boolean;
+  onReset: () => void;
+}) {
+  const supportedClasses = preview.client_classes.filter((c) => c.supported);
+  const unsupportedClasses = preview.client_classes.filter((c) => !c.supported);
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border bg-muted/20 p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            2. Review &amp; commit
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <span>
+              <strong>{preview.scopes.length}</strong> scope
+              {preview.scopes.length === 1 ? "" : "s"}
+            </span>
+            <span>·</span>
+            <span>
+              <strong>{preview.total_pools}</strong> pools
+            </span>
+            <span>·</span>
+            <span>
+              <strong>{preview.total_reservations}</strong> reservations
+            </span>
+            <span>·</span>
+            <span>
+              <strong>{supportedClasses.length}</strong> classes
+            </span>
+          </div>
+        </div>
+
+        {preview.warnings.length > 0 && (
+          <WarnBlock title="Warnings" items={preview.warnings} />
+        )}
+        {preview.unsupported.length > 0 && (
+          <WarnBlock title="Didn't import" items={preview.unsupported} />
+        )}
+
+        <div className="overflow-x-auto rounded-md border bg-background">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/30 text-[11px] uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left">Subnet</th>
+                <th className="px-3 py-2 text-left">Family</th>
+                <th className="px-3 py-2 text-right">Pools</th>
+                <th className="px-3 py-2 text-right">Reservations</th>
+                <th className="px-3 py-2 text-left">IPAM</th>
+                <th className="px-3 py-2 text-left">Status</th>
+                <th className="px-3 py-2 text-left">On conflict</th>
+              </tr>
+            </thead>
+            <tbody>
+              {preview.scopes.map((sc) => {
+                const conflict = conflictByCidr.get(sc.subnet_cidr);
+                const hasScopeConflict = Boolean(conflict?.existing_scope_id);
+                const linksToSubnet = Boolean(conflict?.existing_subnet_id);
+                const decision = decisions[sc.subnet_cidr] ?? {
+                  action: "skip",
+                };
+                return (
+                  <tr key={sc.subnet_cidr} className="border-t align-top">
+                    <td className="px-3 py-2 font-mono text-xs">
+                      {sc.subnet_cidr}
+                      {sc.parse_warnings.length > 0 && (
+                        <div className="mt-0.5 text-[10px] text-amber-600 dark:text-amber-400">
+                          {sc.parse_warnings.length} note
+                          {sc.parse_warnings.length === 1 ? "" : "s"}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-xs">{sc.address_family}</td>
+                    <td className="px-3 py-2 text-right text-xs tabular-nums">
+                      {sc.pools.length}
+                    </td>
+                    <td className="px-3 py-2 text-right text-xs tabular-nums">
+                      {sc.reservations.length}
+                    </td>
+                    <td className="px-3 py-2 text-xs">
+                      {linksToSubnet ? (
+                        <span className="text-muted-foreground">
+                          link → {conflict?.existing_subnet_name}
+                        </span>
+                      ) : canCreateSubnets ? (
+                        <span className="text-emerald-700 dark:text-emerald-400">
+                          create subnet
+                        </span>
+                      ) : (
+                        <span className="text-destructive">
+                          no match — pick space+block
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      {hasScopeConflict ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-400">
+                          <AlertTriangle className="h-3 w-3" />
+                          scope exists ({conflict?.existing_pool_count}p/
+                          {conflict?.existing_reservation_count}r)
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400">
+                          <CheckCircle2 className="h-3 w-3" />
+                          new
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      {hasScopeConflict ? (
+                        <select
+                          value={decision.action}
+                          onChange={(e) =>
+                            setDecisions((prev) => ({
+                              ...prev,
+                              [sc.subnet_cidr]: {
+                                action: e.target
+                                  .value as DHCPImportConflictDecision["action"],
+                              },
+                            }))
+                          }
+                          className="rounded-md border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+                        >
+                          <option value="skip">Skip</option>
+                          <option value="overwrite">Overwrite</option>
+                        </select>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {(supportedClasses.length > 0 || unsupportedClasses.length > 0) && (
+          <div className="mt-3 space-y-2 rounded-md border bg-background p-3 text-xs">
+            <div className="font-medium">Client classes</div>
+            {supportedClasses.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {supportedClasses.map((c) => (
+                  <span
+                    key={c.name}
+                    className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400"
+                  >
+                    <CheckCircle2 className="h-3 w-3" />
+                    {c.name}
+                  </span>
+                ))}
+              </div>
+            )}
+            {unsupportedClasses.length > 0 && (
+              <div className="text-amber-700 dark:text-amber-400">
+                {unsupportedClasses.length} class
+                {unsupportedClasses.length === 1 ? "" : "es"} left for manual
+                review (classifier expression not auto-translated):{" "}
+                <span className="font-mono">
+                  {unsupportedClasses.map((c) => c.name).join(", ")}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <HeaderButton icon={RotateCcw} onClick={onReset} disabled={committing}>
+          Start over
+        </HeaderButton>
+        <HeaderButton
+          variant="primary"
+          icon={committing ? Loader2 : Database}
+          iconClassName={committing ? "animate-spin" : undefined}
+          onClick={onCommit}
+          disabled={committing}
+        >
+          {committing ? "Committing…" : "Commit import"}
+        </HeaderButton>
+      </div>
+    </div>
+  );
+}
+
+function WarnBlock({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div className="mb-3 space-y-1 rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+      <div className="font-medium text-amber-700 dark:text-amber-400">
+        {title}
+      </div>
+      {items.map((w, i) => (
+        <div key={i} className="text-amber-700/90 dark:text-amber-300/90">
+          {w}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CommitResultPanel({
+  result,
+  onReset,
+}: {
+  result: DHCPImportCommitResult;
+  onReset: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border bg-muted/20 p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Import complete
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-xs">
+            <Stat
+              label="Created"
+              value={result.total_scopes_created}
+              tone="success"
+            />
+            <Stat
+              label="Overwrote"
+              value={result.total_scopes_overwrote}
+              tone="amber"
+            />
+            <Stat
+              label="Skipped"
+              value={result.total_scopes_skipped}
+              tone="muted"
+            />
+            <Stat
+              label="Failed"
+              value={result.total_scopes_failed}
+              tone="destructive"
+            />
+            <span className="text-muted-foreground">·</span>
+            <Stat
+              label="Subnets"
+              value={result.total_subnets_created}
+              tone="success"
+            />
+            <Stat
+              label="Pools"
+              value={result.total_pools_created}
+              tone="success"
+            />
+            <Stat
+              label="Reservations"
+              value={result.total_reservations_created}
+              tone="success"
+            />
+            <Stat
+              label="Classes"
+              value={result.client_classes_created}
+              tone="success"
+            />
+          </div>
+        </div>
+
+        <div className="overflow-x-auto rounded-md border bg-background">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/30 text-[11px] uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left">Subnet</th>
+                <th className="px-3 py-2 text-left">Action</th>
+                <th className="px-3 py-2 text-right">Pools</th>
+                <th className="px-3 py-2 text-right">Reservations</th>
+                <th className="px-3 py-2 text-left">Error</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.scopes.map((s) => (
+                <tr key={s.subnet_cidr} className="border-t align-top">
+                  <td className="px-3 py-2 font-mono text-xs">
+                    {s.subnet_cidr}
+                    {s.subnet_created && (
+                      <span className="ml-1 rounded bg-emerald-500/15 px-1 text-[9px] text-emerald-700 dark:text-emerald-400">
+                        +subnet
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    <ActionPill action={s.action_taken} />
+                  </td>
+                  <td className="px-3 py-2 text-right text-xs tabular-nums">
+                    {s.pools_created}
+                  </td>
+                  <td className="px-3 py-2 text-right text-xs tabular-nums">
+                    {s.reservations_created}
+                  </td>
+                  <td className="px-3 py-2 text-xs text-destructive">
+                    {s.error ?? ""}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {result.warnings.length > 0 && (
+          <WarnBlock title="Warnings" items={result.warnings} />
+        )}
+      </div>
+
+      <div className="flex justify-end">
+        <HeaderButton icon={Trash2} onClick={onReset}>
+          Import another
+        </HeaderButton>
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "success" | "amber" | "muted" | "destructive";
+}) {
+  const tones: Record<string, string> = {
+    success: "text-emerald-700 dark:text-emerald-400",
+    amber: "text-amber-700 dark:text-amber-400",
+    muted: "text-muted-foreground",
+    destructive: "text-destructive",
+  };
+  return (
+    <span className="inline-flex items-baseline gap-1">
+      <span className={cn("font-semibold tabular-nums", tones[tone])}>
+        {value}
+      </span>
+      <span className="text-muted-foreground">{label}</span>
+    </span>
+  );
+}
+
+function ActionPill({ action }: { action: string }) {
+  const map: Record<string, { tone: string; label: string }> = {
+    created: {
+      tone: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+      label: "created",
+    },
+    overwrote: {
+      tone: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+      label: "overwrote",
+    },
+    skipped: {
+      tone: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400",
+      label: "skipped",
+    },
+    failed: { tone: "bg-destructive/15 text-destructive", label: "failed" },
+  };
+  const m = map[action] ?? map["skipped"];
+  return (
+    <span
+      className={cn(
+        "inline-flex rounded-full px-2 py-0.5 text-[10px] font-medium",
+        m.tone,
+      )}
+    >
+      {m.label}
+    </span>
+  );
+}


### PR DESCRIPTION
Closes #129.

Sister to the DNS configuration importer (#128): a **one-shot** importer so operators can load a real DHCP estate into a sandbox SpatiumDDI without retyping every scope, pool, reservation, and option-set. Import-to-evaluate, not an ongoing mirror — once committed, SpatiumDDI is the source of truth for the imported objects.

## Sources (all three in this PR)

| Source | Mode |
|---|---|
| **Kea** (`kea-dhcp4.conf` / `kea-dhcp6.conf`) | JSON file upload — strips Kea's comment extensions (string-aware), accepts wrapped or bare `Dhcp4`/`Dhcp6` bodies, inverts the Kea driver's option-name maps. `client-classes` (`test` exprs) import verbatim. |
| **Windows DHCP** | WinRM live-pull — reuses the Path A read driver (`Get-DhcpServerv4Scope` + option values + exclusions + reservations). IPv4 only. |
| **ISC `dhcpd.conf`** | File upload — hand-rolled comment/string-aware tokeniser + recursive-descent walker. ISC classifier DSL doesn't map to our class model, so `class` declarations are surfaced for **manual review** (never auto-created); `failover`/`key`/`zone`/`include` listed in the "didn't import" panel. |

All three reduce to one canonical IR (`ImportedScope`/`Pool`/`Reservation`/`ClientClass`) feeding a source-agnostic **preview → commit** pipeline with per-scope savepoints.

## IPAM linkage (the DHCP-specific wrinkle)

`DHCPScope.subnet_id` is mandatory, so each scope binds to an IPAM `Subnet`. The commit **links** to an existing subnet on the CIDR, or **auto-creates** one under an operator-chosen IP space + block (containment + non-overlap validated). Leave them blank for **link-only** mode — unmatched scopes report an actionable per-scope error instead of failing the batch. Per-scope conflict actions: **skip** (default) / **overwrite**.

## What's NOT imported

Live leases (transient — repopulate from the running daemon), Kea hook libraries / ISC failover (HA is implicit at the group level), TSIG/failover keys, classifier DSL beyond the modellable subset.

## Gating / provenance

- Feature module **`dhcp.import`** (default-on); endpoints under `/api/v1/dhcp/import/{kea,windows,isc}/…`, superadmin-only.
- `import_source` + `imported_at` stamped on every `dhcp_scope`/`dhcp_pool`/`dhcp_static_assignment`/`dhcp_client_class` row — migration `c7f1a3e58b94` (additive, reversible, lint-baselined).

## Frontend

Three-tab **DHCP Import** admin page (placed before DNS Import to keep that nav alphabetical) with file-upload / server-picker forms, IPAM space+block pickers, a scopes preview table (pools/reservations counts, link-vs-create, conflict skip/overwrite), client-class + "didn't import" panels, and a commit-result ledger.

## Docs

New shared `docs/features/MIGRATION.md` covering both importers side-by-side, plus cross-refs in `docs/features/DHCP.md` and `docs/drivers/DHCP_DRIVERS.md`, and a CLAUDE.md doc-map row.

## Tests / checks

- `backend/tests/test_dhcp_import.py` — 18 tests: parser layer (all 3 sources) + commit-layer endpoints (auto-create, link, link-only-fail, skip/overwrite, ISC, provenance, audit).
- Full backend suite **964 passed**. ruff / black / mypy (484 files) / migration-shape linter / prettier / eslint / tsc / vite build all green.

## Deferred follow-up

The `propose_dhcp_import` MCP tool is **not** in this PR — the sister DNS importer shipped without one, and a `propose_*` write needs the heavier Operation preview/apply framework. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)