### PR TITLE
Setup Wizard 'Manage Certificate' deep-links to Web UI Certificate tab (#314)

### DIFF
--- a/frontend/src/pages/appliance/AppliancePage.tsx
+++ b/frontend/src/pages/appliance/AppliancePage.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
@@ -182,6 +184,28 @@ export function AppliancePage() {
   // last visited a now-hidden tab (e.g. after a deployment-kind change).
   const defaultTab: Tab = isApplianceHost ? "tls" : "releases";
   const [tab, setTab] = useSessionState<Tab>("appliance.tab", defaultTab);
+
+  // Deep-link support: ``/appliance?tab=<key>`` forces a specific tab on
+  // arrival regardless of the session-stored last-active tab — e.g. the
+  // Setup Wizard's "Manage certificate" CTA (→ ?tab=tls) and "View
+  // releases" (→ ?tab=releases). We honor it once, persist the choice
+  // into the session-backed tab state, then strip the param so a later
+  // manual tab switch (or a refresh) isn't overridden. Validating
+  // against the full TABS list (not visibleTabs) sidesteps the async
+  // ``info`` load race; ``effectiveTab`` below already falls back when a
+  // deep-linked tab turns out to be hidden on a docker/k8s control plane.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedTab = searchParams.get("tab");
+  useEffect(() => {
+    if (!requestedTab) return;
+    if (TABS.some((t) => t.key === requestedTab)) {
+      setTab(requestedTab as Tab);
+    }
+    const next = new URLSearchParams(searchParams);
+    next.delete("tab");
+    setSearchParams(next, { replace: true });
+  }, [requestedTab, searchParams, setSearchParams, setTab]);
+
   const effectiveTab: Tab = visibleTabs.some((t) => t.key === tab)
     ? tab
     : defaultTab;

--- a/frontend/src/pages/appliance/SetupWizardPage.tsx
+++ b/frontend/src/pages/appliance/SetupWizardPage.tsx
@@ -119,7 +119,7 @@ export function SetupWizardPage() {
               : "Currently serving the self-signed default — replace with a real cert or Let's Encrypt"
           }
           actionLabel="Manage certificate"
-          onAction={() => navigate("/appliance")}
+          onAction={() => navigate("/appliance?tab=tls")}
           icon={KeyRound}
         />
         <Step
@@ -140,7 +140,7 @@ export function SetupWizardPage() {
           actionLabel={
             version.data?.update_available ? "View releases" : undefined
           }
-          onAction={() => navigate("/appliance")}
+          onAction={() => navigate("/appliance?tab=releases")}
         />
       </section>
 


### PR DESCRIPTION
Closes #314.

## Bug

The Setup Wizard's **Manage certificate** button navigated to `/appliance` with no tab target. `AppliancePage` restores its last-active tab from `sessionStorage` (`appliance.tab`), so the operator landed on whatever tab they last viewed (observed: **Releases**) instead of **Web UI Certificate** — a UX-critical miss on the primary first-boot onboarding flow.

## Fix

- **`AppliancePage.tsx`** — added `?tab=<key>` deep-link support. On arrival a valid `?tab=` is applied once, persisted into the session-backed tab state, then the param is stripped so a later manual tab switch / refresh isn't overridden. Validated against the full `TABS` list (not `visibleTabs`) to avoid the async `info`-load race; the existing `effectiveTab` fallback still demotes a deep-linked tab that's hidden on a docker/k8s control plane.
- **`SetupWizardPage.tsx`** — explicit tab targets:
  - **Manage certificate** → `/appliance?tab=tls` (Web UI Certificate)
  - **View releases** (sibling button, same latent bug) → `/appliance?tab=releases`

## Verification

prettier / eslint / tsc / vite build all clean. Frontend-only; no backend changes, no migrations.

Manual: open the Setup Wizard → switch the Appliance page to another tab (e.g. Releases) → return to the wizard → **Manage certificate** now lands on **Web UI Certificate** every time, regardless of the previously active tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)