### PR TITLE
Installer: raise disk floor 24→32 GiB + role-aware Control-plane sizing warning (#312)

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,22 +718,27 @@ Operators get a real Kubernetes node without managing one.
    VMware / Hyper-V / QEMU), or `dd` it to a USB stick for
    bare metal. **amd64** (arm64 ISO is planned).
 
-   **Hard floor (installer refuses below this): 24 GiB disk,
-   2 GiB RAM** — the A/B atomic-upgrade layout needs two 8 GiB
-   OS slots that each carry the full container image set for
-   air-gapped boot.
+   **Hard floor (installer refuses below this): 32 GiB disk** —
+   the A/B atomic-upgrade layout needs two 8 GiB OS slots that
+   each carry the full container image set for air-gapped boot,
+   and `/var` must hold the k3s image store + database + logs.
+   (The floor was 24 GiB; it was raised to 32 because the
+   Control plane's first boot otherwise tipped the kubelet
+   DiskPressure threshold into an eviction storm — issue #312.)
 
    **Recommended per role:**
 
    | Role | vCPU | RAM | Disk |
    |---|---|---|---|
    | **Control plane** (api + worker + frontend + Postgres + Redis + k3s etcd) | 4 | 8 GiB | 40 GiB SSD |
-   | **Appliance** (DNS / DHCP agent box) | 2 | 4 GiB | 24 GiB SSD |
+   | **Appliance** (DNS / DHCP agent box) | 2 | 4 GiB | 32 GiB SSD |
 
    Each control-plane HA node sizes the same as a single control
    plane (4 vCPU / 8 GiB) — every member runs a full api / worker /
    Postgres replica / Redis. SSD strongly preferred for the
-   etcd + Postgres write path.
+   etcd + Postgres write path. When you pick the **Control plane**
+   role on a box below the recommended 40 GiB / 8 GiB, the installer
+   shows a sizing warning before proceeding.
 2. Boot. The installer wizard asks for:
    - **Role** — *Control plane* (the required first install:
      control plane on this box + the k3s etcd seed; DNS / DHCP

--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -115,6 +115,26 @@ TIMEZONE="UTC"
 # convention.
 K3S_POD_CIDR="10.42.0.0/16"
 K3S_SERVICE_CIDR="10.43.0.0/16"
+# Disk / RAM sizing (#312).
+#   MIN_DISK_GIB     — absolute hard floor for the A/B partition layout;
+#                      pick_disk refuses below it for ANY role. Raised
+#                      24 → 32 because the 24 GiB floor left /var only
+#                      ~7 GiB, and the Control plane's first boot (k3s
+#                      image import + CNPG/Redis PVCs all on /var) tipped
+#                      the kubelet DiskPressure threshold into an
+#                      eviction / image-GC thrash loop that never
+#                      converges. 32 GiB leaves ~14 GiB usable /var.
+#   REC_CP_DISK_GIB /
+#   REC_CP_RAM_GIB   — RECOMMENDED Control-plane figures. Between the
+#                      floor and these, pick_disk soft-warns (install
+#                      proceeds) because the box still risks DiskPressure
+#                      under load. The Appliance/agent role is light and
+#                      gets no soft warning. Keep in sync with the
+#                      "Recommended sizing" table in README +
+#                      docs/deployment/APPLIANCE.md.
+MIN_DISK_GIB=32
+REC_CP_DISK_GIB=40
+REC_CP_RAM_GIB=8
 # Default ROLE = appliance (the role screen frames it as "Additional
 # node"). #272 UX fix: operators don't read the body text, and a
 # misclick / blind Enter on "control plane" silently spins up a SECOND
@@ -324,7 +344,7 @@ pick_disk() {
     # back to the menu — used to fire much later from inside
     # do_install AFTER the operator had already filled out hostname /
     # admin user / network / timezone, which was wasted typing.
-    local MIN_BYTES=$((24 * 1024 * 1024 * 1024))
+    local MIN_BYTES=$((MIN_DISK_GIB * 1024 * 1024 * 1024))
     while true; do
         TARGET_DISK=$(whiptail --backtitle "$BACKTITLE" --title "Target Disk" \
             --cancel-button "Back" \
@@ -334,13 +354,75 @@ pick_disk() {
         local DISK_BYTES
         DISK_BYTES=$(blockdev --getsize64 "$TARGET_DISK" 2>/dev/null || echo 0)
         if [ "$DISK_BYTES" -ge "$MIN_BYTES" ]; then
-            log "Picked target disk $TARGET_DISK ($((DISK_BYTES / 1024 / 1024 / 1024)) GiB)"
-            break
+            # Hard floor cleared. The Control plane role gets a second,
+            # SOFT check against the recommended figures (#312) — it can
+            # proceed under-spec but is warned about first-boot
+            # DiskPressure. A declined warning re-prompts the disk menu.
+            if _control_plane_sizing_ok "$DISK_BYTES"; then
+                log "Picked target disk $TARGET_DISK ($((DISK_BYTES / 1024 / 1024 / 1024)) GiB)"
+                break
+            fi
+            continue
         fi
-        log "Operator picked $TARGET_DISK ($((DISK_BYTES / 1024 / 1024 / 1024)) GiB) — below 24 GiB minimum; re-prompting"
+        log "Operator picked $TARGET_DISK ($((DISK_BYTES / 1024 / 1024 / 1024)) GiB) — below ${MIN_DISK_GIB} GiB minimum; re-prompting"
         whiptail --backtitle "$BACKTITLE" --title "Disk too small" --msgbox \
-            "Target disk $TARGET_DISK is only $((DISK_BYTES / 1024 / 1024 / 1024)) GiB.\n\nSpatiumDDI's A/B atomic-upgrade layout needs at least 24 GiB:\n  ESP        512 MiB\n  STATE      256 MiB\n  root_A       8 GiB\n  root_B       8 GiB\n  var       remainder (≥7 GiB usable)\n\nThe slots are sized to carry the full container image set (issue #170 Wave A4) so the appliance works air-gapped without ghcr.io.\n\nPick a different disk, or Cancel out to attach a larger one." 19 76
+            "Target disk $TARGET_DISK is only $((DISK_BYTES / 1024 / 1024 / 1024)) GiB.\n\nSpatiumDDI's A/B atomic-upgrade layout needs at least ${MIN_DISK_GIB} GiB:\n  ESP        512 MiB\n  STATE      256 MiB\n  root_A       8 GiB\n  root_B       8 GiB\n  var       remainder (≥14 GiB usable)\n\nThe slots carry the full container image set (issue #170 Wave A4) so the appliance works air-gapped without ghcr.io, and /var must hold the k3s image store + database + logs without tipping the kubelet DiskPressure threshold on the Control plane role (issue #312).\n\nPick a different disk, or Cancel out to attach a larger one." 21 76
     done
+}
+
+# #312 — soft sizing gate for the heavy Control plane role. The hard
+# floor in pick_disk only guarantees the appliance installs + boots; the
+# Control plane (k3s etcd + CloudNativePG + Redis + api/worker/beat/
+# frontend, plus 2× HA replicas) wants REC_CP_DISK_GIB / REC_CP_RAM_GIB
+# or its first boot risks a DiskPressure eviction storm — the image pull
+# + Postgres/Redis PVCs land on a small /var and tip the kubelet nodefs
+# threshold into an evict / image-GC thrash loop that never converges.
+#
+# Warns, does not block (the operator can knowingly proceed). Returns 0
+# to proceed with the picked disk, 1 to send them back to the disk menu.
+# No-op for the lightweight Appliance/agent role — 32 GiB is plenty
+# there, so it never sees this.
+_control_plane_sizing_ok() {
+    local disk_bytes="$1"
+    [ "$ROLE" = "control-plane" ] || return 0
+
+    local disk_gib ram_kib ram_gib under_disk=0 under_ram=0
+    disk_gib=$((disk_bytes / 1024 / 1024 / 1024))
+    ram_kib=$(awk '/^MemTotal:/ {print $2; exit}' /proc/meminfo 2>/dev/null || echo 0)
+    # Round RAM to the nearest GiB for display; MemTotal sits a little
+    # under provisioned RAM (kernel reserve).
+    ram_gib=$(((ram_kib + 524288) / 1024 / 1024))
+
+    [ "$disk_gib" -lt "$REC_CP_DISK_GIB" ] && under_disk=1
+    # Warn one GiB under the recommendation so a box provisioned at
+    # exactly REC_CP_RAM_GIB (whose MemTotal reads slightly low) doesn't
+    # false-warn. ram_kib==0 means /proc/meminfo was unreadable — skip
+    # the RAM dimension rather than warn on bad data.
+    if [ "$ram_kib" -gt 0 ] && [ "$ram_kib" -lt $(((REC_CP_RAM_GIB - 1) * 1024 * 1024)) ]; then
+        under_ram=1
+    fi
+    if [ "$under_disk" -eq 0 ] && [ "$under_ram" -eq 0 ]; then
+        return 0
+    fi
+
+    local msg
+    msg="The Control plane is the heaviest role — k3s + PostgreSQL (CloudNativePG) + Redis + api / worker / beat / frontend, plus 2× HA replicas.\n\n"
+    msg+="Recommended:  ≥ ${REC_CP_DISK_GIB} GiB disk,  ≥ ${REC_CP_RAM_GIB} GiB RAM\n"
+    msg+="This machine:  ${disk_gib} GiB disk"
+    [ "$ram_kib" -gt 0 ] && msg+=",  ~${ram_gib} GiB RAM"
+    msg+="\n\nIt will INSTALL and boot, but at this size the first boot pulls the full control-plane image set onto /var while the Postgres + Redis volumes also land there — very likely tipping the kubelet's DiskPressure threshold into a pod-eviction / image-GC thrash loop that never converges.\n\n"
+    msg+="See \"Recommended sizing\" in the README / docs/deployment/APPLIANCE.md.\n\n"
+    msg+="Continue with this disk anyway?"
+
+    # --defaultno so a careless Enter re-picks rather than committing to a
+    # known-risky control-plane install.
+    if whiptail --backtitle "$BACKTITLE" --title "Control plane: below recommended size" \
+        --defaultno --yesno "$msg" 23 78; then
+        log "Operator acknowledged under-spec control-plane sizing (disk=${disk_gib}G ram=${ram_gib}G); proceeding"
+        return 0
+    fi
+    log "Operator declined under-spec control-plane sizing (disk=${disk_gib}G ram=${ram_gib}G); re-prompting disk"
+    return 1
 }
 
 # Issue #276 — partition-layout confirmation. Shows the exact GPT
@@ -732,10 +814,12 @@ do_install() {
     # Previous 4 GiB slots predated baking and are too tight once
     # the full container set lives on-rootfs.
     #
-    # Hard floor: 24 GiB target disk (= 1 MiB BBP + 512 MiB ESP + 256
-    # MiB STATE + 2× 8 GiB slots + at least 7 GiB usable /var). Below
+    # Hard floor: MIN_DISK_GIB (32) target disk (= 1 MiB BBP + 512 MiB
+    # ESP + 256 MiB STATE + 2× 8 GiB slots + ~14 GiB usable /var). Below
     # that, postgres + k3s state (containerd content store, local-path
-    # PV dirs) + audit log outgrow /var quickly.
+    # PV dirs) + audit log outgrow /var quickly — on the Control plane
+    # role a 24 GiB disk's ~7 GiB /var tipped the kubelet DiskPressure
+    # threshold into an eviction storm on first boot (issue #312).
     local BBP ESP STATE ROOT_A ROOT_B VAR
     BBP=$(partition_node 1)
     ESP=$(partition_node 2)

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -69,16 +69,16 @@ The pre-#183 docker-compose path fought us on three things every operator-facing
 
 k3s solves all three: HelmChart CRs as the declarative target, helm-controller as the reconciler, kine (SQLite) as the state store (survives slot swap because `/var/lib/rancher/` is on `/var`). The supervisor becomes a thin controller that PATCHes node labels per role-assignment change — the role pod schedules or terminates as a consequence of the label, not as a consequence of a `docker compose` invocation.
 
-The trade-off: k3s adds ~70 MB to the slot rootfs and a steady ~150 MB RAM footprint for the k3s server process itself. On the 24 GiB disk floor + 2 GiB RAM floor the appliance targets, both are well under budget.
+The trade-off: k3s adds ~70 MB to the slot rootfs and a steady ~150 MB RAM footprint for the k3s server process itself. On the 32 GiB disk floor the appliance targets, both are well under budget.
 
 **Recommended sizing (per role):**
 
 | Role | vCPU | RAM | Disk |
 |---|---|---|---|
 | **Control plane** (api + worker + frontend + Postgres + Redis + k3s etcd seed) | 4 | 8 GiB | 40 GiB SSD |
-| **Appliance** (DNS / DHCP agent) | 2 | 4 GiB | 24 GiB SSD |
+| **Appliance** (DNS / DHCP agent) | 2 | 4 GiB | 32 GiB SSD |
 
-The 2 GiB RAM floor boots a single-node control plane but is tight once Postgres + Redis + the Python api/worker are all resident; 8 GiB is the comfortable recommendation. Each control-plane **HA member** sizes the same as a standalone control plane (4 vCPU / 8 GiB) — every member runs a full api / worker / Postgres replica / Redis. SSD is strongly preferred for the etcd + Postgres write path; the installer's disk floor assumes the baked image set lands on the slots, not RAM.
+The installer's **hard disk floor is 32 GiB** for every role (raised from 24 GiB — issue #312: a 24 GiB disk left `/var` only ~7 GiB, and the Control plane's first boot tipped the kubelet DiskPressure threshold into an eviction storm). 2 GiB RAM boots a single-node control plane but is tight once Postgres + Redis + the Python api/worker are all resident; 8 GiB is the comfortable recommendation. When the operator picks the **Control plane** role on a box below the recommended 40 GiB disk / 8 GiB RAM, `spatium-install` shows a soft sizing warning before proceeding (the lighter Appliance/agent role is fine at the 32 GiB floor and gets no warning). Each control-plane **HA member** sizes the same as a standalone control plane (4 vCPU / 8 GiB) — every member runs a full api / worker / Postgres replica / Redis. SSD is strongly preferred for the etcd + Postgres write path; the installer's disk floor assumes the baked image set lands on the slots, not RAM.
 
 ### Appliance management surfaces (k3s-aware)
 
@@ -698,11 +698,14 @@ p6 var         balance   8300   shared across slots (/var/lib/rancher,
                                 /var/persist/etc, /var/home, /var/root)
 ```
 
-Hard floor: **24 GiB target disk** (installer refuses below it). The
-slots grew from 4 → 8 GiB once the full container image set started
-baking into the rootfs (so the appliance boots air-gapped without
-ghcr.io) — base Debian + Python + the baked images is ~3 GiB, leaving
-~2.7× headroom per slot.
+Hard floor: **32 GiB target disk** (installer refuses below it; raised
+from 24 GiB in issue #312 so `/var` gets ~14 GiB rather than ~7 GiB —
+the Control plane's first-boot image import + Postgres/Redis PVCs
+otherwise tipped the kubelet DiskPressure threshold). The slots grew
+from 4 → 8 GiB once the full container image set started baking into
+the rootfs (so the appliance boots air-gapped without ghcr.io) — base
+Debian + Python + the baked images is ~3 GiB, leaving ~2.7× headroom
+per slot.
 
 **/etc overlayfs:** each slot ships an image-baseline `/etc`
 at `/usr/lib/etc.image/`. At boot, a systemd `etc.mount` unit


### PR DESCRIPTION
Closes #312.

## Problem

`spatium-install` enforced a single **24 GiB** hard floor for every role. That floor only guarantees the appliance *installs and boots* — it left `/var` only ~7 GiB, which is not enough to *run the Control plane* (k3s etcd + CloudNativePG + Redis + api/worker/beat/frontend + 2× HA replicas). A field tester at ~24 GiB / 3.8 GiB in Control-plane mode installed cleanly, then died on first boot in a **DiskPressure eviction storm**: the image import + Postgres/Redis PVCs filled `/var`, crossed the kubelet nodefs threshold, and the eviction manager + image-GC thrashed mid-pull (postgresql-initdb Failed, supervisor Evicted). The recommended sizing was documented but nothing surfaced it when the operator picked the role.

## Change

**Global 32 GiB hard floor** (per maintainer direction) + a **control-plane-only soft warning**:

- **Hard floor 24 → 32 GiB** (`MIN_DISK_GIB`) for every role — `/var` now gets ~14 GiB instead of ~7 GiB. `pick_disk` refuses below it; the too-small message and the `do_install` comment cite the new figure.
- **Soft warning** (`_control_plane_sizing_ok`): on the **Control plane** role, if the box is below the recommended **40 GiB disk / 8 GiB RAM**, a `whiptail --defaultno` warning fires before proceeding — naming actual vs recommended, explaining the DiskPressure risk, and pointing at the sizing docs. Confirm proceeds; declining re-prompts the disk menu. The lightweight **Appliance/agent** role is fine at the 32 GiB floor and gets no warning. RAM is read from `/proc/meminfo` (one GiB of slack so an exactly-8 GiB box doesn't false-warn; the dimension is skipped if `/proc/meminfo` is unreadable).
- **Docs** — README "Quick start" + APPLIANCE.md "Recommended sizing" + the partition-layout note updated to the 32 GiB floor. The Appliance row moved 24 → 32 GiB (it's below the new global floor otherwise), and the control-plane soft warning is documented.

## Acceptance (from the issue)
- ✅ Selecting Control plane below the recommendation shows a clear warning naming recommended disk/RAM before install. (Below 32 GiB is now hard-refused before the warning is even reached.)
- ✅ The hard floor still blocks truly-too-small disks (raised to 32 GiB).
- ✅ Installer copy points at the recommended numbers + the sizing docs.

## Verification
- `bash -n` clean; `shellcheck -S warning` clean on all additions (the one pre-existing SC2010 at line 558 is unrelated).
- Threshold math unit-checked across 24/32/40 GiB × 4/8/16 GiB RAM and the unreadable-`/proc/meminfo` case — the tester's 24 GiB box now hits the hard floor before the warning shows.

Installer + docs only — no app code, no migration.

## Deferred (issue's optional "nice-to-haves")
Left out to keep this focused and off the critical boot path: kubelet `--eviction-hard` / `--image-gc-high-threshold` tuning (the issue itself flags it as "needs care — don't mask a genuinely full disk"), and a first-boot `/var`-free preflight in `spatiumddi-firstboot`. Happy to follow up with the preflight if you want the extra safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)