### PR TITLE
Cloud integration (AWS / Azure / GCP) — IPAM infra mirror + Cloud DNS driver family (#37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ further down.
 - ⬜ [**IP discovery**](https://github.com/spatiumddi/spatiumddi/issues/23)
 - ⬜ [**DNS Views — end-to-end split-horizon wiring**](https://github.com/spatiumddi/spatiumddi/issues/24)
 - ⬜ [**ACME embedded client — certs for SpatiumDDI's own services**](https://github.com/spatiumddi/spatiumddi/issues/28)
-- ⬜ [**Cloud DNS driver family — Route 53 / Azure DNS / Cisco DNA**](https://github.com/spatiumddi/spatiumddi/issues/29)
+- 🟡 [**Cloud DNS driver family — Route 53 / Azure DNS / Cisco DNA**](https://github.com/spatiumddi/spatiumddi/issues/29) — Route 53 + Azure DNS + Cloudflare + Google Cloud DNS landed as agentless first-class drivers via #37 Part B (`issue-37`, pending release). Cisco DNA stays out of scope (SD-Access controller, not a hosted-DNS service).
 - ⬜ [**DHCP configuration importer — ISC DHCP, Kea, Windows DHCP**](https://github.com/spatiumddi/spatiumddi/issues/129)
 
 ### Integration roadmap (⬜ pending)
@@ -290,7 +290,7 @@ write surface, not a read-only pull mirror.
 - ⬜ [**Incus / LXD (tier 2 — Docker-adjacent)**](https://github.com/spatiumddi/spatiumddi/issues/34)
 - ⬜ [**HashiCorp Nomad (tier 2 — Kubernetes alt)**](https://github.com/spatiumddi/spatiumddi/issues/35)
 - ⬜ [**NetBox read-only import (one-shot)**](https://github.com/spatiumddi/spatiumddi/issues/36)
-- ⬜ [**Cloud connectors — unified "Cloud" integration with per-provider picker (Azure / AWS / GCP)**](https://github.com/spatiumddi/spatiumddi/issues/37)
+- ✅ [**Cloud connectors — unified "Cloud" integration with per-provider picker (Azure / AWS / GCP)**](https://github.com/spatiumddi/spatiumddi/issues/37) — implemented on `issue-37` (pending release cut). Part A: read-only infra mirror (`cloud_endpoint` + AWS/Azure/GCP connectors → IPBlock/Subnet/IPAddress, `services/cloud/`, feature module `integrations.cloud`). Part B: Cloudflare / Route 53 / Azure DNS / Google Cloud DNS as agentless first-class DNS drivers (`drivers/dns/{cloudflare,route53,azuredns,googledns}.py`) with import-existing-zones (`services/dns_import/cloud.py`). See `docs/features/INTEGRATIONS.md` + `docs/drivers/DNS_DRIVERS.md`. Stretch token-only DNS providers (DigitalOcean / Hetzner / Linode / Vultr) deferred.
 - ⬜ [**Load balancer family (F5 BIG-IP, HAProxy, nginx, KEMP, A10, Citrix ADC)**](https://github.com/spatiumddi/spatiumddi/issues/38)
 - **VMware vCenter / ESXi.** Bigger enterprise audience, but
   vCenter's SOAP-heavy + licensed API makes it a significantly

--- a/NOTICE
+++ b/NOTICE
@@ -53,6 +53,10 @@ components. Grouped by role; license + project URL for each.
 - reportlab (PDF export) — BSD 3-Clause — https://www.reportlab.com
 - Scapy (passive DHCP fingerprinting) — GPL v2 — https://scapy.net
 - nmap (network scanning) — NPSL (Nmap Public Source License) — https://nmap.org
+- boto3 / botocore (AWS — infra mirror + Route 53 DNS) — Apache 2.0 — https://github.com/boto/boto3
+- azure-identity / azure-mgmt-network / azure-mgmt-compute / azure-mgmt-dns / azure-mgmt-resource (Azure — infra mirror + Azure DNS) — MIT — https://github.com/Azure/azure-sdk-for-python
+- google-cloud-compute / google-cloud-dns / google-auth (GCP — infra mirror + Cloud DNS) — Apache 2.0 — https://github.com/googleapis/google-cloud-python
+- Cloudflare DNS is reached via plain REST over httpx (no SDK dependency)
 
 ── Frontend (TypeScript / React) ──────────────────────────────────────────
 - React — MIT — https://react.dev

--- a/NOTICE
+++ b/NOTICE
@@ -56,7 +56,7 @@ components. Grouped by role; license + project URL for each.
 - boto3 / botocore (AWS — infra mirror + Route 53 DNS) — Apache 2.0 — https://github.com/boto/boto3
 - azure-identity / azure-mgmt-network / azure-mgmt-compute / azure-mgmt-dns / azure-mgmt-resource (Azure — infra mirror + Azure DNS) — MIT — https://github.com/Azure/azure-sdk-for-python
 - google-cloud-compute / google-cloud-dns / google-auth (GCP — infra mirror + Cloud DNS) — Apache 2.0 — https://github.com/googleapis/google-cloud-python
-- Cloudflare DNS is reached via plain REST over httpx (no SDK dependency)
+- Cloudflare DNS API (Cloud DNS driver) — service API, no SDK (plain REST via httpx) — https://api.cloudflare.com
 
 ── Frontend (TypeScript / React) ──────────────────────────────────────────
 - React — MIT — https://react.dev

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -283,6 +283,10 @@ backend/alembic/versions/c9f2a83b04d7_appliance_certificate.py:drop_table:90
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:107
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:110
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_table:112
+backend/alembic/versions/d1e7c4a90fb3_cloud_integration.py:drop_column:149
+backend/alembic/versions/d1e7c4a90fb3_cloud_integration.py:drop_column:153
+backend/alembic/versions/d1e7c4a90fb3_cloud_integration.py:drop_constraint_fk:152
+backend/alembic/versions/d1e7c4a90fb3_cloud_integration.py:drop_table:155
 backend/alembic/versions/d2a8e417b9f3_backup_target.py:drop_table:112
 backend/alembic/versions/d2f7a91e4c8b_nmap_scans.py:drop_table:96
 backend/alembic/versions/d3a9c5b71e84_subnet_kind.py:drop_column:71

--- a/backend/alembic/versions/d1e7c4a90fb3_cloud_integration.py
+++ b/backend/alembic/versions/d1e7c4a90fb3_cloud_integration.py
@@ -1,0 +1,143 @@
+"""cloud integration: cloud_endpoint table + cloud_endpoint_id FKs + settings + module
+
+Revision ID: d1e7c4a90fb3
+Revises: c7f1a3e58b94
+Create Date: 2026-05-30 18:00:00.000000
+
+Cloud integration (issue #37, Part A — IPAM infrastructure mirror).
+
+* ``cloud_endpoint`` — one row per connected public-cloud account
+  (AWS / Azure / GCP). Fernet-encrypted ``credentials_encrypted`` blob +
+  non-secret ``provider_config`` JSONB (subscription/project ids) +
+  ``regions`` allow-list. Bound to an IPAM space (RESTRICT) + optional
+  public space (SET NULL) + optional DNS group (SET NULL).
+* ``cloud_endpoint_id`` FK (ON DELETE CASCADE, indexed) on ``ip_block`` /
+  ``subnet`` / ``ip_address`` so removing an endpoint sweeps every
+  mirrored row atomically — same contract every other integration uses.
+* ``platform_settings.integration_cloud_enabled`` — the Celery-beat kill
+  switch kept in lock-step with the ``integrations.cloud`` feature
+  module by the toggle endpoint.
+* ``feature_module`` seed (``integrations.cloud``, disabled) — operator
+  opts in; matches ``ModuleSpec.default_enabled=False``.
+
+Part B (Cloud DNS as a first-class driver) needs no schema: cloud DNS
+drivers reuse the existing ``dns_server.driver`` string + the
+``dns_server.credentials_encrypted`` column + the ``dns_zone`` /
+``dns_record`` ``import_source`` / ``imported_at`` provenance columns.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "d1e7c4a90fb3"
+down_revision: Union[str, None] = "c7f1a3e58b94"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_FK_TABLES = ("ip_block", "subnet", "ip_address")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cloud_endpoint",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("modified_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("provider", sa.String(length=16), nullable=False),
+        sa.Column(
+            "credentials_encrypted",
+            sa.LargeBinary(),
+            nullable=False,
+            server_default=sa.text("''::bytea"),
+        ),
+        sa.Column(
+            "provider_config",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "regions",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("ipam_space_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("public_space_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("dns_group_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("mirror_load_balancers", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "mirror_stopped_instances", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column("sync_interval_seconds", sa.Integer(), nullable=False, server_default="300"),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_sync_error", sa.Text(), nullable=True),
+        sa.Column("provider_account_id", sa.String(length=255), nullable=True),
+        sa.Column("network_count", sa.Integer(), nullable=True),
+        sa.Column("instance_count", sa.Integer(), nullable=True),
+        sa.Column("last_discovery", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.ForeignKeyConstraint(["ipam_space_id"], ["ip_space.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["public_space_id"], ["ip_space.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["dns_group_id"], ["dns_server_group.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_cloud_endpoint_name", "cloud_endpoint", ["name"], unique=True)
+
+    # cloud_endpoint_id provenance FK on the three IPAM row types.
+    for table in _FK_TABLES:
+        op.add_column(
+            table,
+            sa.Column("cloud_endpoint_id", postgresql.UUID(as_uuid=True), nullable=True),
+        )
+        op.create_foreign_key(
+            f"fk_{table}_cloud_endpoint_id",
+            table,
+            "cloud_endpoint",
+            ["cloud_endpoint_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        op.create_index(
+            f"ix_{table}_cloud_endpoint_id",
+            table,
+            ["cloud_endpoint_id"],
+        )
+
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "integration_cloud_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    # ── feature_module seed (disabled; operator opts in) ────────────────
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('integrations.cloud', FALSE)
+            ON CONFLICT (id) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'integrations.cloud'"))
+    op.drop_column("platform_settings", "integration_cloud_enabled")
+    for table in _FK_TABLES:
+        op.drop_index(f"ix_{table}_cloud_endpoint_id", table_name=table)
+        op.drop_constraint(f"fk_{table}_cloud_endpoint_id", table, type_="foreignkey")
+        op.drop_column(table, "cloud_endpoint_id")
+    op.drop_index("ix_cloud_endpoint_name", table_name="cloud_endpoint")
+    op.drop_table("cloud_endpoint")

--- a/backend/alembic/versions/d1e7c4a90fb3_cloud_integration.py
+++ b/backend/alembic/versions/d1e7c4a90fb3_cloud_integration.py
@@ -26,16 +26,17 @@ drivers reuse the existing ``dns_server.driver`` string + the
 ``dns_record`` ``import_source`` / ``imported_at`` provenance columns.
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects import postgresql
 
+from alembic import op
+
 revision: str = "d1e7c4a90fb3"
-down_revision: Union[str, None] = "c7f1a3e58b94"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "c7f1a3e58b94"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 _FK_TABLES = ("ip_block", "subnet", "ip_address")
@@ -45,8 +46,18 @@ def upgrade() -> None:
     op.create_table(
         "cloud_endpoint",
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
-        sa.Column("modified_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("description", sa.Text(), nullable=False, server_default=""),
         sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
@@ -72,9 +83,14 @@ def upgrade() -> None:
         sa.Column("ipam_space_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("public_space_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("dns_group_id", postgresql.UUID(as_uuid=True), nullable=True),
-        sa.Column("mirror_load_balancers", sa.Boolean(), nullable=False, server_default=sa.text("true")),
         sa.Column(
-            "mirror_stopped_instances", sa.Boolean(), nullable=False, server_default=sa.text("false")
+            "mirror_load_balancers", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "mirror_stopped_instances",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
         ),
         sa.Column("sync_interval_seconds", sa.Integer(), nullable=False, server_default="300"),
         sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=True),
@@ -121,15 +137,11 @@ def upgrade() -> None:
     )
 
     # ── feature_module seed (disabled; operator opts in) ────────────────
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             INSERT INTO feature_module (id, enabled)
             VALUES ('integrations.cloud', FALSE)
             ON CONFLICT (id) DO NOTHING
-            """
-        )
-    )
+            """))
 
 
 def downgrade() -> None:

--- a/backend/app/api/v1/cloud/__init__.py
+++ b/backend/app/api/v1/cloud/__init__.py
@@ -1,0 +1,3 @@
+from app.api.v1.cloud.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/cloud/router.py
+++ b/backend/app/api/v1/cloud/router.py
@@ -1,0 +1,446 @@
+"""Cloud integration CRUD + probe + sync endpoints (issue #37, Part A).
+
+Parallels ``app/api/v1/proxmox/router.py``. One ``CloudEndpoint`` row per
+connected public-cloud account (AWS / Azure / GCP). Credentials are a
+provider-specific dict, Fernet-encrypted at rest. Reads gate on the
+``cloud_endpoint`` resource permission; writes require superadmin.
+
+The reconcile itself is connector-agnostic — this router only does CRUD,
+a test-connection probe (``CloudConnector.probe``), and enqueues the
+Celery sweep for a one-off "Sync now".
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, field_validator
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser, SuperAdmin
+from app.core.crypto import decrypt_dict, encrypt_dict
+from app.core.demo_mode import forbid_in_demo_mode
+from app.core.permissions import require_resource_permission
+from app.models.audit import AuditLog
+from app.models.cloud import CloudEndpoint
+from app.models.dns import DNSServerGroup
+from app.models.ipam import IPSpace
+from app.services.cloud.base import (
+    CloudConnectorError,
+    get_connector,
+    implemented_providers,
+)
+
+router = APIRouter(
+    tags=["cloud"],
+    dependencies=[Depends(require_resource_permission("cloud_endpoint"))],
+)
+
+
+# Required credential / provider_config keys per provider. The connector
+# needs these to authenticate + scope; we validate at the API boundary so
+# operators get a clear 422 instead of a confusing reconcile failure.
+_REQUIRED_CREDENTIAL_KEYS: dict[str, tuple[str, ...]] = {
+    "aws": ("access_key_id", "secret_access_key"),
+    "azure": ("tenant_id", "client_id", "client_secret"),
+    "gcp": ("service_account_json",),
+}
+# provider_config keys that must be a non-empty list.
+_REQUIRED_CONFIG_LISTS: dict[str, str] = {
+    "azure": "subscription_ids",
+    "gcp": "project_ids",
+}
+
+
+# ── Pydantic schemas ─────────────────────────────────────────────────
+
+
+class EndpointBase(BaseModel):
+    name: str
+    description: str = ""
+    enabled: bool = True
+    provider_config: dict[str, Any] = {}
+    regions: list[str] = []
+    ipam_space_id: uuid.UUID
+    public_space_id: uuid.UUID | None = None
+    dns_group_id: uuid.UUID | None = None
+    mirror_load_balancers: bool = True
+    mirror_stopped_instances: bool = False
+    sync_interval_seconds: int = 300
+
+    @field_validator("name")
+    @classmethod
+    def _strip_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("name is required")
+        return v
+
+    @field_validator("sync_interval_seconds")
+    @classmethod
+    def _floor_interval(cls, v: int) -> int:
+        if v < 60:
+            raise ValueError("sync_interval_seconds must be ≥ 60")
+        return v
+
+    @field_validator("regions")
+    @classmethod
+    def _clean_regions(cls, v: list[str]) -> list[str]:
+        return [r.strip() for r in v if r and r.strip()]
+
+
+class EndpointCreate(EndpointBase):
+    provider: str
+    # Provider-specific secret dict; encrypted before persist. Required.
+    credentials: dict[str, Any]
+
+    @field_validator("provider")
+    @classmethod
+    def _valid_provider(cls, v: str) -> str:
+        v = v.strip().lower()
+        if v not in implemented_providers():
+            raise ValueError(
+                f"provider must be one of: {', '.join(sorted(implemented_providers()))}"
+            )
+        return v
+
+
+class EndpointUpdate(BaseModel):
+    # provider is immutable post-create (like the AI-provider kind).
+    name: str | None = None
+    description: str | None = None
+    enabled: bool | None = None
+    # Omit or send empty to keep the stored credentials; non-empty rotates.
+    credentials: dict[str, Any] | None = None
+    provider_config: dict[str, Any] | None = None
+    regions: list[str] | None = None
+    ipam_space_id: uuid.UUID | None = None
+    public_space_id: uuid.UUID | None = None
+    dns_group_id: uuid.UUID | None = None
+    mirror_load_balancers: bool | None = None
+    mirror_stopped_instances: bool | None = None
+    sync_interval_seconds: int | None = None
+
+
+class EndpointResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str
+    enabled: bool
+    provider: str
+    credentials_present: bool
+    provider_config: dict[str, Any]
+    regions: list[str]
+    ipam_space_id: uuid.UUID
+    public_space_id: uuid.UUID | None
+    dns_group_id: uuid.UUID | None
+    mirror_load_balancers: bool
+    mirror_stopped_instances: bool
+    sync_interval_seconds: int
+    last_synced_at: datetime | None
+    last_sync_error: str | None
+    provider_account_id: str | None
+    network_count: int | None
+    instance_count: int | None
+    last_discovery: dict | None
+    created_at: datetime
+    modified_at: datetime
+
+
+class TestConnectionRequest(BaseModel):
+    endpoint_id: uuid.UUID | None = None
+    provider: str | None = None
+    credentials: dict[str, Any] | None = None
+    provider_config: dict[str, Any] | None = None
+    regions: list[str] | None = None
+
+
+class TestConnectionResponse(BaseModel):
+    ok: bool
+    message: str
+    provider_account_id: str | None = None
+    network_count: int | None = None
+    instance_count: int | None = None
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _to_response(e: CloudEndpoint) -> EndpointResponse:
+    return EndpointResponse(
+        id=e.id,
+        name=e.name,
+        description=e.description,
+        enabled=e.enabled,
+        provider=e.provider,
+        credentials_present=bool(e.credentials_encrypted),
+        provider_config=e.provider_config or {},
+        regions=e.regions or [],
+        ipam_space_id=e.ipam_space_id,
+        public_space_id=e.public_space_id,
+        dns_group_id=e.dns_group_id,
+        mirror_load_balancers=e.mirror_load_balancers,
+        mirror_stopped_instances=e.mirror_stopped_instances,
+        sync_interval_seconds=e.sync_interval_seconds,
+        last_synced_at=e.last_synced_at,
+        last_sync_error=e.last_sync_error,
+        provider_account_id=e.provider_account_id,
+        network_count=e.network_count,
+        instance_count=e.instance_count,
+        last_discovery=e.last_discovery,
+        created_at=e.created_at,
+        modified_at=e.modified_at,
+    )
+
+
+def _validate_provider_payload(
+    provider: str, credentials: dict[str, Any], provider_config: dict[str, Any]
+) -> None:
+    """422 when required credential / routing keys are missing."""
+    missing = [k for k in _REQUIRED_CREDENTIAL_KEYS.get(provider, ()) if not credentials.get(k)]
+    if missing:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{provider} credentials require: {', '.join(missing)}",
+        )
+    list_key = _REQUIRED_CONFIG_LISTS.get(provider)
+    if list_key:
+        value = provider_config.get(list_key)
+        if not isinstance(value, list) or not value:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{provider} provider_config requires a non-empty {list_key} list",
+            )
+
+
+async def _validate_bindings(
+    db: Any,
+    ipam_space_id: uuid.UUID,
+    public_space_id: uuid.UUID | None,
+    dns_group_id: uuid.UUID | None,
+) -> None:
+    if await db.get(IPSpace, ipam_space_id) is None:
+        raise HTTPException(status_code=422, detail="ipam_space_id not found")
+    if public_space_id is not None and await db.get(IPSpace, public_space_id) is None:
+        raise HTTPException(status_code=422, detail="public_space_id not found")
+    if dns_group_id is not None and await db.get(DNSServerGroup, dns_group_id) is None:
+        raise HTTPException(status_code=422, detail="dns_group_id not found")
+
+
+def _audit(
+    db: Any,
+    *,
+    user: Any,
+    action: str,
+    endpoint_id: uuid.UUID,
+    endpoint_name: str,
+    changed_fields: list[str] | None = None,
+    new_value: dict | None = None,
+) -> None:
+    db.add(
+        AuditLog(
+            user_id=user.id if user else None,
+            user_display_name=user.display_name if user else "system",
+            auth_source=user.auth_source if user else "system",
+            action=action,
+            resource_type="cloud_endpoint",
+            resource_id=str(endpoint_id),
+            resource_display=endpoint_name,
+            changed_fields=changed_fields,
+            new_value=new_value,
+        )
+    )
+
+
+# ── Endpoints ────────────────────────────────────────────────────────
+
+
+@router.get("/endpoints", response_model=list[EndpointResponse])
+async def list_endpoints(db: DB, _: CurrentUser) -> list[EndpointResponse]:
+    res = await db.execute(select(CloudEndpoint).order_by(CloudEndpoint.name))
+    return [_to_response(e) for e in res.scalars().all()]
+
+
+@router.post("/endpoints", response_model=EndpointResponse, status_code=status.HTTP_201_CREATED)
+async def create_endpoint(body: EndpointCreate, db: DB, user: SuperAdmin) -> EndpointResponse:
+    forbid_in_demo_mode("Cloud endpoint registration is disabled")
+    _validate_provider_payload(body.provider, body.credentials, body.provider_config)
+    await _validate_bindings(db, body.ipam_space_id, body.public_space_id, body.dns_group_id)
+
+    existing = await db.execute(select(CloudEndpoint).where(CloudEndpoint.name == body.name))
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="A Cloud endpoint with that name exists")
+
+    e = CloudEndpoint(
+        name=body.name,
+        description=body.description,
+        enabled=body.enabled,
+        provider=body.provider,
+        credentials_encrypted=encrypt_dict(body.credentials),
+        provider_config=body.provider_config,
+        regions=body.regions,
+        ipam_space_id=body.ipam_space_id,
+        public_space_id=body.public_space_id,
+        dns_group_id=body.dns_group_id,
+        mirror_load_balancers=body.mirror_load_balancers,
+        mirror_stopped_instances=body.mirror_stopped_instances,
+        sync_interval_seconds=body.sync_interval_seconds,
+    )
+    db.add(e)
+    await db.flush()
+    _audit(
+        db,
+        user=user,
+        action="create",
+        endpoint_id=e.id,
+        endpoint_name=e.name,
+        new_value=body.model_dump(mode="json", exclude={"credentials"}),
+    )
+    await db.commit()
+    await db.refresh(e)
+    return _to_response(e)
+
+
+@router.put("/endpoints/{endpoint_id}", response_model=EndpointResponse)
+async def update_endpoint(
+    endpoint_id: uuid.UUID, body: EndpointUpdate, db: DB, user: SuperAdmin
+) -> EndpointResponse:
+    e = await db.get(CloudEndpoint, endpoint_id)
+    if e is None:
+        raise HTTPException(status_code=404, detail="Cloud endpoint not found")
+
+    changes = body.model_dump(exclude_unset=True)
+
+    new_ipam = changes.get("ipam_space_id", e.ipam_space_id)
+    new_public = changes.get("public_space_id", e.public_space_id)
+    new_dns = changes.get("dns_group_id", e.dns_group_id)
+    if {"ipam_space_id", "public_space_id", "dns_group_id"} & changes.keys():
+        await _validate_bindings(db, new_ipam, new_public, new_dns)
+
+    # Re-validate provider payload when credentials or routing config change.
+    new_creds = changes.get("credentials")
+    if new_creds:
+        _validate_provider_payload(
+            e.provider, new_creds, changes.get("provider_config", e.provider_config or {})
+        )
+
+    for k, v in changes.items():
+        if k == "credentials":
+            if v:
+                e.credentials_encrypted = encrypt_dict(v)
+        else:
+            setattr(e, k, v)
+
+    _audit(
+        db,
+        user=user,
+        action="update",
+        endpoint_id=e.id,
+        endpoint_name=e.name,
+        changed_fields=list(changes.keys()),
+        new_value={k: v for k, v in changes.items() if k != "credentials"},
+    )
+    await db.commit()
+    await db.refresh(e)
+    return _to_response(e)
+
+
+@router.delete("/endpoints/{endpoint_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_endpoint(endpoint_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
+    e = await db.get(CloudEndpoint, endpoint_id)
+    if e is None:
+        raise HTTPException(status_code=404, detail="Cloud endpoint not found")
+    _audit(db, user=user, action="delete", endpoint_id=e.id, endpoint_name=e.name)
+    # Mirror rows (IPBlock/Subnet/IPAddress) cascade via cloud_endpoint_id FK.
+    await db.delete(e)
+    await db.commit()
+
+
+@router.post("/endpoints/{endpoint_id}/sync", status_code=status.HTTP_202_ACCEPTED)
+async def sync_endpoint(endpoint_id: uuid.UUID, db: DB, _: SuperAdmin) -> dict[str, str]:
+    e = await db.get(CloudEndpoint, endpoint_id)
+    if e is None:
+        raise HTTPException(status_code=404, detail="Cloud endpoint not found")
+
+    from app.tasks.cloud_sync import sync_endpoint_now  # noqa: PLC0415
+
+    try:
+        result = sync_endpoint_now.delay(str(e.id))
+        return {"status": "queued", "task_id": result.id}
+    except Exception:  # noqa: BLE001 — broker may be down; surface gracefully
+        return {"status": "broker_unavailable", "task_id": ""}
+
+
+@router.post("/endpoints/test", response_model=TestConnectionResponse)
+async def test_connection(
+    body: TestConnectionRequest, db: DB, _: SuperAdmin
+) -> TestConnectionResponse:
+    provider = (body.provider or "").strip().lower()
+    credentials = body.credentials
+    provider_config = body.provider_config if body.provider_config is not None else {}
+    regions = body.regions if body.regions is not None else []
+
+    if body.endpoint_id is not None:
+        stored = await db.get(CloudEndpoint, body.endpoint_id)
+        if stored is None:
+            raise HTTPException(status_code=404, detail="Cloud endpoint not found")
+        provider = provider or stored.provider
+        provider_config = (
+            body.provider_config
+            if body.provider_config is not None
+            else (stored.provider_config or {})
+        )
+        regions = body.regions if body.regions is not None else (stored.regions or [])
+        if not credentials and stored.credentials_encrypted:
+            try:
+                credentials = decrypt_dict(stored.credentials_encrypted)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Stored credentials could not be decrypted — re-enter them",
+                ) from exc
+
+    if provider not in implemented_providers():
+        raise HTTPException(
+            status_code=422,
+            detail=f"provider must be one of: {', '.join(sorted(implemented_providers()))}",
+        )
+    if not credentials:
+        raise HTTPException(
+            status_code=422,
+            detail="credentials are required (either in the body or via a stored endpoint_id)",
+        )
+
+    try:
+        connector = get_connector(
+            provider,
+            credentials=credentials,
+            provider_config=provider_config,
+            regions=regions,
+        )
+        result = await connector.probe()
+    except CloudConnectorError as exc:
+        return TestConnectionResponse(ok=False, message=str(exc))
+    except Exception as exc:  # noqa: BLE001 — never 500 the probe
+        return TestConnectionResponse(ok=False, message=f"{provider} probe error: {exc}")
+
+    if body.endpoint_id is not None and result.ok:
+        stored = await db.get(CloudEndpoint, body.endpoint_id)
+        if stored is not None:
+            stored.provider_account_id = result.account_id
+            stored.last_sync_error = None
+            await db.commit()
+
+    return TestConnectionResponse(
+        ok=result.ok,
+        message=result.message,
+        provider_account_id=result.account_id,
+        network_count=result.network_count,
+        instance_count=result.instance_count,
+    )
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/cloud/router.py
+++ b/backend/app/api/v1/cloud/router.py
@@ -320,11 +320,22 @@ async def update_endpoint(
     if {"ipam_space_id", "public_space_id", "dns_group_id"} & changes.keys():
         await _validate_bindings(db, new_ipam, new_public, new_dns)
 
-    # Re-validate provider payload when credentials or routing config change.
+    # Re-validate the provider payload when EITHER credentials or the
+    # routing config (provider_config) changes — clearing
+    # subscription_ids / project_ids without rotating creds would
+    # otherwise save an invalid endpoint that only fails later at
+    # sync/probe time. When creds aren't being rotated, validate the new
+    # config against the stored creds.
     new_creds = changes.get("credentials")
-    if new_creds:
+    if new_creds or "provider_config" in changes:
+        creds_for_check: dict[str, Any] = new_creds or {}
+        if not new_creds and e.credentials_encrypted:
+            try:
+                creds_for_check = decrypt_dict(e.credentials_encrypted)
+            except ValueError:
+                creds_for_check = {}
         _validate_provider_payload(
-            e.provider, new_creds, changes.get("provider_config", e.provider_config or {})
+            e.provider, creds_for_check, changes.get("provider_config", e.provider_config or {})
         )
 
     for k, v in changes.items():

--- a/backend/app/api/v1/dashboards/integrations.py
+++ b/backend/app/api/v1/dashboards/integrations.py
@@ -27,6 +27,7 @@ from sqlalchemy import desc, select
 
 from app.api.deps import DB, CurrentUser  # noqa: F401
 from app.models.audit import AuditLog
+from app.models.cloud import CloudEndpoint
 from app.models.docker import DockerHost
 from app.models.kubernetes import KubernetesCluster
 from app.models.proxmox import ProxmoxNode
@@ -87,6 +88,7 @@ _INTEGRATION_RESOURCE_TYPES = (
     "proxmox_node",
     "tailscale_tenant",
     "unifi_controller",
+    "cloud_endpoint",
 )
 
 
@@ -164,6 +166,7 @@ async def integrations_summary(
     proxmox_targets = list((await db.execute(select(ProxmoxNode))).scalars().all())
     tailscale_targets = list((await db.execute(select(TailscaleTenant))).scalars().all())
     unifi_targets = list((await db.execute(select(UnifiController))).scalars().all())
+    cloud_targets = list((await db.execute(select(CloudEndpoint))).scalars().all())
 
     panels = [
         _build_panel(
@@ -203,6 +206,14 @@ async def integrations_summary(
             label="UniFi",
             enabled=getattr(settings, "integration_unifi_enabled", False),
             targets=unifi_targets,
+            display_attr="name",
+            now=now,
+        ),
+        _build_panel(
+            kind="cloud",
+            label="Cloud (AWS / Azure / GCP)",
+            enabled=getattr(settings, "integration_cloud_enabled", False),
+            targets=cloud_targets,
             display_attr="name",
             now=now,
         ),

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -21,7 +21,7 @@ from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.crypto import decrypt_dict, encrypt_dict, encrypt_str
 from app.core.permissions import require_any_resource_permission
 from app.drivers.dns import _DRIVERS as _DNS_DRIVERS
-from app.drivers.dns import is_agentless
+from app.drivers.dns import CLOUD_DNS_DRIVERS, is_agentless
 from app.drivers.dns.windows import test_winrm_credentials
 from app.models.audit import AuditLog
 from app.models.dns import (
@@ -231,6 +231,11 @@ class ServerCreate(BaseModel):
     # falls back to Path A (RFC 2136 record CRUD only, no zone topology
     # management).
     windows_credentials: WindowsCredentialsInput | None = None
+    # Provider-specific credential dict for cloud DNS drivers
+    # (cloudflare/route53/azure_dns/google_dns — issue #37 Part B).
+    # Fernet-encrypted into the same ``credentials_encrypted`` column.
+    # Shape varies per driver (e.g. {"api_token"} for cloudflare).
+    cloud_credentials: dict[str, Any] | None = None
 
     @field_validator("driver")
     @classmethod
@@ -257,6 +262,9 @@ class ServerUpdate(BaseModel):
     #   * dict → partial patch if server already has creds (decrypt-merge-
     #            reencrypt), full username+password if it doesn't
     windows_credentials: WindowsCredentialsInput | dict[str, Any] | None = None
+    # Cloud DNS driver credentials (issue #37). Same contract as the
+    # windows block: None = leave alone, {} = clear, dict = replace.
+    cloud_credentials: dict[str, Any] | None = None
 
     @field_validator("driver")
     @classmethod
@@ -926,7 +934,7 @@ async def create_server(
             detail="A server with that name already exists in this group",
         )
 
-    data = body.model_dump(exclude={"api_key", "windows_credentials"})
+    data = body.model_dump(exclude={"api_key", "windows_credentials", "cloud_credentials"})
     data["group_id"] = group_id
     if body.api_key:
         # Issue #210 — Fernet-encrypted at rest, matching the unifi /
@@ -962,6 +970,17 @@ async def create_server(
         creds.setdefault("verify_tls", False)
         server.credentials_encrypted = encrypt_dict(creds)
 
+    # Cloud DNS driver credentials (issue #37) — provider-specific dict,
+    # Fernet-encrypted into the same column. Required on create for an
+    # agentless cloud driver (without them the driver can't reach the API).
+    if body.driver in CLOUD_DNS_DRIVERS:
+        if not body.cloud_credentials:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{body.driver} create requires cloud_credentials",
+            )
+        server.credentials_encrypted = encrypt_dict(body.cloud_credentials)
+
     db.add(server)
     db.add(
         AuditLog(
@@ -989,7 +1008,9 @@ async def update_server(
     current_user: SuperAdmin,
 ) -> ServerResponse:
     server = await _require_server(group_id, server_id, db)
-    changes = body.model_dump(exclude_none=True, exclude={"api_key", "windows_credentials"})
+    changes = body.model_dump(
+        exclude_none=True, exclude={"api_key", "windows_credentials", "cloud_credentials"}
+    )
     if body.api_key is not None:
         # Issue #210 — Fernet-encrypted at rest; matches the create
         # path above. ``body.api_key == ""`` clears the column.
@@ -1038,6 +1059,17 @@ async def update_server(
         elif body.windows_credentials == {}:
             server.credentials_encrypted = None
             changes["windows_credentials_cleared"] = True
+
+    # Cloud DNS driver credentials (issue #37): None → leave alone,
+    # {} → clear, non-empty dict → full replace (the modal sends the
+    # complete provider cred set, so no partial-merge needed).
+    if body.cloud_credentials is not None:
+        if body.cloud_credentials == {}:
+            server.credentials_encrypted = None
+            changes["cloud_credentials_cleared"] = True
+        else:
+            server.credentials_encrypted = encrypt_dict(body.cloud_credentials)
+            changes["cloud_credentials_set"] = True
 
     db.add(
         AuditLog(
@@ -1254,25 +1286,31 @@ async def pull_zones_from_server(
     — caller decides what to do next (show in UI, import, reconcile).
     """
     server = await _require_server(group_id, server_id, db)
-    if server.driver != "windows_dns":
+    # Zone-topology reads are supported by the agentless drivers that
+    # implement ``pull_zones_from_server`` — Windows DNS (WinRM) + the
+    # cloud DNS drivers (provider API, issue #37).
+    if server.driver != "windows_dns" and server.driver not in CLOUD_DNS_DRIVERS:
         raise HTTPException(
             status_code=400,
-            detail=f"pull-zones is only supported on windows_dns (got {server.driver!r})",
+            detail=(
+                f"pull-zones is only supported on windows_dns + cloud DNS drivers "
+                f"(got {server.driver!r})"
+            ),
         )
     if not server.credentials_encrypted:
         raise HTTPException(
             status_code=400,
             detail=(
-                "This server has no Windows credentials configured. "
-                "Add credentials on the server to enable WinRM zone topology reads."
+                "This server has no credentials configured. Add credentials on the "
+                "server to enable zone topology reads."
             ),
         )
 
-    from app.drivers.dns.windows import WindowsDNSDriver  # noqa: PLC0415
+    from app.drivers.dns import get_driver  # noqa: PLC0415
 
-    driver = WindowsDNSDriver()
+    driver = get_driver(server.driver)
     try:
-        zones = await driver.pull_zones_from_server(server)
+        zones = await driver.pull_zones_from_server(server)  # type: ignore[attr-defined]
     except Exception as exc:  # noqa: BLE001 — surface PS / WinRM errors verbatim
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
@@ -1402,18 +1440,23 @@ async def _sync_single_server(
          on the first record-push — exactly the joe.com drift we hit.
       4. Run the existing bi-directional per-zone sync for records.
     """
-    from app.drivers.dns.windows import WindowsDNSDriver  # noqa: PLC0415
+    from app.drivers.dns import get_driver  # noqa: PLC0415
     from app.services.dns.pull_from_server import sync_zone_with_server  # noqa: PLC0415
 
     group_id = server.group_id
+    # Agentless drivers that can list zones from the authoritative side:
+    # Windows DNS (WinRM Path B) + the cloud DNS drivers (provider API).
+    topology_capable = (
+        server.driver == "windows_dns" or server.driver in CLOUD_DNS_DRIVERS
+    ) and bool(server.credentials_encrypted)
 
-    # 1. Path B discovery.
+    # 1. Topology discovery (Path B for Windows / provider API for cloud).
     zones_on_server: list[str] = []
     zone_meta_by_name: dict[str, dict[str, Any]] = {}
-    if server.driver == "windows_dns" and server.credentials_encrypted:
+    if topology_capable:
         try:
-            winrm_zones = await WindowsDNSDriver().pull_zones_from_server(server)
-            for z in winrm_zones:
+            discovered = await get_driver(server.driver).pull_zones_from_server(server)  # type: ignore[attr-defined]
+            for z in discovered:
                 name = str(z.get("name") or "").rstrip(".")
                 if not name:
                     continue
@@ -1421,8 +1464,9 @@ async def _sync_single_server(
                 zone_meta_by_name[name] = z
         except Exception as exc:  # noqa: BLE001 — informational, keep going
             logger.warning(
-                "dns.sync_from_server.pull_zones_winrm_failed",
+                "dns.sync_from_server.pull_zones_failed",
                 server=str(server.id),
+                driver=server.driver,
                 error=str(exc),
             )
 
@@ -1477,12 +1521,13 @@ async def _sync_single_server(
         if zones_imported:
             await db.flush()
 
-    # 3. Push missing zones DB→server (windows_dns+creds only).
+    # 3. Push missing zones DB→server (topology-capable drivers only:
+    #    Windows DNS over WinRM + cloud DNS via provider API).
     zones_pushed_to_server: list[str] = []
     zones_push_to_server_errors: list[str] = []
-    if server.driver == "windows_dns" and server.credentials_encrypted:
+    if topology_capable:
         server_zone_set = {n for n in zones_on_server}
-        driver = WindowsDNSDriver()
+        driver = get_driver(server.driver)
         # Re-query zones after the import step so newly-imported rows
         # are excluded from the "missing on server" set automatically.
         db_zones_res = await db.execute(select(DNSZone).where(DNSZone.group_id == group_id))
@@ -3659,10 +3704,13 @@ async def apply_delegation(
 async def _push_zone_to_agentless_servers(db: DB, zone: DNSZone, op: str) -> None:
     """Push ``create`` / ``delete`` to every agentless-with-creds server.
 
-    "Agentless" today means ``windows_dns``; "with creds" means Path B
-    (WinRM). Those are the only servers that have an admin channel the
-    control plane can use directly — agent-based drivers (bind9) get
-    zone changes through the ConfigBundle long-poll, not here.
+    "Agentless" means ``windows_dns`` (WinRM Path B) + the cloud DNS
+    drivers (cloudflare / route53 / azure_dns / google_dns — issue #37),
+    each of which implements ``apply_zone_change``. "With creds" means a
+    credential blob is configured. Those are the servers with an admin
+    channel the control plane can drive directly — agent-based drivers
+    (bind9 / powerdns) get zone changes through the ConfigBundle
+    long-poll, not here.
 
     Failure surfaces as a 502 so the caller's ``db.commit()`` never runs
     — the DB row stays in an uncommitted state and the session rollback

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -1063,7 +1063,20 @@ async def update_server(
     # Cloud DNS driver credentials (issue #37): None → leave alone,
     # {} → clear, non-empty dict → full replace (the modal sends the
     # complete provider cred set, so no partial-merge needed).
+    # ``server.driver`` here is the EFFECTIVE driver (the changes loop
+    # above already applied any driver change). Reject cloud_credentials
+    # on a non-cloud driver so we never clobber a Windows server's
+    # ``credentials_encrypted`` (or set a meaningless blob on bind9).
     if body.cloud_credentials is not None:
+        if server.driver not in CLOUD_DNS_DRIVERS:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "cloud_credentials is only valid for cloud DNS drivers "
+                    f"({', '.join(sorted(CLOUD_DNS_DRIVERS))}); this server's driver "
+                    f"is {server.driver!r}"
+                ),
+            )
         if body.cloud_credentials == {}:
             server.credentials_encrypted = None
             changes["cloud_credentials_cleared"] = True

--- a/backend/app/api/v1/dns_import/router.py
+++ b/backend/app/api/v1/dns_import/router.py
@@ -24,6 +24,8 @@ from sqlalchemy import select
 from app.api.deps import DB, SuperAdmin
 from app.models.dns import DNSServer, DNSServerGroup
 from app.services.dns_import import (
+    CLOUD_DRIVERS,
+    CloudDNSImportError,
     CommitResult,
     ImportSourceError,
     PowerDNSImportError,
@@ -31,6 +33,7 @@ from app.services.dns_import import (
     parse_bind9_archive,
     parse_powerdns_server,
     parse_windows_dns_server,
+    preview_cloud_import,
     test_powerdns_connection,
 )
 from app.services.dns_import.canonical import (
@@ -99,7 +102,15 @@ class PreviewOut(BaseModel):
     """Preview response shape — also the commit request payload's
     ``plan`` field, so the UI hands back the same shape it received."""
 
-    source: Literal["bind9", "windows_dns", "powerdns"]
+    source: Literal[
+        "bind9",
+        "windows_dns",
+        "powerdns",
+        "cloudflare",
+        "route53",
+        "azure_dns",
+        "google_dns",
+    ]
     zones: list[ImportedZoneOut]
     conflicts: list[ZoneConflictOut]
     warnings: list[str]
@@ -145,6 +156,33 @@ class WindowsDNSServerOption(BaseModel):
     id: uuid.UUID
     name: str
     host: str
+    group_id: uuid.UUID
+    group_name: str
+    has_credentials: bool
+
+
+class CloudDNSPreviewIn(BaseModel):
+    """Body shape for ``POST /dns/import/cloud/preview``.
+
+    Like Windows DNS, cloud DNS is a live pull — the operator picks a
+    pre-registered cloud DNS server row (driver in {cloudflare, route53,
+    azure_dns, google_dns}) and the control plane pulls hosted zones +
+    records via the provider API. This is also the engine behind the
+    "Sync from provider" button on a cloud DNS server.
+    """
+
+    server_id: uuid.UUID
+    target_group_id: uuid.UUID
+    target_view_id: uuid.UUID | None = None
+
+
+class CloudDNSServerOption(BaseModel):
+    """One row in the cloud-DNS server picker — filtered to cloud-driver
+    rows that have credentials configured."""
+
+    id: uuid.UUID
+    name: str
+    driver: str
     group_id: uuid.UUID
     group_name: str
     has_credentials: bool
@@ -683,6 +721,138 @@ async def powerdns_commit(
 
     logger.info(
         "dns_import_powerdns_commit",
+        target_group_id=str(body.target_group_id),
+        zones_created=result.total_zones_created,
+        zones_overwrote=result.total_zones_overwrote,
+        zones_renamed=result.total_zones_renamed,
+        zones_skipped=result.total_zones_skipped,
+        zones_failed=result.total_zones_failed,
+        records_created=result.total_records_created,
+        user=current_user.display_name,
+    )
+    return _commit_result_to_pydantic(result)
+
+
+# ── Cloud DNS endpoints (issue #37, Part B) ──────────────────────────
+
+
+@router.get("/cloud/servers", response_model=list[CloudDNSServerOption])
+async def cloud_dns_servers(
+    _: SuperAdmin,
+    db: DB,
+) -> list[CloudDNSServerOption]:
+    """List every cloud-driver DNS server with its group, for the UI's
+    server picker.
+
+    Returns ``has_credentials`` so the picker can grey out servers
+    missing their provider API token / key — the live pull needs them.
+    """
+
+    rows = (
+        await db.execute(
+            select(DNSServer, DNSServerGroup)
+            .join(DNSServerGroup, DNSServer.group_id == DNSServerGroup.id)
+            .where(DNSServer.driver.in_(sorted(CLOUD_DRIVERS)))
+            .order_by(DNSServerGroup.name, DNSServer.name)
+        )
+    ).all()
+    return [
+        CloudDNSServerOption(
+            id=server.id,
+            name=server.name,
+            driver=server.driver,
+            group_id=group.id,
+            group_name=group.name,
+            has_credentials=bool(server.credentials_encrypted),
+        )
+        for (server, group) in rows
+    ]
+
+
+@router.post("/cloud/preview", response_model=PreviewOut)
+async def cloud_dns_preview(
+    current_user: SuperAdmin,
+    db: DB,
+    body: CloudDNSPreviewIn = Body(...),
+) -> PreviewOut:
+    """Live-pull every hosted zone + record from a cloud DNS provider.
+
+    Delegates to :func:`preview_cloud_import`, which validates the
+    server is a cloud driver, pulls zones + records through the driver,
+    and stamps the provider name as ``import_source``. Side-effect-free
+    — only the commit endpoint mutates state.
+    """
+
+    try:
+        preview = await preview_cloud_import(
+            db,
+            server_id=body.server_id,
+            target_group_id=body.target_group_id,
+            target_view_id=body.target_view_id,
+        )
+    except CloudDNSImportError as exc:
+        # Validation failures (not a cloud driver / unknown server) → 400.
+        raise HTTPException(status_code=400, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    logger.info(
+        "dns_import_cloud_preview",
+        server_id=str(body.server_id),
+        source=preview.source,
+        zone_count=len(preview.zones),
+        record_count=preview.total_records,
+        conflict_count=len(preview.conflicts),
+        warning_count=len(preview.warnings),
+        target_group_id=str(body.target_group_id),
+        user=current_user.display_name,
+    )
+    return _preview_to_pydantic(preview)
+
+
+@router.post("/cloud/commit", response_model=CommitOut)
+async def cloud_dns_commit(
+    current_user: SuperAdmin,
+    db: DB,
+    body: CommitIn = Body(...),
+) -> CommitOut:
+    """Apply a previously-previewed cloud DNS import.
+
+    Identical pipeline to the other sources (re-detect conflicts,
+    per-zone savepoints, audit per zone). The plan's ``source`` must be
+    one of the cloud provider names so provenance stays per-provider.
+    """
+
+    if body.plan.source not in CLOUD_DRIVERS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Plan source mismatch: endpoint=cloud plan={body.plan.source} "
+                f"(expected one of {', '.join(sorted(CLOUD_DRIVERS))})"
+            ),
+        )
+
+    preview = _preview_from_pydantic(body.plan)
+    actions: dict[str, tuple[ConflictAction, str | None]] = {
+        zone_name: (decision.action, decision.rename_to)
+        for zone_name, decision in body.conflict_actions.items()
+    }
+
+    try:
+        result = await commit_import(
+            db,
+            preview=preview,
+            target_group_id=body.target_group_id,
+            target_view_id=body.target_view_id,
+            conflict_actions=actions,
+            current_user=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    logger.info(
+        "dns_import_cloud_commit",
+        source=body.plan.source,
         target_group_id=str(body.target_group_id),
         zones_created=result.total_zones_created,
         zones_overwrote=result.total_zones_overwrote,

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -18,6 +18,7 @@ from app.api.v1.auth_providers.router import router as auth_providers_router
 from app.api.v1.backup import router as backup_router
 from app.api.v1.bgp import router as bgp_router
 from app.api.v1.circuits import router as circuits_router
+from app.api.v1.cloud import router as cloud_router
 from app.api.v1.conformity import router as conformity_router
 from app.api.v1.custom_fields.router import router as custom_fields_router
 from app.api.v1.dashboards import router as dashboards_router
@@ -104,6 +105,12 @@ api_v1_router.include_router(
     prefix="/circuits",
     tags=["circuits"],
     dependencies=[Depends(require_module("network.circuit"))],
+)
+api_v1_router.include_router(
+    cloud_router,
+    prefix="/cloud",
+    tags=["cloud"],
+    dependencies=[Depends(require_module("integrations.cloud"))],
 )
 api_v1_router.include_router(
     conformity_router,

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -97,6 +97,7 @@ class SettingsResponse(BaseModel):
     integration_docker_enabled: bool
     integration_proxmox_enabled: bool
     integration_tailscale_enabled: bool
+    integration_cloud_enabled: bool
     domain_whois_interval_hours: int
     # Device profiling — fingerbank API key. Boolean reflects whether
     # an encrypted key is stored; the plaintext is never returned.
@@ -350,6 +351,7 @@ class SettingsUpdate(BaseModel):
     integration_docker_enabled: bool | None = None
     integration_proxmox_enabled: bool | None = None
     integration_tailscale_enabled: bool | None = None
+    integration_cloud_enabled: bool | None = None
     domain_whois_interval_hours: int | None = None
     # Device profiling — fingerbank API key. Plaintext on the wire
     # (TLS-protected); empty string clears the stored value. Omit the

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -37,6 +37,7 @@ celery_app = Celery(
         "app.tasks.proxmox_sync",
         "app.tasks.tailscale_sync",
         "app.tasks.unifi_sync",
+        "app.tasks.cloud_sync",
         "app.tasks.snmp_poll",
         "app.tasks.nmap",
         "app.tasks.dns_pool_healthcheck",
@@ -88,6 +89,7 @@ celery_app.conf.update(
         "app.tasks.proxmox_sync.*": {"queue": "default"},
         "app.tasks.tailscale_sync.*": {"queue": "default"},
         "app.tasks.unifi_sync.*": {"queue": "default"},
+        "app.tasks.cloud_sync.*": {"queue": "default"},
         "app.tasks.snmp_poll.*": {"queue": "default"},
         "app.tasks.nmap.*": {"queue": "default"},
         "app.tasks.dns_pool_healthcheck.*": {"queue": "dns"},
@@ -308,6 +310,13 @@ celery_app.conf.update(
         # Cloud-mode controllers floor at 60 s inside the task.
         "unifi-sync-sweep": {
             "task": "app.tasks.unifi_sync.sweep_unifi_controllers",
+            "schedule": schedule(run_every=30.0),
+        },
+        # Cloud (AWS/Azure/GCP) — same 30 s beat, per-endpoint interval
+        # gate (300 s default, cloud APIs are rate-limited). Gated overall
+        # by ``PlatformSettings.integration_cloud_enabled``.
+        "cloud-sync-sweep": {
+            "task": "app.tasks.cloud_sync.sweep_cloud_endpoints",
             "schedule": schedule(run_every=30.0),
         },
         # Every 60 s, fan-out SNMP polls to network devices whose

--- a/backend/app/drivers/dns/__init__.py
+++ b/backend/app/drivers/dns/__init__.py
@@ -11,6 +11,7 @@ service layer.
 
 from __future__ import annotations
 
+from app.drivers.dns.azuredns import AzureDNSDriver
 from app.drivers.dns.base import (
     ConfigBundle,
     DNSDriver,
@@ -22,20 +23,39 @@ from app.drivers.dns.base import (
     ZoneData,
 )
 from app.drivers.dns.bind9 import BIND9Driver
+from app.drivers.dns.cloudflare import CloudflareDNSDriver
+from app.drivers.dns.googledns import GoogleCloudDNSDriver
 from app.drivers.dns.powerdns import PowerDNSDriver
+from app.drivers.dns.route53 import Route53DNSDriver
 from app.drivers.dns.windows import WindowsDNSDriver
 
 _DRIVERS: dict[str, type[DNSDriver]] = {
     "bind9": BIND9Driver,
     "powerdns": PowerDNSDriver,
     "windows_dns": WindowsDNSDriver,
+    # Agentless cloud-hosted DNS providers (issue #37, Part B). The
+    # control plane calls the provider REST/SDK API directly — same
+    # shape as windows_dns Path B. Their modules lazy-import their heavy
+    # SDKs inside methods, so importing them here is cheap + safe.
+    "cloudflare": CloudflareDNSDriver,
+    "route53": Route53DNSDriver,
+    "azure_dns": AzureDNSDriver,
+    "google_dns": GoogleCloudDNSDriver,
 }
 
 # Drivers whose record ops run from the control plane directly, with no
 # agent co-located with the daemon. The record_ops service short-circuits
 # the queue for these — applying the change synchronously and writing a
 # DNSRecordOp row as ``applied`` / ``failed`` for audit purposes.
-AGENTLESS_DRIVERS: frozenset[str] = frozenset({"windows_dns"})
+AGENTLESS_DRIVERS: frozenset[str] = frozenset(
+    {"windows_dns", "cloudflare", "route53", "azure_dns", "google_dns"}
+)
+
+# Agentless cloud-hosted DNS drivers (subset of AGENTLESS_DRIVERS).
+# Used by the DNS server create/update path + the cloud import + the
+# sync-from-server widening to recognise a cloud DNS server (credentials
+# live in DNSServer.credentials_encrypted as a provider-specific dict).
+CLOUD_DNS_DRIVERS: frozenset[str] = frozenset({"cloudflare", "route53", "azure_dns", "google_dns"})
 
 
 def is_agentless(driver_name: str) -> bool:
@@ -57,6 +77,8 @@ def register_driver(name: str, driver_cls: type[DNSDriver]) -> None:
 
 
 __all__ = [
+    "AGENTLESS_DRIVERS",
+    "CLOUD_DNS_DRIVERS",
     "ConfigBundle",
     "DNSDriver",
     "EffectiveBlocklistData",

--- a/backend/app/drivers/dns/_cloud_base.py
+++ b/backend/app/drivers/dns/_cloud_base.py
@@ -266,9 +266,7 @@ class CloudDNSDriverBase(DNSDriver):
         """Return records for ``zone_name`` (FQDN), names relative to apex."""
 
     @abstractmethod
-    async def _apply_record(
-        self, server: Any, creds: dict[str, Any], change: RecordChange
-    ) -> None:
+    async def _apply_record(self, server: Any, creds: dict[str, Any], change: RecordChange) -> None:
         """Create / update / delete one record on the provider."""
 
     @abstractmethod

--- a/backend/app/drivers/dns/_cloud_base.py
+++ b/backend/app/drivers/dns/_cloud_base.py
@@ -1,0 +1,289 @@
+"""Shared base for agentless cloud-hosted DNS drivers (issue #37, Part B).
+
+Cloudflare / Route 53 / Azure DNS / Google Cloud DNS are managed exactly
+like a local BIND9 / PowerDNS / Windows zone — same Zones / Records /
+group surfaces — but the control plane calls the provider's REST/SDK API
+directly instead of driving an agent. This mirrors how ``windows_dns``
+Path B already works (see ``drivers/dns/windows.py``):
+
+* No ConfigBundle / long-poll. The render_* methods return ``""`` and
+  reload_* are no-ops — agentless drivers never render daemon config.
+* Credentials live Fernet-encrypted in the existing
+  ``DNSServer.credentials_encrypted`` column (no new credential store).
+* Record writes run synchronously from the control plane via
+  ``record_ops._apply_agentless`` once the driver name is listed in
+  ``AGENTLESS_DRIVERS``.
+* Zone topology reads use the same ``pull_zones_from_server`` /
+  ``pull_zone_records`` method names Windows DNS exposes, so the existing
+  ``sync-from-server`` drift path + the new "import existing zones"
+  service both work against any cloud driver with no per-provider glue.
+
+A concrete provider driver subclasses :class:`CloudDNSDriverBase` and
+implements only the five cloud-specific hooks (``_list_zones``,
+``_list_zone_records``, ``_apply_record``, ``_apply_zone``,
+``capabilities``) plus the ``name`` / ``credential_fields`` class attrs.
+Everything DNSDriver-shaped is handled here.
+
+Per-driver credential dict shapes (decrypted from
+``DNSServer.credentials_encrypted``):
+    cloudflare → {"api_token"}
+    route53    → {"access_key_id", "secret_access_key"}
+    azure_dns  → {"tenant_id","client_id","client_secret",
+                  "subscription_id","resource_group"}
+    google_dns → {"service_account_json", "project_id"}
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from app.core.crypto import decrypt_dict
+from app.drivers.dns.base import (
+    ConfigBundle,
+    DNSDriver,
+    EffectiveBlocklistData,
+    RecordChange,
+    RecordData,
+    ServerOptions,
+    ZoneData,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class CloudDNSError(Exception):
+    """Auth / API / config failure from a cloud DNS provider call.
+
+    Raised so the record-ops + import + probe paths surface a clean
+    operator-facing message instead of a raw SDK traceback.
+    """
+
+
+@dataclass(frozen=True)
+class CloudDNSZone:
+    """A hosted zone discovered on a cloud DNS provider.
+
+    ``name`` is normalised to a trailing-dot FQDN. ``zone_id`` is the
+    provider's opaque handle (Cloudflare zone id, Route 53 hosted-zone
+    id, Azure zone resource name, GCP managed-zone name) — providers may
+    need it to scope record calls and should cache/resolve it from
+    ``name`` when not threaded through.
+    """
+
+    name: str
+    zone_id: str = ""
+    is_reverse: bool = False
+    dnssec_enabled: bool = False
+    record_count: int | None = None
+
+
+@dataclass(frozen=True)
+class CloudDNSProbe:
+    """Result of a cloud DNS credential probe (Add-DNS-server test button)."""
+
+    ok: bool
+    message: str
+    zone_count: int | None = None
+
+
+def normalize_fqdn(name: str) -> str:
+    """Lower-case + ensure a single trailing dot. ``""`` / ``"@"`` → ``"."``."""
+    n = (name or "").strip().lower()
+    if not n or n == "@":
+        return "."
+    if not n.endswith("."):
+        n += "."
+    return n
+
+
+class CloudDNSDriverBase(DNSDriver):
+    """Agentless base for cloud-hosted authoritative DNS providers."""
+
+    name: str = "cloud_dns"
+    # Ordered credential field names the Add-DNS-server modal renders +
+    # the probe validates as required. Providers override.
+    credential_fields: tuple[str, ...] = ()
+
+    # ── Agentless no-ops (control plane talks to the cloud API) ─────────
+    def render_server_config(
+        self, server: Any, options: ServerOptions, *, bundle: ConfigBundle | None = None
+    ) -> str:
+        return ""
+
+    def render_zone_config(self, zone: ZoneData) -> str:
+        return ""
+
+    def render_zone_file(self, zone: ZoneData, records: list[RecordData]) -> str:
+        return ""
+
+    def render_rpz_zone(self, blocklist: EffectiveBlocklistData) -> str:
+        return ""
+
+    async def reload_config(self, server: Any) -> None:
+        return
+
+    async def reload_zone(self, server: Any, zone_name: str) -> None:
+        return
+
+    def validate_config(self, bundle: ConfigBundle) -> tuple[bool, list[str]]:
+        # No daemon config is rendered for cloud DNS; the bundle is
+        # informational. Accept anything so upstream validators don't block.
+        return (True, [])
+
+    # ── Credential handling ─────────────────────────────────────────────
+    def _load_credentials(self, server: Any) -> dict[str, Any]:
+        """Decrypt the provider credential dict from the server row.
+
+        Raises :class:`CloudDNSError` when unset so the caller can tell
+        "not configured" apart from "API rejected the key".
+        """
+        blob = getattr(server, "credentials_encrypted", None)
+        if not blob:
+            raise CloudDNSError(
+                f"DNS server {getattr(server, 'name', '<unknown>')!r} has no "
+                f"{self.name} credentials configured."
+            )
+        try:
+            return decrypt_dict(blob)
+        except ValueError as exc:
+            raise CloudDNSError(f"{self.name} credentials could not be decrypted: {exc}") from exc
+
+    # ── Record write path (synchronous, control-plane) ──────────────────
+    async def apply_record_change(self, server: Any, change: RecordChange) -> None:
+        """Apply one record op against the cloud provider.
+
+        ``record_ops._apply_agentless`` calls this and records the op as
+        ``applied`` / ``failed`` on a ``DNSRecordOp`` row. Per-op failures
+        raise here; the default batch loop in :class:`DNSDriver` isolates
+        them into ``RecordChangeResult(ok=False)``.
+        """
+        creds = self._load_credentials(server)
+        await self._apply_record(server, creds, change)
+        logger.info(
+            "cloud_dns.apply_record_change",
+            driver=self.name,
+            server=str(getattr(server, "id", "")),
+            zone=change.zone_name,
+            op=change.op,
+            rtype=change.record.record_type,
+        )
+
+    async def apply_zone_change(self, server: Any, zone: Any, op: str) -> None:
+        """Create / delete a hosted zone on the provider.
+
+        Called by the zone-CRUD service helper for agentless drivers. ``op``
+        is ``create`` | ``delete``. Cloud providers have no rename — the
+        caller sends delete+create.
+        """
+        if op not in {"create", "delete"}:
+            raise ValueError(f"{self.name}.apply_zone_change: unsupported op {op!r}")
+        creds = self._load_credentials(server)
+        await self._apply_zone(server, creds, zone, op)
+        logger.info(
+            "cloud_dns.apply_zone_change",
+            driver=self.name,
+            server=str(getattr(server, "id", "")),
+            zone=getattr(zone, "name", ""),
+            op=op,
+        )
+
+    # ── Zone / record reads (import + drift sync) ───────────────────────
+    async def pull_zones_from_server(self, server: Any) -> list[dict[str, Any]]:
+        """List hosted zones on the provider account.
+
+        Returns the same neutral dict shape ``windows_dns`` uses so the
+        existing sync-from-server reconciliation + the cloud import
+        service consume it identically::
+
+            {"name": "example.com.", "zone_type": "Primary",
+             "is_reverse_lookup": False, "dnssec_enabled": False,
+             "zone_id": "<provider-handle>", "record_count": 12}
+        """
+        creds = self._load_credentials(server)
+        zones = await self._list_zones(server, creds)
+        return [
+            {
+                "name": normalize_fqdn(z.name),
+                "zone_type": "Primary",
+                "is_reverse_lookup": z.is_reverse,
+                "dnssec_enabled": z.dnssec_enabled,
+                "zone_id": z.zone_id,
+                "record_count": z.record_count,
+            }
+            for z in zones
+        ]
+
+    async def pull_zone_records(self, server: Any, zone_name: str) -> list[RecordData]:
+        """Return the records for ``zone_name`` from the provider.
+
+        Record names are returned **relative** to the zone apex (``"@"``
+        for apex) to match BIND9 / Windows pulls, so the import + drift
+        machinery keys records consistently across drivers.
+        """
+        creds = self._load_credentials(server)
+        records = await self._list_zone_records(server, creds, normalize_fqdn(zone_name))
+        logger.info(
+            "cloud_dns.pull_zone_records",
+            driver=self.name,
+            server=str(getattr(server, "id", "")),
+            zone=zone_name,
+            count=len(records),
+        )
+        return records
+
+    async def probe(self, server: Any) -> CloudDNSProbe:
+        """Cheap credential check for the Add-DNS-server test button.
+
+        Default: list zones and report the count. Providers with a
+        cheaper auth-only call may override. Never raises for an expected
+        failure — returns ``ok=False`` with the provider message.
+        """
+        try:
+            zones = await self.pull_zones_from_server(server)
+        except CloudDNSError as exc:
+            return CloudDNSProbe(ok=False, message=str(exc))
+        except Exception as exc:  # noqa: BLE001 — surface any SDK error cleanly
+            return CloudDNSProbe(ok=False, message=f"{self.name} API error: {exc}")
+        return CloudDNSProbe(
+            ok=True,
+            message=f"Authenticated; {len(zones)} hosted zone(s) visible.",
+            zone_count=len(zones),
+        )
+
+    # ── Provider hooks (subclasses implement) ───────────────────────────
+    @abstractmethod
+    async def _list_zones(self, server: Any, creds: dict[str, Any]) -> list[CloudDNSZone]:
+        """Return every hosted zone visible to the credentials."""
+
+    @abstractmethod
+    async def _list_zone_records(
+        self, server: Any, creds: dict[str, Any], zone_name: str
+    ) -> list[RecordData]:
+        """Return records for ``zone_name`` (FQDN), names relative to apex."""
+
+    @abstractmethod
+    async def _apply_record(
+        self, server: Any, creds: dict[str, Any], change: RecordChange
+    ) -> None:
+        """Create / update / delete one record on the provider."""
+
+    @abstractmethod
+    async def _apply_zone(self, server: Any, creds: dict[str, Any], zone: Any, op: str) -> None:
+        """Create / delete one hosted zone on the provider."""
+
+    @abstractmethod
+    def capabilities(self) -> dict[str, Any]:
+        """Driver capability dict (see ``windows.py`` for the shape)."""
+
+
+__all__ = [
+    "CloudDNSDriverBase",
+    "CloudDNSError",
+    "CloudDNSProbe",
+    "CloudDNSZone",
+    "normalize_fqdn",
+]

--- a/backend/app/drivers/dns/azuredns.py
+++ b/backend/app/drivers/dns/azuredns.py
@@ -29,8 +29,6 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-import structlog
-
 from app.drivers.dns._cloud_base import (
     CloudDNSDriverBase,
     CloudDNSError,
@@ -38,9 +36,6 @@ from app.drivers.dns._cloud_base import (
     normalize_fqdn,
 )
 from app.drivers.dns.base import RecordChange, RecordData
-
-logger = structlog.get_logger(__name__)
-
 
 # Azure record-set ``type`` is the full ARM resource type. Map the suffix
 # back to the neutral record-type label we expose everywhere else. SOA is
@@ -55,6 +50,22 @@ _AZURE_TYPE_TO_RECORD_TYPE = {
     "Microsoft.Network/dnszones/SRV": "SRV",
     "Microsoft.Network/dnszones/PTR": "PTR",
     "Microsoft.Network/dnszones/CAA": "CAA",
+}
+
+# Neutral record type → the typed record-list attribute on an Azure record
+# set (``a_records`` / ``mx_records`` / …). Used by the read-merge path to
+# pull the live RRset's per-record entries off whatever the SDK returned.
+# ``CNAME`` is intentionally absent — it is a single-valued ``cname_record``,
+# never a list, so it always uses the replace path.
+_RECORD_TYPE_TO_AZURE_ATTR = {
+    "A": "a_records",
+    "AAAA": "aaaa_records",
+    "MX": "mx_records",
+    "TXT": "txt_records",
+    "NS": "ns_records",
+    "SRV": "srv_records",
+    "PTR": "ptr_records",
+    "CAA": "caa_records",
 }
 
 
@@ -231,18 +242,19 @@ class AzureDNSDriver(CloudDNSDriverBase):
         rtype = change.record.record_type.upper()
 
         if change.op == "delete":
-
-            def _delete() -> None:
-                client.record_sets.delete(rg, zone_label, relative, rtype)
-
-            try:
-                await asyncio.to_thread(_delete)
-            except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
-                raise self._wrap_errors(exc) from exc
+            await self._apply_delete(client, rg, zone_label, relative, rtype, change.record)
             return
 
-        # create / update — Azure has no distinct create vs update, both
-        # are a PUT (create_or_update) of the full record set.
+        if change.op == "create":
+            await self._apply_create(client, rg, zone_label, relative, rtype, change.record)
+            return
+
+        # update — keep the single-value replace-the-RRset behaviour. The
+        # update op carries only the NEW value (no old value to match
+        # against), so a correct multi-value merge is impossible at this
+        # layer. Replace is right for the common single-value RRset (CNAME,
+        # a host with one A/TXT). Multi-value value-edits are an inherent
+        # per-row→RRset limitation tracked in issue #29.
         params = self._build_record_set_params(change.record)
 
         def _put() -> None:
@@ -252,6 +264,202 @@ class AzureDNSDriver(CloudDNSDriverBase):
             await asyncio.to_thread(_put)
         except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
             raise self._wrap_errors(exc) from exc
+
+    async def _apply_create(
+        self,
+        client: Any,
+        rg: str,
+        zone_label: str,
+        relative: str,
+        rtype: str,
+        record: RecordData,
+    ) -> None:
+        """Create one record value, read-merging into the live RRset.
+
+        Cloud providers group every value under one RRset keyed by
+        ``{name, type}`` (round-robin A, multiple MX/NS/TXT). SpatiumDDI
+        emits one op per stored row, so we must read the provider's current
+        RRset and write back the union — otherwise the first PUT would drop
+        every sibling value already in the set.
+        """
+        # CNAME (and any non-listable type) is single-valued — there is no
+        # set to merge into, so use the plain replace path.
+        if rtype not in _RECORD_TYPE_TO_AZURE_ATTR:
+            params = self._build_record_set_params(record)
+
+            def _put() -> None:
+                client.record_sets.create_or_update(rg, zone_label, relative, rtype, params)
+
+            try:
+                await asyncio.to_thread(_put)
+            except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
+                raise self._wrap_errors(exc) from exc
+            return
+
+        new_entry = self._build_record_entry(record)
+
+        def _merge_and_put() -> None:
+            existing = self._get_record_set(client, rg, zone_label, relative, rtype)
+            entries = [] if existing is None else self._existing_entries(existing, rtype)
+            # Dedupe: if this value is already in the set, it's a no-op.
+            present = {self._entry_key(rtype, e) for e in entries}
+            if self._entry_key(rtype, new_entry) not in present:
+                entries = entries + [new_entry]
+            # TTL: prefer the change's ttl, fall back to the existing set's,
+            # then the driver default.
+            ttl = record.ttl
+            if ttl is None and existing is not None:
+                ttl = getattr(existing, "ttl", None)
+            if ttl is None:
+                ttl = 3600
+            params = {"ttl": ttl, _RECORD_TYPE_TO_AZURE_ATTR[rtype]: entries}
+            client.record_sets.create_or_update(rg, zone_label, relative, rtype, params)
+
+        try:
+            await asyncio.to_thread(_merge_and_put)
+        except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
+            raise self._wrap_errors(exc) from exc
+
+    async def _apply_delete(
+        self,
+        client: Any,
+        rg: str,
+        zone_label: str,
+        relative: str,
+        rtype: str,
+        record: RecordData,
+    ) -> None:
+        """Delete one record value, reducing the live RRset.
+
+        Reads the current RRset, removes THIS value, and writes the reduced
+        set. If the value was the last one (or the set is gone) the whole
+        RRset is deleted. A missing value/RRset is an idempotent no-op.
+        """
+
+        def _read_and_reduce() -> None:
+            existing = self._get_record_set(client, rg, zone_label, relative, rtype)
+            if existing is None:
+                # RRset already absent — idempotent no-op.
+                return
+
+            # CNAME / unlistable types: deleting the value deletes the set.
+            if rtype not in _RECORD_TYPE_TO_AZURE_ATTR:
+                client.record_sets.delete(rg, zone_label, relative, rtype)
+                return
+
+            target_key = self._entry_key(rtype, self._build_record_entry(record))
+            entries = self._existing_entries(existing, rtype)
+            remaining = [e for e in entries if self._entry_key(rtype, e) != target_key]
+            if len(remaining) == len(entries):
+                # Value isn't present — idempotent no-op.
+                return
+            if not remaining:
+                client.record_sets.delete(rg, zone_label, relative, rtype)
+                return
+            ttl = getattr(existing, "ttl", None) or 3600
+            params = {"ttl": ttl, _RECORD_TYPE_TO_AZURE_ATTR[rtype]: remaining}
+            client.record_sets.create_or_update(rg, zone_label, relative, rtype, params)
+
+        try:
+            await asyncio.to_thread(_read_and_reduce)
+        except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
+            raise self._wrap_errors(exc) from exc
+
+    def _get_record_set(
+        self, client: Any, rg: str, zone_label: str, relative: str, rtype: str
+    ) -> Any | None:
+        """Read the live record set, or ``None`` when it doesn't exist.
+
+        Azure raises ``ResourceNotFoundError`` (a ``HttpResponseError``
+        subclass) for an absent set; we lazy-import both and treat either as
+        "no existing set". Any other SDK error propagates to be wrapped.
+        """
+        not_found_types: tuple[type[Exception], ...] = ()
+        http_error_type: type[Exception] | None = None
+        try:
+            from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+
+            not_found_types = (ResourceNotFoundError,)
+            http_error_type = HttpResponseError
+        except ImportError:  # pragma: no cover — env-dependent
+            pass
+        try:
+            return client.record_sets.get(rg, zone_label, relative, rtype)
+        except Exception as exc:  # noqa: BLE001 — narrowed below
+            if not_found_types and isinstance(exc, not_found_types):
+                return None
+            if (
+                http_error_type is not None
+                and isinstance(exc, http_error_type)
+                and getattr(getattr(exc, "response", None), "status_code", None) == 404
+            ):
+                return None
+            raise
+
+    def _existing_entries(self, record_set: Any, rtype: str) -> list[dict[str, Any]]:
+        """Normalise a live record set's typed records into entry dicts.
+
+        Returns the same dict shape :meth:`_build_record_entry` produces so
+        merge/dedupe/removal can compare with ``==`` / ``in``.
+        """
+        attr = _RECORD_TYPE_TO_AZURE_ATTR[rtype]
+        records = getattr(record_set, attr, None) or []
+        out: list[dict[str, Any]] = []
+        for r in records:
+            if rtype == "A":
+                out.append({"ipv4_address": r.ipv4_address})
+            elif rtype == "AAAA":
+                out.append({"ipv6_address": r.ipv6_address})
+            elif rtype == "MX":
+                out.append({"preference": int(r.preference), "exchange": r.exchange})
+            elif rtype == "TXT":
+                out.append({"value": list(r.value)})
+            elif rtype == "NS":
+                out.append({"nsdname": r.nsdname})
+            elif rtype == "SRV":
+                out.append(
+                    {
+                        "priority": int(r.priority),
+                        "weight": int(r.weight),
+                        "port": int(r.port),
+                        "target": r.target,
+                    }
+                )
+            elif rtype == "PTR":
+                out.append({"ptrdname": r.ptrdname})
+            elif rtype == "CAA":
+                out.append({"flags": int(r.flags), "tag": r.tag, "value": r.value})
+        return out
+
+    def _build_record_entry(self, record: RecordData) -> dict[str, Any]:
+        """Build the single per-type record-entry dict for one neutral value.
+
+        This is the element that lives inside the typed record list
+        (``a_records[i]`` etc.); :meth:`_build_record_set_params` wraps it as
+        a one-element list. Sharing this builder keeps the merge path's
+        dedupe comparison identical to what a plain write would produce.
+        """
+        rtype = record.record_type.upper()
+        params = self._build_record_set_params(record)
+        attr = _RECORD_TYPE_TO_AZURE_ATTR.get(rtype)
+        if attr is None:  # pragma: no cover — only listable types reach here
+            raise CloudDNSError(f"azure_dns: {rtype!r} is not a multi-value record type")
+        entry: dict[str, Any] = params[attr][0]
+        return entry
+
+    def _entry_key(self, rtype: str, entry: dict[str, Any]) -> tuple[Any, ...]:
+        """A hashable, comparison-stable identity for one record entry.
+
+        Used for dedupe (create) and removal (delete) so the same value
+        compares equal regardless of incidental representation. The TXT case
+        joins the value chunks: Azure may store a long TXT string split into
+        several 255-byte chunks (``["v=spf1 ", "-all"]``) while a freshly
+        built entry has a single chunk (``["v=spf1 -all"]``) — both denote
+        the same record and must dedupe / remove correctly.
+        """
+        if rtype == "TXT":
+            return ("TXT", "".join(entry.get("value", [])))
+        return (rtype, tuple(sorted(entry.items(), key=lambda kv: kv[0])))
 
     def _build_record_set_params(self, record: RecordData) -> dict[str, Any]:
         """Build the create_or_update body for one neutral record.

--- a/backend/app/drivers/dns/azuredns.py
+++ b/backend/app/drivers/dns/azuredns.py
@@ -1,0 +1,356 @@
+"""Azure DNS driver (issue #37, Part B — agentless cloud provider).
+
+Drives Azure DNS public zones through the ``azure-mgmt-dns`` management
+SDK, authenticating with a service-principal client secret. Like the
+other cloud drivers (Cloudflare / Route 53 / Google Cloud DNS) it
+subclasses :class:`CloudDNSDriverBase` and implements only the five
+provider hooks — everything DNSDriver-shaped (no-op renders, credential
+decrypt, the import / drift / probe wrappers) lives in the base.
+
+Credential dict shape (decrypted from ``DNSServer.credentials_encrypted``)::
+
+    {"tenant_id": ..., "client_id": ..., "client_secret": ...,
+     "subscription_id": ..., "resource_group": ...}
+
+The Azure resource model splits a zone's records into *record sets*, one
+per ``(relative_name, record_type)`` pair, each carrying a typed list of
+records (``a_records``, ``mx_records``, …). We expand each record set into
+one neutral :class:`RecordData` per contained record so the import + drift
+machinery sees a flat record list like every other driver.
+
+The ``azure.*`` SDKs are lazy-imported inside :meth:`_client` so importing
+this module never fails when the optional dependency is absent, and tests
+can monkeypatch the client factory. Blocking SDK calls run in
+``asyncio.to_thread`` per the async-throughout non-negotiable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import structlog
+
+from app.drivers.dns._cloud_base import (
+    CloudDNSDriverBase,
+    CloudDNSError,
+    CloudDNSZone,
+    normalize_fqdn,
+)
+from app.drivers.dns.base import RecordChange, RecordData
+
+logger = structlog.get_logger(__name__)
+
+
+# Azure record-set ``type`` is the full ARM resource type. Map the suffix
+# back to the neutral record-type label we expose everywhere else. SOA is
+# intentionally absent — Azure manages the apex SOA itself and we skip it.
+_AZURE_TYPE_TO_RECORD_TYPE = {
+    "Microsoft.Network/dnszones/A": "A",
+    "Microsoft.Network/dnszones/AAAA": "AAAA",
+    "Microsoft.Network/dnszones/CNAME": "CNAME",
+    "Microsoft.Network/dnszones/MX": "MX",
+    "Microsoft.Network/dnszones/TXT": "TXT",
+    "Microsoft.Network/dnszones/NS": "NS",
+    "Microsoft.Network/dnszones/SRV": "SRV",
+    "Microsoft.Network/dnszones/PTR": "PTR",
+    "Microsoft.Network/dnszones/CAA": "CAA",
+}
+
+
+def _zone_label(zone_name: str) -> str:
+    """Azure zone resource names carry no trailing dot — strip it."""
+    return normalize_fqdn(zone_name).rstrip(".")
+
+
+def _relative_name(name: str) -> str:
+    """Azure uses ``"@"`` for the apex, same as us — pass through."""
+    n = (name or "").strip()
+    return n or "@"
+
+
+class AzureDNSDriver(CloudDNSDriverBase):
+    """Agentless Azure DNS driver via the ``azure-mgmt-dns`` SDK."""
+
+    name = "azure_dns"
+    credential_fields = (
+        "tenant_id",
+        "client_id",
+        "client_secret",
+        "subscription_id",
+        "resource_group",
+    )
+
+    # ── SDK client factory (lazy import; patched in tests) ───────────────
+    def _client(self, creds: dict[str, Any]) -> Any:
+        """Build a ``DnsManagementClient`` from a service-principal secret.
+
+        Lazy-imports the Azure SDKs so this module imports cleanly without
+        ``azure-identity`` / ``azure-mgmt-dns`` installed. Raises
+        :class:`CloudDNSError` on a missing dependency so the operator gets
+        an actionable message rather than a bare ``ImportError``.
+        """
+        try:
+            from azure.identity import ClientSecretCredential
+            from azure.mgmt.dns import DnsManagementClient
+        except ImportError as exc:  # pragma: no cover — env-dependent
+            raise CloudDNSError(
+                "azure_dns driver requires the 'azure-identity' and "
+                "'azure-mgmt-dns' packages to be installed."
+            ) from exc
+
+        credential = ClientSecretCredential(
+            tenant_id=creds["tenant_id"],
+            client_id=creds["client_id"],
+            client_secret=creds["client_secret"],
+        )
+        return DnsManagementClient(credential, creds["subscription_id"])
+
+    def _wrap_errors(self, exc: Exception) -> CloudDNSError:
+        """Translate an Azure SDK error into a clean :class:`CloudDNSError`.
+
+        Lazy-imports the SDK exception types so we recognise auth / HTTP
+        failures even though the import lives inside a method. Any other
+        exception is re-wrapped verbatim by the caller.
+        """
+        try:
+            from azure.core.exceptions import (
+                ClientAuthenticationError,
+                HttpResponseError,
+            )
+        except ImportError:  # pragma: no cover — env-dependent
+            return CloudDNSError(f"azure_dns API error: {exc}")
+        if isinstance(exc, ClientAuthenticationError):
+            return CloudDNSError(f"azure_dns authentication failed: {exc}")
+        if isinstance(exc, HttpResponseError):
+            return CloudDNSError(f"azure_dns API error: {exc}")
+        return CloudDNSError(f"azure_dns error: {exc}")
+
+    # ── Zone listing ─────────────────────────────────────────────────────
+    async def _list_zones(self, server: Any, creds: dict[str, Any]) -> list[CloudDNSZone]:
+        client = self._client(creds)
+        rg = (creds.get("resource_group") or "").strip()
+
+        def _list() -> list[Any]:
+            if rg:
+                return list(client.zones.list_by_resource_group(rg))
+            return list(client.zones.list())
+
+        try:
+            zones = await asyncio.to_thread(_list)
+        except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
+            raise self._wrap_errors(exc) from exc
+
+        out: list[CloudDNSZone] = []
+        for z in zones:
+            name = normalize_fqdn(z.name)
+            out.append(
+                CloudDNSZone(
+                    name=name,
+                    zone_id=z.name,
+                    is_reverse=name.rstrip(".").endswith("arpa"),
+                    record_count=getattr(z, "number_of_record_sets", None),
+                )
+            )
+        return out
+
+    # ── Record listing ───────────────────────────────────────────────────
+    async def _list_zone_records(
+        self, server: Any, creds: dict[str, Any], zone_name: str
+    ) -> list[RecordData]:
+        client = self._client(creds)
+        rg = (creds.get("resource_group") or "").strip()
+        zone_label = _zone_label(zone_name)
+
+        def _list() -> list[Any]:
+            return list(client.record_sets.list_by_dns_zone(rg, zone_label))
+
+        try:
+            record_sets = await asyncio.to_thread(_list)
+        except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
+            raise self._wrap_errors(exc) from exc
+
+        records: list[RecordData] = []
+        for rs in record_sets:
+            records.extend(self._expand_record_set(rs))
+        return records
+
+    def _expand_record_set(self, rs: Any) -> list[RecordData]:
+        """Expand one Azure record set into per-record neutral rows.
+
+        Skips SOA (apex, Azure-managed) and any record-set ``type`` we
+        don't map. ``name`` is already relative to the apex (``"@"``).
+        """
+        rtype = _AZURE_TYPE_TO_RECORD_TYPE.get(getattr(rs, "type", "") or "")
+        if rtype is None:
+            return []  # SOA or an unmapped type — drop silently
+
+        name = _relative_name(getattr(rs, "name", "@"))
+        ttl = getattr(rs, "ttl", None)
+        out: list[RecordData] = []
+
+        def add(value: str) -> None:
+            out.append(RecordData(name=name, record_type=rtype, value=value, ttl=ttl))
+
+        if rtype == "A":
+            for r in getattr(rs, "a_records", None) or []:
+                add(r.ipv4_address)
+        elif rtype == "AAAA":
+            for r in getattr(rs, "aaaa_records", None) or []:
+                add(r.ipv6_address)
+        elif rtype == "CNAME":
+            cname = getattr(rs, "cname_record", None)
+            if cname is not None:
+                add(cname.cname)
+        elif rtype == "MX":
+            for r in getattr(rs, "mx_records", None) or []:
+                add(f"{r.preference} {r.exchange}")
+        elif rtype == "TXT":
+            for r in getattr(rs, "txt_records", None) or []:
+                add("".join(r.value))
+        elif rtype == "NS":
+            for r in getattr(rs, "ns_records", None) or []:
+                add(r.nsdname)
+        elif rtype == "SRV":
+            for r in getattr(rs, "srv_records", None) or []:
+                add(f"{r.priority} {r.weight} {r.port} {r.target}")
+        elif rtype == "PTR":
+            for r in getattr(rs, "ptr_records", None) or []:
+                add(r.ptrdname)
+        elif rtype == "CAA":
+            for r in getattr(rs, "caa_records", None) or []:
+                add(f"{r.flags} {r.tag} {r.value}")
+        return out
+
+    # ── Record write ─────────────────────────────────────────────────────
+    async def _apply_record(self, server: Any, creds: dict[str, Any], change: RecordChange) -> None:
+        client = self._client(creds)
+        rg = (creds.get("resource_group") or "").strip()
+        zone_label = _zone_label(change.zone_name)
+        relative = _relative_name(change.record.name)
+        rtype = change.record.record_type.upper()
+
+        if change.op == "delete":
+
+            def _delete() -> None:
+                client.record_sets.delete(rg, zone_label, relative, rtype)
+
+            try:
+                await asyncio.to_thread(_delete)
+            except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
+                raise self._wrap_errors(exc) from exc
+            return
+
+        # create / update — Azure has no distinct create vs update, both
+        # are a PUT (create_or_update) of the full record set.
+        params = self._build_record_set_params(change.record)
+
+        def _put() -> None:
+            client.record_sets.create_or_update(rg, zone_label, relative, rtype, params)
+
+        try:
+            await asyncio.to_thread(_put)
+        except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
+            raise self._wrap_errors(exc) from exc
+
+    def _build_record_set_params(self, record: RecordData) -> dict[str, Any]:
+        """Build the create_or_update body for one neutral record.
+
+        Returns the loosely-typed dict form the SDK accepts (``ttl`` plus
+        the type-specific record list); MX / SRV string values are split
+        back into their structured components.
+        """
+        rtype = record.record_type.upper()
+        ttl = record.ttl if record.ttl is not None else 3600
+        params: dict[str, Any] = {"ttl": ttl}
+        value = (record.value or "").strip()
+
+        if rtype == "A":
+            params["a_records"] = [{"ipv4_address": value}]
+        elif rtype == "AAAA":
+            params["aaaa_records"] = [{"ipv6_address": value}]
+        elif rtype == "CNAME":
+            params["cname_record"] = {"cname": value}
+        elif rtype == "MX":
+            pref, _, exch = value.partition(" ")
+            params["mx_records"] = [{"preference": int(pref), "exchange": exch.strip()}]
+        elif rtype == "TXT":
+            params["txt_records"] = [{"value": [value]}]
+        elif rtype == "NS":
+            params["ns_records"] = [{"nsdname": value}]
+        elif rtype == "SRV":
+            prio, weight, port, target = (value.split(None, 3) + ["", "", "", ""])[:4]
+            params["srv_records"] = [
+                {
+                    "priority": int(prio),
+                    "weight": int(weight),
+                    "port": int(port),
+                    "target": target.strip(),
+                }
+            ]
+        elif rtype == "PTR":
+            params["ptr_records"] = [{"ptrdname": value}]
+        elif rtype == "CAA":
+            flags, tag, caa_value = (value.split(None, 2) + ["", "", ""])[:3]
+            params["caa_records"] = [{"flags": int(flags), "tag": tag, "value": caa_value.strip()}]
+        else:
+            raise CloudDNSError(f"azure_dns: unsupported record type {rtype!r}")
+        return params
+
+    # ── Zone write ───────────────────────────────────────────────────────
+    async def _apply_zone(self, server: Any, creds: dict[str, Any], zone: Any, op: str) -> None:
+        client = self._client(creds)
+        rg = (creds.get("resource_group") or "").strip()
+        zone_label = _zone_label(getattr(zone, "name", ""))
+
+        if op == "create":
+
+            def _create() -> None:
+                client.zones.create_or_update(rg, zone_label, {"location": "global"})
+
+            try:
+                await asyncio.to_thread(_create)
+            except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
+                raise self._wrap_errors(exc) from exc
+            return
+
+        # delete — zone delete is a long-running operation; block on the
+        # poller. Some SDK versions expose a synchronous ``delete`` instead.
+        def _delete() -> None:
+            if hasattr(client.zones, "begin_delete"):
+                client.zones.begin_delete(rg, zone_label).result()
+            else:
+                client.zones.delete(rg, zone_label)
+
+        try:
+            await asyncio.to_thread(_delete)
+        except Exception as exc:  # noqa: BLE001 — wrapped into CloudDNSError
+            raise self._wrap_errors(exc) from exc
+
+    # ── Capabilities ─────────────────────────────────────────────────────
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "name": "azure_dns",
+            "agentless": True,
+            "manages_zones": True,
+            "views": False,
+            "rpz": False,
+            "dnssec_online": False,
+            "alias_records": True,
+            "record_types": [
+                "A",
+                "AAAA",
+                "CNAME",
+                "MX",
+                "TXT",
+                "NS",
+                "SRV",
+                "CAA",
+                "PTR",
+                "SOA",
+            ],
+            "notes": "Azure DNS — online DNSSEC not supported via this driver.",
+        }
+
+
+__all__ = ["AzureDNSDriver"]

--- a/backend/app/drivers/dns/cloudflare.py
+++ b/backend/app/drivers/dns/cloudflare.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 from typing import Any
 
 import httpx
-import structlog
 
 from app.drivers.dns._cloud_base import (
     CloudDNSDriverBase,
@@ -38,8 +37,6 @@ from app.drivers.dns._cloud_base import (
     normalize_fqdn,
 )
 from app.drivers.dns.base import RecordChange, RecordData
-
-logger = structlog.get_logger(__name__)
 
 # Cloudflare API v4 base. Pinned here (not configurable) — there is no
 # self-hosted Cloudflare. The token in the Authorization header is the

--- a/backend/app/drivers/dns/cloudflare.py
+++ b/backend/app/drivers/dns/cloudflare.py
@@ -1,0 +1,355 @@
+"""Cloudflare DNS driver (agentless, REST API — issue #37).
+
+Cloudflare hosts authoritative zones and exposes a flat REST API at
+``https://api.cloudflare.com/client/v4``. SpatiumDDI manages those zones
+exactly like a local BIND9 / PowerDNS zone — same Zones / Records group
+surfaces — driving the API directly from the control plane rather than an
+agent (see :mod:`app.drivers.dns._cloud_base` for the agentless contract).
+
+Authentication is a single scoped **API token** (``Bearer`` header). The
+account's zone-id is opaque and required to scope every record call, so
+``_resolve_zone_id`` looks it up by name and the methods cache nothing —
+each call is cheap and idempotent.
+
+Unlike the AWS / Azure / GCP cloud drivers, Cloudflare needs no vendor SDK:
+the API is plain JSON over HTTPS, so this driver uses ``httpx`` directly
+(already a top-level dependency). ``_client`` is the single seam tests
+patch to inject a fake transport.
+
+Credential dict shape (decrypted from ``DNSServer.credentials_encrypted``)::
+
+    {"api_token": "<scoped-token>", "account_id": "<optional>"}
+
+``account_id`` is only consulted when *creating* a zone — Cloudflare's
+``POST /zones`` requires the owning account, but record / read calls do not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import structlog
+
+from app.drivers.dns._cloud_base import (
+    CloudDNSDriverBase,
+    CloudDNSError,
+    CloudDNSZone,
+    normalize_fqdn,
+)
+from app.drivers.dns.base import RecordChange, RecordData
+
+logger = structlog.get_logger(__name__)
+
+# Cloudflare API v4 base. Pinned here (not configurable) — there is no
+# self-hosted Cloudflare. The token in the Authorization header is the
+# only per-server input.
+_API_BASE = "https://api.cloudflare.com/client/v4"
+
+# Cloudflare's per-page maximum is 100; 50 keeps responses small while
+# still rarely needing a second round trip for typical accounts.
+_PER_PAGE = 50
+
+# Cloudflare encodes "automatic TTL" as the sentinel value 1. We surface
+# that as ``ttl=None`` on the neutral RecordData so it round-trips as
+# "let the provider decide" rather than a literal 1-second TTL.
+_TTL_AUTO = 1
+
+
+class CloudflareDNSDriver(CloudDNSDriverBase):
+    """Agentless driver for Cloudflare-hosted authoritative zones."""
+
+    name = "cloudflare"
+    # The Add-DNS-server modal renders + the probe requires only the token.
+    # ``account_id`` is optional (zone-create only) so it is not listed here.
+    credential_fields: tuple[str, ...] = ("api_token",)
+
+    # ── HTTP plumbing ───────────────────────────────────────────────────
+    def _client(self, token: str) -> httpx.AsyncClient:
+        """Return an httpx client bound to the API base + bearer token.
+
+        This is the single seam tests patch to inject a fake transport —
+        keep all request construction flowing through the returned client.
+        """
+        return httpx.AsyncClient(
+            base_url=_API_BASE,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+
+    @staticmethod
+    def _unwrap(response: Any) -> dict[str, Any]:
+        """Validate a Cloudflare response envelope and return its body.
+
+        Cloudflare wraps every reply as ``{"success": bool, "errors": [...],
+        "result": ..., "result_info": {...}}``. Raise :class:`CloudDNSError`
+        with the joined ``errors[].message`` on a non-2xx status *or* an
+        ``success: false`` envelope (the API returns 200 with
+        ``success: false`` for some validation failures).
+        """
+        body: dict[str, Any]
+        try:
+            body = response.json()
+        except (ValueError, TypeError):
+            body = {}
+        status = getattr(response, "status_code", 0)
+        ok = 200 <= status < 300 and bool(body.get("success", False))
+        if ok:
+            return body
+        errors = body.get("errors") or []
+        messages = [str(e.get("message", e)) for e in errors if e]
+        detail = "; ".join(m for m in messages if m) or f"HTTP {status}"
+        raise CloudDNSError(f"Cloudflare API error: {detail}")
+
+    def _token(self, creds: dict[str, Any]) -> str:
+        token = (creds or {}).get("api_token")
+        if not token:
+            raise CloudDNSError("Cloudflare credentials missing 'api_token'.")
+        return str(token)
+
+    async def _resolve_zone_id(self, client: httpx.AsyncClient, zone_fqdn: str) -> str:
+        """Look up the opaque Cloudflare zone id for a zone FQDN.
+
+        Cloudflare's ``GET /zones?name=`` filter wants the bare name with no
+        trailing dot, so the apex FQDN is de-dotted before the query.
+        """
+        name = normalize_fqdn(zone_fqdn).rstrip(".")
+        resp = await client.get("/zones", params={"name": name})
+        body = self._unwrap(resp)
+        results = body.get("result") or []
+        if not results:
+            raise CloudDNSError(f"Cloudflare zone {name!r} not found on this account.")
+        return str(results[0]["id"])
+
+    @staticmethod
+    def _relativize(fqdn: str, zone_fqdn: str) -> str:
+        """Return ``fqdn`` relative to ``zone_fqdn`` (apex → ``"@"``).
+
+        Both sides are normalised to trailing-dot FQDNs first so the suffix
+        match is exact. A name equal to the apex collapses to ``"@"`` to
+        match the BIND9 / Windows pull convention.
+        """
+        name = normalize_fqdn(fqdn)
+        zone = normalize_fqdn(zone_fqdn)
+        if name == zone:
+            return "@"
+        if name.endswith("." + zone):
+            return name[: -(len(zone) + 1)]
+        # Not actually under the zone — return the de-dotted name as a
+        # best-effort fallback rather than raising mid-import.
+        return name.rstrip(".")
+
+    # ── Zone reads ──────────────────────────────────────────────────────
+    async def _list_zones(self, server: Any, creds: dict[str, Any]) -> list[CloudDNSZone]:
+        token = self._token(creds)
+        zones: list[CloudDNSZone] = []
+        async with self._client(token) as client:
+            page = 1
+            while True:
+                resp = await client.get("/zones", params={"per_page": _PER_PAGE, "page": page})
+                body = self._unwrap(resp)
+                for z in body.get("result") or []:
+                    name = normalize_fqdn(z["name"])
+                    is_reverse = name.endswith((".in-addr.arpa.", ".ip6.arpa."))
+                    zones.append(
+                        CloudDNSZone(
+                            name=name,
+                            zone_id=str(z["id"]),
+                            is_reverse=is_reverse,
+                            # Cloudflare reports DNSSEC via a separate
+                            # endpoint; we leave it False on the list pull
+                            # and treat capability advertising as the source
+                            # of truth for online-signing support.
+                            dnssec_enabled=False,
+                            record_count=None,
+                        )
+                    )
+                info = body.get("result_info") or {}
+                total_pages = int(info.get("total_pages") or 1)
+                if page >= total_pages:
+                    break
+                page += 1
+        return zones
+
+    async def _list_zone_records(
+        self, server: Any, creds: dict[str, Any], zone_name: str
+    ) -> list[RecordData]:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(zone_name)
+        records: list[RecordData] = []
+        async with self._client(token) as client:
+            zone_id = await self._resolve_zone_id(client, zone_fqdn)
+            page = 1
+            while True:
+                resp = await client.get(
+                    f"/zones/{zone_id}/dns_records",
+                    params={"per_page": _PER_PAGE, "page": page},
+                )
+                body = self._unwrap(resp)
+                for rec in body.get("result") or []:
+                    raw_ttl = rec.get("ttl")
+                    ttl = None if raw_ttl == _TTL_AUTO else raw_ttl
+                    records.append(
+                        RecordData(
+                            name=self._relativize(rec["name"], zone_fqdn),
+                            record_type=rec["type"],
+                            value=rec["content"],
+                            ttl=ttl,
+                            priority=rec.get("priority"),
+                        )
+                    )
+                info = body.get("result_info") or {}
+                total_pages = int(info.get("total_pages") or 1)
+                if page >= total_pages:
+                    break
+                page += 1
+        return records
+
+    # ── Record writes ───────────────────────────────────────────────────
+    @staticmethod
+    def _absolute_name(label: str, zone_fqdn: str) -> str:
+        """Render the absolute record name Cloudflare expects (no trailing dot).
+
+        Apex (``"@"`` / empty) → the bare zone name; otherwise the relative
+        label joined to the zone.
+        """
+        zone = normalize_fqdn(zone_fqdn).rstrip(".")
+        rel = (label or "").strip().rstrip(".")
+        if not rel or rel == "@":
+            return zone
+        if rel.endswith("." + zone) or rel == zone:
+            return rel
+        return f"{rel}.{zone}"
+
+    def _record_payload(self, change: RecordChange, zone_fqdn: str) -> dict[str, Any]:
+        rec = change.record
+        payload: dict[str, Any] = {
+            "type": rec.record_type,
+            "name": self._absolute_name(rec.name, zone_fqdn),
+            "content": rec.value,
+            # Cloudflare's "automatic" TTL is the sentinel 1.
+            "ttl": _TTL_AUTO if rec.ttl is None else rec.ttl,
+        }
+        if rec.priority is not None:
+            payload["priority"] = rec.priority
+        return payload
+
+    async def _find_record_id(
+        self,
+        client: httpx.AsyncClient,
+        zone_id: str,
+        name: str,
+        record_type: str,
+    ) -> str | None:
+        """Return the Cloudflare record id matching name+type, or ``None``."""
+        resp = await client.get(
+            f"/zones/{zone_id}/dns_records",
+            params={"name": name, "type": record_type},
+        )
+        body = self._unwrap(resp)
+        results = body.get("result") or []
+        if not results:
+            return None
+        return str(results[0]["id"])
+
+    async def _apply_record(self, server: Any, creds: dict[str, Any], change: RecordChange) -> None:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(change.zone_name)
+        payload = self._record_payload(change, zone_fqdn)
+        async with self._client(token) as client:
+            zone_id = await self._resolve_zone_id(client, zone_fqdn)
+
+            if change.op == "create":
+                resp = await client.post(f"/zones/{zone_id}/dns_records", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "update":
+                rid = await self._find_record_id(
+                    client, zone_id, payload["name"], change.record.record_type
+                )
+                if rid is None:
+                    # No existing row to update — treat as create so the
+                    # desired state still lands (mirrors the windows_dns +
+                    # _cloud_base "update is create on miss" contract).
+                    resp = await client.post(f"/zones/{zone_id}/dns_records", json=payload)
+                    self._unwrap(resp)
+                    return
+                resp = await client.put(f"/zones/{zone_id}/dns_records/{rid}", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "delete":
+                rid = await self._find_record_id(
+                    client, zone_id, payload["name"], change.record.record_type
+                )
+                if rid is None:
+                    # Idempotent delete — nothing to remove.
+                    return
+                resp = await client.delete(f"/zones/{zone_id}/dns_records/{rid}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"Cloudflare: unsupported record op {change.op!r}")
+
+    # ── Zone writes ─────────────────────────────────────────────────────
+    async def _apply_zone(self, server: Any, creds: dict[str, Any], zone: Any, op: str) -> None:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(getattr(zone, "name", ""))
+        bare = zone_fqdn.rstrip(".")
+        async with self._client(token) as client:
+            if op == "create":
+                payload: dict[str, Any] = {"name": bare}
+                # Real Cloudflare requires the owning account on zone create;
+                # include it when the operator supplied an account_id.
+                account_id = (creds or {}).get("account_id")
+                if account_id:
+                    payload["account"] = {"id": str(account_id)}
+                resp = await client.post("/zones", json=payload)
+                self._unwrap(resp)
+                return
+
+            if op == "delete":
+                zone_id = await self._resolve_zone_id(client, zone_fqdn)
+                resp = await client.delete(f"/zones/{zone_id}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"Cloudflare: unsupported zone op {op!r}")
+
+    # ── Capabilities ────────────────────────────────────────────────────
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "name": "cloudflare",
+            "agentless": True,
+            "manages_zones": True,
+            "views": False,
+            "rpz": False,
+            "dnssec_online": True,
+            "record_types": [
+                "A",
+                "AAAA",
+                "CNAME",
+                "MX",
+                "TXT",
+                "NS",
+                "SRV",
+                "CAA",
+                "PTR",
+                "SOA",
+            ],
+            "apex_cname": "flatten",
+            "notes": (
+                "Agentless Cloudflare DNS driver over the v4 REST API "
+                "(Bearer API token). Zones + records managed from the "
+                "control plane; CNAME-at-apex is auto-flattened by "
+                "Cloudflare. account_id credential is only needed for "
+                "zone creation."
+            ),
+        }
+
+
+__all__ = ["CloudflareDNSDriver"]

--- a/backend/app/drivers/dns/googledns.py
+++ b/backend/app/drivers/dns/googledns.py
@@ -27,8 +27,11 @@ A few Cloud-DNS-specific wrinkles the hooks paper over:
 * **rrdatas is a list.** A single ``ResourceRecordSet`` carries one or
   more ``rrdatas`` strings (Cloud DNS groups same-name/same-type values
   into one rrset; the rest of SpatiumDDI keys records per value). We
-  expand one ``RecordData`` per ``rrdata`` on read, and collapse back to
-  a single-value rrset on write.
+  expand one ``RecordData`` per ``rrdata`` on read. On write, a per-value
+  create / delete **read-merges** against the provider's live rrset so a
+  single-value op never drops the sibling values that share the rrset
+  (see ``_apply_record``); an update replaces the rrset with its single
+  new value (per-row→RRset value-edit limitation, tracked in #29).
 * **Changes are transactional + asynchronous.** A write builds a
   ``Changes`` object (additions + deletions), commits it with
   ``changes.create()``, and the change goes ``pending`` → ``done``. We
@@ -232,31 +235,60 @@ class GoogleCloudDNSDriver(CloudDNSDriverBase):
         rr = change.record
         rtype = rr.record_type.upper()
         absolute = self._absolutize(rr.name, apex)
-        ttl = int(rr.ttl) if rr.ttl else 300
 
-        # Build the transactional change set. A create adds the new
-        # rrset; a delete removes the exact existing rrset (Cloud DNS
-        # requires the deletion to match name + type + ttl + rrdatas);
-        # an update does both in one atomic change set.
+        # Cloud DNS groups every same-{name,type} value under a single
+        # rrset (round-robin A, multiple MX/NS/TXT, …) but SpatiumDDI
+        # stores one DB row → one ``RecordChange`` per value. Writing a
+        # one-value rrset on create / delete would silently DROP the
+        # sibling values that share the rrset. So create + delete
+        # read-merge against the provider's CURRENT rrset and write the
+        # FULL merged/reduced value set in one transactional change.
         def _build_and_commit() -> Any:
             changes = zone.changes()
-            wants_add = change.op in {"create", "update"}
-            wants_delete = change.op in {"update", "delete"}
 
-            if wants_delete:
+            if change.op == "create":
                 existing = self._find_rrset(zone, absolute, rtype)
+                merged, ttl = self._merge_create(existing, rr.value, rr.ttl)
+                if existing is not None and self._rrdatas(existing) == merged:
+                    # Value already present with an unchanged set — no-op.
+                    return None
                 if existing is not None:
+                    # Cloud DNS has no in-place update; replace the whole
+                    # rrset (delete old + add merged) in one atomic change.
                     changes.delete_record_set(existing)
-                elif change.op == "delete":
-                    # Nothing to delete — desired end state already met.
-                    # Skip the commit entirely so we don't fire an empty
+                new_rrset = zone.resource_record_set(absolute, rtype, ttl, merged)
+                changes.add_record_set(new_rrset)
+                changes.create()
+                return changes
+
+            if change.op == "delete":
+                existing = self._find_rrset(zone, absolute, rtype)
+                if existing is None or rr.value not in self._rrdatas(existing):
+                    # Value (or whole rrset) already gone — idempotent
+                    # no-op. Skip the commit so we don't fire an empty
                     # change set (Cloud DNS rejects those).
                     return None
+                reduced = [v for v in self._rrdatas(existing) if v != rr.value]
+                changes.delete_record_set(existing)
+                if reduced:
+                    # Siblings remain — re-add the reduced rrset rather
+                    # than dropping the whole set.
+                    ttl = int(existing.ttl) if existing.ttl is not None else 300
+                    changes.add_record_set(zone.resource_record_set(absolute, rtype, ttl, reduced))
+                changes.create()
+                return changes
 
-            if wants_add:
-                new_rrset = zone.resource_record_set(absolute, rtype, ttl, [rr.value])
-                changes.add_record_set(new_rrset)
-
+            # ``update`` carries only the NEW value (no old value), so a
+            # correct multi-value merge is impossible at this layer —
+            # replace the whole rrset with the single new value. Correct
+            # for the common single-value rrset (CNAME, SOA, a host with
+            # one A/TXT); multi-value value-edits are an inherent
+            # per-row→RRset limitation tracked in #29.
+            ttl = int(rr.ttl) if rr.ttl else 300
+            existing = self._find_rrset(zone, absolute, rtype)
+            if existing is not None:
+                changes.delete_record_set(existing)
+            changes.add_record_set(zone.resource_record_set(absolute, rtype, ttl, [rr.value]))
             changes.create()
             return changes
 
@@ -264,15 +296,44 @@ class GoogleCloudDNSDriver(CloudDNSDriverBase):
             self._wrap_call, "change_record_sets", _build_and_commit
         )
         if committed is None:
+            # create-already-present or delete-missing — desired end state
+            # already met, nothing to commit.
             logger.info(
-                "google_dns.apply_record.delete_noop",
+                "google_dns.apply_record.noop",
                 server=str(getattr(server, "id", "")),
                 zone=change.zone_name,
                 name=rr.name,
                 rtype=rtype,
+                op=change.op,
             )
             return
         await self._wait_for_change(committed)
+
+    @staticmethod
+    def _rrdatas(rrset: Any) -> list[str]:
+        """Return an rrset's values as a list of strings (empty if none)."""
+        return [str(v) for v in (getattr(rrset, "rrdatas", None) or [])]
+
+    def _merge_create(
+        self, existing: Any | None, value: str, change_ttl: int | None
+    ) -> tuple[list[str], int]:
+        """Compute the merged value set + ttl for a create.
+
+        New values = existing values ∪ {``value``}, order-preserving + de-
+        duped (an already-present value yields an unchanged set, which the
+        caller treats as a no-op). TTL is the change's ttl, falling back to
+        the existing rrset's ttl, then the 300 s default.
+        """
+        merged: list[str] = list(self._rrdatas(existing)) if existing is not None else []
+        if value not in merged:
+            merged.append(value)
+        if change_ttl:
+            ttl = int(change_ttl)
+        elif existing is not None and existing.ttl is not None:
+            ttl = int(existing.ttl)
+        else:
+            ttl = 300
+        return merged, ttl
 
     def _find_rrset(self, zone: Any, absolute_name: str, rtype: str) -> Any | None:
         """Fetch the existing rrset matching ``absolute_name`` + ``rtype``.

--- a/backend/app/drivers/dns/googledns.py
+++ b/backend/app/drivers/dns/googledns.py
@@ -1,0 +1,387 @@
+"""Google Cloud DNS agentless cloud DNS driver (issue #37).
+
+Cloud DNS is managed exactly like a local BIND9 / PowerDNS zone — same
+Zones / Records / group surfaces — but the control plane drives the
+``google-cloud-dns`` SDK directly instead of an agent. See
+``drivers/dns/_cloud_base.py`` for the agentless contract; this module
+only implements the five provider hooks plus the ``name`` /
+``credential_fields`` class attrs.
+
+Credential dict shape (decrypted from ``DNSServer.credentials_encrypted``)::
+
+    {"service_account_json": "<service-account-key JSON string>",
+     "project_id": "my-gcp-project"}
+
+The ``service_account_json`` is the raw JSON key the operator downloads
+from the GCP console (a string, not a dict) — we ``json.loads`` it and
+hand it to ``Credentials.from_service_account_info``.
+
+A few Cloud-DNS-specific wrinkles the hooks paper over:
+
+* **Managed zone id vs. DNS name.** Cloud DNS scopes every call by the
+  *managed-zone id* (``z.name`` — a slug like ``"example-com"``), not by
+  the zone's DNS name (``z.dns_name`` — the FQDN ``"example.com."``).
+  We surface the DNS name as ``CloudDNSZone.name`` and stash the slug in
+  ``zone_id``; the record / zone hooks re-resolve the managed zone by
+  matching ``dns_name`` when they only know the FQDN.
+* **rrdatas is a list.** A single ``ResourceRecordSet`` carries one or
+  more ``rrdatas`` strings (Cloud DNS groups same-name/same-type values
+  into one rrset; the rest of SpatiumDDI keys records per value). We
+  expand one ``RecordData`` per ``rrdata`` on read, and collapse back to
+  a single-value rrset on write.
+* **Changes are transactional + asynchronous.** A write builds a
+  ``Changes`` object (additions + deletions), commits it with
+  ``changes.create()``, and the change goes ``pending`` → ``done``. We
+  poll ``changes.status`` with a bounded sleep loop so the op only
+  returns once Cloud DNS has applied it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from typing import Any
+
+import structlog
+
+from app.drivers.dns._cloud_base import (
+    CloudDNSDriverBase,
+    CloudDNSError,
+    CloudDNSZone,
+    normalize_fqdn,
+)
+from app.drivers.dns.base import RecordChange, RecordData
+
+logger = structlog.get_logger(__name__)
+
+# Bounded poll loop for a committed change set reaching ``done``. Cloud
+# DNS changes usually settle in a few seconds; cap the wait so a stuck
+# change surfaces as an error instead of blocking the op forever.
+_CHANGE_POLL_INTERVAL_S = 1.0
+_CHANGE_POLL_MAX_ATTEMPTS = 60
+
+
+def _zone_slug(dns_name: str) -> str:
+    """Derive a Cloud DNS managed-zone id from a zone DNS name.
+
+    Cloud DNS managed-zone ids must start with a letter, contain only
+    lower-case letters / digits / hyphens, and be ≤ 63 chars. We slugify
+    the FQDN (``"example.com."`` → ``"example-com"``) for the create
+    path; the operator can rename it in the GCP console afterwards.
+    """
+    base = normalize_fqdn(dns_name).rstrip(".")
+    slug = re.sub(r"[^a-z0-9-]+", "-", base.lower()).strip("-")
+    if not slug or not slug[0].isalpha():
+        slug = "zone-" + slug
+    return slug[:63].rstrip("-")
+
+
+class GoogleCloudDNSDriver(CloudDNSDriverBase):
+    """Agentless driver for Google Cloud DNS managed zones."""
+
+    name: str = "google_dns"
+    # Ordered credential fields the Add-DNS-server modal renders + the
+    # probe validates as required.
+    credential_fields: tuple[str, ...] = ("service_account_json", "project_id")
+
+    # ── Client factory ──────────────────────────────────────────────────
+    def _client(self, creds: dict[str, Any]) -> Any:
+        """Build a ``google.cloud.dns.Client`` from the decrypted creds.
+
+        The GCP SDKs are imported lazily so importing this module never
+        fails on a host without ``google-cloud-dns`` installed, and so
+        tests can monkeypatch this factory without the wheel present.
+        """
+        # Deferred import: keeps worker startup light + lets agent-only
+        # hosts skip the google-cloud-dns wheel entirely.
+        from google.cloud import dns  # noqa: PLC0415
+        from google.oauth2 import service_account  # noqa: PLC0415
+
+        sa_json = creds.get("service_account_json")
+        project_id = creds.get("project_id")
+        if not sa_json or not project_id:
+            raise CloudDNSError(
+                "google_dns credentials require both 'service_account_json' and 'project_id'."
+            )
+        try:
+            info = json.loads(sa_json) if isinstance(sa_json, str) else sa_json
+            credentials = service_account.Credentials.from_service_account_info(info)
+        except (ValueError, TypeError) as exc:
+            raise CloudDNSError(
+                f"google_dns service_account_json is not valid JSON: {exc}"
+            ) from exc
+        return dns.Client(project=project_id, credentials=credentials)
+
+    def _wrap_call(self, what: str, fn: Any, *args: Any, **kwargs: Any) -> Any:
+        """Run a blocking SDK call in a thread, wrapping GCP errors.
+
+        ``google.api_core.exceptions.GoogleAPICallError`` (API-side
+        failures) and ``google.auth.exceptions.GoogleAuthError``
+        (credential failures) are imported lazily and re-raised as
+        :class:`CloudDNSError` so the record-ops + import + probe paths
+        surface a clean operator-facing message instead of a raw SDK
+        traceback.
+        """
+        # Imported lazily so the except clauses don't drag the SDK in at
+        # module import time (mirrors ``_client``).
+        from google.api_core import exceptions as gax_exceptions  # noqa: PLC0415
+        from google.auth import exceptions as gauth_exceptions  # noqa: PLC0415
+
+        try:
+            return fn(*args, **kwargs)
+        except (
+            gax_exceptions.GoogleAPICallError,
+            gauth_exceptions.GoogleAuthError,
+        ) as exc:
+            raise CloudDNSError(f"google_dns {what} failed: {exc}") from exc
+
+    # ── Zone listing ────────────────────────────────────────────────────
+    async def _list_zones(self, server: Any, creds: dict[str, Any]) -> list[CloudDNSZone]:
+        client = self._client(creds)
+        # ``client.list_zones()`` returns an iterator that lazily pages
+        # under the hood — materialise it inside the thread so we don't
+        # block the event loop on per-page network round trips.
+        managed_zones = await asyncio.to_thread(
+            self._wrap_call, "list_zones", lambda: list(client.list_zones())
+        )
+        zones: list[CloudDNSZone] = []
+        for z in managed_zones:
+            name = normalize_fqdn(z.dns_name)
+            zones.append(
+                CloudDNSZone(
+                    name=name,
+                    # ``z.name`` is the GCP managed-zone id (slug); calls
+                    # scope by it, so keep it for the import provenance.
+                    zone_id=z.name,
+                    is_reverse=name.rstrip(".").endswith("arpa"),
+                    dnssec_enabled=False,
+                )
+            )
+        return zones
+
+    # ── Record listing ──────────────────────────────────────────────────
+    async def _list_zone_records(
+        self, server: Any, creds: dict[str, Any], zone_name: str
+    ) -> list[RecordData]:
+        client = self._client(creds)
+        apex = normalize_fqdn(zone_name)
+        zone = await self._resolve_zone(client, apex)
+
+        rrsets = await asyncio.to_thread(
+            self._wrap_call,
+            "list_resource_record_sets",
+            lambda: list(zone.list_resource_record_sets()),
+        )
+        records: list[RecordData] = []
+        for rrset in rrsets:
+            rtype = str(rrset.record_type).upper()
+            # Cloud DNS owns the apex SOA; skip it so the import +
+            # drift machinery doesn't try to round-trip it.
+            if rtype == "SOA":
+                continue
+            name = self._relativize(str(rrset.name), apex)
+            ttl = rrset.ttl
+            for rdata in rrset.rrdatas:
+                records.append(
+                    RecordData(
+                        name=name,
+                        record_type=rtype,
+                        value=str(rdata),
+                        ttl=int(ttl) if ttl is not None else None,
+                    )
+                )
+        return records
+
+    def _relativize(self, fqdn: str, apex: str) -> str:
+        """Return ``fqdn`` relative to ``apex`` (``"@"`` for the apex itself).
+
+        Both inputs are normalised to trailing-dot FQDNs first. A name
+        outside the apex (shouldn't happen for a zone's own rrsets) is
+        returned as its normalised FQDN unchanged.
+        """
+        f = normalize_fqdn(fqdn)
+        a = normalize_fqdn(apex)
+        if f == a:
+            return "@"
+        suffix = "." + a
+        if f.endswith(suffix):
+            return f[: -len(suffix)]
+        return f
+
+    def _absolutize(self, name: str, apex: str) -> str:
+        """Render a relative record label into an absolute FQDN for the apex."""
+        apex = normalize_fqdn(apex)
+        if name in ("", "@"):
+            return apex
+        label = normalize_fqdn(name)
+        # Already absolute under the apex (or some other suffix) — leave it.
+        if label.endswith("." + apex) or label == apex:
+            return label
+        return normalize_fqdn(name.rstrip(".") + "." + apex.rstrip("."))
+
+    # ── Record write ────────────────────────────────────────────────────
+    async def _apply_record(self, server: Any, creds: dict[str, Any], change: RecordChange) -> None:
+        if change.op not in {"create", "update", "delete"}:
+            raise CloudDNSError(f"google_dns._apply_record: bad op {change.op!r}")
+
+        client = self._client(creds)
+        apex = normalize_fqdn(change.zone_name)
+        zone = await self._resolve_zone(client, apex)
+
+        rr = change.record
+        rtype = rr.record_type.upper()
+        absolute = self._absolutize(rr.name, apex)
+        ttl = int(rr.ttl) if rr.ttl else 300
+
+        # Build the transactional change set. A create adds the new
+        # rrset; a delete removes the exact existing rrset (Cloud DNS
+        # requires the deletion to match name + type + ttl + rrdatas);
+        # an update does both in one atomic change set.
+        def _build_and_commit() -> Any:
+            changes = zone.changes()
+            wants_add = change.op in {"create", "update"}
+            wants_delete = change.op in {"update", "delete"}
+
+            if wants_delete:
+                existing = self._find_rrset(zone, absolute, rtype)
+                if existing is not None:
+                    changes.delete_record_set(existing)
+                elif change.op == "delete":
+                    # Nothing to delete — desired end state already met.
+                    # Skip the commit entirely so we don't fire an empty
+                    # change set (Cloud DNS rejects those).
+                    return None
+
+            if wants_add:
+                new_rrset = zone.resource_record_set(absolute, rtype, ttl, [rr.value])
+                changes.add_record_set(new_rrset)
+
+            changes.create()
+            return changes
+
+        committed = await asyncio.to_thread(
+            self._wrap_call, "change_record_sets", _build_and_commit
+        )
+        if committed is None:
+            logger.info(
+                "google_dns.apply_record.delete_noop",
+                server=str(getattr(server, "id", "")),
+                zone=change.zone_name,
+                name=rr.name,
+                rtype=rtype,
+            )
+            return
+        await self._wait_for_change(committed)
+
+    def _find_rrset(self, zone: Any, absolute_name: str, rtype: str) -> Any | None:
+        """Fetch the existing rrset matching ``absolute_name`` + ``rtype``.
+
+        Cloud DNS deletes must reference the *exact* current rrset (same
+        ttl + rrdatas), so we read the zone's record sets and return the
+        matching ``ResourceRecordSet`` object. Returns ``None`` when no
+        such rrset exists (the delete becomes a no-op).
+        """
+        target = normalize_fqdn(absolute_name)
+        for rrset in zone.list_resource_record_sets():
+            if (
+                normalize_fqdn(str(rrset.name)) == target
+                and str(rrset.record_type).upper() == rtype
+            ):
+                return rrset
+        return None
+
+    async def _wait_for_change(self, changes: Any) -> None:
+        """Poll a committed ``Changes`` object until it reaches ``done``.
+
+        Bounded loop — Cloud DNS settles a change in a few seconds; a
+        change still ``pending`` after the cap surfaces as an error so a
+        stuck op doesn't block the caller forever.
+        """
+        for _ in range(_CHANGE_POLL_MAX_ATTEMPTS):
+            status = getattr(changes, "status", None)
+            if status == "done":
+                return
+            await asyncio.sleep(_CHANGE_POLL_INTERVAL_S)
+            await asyncio.to_thread(self._wrap_call, "changes.reload", changes.reload)
+        raise CloudDNSError(
+            f"google_dns change did not reach 'done' within "
+            f"{_CHANGE_POLL_MAX_ATTEMPTS}s (last status: {getattr(changes, 'status', None)!r})"
+        )
+
+    # ── Zone write ──────────────────────────────────────────────────────
+    async def _apply_zone(self, server: Any, creds: dict[str, Any], zone: Any, op: str) -> None:
+        client = self._client(creds)
+        name = normalize_fqdn(getattr(zone, "name", "") or "")
+        if name == ".":
+            raise CloudDNSError("google_dns._apply_zone: zone name is required")
+
+        if op == "create":
+            slug = _zone_slug(name)
+            managed = await asyncio.to_thread(
+                self._wrap_call,
+                "zone",
+                client.zone,
+                slug,
+                dns_name=name,
+            )
+            await asyncio.to_thread(self._wrap_call, "create_zone", managed.create)
+            return
+
+        if op == "delete":
+            managed = await self._resolve_zone(client, name)
+            await asyncio.to_thread(self._wrap_call, "delete_zone", managed.delete)
+            return
+
+        raise CloudDNSError(f"google_dns._apply_zone: unsupported op {op!r}")
+
+    # ── Managed-zone resolution ─────────────────────────────────────────
+    async def _resolve_zone(self, client: Any, zone_name: str) -> Any:
+        """Resolve a Cloud DNS managed-zone object from a zone FQDN.
+
+        Cloud DNS scopes record / delete calls by the managed-zone id
+        (``z.name`` slug), not by DNS name, so iterate ``list_zones()``
+        and match on ``dns_name``.
+        """
+        apex = normalize_fqdn(zone_name)
+        managed_zones = await asyncio.to_thread(
+            self._wrap_call, "list_zones", lambda: list(client.list_zones())
+        )
+        for z in managed_zones:
+            if normalize_fqdn(z.dns_name) == apex:
+                return z
+        raise CloudDNSError(f"google_dns: managed zone {zone_name!r} not found")
+
+    # ── Capabilities ────────────────────────────────────────────────────
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "name": "google_dns",
+            "agentless": True,
+            "manages_zones": True,
+            "views": False,
+            "rpz": False,
+            "dnssec_online": True,
+            "record_types": [
+                "A",
+                "AAAA",
+                "CNAME",
+                "MX",
+                "TXT",
+                "NS",
+                "SRV",
+                "CAA",
+                "PTR",
+                "SOA",
+            ],
+            "notes": (
+                "Agentless Google Cloud DNS driver. Zone + record CRUD via "
+                "the google-cloud-dns SDK from the control plane (no agent). "
+                "Calls scope by the managed-zone id (slug) resolved from the "
+                "zone DNS name; writes go through transactional change sets "
+                "and the op blocks until the change reaches 'done'. MX/SRV "
+                "priority is carried inside the record value."
+            ),
+        }
+
+
+__all__ = ["GoogleCloudDNSDriver"]

--- a/backend/app/drivers/dns/route53.py
+++ b/backend/app/drivers/dns/route53.py
@@ -1,0 +1,377 @@
+"""Amazon Route 53 agentless cloud DNS driver (issue #37).
+
+Route 53 is managed exactly like a local BIND9 / PowerDNS zone — same
+Zones / Records / group surfaces — but the control plane drives the AWS
+SDK (``boto3``) directly instead of an agent. See
+``drivers/dns/_cloud_base.py`` for the agentless contract; this module
+only implements the five provider hooks plus the ``name`` /
+``credential_fields`` class attrs.
+
+Credential dict shape (decrypted from ``DNSServer.credentials_encrypted``)::
+
+    {"access_key_id": "AKIA...", "secret_access_key": "..."}
+
+Route 53 is a global service — there is no region to configure. Each
+hosted-zone API call is scoped by the opaque hosted-zone id (``Z...``),
+which we resolve from the zone FQDN with ``list_hosted_zones_by_name``
+when the caller only knows the name.
+
+A couple of Route-53-specific wrinkles the hooks paper over:
+
+* **MX / SRV priority is baked into the record value.** Route 53's
+  ``ResourceRecords[].Value`` for an MX record is the full
+  ``"10 mail.example.com."`` string. We keep that raw string in
+  ``RecordData.value`` and leave ``priority`` / ``weight`` / ``port``
+  ``None`` so the value isn't double-encoded on the way back out.
+* **ALIAS records** (``AliasTarget``) have no ``ResourceRecords`` and no
+  TTL (Route 53 inherits the target's TTL). We surface them as a record
+  whose ``value`` is the alias target DNS name and ``ttl`` is ``None``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+import structlog
+
+from app.drivers.dns._cloud_base import (
+    CloudDNSDriverBase,
+    CloudDNSError,
+    CloudDNSZone,
+    normalize_fqdn,
+)
+from app.drivers.dns.base import RecordChange, RecordData
+
+logger = structlog.get_logger(__name__)
+
+
+class Route53DNSDriver(CloudDNSDriverBase):
+    """Agentless driver for Amazon Route 53 hosted zones."""
+
+    name: str = "route53"
+    # Ordered credential fields the Add-DNS-server modal renders + the
+    # probe validates as required. Route 53 is global — no region.
+    credential_fields: tuple[str, ...] = ("access_key_id", "secret_access_key")
+
+    # ── Client factory ──────────────────────────────────────────────────
+    def _client(self, creds: dict[str, Any]) -> Any:
+        """Build a boto3 Route 53 client from the decrypted creds.
+
+        ``boto3`` is imported lazily so importing this module never fails
+        on a host without the AWS SDK installed, and so tests can
+        monkeypatch this factory without the wheel present.
+        """
+        # Deferred import: keeps worker startup light + lets agent-only
+        # hosts skip the boto3 wheel entirely.
+        import boto3  # noqa: PLC0415
+
+        access_key_id = creds.get("access_key_id")
+        secret_access_key = creds.get("secret_access_key")
+        if not access_key_id or not secret_access_key:
+            raise CloudDNSError(
+                "route53 credentials require both 'access_key_id' and 'secret_access_key'."
+            )
+        # Route 53 is a global endpoint; pass a region anyway because some
+        # boto3/botocore configurations refuse to construct a client
+        # without one, even though the service ignores it.
+        return boto3.client(
+            "route53",
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            region_name="us-east-1",
+        )
+
+    # ── Zone listing ────────────────────────────────────────────────────
+    async def _list_zones(self, server: Any, creds: dict[str, Any]) -> list[CloudDNSZone]:
+        client = self._client(creds)
+        zones: list[CloudDNSZone] = []
+        marker: str | None = None
+        try:
+            while True:
+                kwargs: dict[str, Any] = {"MaxItems": "100"}
+                if marker:
+                    kwargs["Marker"] = marker
+                resp = await asyncio.to_thread(client.list_hosted_zones, **kwargs)
+                for z in resp.get("HostedZones", []):
+                    name = normalize_fqdn(z.get("Name", ""))
+                    zones.append(
+                        CloudDNSZone(
+                            name=name,
+                            # Route 53 hosted-zone ids arrive as
+                            # ``/hostedzone/Z123ABC`` — keep only the bare id.
+                            zone_id=str(z.get("Id", "")).split("/")[-1],
+                            is_reverse=name.rstrip(".").endswith("arpa"),
+                            record_count=z.get("ResourceRecordSetCount"),
+                        )
+                    )
+                if resp.get("IsTruncated"):
+                    marker = resp.get("NextMarker")
+                    continue
+                break
+        except Exception as exc:  # noqa: BLE001 — wrap any botocore/SDK error
+            raise CloudDNSError(f"route53 list_hosted_zones failed: {exc}") from exc
+        return zones
+
+    # ── Record listing ──────────────────────────────────────────────────
+    async def _list_zone_records(
+        self, server: Any, creds: dict[str, Any], zone_name: str
+    ) -> list[RecordData]:
+        client = self._client(creds)
+        apex = normalize_fqdn(zone_name)
+        zone_id = await self._resolve_zone_id(client, apex)
+
+        records: list[RecordData] = []
+        next_name: str | None = None
+        next_type: str | None = None
+        try:
+            while True:
+                kwargs: dict[str, Any] = {"HostedZoneId": zone_id, "MaxItems": "300"}
+                if next_name:
+                    kwargs["StartRecordName"] = next_name
+                if next_type:
+                    kwargs["StartRecordType"] = next_type
+                resp = await asyncio.to_thread(client.list_resource_record_sets, **kwargs)
+                for rrset in resp.get("ResourceRecordSets", []):
+                    records.extend(self._expand_rrset(rrset, apex))
+                if resp.get("IsTruncated"):
+                    next_name = resp.get("NextRecordName")
+                    next_type = resp.get("NextRecordType")
+                    continue
+                break
+        except CloudDNSError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — wrap any botocore/SDK error
+            raise CloudDNSError(
+                f"route53 list_resource_record_sets failed for {zone_name!r}: {exc}"
+            ) from exc
+        return records
+
+    def _expand_rrset(self, rrset: dict[str, Any], apex: str) -> list[RecordData]:
+        """Expand one Route 53 ResourceRecordSet into ``RecordData`` rows.
+
+        A normal rrset carries an ``ResourceRecords`` list — one
+        ``RecordData`` per value (Route 53 groups same-name/same-type
+        values into a single rrset; the rest of SpatiumDDI keys records
+        per value). An ALIAS rrset carries ``AliasTarget`` instead and
+        has no TTL — surface its ``DNSName`` as the value.
+        """
+        rtype = str(rrset.get("Type", "")).upper()
+        name = self._relativize(str(rrset.get("Name", "")), apex)
+        ttl = rrset.get("TTL")
+
+        alias = rrset.get("AliasTarget")
+        if alias:
+            return [
+                RecordData(
+                    name=name,
+                    record_type=rtype,
+                    value=normalize_fqdn(str(alias.get("DNSName", ""))),
+                    ttl=None,
+                )
+            ]
+
+        out: list[RecordData] = []
+        for rr in rrset.get("ResourceRecords", []):
+            value = rr.get("Value")
+            if value is None:
+                continue
+            # MX / SRV values keep priority baked into the string
+            # ("10 mail.example.com.") — leave priority/weight/port None to
+            # avoid re-encoding it on the write path.
+            out.append(
+                RecordData(
+                    name=name,
+                    record_type=rtype,
+                    value=str(value),
+                    ttl=int(ttl) if ttl is not None else None,
+                )
+            )
+        return out
+
+    def _relativize(self, fqdn: str, apex: str) -> str:
+        """Return ``fqdn`` relative to ``apex`` (``"@"`` for the apex itself).
+
+        Both inputs are normalised to trailing-dot FQDNs first. A name
+        outside the apex (shouldn't happen for a zone's own rrsets) is
+        returned as its normalised FQDN unchanged.
+        """
+        f = normalize_fqdn(fqdn)
+        a = normalize_fqdn(apex)
+        if f == a:
+            return "@"
+        suffix = "." + a
+        if f.endswith(suffix):
+            return f[: -len(suffix)]
+        return f
+
+    # ── Record write ────────────────────────────────────────────────────
+    async def _apply_record(self, server: Any, creds: dict[str, Any], change: RecordChange) -> None:
+        if change.op not in {"create", "update", "delete"}:
+            raise CloudDNSError(f"route53._apply_record: bad op {change.op!r}")
+
+        client = self._client(creds)
+        apex = normalize_fqdn(change.zone_name)
+        zone_id = await self._resolve_zone_id(client, apex)
+
+        rr = change.record
+        rtype = rr.record_type.upper()
+        absolute = self._absolutize(rr.name, apex)
+        ttl = int(rr.ttl) if rr.ttl else 300
+
+        rrset: dict[str, Any] = {
+            "Name": absolute,
+            "Type": rtype,
+            "TTL": ttl,
+            # MX / SRV: ``value`` already carries the priority/target, so a
+            # single ResourceRecords entry is correct.
+            "ResourceRecords": [{"Value": rr.value}],
+        }
+        action = "DELETE" if change.op == "delete" else "UPSERT"
+        change_batch = {"Changes": [{"Action": action, "ResourceRecordSet": rrset}]}
+
+        try:
+            await asyncio.to_thread(
+                client.change_resource_record_sets,
+                HostedZoneId=zone_id,
+                ChangeBatch=change_batch,
+            )
+        except Exception as exc:  # noqa: BLE001 — wrap any botocore/SDK error
+            # A DELETE of a non-existent rrset raises InvalidChangeBatch.
+            # The desired end state (record gone) is already met, so treat
+            # it as an idempotent no-op rather than a failed op.
+            if change.op == "delete" and _is_invalid_change_batch(exc):
+                logger.info(
+                    "route53.apply_record.delete_noop",
+                    server=str(getattr(server, "id", "")),
+                    zone=change.zone_name,
+                    name=rr.name,
+                    rtype=rtype,
+                )
+                return
+            raise CloudDNSError(
+                f"route53 change_resource_record_sets ({action}) failed for "
+                f"{rr.name!r} {rtype} in {change.zone_name!r}: {exc}"
+            ) from exc
+
+    def _absolutize(self, name: str, apex: str) -> str:
+        """Render a relative record label into an absolute FQDN for the apex."""
+        apex = normalize_fqdn(apex)
+        if name in ("", "@"):
+            return apex
+        label = normalize_fqdn(name)
+        # Already absolute under the apex (or some other suffix) — leave it.
+        if label.endswith("." + apex) or label == apex:
+            return label
+        return normalize_fqdn(name.rstrip(".") + "." + apex.rstrip("."))
+
+    # ── Zone write ──────────────────────────────────────────────────────
+    async def _apply_zone(self, server: Any, creds: dict[str, Any], zone: Any, op: str) -> None:
+        client = self._client(creds)
+        name = normalize_fqdn(getattr(zone, "name", "") or "")
+        if name == ".":
+            raise CloudDNSError("route53._apply_zone: zone name is required")
+
+        if op == "create":
+            try:
+                await asyncio.to_thread(
+                    client.create_hosted_zone,
+                    Name=name,
+                    # CallerReference must be unique per create — a fresh
+                    # uuid makes the call idempotently safe to retry only
+                    # within the same uuid; a new attempt mints a new one.
+                    CallerReference=uuid.uuid4().hex,
+                )
+            except Exception as exc:  # noqa: BLE001 — wrap any botocore/SDK error
+                raise CloudDNSError(
+                    f"route53 create_hosted_zone failed for {name!r}: {exc}"
+                ) from exc
+            return
+
+        if op == "delete":
+            zone_id = await self._resolve_zone_id(client, name)
+            try:
+                await asyncio.to_thread(client.delete_hosted_zone, Id=zone_id)
+            except Exception as exc:  # noqa: BLE001 — wrap any botocore/SDK error
+                raise CloudDNSError(
+                    f"route53 delete_hosted_zone failed for {name!r}: {exc}"
+                ) from exc
+            return
+
+        raise CloudDNSError(f"route53._apply_zone: unsupported op {op!r}")
+
+    # ── Hosted-zone id resolution ───────────────────────────────────────
+    async def _resolve_zone_id(self, client: Any, zone_name: str) -> str:
+        """Resolve a hosted-zone id from a zone FQDN.
+
+        Uses ``list_hosted_zones_by_name`` (an exact-name prefix query)
+        and matches the normalised ``Name`` exactly — the API returns the
+        first zone at-or-after ``DNSName`` alphabetically, which may be a
+        different zone when ours doesn't exist.
+        """
+        apex = normalize_fqdn(zone_name)
+        try:
+            resp = await asyncio.to_thread(
+                client.list_hosted_zones_by_name, DNSName=apex, MaxItems="1"
+            )
+        except Exception as exc:  # noqa: BLE001 — wrap any botocore/SDK error
+            raise CloudDNSError(
+                f"route53 list_hosted_zones_by_name failed for {zone_name!r}: {exc}"
+            ) from exc
+        for z in resp.get("HostedZones", []):
+            if normalize_fqdn(z.get("Name", "")) == apex:
+                return str(z.get("Id", "")).split("/")[-1]
+        raise CloudDNSError(f"route53: hosted zone {zone_name!r} not found")
+
+    # ── Capabilities ────────────────────────────────────────────────────
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "name": "route53",
+            "agentless": True,
+            "manages_zones": True,
+            "views": False,
+            "rpz": False,
+            "dnssec_online": True,
+            "alias_records": True,
+            "record_types": [
+                "A",
+                "AAAA",
+                "CNAME",
+                "MX",
+                "TXT",
+                "NS",
+                "SRV",
+                "CAA",
+                "PTR",
+                "SOA",
+                "ALIAS",
+            ],
+            "notes": (
+                "Agentless Amazon Route 53 driver. Zone + record CRUD via "
+                "the boto3 SDK from the control plane (no agent). Route 53 "
+                "is a global service — no region to configure. MX/SRV "
+                "priority is carried inside the record value; ALIAS records "
+                "(AliasTarget) surface with a null TTL."
+            ),
+        }
+
+
+def _is_invalid_change_batch(exc: Exception) -> bool:
+    """True when ``exc`` is a Route 53 InvalidChangeBatch (e.g. delete of a
+    record that doesn't exist).
+
+    botocore raises ``ClientError`` with the AWS error code under
+    ``response["Error"]["Code"]``. We sniff that without importing
+    botocore (which may not be installed) and fall back to a substring
+    check on the message so the behaviour holds for stubbed SDKs in tests.
+    """
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        code = str(response.get("Error", {}).get("Code", ""))
+        if code in {"InvalidChangeBatch", "NoSuchChange"}:
+            return True
+    return "InvalidChangeBatch" in str(exc)
+
+
+__all__ = ["Route53DNSDriver"]

--- a/backend/app/drivers/dns/route53.py
+++ b/backend/app/drivers/dns/route53.py
@@ -218,19 +218,171 @@ class Route53DNSDriver(CloudDNSDriverBase):
         rr = change.record
         rtype = rr.record_type.upper()
         absolute = self._absolutize(rr.name, apex)
-        ttl = int(rr.ttl) if rr.ttl else 300
+        default_ttl = int(rr.ttl) if rr.ttl else 300
 
-        rrset: dict[str, Any] = {
-            "Name": absolute,
-            "Type": rtype,
-            "TTL": ttl,
-            # MX / SRV: ``value`` already carries the priority/target, so a
-            # single ResourceRecords entry is correct.
-            "ResourceRecords": [{"Value": rr.value}],
-        }
-        action = "DELETE" if change.op == "delete" else "UPSERT"
+        # SpatiumDDI stores one DB row per record value and emits one
+        # RecordChange per row, but Route 53 groups every value sharing the
+        # same {Name, Type} into a single ResourceRecordSet. Writing only
+        # this op's value would clobber the rrset's siblings (round-robin A,
+        # multiple MX/NS/TXT). For create/delete we read the live rrset and
+        # merge so siblings survive; update keeps the single-value replace
+        # (see below).
+        if change.op == "update":
+            # Replace the rrset with this single value. The update op carries
+            # only the NEW value (no old value), so a correct multi-value
+            # merge is impossible at this per-row→RRset layer — replace is
+            # correct for the common single-value rrset (CNAME, SOA, a host
+            # with one A/TXT). Multi-value value-edits are an inherent
+            # per-row→RRset limitation tracked in #29.
+            rrset: dict[str, Any] = {
+                "Name": absolute,
+                "Type": rtype,
+                "TTL": default_ttl,
+                # MX / SRV: ``value`` already carries the priority/target, so
+                # a single ResourceRecords entry is correct.
+                "ResourceRecords": [{"Value": rr.value}],
+            }
+            await self._submit_change(server, client, zone_id, "UPSERT", rrset, change)
+            return
+
+        # Read the provider's current rrset for {name, type} so we can merge.
+        existing = await self._read_rrset(server, client, zone_id, absolute, rtype)
+
+        if change.op == "create":
+            if existing is not None and existing.get("AliasTarget"):
+                # ALIAS rrsets (AliasTarget) are single-valued and have no
+                # ResourceRecords — never merge a value into an alias rrset.
+                # Replace it with the new value-bearing rrset instead.
+                existing = None
+            existing_values = self._existing_values(existing)
+            if rr.value in existing_values:
+                # Value already present — the desired set is unchanged, so
+                # this is an idempotent no-op.
+                logger.info(
+                    "route53.apply_record.create_noop",
+                    server=str(getattr(server, "id", "")),
+                    zone=change.zone_name,
+                    name=rr.name,
+                    rtype=rtype,
+                )
+                return
+            merged_values = existing_values + [rr.value]
+            ttl = self._merge_ttl(rr.ttl, existing, default_ttl)
+            rrset = {
+                "Name": absolute,
+                "Type": rtype,
+                "TTL": ttl,
+                "ResourceRecords": [{"Value": v} for v in merged_values],
+            }
+            await self._submit_change(server, client, zone_id, "UPSERT", rrset, change)
+            return
+
+        # op == "delete": remove this value from the live rrset.
+        if existing is None or existing.get("AliasTarget"):
+            # Nothing to delete (or an alias rrset whose single value isn't a
+            # plain ResourceRecords value) — idempotent no-op.
+            logger.info(
+                "route53.apply_record.delete_noop",
+                server=str(getattr(server, "id", "")),
+                zone=change.zone_name,
+                name=rr.name,
+                rtype=rtype,
+            )
+            return
+        existing_values = self._existing_values(existing)
+        if rr.value not in existing_values:
+            # Value isn't in the rrset — idempotent no-op.
+            logger.info(
+                "route53.apply_record.delete_noop",
+                server=str(getattr(server, "id", "")),
+                zone=change.zone_name,
+                name=rr.name,
+                rtype=rtype,
+            )
+            return
+        remaining = [v for v in existing_values if v != rr.value]
+        if remaining:
+            # Other values survive — UPSERT the reduced set, keeping the
+            # rrset's live TTL.
+            ttl = int(existing.get("TTL", default_ttl) or default_ttl)
+            rrset = {
+                "Name": absolute,
+                "Type": rtype,
+                "TTL": ttl,
+                "ResourceRecords": [{"Value": v} for v in remaining],
+            }
+            await self._submit_change(server, client, zone_id, "UPSERT", rrset, change)
+            return
+        # Last value removed — delete the whole rrset. Route 53 requires the
+        # EXACT existing rrset (incl. its TTL + every value) to delete.
+        await self._submit_change(server, client, zone_id, "DELETE", existing, change)
+
+    async def _read_rrset(
+        self, server: Any, client: Any, zone_id: str, absolute: str, rtype: str
+    ) -> dict[str, Any] | None:
+        """Return the live Route 53 rrset for exactly ``{absolute, rtype}``.
+
+        ``list_resource_record_sets`` returns the first rrset at-or-after the
+        start key lexically, so when no exact match exists Route 53 hands
+        back the NEXT rrset — we compare normalised names + type and discard
+        a non-match. Returns ``None`` when no such rrset exists.
+        """
+        try:
+            resp = await asyncio.to_thread(
+                client.list_resource_record_sets,
+                HostedZoneId=zone_id,
+                StartRecordName=absolute,
+                StartRecordType=rtype,
+                MaxItems="1",
+            )
+        except Exception as exc:  # noqa: BLE001 — wrap any botocore/SDK error
+            raise CloudDNSError(
+                f"route53 list_resource_record_sets (read-merge) failed for "
+                f"{absolute!r} {rtype} on {zone_id!r}: {exc}"
+            ) from exc
+        for candidate in resp.get("ResourceRecordSets", []):
+            if (
+                normalize_fqdn(str(candidate.get("Name", ""))) == normalize_fqdn(absolute)
+                and str(candidate.get("Type", "")).upper() == rtype
+            ):
+                return candidate
+        return None
+
+    @staticmethod
+    def _existing_values(rrset: dict[str, Any] | None) -> list[str]:
+        """Return the rrset's current ``ResourceRecords[].Value`` list."""
+        if not rrset:
+            return []
+        return [
+            str(rr["Value"])
+            for rr in rrset.get("ResourceRecords", [])
+            if rr.get("Value") is not None
+        ]
+
+    @staticmethod
+    def _merge_ttl(
+        change_ttl: int | None, existing: dict[str, Any] | None, default_ttl: int
+    ) -> int:
+        """TTL for a merged rrset: the change's ttl, else the live rrset's,
+        else the default."""
+        if change_ttl:
+            return int(change_ttl)
+        if existing and existing.get("TTL") is not None:
+            return int(existing["TTL"])
+        return default_ttl
+
+    async def _submit_change(
+        self,
+        server: Any,
+        client: Any,
+        zone_id: str,
+        action: str,
+        rrset: dict[str, Any],
+        change: RecordChange,
+    ) -> None:
+        """Submit a single-change ChangeBatch, wrapping errors + treating an
+        InvalidChangeBatch on DELETE as an idempotent no-op."""
         change_batch = {"Changes": [{"Action": action, "ResourceRecordSet": rrset}]}
-
         try:
             await asyncio.to_thread(
                 client.change_resource_record_sets,
@@ -246,13 +398,14 @@ class Route53DNSDriver(CloudDNSDriverBase):
                     "route53.apply_record.delete_noop",
                     server=str(getattr(server, "id", "")),
                     zone=change.zone_name,
-                    name=rr.name,
-                    rtype=rtype,
+                    name=change.record.name,
+                    rtype=change.record.record_type.upper(),
                 )
                 return
             raise CloudDNSError(
                 f"route53 change_resource_record_sets ({action}) failed for "
-                f"{rr.name!r} {rtype} in {change.zone_name!r}: {exc}"
+                f"{change.record.name!r} {change.record.record_type.upper()} "
+                f"in {change.zone_name!r}: {exc}"
             ) from exc
 
     def _absolutize(self, name: str, apex: str) -> str:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -92,6 +92,7 @@ from app.models.overlay import (
     OverlaySite,
     RoutingPolicy,
 )
+from app.models.cloud import CloudEndpoint
 from app.models.ownership import Customer, Provider, Site
 from app.models.proxmox import ProxmoxNode
 from app.models.settings import PlatformSettings
@@ -176,6 +177,7 @@ __all__ = [
     "DHCPMetricSample",
     "DNSQueryLogEntry",
     "DHCPLogEntry",
+    "CloudEndpoint",
     "DockerHost",
     "Domain",
     "KubernetesCluster",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.auth_provider import AuthGroupMapping, AuthProvider
 from app.models.backup import BackupTarget
 from app.models.base import Base
 from app.models.circuit import Circuit
+from app.models.cloud import CloudEndpoint
 from app.models.conformity import ConformityPolicy, ConformityResult
 from app.models.dhcp import (
     DHCPClientClass,
@@ -92,7 +93,6 @@ from app.models.overlay import (
     OverlaySite,
     RoutingPolicy,
 )
-from app.models.cloud import CloudEndpoint
 from app.models.ownership import Customer, Provider, Site
 from app.models.proxmox import ProxmoxNode
 from app.models.settings import PlatformSettings

--- a/backend/app/models/cloud.py
+++ b/backend/app/models/cloud.py
@@ -1,0 +1,147 @@
+"""Cloud integration (issue #37, Part A) — per-account endpoint config.
+
+Same read-only-mirror shape as ``ProxmoxNode`` / ``DockerHost`` /
+``KubernetesCluster`` / ``UnifiController`` but for a public-cloud
+account. A single ``CloudEndpoint`` row represents one cloud account
+SpatiumDDI polls for infrastructure state (VPCs / subnets / instance
+NICs / public IPs / load-balancer frontends → IPAM rows).
+
+The ``provider`` discriminator gates connector dispatch. AWS / Azure /
+GCP are implemented; the enum reserves the token-only providers
+(``hetzner`` / ``digitalocean`` / ``linode`` / ``vultr``) so a future
+phase can light them up without a model change — they line up with the
+same provider names Part B (Cloud DNS) reserves, so "I connected my
+DigitalOcean account" could eventually feed both surfaces from one
+credential.
+
+Auth varies per provider and lives Fernet-encrypted in
+``credentials_encrypted`` (a JSON dict; see ``services/cloud/base.py``
+for the per-provider shape). Non-secret routing identifiers
+(subscription ids for Azure, project ids for GCP) live in the plaintext
+``provider_config`` JSONB so the UI can show them without a decrypt;
+``regions`` is a first-class column because it is the common cross-
+provider scope filter.
+
+Mirror rows provenance via the ``cloud_endpoint_id`` FK on
+``IPBlock`` / ``Subnet`` / ``IPAddress`` with ``ON DELETE CASCADE`` so
+removing the endpoint sweeps every materialised row atomically — same
+contract every other integration uses.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    String,
+    Text,
+)
+from sqlalchemy import text as sa_text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+# Providers wired into the connector dispatch today. The model column is
+# a plain ``String`` so reserving more (token-only providers) needs no
+# migration; the API validator is the gate on what's actually accepted.
+CLOUD_PROVIDERS_IMPLEMENTED: frozenset[str] = frozenset({"aws", "azure", "gcp"})
+
+
+class CloudEndpoint(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A public-cloud account SpatiumDDI polls for infrastructure state."""
+
+    __tablename__ = "cloud_endpoint"
+    __table_args__ = (Index("ix_cloud_endpoint_name", "name", unique=True),)
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    # ── Provider selection ──────────────────────────────────────────
+    # "aws" | "azure" | "gcp"  (reserved: hetzner | digitalocean | linode | vultr)
+    provider: Mapped[str] = mapped_column(String(16), nullable=False)
+
+    # ── Credentials (Fernet-encrypted JSON at rest) ─────────────────
+    # AWS:   {"access_key_id", "secret_access_key"}
+    # Azure: {"tenant_id", "client_id", "client_secret"}
+    # GCP:   {"service_account_json"}   (the whole key file as a string)
+    # Empty bytes = unset.
+    credentials_encrypted: Mapped[bytes] = mapped_column(
+        LargeBinary, nullable=False, default=b"", server_default=sa_text("''::bytea")
+    )
+
+    # Non-secret routing scope, shown in the UI without a decrypt:
+    # Azure: {"subscription_ids": [...]}   GCP: {"project_ids": [...]}   AWS: {}
+    provider_config: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=sa_text("'{}'::jsonb")
+    )
+    # Region / location allow-list. Empty = all regions the account can
+    # see. AWS fans out a client per region; Azure / GCP filter the flat
+    # resource list. Stored as a JSON string array.
+    regions: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+
+    # ── Binding ─────────────────────────────────────────────────────
+    # Private VPC/VNet networks + their subnets + instance NICs land
+    # under this space (one IPBlock per VPC CIDR, Subnets beneath).
+    ipam_space_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("ip_space.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    # Optional separate space for cloud-public / cloud-lb IPs. NULL =
+    # keep them in ``ipam_space_id`` (only mirrored when an enclosing
+    # subnet exists there — public IPs are otherwise out-of-band /32s).
+    public_space_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("ip_space.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    dns_group_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dns_server_group.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # ── Mirror policy ───────────────────────────────────────────────
+    mirror_load_balancers: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    # Default OFF → only running instances land in IPAM. ON keeps
+    # stopped / deallocated instances too (capacity-planning views).
+    mirror_stopped_instances: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+
+    # ── Cadence ─────────────────────────────────────────────────────
+    # Cloud APIs are slower + rate-limited; 300 s default, 60 s floor.
+    # Swept by ``sweep_cloud_endpoints`` on a 30 s beat tick.
+    sync_interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=300)
+
+    # ── Sync state ──────────────────────────────────────────────────
+    last_synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Populated by the test-connection probe + every reconcile — shown
+    # in the UI. ``provider_account_id`` is the AWS account id / Azure
+    # tenant-or-sub / GCP project the credentials resolved to.
+    provider_account_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    network_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    instance_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Per-reconcile discovery snapshot — counts + per-instance reason
+    # codes (no NIC / no enclosing subnet / stopped). Drives the
+    # "Discovery" modal, same as Proxmox. Written on every success.
+    last_discovery: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+
+__all__ = ["CLOUD_PROVIDERS_IMPLEMENTED", "CloudEndpoint"]

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -48,6 +48,13 @@ IP_STATUSES_INTEGRATION_OWNED: frozenset[str] = frozenset(
         "proxmox-vm",
         "proxmox-lxc",
         "tailscale-node",
+        # Cloud integration (issue #37, Part A). cloud-instance = a
+        # VM/EC2/GCE NIC private IP; cloud-public = an Elastic/public
+        # IP or external address; cloud-lb = a load-balancer frontend
+        # IP (ELB/ALB/NLB, Azure LB, GCP forwarding rule).
+        "cloud-instance",
+        "cloud-public",
+        "cloud-lb",
         # Stamped by the nmap "Stamp alive hosts → IPAM" action on a
         # multi-host (CIDR) scan result. Marks an IP as "we saw a host
         # on the wire here" without claiming it's allocated. Operators
@@ -253,6 +260,15 @@ class IPBlock(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     unifi_controller_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("unifi_controller.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    # Set by the Cloud reconciler (issue #37) for the IPBlock it creates
+    # per VPC/VNet address-space CIDR under the bound space. Cascades on
+    # endpoint delete.
+    cloud_endpoint_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("cloud_endpoint.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
     )
@@ -639,6 +655,18 @@ class Subnet(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
         nullable=True,
         index=True,
     )
+    # Cloud integration provenance (issue #37). Set on subnets the Cloud
+    # reconciler mirrors from a VPC subnet. Cloud subnets are routed
+    # overlays whose first usable host is the gateway by convention
+    # (x.x.x.1 on AWS/Azure/GCP) but carry no broadcast row — the
+    # reconciler creates them with ``kubernetes_semantics``-style
+    # suppression. Cascades on endpoint delete.
+    cloud_endpoint_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("cloud_endpoint.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
 
     # Computed / cached. ``total_ips`` is BigInteger because IPv6 subnets can
     # be as large as 2^64 addresses (a /64 — the standard LAN size) which
@@ -815,6 +843,15 @@ class IPAddress(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     unifi_controller_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("unifi_controller.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    # Cloud provenance (issue #37) — set on rows mirrored from an
+    # instance NIC (cloud-instance), public IP (cloud-public), or
+    # load-balancer frontend (cloud-lb). Cascades on endpoint delete.
+    cloud_endpoint_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("cloud_endpoint.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
     )

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -265,6 +265,7 @@ class PlatformSettings(Base):
         Boolean, nullable=False, default=False
     )
     integration_unifi_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    integration_cloud_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     # Trash retention — high-blast-radius IPAM/DNS/DHCP rows are soft-
     # deleted (``deleted_at`` set) and the nightly purge sweep hard-

--- a/backend/app/services/ai/tools/integrations.py
+++ b/backend/app/services/ai/tools/integrations.py
@@ -28,6 +28,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.auth import User
+from app.models.cloud import CloudEndpoint
 from app.models.docker import DockerHost
 from app.models.kubernetes import KubernetesCluster
 from app.models.proxmox import ProxmoxNode
@@ -371,6 +372,78 @@ async def list_unifi_targets(
             "site_count": r.site_count,
             "network_count": r.network_count,
             "client_count": r.client_count,
+        }
+        for r in rows
+    ]
+
+
+# ── list_cloud_targets ────────────────────────────────────────────────
+
+
+class ListCloudTargetsArgs(BaseModel):
+    search: str | None = _common_target_args()["search"]
+    enabled: bool | None = _common_target_args()["enabled"]
+    limit: int = _common_target_args()["limit"]
+    provider: str | None = Field(
+        default=None,
+        description="Filter by cloud provider: 'aws', 'azure', or 'gcp'.",
+    )
+
+
+@register_tool(
+    name="list_cloud_targets",
+    module="integrations.cloud",
+    description=(
+        "List configured public-cloud accounts (AWS / Azure / GCP) that "
+        "SpatiumDDI mirrors into IPAM. Each row carries id, name, "
+        "description, provider, enabled flag, regions, ipam_space_id, "
+        "public_space_id, dns_group_id, mirror_load_balancers / "
+        "mirror_stopped_instances, sync_interval_seconds, last_synced_at, "
+        "last_sync_error, provider_account_id, network_count, and "
+        "instance_count. Use for 'which cloud accounts are connected?', "
+        "'is the AWS prod account syncing?', or 'how many VPCs does the "
+        "Azure account expose?'. Credentials never appear."
+    ),
+    args_model=ListCloudTargetsArgs,
+    category="integrations",
+)
+async def list_cloud_targets(
+    db: AsyncSession, user: User, args: ListCloudTargetsArgs
+) -> list[dict[str, Any]]:
+    stmt = select(CloudEndpoint)
+    if args.search:
+        like = f"%{args.search.lower()}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(CloudEndpoint.name).like(like),
+                func.lower(CloudEndpoint.description).like(like),
+            )
+        )
+    if args.enabled is not None:
+        stmt = stmt.where(CloudEndpoint.enabled.is_(args.enabled))
+    if args.provider:
+        stmt = stmt.where(CloudEndpoint.provider == args.provider.strip().lower())
+    stmt = stmt.order_by(CloudEndpoint.name.asc()).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": str(r.id),
+            "name": r.name,
+            "description": r.description,
+            "provider": r.provider,
+            "enabled": r.enabled,
+            "regions": list(r.regions or []),
+            "ipam_space_id": str(r.ipam_space_id),
+            "public_space_id": str(r.public_space_id) if r.public_space_id else None,
+            "dns_group_id": str(r.dns_group_id) if r.dns_group_id else None,
+            "mirror_load_balancers": r.mirror_load_balancers,
+            "mirror_stopped_instances": r.mirror_stopped_instances,
+            "sync_interval_seconds": r.sync_interval_seconds,
+            "last_synced_at": r.last_synced_at.isoformat() if r.last_synced_at else None,
+            "last_sync_error": r.last_sync_error,
+            "provider_account_id": r.provider_account_id,
+            "network_count": r.network_count,
+            "instance_count": r.instance_count,
         }
         for r in rows
     ]

--- a/backend/app/services/cloud/__init__.py
+++ b/backend/app/services/cloud/__init__.py
@@ -1,0 +1,8 @@
+"""Cloud integration (issue #37, Part A) — read-only infrastructure mirror.
+
+``base`` defines the provider-neutral contracts (CloudInventory + the
+CloudConnector ABC + the lazy connector registry). ``reconcile`` upserts
+a CloudInventory into IPAM. Concrete connectors live in ``aws`` /
+``azure`` / ``gcp`` and are resolved via ``base.get_connector`` — the
+service layer never imports them directly.
+"""

--- a/backend/app/services/cloud/aws.py
+++ b/backend/app/services/cloud/aws.py
@@ -1,0 +1,420 @@
+"""AWS connector — EC2 / EIP / ELBv2 / classic-ELB → :class:`CloudInventory`.
+
+Translates one AWS account's networking surface into the provider-neutral
+shapes from :mod:`app.services.cloud.base`:
+
+* ``ec2:DescribeVpcs``      → :class:`CloudNetwork` (one per VPC, all
+  associated CIDRs flattened into ``cidrs``).
+* ``ec2:DescribeSubnets``   → :class:`CloudSubnet`.
+* ``ec2:DescribeInstances`` → :class:`CloudInstance` + per-ENI
+  :class:`CloudNic`.
+* ``ec2:DescribeAddresses`` → :class:`CloudPublicIP` (Elastic IPs).
+* ``elasticloadbalancing v2:DescribeLoadBalancers`` → NLB static IPs as
+  :class:`CloudLoadBalancer`; ALBs are DNS-name-only and skipped with a
+  warning. Classic ELBs (``elb``) are likewise DNS-only and skipped.
+
+AWS scopes by **region**: ``self.regions`` lists the regions to walk; an
+empty list means "discover every enabled region" via
+``ec2:DescribeRegions`` in ``us-east-1``. Per-region failures are
+collected into :attr:`CloudInventory.warnings` and the walk continues —
+only an auth / bootstrap failure (region discovery, STS) raises
+:class:`CloudConnectorError`.
+
+boto3 is imported lazily inside :meth:`_client` so importing this module
+never hard-fails when the optional SDK is absent, and tests can monkeypatch
+``AWSConnector._client`` to return a stub. Every blocking boto3 call runs in
+``asyncio.to_thread`` because the connector's public methods are ``async``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import structlog
+
+from app.services.cloud.base import (
+    CloudConnector,
+    CloudConnectorError,
+    CloudInstance,
+    CloudInventory,
+    CloudLoadBalancer,
+    CloudNetwork,
+    CloudNic,
+    CloudProbeResult,
+    CloudPublicIP,
+    CloudSubnet,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Region used for account-scoped / region-discovery calls. STS + the
+# ``ec2:DescribeRegions`` bootstrap both work against any enabled region;
+# us-east-1 is the universally-enabled default.
+_BOOTSTRAP_REGION = "us-east-1"
+
+
+def _name_from_tags(tags: Any, fallback: str) -> str:
+    """Return the ``Name`` tag value from an AWS ``[{Key,Value}]`` list.
+
+    AWS tags arrive as ``[{"Key": "Name", "Value": "web-1"}, ...]``.
+    Returns ``fallback`` when the list is absent / malformed / has no
+    ``Name`` entry, so every normalised row always carries a usable name.
+    """
+    if not isinstance(tags, list):
+        return fallback
+    for tag in tags:
+        if not isinstance(tag, dict):
+            continue
+        if tag.get("Key") == "Name":
+            value = tag.get("Value")
+            if isinstance(value, str) and value:
+                return value
+    return fallback
+
+
+class AWSConnector(CloudConnector):
+    """Connector for a single AWS account (``credentials`` = access keys)."""
+
+    provider = "aws"
+
+    # ── boto3 client factory ─────────────────────────────────────────
+    #
+    # Isolated so tests can monkeypatch it with a stub returning canned
+    # AWS-shaped dicts. boto3 is imported here (lazily) rather than at
+    # module top level — the only place the SDK is touched.
+
+    def _client(self, service: str, region: str) -> Any:
+        """Build a boto3 client for ``service`` in ``region``.
+
+        Raises :class:`CloudConnectorError` when boto3 is not installed
+        so the caller surfaces a clean operator message instead of a raw
+        ``ModuleNotFoundError``.
+        """
+        try:
+            import boto3
+        except ImportError as exc:  # pragma: no cover - optional dep guard
+            raise CloudConnectorError(
+                "boto3 is not installed; the AWS connector is unavailable."
+            ) from exc
+        return boto3.client(
+            service,
+            region_name=region,
+            aws_access_key_id=self.credentials.get("access_key_id"),
+            aws_secret_access_key=self.credentials.get("secret_access_key"),
+        )
+
+    @staticmethod
+    def _botocore_errors() -> tuple[type[Exception], ...]:
+        """Expected-failure botocore exception classes, resolved lazily.
+
+        Returns ``(ClientError, EndpointConnectionError, NoCredentialsError,
+        BotoCoreError)``. Falls back to an empty tuple when botocore is
+        absent so a bare ``except`` clause built from it simply matches
+        nothing (the import-guard in :meth:`_client` has already raised).
+        """
+        try:
+            from botocore.exceptions import (
+                BotoCoreError,
+                ClientError,
+                EndpointConnectionError,
+                NoCredentialsError,
+            )
+        except ImportError:  # pragma: no cover - optional dep guard
+            return ()
+        return (ClientError, EndpointConnectionError, NoCredentialsError, BotoCoreError)
+
+    # ── region resolution ────────────────────────────────────────────
+
+    async def _resolve_regions(self) -> list[str]:
+        """The regions to walk: explicit ``self.regions`` or every enabled.
+
+        An empty ``self.regions`` triggers ``ec2:DescribeRegions`` in the
+        bootstrap region (``AllRegions=False`` so only opted-in regions
+        come back). Raises :class:`CloudConnectorError` on auth failure —
+        without a region list there is nothing to iterate.
+        """
+        if self.regions:
+            return list(self.regions)
+        try:
+            ec2 = self._client("ec2", _BOOTSTRAP_REGION)
+            resp = await asyncio.to_thread(ec2.describe_regions, AllRegions=False)
+        except self._botocore_errors() as exc:
+            raise CloudConnectorError(f"AWS region discovery failed: {exc}") from exc
+        regions = [
+            str(r["RegionName"])
+            for r in resp.get("Regions", [])
+            if isinstance(r, dict) and r.get("RegionName")
+        ]
+        return sorted(regions)
+
+    # ── probe ─────────────────────────────────────────────────────────
+
+    async def probe(self) -> CloudProbeResult:
+        """Cheap auth check: STS caller identity + VPC count in one region.
+
+        Resolves the account id via ``sts:GetCallerIdentity`` and counts
+        VPCs in the first resolved region. Returns
+        ``CloudProbeResult(ok=False, ...)`` on any expected boto3 failure
+        rather than raising.
+        """
+        errors = self._botocore_errors()
+        try:
+            sts = self._client("sts", _BOOTSTRAP_REGION)
+            identity = await asyncio.to_thread(sts.get_caller_identity)
+            account_id = str(identity.get("Account") or "") or None
+
+            regions = await self._resolve_regions()
+            network_count: int | None = None
+            if regions:
+                ec2 = self._client("ec2", regions[0])
+                vpcs = await asyncio.to_thread(ec2.describe_vpcs)
+                network_count = len(vpcs.get("Vpcs", []))
+        except CloudConnectorError as exc:
+            # boto3 missing or region discovery failed — already a clean
+            # message; surface it as a probe failure, not a crash.
+            return CloudProbeResult(ok=False, message=str(exc))
+        except errors as exc:  # type: ignore[misc]  # tuple may be () when botocore absent
+            return CloudProbeResult(ok=False, message=f"AWS probe failed: {exc}")
+        return CloudProbeResult(
+            ok=True,
+            message=f"Connected to AWS account {account_id}",
+            account_id=account_id,
+            network_count=network_count,
+        )
+
+    # ── inventory ───────────────────────────────────────────────────
+
+    async def fetch_inventory(
+        self,
+        *,
+        include_stopped: bool = False,
+        include_load_balancers: bool = True,
+    ) -> CloudInventory:
+        """Pull the full normalised inventory across every resolved region.
+
+        Auth / region-discovery failures raise
+        :class:`CloudConnectorError`. A single region failing mid-walk is
+        recorded in :attr:`CloudInventory.warnings` and the remaining
+        regions are still processed.
+        """
+        errors = self._botocore_errors()
+
+        # The account id comes from STS once (region-independent). A
+        # failure here is fatal — every IPAM row needs the account scope.
+        try:
+            sts = self._client("sts", _BOOTSTRAP_REGION)
+            identity = await asyncio.to_thread(sts.get_caller_identity)
+            account_id = str(identity.get("Account") or "")
+        except errors as exc:  # type: ignore[misc]
+            raise CloudConnectorError(f"AWS authentication failed: {exc}") from exc
+
+        regions = await self._resolve_regions()
+        inv = CloudInventory(account_id=account_id)
+
+        for region in regions:
+            try:
+                await self._fetch_region(
+                    inv,
+                    region,
+                    include_stopped=include_stopped,
+                    include_load_balancers=include_load_balancers,
+                )
+            except errors as exc:  # type: ignore[misc]
+                # Per-region failure (e.g. a disabled / unreachable
+                # region) shouldn't sink the whole sweep — warn + move on.
+                logger.warning("aws_region_fetch_failed", region=region, error=str(exc))
+                inv.warnings.append(f"region {region}: {exc}")
+
+        return inv
+
+    async def _fetch_region(
+        self,
+        inv: CloudInventory,
+        region: str,
+        *,
+        include_stopped: bool,
+        include_load_balancers: bool,
+    ) -> None:
+        """Append one region's networks / subnets / instances / IPs / LBs.
+
+        Mutates ``inv`` in place. Raises botocore exceptions on failure;
+        the caller turns those into per-region warnings.
+        """
+        ec2 = self._client("ec2", region)
+
+        # VPCs → CloudNetwork. Every associated CIDR (state ``associated``)
+        # becomes one entry in ``cidrs``; the reconciler creates one
+        # IPBlock per CIDR.
+        vpcs = await asyncio.to_thread(ec2.describe_vpcs)
+        for vpc in vpcs.get("Vpcs", []):
+            if not isinstance(vpc, dict):
+                continue
+            vpc_id = str(vpc.get("VpcId") or "")
+            if not vpc_id:
+                continue
+            cidrs: list[str] = []
+            for assoc in vpc.get("CidrBlockAssociationSet", []):
+                if not isinstance(assoc, dict):
+                    continue
+                state = assoc.get("CidrBlockState", {})
+                if isinstance(state, dict) and state.get("State") != "associated":
+                    continue
+                cidr = assoc.get("CidrBlock")
+                if isinstance(cidr, str) and cidr:
+                    cidrs.append(cidr)
+            inv.networks.append(
+                CloudNetwork(
+                    id=vpc_id,
+                    name=_name_from_tags(vpc.get("Tags"), vpc_id),
+                    cidrs=tuple(cidrs),
+                    region=region,
+                )
+            )
+
+        # Subnets → CloudSubnet. ``region`` is reported as the AZ so the
+        # discovery snapshot keeps the placement detail.
+        subnets = await asyncio.to_thread(ec2.describe_subnets)
+        for subnet in subnets.get("Subnets", []):
+            if not isinstance(subnet, dict):
+                continue
+            subnet_id = str(subnet.get("SubnetId") or "")
+            cidr = str(subnet.get("CidrBlock") or "")
+            if not subnet_id or not cidr:
+                continue
+            inv.subnets.append(
+                CloudSubnet(
+                    id=subnet_id,
+                    name=_name_from_tags(subnet.get("Tags"), subnet_id),
+                    network_id=str(subnet.get("VpcId") or ""),
+                    cidr=cidr,
+                    region=str(subnet.get("AvailabilityZone") or region),
+                )
+            )
+
+        # Instances → CloudInstance + per-ENI CloudNic. The running-only
+        # default is enforced server-side with a state-name filter so we
+        # don't transfer stopped instances we'll just discard.
+        kwargs: dict[str, Any] = {}
+        if not include_stopped:
+            kwargs["Filters"] = [{"Name": "instance-state-name", "Values": ["running"]}]
+        reservations = await asyncio.to_thread(ec2.describe_instances, **kwargs)
+        for reservation in reservations.get("Reservations", []):
+            if not isinstance(reservation, dict):
+                continue
+            for instance in reservation.get("Instances", []):
+                if not isinstance(instance, dict):
+                    continue
+                instance_id = str(instance.get("InstanceId") or "")
+                if not instance_id:
+                    continue
+                state = instance.get("State", {})
+                state_name = state.get("Name") if isinstance(state, dict) else None
+                nics: list[CloudNic] = []
+                for eni in instance.get("NetworkInterfaces", []):
+                    if not isinstance(eni, dict):
+                        continue
+                    private_ip = eni.get("PrivateIpAddress")
+                    if not isinstance(private_ip, str) or not private_ip:
+                        continue
+                    assoc = eni.get("Association", {})
+                    public_ip = assoc.get("PublicIp") if isinstance(assoc, dict) else None
+                    nics.append(
+                        CloudNic(
+                            private_ip=private_ip,
+                            public_ip=public_ip if isinstance(public_ip, str) else None,
+                            mac=(
+                                eni.get("MacAddress")
+                                if isinstance(eni.get("MacAddress"), str)
+                                else None
+                            ),
+                        )
+                    )
+                inv.instances.append(
+                    CloudInstance(
+                        id=instance_id,
+                        name=_name_from_tags(instance.get("Tags"), instance_id),
+                        running=state_name == "running",
+                        nics=tuple(nics),
+                        region=region,
+                    )
+                )
+
+        # Elastic IPs → CloudPublicIP. An EIP is "attached" when it is
+        # associated with either an instance or a network interface.
+        addresses = await asyncio.to_thread(ec2.describe_addresses)
+        for addr in addresses.get("Addresses", []):
+            if not isinstance(addr, dict):
+                continue
+            public_ip = addr.get("PublicIp")
+            if not isinstance(public_ip, str) or not public_ip:
+                continue
+            inv.public_ips.append(
+                CloudPublicIP(
+                    address=public_ip,
+                    name=_name_from_tags(addr.get("Tags"), str(addr.get("AllocationId") or "")),
+                    attached=bool(addr.get("InstanceId") or addr.get("NetworkInterfaceId")),
+                )
+            )
+
+        if include_load_balancers:
+            await self._fetch_load_balancers(inv, region)
+
+    async def _fetch_load_balancers(self, inv: CloudInventory, region: str) -> None:
+        """Append NLB static frontend IPs; warn-and-skip DNS-only LBs.
+
+        ELBv2 NLBs expose fixed IPs under
+        ``AvailabilityZones[].LoadBalancerAddresses[].IpAddress``. ELBv2
+        ALBs and classic ELBs are DNS-name-only (their public IPs float),
+        so there is no stable frontend IP to mirror — those are recorded
+        as warnings and skipped.
+        """
+        # ELBv2 — NLB (network) carries static IPs; ALB (application) does not.
+        elbv2 = self._client("elbv2", region)
+        v2 = await asyncio.to_thread(elbv2.describe_load_balancers)
+        for lb in v2.get("LoadBalancers", []):
+            if not isinstance(lb, dict):
+                continue
+            lb_arn = str(lb.get("LoadBalancerArn") or "")
+            lb_name = str(lb.get("LoadBalancerName") or lb_arn)
+            lb_type = lb.get("Type")
+            if lb_type == "network":
+                frontend_ips: list[str] = []
+                for az in lb.get("AvailabilityZones", []):
+                    if not isinstance(az, dict):
+                        continue
+                    for lba in az.get("LoadBalancerAddresses", []):
+                        if not isinstance(lba, dict):
+                            continue
+                        ip = lba.get("IpAddress")
+                        if isinstance(ip, str) and ip:
+                            frontend_ips.append(ip)
+                inv.load_balancers.append(
+                    CloudLoadBalancer(
+                        id=lb_arn or lb_name,
+                        name=lb_name,
+                        frontend_ips=tuple(frontend_ips),
+                        region=region,
+                    )
+                )
+            else:
+                # ALB / gateway LB — DNS-name-only, no fixed frontend IP.
+                inv.warnings.append(
+                    f"region {region}: load balancer {lb_name!r} is DNS-name-only "
+                    f"(type {lb_type!r}); no static frontend IP to mirror — skipped."
+                )
+
+        # Classic ELB — always DNS-name-only.
+        elb = self._client("elb", region)
+        classic = await asyncio.to_thread(elb.describe_load_balancers)
+        for lb in classic.get("LoadBalancerDescriptions", []):
+            if not isinstance(lb, dict):
+                continue
+            lb_name = str(lb.get("LoadBalancerName") or "")
+            inv.warnings.append(
+                f"region {region}: classic load balancer {lb_name!r} is "
+                f"DNS-name-only; no static frontend IP to mirror — skipped."
+            )
+
+
+__all__ = ["AWSConnector"]

--- a/backend/app/services/cloud/azure.py
+++ b/backend/app/services/cloud/azure.py
@@ -315,15 +315,15 @@ class AzureConnector(CloudConnector):
 
         A missing resource group or an instance-view error is treated as
         "not running" rather than failing the whole sync; the running
-        flag is advisory and the reconciler still mirrors the row.
+        flag is advisory and the reconciler still mirrors the row. Any
+        probe failure (HTTP error, transient network, SDK quirk) is
+        caught — a per-VM power-state lookup must never abort the sweep.
         """
-        from azure.core.exceptions import HttpResponseError
-
         if not resource_group:
             return False
         try:
             view = compute_client.virtual_machines.instance_view(resource_group, name)
-        except HttpResponseError as exc:
+        except Exception as exc:  # noqa: BLE001 — best-effort probe; any failure → "not running"
             logger.warning(
                 "cloud.azure.instance_view_failed",
                 vm=name,

--- a/backend/app/services/cloud/azure.py
+++ b/backend/app/services/cloud/azure.py
@@ -1,0 +1,424 @@
+"""Azure connector for the Cloud infrastructure mirror (#37).
+
+Translates the Azure Resource Manager (ARM) SDK responses into the
+provider-neutral :class:`~app.services.cloud.base.CloudInventory` the
+shared reconciler consumes. One VNet → :class:`CloudNetwork` (one
+``IPBlock`` per address-space prefix), each VNet subnet →
+:class:`CloudSubnet`, each VM → :class:`CloudInstance` with its NIC
+private/public IPs + MAC, every public IP → :class:`CloudPublicIP`, and
+(optionally) each load balancer frontend → :class:`CloudLoadBalancer`.
+
+Credentials (decrypted from ``CloudEndpoint.credentials_encrypted``) are a
+service-principal triple ``{"tenant_id", "client_id", "client_secret"}``.
+Non-secret routing (``provider_config``) carries the subscription scope as
+``{"subscription_ids": [str, ...]}``; ``regions`` (Azure *locations*) is an
+allow-list applied to every resource — empty means all locations.
+
+The Azure SDK is imported lazily inside the factory layer so importing
+this module never hard-fails on the optional ``azure-*`` packages, and
+tests can monkeypatch :meth:`AzureConnector._credential` /
+``_network_client`` / ``_compute_client`` to return stub clients. All
+blocking SDK list calls run under :func:`asyncio.to_thread` because the
+public methods are ``async`` (CLAUDE.md non-negotiable #2).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import structlog
+
+from app.services.cloud.base import (
+    CloudConnector,
+    CloudConnectorError,
+    CloudInstance,
+    CloudInventory,
+    CloudLoadBalancer,
+    CloudNetwork,
+    CloudNic,
+    CloudProbeResult,
+    CloudPublicIP,
+    CloudSubnet,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class AzureConnector(CloudConnector):
+    """Mirror Azure VNets / subnets / VMs / public IPs / load balancers."""
+
+    provider = "azure"
+
+    # ── SDK factory layer (monkeypatched in tests) ─────────────────────
+    #
+    # Each factory lazy-imports its Azure package so a missing optional
+    # dependency only bites when a real sync runs, never at import time.
+
+    def _credential(self) -> Any:
+        """Build a service-principal credential from ``self.credentials``."""
+        from azure.identity import ClientSecretCredential
+
+        return ClientSecretCredential(
+            tenant_id=self.credentials["tenant_id"],
+            client_id=self.credentials["client_id"],
+            client_secret=self.credentials["client_secret"],
+        )
+
+    def _network_client(self, subscription_id: str) -> Any:
+        """ARM network management client scoped to one subscription."""
+        from azure.mgmt.network import NetworkManagementClient
+
+        return NetworkManagementClient(self._credential(), subscription_id)
+
+    def _compute_client(self, subscription_id: str) -> Any:
+        """ARM compute management client scoped to one subscription."""
+        from azure.mgmt.compute import ComputeManagementClient
+
+        return ComputeManagementClient(self._credential(), subscription_id)
+
+    # ── Helpers ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _rg_from_id(resource_id: str | None) -> str | None:
+        """Extract the ``resourceGroups/<rg>`` segment from an ARM id.
+
+        ARM ids look like
+        ``/subscriptions/<sub>/resourceGroups/<rg>/providers/...``; the
+        resource-group name is the token after the (case-insensitive)
+        ``resourceGroups`` segment. Returns ``None`` when absent.
+        """
+        if not resource_id:
+            return None
+        parts = resource_id.strip("/").split("/")
+        for idx, part in enumerate(parts):
+            if part.lower() == "resourcegroups" and idx + 1 < len(parts):
+                return parts[idx + 1]
+        return None
+
+    def _in_region(self, location: str | None) -> bool:
+        """``True`` when ``location`` passes the (possibly empty) allow-list."""
+        if not self.regions:
+            return True
+        return location in self.regions
+
+    # ── Probe ──────────────────────────────────────────────────────────
+
+    async def probe(self) -> CloudProbeResult:
+        """Cheap auth + reachability check for the test-connection button.
+
+        Lists the VNets in the first configured subscription, counting
+        them. Expected auth / HTTP failures return ``ok=False`` rather
+        than raising (CLAUDE.md probe contract in ``base.py``).
+        """
+        from azure.core.exceptions import (
+            ClientAuthenticationError,
+            HttpResponseError,
+        )
+
+        subscription_ids = list(self.provider_config.get("subscription_ids") or [])
+        account_id = subscription_ids[0] if subscription_ids else self.credentials.get("tenant_id")
+
+        if not subscription_ids:
+            return CloudProbeResult(
+                ok=False,
+                message="No subscription_ids configured for the Azure endpoint.",
+                account_id=account_id,
+            )
+
+        try:
+            client = self._network_client(subscription_ids[0])
+            vnets = await asyncio.to_thread(lambda: list(client.virtual_networks.list_all()))
+        except (ClientAuthenticationError, HttpResponseError) as exc:
+            return CloudProbeResult(
+                ok=False,
+                message=f"Azure authentication / API error: {exc}",
+                account_id=account_id,
+            )
+
+        count = sum(1 for vnet in vnets if self._in_region(getattr(vnet, "location", None)))
+        return CloudProbeResult(
+            ok=True,
+            message=f"Connected to subscription {subscription_ids[0]}; {count} VNet(s) visible.",
+            account_id=account_id,
+            network_count=count,
+        )
+
+    # ── Inventory ──────────────────────────────────────────────────────
+
+    async def fetch_inventory(
+        self,
+        *,
+        include_stopped: bool = False,
+        include_load_balancers: bool = True,
+    ) -> CloudInventory:
+        """Pull the full normalised inventory across every subscription.
+
+        Per-subscription auth / HTTP failures fold into
+        :attr:`CloudInventory.warnings` so one bad subscription doesn't
+        abort the whole sync. :class:`CloudConnectorError` is raised only
+        when *nothing* could be fetched (e.g. credential build failed for
+        every subscription).
+        """
+        subscription_ids = list(self.provider_config.get("subscription_ids") or [])
+        account_id = subscription_ids[0] if subscription_ids else self.credentials.get("tenant_id")
+        inventory = CloudInventory(account_id=account_id or "")
+
+        if not subscription_ids:
+            raise CloudConnectorError("No subscription_ids configured for the Azure endpoint.")
+
+        succeeded = 0
+        for subscription_id in subscription_ids:
+            try:
+                await self._fetch_subscription(
+                    subscription_id,
+                    inventory,
+                    include_stopped=include_stopped,
+                    include_load_balancers=include_load_balancers,
+                )
+                succeeded += 1
+            except CloudConnectorError as exc:
+                # Auth / HTTP failure for this subscription only — record
+                # it and keep going so the others still reconcile.
+                inventory.warnings.append(f"subscription {subscription_id}: {exc}")
+                logger.warning(
+                    "cloud.azure.subscription_failed",
+                    subscription_id=subscription_id,
+                    error=str(exc),
+                )
+
+        if succeeded == 0:
+            raise CloudConnectorError(
+                "Azure inventory fetch failed for every subscription: "
+                + "; ".join(inventory.warnings)
+            )
+        return inventory
+
+    async def _fetch_subscription(
+        self,
+        subscription_id: str,
+        inventory: CloudInventory,
+        *,
+        include_stopped: bool,
+        include_load_balancers: bool,
+    ) -> None:
+        """Append one subscription's resources into ``inventory`` in place."""
+        from azure.core.exceptions import (
+            ClientAuthenticationError,
+            HttpResponseError,
+        )
+
+        try:
+            network_client = self._network_client(subscription_id)
+            compute_client = self._compute_client(subscription_id)
+
+            vnets = await asyncio.to_thread(
+                lambda: list(network_client.virtual_networks.list_all())
+            )
+            nics = await asyncio.to_thread(
+                lambda: list(network_client.network_interfaces.list_all())
+            )
+            public_ips = await asyncio.to_thread(
+                lambda: list(network_client.public_ip_addresses.list_all())
+            )
+            vms = await asyncio.to_thread(lambda: list(compute_client.virtual_machines.list_all()))
+            lbs = (
+                await asyncio.to_thread(lambda: list(network_client.load_balancers.list_all()))
+                if include_load_balancers
+                else []
+            )
+        except (ClientAuthenticationError, HttpResponseError) as exc:
+            raise CloudConnectorError(str(exc)) from exc
+
+        # Index NICs + public IPs by ARM id so VM / LB frontends resolve
+        # without an extra round-trip per reference.
+        nic_by_id = {nic.id: nic for nic in nics}
+        pip_by_id = {pip.id: pip for pip in public_ips}
+
+        self._collect_networks(vnets, inventory)
+        self._collect_instances(
+            vms,
+            nic_by_id,
+            pip_by_id,
+            compute_client,
+            inventory,
+            include_stopped=include_stopped,
+        )
+        self._collect_public_ips(public_ips, inventory)
+        if include_load_balancers:
+            self._collect_load_balancers(lbs, pip_by_id, inventory)
+
+    # ── Per-resource collectors ────────────────────────────────────────
+
+    def _collect_networks(self, vnets: list[Any], inventory: CloudInventory) -> None:
+        """Normalise VNets + their nested subnets into the inventory."""
+        for vnet in vnets:
+            if not self._in_region(vnet.location):
+                continue
+            address_prefixes = tuple(getattr(vnet.address_space, "address_prefixes", None) or ())
+            inventory.networks.append(
+                CloudNetwork(
+                    id=vnet.id,
+                    name=vnet.name,
+                    cidrs=address_prefixes,
+                    region=vnet.location,
+                )
+            )
+            for subnet in getattr(vnet, "subnets", None) or ():
+                cidr = subnet.address_prefix or next(
+                    iter(getattr(subnet, "address_prefixes", None) or ()),
+                    None,
+                )
+                if not cidr:
+                    continue
+                inventory.subnets.append(
+                    CloudSubnet(
+                        id=subnet.id,
+                        name=subnet.name,
+                        network_id=vnet.id,
+                        cidr=cidr,
+                        region=vnet.location,
+                    )
+                )
+
+    def _collect_instances(
+        self,
+        vms: list[Any],
+        nic_by_id: dict[Any, Any],
+        pip_by_id: dict[Any, Any],
+        compute_client: Any,
+        inventory: CloudInventory,
+        *,
+        include_stopped: bool,
+    ) -> None:
+        """Normalise VMs into instances, resolving NIC IPs + power state."""
+        for vm in vms:
+            if not self._in_region(vm.location):
+                continue
+            resource_group = self._rg_from_id(vm.id)
+            running = self._vm_running(compute_client, resource_group, vm.name)
+            if not include_stopped and not running:
+                continue
+            nics = self._resolve_vm_nics(vm, nic_by_id, pip_by_id)
+            inventory.instances.append(
+                CloudInstance(
+                    id=vm.id,
+                    name=vm.name,
+                    running=running,
+                    nics=tuple(nics),
+                    region=vm.location,
+                )
+            )
+
+    def _vm_running(self, compute_client: Any, resource_group: str | None, name: str) -> bool:
+        """Resolve a VM's power state via ``instance_view`` (best-effort).
+
+        A missing resource group or an instance-view error is treated as
+        "not running" rather than failing the whole sync; the running
+        flag is advisory and the reconciler still mirrors the row.
+        """
+        from azure.core.exceptions import HttpResponseError
+
+        if not resource_group:
+            return False
+        try:
+            view = compute_client.virtual_machines.instance_view(resource_group, name)
+        except HttpResponseError as exc:
+            logger.warning(
+                "cloud.azure.instance_view_failed",
+                vm=name,
+                resource_group=resource_group,
+                error=str(exc),
+            )
+            return False
+        for status in getattr(view, "statuses", None) or ():
+            code = getattr(status, "code", "") or ""
+            if code.startswith("PowerState/"):
+                return code == "PowerState/running"
+        return False
+
+    def _resolve_vm_nics(
+        self,
+        vm: Any,
+        nic_by_id: dict[Any, Any],
+        pip_by_id: dict[Any, Any],
+    ) -> list[CloudNic]:
+        """Map a VM's referenced NICs into :class:`CloudNic` rows."""
+        nics: list[CloudNic] = []
+        profile = getattr(vm, "network_profile", None)
+        for nic_ref in getattr(profile, "network_interfaces", None) or ():
+            nic = nic_by_id.get(getattr(nic_ref, "id", None))
+            if nic is None:
+                continue
+            mac = getattr(nic, "mac_address", None)
+            for ip_config in getattr(nic, "ip_configurations", None) or ():
+                private_ip = getattr(ip_config, "private_ip_address", None)
+                if not private_ip:
+                    continue
+                public_ip = self._resolve_public_ip(
+                    getattr(ip_config, "public_ip_address", None), pip_by_id
+                )
+                nics.append(CloudNic(private_ip=private_ip, public_ip=public_ip, mac=mac))
+        return nics
+
+    @staticmethod
+    def _resolve_public_ip(reference: Any, pip_by_id: dict[Any, Any]) -> str | None:
+        """Resolve a public-IP reference (id-only or inline) to its address."""
+        if reference is None:
+            return None
+        # Inline expansions already carry ``ip_address``; the common ARM
+        # shape is an id-only reference we look up in the pre-built index.
+        address = getattr(reference, "ip_address", None)
+        if address:
+            return address
+        pip = pip_by_id.get(getattr(reference, "id", None))
+        return getattr(pip, "ip_address", None) if pip is not None else None
+
+    def _collect_public_ips(self, public_ips: list[Any], inventory: CloudInventory) -> None:
+        """Normalise standalone public IP address resources."""
+        for pip in public_ips:
+            if not self._in_region(getattr(pip, "location", None)):
+                continue
+            address = getattr(pip, "ip_address", None)
+            if not address:
+                continue  # unassigned (dynamic, not yet allocated) — skip
+            inventory.public_ips.append(
+                CloudPublicIP(
+                    address=address,
+                    name=pip.name or "",
+                    attached=bool(getattr(pip, "ip_configuration", None)),
+                )
+            )
+
+    def _collect_load_balancers(
+        self,
+        lbs: list[Any],
+        pip_by_id: dict[Any, Any],
+        inventory: CloudInventory,
+    ) -> None:
+        """Normalise LB frontend IP configs into load-balancer rows."""
+        for lb in lbs:
+            if not self._in_region(lb.location):
+                continue
+            frontend_ips: list[str] = []
+            for frontend in getattr(lb, "frontend_ip_configurations", None) or ():
+                public_ip = self._resolve_public_ip(
+                    getattr(frontend, "public_ip_address", None), pip_by_id
+                )
+                if public_ip:
+                    frontend_ips.append(public_ip)
+                    continue
+                private_ip = getattr(frontend, "private_ip_address", None)
+                if private_ip:
+                    frontend_ips.append(private_ip)
+            inventory.load_balancers.append(
+                CloudLoadBalancer(
+                    id=lb.id,
+                    name=lb.name,
+                    frontend_ips=tuple(frontend_ips),
+                    region=lb.location,
+                )
+            )
+
+
+__all__ = ["AzureConnector"]

--- a/backend/app/services/cloud/base.py
+++ b/backend/app/services/cloud/base.py
@@ -1,0 +1,247 @@
+"""Provider-neutral contracts for the Cloud infrastructure mirror (#37 A).
+
+A **connector** (``services/cloud/{aws,azure,gcp}.py``) translates one
+provider's SDK responses into a single normalised :class:`CloudInventory`.
+The shared **reconciler** (``services/cloud/reconcile.py``) upserts that
+inventory into IPAM (one ``IPBlock`` per VPC CIDR, ``Subnet`` rows
+beneath, ``IPAddress`` rows for instance NICs / public IPs / LB
+frontends). Per CLAUDE.md non-negotiable #10 the service layer speaks
+only to this interface and resolves a concrete connector lazily via
+:func:`get_connector` — so adding a provider never edits this file.
+
+Credential dict shapes (decrypted from ``CloudEndpoint.credentials_encrypted``):
+    aws   → {"access_key_id": str, "secret_access_key": str}
+    azure → {"tenant_id": str, "client_id": str, "client_secret": str}
+    gcp   → {"service_account_json": str}   # the whole key file as a string
+
+Non-secret routing (``CloudEndpoint.provider_config``):
+    azure → {"subscription_ids": [str, ...]}
+    gcp   → {"project_ids": [str, ...]}
+    aws   → {}                              # AWS scopes by ``regions``
+
+Connectors must be safe to construct per call, perform no I/O in
+``__init__``, and wrap blocking SDK calls in ``asyncio.to_thread`` (the
+public methods are ``async``). SDK imports are done lazily inside methods
+so importing the connector module never hard-fails on a missing optional
+dependency and tests can patch the client factory.
+"""
+
+from __future__ import annotations
+
+import importlib
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+
+class CloudConnectorError(Exception):
+    """Raised by connectors on auth / API / unsupported-provider failures.
+
+    The reconciler + test-connection probe catch this and surface
+    ``str(exc)`` to the operator as ``last_sync_error`` / a probe message.
+    """
+
+
+# ── Normalised inventory dataclasses ───────────────────────────────────
+#
+# These are the *only* shapes the reconciler consumes. Provider-specific
+# quirks are flattened away in the connector. ``region`` is a free string
+# (AWS region / Azure location / GCP region) used purely for naming +
+# the discovery snapshot; ``extra`` carries provider tags/labels that the
+# reconciler may pass through to ``custom_fields`` (Phase 4+).
+
+
+@dataclass(frozen=True)
+class CloudNetwork:
+    """A VPC (AWS) / VNet (Azure) / VPC network (GCP)."""
+
+    id: str
+    name: str
+    cidrs: tuple[str, ...]  # address-space CIDR(s); one IPBlock per entry
+    region: str | None = None
+    extra: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CloudSubnet:
+    """A subnet within a :class:`CloudNetwork`."""
+
+    id: str
+    name: str
+    network_id: str
+    cidr: str
+    region: str | None = None
+    # First usable host by cloud convention (x.x.x.1) unless the provider
+    # reports an explicit gateway. ``None`` lets the reconciler derive it.
+    gateway: str | None = None
+
+
+@dataclass(frozen=True)
+class CloudNic:
+    """One network interface on a :class:`CloudInstance`."""
+
+    private_ip: str
+    public_ip: str | None = None
+    mac: str | None = None
+
+
+@dataclass(frozen=True)
+class CloudInstance:
+    """A VM (Azure) / EC2 instance (AWS) / GCE instance (GCP)."""
+
+    id: str
+    name: str
+    running: bool
+    nics: tuple[CloudNic, ...] = ()
+    region: str | None = None
+
+
+@dataclass(frozen=True)
+class CloudPublicIP:
+    """A public / Elastic / external IP address."""
+
+    address: str
+    name: str = ""
+    attached: bool = False
+
+
+@dataclass(frozen=True)
+class CloudLoadBalancer:
+    """A load balancer's frontend IP(s) (ELB/ALB/NLB, Azure LB, GCP rule)."""
+
+    id: str
+    name: str
+    frontend_ips: tuple[str, ...] = ()
+    region: str | None = None
+
+
+@dataclass
+class CloudInventory:
+    """Everything one reconcile pass needs from a provider."""
+
+    account_id: str
+    networks: list[CloudNetwork] = field(default_factory=list)
+    subnets: list[CloudSubnet] = field(default_factory=list)
+    instances: list[CloudInstance] = field(default_factory=list)
+    public_ips: list[CloudPublicIP] = field(default_factory=list)
+    load_balancers: list[CloudLoadBalancer] = field(default_factory=list)
+    # Non-fatal connector notes (a region that failed, an unsupported
+    # resource skipped) surfaced into the reconcile summary warnings.
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class CloudProbeResult:
+    """Result of a test-connection probe."""
+
+    ok: bool
+    message: str
+    account_id: str | None = None
+    network_count: int | None = None
+    instance_count: int | None = None
+
+
+# ── Connector ABC ──────────────────────────────────────────────────────
+
+
+class CloudConnector(ABC):
+    """Abstract per-provider connector. Construct via :func:`get_connector`."""
+
+    provider: str = "abstract"
+
+    def __init__(
+        self,
+        *,
+        credentials: dict[str, str],
+        provider_config: dict,
+        regions: list[str] | None = None,
+    ) -> None:
+        self.credentials = credentials or {}
+        self.provider_config = provider_config or {}
+        self.regions = list(regions or [])
+
+    @abstractmethod
+    async def probe(self) -> CloudProbeResult:
+        """Cheap auth + reachability check for the test-connection button.
+
+        Never raises for an expected failure (bad creds, network) — it
+        returns ``CloudProbeResult(ok=False, message=...)``. Only truly
+        unexpected programmer errors propagate.
+        """
+
+    @abstractmethod
+    async def fetch_inventory(
+        self,
+        *,
+        include_stopped: bool = False,
+        include_load_balancers: bool = True,
+    ) -> CloudInventory:
+        """Pull the full normalised inventory.
+
+        Raises :class:`CloudConnectorError` on auth / API failure so the
+        reconciler can record ``last_sync_error`` and stop cleanly.
+        """
+
+
+# Provider → (module, class). Lazy so this file never changes when a
+# connector module lands; the connector class names are part of the
+# contract (the connector author must use exactly these).
+_CONNECTOR_REGISTRY: dict[str, tuple[str, str]] = {
+    "aws": ("app.services.cloud.aws", "AWSConnector"),
+    "azure": ("app.services.cloud.azure", "AzureConnector"),
+    "gcp": ("app.services.cloud.gcp", "GCPConnector"),
+}
+
+
+def implemented_providers() -> frozenset[str]:
+    """Providers with a wired connector (gates the API ``provider`` field)."""
+    return frozenset(_CONNECTOR_REGISTRY)
+
+
+def get_connector(
+    provider: str,
+    *,
+    credentials: dict[str, str],
+    provider_config: dict,
+    regions: list[str] | None = None,
+) -> CloudConnector:
+    """Instantiate the connector for ``provider``.
+
+    Raises :class:`CloudConnectorError` for an unknown / unimplemented
+    provider so the caller surfaces a clean message rather than a
+    KeyError / ImportError.
+    """
+    spec = _CONNECTOR_REGISTRY.get(provider)
+    if spec is None:
+        raise CloudConnectorError(
+            f"Cloud provider {provider!r} is not implemented "
+            f"(supported: {', '.join(sorted(_CONNECTOR_REGISTRY))})."
+        )
+    module_name, class_name = spec
+    try:
+        module = importlib.import_module(module_name)
+        connector_cls = getattr(module, class_name)
+    except (ImportError, AttributeError) as exc:  # pragma: no cover - wiring guard
+        raise CloudConnectorError(
+            f"Cloud connector for {provider!r} failed to load: {exc}"
+        ) from exc
+    return connector_cls(
+        credentials=credentials,
+        provider_config=provider_config,
+        regions=regions,
+    )
+
+
+__all__ = [
+    "CloudConnector",
+    "CloudConnectorError",
+    "CloudInstance",
+    "CloudInventory",
+    "CloudLoadBalancer",
+    "CloudNetwork",
+    "CloudNic",
+    "CloudProbeResult",
+    "CloudPublicIP",
+    "CloudSubnet",
+    "get_connector",
+    "implemented_providers",
+]

--- a/backend/app/services/cloud/gcp.py
+++ b/backend/app/services/cloud/gcp.py
@@ -1,0 +1,444 @@
+"""GCP connector — translate Compute Engine resources into a CloudInventory.
+
+GCP's data model is the odd one of the three providers (#37): a **VPC
+network is global and carries no CIDR of its own** — the address ranges
+live on (regional) *subnetworks*. So every :class:`CloudNetwork` we emit
+has ``cidrs=()`` and the real CIDRs ride on the :class:`CloudSubnet` rows
+beneath it. The reconciler knows to derive IPAM blocks from subnet CIDRs
+when a network reports no address space.
+
+Credential shape (decrypted from ``CloudEndpoint.credentials_encrypted``):
+    {"service_account_json": "<the whole key file as a JSON string>"}
+
+Routing (``CloudEndpoint.provider_config``):
+    {"project_ids": [str, ...]}        # one inventory pass spans every id
+
+``regions`` is an optional allow-list (empty = every region). It filters
+regional subnetworks + the region we trim instance zones / addresses /
+forwarding-rules down to; global resources are always included.
+
+The python-compute client surfaces protobuf fields in a snake_case form
+that splits on every internal capital, so ``networkIP`` → ``network_i_p``,
+``natIP`` → ``nat_i_p``, ``IPAddress`` → ``i_p_address``. Those spellings
+are load-bearing below — they are not typos.
+
+Per CLAUDE.md the google SDK is imported lazily inside methods so this
+module imports cleanly without ``google-cloud-compute`` installed and the
+client factories can be monkeypatched in tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from app.services.cloud.base import (
+    CloudConnector,
+    CloudConnectorError,
+    CloudInstance,
+    CloudInventory,
+    CloudLoadBalancer,
+    CloudNetwork,
+    CloudNic,
+    CloudProbeResult,
+    CloudPublicIP,
+    CloudSubnet,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, no runtime import
+    from google.oauth2.service_account import Credentials
+
+logger = structlog.get_logger(__name__)
+
+
+def _basename(url: str | None) -> str:
+    """Last path segment of a GCP self-link (or bare name).
+
+    GCP cross-references resources by full self-link
+    (``.../regions/us-central1`` , ``.../zones/us-central1-a`` ,
+    ``.../networks/default``). The reconciler only wants the trailing
+    identifier, so collapse the link to its basename. ``None`` / empty
+    returns ``""``.
+    """
+    if not url:
+        return ""
+    return url.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _region_from_zone(zone_url: str | None) -> str:
+    """Trim a zone basename (``us-central1-a``) to its region (``us-central1``).
+
+    GCE instances live in zones; we surface the parent region for naming
+    parity with the other providers. A zone is the region plus a trailing
+    ``-<letter>`` suffix, so drop the last hyphen-delimited segment.
+    """
+    zone = _basename(zone_url)
+    if not zone:
+        return ""
+    head, _, _tail = zone.rpartition("-")
+    return head or zone
+
+
+class GCPConnector(CloudConnector):
+    """Read-only GCP Compute Engine connector (provider ``gcp``)."""
+
+    provider = "gcp"
+
+    # ── Project / region helpers ───────────────────────────────────────
+
+    @property
+    def _project_ids(self) -> list[str]:
+        ids = self.provider_config.get("project_ids") or []
+        return [str(p) for p in ids if p]
+
+    def _region_allowed(self, region: str | None) -> bool:
+        """A region passes when no allow-list is set or it is listed."""
+        if not self.regions:
+            return True
+        return (region or "") in self.regions
+
+    # ── Credential + client factory layer (monkeypatched in tests) ──────
+
+    def _parsed_key(self) -> dict[str, Any]:
+        """Parse the service-account key JSON string into a dict.
+
+        Raises :class:`CloudConnectorError` on missing / malformed JSON so
+        the probe + reconciler surface a clean message instead of a raw
+        ``KeyError`` / ``JSONDecodeError``.
+        """
+        raw = self.credentials.get("service_account_json")
+        if not raw:
+            raise CloudConnectorError("GCP credentials missing 'service_account_json'.")
+        try:
+            data = json.loads(raw)
+        except (ValueError, TypeError) as exc:
+            raise CloudConnectorError(f"GCP service_account_json is not valid JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise CloudConnectorError("GCP service_account_json must decode to an object.")
+        return data
+
+    def _credentials(self) -> Credentials:
+        """Build google-auth service-account credentials from the key dict.
+
+        Lazy SDK import; raises :class:`CloudConnectorError` if the google
+        libraries are absent or the key is rejected.
+        """
+        info = self._parsed_key()
+        try:
+            from google.oauth2 import service_account
+        except ImportError as exc:  # pragma: no cover - optional dependency guard
+            raise CloudConnectorError(
+                "google-auth is not installed; cannot build GCP credentials."
+            ) from exc
+        try:
+            return service_account.Credentials.from_service_account_info(info)
+        except (ValueError, KeyError) as exc:
+            raise CloudConnectorError(f"GCP service-account key is invalid: {exc}") from exc
+
+    # One factory per compute client. Each lazy-imports compute_v1 so the
+    # module never hard-depends on it and tests patch these directly.
+
+    def _networks_client(self, credentials: Credentials) -> Any:
+        from google.cloud import compute_v1
+
+        return compute_v1.NetworksClient(credentials=credentials)
+
+    def _subnetworks_client(self, credentials: Credentials) -> Any:
+        from google.cloud import compute_v1
+
+        return compute_v1.SubnetworksClient(credentials=credentials)
+
+    def _instances_client(self, credentials: Credentials) -> Any:
+        from google.cloud import compute_v1
+
+        return compute_v1.InstancesClient(credentials=credentials)
+
+    def _addresses_client(self, credentials: Credentials) -> Any:
+        from google.cloud import compute_v1
+
+        return compute_v1.AddressesClient(credentials=credentials)
+
+    def _global_addresses_client(self, credentials: Credentials) -> Any:
+        from google.cloud import compute_v1
+
+        return compute_v1.GlobalAddressesClient(credentials=credentials)
+
+    def _forwarding_rules_client(self, credentials: Credentials) -> Any:
+        from google.cloud import compute_v1
+
+        return compute_v1.ForwardingRulesClient(credentials=credentials)
+
+    def _global_forwarding_rules_client(self, credentials: Credentials) -> Any:
+        from google.cloud import compute_v1
+
+        return compute_v1.GlobalForwardingRulesClient(credentials=credentials)
+
+    # ── Probe ──────────────────────────────────────────────────────────
+
+    async def probe(self) -> CloudProbeResult:
+        """Cheap auth + reachability check: list networks in the first project.
+
+        Returns ``ok=False`` for any expected failure (bad key, denied
+        permission, network error) rather than raising.
+        """
+        try:
+            credentials = self._credentials()
+        except CloudConnectorError as exc:
+            return CloudProbeResult(ok=False, message=str(exc))
+
+        projects = self._project_ids
+        if not projects:
+            return CloudProbeResult(ok=False, message="GCP provider_config has no project_ids.")
+        first_project = projects[0]
+
+        key = self._parsed_key()
+        account_id = key.get("client_email") or first_project
+
+        try:
+            client = self._networks_client(credentials)
+            networks = await asyncio.to_thread(self._list_networks, client, first_project)
+        except Exception as exc:  # noqa: BLE001 - normalise every API/auth fault to ok=False
+            return CloudProbeResult(
+                ok=False, message=self._describe_error(exc), account_id=account_id
+            )
+
+        return CloudProbeResult(
+            ok=True,
+            message=f"Connected to GCP project {first_project} ({len(networks)} networks).",
+            account_id=account_id,
+            network_count=len(networks),
+        )
+
+    # ── Inventory ──────────────────────────────────────────────────────
+
+    async def fetch_inventory(
+        self,
+        *,
+        include_stopped: bool = False,
+        include_load_balancers: bool = True,
+    ) -> CloudInventory:
+        """Pull the normalised inventory across every configured project.
+
+        A credential-build failure is fatal (raises
+        :class:`CloudConnectorError`); a single project's API failure is
+        downgraded to a warning so one denied project doesn't abort the
+        whole sweep.
+        """
+        credentials = self._credentials()  # fatal on failure, per contract
+        key = self._parsed_key()
+        account_id = key.get("client_email") or (self._project_ids[0] if self._project_ids else "")
+
+        inventory = CloudInventory(account_id=account_id)
+        if not self._project_ids:
+            inventory.warnings.append("GCP provider_config has no project_ids; nothing to sync.")
+            return inventory
+
+        for project in self._project_ids:
+            try:
+                await asyncio.to_thread(
+                    self._collect_project,
+                    credentials,
+                    project,
+                    inventory,
+                    include_stopped,
+                    include_load_balancers,
+                )
+            except Exception as exc:  # noqa: BLE001 - one project's fault must not abort the rest
+                msg = f"GCP project {project}: {self._describe_error(exc)}"
+                logger.warning("cloud.gcp.project_failed", project=project, error=str(exc))
+                inventory.warnings.append(msg)
+
+        return inventory
+
+    # ── Per-project collection (runs in a worker thread) ────────────────
+
+    def _collect_project(
+        self,
+        credentials: Credentials,
+        project: str,
+        inventory: CloudInventory,
+        include_stopped: bool,
+        include_load_balancers: bool,
+    ) -> None:
+        """Blocking: gather one project's resources and append to inventory.
+
+        Invoked via ``asyncio.to_thread`` from :meth:`fetch_inventory`.
+        Network → subnetwork name resolution is local to this project.
+        """
+        # Networks first so subnets can resolve their parent by name.
+        net_by_name: dict[str, CloudNetwork] = {}
+        networks_client = self._networks_client(credentials)
+        for net in self._list_networks(networks_client, project):
+            network = CloudNetwork(id=str(net.id), name=net.name, cidrs=())
+            inventory.networks.append(network)
+            net_by_name[net.name] = network
+
+        # Subnetworks (regional, aggregated across every region).
+        subnets_client = self._subnetworks_client(credentials)
+        for sn in self._aggregated_items(subnets_client.aggregated_list(project=project)):
+            region = _basename(getattr(sn, "region", None))
+            if not self._region_allowed(region):
+                continue
+            parent_name = _basename(getattr(sn, "network", None))
+            if parent_name not in net_by_name:
+                inventory.warnings.append(
+                    f"GCP project {project}: subnet {sn.name} references unknown "
+                    f"network {parent_name!r}; skipped."
+                )
+                continue
+            inventory.subnets.append(
+                CloudSubnet(
+                    id=str(sn.id),
+                    name=sn.name,
+                    network_id=net_by_name[parent_name].id,
+                    cidr=sn.ip_cidr_range,
+                    region=region or None,
+                )
+            )
+
+        # Instances (zonal, aggregated). region = parent of the zone.
+        instances_client = self._instances_client(credentials)
+        for inst in self._aggregated_items(instances_client.aggregated_list(project=project)):
+            running = getattr(inst, "status", "") == "RUNNING"
+            if not running and not include_stopped:
+                continue
+            region = _region_from_zone(getattr(inst, "zone", None))
+            if not self._region_allowed(region):
+                continue
+            inventory.instances.append(
+                CloudInstance(
+                    id=str(inst.id),
+                    name=inst.name,
+                    running=running,
+                    region=region or None,
+                    nics=self._nics_from_instance(inst),
+                )
+            )
+
+        # External addresses: regional (aggregated) + global.
+        addresses_client = self._addresses_client(credentials)
+        for addr in self._aggregated_items(addresses_client.aggregated_list(project=project)):
+            self._append_public_ip(addr, inventory)
+        global_addresses_client = self._global_addresses_client(credentials)
+        for addr in global_addresses_client.list(project=project):
+            self._append_public_ip(addr, inventory)
+
+        # Load balancers surface as forwarding rules: regional + global.
+        if include_load_balancers:
+            fr_client = self._forwarding_rules_client(credentials)
+            for fr in self._aggregated_items(fr_client.aggregated_list(project=project)):
+                region = _basename(getattr(fr, "region", None)) or "global"
+                if region != "global" and not self._region_allowed(region):
+                    continue
+                inventory.load_balancers.append(self._lb_from_rule(fr, region))
+            global_fr_client = self._global_forwarding_rules_client(credentials)
+            for fr in global_fr_client.list(project=project):
+                inventory.load_balancers.append(self._lb_from_rule(fr, "global"))
+
+    # ── Per-resource shaping ────────────────────────────────────────────
+
+    @staticmethod
+    def _list_networks(client: Any, project: str) -> list[Any]:
+        """Materialise the (lazy, paginated) networks list for a project."""
+        return list(client.list(project=project))
+
+    @staticmethod
+    def _aggregated_items(pages: Any) -> list[Any]:
+        """Flatten a GCP ``aggregated_list`` response into a flat item list.
+
+        ``aggregated_list`` iterates ``(scope, scoped_list)`` pairs keyed by
+        region/zone; each ``scoped_list`` carries the resource list under an
+        attribute named after the resource (``subnetworks`` / ``instances`` /
+        ``addresses`` / ``forwarding_rules``). We don't know the attribute
+        name up front, so pull whichever list-valued attribute the scoped
+        list exposes (skipping the ``warning`` field empty scopes carry).
+        """
+        items: list[Any] = []
+        for _scope, scoped_list in pages:
+            for attr in ("subnetworks", "instances", "addresses", "forwarding_rules"):
+                value = getattr(scoped_list, attr, None)
+                if value:
+                    items.extend(value)
+                    break
+        return items
+
+    @staticmethod
+    def _nics_from_instance(inst: Any) -> tuple[CloudNic, ...]:
+        """Map an instance's network interfaces to :class:`CloudNic` rows.
+
+        ``network_i_p`` is the protobuf snake_case for ``networkIP`` (the
+        private address); ``nat_i_p`` likewise for the access-config
+        ``natIP`` (the ephemeral/static public address, if any). GCP does
+        not surface NIC MAC addresses.
+        """
+        nics: list[CloudNic] = []
+        for ni in getattr(inst, "network_interfaces", None) or ():
+            public_ip: str | None = None
+            access_configs = getattr(ni, "access_configs", None) or ()
+            if access_configs:
+                public_ip = getattr(access_configs[0], "nat_i_p", None) or None
+            nics.append(
+                CloudNic(
+                    private_ip=getattr(ni, "network_i_p", None) or "",
+                    public_ip=public_ip,
+                    mac=None,
+                )
+            )
+        return tuple(nics)
+
+    @staticmethod
+    def _append_public_ip(addr: Any, inventory: CloudInventory) -> None:
+        """Append a reserved EXTERNAL address; INTERNAL addresses are skipped."""
+        if getattr(addr, "address_type", "") != "EXTERNAL":
+            return
+        inventory.public_ips.append(
+            CloudPublicIP(
+                address=getattr(addr, "address", "") or "",
+                name=getattr(addr, "name", "") or "",
+                attached=bool(getattr(addr, "users", None)),
+            )
+        )
+
+    @staticmethod
+    def _lb_from_rule(fr: Any, region: str) -> CloudLoadBalancer:
+        """Shape a forwarding rule into a :class:`CloudLoadBalancer`.
+
+        ``i_p_address`` is the protobuf snake_case for the rule's
+        ``IPAddress`` frontend.
+        """
+        frontend = getattr(fr, "i_p_address", None)
+        return CloudLoadBalancer(
+            id=str(fr.id),
+            name=fr.name,
+            frontend_ips=(frontend,) if frontend else (),
+            region=region or "global",
+        )
+
+    # ── Error description ───────────────────────────────────────────────
+
+    @staticmethod
+    def _describe_error(exc: Exception) -> str:
+        """Render a google-auth / google-api-core fault into a short message.
+
+        Both google exception hierarchies are imported lazily so this stays
+        importable without the SDK; if a recognised type matches we keep its
+        message, otherwise we fall back to ``str(exc)``.
+        """
+        try:
+            from google.api_core import exceptions as api_exceptions
+            from google.auth import exceptions as auth_exceptions
+        except ImportError:  # pragma: no cover - optional dependency guard
+            return str(exc) or exc.__class__.__name__
+        if isinstance(exc, auth_exceptions.GoogleAuthError):
+            return f"GCP authentication failed: {exc}"
+        if isinstance(exc, api_exceptions.Forbidden):
+            return f"GCP permission denied: {exc}"
+        if isinstance(exc, api_exceptions.GoogleAPICallError):
+            return f"GCP API error: {exc}"
+        return str(exc) or exc.__class__.__name__
+
+
+__all__ = ["GCPConnector"]

--- a/backend/app/services/cloud/reconcile.py
+++ b/backend/app/services/cloud/reconcile.py
@@ -1,0 +1,900 @@
+"""Per-endpoint Cloud (AWS / Azure / GCP) reconciler (issue #37, Part A).
+
+For one :class:`CloudEndpoint` row (one cloud account / subscription /
+project set):
+
+  1. Decrypt the per-provider credential dict.
+  2. Resolve a concrete connector via :func:`get_connector` and pull a
+     single normalised :class:`CloudInventory`.
+  3. Compute the desired set of IPBlock / Subnet / IPAddress rows.
+  4. Load currently-mirrored rows (FK lookup on ``cloud_endpoint_id``).
+  5. Apply the diff: create, update, delete.
+  6. Persist ``last_synced_at`` / ``last_sync_error`` /
+     ``provider_account_id`` / ``network_count`` / ``instance_count`` +
+     a discovery snapshot + a summary audit entry.
+
+Parallels the Proxmox reconciler — same ownership-claim, soft-field
+``user_modified_at`` lock, prune-unclaimed pass, and audit write. Cloud
+specifics:
+
+* **One IPBlock per VPC/VNet CIDR.** A :class:`CloudNetwork` reports its
+  address-space CIDR(s) (one or more on AWS/Azure); each lands as a
+  ``cloud_endpoint_id``-owned IPBlock under ``ipam_space_id``, named
+  ``"<provider>:<network> <cidr>"`` (the CIDR suffix dropped when the
+  network has exactly one CIDR).
+* **GCP networks have no own CIDR.** GCP VPCs are CIDR-less containers —
+  the addressing lives entirely on the subnets. For a network with
+  ``cidrs=()`` we create one IPBlock per *distinct subnet CIDR* belonging
+  to that network (the block is the subnet's exact CIDR). The subnet then
+  nests directly inside its same-CIDR block. This keeps every Subnet row
+  enclosed by a block without speculatively inventing a supernet we can't
+  derive reliably.
+* **Subnets are routed overlays.** Cloud subnets carry no broadcast row
+  and the first usable host (``x.x.x.1`` by AWS/Azure/GCP convention) is
+  the gateway. They are created with ``kubernetes_semantics=True`` so the
+  IPAM tree + UI suppress the LAN-specific gateway / broadcast / network
+  placeholder rows, exactly like Kubernetes pod-CIDR / Tailnet subnets.
+* **Public + LB IPs are usually out-of-band /32s.** A ``cloud-public`` /
+  ``cloud-lb`` row only materialises when an enclosing mirrored subnet
+  exists (in ``public_space_id`` when set, else ``ipam_space_id``).
+  Public IPs that fall outside every mirrored subnet are counted under
+  ``skipped_no_subnet`` — a documented limitation, not an error.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import decrypt_dict
+from app.models.audit import AuditLog
+from app.models.cloud import CloudEndpoint
+from app.models.ipam import IPAddress, IPBlock, Subnet
+from app.services.cloud.base import (
+    CloudConnectorError,
+    CloudInventory,
+    get_connector,
+)
+
+logger = structlog.get_logger(__name__)
+
+_BIGINT_MAX = 2**63 - 1
+
+
+# ── Desired-state dataclasses ────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _DesiredBlock:
+    network: str  # CIDR
+    name: str
+    description: str
+
+
+@dataclass(frozen=True)
+class _DesiredSubnet:
+    network: str  # CIDR
+    name: str
+    description: str
+    gateway: str | None = None
+
+
+@dataclass(frozen=True)
+class _DesiredAddress:
+    address: str
+    status: str  # cloud-instance | cloud-public | cloud-lb
+    hostname: str
+    description: str
+    mac: str | None = None
+    # Which space the row belongs in. cloud-public / cloud-lb rows route
+    # to the endpoint's ``public_space_id`` when one is configured; every
+    # other row (and the fallback) lands in ``ipam_space_id``.
+    public: bool = False
+
+
+@dataclass
+class ReconcileSummary:
+    ok: bool
+    error: str | None = None
+    provider_account_id: str | None = None
+    network_count: int = 0
+    instance_count: int = 0
+    blocks_created: int = 0
+    blocks_deleted: int = 0
+    subnets_created: int = 0
+    subnets_updated: int = 0
+    subnets_deleted: int = 0
+    # Counted when a pre-existing operator-owned subnet at an exact-CIDR
+    # match was reused instead of creating a duplicate — mirrors the
+    # Proxmox reconciler's issue #177 behaviour.
+    subnets_matched: int = 0
+    addresses_created: int = 0
+    addresses_updated: int = 0
+    addresses_deleted: int = 0
+    skipped_no_subnet: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _parse_net(value: str) -> ipaddress.IPv4Network | ipaddress.IPv6Network | None:
+    try:
+        return ipaddress.ip_network(value, strict=False)
+    except (ValueError, TypeError):
+        return None
+
+
+def _lan_total_ips(net: ipaddress.IPv4Network | ipaddress.IPv6Network) -> int:
+    # Cloud subnets are routed overlays without network / broadcast
+    # reservation in IPAM, so the whole range is usable — no -2.
+    if isinstance(net, ipaddress.IPv6Network):
+        return min(net.num_addresses, _BIGINT_MAX)
+    return min(net.num_addresses, _BIGINT_MAX)
+
+
+def _first_usable_host(cidr: str) -> str | None:
+    """First usable host of ``cidr`` (the cloud gateway convention).
+
+    ``10.0.1.0/24 → 10.0.1.1``. For /31 / /32 (and v6 equivalents) where
+    there's no distinct host below the network address we just return the
+    network address itself. ``None`` on parse failure.
+    """
+    net = _parse_net(cidr)
+    if net is None:
+        return None
+    if net.num_addresses <= 1:
+        return str(net.network_address)
+    return str(net.network_address + 1)
+
+
+def _find_enclosing_operator_block(
+    blocks: list[IPBlock], cidr: str, endpoint_id: Any
+) -> IPBlock | None:
+    """Most-specific block (not owned by this endpoint) that encloses ``cidr``.
+
+    Used at block-creation time to decide whether we even need to create
+    an endpoint-owned block — if an operator (or other-integration) block
+    already encloses the CIDR we nest under it instead.
+    """
+    return _find_enclosing_block(blocks, cidr, exclude_endpoint_id=endpoint_id)
+
+
+def _find_enclosing_block(
+    blocks: list[IPBlock], cidr: str, *, exclude_endpoint_id: Any = None
+) -> IPBlock | None:
+    """Most-specific block that encloses ``cidr``.
+
+    With ``exclude_endpoint_id`` set, blocks owned by that endpoint are
+    skipped (the operator/foreign-only view). With it ``None`` every block
+    is eligible — that's what the subnet-parent resolver uses so a subnet
+    correctly nests under the endpoint's own VPC-CIDR block.
+    """
+    net = _parse_net(cidr)
+    if net is None:
+        return None
+    best: IPBlock | None = None
+    best_prefix = -1
+    for b in blocks:
+        if exclude_endpoint_id is not None and b.cloud_endpoint_id == exclude_endpoint_id:
+            continue
+        bnet = _parse_net(str(b.network))
+        if bnet is None or type(bnet) is not type(net):
+            continue
+        if net.subnet_of(bnet) and bnet.prefixlen > best_prefix:  # type: ignore[arg-type]
+            best = b
+            best_prefix = bnet.prefixlen
+    return best
+
+
+def _find_subnet_for_ip(subnets: list[Subnet], ip: str) -> Subnet | None:
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return None
+    best: Subnet | None = None
+    best_prefix: int = -1
+    for s in subnets:
+        net = _parse_net(str(s.network))
+        if net is None:
+            continue
+        if addr in net and net.prefixlen > best_prefix:
+            best = s
+            best_prefix = net.prefixlen
+    return best
+
+
+async def _recompute_subnet_utilization(db: AsyncSession, subnet_id: Any) -> None:
+    allocated = (
+        await db.scalar(
+            select(func.count())
+            .select_from(IPAddress)
+            .where(IPAddress.subnet_id == subnet_id)
+            .where(IPAddress.status != "available")
+        )
+        or 0
+    )
+    subnet = await db.get(Subnet, subnet_id)
+    if subnet is None:
+        return
+    subnet.allocated_ips = allocated
+    subnet.utilization_percent = (
+        round(allocated / subnet.total_ips * 100, 2) if subnet.total_ips > 0 else 0.0
+    )
+
+
+# ── Desired state computation ────────────────────────────────────────
+
+
+def _compute_desired(
+    endpoint: CloudEndpoint,
+    inv: CloudInventory,
+) -> tuple[list[_DesiredBlock], list[_DesiredSubnet], list[_DesiredAddress]]:
+    """Translate a normalised inventory into desired IPAM rows.
+
+    Returns ``(blocks, subnets, addresses)``. Blocks are the VPC/VNet
+    address-space CIDRs (plus the GCP per-subnet-CIDR fallback);
+    subnets are the cloud subnets; addresses are instance NIC private
+    IPs, public IPs, and load-balancer frontends that land in a
+    mirrored subnet.
+    """
+    blocks: list[_DesiredBlock] = []
+    seen_block_cidrs: set[str] = set()
+
+    # Map network_id → its declared CIDRs so the GCP fallback can ask
+    # "does this subnet's network own any CIDR of its own?".
+    network_by_id = {n.id: n for n in inv.networks}
+    network_has_cidr = {n.id: bool(n.cidrs) for n in inv.networks}
+
+    def _add_block(cidr: str, name: str, description: str) -> None:
+        net = _parse_net(cidr)
+        if net is None:
+            return
+        key = str(net)
+        if key in seen_block_cidrs:
+            return
+        seen_block_cidrs.add(key)
+        blocks.append(_DesiredBlock(network=key, name=name, description=description))
+
+    # VPC/VNet CIDRs → one IPBlock each. Single-CIDR networks omit the
+    # CIDR suffix in the name; multi-CIDR networks include it so the two
+    # blocks are distinguishable in the tree.
+    for n in inv.networks:
+        multi = len(n.cidrs) > 1
+        for cidr in n.cidrs:
+            label = f"{endpoint.provider}:{n.name}"
+            if multi:
+                label = f"{label} {cidr}"
+            region_bit = f" in {n.region}" if n.region else ""
+            _add_block(cidr, label, f"{endpoint.provider} VPC/VNet {n.name}{region_bit}")
+
+    # Subnets → one Subnet each, enclosed by the network's block. For a
+    # GCP-style CIDR-less network, create a per-subnet-CIDR block first so
+    # the subnet has an enclosing block at its own CIDR.
+    subnets: list[_DesiredSubnet] = []
+    seen_subnet_cidrs: set[str] = set()
+    for s in inv.subnets:
+        net = _parse_net(s.cidr)
+        if net is None:
+            continue
+        cidr = str(net)
+        if cidr in seen_subnet_cidrs:
+            continue
+        seen_subnet_cidrs.add(cidr)
+
+        parent = network_by_id.get(s.network_id)
+        if parent is not None and not network_has_cidr.get(s.network_id, False):
+            # CIDR-less network (GCP): place the subnet under a block at
+            # its own CIDR. The block won't already exist as a network
+            # CIDR because the network had none.
+            label = f"{endpoint.provider}:{parent.name}"
+            region_bit = f" in {parent.region}" if parent.region else ""
+            _add_block(
+                cidr,
+                label,
+                f"{endpoint.provider} VPC/VNet {parent.name}{region_bit} (subnet block)",
+            )
+
+        net_name = parent.name if parent is not None else s.network_id
+        region_bit = f" in {s.region}" if s.region else ""
+        gateway = s.gateway or _first_usable_host(cidr)
+        subnets.append(
+            _DesiredSubnet(
+                network=cidr,
+                name=f"{endpoint.provider}:{s.name}",
+                description=f"{endpoint.provider} subnet {s.name} in {net_name}{region_bit}",
+                gateway=gateway,
+            )
+        )
+
+    # Instance NIC private IPs → cloud-instance rows. A NIC's public IP,
+    # if present, becomes a cloud-public row too (almost always skipped
+    # for want of an enclosing subnet — that's expected).
+    addresses: list[_DesiredAddress] = []
+    for inst in inv.instances:
+        desc = (
+            f"{endpoint.provider} instance {inst.name} ({'running' if inst.running else 'stopped'})"
+        )
+        for nic in inst.nics:
+            if nic.private_ip:
+                addresses.append(
+                    _DesiredAddress(
+                        address=nic.private_ip,
+                        status="cloud-instance",
+                        hostname=inst.name,
+                        description=desc,
+                        mac=nic.mac,
+                    )
+                )
+            if nic.public_ip:
+                addresses.append(
+                    _DesiredAddress(
+                        address=nic.public_ip,
+                        status="cloud-public",
+                        hostname=inst.name,
+                        description=f"{desc} — public IP",
+                        public=True,
+                    )
+                )
+
+    # Standalone public / Elastic IPs → cloud-public rows.
+    for pub in inv.public_ips:
+        label = pub.name or pub.address
+        addresses.append(
+            _DesiredAddress(
+                address=pub.address,
+                status="cloud-public",
+                hostname=label,
+                description=f"{endpoint.provider} public IP {label}"
+                + (" (attached)" if pub.attached else " (unattached)"),
+                public=True,
+            )
+        )
+
+    # Load-balancer frontends → cloud-lb rows (only when mirroring LBs).
+    if endpoint.mirror_load_balancers:
+        for lb in inv.load_balancers:
+            region_bit = f" in {lb.region}" if lb.region else ""
+            for fip in lb.frontend_ips:
+                addresses.append(
+                    _DesiredAddress(
+                        address=fip,
+                        status="cloud-lb",
+                        hostname=lb.name,
+                        description=f"{endpoint.provider} load balancer {lb.name}{region_bit}",
+                        public=True,
+                    )
+                )
+
+    return blocks, subnets, addresses
+
+
+# ── Apply: blocks + subnets ──────────────────────────────────────────
+
+
+async def _apply_blocks_and_subnets(
+    db: AsyncSession,
+    endpoint: CloudEndpoint,
+    desired_blocks: list[_DesiredBlock],
+    desired_subnets: list[_DesiredSubnet],
+    summary: ReconcileSummary,
+) -> None:
+    block_rows = (
+        (await db.execute(select(IPBlock).where(IPBlock.space_id == endpoint.ipam_space_id)))
+        .scalars()
+        .all()
+    )
+    blocks = list(block_rows)
+    endpoint_blocks = {str(b.network): b for b in blocks if b.cloud_endpoint_id == endpoint.id}
+    existing_networks = {str(b.network): b for b in blocks}
+
+    # Create / keep the endpoint-owned blocks for every desired CIDR that
+    # isn't already enclosed by an operator (or other-integration) block.
+    # If an enclosing block exists we nest beneath it rather than creating
+    # a same-CIDR duplicate.
+    desired_block_cidrs: set[str] = set()
+    for d in desired_blocks:
+        if d.network in existing_networks:
+            # Already present (operator-curated, foreign, or ours). If it's
+            # ours, keep its metadata fresh; otherwise leave it alone.
+            owned = endpoint_blocks.get(d.network)
+            if owned is not None:
+                desired_block_cidrs.add(d.network)
+                if owned.name != d.name:
+                    owned.name = d.name
+                if owned.description != d.description:
+                    owned.description = d.description
+            continue
+        enclosing = _find_enclosing_operator_block(blocks, d.network, endpoint.id)
+        if enclosing is not None:
+            # An operator / foreign block already encloses this CIDR — we
+            # don't need our own block; subnets nest under the enclosing one.
+            continue
+        new_block = IPBlock(
+            space_id=endpoint.ipam_space_id,
+            network=d.network,
+            name=d.name,
+            description=d.description,
+            cloud_endpoint_id=endpoint.id,
+        )
+        db.add(new_block)
+        await db.flush()
+        blocks.append(new_block)
+        endpoint_blocks[d.network] = new_block
+        existing_networks[d.network] = new_block
+        desired_block_cidrs.add(d.network)
+        summary.blocks_created += 1
+
+    # Classify every subnet in the space into endpoint-owned / operator /
+    # foreign — same three-way split the Proxmox reconciler uses.
+    all_subnet_rows = (
+        (await db.execute(select(Subnet).where(Subnet.space_id == endpoint.ipam_space_id)))
+        .scalars()
+        .all()
+    )
+    current_subnets: dict[str, Subnet] = {}
+    operator_subnets: dict[str, Subnet] = {}
+    foreign_subnets: dict[str, Subnet] = {}
+    for s in all_subnet_rows:
+        net_key = str(s.network)
+        if s.cloud_endpoint_id == endpoint.id:
+            current_subnets[net_key] = s
+        elif (
+            s.cloud_endpoint_id is None
+            and s.proxmox_node_id is None
+            and s.kubernetes_cluster_id is None
+            and s.docker_host_id is None
+            and s.tailscale_tenant_id is None
+            and s.unifi_controller_id is None
+        ):
+            operator_subnets[net_key] = s
+        else:
+            foreign_subnets[net_key] = s
+
+    desired_map = {d.network: d for d in desired_subnets}
+
+    # Prune endpoint-owned subnets no longer in the desired set.
+    for net_str, row in current_subnets.items():
+        if net_str in desired_map:
+            continue
+        await db.delete(row)
+        summary.subnets_deleted += 1
+
+    for net_str, d in desired_map.items():
+        # An operator subnet at this exact CIDR wins — reused untouched.
+        if net_str in operator_subnets:
+            summary.subnets_matched += 1
+            continue
+        # Another integration owns this CIDR — don't duplicate, warn.
+        if net_str in foreign_subnets:
+            summary.warnings.append(
+                f"subnet {net_str} already exists, owned by another integration; "
+                "not creating duplicate"
+            )
+            continue
+
+        # Any enclosing block is a valid parent — including the endpoint's
+        # own VPC-CIDR block created above. Only when nothing encloses the
+        # subnet (e.g. a stray cloud subnet outside every discovered VPC
+        # CIDR) do we fall back to a same-CIDR endpoint-owned wrapper.
+        parent_block = _find_enclosing_block(blocks, d.network)
+        if parent_block is None:
+            wrapper = endpoint_blocks.get(d.network)
+            if wrapper is None:
+                wrapper = IPBlock(
+                    space_id=endpoint.ipam_space_id,
+                    network=d.network,
+                    name=f"{endpoint.provider}:{endpoint.name} {d.network}",
+                    description=f"Auto-created for Cloud endpoint {endpoint.name}",
+                    cloud_endpoint_id=endpoint.id,
+                )
+                db.add(wrapper)
+                await db.flush()
+                blocks.append(wrapper)
+                endpoint_blocks[d.network] = wrapper
+                desired_block_cidrs.add(d.network)
+                summary.blocks_created += 1
+            parent_block = wrapper
+
+        net_parsed = _parse_net(d.network)
+        expected_total = _lan_total_ips(net_parsed) if net_parsed is not None else 0
+
+        existing = current_subnets.get(net_str)
+        if existing is None:
+            db.add(
+                Subnet(
+                    space_id=endpoint.ipam_space_id,
+                    block_id=parent_block.id,
+                    network=d.network,
+                    name=d.name,
+                    description=d.description,
+                    gateway=d.gateway,
+                    cloud_endpoint_id=endpoint.id,
+                    kubernetes_semantics=True,  # routed overlay — suppress LAN rows
+                    total_ips=expected_total,
+                )
+            )
+            summary.subnets_created += 1
+        else:
+            changed = False
+            if existing.block_id != parent_block.id:
+                existing.block_id = parent_block.id
+                changed = True
+            if existing.name != d.name:
+                existing.name = d.name
+                changed = True
+            if existing.description != d.description:
+                existing.description = d.description
+                changed = True
+            # Only set the gateway when we know one; never clear an
+            # operator-set value back to None on a sync.
+            if d.gateway and str(existing.gateway or "") != d.gateway:
+                existing.gateway = d.gateway
+                changed = True
+            if existing.total_ips != expected_total:
+                existing.total_ips = expected_total
+                changed = True
+            if changed:
+                summary.subnets_updated += 1
+
+    await db.flush()
+
+    # Drop endpoint-owned blocks that no longer back any subnet.
+    for net_str, block in endpoint_blocks.items():
+        if net_str in desired_block_cidrs:
+            continue
+        refs = await db.execute(select(Subnet).where(Subnet.block_id == block.id))
+        if refs.scalar_one_or_none() is None:
+            await db.delete(block)
+            summary.blocks_deleted += 1
+
+
+# ── Apply: addresses ──────────────────────────────────────────────────
+
+
+async def _apply_addresses(
+    db: AsyncSession,
+    endpoint: CloudEndpoint,
+    desired: list[_DesiredAddress],
+    summary: ReconcileSummary,
+) -> None:
+    subnet_rows = (
+        (await db.execute(select(Subnet).where(Subnet.cloud_endpoint_id == endpoint.id)))
+        .scalars()
+        .all()
+    )
+    # Also consider operator subnets in the same space(s) for IP
+    # containment — an instance IP may land in an operator-curated subnet
+    # the reconciler reused (subnets_matched). We restrict to the bound
+    # space(s) so cross-space overlaps don't mis-bind.
+    space_ids = [endpoint.ipam_space_id]
+    if endpoint.public_space_id is not None and endpoint.public_space_id != endpoint.ipam_space_id:
+        space_ids.append(endpoint.public_space_id)
+    all_space_subnets = (
+        (await db.execute(select(Subnet).where(Subnet.space_id.in_(space_ids)))).scalars().all()
+    )
+    subnets = list(all_space_subnets)
+    endpoint_subnet_ids = {s.id for s in subnet_rows}
+
+    # Dedupe by address — the same IP reported twice (NIC + public IP, or
+    # two LBs sharing a frontend) collapses to the first occurrence.
+    desired_map: dict[str, _DesiredAddress] = {}
+    for d in desired:
+        if d.address in desired_map:
+            continue
+        desired_map[d.address] = d
+
+    # Phase 1 — claim pre-existing operator-owned rows at the desired
+    # addresses, stamping ``user_modified_at`` so their soft fields lock.
+    desired_addrs = list(desired_map.keys())
+    if desired_addrs:
+        existing_rows = (
+            (await db.execute(select(IPAddress).where(IPAddress.address.in_(desired_addrs))))
+            .scalars()
+            .all()
+        )
+        for row in existing_rows:
+            if row.cloud_endpoint_id == endpoint.id:
+                continue  # already ours
+            if row.cloud_endpoint_id is not None:
+                summary.warnings.append(
+                    f"address {row.address} owned by another Cloud endpoint; not claiming"
+                )
+                continue
+            if (
+                row.kubernetes_cluster_id is not None
+                or row.docker_host_id is not None
+                or row.proxmox_node_id is not None
+                or row.tailscale_tenant_id is not None
+                or row.unifi_controller_id is not None
+            ):
+                summary.warnings.append(
+                    f"address {row.address} owned by another integration; not claiming"
+                )
+                continue
+            # Only claim rows that live in a subnet we mirror — otherwise
+            # an unrelated operator IP that happens to share an address
+            # string (different space) would be wrongly adopted.
+            if row.subnet_id not in {s.id for s in subnets}:
+                continue
+            row.cloud_endpoint_id = endpoint.id
+            if row.user_modified_at is None:
+                row.user_modified_at = datetime.now(UTC)
+        await db.flush()
+
+    res = await db.execute(select(IPAddress).where(IPAddress.cloud_endpoint_id == endpoint.id))
+    current = {str(a.address): a for a in res.scalars().all()}
+
+    dirty_subnets: set[Any] = set(endpoint_subnet_ids)
+
+    # Prune endpoint-owned rows no longer desired (preserve operator-edited
+    # rows by releasing the FK instead of deleting).
+    for addr, row in current.items():
+        if addr not in desired_map:
+            dirty_subnets.add(row.subnet_id)
+            if row.user_modified_at is not None:
+                row.cloud_endpoint_id = None
+                summary.addresses_updated += 1
+            else:
+                await db.delete(row)
+                summary.addresses_deleted += 1
+
+    for addr, d in desired_map.items():
+        subnet = _find_subnet_for_ip(subnets, d.address)
+        if subnet is None:
+            # No enclosing mirrored subnet — public / LB / out-of-band IP.
+            summary.skipped_no_subnet += 1
+            continue
+        if addr in current:
+            row = current[addr]
+            changed = False
+            # subnet_id is factual — always correct it.
+            if row.subnet_id != subnet.id:
+                dirty_subnets.add(row.subnet_id)
+                row.subnet_id = subnet.id
+                changed = True
+            if row.user_modified_at is None:
+                if row.status != d.status:
+                    row.status = d.status
+                    changed = True
+                if (row.hostname or "") != d.hostname:
+                    row.hostname = d.hostname
+                    changed = True
+                if (row.description or "") != d.description:
+                    row.description = d.description
+                    changed = True
+                if d.mac and (row.mac_address or "") != d.mac.lower():
+                    row.mac_address = d.mac.lower()
+                    changed = True
+            if changed:
+                dirty_subnets.add(subnet.id)
+                summary.addresses_updated += 1
+        else:
+            db.add(
+                IPAddress(
+                    subnet_id=subnet.id,
+                    address=d.address,
+                    status=d.status,
+                    hostname=d.hostname,
+                    description=d.description,
+                    mac_address=d.mac.lower() if d.mac else None,
+                    cloud_endpoint_id=endpoint.id,
+                )
+            )
+            dirty_subnets.add(subnet.id)
+            summary.addresses_created += 1
+
+    if dirty_subnets:
+        await db.flush()
+        for subnet_id in dirty_subnets:
+            await _recompute_subnet_utilization(db, subnet_id)
+
+
+# ── Discovery payload (UI debugging) ──────────────────────────────────
+
+
+def _build_discovery_payload(
+    inv: CloudInventory,
+    desired_subnets: list[_DesiredSubnet],
+    desired_addresses: list[_DesiredAddress],
+    summary: ReconcileSummary,
+) -> dict[str, Any]:
+    """Counts + per-instance reason codes for the "Discovery" UI modal.
+
+    Categorises every instance by whether any of its NIC IPs landed in a
+    mirrored subnet (``mirrored``) or all were skipped for want of an
+    enclosing subnet (``no_subnet``) / the instance had no NIC at all
+    (``no_nic``). Mirrors the Proxmox reconciler's diagnostic snapshot.
+    """
+    subnet_set = set()
+    for d in desired_subnets:
+        net = _parse_net(d.network)
+        if net is not None:
+            subnet_set.add(net)
+
+    def _in_a_subnet(ip: str) -> bool:
+        try:
+            addr = ipaddress.ip_address(ip)
+        except ValueError:
+            return False
+        return any(addr in net for net in subnet_set)
+
+    instance_rows: list[dict[str, Any]] = []
+    counters = {
+        "instances_total": len(inv.instances),
+        "instances_running": 0,
+        "instances_mirrored": 0,
+        "instances_no_subnet": 0,
+        "instances_no_nic": 0,
+    }
+    for inst in inv.instances:
+        if inst.running:
+            counters["instances_running"] += 1
+        nic_count = len(inst.nics)
+        mirrored = sum(1 for nic in inst.nics if nic.private_ip and _in_a_subnet(nic.private_ip))
+
+        issue: str | None = None
+        hint: str | None = None
+        if nic_count == 0:
+            issue = "no_nic"
+            hint = "This instance has no network interfaces."
+            counters["instances_no_nic"] += 1
+        elif mirrored > 0:
+            counters["instances_mirrored"] += 1
+        else:
+            issue = "no_subnet"
+            hint = (
+                "The instance's private IP is not enclosed by any mirrored subnet. "
+                "Check that the VPC subnet was discovered in this region."
+            )
+            counters["instances_no_subnet"] += 1
+
+        instance_rows.append(
+            {
+                "id": inst.id,
+                "name": inst.name,
+                "running": inst.running,
+                "region": inst.region,
+                "nic_count": nic_count,
+                "ips_mirrored": mirrored,
+                "issue": issue,
+                "hint": hint,
+            }
+        )
+
+    counters["networks_total"] = len(inv.networks)
+    counters["subnets_total"] = len(inv.subnets)
+    counters["public_ips_total"] = len(inv.public_ips)
+    counters["load_balancers_total"] = len(inv.load_balancers)
+    counters["addresses_skipped_no_subnet"] = summary.skipped_no_subnet
+    counters["desired_subnets"] = len(desired_subnets)
+    counters["desired_addresses"] = len(desired_addresses)
+
+    instance_rows.sort(key=lambda r: (r["issue"] is None, r["name"]))
+    return {
+        "summary": counters,
+        "instances": instance_rows,
+        "warnings": list(inv.warnings),
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
+
+
+# ── Entry point ───────────────────────────────────────────────────────
+
+
+async def reconcile_endpoint(db: AsyncSession, endpoint: CloudEndpoint) -> ReconcileSummary:
+    summary = ReconcileSummary(ok=False)
+
+    if not endpoint.credentials_encrypted:
+        summary.error = "credentials not set"
+        endpoint.last_sync_error = summary.error
+        endpoint.last_synced_at = datetime.now(UTC)
+        await db.commit()
+        return summary
+
+    try:
+        credentials = decrypt_dict(endpoint.credentials_encrypted)
+    except ValueError as exc:
+        summary.error = f"credential decrypt failed: {exc}"
+        endpoint.last_sync_error = summary.error
+        endpoint.last_synced_at = datetime.now(UTC)
+        await db.commit()
+        return summary
+
+    try:
+        connector = get_connector(
+            endpoint.provider,
+            credentials=credentials,
+            provider_config=endpoint.provider_config,
+            regions=endpoint.regions,
+        )
+        inv = await connector.fetch_inventory(
+            include_stopped=endpoint.mirror_stopped_instances,
+            include_load_balancers=endpoint.mirror_load_balancers,
+        )
+    except CloudConnectorError as exc:
+        summary.error = str(exc)
+        endpoint.last_sync_error = summary.error
+        endpoint.last_synced_at = datetime.now(UTC)
+        await db.commit()
+        logger.warning(
+            "cloud_reconcile_fetch_failed", endpoint=str(endpoint.id), error=summary.error
+        )
+        return summary
+
+    summary.provider_account_id = inv.account_id
+    summary.network_count = len(inv.networks)
+    summary.instance_count = len(inv.instances)
+
+    desired_blocks, desired_subnets, desired_addresses = _compute_desired(endpoint, inv)
+
+    await _apply_blocks_and_subnets(db, endpoint, desired_blocks, desired_subnets, summary)
+    await _apply_addresses(db, endpoint, desired_addresses, summary)
+
+    summary.warnings.extend(inv.warnings)
+
+    endpoint.last_synced_at = datetime.now(UTC)
+    endpoint.last_sync_error = None
+    endpoint.provider_account_id = inv.account_id
+    endpoint.network_count = summary.network_count
+    endpoint.instance_count = summary.instance_count
+    endpoint.last_discovery = _build_discovery_payload(
+        inv, desired_subnets, desired_addresses, summary
+    )
+
+    db.add(
+        AuditLog(
+            user_display_name="system",
+            auth_source="system",
+            action="cloud.reconcile",
+            resource_type="cloud_endpoint",
+            resource_id=str(endpoint.id),
+            resource_display=endpoint.name,
+            new_value={
+                "provider": endpoint.provider,
+                "account_id": inv.account_id,
+                "blocks": {
+                    "created": summary.blocks_created,
+                    "deleted": summary.blocks_deleted,
+                },
+                "subnets": {
+                    "created": summary.subnets_created,
+                    "updated": summary.subnets_updated,
+                    "deleted": summary.subnets_deleted,
+                    "matched": summary.subnets_matched,
+                },
+                "addresses": {
+                    "created": summary.addresses_created,
+                    "updated": summary.addresses_updated,
+                    "deleted": summary.addresses_deleted,
+                    "skipped_no_subnet": summary.skipped_no_subnet,
+                },
+            },
+        )
+    )
+    await db.commit()
+    summary.ok = True
+    logger.info(
+        "cloud_reconcile_ok",
+        endpoint=str(endpoint.id),
+        provider=endpoint.provider,
+        account_id=inv.account_id,
+        networks=summary.network_count,
+        instances=summary.instance_count,
+        blocks_created=summary.blocks_created,
+        subnets_created=summary.subnets_created,
+        subnets_updated=summary.subnets_updated,
+        addresses_created=summary.addresses_created,
+        addresses_updated=summary.addresses_updated,
+        addresses_deleted=summary.addresses_deleted,
+    )
+    return summary
+
+
+__all__ = ["ReconcileSummary", "reconcile_endpoint"]

--- a/backend/app/services/dns_import/__init__.py
+++ b/backend/app/services/dns_import/__init__.py
@@ -20,6 +20,12 @@ from .canonical import (
     ImportSource,
     ZoneConflict,
 )
+from .cloud import (
+    CLOUD_DRIVERS,
+    CloudDNSImportError,
+    commit_cloud_import,
+    preview_cloud_import,
+)
 from .commit import CommitResult, CommitZoneResult, commit_import, detect_conflicts
 from .powerdns import (
     PowerDNSImportError,
@@ -29,6 +35,8 @@ from .powerdns import (
 from .windows_dns import WindowsDNSImportError, parse_windows_dns_server
 
 __all__ = [
+    "CLOUD_DRIVERS",
+    "CloudDNSImportError",
     "CommitResult",
     "CommitZoneResult",
     "ConflictAction",
@@ -41,9 +49,11 @@ __all__ = [
     "PowerDNSImportError",
     "WindowsDNSImportError",
     "ZoneConflict",
+    "commit_cloud_import",
     "commit_import",
     "detect_conflicts",
     "parse_bind9_archive",
+    "preview_cloud_import",
     "parse_powerdns_server",
     "parse_windows_dns_server",
     "test_powerdns_connection",

--- a/backend/app/services/dns_import/canonical.py
+++ b/backend/app/services/dns_import/canonical.py
@@ -17,7 +17,18 @@ from typing import Literal
 
 # Stable enum the importer stamps on every row it creates. Keep in
 # sync with the values the migration writes into ``import_source``.
-ImportSource = Literal["bind9", "windows_dns", "powerdns"]
+# The cloud-hosted DNS sources (issue #37, Part B) stamp the provider
+# name directly so provenance stays queryable per provider; all four
+# fit the ``import_source`` String(20) column.
+ImportSource = Literal[
+    "bind9",
+    "windows_dns",
+    "powerdns",
+    "cloudflare",
+    "route53",
+    "azure_dns",
+    "google_dns",
+]
 
 # Per-zone conflict resolution. ``rename`` requires ``rename_to`` to
 # carry the new FQDN; the commit endpoint validates that.

--- a/backend/app/services/dns_import/cloud.py
+++ b/backend/app/services/dns_import/cloud.py
@@ -1,4 +1,4 @@
-"""Cloud DNS live-pull importer (issue #37, Part C).
+"""Cloud DNS live-pull importer (issue #37, Part B).
 
 Reuses the agentless :class:`CloudDNSDriverBase` read surface that the
 four cloud drivers (Cloudflare / Route 53 / Azure DNS / Google Cloud
@@ -36,12 +36,11 @@ driver after import.
 (``cloudflare`` / ``route53`` / ``azure_dns`` / ``google_dns``), not a
 generic ``"cloud"`` — that's the same string stamped into every created
 row's ``import_source`` column so provenance stays queryable per
-provider. See the module-level note + the integrator summary: the
-:data:`app.services.dns_import.canonical.ImportSource` ``Literal`` is a
-closed enum that currently lists only ``bind9`` / ``windows_dns`` /
-``powerdns``, so the four provider names are ``cast`` to it here and the
-integrator must widen the ``Literal`` (and the ``import_source`` column
-comment) to include them.
+provider. The :data:`app.services.dns_import.canonical.ImportSource`
+``Literal`` is widened to include all four provider names, so the label
+is type-honest; ``server.driver`` (a runtime ``str``) is ``cast`` to
+``ImportSource`` at the assignment site since the column type is plain
+``String(20)``.
 """
 
 from __future__ import annotations

--- a/backend/app/services/dns_import/cloud.py
+++ b/backend/app/services/dns_import/cloud.py
@@ -1,0 +1,296 @@
+"""Cloud DNS live-pull importer (issue #37, Part C).
+
+Reuses the agentless :class:`CloudDNSDriverBase` read surface that the
+four cloud drivers (Cloudflare / Route 53 / Azure DNS / Google Cloud
+DNS) already expose for the ``sync-from-server`` drift path:
+
+* :meth:`CloudDNSDriverBase.pull_zones_from_server` — lists every
+  hosted zone visible to the account credentials and returns one
+  neutral dict per zone (same shape ``windows_dns`` returns).
+* :meth:`CloudDNSDriverBase.pull_zone_records` — returns
+  ``list[RecordData]`` for one zone, names relative to the apex.
+
+Both method names match Windows DNS Path B verbatim, so this module is
+a near-clone of :mod:`app.services.dns_import.windows_dns`: it wraps the
+driver's reads into the canonical :class:`ImportPreview` shape and hands
+the IR to the same source-agnostic :func:`commit_import` pipeline that
+ships BIND9 / Windows / PowerDNS zones.
+
+**SOA fields:** cloud providers own the SOA on their side and the
+record walkers return records relative to the apex without an SOA row
+(SOA / apex-NS are provider-managed). As Windows DNS does, we apply
+standards-compliant defaults (86400/7200/3600000/3600/3600) on the
+imported zone and surface a per-zone warning. SpatiumDDI's apply
+pipeline rewrites the SOA from the zone's own ``primary_ns`` /
+``admin_email`` columns when it pushes config back, so the defaults are
+placeholders for the operator-facing preview, not load-bearing values.
+
+**DNSSEC:** providers report ``dnssec_enabled`` on the zone-list dict,
+but the canonical IR can't model DNSKEY / RRSIG / NSEC chains (the
+shared committer drops them, same as the BIND9 archive importer). When
+a source zone is signed we surface a per-zone warning so the operator
+knows online-signing state has to be re-established on the destination
+driver after import.
+
+**Source label:** ``ImportPreview.source`` carries the *provider* name
+(``cloudflare`` / ``route53`` / ``azure_dns`` / ``google_dns``), not a
+generic ``"cloud"`` — that's the same string stamped into every created
+row's ``import_source`` column so provenance stays queryable per
+provider. See the module-level note + the integrator summary: the
+:data:`app.services.dns_import.canonical.ImportSource` ``Literal`` is a
+closed enum that currently lists only ``bind9`` / ``windows_dns`` /
+``powerdns``, so the four provider names are ``cast`` to it here and the
+integrator must widen the ``Literal`` (and the ``import_source`` column
+comment) to include them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.drivers.dns import get_driver
+from app.models.auth import User
+from app.models.dns import DNSServer
+
+from .canonical import (
+    ImportedRecord,
+    ImportedSOA,
+    ImportedZone,
+    ImportPreview,
+    ImportSource,
+)
+from .commit import (
+    CommitResult,
+    ConflictAction,
+    commit_import,
+    detect_conflicts,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+class CloudDNSImportError(ValueError):
+    """Raised when a cloud DNS server can't be live-pulled.
+
+    Mirrors :class:`WindowsDNSImportError`: per-zone failures don't
+    raise this — they surface as ``ImportedZone.parse_warnings`` on the
+    affected zone so the operator sees the partial-success state instead
+    of losing the whole import to a flake on one zone.
+    """
+
+
+# Driver names that route through this importer. Kept in lockstep with
+# the four concrete cloud drivers + ``CloudDNSDriverBase`` subclasses
+# the integrator registers in ``app.drivers.dns``. The preview validates
+# ``server.driver`` against this set before touching the driver so a
+# BIND9 / PowerDNS / Windows server gets a clear error rather than a
+# confusing AttributeError downstream.
+CLOUD_DRIVERS: frozenset[str] = frozenset({"cloudflare", "route53", "azure_dns", "google_dns"})
+
+# Default SOA fields applied when the source doesn't provide them.
+# Same conservative RFC 1035 reference numbers ``windows_dns`` uses so
+# both importers seed identical placeholder zones.
+_DEFAULT_SOA = {
+    "refresh": 86400,
+    "retry": 7200,
+    "expire": 3600000,
+    "minimum": 3600,
+    "ttl": 3600,
+}
+
+
+def _normalize_fqdn(name: str) -> str:
+    return name if name.endswith(".") else name + "."
+
+
+async def preview_cloud_import(
+    db: AsyncSession,
+    *,
+    server_id: uuid.UUID,
+    target_group_id: uuid.UUID,
+    target_view_id: uuid.UUID | None = None,
+) -> ImportPreview:
+    """Live-pull every hosted zone + its records from a cloud DNS server.
+
+    Loads the :class:`DNSServer` row identified by ``server_id``,
+    validates it's backed by a cloud driver, resolves the driver via the
+    registry, and coerces the driver's neutral zone / record reads into
+    the canonical :class:`ImportPreview` shape. Conflicts against
+    existing :class:`DNSZone` rows in ``target_group_id`` (+ optional
+    ``target_view_id``) are computed via the shared
+    :func:`detect_conflicts` so the preview's per-zone strategy picker
+    matches every other source.
+
+    Raises :class:`CloudDNSImportError` (a ``ValueError`` subclass) when
+    the server doesn't exist or isn't a cloud driver. Per-zone record
+    pull failures are non-fatal — they land in the affected zone's
+    ``parse_warnings``.
+    """
+
+    server = (
+        await db.execute(select(DNSServer).where(DNSServer.id == server_id))
+    ).scalar_one_or_none()
+    if server is None:
+        raise CloudDNSImportError(f"DNS server {server_id} does not exist")
+    if server.driver not in CLOUD_DRIVERS:
+        raise CloudDNSImportError(
+            f"DNS server {server.name!r} uses driver {server.driver!r}; "
+            f"cloud import requires one of {sorted(CLOUD_DRIVERS)}"
+        )
+
+    # Provider name doubles as the import_source provenance label.
+    source = cast(ImportSource, server.driver)
+    driver = get_driver(server.driver)
+
+    try:
+        zone_meta_list: list[dict[str, Any]] = await driver.pull_zones_from_server(server)
+    except Exception as exc:  # noqa: BLE001 — operator-facing error capture
+        raise CloudDNSImportError(
+            f"Could not list zones on cloud DNS server {server.name!r}: {exc}"
+        ) from exc
+
+    zones: list[ImportedZone] = []
+    overall_warnings: list[str] = []
+
+    for meta in zone_meta_list:
+        raw_name = str(meta.get("name") or "").strip()
+        if not raw_name:
+            continue
+        fqdn = _normalize_fqdn(raw_name).lower()
+        # Cloud providers only host primary (authoritative) zones; the
+        # driver's pull_zones_from_server already reports "Primary".
+        zone_type = "primary"
+        kind = "reverse" if meta.get("is_reverse_lookup") else "forward"
+
+        # SOA defaults — providers own the SOA + apex NS, and the record
+        # walker returns neither. SpatiumDDI rewrites the SOA from the
+        # zone's columns at push time, so these are operator-facing
+        # placeholders, flagged with a warning.
+        soa = ImportedSOA(
+            primary_ns="",
+            admin_email="",
+            serial=0,
+            refresh=_DEFAULT_SOA["refresh"],
+            retry=_DEFAULT_SOA["retry"],
+            expire=_DEFAULT_SOA["expire"],
+            minimum=_DEFAULT_SOA["minimum"],
+            ttl=_DEFAULT_SOA["ttl"],
+        )
+
+        per_zone_warnings: list[str] = [
+            "SOA defaults applied; edit primary_ns / admin_email / serial via the zone editor post-import"
+        ]
+        if meta.get("dnssec_enabled"):
+            per_zone_warnings.append(
+                f"{raw_name!r} is DNSSEC-signed on the provider; signing state "
+                "is not imported — re-enable online signing on the destination "
+                "driver after commit if required."
+            )
+
+        # Per-zone record pull. Failures here are non-fatal — surface
+        # them as warnings on the zone and move on so one bad zone in a
+        # large account doesn't abort the whole import.
+        records: list[ImportedRecord] = []
+        try:
+            pulled = await driver.pull_zone_records(server, raw_name)
+            for r in pulled:
+                records.append(
+                    ImportedRecord(
+                        name=r.name,
+                        record_type=r.record_type,
+                        value=r.value,
+                        ttl=r.ttl,
+                        priority=r.priority,
+                        weight=r.weight,
+                        port=r.port,
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001 — operator-facing
+            per_zone_warnings.append(f"Record pull failed: {exc}")
+
+        zones.append(
+            ImportedZone(
+                name=fqdn,
+                zone_type=zone_type,
+                kind=kind,
+                soa=soa,
+                records=records,
+                # Cloud providers have no BIND9-style view concept; the
+                # operator targets a SpatiumDDI view via target_view_id.
+                view_name=None,
+                forwarders=[],
+                skipped_record_types={},
+                parse_warnings=per_zone_warnings,
+            )
+        )
+
+    if not zones:
+        overall_warnings.append(
+            f"No hosted zones reported by the {server.driver} account. Check "
+            "that the configured credentials have list-zone permission."
+        )
+
+    total_records = sum(len(z.records) for z in zones)
+    histogram: dict[str, int] = {}
+    for z in zones:
+        for r in z.records:
+            histogram[r.record_type] = histogram.get(r.record_type, 0) + 1
+
+    conflicts = await detect_conflicts(
+        db,
+        zone_names=[z.name for z in zones],
+        target_group_id=target_group_id,
+        target_view_id=target_view_id,
+    )
+
+    logger.info(
+        "cloud_dns_import.preview",
+        driver=server.driver,
+        server=str(server.id),
+        zones=len(zones),
+        records=total_records,
+        conflicts=len(conflicts),
+    )
+
+    return ImportPreview(
+        source=source,
+        zones=zones,
+        conflicts=conflicts,
+        warnings=overall_warnings,
+        total_records=total_records,
+        record_type_histogram=histogram,
+    )
+
+
+async def commit_cloud_import(
+    db: AsyncSession,
+    *,
+    preview: ImportPreview,
+    target_group_id: uuid.UUID,
+    target_view_id: uuid.UUID | None,
+    conflict_actions: dict[str, tuple[ConflictAction, str | None]],
+    current_user: User,
+) -> CommitResult:
+    """Commit a cloud import preview.
+
+    Thin pass-through to the source-agnostic :func:`commit_import`. The
+    committer reads ``preview.source`` (the provider name) and stamps it
+    onto every ``DNSZone`` / ``DNSRecord`` ``import_source`` column, so
+    there's no cloud-specific commit logic — this wrapper exists only so
+    the API router can import a symmetric ``preview_*`` / ``commit_*``
+    pair (matching the Windows DNS endpoint's structure).
+    """
+
+    return await commit_import(
+        db,
+        preview=preview,
+        target_group_id=target_group_id,
+        target_view_id=target_view_id,
+        conflict_actions=conflict_actions,
+        current_user=current_user,
+    )

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -219,6 +219,13 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         description="Read-only mirror of UniFi networks + clients into IPAM. Supports local + cloud-hosted controllers; connect controllers from the UniFi page once enabled.",
         default_enabled=False,
     ),
+    ModuleSpec(
+        id="integrations.cloud",
+        label="Cloud (AWS / Azure / GCP)",
+        group="Integrations",
+        description="Read-only mirror of public-cloud infrastructure (VPCs / subnets / instance NICs / public + load-balancer IPs) into IPAM. Connect accounts from the Cloud page once enabled. (Cloud DNS is managed separately via the Add DNS server flow.)",
+        default_enabled=False,
+    ),
 )
 
 # Map a feature_module id to the ``PlatformSettings`` column whose
@@ -232,6 +239,7 @@ INTEGRATION_SETTINGS_MIRROR: Final[dict[str, str]] = {
     "integrations.proxmox": "integration_proxmox_enabled",
     "integrations.tailscale": "integration_tailscale_enabled",
     "integrations.unifi": "integration_unifi_enabled",
+    "integrations.cloud": "integration_cloud_enabled",
 }
 
 MODULES_BY_ID: Final[dict[str, ModuleSpec]] = {m.id: m for m in MODULES}

--- a/backend/app/tasks/cloud_sync.py
+++ b/backend/app/tasks/cloud_sync.py
@@ -1,0 +1,139 @@
+"""Periodic Cloud endpoint reconcile (issue #37, Part A).
+
+Mirrors ``proxmox_sync`` — 30 s beat tick, per-endpoint interval gating,
+platform-wide kill switch via ``PlatformSettings.integration_cloud_enabled``.
+Plus a ``sync_endpoint_now`` task for the UI's "Sync now" button.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.celery_app import celery_app
+from app.config import settings
+from app.models.cloud import CloudEndpoint
+from app.models.settings import PlatformSettings
+
+logger = structlog.get_logger(__name__)
+
+_PLATFORM_SINGLETON_ID = 1
+
+
+async def _run_sweep() -> dict[str, Any]:
+    from app.services.cloud.reconcile import reconcile_endpoint  # noqa: PLC0415
+
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            ps = await db.get(PlatformSettings, _PLATFORM_SINGLETON_ID)
+            if ps is None or not ps.integration_cloud_enabled:
+                return {"status": "disabled"}
+
+            rows = (
+                (await db.execute(select(CloudEndpoint).where(CloudEndpoint.enabled.is_(True))))
+                .scalars()
+                .all()
+            )
+
+            now = datetime.now(UTC)
+            ran = 0
+            skipped_interval = 0
+            ok_count = 0
+            err_count = 0
+            errors: list[str] = []
+
+            for endpoint in rows:
+                if endpoint.last_synced_at is not None:
+                    elapsed = now - endpoint.last_synced_at
+                    if elapsed < timedelta(seconds=endpoint.sync_interval_seconds):
+                        skipped_interval += 1
+                        continue
+                try:
+                    summary = await reconcile_endpoint(db, endpoint)
+                except Exception as exc:  # noqa: BLE001 — one endpoint shouldn't poison the sweep
+                    err_count += 1
+                    errors.append(f"{endpoint.name}: {exc}")
+                    logger.warning(
+                        "cloud_reconcile_crash",
+                        endpoint=str(endpoint.id),
+                        error=str(exc),
+                    )
+                    continue
+                ran += 1
+                if summary.ok:
+                    ok_count += 1
+                else:
+                    err_count += 1
+                    if summary.error:
+                        errors.append(f"{endpoint.name}: {summary.error}")
+
+            return {
+                "status": "ok",
+                "ran": ran,
+                "skipped_interval": skipped_interval,
+                "ok": ok_count,
+                "errors": err_count,
+                "error_messages": errors[:20],
+            }
+    finally:
+        await engine.dispose()
+
+
+async def _run_one(endpoint_id: str) -> dict[str, Any]:
+    import uuid as _uuid  # noqa: PLC0415
+
+    from app.services.cloud.reconcile import reconcile_endpoint  # noqa: PLC0415
+
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            endpoint = await db.get(CloudEndpoint, _uuid.UUID(endpoint_id))
+            if endpoint is None:
+                return {"status": "not_found"}
+            summary = await reconcile_endpoint(db, endpoint)
+            return {
+                "status": "ok" if summary.ok else "error",
+                "error": summary.error,
+                "provider_account_id": summary.provider_account_id,
+                "network_count": summary.network_count,
+                "instance_count": summary.instance_count,
+                "blocks_created": summary.blocks_created,
+                "blocks_deleted": summary.blocks_deleted,
+                "subnets_created": summary.subnets_created,
+                "subnets_updated": summary.subnets_updated,
+                "subnets_deleted": summary.subnets_deleted,
+                "subnets_matched": summary.subnets_matched,
+                "addresses_created": summary.addresses_created,
+                "addresses_updated": summary.addresses_updated,
+                "addresses_deleted": summary.addresses_deleted,
+                "skipped_no_subnet": summary.skipped_no_subnet,
+            }
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(
+    name="app.tasks.cloud_sync.sweep_cloud_endpoints",
+    bind=True,
+)
+def sweep_cloud_endpoints(self: Any) -> dict[str, Any]:  # noqa: ARG001
+    return asyncio.run(_run_sweep())
+
+
+@celery_app.task(
+    name="app.tasks.cloud_sync.sync_endpoint_now",
+    bind=True,
+)
+def sync_endpoint_now(self: Any, endpoint_id: str) -> dict[str, Any]:  # noqa: ARG001
+    return asyncio.run(_run_one(endpoint_id))
+
+
+__all__ = ["sweep_cloud_endpoints", "sync_endpoint_now"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,6 +45,19 @@ dependencies = [
     "azure-storage-blob>=12.20.0",
     "smbprotocol>=1.13.0",
     "google-cloud-storage>=2.18.0",
+    # Cloud integration (issue #37). AWS (infra mirror + Route 53 DNS) is
+    # covered by the existing boto3. Azure + GCP infra + DNS need their
+    # management SDKs; Cloudflare DNS uses plain REST via httpx (no SDK
+    # pin — keeps the dependency surface small + avoids the heavy
+    # cloudflare SDK's pydantic-v1 shim).
+    "azure-identity>=1.19.0",
+    "azure-mgmt-network>=28.0.0",
+    "azure-mgmt-compute>=33.0.0",
+    "azure-mgmt-dns>=8.2.0",
+    "azure-mgmt-resource>=23.0.0",
+    "google-cloud-compute>=1.19.0",
+    "google-cloud-dns>=0.35.0",
+    "google-auth>=2.35.0",
     # docker SDK — only used on the SpatiumDDI OS appliance to send
     # SIGHUP to the frontend container when a new TLS cert is
     # activated (Phase 4b.2, issue #134). The cert deployer is gated

--- a/backend/tests/test_cloud_aws.py
+++ b/backend/tests/test_cloud_aws.py
@@ -1,0 +1,474 @@
+"""Unit tests for the AWS cloud connector.
+
+These tests are fully offline (tier-3 provider, no test account): every
+boto3 call is served by a :class:`_StubClient` returning canned
+AWS-shaped dicts, wired in by monkeypatching ``AWSConnector._client``.
+botocore is not installed in CI, so the connector's lazy
+``_botocore_errors()`` returns an empty tuple — the success paths never
+exercise an ``except`` clause built from it, and the failure-path tests
+inject their own fake exception classes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services.cloud.aws import AWSConnector, _name_from_tags
+from app.services.cloud.base import CloudConnectorError
+
+
+class _StubClient:
+    """A single boto3 client whose method calls return canned dicts.
+
+    Constructed with a mapping of ``method_name -> response dict`` (or a
+    callable taking the call kwargs). Any method not in the map returns
+    an empty dict, mirroring boto3's "absent key" behaviour for the
+    paginated list shapes the connector reads with ``.get(..., [])``.
+    """
+
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self._responses = responses
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def __getattr__(self, name: str) -> Any:
+        def _call(**kwargs: Any) -> Any:
+            self.calls.append((name, kwargs))
+            value = self._responses.get(name, {})
+            return value(kwargs) if callable(value) else value
+
+        return _call
+
+
+def _make_connector(
+    clients: dict[str, _StubClient],
+    *,
+    regions: list[str] | None = None,
+) -> AWSConnector:
+    """Build an AWSConnector with ``_client`` patched to serve ``clients``.
+
+    ``clients`` is keyed by service name (``"ec2"``, ``"sts"``, ...);
+    every region resolves to the same stub for that service. ``regions``
+    is passed through verbatim — an explicit empty list keeps the
+    region-discovery path so ``test_..._discovers_all_regions`` works.
+    """
+    connector = AWSConnector(
+        credentials={"access_key_id": "AKIA", "secret_access_key": "secret"},
+        provider_config={},
+        regions=["us-east-1"] if regions is None else regions,
+    )
+
+    def _client(service: str, region: str) -> _StubClient:  # noqa: ARG001
+        return clients[service]
+
+    connector._client = _client  # type: ignore[method-assign]
+    return connector
+
+
+# ── _name_from_tags ──────────────────────────────────────────────────
+
+
+def test_name_from_tags_returns_name_value() -> None:
+    tags = [{"Key": "env", "Value": "prod"}, {"Key": "Name", "Value": "web-1"}]
+    assert _name_from_tags(tags, "i-fallback") == "web-1"
+
+
+def test_name_from_tags_falls_back_when_no_name() -> None:
+    assert _name_from_tags([{"Key": "env", "Value": "prod"}], "i-123") == "i-123"
+
+
+def test_name_from_tags_falls_back_on_none() -> None:
+    assert _name_from_tags(None, "vpc-fallback") == "vpc-fallback"
+
+
+# ── fetch_inventory ──────────────────────────────────────────────────
+
+
+def _ec2_full() -> _StubClient:
+    """An EC2 stub with a 2-CIDR VPC, one subnet, a running + a stopped
+    instance, and one Elastic IP.
+    """
+    return _StubClient(
+        {
+            "describe_vpcs": {
+                "Vpcs": [
+                    {
+                        "VpcId": "vpc-aaa",
+                        "Tags": [{"Key": "Name", "Value": "main-vpc"}],
+                        "CidrBlockAssociationSet": [
+                            {
+                                "CidrBlock": "10.0.0.0/16",
+                                "CidrBlockState": {"State": "associated"},
+                            },
+                            {
+                                "CidrBlock": "10.1.0.0/16",
+                                "CidrBlockState": {"State": "associated"},
+                            },
+                            {
+                                # disassociating CIDR is dropped
+                                "CidrBlock": "10.2.0.0/16",
+                                "CidrBlockState": {"State": "disassociating"},
+                            },
+                        ],
+                    }
+                ]
+            },
+            "describe_subnets": {
+                "Subnets": [
+                    {
+                        "SubnetId": "subnet-111",
+                        "VpcId": "vpc-aaa",
+                        "CidrBlock": "10.0.1.0/24",
+                        "AvailabilityZone": "us-east-1a",
+                        "Tags": [{"Key": "Name", "Value": "web-subnet"}],
+                    }
+                ]
+            },
+            # describe_instances honours the running-only filter: when the
+            # connector passes a state filter, return only the running box.
+            "describe_instances": _instances_response,
+            "describe_addresses": {
+                "Addresses": [
+                    {
+                        "PublicIp": "52.1.2.3",
+                        "AllocationId": "eipalloc-1",
+                        "InstanceId": "i-running",
+                        "Tags": [{"Key": "Name", "Value": "nat-eip"}],
+                    }
+                ]
+            },
+        }
+    )
+
+
+def _instances_response(kwargs: dict[str, Any]) -> dict[str, Any]:
+    running = {
+        "InstanceId": "i-running",
+        "State": {"Name": "running"},
+        "Tags": [{"Key": "Name", "Value": "app-1"}],
+        "NetworkInterfaces": [
+            {
+                "PrivateIpAddress": "10.0.1.10",
+                "MacAddress": "0a:1b:2c:3d:4e:5f",
+                "Association": {"PublicIp": "52.9.9.9"},
+            }
+        ],
+    }
+    stopped = {
+        "InstanceId": "i-stopped",
+        "State": {"Name": "stopped"},
+        "Tags": [{"Key": "Name", "Value": "app-2"}],
+        "NetworkInterfaces": [{"PrivateIpAddress": "10.0.1.11"}],
+    }
+    # When a state filter is present (include_stopped=False), AWS returns
+    # only the running instance; otherwise both.
+    if kwargs.get("Filters"):
+        return {"Reservations": [{"Instances": [running]}]}
+    return {"Reservations": [{"Instances": [running, stopped]}]}
+
+
+def _elb_stubs() -> dict[str, _StubClient]:
+    """ELBv2 stub with one NLB (static IP) + one ALB (DNS-only), plus a
+    classic ELB stub.
+    """
+    elbv2 = _StubClient(
+        {
+            "describe_load_balancers": {
+                "LoadBalancers": [
+                    {
+                        "LoadBalancerArn": "arn:nlb",
+                        "LoadBalancerName": "net-lb",
+                        "Type": "network",
+                        "AvailabilityZones": [
+                            {"LoadBalancerAddresses": [{"IpAddress": "203.0.113.5"}]}
+                        ],
+                    },
+                    {
+                        "LoadBalancerArn": "arn:alb",
+                        "LoadBalancerName": "app-lb",
+                        "Type": "application",
+                        "AvailabilityZones": [],
+                    },
+                ]
+            }
+        }
+    )
+    elb = _StubClient(
+        {
+            "describe_load_balancers": {
+                "LoadBalancerDescriptions": [{"LoadBalancerName": "classic-lb"}]
+            }
+        }
+    )
+    return {"elbv2": elbv2, "elb": elb}
+
+
+async def test_fetch_inventory_normalizes_running_only() -> None:
+    clients = {
+        "sts": _StubClient({"get_caller_identity": {"Account": "123456789012"}}),
+        "ec2": _ec2_full(),
+        **_elb_stubs(),
+    }
+    connector = _make_connector(clients, regions=["us-east-1"])
+
+    inv = await connector.fetch_inventory(include_stopped=False)
+
+    assert inv.account_id == "123456789012"
+
+    # 2-CIDR VPC: the disassociating third CIDR is dropped.
+    assert len(inv.networks) == 1
+    net = inv.networks[0]
+    assert net.id == "vpc-aaa"
+    assert net.name == "main-vpc"
+    assert net.cidrs == ("10.0.0.0/16", "10.1.0.0/16")
+    assert net.region == "us-east-1"
+
+    # Subnet carries the AZ as its region.
+    assert len(inv.subnets) == 1
+    subnet = inv.subnets[0]
+    assert subnet.id == "subnet-111"
+    assert subnet.network_id == "vpc-aaa"
+    assert subnet.cidr == "10.0.1.0/24"
+    assert subnet.region == "us-east-1a"
+
+    # Only the running instance — the stopped one is filtered out.
+    assert len(inv.instances) == 1
+    inst = inv.instances[0]
+    assert inst.id == "i-running"
+    assert inst.name == "app-1"
+    assert inst.running is True
+    assert len(inst.nics) == 1
+    nic = inst.nics[0]
+    assert nic.private_ip == "10.0.1.10"
+    assert nic.public_ip == "52.9.9.9"
+    assert nic.mac == "0a:1b:2c:3d:4e:5f"
+
+    # Elastic IP, attached because it references an instance.
+    assert len(inv.public_ips) == 1
+    eip = inv.public_ips[0]
+    assert eip.address == "52.1.2.3"
+    assert eip.name == "nat-eip"
+    assert eip.attached is True
+
+
+async def test_fetch_inventory_include_stopped_returns_both() -> None:
+    clients = {
+        "sts": _StubClient({"get_caller_identity": {"Account": "123456789012"}}),
+        "ec2": _ec2_full(),
+        **_elb_stubs(),
+    }
+    connector = _make_connector(clients, regions=["us-east-1"])
+
+    inv = await connector.fetch_inventory(include_stopped=True)
+
+    ids = {i.id for i in inv.instances}
+    assert ids == {"i-running", "i-stopped"}
+    stopped = next(i for i in inv.instances if i.id == "i-stopped")
+    assert stopped.running is False
+
+
+async def test_fetch_inventory_nlb_ip_alb_and_classic_warn() -> None:
+    clients = {
+        "sts": _StubClient({"get_caller_identity": {"Account": "123456789012"}}),
+        "ec2": _ec2_full(),
+        **_elb_stubs(),
+    }
+    connector = _make_connector(clients, regions=["us-east-1"])
+
+    inv = await connector.fetch_inventory(include_load_balancers=True)
+
+    # The NLB is mirrored with its static frontend IP.
+    assert len(inv.load_balancers) == 1
+    nlb = inv.load_balancers[0]
+    assert nlb.name == "net-lb"
+    assert nlb.frontend_ips == ("203.0.113.5",)
+
+    # ALB + classic ELB both produce a warning and are skipped.
+    joined = "\n".join(inv.warnings)
+    assert "app-lb" in joined
+    assert "classic-lb" in joined
+    assert len([w for w in inv.warnings if "DNS-name-only" in w]) == 2
+
+
+async def test_fetch_inventory_skips_load_balancers_when_disabled() -> None:
+    clients = {
+        "sts": _StubClient({"get_caller_identity": {"Account": "123456789012"}}),
+        "ec2": _ec2_full(),
+        **_elb_stubs(),
+    }
+    connector = _make_connector(clients, regions=["us-east-1"])
+
+    inv = await connector.fetch_inventory(include_load_balancers=False)
+
+    assert inv.load_balancers == []
+    # No DNS-only LB warnings either since elbv2/elb were never called.
+    assert not any("DNS-name-only" in w for w in inv.warnings)
+
+
+async def test_fetch_inventory_per_region_failure_warns_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A botocore error in one region becomes a warning, not a raise."""
+
+    class _FakeClientError(Exception):
+        pass
+
+    # Make _botocore_errors match our fake so the per-region except hits.
+    monkeypatch.setattr(
+        AWSConnector,
+        "_botocore_errors",
+        staticmethod(lambda: (_FakeClientError,)),
+    )
+
+    good_ec2 = _ec2_full()
+    sts = _StubClient({"get_caller_identity": {"Account": "123456789012"}})
+
+    def boom(_kwargs: dict[str, Any]) -> Any:
+        raise _FakeClientError("AccessDenied in eu-west-1")
+
+    bad_ec2 = _StubClient({"describe_vpcs": boom})
+    elbs = _elb_stubs()
+
+    connector = AWSConnector(
+        credentials={"access_key_id": "AKIA", "secret_access_key": "secret"},
+        provider_config={},
+        regions=["us-east-1", "eu-west-1"],
+    )
+
+    def _client(service: str, region: str) -> _StubClient:
+        if service == "sts":
+            return sts
+        if service == "ec2":
+            return good_ec2 if region == "us-east-1" else bad_ec2
+        return elbs[service]
+
+    connector._client = _client  # type: ignore[method-assign]
+
+    inv = await connector.fetch_inventory()
+
+    # us-east-1 still produced its VPC; eu-west-1 produced a warning.
+    assert [n.id for n in inv.networks] == ["vpc-aaa"]
+    assert any("eu-west-1" in w and "AccessDenied" in w for w in inv.warnings)
+
+
+async def test_fetch_inventory_auth_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeAuthError(Exception):
+        pass
+
+    monkeypatch.setattr(
+        AWSConnector,
+        "_botocore_errors",
+        staticmethod(lambda: (_FakeAuthError,)),
+    )
+
+    def boom(_kwargs: dict[str, Any]) -> Any:
+        raise _FakeAuthError("InvalidClientTokenId")
+
+    sts = _StubClient({"get_caller_identity": boom})
+    connector = _make_connector({"sts": sts}, regions=["us-east-1"])
+
+    with pytest.raises(CloudConnectorError, match="authentication failed"):
+        await connector.fetch_inventory()
+
+
+async def test_fetch_inventory_discovers_all_regions_when_empty() -> None:
+    """An empty region list triggers ec2:DescribeRegions in the bootstrap
+    region, and the returned regions are walked.
+    """
+    sts = _StubClient({"get_caller_identity": {"Account": "123456789012"}})
+    # The bootstrap ec2 client answers describe_regions; the same stub
+    # also answers the per-region describe_* calls (single VPC).
+    ec2 = _StubClient(
+        {
+            "describe_regions": {
+                "Regions": [
+                    {"RegionName": "us-west-2"},
+                    {"RegionName": "us-east-1"},
+                ]
+            },
+            "describe_vpcs": {
+                "Vpcs": [
+                    {
+                        "VpcId": "vpc-z",
+                        "CidrBlockAssociationSet": [
+                            {
+                                "CidrBlock": "172.16.0.0/16",
+                                "CidrBlockState": {"State": "associated"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        }
+    )
+    connector = _make_connector({"sts": sts, "ec2": ec2, **_elb_stubs()}, regions=[])
+
+    inv = await connector.fetch_inventory(include_load_balancers=False)
+
+    # Two discovered regions × one VPC each (the same ec2 stub).
+    assert [n.id for n in inv.networks] == ["vpc-z", "vpc-z"]
+    assert {n.region for n in inv.networks} == {"us-west-2", "us-east-1"}
+
+
+# ── probe ─────────────────────────────────────────────────────────────
+
+
+async def test_probe_ok() -> None:
+    sts = _StubClient({"get_caller_identity": {"Account": "999988887777"}})
+    ec2 = _StubClient({"describe_vpcs": {"Vpcs": [{"VpcId": "vpc-1"}, {"VpcId": "vpc-2"}]}})
+    connector = _make_connector({"sts": sts, "ec2": ec2}, regions=["us-east-1"])
+
+    result = await connector.probe()
+
+    assert result.ok is True
+    assert result.account_id == "999988887777"
+    assert result.network_count == 2
+
+
+async def test_probe_failure_returns_not_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeError(Exception):
+        pass
+
+    monkeypatch.setattr(
+        AWSConnector,
+        "_botocore_errors",
+        staticmethod(lambda: (_FakeError,)),
+    )
+
+    def boom(_kwargs: dict[str, Any]) -> Any:
+        raise _FakeError("SignatureDoesNotMatch")
+
+    sts = _StubClient({"get_caller_identity": boom})
+    connector = _make_connector({"sts": sts}, regions=["us-east-1"])
+
+    result = await connector.probe()
+
+    assert result.ok is False
+    assert "SignatureDoesNotMatch" in result.message
+    assert result.account_id is None
+
+
+async def test_probe_handles_missing_boto3() -> None:
+    """When _client raises CloudConnectorError (boto3 absent), probe
+    returns ok=False rather than propagating.
+    """
+    connector = AWSConnector(
+        credentials={"access_key_id": "AKIA", "secret_access_key": "secret"},
+        provider_config={},
+        regions=["us-east-1"],
+    )
+
+    def _client(service: str, region: str) -> Any:  # noqa: ARG001
+        raise CloudConnectorError("boto3 is not installed; the AWS connector is unavailable.")
+
+    connector._client = _client  # type: ignore[method-assign]
+
+    result = await connector.probe()
+
+    assert result.ok is False
+    assert "boto3 is not installed" in result.message

--- a/backend/tests/test_cloud_azure.py
+++ b/backend/tests/test_cloud_azure.py
@@ -1,0 +1,386 @@
+"""Offline unit tests for the Azure cloud connector (#37).
+
+These are tier-3 provider tests with no Azure account available, so they
+never touch a real API. The Azure SDK isn't a runtime dependency here, so
+we inject minimal stub ``azure.*`` modules into ``sys.modules`` (giving the
+connector's lazy ``from azure.core.exceptions import ...`` a real exception
+class to catch) and monkeypatch the connector's client-factory layer
+(``_credential`` / ``_network_client`` / ``_compute_client``) to return
+SimpleNamespace stubs shaped like the ARM SDK responses.
+
+Coverage:
+  * ``fetch_inventory`` normalises a VNet with 2 address prefixes + a
+    nested subnet, a running VM with one NIC (private + public + MAC),
+    a standalone public IP, and an LB frontend.
+  * region allow-list filters resources by location.
+  * ``include_stopped`` gates non-running VMs.
+  * a per-subscription HttpResponseError folds into ``warnings`` while a
+    healthy subscription still reconciles; an all-subscriptions failure
+    raises ``CloudConnectorError``.
+  * ``probe`` ok path + ``ClientAuthenticationError`` failure path.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+# ── Stub azure.* modules so the connector's lazy imports resolve ───────
+#
+# The connector only ever imports two exception classes from the SDK
+# (``ClientAuthenticationError`` + ``HttpResponseError``); the client
+# classes themselves are reached through the monkeypatched factory layer,
+# so the stub packages only need to exist (empty) to satisfy the import
+# machinery. Installed at import time, before the connector is imported.
+
+
+class _StubHttpResponseError(Exception):
+    """Stand-in for ``azure.core.exceptions.HttpResponseError``."""
+
+
+class _StubClientAuthenticationError(_StubHttpResponseError):
+    """Stand-in for ``azure.core.exceptions.ClientAuthenticationError``."""
+
+
+def _install_azure_stubs() -> None:
+    core = types.ModuleType("azure.core")
+    core_exc = types.ModuleType("azure.core.exceptions")
+    core_exc.HttpResponseError = _StubHttpResponseError  # type: ignore[attr-defined]
+    core_exc.ClientAuthenticationError = _StubClientAuthenticationError  # type: ignore[attr-defined]
+
+    azure = types.ModuleType("azure")
+    identity = types.ModuleType("azure.identity")
+    mgmt = types.ModuleType("azure.mgmt")
+    mgmt_network = types.ModuleType("azure.mgmt.network")
+    mgmt_compute = types.ModuleType("azure.mgmt.compute")
+    # The factory layer is monkeypatched in tests, so these only need to
+    # be importable; give them no-op placeholders.
+    identity.ClientSecretCredential = object  # type: ignore[attr-defined]
+    mgmt_network.NetworkManagementClient = object  # type: ignore[attr-defined]
+    mgmt_compute.ComputeManagementClient = object  # type: ignore[attr-defined]
+
+    sys.modules.setdefault("azure", azure)
+    sys.modules.setdefault("azure.core", core)
+    sys.modules["azure.core.exceptions"] = core_exc
+    sys.modules["azure.identity"] = identity
+    sys.modules["azure.mgmt"] = mgmt
+    sys.modules["azure.mgmt.network"] = mgmt_network
+    sys.modules["azure.mgmt.compute"] = mgmt_compute
+
+
+_install_azure_stubs()
+
+from app.services.cloud.azure import AzureConnector  # noqa: E402
+from app.services.cloud.base import (  # noqa: E402
+    CloudConnectorError,
+    CloudInventory,
+    CloudProbeResult,
+)
+
+_CREDS = {
+    "tenant_id": "tenant-1",
+    "client_id": "client-1",
+    "client_secret": "secret-1",
+}
+
+# ARM resource ids are long; build them from a shared scope prefix so every
+# literal stays under the 100-char line limit and the shapes read clearly.
+_NET = "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Network"
+_COMPUTE = "/subscriptions/sub-1/resourceGroups/rg1/providers/Microsoft.Compute"
+_VNET_ID = f"{_NET}/virtualNetworks/vnet1"
+_SUBNET_ID = f"{_VNET_ID}/subnets/snet1"
+_PIP_ID = f"{_NET}/publicIPAddresses/pip1"
+_NIC_ID = f"{_NET}/networkInterfaces/nic1"
+_LB_ID = f"{_NET}/loadBalancers/lb1"
+_VM_ID = f"{_COMPUTE}/virtualMachines/vm1"
+
+
+# ── ARM-shaped stub builders ───────────────────────────────────────────
+
+
+def _vnet() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=_VNET_ID,
+        name="vnet1",
+        location="eastus",
+        address_space=SimpleNamespace(address_prefixes=["10.0.0.0/16", "10.1.0.0/16"]),
+        subnets=[
+            SimpleNamespace(
+                id=_SUBNET_ID,
+                name="snet1",
+                address_prefix="10.0.1.0/24",
+                address_prefixes=None,
+            )
+        ],
+    )
+
+
+def _public_ip() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=_PIP_ID,
+        name="pip1",
+        location="eastus",
+        ip_address="52.1.2.3",
+        ip_configuration=SimpleNamespace(id="ipconf-1"),
+    )
+
+
+def _nic() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=_NIC_ID,
+        mac_address="00-0D-3A-11-22-33",
+        ip_configurations=[
+            SimpleNamespace(
+                private_ip_address="10.0.1.4",
+                public_ip_address=SimpleNamespace(id=_PIP_ID, ip_address=None),
+            )
+        ],
+    )
+
+
+def _vm() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=_VM_ID,
+        name="vm1",
+        location="eastus",
+        network_profile=SimpleNamespace(network_interfaces=[SimpleNamespace(id=_NIC_ID)]),
+    )
+
+
+def _lb() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=_LB_ID,
+        name="lb1",
+        location="eastus",
+        frontend_ip_configurations=[
+            SimpleNamespace(
+                public_ip_address=SimpleNamespace(id=_PIP_ID, ip_address=None),
+                private_ip_address=None,
+            )
+        ],
+    )
+
+
+class _StubNetworkClient:
+    def __init__(self, *, raise_on_list: Exception | None = None) -> None:
+        self._raise = raise_on_list
+        self.virtual_networks = SimpleNamespace(list_all=self._vnets)
+        self.network_interfaces = SimpleNamespace(list_all=lambda: [_nic()])
+        self.public_ip_addresses = SimpleNamespace(list_all=lambda: [_public_ip()])
+        self.load_balancers = SimpleNamespace(list_all=lambda: [_lb()])
+
+    def _vnets(self) -> list[SimpleNamespace]:
+        if self._raise is not None:
+            raise self._raise
+        return [_vnet()]
+
+
+class _StubComputeClient:
+    def __init__(self, *, running: bool = True) -> None:
+        self._running = running
+        self.virtual_machines = SimpleNamespace(
+            list_all=lambda: [_vm()],
+            instance_view=self._instance_view,
+        )
+
+    def _instance_view(self, resource_group: str, name: str) -> SimpleNamespace:
+        code = "PowerState/running" if self._running else "PowerState/deallocated"
+        return SimpleNamespace(
+            statuses=[
+                SimpleNamespace(code="ProvisioningState/succeeded"),
+                SimpleNamespace(code=code),
+            ]
+        )
+
+
+def _make_connector(
+    *,
+    regions: list[str] | None = None,
+    network_client: Any = None,
+    compute_client: Any = None,
+    network_factory: Any = None,
+) -> AzureConnector:
+    """Build a connector with monkeypatched factories.
+
+    ``network_factory`` takes precedence (per-subscription dispatch);
+    otherwise a fixed ``network_client`` / ``compute_client`` is returned
+    for every subscription.
+    """
+    conn = AzureConnector(
+        credentials=_CREDS,
+        provider_config={"subscription_ids": ["sub-1"]},
+        regions=regions,
+    )
+    net = network_client or _StubNetworkClient()
+    comp = compute_client or _StubComputeClient()
+    conn._credential = lambda: SimpleNamespace()  # type: ignore[method-assign]
+    if network_factory is not None:
+        conn._network_client = network_factory  # type: ignore[method-assign]
+    else:
+        conn._network_client = lambda subscription_id: net  # type: ignore[method-assign]
+    conn._compute_client = lambda subscription_id: comp  # type: ignore[method-assign]
+    return conn
+
+
+# ── Tests ──────────────────────────────────────────────────────────────
+
+
+async def test_fetch_inventory_normalizes_all_resource_kinds() -> None:
+    conn = _make_connector()
+    inv = await conn.fetch_inventory()
+
+    assert isinstance(inv, CloudInventory)
+    assert inv.account_id == "sub-1"
+    assert inv.warnings == []
+
+    # VNet with two address prefixes → one CloudNetwork carrying both.
+    assert len(inv.networks) == 1
+    net = inv.networks[0]
+    assert net.name == "vnet1"
+    assert net.cidrs == ("10.0.0.0/16", "10.1.0.0/16")
+    assert net.region == "eastus"
+
+    # Nested subnet normalised with parent network_id linkage.
+    assert len(inv.subnets) == 1
+    snet = inv.subnets[0]
+    assert snet.name == "snet1"
+    assert snet.cidr == "10.0.1.0/24"
+    assert snet.network_id == net.id
+
+    # Running VM with a single NIC: private + resolved public + MAC.
+    assert len(inv.instances) == 1
+    vm = inv.instances[0]
+    assert vm.name == "vm1"
+    assert vm.running is True
+    assert len(vm.nics) == 1
+    nic = vm.nics[0]
+    assert nic.private_ip == "10.0.1.4"
+    assert nic.public_ip == "52.1.2.3"  # resolved via pip index, not inline
+    assert nic.mac == "00-0D-3A-11-22-33"
+
+    # Standalone public IP.
+    assert len(inv.public_ips) == 1
+    pip = inv.public_ips[0]
+    assert pip.address == "52.1.2.3"
+    assert pip.name == "pip1"
+    assert pip.attached is True
+
+    # LB frontend resolved to the public IP.
+    assert len(inv.load_balancers) == 1
+    lb = inv.load_balancers[0]
+    assert lb.name == "lb1"
+    assert lb.frontend_ips == ("52.1.2.3",)
+
+
+async def test_region_allowlist_filters_out_non_matching() -> None:
+    conn = _make_connector(regions=["westeurope"])
+    inv = await conn.fetch_inventory()
+    # Every stub resource lives in eastus, so all are filtered out.
+    assert inv.networks == []
+    assert inv.subnets == []
+    assert inv.instances == []
+    assert inv.public_ips == []
+    assert inv.load_balancers == []
+
+
+async def test_include_stopped_gates_non_running_vms() -> None:
+    stopped = _make_connector(compute_client=_StubComputeClient(running=False))
+    inv = await stopped.fetch_inventory(include_stopped=False)
+    assert inv.instances == []
+
+    stopped2 = _make_connector(compute_client=_StubComputeClient(running=False))
+    inv2 = await stopped2.fetch_inventory(include_stopped=True)
+    assert len(inv2.instances) == 1
+    assert inv2.instances[0].running is False
+
+
+async def test_include_load_balancers_false_skips_lbs() -> None:
+    conn = _make_connector()
+    inv = await conn.fetch_inventory(include_load_balancers=False)
+    assert inv.load_balancers == []
+    # Other resources still present.
+    assert len(inv.networks) == 1
+
+
+async def test_per_subscription_failure_folds_into_warnings() -> None:
+    healthy = _StubNetworkClient()
+    broken = _StubNetworkClient(raise_on_list=_StubHttpResponseError("boom"))
+
+    def factory(subscription_id: str) -> _StubNetworkClient:
+        return healthy if subscription_id == "sub-1" else broken
+
+    conn = AzureConnector(
+        credentials=_CREDS,
+        provider_config={"subscription_ids": ["sub-1", "sub-2"]},
+        regions=None,
+    )
+    conn._credential = lambda: SimpleNamespace()  # type: ignore[method-assign]
+    conn._network_client = factory  # type: ignore[method-assign]
+    conn._compute_client = lambda subscription_id: _StubComputeClient()  # type: ignore[method-assign]
+
+    inv = await conn.fetch_inventory()
+    # The healthy subscription still produced its VNet.
+    assert len(inv.networks) == 1
+    # The broken one is recorded as a non-fatal warning.
+    assert any("sub-2" in w and "boom" in w for w in inv.warnings)
+
+
+async def test_all_subscriptions_failing_raises() -> None:
+    broken = _StubNetworkClient(raise_on_list=_StubHttpResponseError("dead"))
+    conn = _make_connector(network_client=broken)
+    with pytest.raises(CloudConnectorError):
+        await conn.fetch_inventory()
+
+
+async def test_no_subscriptions_raises() -> None:
+    conn = AzureConnector(
+        credentials=_CREDS,
+        provider_config={"subscription_ids": []},
+        regions=None,
+    )
+    with pytest.raises(CloudConnectorError):
+        await conn.fetch_inventory()
+
+
+async def test_probe_ok() -> None:
+    conn = _make_connector()
+    result = await conn.probe()
+    assert isinstance(result, CloudProbeResult)
+    assert result.ok is True
+    assert result.account_id == "sub-1"
+    assert result.network_count == 1
+
+
+async def test_probe_auth_failure_returns_not_ok() -> None:
+    broken = _StubNetworkClient(raise_on_list=_StubClientAuthenticationError("bad creds"))
+    conn = _make_connector(network_client=broken)
+    result = await conn.probe()
+    assert result.ok is False
+    assert "bad creds" in result.message
+    assert result.account_id == "sub-1"
+
+
+async def test_probe_no_subscriptions_returns_not_ok() -> None:
+    conn = AzureConnector(
+        credentials=_CREDS,
+        provider_config={"subscription_ids": []},
+        regions=None,
+    )
+    result = await conn.probe()
+    assert result.ok is False
+    # Falls back to tenant_id for the account_id when no subscription set.
+    assert result.account_id == "tenant-1"
+
+
+def test_rg_from_id_extracts_resource_group() -> None:
+    rid = (
+        "/subscriptions/sub-1/resourceGroups/MyRG/providers/"
+        "Microsoft.Compute/virtualMachines/vm1"
+    )
+    assert AzureConnector._rg_from_id(rid) == "MyRG"
+    assert AzureConnector._rg_from_id(None) is None
+    assert AzureConnector._rg_from_id("/subscriptions/sub-1") is None

--- a/backend/tests/test_cloud_azure.py
+++ b/backend/tests/test_cloud_azure.py
@@ -217,7 +217,7 @@ def _make_connector(
     )
     net = network_client or _StubNetworkClient()
     comp = compute_client or _StubComputeClient()
-    conn._credential = lambda: SimpleNamespace()  # type: ignore[method-assign]
+    conn._credential = SimpleNamespace  # type: ignore[method-assign]
     if network_factory is not None:
         conn._network_client = network_factory  # type: ignore[method-assign]
     else:
@@ -318,7 +318,7 @@ async def test_per_subscription_failure_folds_into_warnings() -> None:
         provider_config={"subscription_ids": ["sub-1", "sub-2"]},
         regions=None,
     )
-    conn._credential = lambda: SimpleNamespace()  # type: ignore[method-assign]
+    conn._credential = SimpleNamespace  # type: ignore[method-assign]
     conn._network_client = factory  # type: ignore[method-assign]
     conn._compute_client = lambda subscription_id: _StubComputeClient()  # type: ignore[method-assign]
 

--- a/backend/tests/test_cloud_gcp.py
+++ b/backend/tests/test_cloud_gcp.py
@@ -108,7 +108,7 @@ def _make_connector(
     )
 
     # Skip the real SDK credential build entirely.
-    monkeypatch.setattr(conn, "_credentials", lambda: object())
+    monkeypatch.setattr(conn, "_credentials", object)
 
     def _client(list_items: list[Any] | None = None, agg_pages: Any = None) -> Mock:
         m = Mock()
@@ -341,7 +341,7 @@ async def test_per_project_failure_becomes_warning(monkeypatch: pytest.MonkeyPat
         credentials={"service_account_json": _KEY},
         provider_config={"project_ids": ["proj-1"]},
     )
-    monkeypatch.setattr(conn, "_credentials", lambda: object())
+    monkeypatch.setattr(conn, "_credentials", object)
     monkeypatch.setattr(conn, "_describe_error", staticmethod(lambda exc: f"boom: {exc}"))
 
     def _boom(_c: Any) -> Mock:
@@ -363,7 +363,7 @@ async def test_fetch_inventory_no_projects_warns(monkeypatch: pytest.MonkeyPatch
         credentials={"service_account_json": _KEY},
         provider_config={"project_ids": []},
     )
-    monkeypatch.setattr(conn, "_credentials", lambda: object())
+    monkeypatch.setattr(conn, "_credentials", object)
 
     inv = await conn.fetch_inventory()
 
@@ -411,7 +411,7 @@ async def test_probe_auth_failure_returns_not_ok(monkeypatch: pytest.MonkeyPatch
         credentials={"service_account_json": _KEY},
         provider_config={"project_ids": ["proj-1"]},
     )
-    monkeypatch.setattr(conn, "_credentials", lambda: object())
+    monkeypatch.setattr(conn, "_credentials", object)
     monkeypatch.setattr(conn, "_describe_error", staticmethod(lambda exc: "GCP auth failed"))
 
     def _boom(_c: Any) -> Mock:
@@ -448,7 +448,7 @@ async def test_probe_no_projects_returns_not_ok(monkeypatch: pytest.MonkeyPatch)
         credentials={"service_account_json": _KEY},
         provider_config={"project_ids": []},
     )
-    monkeypatch.setattr(conn, "_credentials", lambda: object())
+    monkeypatch.setattr(conn, "_credentials", object)
 
     result = await conn.probe()
 

--- a/backend/tests/test_cloud_gcp.py
+++ b/backend/tests/test_cloud_gcp.py
@@ -1,0 +1,456 @@
+"""Tests for the GCP cloud connector.
+
+The ``google-cloud-compute`` / ``google-auth`` SDKs are optional and not
+installed in CI, and there is no GCP test account — so every test stubs
+the per-client factory methods (``_networks_client`` etc.) and the
+credential builder (``_credentials``). Each stub returns Mocks whose
+``list`` / ``aggregated_list`` yield ``SimpleNamespace`` objects shaped
+like the real protobuf responses (note the snake_case ``network_i_p`` /
+``nat_i_p`` / ``i_p_address`` quirks). Everything stays offline and
+deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from app.services.cloud.base import CloudConnectorError, CloudProbeResult
+from app.services.cloud.gcp import GCPConnector, _basename, _region_from_zone
+
+# ── Fixtures: fake GCP protobuf objects + aggregated_list pages ──────────
+
+_KEY = json.dumps(
+    {
+        "type": "service_account",
+        "project_id": "proj-1",
+        "client_email": "svc@proj-1.iam.gserviceaccount.com",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+    }
+)
+
+
+def _network(id_: int, name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=id_, name=name)
+
+
+def _subnet(id_: int, name: str, network: str, cidr: str, region: str) -> SimpleNamespace:
+    # ``network`` / ``region`` are full self-links in the real API.
+    return SimpleNamespace(
+        id=id_,
+        name=name,
+        network=f"https://www.googleapis.com/compute/v1/projects/p/global/networks/{network}",
+        ip_cidr_range=cidr,
+        region=f"https://www.googleapis.com/compute/v1/projects/p/regions/{region}",
+    )
+
+
+def _nic(network_ip: str, nat_ip: str | None) -> SimpleNamespace:
+    access = [SimpleNamespace(nat_i_p=nat_ip)] if nat_ip else []
+    return SimpleNamespace(network_i_p=network_ip, access_configs=access)
+
+
+def _instance(
+    id_: int, name: str, status: str, zone: str, nics: list[SimpleNamespace]
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=id_,
+        name=name,
+        status=status,
+        zone=f"https://www.googleapis.com/compute/v1/projects/p/zones/{zone}",
+        network_interfaces=nics,
+    )
+
+
+def _address(name: str, address: str, address_type: str, users: list[str]) -> SimpleNamespace:
+    return SimpleNamespace(name=name, address=address, address_type=address_type, users=users)
+
+
+def _forwarding_rule(id_: int, name: str, ip: str, region: str | None) -> SimpleNamespace:
+    region_link = (
+        f"https://www.googleapis.com/compute/v1/projects/p/regions/{region}" if region else None
+    )
+    return SimpleNamespace(id=id_, name=name, i_p_address=ip, region=region_link)
+
+
+def _agg(attr: str, scope: str, items: list[Any]) -> list[tuple[str, SimpleNamespace]]:
+    """Build one ``aggregated_list`` page: a (scope, scoped_list) pair.
+
+    The scoped list exposes the resource list under ``attr`` (the name the
+    real client uses, e.g. ``subnetworks``). An empty scope carries only a
+    ``warning`` attribute — modelled with the resource attr set to ``[]``.
+    """
+    scoped = SimpleNamespace(**{attr: items})
+    return [(scope, scoped)]
+
+
+def _make_connector(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    networks: list[SimpleNamespace],
+    subnets: list[SimpleNamespace],
+    instances: list[SimpleNamespace],
+    addresses: list[SimpleNamespace],
+    global_addresses: list[SimpleNamespace],
+    forwarding_rules: list[SimpleNamespace],
+    global_forwarding_rules: list[SimpleNamespace],
+    regions: list[str] | None = None,
+    project_ids: list[str] | None = None,
+) -> GCPConnector:
+    conn = GCPConnector(
+        credentials={"service_account_json": _KEY},
+        provider_config={"project_ids": project_ids or ["proj-1"]},
+        regions=regions,
+    )
+
+    # Skip the real SDK credential build entirely.
+    monkeypatch.setattr(conn, "_credentials", lambda: object())
+
+    def _client(list_items: list[Any] | None = None, agg_pages: Any = None) -> Mock:
+        m = Mock()
+        if list_items is not None:
+            m.list.return_value = list_items
+        if agg_pages is not None:
+            m.aggregated_list.return_value = agg_pages
+        return m
+
+    monkeypatch.setattr(conn, "_networks_client", lambda _c: _client(list_items=networks))
+    monkeypatch.setattr(
+        conn,
+        "_subnetworks_client",
+        lambda _c: _client(agg_pages=_agg("subnetworks", "regions/us-central1", subnets)),
+    )
+    monkeypatch.setattr(
+        conn,
+        "_instances_client",
+        lambda _c: _client(agg_pages=_agg("instances", "zones/us-central1-a", instances)),
+    )
+    monkeypatch.setattr(
+        conn,
+        "_addresses_client",
+        lambda _c: _client(agg_pages=_agg("addresses", "regions/us-central1", addresses)),
+    )
+    monkeypatch.setattr(
+        conn, "_global_addresses_client", lambda _c: _client(list_items=global_addresses)
+    )
+    monkeypatch.setattr(
+        conn,
+        "_forwarding_rules_client",
+        lambda _c: _client(
+            agg_pages=_agg("forwarding_rules", "regions/us-central1", forwarding_rules)
+        ),
+    )
+    monkeypatch.setattr(
+        conn,
+        "_global_forwarding_rules_client",
+        lambda _c: _client(list_items=global_forwarding_rules),
+    )
+    return conn
+
+
+# ── Helper unit tests ────────────────────────────────────────────────────
+
+
+def test_basename_handles_selflink_and_empty() -> None:
+    assert _basename("https://x/projects/p/regions/us-central1") == "us-central1"
+    assert _basename("default") == "default"
+    assert _basename(None) == ""
+    assert _basename("") == ""
+
+
+def test_region_from_zone_trims_suffix() -> None:
+    assert _region_from_zone("https://x/zones/us-central1-a") == "us-central1"
+    assert _region_from_zone("europe-west4-b") == "europe-west4"
+    assert _region_from_zone(None) == ""
+
+
+# ── Inventory ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_inventory_full_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _make_connector(
+        monkeypatch,
+        networks=[_network(111, "vpc-a")],
+        subnets=[_subnet(222, "sub-a", "vpc-a", "10.0.0.0/24", "us-central1")],
+        instances=[
+            _instance(
+                333,
+                "vm-running",
+                "RUNNING",
+                "us-central1-a",
+                [_nic("10.0.0.5", "34.1.2.3")],
+            ),
+            _instance(444, "vm-stopped", "TERMINATED", "us-central1-a", [_nic("10.0.0.6", None)]),
+        ],
+        addresses=[
+            _address("ext-ip", "34.9.9.9", "EXTERNAL", users=["fwd-rule"]),
+            _address("int-ip", "10.0.0.250", "INTERNAL", users=[]),
+        ],
+        global_addresses=[],
+        forwarding_rules=[_forwarding_rule(555, "lb-rule", "34.5.5.5", "us-central1")],
+        global_forwarding_rules=[],
+    )
+
+    inv = await conn.fetch_inventory()
+
+    assert inv.account_id == "svc@proj-1.iam.gserviceaccount.com"
+    assert not inv.warnings
+
+    # Network carries NO cidrs (GCP quirk) — CIDR lives on the subnet.
+    assert len(inv.networks) == 1
+    net = inv.networks[0]
+    assert net.id == "111"
+    assert net.name == "vpc-a"
+    assert net.cidrs == ()
+
+    # Subnet carries the CIDR + region and resolves network_id to the net id.
+    assert len(inv.subnets) == 1
+    sub = inv.subnets[0]
+    assert sub.id == "222"
+    assert sub.cidr == "10.0.0.0/24"
+    assert sub.region == "us-central1"
+    assert sub.network_id == net.id
+
+    # include_stopped default False → only the RUNNING instance, with its NIC.
+    assert len(inv.instances) == 1
+    vm = inv.instances[0]
+    assert vm.name == "vm-running"
+    assert vm.running is True
+    assert vm.region == "us-central1"
+    assert len(vm.nics) == 1
+    assert vm.nics[0].private_ip == "10.0.0.5"
+    assert vm.nics[0].public_ip == "34.1.2.3"
+    assert vm.nics[0].mac is None
+
+    # Only the EXTERNAL address surfaces, attached because it has users.
+    assert len(inv.public_ips) == 1
+    pip = inv.public_ips[0]
+    assert pip.address == "34.9.9.9"
+    assert pip.attached is True
+
+    # Forwarding rule → load balancer frontend.
+    assert len(inv.load_balancers) == 1
+    lb = inv.load_balancers[0]
+    assert lb.id == "555"
+    assert lb.frontend_ips == ("34.5.5.5",)
+    assert lb.region == "us-central1"
+
+
+@pytest.mark.asyncio
+async def test_include_stopped_returns_terminated_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _make_connector(
+        monkeypatch,
+        networks=[_network(111, "vpc-a")],
+        subnets=[],
+        instances=[
+            _instance(333, "vm-running", "RUNNING", "us-central1-a", [_nic("10.0.0.5", None)]),
+            _instance(444, "vm-stopped", "TERMINATED", "us-central1-a", [_nic("10.0.0.6", None)]),
+        ],
+        addresses=[],
+        global_addresses=[],
+        forwarding_rules=[],
+        global_forwarding_rules=[],
+    )
+
+    inv = await conn.fetch_inventory(include_stopped=True)
+
+    names = {i.name: i.running for i in inv.instances}
+    assert names == {"vm-running": True, "vm-stopped": False}
+
+
+@pytest.mark.asyncio
+async def test_subnet_unknown_network_warns_and_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _make_connector(
+        monkeypatch,
+        networks=[_network(111, "vpc-a")],
+        subnets=[_subnet(222, "orphan", "vpc-MISSING", "10.0.0.0/24", "us-central1")],
+        instances=[],
+        addresses=[],
+        global_addresses=[],
+        forwarding_rules=[],
+        global_forwarding_rules=[],
+    )
+
+    inv = await conn.fetch_inventory()
+
+    assert inv.subnets == []
+    assert any("unknown network" in w for w in inv.warnings)
+
+
+@pytest.mark.asyncio
+async def test_region_allowlist_filters_subnets_and_lbs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _make_connector(
+        monkeypatch,
+        networks=[_network(111, "vpc-a")],
+        subnets=[
+            _subnet(222, "keep", "vpc-a", "10.0.0.0/24", "us-central1"),
+            _subnet(223, "drop", "vpc-a", "10.1.0.0/24", "europe-west4"),
+        ],
+        instances=[],
+        addresses=[],
+        global_addresses=[],
+        forwarding_rules=[
+            _forwarding_rule(555, "keep-lb", "34.5.5.5", "us-central1"),
+            _forwarding_rule(556, "drop-lb", "34.6.6.6", "europe-west4"),
+        ],
+        global_forwarding_rules=[_forwarding_rule(557, "global-lb", "34.7.7.7", None)],
+        regions=["us-central1"],
+    )
+
+    inv = await conn.fetch_inventory()
+
+    assert [s.name for s in inv.subnets] == ["keep"]
+    # Regional LB outside the allow-list dropped; global LB always kept.
+    lb_names = {lb.name for lb in inv.load_balancers}
+    assert lb_names == {"keep-lb", "global-lb"}
+    assert next(lb for lb in inv.load_balancers if lb.name == "global-lb").region == "global"
+
+
+@pytest.mark.asyncio
+async def test_include_load_balancers_false_skips_rules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _make_connector(
+        monkeypatch,
+        networks=[_network(111, "vpc-a")],
+        subnets=[],
+        instances=[],
+        addresses=[],
+        global_addresses=[],
+        forwarding_rules=[_forwarding_rule(555, "lb-rule", "34.5.5.5", "us-central1")],
+        global_forwarding_rules=[_forwarding_rule(557, "global-lb", "34.7.7.7", None)],
+    )
+
+    inv = await conn.fetch_inventory(include_load_balancers=False)
+
+    assert inv.load_balancers == []
+
+
+@pytest.mark.asyncio
+async def test_per_project_failure_becomes_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = GCPConnector(
+        credentials={"service_account_json": _KEY},
+        provider_config={"project_ids": ["proj-1"]},
+    )
+    monkeypatch.setattr(conn, "_credentials", lambda: object())
+    monkeypatch.setattr(conn, "_describe_error", staticmethod(lambda exc: f"boom: {exc}"))
+
+    def _boom(_c: Any) -> Mock:
+        m = Mock()
+        m.list.side_effect = RuntimeError("api down")
+        return m
+
+    monkeypatch.setattr(conn, "_networks_client", _boom)
+
+    inv = await conn.fetch_inventory()
+
+    assert inv.networks == []
+    assert any("proj-1" in w and "boom" in w for w in inv.warnings)
+
+
+@pytest.mark.asyncio
+async def test_fetch_inventory_no_projects_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = GCPConnector(
+        credentials={"service_account_json": _KEY},
+        provider_config={"project_ids": []},
+    )
+    monkeypatch.setattr(conn, "_credentials", lambda: object())
+
+    inv = await conn.fetch_inventory()
+
+    assert inv.networks == []
+    assert any("no project_ids" in w for w in inv.warnings)
+
+
+@pytest.mark.asyncio
+async def test_fetch_inventory_bad_credentials_raises() -> None:
+    conn = GCPConnector(
+        credentials={"service_account_json": "not-json"},
+        provider_config={"project_ids": ["proj-1"]},
+    )
+    with pytest.raises(CloudConnectorError):
+        await conn.fetch_inventory()
+
+
+# ── Probe ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_probe_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = _make_connector(
+        monkeypatch,
+        networks=[_network(111, "vpc-a"), _network(112, "vpc-b")],
+        subnets=[],
+        instances=[],
+        addresses=[],
+        global_addresses=[],
+        forwarding_rules=[],
+        global_forwarding_rules=[],
+    )
+
+    result = await conn.probe()
+
+    assert isinstance(result, CloudProbeResult)
+    assert result.ok is True
+    assert result.account_id == "svc@proj-1.iam.gserviceaccount.com"
+    assert result.network_count == 2
+
+
+@pytest.mark.asyncio
+async def test_probe_auth_failure_returns_not_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = GCPConnector(
+        credentials={"service_account_json": _KEY},
+        provider_config={"project_ids": ["proj-1"]},
+    )
+    monkeypatch.setattr(conn, "_credentials", lambda: object())
+    monkeypatch.setattr(conn, "_describe_error", staticmethod(lambda exc: "GCP auth failed"))
+
+    def _boom(_c: Any) -> Mock:
+        m = Mock()
+        m.list.side_effect = RuntimeError("403 forbidden")
+        return m
+
+    monkeypatch.setattr(conn, "_networks_client", _boom)
+
+    result = await conn.probe()
+
+    assert result.ok is False
+    assert "GCP auth failed" in result.message
+    # account_id still derived from the parsed key even on failure.
+    assert result.account_id == "svc@proj-1.iam.gserviceaccount.com"
+
+
+@pytest.mark.asyncio
+async def test_probe_bad_credentials_returns_not_ok() -> None:
+    conn = GCPConnector(
+        credentials={"service_account_json": "not-json"},
+        provider_config={"project_ids": ["proj-1"]},
+    )
+
+    result = await conn.probe()
+
+    assert result.ok is False
+    assert "JSON" in result.message or "valid" in result.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_probe_no_projects_returns_not_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = GCPConnector(
+        credentials={"service_account_json": _KEY},
+        provider_config={"project_ids": []},
+    )
+    monkeypatch.setattr(conn, "_credentials", lambda: object())
+
+    result = await conn.probe()
+
+    assert result.ok is False
+    assert "project_ids" in result.message

--- a/backend/tests/test_cloud_reconcile.py
+++ b/backend/tests/test_cloud_reconcile.py
@@ -1,0 +1,623 @@
+"""Tests for the Cloud (AWS / Azure / GCP) reconciler.
+
+Fully offline (tier-3 providers, no test account): ``get_connector`` is
+monkeypatched to return a stub connector whose ``fetch_inventory``
+returns a hand-built :class:`CloudInventory`. Validates VPC-CIDR →
+IPBlock creation, the GCP CIDR-less-network per-subnet-block fallback,
+subnet enclosure + routed-overlay semantics, instance-NIC mirroring,
+idempotency, the ``user_modified_at`` soft-field lock, prune-on-removal,
+and the credential-empty + connector-error error paths.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import encrypt_dict
+from app.models.cloud import CloudEndpoint
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.cloud import reconcile as reconcile_mod
+from app.services.cloud.base import (
+    CloudConnectorError,
+    CloudInstance,
+    CloudInventory,
+    CloudLoadBalancer,
+    CloudNetwork,
+    CloudNic,
+    CloudPublicIP,
+    CloudSubnet,
+)
+from app.services.cloud.reconcile import reconcile_endpoint
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+async def _make_space(db: AsyncSession) -> IPSpace:
+    space = IPSpace(name=f"cloud-test-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    return space
+
+
+async def _make_endpoint(
+    db: AsyncSession,
+    space: IPSpace,
+    *,
+    provider: str = "aws",
+    creds: dict[str, str] | None = None,
+    mirror_load_balancers: bool = True,
+    mirror_stopped_instances: bool = False,
+    public_space_id: uuid.UUID | None = None,
+) -> CloudEndpoint:
+    endpoint = CloudEndpoint(
+        name=f"cloud-{uuid.uuid4().hex[:6]}",
+        provider=provider,
+        credentials_encrypted=encrypt_dict(
+            creds or {"access_key_id": "AKIA", "secret_access_key": "secret"}
+        ),
+        provider_config={},
+        regions=["us-east-1"],
+        ipam_space_id=space.id,
+        public_space_id=public_space_id,
+        mirror_load_balancers=mirror_load_balancers,
+        mirror_stopped_instances=mirror_stopped_instances,
+    )
+    db.add(endpoint)
+    await db.flush()
+    return endpoint
+
+
+class _FakeConnector:
+    """Stub connector — returns a pre-built inventory (or raises)."""
+
+    def __init__(
+        self,
+        *,
+        inventory: CloudInventory | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self._inventory = inventory
+        self._error = error
+        self.fetch_calls: list[dict] = []
+
+    async def probe(self):  # pragma: no cover - not exercised here
+        raise NotImplementedError
+
+    async def fetch_inventory(self, **kwargs):
+        self.fetch_calls.append(kwargs)
+        if self._error is not None:
+            raise self._error
+        assert self._inventory is not None
+        return self._inventory
+
+
+def _patch_connector(fake: _FakeConnector):
+    def _factory(provider, **_kwargs):  # noqa: ARG001
+        return fake
+
+    return patch.object(reconcile_mod, "get_connector", side_effect=_factory)
+
+
+def _aws_inventory() -> CloudInventory:
+    """A single-VPC AWS account with two subnets + two instances."""
+    return CloudInventory(
+        account_id="123456789012",
+        networks=[
+            CloudNetwork(
+                id="vpc-1",
+                name="prod-vpc",
+                cidrs=("10.0.0.0/16",),
+                region="us-east-1",
+            )
+        ],
+        subnets=[
+            CloudSubnet(
+                id="subnet-a",
+                name="app-a",
+                network_id="vpc-1",
+                cidr="10.0.1.0/24",
+                region="us-east-1",
+            ),
+            CloudSubnet(
+                id="subnet-b",
+                name="app-b",
+                network_id="vpc-1",
+                cidr="10.0.2.0/24",
+                region="us-east-1",
+                gateway="10.0.2.254",
+            ),
+        ],
+        instances=[
+            CloudInstance(
+                id="i-aaa",
+                name="web-1",
+                running=True,
+                region="us-east-1",
+                nics=(CloudNic(private_ip="10.0.1.10", mac="0a:11:22:33:44:55"),),
+            ),
+            CloudInstance(
+                id="i-bbb",
+                name="db-1",
+                running=True,
+                region="us-east-1",
+                nics=(CloudNic(private_ip="10.0.2.20"),),
+            ),
+        ],
+        public_ips=[CloudPublicIP(address="203.0.113.10", name="eip-1", attached=True)],
+        load_balancers=[
+            CloudLoadBalancer(id="lb-1", name="web-lb", frontend_ips=("198.51.100.5",))
+        ],
+    )
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_vpc_creates_block_subnets_and_instance_rows(
+    db_session: AsyncSession,
+) -> None:
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space)
+    await db_session.commit()
+
+    fake = _FakeConnector(inventory=_aws_inventory())
+    with _patch_connector(fake):
+        summary = await reconcile_endpoint(db_session, endpoint)
+
+    assert summary.ok, summary.error
+    assert summary.provider_account_id == "123456789012"
+    assert summary.network_count == 1
+    assert summary.instance_count == 2
+
+    # One IPBlock for the VPC CIDR, owned by the endpoint.
+    blocks = (
+        (await db_session.execute(select(IPBlock).where(IPBlock.cloud_endpoint_id == endpoint.id)))
+        .scalars()
+        .all()
+    )
+    assert len(blocks) == 1
+    assert str(blocks[0].network) == "10.0.0.0/16"
+    assert blocks[0].name == "aws:prod-vpc"
+
+    # Two subnets, both enclosed by the VPC block, routed-overlay semantics.
+    subs = (
+        (await db_session.execute(select(Subnet).where(Subnet.cloud_endpoint_id == endpoint.id)))
+        .scalars()
+        .all()
+    )
+    nets = {str(s.network) for s in subs}
+    assert nets == {"10.0.1.0/24", "10.0.2.0/24"}
+    for s in subs:
+        assert s.block_id == blocks[0].id
+        assert s.kubernetes_semantics is True
+
+    # Gateway: derived first-usable-host for subnet-a, explicit for subnet-b.
+    sub_a = next(s for s in subs if str(s.network) == "10.0.1.0/24")
+    sub_b = next(s for s in subs if str(s.network) == "10.0.2.0/24")
+    assert str(sub_a.gateway) == "10.0.1.1"
+    assert str(sub_b.gateway) == "10.0.2.254"
+
+    # Instance NIC private IPs land as cloud-instance rows in their subnets.
+    inst_rows = (
+        (
+            await db_session.execute(
+                select(IPAddress).where(
+                    IPAddress.cloud_endpoint_id == endpoint.id,
+                    IPAddress.status == "cloud-instance",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_addr = {str(r.address): r for r in inst_rows}
+    assert set(by_addr) == {"10.0.1.10", "10.0.2.20"}
+    assert by_addr["10.0.1.10"].hostname == "web-1"
+    assert (by_addr["10.0.1.10"].mac_address or "").lower() == "0a:11:22:33:44:55"
+    assert by_addr["10.0.1.10"].subnet_id == sub_a.id
+
+    # Public IP + LB frontend are out-of-band (no enclosing subnet) → skipped.
+    assert summary.skipped_no_subnet >= 2
+    pub_rows = (
+        (
+            await db_session.execute(
+                select(IPAddress).where(IPAddress.status.in_(["cloud-public", "cloud-lb"]))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert list(pub_rows) == []
+
+    # The fetch was called with the endpoint's mirror policy.
+    assert fake.fetch_calls == [{"include_stopped": False, "include_load_balancers": True}]
+
+
+@pytest.mark.asyncio
+async def test_gcp_cidrless_network_creates_per_subnet_blocks(
+    db_session: AsyncSession,
+) -> None:
+    """GCP VPCs have no own CIDR — each subnet gets a block at its own CIDR."""
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space, provider="gcp")
+    await db_session.commit()
+
+    inv = CloudInventory(
+        account_id="my-gcp-project",
+        networks=[CloudNetwork(id="net-1", name="default", cidrs=(), region=None)],
+        subnets=[
+            CloudSubnet(
+                id="s-1",
+                name="us-central",
+                network_id="net-1",
+                cidr="10.128.0.0/20",
+                region="us-central1",
+            ),
+            CloudSubnet(
+                id="s-2",
+                name="europe-west",
+                network_id="net-1",
+                cidr="10.132.0.0/20",
+                region="europe-west1",
+            ),
+        ],
+        instances=[
+            CloudInstance(
+                id="inst-1",
+                name="gce-1",
+                running=True,
+                nics=(CloudNic(private_ip="10.128.0.5"),),
+            )
+        ],
+    )
+    with _patch_connector(_FakeConnector(inventory=inv)):
+        summary = await reconcile_endpoint(db_session, endpoint)
+
+    assert summary.ok, summary.error
+    # One block per subnet CIDR (no network-level CIDR block).
+    blocks = (
+        (await db_session.execute(select(IPBlock).where(IPBlock.cloud_endpoint_id == endpoint.id)))
+        .scalars()
+        .all()
+    )
+    assert {str(b.network) for b in blocks} == {"10.128.0.0/20", "10.132.0.0/20"}
+
+    # Each subnet nests inside the block at its own CIDR.
+    subs = (
+        (await db_session.execute(select(Subnet).where(Subnet.cloud_endpoint_id == endpoint.id)))
+        .scalars()
+        .all()
+    )
+    by_net = {str(s.network): s for s in subs}
+    block_by_net = {str(b.network): b for b in blocks}
+    assert by_net["10.128.0.0/20"].block_id == block_by_net["10.128.0.0/20"].id
+
+    # Instance row lands in the right subnet.
+    ip = (
+        await db_session.execute(
+            select(IPAddress).where(
+                IPAddress.cloud_endpoint_id == endpoint.id,
+                IPAddress.status == "cloud-instance",
+            )
+        )
+    ).scalar_one()
+    assert str(ip.address) == "10.128.0.5"
+    assert ip.subnet_id == by_net["10.128.0.0/20"].id
+
+
+@pytest.mark.asyncio
+async def test_reconcile_is_idempotent(db_session: AsyncSession) -> None:
+    """A second run against the same inventory creates no duplicates."""
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space)
+    await db_session.commit()
+
+    with _patch_connector(_FakeConnector(inventory=_aws_inventory())):
+        first = await reconcile_endpoint(db_session, endpoint)
+    with _patch_connector(_FakeConnector(inventory=_aws_inventory())):
+        second = await reconcile_endpoint(db_session, endpoint)
+
+    assert first.ok and second.ok
+    assert second.blocks_created == 0
+    assert second.subnets_created == 0
+    assert second.addresses_created == 0
+
+    blocks = (
+        (await db_session.execute(select(IPBlock).where(IPBlock.cloud_endpoint_id == endpoint.id)))
+        .scalars()
+        .all()
+    )
+    subs = (
+        (await db_session.execute(select(Subnet).where(Subnet.cloud_endpoint_id == endpoint.id)))
+        .scalars()
+        .all()
+    )
+    inst = (
+        (
+            await db_session.execute(
+                select(IPAddress).where(
+                    IPAddress.cloud_endpoint_id == endpoint.id,
+                    IPAddress.status == "cloud-instance",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(blocks) == 1
+    assert len(subs) == 2
+    assert len(inst) == 2
+
+
+@pytest.mark.asyncio
+async def test_user_modified_row_not_overwritten(db_session: AsyncSession) -> None:
+    """An operator edit (user_modified_at set) survives a re-sync."""
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space)
+    await db_session.commit()
+
+    with _patch_connector(_FakeConnector(inventory=_aws_inventory())):
+        await reconcile_endpoint(db_session, endpoint)
+
+    row = (
+        await db_session.execute(
+            select(IPAddress).where(
+                IPAddress.cloud_endpoint_id == endpoint.id,
+                IPAddress.address == "10.0.1.10",
+            )
+        )
+    ).scalar_one()
+    assert row.hostname == "web-1"
+
+    # Operator renames the row (simulating the API write path).
+    row.hostname = "golden-web"
+    row.description = "Hand-curated — keep"
+    row.user_modified_at = datetime.now(UTC)
+    await db_session.commit()
+
+    # Re-sync: cloud still reports "web-1" but the operator's edits hold.
+    with _patch_connector(_FakeConnector(inventory=_aws_inventory())):
+        await reconcile_endpoint(db_session, endpoint)
+    await db_session.refresh(row)
+    assert row.hostname == "golden-web"
+    assert row.description == "Hand-curated — keep"
+
+
+@pytest.mark.asyncio
+async def test_removed_instance_prunes_its_row(db_session: AsyncSession) -> None:
+    """An instance gone from the inventory has its mirrored row deleted."""
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space)
+    await db_session.commit()
+
+    with _patch_connector(_FakeConnector(inventory=_aws_inventory())):
+        await reconcile_endpoint(db_session, endpoint)
+    assert (
+        await db_session.scalar(select(IPAddress).where(IPAddress.address == "10.0.2.20"))
+    ) is not None
+
+    # Second pass: db-1 (10.0.2.20) is gone.
+    inv = _aws_inventory()
+    inv.instances = [inv.instances[0]]  # drop db-1
+    with _patch_connector(_FakeConnector(inventory=inv)):
+        summary = await reconcile_endpoint(db_session, endpoint)
+
+    assert summary.ok
+    assert summary.addresses_deleted >= 1
+    gone = await db_session.scalar(select(IPAddress).where(IPAddress.address == "10.0.2.20"))
+    assert gone is None
+    # web-1 still present.
+    assert (
+        await db_session.scalar(select(IPAddress).where(IPAddress.address == "10.0.1.10"))
+    ) is not None
+
+
+@pytest.mark.asyncio
+async def test_public_ip_lands_when_enclosing_subnet_mirrored(
+    db_session: AsyncSession,
+) -> None:
+    """When a public-range subnet is mirrored, public + LB IPs inside it
+    materialise (rather than being skipped)."""
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space)
+    await db_session.commit()
+
+    inv = CloudInventory(
+        account_id="123456789012",
+        networks=[CloudNetwork(id="vpc-1", name="edge-vpc", cidrs=("198.51.100.0/24",))],
+        subnets=[
+            CloudSubnet(id="s-pub", name="public", network_id="vpc-1", cidr="198.51.100.0/24")
+        ],
+        public_ips=[CloudPublicIP(address="198.51.100.50", name="eip-edge", attached=True)],
+        load_balancers=[
+            CloudLoadBalancer(id="lb-1", name="edge-lb", frontend_ips=("198.51.100.60",))
+        ],
+    )
+    with _patch_connector(_FakeConnector(inventory=inv)):
+        summary = await reconcile_endpoint(db_session, endpoint)
+
+    assert summary.ok, summary.error
+    pub = await db_session.scalar(select(IPAddress).where(IPAddress.address == "198.51.100.50"))
+    lb = await db_session.scalar(select(IPAddress).where(IPAddress.address == "198.51.100.60"))
+    assert pub is not None and pub.status == "cloud-public"
+    assert lb is not None and lb.status == "cloud-lb"
+
+
+@pytest.mark.asyncio
+async def test_mirror_load_balancers_off_skips_lb_rows(
+    db_session: AsyncSession,
+) -> None:
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space, mirror_load_balancers=False)
+    await db_session.commit()
+
+    inv = CloudInventory(
+        account_id="123456789012",
+        networks=[CloudNetwork(id="vpc-1", name="edge-vpc", cidrs=("198.51.100.0/24",))],
+        subnets=[
+            CloudSubnet(id="s-pub", name="public", network_id="vpc-1", cidr="198.51.100.0/24")
+        ],
+        load_balancers=[
+            CloudLoadBalancer(id="lb-1", name="edge-lb", frontend_ips=("198.51.100.60",))
+        ],
+    )
+    fake = _FakeConnector(inventory=inv)
+    with _patch_connector(fake):
+        summary = await reconcile_endpoint(db_session, endpoint)
+
+    assert summary.ok
+    lb = await db_session.scalar(select(IPAddress).where(IPAddress.status == "cloud-lb"))
+    assert lb is None
+    # mirror_load_balancers=False flows through to the connector fetch call.
+    assert fake.fetch_calls == [{"include_stopped": False, "include_load_balancers": False}]
+
+
+@pytest.mark.asyncio
+async def test_operator_subnet_reused_not_duplicated(
+    db_session: AsyncSession,
+) -> None:
+    """A pre-existing operator subnet at the exact CIDR is reused; the
+    instance IP still mirrors into it."""
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space)
+    parent = IPBlock(space_id=space.id, network="10.0.0.0/8", name="corp")
+    db_session.add(parent)
+    await db_session.flush()
+    operator_sub = Subnet(
+        space_id=space.id,
+        block_id=parent.id,
+        network="10.0.1.0/24",
+        name="hand-built",
+        description="curated",
+        total_ips=256,
+    )
+    db_session.add(operator_sub)
+    await db_session.commit()
+
+    inv = CloudInventory(
+        account_id="123456789012",
+        networks=[CloudNetwork(id="vpc-1", name="prod-vpc", cidrs=("10.0.0.0/16",))],
+        subnets=[CloudSubnet(id="s-a", name="app-a", network_id="vpc-1", cidr="10.0.1.0/24")],
+        instances=[
+            CloudInstance(
+                id="i-aaa",
+                name="web-1",
+                running=True,
+                nics=(CloudNic(private_ip="10.0.1.10"),),
+            )
+        ],
+    )
+    with _patch_connector(_FakeConnector(inventory=inv)):
+        summary = await reconcile_endpoint(db_session, endpoint)
+
+    assert summary.ok, summary.error
+    assert summary.subnets_matched == 1
+
+    rows = (
+        (
+            await db_session.execute(
+                select(Subnet).where(Subnet.space_id == space.id, Subnet.network == "10.0.1.0/24")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    only = rows[0]
+    assert only.id == operator_sub.id
+    assert only.cloud_endpoint_id is None  # ownership not claimed
+    assert only.name == "hand-built"
+
+    # Instance IP lands in the reused operator subnet.
+    ip = (
+        await db_session.execute(
+            select(IPAddress).where(
+                IPAddress.cloud_endpoint_id == endpoint.id,
+                IPAddress.status == "cloud-instance",
+            )
+        )
+    ).scalar_one()
+    assert ip.subnet_id == operator_sub.id
+
+
+@pytest.mark.asyncio
+async def test_endpoint_delete_cascades(db_session: AsyncSession) -> None:
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space)
+    await db_session.commit()
+
+    with _patch_connector(_FakeConnector(inventory=_aws_inventory())):
+        await reconcile_endpoint(db_session, endpoint)
+
+    endpoint_id = endpoint.id
+    await db_session.delete(endpoint)
+    await db_session.commit()
+
+    subs = (
+        (await db_session.execute(select(Subnet).where(Subnet.cloud_endpoint_id == endpoint_id)))
+        .scalars()
+        .all()
+    )
+    addrs = (
+        (
+            await db_session.execute(
+                select(IPAddress).where(IPAddress.cloud_endpoint_id == endpoint_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert list(subs) == []
+    assert list(addrs) == []
+
+
+# ── Error paths ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_credentials_sets_last_sync_error(db_session: AsyncSession) -> None:
+    space = await _make_space(db_session)
+    endpoint = CloudEndpoint(
+        name=f"cloud-{uuid.uuid4().hex[:6]}",
+        provider="aws",
+        credentials_encrypted=b"",  # unset
+        provider_config={},
+        regions=[],
+        ipam_space_id=space.id,
+    )
+    db_session.add(endpoint)
+    await db_session.commit()
+
+    summary = await reconcile_endpoint(db_session, endpoint)
+
+    assert summary.ok is False
+    assert summary.error is not None
+    await db_session.refresh(endpoint)
+    assert endpoint.last_sync_error is not None
+    assert endpoint.last_synced_at is not None
+
+
+@pytest.mark.asyncio
+async def test_connector_error_sets_last_sync_error(db_session: AsyncSession) -> None:
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space)
+    await db_session.commit()
+
+    fake = _FakeConnector(error=CloudConnectorError("auth failed: invalid keys"))
+    with _patch_connector(fake):
+        summary = await reconcile_endpoint(db_session, endpoint)
+
+    assert summary.ok is False
+    assert summary.error is not None
+    assert "auth failed" in summary.error
+    await db_session.refresh(endpoint)
+    assert endpoint.last_sync_error is not None
+    assert "auth failed" in (endpoint.last_sync_error or "")
+    assert endpoint.last_synced_at is not None

--- a/backend/tests/test_dns_azure_dns.py
+++ b/backend/tests/test_dns_azure_dns.py
@@ -1,0 +1,398 @@
+"""Unit tests for the Azure DNS cloud driver (issue #37, Part B).
+
+These are tier-3 provider tests — no Azure account is available, so the
+``azure-mgmt-dns`` SDK is never imported and never hit. Every test
+monkeypatches :meth:`AzureDNSDriver._client` to return a ``Mock`` whose
+``zones`` / ``record_sets`` namespaces yield ``SimpleNamespace`` objects
+shaped exactly like the ``azure-mgmt-dns`` models. Fully offline +
+deterministic.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from app.drivers.dns._cloud_base import CloudDNSError, CloudDNSZone
+from app.drivers.dns.azuredns import AzureDNSDriver
+from app.drivers.dns.base import RecordChange, RecordData
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+_CREDS = {
+    "tenant_id": "t",
+    "client_id": "c",
+    "client_secret": "s",
+    "subscription_id": "sub",
+    "resource_group": "rg",
+}
+
+
+class _FakeHttpResponseError(Exception):
+    """Stand-in for ``azure.core.exceptions.HttpResponseError``.
+
+    The driver's ``_wrap_errors`` lazy-imports the real exception types;
+    when those imports fail in the test env it falls back to wrapping any
+    exception as a ``CloudDNSError`` anyway, so a plain subclass is enough
+    to exercise the error path deterministically.
+    """
+
+
+@pytest.fixture
+def server() -> SimpleNamespace:
+    return SimpleNamespace(id="srv-1", name="azure-1", credentials_encrypted=b"blob")
+
+
+@pytest.fixture
+def driver(monkeypatch: pytest.MonkeyPatch) -> AzureDNSDriver:
+    """Driver with credential decrypt stubbed (no Fernet key in tests)."""
+    drv = AzureDNSDriver()
+    monkeypatch.setattr(drv, "_load_credentials", lambda srv: dict(_CREDS))
+    return drv
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, client: Any) -> None:
+    monkeypatch.setattr(driver, "_client", lambda creds: client)
+
+
+# ── Registry / capabilities ────────────────────────────────────────────────
+
+
+def test_name_and_credential_fields() -> None:
+    drv = AzureDNSDriver()
+    assert drv.name == "azure_dns"
+    assert drv.credential_fields == (
+        "tenant_id",
+        "client_id",
+        "client_secret",
+        "subscription_id",
+        "resource_group",
+    )
+
+
+def test_capabilities_shape() -> None:
+    caps = AzureDNSDriver().capabilities()
+    assert caps["name"] == "azure_dns"
+    assert caps["agentless"] is True
+    assert caps["manages_zones"] is True
+    assert caps["alias_records"] is True
+    assert caps["dnssec_online"] is False
+    assert "SOA" in caps["record_types"]
+    assert "online DNSSEC" in caps["notes"]
+
+
+# ── Zone listing ────────────────────────────────────────────────────────────
+
+
+async def test_list_zones_by_resource_group(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    client.zones.list_by_resource_group.return_value = [
+        SimpleNamespace(name="example.com", number_of_record_sets=12),
+        SimpleNamespace(name="0.0.10.in-addr.arpa", number_of_record_sets=3),
+    ]
+    _patch_client(monkeypatch, driver, client)
+
+    zones = await driver._list_zones(server, dict(_CREDS))
+
+    client.zones.list_by_resource_group.assert_called_once_with("rg")
+    assert zones == [
+        CloudDNSZone(name="example.com.", zone_id="example.com", is_reverse=False, record_count=12),
+        CloudDNSZone(
+            name="0.0.10.in-addr.arpa.",
+            zone_id="0.0.10.in-addr.arpa",
+            is_reverse=True,
+            record_count=3,
+        ),
+    ]
+
+
+async def test_list_zones_falls_back_to_subscription_list_when_rg_empty(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    client.zones.list.return_value = [SimpleNamespace(name="example.org", number_of_record_sets=1)]
+    _patch_client(monkeypatch, driver, client)
+
+    creds = dict(_CREDS, resource_group="")
+    zones = await driver._list_zones(server, creds)
+
+    client.zones.list.assert_called_once_with()
+    client.zones.list_by_resource_group.assert_not_called()
+    assert [z.name for z in zones] == ["example.org."]
+
+
+async def test_pull_zones_from_server_returns_neutral_dicts(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    client.zones.list_by_resource_group.return_value = [
+        SimpleNamespace(name="example.com", number_of_record_sets=7)
+    ]
+    _patch_client(monkeypatch, driver, client)
+
+    rows = await driver.pull_zones_from_server(server)
+
+    assert rows == [
+        {
+            "name": "example.com.",
+            "zone_type": "Primary",
+            "is_reverse_lookup": False,
+            "dnssec_enabled": False,
+            "zone_id": "example.com",
+            "record_count": 7,
+        }
+    ]
+
+
+# ── Record listing / multi-type expansion ───────────────────────────────────
+
+
+async def test_list_zone_records_expands_multiple_types(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    record_sets = [
+        # A record set with two records.
+        SimpleNamespace(
+            name="www",
+            type="Microsoft.Network/dnszones/A",
+            ttl=300,
+            a_records=[
+                SimpleNamespace(ipv4_address="10.0.0.1"),
+                SimpleNamespace(ipv4_address="10.0.0.2"),
+            ],
+        ),
+        # MX record set.
+        SimpleNamespace(
+            name="@",
+            type="Microsoft.Network/dnszones/MX",
+            ttl=3600,
+            mx_records=[SimpleNamespace(preference=10, exchange="mail.example.com")],
+        ),
+        # TXT record set (Azure splits long strings into a value list).
+        SimpleNamespace(
+            name="@",
+            type="Microsoft.Network/dnszones/TXT",
+            ttl=3600,
+            txt_records=[SimpleNamespace(value=["v=spf1 ", "-all"])],
+        ),
+        # SOA is skipped entirely.
+        SimpleNamespace(name="@", type="Microsoft.Network/dnszones/SOA", ttl=3600),
+    ]
+    client = Mock()
+    client.record_sets.list_by_dns_zone.return_value = record_sets
+    _patch_client(monkeypatch, driver, client)
+
+    records = await driver._list_zone_records(server, dict(_CREDS), "example.com.")
+
+    # Azure zone label is stripped of the trailing dot for the SDK call.
+    client.record_sets.list_by_dns_zone.assert_called_once_with("rg", "example.com")
+
+    assert records == [
+        RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        RecordData(name="www", record_type="A", value="10.0.0.2", ttl=300),
+        RecordData(name="@", record_type="MX", value="10 mail.example.com", ttl=3600),
+        RecordData(name="@", record_type="TXT", value="v=spf1 -all", ttl=3600),
+    ]
+
+
+async def test_list_zone_records_expands_srv_and_caa(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    record_sets = [
+        SimpleNamespace(
+            name="_sip._tcp",
+            type="Microsoft.Network/dnszones/SRV",
+            ttl=3600,
+            srv_records=[
+                SimpleNamespace(priority=10, weight=20, port=5060, target="sip.example.com")
+            ],
+        ),
+        SimpleNamespace(
+            name="@",
+            type="Microsoft.Network/dnszones/CAA",
+            ttl=3600,
+            caa_records=[SimpleNamespace(flags=0, tag="issue", value="letsencrypt.org")],
+        ),
+    ]
+    client = Mock()
+    client.record_sets.list_by_dns_zone.return_value = record_sets
+    _patch_client(monkeypatch, driver, client)
+
+    records = await driver._list_zone_records(server, dict(_CREDS), "example.com.")
+
+    assert records[0] == RecordData(
+        name="_sip._tcp", record_type="SRV", value="10 20 5060 sip.example.com", ttl=3600
+    )
+    assert records[1] == RecordData(
+        name="@", record_type="CAA", value="0 issue letsencrypt.org", ttl=3600
+    )
+
+
+# ── Record write (create_or_update param building) ──────────────────────────
+
+
+async def test_apply_record_create_builds_a_params(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.5", ttl=120),
+        target_serial=1,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    client.record_sets.create_or_update.assert_called_once_with(
+        "rg", "example.com", "www", "A", {"ttl": 120, "a_records": [{"ipv4_address": "10.0.0.5"}]}
+    )
+
+
+async def test_apply_record_update_builds_mx_params(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="MX", value="20 mail2.example.com", ttl=3600),
+        target_serial=2,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    _, _, _, rtype, params = client.record_sets.create_or_update.call_args.args
+    assert rtype == "MX"
+    assert params == {
+        "ttl": 3600,
+        "mx_records": [{"preference": 20, "exchange": "mail2.example.com"}],
+    }
+
+
+async def test_apply_record_builds_srv_params(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(
+            name="_sip._tcp", record_type="SRV", value="10 20 5060 sip.example.com", ttl=3600
+        ),
+        target_serial=3,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    _, _, _, _, params = client.record_sets.create_or_update.call_args.args
+    assert params["srv_records"] == [
+        {"priority": 10, "weight": 20, "port": 5060, "target": "sip.example.com"}
+    ]
+
+
+async def test_apply_record_delete_dispatches_to_delete(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="old", record_type="A", value="10.0.0.9"),
+        target_serial=4,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    client.record_sets.delete.assert_called_once_with("rg", "example.com", "old", "A")
+    client.record_sets.create_or_update.assert_not_called()
+
+
+# ── Zone write ───────────────────────────────────────────────────────────────
+
+
+async def test_apply_zone_create(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    _patch_client(monkeypatch, driver, client)
+
+    zone = SimpleNamespace(name="new.example.com.")
+    await driver._apply_zone(server, dict(_CREDS), zone, "create")
+
+    client.zones.create_or_update.assert_called_once_with(
+        "rg", "new.example.com", {"location": "global"}
+    )
+
+
+async def test_apply_zone_delete_uses_lro_poller(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    poller = Mock()
+    client = Mock()
+    client.zones.begin_delete.return_value = poller
+    _patch_client(monkeypatch, driver, client)
+
+    zone = SimpleNamespace(name="gone.example.com.")
+    await driver._apply_zone(server, dict(_CREDS), zone, "delete")
+
+    client.zones.begin_delete.assert_called_once_with("rg", "gone.example.com")
+    poller.result.assert_called_once_with()
+
+
+# ── Error wrapping ───────────────────────────────────────────────────────────
+
+
+async def test_list_zones_wraps_http_error_as_cloud_dns_error(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    client.zones.list_by_resource_group.side_effect = _FakeHttpResponseError("403 Forbidden")
+    _patch_client(monkeypatch, driver, client)
+
+    with pytest.raises(CloudDNSError) as excinfo:
+        await driver._list_zones(server, dict(_CREDS))
+    assert "403 Forbidden" in str(excinfo.value)
+
+
+async def test_apply_record_wraps_error_as_cloud_dns_error(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    client.record_sets.create_or_update.side_effect = _FakeHttpResponseError("boom")
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        target_serial=5,
+    )
+    with pytest.raises(CloudDNSError):
+        await driver._apply_record(server, dict(_CREDS), change)
+
+
+# ── Probe (inherited from base, exercised end-to-end with mocked client) ─────
+
+
+async def test_probe_ok_reports_zone_count(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    client = Mock()
+    client.zones.list_by_resource_group.return_value = [
+        SimpleNamespace(name="example.com", number_of_record_sets=1)
+    ]
+    _patch_client(monkeypatch, driver, client)
+
+    probe = await driver.probe(server)
+    assert probe.ok is True
+    assert probe.zone_count == 1

--- a/backend/tests/test_dns_azure_dns.py
+++ b/backend/tests/test_dns_azure_dns.py
@@ -234,12 +234,21 @@ async def test_list_zone_records_expands_srv_and_caa(
 
 
 # ── Record write (create_or_update param building) ──────────────────────────
+#
+# Cloud providers group every value under one RRset keyed by {name, type}.
+# SpatiumDDI stores one row per value and emits one op per row, so the create
+# / delete paths read-merge against the provider's live RRset rather than
+# blindly writing a single-value set (which would silently drop the siblings
+# of a round-robin A / multi-MX / multi-NS set). ``record_sets.get`` is mocked
+# to return ``None`` for "no existing set" and a ``SimpleNamespace`` shaped
+# like the SDK model for an existing one.
 
 
-async def test_apply_record_create_builds_a_params(
+async def test_apply_record_create_into_empty_set_builds_a_params(
     monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
 ) -> None:
     client = Mock()
+    client.record_sets.get.return_value = None  # no existing RRset
     _patch_client(monkeypatch, driver, client)
 
     change = RecordChange(
@@ -255,9 +264,111 @@ async def test_apply_record_create_builds_a_params(
     )
 
 
-async def test_apply_record_update_builds_mx_params(
+async def test_apply_record_create_merges_into_existing_rrset(
     monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
 ) -> None:
+    """Creating a 2nd A value writes BOTH values (no silent sibling drop)."""
+    client = Mock()
+    client.record_sets.get.return_value = SimpleNamespace(
+        ttl=300, a_records=[SimpleNamespace(ipv4_address="10.0.0.1")]
+    )
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.2", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    client.record_sets.get.assert_called_once_with("rg", "example.com", "www", "A")
+    client.record_sets.create_or_update.assert_called_once_with(
+        "rg",
+        "example.com",
+        "www",
+        "A",
+        {"ttl": 300, "a_records": [{"ipv4_address": "10.0.0.1"}, {"ipv4_address": "10.0.0.2"}]},
+    )
+
+
+async def test_apply_record_create_dedupes_existing_value(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    """Creating a value already in the RRset is a merge no-op (no duplicate)."""
+    client = Mock()
+    client.record_sets.get.return_value = SimpleNamespace(
+        ttl=300,
+        a_records=[
+            SimpleNamespace(ipv4_address="10.0.0.1"),
+            SimpleNamespace(ipv4_address="10.0.0.2"),
+        ],
+    )
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    _, _, _, _, params = client.record_sets.create_or_update.call_args.args
+    assert params["a_records"] == [{"ipv4_address": "10.0.0.1"}, {"ipv4_address": "10.0.0.2"}]
+
+
+async def test_apply_record_create_falls_back_to_existing_ttl(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    """When the change carries no TTL, the existing RRset's TTL is kept."""
+    client = Mock()
+    client.record_sets.get.return_value = SimpleNamespace(
+        ttl=900, a_records=[SimpleNamespace(ipv4_address="10.0.0.1")]
+    )
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.2", ttl=None),
+        target_serial=1,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    _, _, _, _, params = client.record_sets.create_or_update.call_args.args
+    assert params["ttl"] == 900
+
+
+async def test_apply_record_create_cname_uses_replace_no_get(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    """CNAME is single-valued (``cname_record``) — replace, never read-merge."""
+    client = Mock()
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="alias", record_type="CNAME", value="target.example.com", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    client.record_sets.get.assert_not_called()
+    client.record_sets.create_or_update.assert_called_once_with(
+        "rg",
+        "example.com",
+        "alias",
+        "CNAME",
+        {"ttl": 300, "cname_record": {"cname": "target.example.com"}},
+    )
+
+
+async def test_apply_record_update_replaces_rrset(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    """update keeps single-value replace — it never read-merges (see #29)."""
     client = Mock()
     _patch_client(monkeypatch, driver, client)
 
@@ -269,6 +380,7 @@ async def test_apply_record_update_builds_mx_params(
     )
     await driver._apply_record(server, dict(_CREDS), change)
 
+    client.record_sets.get.assert_not_called()
     _, _, _, rtype, params = client.record_sets.create_or_update.call_args.args
     assert rtype == "MX"
     assert params == {
@@ -277,10 +389,11 @@ async def test_apply_record_update_builds_mx_params(
     }
 
 
-async def test_apply_record_builds_srv_params(
+async def test_apply_record_create_builds_srv_params(
     monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
 ) -> None:
     client = Mock()
+    client.record_sets.get.return_value = None
     _patch_client(monkeypatch, driver, client)
 
     change = RecordChange(
@@ -299,10 +412,42 @@ async def test_apply_record_builds_srv_params(
     ]
 
 
-async def test_apply_record_delete_dispatches_to_delete(
+async def test_apply_record_delete_one_of_two_leaves_the_other(
     monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
 ) -> None:
+    """Deleting one value of a 2-value RRset writes the reduced set, not delete."""
     client = Mock()
+    client.record_sets.get.return_value = SimpleNamespace(
+        ttl=300,
+        a_records=[
+            SimpleNamespace(ipv4_address="10.0.0.1"),
+            SimpleNamespace(ipv4_address="10.0.0.2"),
+        ],
+    )
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1"),
+        target_serial=4,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    client.record_sets.delete.assert_not_called()
+    client.record_sets.create_or_update.assert_called_once_with(
+        "rg", "example.com", "www", "A", {"ttl": 300, "a_records": [{"ipv4_address": "10.0.0.2"}]}
+    )
+
+
+async def test_apply_record_delete_last_value_removes_rrset(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    """Deleting the last remaining value removes the whole RRset."""
+    client = Mock()
+    client.record_sets.get.return_value = SimpleNamespace(
+        ttl=300, a_records=[SimpleNamespace(ipv4_address="10.0.0.9")]
+    )
     _patch_client(monkeypatch, driver, client)
 
     change = RecordChange(
@@ -315,6 +460,75 @@ async def test_apply_record_delete_dispatches_to_delete(
 
     client.record_sets.delete.assert_called_once_with("rg", "example.com", "old", "A")
     client.record_sets.create_or_update.assert_not_called()
+
+
+async def test_apply_record_delete_missing_value_is_noop(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    """Deleting a value that isn't in the RRset is an idempotent no-op."""
+    client = Mock()
+    client.record_sets.get.return_value = SimpleNamespace(
+        ttl=300, a_records=[SimpleNamespace(ipv4_address="10.0.0.1")]
+    )
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.99"),
+        target_serial=4,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    client.record_sets.delete.assert_not_called()
+    client.record_sets.create_or_update.assert_not_called()
+
+
+async def test_apply_record_delete_missing_rrset_is_noop(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    """Deleting from an absent RRset is an idempotent no-op."""
+    client = Mock()
+    client.record_sets.get.return_value = None
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="gone", record_type="A", value="10.0.0.9"),
+        target_serial=4,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    client.record_sets.delete.assert_not_called()
+    client.record_sets.create_or_update.assert_not_called()
+
+
+async def test_apply_record_delete_txt_dedupes_across_chunk_split(
+    monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
+) -> None:
+    """A TXT value Azure stored as multiple chunks still matches for removal."""
+    client = Mock()
+    client.record_sets.get.return_value = SimpleNamespace(
+        ttl=3600,
+        txt_records=[
+            SimpleNamespace(value=["v=spf1 ", "-all"]),
+            SimpleNamespace(value=["keep-me"]),
+        ],
+    )
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="TXT", value="v=spf1 -all"),
+        target_serial=4,
+    )
+    await driver._apply_record(server, dict(_CREDS), change)
+
+    client.record_sets.delete.assert_not_called()
+    _, _, _, _, params = client.record_sets.create_or_update.call_args.args
+    assert params["txt_records"] == [{"value": ["keep-me"]}]
 
 
 # ── Zone write ───────────────────────────────────────────────────────────────
@@ -368,6 +582,7 @@ async def test_apply_record_wraps_error_as_cloud_dns_error(
     monkeypatch: pytest.MonkeyPatch, driver: AzureDNSDriver, server: SimpleNamespace
 ) -> None:
     client = Mock()
+    client.record_sets.get.return_value = None  # no existing set → reach create_or_update
     client.record_sets.create_or_update.side_effect = _FakeHttpResponseError("boom")
     _patch_client(monkeypatch, driver, client)
 

--- a/backend/tests/test_dns_cloudflare.py
+++ b/backend/tests/test_dns_cloudflare.py
@@ -1,0 +1,379 @@
+"""Offline unit tests for the Cloudflare DNS driver (issue #37).
+
+Cloudflare is a tier-3 provider with no test account, so every test
+monkeypatches :meth:`CloudflareDNSDriver._client` to return a fake
+async-context-manager client that serves canned envelopes and records the
+calls made against it. Nothing here touches the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.drivers.dns._cloud_base import CloudDNSError
+from app.drivers.dns.base import RecordChange, RecordData
+from app.drivers.dns.cloudflare import CloudflareDNSDriver
+
+
+class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` (status + json())."""
+
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeClient:
+    """Async-context-manager fake of ``httpx.AsyncClient``.
+
+    Each verb pops the next queued response off the matching list and
+    records ``(method, path, params, json)`` for assertion. A queued
+    response can be a ``_FakeResponse`` or a zero-arg callable returning
+    one (so a test can vary the reply by call order).
+    """
+
+    def __init__(self, queues: dict[str, list[Any]]) -> None:
+        self._queues = queues
+        self.calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    def _next(self, method: str, path: str, params: Any, body: Any) -> _FakeResponse:
+        self.calls.append({"method": method, "path": path, "params": params, "json": body})
+        queue = self._queues.get(method)
+        if not queue:
+            raise AssertionError(f"unexpected {method} {path} (no queued response)")
+        item = queue.pop(0)
+        return item() if callable(item) else item
+
+    async def get(self, path: str, params: Any = None) -> _FakeResponse:
+        return self._next("get", path, params, None)
+
+    async def post(self, path: str, json: Any = None) -> _FakeResponse:
+        return self._next("post", path, None, json)
+
+    async def put(self, path: str, json: Any = None) -> _FakeResponse:
+        return self._next("put", path, None, json)
+
+    async def delete(self, path: str, params: Any = None) -> _FakeResponse:
+        return self._next("delete", path, params, None)
+
+
+def _env(result: Any, *, total_pages: int = 1, success: bool = True) -> dict[str, Any]:
+    """Build a Cloudflare-shaped response envelope."""
+    return {
+        "success": success,
+        "errors": [],
+        "result": result,
+        "result_info": {"total_pages": total_pages},
+    }
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, fake: _FakeClient) -> CloudflareDNSDriver:
+    driver = CloudflareDNSDriver()
+    monkeypatch.setattr(driver, "_client", lambda token: fake)
+    return driver
+
+
+class _Server:
+    """Stub DNSServer row — only the attrs the driver reads."""
+
+    id = "srv-1"
+    name = "cf-test"
+    credentials_encrypted = b"x"
+
+
+_CREDS = {"api_token": "tok"}
+
+
+# ── _list_zones pagination ──────────────────────────────────────────────
+async def test_list_zones_paginates_and_flags_reverse(monkeypatch: pytest.MonkeyPatch) -> None:
+    page1 = _env(
+        [
+            {"id": "z1", "name": "example.com"},
+            {"id": "z2", "name": "10.in-addr.arpa"},
+        ],
+        total_pages=2,
+    )
+    page2 = _env([{"id": "z3", "name": "example.net"}], total_pages=2)
+    fake = _FakeClient({"get": [_FakeResponse(200, page1), _FakeResponse(200, page2)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    zones = await driver._list_zones(_Server(), _CREDS)
+
+    assert [z.name for z in zones] == ["example.com.", "10.in-addr.arpa.", "example.net."]
+    assert [z.zone_id for z in zones] == ["z1", "z2", "z3"]
+    # Reverse-zone detection.
+    assert zones[1].is_reverse is True
+    assert zones[0].is_reverse is False
+    # Two pages → two GETs.
+    assert sum(1 for c in fake.calls if c["method"] == "get") == 2
+    assert fake.calls[0]["params"] == {"per_page": 50, "page": 1}
+    assert fake.calls[1]["params"] == {"per_page": 50, "page": 2}
+
+
+# ── _list_zone_records relativization + TTL handling ────────────────────
+async def test_list_zone_records_relativizes_and_normalizes_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    zone_lookup = _env([{"id": "zid"}])
+    records = _env(
+        [
+            {"name": "example.com", "type": "A", "content": "1.2.3.4", "ttl": 1},
+            {"name": "www.example.com", "type": "A", "content": "5.6.7.8", "ttl": 300},
+            {
+                "name": "example.com",
+                "type": "MX",
+                "content": "mail.example.com",
+                "ttl": 3600,
+                "priority": 10,
+            },
+        ]
+    )
+    fake = _FakeClient({"get": [_FakeResponse(200, zone_lookup), _FakeResponse(200, records)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    recs = await driver._list_zone_records(_Server(), _CREDS, "example.com.")
+
+    # Apex collapses to "@"; sub-label relativized; ttl=1 → None (automatic).
+    assert recs[0] == RecordData(name="@", record_type="A", value="1.2.3.4", ttl=None)
+    assert recs[1] == RecordData(name="www", record_type="A", value="5.6.7.8", ttl=300)
+    assert recs[2].name == "@"
+    assert recs[2].priority == 10
+    assert recs[2].ttl == 3600
+    # Zone-id was resolved by name (de-dotted).
+    assert fake.calls[0]["params"] == {"name": "example.com"}
+
+
+# ── _apply_record create ────────────────────────────────────────────────
+async def test_apply_record_create_posts_absolute_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _env([{"id": "zid"}]))],
+            "post": [_FakeResponse(200, _env({"id": "new"}))],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    post = next(c for c in fake.calls if c["method"] == "post")
+    assert post["path"] == "/zones/zid/dns_records"
+    assert post["json"] == {
+        "type": "A",
+        "name": "www.example.com",
+        "content": "1.1.1.1",
+        "ttl": 1,  # None → automatic sentinel.
+    }
+
+
+# ── _apply_record update (existing record found → PUT) ──────────────────
+async def test_apply_record_update_puts_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": "zid"}])),  # resolve zone
+                _FakeResponse(200, _env([{"id": "rid"}])),  # find existing record
+            ],
+            "put": [_FakeResponse(200, _env({"id": "rid"}))],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="2.2.2.2", ttl=120),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    put = next(c for c in fake.calls if c["method"] == "put")
+    assert put["path"] == "/zones/zid/dns_records/rid"
+    assert put["json"]["content"] == "2.2.2.2"
+    assert put["json"]["ttl"] == 120
+
+
+# ── _apply_record update with no match → falls back to create (POST) ────
+async def test_apply_record_update_missing_creates(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": "zid"}])),  # resolve zone
+                _FakeResponse(200, _env([])),  # no existing record
+            ],
+            "post": [_FakeResponse(200, _env({"id": "new"}))],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="3.3.3.3", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    assert [c["method"] for c in fake.calls] == ["get", "get", "post"]
+    post = next(c for c in fake.calls if c["method"] == "post")
+    # Apex name renders as the bare zone.
+    assert post["json"]["name"] == "example.com"
+
+
+# ── _apply_record delete (found → DELETE) ───────────────────────────────
+async def test_apply_record_delete_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": "zid"}])),
+                _FakeResponse(200, _env([{"id": "rid"}])),
+            ],
+            "delete": [_FakeResponse(200, _env({"id": "rid"}))],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/zones/zid/dns_records/rid"
+
+
+# ── _apply_record delete with no match → no-op (no DELETE issued) ───────
+async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": "zid"}])),
+                _FakeResponse(200, _env([])),  # nothing to delete
+            ]
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="gone", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Only the two lookups happened — no DELETE.
+    assert [c["method"] for c in fake.calls] == ["get", "get"]
+
+
+# ── _apply_zone create includes account when account_id present ─────────
+async def test_apply_zone_create_with_account(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"post": [_FakeResponse(200, _env({"id": "z9"}))]})
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), {"api_token": "t", "account_id": "acc1"}, zone, "create")
+
+    post = fake.calls[0]
+    assert post["path"] == "/zones"
+    assert post["json"] == {"name": "example.org", "account": {"id": "acc1"}}
+
+
+async def test_apply_zone_create_without_account(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"post": [_FakeResponse(200, _env({"id": "z9"}))]})
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "create")
+
+    assert fake.calls[0]["json"] == {"name": "example.org"}
+
+
+async def test_apply_zone_delete_resolves_then_deletes(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _env([{"id": "zid"}]))],
+            "delete": [_FakeResponse(200, _env({"id": "zid"}))],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "delete")
+
+    assert [c["method"] for c in fake.calls] == ["get", "delete"]
+    assert fake.calls[1]["path"] == "/zones/zid"
+
+
+# ── Error surfacing ─────────────────────────────────────────────────────
+async def test_success_false_raises_clouddnserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "success": False,
+        "errors": [{"code": 1003, "message": "Invalid or missing zone id."}],
+        "result": None,
+    }
+    fake = _FakeClient({"get": [_FakeResponse(200, payload)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "Invalid or missing zone id." in str(exc.value)
+
+
+async def test_non_2xx_raises_clouddnserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"success": False, "errors": [{"message": "Authentication error"}]}
+    fake = _FakeClient({"get": [_FakeResponse(403, payload)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "Authentication error" in str(exc.value)
+
+
+async def test_missing_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = CloudflareDNSDriver()
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+    with pytest.raises(CloudDNSError):
+        await driver._apply_record(_Server(), {}, change)
+
+
+# ── Static helpers ──────────────────────────────────────────────────────
+def test_relativize_helper() -> None:
+    driver = CloudflareDNSDriver()
+    assert driver._relativize("example.com.", "example.com.") == "@"
+    assert driver._relativize("www.example.com", "example.com.") == "www"
+    assert driver._relativize("a.b.example.com.", "example.com") == "a.b"
+
+
+def test_capabilities_shape() -> None:
+    caps = CloudflareDNSDriver().capabilities()
+    assert caps["name"] == "cloudflare"
+    assert caps["agentless"] is True
+    assert caps["manages_zones"] is True
+    assert caps["dnssec_online"] is True
+    assert caps["apex_cname"] == "flatten"
+    assert "CAA" in caps["record_types"]

--- a/backend/tests/test_dns_google_dns.py
+++ b/backend/tests/test_dns_google_dns.py
@@ -1,0 +1,499 @@
+"""Unit tests for the Google Cloud DNS cloud DNS driver (issue #37).
+
+All tests are offline: the ``google-cloud-dns`` SDK is not installed in
+CI (it's an optional tier-3 dependency), so we
+
+* monkeypatch the client factory (``_client``) to return a stub whose
+  ``list_zones()`` yields ``SimpleNamespace`` managed-zone objects, and
+* inject stub ``google.api_core.exceptions`` / ``google.auth.exceptions``
+  modules into ``sys.modules`` so the driver's lazily-imported error
+  wrapping resolves without the real SDK.
+
+Nothing ever touches GCP.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.drivers.dns._cloud_base import CloudDNSError
+from app.drivers.dns.base import RecordChange, RecordData
+from app.drivers.dns.googledns import GoogleCloudDNSDriver
+
+# ── Stub GCP exception modules (installed for the whole test module) ───────
+
+
+class _GoogleAPICallError(Exception):
+    """Stand-in for google.api_core.exceptions.GoogleAPICallError (offline)."""
+
+
+class _GoogleAuthError(Exception):
+    """Stand-in for google.auth.exceptions.GoogleAuthError (offline)."""
+
+
+@pytest.fixture(autouse=True)
+def _stub_google_modules() -> Any:
+    """Make the driver's lazy ``from google... import exceptions`` resolve.
+
+    The driver imports ``google.api_core.exceptions`` +
+    ``google.auth.exceptions`` inside ``_wrap_call`` so the module imports
+    cleanly without the SDK. Inject stub modules carrying our exception
+    classes so the except clauses bind to types we can raise in tests.
+    """
+    created: list[str] = []
+    for mod_name in (
+        "google",
+        "google.api_core",
+        "google.api_core.exceptions",
+        "google.auth",
+        "google.auth.exceptions",
+    ):
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = types.ModuleType(mod_name)
+            created.append(mod_name)
+    sys.modules["google.api_core.exceptions"].GoogleAPICallError = _GoogleAPICallError  # type: ignore[attr-defined]
+    sys.modules["google.auth.exceptions"].GoogleAuthError = _GoogleAuthError  # type: ignore[attr-defined]
+    yield
+    for mod_name in created:
+        sys.modules.pop(mod_name, None)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _server() -> SimpleNamespace:
+    """A stand-in DNS server row (the driver only touches a few attrs)."""
+    return SimpleNamespace(id="srv-1", name="gcp", credentials_encrypted=None)
+
+
+CREDS = {"service_account_json": '{"type": "service_account"}', "project_id": "proj-1"}
+
+
+def _patch_client(
+    monkeypatch: pytest.MonkeyPatch, driver: GoogleCloudDNSDriver, client: Any
+) -> None:
+    """Wire ``driver._client`` to return ``client`` regardless of creds."""
+    monkeypatch.setattr(driver, "_client", lambda creds: client)
+
+
+def _rrset(name: str, rtype: str, ttl: int | None, rrdatas: list[str]) -> SimpleNamespace:
+    """A stub Cloud DNS ``ResourceRecordSet``."""
+    return SimpleNamespace(name=name, record_type=rtype, ttl=ttl, rrdatas=rrdatas)
+
+
+class _StubChanges:
+    """A stub Cloud DNS ``Changes`` transaction.
+
+    Records ``add_record_set`` / ``delete_record_set`` calls, flips to
+    ``done`` on ``create()`` so the driver's bounded poll loop returns on
+    the first check.
+    """
+
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+        self.deleted: list[Any] = []
+        self.created = False
+        self.status = "pending"
+
+    def add_record_set(self, rrset: Any) -> None:
+        self.added.append(rrset)
+
+    def delete_record_set(self, rrset: Any) -> None:
+        self.deleted.append(rrset)
+
+    def create(self) -> None:
+        self.created = True
+        self.status = "done"
+
+    def reload(self) -> None:  # pragma: no cover — done before first poll
+        self.status = "done"
+
+
+class _StubZone:
+    """A stub Cloud DNS managed zone (``ManagedZone``)."""
+
+    def __init__(
+        self, name: str, dns_name: str, rrsets: list[SimpleNamespace] | None = None
+    ) -> None:
+        self.name = name  # GCP managed-zone id (slug)
+        self.dns_name = dns_name  # FQDN
+        self._rrsets = rrsets or []
+        self.changes_obj = _StubChanges()
+        self.created = False
+        self.deleted = False
+        # Capture the args to ``resource_record_set`` for assertions.
+        self.built_rrsets: list[tuple[str, str, int, list[str]]] = []
+
+    def list_resource_record_sets(self) -> list[SimpleNamespace]:
+        return list(self._rrsets)
+
+    def changes(self) -> _StubChanges:
+        return self.changes_obj
+
+    def resource_record_set(
+        self, name: str, record_type: str, ttl: int, rrdatas: list[str]
+    ) -> SimpleNamespace:
+        self.built_rrsets.append((name, record_type, ttl, rrdatas))
+        return _rrset(name, record_type, ttl, rrdatas)
+
+    def create(self) -> None:
+        self.created = True
+
+    def delete(self) -> None:
+        self.deleted = True
+
+
+def _client_with_zones(*zones: _StubZone) -> SimpleNamespace:
+    """A stub ``dns.Client`` whose ``list_zones()`` yields ``zones``."""
+    return SimpleNamespace(
+        list_zones=lambda: iter(zones),
+        zone=lambda slug, dns_name=None: _StubZone(slug, dns_name or ""),
+    )
+
+
+# ── Zone listing ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_zones_name_and_reverse(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    client = _client_with_zones(
+        _StubZone("example-com", "example.com."),
+        _StubZone("rev-10", "10.in-addr.arpa."),
+    )
+    _patch_client(monkeypatch, driver, client)
+
+    zones = await driver._list_zones(_server(), CREDS)
+
+    # ``name`` is the normalised DNS name; ``zone_id`` is the GCP slug.
+    assert [z.name for z in zones] == ["example.com.", "10.in-addr.arpa."]
+    assert [z.zone_id for z in zones] == ["example-com", "rev-10"]
+    assert [z.is_reverse for z in zones] == [False, True]
+    assert all(z.dnssec_enabled is False for z in zones)
+
+
+@pytest.mark.asyncio
+async def test_pull_zones_from_server_neutral_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    client = _client_with_zones(_StubZone("example-com", "Example.COM."))
+    _patch_client(monkeypatch, driver, client)
+    # Bypass credential decrypt — the base loads from credentials_encrypted.
+    monkeypatch.setattr(driver, "_load_credentials", lambda server: CREDS)
+
+    out = await driver.pull_zones_from_server(_server())
+
+    assert out == [
+        {
+            "name": "example.com.",
+            "zone_type": "Primary",
+            "is_reverse_lookup": False,
+            "dnssec_enabled": False,
+            "zone_id": "example-com",
+            "record_count": None,
+        }
+    ]
+
+
+# ── Record listing / relativization / rrdata expansion ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_zone_records_expand_and_relativize(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    zone = _StubZone(
+        "example-com",
+        "example.com.",
+        rrsets=[
+            _rrset("example.com.", "SOA", 21600, ["ns dns 1 2 3 4 5"]),  # skipped
+            _rrset(
+                "example.com.",
+                "NS",
+                172800,
+                ["ns-cloud-a1.googledomains.com.", "ns-cloud-a2.googledomains.com."],
+            ),
+            _rrset("www.example.com.", "A", 300, ["10.0.0.1"]),
+            _rrset("example.com.", "MX", 3600, ["10 mail.example.com."]),
+        ],
+    )
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    records = await driver._list_zone_records(_server(), CREDS, "example.com.")
+
+    # SOA is skipped.
+    assert all(r.record_type != "SOA" for r in records)
+
+    # NS rrset with two rrdatas expands into two RecordData rows, apex → "@".
+    ns = [r for r in records if r.record_type == "NS"]
+    assert len(ns) == 2
+    assert {r.value for r in ns} == {
+        "ns-cloud-a1.googledomains.com.",
+        "ns-cloud-a2.googledomains.com.",
+    }
+    assert all(r.name == "@" for r in ns)
+
+    # www relativized to "www" with its TTL.
+    www = next(r for r in records if r.record_type == "A")
+    assert www.name == "www"
+    assert www.value == "10.0.0.1"
+    assert www.ttl == 300
+
+    # MX keeps priority baked into the value.
+    mx = next(r for r in records if r.record_type == "MX")
+    assert mx.value == "10 mail.example.com."
+    assert mx.name == "@"
+    assert mx.priority is None
+
+
+@pytest.mark.asyncio
+async def test_list_zone_records_zone_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    # Client returns a neighbouring zone, not the one we asked for.
+    client = _client_with_zones(_StubZone("other-com", "other.com."))
+    _patch_client(monkeypatch, driver, client)
+
+    with pytest.raises(CloudDNSError, match="not found"):
+        await driver._list_zone_records(_server(), CREDS, "example.com.")
+
+
+# ── Record write: change-set build for create / update / delete ────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_record_create_builds_add_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    zone = _StubZone("example-com", "example.com.")
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=120),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    ch = zone.changes_obj
+    assert ch.created is True
+    assert ch.deleted == []
+    # The added rrset is the absolutized name + single-value rrdatas.
+    assert zone.built_rrsets == [("www.example.com.", "A", 120, ["10.0.0.1"])]
+    assert len(ch.added) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_record_apex_and_default_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    zone = _StubZone("example-com", "example.com.")
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="TXT", value="v=spf1 -all", ttl=None),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    # Apex absolutized to the zone FQDN, default TTL 300 when None.
+    assert zone.built_rrsets == [("example.com.", "TXT", 300, ["v=spf1 -all"])]
+
+
+@pytest.mark.asyncio
+async def test_apply_record_update_deletes_old_then_adds_new(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    driver = GoogleCloudDNSDriver()
+    existing = _rrset("www.example.com.", "A", 300, ["10.0.0.9"])
+    zone = _StubZone("example-com", "example.com.", rrsets=[existing])
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=600),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    ch = zone.changes_obj
+    # One atomic change set: delete the exact existing rrset + add the new.
+    assert ch.deleted == [existing]
+    assert zone.built_rrsets == [("www.example.com.", "A", 600, ["10.0.0.1"])]
+    assert len(ch.added) == 1
+    assert ch.created is True
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    existing = _rrset("old.example.com.", "A", 300, ["10.0.0.9"])
+    zone = _StubZone("example-com", "example.com.", rrsets=[existing])
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="old", record_type="A", value="10.0.0.9", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    ch = zone.changes_obj
+    # Delete references the exact existing rrset; nothing added.
+    assert ch.deleted == [existing]
+    assert ch.added == []
+    assert ch.created is True
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    zone = _StubZone("example-com", "example.com.", rrsets=[])  # nothing to delete
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="ghost", record_type="A", value="10.0.0.9", ttl=300),
+        target_serial=1,
+    )
+    # No raise — and no empty change set committed.
+    await driver._apply_record(_server(), CREDS, change)
+
+    ch = zone.changes_obj
+    assert ch.created is False
+    assert ch.added == []
+    assert ch.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_apply_record_bad_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    _patch_client(monkeypatch, driver, _client_with_zones(_StubZone("z", "x.test.")))
+    change = RecordChange(
+        op="rename",  # type: ignore[arg-type]
+        zone_name="x.test.",
+        record=RecordData(name="a", record_type="A", value="1.2.3.4", ttl=300),
+        target_serial=1,
+    )
+    with pytest.raises(CloudDNSError, match="bad op"):
+        await driver._apply_record(_server(), CREDS, change)
+
+
+# ── Zone write ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_zone_create(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    created_zones: list[_StubZone] = []
+
+    def _zone_factory(slug: str, dns_name: str | None = None) -> _StubZone:
+        z = _StubZone(slug, dns_name or "")
+        created_zones.append(z)
+        return z
+
+    client = SimpleNamespace(list_zones=lambda: iter(()), zone=_zone_factory)
+    _patch_client(monkeypatch, driver, client)
+
+    zone = SimpleNamespace(name="New.Example.")
+    await driver._apply_zone(_server(), CREDS, zone, "create")
+
+    assert len(created_zones) == 1
+    made = created_zones[0]
+    # Slug derived from the FQDN; dns_name is the normalised FQDN.
+    assert made.name == "new-example"
+    assert made.dns_name == "new.example."
+    assert made.created is True
+
+
+@pytest.mark.asyncio
+async def test_apply_zone_delete_resolves_zone(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    target = _StubZone("doomed-example", "doomed.example.")
+    client = _client_with_zones(target)
+    _patch_client(monkeypatch, driver, client)
+
+    zone = SimpleNamespace(name="doomed.example.")
+    await driver._apply_zone(_server(), CREDS, zone, "delete")
+
+    assert target.deleted is True
+
+
+@pytest.mark.asyncio
+async def test_apply_zone_bad_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+    _patch_client(monkeypatch, driver, _client_with_zones())
+    with pytest.raises(CloudDNSError, match="unsupported op"):
+        await driver._apply_zone(_server(), CREDS, SimpleNamespace(name="x.test."), "rename")
+
+
+# ── Error wrapping ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_zones_wraps_google_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+
+    def _boom() -> Any:
+        raise _GoogleAPICallError("permission denied")
+
+    client = SimpleNamespace(list_zones=_boom, zone=lambda *a, **k: None)
+    _patch_client(monkeypatch, driver, client)
+
+    with pytest.raises(CloudDNSError, match="list_zones failed"):
+        await driver._list_zones(_server(), CREDS)
+
+
+@pytest.mark.asyncio
+async def test_apply_record_wraps_google_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = GoogleCloudDNSDriver()
+
+    class _AuthZone(_StubZone):
+        def changes(self) -> _StubChanges:
+            raise _GoogleAuthError("invalid credentials")
+
+    zone = _AuthZone("example-com", "example.com.")
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=120),
+        target_serial=1,
+    )
+    with pytest.raises(CloudDNSError, match="change_record_sets failed"):
+        await driver._apply_record(_server(), CREDS, change)
+
+
+# ── Capabilities + credential fields ───────────────────────────────────────
+
+
+def test_capabilities_shape() -> None:
+    caps = GoogleCloudDNSDriver().capabilities()
+    assert caps["name"] == "google_dns"
+    assert caps["agentless"] is True
+    assert caps["manages_zones"] is True
+    assert caps["dnssec_online"] is True
+    assert caps["views"] is False
+    assert caps["rpz"] is False
+    assert "A" in caps["record_types"]
+    assert "SOA" in caps["record_types"]
+
+
+def test_credential_fields() -> None:
+    driver = GoogleCloudDNSDriver()
+    assert driver.name == "google_dns"
+    assert driver.credential_fields == ("service_account_json", "project_id")

--- a/backend/tests/test_dns_google_dns.py
+++ b/backend/tests/test_dns_google_dns.py
@@ -377,6 +377,170 @@ async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPat
     assert ch.deleted == []
 
 
+# ── Record write: multi-value RRset read-merge (the #328 data-loss fix) ─────
+
+
+@pytest.mark.asyncio
+async def test_apply_record_create_merges_into_existing_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Creating a 2nd value for an existing {name,type} keeps the sibling.
+
+    A round-robin A record: the rrset already holds 10.0.0.1; creating
+    10.0.0.2 must write the FULL merged set, not drop the original.
+    """
+    driver = GoogleCloudDNSDriver()
+    existing = _rrset("www.example.com.", "A", 300, ["10.0.0.1"])
+    zone = _StubZone("example-com", "example.com.", rrsets=[existing])
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.2", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    ch = zone.changes_obj
+    assert ch.created is True
+    # Old rrset deleted, merged rrset (both values) added — one atomic change.
+    assert ch.deleted == [existing]
+    assert zone.built_rrsets == [("www.example.com.", "A", 300, ["10.0.0.1", "10.0.0.2"])]
+    assert len(ch.added) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_record_create_existing_value_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-creating an already-present value writes nothing (idempotent)."""
+    driver = GoogleCloudDNSDriver()
+    existing = _rrset("www.example.com.", "A", 300, ["10.0.0.1"])
+    zone = _StubZone("example-com", "example.com.", rrsets=[existing])
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    ch = zone.changes_obj
+    assert ch.created is False
+    assert ch.added == []
+    assert ch.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_apply_record_create_uses_change_ttl_on_merge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A merge applies the change's ttl across the whole rrset."""
+    driver = GoogleCloudDNSDriver()
+    existing = _rrset("@", "MX", 3600, ["10 mail1.example.com."])
+    # Apex rrset is stored under the absolute apex FQDN.
+    existing.name = "example.com."
+    zone = _StubZone("example-com", "example.com.", rrsets=[existing])
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="MX", value="20 mail2.example.com.", ttl=600),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    # Both MX values present, ttl from the change (600).
+    assert zone.built_rrsets == [
+        ("example.com.", "MX", 600, ["10 mail1.example.com.", "20 mail2.example.com."])
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_one_of_two_leaves_other(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting one value of a 2-value rrset re-writes the reduced set."""
+    driver = GoogleCloudDNSDriver()
+    existing = _rrset("www.example.com.", "A", 300, ["10.0.0.1", "10.0.0.2"])
+    zone = _StubZone("example-com", "example.com.", rrsets=[existing])
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    ch = zone.changes_obj
+    assert ch.created is True
+    # Old (full) rrset deleted; reduced rrset (the surviving value) re-added.
+    assert ch.deleted == [existing]
+    assert zone.built_rrsets == [("www.example.com.", "A", 300, ["10.0.0.2"])]
+    assert len(ch.added) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_last_value_removes_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting the only value removes the whole rrset (no re-add)."""
+    driver = GoogleCloudDNSDriver()
+    existing = _rrset("www.example.com.", "A", 300, ["10.0.0.1"])
+    zone = _StubZone("example-com", "example.com.", rrsets=[existing])
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    ch = zone.changes_obj
+    assert ch.created is True
+    assert ch.deleted == [existing]
+    assert ch.added == []
+    assert zone.built_rrsets == []
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_value_not_in_rrset_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting a value absent from the live rrset is an idempotent no-op."""
+    driver = GoogleCloudDNSDriver()
+    existing = _rrset("www.example.com.", "A", 300, ["10.0.0.1", "10.0.0.2"])
+    zone = _StubZone("example-com", "example.com.", rrsets=[existing])
+    client = _client_with_zones(zone)
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.9", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    ch = zone.changes_obj
+    assert ch.created is False
+    assert ch.added == []
+    assert ch.deleted == []
+
+
 @pytest.mark.asyncio
 async def test_apply_record_bad_op(monkeypatch: pytest.MonkeyPatch) -> None:
     driver = GoogleCloudDNSDriver()

--- a/backend/tests/test_dns_import_cloud.py
+++ b/backend/tests/test_dns_import_cloud.py
@@ -1,0 +1,243 @@
+"""Tests for the cloud DNS live-pull importer (issue #37, Part C).
+
+The four cloud drivers (Cloudflare / Route 53 / Azure DNS / Google
+Cloud DNS) hit a real provider API, so we monkeypatch the ``get_driver``
+registry lookup the importer uses and return a fake driver whose
+``pull_zones_from_server`` / ``pull_zone_records`` return synthetic data.
+This exercises the same canonical-shape coercion + conflict-detection
+paths the production importer hits, entirely offline.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.drivers.dns.base import RecordData
+from app.models.dns import DNSServer, DNSServerGroup, DNSZone
+from app.services.dns_import import cloud as cloud_import
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+async def _make_group(db: AsyncSession, name: str = "cloud-grp") -> DNSServerGroup:
+    g = DNSServerGroup(name=name)
+    db.add(g)
+    await db.flush()
+    return g
+
+
+async def _make_cloud_server(
+    db: AsyncSession,
+    group: DNSServerGroup,
+    *,
+    name: str = "cf01",
+    driver: str = "cloudflare",
+    host: str = "api.cloudflare.com",
+) -> DNSServer:
+    server = DNSServer(
+        group_id=group.id,
+        name=name,
+        driver=driver,
+        host=host,
+        port=443,
+        is_enabled=True,
+        # The fake driver never decrypts this; the importer only reads
+        # zone / record methods. Any placeholder blob works.
+        credentials_encrypted=b"placeholder-encrypted-blob",
+    )
+    db.add(server)
+    await db.flush()
+    return server
+
+
+# Synthetic provider data. Mirrors CloudDNSDriverBase.pull_zones_from_server
+# (trailing-dot FQDN, "Primary" zone_type, is_reverse_lookup +
+# dnssec_enabled flags) + pull_zone_records (RecordData relative to apex).
+_FAKE_ZONES = [
+    {
+        "name": "example.com.",
+        "zone_type": "Primary",
+        "is_reverse_lookup": False,
+        "dnssec_enabled": True,
+        "zone_id": "cf-zone-1",
+        "record_count": 3,
+    },
+    {
+        "name": "10.in-addr.arpa.",
+        "zone_type": "Primary",
+        "is_reverse_lookup": True,
+        "dnssec_enabled": False,
+        "zone_id": "cf-zone-2",
+        "record_count": 1,
+    },
+]
+
+_FAKE_RECORDS = {
+    "example.com.": [
+        RecordData(name="@", record_type="A", value="203.0.113.10", ttl=300),
+        RecordData(name="www", record_type="A", value="203.0.113.10", ttl=300),
+        RecordData(
+            name="@",
+            record_type="MX",
+            value="mail.example.com.",
+            ttl=3600,
+            priority=10,
+        ),
+    ],
+    "10.in-addr.arpa.": [
+        RecordData(name="10.0.0", record_type="PTR", value="host.example.com.", ttl=3600),
+    ],
+}
+
+
+class _FakeCloudDriver:
+    """Stub matching the CloudDNSDriverBase read surface the importer uses."""
+
+    async def pull_zones_from_server(self, server):  # noqa: ARG002 — signature parity
+        return [dict(z) for z in _FAKE_ZONES]
+
+    async def pull_zone_records(self, server, zone_name):  # noqa: ARG002
+        # Normalise to the trailing-dot key the importer passes in.
+        key = zone_name if zone_name.endswith(".") else zone_name + "."
+        return list(_FAKE_RECORDS.get(key, []))
+
+
+@pytest.fixture
+def patched_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the registry lookup so the importer gets the fake driver."""
+
+    monkeypatch.setattr(cloud_import, "get_driver", lambda _name: _FakeCloudDriver())
+
+
+# ── Service-layer ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_preview_cloud_import_canonical_shape(
+    db_session: AsyncSession, patched_driver: None
+) -> None:
+    group = await _make_group(db_session)
+    server = await _make_cloud_server(db_session, group)
+    await db_session.commit()
+
+    preview = await cloud_import.preview_cloud_import(
+        db_session, server_id=server.id, target_group_id=group.id
+    )
+
+    # Source label carries the provider name, not a generic "cloud".
+    assert preview.source == "cloudflare"
+    assert len(preview.zones) == 2
+    assert preview.conflicts == []  # nothing in the target group yet
+
+    by_name = {z.name: z for z in preview.zones}
+    assert "example.com." in by_name
+    assert "10.in-addr.arpa." in by_name
+
+    forward = by_name["example.com."]
+    assert forward.kind == "forward"
+    assert forward.zone_type == "primary"
+    assert {r.record_type for r in forward.records} == {"A", "MX"}
+    mx = next(r for r in forward.records if r.record_type == "MX")
+    assert mx.priority == 10
+    # SOA defaults applied with the operator-facing warning.
+    assert forward.soa is not None
+    assert forward.soa.ttl == 3600
+    assert forward.soa.refresh == 86400
+    assert any("SOA defaults" in w for w in forward.parse_warnings)
+    # DNSSEC-signed source surfaces a per-zone warning.
+    assert any("DNSSEC-signed" in w for w in forward.parse_warnings)
+
+    rev = by_name["10.in-addr.arpa."]
+    assert rev.kind == "reverse"
+    # Reverse zone is not signed → no DNSSEC warning.
+    assert not any("DNSSEC-signed" in w for w in rev.parse_warnings)
+
+    # Histogram aggregates across zones.
+    assert preview.record_type_histogram["A"] == 2
+    assert preview.record_type_histogram["MX"] == 1
+    assert preview.record_type_histogram["PTR"] == 1
+    assert preview.total_records == 4
+
+
+@pytest.mark.asyncio
+async def test_preview_cloud_import_flags_conflict(
+    db_session: AsyncSession, patched_driver: None
+) -> None:
+    group = await _make_group(db_session)
+    server = await _make_cloud_server(db_session, group)
+    # Pre-create a zone that collides with one of the fake zones.
+    existing = DNSZone(
+        group_id=group.id,
+        name="example.com.",
+        zone_type="primary",
+        kind="forward",
+    )
+    db_session.add(existing)
+    await db_session.commit()
+
+    preview = await cloud_import.preview_cloud_import(
+        db_session, server_id=server.id, target_group_id=group.id
+    )
+
+    assert {c.zone_name for c in preview.conflicts} == {"example.com."}
+    conflict = preview.conflicts[0]
+    assert conflict.existing_zone_id == str(existing.id)
+    # The non-colliding reverse zone is not flagged.
+    assert "10.in-addr.arpa." not in {c.zone_name for c in preview.conflicts}
+
+
+@pytest.mark.asyncio
+async def test_preview_rejects_non_cloud_driver(
+    db_session: AsyncSession, patched_driver: None
+) -> None:
+    group = await _make_group(db_session)
+    bind_server = await _make_cloud_server(
+        db_session, group, name="bind1", driver="bind9", host="bind1.example.com"
+    )
+    await db_session.commit()
+
+    with pytest.raises(ValueError) as exc_info:
+        await cloud_import.preview_cloud_import(
+            db_session, server_id=bind_server.id, target_group_id=group.id
+        )
+    assert "bind9" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_preview_rejects_unknown_server(db_session: AsyncSession) -> None:
+    group = await _make_group(db_session)
+    await db_session.commit()
+
+    with pytest.raises(ValueError) as exc_info:
+        await cloud_import.preview_cloud_import(
+            db_session, server_id=uuid.uuid4(), target_group_id=group.id
+        )
+    assert "does not exist" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_preview_empty_account_warns(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    group = await _make_group(db_session)
+    server = await _make_cloud_server(db_session, group)
+    await db_session.commit()
+
+    class _EmptyDriver:
+        async def pull_zones_from_server(self, server):  # noqa: ARG002
+            return []
+
+        async def pull_zone_records(self, server, zone_name):  # noqa: ARG002
+            return []
+
+    monkeypatch.setattr(cloud_import, "get_driver", lambda _name: _EmptyDriver())
+
+    preview = await cloud_import.preview_cloud_import(
+        db_session, server_id=server.id, target_group_id=group.id
+    )
+    assert preview.zones == []
+    assert preview.total_records == 0
+    assert any("No hosted zones" in w for w in preview.warnings)

--- a/backend/tests/test_dns_import_cloud.py
+++ b/backend/tests/test_dns_import_cloud.py
@@ -1,4 +1,4 @@
-"""Tests for the cloud DNS live-pull importer (issue #37, Part C).
+"""Tests for the cloud DNS live-pull importer (issue #37, Part B).
 
 The four cloud drivers (Cloudflare / Route 53 / Azure DNS / Google
 Cloud DNS) hit a real provider API, so we monkeypatch the ``get_driver``

--- a/backend/tests/test_dns_route53.py
+++ b/backend/tests/test_dns_route53.py
@@ -210,11 +210,17 @@ async def test_list_zone_records_zone_not_found(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.asyncio
-async def test_apply_record_upsert_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_apply_record_create_new_rrset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Creating a value when no rrset exists yet writes just that value."""
     driver = Route53DNSDriver()
     client = MagicMock()
     client.list_hosted_zones_by_name.return_value = {
         "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    # Read-merge: Route 53 returns the lexically-next rrset (a non-match),
+    # so the driver treats {www, A} as absent.
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [{"Name": "zzz.example.com.", "Type": "A"}]
     }
     _patch_client(monkeypatch, driver, client)
 
@@ -237,6 +243,119 @@ async def test_apply_record_upsert_batch(monkeypatch: pytest.MonkeyPatch) -> Non
         "TTL": 120,
         "ResourceRecords": [{"Value": "10.0.0.1"}],
     }
+
+
+@pytest.mark.asyncio
+async def test_apply_record_create_merges_into_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Creating a 2nd value for an existing {name,type} writes BOTH values."""
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    # Live rrset already carries one A value at the round-robin host.
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "rr.example.com.",
+                "Type": "A",
+                "TTL": 300,
+                "ResourceRecords": [{"Value": "10.0.0.1"}],
+            }
+        ]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="rr", record_type="A", value="10.0.0.2", ttl=None),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    # The read used the absolute name + type as the start key.
+    read_kwargs = client.list_resource_record_sets.call_args.kwargs
+    assert read_kwargs["StartRecordName"] == "rr.example.com."
+    assert read_kwargs["StartRecordType"] == "A"
+    assert read_kwargs["MaxItems"] == "1"
+
+    batch_change = client.change_resource_record_sets.call_args.kwargs["ChangeBatch"]["Changes"][0]
+    assert batch_change["Action"] == "UPSERT"
+    rrset = batch_change["ResourceRecordSet"]
+    assert rrset["Name"] == "rr.example.com."
+    assert rrset["Type"] == "A"
+    # TTL falls back to the live rrset's TTL when the change carries none.
+    assert rrset["TTL"] == 300
+    # BOTH values present — the sibling was NOT clobbered.
+    assert {v["Value"] for v in rrset["ResourceRecords"]} == {"10.0.0.1", "10.0.0.2"}
+
+
+@pytest.mark.asyncio
+async def test_apply_record_create_duplicate_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Creating a value already in the rrset writes nothing (idempotent)."""
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "rr.example.com.",
+                "Type": "A",
+                "TTL": 300,
+                "ResourceRecords": [{"Value": "10.0.0.1"}],
+            }
+        ]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="rr", record_type="A", value="10.0.0.1", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    # Value already present — no write submitted.
+    client.change_resource_record_sets.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_record_create_skips_alias_merge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An ALIAS rrset is single-valued — create replaces, never merges."""
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "app.example.com.",
+                "Type": "A",
+                "AliasTarget": {"DNSName": "elb-123.elb.amazonaws.com."},
+            }
+        ]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="app", record_type="A", value="10.0.0.5", ttl=120),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    rrset = client.change_resource_record_sets.call_args.kwargs["ChangeBatch"]["Changes"][0][
+        "ResourceRecordSet"
+    ]
+    # Replaced with the value-bearing rrset; no alias merge attempted.
+    assert "AliasTarget" not in rrset
+    assert rrset["ResourceRecords"] == [{"Value": "10.0.0.5"}]
 
 
 @pytest.mark.asyncio
@@ -264,11 +383,24 @@ async def test_apply_record_apex_and_default_ttl(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
-async def test_apply_record_delete_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_apply_record_delete_last_value_removes_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting the only value submits a DELETE of the EXACT live rrset."""
     driver = Route53DNSDriver()
     client = MagicMock()
     client.list_hosted_zones_by_name.return_value = {
         "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "old.example.com.",
+                "Type": "A",
+                "TTL": 300,
+                "ResourceRecords": [{"Value": "10.0.0.9"}],
+            }
+        ]
     }
     _patch_client(monkeypatch, driver, client)
 
@@ -282,7 +414,7 @@ async def test_apply_record_delete_batch(monkeypatch: pytest.MonkeyPatch) -> Non
 
     batch_change = client.change_resource_record_sets.call_args.kwargs["ChangeBatch"]["Changes"][0]
     assert batch_change["Action"] == "DELETE"
-    # DELETE must reconstruct the exact rrset (TTL + value).
+    # DELETE must carry the EXACT existing rrset (TTL + value) verbatim.
     assert batch_change["ResourceRecordSet"] == {
         "Name": "old.example.com.",
         "Type": "A",
@@ -292,11 +424,120 @@ async def test_apply_record_delete_batch(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_apply_record_delete_one_of_many_leaves_others(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting one value of a multi-value rrset UPSERTs the reduced set."""
     driver = Route53DNSDriver()
     client = MagicMock()
     client.list_hosted_zones_by_name.return_value = {
         "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "rr.example.com.",
+                "Type": "A",
+                "TTL": 300,
+                "ResourceRecords": [{"Value": "10.0.0.1"}, {"Value": "10.0.0.2"}],
+            }
+        ]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="rr", record_type="A", value="10.0.0.1", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    batch_change = client.change_resource_record_sets.call_args.kwargs["ChangeBatch"]["Changes"][0]
+    # Reduced set is UPSERTed, NOT deleted — the surviving sibling stays.
+    assert batch_change["Action"] == "UPSERT"
+    rrset = batch_change["ResourceRecordSet"]
+    assert rrset["TTL"] == 300
+    assert rrset["ResourceRecords"] == [{"Value": "10.0.0.2"}]
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_value_not_present_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deleting a value absent from the live rrset writes nothing."""
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "rr.example.com.",
+                "Type": "A",
+                "TTL": 300,
+                "ResourceRecords": [{"Value": "10.0.0.1"}],
+            }
+        ]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="rr", record_type="A", value="10.0.0.9", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    client.change_resource_record_sets.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_missing_rrset_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No rrset at all for {name,type} → idempotent no-op (no write)."""
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    # Route 53 returns a neighbouring rrset, not the one we asked for.
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [{"Name": "zzz.example.com.", "Type": "A"}]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="ghost", record_type="A", value="10.0.0.9", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    client.change_resource_record_sets.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_invalid_batch_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A racing InvalidChangeBatch on the DELETE write is still a no-op."""
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [
+            {
+                "Name": "old.example.com.",
+                "Type": "A",
+                "TTL": 300,
+                "ResourceRecords": [{"Value": "10.0.0.9"}],
+            }
+        ]
     }
     client.change_resource_record_sets.side_effect = _ClientError(
         "InvalidChangeBatch", "tried to delete a record that doesn't exist"
@@ -306,10 +547,10 @@ async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPat
     change = RecordChange(
         op="delete",
         zone_name="example.com.",
-        record=RecordData(name="ghost", record_type="A", value="10.0.0.9", ttl=300),
+        record=RecordData(name="old", record_type="A", value="10.0.0.9", ttl=300),
         target_serial=1,
     )
-    # No raise — idempotent delete of an absent record.
+    # No raise — InvalidChangeBatch on the write is treated as idempotent.
     await driver._apply_record(_server(), CREDS, change)
 
 
@@ -320,6 +561,8 @@ async def test_apply_record_wraps_client_error(monkeypatch: pytest.MonkeyPatch) 
     client.list_hosted_zones_by_name.return_value = {
         "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
     }
+    # Read-merge finds no existing rrset; the write then fails on auth.
+    client.list_resource_record_sets.return_value = {"ResourceRecordSets": []}
     client.change_resource_record_sets.side_effect = _ClientError("AccessDenied", "not authorized")
     _patch_client(monkeypatch, driver, client)
 
@@ -331,6 +574,52 @@ async def test_apply_record_wraps_client_error(monkeypatch: pytest.MonkeyPatch) 
     )
     with pytest.raises(CloudDNSError, match="change_resource_record_sets"):
         await driver._apply_record(_server(), CREDS, change)
+
+
+@pytest.mark.asyncio
+async def test_apply_record_wraps_read_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure on the read-merge call surfaces as a CloudDNSError."""
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.list_resource_record_sets.side_effect = _ClientError("AccessDenied", "not authorized")
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        target_serial=1,
+    )
+    with pytest.raises(CloudDNSError, match="read-merge"):
+        await driver._apply_record(_server(), CREDS, change)
+
+
+@pytest.mark.asyncio
+async def test_apply_record_update_replaces_without_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Update keeps single-value replace — it never reads the live rrset."""
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.7", ttl=120),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    # No read-merge for update (the op carries only the new value).
+    client.list_resource_record_sets.assert_not_called()
+    batch_change = client.change_resource_record_sets.call_args.kwargs["ChangeBatch"]["Changes"][0]
+    assert batch_change["Action"] == "UPSERT"
+    assert batch_change["ResourceRecordSet"]["ResourceRecords"] == [{"Value": "10.0.0.7"}]
 
 
 # ── Zone write ─────────────────────────────────────────────────────────────

--- a/backend/tests/test_dns_route53.py
+++ b/backend/tests/test_dns_route53.py
@@ -1,0 +1,395 @@
+"""Unit tests for the Amazon Route 53 cloud DNS driver (issue #37).
+
+All tests are offline: the boto3 client factory (``_client``) is
+monkeypatched to a ``Mock`` returning canned Route 53 API dicts, so
+nothing ever touches AWS.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.drivers.dns._cloud_base import CloudDNSError
+from app.drivers.dns.base import RecordChange, RecordData
+from app.drivers.dns.route53 import Route53DNSDriver
+
+
+def _server() -> SimpleNamespace:
+    """A stand-in DNS server row (the driver only touches a few attrs)."""
+    return SimpleNamespace(id="srv-1", name="aws", credentials_encrypted=None)
+
+
+CREDS = {"access_key_id": "AKIAEXAMPLE", "secret_access_key": "secret"}
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, driver: Route53DNSDriver, client: Any) -> None:
+    """Wire ``driver._client`` to return ``client`` regardless of creds."""
+    monkeypatch.setattr(driver, "_client", lambda creds: client)
+
+
+class _ClientError(Exception):
+    """Stand-in for botocore.exceptions.ClientError (offline)."""
+
+    def __init__(self, code: str, message: str = "boom") -> None:
+        super().__init__(f"{code}: {message}")
+        self.response = {"Error": {"Code": code, "Message": message}}
+
+
+# ── Zone listing ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_zones_paginated_and_reverse(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones.side_effect = [
+        {
+            "HostedZones": [
+                {"Id": "/hostedzone/Z1", "Name": "example.com.", "ResourceRecordSetCount": 5},
+            ],
+            "IsTruncated": True,
+            "NextMarker": "m2",
+        },
+        {
+            "HostedZones": [
+                {
+                    "Id": "/hostedzone/Z2",
+                    "Name": "10.in-addr.arpa.",
+                    "ResourceRecordSetCount": 2,
+                },
+            ],
+            "IsTruncated": False,
+        },
+    ]
+    _patch_client(monkeypatch, driver, client)
+
+    zones = await driver._list_zones(_server(), CREDS)
+
+    assert [z.name for z in zones] == ["example.com.", "10.in-addr.arpa."]
+    assert [z.zone_id for z in zones] == ["Z1", "Z2"]
+    assert [z.is_reverse for z in zones] == [False, True]
+    assert [z.record_count for z in zones] == [5, 2]
+    # Second page must be requested with the marker from the first page.
+    assert client.list_hosted_zones.call_count == 2
+    assert client.list_hosted_zones.call_args_list[1].kwargs["Marker"] == "m2"
+
+
+@pytest.mark.asyncio
+async def test_pull_zones_from_server_neutral_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones.return_value = {
+        "HostedZones": [
+            {"Id": "/hostedzone/Z1", "Name": "Example.COM.", "ResourceRecordSetCount": 3},
+        ],
+        "IsTruncated": False,
+    }
+    monkeypatch.setattr(_server(), "credentials_encrypted", b"x", raising=False)
+    _patch_client(monkeypatch, driver, client)
+    # Bypass credential decrypt — the base loads from credentials_encrypted.
+    monkeypatch.setattr(driver, "_load_credentials", lambda server: CREDS)
+
+    out = await driver.pull_zones_from_server(_server())
+
+    assert out == [
+        {
+            "name": "example.com.",
+            "zone_type": "Primary",
+            "is_reverse_lookup": False,
+            "dnssec_enabled": False,
+            "zone_id": "Z1",
+            "record_count": 3,
+        }
+    ]
+
+
+# ── Record listing / relativization / multi-value expansion ───────────────
+
+
+@pytest.mark.asyncio
+async def test_list_zone_records_relativize_and_expand(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.list_resource_record_sets.side_effect = [
+        {
+            "ResourceRecordSets": [
+                {
+                    "Name": "example.com.",
+                    "Type": "NS",
+                    "TTL": 172800,
+                    "ResourceRecords": [
+                        {"Value": "ns-1.awsdns.com."},
+                        {"Value": "ns-2.awsdns.net."},
+                    ],
+                },
+                {
+                    "Name": "www.example.com.",
+                    "Type": "A",
+                    "TTL": 300,
+                    "ResourceRecords": [{"Value": "10.0.0.1"}],
+                },
+            ],
+            "IsTruncated": True,
+            "NextRecordName": "www.example.com.",
+            "NextRecordType": "MX",
+        },
+        {
+            "ResourceRecordSets": [
+                {
+                    "Name": "example.com.",
+                    "Type": "MX",
+                    "TTL": 3600,
+                    "ResourceRecords": [{"Value": "10 mail.example.com."}],
+                },
+                {
+                    "Name": "app.example.com.",
+                    "Type": "A",
+                    "AliasTarget": {"DNSName": "elb-123.us-east-1.elb.amazonaws.com."},
+                },
+            ],
+            "IsTruncated": False,
+        },
+    ]
+    _patch_client(monkeypatch, driver, client)
+
+    records = await driver._list_zone_records(_server(), CREDS, "example.com.")
+
+    # NS apex rrset expands into two RecordData rows (one per value),
+    # relativized to "@".
+    ns = [r for r in records if r.record_type == "NS"]
+    assert len(ns) == 2
+    assert {r.value for r in ns} == {"ns-1.awsdns.com.", "ns-2.awsdns.net."}
+    assert all(r.name == "@" for r in ns)
+
+    www = next(r for r in records if r.record_type == "A" and r.value == "10.0.0.1")
+    assert www.name == "www"
+    assert www.ttl == 300
+
+    # MX keeps the priority baked into the value; priority stays None.
+    mx = next(r for r in records if r.record_type == "MX")
+    assert mx.value == "10 mail.example.com."
+    assert mx.priority is None
+    assert mx.name == "@"
+
+    # ALIAS rrset → value is the target DNS name, ttl is None.
+    alias = next(r for r in records if r.name == "app")
+    assert alias.value == "elb-123.us-east-1.elb.amazonaws.com."
+    assert alias.ttl is None
+
+    # Pagination: the second call carries the start markers.
+    assert client.list_resource_record_sets.call_count == 2
+    second = client.list_resource_record_sets.call_args_list[1].kwargs
+    assert second["StartRecordName"] == "www.example.com."
+    assert second["StartRecordType"] == "MX"
+
+
+@pytest.mark.asyncio
+async def test_list_zone_records_zone_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    # API returns a neighbouring zone, not the one we asked for.
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z9", "Name": "other.com."}]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    with pytest.raises(CloudDNSError, match="not found"):
+        await driver._list_zone_records(_server(), CREDS, "example.com.")
+
+
+# ── Record write: UPSERT vs DELETE change batches ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_record_upsert_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=120),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    kwargs = client.change_resource_record_sets.call_args.kwargs
+    assert kwargs["HostedZoneId"] == "Z1"
+    batch_change = kwargs["ChangeBatch"]["Changes"][0]
+    assert batch_change["Action"] == "UPSERT"
+    rrset = batch_change["ResourceRecordSet"]
+    assert rrset == {
+        "Name": "www.example.com.",
+        "Type": "A",
+        "TTL": 120,
+        "ResourceRecords": [{"Value": "10.0.0.1"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_apply_record_apex_and_default_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="TXT", value="v=spf1 -all", ttl=None),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    rrset = client.change_resource_record_sets.call_args.kwargs["ChangeBatch"]["Changes"][0][
+        "ResourceRecordSet"
+    ]
+    assert rrset["Name"] == "example.com."  # apex absolutized
+    assert rrset["TTL"] == 300  # default when ttl is None
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="old", record_type="A", value="10.0.0.9", ttl=300),
+        target_serial=1,
+    )
+    await driver._apply_record(_server(), CREDS, change)
+
+    batch_change = client.change_resource_record_sets.call_args.kwargs["ChangeBatch"]["Changes"][0]
+    assert batch_change["Action"] == "DELETE"
+    # DELETE must reconstruct the exact rrset (TTL + value).
+    assert batch_change["ResourceRecordSet"] == {
+        "Name": "old.example.com.",
+        "Type": "A",
+        "TTL": 300,
+        "ResourceRecords": [{"Value": "10.0.0.9"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.change_resource_record_sets.side_effect = _ClientError(
+        "InvalidChangeBatch", "tried to delete a record that doesn't exist"
+    )
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="ghost", record_type="A", value="10.0.0.9", ttl=300),
+        target_serial=1,
+    )
+    # No raise — idempotent delete of an absent record.
+    await driver._apply_record(_server(), CREDS, change)
+
+
+@pytest.mark.asyncio
+async def test_apply_record_wraps_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z1", "Name": "example.com."}]
+    }
+    client.change_resource_record_sets.side_effect = _ClientError("AccessDenied", "not authorized")
+    _patch_client(monkeypatch, driver, client)
+
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        target_serial=1,
+    )
+    with pytest.raises(CloudDNSError, match="change_resource_record_sets"):
+        await driver._apply_record(_server(), CREDS, change)
+
+
+# ── Zone write ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_zone_create(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    _patch_client(monkeypatch, driver, client)
+
+    zone = SimpleNamespace(name="new.example.")
+    await driver._apply_zone(_server(), CREDS, zone, "create")
+
+    kwargs = client.create_hosted_zone.call_args.kwargs
+    assert kwargs["Name"] == "new.example."
+    # CallerReference must be a non-empty unique token.
+    assert kwargs["CallerReference"]
+
+
+@pytest.mark.asyncio
+async def test_apply_zone_delete_resolves_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    client = MagicMock()
+    client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/Z42", "Name": "doomed.example."}]
+    }
+    _patch_client(monkeypatch, driver, client)
+
+    zone = SimpleNamespace(name="doomed.example.")
+    await driver._apply_zone(_server(), CREDS, zone, "delete")
+
+    assert client.delete_hosted_zone.call_args.kwargs["Id"] == "Z42"
+
+
+@pytest.mark.asyncio
+async def test_apply_zone_bad_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = Route53DNSDriver()
+    _patch_client(monkeypatch, driver, MagicMock())
+    with pytest.raises(CloudDNSError, match="unsupported op"):
+        await driver._apply_zone(_server(), CREDS, SimpleNamespace(name="x.test."), "rename")
+
+
+# ── Capabilities ───────────────────────────────────────────────────────────
+
+
+def test_capabilities_shape() -> None:
+    caps = Route53DNSDriver().capabilities()
+    assert caps["name"] == "route53"
+    assert caps["agentless"] is True
+    assert caps["manages_zones"] is True
+    assert caps["dnssec_online"] is True
+    assert caps["alias_records"] is True
+    assert "ALIAS" in caps["record_types"]
+    assert caps["views"] is False
+    assert caps["rpz"] is False
+
+
+def test_credential_fields() -> None:
+    driver = Route53DNSDriver()
+    assert driver.name == "route53"
+    assert driver.credential_fields == ("access_key_id", "secret_access_key")

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -235,13 +235,15 @@ Required security group for the service account: `DnsAdmins` on the domain (or a
 
 ### 3.4 Driver registry classification
 
-In [`app/drivers/dns/registry.py`](../../backend/app/drivers/dns/registry.py):
+In [`app/drivers/dns/__init__.py`](../../backend/app/drivers/dns/__init__.py):
 
 ```python
-AGENTLESS_DRIVERS: frozenset[str] = frozenset({"windows_dns"})
+AGENTLESS_DRIVERS: frozenset[str] = frozenset(
+    {"windows_dns", "cloudflare", "route53", "azure_dns", "google_dns"}
+)
 ```
 
-Agentless drivers don't emit a `ConfigBundle`; the API's `record_ops.enqueue_record_op` short-circuits them and calls `apply_record_change` directly instead of queueing for a co-located agent.
+Agentless drivers don't emit a `ConfigBundle`; the API's `record_ops.enqueue_record_op` short-circuits them and calls `apply_record_change` directly instead of queueing for a co-located agent. The four cloud-hosted DNS providers (§4A) joined this set in issue #37.
 
 ### 3.5 Write-through pattern
 
@@ -433,19 +435,87 @@ LMDB cache survives control-plane outages — non-negotiable #5 in `CLAUDE.md`. 
 
 ---
 
+## 4A. Cloud DNS drivers (agentless) — issue #37 Part B
+
+Four cloud-hosted authoritative-DNS providers ship as a driver family: **Cloudflare**, **Amazon Route 53** (`route53`), **Azure DNS** (`azure_dns`), and **Google Cloud DNS** (`google_dns`). SpatiumDDI manages their zones and records exactly like a local BIND9 / PowerDNS / Windows zone — same Zones / Records / group surfaces — except the control plane calls the provider's REST/SDK API directly. There is **no agent**.
+
+These are infrastructure-DNS drivers, distinct from the *Cloud (AWS / Azure / GCP)* read-only infrastructure mirror (issue #37 Part A, in [INTEGRATIONS.md](../features/INTEGRATIONS.md)). A cloud DNS server is added through the normal Add DNS server flow and lives in a `DNSServerGroup`; it has no `CloudEndpoint` row.
+
+### 4A.1 Agentless shape (reuses Windows-DNS Path B)
+
+The shared base [`drivers/dns/_cloud_base.py`](../../backend/app/drivers/dns/_cloud_base.py) (`CloudDNSDriverBase`) mirrors how `windows_dns` Path B already works (§3 above):
+
+- **No ConfigBundle / long-poll.** The `render_*` methods return `""` and the `reload_*` methods are no-ops — agentless drivers never render daemon config. `validate_config` accepts anything.
+- **Credentials in the existing column.** The per-provider credential dict is Fernet-encrypted in the existing `DNSServer.credentials_encrypted` column — no new credential store. `_load_credentials` decrypts it, raising a clean `CloudDNSError` when unset vs. when the API rejects the key.
+- **Record writes run synchronously from the control plane.** Once the driver name is listed in `AGENTLESS_DRIVERS` (registry §5), the API's `record_ops._apply_agentless` calls `apply_record_change` directly and records each op as `applied` / `failed` on a `DNSRecordOp` row — exactly the path Windows DNS uses. The default batch loop in `DNSDriver` isolates a per-op failure into a `RecordChangeResult(ok=False)`.
+- **Zone create / delete via `apply_zone_change(server, zone, op)`** (`op` ∈ `create` / `delete`) — cloud providers have no rename, so the caller sends delete+create. Routed through the same write-through pattern as Windows zone CRUD (§3.5): pushed to the provider before the SpatiumDDI DB commit so the two states stay consistent.
+- **Reads via `pull_zones_from_server` / `pull_zone_records`** — the same method names Windows DNS exposes, returning the same neutral dict / `RecordData` shape (record names relative to the apex, `@` for apex). So the existing `sync-from-server` drift path *and* the cloud import service (§ MIGRATION.md) both work against any cloud driver with no per-provider glue.
+
+A concrete provider subclasses `CloudDNSDriverBase` and implements only five cloud-specific hooks — `_list_zones`, `_list_zone_records`, `_apply_record`, `_apply_zone`, `capabilities` — plus the `name` / `credential_fields` class attrs. Everything DNSDriver-shaped lives in the base.
+
+### 4A.2 Per-driver credential dict shapes
+
+`credential_fields` is an ordered tuple the Add-DNS-server modal renders and the probe validates as required:
+
+| Driver | `name` | Credential dict (decrypted from `DNSServer.credentials_encrypted`) | SDK / transport |
+|---|---|---|---|
+| Cloudflare | `cloudflare` | `{api_token}` — `account_id` optional, only consulted on zone create | plain `httpx` REST against `api.cloudflare.com/client/v4` (no vendor SDK) |
+| Route 53 | `route53` | `{access_key_id, secret_access_key}` — global service, no region | `boto3` |
+| Azure DNS | `azure_dns` | `{tenant_id, client_id, client_secret, subscription_id, resource_group}` | `azure-identity` + `azure-mgmt-dns` |
+| Google Cloud DNS | `google_dns` | `{service_account_json, project_id}` | `google-cloud-dns` |
+
+All SDK imports are lazy (inside the client factory) so the modules import cleanly without the optional wheel, and tests can patch the factory; blocking SDK calls run under `asyncio.to_thread`. Cloudflare is the exception — pure JSON over HTTPS, so it uses `httpx` directly.
+
+### 4A.3 Capabilities + online-DNSSEC matrix
+
+Each driver's `capabilities()` returns the same dict shape Windows / PowerDNS use (`agentless: True`, `manages_zones: True`, `views: False`, `rpz: False`, a `record_types` list, a `notes` blurb). The operator-visible differences:
+
+| | Cloudflare | Route 53 | Azure DNS | Google Cloud DNS |
+|---|:---:|:---:|:---:|:---:|
+| `dnssec_online` | ✅ | ✅ | ❌ | ✅ |
+| ALIAS records | apex CNAME auto-flattened | ✅ (`AliasTarget`, null TTL) | ✅ | — |
+| Apex handling | Cloudflare flattens CNAME-at-apex | apex SOA / NS provider-managed | apex SOA Azure-managed (skipped on read) | apex SOA provider-managed |
+
+`azure_dns` is the only cloud driver without online DNSSEC support — its capability dict carries `dnssec_online: False` and the notes call it out. The DNSSEC sign/unsign/rollover operations stay gated server-side by `_DRIVER_GATED_OPERATIONS` as for every other driver.
+
+### 4A.4 Provider-specific wrinkles the hooks paper over
+
+- **Cloudflare** — every reply is wrapped in a `{success, errors, result, result_info}` envelope; `_unwrap` raises `CloudDNSError` on non-2xx *or* a `success: false` (the API returns 200 with `success: false` for some validation failures). The opaque zone id is resolved by name per call. "Automatic" TTL is the sentinel `1`, surfaced as `ttl=None`. `update` is create-on-miss.
+- **Route 53** — MX / SRV priority is baked into the record value (`"10 mail.example.com."`), kept raw so it isn't double-encoded on write. ALIAS rrsets (`AliasTarget`) have no TTL → surfaced with `ttl=None`. Writes are `UPSERT`/`DELETE` change batches; a `DELETE` of a non-existent rrset (`InvalidChangeBatch`) is treated as an idempotent no-op. Hosted-zone id resolved from the FQDN via `list_hosted_zones_by_name` with an exact-name match.
+- **Azure DNS** — records live in *record sets*, one per `(name, type)`, each with a typed list (`a_records`, `mx_records`, …); each set expands into one neutral `RecordData` per contained record. Create and update are both a `create_or_update` PUT of the full set. SOA is Azure-managed and dropped on read.
+- **Google Cloud DNS** — calls scope by the managed-zone *id* (a slug like `example-com`), not the DNS name, so the hooks re-resolve the managed zone by matching `dns_name`. A single rrset carries one or more `rrdatas` (one `RecordData` each on read, collapsed to a single-value rrset on write). Writes are transactional change sets (`changes.create()`); the op polls `changes.status` until `done` (bounded ~60 s) so it only returns once Cloud DNS has applied it.
+
+### 4A.5 Probe
+
+`CloudDNSDriverBase.probe(server)` is the cheap credential check behind the Add-DNS-server **Test** button — by default it lists zones and reports the count, never raising for an expected failure (returns `ok=False` with the provider message). The Cloudflare driver's `_unwrap`, Route 53's `_is_invalid_change_batch`, Azure's `_wrap_errors`, and Google's `_wrap_call` all normalise raw SDK faults into operator-facing `CloudDNSError` messages first.
+
+---
+
 ## 5. Driver Selection and Registration
 
 Drivers are registered by name and instantiated by the service layer:
 
 ```python
-# app/drivers/dns/registry.py
+# app/drivers/dns/__init__.py
 _DRIVERS: dict[str, type[DNSDriver]] = {
     "bind9": BIND9Driver,
     "powerdns": PowerDNSDriver,
     "windows_dns": WindowsDNSDriver,
+    # Agentless cloud-hosted DNS providers (issue #37, Part B).
+    "cloudflare": CloudflareDNSDriver,
+    "route53": Route53DNSDriver,
+    "azure_dns": AzureDNSDriver,
+    "google_dns": GoogleCloudDNSDriver,
 }
 
-AGENTLESS_DRIVERS: frozenset[str] = frozenset({"windows_dns"})
+# Drivers whose record ops run from the control plane directly, no agent.
+AGENTLESS_DRIVERS: frozenset[str] = frozenset(
+    {"windows_dns", "cloudflare", "route53", "azure_dns", "google_dns"}
+)
+# The cloud subset (used by the cloud import + sync-from-server widening).
+CLOUD_DNS_DRIVERS: frozenset[str] = frozenset(
+    {"cloudflare", "route53", "azure_dns", "google_dns"}
+)
 
 def get_driver(server_type: str) -> DNSDriver:
     cls = _DRIVERS.get(server_type)

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -47,6 +47,16 @@ PowerDNS-only features (ALIAS / LUA / online DNSSEC sign+unsign) are server-side
 
 The Operator Copilot's `propose_create_dns_zone` tool accepts an explicit `driver_hint` argument (`bind9` / `powerdns` / `windows_dns`) so the LLM can route DNSSEC-required zones to PowerDNS groups without operators having to specify the group UUID by hand. See `app.services.ai.operations.CreateDNSZoneArgs`.
 
+### 0a. Cloud DNS providers — Cloudflare / Route 53 / Azure DNS / Google Cloud DNS (issue #37)
+
+**Add DNS server** also offers four cloud-hosted authoritative-DNS providers as driver choices: **Cloudflare**, **Amazon Route 53**, **Azure DNS**, and **Google Cloud DNS**. Once added, their zones and records are managed exactly like a local BIND9 / PowerDNS zone — same Zones / Records / group surfaces, same CRUD — but the control plane drives the provider's REST/SDK API directly instead of an agent (an *agentless* driver, the same shape as Windows DNS Path B). A cloud DNS server lives in a normal `DNSServerGroup`; credentials are a provider-specific dict (Cloudflare API token, Route 53 access keys, an Azure service-principal triple + subscription / resource group, or a GCP service-account JSON + project id) entered in the Add DNS server modal and Fernet-encrypted in `DNSServer.credentials_encrypted`.
+
+The modal renders a per-driver **in-modal setup guide** for the required credential fields and a **Test** button that does a cheap auth + list-zones probe before save. Online DNSSEC is supported on Cloudflare / Route 53 / Google Cloud DNS but **not** Azure DNS. Full per-driver internals (credential shapes, capability matrix, per-provider wrinkles) are in [DNS_DRIVERS.md §4A](../drivers/DNS_DRIVERS.md).
+
+**Bringing existing zones in.** A cloud account that already hosts zones imports through the DNS importer's cloud source (preview → commit; see [MIGRATION.md](MIGRATION.md)). After that, ongoing drift is reconciled the same way as any other server — the **sync-from-server** path pulls the provider's live zone/record state via the driver's `pull_zones_from_server` / `pull_zone_records` reads.
+
+These cloud-DNS drivers are distinct from the *Cloud (AWS / Azure / GCP)* read-only **infrastructure** mirror (issue #37 Part A — VPCs / subnets / instance IPs into IPAM; see [INTEGRATIONS.md](INTEGRATIONS.md)). One is authoritative-DNS management; the other is an IPAM reconciler. They share a provider vocabulary, not a code path.
+
 ---
 
 ## 1. DNS Server Groups

--- a/docs/features/INTEGRATIONS.md
+++ b/docs/features/INTEGRATIONS.md
@@ -232,11 +232,98 @@ Shipped as Option 2 from the original plan (synthetic `DNSZone` materialised by 
 
 ---
 
+## Cloud (AWS / Azure / GCP)
+
+**Phase status**: Part A shipped (read-only infrastructure mirror). Cloud DNS — the agentless authoritative-DNS driver family for Cloudflare / Route 53 / Azure DNS / Google Cloud DNS — is **Part B** and is *not* part of this integration; it ships through the Add DNS server flow instead (see [DNS.md](DNS.md) and [DNS_DRIVERS.md](../drivers/DNS_DRIVERS.md)).
+
+Gated behind the `integrations.cloud` feature module (**default off** — Settings → Features). One `CloudEndpoint` row per cloud account / subscription set / project set. AWS, Azure, and GCP are wired today; the model reserves the token-only providers (Hetzner / DigitalOcean / Linode / Vultr) for a future phase without a schema change.
+
+Per-endpoint config (`CloudEndpoint` rows):
+
+| Field | Notes |
+|---|---|
+| `provider` | `aws` \| `azure` \| `gcp`. Immutable after create (re-create to switch). |
+| `credentials` | Provider-specific secret dict, Fernet-encrypted at rest. AWS: `{access_key_id, secret_access_key}`. Azure: `{tenant_id, client_id, client_secret}`. GCP: `{service_account_json}` (the whole key file as a string). |
+| `provider_config` | Non-secret routing scope, shown in the UI without a decrypt. Azure: `{subscription_ids: [...]}` (required). GCP: `{project_ids: [...]}` (required). AWS: `{}` — AWS scopes by `regions`. |
+| `regions` | Region / location allow-list. Empty = all regions the account can see. AWS fans out one client per region (empty → `ec2:DescribeRegions` discovers every opted-in region); Azure / GCP filter the flat resource list. |
+| `ipam_space_id` | **Required.** Private VPC/VNet networks + their subnets + instance NICs land under this space (one `IPBlock` per VPC CIDR, `Subnet` rows beneath). |
+| `public_space_id` | Optional. A separate space for `cloud-public` / `cloud-lb` IPs. NULL keeps them in `ipam_space_id`. |
+| `dns_group_id` | Optional. Held for future cloud-DNS surfacing; unused by the infra mirror today. |
+| `mirror_load_balancers` | Default `true`. Mirror load-balancer frontend IPs as `cloud-lb` rows. |
+| `mirror_stopped_instances` | Default `false` — only running instances land in IPAM. On keeps stopped / deallocated instances too (capacity-planning views). |
+| `sync_interval_seconds` | Default `300`. Floor `60`. Cloud APIs are slower + rate-limited, so the cadence is deliberately longer than the 30 s shared default. Swept by `sweep_cloud_endpoints` on a 30 s beat tick. |
+
+### Mirror semantics
+
+- **VPCs / VNets** → one `IPBlock` per address-space CIDR under the bound space, named `<provider>:<network>` (the CIDR suffix is appended only when a network declares more than one CIDR). When an operator (or other-integration) block already encloses the CIDR, the reconciler nests beneath it rather than creating a same-CIDR duplicate.
+- **GCP networks carry no CIDR of their own** — a GCP VPC is a global CIDR-less container and the addressing lives entirely on its (regional) subnetworks. For those the reconciler creates one block per distinct subnet CIDR, and the subnet nests directly inside its same-CIDR block. No supernet is speculatively invented.
+- **Subnets** → one `Subnet` each, enclosed by the network's block. Cloud subnets are routed overlays: they are created with `kubernetes_semantics=True` so the IPAM tree suppresses the LAN-specific network / broadcast / gateway placeholder rows (same as Kubernetes pod-CIDR / Tailnet subnets). The gateway defaults to the first usable host (`x.x.x.1`) unless the provider reports one.
+- **Instance NICs** → `IPAddress` with `status="cloud-instance"`, hostname = instance name, MAC from the NIC when the provider exposes it (AWS / Azure do; GCP does not). A NIC's public IP, if present, also yields a `cloud-public` row.
+- **Standalone public / Elastic / external IPs** → `IPAddress` with `status="cloud-public"`.
+- **Load-balancer frontends** (when `mirror_load_balancers`) → `IPAddress` with `status="cloud-lb"`. AWS NLBs expose static frontend IPs; AWS ALBs + classic ELBs are DNS-name-only (their public IPs float) so they are skipped with a warning.
+- **Public + LB IPs are usually out-of-band /32s.** A `cloud-public` / `cloud-lb` row only materialises when an enclosing **mirrored** subnet exists (in `public_space_id` when set, else `ipam_space_id`). IPs that fall outside every mirrored subnet are counted under `skipped_no_subnet` — a documented limitation, not an error.
+
+### Lock semantics
+
+Same ownership shape as Proxmox / Tailscale: pre-existing operator rows at a desired address are claimed (FK stamped, `user_modified_at` set so the operator's soft fields lock); rows owned by another integration are skipped with a warning; locked rows whose upstream resource disappears release the FK (appear as "manually managed") instead of being deleted; an operator subnet at an exact-CIDR match is reused untouched (`subnets_matched`). The reconciler always corrects the factual `subnet_id`.
+
+### Setup — least-privilege credentials
+
+The admin page at `/cloud` ships a per-provider copy-paste guide. **Test Connection** (`POST /endpoints/test`) does a cheap auth + reachability probe — AWS resolves the account via `sts:GetCallerIdentity` + counts VPCs in one region; Azure lists VNets in the first subscription; GCP lists networks in the first project — and surfaces a clean message on failure rather than a raw SDK traceback.
+
+**AWS** — create an IAM user with programmatic access and attach the three AWS-managed read-only policies:
+
+```
+AmazonVPCReadOnlyAccess
+AmazonEC2ReadOnlyAccess
+ElasticLoadBalancingReadOnly
+```
+
+Paste the access key id + secret access key into the form. Leave **Regions** blank to walk every opted-in region, or pin a subset.
+
+**Azure** — create a read-only service principal scoped to the subscription(s):
+
+```sh
+az ad sp create-for-rbac --name spatiumddi-readonly --role Reader \
+  --scopes /subscriptions/<subscription-id>
+```
+
+Paste the printed `tenant` / `appId` / `password` into **Tenant ID** / **Client ID** / **Client secret**, and the subscription id(s) into **Subscription IDs** (required — Azure scopes by subscription).
+
+**GCP** — create a service account, grant it `roles/compute.viewer`, and download a JSON key:
+
+```sh
+gcloud iam service-accounts create spatiumddi-readonly
+gcloud projects add-iam-policy-binding <project-id> \
+  --member="serviceAccount:spatiumddi-readonly@<project-id>.iam.gserviceaccount.com" \
+  --role="roles/compute.viewer"
+gcloud iam service-accounts keys create key.json \
+  --iam-account=spatiumddi-readonly@<project-id>.iam.gserviceaccount.com
+```
+
+Paste the whole `key.json` contents into **Service account JSON** and the project id(s) into **Project IDs** (required).
+
+### Discovery modal
+
+The reconciler writes a `last_discovery` JSONB snapshot on every successful sync — category counters (networks / subnets / public IPs / load balancers totals, instances running / mirrored / no-subnet / no-NIC) plus a per-instance diagnostic list categorising each instance as `mirrored`, `no_subnet` (its private IP isn't enclosed by any mirrored subnet — check the VPC subnet was discovered in this region), or `no_nic`. Same shape + magnifier-icon button as the Proxmox Discovery modal. Disabled until the endpoint has synced at least once.
+
+### Delete semantics
+
+Mirror rows provenance via the `cloud_endpoint_id` FK on `IPBlock` / `Subnet` / `IPAddress` with `ON DELETE CASCADE`, so deleting the endpoint sweeps every materialised row atomically. Endpoint-owned blocks that no longer back any subnet are dropped on each reconcile.
+
+### Non-goals
+
+- **Read-only.** SpatiumDDI never writes back to the cloud — no instance / network / DNS mutation, no tagging.
+- **Cloudflare is not a Part A provider.** It has no VPC / instance concept; it appears only as a Part B cloud-DNS driver.
+- **No per-resource management surface** (start / stop / console) — outside the read-only-mirror scope.
+
+---
+
 ## Dashboard surface
 
 When **any** integration toggle is on, the dashboard renders an **Integrations panel** below the service health strip with:
 
-- One column per enabled integration (Kubernetes / Docker / Proxmox / Tailscale), header linking to the full admin page.
+- One column per enabled integration (Kubernetes / Docker / Proxmox / Tailscale / UniFi / Cloud), header linking to the full admin page.
 - Per-row: status dot (green = synced recently, amber = stalled > 3× sync interval, red = `last_sync_error`, gray = disabled or never synced), name, endpoint, node / container count, humanized last-synced age.
 - `last_sync_error` is exposed as the row tooltip so operators can triage without leaving the dashboard.
 
@@ -248,6 +335,6 @@ Tier 1 remaining (tracked in [CLAUDE.md §Future Phases § Additional integratio
 
 Tier 2 (narrower): MikroTik RouterOS 7, Incus / LXD, HashiCorp Nomad, NetBox one-shot import.
 
-Tier 3 (cloud — AWS / Azure / GCP / Hetzner / DO / Linode / Vultr VPC family): roadmap-coherent but not a lab-first priority.
+Tier 3 (cloud VPC family): AWS / Azure / GCP **shipped** (see [Cloud](#cloud-aws--azure--gcp) above). The token-only providers (Hetzner / DigitalOcean / Linode / Vultr) are reserved in the `CloudEndpoint` provider enum for a future phase.
 
 **Explicit non-goals**: VMware vCenter / ESXi (SOAP-heavy, enterprise effort), SNMP polling (tracked as a separate IPAM discovery line item), WireGuard raw config (no API).

--- a/docs/features/MIGRATION.md
+++ b/docs/features/MIGRATION.md
@@ -19,7 +19,7 @@ surface can hide it (Settings → Features).
 |---|---|---|
 | Feature module | `dns.import` | `dhcp.import` |
 | Admin surface | DNS Import (sidebar) | DHCP Import (sidebar) |
-| Sources | BIND9 archive · Windows DNS live-pull · PowerDNS REST | Kea JSON file · Windows DHCP live-pull · ISC `dhcpd.conf` |
+| Sources | BIND9 archive · Windows DNS live-pull · PowerDNS REST · Cloud DNS live-pull (Cloudflare / Route 53 / Azure DNS / Google Cloud DNS) | Kea JSON file · Windows DHCP live-pull · ISC `dhcpd.conf` |
 | Target | DNS server group (+ optional view) | DHCP server group (+ IPAM linkage) |
 | Provenance columns | `dns_zone` / `dns_record` `import_source` + `imported_at` | `dhcp_scope` / `dhcp_pool` / `dhcp_static_assignment` / `dhcp_client_class` `import_source` + `imported_at` |
 | Conflict actions | skip / overwrite / rename (per zone) | skip / overwrite (per scope) |
@@ -73,12 +73,38 @@ Three sources, all reducing to canonical `ImportedZone` + `ImportedRecord`:
   `Get-DnsServerResourceRecord`.
 - **PowerDNS REST** — paste an API URL + key (read once, never
   persisted); the importer walks `/api/v1/servers/{server}/zones`.
+- **Cloud DNS live-pull** *(issue #37)* — pick a registered cloud DNS
+  server (driver in `{cloudflare, route53, azure_dns, google_dns}`)
+  that has its provider credentials configured. The control plane
+  pulls every hosted zone + its records through the agentless driver's
+  `pull_zones_from_server` / `pull_zone_records` reads — the same
+  method names Windows DNS uses, so this source is a near-clone of the
+  Windows live-pull. Cloud providers own the SOA + apex NS on their
+  side, so the importer applies standards-compliant SOA defaults
+  (rewritten from the zone's own `primary_ns` / `admin_email` at push
+  time) and surfaces a per-zone warning; a DNSSEC-signed source zone
+  warns that signing state isn't imported and must be re-established on
+  the destination driver after commit.
+
+Endpoints: `GET /dns/import/cloud/servers` (the credentialled
+server picker), `POST /dns/import/cloud/preview`, and
+`POST /dns/import/cloud/commit` — same preview → commit shape, same
+per-zone conflict actions (below). This is also the engine behind a
+cloud DNS server's **Sync from provider** button.
 
 Per-zone conflict actions: **skip** (default — never trample an
 existing zone), **overwrite** (delete + recreate), **rename** (create
 under an operator-typed FQDN).
 
-See `docs/drivers/DNS_DRIVERS.md` for parser internals.
+**Per-provider provenance.** Unlike the other DNS sources (which stamp
+a single `bind9` / `windows_dns` / `powerdns` label), the cloud source
+stamps the **provider name** — `cloudflare`, `route53`, `azure_dns`,
+or `google_dns` — into every created row's `import_source` column, so
+provenance stays queryable per provider. The plan's `source` field
+must match the endpoint or the commit is rejected.
+
+See `docs/drivers/DNS_DRIVERS.md` for parser + agentless-driver
+internals.
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import { PXEProfilesPage } from "@/pages/dhcp/PXEProfilesPage";
 import { KubernetesPage } from "@/pages/kubernetes/KubernetesPage";
 import { DockerPage } from "@/pages/docker/DockerPage";
 import { ProxmoxPage } from "@/pages/proxmox/ProxmoxPage";
+import { CloudPage } from "@/pages/cloud/CloudPage";
 import { TailscalePage } from "@/pages/tailscale/TailscalePage";
 import { UnifiPage } from "@/pages/unifi/UnifiPage";
 import { UnifiControllerDetailPage } from "@/pages/unifi/UnifiControllerDetailPage";
@@ -145,6 +146,7 @@ export default function App() {
         <Route path="kubernetes" element={<KubernetesPage />} />
         <Route path="docker" element={<DockerPage />} />
         <Route path="proxmox" element={<ProxmoxPage />} />
+        <Route path="cloud" element={<CloudPage />} />
         <Route path="tailscale" element={<TailscalePage />} />
         <Route path="unifi" element={<UnifiPage />} />
         <Route path="unifi/:id" element={<UnifiControllerDetailPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -33,6 +33,7 @@ import {
   BellRing,
   Sparkles,
   Boxes,
+  Cloud,
   Container as ContainerIcon,
   Cpu,
   Earth,
@@ -494,6 +495,9 @@ export function Sidebar({
   // of the order we added integrations here — adding a new one later
   // shouldn't re-shuffle the sidebar for operators already using it.
   const integrationsNav = [
+    ...(moduleEnabled("integrations.cloud")
+      ? [{ label: "Cloud", icon: Cloud, to: "/cloud" }]
+      : []),
     ...(moduleEnabled("integrations.kubernetes")
       ? [{ label: "Kubernetes", icon: Boxes, to: "/kubernetes" }]
       : []),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2845,6 +2845,7 @@ export interface PlatformSettings {
   integration_proxmox_enabled: boolean;
   integration_tailscale_enabled: boolean;
   integration_unifi_enabled: boolean;
+  integration_cloud_enabled: boolean;
   /** Domain WHOIS refresh cadence (hours). Beat ticks hourly; the
    *  task itself reads this on every fire so cadence changes take
    *  effect on the next tick without restarting beat. 1–168 h range
@@ -4391,6 +4392,9 @@ export const dnsApi = {
     data: Partial<DNSServer> & {
       api_key?: string;
       windows_credentials?: WindowsDNSCredentials | Record<string, never>;
+      // Cloud DNS driver credentials (issue #37). Provider-specific dict
+      // (e.g. {api_token} for cloudflare); Fernet-encrypted server-side.
+      cloud_credentials?: Record<string, string>;
     },
   ) =>
     api
@@ -4404,6 +4408,8 @@ export const dnsApi = {
       windows_credentials?:
         | Partial<WindowsDNSCredentials>
         | Record<string, never>;
+      // None = leave alone, {} = clear, dict = replace.
+      cloud_credentials?: Record<string, string> | Record<string, never>;
     },
   ) =>
     api
@@ -4995,6 +5001,19 @@ export interface WindowsDNSServerOption {
   has_credentials: boolean;
 }
 
+// Cloud DNS import (issue #37, Part B). One row in the cloud-DNS server
+// picker — filtered to cloud-driver rows (cloudflare/route53/azure_dns/
+// google_dns). Mirrors WindowsDNSServerOption but carries the driver
+// name instead of a host.
+export interface CloudDNSServerOption {
+  id: string;
+  name: string;
+  driver: string;
+  group_id: string;
+  group_name: string;
+  has_credentials: boolean;
+}
+
 export const dnsImportApi = {
   bind9Preview: (
     file: File,
@@ -5075,6 +5094,31 @@ export const dnsImportApi = {
   }) =>
     api
       .post<DNSImportCommitResult>("/dns/import/powerdns/commit", body)
+      .then((r) => r.data),
+
+  // Cloud DNS (issue #37, Part B) — live pull of hosted zones + records
+  // from a cloud DNS provider. Also the engine behind "Sync from
+  // provider" on a cloud DNS server.
+  cloudDNSServers: () =>
+    api
+      .get<CloudDNSServerOption[]>("/dns/import/cloud/servers")
+      .then((r) => r.data),
+  cloudDNSPreview: (body: {
+    server_id: string;
+    target_group_id: string;
+    target_view_id?: string | null;
+  }) =>
+    api
+      .post<DNSImportPreview>("/dns/import/cloud/preview", body)
+      .then((r) => r.data),
+  cloudDNSCommit: (body: {
+    target_group_id: string;
+    target_view_id?: string | null;
+    plan: DNSImportPreview;
+    conflict_actions: Record<string, DNSImportConflictDecision>;
+  }) =>
+    api
+      .post<DNSImportCommitResult>("/dns/import/cloud/commit", body)
       .then((r) => r.data),
 };
 
@@ -6931,7 +6975,8 @@ export type IntegrationDashboardKind =
   | "docker"
   | "proxmox"
   | "tailscale"
-  | "unifi";
+  | "unifi"
+  | "cloud";
 export interface IntegrationsDashboardTargetRow {
   id: string;
   display: string;
@@ -8817,6 +8862,100 @@ export const proxmoxApi = {
   syncNow: (id: string) =>
     api
       .post<{ status: string; task_id: string }>(`/proxmox/nodes/${id}/sync`)
+      .then((r) => r.data),
+};
+
+// ── Cloud integration (issue #37, Part A — AWS / Azure / GCP) ──────
+
+export type CloudProvider = "aws" | "azure" | "gcp";
+
+export interface CloudEndpoint {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  provider: CloudProvider;
+  credentials_present: boolean;
+  // Non-secret routing scope: azure {subscription_ids}, gcp {project_ids}.
+  provider_config: Record<string, unknown>;
+  regions: string[];
+  ipam_space_id: string;
+  public_space_id: string | null;
+  dns_group_id: string | null;
+  mirror_load_balancers: boolean;
+  mirror_stopped_instances: boolean;
+  sync_interval_seconds: number;
+  last_synced_at: string | null;
+  last_sync_error: string | null;
+  provider_account_id: string | null;
+  network_count: number | null;
+  instance_count: number | null;
+  last_discovery: Record<string, unknown> | null;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface CloudEndpointCreate {
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  provider: CloudProvider;
+  credentials: Record<string, string>;
+  provider_config?: Record<string, unknown>;
+  regions?: string[];
+  ipam_space_id: string;
+  public_space_id?: string | null;
+  dns_group_id?: string | null;
+  mirror_load_balancers?: boolean;
+  mirror_stopped_instances?: boolean;
+  sync_interval_seconds?: number;
+}
+
+export interface CloudEndpointUpdate {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  // Omit/empty to keep stored creds; non-empty rotates.
+  credentials?: Record<string, string>;
+  provider_config?: Record<string, unknown>;
+  regions?: string[];
+  ipam_space_id?: string;
+  public_space_id?: string | null;
+  dns_group_id?: string | null;
+  mirror_load_balancers?: boolean;
+  mirror_stopped_instances?: boolean;
+  sync_interval_seconds?: number;
+}
+
+export interface CloudTestResult {
+  ok: boolean;
+  message: string;
+  provider_account_id: string | null;
+  network_count: number | null;
+  instance_count: number | null;
+}
+
+export const cloudApi = {
+  listEndpoints: () =>
+    api.get<CloudEndpoint[]>("/cloud/endpoints").then((r) => r.data),
+  createEndpoint: (data: CloudEndpointCreate) =>
+    api.post<CloudEndpoint>("/cloud/endpoints", data).then((r) => r.data),
+  updateEndpoint: (id: string, data: CloudEndpointUpdate) =>
+    api.put<CloudEndpoint>(`/cloud/endpoints/${id}`, data).then((r) => r.data),
+  deleteEndpoint: (id: string) => api.delete(`/cloud/endpoints/${id}`),
+  testConnection: (body: {
+    endpoint_id?: string;
+    provider?: CloudProvider;
+    credentials?: Record<string, string>;
+    provider_config?: Record<string, unknown>;
+    regions?: string[];
+  }) =>
+    api
+      .post<CloudTestResult>("/cloud/endpoints/test", body)
+      .then((r) => r.data),
+  syncNow: (id: string) =>
+    api
+      .post<{ status: string; task_id: string }>(`/cloud/endpoints/${id}/sync`)
       .then((r) => r.data),
 };
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ClipboardCheck,
   Clock,
+  Cloud,
   Container as ContainerIcon,
   Cpu,
   FileDown,
@@ -42,6 +43,7 @@ import {
   kubernetesApi,
   dockerApi,
   proxmoxApi,
+  cloudApi,
   tailscaleApi,
   unifiApi,
   platformHealthApi,
@@ -59,6 +61,7 @@ import {
   type KubernetesCluster,
   type DockerHost,
   type ProxmoxNode,
+  type CloudEndpoint,
   type TailscaleTenant,
   type UnifiController,
   type PlatformHealthResponse,
@@ -840,6 +843,7 @@ export function DashboardPage() {
   const kubernetesEnabled = settings?.integration_kubernetes_enabled ?? false;
   const dockerEnabled = settings?.integration_docker_enabled ?? false;
   const proxmoxEnabled = settings?.integration_proxmox_enabled ?? false;
+  const cloudEnabled = settings?.integration_cloud_enabled ?? false;
   const tailscaleEnabled = settings?.integration_tailscale_enabled ?? false;
   const unifiEnabled = settings?.integration_unifi_enabled ?? false;
   const { data: k8sClusters = [] } = useQuery<KubernetesCluster[]>({
@@ -864,6 +868,13 @@ export function DashboardPage() {
     queryKey: ["proxmox-nodes"],
     queryFn: proxmoxApi.listNodes,
     enabled: proxmoxEnabled,
+    refetchInterval: 30_000,
+  });
+
+  const { data: cloudEndpoints = [] } = useQuery<CloudEndpoint[]>({
+    queryKey: ["cloud-endpoints"],
+    queryFn: cloudApi.listEndpoints,
+    enabled: cloudEnabled,
     refetchInterval: 30_000,
   });
 
@@ -1544,6 +1555,7 @@ export function DashboardPage() {
           (kubernetesEnabled ||
             dockerEnabled ||
             proxmoxEnabled ||
+            cloudEnabled ||
             tailscaleEnabled ||
             unifiEnabled) && (
             <div className="space-y-1.5">
@@ -1557,11 +1569,13 @@ export function DashboardPage() {
                 kubernetesEnabled={kubernetesEnabled}
                 dockerEnabled={dockerEnabled}
                 proxmoxEnabled={proxmoxEnabled}
+                cloudEnabled={cloudEnabled}
                 tailscaleEnabled={tailscaleEnabled}
                 unifiEnabled={unifiEnabled}
                 clusters={k8sClusters}
                 hosts={dockerHosts}
                 proxmoxNodes={proxmoxNodes}
+                cloudEndpoints={cloudEndpoints}
                 tailscaleTenants={tailscaleTenants}
                 unifiControllers={unifiControllers}
               />
@@ -1960,37 +1974,48 @@ function IntegrationsPanel({
   kubernetesEnabled,
   dockerEnabled,
   proxmoxEnabled,
+  cloudEnabled,
   tailscaleEnabled,
   unifiEnabled,
   clusters,
   hosts,
   proxmoxNodes,
+  cloudEndpoints,
   tailscaleTenants,
   unifiControllers,
 }: {
   kubernetesEnabled: boolean;
   dockerEnabled: boolean;
   proxmoxEnabled: boolean;
+  cloudEnabled: boolean;
   tailscaleEnabled: boolean;
   unifiEnabled: boolean;
   clusters: KubernetesCluster[];
   hosts: DockerHost[];
   proxmoxNodes: ProxmoxNode[];
+  cloudEndpoints: CloudEndpoint[];
   tailscaleTenants: TailscaleTenant[];
   unifiControllers: UnifiController[];
 }) {
   const hasK8s = kubernetesEnabled;
   const hasDocker = dockerEnabled;
   const hasProxmox = proxmoxEnabled;
+  const hasCloud = cloudEnabled;
   const hasTailscale = tailscaleEnabled;
   const hasUnifi = unifiEnabled;
-  const cols = [hasK8s, hasDocker, hasProxmox, hasTailscale, hasUnifi].filter(
-    Boolean,
-  ).length;
+  const cols = [
+    hasK8s,
+    hasDocker,
+    hasProxmox,
+    hasCloud,
+    hasTailscale,
+    hasUnifi,
+  ].filter(Boolean).length;
   const totalTargets =
     clusters.length +
     hosts.length +
     proxmoxNodes.length +
+    cloudEndpoints.length +
     tailscaleTenants.length +
     unifiControllers.length;
   return (
@@ -2014,6 +2039,7 @@ function IntegrationsPanel({
           cols === 3 && "md:grid-cols-3 md:divide-x md:divide-y-0",
           cols === 4 && "md:grid-cols-4 md:divide-x md:divide-y-0",
           cols === 5 && "md:grid-cols-5 md:divide-x md:divide-y-0",
+          cols === 6 && "md:grid-cols-6 md:divide-x md:divide-y-0",
         )}
       >
         {hasK8s && (
@@ -2125,6 +2151,51 @@ function IntegrationsPanel({
                     lastSyncError={p.last_sync_error}
                     intervalSeconds={p.sync_interval_seconds}
                     enabled={p.enabled}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {hasCloud && (
+          <div className="min-w-0">
+            <Link
+              to="/cloud"
+              className="flex items-center gap-1.5 bg-muted/30 px-4 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:bg-muted/50"
+            >
+              <Cloud className="h-3 w-3" />
+              Cloud ({cloudEndpoints.length})
+              <span className="ml-auto text-[10px] text-muted-foreground/70">
+                view all →
+              </span>
+            </Link>
+            {cloudEndpoints.length === 0 ? (
+              <p className="px-4 py-3 text-[11px] italic text-muted-foreground">
+                No accounts registered.
+              </p>
+            ) : (
+              <div className="divide-y">
+                {cloudEndpoints.map((ep) => (
+                  <IntegrationRow
+                    key={ep.id}
+                    to={`/cloud`}
+                    name={ep.name}
+                    subtitle={
+                      ep.provider_account_id
+                        ? `${ep.provider} · ${ep.provider_account_id}`
+                        : ep.provider
+                    }
+                    meta={
+                      ep.network_count != null || ep.instance_count != null
+                        ? `${ep.network_count ?? 0} net${
+                            ep.network_count === 1 ? "" : "s"
+                          } · ${ep.instance_count ?? 0} inst`
+                        : "—"
+                    }
+                    lastSyncedAt={ep.last_synced_at}
+                    lastSyncError={ep.last_sync_error}
+                    intervalSeconds={ep.sync_interval_seconds}
+                    enabled={ep.enabled}
                   />
                 ))}
               </div>

--- a/frontend/src/pages/admin/DNSImportPage.tsx
+++ b/frontend/src/pages/admin/DNSImportPage.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   AlertTriangle,
   CheckCircle2,
+  Cloud,
   Database,
   Download,
   FileArchive,
@@ -18,6 +20,7 @@ import {
 import {
   dnsApi,
   dnsImportApi,
+  type CloudDNSServerOption,
   type DNSImportCommitResult,
   type DNSImportConflictDecision,
   type DNSImportPreview,
@@ -34,7 +37,10 @@ import { HeaderButton } from "@/components/ui/header-button";
 // stay rendered (so the operator sees the roadmap) but are
 // click-disabled with a "Phase 2/3" badge. When those phases land,
 // flip ``available`` and add the matching tab body.
-type TabId = DNSImportSource;
+// ``cloud`` isn't a ``DNSImportSource`` (that union is the wire-level
+// importer type and lives in lib/api.ts); it's a UI-only tab that pulls
+// from a registered cloud-DNS server row via the dedicated endpoints.
+type TabId = DNSImportSource | "cloud";
 
 interface TabDef {
   id: TabId;
@@ -45,6 +51,7 @@ interface TabDef {
   description: string;
 }
 
+// Tabs ordered alphabetically by label: BIND9 / Cloud / PowerDNS / Windows DNS.
 const TABS: TabDef[] = [
   {
     id: "bind9",
@@ -55,12 +62,12 @@ const TABS: TabDef[] = [
       "Upload a tarball or zip containing your named.conf plus all referenced zone files. The importer parses every zone declaration (including those nested inside view {} blocks), reads the master file from the archive, and stages the canonical zone + record IR for review. SOA, MX priority, SRV priority/weight/port, and CNAME records all carry through. DNSSEC records (DNSKEY/RRSIG/NSEC*/DS) get stripped — re-sign post-import via the zone DNSSEC tab.",
   },
   {
-    id: "windows_dns",
-    label: "Windows DNS",
-    short: "WinRM live pull",
+    id: "cloud",
+    label: "Cloud",
+    short: "provider API live pull",
     available: true,
     description:
-      "Live-pull every zone + record from a Windows DNS server using the same WinRM read driver the Logs surface uses. Pick a Windows DNS server already registered in SpatiumDDI (with WinRM credentials configured) and the importer walks Get-DnsServerZone + Get-DnsServerResourceRecord. Windows owns SOA on the server side — imported zones get default SOA values that you can edit via the zone editor post-import.",
+      "Live-pull every hosted zone + record set from a cloud DNS provider (Cloudflare / AWS Route 53 / Azure DNS / Google Cloud DNS) already registered as a cloud-driver DNS server in SpatiumDDI. Pick the server — its stored provider credentials drive the pull — and the importer walks the provider's hosted-zone + record APIs. Provider-managed apex records (SOA / provider NS) get default values you can edit post-import.",
   },
   {
     id: "powerdns",
@@ -69,6 +76,14 @@ const TABS: TabDef[] = [
     available: true,
     description:
       "Live-pull every zone + record from a PowerDNS Authoritative REST API. Provide the API URL + API key; the importer walks /api/v1/servers/{server}/zones and resolves each zone's full record set. Credentials are read-once and never persisted. DNSSEC records get stripped — re-sign post-import via the zone DNSSEC tab.",
+  },
+  {
+    id: "windows_dns",
+    label: "Windows DNS",
+    short: "WinRM live pull",
+    available: true,
+    description:
+      "Live-pull every zone + record from a Windows DNS server using the same WinRM read driver the Logs surface uses. Pick a Windows DNS server already registered in SpatiumDDI (with WinRM credentials configured) and the importer walks Get-DnsServerZone + Get-DnsServerResourceRecord. Windows owns SOA on the server side — imported zones get default SOA values that you can edit via the zone editor post-import.",
   },
 ];
 
@@ -99,7 +114,14 @@ function emptyState(): BindUploadState {
 }
 
 export function DNSImportPage() {
-  const [tab, setTab] = useState<TabId>("bind9");
+  const location = useLocation();
+  // Deep-link from the DNS server modal / list "Sync from provider" button:
+  // navigate("/admin/dns-import", { state: { cloudServerId } }). Open the
+  // Cloud tab pre-selected to that server.
+  const deepLinkServerId =
+    (location.state as { cloudServerId?: string } | null)?.cloudServerId ??
+    null;
+  const [tab, setTab] = useState<TabId>(deepLinkServerId ? "cloud" : "bind9");
   const active = TABS.find((t) => t.id === tab) ?? TABS[0];
 
   return (
@@ -110,9 +132,10 @@ export function DNSImportPage() {
           <div className="min-w-0">
             <h1 className="text-lg font-semibold">DNS configuration import</h1>
             <p className="text-xs text-muted-foreground">
-              One-shot import of zones + records from BIND9 / Windows DNS /
-              PowerDNS into native SpatiumDDI rows. Once imported, SpatiumDDI is
-              the source of truth — there is no continuous two-way mirror.
+              One-shot import of zones + records from BIND9 / Cloud DNS /
+              PowerDNS / Windows DNS into native SpatiumDDI rows. Once imported,
+              SpatiumDDI is the source of truth — there is no continuous two-way
+              mirror.
             </p>
           </div>
         </div>
@@ -154,6 +177,9 @@ export function DNSImportPage() {
         </div>
 
         {tab === "bind9" && <BindTab />}
+        {tab === "cloud" && (
+          <CloudDNSTab initialServerId={deepLinkServerId ?? undefined} />
+        )}
         {tab === "windows_dns" && <WindowsDNSTab />}
         {tab === "powerdns" && <PowerDNSTab />}
       </div>
@@ -584,6 +610,343 @@ function WindowsDNSPullForm({
         <HeaderButton
           variant="primary"
           icon={previewing ? Loader2 : ServerIcon}
+          iconClassName={previewing ? "animate-spin" : undefined}
+          onClick={onPreview}
+          disabled={!canPreview}
+        >
+          {previewing ? "Pulling zones…" : "Preview import"}
+        </HeaderButton>
+      </div>
+    </div>
+  );
+}
+
+// ── Cloud DNS tab body (issue #37, Part B) ───────────────────────────
+
+const CLOUD_DRIVER_LABELS: Record<string, string> = {
+  cloudflare: "Cloudflare",
+  route53: "AWS Route 53",
+  azure_dns: "Azure DNS",
+  google_dns: "Google Cloud DNS",
+};
+
+function cloudDriverLabel(driver: string): string {
+  return CLOUD_DRIVER_LABELS[driver] ?? driver;
+}
+
+interface CloudDNSState {
+  serverId: string;
+  groupId: string;
+  viewId: string;
+  preview: DNSImportPreview | null;
+  decisions: Record<string, DNSImportConflictDecision>;
+  result: DNSImportCommitResult | null;
+  phase: Phase;
+  error: string | null;
+}
+
+function emptyCloudState(serverId = ""): CloudDNSState {
+  return {
+    serverId,
+    groupId: "",
+    viewId: "",
+    preview: null,
+    decisions: {},
+    result: null,
+    phase: "select",
+    error: null,
+  };
+}
+
+function CloudDNSTab({ initialServerId }: { initialServerId?: string }) {
+  const [state, setState] = useState<CloudDNSState>(() =>
+    emptyCloudState(initialServerId),
+  );
+
+  const groupsQ = useQuery({
+    queryKey: ["dns-groups"],
+    queryFn: () => dnsApi.listGroups(),
+  });
+  const viewsQ = useQuery({
+    queryKey: ["dns-views", state.groupId],
+    queryFn: () =>
+      state.groupId ? dnsApi.listViews(state.groupId) : Promise.resolve([]),
+    enabled: Boolean(state.groupId),
+  });
+  const serversQ = useQuery({
+    queryKey: ["dns-import-cloud-servers"],
+    queryFn: () => dnsImportApi.cloudDNSServers(),
+  });
+
+  // When deep-linked to a server that has no creds (or that isn't in the
+  // list yet), don't silently keep an invalid id selected. Once the server
+  // list resolves, clear the selection if the deep-linked row isn't eligible.
+  useEffect(() => {
+    if (!state.serverId || !serversQ.data) return;
+    const row = serversQ.data.find((s) => s.id === state.serverId);
+    if (!row || !row.has_credentials) {
+      setState((s) => ({ ...s, serverId: "" }));
+    }
+    // Only re-run when the server list arrives.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serversQ.data]);
+
+  const selectedServer = useMemo(
+    () => serversQ.data?.find((s) => s.id === state.serverId) ?? null,
+    [serversQ.data, state.serverId],
+  );
+
+  const previewMut = useMutation({
+    mutationFn: () => {
+      if (!state.serverId || !state.groupId) {
+        throw new Error(
+          "Pick a cloud DNS server and target server group first",
+        );
+      }
+      return dnsImportApi.cloudDNSPreview({
+        server_id: state.serverId,
+        target_group_id: state.groupId,
+        target_view_id: state.viewId || null,
+      });
+    },
+    onSuccess: (preview) => {
+      const decisions: Record<string, DNSImportConflictDecision> = {};
+      for (const c of preview.conflicts) {
+        decisions[c.zone_name] = { action: c.action, rename_to: c.rename_to };
+      }
+      setState((s) => ({
+        ...s,
+        preview,
+        decisions,
+        phase: "ready",
+        error: null,
+      }));
+    },
+    onError: (err: unknown) => {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? formatApiError(err);
+      setState((s) => ({ ...s, phase: "select", error: detail }));
+    },
+  });
+
+  const commitMut = useMutation({
+    mutationFn: () => {
+      if (!state.preview) throw new Error("Preview the server first");
+      return dnsImportApi.cloudDNSCommit({
+        target_group_id: state.groupId,
+        target_view_id: state.viewId || null,
+        plan: state.preview,
+        conflict_actions: state.decisions,
+      });
+    },
+    onSuccess: (result) => {
+      setState((s) => ({ ...s, result, phase: "result", error: null }));
+    },
+    onError: (err: unknown) => {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? formatApiError(err);
+      setState((s) => ({ ...s, phase: "ready", error: detail }));
+    },
+  });
+
+  const conflictByZone = useMemo(() => {
+    const m = new Map<string, DNSImportZoneConflict>();
+    for (const c of state.preview?.conflicts ?? []) m.set(c.zone_name, c);
+    return m;
+  }, [state.preview]);
+
+  const reset = () => setState(emptyCloudState());
+
+  return (
+    <div className="space-y-4">
+      {state.error && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <div>{state.error}</div>
+        </div>
+      )}
+
+      {state.phase === "result" && state.result ? (
+        <CommitResultPanel result={state.result} onReset={reset} />
+      ) : (
+        <>
+          <CloudDNSPullForm
+            state={state}
+            setState={setState}
+            servers={serversQ.data ?? []}
+            serversLoading={serversQ.isLoading}
+            selectedServer={selectedServer}
+            groups={groupsQ.data ?? []}
+            views={viewsQ.data ?? []}
+            onPreview={() => {
+              setState((s) => ({ ...s, phase: "previewing", error: null }));
+              previewMut.mutate();
+            }}
+            previewing={previewMut.isPending}
+          />
+
+          {state.preview && state.phase !== "previewing" && (
+            <PreviewPanel
+              preview={state.preview}
+              decisions={state.decisions}
+              setDecisions={(updater) =>
+                setState((s) => ({ ...s, decisions: updater(s.decisions) }))
+              }
+              conflictByZone={conflictByZone}
+              onCommit={() => {
+                setState((s) => ({ ...s, phase: "committing", error: null }));
+                commitMut.mutate();
+              }}
+              committing={commitMut.isPending}
+              onReset={reset}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function CloudDNSPullForm({
+  state,
+  setState,
+  servers,
+  serversLoading,
+  selectedServer,
+  groups,
+  views,
+  onPreview,
+  previewing,
+}: {
+  state: CloudDNSState;
+  setState: React.Dispatch<React.SetStateAction<CloudDNSState>>;
+  servers: CloudDNSServerOption[];
+  serversLoading: boolean;
+  selectedServer: CloudDNSServerOption | null;
+  groups: { id: string; name: string }[];
+  views: { id: string; name: string }[];
+  onPreview: () => void;
+  previewing: boolean;
+}) {
+  const canPreview = Boolean(state.serverId && state.groupId) && !previewing;
+  const eligible = servers.filter((s) => s.has_credentials);
+  const hasIneligible = servers.length > eligible.length;
+
+  return (
+    <div className="rounded-md border bg-muted/20 p-4">
+      <div className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        1. Pick source + target
+      </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <label className="block text-sm font-medium">Cloud DNS server</label>
+          <p className="mb-2 text-[11px] text-muted-foreground">
+            Pick a registered cloud-driver DNS server (Cloudflare / Route 53 /
+            Azure DNS / Google Cloud DNS) with provider credentials configured.
+            The pull walks the provider's hosted-zone + record APIs. Servers
+            without credentials are greyed out — open the DNS server modal to
+            add them.
+          </p>
+          <select
+            value={state.serverId}
+            onChange={(e) =>
+              setState((s) => ({
+                ...s,
+                serverId: e.target.value,
+                preview: null,
+                error: null,
+              }))
+            }
+            disabled={serversLoading}
+            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            <option value="">
+              {serversLoading
+                ? "Loading…"
+                : eligible.length === 0
+                  ? "— no eligible servers —"
+                  : "— select —"}
+            </option>
+            {servers.map((srv) => (
+              <option
+                key={srv.id}
+                value={srv.id}
+                disabled={!srv.has_credentials}
+              >
+                {srv.group_name} / {srv.name} ({cloudDriverLabel(srv.driver)})
+                {!srv.has_credentials ? " — no creds" : ""}
+              </option>
+            ))}
+          </select>
+          {selectedServer && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Source provider:{" "}
+              <span className="font-medium text-foreground">
+                {cloudDriverLabel(selectedServer.driver)}
+              </span>
+            </p>
+          )}
+          {hasIneligible && (
+            <p className="mt-1 text-[11px] text-amber-700 dark:text-amber-400">
+              Some servers are listed but disabled — they don't have provider
+              credentials configured yet.
+            </p>
+          )}
+        </div>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium">
+              Target server group
+            </label>
+            <p className="mb-2 text-[11px] text-muted-foreground">
+              Imported zones land in this group — usually the same one the
+              source server already belongs to, but you can land them in a
+              different group (e.g., a staging group) for review.
+            </p>
+            <select
+              value={state.groupId}
+              onChange={(e) =>
+                setState((s) => ({ ...s, groupId: e.target.value, viewId: "" }))
+              }
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">— select —</option>
+              {groups.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          {views.length > 0 && (
+            <div>
+              <label className="block text-sm font-medium">
+                Target view (optional)
+              </label>
+              <select
+                value={state.viewId}
+                onChange={(e) =>
+                  setState((s) => ({ ...s, viewId: e.target.value }))
+                }
+                className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                <option value="">Default view</option>
+                {views.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <HeaderButton
+          variant="primary"
+          icon={previewing ? Loader2 : Cloud}
           iconClassName={previewing ? "animate-spin" : undefined}
           onClick={onPreview}
           disabled={!canPreview}

--- a/frontend/src/pages/cloud/CloudPage.tsx
+++ b/frontend/src/pages/cloud/CloudPage.tsx
@@ -1,0 +1,981 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Check,
+  Cloud,
+  Clipboard,
+  Pencil,
+  Plus,
+  RefreshCw,
+  RotateCw,
+  TestTube2,
+  Trash2,
+} from "lucide-react";
+
+import {
+  cloudApi,
+  dnsApi,
+  type CloudEndpoint,
+  type CloudEndpointCreate,
+  type CloudEndpointUpdate,
+  type CloudProvider,
+  type CloudTestResult,
+  type DNSServerGroup,
+} from "@/lib/api";
+import { copyToClipboard } from "@/lib/clipboard";
+import { HeaderButton } from "@/components/ui/header-button";
+import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { IPSpacePicker } from "@/components/ipam/space-picker";
+
+// ── Provider metadata ───────────────────────────────────────────────
+
+const PROVIDER_LABEL: Record<CloudProvider, string> = {
+  aws: "AWS",
+  azure: "Azure",
+  gcp: "GCP",
+};
+
+// Setup guides — one-shot snippets operators paste into a shell to mint
+// the read-only credential each provider's reconciler needs.
+
+const AWS_GUIDE = `# In the AWS console (or via the CLI):
+#
+# 1. Create a dedicated IAM user for SpatiumDDI (no console access).
+# 2. Attach these AWS-managed, read-only policies:
+#      - AmazonVPCReadOnlyAccess
+#      - AmazonEC2ReadOnlyAccess
+#      - ElasticLoadBalancingReadOnly   (only if mirroring load balancers)
+# 3. Generate an access key for the user and paste both halves below.
+#
+# CLI equivalent:
+aws iam create-user --user-name spatiumddi
+aws iam attach-user-policy --user-name spatiumddi \\
+  --policy-arn arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess
+aws iam attach-user-policy --user-name spatiumddi \\
+  --policy-arn arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+aws iam attach-user-policy --user-name spatiumddi \\
+  --policy-arn arn:aws:iam::aws:policy/ElasticLoadBalancingReadOnly
+aws iam create-access-key --user-name spatiumddi
+#   Prints AccessKeyId + SecretAccessKey — paste them below.`;
+
+const AZURE_GUIDE = `# Create a service principal with the read-only "Reader" role,
+# scoped to each subscription you want SpatiumDDI to mirror:
+
+az ad sp create-for-rbac --name spatiumddi --role Reader \\
+  --scopes /subscriptions/<sub-id>
+
+#   Prints:
+#     {
+#       "appId":    "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",  → Client ID
+#       "password": "xxxxxxxx~xxxxxxxxxxxxxxxxxxxxxxxxxxxxx",  → Client Secret
+#       "tenant":   "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"   → Tenant ID
+#     }
+#
+# Paste appId → Client ID, password → Client Secret, tenant → Tenant ID.
+# List the subscription IDs (comma-separated) in "Subscription IDs".`;
+
+const GCP_GUIDE = `# Create a service account, grant it the read-only Compute Viewer
+# role on each project, and download a JSON key:
+
+gcloud iam service-accounts create spatiumddi \\
+  --display-name "SpatiumDDI"
+
+gcloud projects add-iam-policy-binding <project-id> \\
+  --member "serviceAccount:spatiumddi@<project-id>.iam.gserviceaccount.com" \\
+  --role roles/compute.viewer
+
+gcloud iam service-accounts keys create key.json \\
+  --iam-account spatiumddi@<project-id>.iam.gserviceaccount.com
+
+# Paste the full contents of key.json into "Service account JSON".
+# List the project IDs (comma-separated) in "Project IDs".`;
+
+// ── Page ─────────────────────────────────────────────────────────────
+
+export function CloudPage() {
+  const qc = useQueryClient();
+  const { data: endpoints = [], isFetching } = useQuery({
+    queryKey: ["cloud-endpoints"],
+    queryFn: cloudApi.listEndpoints,
+    refetchInterval: 30_000,
+  });
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [edit, setEdit] = useState<CloudEndpoint | null>(null);
+  const [del, setDel] = useState<CloudEndpoint | null>(null);
+  const [inlineTest, setInlineTest] = useState<
+    Record<string, CloudTestResult | undefined>
+  >({});
+
+  const delMut = useMutation({
+    mutationFn: (id: string) => cloudApi.deleteEndpoint(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cloud-endpoints"] });
+      setDel(null);
+    },
+  });
+
+  const testMut = useMutation({
+    mutationFn: (id: string) => cloudApi.testConnection({ endpoint_id: id }),
+    onMutate: (id) => {
+      setInlineTest((prev) => ({ ...prev, [id]: undefined }));
+    },
+    onSuccess: (result, id) => {
+      setInlineTest((prev) => ({ ...prev, [id]: result }));
+      qc.invalidateQueries({ queryKey: ["cloud-endpoints"] });
+    },
+  });
+
+  const syncMut = useMutation({
+    mutationFn: (id: string) => cloudApi.syncNow(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cloud-endpoints"] });
+      setTimeout(
+        () => qc.invalidateQueries({ queryKey: ["cloud-endpoints"] }),
+        5000,
+      );
+    },
+  });
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="border-b px-6 py-4 bg-card">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <Cloud className="h-5 w-5 text-muted-foreground" />
+              <h1 className="text-lg font-semibold">Cloud</h1>
+              <span className="text-xs text-muted-foreground">
+                {endpoints.length} configured
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground max-w-3xl">
+              Read-only integration. Each account is polled with a read-only
+              credential (AWS / Azure / GCP). VPCs / VNets / GCP networks land
+              in the bound IPAM space as subnets; instances land as IP addresses
+              (private and, optionally, public). SpatiumDDI never writes to the
+              cloud provider.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <HeaderButton
+              icon={RefreshCw}
+              iconClassName={isFetching ? "animate-spin" : ""}
+              onClick={() =>
+                qc.invalidateQueries({ queryKey: ["cloud-endpoints"] })
+              }
+            >
+              Refresh
+            </HeaderButton>
+            <HeaderButton
+              variant="primary"
+              icon={Plus}
+              onClick={() => setShowCreate(true)}
+            >
+              Add account
+            </HeaderButton>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto p-6">
+        <div className="rounded-lg border">
+          {endpoints.length === 0 ? (
+            <div className="p-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                No cloud accounts configured yet.
+              </p>
+              <button
+                onClick={() => setShowCreate(true)}
+                className="mt-3 inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs hover:bg-accent"
+              >
+                <Plus className="h-3 w-3" /> Add account
+              </button>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[1020px] text-xs">
+                <thead>
+                  <tr className="border-b bg-muted/30">
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Enabled
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Name
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Provider
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Account
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Networks
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Instances
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Last sync
+                    </th>
+                    <th className="px-3 py-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {endpoints.map((ep) => {
+                    const tr = inlineTest[ep.id];
+                    return (
+                      <tr key={ep.id} className="border-b last:border-0">
+                        <td className="whitespace-nowrap px-3 py-2">
+                          {ep.enabled ? (
+                            <span className="inline-flex rounded bg-emerald-500/10 px-1.5 py-0.5 text-[11px] text-emerald-700 dark:text-emerald-400">
+                              enabled
+                            </span>
+                          ) : (
+                            <span className="inline-flex rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                              disabled
+                            </span>
+                          )}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 font-medium">
+                          {ep.name}
+                          {ep.description && (
+                            <div
+                              className="text-[11px] text-muted-foreground max-w-md truncate"
+                              title={ep.description}
+                            >
+                              {ep.description}
+                            </div>
+                          )}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                          {PROVIDER_LABEL[ep.provider]}
+                        </td>
+                        <td
+                          className="max-w-xs truncate px-3 py-2 font-mono text-[11px] text-muted-foreground"
+                          title={ep.provider_account_id ?? undefined}
+                        >
+                          {ep.provider_account_id ?? "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                          {ep.network_count ?? "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                          {ep.instance_count ?? "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                          {ep.last_synced_at
+                            ? new Date(ep.last_synced_at).toLocaleString()
+                            : "never"}
+                          {ep.last_sync_error && (
+                            <div
+                              className="text-[11px] text-destructive max-w-xs truncate"
+                              title={ep.last_sync_error}
+                            >
+                              {ep.last_sync_error}
+                            </div>
+                          )}
+                          {tr && (
+                            <div
+                              className={`max-w-xs truncate text-[11px] ${
+                                tr.ok
+                                  ? "text-emerald-600 dark:text-emerald-400"
+                                  : "text-destructive"
+                              }`}
+                              title={tr.message}
+                            >
+                              {tr.ok ? "✓" : "✗"} {tr.message}
+                            </div>
+                          )}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-right">
+                          <button
+                            onClick={() => testMut.mutate(ep.id)}
+                            disabled={
+                              testMut.isPending && testMut.variables === ep.id
+                            }
+                            className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-50"
+                            title="Test connection"
+                          >
+                            <TestTube2 className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            onClick={() => syncMut.mutate(ep.id)}
+                            disabled={
+                              syncMut.isPending && syncMut.variables === ep.id
+                            }
+                            className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-50"
+                            title="Sync now"
+                          >
+                            <RotateCw
+                              className={`h-3.5 w-3.5 ${
+                                syncMut.isPending && syncMut.variables === ep.id
+                                  ? "animate-spin"
+                                  : ""
+                              }`}
+                            />
+                          </button>
+                          <button
+                            onClick={() => setEdit(ep)}
+                            className="rounded p-1 text-muted-foreground hover:text-foreground"
+                            title="Edit"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            onClick={() => setDel(ep)}
+                            className="rounded p-1 text-muted-foreground hover:text-destructive"
+                            title="Delete"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showCreate && <EndpointModal onClose={() => setShowCreate(false)} />}
+      {edit && <EndpointModal endpoint={edit} onClose={() => setEdit(null)} />}
+      <ConfirmModal
+        open={!!del}
+        title="Delete cloud account"
+        confirmLabel="Delete"
+        tone="destructive"
+        loading={delMut.isPending}
+        onConfirm={() => del && delMut.mutate(del.id)}
+        onClose={() => setDel(null)}
+        message={
+          del ? (
+            <>
+              Remove the cloud account{" "}
+              <span className="font-semibold">{del.name}</span>? This only
+              affects SpatiumDDI — nothing on the {PROVIDER_LABEL[del.provider]}{" "}
+              side changes. All IPAM rows mirrored from this account (subnets +
+              addresses) will be removed via the FK cascade.
+            </>
+          ) : (
+            ""
+          )
+        }
+      />
+    </div>
+  );
+}
+
+// ── Create / Edit modal ─────────────────────────────────────────────
+
+function EndpointModal({
+  endpoint,
+  onClose,
+}: {
+  endpoint?: CloudEndpoint;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const editing = !!endpoint;
+
+  const { data: dnsGroups = [] } = useQuery<DNSServerGroup[]>({
+    queryKey: ["dns-groups"],
+    queryFn: () => dnsApi.listGroups(),
+  });
+
+  const [provider, setProvider] = useState<CloudProvider>(
+    endpoint?.provider ?? "aws",
+  );
+  const [name, setName] = useState(endpoint?.name ?? "");
+  const [description, setDescription] = useState(endpoint?.description ?? "");
+  const [enabled, setEnabled] = useState(endpoint?.enabled ?? true);
+  const [spaceId, setSpaceId] = useState(endpoint?.ipam_space_id ?? "");
+  const [publicSpaceId, setPublicSpaceId] = useState(
+    endpoint?.public_space_id ?? "",
+  );
+  const [dnsGroupId, setDnsGroupId] = useState(endpoint?.dns_group_id ?? "");
+  const [regions, setRegions] = useState((endpoint?.regions ?? []).join(", "));
+  const [mirrorLoadBalancers, setMirrorLoadBalancers] = useState(
+    endpoint?.mirror_load_balancers ?? true,
+  );
+  const [mirrorStoppedInstances, setMirrorStoppedInstances] = useState(
+    endpoint?.mirror_stopped_instances ?? false,
+  );
+  const [syncInterval, setSyncInterval] = useState(
+    endpoint?.sync_interval_seconds ?? 300,
+  );
+
+  // AWS credentials
+  const [awsAccessKeyId, setAwsAccessKeyId] = useState("");
+  const [awsSecretAccessKey, setAwsSecretAccessKey] = useState("");
+
+  // Azure credentials + config
+  const [azTenantId, setAzTenantId] = useState("");
+  const [azClientId, setAzClientId] = useState("");
+  const [azClientSecret, setAzClientSecret] = useState("");
+  const [azSubscriptionIds, setAzSubscriptionIds] = useState(
+    providerConfigList(endpoint?.provider_config, "subscription_ids"),
+  );
+
+  // GCP credentials + config
+  const [gcpServiceAccountJson, setGcpServiceAccountJson] = useState("");
+  const [gcpProjectIds, setGcpProjectIds] = useState(
+    providerConfigList(endpoint?.provider_config, "project_ids"),
+  );
+
+  const [showGuide, setShowGuide] = useState(!editing);
+  const [error, setError] = useState("");
+  const [testResult, setTestResult] = useState<CloudTestResult | null>(null);
+
+  const credsStored = editing && endpoint?.credentials_present;
+  const credPlaceholder = credsStored
+    ? "••• stored — leave blank to keep"
+    : undefined;
+
+  // Build the credential dict from the active provider's form fields.
+  // Returns {} when nothing was typed (editing: keep stored creds).
+  function buildCredentials(): Record<string, string> {
+    if (provider === "aws") {
+      const c: Record<string, string> = {};
+      if (awsAccessKeyId) c.access_key_id = awsAccessKeyId;
+      if (awsSecretAccessKey) c.secret_access_key = awsSecretAccessKey;
+      return c;
+    }
+    if (provider === "azure") {
+      const c: Record<string, string> = {};
+      if (azTenantId) c.tenant_id = azTenantId;
+      if (azClientId) c.client_id = azClientId;
+      if (azClientSecret) c.client_secret = azClientSecret;
+      return c;
+    }
+    const c: Record<string, string> = {};
+    if (gcpServiceAccountJson) c.service_account_json = gcpServiceAccountJson;
+    return c;
+  }
+
+  function buildProviderConfig(): Record<string, unknown> {
+    if (provider === "azure") {
+      return { subscription_ids: parseCsv(azSubscriptionIds) };
+    }
+    if (provider === "gcp") {
+      return { project_ids: parseCsv(gcpProjectIds) };
+    }
+    return {};
+  }
+
+  const testMut = useMutation({
+    mutationFn: () =>
+      cloudApi.testConnection({
+        endpoint_id: endpoint?.id,
+        provider,
+        credentials: buildCredentials(),
+        provider_config: buildProviderConfig(),
+        regions: parseCsv(regions),
+      }),
+    onSuccess: (result) => setTestResult(result),
+    onError: (e) =>
+      setTestResult({
+        ok: false,
+        message: errMsg(e, "Test failed"),
+        provider_account_id: null,
+        network_count: null,
+        instance_count: null,
+      }),
+  });
+
+  const saveMut = useMutation({
+    mutationFn: () => {
+      const creds = buildCredentials();
+      if (editing) {
+        const update: CloudEndpointUpdate = {
+          name,
+          description,
+          enabled,
+          provider_config: buildProviderConfig(),
+          regions: parseCsv(regions),
+          ipam_space_id: spaceId,
+          public_space_id: publicSpaceId || null,
+          dns_group_id: dnsGroupId || null,
+          mirror_load_balancers: mirrorLoadBalancers,
+          mirror_stopped_instances: mirrorStoppedInstances,
+          sync_interval_seconds: syncInterval,
+        };
+        if (Object.keys(creds).length > 0) update.credentials = creds;
+        return cloudApi.updateEndpoint(endpoint!.id, update);
+      }
+      const create: CloudEndpointCreate = {
+        name,
+        description,
+        enabled,
+        provider,
+        credentials: creds,
+        provider_config: buildProviderConfig(),
+        regions: parseCsv(regions),
+        ipam_space_id: spaceId,
+        public_space_id: publicSpaceId || null,
+        dns_group_id: dnsGroupId || null,
+        mirror_load_balancers: mirrorLoadBalancers,
+        mirror_stopped_instances: mirrorStoppedInstances,
+        sync_interval_seconds: syncInterval,
+      };
+      return cloudApi.createEndpoint(create);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["cloud-endpoints"] });
+      onClose();
+    },
+    onError: (e) => setError(errMsg(e, "Failed to save account")),
+  });
+
+  // Whether enough is filled in to enable Test. On create we need
+  // credentials; on edit we can test stored creds.
+  const credsFilled = Object.keys(buildCredentials()).length > 0;
+  const canTest = editing ? true : credsFilled;
+
+  const guide =
+    provider === "aws"
+      ? AWS_GUIDE
+      : provider === "azure"
+        ? AZURE_GUIDE
+        : GCP_GUIDE;
+
+  return (
+    <Modal
+      title={editing ? "Edit cloud account" : "Add cloud account"}
+      onClose={onClose}
+      wide
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          saveMut.mutate();
+        }}
+        className="space-y-3"
+      >
+        {/* Provider FIRST */}
+        <Field
+          label="Provider"
+          hint={
+            editing ? "Provider can't be changed after creation." : undefined
+          }
+        >
+          <select
+            className={`${inputCls} disabled:opacity-60`}
+            value={provider}
+            onChange={(e) => {
+              setProvider(e.target.value as CloudProvider);
+              setTestResult(null);
+            }}
+            disabled={editing}
+          >
+            <option value="aws">AWS</option>
+            <option value="azure">Azure</option>
+            <option value="gcp">GCP</option>
+          </select>
+        </Field>
+
+        {/* Setup guide — provider-specific */}
+        <div className="rounded-md border bg-muted/30 p-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold">
+              Setup guide — {PROVIDER_LABEL[provider]}
+            </h3>
+            <button
+              type="button"
+              onClick={() => setShowGuide((v) => !v)}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              {showGuide ? "Hide" : "Show"}
+            </button>
+          </div>
+          {showGuide && (
+            <div className="mt-2 space-y-2 text-xs">
+              <p className="text-muted-foreground">
+                Create a read-only credential. SpatiumDDI only ever reads from{" "}
+                {PROVIDER_LABEL[provider]} — it never writes.
+              </p>
+              <CopyablePre
+                text={guide}
+                label={`${PROVIDER_LABEL[provider]} setup`}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Name">
+            <input
+              className={inputCls}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </Field>
+          <label className="flex cursor-pointer items-center gap-2 pt-6 text-sm">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+            />
+            <span>Enabled</span>
+          </label>
+        </div>
+
+        <Field label="Description">
+          <input
+            className={inputCls}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </Field>
+
+        {/* ── Provider-specific credential form ───────────────────── */}
+        <div className="space-y-3 border-t pt-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Credentials
+          </h3>
+
+          {provider === "aws" && (
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Access key ID">
+                <input
+                  className={`${inputCls} font-mono text-[11px]`}
+                  value={awsAccessKeyId}
+                  onChange={(e) => setAwsAccessKeyId(e.target.value)}
+                  placeholder={credPlaceholder ?? "AKIA…"}
+                  autoComplete="off"
+                  required={!editing}
+                />
+              </Field>
+              <Field label="Secret access key">
+                <input
+                  type="password"
+                  className={`${inputCls} font-mono text-[11px]`}
+                  value={awsSecretAccessKey}
+                  onChange={(e) => setAwsSecretAccessKey(e.target.value)}
+                  placeholder={credPlaceholder}
+                  autoComplete="off"
+                  required={!editing}
+                />
+              </Field>
+            </div>
+          )}
+
+          {provider === "azure" && (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Tenant ID">
+                  <input
+                    className={`${inputCls} font-mono text-[11px]`}
+                    value={azTenantId}
+                    onChange={(e) => setAzTenantId(e.target.value)}
+                    placeholder={credPlaceholder ?? "xxxxxxxx-xxxx-…"}
+                    autoComplete="off"
+                    required={!editing}
+                  />
+                </Field>
+                <Field label="Client ID (appId)">
+                  <input
+                    className={`${inputCls} font-mono text-[11px]`}
+                    value={azClientId}
+                    onChange={(e) => setAzClientId(e.target.value)}
+                    placeholder={credPlaceholder ?? "xxxxxxxx-xxxx-…"}
+                    autoComplete="off"
+                    required={!editing}
+                  />
+                </Field>
+              </div>
+              <Field label="Client secret (password)">
+                <input
+                  type="password"
+                  className={`${inputCls} font-mono text-[11px]`}
+                  value={azClientSecret}
+                  onChange={(e) => setAzClientSecret(e.target.value)}
+                  placeholder={credPlaceholder}
+                  autoComplete="off"
+                  required={!editing}
+                />
+              </Field>
+              <Field
+                label="Subscription IDs"
+                hint="Comma-separated. The reconciler enumerates VNets across these subscriptions."
+              >
+                <input
+                  className={`${inputCls} font-mono text-[11px]`}
+                  value={azSubscriptionIds}
+                  onChange={(e) => setAzSubscriptionIds(e.target.value)}
+                  placeholder="xxxxxxxx-xxxx-…, yyyyyyyy-yyyy-…"
+                  required
+                />
+              </Field>
+            </>
+          )}
+
+          {provider === "gcp" && (
+            <>
+              <Field
+                label="Service account JSON"
+                hint="Paste the entire downloaded key file."
+              >
+                <textarea
+                  className={`${inputCls} font-mono text-[11px]`}
+                  rows={5}
+                  value={gcpServiceAccountJson}
+                  onChange={(e) => setGcpServiceAccountJson(e.target.value)}
+                  placeholder={
+                    credPlaceholder ??
+                    '{\n  "type": "service_account",\n  ...\n}'
+                  }
+                  required={!editing}
+                />
+              </Field>
+              <Field
+                label="Project IDs"
+                hint="Comma-separated. The reconciler enumerates networks across these projects."
+              >
+                <input
+                  className={`${inputCls} font-mono text-[11px]`}
+                  value={gcpProjectIds}
+                  onChange={(e) => setGcpProjectIds(e.target.value)}
+                  placeholder="my-project, my-other-project"
+                  required
+                />
+              </Field>
+            </>
+          )}
+
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => testMut.mutate()}
+              disabled={testMut.isPending || !canTest}
+              className="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs hover:bg-accent disabled:opacity-50"
+            >
+              <TestTube2 className="h-3.5 w-3.5" />
+              {testMut.isPending ? "Testing…" : "Test connection"}
+            </button>
+            {testResult && (
+              <span
+                className={`text-xs ${
+                  testResult.ok
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-destructive"
+                }`}
+                title={testResult.message}
+              >
+                {testResult.ok ? "✓" : "✗"} {testResult.message}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* ── Mirror destination ──────────────────────────────────── */}
+        <div className="grid grid-cols-2 gap-3 border-t pt-3">
+          <Field label="IPAM space">
+            <IPSpacePicker value={spaceId} onChange={setSpaceId} required />
+          </Field>
+          <Field
+            label="Public IPAM space (optional)"
+            hint="Where public IPs land. Leave blank to skip public IP mirroring."
+          >
+            <IPSpacePicker value={publicSpaceId} onChange={setPublicSpaceId} />
+          </Field>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="DNS server group (optional)">
+            <select
+              className={inputCls}
+              value={dnsGroupId ?? ""}
+              onChange={(e) => setDnsGroupId(e.target.value)}
+            >
+              <option value="">— none —</option>
+              {dnsGroups.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field
+            label="Regions"
+            hint="Comma-separated. Leave blank to use the provider default region set."
+          >
+            <input
+              className={`${inputCls} font-mono text-[11px]`}
+              value={regions}
+              onChange={(e) => setRegions(e.target.value)}
+              placeholder="us-east-1, eu-west-1"
+            />
+          </Field>
+        </div>
+
+        <Field label="Sync interval (seconds)" hint="Minimum 60 s.">
+          <input
+            type="number"
+            className={inputCls}
+            value={syncInterval}
+            min={60}
+            onChange={(e) => setSyncInterval(parseInt(e.target.value) || 300)}
+          />
+        </Field>
+
+        <div className="space-y-2 border-t pt-2">
+          <label className="flex cursor-pointer items-start gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={mirrorLoadBalancers}
+              onChange={(e) => setMirrorLoadBalancers(e.target.checked)}
+              className="mt-0.5"
+            />
+            <div>
+              <span>Mirror load balancers</span>
+              <p className="text-[11px] text-muted-foreground/70">
+                On by default. ELB / Azure LB / GCP forwarding-rule frontends
+                land in IPAM as addresses.
+              </p>
+            </div>
+          </label>
+          <label className="flex cursor-pointer items-start gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={mirrorStoppedInstances}
+              onChange={(e) => setMirrorStoppedInstances(e.target.checked)}
+              className="mt-0.5"
+            />
+            <div>
+              <span>Include stopped instances</span>
+              <p className="text-[11px] text-muted-foreground/70">
+                Off by default. Only running instances land in IPAM unless
+                enabled — useful for capacity-planning views.
+              </p>
+            </div>
+          </label>
+        </div>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saveMut.isPending}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saveMut.isPending ? "Saving…" : editing ? "Save" : "Create"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function parseCsv(s: string): string[] {
+  return s
+    .split(",")
+    .map((x) => x.trim())
+    .filter(Boolean);
+}
+
+function providerConfigList(
+  config: Record<string, unknown> | undefined,
+  key: string,
+): string {
+  const v = config?.[key];
+  if (Array.isArray(v)) return v.map((x) => String(x)).join(", ");
+  return "";
+}
+
+function CopyablePre({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  // Reset the "Copied" flash if the snippet changes (e.g. provider swap).
+  useEffect(() => setCopied(false), [text]);
+  async function handle() {
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    }
+  }
+  return (
+    <div className="relative">
+      <pre className="overflow-auto rounded bg-background p-2 pr-20 font-mono text-[11px] leading-tight">
+        {text}
+      </pre>
+      <button
+        type="button"
+        onClick={handle}
+        className="absolute right-1.5 top-1.5 inline-flex items-center gap-1 rounded border bg-background px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
+        aria-label={`Copy ${label}`}
+        title={`Copy ${label}`}
+      >
+        {copied ? (
+          <>
+            <Check className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+            Copied
+          </>
+        ) : (
+          <>
+            <Clipboard className="h-3 w-3" />
+            Copy
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+const inputCls =
+  "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="block text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      {children}
+      {hint && <p className="text-[11px] text-muted-foreground/70">{hint}</p>}
+    </div>
+  );
+}
+
+function errMsg(e: unknown, fallback: string): string {
+  const ae = e as {
+    response?: { data?: { detail?: unknown } };
+    message?: string;
+  };
+  const d = ae?.response?.data?.detail;
+  if (typeof d === "string") return d;
+  if (Array.isArray(d)) {
+    return (
+      (d as Array<{ loc?: (string | number)[]; msg?: string }>)
+        .map((err) => {
+          const field = (err.loc ?? []).filter((p) => p !== "body").join(".");
+          return field ? `${field}: ${err.msg}` : err.msg;
+        })
+        .filter(Boolean)
+        .join("; ") || fallback
+    );
+  }
+  return ae?.message || fallback;
+}

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -35,7 +35,12 @@ import {
   Copy,
   Pause,
   Play,
+  Check,
+  Clipboard,
+  Cloud,
+  ExternalLink,
 } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { TagFilterChips } from "@/components/TagFilterChips";
 import { PropagationCheckModal } from "./PropagationCheckModal";
 import { BlocklistCatalogModal } from "./BlocklistCatalogModal";
@@ -140,6 +145,225 @@ function Btns({
         {pending ? "Saving…" : (label ?? "Save")}
       </button>
     </div>
+  );
+}
+
+// ── CLI setup-guide copy block (mirrors ProxmoxPage / DHCP CreateServerModal) ──
+
+function CopyablePre({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  async function handle() {
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    }
+  }
+  return (
+    <div className="relative">
+      <pre className="overflow-auto rounded bg-background p-2 pr-20 font-mono text-[11px] leading-tight whitespace-pre-wrap">
+        {text}
+      </pre>
+      <button
+        type="button"
+        onClick={handle}
+        className="absolute right-1.5 top-1.5 inline-flex items-center gap-1 rounded border bg-background px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
+        aria-label={`Copy ${label}`}
+        title={`Copy ${label}`}
+      >
+        {copied ? (
+          <>
+            <Check className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+            Copied
+          </>
+        ) : (
+          <>
+            <Clipboard className="h-3 w-3" />
+            Copy
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+// ── Cloud DNS driver metadata (issue #37, Part B) ────────────────────────────
+//
+// The 4 cloud DNS drivers are agentless — record CRUD runs from the control
+// plane against the provider API. The server modal hides the agent/host/api
+// fields and renders a provider-specific credential form + setup guide.
+
+const CLOUD_DNS_DRIVERS = [
+  "cloudflare",
+  "route53",
+  "azure_dns",
+  "google_dns",
+] as const;
+type CloudDNSDriver = (typeof CLOUD_DNS_DRIVERS)[number];
+
+const CLOUD_DNS_LABELS: Record<CloudDNSDriver, string> = {
+  cloudflare: "Cloudflare",
+  route53: "AWS Route 53",
+  azure_dns: "Azure DNS",
+  google_dns: "Google Cloud DNS",
+};
+
+function isCloudDriver(d: string): d is CloudDNSDriver {
+  return (CLOUD_DNS_DRIVERS as readonly string[]).includes(d);
+}
+
+// One credential field rendered in the provider form. ``textarea`` is used
+// for the GCP service-account JSON blob.
+interface CloudCredField {
+  key: string;
+  label: string;
+  placeholder?: string;
+  secret?: boolean;
+  textarea?: boolean;
+}
+
+const CLOUD_DNS_FIELDS: Record<CloudDNSDriver, CloudCredField[]> = {
+  cloudflare: [
+    {
+      key: "api_token",
+      label: "API token",
+      placeholder: "cloudflare scoped API token",
+      secret: true,
+    },
+  ],
+  route53: [
+    {
+      key: "access_key_id",
+      label: "Access key ID",
+      placeholder: "AKIA…",
+    },
+    {
+      key: "secret_access_key",
+      label: "Secret access key",
+      placeholder: "secret access key",
+      secret: true,
+    },
+  ],
+  azure_dns: [
+    { key: "tenant_id", label: "Tenant ID", placeholder: "00000000-0000-…" },
+    { key: "client_id", label: "Client ID (app ID)", placeholder: "app id" },
+    {
+      key: "client_secret",
+      label: "Client secret",
+      placeholder: "client secret",
+      secret: true,
+    },
+    {
+      key: "subscription_id",
+      label: "Subscription ID",
+      placeholder: "subscription id",
+    },
+    {
+      key: "resource_group",
+      label: "Resource group",
+      placeholder: "my-dns-rg",
+    },
+  ],
+  google_dns: [
+    {
+      key: "service_account_json",
+      label: "Service account key (JSON)",
+      placeholder: "Paste the full service-account key JSON",
+      secret: true,
+      textarea: true,
+    },
+    { key: "project_id", label: "Project ID", placeholder: "my-gcp-project" },
+  ],
+};
+
+function CloudSetupGuide({ driver }: { driver: CloudDNSDriver }) {
+  return (
+    <details className="rounded border bg-background/40 text-xs">
+      <summary className="cursor-pointer px-3 py-2 font-medium select-none">
+        {CLOUD_DNS_LABELS[driver]} setup guide — click to expand
+      </summary>
+      <div className="space-y-3 border-t px-3 py-2.5 text-muted-foreground">
+        {driver === "cloudflare" && (
+          <div>
+            <p>
+              In the Cloudflare dashboard go to{" "}
+              <span className="font-medium text-foreground">
+                My Profile → API Tokens → Create Token
+              </span>{" "}
+              and use the{" "}
+              <span className="font-medium text-foreground">Edit zone DNS</span>{" "}
+              template (grants{" "}
+              <code className="font-mono">Zone : DNS : Edit</code> +{" "}
+              <code className="font-mono">Zone : Zone : Read</code>), optionally
+              scoped to specific zones. Paste the generated token into the field
+              above.
+            </p>
+          </div>
+        )}
+        {driver === "route53" && (
+          <div>
+            <p>
+              Create an IAM user (or role) and attach{" "}
+              <code className="font-mono">AmazonRoute53ReadOnlyAccess</code> for
+              import plus{" "}
+              <code className="font-mono">
+                route53:ChangeResourceRecordSets
+              </code>{" "}
+              on the hosted zone for writes. Then generate an access key and
+              paste the key ID + secret above.
+            </p>
+          </div>
+        )}
+        {driver === "azure_dns" && (
+          <div className="space-y-2">
+            <p>
+              Create a service principal scoped to the resource group holding
+              your DNS zones with the{" "}
+              <span className="font-medium text-foreground">
+                DNS Zone Contributor
+              </span>{" "}
+              role:
+            </p>
+            <CopyablePre
+              label="az service principal"
+              text={
+                'az ad sp create-for-rbac --role "DNS Zone Contributor" \\\n  --scopes /subscriptions/<sub>/resourceGroups/<rg>'
+              }
+            />
+            <p>
+              The command prints <code className="font-mono">appId</code>{" "}
+              (client ID), <code className="font-mono">password</code> (client
+              secret), and <code className="font-mono">tenant</code> (tenant
+              ID).
+            </p>
+          </div>
+        )}
+        {driver === "google_dns" && (
+          <div className="space-y-2">
+            <p>
+              Create a service account, grant it the{" "}
+              <span className="font-medium text-foreground">DNS Admin</span>{" "}
+              role, and download a JSON key:
+            </p>
+            <CopyablePre
+              label="gcloud service account"
+              text={
+                "gcloud iam service-accounts create spatiumddi\n" +
+                "gcloud projects add-iam-policy-binding <proj> \\\n" +
+                "  --member serviceAccount:spatiumddi@<proj>.iam.gserviceaccount.com \\\n" +
+                "  --role roles/dns.admin\n" +
+                "gcloud iam service-accounts keys create key.json \\\n" +
+                "  --iam-account spatiumddi@<proj>.iam.gserviceaccount.com"
+              }
+            />
+            <p>
+              Paste the contents of <code className="font-mono">key.json</code>{" "}
+              into the field above.
+            </p>
+          </div>
+        )}
+      </div>
+    </details>
   );
 }
 
@@ -739,6 +963,7 @@ function ServerModal({
   onClose: () => void;
 }) {
   const qc = useQueryClient();
+  const navigate = useNavigate();
   const editing = !!server;
   const [name, setName] = useState(server?.name ?? "");
   const [driver, setDriver] = useState(server?.driver ?? "bind9");
@@ -768,7 +993,16 @@ function ServerModal({
     message: string;
   } | null>(null);
 
+  // Cloud DNS credential state (issue #37, Part B). Provider-specific dict
+  // keyed by field. On edit, fields render blank ("leave blank to keep") and
+  // we only send the cloud_credentials block when the operator types
+  // something — or {} to clear.
+  const [cloudCreds, setCloudCreds] = useState<Record<string, string>>({});
+  const [cloudClearCreds, setCloudClearCreds] = useState(false);
+
   const hasExistingCreds = !!server?.has_credentials;
+
+  const cloudDriver = isCloudDriver(driver) ? driver : null;
 
   const testMut = useMutation({
     mutationFn: () => {
@@ -817,17 +1051,57 @@ function ServerModal({
       .map((r) => r.trim())
       .filter(Boolean);
 
+    const cloud = isCloudDriver(driver);
+
     const payload: Record<string, unknown> = {
       name,
       driver,
-      host,
-      port: parseInt(port, 10),
-      api_port: apiPort ? parseInt(apiPort, 10) : null,
+      // Cloud drivers are agentless — there's no host/port/api_port to reach.
+      // Send a stable sentinel host so the row is valid; the provider API is
+      // addressed via the stored cloud credentials, not host:port.
+      host: cloud ? driver : host,
+      port: cloud ? 443 : parseInt(port, 10),
+      api_port: cloud ? null : apiPort ? parseInt(apiPort, 10) : null,
       roles: roleList,
       notes,
       is_enabled: isEnabled,
-      ...(apiKey ? { api_key: apiKey } : {}),
+      ...(apiKey && !cloud ? { api_key: apiKey } : {}),
     };
+
+    if (cloud) {
+      if (cloudClearCreds) {
+        payload.cloud_credentials = {};
+      } else {
+        const fields = CLOUD_DNS_FIELDS[driver as CloudDNSDriver];
+        const entered: Record<string, string> = {};
+        for (const f of fields) {
+          const v = (cloudCreds[f.key] ?? "").trim();
+          if (v) entered[f.key] = v;
+        }
+        if (Object.keys(entered).length > 0) {
+          // First-time create requires every field — a partial cloud
+          // credential set can't authenticate. On edit a partial set merges
+          // server-side only when stored creds already exist.
+          const missing = fields.filter((f) => !entered[f.key]);
+          if (!editing && missing.length > 0) {
+            setError(
+              `${CLOUD_DNS_LABELS[driver as CloudDNSDriver]} requires all credential fields: ${fields
+                .map((f) => f.label)
+                .join(", ")}.`,
+            );
+            return;
+          }
+          payload.cloud_credentials = entered;
+        } else if (!editing) {
+          setError(
+            `Enter ${CLOUD_DNS_LABELS[driver as CloudDNSDriver]} credentials to enable this server.`,
+          );
+          return;
+        }
+        // editing + nothing entered → omit cloud_credentials entirely
+        // (None = leave stored creds alone).
+      }
+    }
 
     if (driver === "windows_dns") {
       if (winClearCreds) {
@@ -887,12 +1161,22 @@ function ServerModal({
               className={inputCls}
               value={driver}
               onChange={(e) => setDriver(e.target.value)}
+              // Provider/driver is immutable on edit — changing it would
+              // strand the stored credentials + rendered config.
+              disabled={editing}
             >
               <option value="bind9">BIND9 (agent-managed)</option>
               <option value="powerdns">PowerDNS (agent-managed)</option>
               <option value="windows_dns">
                 Windows DNS (agentless, RFC 2136 + optional WinRM)
               </option>
+              <optgroup label="Cloud DNS (agentless)">
+                {CLOUD_DNS_DRIVERS.map((d) => (
+                  <option key={d} value={d}>
+                    {CLOUD_DNS_LABELS[d]}
+                  </option>
+                ))}
+              </optgroup>
             </select>
           </Field>
         </div>
@@ -920,63 +1204,80 @@ function ServerModal({
             and rotates the API key automatically — leave the field below blank.
           </div>
         )}
-        <div className="grid grid-cols-2 gap-3">
-          <Field label="Host / IP">
-            <input
-              className={inputCls}
-              value={host}
-              onChange={(e) => setHost(e.target.value)}
-              placeholder="10.0.0.53"
-              required
-            />
-          </Field>
-          <Field label="DNS Port">
-            <input
-              className={inputCls}
-              value={port}
-              onChange={(e) => setPort(e.target.value)}
-              placeholder="53"
-            />
-          </Field>
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          <Field label="API Port (rndc / REST)">
-            <input
-              className={inputCls}
-              value={apiPort}
-              onChange={(e) => setApiPort(e.target.value)}
-              placeholder={
-                driver === "powerdns"
-                  ? "8081 (PowerDNS REST, loopback)"
-                  : driver === "bind9"
-                    ? "953 (rndc)"
-                    : "953 / 8081"
-              }
-            />
-          </Field>
-          {driver === "powerdns" ? (
-            <Field label="API Key">
-              <input
-                className={`${inputCls} bg-muted/50 cursor-not-allowed`}
-                value="(generated by agent on first boot)"
-                disabled
-                readOnly
-              />
-            </Field>
-          ) : (
-            <Field
-              label={server ? "New API Key (leave blank to keep)" : "API Key"}
-            >
-              <input
-                type="password"
-                className={inputCls}
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder={server ? "unchanged" : "optional"}
-              />
-            </Field>
-          )}
-        </div>
+        {cloudDriver && (
+          <div className="rounded-md border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs text-sky-800 dark:text-sky-300">
+            <strong>{CLOUD_DNS_LABELS[cloudDriver]}:</strong> agentless. Record
+            CRUD runs from the SpatiumDDI control plane against the provider API
+            — no agent container, host, or port to configure. Provide the
+            provider credentials below; they're stored Fernet-encrypted and
+            never returned by the API. Once registered you can pull existing
+            hosted zones in via{" "}
+            <span className="font-medium">DNS Import → Cloud</span>.
+          </div>
+        )}
+        {!cloudDriver && (
+          <>
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Host / IP">
+                <input
+                  className={inputCls}
+                  value={host}
+                  onChange={(e) => setHost(e.target.value)}
+                  placeholder="10.0.0.53"
+                  required
+                />
+              </Field>
+              <Field label="DNS Port">
+                <input
+                  className={inputCls}
+                  value={port}
+                  onChange={(e) => setPort(e.target.value)}
+                  placeholder="53"
+                />
+              </Field>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="API Port (rndc / REST)">
+                <input
+                  className={inputCls}
+                  value={apiPort}
+                  onChange={(e) => setApiPort(e.target.value)}
+                  placeholder={
+                    driver === "powerdns"
+                      ? "8081 (PowerDNS REST, loopback)"
+                      : driver === "bind9"
+                        ? "953 (rndc)"
+                        : "953 / 8081"
+                  }
+                />
+              </Field>
+              {driver === "powerdns" ? (
+                <Field label="API Key">
+                  <input
+                    className={`${inputCls} bg-muted/50 cursor-not-allowed`}
+                    value="(generated by agent on first boot)"
+                    disabled
+                    readOnly
+                  />
+                </Field>
+              ) : (
+                <Field
+                  label={
+                    server ? "New API Key (leave blank to keep)" : "API Key"
+                  }
+                >
+                  <input
+                    type="password"
+                    className={inputCls}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={server ? "unchanged" : "optional"}
+                  />
+                </Field>
+              )}
+            </div>
+          </>
+        )}
         <Field label="Roles (comma-separated)">
           <input
             className={inputCls}
@@ -1200,7 +1501,117 @@ function ServerModal({
           </div>
         )}
 
-        {server && (
+        {cloudDriver && (
+          <div className="rounded-md border border-sky-500/40 bg-sky-500/5 p-3 space-y-3">
+            <div className="text-xs">
+              <div className="font-medium text-sky-600 dark:text-sky-400">
+                {CLOUD_DNS_LABELS[cloudDriver]} credentials
+              </div>
+              <p className="mt-1 text-muted-foreground">
+                Stored Fernet-encrypted and never returned by the API.
+                {editing && hasExistingCreds
+                  ? " Leave fields blank to keep the stored credentials, or enter new values to replace them."
+                  : ""}
+              </p>
+            </div>
+
+            <CloudSetupGuide driver={cloudDriver} />
+
+            {editing && hasExistingCreds && !cloudClearCreds && (
+              <div className="flex items-center justify-between rounded border bg-background/50 px-3 py-2 text-xs">
+                <span>
+                  <span className="font-medium">Credentials set.</span> Leave
+                  fields blank to keep them, or enter new values to replace.
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setCloudClearCreds(true)}
+                  className="rounded border px-2 py-0.5 text-[11px] hover:bg-muted"
+                >
+                  Clear
+                </button>
+              </div>
+            )}
+            {cloudClearCreds && (
+              <div className="flex items-center justify-between rounded border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs">
+                <span className="text-destructive">
+                  Credentials will be removed on save — this server won't be
+                  able to reach the provider until new credentials are set.
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setCloudClearCreds(false)}
+                  className="rounded border px-2 py-0.5 text-[11px] hover:bg-muted"
+                >
+                  Undo
+                </button>
+              </div>
+            )}
+
+            <div
+              className={`space-y-3 ${cloudClearCreds ? "opacity-40 pointer-events-none" : ""}`}
+            >
+              {CLOUD_DNS_FIELDS[cloudDriver].map((f) => (
+                <Field key={f.key} label={f.label}>
+                  {f.textarea ? (
+                    <textarea
+                      className={`${inputCls} font-mono text-xs`}
+                      rows={6}
+                      value={cloudCreds[f.key] ?? ""}
+                      onChange={(e) =>
+                        setCloudCreds((c) => ({
+                          ...c,
+                          [f.key]: e.target.value,
+                        }))
+                      }
+                      placeholder={
+                        editing && hasExistingCreds
+                          ? "(unchanged)"
+                          : (f.placeholder ?? "")
+                      }
+                      autoComplete="off"
+                    />
+                  ) : (
+                    <input
+                      type={f.secret ? "password" : "text"}
+                      className={inputCls}
+                      value={cloudCreds[f.key] ?? ""}
+                      onChange={(e) =>
+                        setCloudCreds((c) => ({
+                          ...c,
+                          [f.key]: e.target.value,
+                        }))
+                      }
+                      placeholder={
+                        editing && hasExistingCreds
+                          ? "(unchanged)"
+                          : (f.placeholder ?? "")
+                      }
+                      autoComplete="off"
+                    />
+                  )}
+                </Field>
+              ))}
+            </div>
+
+            {editing && server && (
+              <button
+                type="button"
+                onClick={() =>
+                  navigate("/admin/dns-import", {
+                    state: { cloudServerId: server.id },
+                  })
+                }
+                className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs hover:bg-accent"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                Sync from provider (DNS Import → Cloud)
+              </button>
+            )}
+          </div>
+        )}
+
+        {server && !cloudDriver && (
           <p className="text-xs text-muted-foreground">
             Servers can also be auto-registered by the DNS agent container — see{" "}
             <code>DNS_AGENT_KEY</code> in deployment docs.
@@ -3269,6 +3680,7 @@ function Stat({
 
 function ServersTab({ group }: { group: DNSServerGroup }) {
   const qc = useQueryClient();
+  const navigate = useNavigate();
   const [showAdd, setShowAdd] = useState(false);
   const [editServer, setEditServer] = useState<DNSServer | null>(null);
   const [detailServer, setDetailServer] = useState<DNSServer | null>(null);
@@ -3450,6 +3862,22 @@ function ServersTab({ group }: { group: DNSServerGroup }) {
               </div>
             </div>
             <div className="flex items-center gap-1">
+              {isCloudDriver(s.driver) && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigate("/admin/dns-import", {
+                      state: { cloudServerId: s.id },
+                    });
+                  }}
+                  className="inline-flex items-center gap-1 rounded border border-sky-600/40 bg-sky-500/10 px-1.5 py-1 text-[11px] font-medium text-sky-700 hover:bg-sky-500/20 dark:text-sky-400"
+                  title="Sync existing hosted zones in from the provider"
+                >
+                  <Cloud className="h-3 w-3" />
+                  Sync
+                </button>
+              )}
               {s.maintenance_mode ? (
                 <button
                   type="button"


### PR DESCRIPTION
## Cloud integration (AWS / Azure / GCP) — IPAM infra mirror + Cloud DNS as a first-class DNS driver

Implements #37 end-to-end. Two parts that share a per-provider
credential-entry + in-modal setup-guide UX.

### Part A — IPAM infrastructure mirror (read-only)
- `CloudEndpoint` model + migration `d1e7c4a90fb3`: Fernet
  `credentials_encrypted`, non-secret `provider_config`, `regions`,
  required `ipam_space_id` + optional `public_space_id` + `dns_group_id`,
  mirror toggles, 300 s cadence / 60 s floor.
- `cloud_endpoint_id` `ON DELETE CASCADE` FK on `IPBlock` / `Subnet` /
  `IPAddress`; new statuses `cloud-instance` / `cloud-public` /
  `cloud-lb`.
- AWS / Azure / GCP connectors → provider-neutral `CloudInventory` →
  shared reconciler (VPC/VNet→IPBlock, subnet→Subnet, instance NIC→
  `cloud-instance`, public IP→`cloud-public`, LB frontend→`cloud-lb`),
  with the `user_modified_at` sticky-edit lock + prune (Proxmox shape).
- CRUD + provider-first test-connection probe + sync-now API; Celery
  30 s sweep (interval-gated, killed by `integration_cloud_enabled`).
- Feature module `integrations.cloud` (default-off); `provider` enum
  reserves hetzner/DO/linode/vultr for later (no schema change → #327).
- Frontend: **CloudPage** (provider-first modal + per-provider
  credential forms + embedded CLI/console setup guides), sidebar entry,
  both Dashboard surfaces.

### Part B — Cloud DNS as first-class agentless drivers (realizes #29)
- **Cloudflare** (REST/httpx) / **Route 53** (boto3) / **Azure DNS** /
  **Google Cloud DNS** drivers, Windows-Path-B agentless shape: control
  plane calls the provider API directly, creds in
  `DNSServer.credentials_encrypted`, writes synchronous via
  `record_ops._apply_agentless`, zone CRUD via `apply_zone_change`,
  reads via `pull_zones_from_server` / `pull_zone_records`.
- Selectable in the normal **Add DNS server** flow with in-modal setup
  guides + per-provider credential forms.
- **Import existing zones** — `/dns/import/cloud/{servers,preview,commit}`
  reusing the #128 importer (preview→commit, `on_collision`
  skip/update/abort, per-provider `import_source` provenance). Ongoing
  drift reuses the sync-from-server loop (widened to cloud).
- Frontend: driver picker + setup guides; new **Cloud** tab on the DNS
  Import page; "Sync from provider" deep-link.

### Cross-cutting
- MCP `list_cloud_targets` read tool (gated on `integrations.cloud`).
- Both dashboard surfaces (non-negotiable #15).
- Docs: `INTEGRATIONS.md`, `DNS_DRIVERS.md`, `DNS.md`, `MIGRATION.md`;
  `NOTICE` (cloud SDKs); CLAUDE.md roadmap. NOTICE/pyproject add
  azure-mgmt-{network,compute,dns,resource} + azure-identity +
  google-cloud-{compute,dns} + google-auth (boto3 already present;
  Cloudflare uses plain httpx).

## Testing
- Backend: **1097 tests pass** (incl. 116 new cloud tests); ruff + black
  + mypy clean (502 files); migration applies + autogenerate parity
  (only pre-existing repo drift).
- Frontend: `tsc -b` + eslint (`--max-warnings 0`) + prettier clean.
- ⚠️ AWS/Azure/GCP are tier-3 (no test account) — provider logic is
  unit-tested with **mocked SDKs**. Real-cloud E2E still needs live
  accounts.

## Deferred / follow-ups (not blocking)
- Token-only DNS + infra providers (DigitalOcean / Hetzner / Linode /
  Vultr) → **#327** (enum already reserved).
- Per-driver authoring gaps — cloud online-DNSSEC, ALIAS for Route 53 /
  Azure, Route 53 routing policies → **#29** (re-scoped).
- Cisco DNA — out of scope (SD-Access controller, not hosted DNS).
- CHANGELOG entry added at release-cut (the file is release-structured).

Two commits on the branch (`1a0ab27` foundation + providers, `a90d2c0`
integration + frontend + docs); squash-merge collapses them.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
