### PR TITLE
chore(appliance): bump k3s v1.35.4+k3s1 → v1.35.5+k3s1 (#325)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ appliance-clean:
 # Bump in PRs alongside the slot image cut; the fetch script caches
 # downloads under mkosi.extra/ keyed on this version so re-runs are
 # cheap when nothing's changed.
-K3S_VERSION ?= v1.35.4+k3s1
+K3S_VERSION ?= v1.35.5+k3s1
 
 # Issue #183 Phase 1 — air-gap-ready k3s baking. Downloads the pinned
 # k3s static binary + airgap images tarball + LICENSE into mkosi.extra/

--- a/appliance/scripts/fetch-k3s.sh
+++ b/appliance/scripts/fetch-k3s.sh
@@ -38,7 +38,7 @@ set -euo pipefail
 # this script directly (without ``make``); CI + the Makefile always
 # override it. Keep this in sync with the Makefile pin so a direct
 # invocation never silently pulls a stale release tag.
-K3S_VERSION="${K3S_VERSION:-v1.35.4+k3s1}"
+K3S_VERSION="${K3S_VERSION:-v1.35.5+k3s1}"
 
 # Target architecture. Defaults to the build host's arch; release CI
 # overrides per matrix entry so each arch carries its own k3s + airgap

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -993,7 +993,7 @@ class SupervisorHeartbeatRequest(BaseModel):
     cluster_health: dict[str, Any] | None = None
     # Issue #183 Phase 5 — operator-facing k3s metadata.
     # ``k3s_version`` is the upstream release tag the slot was baked
-    # against (e.g. ``v1.35.4+k3s1``). ``kubeconfig`` is the raw
+    # against (e.g. ``v1.35.5+k3s1``). ``kubeconfig`` is the raw
     # admin kubeconfig YAML straight off the appliance — the backend
     # rewrites ``server:`` for operator reachability + Fernet-encrypts
     # before persisting. Both ``None`` = supervisor didn't ship them

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -621,7 +621,7 @@ class Appliance(Base):
 
     # Issue #183 Phase 5 — operator-facing k3s metadata.
     # ``k3s_version`` is the upstream release tag the slot was baked
-    # against (e.g. ``v1.35.4+k3s1``); Fleet UI shows it on the row.
+    # against (e.g. ``v1.35.5+k3s1``); Fleet UI shows it on the row.
     # ``kubeconfig_encrypted`` is the supervisor-supplied admin
     # kubeconfig, Fernet-encrypted at rest. NULL until the supervisor
     # ships one (legacy compose / pre-#183 supervisors / k3s not yet

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7936,7 +7936,7 @@ export interface ApplianceRow {
     pods_total?: number;
     pods_by_phase?: Record<string, number>;
   };
-  // Issue #183 Phase 5 — installed k3s version (e.g. ``v1.35.4+k3s1``).
+  // Issue #183 Phase 5 — installed k3s version (e.g. ``v1.35.5+k3s1``).
   // Null on legacy compose / pre-#183 supervisors.
   k3s_version: string | null;
   // Issue #183 Phase 5 — boolean "supervisor has shipped a kubeconfig".


### PR DESCRIPTION
Closes #325.

Patch bump of the appliance's pinned k3s: **v1.35.4+k3s1 → v1.35.5+k3s1** (upstream Kubernetes v1.35.5 + the May-2026 backports + refreshed embedded components — containerd / etcd / runc / Flannel / CoreDNS / Traefik / metrics-server / helm-controller / local-path-provisioner). Release: https://github.com/k3s-io/k3s/releases/tag/v1.35.5+k3s1

## Changes

**Functional pins (the actual upgrade):**
- `Makefile` `K3S_VERSION` — the source of truth.
- `appliance/scripts/fetch-k3s.sh` fallback default — kept in lock-step.

**Cosmetic (doc drift):** three `e.g. v1.35.x+k3s1` example strings in comments/docstrings — `backend/app/api/v1/appliance/supervisor.py`, `backend/app/models/appliance.py`, `frontend/src/lib/api.ts`.

## Why this is the whole diff

Every baked k3s artifact — the static binary, the airgap images `.tar.zst`, `LICENSE`, `NOTICE`, `k3s-images.txt`, and the `.version` cache-stamp — is **gitignored** (`appliance/.gitignore`) and re-downloaded fresh at build time by `fetch-k3s.sh` (cache-keyed on `K3S_VERSION`). So bumping the pin is sufficient; the CI ISO build re-fetches the new release automatically. Nothing baked is committed.

## Verification
- The v1.35.5+k3s1 release assets — **amd64 + arm64** binaries, both airgap tarballs, `k3s-images.txt`, and `LICENSE` — all return HTTP 200, so the fetch URLs resolve unchanged.
- `bash -n` + `shellcheck -S warning` clean on `fetch-k3s.sh`; `black`/`ruff` clean on the touched `.py`; `prettier` clean on `api.ts` (comment-only edits, identical length).

No app code, no migration, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)