### PR TITLE
Pin cloudnative-pg operator resources + loosen startup probe (#315)

### DIFF
--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -243,6 +243,43 @@ cnpg:
   # rendered consistently) back to ``cloudnative-pg`` so self-discovery
   # works. Do NOT remove without also de-aliasing the dependency.
   nameOverride: cloudnative-pg
+  # #315 — pin the operator pod's resources + loosen its startup probe.
+  #
+  # The upstream chart ships ``resources: {}``, which makes the operator
+  # pod **BestEffort** QoS — the first thing kubelet evicts / OOM-kills
+  # under node memory pressure. On the all-in-one control node (api + db
+  # + frontend + observability on one box) that bites: when the node
+  # gets tight the operator dies, then its restart re-attaches every
+  # watched volume at once → a reconciliation storm + log flood (the
+  # operator restart was observed alongside an ``api`` pod restart,
+  # i.e. node-level pressure, while the Postgres ``Cluster`` itself
+  # stayed healthy). Setting requests moves it to **Burstable** so it is
+  # no longer first in the eviction line; the (generous) memory limit is
+  # a backstop against a genuine runaway — well above the operator's
+  # real footprint (~30-150 MiB) so it never cgroup-OOMKills normal
+  # reconciliation.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  # Loosen the default 3s-delay / 30s-window (6 × 5s) startup gate — on
+  # constrained appliance VMs the operator + its webhook TLS bootstrap
+  # can take longer than 30s to answer ``/readyz``, and a startup-probe
+  # miss is itself a restart cause. 60s window + later liveness/readiness
+  # start give honest headroom without masking a truly wedged operator.
+  # These keys merge into the chart's webhook defaults (port / mutating /
+  # validating stay intact).
+  webhook:
+    livenessProbe:
+      initialDelaySeconds: 15
+    readinessProbe:
+      initialDelaySeconds: 10
+    startupProbe:
+      failureThreshold: 12
+      periodSeconds: 5
   # Replica topology for the SpatiumDDI ``Cluster`` CR. 3 replicas
   # (primary + sync + async) is the etcd-quorum-friendly default;
   # 5 / 7 work for larger clusters. Even counts refused at the

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -131,7 +131,13 @@ the reference topologies are in
 - **PostgreSQL HA = CloudNativePG.** The operator-managed `Cluster` CR
   is the permanent appliance default (`postgresql.kind=cnpg`); instances
   scale with the committed member count (1 → 3/5/7, primary + streaming
-  replicas + automatic failover).
+  replicas + automatic failover). The CNPG **operator** pod itself is
+  pinned to a small Burstable footprint (`cnpg.resources`: 50m/128Mi
+  requests, 500m/512Mi limits) so it isn't the first thing kubelet OOM-
+  kills when the all-in-one control node gets tight — an unbounded
+  BestEffort operator restart triggers a watched-volume reconciliation
+  storm (issue #315). Its startup probe is also loosened to a 60s window
+  for slow VMs. Budget ~128 MiB for it when sizing a control node.
 - **Redis HA = Sentinel.** Each member pairs a redis-server + a sentinel
   sidecar; app / worker / beat resolve the master via a `sentinel://`
   URL. `sentinel.replicas` scales with the member count.


### PR DESCRIPTION
Closes #315.

## Root cause

The appliance chart left the CloudNativePG **operator** with the upstream default `resources: {}`, making the operator pod **BestEffort** QoS — the first thing kubelet evicts / OOM-kills under node memory pressure. On the all-in-one control node (`spatium-01`: api + db + frontend + observability on one box) that bites: under pressure the operator dies, and its restart re-attaches every watched volume at once → the reconciliation storm + log flood reported in the issue. The `api` pod restart observed in the same window — while the Postgres `Cluster` itself stayed healthy — is the node-pressure fingerprint (the operator was simply the cheapest pod to reclaim).

## Fix (`charts/spatiumddi-appliance/values.yaml`, `cnpg:` block)

- **`cnpg.resources`** — requests `50m`/`128Mi`, limits `500m`/`512Mi`. Requests move the operator from BestEffort → **Burstable** so it's no longer first in the eviction line; the generous 512Mi memory limit is a runaway backstop well above the operator's real ~30–150 MiB footprint, so it never cgroup-OOMKills normal reconciliation.
- **`cnpg.webhook` probes** — startup window 30s → **60s** (`failureThreshold 12 × 5s`), liveness/readiness `initialDelaySeconds` 3s → 15s/10s. A slow webhook-TLS bootstrap on a constrained appliance VM is itself a startup-probe restart cause otherwise. These keys merge into the chart's `webhook` defaults (port / mutating / validating untouched).
- **`docs/deployment/APPLIANCE.md`** — operator sizing note (budget ~128 MiB when sizing a control node).

## Verification

- `helm template charts/spatiumddi-appliance --set cnpg.enabled=true` — the new requests/limits + loosened probes render on the operator `manager` container (Deployment `t-cloudnative-pg`).
- `helm lint` passes.

Chart-values + docs only — no application code, no migrations. (No CI step lints the appliance chart; `agent-e2e` exercises the umbrella chart, not this one.)

## Couldn't action from here / deferred

No access to the running `spatium-01` cluster to confirm the exact crash reason from live logs. The issue's checklist item **"add a PodMonitor / alert for operator pod restarts"** needs the Prometheus-Operator CRDs present (the appliance ships kube-state-metrics, which already exposes `kube_pod_container_status_restarts_total`, but a `PodMonitor` / `PrometheusRule` would fail to apply if the CRDs aren't installed) — suggested as a separate follow-up rather than risk a broken manifest here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)