### PR TITLE
Cloud DNS providers + DNS record types + DHCP pool alert + bulk-sync batching (#327, #338, #339, #341)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -114,6 +114,7 @@ backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:94
 backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py:drop_column:54
 backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py:drop_column:55
 backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py:drop_column:56
+backend/alembic/versions/a7f3c1e85d20_alert_rule_min_free_addresses.py:drop_column:29
 backend/alembic/versions/a8d2e91f5c47_appliance_variant.py:drop_column:38
 backend/alembic/versions/a8d31e6b2f47_ipv6_allocation_policy.py:drop_column:38
 backend/alembic/versions/a8e3f127c094_system_upgrade_run.py:drop_table:119

--- a/backend/alembic/versions/a7f3c1e85d20_alert_rule_min_free_addresses.py
+++ b/backend/alembic/versions/a7f3c1e85d20_alert_rule_min_free_addresses.py
@@ -1,0 +1,29 @@
+"""alert_rule.min_free_addresses (dhcp_pool_exhaustion alert, #339)
+
+Adds the absolute free-address floor for the new ``dhcp_pool_exhaustion``
+alert rule type. The rule fires when a dynamic DHCP pool's occupancy
+reaches ``threshold_percent`` (already present) OR its free-address count
+drops below ``min_free_addresses``. Nullable — only meaningful for the new
+rule type; every existing rule keeps NULL.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a7f3c1e85d20"
+# Chains off the real single head on main (the #336 dns_zone masters
+# migration merged via #342) — NOT fe6715916c27, which sits mid-chain.
+down_revision: str | None = "c9a1f7e0b234"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("alert_rule", sa.Column("min_free_addresses", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("alert_rule", "min_free_addresses")

--- a/backend/app/api/v1/alerts/router.py
+++ b/backend/app/api/v1/alerts/router.py
@@ -45,6 +45,8 @@ class AlertRuleCreate(BaseModel):
     rule_type: str
     threshold_percent: int | None = None
     threshold_days: int | None = None
+    # ``dhcp_pool_exhaustion`` absolute free-address floor (issue #339).
+    min_free_addresses: int | None = None
     server_type: str | None = None
     # ``compliance_change`` params — see issue #105.
     classification: str | None = None
@@ -101,6 +103,15 @@ class AlertRuleCreate(BaseModel):
             raise ValueError("threshold_days must be 1..3650")
         return v
 
+    @field_validator("min_free_addresses")
+    @classmethod
+    def _v_min_free(cls, v: int | None) -> int | None:
+        if v is None:
+            return None
+        if v < 1:
+            raise ValueError("min_free_addresses must be ≥ 1")
+        return v
+
     @field_validator("classification")
     @classmethod
     def _v_classification(cls, v: str | None) -> str | None:
@@ -132,6 +143,7 @@ class AlertRuleUpdate(BaseModel):
     enabled: bool | None = None
     threshold_percent: int | None = None
     threshold_days: int | None = None
+    min_free_addresses: int | None = None
     server_type: str | None = None
     classification: str | None = None
     change_scope: str | None = None
@@ -176,6 +188,15 @@ class AlertRuleUpdate(BaseModel):
             raise ValueError("threshold_days must be 1..3650")
         return v
 
+    @field_validator("min_free_addresses")
+    @classmethod
+    def _v_min_free(cls, v: int | None) -> int | None:
+        if v is None:
+            return None
+        if v < 1:
+            raise ValueError("min_free_addresses must be ≥ 1")
+        return v
+
     @field_validator("classification")
     @classmethod
     def _v_classification(cls, v: str | None) -> str | None:
@@ -209,6 +230,7 @@ class AlertRuleResponse(BaseModel):
     rule_type: str
     threshold_percent: int | None
     threshold_days: int | None
+    min_free_addresses: int | None
     server_type: str | None
     classification: str | None
     change_scope: str | None

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -99,6 +99,11 @@ VALID_RECORD_TYPES = {
     "NAPTR",
     "LOC",
     "LUA",
+    # RFC 9460 service binding (HTTP/3, ECH, alt-svc) + RFC 6672 subtree
+    # redirection. Self-hosted authoritative only (see the gate below).
+    "SVCB",
+    "HTTPS",
+    "DNAME",
 }
 
 # Record types only some drivers support. Used to gate at the create /
@@ -108,6 +113,14 @@ VALID_RECORD_TYPES = {
 _DRIVER_GATED_RECORD_TYPES: dict[str, frozenset[str]] = {
     "ALIAS": frozenset({"powerdns"}),
     "LUA": frozenset({"powerdns"}),
+    # SVCB / HTTPS (RFC 9460) + DNAME (RFC 6672) are served natively only by
+    # our self-hosted authoritative backends. The hosted-DNS providers vary
+    # (and would fail at apply rather than create), so gate to bind9 + pdns
+    # and let a follow-up widen the set once a provider's apply path is
+    # verified. issue #338.
+    "SVCB": frozenset({"bind9", "powerdns"}),
+    "HTTPS": frozenset({"bind9", "powerdns"}),
+    "DNAME": frozenset({"bind9", "powerdns"}),
 }
 
 # Zone-level operations only some drivers support. Same shape as

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -1,5 +1,7 @@
 """IPAM API — IP spaces, blocks, subnets, and addresses."""
 
+import contextlib
+import contextvars
 import hashlib
 import ipaddress
 import re
@@ -764,6 +766,18 @@ async def _resolve_reverse_zone(
     return best
 
 
+# When set (inside a ``_batched_dns_ops`` block), ``_enqueue_dns_op`` defers
+# every op into this collector instead of enqueuing it inline. The bulk
+# IPAM→DNS paths (sync / bulk-allocate / bulk-edit) then flush the collector
+# grouped by zone so an agentless Windows-DNS primary takes ONE WinRM round
+# trip per zone instead of one per record (issue #341). A contextvar avoids
+# threading a parameter through ``_sync_dns_record``'s dozen enqueue calls;
+# it is task-local so concurrent requests never share a collector.
+_dns_op_collector: contextvars.ContextVar[list[tuple[DNSZone, dict[str, Any]]] | None] = (
+    contextvars.ContextVar("_dns_op_collector", default=None)
+)
+
+
 async def _enqueue_dns_op(
     db: AsyncSession, zone: DNSZone, op: str, name: str, rtype: str, value: str, ttl: int | None
 ) -> None:
@@ -773,13 +787,60 @@ async def _enqueue_dns_op(
     from app.services.dns.serial import bump_zone_serial
 
     target_serial = bump_zone_serial(zone)
-    await enqueue_record_op(
-        db,
-        zone,
-        op,
-        {"name": name, "type": rtype, "value": value, "ttl": ttl},
-        target_serial=target_serial,
-    )
+    record = {"name": name, "type": rtype, "value": value, "ttl": ttl}
+
+    collector = _dns_op_collector.get()
+    if collector is not None:
+        # Batch mode — defer; the enclosing ``_batched_dns_ops`` flushes per
+        # zone. The serial bump above still happens per op exactly as the
+        # inline path does, so ``target_serial`` snapshots match.
+        collector.append((zone, {"op": op, "record": record, "target_serial": target_serial}))
+        return
+
+    await enqueue_record_op(db, zone, op, record, target_serial=target_serial)
+
+
+async def _flush_dns_op_collector(
+    db: AsyncSession, collector: list[tuple[DNSZone, dict[str, Any]]]
+) -> None:
+    """Flush deferred record ops, one batched driver call per zone.
+
+    ``enqueue_record_ops_batch`` already does the right thing per driver: an
+    agentless primary gets a single batched apply; an agent-based primary
+    falls through to per-op DB rows (identical to the inline path), so this
+    is safe for every group shape — no ``is_agentless`` gate needed here.
+    Zone order is preserved so a delete-then-recreate (address-family swap)
+    applies in the same order it was collected.
+    """
+    if not collector:
+        return
+    from app.services.dns.record_ops import enqueue_record_ops_batch
+
+    by_zone: dict[uuid.UUID, tuple[DNSZone, list[dict[str, Any]]]] = {}
+    order: list[uuid.UUID] = []
+    for zone, op in collector:
+        if zone.id not in by_zone:
+            by_zone[zone.id] = (zone, [])
+            order.append(zone.id)
+        by_zone[zone.id][1].append(op)
+    for zid in order:
+        zone, ops = by_zone[zid]
+        await enqueue_record_ops_batch(db, zone, ops)
+
+
+@contextlib.asynccontextmanager
+async def _batched_dns_ops(db: AsyncSession) -> Any:
+    """Collect every ``_enqueue_dns_op`` fired inside the block and flush it
+    grouped by zone on a clean exit. On an exception the partial collector is
+    dropped unflushed — callers handle per-row failures inside the loop so the
+    block body itself stays exception-free in the happy path."""
+    collector: list[tuple[DNSZone, dict[str, Any]]] = []
+    token = _dns_op_collector.set(collector)
+    try:
+        yield
+    finally:
+        _dns_op_collector.reset(token)
+    await _flush_dns_op_collector(db, collector)
 
 
 async def _create_alias_records(
@@ -5304,22 +5365,26 @@ async def _apply_dns_sync(
         ips_res = await db.execute(q)
         # Cache subnets so we don't re-fetch per IP in the same subnet.
         subnet_cache: dict[uuid.UUID, Subnet | None] = {}
-        for ip in ips_res.scalars().all():
-            sn = subnet_cache.get(ip.subnet_id)
-            if sn is None and ip.subnet_id not in subnet_cache:
-                sn = await db.get(Subnet, ip.subnet_id)
-                subnet_cache[ip.subnet_id] = sn
-            if sn is None:
-                errors.append(f"{ip.address}: parent subnet missing")
-                continue
-            try:
-                await _sync_dns_record(db, ip, sn, action="create")
-                if ip.id in body.create_for_ip_ids:
-                    created += 1
-                else:
-                    updated += 1
-            except Exception as exc:
-                errors.append(f"{ip.address}: {exc}")
+        # Batch the forward/reverse ops per zone so an agentless Windows-DNS
+        # primary takes one WinRM round trip per zone, matching the delete
+        # branch below (issue #341).
+        async with _batched_dns_ops(db):
+            for ip in ips_res.scalars().all():
+                sn = subnet_cache.get(ip.subnet_id)
+                if sn is None and ip.subnet_id not in subnet_cache:
+                    sn = await db.get(Subnet, ip.subnet_id)
+                    subnet_cache[ip.subnet_id] = sn
+                if sn is None:
+                    errors.append(f"{ip.address}: parent subnet missing")
+                    continue
+                try:
+                    await _sync_dns_record(db, ip, sn, action="create")
+                    if ip.id in body.create_for_ip_ids:
+                        created += 1
+                    else:
+                        updated += 1
+                except Exception as exc:
+                    errors.append(f"{ip.address}: {exc}")
 
     if body.delete_stale_record_ids:
         from app.services.dns.record_ops import (  # noqa: PLC0415
@@ -6953,41 +7018,45 @@ async def bulk_allocate_commit(
 
     explicit_zone = uuid.UUID(body.dns_zone_id) if body.dns_zone_id else None
     created_addrs: list[str] = []
-    for item in items:
-        if item.in_use or item.in_dynamic_pool or item.fqdn_collision:
-            continue
-        ip = IPAddress(
-            subnet_id=subnet_id,
-            address=item.address,
-            status=body.status,
-            hostname=item.hostname,
-            description=body.description,
-            tags=dict(body.tags),
-            custom_fields=dict(body.custom_fields),
-            created_by_user_id=current_user.id,
-        )
-        db.add(ip)
-        await db.flush()
-
-        if body.create_dns_records:
-            await _sync_dns_record(db, ip, subnet, zone_id=explicit_zone, action="create")
-
-        db.add(
-            _audit(
-                current_user,
-                "create",
-                "ip_address",
-                str(ip.id),
-                item.address,
-                new_value={
-                    "address": item.address,
-                    "hostname": item.hostname,
-                    "status": body.status,
-                    "reason": "bulk_allocate",
-                },
+    # Every allocated IP lands in the same subnet → same zone(s); batch the
+    # DNS ops per zone so an agentless Windows-DNS primary takes one WinRM
+    # round trip instead of one per IP (issue #341).
+    async with _batched_dns_ops(db):
+        for item in items:
+            if item.in_use or item.in_dynamic_pool or item.fqdn_collision:
+                continue
+            ip = IPAddress(
+                subnet_id=subnet_id,
+                address=item.address,
+                status=body.status,
+                hostname=item.hostname,
+                description=body.description,
+                tags=dict(body.tags),
+                custom_fields=dict(body.custom_fields),
+                created_by_user_id=current_user.id,
             )
-        )
-        created_addrs.append(item.address)
+            db.add(ip)
+            await db.flush()
+
+            if body.create_dns_records:
+                await _sync_dns_record(db, ip, subnet, zone_id=explicit_zone, action="create")
+
+            db.add(
+                _audit(
+                    current_user,
+                    "create",
+                    "ip_address",
+                    str(ip.id),
+                    item.address,
+                    new_value={
+                        "address": item.address,
+                        "hostname": item.hostname,
+                        "status": body.status,
+                        "reason": "bulk_allocate",
+                    },
+                )
+            )
+            created_addrs.append(item.address)
 
     await db.flush()
     db.add(
@@ -7903,64 +7972,70 @@ async def bulk_edit_addresses(
     # Cache the subnet rows so per-IP DNS sync doesn't re-query for every row.
     subnet_cache: dict[uuid.UUID, Subnet] = {}
 
-    for ip in rows:
-        if ip.status in ("network", "broadcast", "orphan"):
-            skipped.append(ip.id)
-            continue
-        # Skip dynamic-lease mirrors — DHCP server owns their state and any
-        # edit here would be overwritten on the next pull. The UI already
-        # blocks these from being selected; this is defence-in-depth.
-        if ip.auto_from_lease:
-            skipped.append(ip.id)
-            continue
+    # A zone re-assignment edit fans the same op out to one new zone across
+    # every selected IP — batch per zone so an agentless Windows-DNS primary
+    # takes one WinRM round trip instead of one per IP (issue #341).
+    async with _batched_dns_ops(db):
+        for ip in rows:
+            if ip.status in ("network", "broadcast", "orphan"):
+                skipped.append(ip.id)
+                continue
+            # Skip dynamic-lease mirrors — DHCP server owns their state and any
+            # edit here would be overwritten on the next pull. The UI already
+            # blocks these from being selected; this is defence-in-depth.
+            if ip.auto_from_lease:
+                skipped.append(ip.id)
+                continue
 
-        old: dict[str, Any] = {}
-        for k in scalar_changes:
-            old[k] = getattr(ip, k, None)
-        for k, v in scalar_changes.items():
-            setattr(ip, k, v)
+            old: dict[str, Any] = {}
+            for k in scalar_changes:
+                old[k] = getattr(ip, k, None)
+            for k, v in scalar_changes.items():
+                setattr(ip, k, v)
 
-        if tags_patch is not None:
-            merged = dict(ip.tags or {})
-            for k, v in tags_patch.items():
-                if v is None:
-                    merged.pop(k, None)
-                else:
-                    merged[k] = v
-            old["tags"] = ip.tags or {}
-            ip.tags = merged
-        if cf_patch is not None:
-            merged_cf = dict(ip.custom_fields or {})
-            for k, v in cf_patch.items():
-                if v is None:
-                    merged_cf.pop(k, None)
-                else:
-                    merged_cf[k] = v
-            old["custom_fields"] = ip.custom_fields or {}
-            ip.custom_fields = merged_cf
+            if tags_patch is not None:
+                merged = dict(ip.tags or {})
+                for k, v in tags_patch.items():
+                    if v is None:
+                        merged.pop(k, None)
+                    else:
+                        merged[k] = v
+                old["tags"] = ip.tags or {}
+                ip.tags = merged
+            if cf_patch is not None:
+                merged_cf = dict(ip.custom_fields or {})
+                for k, v in cf_patch.items():
+                    if v is None:
+                        merged_cf.pop(k, None)
+                    else:
+                        merged_cf[k] = v
+                old["custom_fields"] = ip.custom_fields or {}
+                ip.custom_fields = merged_cf
 
-        if apply_zone:
-            subnet = subnet_cache.get(ip.subnet_id)
-            if subnet is None:
-                subnet = await db.get(Subnet, ip.subnet_id)
+            if apply_zone:
+                subnet = subnet_cache.get(ip.subnet_id)
+                if subnet is None:
+                    subnet = await db.get(Subnet, ip.subnet_id)
+                    if subnet is not None:
+                        subnet_cache[ip.subnet_id] = subnet
                 if subnet is not None:
-                    subnet_cache[ip.subnet_id] = subnet
-            if subnet is not None:
-                old["forward_zone_id"] = str(ip.forward_zone_id) if ip.forward_zone_id else None
-                await _sync_dns_record(db, ip, subnet, zone_id=new_zone_id, action="update")
+                    old["forward_zone_id"] = str(ip.forward_zone_id) if ip.forward_zone_id else None
+                    await _sync_dns_record(db, ip, subnet, zone_id=new_zone_id, action="update")
 
-        db.add(
-            _audit(
-                current_user,
-                "update",
-                "ip_address",
-                str(ip.id),
-                str(ip.address),
-                old_value={k: (str(v) if isinstance(v, uuid.UUID) else v) for k, v in old.items()},
-                new_value={**changes, "batch_id": str(batch_id)},
+            db.add(
+                _audit(
+                    current_user,
+                    "update",
+                    "ip_address",
+                    str(ip.id),
+                    str(ip.address),
+                    old_value={
+                        k: (str(v) if isinstance(v, uuid.UUID) else v) for k, v in old.items()
+                    },
+                    new_value={**changes, "batch_id": str(batch_id)},
+                )
             )
-        )
-        updated += 1
+            updated += 1
 
     await db.commit()
     logger.info(

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -832,15 +832,17 @@ async def _flush_dns_op_collector(
 async def _batched_dns_ops(db: AsyncSession) -> Any:
     """Collect every ``_enqueue_dns_op`` fired inside the block and flush it
     grouped by zone on a clean exit. On an exception the partial collector is
-    dropped unflushed — callers handle per-row failures inside the loop so the
-    block body itself stays exception-free in the happy path."""
+    dropped unflushed — the flush sits on the success path inside ``try`` so
+    an aborting body never half-applies a batch (callers also handle per-row
+    failures inside the loop so the happy path stays exception-free)."""
     collector: list[tuple[DNSZone, dict[str, Any]]] = []
     token = _dns_op_collector.set(collector)
     try:
         yield
+        # Reached only when the block body completed without raising.
+        await _flush_dns_op_collector(db, collector)
     finally:
         _dns_op_collector.reset(token)
-    await _flush_dns_op_collector(db, collector)
 
 
 async def _create_alias_records(

--- a/backend/app/drivers/dns/__init__.py
+++ b/backend/app/drivers/dns/__init__.py
@@ -24,9 +24,13 @@ from app.drivers.dns.base import (
 )
 from app.drivers.dns.bind9 import BIND9Driver
 from app.drivers.dns.cloudflare import CloudflareDNSDriver
+from app.drivers.dns.digitalocean import DigitalOceanDNSDriver
 from app.drivers.dns.googledns import GoogleCloudDNSDriver
+from app.drivers.dns.hetzner import HetznerDNSDriver
+from app.drivers.dns.linode import LinodeDNSDriver
 from app.drivers.dns.powerdns import PowerDNSDriver
 from app.drivers.dns.route53 import Route53DNSDriver
+from app.drivers.dns.vultr import VultrDNSDriver
 from app.drivers.dns.windows import WindowsDNSDriver
 
 _DRIVERS: dict[str, type[DNSDriver]] = {
@@ -41,6 +45,12 @@ _DRIVERS: dict[str, type[DNSDriver]] = {
     "route53": Route53DNSDriver,
     "azure_dns": AzureDNSDriver,
     "google_dns": GoogleCloudDNSDriver,
+    # Token-only providers (issue #327) — single API token, plain JSON
+    # over httpx, same agentless CloudDNSDriverBase shape.
+    "digitalocean": DigitalOceanDNSDriver,
+    "hetzner": HetznerDNSDriver,
+    "linode": LinodeDNSDriver,
+    "vultr": VultrDNSDriver,
 }
 
 # Drivers whose record ops run from the control plane directly, with no
@@ -48,14 +58,35 @@ _DRIVERS: dict[str, type[DNSDriver]] = {
 # the queue for these — applying the change synchronously and writing a
 # DNSRecordOp row as ``applied`` / ``failed`` for audit purposes.
 AGENTLESS_DRIVERS: frozenset[str] = frozenset(
-    {"windows_dns", "cloudflare", "route53", "azure_dns", "google_dns"}
+    {
+        "windows_dns",
+        "cloudflare",
+        "route53",
+        "azure_dns",
+        "google_dns",
+        "digitalocean",
+        "hetzner",
+        "linode",
+        "vultr",
+    }
 )
 
 # Agentless cloud-hosted DNS drivers (subset of AGENTLESS_DRIVERS).
 # Used by the DNS server create/update path + the cloud import + the
 # sync-from-server widening to recognise a cloud DNS server (credentials
 # live in DNSServer.credentials_encrypted as a provider-specific dict).
-CLOUD_DNS_DRIVERS: frozenset[str] = frozenset({"cloudflare", "route53", "azure_dns", "google_dns"})
+CLOUD_DNS_DRIVERS: frozenset[str] = frozenset(
+    {
+        "cloudflare",
+        "route53",
+        "azure_dns",
+        "google_dns",
+        "digitalocean",
+        "hetzner",
+        "linode",
+        "vultr",
+    }
+)
 
 
 def is_agentless(driver_name: str) -> bool:

--- a/backend/app/drivers/dns/bind9.py
+++ b/backend/app/drivers/dns/bind9.py
@@ -316,6 +316,9 @@ class BIND9Driver(DNSDriver):
                 "SSHFP",
                 "NAPTR",
                 "LOC",
+                "SVCB",
+                "HTTPS",
+                "DNAME",
             ],
         }
 

--- a/backend/app/drivers/dns/digitalocean.py
+++ b/backend/app/drivers/dns/digitalocean.py
@@ -1,0 +1,391 @@
+"""DigitalOcean DNS driver (agentless, REST API — issue #37).
+
+DigitalOcean hosts authoritative zones ("domains") and exposes a flat REST
+API at ``https://api.digitalocean.com/v2``. SpatiumDDI manages those zones
+exactly like a local BIND9 / PowerDNS zone — same Zones / Records group
+surfaces — driving the API directly from the control plane rather than an
+agent (see :mod:`app.drivers.dns._cloud_base` for the agentless contract).
+
+Authentication is a single Personal Access / OAuth **API token** sent as a
+``Bearer`` header. Unlike Cloudflare, DigitalOcean scopes records by the bare
+**domain name** (``/v2/domains/{name}/records``) rather than an opaque zone
+id, so there is no zone-id resolution step — the zone FQDN (de-dotted) is the
+handle. The integer ``id`` returned per record is still needed to scope
+update / delete calls.
+
+Like the other token-only cloud drivers, DigitalOcean needs no vendor SDK:
+the API is plain JSON over HTTPS, so this driver uses ``httpx`` directly
+(already a top-level dependency). ``_client`` is the single seam tests patch
+to inject a fake transport.
+
+Credential dict shape (decrypted from ``DNSServer.credentials_encrypted``)::
+
+    {"api_token": "<personal-access-token>"}
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.drivers.dns._cloud_base import (
+    CloudDNSDriverBase,
+    CloudDNSError,
+    CloudDNSZone,
+    normalize_fqdn,
+)
+from app.drivers.dns.base import RecordChange, RecordData
+
+# DigitalOcean API v2 base. Pinned here (not configurable) — there is no
+# self-hosted DigitalOcean. The token in the Authorization header is the
+# only per-server input.
+_API_BASE = "https://api.digitalocean.com/v2"
+
+# DigitalOcean's per-page maximum is 200; 50 keeps responses small while
+# still rarely needing a second round trip for typical accounts.
+_PER_PAGE = 50
+
+# DigitalOcean stamps records with no explicit TTL at 1800s (the account
+# default). We surface that as ``ttl=None`` on the neutral RecordData so it
+# round-trips as "let the provider decide" rather than a literal value, and
+# omit ``ttl`` from writes when None so the API applies its default.
+_TTL_DEFAULT = 1800
+
+
+class DigitalOceanDNSDriver(CloudDNSDriverBase):
+    """Agentless driver for DigitalOcean-hosted authoritative zones."""
+
+    name = "digitalocean"
+    # The Add-DNS-server modal renders + the probe requires only the token.
+    credential_fields: tuple[str, ...] = ("api_token",)
+
+    # ── HTTP plumbing ───────────────────────────────────────────────────
+    def _client(self, token: str) -> httpx.AsyncClient:
+        """Return an httpx client bound to the API base + bearer token.
+
+        This is the single seam tests patch to inject a fake transport —
+        keep all request construction flowing through the returned client.
+        """
+        return httpx.AsyncClient(
+            base_url=_API_BASE,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+
+    @staticmethod
+    def _unwrap(response: Any) -> dict[str, Any]:
+        """Validate a DigitalOcean response and return its parsed body.
+
+        DigitalOcean has no success-envelope: a 2xx status *is* the success
+        signal (DELETE returns 204 with an empty body). Failures come back
+        non-2xx with ``{"id": "...", "message": "...", "request_id": "..."}``.
+        Raise :class:`CloudDNSError` carrying that ``message`` on any non-2xx.
+        """
+        body: dict[str, Any]
+        try:
+            parsed = response.json()
+            body = parsed if isinstance(parsed, dict) else {}
+        except (ValueError, TypeError):
+            body = {}
+        status = getattr(response, "status_code", 0)
+        if 200 <= status < 300:
+            return body
+        detail = str(body.get("message") or "") or f"HTTP {status}"
+        raise CloudDNSError(f"DigitalOcean API error: {detail}")
+
+    def _token(self, creds: dict[str, Any]) -> str:
+        token = (creds or {}).get("api_token")
+        if not token:
+            raise CloudDNSError("DigitalOcean credentials missing 'api_token'.")
+        return str(token)
+
+    @staticmethod
+    def _zone_handle(zone_fqdn: str) -> str:
+        """DigitalOcean scopes records by the bare domain name (no trailing dot)."""
+        return normalize_fqdn(zone_fqdn).rstrip(".")
+
+    @staticmethod
+    def _relativize(name: str, zone_fqdn: str) -> str:
+        """Return the record name relative to ``zone_fqdn`` (apex → ``"@"``).
+
+        DigitalOcean already stores names relative to the apex (and emits
+        ``"@"`` for apex), but a record list can surface fully-qualified
+        names in some edge cases, so we normalise defensively the same way
+        the Cloudflare driver does. A name equal to the apex collapses to
+        ``"@"`` to match the BIND9 / Windows pull convention.
+        """
+        raw = (name or "").strip()
+        if not raw or raw == "@":
+            return "@"
+        candidate = normalize_fqdn(raw)
+        zone = normalize_fqdn(zone_fqdn)
+        if candidate == zone:
+            return "@"
+        if candidate.endswith("." + zone):
+            return candidate[: -(len(zone) + 1)]
+        # Already a relative label DigitalOcean handed back verbatim.
+        return raw.rstrip(".")
+
+    @staticmethod
+    def _write_name(label: str) -> str:
+        """Render the record name DigitalOcean expects on a write.
+
+        DigitalOcean takes **relative** names with ``"@"`` for the apex, so
+        an empty / ``"@"`` label stays ``"@"`` and any other label is sent as
+        the bare relative form (trailing dot stripped).
+        """
+        rel = (label or "").strip().rstrip(".")
+        if not rel or rel == "@":
+            return "@"
+        return rel
+
+    # ── Zone reads ──────────────────────────────────────────────────────
+    async def _list_zones(self, server: Any, creds: dict[str, Any]) -> list[CloudDNSZone]:
+        token = self._token(creds)
+        zones: list[CloudDNSZone] = []
+        async with self._client(token) as client:
+            page = 1
+            while True:
+                resp = await client.get("/domains", params={"per_page": _PER_PAGE, "page": page})
+                body = self._unwrap(resp)
+                for z in body.get("domains") or []:
+                    name = normalize_fqdn(z["name"])
+                    is_reverse = name.endswith((".in-addr.arpa.", ".ip6.arpa."))
+                    zones.append(
+                        CloudDNSZone(
+                            name=name,
+                            # DigitalOcean has no opaque zone id — record
+                            # calls are scoped by the bare domain name. Store
+                            # it so the neutral shape still carries a handle.
+                            zone_id=name.rstrip("."),
+                            is_reverse=is_reverse,
+                            # DigitalOcean exposes no online DNSSEC state via
+                            # the API; capability advertising is the source of
+                            # truth (dnssec_online is False).
+                            dnssec_enabled=False,
+                            record_count=None,
+                        )
+                    )
+                if not self._has_next_page(body):
+                    break
+                page += 1
+        return zones
+
+    @staticmethod
+    def _has_next_page(body: dict[str, Any]) -> bool:
+        """True when the response advertises a ``links.pages.next`` URL."""
+        pages = ((body.get("links") or {}).get("pages")) or {}
+        return bool(pages.get("next"))
+
+    async def _list_zone_records(
+        self, server: Any, creds: dict[str, Any], zone_name: str
+    ) -> list[RecordData]:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(zone_name)
+        handle = self._zone_handle(zone_fqdn)
+        records: list[RecordData] = []
+        async with self._client(token) as client:
+            page = 1
+            while True:
+                resp = await client.get(
+                    f"/domains/{handle}/records",
+                    params={"per_page": _PER_PAGE, "page": page},
+                )
+                body = self._unwrap(resp)
+                for rec in body.get("domain_records") or []:
+                    raw_ttl = rec.get("ttl")
+                    ttl = None if raw_ttl == _TTL_DEFAULT else raw_ttl
+                    records.append(
+                        RecordData(
+                            name=self._relativize(rec.get("name", "@"), zone_fqdn),
+                            record_type=rec["type"],
+                            value=rec.get("data", ""),
+                            ttl=ttl,
+                            priority=rec.get("priority"),
+                            weight=rec.get("weight"),
+                            port=rec.get("port"),
+                        )
+                    )
+                if not self._has_next_page(body):
+                    break
+                page += 1
+        return records
+
+    # ── Record writes ───────────────────────────────────────────────────
+    def _record_payload(self, change: RecordChange) -> dict[str, Any]:
+        rec = change.record
+        payload: dict[str, Any] = {
+            "type": rec.record_type,
+            "name": self._write_name(rec.name),
+            "data": rec.value,
+        }
+        # Omit ttl when None so DigitalOcean applies its account default
+        # (1800s), mirroring the auto-TTL round-trip on the read path.
+        if rec.ttl is not None:
+            payload["ttl"] = rec.ttl
+        if rec.priority is not None:
+            payload["priority"] = rec.priority
+        if rec.port is not None:
+            payload["port"] = rec.port
+        if rec.weight is not None:
+            payload["weight"] = rec.weight
+        return payload
+
+    async def _find_record_id(
+        self,
+        client: httpx.AsyncClient,
+        handle: str,
+        zone_fqdn: str,
+        name: str,
+        record_type: str,
+        value: str | None = None,
+        priority: int | None = None,
+    ) -> int | None:
+        """Return the DigitalOcean record id matching name+type+value, or ``None``.
+
+        SpatiumDDI keys DNS records per value and supports round-robin (multiple
+        A/AAAA at one hostname) and multiple MX/NS/TXT. So when ``value`` is
+        given we must match the *specific* value being changed — matching on
+        name+type alone returns the first row of a multi-value RRset and would
+        update/delete the wrong value (issue #331).
+
+        DigitalOcean's record list has no server-side ``data`` filter, so we
+        page through the records and match the relative name + type +
+        ``data`` (and ``priority`` for MX/SRV) entirely client-side.
+        """
+        target_name = self._write_name(name)
+        page = 1
+        first_match: int | None = None
+        while True:
+            resp = await client.get(
+                f"/domains/{handle}/records",
+                params={"per_page": _PER_PAGE, "page": page},
+            )
+            body = self._unwrap(resp)
+            for rec in body.get("domain_records") or []:
+                if rec.get("type") != record_type:
+                    continue
+                if self._relativize(rec.get("name", "@"), zone_fqdn) != self._relativize(
+                    target_name, zone_fqdn
+                ):
+                    continue
+                # Name+type-only lookup (value unknown): remember first match.
+                if value is None:
+                    if first_match is None:
+                        first_match = int(rec["id"])
+                    continue
+                if rec.get("data") != value:
+                    continue
+                if priority is not None and rec.get("priority") != priority:
+                    continue
+                return int(rec["id"])
+            if not self._has_next_page(body):
+                break
+            page += 1
+        return first_match
+
+    async def _apply_record(self, server: Any, creds: dict[str, Any], change: RecordChange) -> None:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(change.zone_name)
+        handle = self._zone_handle(zone_fqdn)
+        payload = self._record_payload(change)
+        async with self._client(token) as client:
+            if change.op == "create":
+                resp = await client.post(f"/domains/{handle}/records", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "update":
+                rid = await self._find_record_id(
+                    client,
+                    handle,
+                    zone_fqdn,
+                    change.record.name,
+                    change.record.record_type,
+                    value=change.record.value,
+                    priority=change.record.priority,
+                )
+                if rid is None:
+                    # No existing row to update — treat as create so the
+                    # desired state still lands (mirrors the windows_dns +
+                    # _cloud_base "update is create on miss" contract).
+                    resp = await client.post(f"/domains/{handle}/records", json=payload)
+                    self._unwrap(resp)
+                    return
+                resp = await client.put(f"/domains/{handle}/records/{rid}", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "delete":
+                rid = await self._find_record_id(
+                    client,
+                    handle,
+                    zone_fqdn,
+                    change.record.name,
+                    change.record.record_type,
+                    value=change.record.value,
+                    priority=change.record.priority,
+                )
+                if rid is None:
+                    # Idempotent delete — nothing to remove.
+                    return
+                resp = await client.delete(f"/domains/{handle}/records/{rid}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"DigitalOcean: unsupported record op {change.op!r}")
+
+    # ── Zone writes ─────────────────────────────────────────────────────
+    async def _apply_zone(self, server: Any, creds: dict[str, Any], zone: Any, op: str) -> None:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(getattr(zone, "name", ""))
+        bare = zone_fqdn.rstrip(".")
+        async with self._client(token) as client:
+            if op == "create":
+                resp = await client.post("/domains", json={"name": bare})
+                self._unwrap(resp)
+                return
+
+            if op == "delete":
+                resp = await client.delete(f"/domains/{bare}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"DigitalOcean: unsupported zone op {op!r}")
+
+    # ── Capabilities ────────────────────────────────────────────────────
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "name": "digitalocean",
+            "agentless": True,
+            "manages_zones": True,
+            "views": False,
+            "rpz": False,
+            # DigitalOcean does not expose online DNSSEC signing via the API.
+            "dnssec_online": False,
+            "record_types": [
+                "A",
+                "AAAA",
+                "CNAME",
+                "MX",
+                "TXT",
+                "NS",
+                "SRV",
+                "CAA",
+                "PTR",
+                "SOA",
+            ],
+            "notes": (
+                "Agentless DigitalOcean DNS driver over the v2 REST API "
+                "(Bearer API token). Zones ('domains') + records managed from "
+                "the control plane; records are scoped by domain name (no "
+                "opaque zone id). Online DNSSEC is not exposed via the API."
+            ),
+        }
+
+
+__all__ = ["DigitalOceanDNSDriver"]

--- a/backend/app/drivers/dns/hetzner.py
+++ b/backend/app/drivers/dns/hetzner.py
@@ -270,18 +270,27 @@ class HetznerDNSDriver(CloudDNSDriverBase):
         RRset and would update/delete the wrong value (issue #331).
 
         Hetzner has no server-side ``value`` filter on ``GET /records``, so
-        we list the zone's records and match client-side (``priority`` too
-        for MX/SRV).
+        we page the whole zone's record set and match client-side
+        (``priority`` too for MX/SRV). Pagination is required — without it a
+        zone with more than ``_PER_PAGE`` records could miss the target row
+        and wrongly fall back to create-on-miss (update) or no-op (delete).
         """
-        resp = await client.get("/records", params={"zone_id": zone_id})
-        body = self._unwrap(resp)
+        all_records: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            resp = await client.get(
+                "/records",
+                params={"zone_id": zone_id, "per_page": _PER_PAGE, "page": page},
+            )
+            body = self._unwrap(resp)
+            all_records.extend(body.get("records") or [])
+            pagination = (body.get("meta") or {}).get("pagination") or {}
+            if page >= int(pagination.get("last_page") or 1):
+                break
+            page += 1
         # ``name`` here is already the relative label the payload uses (apex
         # as "@"), which is exactly how Hetzner stores it — compare directly.
-        results = [
-            r
-            for r in (body.get("records") or [])
-            if r.get("name") == name and r.get("type") == record_type
-        ]
+        results = [r for r in all_records if r.get("name") == name and r.get("type") == record_type]
         if not results:
             return None
         # Name+type-only lookup (value unknown): keep legacy first-match.

--- a/backend/app/drivers/dns/hetzner.py
+++ b/backend/app/drivers/dns/hetzner.py
@@ -1,0 +1,401 @@
+"""Hetzner DNS driver (agentless, REST API — issue #37).
+
+Hetzner hosts authoritative zones and exposes a flat REST API at
+``https://dns.hetzner.com/api/v1``. SpatiumDDI manages those zones exactly
+like a local BIND9 / PowerDNS zone — same Zones / Records group surfaces —
+driving the API directly from the control plane rather than an agent (see
+:mod:`app.drivers.dns._cloud_base` for the agentless contract).
+
+Authentication is a single account-scoped **API token** carried in the
+``Auth-API-Token`` header (note: *not* a ``Bearer`` Authorization header —
+this is Hetzner-specific). Records are scoped by an opaque ``zone_id`` so
+``_resolve_zone_id`` looks the id up by name (``GET /zones?name=``) and the
+methods cache nothing — each call is cheap and idempotent.
+
+Like Cloudflare, Hetzner needs no vendor SDK: the API is plain JSON over
+HTTPS, so this driver uses ``httpx`` directly (already a top-level
+dependency). ``_client`` is the single seam tests patch to inject a fake
+transport.
+
+Credential dict shape (decrypted from ``DNSServer.credentials_encrypted``)::
+
+    {"api_token": "<account-api-token>"}
+
+TTL: Hetzner has no numeric "automatic" sentinel — a record with no ``ttl``
+falls back to the zone default, and the API simply omits the field. So this
+driver maps an *absent* ``ttl`` on read to ``ttl=None`` and, on write, omits
+the ``ttl`` key entirely when ``RecordData.ttl`` is ``None`` (mirroring
+Cloudflare's ``_TTL_AUTO`` round-trip, just keyed on presence not a value).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.drivers.dns._cloud_base import (
+    CloudDNSDriverBase,
+    CloudDNSError,
+    CloudDNSZone,
+    normalize_fqdn,
+)
+from app.drivers.dns.base import RecordChange, RecordData
+
+# Hetzner DNS API v1 base. Pinned here (not configurable) — there is no
+# self-hosted Hetzner DNS. The token in the Auth-API-Token header is the
+# only per-server input.
+_API_BASE = "https://dns.hetzner.com/api/v1"
+
+# Hetzner's per-page maximum is 100; 50 keeps responses small while still
+# rarely needing a second round trip for typical accounts.
+_PER_PAGE = 50
+
+
+class HetznerDNSDriver(CloudDNSDriverBase):
+    """Agentless driver for Hetzner-hosted authoritative zones."""
+
+    name = "hetzner"
+    # The Add-DNS-server modal renders + the probe requires only the token.
+    credential_fields: tuple[str, ...] = ("api_token",)
+
+    # ── HTTP plumbing ───────────────────────────────────────────────────
+    def _client(self, token: str) -> httpx.AsyncClient:
+        """Return an httpx client bound to the API base + auth token header.
+
+        This is the single seam tests patch to inject a fake transport —
+        keep all request construction flowing through the returned client.
+        Hetzner authenticates with a bare ``Auth-API-Token`` header, *not*
+        an ``Authorization: Bearer`` header.
+        """
+        return httpx.AsyncClient(
+            base_url=_API_BASE,
+            headers={
+                "Auth-API-Token": token,
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+
+    @staticmethod
+    def _unwrap(response: Any) -> dict[str, Any]:
+        """Validate a Hetzner response and return its parsed body.
+
+        Hetzner returns the bare resource envelope on success
+        (``{"zones": [...], "meta": {...}}`` / ``{"records": [...]}`` /
+        ``{"record": {...}}``) and signals failure with a non-2xx status.
+        The error body is either ``{"error": {"message", "code"}}`` or a
+        flat ``{"message": ...}``. Raise :class:`CloudDNSError` with the
+        cleanest message available on any non-2xx reply.
+        """
+        body: dict[str, Any]
+        try:
+            body = response.json()
+        except (ValueError, TypeError):
+            body = {}
+        status = getattr(response, "status_code", 0)
+        if 200 <= status < 300:
+            return body if isinstance(body, dict) else {}
+        detail = ""
+        err = body.get("error") if isinstance(body, dict) else None
+        if isinstance(err, dict):
+            detail = str(err.get("message") or err.get("code") or "")
+        elif isinstance(body, dict):
+            detail = str(body.get("message") or "")
+        if not detail:
+            detail = f"HTTP {status}"
+        raise CloudDNSError(f"Hetzner API error: {detail}")
+
+    def _token(self, creds: dict[str, Any]) -> str:
+        token = (creds or {}).get("api_token")
+        if not token:
+            raise CloudDNSError("Hetzner credentials missing 'api_token'.")
+        return str(token)
+
+    async def _resolve_zone_id(self, client: httpx.AsyncClient, zone_fqdn: str) -> str:
+        """Look up the opaque Hetzner zone id for a zone FQDN.
+
+        Hetzner's ``GET /zones?name=`` filter wants the bare name with no
+        trailing dot, so the apex FQDN is de-dotted before the query.
+        """
+        name = normalize_fqdn(zone_fqdn).rstrip(".")
+        resp = await client.get("/zones", params={"name": name})
+        body = self._unwrap(resp)
+        zones = body.get("zones") or []
+        if not zones:
+            raise CloudDNSError(f"Hetzner zone {name!r} not found on this account.")
+        return str(zones[0]["id"])
+
+    @staticmethod
+    def _relativize(record_name: str, zone_fqdn: str) -> str:
+        """Return ``record_name`` relative to ``zone_fqdn`` (apex → ``"@"``).
+
+        Hetzner already returns names relative to the zone apex (apex as
+        ``"@"``, sub-labels as the bare left-hand label). This still
+        normalises the input — collapsing an absolute FQDN or an empty /
+        ``"@"`` name to ``"@"`` at the apex — so the pull is robust if
+        Hetzner ever returns an absolute name.
+        """
+        raw = (record_name or "").strip()
+        if not raw or raw == "@":
+            return "@"
+        # Already-relative label (Hetzner's normal case): no trailing dot,
+        # not the zone itself → return verbatim.
+        zone = normalize_fqdn(zone_fqdn)
+        candidate = normalize_fqdn(raw)
+        if candidate == zone:
+            return "@"
+        if candidate.endswith("." + zone):
+            return candidate[: -(len(zone) + 1)]
+        # A bare relative label that isn't an FQDN under the zone — return
+        # it stripped of any stray trailing dot.
+        return raw.rstrip(".")
+
+    # ── Zone reads ──────────────────────────────────────────────────────
+    async def _list_zones(self, server: Any, creds: dict[str, Any]) -> list[CloudDNSZone]:
+        token = self._token(creds)
+        zones: list[CloudDNSZone] = []
+        async with self._client(token) as client:
+            page = 1
+            while True:
+                resp = await client.get("/zones", params={"per_page": _PER_PAGE, "page": page})
+                body = self._unwrap(resp)
+                for z in body.get("zones") or []:
+                    name = normalize_fqdn(z["name"])
+                    is_reverse = name.endswith((".in-addr.arpa.", ".ip6.arpa."))
+                    zones.append(
+                        CloudDNSZone(
+                            name=name,
+                            zone_id=str(z["id"]),
+                            is_reverse=is_reverse,
+                            # Hetzner has no online DNSSEC signing — leave
+                            # False; capability advertising is the source of
+                            # truth for signing support.
+                            dnssec_enabled=False,
+                            record_count=None,
+                        )
+                    )
+                pagination = (body.get("meta") or {}).get("pagination") or {}
+                last_page = int(pagination.get("last_page") or 1)
+                if page >= last_page:
+                    break
+                page += 1
+        return zones
+
+    async def _list_zone_records(
+        self, server: Any, creds: dict[str, Any], zone_name: str
+    ) -> list[RecordData]:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(zone_name)
+        records: list[RecordData] = []
+        async with self._client(token) as client:
+            zone_id = await self._resolve_zone_id(client, zone_fqdn)
+            page = 1
+            while True:
+                resp = await client.get(
+                    "/records",
+                    params={"zone_id": zone_id, "per_page": _PER_PAGE, "page": page},
+                )
+                body = self._unwrap(resp)
+                for rec in body.get("records") or []:
+                    # Absent ttl → zone default → surface as None.
+                    raw_ttl = rec.get("ttl")
+                    records.append(
+                        RecordData(
+                            name=self._relativize(rec["name"], zone_fqdn),
+                            record_type=rec["type"],
+                            value=rec["value"],
+                            ttl=raw_ttl,
+                            priority=rec.get("priority"),
+                        )
+                    )
+                pagination = (body.get("meta") or {}).get("pagination") or {}
+                last_page = int(pagination.get("last_page") or 1)
+                if page >= last_page:
+                    break
+                page += 1
+        return records
+
+    # ── Record writes ───────────────────────────────────────────────────
+    @staticmethod
+    def _absolute_name(label: str, zone_fqdn: str) -> str:
+        """Render the relative record name Hetzner expects.
+
+        Hetzner stores names relative to the zone apex: apex is ``"@"`` and
+        sub-records are the bare left-hand label (``"www"``, ``"a.b"``). So
+        this collapses apex / empty to ``"@"`` and strips the zone suffix
+        from an absolute FQDN, leaving the relative label.
+        """
+        zone = normalize_fqdn(zone_fqdn)
+        rel = (label or "").strip()
+        if not rel or rel == "@":
+            return "@"
+        candidate = normalize_fqdn(rel)
+        if candidate == zone:
+            return "@"
+        if candidate.endswith("." + zone):
+            return candidate[: -(len(zone) + 1)]
+        # Already a bare relative label — return it without a trailing dot.
+        return rel.rstrip(".")
+
+    def _record_payload(self, change: RecordChange, zone_id: str, zone_fqdn: str) -> dict[str, Any]:
+        rec = change.record
+        payload: dict[str, Any] = {
+            "zone_id": zone_id,
+            "type": rec.record_type,
+            "name": self._absolute_name(rec.name, zone_fqdn),
+            "value": rec.value,
+        }
+        # Hetzner has no numeric "automatic" sentinel: omit ttl entirely to
+        # inherit the zone default; only send it when an explicit TTL is set.
+        if rec.ttl is not None:
+            payload["ttl"] = rec.ttl
+        return payload
+
+    async def _find_record_id(
+        self,
+        client: httpx.AsyncClient,
+        zone_id: str,
+        name: str,
+        record_type: str,
+        value: str | None = None,
+        priority: int | None = None,
+    ) -> str | None:
+        """Return the Hetzner record id matching name+type+value, or ``None``.
+
+        SpatiumDDI keys DNS records per value and supports round-robin
+        (multiple A/AAAA at one hostname) and multiple MX/NS/TXT. So when
+        ``value`` is given we must match the *specific* value being changed —
+        matching on name+type alone returns the first row of a multi-value
+        RRset and would update/delete the wrong value (issue #331).
+
+        Hetzner has no server-side ``value`` filter on ``GET /records``, so
+        we list the zone's records and match client-side (``priority`` too
+        for MX/SRV).
+        """
+        resp = await client.get("/records", params={"zone_id": zone_id})
+        body = self._unwrap(resp)
+        # ``name`` here is already the relative label the payload uses (apex
+        # as "@"), which is exactly how Hetzner stores it — compare directly.
+        results = [
+            r
+            for r in (body.get("records") or [])
+            if r.get("name") == name and r.get("type") == record_type
+        ]
+        if not results:
+            return None
+        # Name+type-only lookup (value unknown): keep legacy first-match.
+        if value is None:
+            return str(results[0]["id"])
+        # Value-keyed lookup: pick the row whose value (and priority for
+        # MX/SRV) actually matches.
+        for rec in results:
+            if rec.get("value") != value:
+                continue
+            if priority is not None and rec.get("priority") != priority:
+                continue
+            return str(rec["id"])
+        return None
+
+    async def _apply_record(self, server: Any, creds: dict[str, Any], change: RecordChange) -> None:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(change.zone_name)
+        async with self._client(token) as client:
+            zone_id = await self._resolve_zone_id(client, zone_fqdn)
+            payload = self._record_payload(change, zone_id, zone_fqdn)
+
+            if change.op == "create":
+                resp = await client.post("/records", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "update":
+                rid = await self._find_record_id(
+                    client,
+                    zone_id,
+                    payload["name"],
+                    change.record.record_type,
+                    value=change.record.value,
+                    priority=change.record.priority,
+                )
+                if rid is None:
+                    # No existing row to update — treat as create so the
+                    # desired state still lands (mirrors the windows_dns +
+                    # _cloud_base "update is create on miss" contract).
+                    resp = await client.post("/records", json=payload)
+                    self._unwrap(resp)
+                    return
+                resp = await client.put(f"/records/{rid}", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "delete":
+                rid = await self._find_record_id(
+                    client,
+                    zone_id,
+                    payload["name"],
+                    change.record.record_type,
+                    value=change.record.value,
+                    priority=change.record.priority,
+                )
+                if rid is None:
+                    # Idempotent delete — nothing to remove.
+                    return
+                resp = await client.delete(f"/records/{rid}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"Hetzner: unsupported record op {change.op!r}")
+
+    # ── Zone writes ─────────────────────────────────────────────────────
+    async def _apply_zone(self, server: Any, creds: dict[str, Any], zone: Any, op: str) -> None:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(getattr(zone, "name", ""))
+        bare = zone_fqdn.rstrip(".")
+        async with self._client(token) as client:
+            if op == "create":
+                resp = await client.post("/zones", json={"name": bare})
+                self._unwrap(resp)
+                return
+
+            if op == "delete":
+                zone_id = await self._resolve_zone_id(client, zone_fqdn)
+                resp = await client.delete(f"/zones/{zone_id}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"Hetzner: unsupported zone op {op!r}")
+
+    # ── Capabilities ────────────────────────────────────────────────────
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "name": "hetzner",
+            "agentless": True,
+            "manages_zones": True,
+            "views": False,
+            "rpz": False,
+            # Hetzner DNS Console has no online DNSSEC signing via the API.
+            "dnssec_online": False,
+            "record_types": [
+                "A",
+                "AAAA",
+                "CNAME",
+                "MX",
+                "TXT",
+                "NS",
+                "SRV",
+                "CAA",
+                "PTR",
+                "SOA",
+            ],
+            "notes": (
+                "Agentless Hetzner DNS driver over the v1 REST API "
+                "(Auth-API-Token header, not Bearer). Zones + records "
+                "managed from the control plane. No online DNSSEC signing "
+                "via the API; the SOA record is read-only on Hetzner. "
+                "Records with no explicit TTL inherit the zone default."
+            ),
+        }
+
+
+__all__ = ["HetznerDNSDriver"]

--- a/backend/app/drivers/dns/linode.py
+++ b/backend/app/drivers/dns/linode.py
@@ -1,0 +1,431 @@
+"""Linode DNS Manager driver (agentless, REST API — issue #29 / #37 Part B).
+
+Linode (Akamai) hosts authoritative zones — "Domains" in their parlance —
+and exposes a flat REST API at ``https://api.linode.com/v4``. SpatiumDDI
+manages those zones exactly like a local BIND9 / PowerDNS zone — same
+Zones / Records group surfaces — driving the API directly from the
+control plane rather than an agent (see :mod:`app.drivers.dns._cloud_base`
+for the agentless contract).
+
+Authentication is a single Personal Access Token (``Bearer`` header). A
+zone's numeric domain id is required to scope every record call, so
+``_resolve_domain_id`` looks it up by name (via the ``X-Filter`` header)
+and the methods cache nothing — each call is cheap and idempotent.
+
+Like the Cloudflare driver, Linode needs no vendor SDK: the API is plain
+JSON over HTTPS, so this driver uses ``httpx`` directly (already a
+top-level dependency). ``_client`` is the single seam tests patch to
+inject a fake transport.
+
+Key shape differences from Cloudflare:
+
+* No ``{"success": bool}`` envelope — Linode signals failure purely with a
+  non-2xx status and a ``{"errors": [{"reason", "field?"}]}`` body. The
+  ``_unwrap`` helper joins ``errors[].reason``.
+* No server-side ``content`` filter on records, so the multi-value RRset
+  disambiguation (issue #331) lists every record of the matching
+  name+type and matches the desired ``target`` (and ``priority`` for
+  MX/SRV) client-side.
+* Record names are stored **relative** to the zone apex with the apex as
+  the empty string ``""`` (Cloudflare uses the absolute name). We map the
+  empty/``"@"`` apex form on both read and write.
+* ``ttl_sec == 0`` means "use the zone default TTL" — surfaced as
+  ``ttl=None`` on the neutral RecordData and written back as ``0``.
+
+Credential dict shape (decrypted from ``DNSServer.credentials_encrypted``)::
+
+    {"api_token": "<personal-access-token>"}
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from app.drivers.dns._cloud_base import (
+    CloudDNSDriverBase,
+    CloudDNSError,
+    CloudDNSZone,
+    normalize_fqdn,
+)
+from app.drivers.dns.base import RecordChange, RecordData
+
+# Linode API v4 base. Pinned here (not configurable) — there is no
+# self-hosted Linode. The token in the Authorization header is the only
+# per-server input.
+_API_BASE = "https://api.linode.com/v4"
+
+# Linode's per-page maximum is 500; 100 (the API default) keeps responses
+# small while still rarely needing a second round trip for typical zones.
+_PER_PAGE = 100
+
+# Linode encodes "use the zone default TTL" as ttl_sec == 0. We surface
+# that as ``ttl=None`` on the neutral RecordData so it round-trips as
+# "let the provider decide" rather than a literal 0-second TTL.
+_TTL_DEFAULT = 0
+
+# Record types carried as the neutral RecordData.priority that Linode also
+# disambiguates by priority within a name+type set (MX preference, SRV
+# priority). Used to decide whether priority participates in RRset matching.
+_PRIORITY_TYPES = frozenset({"MX", "SRV"})
+
+
+class LinodeDNSDriver(CloudDNSDriverBase):
+    """Agentless driver for Linode-hosted (DNS Manager) authoritative zones."""
+
+    name = "linode"
+    # The Add-DNS-server modal renders + the probe requires only the token.
+    credential_fields: tuple[str, ...] = ("api_token",)
+
+    # ── HTTP plumbing ───────────────────────────────────────────────────
+    def _client(self, token: str) -> httpx.AsyncClient:
+        """Return an httpx client bound to the API base + bearer token.
+
+        This is the single seam tests patch to inject a fake transport —
+        keep all request construction flowing through the returned client.
+        """
+        return httpx.AsyncClient(
+            base_url=_API_BASE,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+
+    @staticmethod
+    def _unwrap(response: Any) -> dict[str, Any]:
+        """Validate a Linode response and return its parsed body.
+
+        Linode has no ``success`` envelope — it signals failure with a
+        non-2xx status and a body shaped ``{"errors": [{"reason", "field"}]}``.
+        Raise :class:`CloudDNSError` with the joined ``errors[].reason`` on
+        any non-2xx status.
+        """
+        body: dict[str, Any]
+        try:
+            body = response.json()
+        except (ValueError, TypeError):
+            body = {}
+        status = getattr(response, "status_code", 0)
+        if 200 <= status < 300:
+            return body
+        errors = body.get("errors") or []
+        messages = []
+        for e in errors:
+            if not e:
+                continue
+            reason = e.get("reason") if isinstance(e, dict) else None
+            field = e.get("field") if isinstance(e, dict) else None
+            if reason and field:
+                messages.append(f"{field}: {reason}")
+            elif reason:
+                messages.append(str(reason))
+            else:
+                messages.append(str(e))
+        detail = "; ".join(m for m in messages if m) or f"HTTP {status}"
+        raise CloudDNSError(f"Linode API error: {detail}")
+
+    def _token(self, creds: dict[str, Any]) -> str:
+        token = (creds or {}).get("api_token")
+        if not token:
+            raise CloudDNSError("Linode credentials missing 'api_token'.")
+        return str(token)
+
+    async def _resolve_domain_id(self, client: httpx.AsyncClient, zone_fqdn: str) -> int:
+        """Look up the numeric Linode domain id for a zone FQDN.
+
+        Linode's list endpoint accepts an ``X-Filter`` header (JSON) to
+        narrow server-side; the apex FQDN is de-dotted for the match.
+        """
+        name = normalize_fqdn(zone_fqdn).rstrip(".")
+        resp = await client.get(
+            "/domains",
+            headers={"X-Filter": json.dumps({"domain": name})},
+        )
+        body = self._unwrap(resp)
+        results = body.get("data") or []
+        for d in results:
+            if str(d.get("domain", "")).lower().rstrip(".") == name:
+                return int(d["id"])
+        raise CloudDNSError(f"Linode domain {name!r} not found on this account.")
+
+    @staticmethod
+    def _relativize(label: str, zone_fqdn: str) -> str:
+        """Return a Linode record ``name`` relative to the apex (apex → ``"@"``).
+
+        Linode already stores names relative to the zone (apex is the empty
+        string), so this collapses the apex sentinel to ``"@"`` to match the
+        BIND9 / Windows pull convention and otherwise hands the label back
+        with any stray trailing dot trimmed.
+        """
+        rel = (label or "").strip().rstrip(".")
+        if not rel or rel == "@":
+            return "@"
+        # Defensive: if the provider ever returned an absolute name, strip
+        # the zone suffix so the stored value stays relative.
+        zone = normalize_fqdn(zone_fqdn).rstrip(".")
+        if zone and rel.lower().endswith("." + zone):
+            return rel[: -(len(zone) + 1)]
+        if zone and rel.lower() == zone:
+            return "@"
+        return rel
+
+    @staticmethod
+    def _relative_name(label: str, zone_fqdn: str) -> str:
+        """Render the relative record ``name`` Linode expects on writes.
+
+        Linode uses the **empty string** for the apex and a bare relative
+        label for sub-names. An absolute label under the zone is reduced to
+        its relative form; the apex (``"@"`` / empty) → ``""``.
+        """
+        rel = (label or "").strip().rstrip(".")
+        if not rel or rel == "@":
+            return ""
+        zone = normalize_fqdn(zone_fqdn).rstrip(".")
+        if zone and rel.lower().endswith("." + zone):
+            return rel[: -(len(zone) + 1)]
+        if zone and rel.lower() == zone:
+            return ""
+        return rel
+
+    # ── Zone reads ──────────────────────────────────────────────────────
+    async def _list_zones(self, server: Any, creds: dict[str, Any]) -> list[CloudDNSZone]:
+        token = self._token(creds)
+        zones: list[CloudDNSZone] = []
+        async with self._client(token) as client:
+            page = 1
+            while True:
+                resp = await client.get("/domains", params={"page_size": _PER_PAGE, "page": page})
+                body = self._unwrap(resp)
+                for d in body.get("data") or []:
+                    name = normalize_fqdn(d["domain"])
+                    is_reverse = name.endswith((".in-addr.arpa.", ".ip6.arpa."))
+                    zones.append(
+                        CloudDNSZone(
+                            name=name,
+                            zone_id=str(d["id"]),
+                            is_reverse=is_reverse,
+                            # Linode online-DNSSEC signing is not offered;
+                            # capabilities() advertises dnssec_online=False.
+                            dnssec_enabled=False,
+                            record_count=None,
+                        )
+                    )
+                total_pages = int(body.get("pages") or 1)
+                if page >= total_pages:
+                    break
+                page += 1
+        return zones
+
+    async def _list_zone_records(
+        self, server: Any, creds: dict[str, Any], zone_name: str
+    ) -> list[RecordData]:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(zone_name)
+        records: list[RecordData] = []
+        async with self._client(token) as client:
+            domain_id = await self._resolve_domain_id(client, zone_fqdn)
+            page = 1
+            while True:
+                resp = await client.get(
+                    f"/domains/{domain_id}/records",
+                    params={"page_size": _PER_PAGE, "page": page},
+                )
+                body = self._unwrap(resp)
+                for rec in body.get("data") or []:
+                    raw_ttl = rec.get("ttl_sec")
+                    ttl = None if raw_ttl in (None, _TTL_DEFAULT) else raw_ttl
+                    records.append(
+                        RecordData(
+                            name=self._relativize(rec.get("name") or "", zone_fqdn),
+                            record_type=rec["type"],
+                            value=rec["target"],
+                            ttl=ttl,
+                            priority=rec.get("priority"),
+                        )
+                    )
+                total_pages = int(body.get("pages") or 1)
+                if page >= total_pages:
+                    break
+                page += 1
+        return records
+
+    # ── Record writes ───────────────────────────────────────────────────
+    def _record_payload(self, change: RecordChange, zone_fqdn: str) -> dict[str, Any]:
+        rec = change.record
+        payload: dict[str, Any] = {
+            "type": rec.record_type,
+            "name": self._relative_name(rec.name, zone_fqdn),
+            "target": rec.value,
+            # Linode's "use the zone default TTL" is the sentinel 0.
+            "ttl_sec": _TTL_DEFAULT if rec.ttl is None else rec.ttl,
+        }
+        if rec.priority is not None:
+            payload["priority"] = rec.priority
+        return payload
+
+    async def _find_record_id(
+        self,
+        client: httpx.AsyncClient,
+        domain_id: int,
+        name: str,
+        record_type: str,
+        target: str | None = None,
+        priority: int | None = None,
+    ) -> int | None:
+        """Return the Linode record id matching name+type+target, or ``None``.
+
+        SpatiumDDI keys DNS records per value and supports round-robin
+        (multiple A/AAAA at one hostname) and multiple MX/NS/TXT. So when
+        ``target`` is given we must match the *specific* value being changed
+        — matching on name+type alone returns the first row of a
+        multi-value RRset and would update/delete the wrong value
+        (issue #331).
+
+        Linode offers no server-side ``content`` filter, so we narrow with
+        ``X-Filter`` on name+type and then verify the match client-side over
+        the returned list (``priority`` too for MX/SRV).
+        """
+        x_filter: dict[str, Any] = {"type": record_type, "name": name}
+        results: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            resp = await client.get(
+                f"/domains/{domain_id}/records",
+                params={"page_size": _PER_PAGE, "page": page},
+                headers={"X-Filter": json.dumps(x_filter)},
+            )
+            body = self._unwrap(resp)
+            results.extend(body.get("data") or [])
+            total_pages = int(body.get("pages") or 1)
+            if page >= total_pages:
+                break
+            page += 1
+        if not results:
+            return None
+        # Name+type-only lookup (target unknown): keep legacy first-match.
+        if target is None:
+            return int(results[0]["id"])
+        # Value-keyed lookup: pick the row whose target (and priority for
+        # MX/SRV) actually matches.
+        match_priority = priority is not None and record_type in _PRIORITY_TYPES
+        for rec in results:
+            if rec.get("target") != target:
+                continue
+            if match_priority and rec.get("priority") != priority:
+                continue
+            return int(rec["id"])
+        return None
+
+    async def _apply_record(self, server: Any, creds: dict[str, Any], change: RecordChange) -> None:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(change.zone_name)
+        payload = self._record_payload(change, zone_fqdn)
+        async with self._client(token) as client:
+            domain_id = await self._resolve_domain_id(client, zone_fqdn)
+
+            if change.op == "create":
+                resp = await client.post(f"/domains/{domain_id}/records", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "update":
+                rid = await self._find_record_id(
+                    client,
+                    domain_id,
+                    payload["name"],
+                    change.record.record_type,
+                    target=change.record.value,
+                    priority=change.record.priority,
+                )
+                if rid is None:
+                    # No existing row to update — treat as create so the
+                    # desired state still lands (mirrors the windows_dns +
+                    # _cloud_base "update is create on miss" contract).
+                    resp = await client.post(f"/domains/{domain_id}/records", json=payload)
+                    self._unwrap(resp)
+                    return
+                resp = await client.put(f"/domains/{domain_id}/records/{rid}", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "delete":
+                rid = await self._find_record_id(
+                    client,
+                    domain_id,
+                    payload["name"],
+                    change.record.record_type,
+                    target=change.record.value,
+                    priority=change.record.priority,
+                )
+                if rid is None:
+                    # Idempotent delete — nothing to remove.
+                    return
+                resp = await client.delete(f"/domains/{domain_id}/records/{rid}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"Linode: unsupported record op {change.op!r}")
+
+    # ── Zone writes ─────────────────────────────────────────────────────
+    async def _apply_zone(self, server: Any, creds: dict[str, Any], zone: Any, op: str) -> None:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(getattr(zone, "name", ""))
+        bare = zone_fqdn.rstrip(".")
+        async with self._client(token) as client:
+            if op == "create":
+                # Linode master zones REQUIRE a soa_email; derive a sane
+                # placeholder when the caller has no contact to offer.
+                payload: dict[str, Any] = {
+                    "domain": bare,
+                    "type": "master",
+                    "soa_email": f"hostmaster@{bare}",
+                }
+                resp = await client.post("/domains", json=payload)
+                self._unwrap(resp)
+                return
+
+            if op == "delete":
+                domain_id = await self._resolve_domain_id(client, zone_fqdn)
+                resp = await client.delete(f"/domains/{domain_id}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"Linode: unsupported zone op {op!r}")
+
+    # ── Capabilities ────────────────────────────────────────────────────
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "name": "linode",
+            "agentless": True,
+            "manages_zones": True,
+            "views": False,
+            "rpz": False,
+            # Linode DNS Manager does not offer online DNSSEC signing.
+            "dnssec_online": False,
+            "record_types": [
+                "A",
+                "AAAA",
+                "CNAME",
+                "MX",
+                "TXT",
+                "NS",
+                "SRV",
+                "CAA",
+                "PTR",
+                "SOA",
+            ],
+            "notes": (
+                "Agentless Linode DNS Manager driver over the v4 REST API "
+                "(Bearer personal access token). Zones ('Domains') + records "
+                "managed from the control plane. Master zone creation derives "
+                "a placeholder soa_email (hostmaster@<zone>) since Linode "
+                "requires one. No online DNSSEC signing."
+            ),
+        }
+
+
+__all__ = ["LinodeDNSDriver"]

--- a/backend/app/drivers/dns/powerdns.py
+++ b/backend/app/drivers/dns/powerdns.py
@@ -80,6 +80,9 @@ _SUPPORTED_RECORD_TYPES = frozenset(
         "LOC",
         "LUA",
         "SOA",
+        "SVCB",
+        "HTTPS",
+        "DNAME",
     }
 )
 

--- a/backend/app/drivers/dns/vultr.py
+++ b/backend/app/drivers/dns/vultr.py
@@ -1,0 +1,387 @@
+"""Vultr DNS driver (agentless, REST API — issue #29 cloud DNS family).
+
+Vultr hosts authoritative zones ("domains") and exposes a flat REST API at
+``https://api.vultr.com/v2``. SpatiumDDI manages those zones exactly like a
+local BIND9 / PowerDNS zone — same Zones / Records group surfaces — driving
+the API directly from the control plane rather than an agent (see
+:mod:`app.drivers.dns._cloud_base` for the agentless contract).
+
+Authentication is a single personal **API token** (``Bearer`` header). Unlike
+Cloudflare, record calls are scoped by the domain **name** (not an opaque
+zone id), so there is no zone-id resolution step — the FQDN's bare name is
+threaded straight into the record path.
+
+Unlike the AWS / Azure / GCP cloud drivers, Vultr needs no vendor SDK: the API
+is plain JSON over HTTPS, so this driver uses ``httpx`` directly (already a
+top-level dependency). ``_client`` is the single seam tests patch to inject a
+fake transport.
+
+Credential dict shape (decrypted from ``DNSServer.credentials_encrypted``)::
+
+    {"api_token": "<personal-api-token>"}
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.drivers.dns._cloud_base import (
+    CloudDNSDriverBase,
+    CloudDNSError,
+    CloudDNSZone,
+    normalize_fqdn,
+)
+from app.drivers.dns.base import RecordChange, RecordData
+
+# Vultr API v2 base. Pinned here (not configurable) — there is no self-hosted
+# Vultr. The token in the Authorization header is the only per-server input.
+_API_BASE = "https://api.vultr.com/v2"
+
+# Vultr's per-page maximum is 500; 100 keeps responses small while still
+# rarely needing a second cursor round trip for typical accounts.
+_PER_PAGE = 100
+
+# Vultr encodes "automatic / default TTL" as the sentinel value 0 on a record
+# (the API auto-assigns when ttl is omitted/0). We surface that as
+# ``ttl=None`` on the neutral RecordData so it round-trips as "let the provider
+# decide" rather than a literal 0-second TTL, and map None back to 0 on write.
+_TTL_AUTO = 0
+
+
+class VultrDNSDriver(CloudDNSDriverBase):
+    """Agentless driver for Vultr-hosted authoritative zones (domains)."""
+
+    name = "vultr"
+    # The Add-DNS-server modal renders + the probe requires only the token.
+    credential_fields: tuple[str, ...] = ("api_token",)
+
+    # ── HTTP plumbing ───────────────────────────────────────────────────
+    def _client(self, token: str) -> httpx.AsyncClient:
+        """Return an httpx client bound to the API base + bearer token.
+
+        This is the single seam tests patch to inject a fake transport —
+        keep all request construction flowing through the returned client.
+        """
+        return httpx.AsyncClient(
+            base_url=_API_BASE,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+
+    @staticmethod
+    def _unwrap(response: Any) -> dict[str, Any]:
+        """Validate a Vultr response and return its parsed body.
+
+        Vultr has no success envelope — a 2xx status is the only signal. On a
+        non-2xx the body is ``{"error": "<message>"}`` (sometimes with extra
+        ``status`` keys); raise :class:`CloudDNSError` with that message.
+
+        Success bodies for DELETE / PATCH are commonly empty (HTTP 204); a body
+        that doesn't parse as a dict collapses to ``{}`` so callers that ignore
+        the return value (writes) work uniformly.
+        """
+        status = getattr(response, "status_code", 0)
+        body: dict[str, Any]
+        try:
+            parsed = response.json()
+            body = parsed if isinstance(parsed, dict) else {}
+        except (ValueError, TypeError):
+            body = {}
+        if 200 <= status < 300:
+            return body
+        detail = str(body.get("error") or "").strip() or f"HTTP {status}"
+        raise CloudDNSError(f"Vultr API error: {detail}")
+
+    def _token(self, creds: dict[str, Any]) -> str:
+        token = (creds or {}).get("api_token")
+        if not token:
+            raise CloudDNSError("Vultr credentials missing 'api_token'.")
+        return str(token)
+
+    @staticmethod
+    def _zone_label(zone_fqdn: str) -> str:
+        """Return the bare domain name Vultr scopes record/zone calls by."""
+        return normalize_fqdn(zone_fqdn).rstrip(".")
+
+    @staticmethod
+    def _relativize(name: str, zone_fqdn: str) -> str:
+        """Return ``name`` relative to ``zone_fqdn`` (apex → ``"@"``).
+
+        Vultr already returns record names relative to the apex (``""`` for
+        apex), but it may also hand back a fully-qualified label in some
+        responses, so normalise both shapes. Both sides are normalised to
+        trailing-dot FQDNs first so the suffix match is exact; a name equal to
+        the apex (or empty) collapses to ``"@"`` to match the BIND9 / Windows
+        pull convention.
+        """
+        rel = (name or "").strip()
+        if not rel or rel == "@":
+            return "@"
+        zone = normalize_fqdn(zone_fqdn)
+        fqdn = normalize_fqdn(rel)
+        if fqdn == zone:
+            return "@"
+        if fqdn.endswith("." + zone):
+            return fqdn[: -(len(zone) + 1)]
+        # Already a bare relative label (Vultr's normal case) — strip any
+        # accidental trailing dot and return as-is.
+        return rel.rstrip(".")
+
+    @staticmethod
+    def _relative_name(label: str) -> str:
+        """Render the relative record name Vultr expects on writes.
+
+        Vultr's record model stores names **relative** to the zone apex with
+        the empty string for the apex (not ``"@"``). So apex → ``""`` and any
+        other label is passed through de-dotted.
+        """
+        rel = (label or "").strip().rstrip(".")
+        if not rel or rel == "@":
+            return ""
+        return rel
+
+    # ── Zone reads ──────────────────────────────────────────────────────
+    async def _list_zones(self, server: Any, creds: dict[str, Any]) -> list[CloudDNSZone]:
+        token = self._token(creds)
+        zones: list[CloudDNSZone] = []
+        async with self._client(token) as client:
+            cursor: str | None = None
+            while True:
+                params: dict[str, Any] = {"per_page": _PER_PAGE}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get("/domains", params=params)
+                body = self._unwrap(resp)
+                for d in body.get("domains") or []:
+                    name = normalize_fqdn(d["domain"])
+                    is_reverse = name.endswith((".in-addr.arpa.", ".ip6.arpa."))
+                    zones.append(
+                        CloudDNSZone(
+                            name=name,
+                            # Vultr scopes by domain name, not an opaque id;
+                            # store the bare name so downstream callers have a
+                            # stable handle.
+                            zone_id=self._zone_label(name),
+                            is_reverse=is_reverse,
+                            dnssec_enabled=str(d.get("dns_sec") or "").lower() == "enabled",
+                            record_count=None,
+                        )
+                    )
+                cursor = self._next_cursor(body)
+                if not cursor:
+                    break
+        return zones
+
+    @staticmethod
+    def _next_cursor(body: dict[str, Any]) -> str | None:
+        """Pull ``meta.links.next`` from a Vultr list body (empty → done)."""
+        meta = body.get("meta") or {}
+        links = meta.get("links") or {}
+        nxt = links.get("next")
+        return str(nxt) if nxt else None
+
+    async def _list_zone_records(
+        self, server: Any, creds: dict[str, Any], zone_name: str
+    ) -> list[RecordData]:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(zone_name)
+        label = self._zone_label(zone_fqdn)
+        records: list[RecordData] = []
+        async with self._client(token) as client:
+            cursor: str | None = None
+            while True:
+                params: dict[str, Any] = {"per_page": _PER_PAGE}
+                if cursor:
+                    params["cursor"] = cursor
+                resp = await client.get(f"/domains/{label}/records", params=params)
+                body = self._unwrap(resp)
+                for rec in body.get("records") or []:
+                    raw_ttl = rec.get("ttl")
+                    ttl = None if raw_ttl == _TTL_AUTO else raw_ttl
+                    # Vultr returns priority 0 (or -1) for non-MX/SRV records;
+                    # only surface it for record types that carry a priority.
+                    priority = rec.get("priority")
+                    if rec.get("type") not in ("MX", "SRV"):
+                        priority = None
+                    records.append(
+                        RecordData(
+                            name=self._relativize(rec.get("name", ""), zone_fqdn),
+                            record_type=rec["type"],
+                            value=rec["data"],
+                            ttl=ttl,
+                            priority=priority,
+                        )
+                    )
+                cursor = self._next_cursor(body)
+                if not cursor:
+                    break
+        return records
+
+    # ── Record writes ───────────────────────────────────────────────────
+    def _record_payload(self, change: RecordChange) -> dict[str, Any]:
+        rec = change.record
+        payload: dict[str, Any] = {
+            "name": self._relative_name(rec.name),
+            "type": rec.record_type,
+            "data": rec.value,
+            # Vultr's "automatic" TTL is the sentinel 0.
+            "ttl": _TTL_AUTO if rec.ttl is None else rec.ttl,
+        }
+        if rec.priority is not None:
+            payload["priority"] = rec.priority
+        return payload
+
+    async def _find_record_id(
+        self,
+        client: httpx.AsyncClient,
+        label: str,
+        name: str,
+        record_type: str,
+        content: str,
+        priority: int | None = None,
+    ) -> str | None:
+        """Return the Vultr record id matching name+type+value, or ``None``.
+
+        SpatiumDDI keys DNS records per value and supports round-robin (multiple
+        A/AAAA at one hostname) and multiple MX/NS/TXT. So we must match the
+        *specific* value being changed — matching on name+type alone returns the
+        first row of a multi-value RRset and would update/delete the wrong value
+        (issue #331).
+
+        Vultr's ``GET /domains/{domain}/records`` has no server-side content
+        filter, so we page the whole record set and match client-side on
+        name+type+data (and ``priority`` too for MX/SRV).
+        """
+        cursor: str | None = None
+        while True:
+            params: dict[str, Any] = {"per_page": _PER_PAGE}
+            if cursor:
+                params["cursor"] = cursor
+            resp = await client.get(f"/domains/{label}/records", params=params)
+            body = self._unwrap(resp)
+            for rec in body.get("records") or []:
+                if rec.get("type") != record_type:
+                    continue
+                if (rec.get("name") or "") != name:
+                    continue
+                if rec.get("data") != content:
+                    continue
+                if priority is not None and rec.get("priority") != priority:
+                    continue
+                return str(rec["id"])
+            cursor = self._next_cursor(body)
+            if not cursor:
+                break
+        return None
+
+    async def _apply_record(self, server: Any, creds: dict[str, Any], change: RecordChange) -> None:
+        token = self._token(creds)
+        zone_fqdn = normalize_fqdn(change.zone_name)
+        label = self._zone_label(zone_fqdn)
+        payload = self._record_payload(change)
+        async with self._client(token) as client:
+            if change.op == "create":
+                resp = await client.post(f"/domains/{label}/records", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "update":
+                rid = await self._find_record_id(
+                    client,
+                    label,
+                    payload["name"],
+                    change.record.record_type,
+                    change.record.value,
+                    priority=change.record.priority,
+                )
+                if rid is None:
+                    # No existing row to update — treat as create so the desired
+                    # state still lands (mirrors the windows_dns + _cloud_base
+                    # "update is create on miss" contract).
+                    resp = await client.post(f"/domains/{label}/records", json=payload)
+                    self._unwrap(resp)
+                    return
+                # Vultr updates records via PATCH (not PUT). It accepts a partial
+                # body; send the full payload so name/data/ttl/priority all land.
+                resp = await client.patch(f"/domains/{label}/records/{rid}", json=payload)
+                self._unwrap(resp)
+                return
+
+            if change.op == "delete":
+                rid = await self._find_record_id(
+                    client,
+                    label,
+                    payload["name"],
+                    change.record.record_type,
+                    change.record.value,
+                    priority=change.record.priority,
+                )
+                if rid is None:
+                    # Idempotent delete — nothing to remove.
+                    return
+                resp = await client.delete(f"/domains/{label}/records/{rid}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"Vultr: unsupported record op {change.op!r}")
+
+    # ── Zone writes ─────────────────────────────────────────────────────
+    async def _apply_zone(self, server: Any, creds: dict[str, Any], zone: Any, op: str) -> None:
+        token = self._token(creds)
+        label = self._zone_label(getattr(zone, "name", ""))
+        async with self._client(token) as client:
+            if op == "create":
+                # Omit "ip" so Vultr creates an empty zone (no seeded A record);
+                # SpatiumDDI then pushes records explicitly. DNSSEC defaults off.
+                payload = {"domain": label, "dns_sec": "disabled"}
+                resp = await client.post("/domains", json=payload)
+                self._unwrap(resp)
+                return
+
+            if op == "delete":
+                resp = await client.delete(f"/domains/{label}")
+                self._unwrap(resp)
+                return
+
+            raise CloudDNSError(f"Vultr: unsupported zone op {op!r}")
+
+    # ── Capabilities ────────────────────────────────────────────────────
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "name": "vultr",
+            "agentless": True,
+            "manages_zones": True,
+            "views": False,
+            "rpz": False,
+            # Vultr exposes pre-generated DNSSEC keys for upload to the
+            # registrar but offers no online sign/unsign API, so SpatiumDDI
+            # cannot drive DNSSEC signing here.
+            "dnssec_online": False,
+            "record_types": [
+                "A",
+                "AAAA",
+                "CNAME",
+                "MX",
+                "TXT",
+                "NS",
+                "SRV",
+                "CAA",
+                "PTR",
+                "SOA",
+            ],
+            "notes": (
+                "Agentless Vultr DNS driver over the v2 REST API "
+                "(Bearer API token). Zones ('domains') + records managed "
+                "from the control plane; record calls are scoped by domain "
+                "name (no opaque zone id). Record updates use PATCH; "
+                "DNSSEC keys are export-only (no online signing)."
+            ),
+        }
+
+
+__all__ = ["VultrDNSDriver"]

--- a/backend/app/models/alerts.py
+++ b/backend/app/models/alerts.py
@@ -79,8 +79,16 @@ class AlertRule(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     #                                    issue #105.
     rule_type: Mapped[str] = mapped_column(String(40), nullable=False)
 
-    # Subnet utilization params.
+    # Subnet utilization params. Re-used as the occupancy-% threshold by
+    # ``dhcp_pool_exhaustion`` (issue #339) and as a raw-count threshold by
+    # ``voice_lease_count_below`` / ``stale_ip_count``.
     threshold_percent: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # ``dhcp_pool_exhaustion`` params (issue #339) — absolute free-address
+    # floor. The rule fires when a dynamic pool's occupancy reaches
+    # ``threshold_percent`` OR its free-address count drops below this; both
+    # are optional so an operator can alert on either signal (or both).
+    min_free_addresses: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # Server-unreachable params.
     server_type: Mapped[str | None] = mapped_column(String(10), nullable=True)

--- a/backend/app/services/ai/tools/dhcp.py
+++ b/backend/app/services/ai/tools/dhcp.py
@@ -631,3 +631,63 @@ async def list_dhcp_mac_blocks(
         }
         for b in rows
     ]
+
+
+class FindDHCPPoolOccupancyArgs(BaseModel):
+    group_id: str | None = Field(default=None, description="Filter to one DHCP server group UUID.")
+    scope_id: str | None = Field(default=None, description="Filter to one DHCP scope UUID.")
+    min_percent: float = Field(
+        default=0.0,
+        description="Only return pools at or above this live occupancy percent (0-100).",
+    )
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+@register_tool(
+    name="find_dhcp_pool_occupancy",
+    description=(
+        "Live occupancy of dynamic DHCP pools — assigned vs total addresses, "
+        "free count, and occupancy percent, computed from active leases inside "
+        "each pool range (works for Kea and Windows DHCP). Sorted most-full "
+        "first. Use to answer 'which pools are near capacity / exhausted?'."
+    ),
+    args_model=FindDHCPPoolOccupancyArgs,
+    category="dhcp",
+)
+async def find_dhcp_pool_occupancy(
+    db: AsyncSession, user: User, args: FindDHCPPoolOccupancyArgs
+) -> list[dict[str, Any]]:
+    from app.services.dhcp.pool_occupancy import compute_pool_occupancy
+
+    stmt = select(DHCPPool, DHCPScope).join(DHCPScope, DHCPScope.id == DHCPPool.scope_id)
+    stmt = stmt.where(DHCPPool.pool_type == "dynamic")
+    if args.scope_id:
+        stmt = stmt.where(DHCPPool.scope_id == args.scope_id)
+    if args.group_id:
+        stmt = stmt.where(DHCPScope.group_id == args.group_id)
+    # ``.unique()`` is required because the ORM entities carry eager-loaded
+    # collection relationships (DHCPScope.pools etc.).
+    rows = (await db.execute(stmt)).unique().all()
+
+    out: list[dict[str, Any]] = []
+    for pool, scope in rows:
+        occ = await compute_pool_occupancy(db, pool)
+        if occ.percent < args.min_percent:
+            continue
+        out.append(
+            {
+                "pool_id": str(pool.id),
+                "pool_name": pool.name or None,
+                "scope_id": str(pool.scope_id),
+                "scope_name": scope.name or None,
+                "group_id": str(scope.group_id),
+                "start_ip": str(pool.start_ip),
+                "end_ip": str(pool.end_ip),
+                "assigned": occ.assigned,
+                "total": occ.total,
+                "free": occ.free,
+                "occupancy_percent": round(occ.percent, 1),
+            }
+        )
+    out.sort(key=lambda r: r["occupancy_percent"], reverse=True)
+    return out[: args.limit]

--- a/backend/app/services/ai/tools/dhcp.py
+++ b/backend/app/services/ai/tools/dhcp.py
@@ -657,7 +657,7 @@ class FindDHCPPoolOccupancyArgs(BaseModel):
 async def find_dhcp_pool_occupancy(
     db: AsyncSession, user: User, args: FindDHCPPoolOccupancyArgs
 ) -> list[dict[str, Any]]:
-    from app.services.dhcp.pool_occupancy import compute_pool_occupancy
+    from app.services.dhcp.pool_occupancy import compute_pool_occupancy_batch
 
     stmt = select(DHCPPool, DHCPScope).join(DHCPScope, DHCPScope.id == DHCPPool.scope_id)
     stmt = stmt.where(DHCPPool.pool_type == "dynamic")
@@ -669,9 +669,12 @@ async def find_dhcp_pool_occupancy(
     # collection relationships (DHCPScope.pools etc.).
     rows = (await db.execute(stmt)).unique().all()
 
+    # One batched lease query for all pools rather than one per pool (N+1).
+    occ_by_pool = await compute_pool_occupancy_batch(db, [pool for pool, _ in rows])
+
     out: list[dict[str, Any]] = []
     for pool, scope in rows:
-        occ = await compute_pool_occupancy(db, pool)
+        occ = occ_by_pool[pool.id]
         if occ.percent < args.min_percent:
             continue
         out.append(

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -41,7 +41,7 @@ from app.models.alerts import AlertEvent, AlertRule
 from app.models.asn import ASN, ASNRpkiRoa
 from app.models.audit import AuditLog
 from app.models.circuit import Circuit
-from app.models.dhcp import DHCPLease, DHCPScope, DHCPServer
+from app.models.dhcp import DHCPLease, DHCPPool, DHCPScope, DHCPServer
 from app.models.dns import DNSServer, DNSZone
 from app.models.domain import Domain
 from app.models.ipam import IPAddress, IPBlock, Subnet
@@ -98,6 +98,14 @@ RULE_TYPE_K3S_API_CERT_EXPIRING = "k3s_api_cert_expiring"
 # drilldown, this is the passive "your hygiene is slipping" feed.
 RULE_TYPE_STALE_IP_COUNT = "stale_ip_count"
 
+# A dynamic DHCP pool whose live occupancy has reached ``threshold_percent``
+# (assigned ÷ range size) OR whose free-address count has dropped below
+# ``min_free_addresses``. Orthogonal to ``subnet_utilization`` — that counts
+# allocated IPAM rows, this counts active DHCP leases inside the pool range,
+# so a pool can be exhausted (clients failing to get a lease) while the IPAM
+# subnet shows low allocated-row utilisation. Issue #339.
+RULE_TYPE_DHCP_POOL_EXHAUSTION = "dhcp_pool_exhaustion"
+
 RULE_TYPES = frozenset(
     {
         RULE_TYPE_SUBNET_UTILIZATION,
@@ -119,6 +127,7 @@ RULE_TYPES = frozenset(
         RULE_TYPE_VOICE_LEASE_COUNT_BELOW,
         RULE_TYPE_K3S_API_CERT_EXPIRING,
         RULE_TYPE_STALE_IP_COUNT,
+        RULE_TYPE_DHCP_POOL_EXHAUSTION,
     }
 )
 
@@ -295,6 +304,65 @@ async def _matching_voice_lease_count_below_subjects(
             f"(threshold {threshold}) — possible mass-disconnect event"
         )
         matches.append((str(s.id), display, message))
+    return matches
+
+
+async def _matching_dhcp_pool_exhaustion_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+) -> list[tuple[str, str, str]]:
+    """Dynamic DHCP pools that have hit ``threshold_percent`` occupancy OR
+    dropped below ``min_free_addresses`` free addresses (issue #339).
+
+    Occupancy is live, from active ``DHCPLease`` rows inside the pool range
+    (see :func:`app.services.dhcp.pool_occupancy.compute_pool_occupancy`), so
+    it works for Kea and Windows alike. Only ``pool_type='dynamic'`` pools are
+    considered — excluded / reserved ranges never hand out leases. With
+    neither threshold set the rule defaults to 90% occupancy so a bare
+    enable still does something sensible.
+    """
+    from app.services.dhcp.pool_occupancy import compute_pool_occupancy
+
+    pct_threshold = rule.threshold_percent
+    min_free = rule.min_free_addresses
+    if pct_threshold is None and min_free is None:
+        pct_threshold = 90
+
+    pools = list(
+        (await db.execute(select(DHCPPool).where(DHCPPool.pool_type == "dynamic"))).scalars().all()
+    )
+    if not pools:
+        return []
+
+    # Resolve scope display names in one query (pool → scope name).
+    scope_ids = {p.scope_id for p in pools}
+    scope_rows = (
+        await db.execute(select(DHCPScope.id, DHCPScope.name).where(DHCPScope.id.in_(scope_ids)))
+    ).all()
+    scope_names: dict[uuid.UUID, str] = {row[0]: row[1] for row in scope_rows}
+
+    matches: list[tuple[str, str, str]] = []
+    for pool in pools:
+        occ = await compute_pool_occupancy(db, pool)
+        if occ.total <= 0:
+            continue
+        over_pct = pct_threshold is not None and occ.percent >= pct_threshold
+        under_free = min_free is not None and occ.free < min_free
+        if not (over_pct or under_free):
+            continue
+        scope_name = scope_names.get(pool.scope_id) or ""
+        pool_label = pool.name or f"{pool.start_ip}–{pool.end_ip}"
+        display = pool_label + (f" ({scope_name})" if scope_name else "")
+        reasons = []
+        if over_pct:
+            reasons.append(f"{occ.percent:.1f}% occupied (threshold {pct_threshold}%)")
+        if under_free:
+            reasons.append(f"{occ.free} free (floor {min_free})")
+        message = (
+            f"DHCP pool {display} — {', '.join(reasons)}; "
+            f"{occ.assigned}/{occ.total} addresses leased"
+        )
+        matches.append((str(pool.id), display, message))
     return matches
 
 
@@ -1554,6 +1622,10 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 base = await _matching_stale_ip_count_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]
                 subject_type = "subnet"
+            elif rule.rule_type == RULE_TYPE_DHCP_POOL_EXHAUSTION:
+                base = await _matching_dhcp_pool_exhaustion_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "dhcp_pool"
             elif rule.rule_type == RULE_TYPE_SERVER_UNREACHABLE:
                 base = await _matching_server_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -315,13 +315,13 @@ async def _matching_dhcp_pool_exhaustion_subjects(
     dropped below ``min_free_addresses`` free addresses (issue #339).
 
     Occupancy is live, from active ``DHCPLease`` rows inside the pool range
-    (see :func:`app.services.dhcp.pool_occupancy.compute_pool_occupancy`), so
-    it works for Kea and Windows alike. Only ``pool_type='dynamic'`` pools are
-    considered — excluded / reserved ranges never hand out leases. With
+    (see :func:`app.services.dhcp.pool_occupancy.compute_pool_occupancy_batch`),
+    so it works for Kea and Windows alike. Only ``pool_type='dynamic'`` pools
+    are considered — excluded / reserved ranges never hand out leases. With
     neither threshold set the rule defaults to 90% occupancy so a bare
     enable still does something sensible.
     """
-    from app.services.dhcp.pool_occupancy import compute_pool_occupancy
+    from app.services.dhcp.pool_occupancy import compute_pool_occupancy_batch
 
     pct_threshold = rule.threshold_percent
     min_free = rule.min_free_addresses
@@ -341,9 +341,12 @@ async def _matching_dhcp_pool_exhaustion_subjects(
     ).all()
     scope_names: dict[uuid.UUID, str] = {row[0]: row[1] for row in scope_rows}
 
+    # One batched lease query for all pools rather than one per pool (N+1).
+    occ_by_pool = await compute_pool_occupancy_batch(db, pools)
+
     matches: list[tuple[str, str, str]] = []
     for pool in pools:
-        occ = await compute_pool_occupancy(db, pool)
+        occ = occ_by_pool[pool.id]
         if occ.total <= 0:
             continue
         over_pct = pct_threshold is not None and occ.percent >= pct_threshold

--- a/backend/app/services/dhcp/pool_occupancy.py
+++ b/backend/app/services/dhcp/pool_occupancy.py
@@ -1,0 +1,82 @@
+"""Per-pool DHCP occupancy — live, driver-agnostic (issue #339).
+
+Occupancy is computed from the mirrored ``DHCPLease`` rows rather than a
+per-driver statistics call, so it works identically for Kea and Windows
+DHCP (both pull active leases into ``dhcp_lease``) with no agent-protocol
+change. A dynamic pool's *assigned* count is the number of distinct
+active-lease IPs that fall inside ``[start_ip, end_ip]`` for the pool's
+scope (DISTINCT dedupes the two rows an HA pair reports for one lease);
+*total* is the address count of the inclusive range.
+
+This is the data source for both the ``find_dhcp_pool_occupancy`` MCP tool
+and the ``dhcp_pool_exhaustion`` alert evaluator.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass
+
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp import DHCPLease, DHCPPool
+
+
+@dataclass(frozen=True)
+class PoolOccupancy:
+    assigned: int
+    total: int
+
+    @property
+    def free(self) -> int:
+        return max(0, self.total - self.assigned)
+
+    @property
+    def percent(self) -> float:
+        """Occupancy as a 0..100 float; 0.0 for a zero-size pool."""
+        return (self.assigned / self.total * 100.0) if self.total > 0 else 0.0
+
+
+def pool_total_addresses(start_ip: str, end_ip: str) -> int:
+    """Inclusive address count of ``[start_ip, end_ip]``.
+
+    Returns 0 if the range is malformed or inverted (start > end) or the two
+    ends are different families, so a bad pool can't make occupancy blow up.
+    """
+    try:
+        start = ipaddress.ip_address(str(start_ip))
+        end = ipaddress.ip_address(str(end_ip))
+    except ValueError:
+        return 0
+    if start.version != end.version:
+        return 0
+    n = int(end) - int(start) + 1
+    return n if n > 0 else 0
+
+
+async def compute_pool_occupancy(db: AsyncSession, pool: DHCPPool) -> PoolOccupancy:
+    """Return live occupancy for one pool.
+
+    Counts distinct active-lease IPs inside the pool range for the pool's
+    scope. ``ip_address`` is INET, so the range comparison is cast
+    explicitly (asyncpg otherwise binds the params as VARCHAR and Postgres
+    rejects the inet operators — same cast the voice-lease alert uses).
+    """
+    total = pool_total_addresses(pool.start_ip, pool.end_ip)
+    assigned = (
+        await db.execute(
+            select(func.count(func.distinct(DHCPLease.ip_address)))
+            .where(DHCPLease.scope_id == pool.scope_id)
+            .where(DHCPLease.state == "active")
+            .where(
+                text(
+                    "ip_address >= CAST(:start AS inet) AND ip_address <= CAST(:end AS inet)"
+                ).bindparams(start=str(pool.start_ip), end=str(pool.end_ip))
+            )
+        )
+    ).scalar_one()
+    return PoolOccupancy(assigned=int(assigned or 0), total=total)
+
+
+__all__ = ["PoolOccupancy", "compute_pool_occupancy", "pool_total_addresses"]

--- a/backend/app/services/dhcp/pool_occupancy.py
+++ b/backend/app/services/dhcp/pool_occupancy.py
@@ -15,6 +15,8 @@ and the ``dhcp_pool_exhaustion`` alert evaluator.
 from __future__ import annotations
 
 import ipaddress
+import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from sqlalchemy import func, select, text
@@ -64,6 +66,12 @@ async def compute_pool_occupancy(db: AsyncSession, pool: DHCPPool) -> PoolOccupa
     rejects the inet operators — same cast the voice-lease alert uses).
     """
     total = pool_total_addresses(pool.start_ip, pool.end_ip)
+    if total == 0:
+        # Malformed / inverted / mixed-family range — skip the DB range query
+        # entirely. Running it could match unrelated rows (inet ordering across
+        # families) and hand back a non-zero ``assigned`` for a 0-size pool,
+        # so a bad pool can't make occupancy blow up.
+        return PoolOccupancy(assigned=0, total=0)
     assigned = (
         await db.execute(
             select(func.count(func.distinct(DHCPLease.ip_address)))
@@ -79,4 +87,57 @@ async def compute_pool_occupancy(db: AsyncSession, pool: DHCPPool) -> PoolOccupa
     return PoolOccupancy(assigned=int(assigned or 0), total=total)
 
 
-__all__ = ["PoolOccupancy", "compute_pool_occupancy", "pool_total_addresses"]
+async def compute_pool_occupancy_batch(
+    db: AsyncSession, pools: Sequence[DHCPPool]
+) -> dict[uuid.UUID, PoolOccupancy]:
+    """Occupancy for many pools in a single lease query (no N+1).
+
+    Fetches the distinct active-lease ``(scope_id, ip)`` pairs for every
+    scope the pools live in with one query, then buckets them into pool
+    ranges in memory. Use this in hot paths (the 60s alert tick, the MCP
+    tool) instead of calling :func:`compute_pool_occupancy` per pool.
+    """
+    result: dict[uuid.UUID, PoolOccupancy] = {}
+    totals: dict[uuid.UUID, int] = {}
+    valid: list[DHCPPool] = []
+    for pool in pools:
+        total = pool_total_addresses(pool.start_ip, pool.end_ip)
+        totals[pool.id] = total
+        if total == 0:
+            result[pool.id] = PoolOccupancy(assigned=0, total=0)
+        else:
+            valid.append(pool)
+    if not valid:
+        return result
+
+    scope_ids = {p.scope_id for p in valid}
+    rows = (
+        await db.execute(
+            select(DHCPLease.scope_id, DHCPLease.ip_address)
+            .where(DHCPLease.scope_id.in_(scope_ids))
+            .where(DHCPLease.state == "active")
+            .distinct()
+        )
+    ).all()
+    # Bucket distinct lease IPs (as ints) by scope.
+    by_scope: dict[uuid.UUID, list[int]] = {}
+    for scope_id, ip in rows:
+        try:
+            by_scope.setdefault(scope_id, []).append(int(ipaddress.ip_address(str(ip))))
+        except ValueError:
+            continue
+
+    for pool in valid:
+        start = int(ipaddress.ip_address(str(pool.start_ip)))
+        end = int(ipaddress.ip_address(str(pool.end_ip)))
+        assigned = sum(1 for v in by_scope.get(pool.scope_id, ()) if start <= v <= end)
+        result[pool.id] = PoolOccupancy(assigned=assigned, total=totals[pool.id])
+    return result
+
+
+__all__ = [
+    "PoolOccupancy",
+    "compute_pool_occupancy",
+    "compute_pool_occupancy_batch",
+    "pool_total_addresses",
+]

--- a/backend/app/services/dns_import/canonical.py
+++ b/backend/app/services/dns_import/canonical.py
@@ -28,6 +28,10 @@ ImportSource = Literal[
     "route53",
     "azure_dns",
     "google_dns",
+    "digitalocean",
+    "hetzner",
+    "linode",
+    "vultr",
 ]
 
 # Per-zone conflict resolution. ``rename`` requires ``rename_to`` to

--- a/backend/app/services/dns_import/cloud.py
+++ b/backend/app/services/dns_import/cloud.py
@@ -52,7 +52,7 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.drivers.dns import get_driver
+from app.drivers.dns import CLOUD_DNS_DRIVERS, get_driver
 from app.models.auth import User
 from app.models.dns import DNSServer
 
@@ -83,13 +83,13 @@ class CloudDNSImportError(ValueError):
     """
 
 
-# Driver names that route through this importer. Kept in lockstep with
-# the four concrete cloud drivers + ``CloudDNSDriverBase`` subclasses
-# the integrator registers in ``app.drivers.dns``. The preview validates
-# ``server.driver`` against this set before touching the driver so a
-# BIND9 / PowerDNS / Windows server gets a clear error rather than a
-# confusing AttributeError downstream.
-CLOUD_DRIVERS: frozenset[str] = frozenset({"cloudflare", "route53", "azure_dns", "google_dns"})
+# Driver names that route through this importer — sourced directly from the
+# driver registry so a newly-registered CloudDNSDriverBase subclass (e.g. the
+# token-only providers in #327) is recognised here with no second edit. The
+# preview validates ``server.driver`` against this set before touching the
+# driver so a BIND9 / PowerDNS / Windows server gets a clear error rather than
+# a confusing AttributeError downstream.
+CLOUD_DRIVERS: frozenset[str] = CLOUD_DNS_DRIVERS
 
 # Default SOA fields applied when the source doesn't provide them.
 # Same conservative RFC 1035 reference numbers ``windows_dns`` uses so

--- a/backend/app/services/dns_io/parser.py
+++ b/backend/app/services/dns_io/parser.py
@@ -26,6 +26,9 @@ SUPPORTED_RECORD_TYPES = {
     "NAPTR",
     "LOC",
     "SOA",
+    "SVCB",
+    "HTTPS",
+    "DNAME",
 }
 
 

--- a/backend/app/services/dns_io/writer.py
+++ b/backend/app/services/dns_io/writer.py
@@ -27,7 +27,10 @@ def _format_record(zone_name: str, r: DNSRecord) -> str:
         wgt = r.weight if r.weight is not None else 0
         prt = r.port if r.port is not None else 0
         rdata = f"{pri} {wgt} {prt} {_fqdn(r.value)}"
-    elif rtype in {"CNAME", "NS", "PTR"}:
+    elif rtype in {"CNAME", "NS", "PTR", "DNAME"}:
+        # DNAME (RFC 6672) rdata is a single redirection target — normalise
+        # to an FQDN like the other name-valued types. SVCB/HTTPS rdata
+        # (priority + target + SvcParams) falls through to verbatim passthrough.
         rdata = _fqdn(r.value)
     elif rtype == "TXT":
         v = r.value

--- a/backend/tests/test_dhcp_pool_exhaustion.py
+++ b/backend/tests/test_dhcp_pool_exhaustion.py
@@ -1,0 +1,243 @@
+"""DHCP per-pool occupancy + dhcp_pool_exhaustion alert (issue #339).
+
+Occupancy is computed live from active DHCPLease rows inside a dynamic
+pool's range; the alert fires when occupancy reaches threshold_percent OR
+free addresses drop below min_free_addresses, and resolves when it recovers.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import hash_password
+from app.models.alerts import AlertEvent, AlertRule
+from app.models.auth import User
+from app.models.dhcp import DHCPLease, DHCPPool, DHCPScope, DHCPServer, DHCPServerGroup
+from app.models.ipam import IPBlock, IPSpace, Subnet
+from app.services.alerts import RULE_TYPE_DHCP_POOL_EXHAUSTION, evaluate_all
+from app.services.dhcp.pool_occupancy import compute_pool_occupancy, pool_total_addresses
+
+CIDR = "10.60.0.0/24"
+POOL_START = "10.60.0.10"
+POOL_END = "10.60.0.19"  # 10 addresses inclusive
+
+
+async def _scope_and_server(db: AsyncSession) -> tuple[DHCPScope, DHCPServer]:
+    space = IPSpace(name=f"s-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=CIDR, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=CIDR, name="s")
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, grp])
+    await db.flush()
+    scope = DHCPScope(group_id=grp.id, subnet_id=subnet.id, name="scope-a")
+    server = DHCPServer(name=f"kea-{uuid.uuid4().hex[:6]}", host="10.0.0.1", driver="kea")
+    db.add_all([scope, server])
+    await db.flush()
+    return scope, server
+
+
+async def _pool(db: AsyncSession, scope: DHCPScope, pool_type: str = "dynamic") -> DHCPPool:
+    pool = DHCPPool(
+        scope_id=scope.id,
+        name="pool-a",
+        start_ip=POOL_START,
+        end_ip=POOL_END,
+        pool_type=pool_type,
+    )
+    db.add(pool)
+    await db.flush()
+    return pool
+
+
+async def _lease(
+    db: AsyncSession,
+    server: DHCPServer,
+    scope: DHCPScope,
+    last_octet: int,
+    *,
+    state: str = "active",
+) -> None:
+    db.add(
+        DHCPLease(
+            server_id=server.id,
+            scope_id=scope.id,
+            ip_address=f"10.60.0.{last_octet}",
+            mac_address=f"02:00:00:00:00:{last_octet:02x}",
+            state=state,
+        )
+    )
+
+
+# ── Occupancy computation ─────────────────────────────────────────────────
+
+
+def test_pool_total_addresses() -> None:
+    assert pool_total_addresses("10.60.0.10", "10.60.0.19") == 10
+    assert pool_total_addresses("10.60.0.10", "10.60.0.10") == 1
+    # Inverted / malformed / mixed-family → 0 (can't divide by it).
+    assert pool_total_addresses("10.60.0.19", "10.60.0.10") == 0
+    assert pool_total_addresses("nonsense", "10.60.0.10") == 0
+    assert pool_total_addresses("10.60.0.10", "2001:db8::1") == 0
+
+
+async def test_compute_pool_occupancy_counts_active_in_range(db_session: AsyncSession) -> None:
+    scope, server = await _scope_and_server(db_session)
+    pool = await _pool(db_session, scope)
+    # 3 active leases inside the pool range…
+    for octet in (10, 11, 12):
+        await _lease(db_session, server, scope, octet)
+    # …one outside the range (ignored)…
+    await _lease(db_session, server, scope, 50)
+    # …and one released inside the range (ignored).
+    await _lease(db_session, server, scope, 13, state="released")
+    await db_session.flush()
+
+    occ = await compute_pool_occupancy(db_session, pool)
+    assert occ.total == 10
+    assert occ.assigned == 3
+    assert occ.free == 7
+    assert round(occ.percent, 1) == 30.0
+
+
+async def test_compute_pool_occupancy_dedupes_ha_peers(db_session: AsyncSession) -> None:
+    # An HA pair reports the same lease IP from two servers — one assignment.
+    scope, server_a = await _scope_and_server(db_session)
+    server_b = DHCPServer(name=f"kea-{uuid.uuid4().hex[:6]}", host="10.0.0.2", driver="kea")
+    db_session.add(server_b)
+    await db_session.flush()
+    pool = await _pool(db_session, scope)
+    await _lease(db_session, server_a, scope, 10)
+    await _lease(db_session, server_b, scope, 10)
+    await db_session.flush()
+
+    occ = await compute_pool_occupancy(db_session, pool)
+    assert occ.assigned == 1
+
+
+# ── Alert evaluator ───────────────────────────────────────────────────────
+
+
+async def _rule(db: AsyncSession, **kw: object) -> AlertRule:
+    rule = AlertRule(
+        name=f"pool-{uuid.uuid4().hex[:6]}",
+        rule_type=RULE_TYPE_DHCP_POOL_EXHAUSTION,
+        enabled=True,
+        severity="warning",
+        **kw,
+    )
+    db.add(rule)
+    await db.flush()
+    return rule
+
+
+async def _open_events(db: AsyncSession, rule: AlertRule) -> list[AlertEvent]:
+    rows = (
+        (
+            await db.execute(
+                select(AlertEvent).where(
+                    AlertEvent.rule_id == rule.id, AlertEvent.resolved_at.is_(None)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return list(rows)
+
+
+async def test_alert_fires_on_percent_then_resolves(db_session: AsyncSession) -> None:
+    scope, server = await _scope_and_server(db_session)
+    await _pool(db_session, scope)
+    rule = await _rule(db_session, threshold_percent=80)
+    # 9 of 10 leased = 90% ≥ 80 → fire.
+    for octet in range(10, 19):
+        await _lease(db_session, server, scope, octet)
+    await db_session.commit()
+
+    await evaluate_all(db_session)
+    events = await _open_events(db_session, rule)
+    assert len(events) == 1
+    assert events[0].subject_type == "dhcp_pool"
+    assert "90.0%" in events[0].message
+
+    # Drop to 4 leases = 40% < 80 → resolve.
+    leases = (await db_session.execute(select(DHCPLease))).scalars().all()
+    for lease in leases[:5]:
+        await db_session.delete(lease)
+    await db_session.commit()
+
+    await evaluate_all(db_session)
+    assert await _open_events(db_session, rule) == []
+
+
+async def test_alert_fires_on_min_free(db_session: AsyncSession) -> None:
+    scope, server = await _scope_and_server(db_session)
+    await _pool(db_session, scope)
+    # Percent unset; fire purely on the free-address floor.
+    rule = await _rule(db_session, threshold_percent=None, min_free_addresses=5)
+    # 6 of 10 leased → 4 free < 5 → fire.
+    for octet in range(10, 16):
+        await _lease(db_session, server, scope, octet)
+    await db_session.commit()
+
+    await evaluate_all(db_session)
+    events = await _open_events(db_session, rule)
+    assert len(events) == 1
+    assert "4 free" in events[0].message
+
+
+async def test_alert_ignores_non_dynamic_pools(db_session: AsyncSession) -> None:
+    scope, server = await _scope_and_server(db_session)
+    await _pool(db_session, scope, pool_type="reserved")
+    rule = await _rule(db_session, threshold_percent=10)
+    for octet in range(10, 19):
+        await _lease(db_session, server, scope, octet)
+    await db_session.commit()
+
+    await evaluate_all(db_session)
+    # Reserved pools never hand out leases → never alert.
+    assert await _open_events(db_session, rule) == []
+
+
+# ── MCP tool ───────────────────────────────────────────────────────────────
+
+
+async def test_find_dhcp_pool_occupancy_tool(db_session: AsyncSession) -> None:
+    from app.services.ai.tools.dhcp import FindDHCPPoolOccupancyArgs, find_dhcp_pool_occupancy
+
+    scope, server = await _scope_and_server(db_session)
+    pool = await _pool(db_session, scope)
+    for octet in (10, 11, 12, 13, 14):  # 5/10 = 50%
+        await _lease(db_session, server, scope, octet)
+    await db_session.commit()
+
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="t",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    rows = await find_dhcp_pool_occupancy(db_session, user, FindDHCPPoolOccupancyArgs())
+    mine = [r for r in rows if r["pool_id"] == str(pool.id)]
+    assert len(mine) == 1
+    assert mine[0]["assigned"] == 5
+    assert mine[0]["total"] == 10
+    assert mine[0]["free"] == 5
+    assert mine[0]["occupancy_percent"] == 50.0
+
+    # min_percent filter excludes it.
+    filtered = await find_dhcp_pool_occupancy(
+        db_session, user, FindDHCPPoolOccupancyArgs(min_percent=60)
+    )
+    assert all(r["pool_id"] != str(pool.id) for r in filtered)

--- a/backend/tests/test_dhcp_pool_exhaustion.py
+++ b/backend/tests/test_dhcp_pool_exhaustion.py
@@ -18,7 +18,11 @@ from app.models.auth import User
 from app.models.dhcp import DHCPLease, DHCPPool, DHCPScope, DHCPServer, DHCPServerGroup
 from app.models.ipam import IPBlock, IPSpace, Subnet
 from app.services.alerts import RULE_TYPE_DHCP_POOL_EXHAUSTION, evaluate_all
-from app.services.dhcp.pool_occupancy import compute_pool_occupancy, pool_total_addresses
+from app.services.dhcp.pool_occupancy import (
+    compute_pool_occupancy,
+    compute_pool_occupancy_batch,
+    pool_total_addresses,
+)
 
 CIDR = "10.60.0.0/24"
 POOL_START = "10.60.0.10"
@@ -119,6 +123,54 @@ async def test_compute_pool_occupancy_dedupes_ha_peers(db_session: AsyncSession)
 
     occ = await compute_pool_occupancy(db_session, pool)
     assert occ.assigned == 1
+
+
+async def test_compute_pool_occupancy_invalid_range_is_zero(db_session: AsyncSession) -> None:
+    # An inverted range yields total 0; occupancy must short-circuit to (0, 0)
+    # and never count leases — a bad pool can't make occupancy blow up.
+    scope, server = await _scope_and_server(db_session)
+    bad = DHCPPool(
+        scope_id=scope.id,
+        name="inverted",
+        start_ip="10.60.0.19",
+        end_ip="10.60.0.10",
+        pool_type="dynamic",
+    )
+    db_session.add(bad)
+    await db_session.flush()
+    for octet in (10, 11, 12):
+        await _lease(db_session, server, scope, octet)
+    await db_session.flush()
+
+    occ = await compute_pool_occupancy(db_session, bad)
+    assert occ.total == 0
+    assert occ.assigned == 0
+
+
+async def test_compute_pool_occupancy_batch_matches_single(db_session: AsyncSession) -> None:
+    scope, server = await _scope_and_server(db_session)
+    pool = await _pool(db_session, scope)
+    # A second dynamic pool in the same scope, different sub-range.
+    pool2 = DHCPPool(
+        scope_id=scope.id,
+        name="pool-b",
+        start_ip="10.60.0.20",
+        end_ip="10.60.0.29",
+        pool_type="dynamic",
+    )
+    db_session.add(pool2)
+    await db_session.flush()
+    for octet in (10, 11, 12, 20):  # 3 in pool, 1 in pool2
+        await _lease(db_session, server, scope, octet)
+    await db_session.flush()
+
+    batch = await compute_pool_occupancy_batch(db_session, [pool, pool2])
+    assert batch[pool.id].assigned == 3
+    assert batch[pool.id].total == 10
+    assert batch[pool2.id].assigned == 1
+    # Batch result matches the per-pool helper exactly.
+    single = await compute_pool_occupancy(db_session, pool)
+    assert (batch[pool.id].assigned, batch[pool.id].total) == (single.assigned, single.total)
 
 
 # ── Alert evaluator ───────────────────────────────────────────────────────

--- a/backend/tests/test_dns_digitalocean.py
+++ b/backend/tests/test_dns_digitalocean.py
@@ -1,0 +1,556 @@
+"""Offline unit tests for the DigitalOcean DNS driver (issue #37).
+
+DigitalOcean is a tier-3 provider with no test account, so every test
+monkeypatches :meth:`DigitalOceanDNSDriver._client` to return a fake
+async-context-manager client that serves canned envelopes and records the
+calls made against it. Nothing here touches the network.
+
+Unlike Cloudflare, DigitalOcean has no success-envelope (a 2xx status is the
+success signal) and no opaque zone id — records are scoped by the bare domain
+name and the record list has no server-side ``data`` filter, so multi-value
+RRset disambiguation (issue #331) happens entirely client-side.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.drivers.dns._cloud_base import CloudDNSError
+from app.drivers.dns.base import RecordChange, RecordData
+from app.drivers.dns.digitalocean import DigitalOceanDNSDriver
+
+
+class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` (status + json())."""
+
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class _FakeClient:
+    """Async-context-manager fake of ``httpx.AsyncClient``.
+
+    Each verb pops the next queued response off the matching list and
+    records ``(method, path, params, json)`` for assertion. A queued
+    response can be a ``_FakeResponse`` or a zero-arg callable returning
+    one (so a test can vary the reply by call order).
+    """
+
+    def __init__(self, queues: dict[str, list[Any]]) -> None:
+        self._queues = queues
+        self.calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    def _next(self, method: str, path: str, params: Any, body: Any) -> _FakeResponse:
+        self.calls.append({"method": method, "path": path, "params": params, "json": body})
+        queue = self._queues.get(method)
+        if not queue:
+            raise AssertionError(f"unexpected {method} {path} (no queued response)")
+        item = queue.pop(0)
+        return item() if callable(item) else item
+
+    async def get(self, path: str, params: Any = None) -> _FakeResponse:
+        return self._next("get", path, params, None)
+
+    async def post(self, path: str, json: Any = None) -> _FakeResponse:
+        return self._next("post", path, None, json)
+
+    async def put(self, path: str, json: Any = None) -> _FakeResponse:
+        return self._next("put", path, None, json)
+
+    async def delete(self, path: str, params: Any = None) -> _FakeResponse:
+        return self._next("delete", path, params, None)
+
+
+def _domains(names: list[str], *, next_url: str | None = None) -> dict[str, Any]:
+    """Build a DigitalOcean ``GET /v2/domains`` response."""
+    return {
+        "domains": [{"name": n} for n in names],
+        "links": {"pages": {"next": next_url}} if next_url else {"pages": {}},
+        "meta": {"total": len(names)},
+    }
+
+
+def _records(recs: list[dict[str, Any]], *, next_url: str | None = None) -> dict[str, Any]:
+    """Build a DigitalOcean ``GET /v2/domains/{d}/records`` response."""
+    return {
+        "domain_records": recs,
+        "links": {"pages": {"next": next_url}} if next_url else {"pages": {}},
+        "meta": {"total": len(recs)},
+    }
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, fake: _FakeClient) -> DigitalOceanDNSDriver:
+    driver = DigitalOceanDNSDriver()
+    monkeypatch.setattr(driver, "_client", lambda token: fake)
+    return driver
+
+
+class _Server:
+    """Stub DNSServer row — only the attrs the driver reads."""
+
+    id = "srv-1"
+    name = "do-test"
+    credentials_encrypted = b"x"
+
+
+_CREDS = {"api_token": "tok"}
+
+
+# ── _list_zones pagination ──────────────────────────────────────────────
+async def test_list_zones_paginates_and_flags_reverse(monkeypatch: pytest.MonkeyPatch) -> None:
+    page1 = _domains(["example.com", "10.in-addr.arpa"], next_url="https://api/domains?page=2")
+    page2 = _domains(["example.net"])
+    fake = _FakeClient({"get": [_FakeResponse(200, page1), _FakeResponse(200, page2)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    zones = await driver._list_zones(_Server(), _CREDS)
+
+    assert [z.name for z in zones] == ["example.com.", "10.in-addr.arpa.", "example.net."]
+    # No opaque zone id — the bare domain name is the handle.
+    assert [z.zone_id for z in zones] == ["example.com", "10.in-addr.arpa", "example.net"]
+    # Reverse-zone detection.
+    assert zones[1].is_reverse is True
+    assert zones[0].is_reverse is False
+    # Two pages → two GETs (page 2 followed via links.pages.next).
+    assert sum(1 for c in fake.calls if c["method"] == "get") == 2
+    assert fake.calls[0]["path"] == "/domains"
+    assert fake.calls[0]["params"] == {"per_page": 50, "page": 1}
+    assert fake.calls[1]["params"] == {"per_page": 50, "page": 2}
+
+
+# ── _list_zone_records relativization + TTL handling ────────────────────
+async def test_list_zone_records_relativizes_and_normalizes_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = _records(
+        [
+            {"id": 1, "name": "@", "type": "A", "data": "1.2.3.4", "ttl": 1800},
+            {"id": 2, "name": "www", "type": "A", "data": "5.6.7.8", "ttl": 300},
+            {
+                "id": 3,
+                "name": "@",
+                "type": "MX",
+                "data": "mail.example.com.",
+                "ttl": 3600,
+                "priority": 10,
+            },
+        ]
+    )
+    fake = _FakeClient({"get": [_FakeResponse(200, records)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    recs = await driver._list_zone_records(_Server(), _CREDS, "example.com.")
+
+    # Apex stays "@"; sub-label kept relative; ttl=1800 (default) → None.
+    assert recs[0] == RecordData(name="@", record_type="A", value="1.2.3.4", ttl=None)
+    assert recs[1] == RecordData(name="www", record_type="A", value="5.6.7.8", ttl=300)
+    assert recs[2].name == "@"
+    assert recs[2].priority == 10
+    assert recs[2].ttl == 3600
+    # Records are scoped by the bare domain name (no zone-id lookup).
+    assert fake.calls[0]["path"] == "/domains/example.com/records"
+    assert fake.calls[0]["params"] == {"per_page": 50, "page": 1}
+
+
+# ── _apply_record create ────────────────────────────────────────────────
+async def test_apply_record_create_posts_relative_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"post": [_FakeResponse(201, {"domain_record": {"id": 99}})]})
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    post = next(c for c in fake.calls if c["method"] == "post")
+    assert post["path"] == "/domains/example.com/records"
+    # ttl omitted when None → DigitalOcean applies its account default.
+    assert post["json"] == {"type": "A", "name": "www", "data": "1.1.1.1"}
+
+
+async def test_apply_record_create_apex_uses_at_sign(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"post": [_FakeResponse(201, {"domain_record": {"id": 1}})]})
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="9.9.9.9", ttl=600),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    post = fake.calls[0]
+    # Apex renders as "@" (DigitalOcean takes relative names), ttl threaded.
+    assert post["json"] == {"type": "A", "name": "@", "data": "9.9.9.9", "ttl": 600}
+
+
+# ── _apply_record update (existing record found → PUT) ──────────────────
+async def test_apply_record_update_puts_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(
+                    200,
+                    _records([{"id": 42, "name": "www", "type": "A", "data": "2.2.2.2"}]),
+                ),
+            ],
+            "put": [_FakeResponse(200, {"domain_record": {"id": 42}})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="2.2.2.2", ttl=120),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    put = next(c for c in fake.calls if c["method"] == "put")
+    assert put["path"] == "/domains/example.com/records/42"
+    assert put["json"]["data"] == "2.2.2.2"
+    assert put["json"]["ttl"] == 120
+
+
+# ── _apply_record update with no match → falls back to create (POST) ────
+async def test_apply_record_update_missing_creates(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _records([]))],  # no existing record
+            "post": [_FakeResponse(201, {"domain_record": {"id": 7}})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="3.3.3.3", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    assert [c["method"] for c in fake.calls] == ["get", "post"]
+    post = next(c for c in fake.calls if c["method"] == "post")
+    assert post["json"]["name"] == "@"
+    assert post["path"] == "/domains/example.com/records"
+
+
+# ── _apply_record delete (found → DELETE) ───────────────────────────────
+async def test_apply_record_delete_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(
+                    200,
+                    _records([{"id": 55, "name": "www", "type": "A", "data": "1.1.1.1"}]),
+                ),
+            ],
+            "delete": [_FakeResponse(204, None)],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/domains/example.com/records/55"
+
+
+# ── _apply_record delete with no match → no-op (no DELETE issued) ───────
+async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"get": [_FakeResponse(200, _records([]))]})  # nothing to delete
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="gone", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Only the lookup happened — no DELETE.
+    assert [c["method"] for c in fake.calls] == ["get"]
+
+
+# ── _apply_record update targets the right value of a multi-value RRset ──
+async def test_apply_record_update_matches_content_in_multivalue_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A round-robin A name has two values on DigitalOcean; updating the TTL of
+    the ``5.6.7.8`` record must PUT against *its* id, not the first row's
+    (issue #331). DigitalOcean has no server-side data filter, so the match is
+    purely client-side."""
+    multi = _records(
+        [
+            {"id": 100, "type": "A", "name": "www", "data": "1.2.3.4"},
+            {"id": 101, "type": "A", "name": "www", "data": "5.6.7.8"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, multi)],
+            "put": [_FakeResponse(200, {"domain_record": {"id": 101}})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="5.6.7.8", ttl=600),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # We PUT against the id whose data actually matched the op value.
+    put = next(c for c in fake.calls if c["method"] == "put")
+    assert put["path"] == "/domains/example.com/records/101"
+    assert put["json"]["data"] == "5.6.7.8"
+    assert put["json"]["ttl"] == 600
+
+
+# ── _apply_record delete targets the right value of a multi-value RRset ──
+async def test_apply_record_delete_matches_content_in_multivalue_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``delete A 1.2.3.4`` against a 2-value RRset must DELETE the row holding
+    ``1.2.3.4`` even if DigitalOcean lists ``5.6.7.8`` first (issue #331)."""
+    multi = _records(
+        [
+            {"id": 200, "type": "A", "name": "www", "data": "5.6.7.8"},
+            {"id": 201, "type": "A", "name": "www", "data": "1.2.3.4"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, multi)],
+            "delete": [_FakeResponse(204, None)],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.2.3.4"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    # The value-keyed row, not the first-listed sibling.
+    assert delete["path"] == "/domains/example.com/records/201"
+
+
+# ── _apply_record delete is a no-op when no value matches ───────────────
+async def test_apply_record_delete_no_content_match_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If DigitalOcean returns sibling values but none equal the op value, the
+    delete must be a safe no-op (no DELETE issued) rather than removing a
+    wrong-value row (issue #331)."""
+    multi = _records(
+        [
+            {"id": 300, "type": "A", "name": "www", "data": "5.6.7.8"},
+            {"id": 301, "type": "A", "name": "www", "data": "9.9.9.9"},
+        ]
+    )
+    fake = _FakeClient({"get": [_FakeResponse(200, multi)]})
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.2.3.4"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Only the lookup happened — no DELETE against a non-matching value.
+    assert [c["method"] for c in fake.calls] == ["get"]
+
+
+# ── _find_record_id disambiguates MX rows by priority too ───────────────
+async def test_apply_record_delete_mx_matches_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two MX records at the apex share a content host but differ by priority;
+    deleting one must match content *and* priority (issue #331)."""
+    multi = _records(
+        [
+            {"id": 10, "type": "MX", "name": "@", "data": "mail.example.com.", "priority": 10},
+            {"id": 20, "type": "MX", "name": "@", "data": "mail.example.com.", "priority": 20},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, multi)],
+            "delete": [_FakeResponse(204, None)],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="MX", value="mail.example.com.", priority=20),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/domains/example.com/records/20"
+
+
+# ── _find_record_id pages through records to find a match ───────────────
+async def test_find_record_id_follows_pagination(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The target value lives on page 2 — the client-side matcher must follow
+    links.pages.next before giving up."""
+    page1 = _records(
+        [{"id": 1, "type": "A", "name": "www", "data": "1.1.1.1"}],
+        next_url="https://api/domains/example.com/records?page=2",
+    )
+    page2 = _records([{"id": 2, "type": "A", "name": "www", "data": "2.2.2.2"}])
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, page1), _FakeResponse(200, page2)],
+            "delete": [_FakeResponse(204, None)],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="2.2.2.2"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    assert sum(1 for c in fake.calls if c["method"] == "get") == 2
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/domains/example.com/records/2"
+
+
+# ── _apply_zone create ───────────────────────────────────────────────────
+async def test_apply_zone_create_posts_bare_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"post": [_FakeResponse(201, {"domain": {"name": "example.org"}})]})
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "create")
+
+    post = fake.calls[0]
+    assert post["path"] == "/domains"
+    assert post["json"] == {"name": "example.org"}
+
+
+async def test_apply_zone_delete_uses_bare_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"delete": [_FakeResponse(204, None)]})
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "delete")
+
+    assert [c["method"] for c in fake.calls] == ["delete"]
+    assert fake.calls[0]["path"] == "/domains/example.org"
+
+
+# ── Error surfacing ─────────────────────────────────────────────────────
+async def test_non_2xx_raises_clouddnserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"id": "unauthorized", "message": "Unable to authenticate you."}
+    fake = _FakeClient({"get": [_FakeResponse(401, payload)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "Unable to authenticate you." in str(exc.value)
+
+
+async def test_error_envelope_message_surfaced(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"id": "not_found", "message": "The resource you requested could not be found."}
+    fake = _FakeClient({"get": [_FakeResponse(404, payload)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zone_records(_Server(), _CREDS, "example.com.")
+    assert "could not be found" in str(exc.value)
+
+
+async def test_non_2xx_without_message_falls_back_to_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeClient({"get": [_FakeResponse(500, "not json")]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "HTTP 500" in str(exc.value)
+
+
+async def test_missing_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = DigitalOceanDNSDriver()
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+    with pytest.raises(CloudDNSError):
+        await driver._apply_record(_Server(), {}, change)
+
+
+# ── Static helpers ──────────────────────────────────────────────────────
+def test_relativize_helper() -> None:
+    driver = DigitalOceanDNSDriver()
+    assert driver._relativize("@", "example.com.") == "@"
+    assert driver._relativize("www", "example.com.") == "www"
+    assert driver._relativize("example.com.", "example.com.") == "@"
+    assert driver._relativize("a.b.example.com.", "example.com") == "a.b"
+
+
+def test_write_name_helper() -> None:
+    driver = DigitalOceanDNSDriver()
+    assert driver._write_name("@") == "@"
+    assert driver._write_name("") == "@"
+    assert driver._write_name("www") == "www"
+    assert driver._write_name("www.") == "www"
+
+
+def test_capabilities_shape() -> None:
+    caps = DigitalOceanDNSDriver().capabilities()
+    assert caps["name"] == "digitalocean"
+    assert caps["agentless"] is True
+    assert caps["manages_zones"] is True
+    assert caps["views"] is False
+    assert caps["rpz"] is False
+    # DigitalOcean exposes no online DNSSEC management via the API.
+    assert caps["dnssec_online"] is False
+    assert "CAA" in caps["record_types"]
+    assert "SVCB" not in caps["record_types"]
+    assert "HTTPS" not in caps["record_types"]

--- a/backend/tests/test_dns_hetzner.py
+++ b/backend/tests/test_dns_hetzner.py
@@ -323,6 +323,46 @@ async def test_apply_record_delete_dispatches(monkeypatch: pytest.MonkeyPatch) -
     assert delete["path"] == "/records/rid"
 
 
+# ── _find_record_id pages the full record set (issue #344 review) ───────
+async def test_find_record_id_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The target record sits on page 2 of GET /records. Without pagination
+    _find_record_id would miss it and the delete would silently no-op."""
+    page1 = _records_env(
+        [{"id": "other", "name": "a", "type": "A", "value": "9.9.9.9"}],
+        last_page=2,
+    )
+    page2 = _records_env(
+        [{"id": "rid", "name": "www", "type": "A", "value": "1.1.1.1"}],
+        last_page=2,
+        page=2,
+    )
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}])),
+                _FakeResponse(200, page1),
+                _FakeResponse(200, page2),
+            ],
+            "delete": [_FakeResponse(200, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Both record pages were fetched, and the page-2 row was deleted.
+    record_gets = [c for c in fake.calls if c["method"] == "get" and c["path"] == "/records"]
+    assert len(record_gets) == 2
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/records/rid"
+
+
 # ── _apply_record delete with no match → no-op (no DELETE issued) ───────
 async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     fake = _FakeClient(

--- a/backend/tests/test_dns_hetzner.py
+++ b/backend/tests/test_dns_hetzner.py
@@ -1,0 +1,613 @@
+"""Offline unit tests for the Hetzner DNS driver (issue #37).
+
+Hetzner is a tier-3 provider with no test account, so every test
+monkeypatches :meth:`HetznerDNSDriver._client` to return a fake
+async-context-manager client that serves canned envelopes and records the
+calls made against it. Nothing here touches the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.drivers.dns._cloud_base import CloudDNSError
+from app.drivers.dns.base import RecordChange, RecordData
+from app.drivers.dns.hetzner import HetznerDNSDriver
+
+
+class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` (status + json())."""
+
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeClient:
+    """Async-context-manager fake of ``httpx.AsyncClient``.
+
+    Each verb pops the next queued response off the matching list and
+    records ``(method, path, params, json)`` for assertion. A queued
+    response can be a ``_FakeResponse`` or a zero-arg callable returning
+    one (so a test can vary the reply by call order).
+    """
+
+    def __init__(self, queues: dict[str, list[Any]]) -> None:
+        self._queues = queues
+        self.calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    def _next(self, method: str, path: str, params: Any, body: Any) -> _FakeResponse:
+        self.calls.append({"method": method, "path": path, "params": params, "json": body})
+        queue = self._queues.get(method)
+        if not queue:
+            raise AssertionError(f"unexpected {method} {path} (no queued response)")
+        item = queue.pop(0)
+        return item() if callable(item) else item
+
+    async def get(self, path: str, params: Any = None) -> _FakeResponse:
+        return self._next("get", path, params, None)
+
+    async def post(self, path: str, json: Any = None) -> _FakeResponse:
+        return self._next("post", path, None, json)
+
+    async def put(self, path: str, json: Any = None) -> _FakeResponse:
+        return self._next("put", path, None, json)
+
+    async def delete(self, path: str, params: Any = None) -> _FakeResponse:
+        return self._next("delete", path, params, None)
+
+
+def _zones_env(zones: list[Any], *, last_page: int = 1, page: int = 1) -> dict[str, Any]:
+    """Build a Hetzner-shaped ``GET /zones`` envelope."""
+    return {
+        "zones": zones,
+        "meta": {
+            "pagination": {
+                "page": page,
+                "per_page": 50,
+                "last_page": last_page,
+                "total_entries": len(zones),
+            }
+        },
+    }
+
+
+def _records_env(records: list[Any], *, last_page: int = 1, page: int = 1) -> dict[str, Any]:
+    """Build a Hetzner-shaped ``GET /records`` envelope."""
+    return {
+        "records": records,
+        "meta": {
+            "pagination": {
+                "page": page,
+                "per_page": 50,
+                "last_page": last_page,
+                "total_entries": len(records),
+            }
+        },
+    }
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, fake: _FakeClient) -> HetznerDNSDriver:
+    driver = HetznerDNSDriver()
+    monkeypatch.setattr(driver, "_client", lambda token: fake)
+    return driver
+
+
+class _Server:
+    """Stub DNSServer row — only the attrs the driver reads."""
+
+    id = "srv-1"
+    name = "hz-test"
+    credentials_encrypted = b"x"
+
+
+_CREDS = {"api_token": "tok"}
+
+
+# ── _list_zones pagination ──────────────────────────────────────────────
+async def test_list_zones_paginates_and_flags_reverse(monkeypatch: pytest.MonkeyPatch) -> None:
+    page1 = _zones_env(
+        [
+            {"id": "z1", "name": "example.com"},
+            {"id": "z2", "name": "10.in-addr.arpa"},
+        ],
+        last_page=2,
+        page=1,
+    )
+    page2 = _zones_env([{"id": "z3", "name": "example.net"}], last_page=2, page=2)
+    fake = _FakeClient({"get": [_FakeResponse(200, page1), _FakeResponse(200, page2)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    zones = await driver._list_zones(_Server(), _CREDS)
+
+    assert [z.name for z in zones] == ["example.com.", "10.in-addr.arpa.", "example.net."]
+    assert [z.zone_id for z in zones] == ["z1", "z2", "z3"]
+    # Reverse-zone detection.
+    assert zones[1].is_reverse is True
+    assert zones[0].is_reverse is False
+    # Two pages → two GETs.
+    assert sum(1 for c in fake.calls if c["method"] == "get") == 2
+    assert fake.calls[0]["params"] == {"per_page": 50, "page": 1}
+    assert fake.calls[1]["params"] == {"per_page": 50, "page": 2}
+
+
+# ── _list_zone_records relativization + TTL handling ────────────────────
+async def test_list_zone_records_relativizes_and_normalizes_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    zone_lookup = _zones_env([{"id": "zid", "name": "example.com"}])
+    records = _records_env(
+        [
+            # apex record — Hetzner returns "@"; ttl absent → zone default.
+            {"id": "r1", "name": "@", "type": "A", "value": "1.2.3.4"},
+            {"id": "r2", "name": "www", "type": "A", "value": "5.6.7.8", "ttl": 300},
+            {
+                "id": "r3",
+                "name": "@",
+                "type": "MX",
+                "value": "mail.example.com",
+                "ttl": 3600,
+                "priority": 10,
+            },
+        ]
+    )
+    fake = _FakeClient({"get": [_FakeResponse(200, zone_lookup), _FakeResponse(200, records)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    recs = await driver._list_zone_records(_Server(), _CREDS, "example.com.")
+
+    # Apex stays "@"; sub-label verbatim; absent ttl → None (zone default).
+    assert recs[0] == RecordData(name="@", record_type="A", value="1.2.3.4", ttl=None)
+    assert recs[1] == RecordData(name="www", record_type="A", value="5.6.7.8", ttl=300)
+    assert recs[2].name == "@"
+    assert recs[2].priority == 10
+    assert recs[2].ttl == 3600
+    # Zone-id was resolved by name (de-dotted).
+    assert fake.calls[0]["params"] == {"name": "example.com"}
+    # Records were fetched scoped by the resolved zone_id.
+    assert fake.calls[1]["params"]["zone_id"] == "zid"
+
+
+# ── _apply_record create ────────────────────────────────────────────────
+async def test_apply_record_create_posts_relative_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}]))],
+            "post": [_FakeResponse(201, {"record": {"id": "new"}})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    post = next(c for c in fake.calls if c["method"] == "post")
+    assert post["path"] == "/records"
+    # ttl omitted entirely when None (inherit zone default).
+    assert post["json"] == {
+        "zone_id": "zid",
+        "type": "A",
+        "name": "www",
+        "value": "1.1.1.1",
+    }
+
+
+# ── _apply_record create at apex renders "@" ────────────────────────────
+async def test_apply_record_create_apex_uses_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}]))],
+            "post": [_FakeResponse(201, {"record": {"id": "new"}})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="3.3.3.3", ttl=120),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    post = next(c for c in fake.calls if c["method"] == "post")
+    assert post["json"] == {
+        "zone_id": "zid",
+        "type": "A",
+        "name": "@",
+        "value": "3.3.3.3",
+        "ttl": 120,
+    }
+
+
+# ── _apply_record update (existing record found → PUT) ──────────────────
+async def test_apply_record_update_puts_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}])),
+                # find existing record (client-side value match over the zone)
+                _FakeResponse(
+                    200,
+                    _records_env([{"id": "rid", "name": "www", "type": "A", "value": "2.2.2.2"}]),
+                ),
+            ],
+            "put": [_FakeResponse(200, {"record": {"id": "rid"}})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="2.2.2.2", ttl=120),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    put = next(c for c in fake.calls if c["method"] == "put")
+    assert put["path"] == "/records/rid"
+    assert put["json"]["value"] == "2.2.2.2"
+    assert put["json"]["ttl"] == 120
+    assert put["json"]["zone_id"] == "zid"
+
+
+# ── _apply_record update with no match → falls back to create (POST) ────
+async def test_apply_record_update_missing_creates(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}])),
+                _FakeResponse(200, _records_env([])),  # no existing record
+            ],
+            "post": [_FakeResponse(201, {"record": {"id": "new"}})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="3.3.3.3", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    assert [c["method"] for c in fake.calls] == ["get", "get", "post"]
+    post = next(c for c in fake.calls if c["method"] == "post")
+    # Apex name renders as "@".
+    assert post["json"]["name"] == "@"
+
+
+# ── _apply_record delete (found → DELETE) ───────────────────────────────
+async def test_apply_record_delete_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}])),
+                _FakeResponse(
+                    200,
+                    _records_env([{"id": "rid", "name": "www", "type": "A", "value": "1.1.1.1"}]),
+                ),
+            ],
+            "delete": [_FakeResponse(200, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/records/rid"
+
+
+# ── _apply_record delete with no match → no-op (no DELETE issued) ───────
+async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}])),
+                _FakeResponse(200, _records_env([])),  # nothing to delete
+            ]
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="gone", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Only the two lookups happened — no DELETE.
+    assert [c["method"] for c in fake.calls] == ["get", "get"]
+
+
+# ── _apply_record update targets the right value of a multi-value RRset ──
+async def test_apply_record_update_matches_value_in_multivalue_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A round-robin A name has two values on Hetzner; updating the TTL of
+    the ``5.6.7.8`` record must PUT against *its* id, not the first row's
+    (issue #331)."""
+    multi = _records_env(
+        [
+            {"id": "rid-a", "type": "A", "name": "www", "value": "1.2.3.4"},
+            {"id": "rid-b", "type": "A", "name": "www", "value": "5.6.7.8"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}])),
+                _FakeResponse(200, multi),  # find existing record
+            ],
+            "put": [_FakeResponse(200, {"record": {"id": "rid-b"}})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="5.6.7.8", ttl=600),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # We PUT against the id whose value actually matched the op value.
+    put = next(c for c in fake.calls if c["method"] == "put")
+    assert put["path"] == "/records/rid-b"
+    assert put["json"]["value"] == "5.6.7.8"
+    assert put["json"]["ttl"] == 600
+
+
+# ── _apply_record delete targets the right value of a multi-value RRset ──
+async def test_apply_record_delete_matches_value_in_multivalue_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``delete A 1.2.3.4`` against a 2-value RRset must DELETE the row holding
+    ``1.2.3.4`` even if Hetzner lists ``5.6.7.8`` first (issue #331)."""
+    multi = _records_env(
+        [
+            {"id": "rid-keep", "type": "A", "name": "www", "value": "5.6.7.8"},
+            {"id": "rid-drop", "type": "A", "name": "www", "value": "1.2.3.4"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}])),
+                _FakeResponse(200, multi),
+            ],
+            "delete": [_FakeResponse(200, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.2.3.4"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    # The value-keyed row, not the first-listed sibling.
+    assert delete["path"] == "/records/rid-drop"
+
+
+# ── _apply_record delete is a no-op when no value matches ───────────────
+async def test_apply_record_delete_no_value_match_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If Hetzner returns sibling values but none equal the op value, the
+    delete must be a safe no-op (no DELETE issued) rather than removing a
+    wrong-value row (issue #331)."""
+    multi = _records_env(
+        [
+            {"id": "rid-a", "type": "A", "name": "www", "value": "5.6.7.8"},
+            {"id": "rid-b", "type": "A", "name": "www", "value": "9.9.9.9"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}])),
+                _FakeResponse(200, multi),
+            ]
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.2.3.4"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Only the two lookups happened — no DELETE against a non-matching value.
+    assert [c["method"] for c in fake.calls] == ["get", "get"]
+
+
+# ── _find_record_id disambiguates MX rows by priority too ───────────────
+async def test_apply_record_delete_mx_matches_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two MX records at the apex share a content host but differ by priority;
+    deleting one must match value *and* priority (issue #331)."""
+    multi = _records_env(
+        [
+            {
+                "id": "mx-10",
+                "type": "MX",
+                "name": "@",
+                "value": "mail.example.com",
+                "priority": 10,
+            },
+            {
+                "id": "mx-20",
+                "type": "MX",
+                "name": "@",
+                "value": "mail.example.com",
+                "priority": 20,
+            },
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _zones_env([{"id": "zid", "name": "example.com"}])),
+                _FakeResponse(200, multi),
+            ],
+            "delete": [_FakeResponse(200, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="MX", value="mail.example.com", priority=20),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/records/mx-20"
+
+
+# ── _apply_zone create ──────────────────────────────────────────────────
+async def test_apply_zone_create(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"post": [_FakeResponse(201, {"zone": {"id": "z9"}})]})
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "create")
+
+    post = fake.calls[0]
+    assert post["path"] == "/zones"
+    # Bare name (no trailing dot) on create.
+    assert post["json"] == {"name": "example.org"}
+
+
+async def test_apply_zone_delete_resolves_then_deletes(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _zones_env([{"id": "zid", "name": "example.org"}]))],
+            "delete": [_FakeResponse(200, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "delete")
+
+    assert [c["method"] for c in fake.calls] == ["get", "delete"]
+    assert fake.calls[0]["params"] == {"name": "example.org"}
+    assert fake.calls[1]["path"] == "/zones/zid"
+
+
+# ── Error surfacing ─────────────────────────────────────────────────────
+async def test_error_envelope_raises_clouddnserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"error": {"message": "Invalid zone id.", "code": 422}}
+    fake = _FakeClient({"get": [_FakeResponse(422, payload)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "Invalid zone id." in str(exc.value)
+
+
+async def test_flat_message_error_raises_clouddnserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"message": "Unauthorized"}
+    fake = _FakeClient({"get": [_FakeResponse(401, payload)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "Unauthorized" in str(exc.value)
+
+
+async def test_non_2xx_no_body_raises_clouddnserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"get": [_FakeResponse(500, {})]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "HTTP 500" in str(exc.value)
+
+
+async def test_missing_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = HetznerDNSDriver()
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+    with pytest.raises(CloudDNSError):
+        await driver._apply_record(_Server(), {}, change)
+
+
+# ── Static helpers ──────────────────────────────────────────────────────
+def test_relativize_helper() -> None:
+    driver = HetznerDNSDriver()
+    # Hetzner returns relative names already; apex collapses to "@".
+    assert driver._relativize("@", "example.com.") == "@"
+    assert driver._relativize("www", "example.com.") == "www"
+    # Robust against an absolute FQDN if Hetzner ever returns one.
+    assert driver._relativize("example.com.", "example.com.") == "@"
+    assert driver._relativize("a.b.example.com.", "example.com") == "a.b"
+
+
+def test_absolute_name_helper() -> None:
+    driver = HetznerDNSDriver()
+    assert driver._absolute_name("@", "example.com.") == "@"
+    assert driver._absolute_name("", "example.com.") == "@"
+    assert driver._absolute_name("www", "example.com.") == "www"
+    # Absolute FQDN → relative label.
+    assert driver._absolute_name("www.example.com.", "example.com.") == "www"
+    assert driver._absolute_name("example.com.", "example.com.") == "@"
+
+
+def test_capabilities_shape() -> None:
+    caps = HetznerDNSDriver().capabilities()
+    assert caps["name"] == "hetzner"
+    assert caps["agentless"] is True
+    assert caps["manages_zones"] is True
+    assert caps["views"] is False
+    assert caps["rpz"] is False
+    # Hetzner has no online DNSSEC signing via the API.
+    assert caps["dnssec_online"] is False
+    assert "CAA" in caps["record_types"]
+    # Must NOT advertise types Hetzner's API doesn't serve.
+    assert "SVCB" not in caps["record_types"]
+    assert "HTTPS" not in caps["record_types"]

--- a/backend/tests/test_dns_linode.py
+++ b/backend/tests/test_dns_linode.py
@@ -1,0 +1,583 @@
+"""Offline unit tests for the Linode DNS Manager driver (issue #29 / #37).
+
+Linode is a token-only tier-3 provider with no test account, so every test
+monkeypatches :meth:`LinodeDNSDriver._client` to return a fake
+async-context-manager client that serves canned envelopes and records the
+calls made against it. Nothing here touches the network.
+
+Linode differs from Cloudflare in two ways the harness models:
+
+* No ``{"success": bool}`` envelope — failure is a non-2xx status plus a
+  ``{"errors": [{"reason"}]}`` body.
+* Pagination is ``{"data": [...], "page", "pages", "results"}`` and record
+  names are relative to the zone (apex is the empty string).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from app.drivers.dns._cloud_base import CloudDNSError
+from app.drivers.dns.base import RecordChange, RecordData
+from app.drivers.dns.linode import LinodeDNSDriver
+
+
+class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` (status + json())."""
+
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeClient:
+    """Async-context-manager fake of ``httpx.AsyncClient``.
+
+    Each verb pops the next queued response off the matching list and
+    records ``(method, path, params, headers, json)`` for assertion. A
+    queued response can be a ``_FakeResponse`` or a zero-arg callable
+    returning one (so a test can vary the reply by call order).
+    """
+
+    def __init__(self, queues: dict[str, list[Any]]) -> None:
+        self._queues = queues
+        self.calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    def _next(self, method: str, path: str, params: Any, headers: Any, body: Any) -> _FakeResponse:
+        self.calls.append(
+            {"method": method, "path": path, "params": params, "headers": headers, "json": body}
+        )
+        queue = self._queues.get(method)
+        if not queue:
+            raise AssertionError(f"unexpected {method} {path} (no queued response)")
+        item = queue.pop(0)
+        return item() if callable(item) else item
+
+    async def get(self, path: str, params: Any = None, headers: Any = None) -> _FakeResponse:
+        return self._next("get", path, params, headers, None)
+
+    async def post(self, path: str, json: Any = None, headers: Any = None) -> _FakeResponse:
+        return self._next("post", path, None, headers, json)
+
+    async def put(self, path: str, json: Any = None, headers: Any = None) -> _FakeResponse:
+        return self._next("put", path, None, headers, json)
+
+    async def delete(self, path: str, params: Any = None, headers: Any = None) -> _FakeResponse:
+        return self._next("delete", path, params, headers, None)
+
+
+def _env(data: Any, *, page: int = 1, pages: int = 1) -> dict[str, Any]:
+    """Build a Linode-shaped paginated list envelope."""
+    items = data if isinstance(data, list) else [data]
+    return {"data": items, "page": page, "pages": pages, "results": len(items)}
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, fake: _FakeClient) -> LinodeDNSDriver:
+    driver = LinodeDNSDriver()
+    monkeypatch.setattr(driver, "_client", lambda token: fake)
+    return driver
+
+
+class _Server:
+    """Stub DNSServer row — only the attrs the driver reads."""
+
+    id = "srv-1"
+    name = "linode-test"
+    credentials_encrypted = b"x"
+
+
+_CREDS = {"api_token": "tok"}
+
+
+# ── _list_zones pagination + reverse flag ───────────────────────────────
+async def test_list_zones_paginates_and_flags_reverse(monkeypatch: pytest.MonkeyPatch) -> None:
+    page1 = _env(
+        [
+            {"id": 1, "domain": "example.com", "type": "master"},
+            {"id": 2, "domain": "10.in-addr.arpa", "type": "master"},
+        ],
+        page=1,
+        pages=2,
+    )
+    page2 = _env([{"id": 3, "domain": "example.net", "type": "master"}], page=2, pages=2)
+    fake = _FakeClient({"get": [_FakeResponse(200, page1), _FakeResponse(200, page2)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    zones = await driver._list_zones(_Server(), _CREDS)
+
+    assert [z.name for z in zones] == ["example.com.", "10.in-addr.arpa.", "example.net."]
+    assert [z.zone_id for z in zones] == ["1", "2", "3"]
+    # Reverse-zone detection.
+    assert zones[1].is_reverse is True
+    assert zones[0].is_reverse is False
+    # Two pages → two GETs.
+    assert sum(1 for c in fake.calls if c["method"] == "get") == 2
+    assert fake.calls[0]["params"] == {"page_size": 100, "page": 1}
+    assert fake.calls[1]["params"] == {"page_size": 100, "page": 2}
+
+
+# ── _list_zone_records relativization + TTL handling + MX priority ──────
+async def test_list_zone_records_relativizes_and_normalizes_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    domain_lookup = _env([{"id": 42, "domain": "example.com"}])
+    records = _env(
+        [
+            {"id": 100, "name": "", "type": "A", "target": "1.2.3.4", "ttl_sec": 0},
+            {"id": 101, "name": "www", "type": "A", "target": "5.6.7.8", "ttl_sec": 300},
+            {
+                "id": 102,
+                "name": "",
+                "type": "MX",
+                "target": "mail.example.com",
+                "ttl_sec": 3600,
+                "priority": 10,
+            },
+        ]
+    )
+    fake = _FakeClient({"get": [_FakeResponse(200, domain_lookup), _FakeResponse(200, records)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    recs = await driver._list_zone_records(_Server(), _CREDS, "example.com.")
+
+    # Apex (empty name) collapses to "@"; sub-label kept; ttl_sec=0 → None.
+    assert recs[0] == RecordData(name="@", record_type="A", value="1.2.3.4", ttl=None)
+    assert recs[1] == RecordData(name="www", record_type="A", value="5.6.7.8", ttl=300)
+    assert recs[2].name == "@"
+    assert recs[2].priority == 10
+    assert recs[2].ttl == 3600
+    # Domain id was resolved by name via the X-Filter header.
+    assert fake.calls[0]["headers"] == {"X-Filter": json.dumps({"domain": "example.com"})}
+
+
+# ── _apply_record create ────────────────────────────────────────────────
+async def test_apply_record_create_posts_relative_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _env([{"id": 42, "domain": "example.com"}]))],
+            "post": [_FakeResponse(200, {"id": 500})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    post = next(c for c in fake.calls if c["method"] == "post")
+    assert post["path"] == "/domains/42/records"
+    assert post["json"] == {
+        "type": "A",
+        "name": "www",  # relative label, not absolute.
+        "target": "1.1.1.1",
+        "ttl_sec": 0,  # None → zone-default sentinel.
+    }
+
+
+# ── _apply_record create at apex uses empty name ────────────────────────
+async def test_apply_record_create_apex_empty_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _env([{"id": 42, "domain": "example.com"}]))],
+            "post": [_FakeResponse(200, {"id": 500})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="3.3.3.3", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    post = next(c for c in fake.calls if c["method"] == "post")
+    assert post["json"]["name"] == ""
+
+
+# ── _apply_record update (existing record found → PUT) ──────────────────
+async def test_apply_record_update_puts_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": 42, "domain": "example.com"}])),  # resolve
+                # find existing record (target-keyed lookup)
+                _FakeResponse(200, _env([{"id": 700, "type": "A", "target": "2.2.2.2"}])),
+            ],
+            "put": [_FakeResponse(200, {"id": 700})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="2.2.2.2", ttl=120),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    put = next(c for c in fake.calls if c["method"] == "put")
+    assert put["path"] == "/domains/42/records/700"
+    assert put["json"]["target"] == "2.2.2.2"
+    assert put["json"]["ttl_sec"] == 120
+
+
+# ── _apply_record update with no match → falls back to create (POST) ────
+async def test_apply_record_update_missing_creates(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": 42, "domain": "example.com"}])),  # resolve
+                _FakeResponse(200, _env([])),  # no existing record
+            ],
+            "post": [_FakeResponse(200, {"id": 500})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="3.3.3.3", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    assert [c["method"] for c in fake.calls] == ["get", "get", "post"]
+    post = next(c for c in fake.calls if c["method"] == "post")
+    # Apex name renders as the empty string.
+    assert post["json"]["name"] == ""
+
+
+# ── _apply_record delete (found → DELETE) ───────────────────────────────
+async def test_apply_record_delete_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": 42, "domain": "example.com"}])),
+                _FakeResponse(200, _env([{"id": 700, "type": "A", "target": "1.1.1.1"}])),
+            ],
+            "delete": [_FakeResponse(200, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/domains/42/records/700"
+
+
+# ── _apply_record delete with no match → no-op (no DELETE issued) ───────
+async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": 42, "domain": "example.com"}])),
+                _FakeResponse(200, _env([])),  # nothing to delete
+            ]
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="gone", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Only the two lookups happened — no DELETE.
+    assert [c["method"] for c in fake.calls] == ["get", "get"]
+
+
+# ── _apply_record update targets the right value of a multi-value RRset ──
+async def test_apply_record_update_matches_target_in_multivalue_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A round-robin A name has two values on Linode; updating the TTL of the
+    ``5.6.7.8`` record must PUT against *its* id, not the first row's
+    (issue #331)."""
+    multi = _env(
+        [
+            {"id": 800, "type": "A", "name": "www", "target": "1.2.3.4"},
+            {"id": 801, "type": "A", "name": "www", "target": "5.6.7.8"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": 42, "domain": "example.com"}])),  # resolve
+                _FakeResponse(200, multi),  # find existing record (name+type X-Filter)
+            ],
+            "put": [_FakeResponse(200, {"id": 801})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="5.6.7.8", ttl=600),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # The lookup carried the name+type X-Filter so Linode narrows the RRset…
+    lookup = fake.calls[1]
+    assert lookup["headers"] == {"X-Filter": json.dumps({"type": "A", "name": "www"})}
+    # …and we PUT against the id whose target actually matched the op value.
+    put = next(c for c in fake.calls if c["method"] == "put")
+    assert put["path"] == "/domains/42/records/801"
+    assert put["json"]["target"] == "5.6.7.8"
+    assert put["json"]["ttl_sec"] == 600
+
+
+# ── _apply_record delete targets the right value of a multi-value RRset ──
+async def test_apply_record_delete_matches_target_in_multivalue_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``delete A 1.2.3.4`` against a 2-value RRset must DELETE the row holding
+    ``1.2.3.4`` even if Linode lists ``5.6.7.8`` first (issue #331)."""
+    multi = _env(
+        [
+            {"id": 900, "type": "A", "name": "www", "target": "5.6.7.8"},
+            {"id": 901, "type": "A", "name": "www", "target": "1.2.3.4"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": 42, "domain": "example.com"}])),
+                _FakeResponse(200, multi),
+            ],
+            "delete": [_FakeResponse(200, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.2.3.4"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    # The value-keyed row, not the first-listed sibling.
+    assert delete["path"] == "/domains/42/records/901"
+
+
+# ── _apply_record delete is a no-op when no value matches ───────────────
+async def test_apply_record_delete_no_target_match_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If Linode returns sibling values but none equal the op value, the delete
+    must be a safe no-op (no DELETE issued) rather than removing a
+    wrong-value row (issue #331)."""
+    multi = _env(
+        [
+            {"id": 900, "type": "A", "name": "www", "target": "5.6.7.8"},
+            {"id": 901, "type": "A", "name": "www", "target": "9.9.9.9"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": 42, "domain": "example.com"}])),
+                _FakeResponse(200, multi),
+            ]
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.2.3.4"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Only the two lookups happened — no DELETE against a non-matching value.
+    assert [c["method"] for c in fake.calls] == ["get", "get"]
+
+
+# ── _find_record_id disambiguates MX rows by priority too ───────────────
+async def test_apply_record_delete_mx_matches_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two MX records at the apex share a target host but differ by priority;
+    deleting one must match target *and* priority (issue #331)."""
+    multi = _env(
+        [
+            {
+                "id": 10,
+                "type": "MX",
+                "name": "",
+                "target": "mail.example.com",
+                "priority": 10,
+            },
+            {
+                "id": 20,
+                "type": "MX",
+                "name": "",
+                "target": "mail.example.com",
+                "priority": 20,
+            },
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(200, _env([{"id": 42, "domain": "example.com"}])),
+                _FakeResponse(200, multi),
+            ],
+            "delete": [_FakeResponse(200, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="MX", value="mail.example.com", priority=20),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/domains/42/records/20"
+
+
+# ── _apply_zone create derives soa_email + sends type=master ────────────
+async def test_apply_zone_create(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"post": [_FakeResponse(200, {"id": 99})]})
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "create")
+
+    post = fake.calls[0]
+    assert post["path"] == "/domains"
+    assert post["json"] == {
+        "domain": "example.org",
+        "type": "master",
+        "soa_email": "hostmaster@example.org",
+    }
+
+
+async def test_apply_zone_delete_resolves_then_deletes(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _env([{"id": 77, "domain": "example.org"}]))],
+            "delete": [_FakeResponse(200, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "delete")
+
+    assert [c["method"] for c in fake.calls] == ["get", "delete"]
+    assert fake.calls[1]["path"] == "/domains/77"
+
+
+# ── Error surfacing ─────────────────────────────────────────────────────
+async def test_error_envelope_raises_clouddnserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"errors": [{"reason": "Invalid Token", "field": None}]}
+    fake = _FakeClient({"get": [_FakeResponse(401, payload)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "Invalid Token" in str(exc.value)
+
+
+async def test_error_envelope_with_field_is_qualified(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"errors": [{"reason": "domain must be unique", "field": "domain"}]}
+    fake = _FakeClient({"post": [_FakeResponse(400, payload)]})
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._apply_zone(_Server(), _CREDS, zone, "create")
+    assert "domain: domain must be unique" in str(exc.value)
+
+
+async def test_non_2xx_without_errors_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"get": [_FakeResponse(500, {})]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "HTTP 500" in str(exc.value)
+
+
+async def test_missing_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = LinodeDNSDriver()
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+    with pytest.raises(CloudDNSError):
+        await driver._apply_record(_Server(), {}, change)
+
+
+# ── Static helpers ──────────────────────────────────────────────────────
+def test_relativize_helper() -> None:
+    driver = LinodeDNSDriver()
+    assert driver._relativize("", "example.com.") == "@"
+    assert driver._relativize("@", "example.com.") == "@"
+    assert driver._relativize("www", "example.com.") == "www"
+    # Defensive: an absolute name under the zone reduces to relative.
+    assert driver._relativize("a.b.example.com.", "example.com") == "a.b"
+
+
+def test_relative_name_helper() -> None:
+    driver = LinodeDNSDriver()
+    assert driver._relative_name("@", "example.com.") == ""
+    assert driver._relative_name("", "example.com.") == ""
+    assert driver._relative_name("www", "example.com.") == "www"
+    assert driver._relative_name("www.example.com.", "example.com") == "www"
+
+
+def test_capabilities_shape() -> None:
+    caps = LinodeDNSDriver().capabilities()
+    assert caps["name"] == "linode"
+    assert caps["agentless"] is True
+    assert caps["manages_zones"] is True
+    assert caps["views"] is False
+    assert caps["rpz"] is False
+    assert caps["dnssec_online"] is False
+    assert "CAA" in caps["record_types"]
+    assert "SVCB" not in caps["record_types"]
+    assert "HTTPS" not in caps["record_types"]

--- a/backend/tests/test_dns_modern_record_types.py
+++ b/backend/tests/test_dns_modern_record_types.py
@@ -1,0 +1,156 @@
+"""Modern DNS record types — SVCB / HTTPS (RFC 9460) + DNAME (RFC 6672), issue #338.
+
+Three layers are exercised:
+
+* the BIND9 zone-file writer renders the new types (SVCB/HTTPS passthrough,
+  DNAME FQDN-normalised like CNAME),
+* the PowerDNS driver's supported-type set accepts them (it rejects unknown
+  types at render otherwise),
+* the record-create API accepts them on a bind9/powerdns group but gates them
+  off a group that also runs a hosted-DNS driver (clear 422, not a late apply
+  failure).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.drivers.dns.powerdns import _SUPPORTED_RECORD_TYPES
+from app.models.auth import User
+from app.models.dns import DNSServer, DNSServerGroup, DNSZone
+from app.services.dns_io import parse_zone_file, write_zone_file
+
+
+@dataclass
+class _Zone:
+    name: str = "example.com."
+    primary_ns: str = "ns1.example.com."
+    admin_email: str = "hostmaster.example.com."
+    ttl: int = 3600
+    refresh: int = 86400
+    retry: int = 7200
+    expire: int = 3600000
+    minimum: int = 3600
+    last_serial: int = 2024010101
+
+
+@dataclass
+class _Rec:
+    id: str
+    name: str
+    record_type: str
+    value: str
+    ttl: int | None = 3600
+    priority: int | None = None
+    weight: int | None = None
+    port: int | None = None
+
+
+# ── Renderer ────────────────────────────────────────────────────────────────
+
+
+def test_writer_renders_svcb_https_dname() -> None:
+    records = [
+        _Rec(id="1", name="@", record_type="HTTPS", value='1 . alpn="h2,h3"'),
+        _Rec(id="2", name="_dns", record_type="SVCB", value="1 dns.example.com."),
+        # DNAME target without a trailing dot must be FQDN-normalised.
+        _Rec(id="3", name="legacy", record_type="DNAME", value="new.example.net"),
+    ]
+    text = write_zone_file(_Zone(), records)  # type: ignore[arg-type]
+
+    assert '@\t3600\tIN\tHTTPS\t1 . alpn="h2,h3"' in text
+    assert "_dns\t3600\tIN\tSVCB\t1 dns.example.com." in text
+    # DNAME gained a trailing dot.
+    assert "legacy\t3600\tIN\tDNAME\tnew.example.net." in text
+
+    # The output round-trips through the parser without losing the types.
+    kinds = {r.record_type for r in parse_zone_file(text, "example.com").records}
+    assert {"HTTPS", "SVCB", "DNAME"}.issubset(kinds)
+
+
+def test_powerdns_supports_modern_types() -> None:
+    assert {"SVCB", "HTTPS", "DNAME"} <= _SUPPORTED_RECORD_TYPES
+
+
+# ── API driver-gate ──────────────────────────────────────────────────────────
+
+
+async def _admin_headers(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _group_with_driver(db: AsyncSession, driver: str) -> tuple[DNSServerGroup, DNSZone]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    db.add(
+        DNSServer(
+            group_id=grp.id,
+            driver=driver,
+            host=f"{driver}.example.com",
+            name=f"srv-{uuid.uuid4().hex[:6]}",
+        )
+    )
+    zone = DNSZone(
+        group_id=grp.id,
+        name="example.com.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.com.",
+        admin_email="admin.example.com.",
+    )
+    db.add(zone)
+    await db.flush()
+    return grp, zone
+
+
+async def test_create_modern_record_on_bind9_group_succeeds(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone = await _group_with_driver(db_session, "bind9")
+    await db_session.commit()
+
+    for rtype, value in (
+        ("HTTPS", '1 . alpn="h2"'),
+        ("SVCB", "1 svc.example.com."),
+        ("DNAME", "target.example.net."),
+    ):
+        r = await client.post(
+            f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+            headers=h,
+            json={"name": rtype.lower(), "record_type": rtype, "value": value},
+        )
+        assert r.status_code == 201, f"{rtype}: {r.text}"
+        assert r.json()["record_type"] == rtype
+
+
+async def test_modern_record_gated_off_cloud_driver_group(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # A group that also runs an agentless hosted-DNS driver can't serve
+    # SVCB/HTTPS/DNAME — the API must 422 up front rather than fail at apply.
+    h = await _admin_headers(db_session)
+    grp, zone = await _group_with_driver(db_session, "cloudflare")
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={"name": "svc", "record_type": "HTTPS", "value": '1 . alpn="h2"'},
+    )
+    assert r.status_code == 422, r.text

--- a/backend/tests/test_dns_vultr.py
+++ b/backend/tests/test_dns_vultr.py
@@ -1,0 +1,578 @@
+"""Offline unit tests for the Vultr DNS driver (issue #29 cloud DNS family).
+
+Vultr is a tier-3 token-only provider with no test account, so every test
+monkeypatches :meth:`VultrDNSDriver._client` to return a fake
+async-context-manager client that serves canned bodies and records the calls
+made against it. Nothing here touches the network.
+
+Vultr differs from Cloudflare in several shapes the harness mirrors:
+  * no ``success`` envelope — a 2xx status is the only success signal, and
+    errors come back as ``{"error": "..."}``;
+  * cursor pagination via ``meta.links.next`` (empty → done) rather than
+    ``result_info.total_pages``;
+  * records are scoped by domain **name**, not an opaque zone id, so there is
+    no zone-id resolution GET before record calls;
+  * record names are relative with ``""`` for apex (not ``"@"``), the value
+    field is ``data``, and updates use **PATCH** (not PUT).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.drivers.dns._cloud_base import CloudDNSError
+from app.drivers.dns.base import RecordChange, RecordData
+from app.drivers.dns.vultr import VultrDNSDriver
+
+
+class _FakeResponse:
+    """Minimal stand-in for an ``httpx.Response`` (status + json())."""
+
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class _FakeClient:
+    """Async-context-manager fake of ``httpx.AsyncClient``.
+
+    Each verb pops the next queued response off the matching list and records
+    ``(method, path, params, json)`` for assertion. A queued response can be a
+    ``_FakeResponse`` or a zero-arg callable returning one (so a test can vary
+    the reply by call order). Includes a ``patch()`` verb (Vultr updates via
+    PATCH).
+    """
+
+    def __init__(self, queues: dict[str, list[Any]]) -> None:
+        self._queues = queues
+        self.calls: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    def _next(self, method: str, path: str, params: Any, body: Any) -> _FakeResponse:
+        self.calls.append({"method": method, "path": path, "params": params, "json": body})
+        queue = self._queues.get(method)
+        if not queue:
+            raise AssertionError(f"unexpected {method} {path} (no queued response)")
+        item = queue.pop(0)
+        return item() if callable(item) else item
+
+    async def get(self, path: str, params: Any = None) -> _FakeResponse:
+        return self._next("get", path, params, None)
+
+    async def post(self, path: str, json: Any = None) -> _FakeResponse:
+        return self._next("post", path, None, json)
+
+    async def patch(self, path: str, json: Any = None) -> _FakeResponse:
+        return self._next("patch", path, None, json)
+
+    async def delete(self, path: str, params: Any = None) -> _FakeResponse:
+        return self._next("delete", path, params, None)
+
+
+def _domains_env(domains: list[dict[str, Any]], *, next_cursor: str = "") -> dict[str, Any]:
+    """Build a Vultr-shaped list-domains body with cursor pagination."""
+    return {
+        "domains": domains,
+        "meta": {"total": len(domains), "links": {"next": next_cursor, "prev": ""}},
+    }
+
+
+def _records_env(records: list[dict[str, Any]], *, next_cursor: str = "") -> dict[str, Any]:
+    """Build a Vultr-shaped list-records body with cursor pagination."""
+    return {
+        "records": records,
+        "meta": {"total": len(records), "links": {"next": next_cursor, "prev": ""}},
+    }
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, fake: _FakeClient) -> VultrDNSDriver:
+    driver = VultrDNSDriver()
+    monkeypatch.setattr(driver, "_client", lambda token: fake)
+    return driver
+
+
+class _Server:
+    """Stub DNSServer row — only the attrs the driver reads."""
+
+    id = "srv-1"
+    name = "vultr-test"
+    credentials_encrypted = b"x"
+
+
+_CREDS = {"api_token": "tok"}
+
+
+# ── _list_zones cursor pagination + reverse + dnssec flags ──────────────
+async def test_list_zones_paginates_and_flags_reverse(monkeypatch: pytest.MonkeyPatch) -> None:
+    page1 = _domains_env(
+        [
+            {"domain": "example.com", "dns_sec": "disabled"},
+            {"domain": "10.in-addr.arpa", "dns_sec": "disabled"},
+        ],
+        next_cursor="CURSOR2",
+    )
+    page2 = _domains_env([{"domain": "example.net", "dns_sec": "enabled"}], next_cursor="")
+    fake = _FakeClient({"get": [_FakeResponse(200, page1), _FakeResponse(200, page2)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    zones = await driver._list_zones(_Server(), _CREDS)
+
+    assert [z.name for z in zones] == ["example.com.", "10.in-addr.arpa.", "example.net."]
+    # zone_id is the bare domain name (Vultr scopes by name, not opaque id).
+    assert [z.zone_id for z in zones] == ["example.com", "10.in-addr.arpa", "example.net"]
+    # Reverse-zone detection.
+    assert zones[1].is_reverse is True
+    assert zones[0].is_reverse is False
+    # dns_sec string → bool.
+    assert zones[2].dnssec_enabled is True
+    assert zones[0].dnssec_enabled is False
+    # Two pages → two GETs; first carries no cursor, second carries it.
+    assert sum(1 for c in fake.calls if c["method"] == "get") == 2
+    assert fake.calls[0]["params"] == {"per_page": 100}
+    assert fake.calls[1]["params"] == {"per_page": 100, "cursor": "CURSOR2"}
+
+
+# ── _list_zone_records relativization + TTL handling + MX priority ──────
+async def test_list_zone_records_relativizes_and_normalizes_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = _records_env(
+        [
+            {"id": "r1", "name": "", "type": "A", "data": "1.2.3.4", "ttl": 0},
+            {"id": "r2", "name": "www", "type": "A", "data": "5.6.7.8", "ttl": 300},
+            {
+                "id": "r3",
+                "name": "",
+                "type": "MX",
+                "data": "mail.example.com",
+                "ttl": 3600,
+                "priority": 10,
+            },
+        ]
+    )
+    fake = _FakeClient({"get": [_FakeResponse(200, records)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    recs = await driver._list_zone_records(_Server(), _CREDS, "example.com.")
+
+    # Empty apex name collapses to "@"; sub-label relativized; ttl=0 → None.
+    assert recs[0] == RecordData(name="@", record_type="A", value="1.2.3.4", ttl=None)
+    assert recs[1] == RecordData(name="www", record_type="A", value="5.6.7.8", ttl=300)
+    assert recs[2].name == "@"
+    assert recs[2].priority == 10
+    assert recs[2].ttl == 3600
+    # Records scoped directly by domain name — no zone-id resolution GET.
+    assert fake.calls[0]["path"] == "/domains/example.com/records"
+    assert fake.calls[0]["params"] == {"per_page": 100}
+
+
+async def test_list_zone_records_drops_priority_for_non_mx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vultr returns priority 0/-1 for A/CNAME/etc.; it must not leak as 0."""
+    records = _records_env(
+        [{"id": "r1", "name": "www", "type": "A", "data": "1.1.1.1", "ttl": 60, "priority": -1}]
+    )
+    fake = _FakeClient({"get": [_FakeResponse(200, records)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    recs = await driver._list_zone_records(_Server(), _CREDS, "example.com.")
+
+    assert recs[0].priority is None
+
+
+# ── _apply_record create ────────────────────────────────────────────────
+async def test_apply_record_create_posts_relative_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"post": [_FakeResponse(201, {"record": {"id": "new"}})]})
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    post = next(c for c in fake.calls if c["method"] == "post")
+    assert post["path"] == "/domains/example.com/records"
+    assert post["json"] == {
+        "name": "www",  # relative label (not absolute).
+        "type": "A",
+        "data": "1.1.1.1",
+        "ttl": 0,  # None → automatic sentinel.
+    }
+
+
+async def test_apply_record_create_apex_uses_empty_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Apex record renders name as the empty string Vultr expects."""
+    fake = _FakeClient({"post": [_FakeResponse(201, {"record": {"id": "new"}})]})
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="3.3.3.3", ttl=120),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    post = next(c for c in fake.calls if c["method"] == "post")
+    assert post["json"]["name"] == ""
+    assert post["json"]["ttl"] == 120
+
+
+# ── _apply_record update (existing record found → PATCH) ────────────────
+async def test_apply_record_update_patches_existing(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(
+                    200,
+                    _records_env([{"id": "rid", "name": "www", "type": "A", "data": "2.2.2.2"}]),
+                ),
+            ],
+            "patch": [_FakeResponse(204, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="2.2.2.2", ttl=120),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    patch = next(c for c in fake.calls if c["method"] == "patch")
+    assert patch["path"] == "/domains/example.com/records/rid"
+    assert patch["json"]["data"] == "2.2.2.2"
+    assert patch["json"]["ttl"] == 120
+
+
+# ── _apply_record update with no match → falls back to create (POST) ────
+async def test_apply_record_update_missing_creates(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, _records_env([]))],  # no existing record
+            "post": [_FakeResponse(201, {"record": {"id": "new"}})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="3.3.3.3", ttl=None),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    assert [c["method"] for c in fake.calls] == ["get", "post"]
+    post = next(c for c in fake.calls if c["method"] == "post")
+    # Apex name renders as the empty string.
+    assert post["json"]["name"] == ""
+
+
+# ── _apply_record delete (found → DELETE) ───────────────────────────────
+async def test_apply_record_delete_dispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        {
+            "get": [
+                _FakeResponse(
+                    200,
+                    _records_env([{"id": "rid", "name": "www", "type": "A", "data": "1.1.1.1"}]),
+                ),
+            ],
+            "delete": [_FakeResponse(204, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/domains/example.com/records/rid"
+
+
+# ── _apply_record delete with no match → no-op (no DELETE issued) ───────
+async def test_apply_record_delete_missing_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"get": [_FakeResponse(200, _records_env([]))]})
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="gone", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Only the lookup happened — no DELETE.
+    assert [c["method"] for c in fake.calls] == ["get"]
+
+
+# ── _apply_record update targets the right value of a multi-value RRset ──
+async def test_apply_record_update_matches_content_in_multivalue_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A round-robin A name has two values on Vultr; updating the TTL of the
+    ``5.6.7.8`` record must PATCH against *its* id, not the first row's
+    (issue #331)."""
+    multi = _records_env(
+        [
+            {"id": "rid-a", "type": "A", "name": "www", "data": "1.2.3.4"},
+            {"id": "rid-b", "type": "A", "name": "www", "data": "5.6.7.8"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, multi)],
+            "patch": [_FakeResponse(204, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="5.6.7.8", ttl=600),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # We PATCH against the id whose data actually matched the op value.
+    patch = next(c for c in fake.calls if c["method"] == "patch")
+    assert patch["path"] == "/domains/example.com/records/rid-b"
+    assert patch["json"]["data"] == "5.6.7.8"
+    assert patch["json"]["ttl"] == 600
+
+
+# ── _apply_record delete targets the right value of a multi-value RRset ──
+async def test_apply_record_delete_matches_content_in_multivalue_rrset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``delete A 1.2.3.4`` against a 2-value RRset must DELETE the row holding
+    ``1.2.3.4`` even if Vultr lists ``5.6.7.8`` first (issue #331)."""
+    multi = _records_env(
+        [
+            {"id": "rid-keep", "type": "A", "name": "www", "data": "5.6.7.8"},
+            {"id": "rid-drop", "type": "A", "name": "www", "data": "1.2.3.4"},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, multi)],
+            "delete": [_FakeResponse(204, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.2.3.4"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    # The value-keyed row, not the first-listed sibling.
+    assert delete["path"] == "/domains/example.com/records/rid-drop"
+
+
+# ── _apply_record delete is a no-op when no value matches ───────────────
+async def test_apply_record_delete_no_content_match_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If Vultr returns sibling values but none equal the op value, the delete
+    must be a safe no-op (no DELETE issued) rather than removing a wrong-value
+    row (issue #331)."""
+    multi = _records_env(
+        [
+            {"id": "rid-a", "type": "A", "name": "www", "data": "5.6.7.8"},
+            {"id": "rid-b", "type": "A", "name": "www", "data": "9.9.9.9"},
+        ]
+    )
+    fake = _FakeClient({"get": [_FakeResponse(200, multi)]})
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.2.3.4"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Only the lookup happened — no DELETE against a non-matching value.
+    assert [c["method"] for c in fake.calls] == ["get"]
+
+
+# ── _find_record_id disambiguates MX rows by priority too ───────────────
+async def test_apply_record_delete_mx_matches_priority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two MX records at the apex share a content host but differ by priority;
+    deleting one must match data *and* priority (issue #331)."""
+    multi = _records_env(
+        [
+            {"id": "mx-10", "type": "MX", "name": "", "data": "mail.example.com", "priority": 10},
+            {"id": "mx-20", "type": "MX", "name": "", "data": "mail.example.com", "priority": 20},
+        ]
+    )
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, multi)],
+            "delete": [_FakeResponse(204, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="MX", value="mail.example.com", priority=20),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/domains/example.com/records/mx-20"
+
+
+# ── _find_record_id pages through a multi-page record set ───────────────
+async def test_find_record_id_follows_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The target record lives on the second cursor page; the lookup must page."""
+    page1 = _records_env(
+        [{"id": "other", "type": "A", "name": "www", "data": "9.9.9.9"}],
+        next_cursor="NEXT",
+    )
+    page2 = _records_env([{"id": "want", "type": "A", "name": "www", "data": "1.1.1.1"}])
+    fake = _FakeClient(
+        {
+            "get": [_FakeResponse(200, page1), _FakeResponse(200, page2)],
+            "delete": [_FakeResponse(204, {})],
+        }
+    )
+    driver = _patch_client(monkeypatch, fake)
+    change = RecordChange(
+        op="delete",
+        zone_name="example.com.",
+        record=RecordData(name="www", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+
+    await driver._apply_record(_Server(), _CREDS, change)
+
+    # Two list pages walked, then the delete against the page-2 row.
+    assert [c["method"] for c in fake.calls] == ["get", "get", "delete"]
+    assert fake.calls[1]["params"] == {"per_page": 100, "cursor": "NEXT"}
+    delete = next(c for c in fake.calls if c["method"] == "delete")
+    assert delete["path"] == "/domains/example.com/records/want"
+
+
+# ── _apply_zone create + delete ─────────────────────────────────────────
+async def test_apply_zone_create(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"post": [_FakeResponse(201, {"domain": {"domain": "example.org"}})]})
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "create")
+
+    post = fake.calls[0]
+    assert post["path"] == "/domains"
+    # Empty zone (no "ip" key) + DNSSEC off.
+    assert post["json"] == {"domain": "example.org", "dns_sec": "disabled"}
+
+
+async def test_apply_zone_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient({"delete": [_FakeResponse(204, {})]})
+    driver = _patch_client(monkeypatch, fake)
+    zone = type("Z", (), {"name": "example.org."})()
+
+    await driver._apply_zone(_Server(), _CREDS, zone, "delete")
+
+    assert [c["method"] for c in fake.calls] == ["delete"]
+    assert fake.calls[0]["path"] == "/domains/example.org"
+
+
+# ── Error surfacing ─────────────────────────────────────────────────────
+async def test_error_envelope_raises_clouddnserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"error": "Invalid API key.", "status": 401}
+    fake = _FakeClient({"get": [_FakeResponse(401, payload)]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "Invalid API key." in str(exc.value)
+
+
+async def test_non_2xx_without_error_body_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-2xx with no parseable error body still raises with the status."""
+    fake = _FakeClient({"get": [_FakeResponse(500, "boom")]})
+    driver = _patch_client(monkeypatch, fake)
+
+    with pytest.raises(CloudDNSError) as exc:
+        await driver._list_zones(_Server(), _CREDS)
+    assert "HTTP 500" in str(exc.value)
+
+
+async def test_missing_token_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = VultrDNSDriver()
+    change = RecordChange(
+        op="create",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="A", value="1.1.1.1"),
+        target_serial=1,
+    )
+    with pytest.raises(CloudDNSError):
+        await driver._apply_record(_Server(), {}, change)
+
+
+# ── Static helpers ──────────────────────────────────────────────────────
+def test_relativize_helper() -> None:
+    driver = VultrDNSDriver()
+    assert driver._relativize("", "example.com.") == "@"
+    assert driver._relativize("@", "example.com.") == "@"
+    assert driver._relativize("www", "example.com.") == "www"
+    assert driver._relativize("example.com.", "example.com.") == "@"
+    assert driver._relativize("a.b.example.com.", "example.com") == "a.b"
+
+
+def test_relative_name_helper() -> None:
+    driver = VultrDNSDriver()
+    assert driver._relative_name("@") == ""
+    assert driver._relative_name("") == ""
+    assert driver._relative_name("www") == "www"
+    assert driver._relative_name("www.") == "www"
+
+
+def test_capabilities_shape() -> None:
+    caps = VultrDNSDriver().capabilities()
+    assert caps["name"] == "vultr"
+    assert caps["agentless"] is True
+    assert caps["manages_zones"] is True
+    assert caps["views"] is False
+    assert caps["rpz"] is False
+    # Vultr has no online DNSSEC signing API.
+    assert caps["dnssec_online"] is False
+    assert "CAA" in caps["record_types"]
+    assert "HTTPS" not in caps["record_types"]

--- a/backend/tests/test_ipam_dns_sync_batching.py
+++ b/backend/tests/test_ipam_dns_sync_batching.py
@@ -1,0 +1,174 @@
+"""Bulk IPAM→DNS sync batches the create path per zone (issue #341).
+
+The delete branch of ``_apply_dns_sync`` already groups stale records by zone
+and fires one ``enqueue_record_ops_batch`` per zone (one WinRM round trip for
+an agentless Windows-DNS primary). The create/update branch used to loop
+``_sync_dns_record`` per IP, each enqueuing singularly — N WinRM round trips.
+
+These tests pin the fix: the bulk create path now routes every op through the
+batch enqueue (one call per zone, carrying all the IPs' ops) and never touches
+the singular ``enqueue_record_op``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.ipam.router import (
+    DnsSyncCommitRequest,
+    _apply_dns_sync,
+    _batched_dns_ops,
+    _enqueue_dns_op,
+)
+from app.models.dns import DNSServerGroup, DNSZone
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+CIDR = "10.50.0.0/24"
+
+
+async def _fixture(db: AsyncSession) -> tuple[Subnet, DNSZone, list[IPAddress]]:
+    space = IPSpace(name=f"s-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=CIDR, name="b")
+    db.add(block)
+    await db.flush()
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name="example.com.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.com.",
+        admin_email="admin.example.com.",
+    )
+    db.add(zone)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network=CIDR,
+        name="s",
+        # Pin the zone on the subnet itself — _resolve_effective_dns only
+        # consults subnet.dns_zone_id when inherit is off.
+        dns_inherit_settings=False,
+        dns_zone_id=str(zone.id),
+    )
+    db.add(subnet)
+    await db.flush()
+    ips = [
+        IPAddress(
+            subnet_id=subnet.id, address=f"10.50.0.{n}", hostname=f"host{n}", status="allocated"
+        )
+        for n in (10, 11, 12)
+    ]
+    db.add_all(ips)
+    await db.flush()
+    return subnet, zone, ips
+
+
+async def test_bulk_sync_create_batches_per_zone(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subnet, zone, ips = await _fixture(db_session)
+    await db_session.commit()
+
+    batch_calls: list[tuple[uuid.UUID, int]] = []
+    singular_calls: list[Any] = []
+
+    async def fake_batch(db: Any, z: Any, ops: list[dict[str, Any]]) -> list[Any]:
+        batch_calls.append((z.id, len(ops)))
+        return [object()] * len(ops)
+
+    async def fake_singular(
+        db: Any, z: Any, op: str, record: dict, target_serial: Any = None
+    ) -> Any:
+        singular_calls.append((z.id, op))
+        return None
+
+    monkeypatch.setattr("app.services.dns.record_ops.enqueue_record_ops_batch", fake_batch)
+    monkeypatch.setattr("app.services.dns.record_ops.enqueue_record_op", fake_singular)
+
+    body = DnsSyncCommitRequest(create_for_ip_ids=[ip.id for ip in ips])
+    created, _updated, _deleted, errors = await _apply_dns_sync(db_session, body)
+
+    assert created == 3, errors
+    # The bulk create path must NEVER fall back to the singular per-op enqueue.
+    assert singular_calls == []
+    # The forward zone received exactly one batched call carrying all 3 creates
+    # (not three separate calls) — this is the round-trip saving.
+    fwd = [c for zid, c in batch_calls if zid == zone.id]
+    assert fwd == [3], batch_calls
+    # Any zone touched (forward + an auto-created reverse) is batched, never per-IP.
+    assert all(c == 3 for _zid, c in batch_calls), batch_calls
+
+
+async def test_enqueue_dns_op_inline_without_batch_context(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Outside a ``_batched_dns_ops`` block the singular path is unchanged —
+    # single-IP callers (allocate one IP, edit one IP) keep enqueuing inline.
+    _subnet, zone, _ips = await _fixture(db_session)
+    await db_session.commit()
+
+    singular_calls: list[Any] = []
+    batch_calls: list[Any] = []
+
+    async def fake_singular(
+        db: Any, z: Any, op: str, record: dict, target_serial: Any = None
+    ) -> Any:
+        singular_calls.append((z.id, op, record["type"]))
+        return None
+
+    async def fake_batch(db: Any, z: Any, ops: list[dict[str, Any]]) -> list[Any]:
+        batch_calls.append((z.id, len(ops)))
+        return [object()] * len(ops)
+
+    monkeypatch.setattr("app.services.dns.record_ops.enqueue_record_op", fake_singular)
+    monkeypatch.setattr("app.services.dns.record_ops.enqueue_record_ops_batch", fake_batch)
+
+    await _enqueue_dns_op(db_session, zone, "create", "h", "A", "10.50.0.10", None)
+    assert singular_calls == [(zone.id, "create", "A")]
+    assert batch_calls == []
+
+
+async def test_batched_dns_ops_groups_and_flushes(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Two zones, three ops — flush groups by zone, one batch per zone, order
+    # preserved.
+    _subnet, zone_a, _ips = await _fixture(db_session)
+    grp_b = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp_b)
+    await db_session.flush()
+    zone_b = DNSZone(
+        group_id=grp_b.id,
+        name="b.example.com.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.b.example.com.",
+        admin_email="admin.b.example.com.",
+    )
+    db_session.add(zone_b)
+    await db_session.commit()
+
+    batch_calls: list[tuple[uuid.UUID, int]] = []
+
+    async def fake_batch(db: Any, z: Any, ops: list[dict[str, Any]]) -> list[Any]:
+        batch_calls.append((z.id, len(ops)))
+        return [object()] * len(ops)
+
+    monkeypatch.setattr("app.services.dns.record_ops.enqueue_record_ops_batch", fake_batch)
+
+    async with _batched_dns_ops(db_session):
+        await _enqueue_dns_op(db_session, zone_a, "create", "h1", "A", "10.50.0.10", None)
+        await _enqueue_dns_op(db_session, zone_b, "create", "h2", "A", "10.60.0.10", None)
+        await _enqueue_dns_op(db_session, zone_a, "create", "h3", "A", "10.50.0.11", None)
+
+    assert batch_calls == [(zone_a.id, 2), (zone_b.id, 1)]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6643,7 +6643,8 @@ export type AlertRuleType =
   | "service_resource_orphaned"
   | "compliance_change"
   | "voice_lease_count_below"
-  | "stale_ip_count";
+  | "stale_ip_count"
+  | "dhcp_pool_exhaustion";
 export type AlertSeverity = "info" | "warning" | "critical";
 export type AlertServerType = "dns" | "dhcp" | "any";
 // ``compliance_change`` rule type — keep in lock-step with
@@ -6663,6 +6664,7 @@ export interface AlertRule {
   rule_type: AlertRuleType;
   threshold_percent: number | null;
   threshold_days: number | null;
+  min_free_addresses: number | null;
   server_type: AlertServerType | null;
   classification: AlertClassification | null;
   change_scope: AlertChangeScope | null;
@@ -6682,6 +6684,7 @@ export interface AlertRuleCreate {
   rule_type: AlertRuleType;
   threshold_percent?: number | null;
   threshold_days?: number | null;
+  min_free_addresses?: number | null;
   server_type?: AlertServerType | null;
   classification?: AlertClassification | null;
   change_scope?: AlertChangeScope | null;
@@ -6697,6 +6700,7 @@ export interface AlertRuleUpdate {
   enabled?: boolean;
   threshold_percent?: number | null;
   threshold_days?: number | null;
+  min_free_addresses?: number | null;
   server_type?: AlertServerType | null;
   classification?: AlertClassification | null;
   change_scope?: AlertChangeScope | null;

--- a/frontend/src/pages/admin/AlertsPage.tsx
+++ b/frontend/src/pages/admin/AlertsPage.tsx
@@ -36,6 +36,7 @@ const RULE_TYPE_PARAM_DEFAULTS: Partial<
   subnet_utilization: { threshold: 90 },
   voice_lease_count_below: { threshold: 10 },
   stale_ip_count: { threshold: 10, thresholdDays: 90 },
+  dhcp_pool_exhaustion: { threshold: 90 },
   domain_expiring: { thresholdDays: 30 },
   circuit_term_expiring: { thresholdDays: 30 },
   service_term_expiring: { thresholdDays: 30 },
@@ -83,6 +84,10 @@ function RuleEditorModal({
   const [thresholdDays, setThresholdDays] = useState<number>(
     existing?.threshold_days ?? 30,
   );
+  // dhcp_pool_exhaustion: 0 means "no free-address floor" (occupancy % only).
+  const [minFree, setMinFree] = useState<number>(
+    existing?.min_free_addresses ?? 0,
+  );
   const [serverType, setServerType] = useState<AlertServerType>(
     (existing?.server_type as AlertServerType | null) ?? "any",
   );
@@ -117,9 +122,12 @@ function RuleEditorModal({
         threshold_percent:
           ruleType === "subnet_utilization" ||
           ruleType === "voice_lease_count_below" ||
-          ruleType === "stale_ip_count"
+          ruleType === "stale_ip_count" ||
+          ruleType === "dhcp_pool_exhaustion"
             ? threshold
             : null,
+        min_free_addresses:
+          ruleType === "dhcp_pool_exhaustion" && minFree > 0 ? minFree : null,
         threshold_days:
           ruleType === "domain_expiring" ||
           ruleType === "circuit_term_expiring" ||
@@ -187,6 +195,9 @@ function RuleEditorModal({
             >
               <optgroup label="Infrastructure">
                 <option value="subnet_utilization">Subnet utilization</option>
+                <option value="dhcp_pool_exhaustion">
+                  DHCP pool exhaustion (dynamic pool pressure)
+                </option>
                 <option value="server_unreachable">Server unreachable</option>
                 <option value="stale_ip_count">
                   Stale IP count (address-space hygiene)
@@ -269,6 +280,35 @@ function RuleEditorModal({
               onChange={(e) => setThreshold(Number(e.target.value))}
             />
           </Field>
+        )}
+        {ruleType === "dhcp_pool_exhaustion" && (
+          <>
+            <Field
+              label="Occupancy threshold (%)"
+              hint="Fires when a dynamic DHCP pool's live occupancy (active leases ÷ pool size) reaches this. Orthogonal to subnet utilization, which counts allocated IPAM rows — a pool can be exhausted while the subnet looks empty."
+            >
+              <input
+                type="number"
+                min={0}
+                max={100}
+                className={inputCls}
+                value={threshold}
+                onChange={(e) => setThreshold(Number(e.target.value))}
+              />
+            </Field>
+            <Field
+              label="Minimum free addresses (optional)"
+              hint="Also fire when fewer than this many addresses are free in the pool, regardless of percent. Set 0 to use the percent threshold only."
+            >
+              <input
+                type="number"
+                min={0}
+                className={inputCls}
+                value={minFree}
+                onChange={(e) => setMinFree(Number(e.target.value))}
+              />
+            </Field>
+          </>
         )}
         {ruleType === "stale_ip_count" && (
           <>

--- a/frontend/src/pages/admin/DNSImportPage.tsx
+++ b/frontend/src/pages/admin/DNSImportPage.tsx
@@ -628,6 +628,10 @@ const CLOUD_DRIVER_LABELS: Record<string, string> = {
   route53: "AWS Route 53",
   azure_dns: "Azure DNS",
   google_dns: "Google Cloud DNS",
+  digitalocean: "DigitalOcean",
+  hetzner: "Hetzner DNS",
+  linode: "Linode",
+  vultr: "Vultr",
 };
 
 function cloudDriverLabel(driver: string): string {

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -412,12 +412,13 @@ function CloudSetupGuide({ driver }: { driver: CloudDNSDriver }) {
                 API → Tokens → Generate New Token
               </span>
               , give it a name and{" "}
+              <span className="font-medium text-foreground">Write</span> scope
+              (the DNS API rides the same personal access token), then paste it
+              above. The domains you manage must already be added under{" "}
               <span className="font-medium text-foreground">
-                Write
-              </span>{" "}
-              scope (the DNS API rides the same personal access token), then
-              paste it above. The domains you manage must already be added under{" "}
-              <span className="font-medium text-foreground">Networking → Domains</span>.
+                Networking → Domains
+              </span>
+              .
             </p>
           </div>
         )}
@@ -454,9 +455,7 @@ function CloudSetupGuide({ driver }: { driver: CloudDNSDriver }) {
           <div>
             <p>
               In the Vultr customer portal go to{" "}
-              <span className="font-medium text-foreground">
-                Account → API
-              </span>
+              <span className="font-medium text-foreground">Account → API</span>
               , enable the API, and copy your{" "}
               <span className="font-medium text-foreground">API key</span>. Add
               your IP to the access-control allowlist if enabled, then paste the

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -2234,6 +2234,9 @@ const RECORD_TYPES = [
   "NAPTR",
   "LOC",
   "LUA",
+  "SVCB",
+  "HTTPS",
+  "DNAME",
 ];
 
 function RecordModal({

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -198,6 +198,10 @@ const CLOUD_DNS_DRIVERS = [
   "route53",
   "azure_dns",
   "google_dns",
+  "digitalocean",
+  "hetzner",
+  "linode",
+  "vultr",
 ] as const;
 type CloudDNSDriver = (typeof CLOUD_DNS_DRIVERS)[number];
 
@@ -206,6 +210,10 @@ const CLOUD_DNS_LABELS: Record<CloudDNSDriver, string> = {
   route53: "AWS Route 53",
   azure_dns: "Azure DNS",
   google_dns: "Google Cloud DNS",
+  digitalocean: "DigitalOcean",
+  hetzner: "Hetzner DNS",
+  linode: "Linode",
+  vultr: "Vultr",
 };
 
 function isCloudDriver(d: string): d is CloudDNSDriver {
@@ -273,6 +281,40 @@ const CLOUD_DNS_FIELDS: Record<CloudDNSDriver, CloudCredField[]> = {
       textarea: true,
     },
     { key: "project_id", label: "Project ID", placeholder: "my-gcp-project" },
+  ],
+  // Token-only providers (issue #327) — a single API token authenticates
+  // both the DNS read + write surfaces.
+  digitalocean: [
+    {
+      key: "api_token",
+      label: "API token",
+      placeholder: "DigitalOcean personal access token",
+      secret: true,
+    },
+  ],
+  hetzner: [
+    {
+      key: "api_token",
+      label: "API token",
+      placeholder: "Hetzner DNS API token",
+      secret: true,
+    },
+  ],
+  linode: [
+    {
+      key: "api_token",
+      label: "API token",
+      placeholder: "Linode personal access token",
+      secret: true,
+    },
+  ],
+  vultr: [
+    {
+      key: "api_token",
+      label: "API key",
+      placeholder: "Vultr API key",
+      secret: true,
+    },
   ],
 };
 
@@ -359,6 +401,66 @@ function CloudSetupGuide({ driver }: { driver: CloudDNSDriver }) {
             <p>
               Paste the contents of <code className="font-mono">key.json</code>{" "}
               into the field above.
+            </p>
+          </div>
+        )}
+        {driver === "digitalocean" && (
+          <div>
+            <p>
+              In the DigitalOcean control panel go to{" "}
+              <span className="font-medium text-foreground">
+                API → Tokens → Generate New Token
+              </span>
+              , give it a name and{" "}
+              <span className="font-medium text-foreground">
+                Write
+              </span>{" "}
+              scope (the DNS API rides the same personal access token), then
+              paste it above. The domains you manage must already be added under{" "}
+              <span className="font-medium text-foreground">Networking → Domains</span>.
+            </p>
+          </div>
+        )}
+        {driver === "hetzner" && (
+          <div>
+            <p>
+              Open the{" "}
+              <span className="font-medium text-foreground">
+                Hetzner DNS Console
+              </span>{" "}
+              (dns.hetzner.com) and go to{" "}
+              <span className="font-medium text-foreground">
+                API tokens → Create access token
+              </span>
+              . This is a DNS-specific token (separate from the Hetzner Cloud
+              API). Paste it above.
+            </p>
+          </div>
+        )}
+        {driver === "linode" && (
+          <div>
+            <p>
+              In the Linode Cloud Manager go to{" "}
+              <span className="font-medium text-foreground">
+                Profile → API Tokens → Create a Personal Access Token
+              </span>{" "}
+              and grant{" "}
+              <span className="font-medium text-foreground">Domains</span>{" "}
+              read/write access. Paste the token above.
+            </p>
+          </div>
+        )}
+        {driver === "vultr" && (
+          <div>
+            <p>
+              In the Vultr customer portal go to{" "}
+              <span className="font-medium text-foreground">
+                Account → API
+              </span>
+              , enable the API, and copy your{" "}
+              <span className="font-medium text-foreground">API key</span>. Add
+              your IP to the access-control allowlist if enabled, then paste the
+              key above.
             </p>
           </div>
         )}

--- a/frontend/src/pages/dns/recordTypeBadge.ts
+++ b/frontend/src/pages/dns/recordTypeBadge.ts
@@ -21,6 +21,9 @@ export const RECORD_TYPE_BADGE: Record<string, string> = {
   PTR: "bg-cyan-500/15 text-cyan-600",
   SRV: "bg-teal-500/15 text-teal-600",
   SOA: "bg-stone-500/15 text-stone-600",
+  HTTPS: "bg-sky-500/15 text-sky-600",
+  SVCB: "bg-indigo-500/15 text-indigo-600",
+  DNAME: "bg-amber-500/15 text-amber-600",
 };
 
 export const RECORD_TYPE_BADGE_FALLBACK = "bg-muted text-muted-foreground";


### PR DESCRIPTION
Implements four review-batch issues on one branch (per-issue commits).

## #338 — SVCB / HTTPS (RFC 9460) + DNAME (RFC 6672) record types
`VALID_RECORD_TYPES` rejected service-binding + subtree-redirection records. Added them, gated to `{bind9, powerdns}` (a group with a hosted-DNS driver gets a clear 422 instead of a late apply failure), extended PowerDNS `_SUPPORTED_RECORD_TYPES`, FQDN-normalised DNAME in the zone writer, taught the dns_io parser to round-trip them (so the BIND9 reconcile path doesn't drop them as drift), and added the frontend dropdown + badges.

## #341 — bulk IPAM→DNS sync batches the create/update path per zone
The delete branch already batched (one WinRM round trip per zone for agentless Windows DNS); the create/update branch looped `_sync_dns_record` per IP — N round trips, defeating the 2026.04.19 batching fix. Introduced a task-local contextvar op-collector: inside a `_batched_dns_ops(db)` block, `_enqueue_dns_op` defers each op (still bumping the serial) and the collector flushes grouped by zone via `enqueue_record_ops_batch` (which already does the right thing per driver). DB record mutations stay per-IP; only the agent-op enqueue is batched. Wired into `_apply_dns_sync`, `bulk_allocate_commit`, and `bulk_edit_addresses`.

## #327 — token-only cloud DNS drivers (DigitalOcean / Hetzner / Linode / Vultr)
Spun out of #37. Each is a `CloudDNSDriverBase` subclass over httpx (no vendor SDK), implementing the five hooks. Per-provider quirks handled (Hetzner's `Auth-API-Token` header, DO/Vultr scoping by bare domain name, Linode `soa_email`, Vultr cursor pagination + PATCH, TTL sentinels), plus client-side multi-value RRset disambiguation (#331 contract), update-is-create-on-miss, delete-is-noop-on-miss. Registered in the registry + `AGENTLESS_DRIVERS` + `CLOUD_DNS_DRIVERS`; the import service now derives its driver set from the registry so future cloud drivers need no second edit. Frontend pickers + per-provider setup guides. Part A infra-mirror stays deferred per the issue.

## #339 — DHCP per-pool occupancy metric + `dhcp_pool_exhaustion` alert
`subnet_utilization` counts allocated IPAM rows, orthogonal to live lease pressure — a pool can be exhausted while the subnet looks empty. Occupancy is computed live from the mirrored `DHCPLease` rows inside a dynamic pool's range (driver-agnostic: Kea + Windows; HA-deduped via DISTINCT; no agent-protocol change). New `dhcp_pool_exhaustion` rule fires on occupancy ≥ `threshold_percent` OR free < `min_free_addresses` (new nullable column, migration `a7f3c1e85d20`) and auto-resolves on recovery. Added the `find_dhcp_pool_occupancy` MCP read tool (default-enabled, no secrets) and the AlertsPage rule editor.

## Verification
- Full backend suite **1259 passed** (`pytest -n auto`, includes `test_health_schema_check`)
- New tests: 4 DNS record-type, 3 bulk-sync batching, 40 cloud-driver, 7 DHCP-pool-occupancy/alert
- ruff / black / mypy clean; frontend eslint + build + prettier clean
- Single Alembic head; migration applies cleanly; migration-linter baselined

Closes #327
Closes #338
Closes #339
Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)