### PR TITLE
Appliance: LLDP (lldpd) host-config plane — Phase 1 (#343)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -13,6 +13,7 @@ components. Grouped by role; license + project URL for each.
 - NetworkManager — GPL v2+ — https://networkmanager.dev
 - chrony (NTP) — GPL v2 — https://chrony-project.org
 - Net-SNMP (snmpd) — BSD-style (multiple) — https://net-snmp.org
+- lldpd — ISC — https://lldpd.github.io
 - nftables — GPL v2 — https://netfilter.org
 
 ── Kubernetes control plane / orchestration (multi-node HA appliance) ─────

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -327,6 +327,10 @@ _SNMP_STATUS_SIDECAR = Path("/var/lib/spatiumddi-host/release-state/snmp-status"
 _NTP_TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/ntp-config-pending")
 _NTP_HASH_SIDECAR = Path("/var/lib/spatiumddi-host/release-state/ntp-config-hash")
 _NTP_STATUS_SIDECAR = Path("/var/lib/spatiumddi-host/release-state/ntp-status")
+# Issue #343 — LLDP / lldpd equivalents. Same shape as SNMP / NTP.
+_LLDP_TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/lldp-config-pending")
+_LLDP_HASH_SIDECAR = Path("/var/lib/spatiumddi-host/release-state/lldp-config-hash")
+_LLDP_STATUS_SIDECAR = Path("/var/lib/spatiumddi-host/release-state/lldp-status")
 
 # #272 Phase 7b — control-plane cluster join/leave. The join trigger
 # carries the seed's kubeapi URL + join token; the host-side runner
@@ -693,9 +697,7 @@ def maybe_fire_cluster_join(
     try:
         _CLUSTER_JOIN_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
         tmp = _CLUSTER_JOIN_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(
-            f"{_CLUSTER_JOIN_CONFIRM}\n{server_url}\n{join_token}\n", encoding="utf-8"
-        )
+        tmp.write_text(f"{_CLUSTER_JOIN_CONFIRM}\n{server_url}\n{join_token}\n", encoding="utf-8")
         tmp.replace(_CLUSTER_JOIN_TRIGGER_FILE)
         return True
     except OSError:
@@ -779,6 +781,71 @@ def read_snmpd_running() -> bool | None:
         return None
     try:
         text = _SNMP_STATUS_SIDECAR.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if text == "running":
+        return True
+    if text == "stopped":
+        return False
+    return None
+
+
+def maybe_fire_lldp_reload(bundle_block: object) -> bool:
+    """Issue #343 — write the lldp-config trigger when the control plane's
+    rendered lldpd config hash differs from the last one this agent applied.
+
+    Identical idempotency + appliance-only gate to ``maybe_fire_snmp_reload``.
+    The payload is four sections (LLDP carries an extra ``daemon_args`` line
+    for the CDP/EDP/FDP/SONMP reception flags, which live in
+    ``/etc/default/lldpd`` rather than the lldpcli conf body):
+
+        line 1:   ``enabled`` | ``disabled`` marker
+        line 2:   config_hash (sha256 hex, blank when disabled)
+        line 3:   daemon_args (``-c -e`` …, blank when none)
+        line 4+:  rendered /etc/lldpd.d/spatium.conf body (ends with \\n)
+    """
+    if detect_deployment_kind() != "appliance":
+        return False
+    if not isinstance(bundle_block, dict):
+        return False
+    config_hash = str(bundle_block.get("config_hash") or "")
+    lldpd_conf = str(bundle_block.get("lldpd_conf") or "")
+    daemon_args = str(bundle_block.get("daemon_args") or "")
+    enabled = bool(bundle_block.get("enabled"))
+    last_hash = ""
+    if _LLDP_HASH_SIDECAR.exists():
+        try:
+            last_hash = _LLDP_HASH_SIDECAR.read_text(encoding="utf-8").strip()
+        except OSError:
+            last_hash = ""
+    if config_hash == last_hash:
+        return False
+    if _LLDP_TRIGGER_FILE.exists():
+        return False
+    try:
+        _LLDP_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
+        payload = (
+            ("enabled\n" if enabled else "disabled\n")
+            + (config_hash + "\n")
+            + (daemon_args + "\n")
+            + lldpd_conf
+        )
+        tmp = _LLDP_TRIGGER_FILE.with_suffix(".new")
+        tmp.write_text(payload, encoding="utf-8")
+        tmp.replace(_LLDP_TRIGGER_FILE)
+        return True
+    except OSError:
+        return False
+
+
+def read_lldpd_running() -> bool | None:
+    """Read lldpd's last-reported status from the sidecar the host-side
+    runner writes after each apply. ``True`` = running, ``False`` = stopped,
+    ``None`` = unknown (sidecar missing / unreadable / non-appliance)."""
+    if not _LLDP_STATUS_SIDECAR.exists():
+        return None
+    try:
+        text = _LLDP_STATUS_SIDECAR.read_text(encoding="utf-8").strip()
     except OSError:
         return None
     if text == "running":
@@ -1138,6 +1205,9 @@ def collect() -> dict[str, object]:
         # reference / stratum >= 16; ``unknown`` = chronyc unreadable
         # (transient at boot). None on non-appliance deploys.
         "ntp_sync_state": read_ntp_sync_state() if is_appliance else None,
+        # Issue #343 — lldpd running state from the host-side runner's
+        # status sidecar. None on non-appliance deploys.
+        "lldpd_running": read_lldpd_running() if is_appliance else None,
         # Issue #183 Phase 4 — local k3s health summary. Slow drift
         # signals that ride the heartbeat (fast actions go through
         # the proxy). Empty dict on non-k3s appliances; never None

--- a/agent/supervisor/tests/test_lldp_triggers.py
+++ b/agent/supervisor/tests/test_lldp_triggers.py
@@ -1,0 +1,83 @@
+"""Supervisor LLDP config-reload trigger writer (#343).
+
+Covers the appliance-only gate, the 4-section payload shape (LLDP carries
+an extra daemon_args line vs SNMP/NTP), hash-based idempotency, and the
+status-sidecar reader. The actual lldpd reload is the host-side runner
+(spatiumddi-lldp-reload).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from spatium_supervisor import appliance_state
+
+
+@pytest.fixture
+def lldp_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(appliance_state, "detect_deployment_kind", lambda: "appliance")
+    monkeypatch.setattr(appliance_state, "_LLDP_TRIGGER_FILE", tmp_path / "lldp-config-pending")
+    monkeypatch.setattr(appliance_state, "_LLDP_HASH_SIDECAR", tmp_path / "lldp-config-hash")
+    monkeypatch.setattr(appliance_state, "_LLDP_STATUS_SIDECAR", tmp_path / "lldp-status")
+    return tmp_path
+
+
+_BLOCK = {
+    "enabled": True,
+    "config_hash": "abc123",
+    "lldpd_conf": "configure lldp tx-interval 30\n",
+    "daemon_args": "-c -e",
+}
+
+
+def test_enabled_writes_four_section_payload(lldp_paths: Path) -> None:
+    assert appliance_state.maybe_fire_lldp_reload(_BLOCK) is True
+    body = (lldp_paths / "lldp-config-pending").read_text()
+    lines = body.split("\n")
+    assert lines[0] == "enabled"
+    assert lines[1] == "abc123"
+    assert lines[2] == "-c -e"  # daemon_args — the LLDP-specific 3rd line
+    assert "configure lldp tx-interval 30" in body
+
+
+def test_idempotent_until_consumed(lldp_paths: Path) -> None:
+    assert appliance_state.maybe_fire_lldp_reload(_BLOCK) is True
+    # Trigger already present → don't stack.
+    assert appliance_state.maybe_fire_lldp_reload(_BLOCK) is False
+
+
+def test_hash_unchanged_does_not_fire(lldp_paths: Path) -> None:
+    (lldp_paths / "lldp-config-hash").write_text("abc123\n")
+    # Sidecar hash matches the bundle hash → nothing to apply.
+    assert appliance_state.maybe_fire_lldp_reload(_BLOCK) is False
+    assert not (lldp_paths / "lldp-config-pending").exists()
+
+
+def test_disabled_block_fires_when_previously_applied(lldp_paths: Path) -> None:
+    (lldp_paths / "lldp-config-hash").write_text("abc123\n")
+    disabled = {
+        "enabled": False,
+        "config_hash": "",
+        "lldpd_conf": "",
+        "daemon_args": "",
+    }
+    assert appliance_state.maybe_fire_lldp_reload(disabled) is True
+    assert (lldp_paths / "lldp-config-pending").read_text().split("\n")[0] == "disabled"
+
+
+def test_skipped_off_appliance(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(appliance_state, "detect_deployment_kind", lambda: "docker")
+    monkeypatch.setattr(appliance_state, "_LLDP_TRIGGER_FILE", tmp_path / "lldp-config-pending")
+    monkeypatch.setattr(appliance_state, "_LLDP_HASH_SIDECAR", tmp_path / "lldp-config-hash")
+    assert appliance_state.maybe_fire_lldp_reload(_BLOCK) is False
+    assert not (tmp_path / "lldp-config-pending").exists()
+
+
+def test_read_lldpd_running(lldp_paths: Path) -> None:
+    assert appliance_state.read_lldpd_running() is None  # sidecar missing
+    (lldp_paths / "lldp-status").write_text("running\n")
+    assert appliance_state.read_lldpd_running() is True
+    (lldp_paths / "lldp-status").write_text("stopped\n")
+    assert appliance_state.read_lldpd_running() is False

--- a/appliance/mkosi.conf
+++ b/appliance/mkosi.conf
@@ -227,6 +227,12 @@ Packages=
         # (SNMPv2-MIB / IF-MIB / HOST-RESOURCES-MIB) ship with
         # snmpd itself in /usr/share/snmp/mibs-downloaded.
         snmpd
+        # Issue #343 — LLDP (lldpd) for L2 neighbour discovery +
+        # self-advertisement. Installed but NOT auto-started; operators
+        # opt in via Appliance → LLDP, which writes a config trigger the
+        # spatiumddi-lldp-reload.path unit picks up. Multi-arch in Debian
+        # for both amd64 + arm64.
+        lldpd
 
 # Disable root password — cloud-init seeds the operator account.
 RootPassword=hashed:!

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-lldp-reload.path
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-lldp-reload.path
@@ -1,0 +1,13 @@
+[Unit]
+Description=Watch for SpatiumDDI LLDP config-reload trigger (issue #343)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/343
+# Skip on the live ISO — lldpd isn't part of the installer environment.
+ConditionKernelCommandLine=!boot=live
+
+[Path]
+# PathChanged fires on close-after-write. The supervisor writes this file
+# via an atomic .new → mv rename, so the unit fires once per applied config.
+PathChanged=/var/lib/spatiumddi/release-state/lldp-config-pending
+
+[Install]
+WantedBy=multi-user.target

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-lldp-reload.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-lldp-reload.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Apply pending SpatiumDDI lldpd config (issue #343)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/343
+# The runner writes /etc/lldpd.d/spatium.conf + /etc/default/lldpd, both of
+# which need the /etc overlay (Phase 8a, lower=/usr/lib/etc.image,
+# upper=/var/persist/etc) mounted so the writes land on the /var-backed
+# upper layer and persist across A/B slot swaps. The .path unit's trigger
+# file lives under /var/lib/spatiumddi which isn't available until
+# local-fs.target either. (No firewall step — LLDP is raw L2, no port.)
+After=etc.mount local-fs.target
+Requires=etc.mount
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/spatiumddi-lldp-reload
+# No Install section — only invoked by the matching .path unit, never
+# directly enabled at boot.

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-lldp-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-lldp-reload
@@ -1,0 +1,149 @@
+#!/bin/bash
+# spatiumddi-lldp-reload — host-side lldpd config-apply runner (issue #343).
+#
+# The supervisor writes
+# /var/lib/spatiumddi/release-state/lldp-config-pending whenever the control
+# plane's rendered lldpd config changes vs. what's been applied here. File
+# format (no JSON to keep the runner dependency-free):
+#   line 1:    "enabled" | "disabled"
+#   line 2:    sha256 hex of the rendered config (blank when disabled)
+#   line 3:    DAEMON_ARGS for /etc/default/lldpd ("-c -e" …, blank = none)
+#   line 4+:   rendered /etc/lldpd.d/spatium.conf body (lldpcli directives)
+#
+# ⚠️ NO FIREWALL CHANGE. Unlike spatiumddi-snmp-reload (UDP 161) and
+# spatiumddi-chrony-reload (UDP 123), LLDP is raw L2 multicast
+# (01:80:c2:00:00:0e, ethertype 0x88cc) — it never traverses IP/UDP and
+# cannot be filtered by an nftables port rule. This runner therefore does
+# NOT write an /etc/nftables.d/ drop-in. There is no port to open.
+#
+# Apply flow when enabled:
+#   1. Extract body → /etc/lldpd.d/spatium.conf (atomic swap)
+#   2. Write DAEMON_ARGS → /etc/default/lldpd (managed file)
+#   3. systemctl enable --now lldpd; restart so the new conf + args load
+#   4. Verify active; write hash + status sidecars
+#
+# Apply flow when disabled:
+#   1. systemctl disable --now lldpd (idempotent)
+#   2. Stub /etc/lldpd.d/spatium.conf + clear DAEMON_ARGS
+#   3. Write hash sidecar (empty) + status sidecar (stopped)
+#
+# Persistence across A/B slot swaps (Phase 8a, issue #138): /etc/lldpd.d/ +
+# /etc/default/lldpd live on the /etc overlay upper (/var/persist/etc) and
+# the sidecars on /var directly, so operator LLDP config + lldpd's enable
+# state survive a slot swap with no reapply.
+
+set -euo pipefail
+
+TRIGGER=/var/lib/spatiumddi/release-state/lldp-config-pending
+HASH_SIDECAR=/var/lib/spatiumddi/release-state/lldp-config-hash
+STATUS_SIDECAR=/var/lib/spatiumddi/release-state/lldp-status
+LOG_DIR=/var/log/spatiumddi
+LOG="$LOG_DIR/lldp-reload.log"
+ETC_CONF=/etc/lldpd.d/spatium.conf
+ETC_DEFAULT=/etc/default/lldpd
+LOCK=/run/spatiumddi-lldp-reload.lock
+
+mkdir -p "$LOG_DIR" "$(dirname "$HASH_SIDECAR")" "$(dirname "$ETC_CONF")"
+exec >> "$LOG" 2>&1
+
+echo
+echo "[$(date -Iseconds)] === spatiumddi-lldp-reload fired ==="
+
+if [ ! -f "$TRIGGER" ]; then
+    echo "  no trigger file at $TRIGGER, nothing to do"
+    exit 0
+fi
+
+# Serialise concurrent invocations.
+exec 9>"$LOCK"
+if ! flock -n 9; then
+    echo "  another reload in progress, deferring"
+    exit 0
+fi
+
+MARKER=$(sed -n '1p' "$TRIGGER" | tr -d '\r\n')
+HASH=$(sed -n '2p' "$TRIGGER" | tr -d '\r\n')
+DAEMON_ARGS=$(sed -n '3p' "$TRIGGER" | tr -d '\r\n')
+TMP_BODY=$(mktemp /tmp/spatium-lldpd.conf.XXXXXX)
+trap 'rm -f "$TMP_BODY"' EXIT
+tail -n +4 "$TRIGGER" > "$TMP_BODY"
+
+echo "  marker:      $MARKER"
+echo "  hash:        ${HASH:-<empty>}"
+echo "  daemon_args: ${DAEMON_ARGS:-<none>}"
+echo "  body size:   $(wc -c < "$TMP_BODY") bytes"
+
+write_default() {
+    # Managed /etc/default/lldpd carrying DAEMON_ARGS (the -c/-e/-f/-s
+    # protocol-reception flags). Whole-file rewrite keeps it simple; lldpd's
+    # init sources this for the daemon command line.
+    cat > "$ETC_DEFAULT" <<EOF
+# Managed by spatiumddi-lldp-reload — do not edit manually.
+# Source of truth: Appliance → LLDP in the SpatiumDDI UI.
+DAEMON_ARGS="${1}"
+EOF
+    chmod 0644 "$ETC_DEFAULT"
+}
+
+case "$MARKER" in
+    enabled)
+        if ! command -v lldpd >/dev/null 2>&1; then
+            echo "  ✗ lldpd binary not found — is lldpd installed?"
+            echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
+            mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
+            exit 1
+        fi
+        # Atomic swap of the lldpcli-directive config + the daemon args.
+        install -o root -g root -m 0644 "$TMP_BODY" "$ETC_CONF"
+        write_default "$DAEMON_ARGS"
+
+        # Restart so the daemon picks up new DAEMON_ARGS (a plain reload
+        # wouldn't re-read /etc/default). enable --now covers first apply.
+        if ! systemctl enable --now lldpd; then
+            echo "  ✗ systemctl enable --now lldpd failed"
+            echo "stopped" > "$STATUS_SIDECAR"
+            echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
+            mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
+            exit 1
+        fi
+        systemctl restart lldpd >/dev/null 2>&1 || true
+        sleep 2
+        if systemctl is-active --quiet lldpd; then
+            echo "  ✓ lldpd is active"
+            # Push the running config through lldpcli too so a live daemon
+            # (that didn't restart cleanly) still converges. Best-effort.
+            lldpcli -c "$ETC_CONF" >/dev/null 2>&1 || true
+            echo "running" > "$STATUS_SIDECAR"
+            echo "$HASH" > "$HASH_SIDECAR"
+            echo "done $(date -Iseconds)" > "${TRIGGER}.state"
+            mv "$TRIGGER" "${TRIGGER}.done.$(date +%s)"
+        else
+            echo "  ✗ lldpd not active after start"
+            systemctl status lldpd --no-pager | sed 's/^/      /' || true
+            echo "stopped" > "$STATUS_SIDECAR"
+            echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
+            mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
+            exit 1
+        fi
+        ;;
+    disabled)
+        systemctl disable --now lldpd >/dev/null 2>&1 || true
+        cat > "$ETC_CONF" <<'EOF'
+# Managed by SpatiumDDI — LLDP is currently disabled.
+# Enable via the LLDP tab under Appliance → Fleet → Services.
+EOF
+        chmod 0644 "$ETC_CONF"
+        write_default ""
+        echo "stopped" > "$STATUS_SIDECAR"
+        : > "$HASH_SIDECAR"
+        echo "  ✓ lldpd stopped + disabled, config stubbed (no firewall change needed)"
+        echo "done $(date -Iseconds)" > "${TRIGGER}.state"
+        mv "$TRIGGER" "${TRIGGER}.done.$(date +%s)"
+        ;;
+    *)
+        echo "  ✗ unknown marker line: ${MARKER:-<empty>}"
+        echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
+        mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
+        exit 1
+        ;;
+esac

--- a/appliance/mkosi.postinst
+++ b/appliance/mkosi.postinst
@@ -50,6 +50,7 @@ for unit in chrony.service ssh.service \
             k3s.service \
             spatiumddi-snmp-reload.path \
             spatiumddi-chrony-reload.path \
+            spatiumddi-lldp-reload.path \
             spatiumddi-tz-reload.path \
             spatium-firewall-reload.path \
             spatium-install.service \
@@ -85,6 +86,14 @@ done
 # ``systemctl enable --now snmpd``. Disable (not mask) so the
 # runner's enable+start works without an unmask step.
 rm -f "$BUILDROOT/etc/systemd/system/multi-user.target.wants/snmpd.service"
+
+# Issue #343 — lldpd is installed but NOT auto-started, same rationale as
+# snmpd above. Debian's lldpd postinst enables lldpd.service by default;
+# remove that symlink so a fresh appliance comes up with lldpd inactive.
+# Operator opts in via Appliance → LLDP, which writes the lldp-config-pending
+# trigger; the spatiumddi-lldp-reload runner then ``enable --now``s it.
+# Disable (not mask) so the runner's enable+start works without an unmask.
+rm -f "$BUILDROOT/etc/systemd/system/multi-user.target.wants/lldpd.service"
 
 # Mask systemd-networkd so it doesn't fight NetworkManager for
 # the same interfaces. The package stays installed (it ships in
@@ -232,6 +241,9 @@ chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-snmp-reload.service"
 chmod 0755 "$BUILDROOT/usr/local/bin/spatiumddi-chrony-reload"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-chrony-reload.path"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-chrony-reload.service"
+chmod 0755 "$BUILDROOT/usr/local/bin/spatiumddi-lldp-reload"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-lldp-reload.path"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-lldp-reload.service"
 chmod 0755 "$BUILDROOT/usr/local/bin/spatium-firewall-reload"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatium-firewall-reload.path"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatium-firewall-reload.service"

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -171,6 +171,7 @@ backend/alembic/versions/b7e2d9a5f314_dns_import_source.py:drop_column:88
 backend/alembic/versions/b7e2d9a5f314_dns_import_source.py:drop_column:89
 backend/alembic/versions/b7e3a1f4c8d2_add_dns_agent_ops.py:drop_column:67
 backend/alembic/versions/b7e3a1f4c8d2_add_dns_agent_ops.py:drop_table:61
+backend/alembic/versions/b8c3f2a9e147_appliance_lldp_settings.py:drop_column:109
 backend/alembic/versions/b95e2d71f042_appliance_snmp_settings.py:drop_column:95
 backend/alembic/versions/b9e1c43f7d28_pairing_code_auto_approve.py:drop_column:44
 backend/alembic/versions/b9e4d2a17c83_network_neighbour.py:drop_column:112

--- a/backend/alembic/versions/b8c3f2a9e147_appliance_lldp_settings.py
+++ b/backend/alembic/versions/b8c3f2a9e147_appliance_lldp_settings.py
@@ -1,0 +1,109 @@
+"""appliance LLDP settings (issue #343)
+
+Adds the ``lldp_*`` columns to ``platform_settings`` for host-managed lldpd
+on the appliance — same host-config plane as SNMP (#153) / chrony (#154).
+All columns carry a server_default so the singleton row backfills cleanly;
+only meaningful on appliance hosts (ignored on docker / k8s control planes).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "b8c3f2a9e147"
+down_revision: str | None = "a7f3c1e85d20"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_DEFAULT_IFACE = "eth*,en*,!docker*,!veth*,!br-*,!cni0,!flannel.1"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column("lldp_enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column("lldp_tx_interval", sa.Integer(), nullable=False, server_default=sa.text("30")),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column("lldp_tx_hold", sa.Integer(), nullable=False, server_default=sa.text("4")),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "lldp_protocols",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "lldp_interface_pattern",
+            sa.String(length=512),
+            nullable=False,
+            server_default=sa.text(f"'{_DEFAULT_IFACE}'"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "lldp_management_pattern",
+            sa.String(length=255),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "lldp_sys_name", sa.String(length=255), nullable=False, server_default=sa.text("''")
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "lldp_sys_description",
+            sa.String(length=255),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "lldp_med_location",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "lldp_snmp_agentx", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+    )
+
+
+def downgrade() -> None:
+    for col in (
+        "lldp_snmp_agentx",
+        "lldp_med_location",
+        "lldp_sys_description",
+        "lldp_sys_name",
+        "lldp_management_pattern",
+        "lldp_interface_pattern",
+        "lldp_protocols",
+        "lldp_tx_hold",
+        "lldp_tx_interval",
+        "lldp_enabled",
+    ):
+        op.drop_column("platform_settings", col)

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -31,6 +31,7 @@ from app.models.dhcp import (
 from app.models.logs import DHCPLogEntry
 from app.models.metrics import DHCPMetricSample
 from app.models.settings import PlatformSettings
+from app.services.appliance.lldp import lldp_bundle
 from app.services.appliance.ntp import ntp_bundle
 from app.services.appliance.snmp import snmp_bundle
 from app.services.dhcp.agent_token import (
@@ -338,6 +339,13 @@ async def agent_config_longpoll(
                 "chrony_conf": "",
             }
         )
+        # Issue #343 — same pattern for lldpd. Stable dict shape so the etag
+        # math stays uniform whether settings exist or not.
+        lldp_block = (
+            lldp_bundle(settings_row)
+            if settings_row is not None
+            else {"enabled": False, "config_hash": "", "lldpd_conf": "", "daemon_args": ""}
+        )
         # Phase 8f-3 — mix the fleet-upgrade intent into the ETag so a
         # Fleet view change wakes the agent's long-poll even when the
         # driver-side bundle is unchanged. Deterministic — re-reading
@@ -348,6 +356,7 @@ async def agent_config_longpoll(
             f"|{int(server.reboot_requested)}"
             f"|snmp:{int(bool(snmp_block.get('enabled')))}:{snmp_block.get('config_hash', '')}"
             f"|ntp:{int(bool(ntp_block.get('allow_clients')))}:{ntp_block.get('config_hash', '')}"
+            f"|lldp:{int(bool(lldp_block.get('enabled')))}:{lldp_block.get('config_hash', '')}"
         )
         etag = "sha256:" + hashlib.sha256(f"{bundle.etag}|{fleet_marker}".encode()).hexdigest()
 
@@ -486,6 +495,10 @@ async def agent_config_longpoll(
                 # writes ntp-config-pending on hash change; host-side
                 # spatiumddi-chrony-reload.path applies + reloads.
                 "ntp_settings": ntp_block,
+                # Issue #343 — rendered lldpd config + daemon args. Agent
+                # writes lldp-config-pending on hash change; host-side
+                # spatiumddi-lldp-reload.path applies + reloads lldpd.
+                "lldp_settings": lldp_block,
             }
         if asyncio.get_running_loop().time() >= deadline:
             return Response(status_code=304, headers={"ETag": etag})

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from ipaddress import ip_network
 from typing import Any
@@ -149,6 +150,19 @@ class SettingsResponse(BaseModel):
     # ── Appliance timezone (issue #165) ───────────────────────────
     # Empty string means "follow install-time default" (no override).
     timezone: str = ""
+    # ── Appliance LLDP (issue #343) ───────────────────────────────
+    # No secrets — LLDP advertises public identity, so the read shape
+    # mirrors the stored shape directly (like NTP).
+    lldp_enabled: bool = False
+    lldp_tx_interval: int = 30
+    lldp_tx_hold: int = 4
+    lldp_protocols: list[str] = []
+    lldp_interface_pattern: str = ""
+    lldp_management_pattern: str = ""
+    lldp_sys_name: str = ""
+    lldp_sys_description: str = ""
+    lldp_med_location: dict[str, Any] = {}
+    lldp_snmp_agentx: bool = False
 
     model_config = {"from_attributes": True}
 
@@ -399,6 +413,70 @@ class SettingsUpdate(BaseModel):
     ntp_allow_client_networks: list[str] | None = None
     # ── Appliance timezone (issue #165) ───────────────────────────
     timezone: str | None = None
+    # ── Appliance LLDP (issue #343) ───────────────────────────────
+    lldp_enabled: bool | None = None
+    lldp_tx_interval: int | None = None
+    lldp_tx_hold: int | None = None
+    lldp_protocols: list[str] | None = None
+    lldp_interface_pattern: str | None = None
+    lldp_management_pattern: str | None = None
+    lldp_sys_name: str | None = None
+    lldp_sys_description: str | None = None
+    lldp_med_location: dict[str, Any] | None = None
+    lldp_snmp_agentx: bool | None = None
+
+    @field_validator("lldp_tx_interval")
+    @classmethod
+    def _valid_lldp_tx_interval(cls, v: int | None) -> int | None:
+        if v is not None and not (1 <= v <= 3600):
+            raise ValueError("lldp_tx_interval must be 1..3600 seconds")
+        return v
+
+    @field_validator("lldp_tx_hold")
+    @classmethod
+    def _valid_lldp_tx_hold(cls, v: int | None) -> int | None:
+        if v is not None and not (1 <= v <= 100):
+            raise ValueError("lldp_tx_hold must be 1..100")
+        return v
+
+    @field_validator("lldp_protocols")
+    @classmethod
+    def _valid_lldp_protocols(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        allowed = {"cdp", "edp", "fdp", "sonmp"}
+        out: list[str] = []
+        for p in v:
+            pl = str(p).strip().lower()
+            if pl not in allowed:
+                raise ValueError(f"lldp_protocols entries must be one of {sorted(allowed)}")
+            if pl not in out:
+                out.append(pl)
+        return out
+
+    @field_validator("lldp_interface_pattern", "lldp_management_pattern")
+    @classmethod
+    def _valid_lldp_pattern(cls, v: str | None) -> str | None:
+        # Rendered straight into an lldpcli ``configure … pattern`` directive,
+        # so reject anything outside the glob/CIDR charset to keep config
+        # injection out (newlines, quotes, shell metachars).
+        if v is None:
+            return None
+        v = v.strip()
+        if v and not re.fullmatch(r"[A-Za-z0-9_*!,.\- /:]+", v):
+            raise ValueError("pattern may only contain letters, digits, and * ! , . - _ / : space")
+        return v
+
+    @field_validator("lldp_sys_name", "lldp_sys_description")
+    @classmethod
+    def _valid_lldp_sys_text(cls, v: str | None) -> str | None:
+        # Quoted by the renderer, but reject control chars / newlines outright
+        # so a value can't break out of the lldpcli line.
+        if v is None:
+            return None
+        if any(ord(c) < 32 for c in v):
+            raise ValueError("must not contain control characters or newlines")
+        return v
 
     @field_validator("timezone")
     @classmethod

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -443,6 +443,52 @@ class PlatformSettings(Base):
         String(64), nullable=False, default="", server_default=sa_text("''")
     )
 
+    # ── Appliance LLDP support (issue #343) ─────────────────────────
+    # lldpd runs at the Debian host level on every appliance host (same
+    # host-config plane as SNMP / chrony) so it can see the host's real
+    # L2 interfaces and send/receive raw ethertype-0x88cc frames. No
+    # Fernet — LLDP advertises public identity, not secrets. Default-off
+    # so existing appliances leak no topology. ``lldp_interface_pattern``
+    # is an lldpd ``configure system interface pattern`` whitelist that
+    # excludes container / k3s vNICs by default (we never advertise into
+    # the overlay network). ``lldp_protocols`` enables RECEPTION of extra
+    # neighbour protocols (cdp / edp / fdp / sonmp) on top of LLDP.
+    # ``lldp_med_location`` + ``lldp_snmp_agentx`` are stored for Phase 3
+    # (LLDP-MED location + AgentX-to-snmpd) and not yet rendered.
+    lldp_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    lldp_tx_interval: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=30, server_default=sa_text("30")
+    )
+    lldp_tx_hold: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=4, server_default=sa_text("4")
+    )
+    lldp_protocols: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+    lldp_interface_pattern: Mapped[str] = mapped_column(
+        String(512),
+        nullable=False,
+        default="eth*,en*,!docker*,!veth*,!br-*,!cni0,!flannel.1",
+        server_default=sa_text("'eth*,en*,!docker*,!veth*,!br-*,!cni0,!flannel.1'"),
+    )
+    lldp_management_pattern: Mapped[str] = mapped_column(
+        String(255), nullable=False, default="", server_default=sa_text("''")
+    )
+    lldp_sys_name: Mapped[str] = mapped_column(
+        String(255), nullable=False, default="", server_default=sa_text("''")
+    )
+    lldp_sys_description: Mapped[str] = mapped_column(
+        String(255), nullable=False, default="", server_default=sa_text("''")
+    )
+    lldp_med_location: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=sa_text("'{}'::jsonb")
+    )
+    lldp_snmp_agentx: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+
     # ── Aggregation candidate snooze (issue #114) ───────────────────
     # Operator-driven hide-list for the IPAM aggregation badge popover.
     # Keys are stable per-candidate hashes derived from the parent

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -21,6 +21,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     imports,
     integrations,
     ipam,
+    lldp,
     multicast,
     network,
     network_modeling,

--- a/backend/app/services/ai/tools/lldp.py
+++ b/backend/app/services/ai/tools/lldp.py
@@ -1,0 +1,70 @@
+"""Operator Copilot read tool for the appliance LLDP surface (issue #343).
+
+Surfaces the singleton ``platform_settings`` LLDP config so an operator can
+ask the Copilot "is LLDP on?", "what interfaces does it advertise on?", or
+"what TTL are we sending?". No secrets — LLDP advertises public identity, so
+the response mirrors the stored shape directly.
+
+The neighbour-data tool ``find_lldp_neighbors`` (joining the appliance's
+discovered L2 neighbours into IPAM) is Phase 2 — it needs the supervisor to
+ship ``lldpcli show neighbors`` back to the control plane first. This tool is
+the Phase-1 config-visibility counterpart, matching ``find_snmp_settings``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.settings import PlatformSettings
+from app.services.ai.tools.base import register_tool
+
+
+class FindLLDPSettingsArgs(BaseModel):
+    """No arguments — there is exactly one LLDP config row."""
+
+    pass
+
+
+@register_tool(
+    name="find_lldp_settings",
+    description=(
+        "Return the appliance LLDP configuration — master toggle, transmit "
+        "interval + hold (and the advertised TTL = interval × hold), which "
+        "extra neighbour protocols (CDP / EDP / FDP / SONMP) are received, the "
+        "interface allowlist pattern, the management-address pattern, and any "
+        "system-name / description overrides. Use to answer 'is LLDP on?', "
+        "'what interfaces do we advertise on?', 'what TTL are neighbours told?'. "
+        "lldpd runs on every SpatiumDDI appliance host; on docker / k8s deploys "
+        "these settings still drive registered appliance agents."
+    ),
+    args_model=FindLLDPSettingsArgs,
+    category="admin",
+    # Default enabled (NN #13) — read-only, no secrets, no off-prem calls.
+    # module=None: LLDP is plain host-config (like SNMP/NTP), not a feature
+    # module, so it stays unambiguously always-available.
+    default_enabled=True,
+    module=None,
+)
+async def find_lldp_settings(
+    db: AsyncSession, user: User, args: FindLLDPSettingsArgs
+) -> dict[str, Any]:
+    settings = await db.get(PlatformSettings, 1)
+    if settings is None:
+        return {"enabled": False, "note": "platform_settings row missing"}
+    interval = int(settings.lldp_tx_interval or 30)
+    hold = int(settings.lldp_tx_hold or 4)
+    return {
+        "enabled": bool(settings.lldp_enabled),
+        "tx_interval_seconds": interval,
+        "tx_hold": hold,
+        "advertised_ttl_seconds": max(1, interval) * max(1, hold),
+        "extra_protocols_received": list(settings.lldp_protocols or []),
+        "interface_pattern": settings.lldp_interface_pattern,
+        "management_pattern": settings.lldp_management_pattern or "(auto)",
+        "system_name_override": settings.lldp_sys_name or None,
+        "system_description_override": settings.lldp_sys_description or None,
+    }

--- a/backend/app/services/appliance/lldp.py
+++ b/backend/app/services/appliance/lldp.py
@@ -1,0 +1,136 @@
+"""Issue #343 — appliance LLDP support.
+
+Source-of-truth lives on ``platform_settings`` (singleton); this module
+renders the lldpd host config from those columns and folds it into the DNS +
+DHCP ConfigBundle long-poll so every appliance host (local + remote agents)
+picks it up the same way SNMP (#153) and chrony (#154) do.
+
+Design notes:
+
+* lldpd runs at the OS level on the appliance image, NOT in a container — it
+  must see the host's real L2 interfaces and send/receive raw ethertype-0x88cc
+  frames, which a container can't without host networking + CAP_NET_RAW.
+* Two artefacts are rendered: ``/etc/lldpd.d/spatium.conf`` (a script of
+  ``lldpcli configure …`` directives lldpd sources at start) and the
+  ``/etc/default/lldpd`` DAEMON_ARGS string (the ``-c``/``-e``/``-f``/``-s``
+  flags that turn on *reception* of CDP / EDP / FDP / SONMP alongside LLDP).
+  Protocol reception is a daemon-arg, not an lldpcli directive, so it can't
+  live in the conf body.
+* UNLIKE SNMP / NTP there is no firewall change: LLDP is raw L2 multicast
+  (01:80:c2:00:00:0e, ethertype 0x88cc), not IP/UDP — there is no port to
+  open, so the host-side runner must NOT write an ``/etc/nftables.d`` drop-in.
+* No Fernet: LLDP advertises public identity (hostname, mgmt IP, capabilities)
+  to anything on the wire — there is nothing secret to encrypt. Mitigated by
+  default-off + the per-interface allowlist that excludes container vNICs.
+* A disabled / empty config still renders a *valid* body so the host-side
+  runner can compare it byte-for-byte and skip the reload when nothing changed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from app.models.settings import PlatformSettings
+
+# lldp_protocols value → lldpd daemon flag enabling RECEPTION of that protocol.
+# (LLDP itself is always on; these add the legacy/vendor neighbour protocols.)
+_PROTOCOL_FLAGS: dict[str, str] = {
+    "cdp": "-c",  # Cisco Discovery Protocol
+    "edp": "-e",  # Extreme Discovery Protocol
+    "fdp": "-f",  # Foundry Discovery Protocol
+    "sonmp": "-s",  # Nortel/SynOptics
+}
+
+
+def _maybe_quote(s: str) -> str:
+    """lldpcli uses shell-like word splitting — only values containing
+    whitespace need quoting. Simple tokens (hostnames, single words) render
+    bare to match the canonical lldpcli config style; anything with a space
+    is double-quoted with embedded quotes/backslashes escaped."""
+    if not any(c.isspace() for c in s):
+        return s
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def render_lldpd_conf(settings: PlatformSettings) -> str:
+    """Return the ``/etc/lldpd.d/spatium.conf`` body (lldpcli directives).
+
+    Deterministic — same settings → same bytes — so the host-side runner can
+    diff against the on-disk file and skip the reload when nothing changed.
+    """
+    lines: list[str] = [
+        "# Managed by SpatiumDDI — edits will be overwritten on next config push.",
+        "# Source of truth: Appliance → LLDP in the SpatiumDDI UI.",
+        "",
+    ]
+
+    sys_name = (settings.lldp_sys_name or "").strip()
+    sys_desc = (settings.lldp_sys_description or "").strip()
+    if sys_name:
+        lines.append(f"configure system hostname {_maybe_quote(sys_name)}")
+    if sys_desc:
+        lines.append(f"configure system description {_maybe_quote(sys_desc)}")
+
+    # tx-interval × tx-hold = the advertised TTL. Floor at sane minimums so a
+    # zero never disables advertising silently.
+    tx_interval = max(1, int(settings.lldp_tx_interval or 30))
+    tx_hold = max(1, int(settings.lldp_tx_hold or 4))
+    lines.append(f"configure lldp tx-interval {tx_interval}")
+    lines.append(f"configure lldp tx-hold {tx_hold}")
+
+    # Management-address pattern: empty → let lldpd auto-select the primary
+    # routable IP (its default). Operators pin one (e.g. ``eth0`` / a CIDR)
+    # to control which address upstream switches learn.
+    mgmt = (settings.lldp_management_pattern or "").strip()
+    if mgmt:
+        lines.append(f"configure system ip management pattern {mgmt}")
+
+    # Interface allowlist — always emitted. The default excludes docker / k3s
+    # vNICs so we never advertise into the overlay network.
+    iface = (settings.lldp_interface_pattern or "").strip()
+    if iface:
+        lines.append(f"configure system interface pattern {iface}")
+
+    # Advertise the management address + capabilities (router/bridge/…) so the
+    # appliance shows up usefully in upstream LLDP/NMS tables.
+    lines.append("configure lldp management-addresses-advertisements enable")
+    lines.append("configure lldp capabilities-advertisements enable")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_lldpd_daemon_args(settings: PlatformSettings) -> str:
+    """Return the ``DAEMON_ARGS`` value for ``/etc/default/lldpd``.
+
+    Enables reception of the operator-selected legacy/vendor protocols on top
+    of LLDP. Deterministic flag order so the bundle hash is stable.
+    """
+    protocols = {str(p).strip().lower() for p in (settings.lldp_protocols or [])}
+    flags = [_PROTOCOL_FLAGS[p] for p in ("cdp", "edp", "fdp", "sonmp") if p in protocols]
+    return " ".join(flags)
+
+
+def lldp_bundle(settings: PlatformSettings) -> dict[str, Any]:
+    """Build the ``lldp_settings`` block the DNS + DHCP ConfigBundle ships.
+
+    Carries the rendered conf body + daemon args + a config-hash the agent
+    short-circuits on (skip the trigger file when nothing changed since the
+    last bundle). The hash spans both artefacts so a protocol-only change
+    still shifts it.
+    """
+    enabled = bool(settings.lldp_enabled)
+    body = render_lldpd_conf(settings) if enabled else ""
+    daemon_args = render_lldpd_daemon_args(settings) if enabled else ""
+    config_hash = (
+        hashlib.sha256(f"{body}\n--args--\n{daemon_args}".encode()).hexdigest() if enabled else ""
+    )
+    return {
+        "enabled": enabled,
+        "config_hash": config_hash,
+        "lldpd_conf": body,
+        "daemon_args": daemon_args,
+    }
+
+
+__all__ = ["lldp_bundle", "render_lldpd_conf", "render_lldpd_daemon_args"]

--- a/backend/tests/test_appliance_lldp.py
+++ b/backend/tests/test_appliance_lldp.py
@@ -1,0 +1,189 @@
+"""Appliance LLDP — renderer + bundle + settings API (issue #343).
+
+The renderer is deterministic over an in-memory ``PlatformSettings`` row
+(no DB). The settings-API tests drive the real ``PUT /api/v1/settings``
+round-trip + the LLDP field validators.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.settings import PlatformSettings
+from app.services.appliance.lldp import (
+    lldp_bundle,
+    render_lldpd_conf,
+    render_lldpd_daemon_args,
+)
+
+_DEFAULT_IFACE = "eth*,en*,!docker*,!veth*,!br-*,!cni0,!flannel.1"
+
+
+def _bare_settings() -> PlatformSettings:
+    s = PlatformSettings(id=1)
+    s.lldp_enabled = True
+    s.lldp_tx_interval = 30
+    s.lldp_tx_hold = 4
+    s.lldp_protocols = []
+    s.lldp_interface_pattern = _DEFAULT_IFACE
+    s.lldp_management_pattern = ""
+    s.lldp_sys_name = ""
+    s.lldp_sys_description = ""
+    s.lldp_med_location = {}
+    s.lldp_snmp_agentx = False
+    return s
+
+
+# ── Renderer ────────────────────────────────────────────────────────────
+
+
+def test_renders_core_directives() -> None:
+    s = _bare_settings()
+    out = render_lldpd_conf(s)
+    assert "configure lldp tx-interval 30" in out
+    assert "configure lldp tx-hold 4" in out
+    # Interface allowlist always emitted (excludes container vNICs).
+    assert f"configure system interface pattern {_DEFAULT_IFACE}" in out
+    assert "configure lldp management-addresses-advertisements enable" in out
+    assert "configure lldp capabilities-advertisements enable" in out
+    # No mgmt pattern / hostname / description lines when those are empty.
+    assert "ip management pattern" not in out
+    assert "configure system hostname" not in out
+    assert "configure system description" not in out
+
+
+def test_renders_optional_overrides() -> None:
+    s = _bare_settings()
+    s.lldp_sys_name = "core-rtr1"
+    s.lldp_sys_description = "SpatiumDDI Appliance"
+    s.lldp_management_pattern = "eth0"
+    out = render_lldpd_conf(s)
+    assert "configure system hostname core-rtr1" in out
+    assert 'configure system description "SpatiumDDI Appliance"' in out
+    assert "configure system ip management pattern eth0" in out
+
+
+def test_tx_falsy_falls_back_to_default() -> None:
+    # The API validator enforces 1..3600 / 1..100, so 0 can't actually
+    # persist; the renderer's ``or 30`` / ``or 4`` defensively defaults a
+    # falsy value rather than emitting a 0 that would disable advertising.
+    s = _bare_settings()
+    s.lldp_tx_interval = 0
+    s.lldp_tx_hold = 0
+    out = render_lldpd_conf(s)
+    assert "configure lldp tx-interval 30" in out
+    assert "configure lldp tx-hold 4" in out
+
+
+def test_daemon_args_flags_in_deterministic_order() -> None:
+    s = _bare_settings()
+    s.lldp_protocols = ["sonmp", "cdp"]  # unordered input
+    assert render_lldpd_daemon_args(s) == "-c -s"  # cdp, edp, fdp, sonmp order
+    s.lldp_protocols = []
+    assert render_lldpd_daemon_args(s) == ""
+
+
+def test_renderer_is_deterministic() -> None:
+    s = _bare_settings()
+    s.lldp_protocols = ["cdp"]
+    assert render_lldpd_conf(s) == render_lldpd_conf(s)
+    assert render_lldpd_daemon_args(s) == render_lldpd_daemon_args(s)
+
+
+def test_bundle_enabled_vs_disabled() -> None:
+    s = _bare_settings()
+    s.lldp_protocols = ["cdp"]
+    b = lldp_bundle(s)
+    assert b["enabled"] is True
+    assert b["config_hash"]
+    assert "configure lldp tx-interval 30" in b["lldpd_conf"]
+    assert b["daemon_args"] == "-c"
+
+    s.lldp_enabled = False
+    d = lldp_bundle(s)
+    # Stable key set, all empty when disabled.
+    assert set(d) == set(b)
+    assert d["enabled"] is False
+    assert d["config_hash"] == ""
+    assert d["lldpd_conf"] == ""
+    assert d["daemon_args"] == ""
+
+
+def test_bundle_hash_shifts_on_protocol_change() -> None:
+    s = _bare_settings()
+    h0 = lldp_bundle(s)["config_hash"]
+    s.lldp_protocols = ["cdp"]
+    h1 = lldp_bundle(s)["config_hash"]
+    # daemon_args change alone (conf body unchanged) still shifts the hash.
+    assert h0 != h1
+
+
+# ── Settings API ──────────────────────────────────────────────────────────
+
+
+async def _admin_headers(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    await db.commit()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def test_settings_lldp_round_trip(client: AsyncClient, db_session: AsyncSession) -> None:
+    h = await _admin_headers(db_session)
+    r = await client.put(
+        "/api/v1/settings",
+        headers=h,
+        json={
+            "lldp_enabled": True,
+            "lldp_tx_interval": 45,
+            "lldp_tx_hold": 3,
+            "lldp_protocols": ["cdp", "cdp", "edp"],  # de-duped by validator
+            "lldp_interface_pattern": "eth*,!docker*",
+            "lldp_sys_name": "edge1",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["lldp_enabled"] is True
+    assert body["lldp_tx_interval"] == 45
+    assert body["lldp_protocols"] == ["cdp", "edp"]
+    assert body["lldp_interface_pattern"] == "eth*,!docker*"
+    assert body["lldp_sys_name"] == "edge1"
+
+    # GET reflects the persisted values.
+    g = await client.get("/api/v1/settings", headers=h)
+    assert g.json()["lldp_tx_interval"] == 45
+
+
+async def test_settings_lldp_validators(client: AsyncClient, db_session: AsyncSession) -> None:
+    h = await _admin_headers(db_session)
+    # tx_interval out of range.
+    assert (
+        await client.put("/api/v1/settings", headers=h, json={"lldp_tx_interval": 99999})
+    ).status_code == 422
+    # bogus protocol.
+    assert (
+        await client.put("/api/v1/settings", headers=h, json={"lldp_protocols": ["bogus"]})
+    ).status_code == 422
+    # config-injection chars in the interface pattern.
+    assert (
+        await client.put(
+            "/api/v1/settings", headers=h, json={"lldp_interface_pattern": "eth0; rm -rf /"}
+        )
+    ).status_code == 422
+    # control char in the system name.
+    assert (
+        await client.put("/api/v1/settings", headers=h, json={"lldp_sys_name": "a\nb"})
+    ).status_code == 422

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -358,7 +358,17 @@ The Talos-style console got a wave of usability fixes:
 ### Fleet UI updates
 
 - File rename `frontend/src/pages/appliance/ApprovalsTab.tsx` → `FleetTab.tsx` (component + React-Query keys + URL hash all migrated from `approvals` → `fleet`). The original "Approvals" framing predates the full Fleet management surface that now lives in the tab.
-- Sidebar regrouped into two sub-headings — **Infrastructure** (Appliances / Pairing codes / Slot images) and **Services** (NTP / SNMP) — so future Wave-E host-config surfaces (#155–#166) drop into Services without restructuring.
+- Sidebar regrouped into two sub-headings — **Infrastructure** (Appliances / Pairing codes / Slot images) and **Services** (LLDP / NTP / SNMP) — so future Wave-E host-config surfaces (#155–#166) drop into Services without restructuring.
+
+### LLDP (lldpd) — issue #343
+
+`lldpd` runs as a **host OS package** on every appliance host (same host-config plane as SNMP / chrony), configured from **Appliance → Fleet → Services → LLDP**. It advertises the node to upstream switches (chassis-id, system name, management IP, capabilities) and learns its L2 neighbours.
+
+- **Default-off**, opt-in per the standard `platform_settings` → ConfigBundle → trigger-file → `spatiumddi-lldp-reload` host-runner pattern. Config persists across A/B slot swaps via the `/etc` overlay.
+- **No firewall change.** Unlike snmpd (UDP 161) and chrony (UDP 123), LLDP is raw Layer-2 multicast (`01:80:c2:00:00:0e`, ethertype `0x88cc`) — there is no IP port to open, so the runner deliberately writes **no** `/etc/nftables.d/` drop-in.
+- **Interface allowlist** defaults to `eth*,en*,!docker*,!veth*,!br-*,!cni0,!flannel.1` so the appliance never advertises into the docker / k3s overlay network.
+- Optional reception of CDP / EDP / FDP / SONMP alongside LLDP (`/etc/default/lldpd` `DAEMON_ARGS`).
+- Phase 2 (deferred): the supervisor ships `lldpcli show neighbors` back to the control plane to populate the existing `NetworkNeighbour` discovery surface, and the `find_lldp_neighbors` MCP tool. Phase 1 exposes config + the read-only `find_lldp_settings` MCP tool. Runtime activation rides the shared #155–#166 host-config-delivery plane.
 - New **Services** column on the Appliances list with per-role chips coloured by `role_switch_state` (green `ready` ✓ / amber `pending` / rose `failed` / neutral `observer`) so operators see at a glance what's actually configured and running on each box.
 - **Service health** section in the per-appliance drilldown rendering one row per `role_health` entry — service name · role · status chip · relative `since` (e.g. "3m ago") · short container id.
 - **Approve + sign cert** mutation now refreshes the drilldown row on success (was leaving the operator staring at a stale `pending_approval` modal).

--- a/frontend/src/components/LLDPSection.tsx
+++ b/frontend/src/components/LLDPSection.tsx
@@ -1,0 +1,283 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AlertCircle } from "lucide-react";
+
+import {
+  settingsApi,
+  type LldpProtocol,
+  type PlatformSettings,
+} from "@/lib/api";
+import { Toggle } from "@/components/ui/toggle";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  values: PlatformSettings;
+  isSuperadmin: boolean;
+  applianceMode: boolean;
+  inputCls: string;
+}
+
+const ALL_PROTOCOLS: { key: LldpProtocol; label: string }[] = [
+  { key: "cdp", label: "CDP (Cisco)" },
+  { key: "edp", label: "EDP (Extreme)" },
+  { key: "fdp", label: "FDP (Foundry)" },
+  { key: "sonmp", label: "SONMP (Nortel)" },
+];
+
+function Field({
+  label,
+  description,
+  children,
+}: {
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-8 py-3">
+      <div className="max-w-xl">
+        <div className="text-sm font-medium">{label}</div>
+        {description && (
+          <div className="text-xs text-muted-foreground">{description}</div>
+        )}
+      </div>
+      <div className="flex-shrink-0">{children}</div>
+    </div>
+  );
+}
+
+export function LLDPSection({
+  values,
+  isSuperadmin,
+  applianceMode,
+  inputCls,
+}: Props) {
+  const qc = useQueryClient();
+  const [enabled, setEnabled] = useState<boolean>(values.lldp_enabled);
+  const [txInterval, setTxInterval] = useState<number>(values.lldp_tx_interval);
+  const [txHold, setTxHold] = useState<number>(values.lldp_tx_hold);
+  const [protocols, setProtocols] = useState<LldpProtocol[]>(
+    values.lldp_protocols || [],
+  );
+  const [ifacePattern, setIfacePattern] = useState<string>(
+    values.lldp_interface_pattern,
+  );
+  const [mgmtPattern, setMgmtPattern] = useState<string>(
+    values.lldp_management_pattern,
+  );
+  const [sysName, setSysName] = useState<string>(values.lldp_sys_name);
+  const [sysDesc, setSysDesc] = useState<string>(values.lldp_sys_description);
+
+  const dirty =
+    enabled !== values.lldp_enabled ||
+    txInterval !== values.lldp_tx_interval ||
+    txHold !== values.lldp_tx_hold ||
+    JSON.stringify([...protocols].sort()) !==
+      JSON.stringify([...(values.lldp_protocols || [])].sort()) ||
+    ifacePattern !== values.lldp_interface_pattern ||
+    mgmtPattern !== values.lldp_management_pattern ||
+    sysName !== values.lldp_sys_name ||
+    sysDesc !== values.lldp_sys_description;
+
+  const [saveErr, setSaveErr] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (patch: Partial<PlatformSettings>) => settingsApi.update(patch),
+    onSuccess: (updated) => {
+      qc.setQueryData(["settings"], updated);
+      setEnabled(updated.lldp_enabled);
+      setTxInterval(updated.lldp_tx_interval);
+      setTxHold(updated.lldp_tx_hold);
+      setProtocols(updated.lldp_protocols || []);
+      setIfacePattern(updated.lldp_interface_pattern);
+      setMgmtPattern(updated.lldp_management_pattern);
+      setSysName(updated.lldp_sys_name);
+      setSysDesc(updated.lldp_sys_description);
+      setSaveErr(null);
+      setSavedAt(Date.now());
+      setTimeout(() => setSavedAt(null), 2500);
+    },
+    onError: (err: unknown) => {
+      setSaveErr(err instanceof Error ? err.message : String(err));
+    },
+  });
+
+  function toggleProtocol(p: LldpProtocol) {
+    setProtocols((prev) =>
+      prev.includes(p) ? prev.filter((x) => x !== p) : [...prev, p],
+    );
+  }
+
+  function handleSave() {
+    mutation.mutate({
+      lldp_enabled: enabled,
+      lldp_tx_interval: txInterval,
+      lldp_tx_hold: txHold,
+      lldp_protocols: protocols,
+      lldp_interface_pattern: ifacePattern.trim(),
+      lldp_management_pattern: mgmtPattern.trim(),
+      lldp_sys_name: sysName,
+      lldp_sys_description: sysDesc,
+    });
+  }
+
+  const ttl = Math.max(1, txInterval) * Math.max(1, txHold);
+
+  return (
+    <div className="space-y-2">
+      {!applianceMode && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs">
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700 dark:text-amber-400" />
+          <div className="space-y-1">
+            <p className="font-medium text-amber-700 dark:text-amber-400">
+              lldpd is only configured on appliance hosts
+            </p>
+            <p className="text-muted-foreground">
+              This control plane is running in docker / k8s, where lldpd isn't
+              part of the SpatiumDDI image. Settings saved here still flow
+              through the ConfigBundle to any <em>appliance agents</em>{" "}
+              registered with this control plane.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <Field
+        label="Enable LLDP"
+        description="Run lldpd on the appliance host(s) to advertise this node to upstream switches and discover L2 neighbours. Off by default — when off, the host advertises nothing."
+      >
+        <Toggle
+          checked={enabled}
+          onChange={setEnabled}
+          disabled={!isSuperadmin}
+        />
+      </Field>
+
+      <Field
+        label="Transmit interval (s)"
+        description={`How often lldpd sends advertisements. TTL advertised to neighbours = interval × hold = ${ttl}s.`}
+      >
+        <input
+          type="number"
+          min={1}
+          max={3600}
+          value={txInterval}
+          onChange={(e) => setTxInterval(Number(e.target.value))}
+          disabled={!isSuperadmin}
+          className={cn(inputCls, "w-24")}
+        />
+      </Field>
+
+      <Field
+        label="Transmit hold"
+        description="TTL multiplier. The advertised time-to-live is interval × hold; neighbours drop this node that long after the last frame."
+      >
+        <input
+          type="number"
+          min={1}
+          max={100}
+          value={txHold}
+          onChange={(e) => setTxHold(Number(e.target.value))}
+          disabled={!isSuperadmin}
+          className={cn(inputCls, "w-24")}
+        />
+      </Field>
+
+      <Field
+        label="Also receive"
+        description="Enable reception of legacy/vendor neighbour protocols on top of LLDP. Useful when upstream gear only speaks CDP (Cisco) etc."
+      >
+        <div className="flex flex-wrap gap-3">
+          {ALL_PROTOCOLS.map((p) => (
+            <label key={p.key} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="checkbox"
+                checked={protocols.includes(p.key)}
+                onChange={() => toggleProtocol(p.key)}
+                disabled={!isSuperadmin}
+              />
+              {p.label}
+            </label>
+          ))}
+        </div>
+      </Field>
+
+      <Field
+        label="Interface pattern"
+        description="lldpd interface allowlist (comma-separated globs; ! excludes). The default excludes docker / k3s vNICs so the appliance never advertises into the overlay network."
+      >
+        <input
+          type="text"
+          value={ifacePattern}
+          onChange={(e) => setIfacePattern(e.target.value)}
+          placeholder="eth*,en*,!docker*,!veth*,!br-*,!cni0,!flannel.1"
+          disabled={!isSuperadmin}
+          className={cn(inputCls, "w-96 max-w-full font-mono")}
+        />
+      </Field>
+
+      <Field
+        label="Management address pattern"
+        description="Which interface / CIDR's IP to advertise as the management address. Empty = let lldpd auto-select the primary routable IP."
+      >
+        <input
+          type="text"
+          value={mgmtPattern}
+          onChange={(e) => setMgmtPattern(e.target.value)}
+          placeholder="(auto) — or e.g. eth0 / 10.0.0.0/8"
+          disabled={!isSuperadmin}
+          className={cn(inputCls, "w-96 max-w-full font-mono")}
+        />
+      </Field>
+
+      <Field
+        label="System name override"
+        description="Advertised system name. Empty = the host's FQDN."
+      >
+        <input
+          type="text"
+          value={sysName}
+          onChange={(e) => setSysName(e.target.value)}
+          placeholder="(host FQDN)"
+          disabled={!isSuperadmin}
+          className={cn(inputCls, "w-96 max-w-full")}
+        />
+      </Field>
+
+      <Field
+        label="System description override"
+        description="Advertised system description. Empty = lldpd's default (kernel + OS)."
+      >
+        <input
+          type="text"
+          value={sysDesc}
+          onChange={(e) => setSysDesc(e.target.value)}
+          placeholder="(default)"
+          disabled={!isSuperadmin}
+          className={cn(inputCls, "w-96 max-w-full")}
+        />
+      </Field>
+
+      <div className="mt-4 flex items-center gap-3 border-t pt-4">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!isSuperadmin || !dirty || mutation.isPending}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-40"
+        >
+          {mutation.isPending
+            ? "Saving…"
+            : savedAt
+              ? "Saved!"
+              : "Save LLDP settings"}
+        </button>
+        {saveErr && (
+          <span className="text-xs text-destructive">
+            Failed to save: {saveErr}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2911,9 +2911,23 @@ export interface PlatformSettings {
   // Issue #165 — operator-set IANA timezone. Empty = no override
   // (host falls back to install-time default).
   timezone: string;
+  /** Appliance LLDP (issue #343). No secrets — LLDP advertises public
+   *  identity, so read + write shapes match. ``lldp_protocols`` enables
+   *  reception of CDP/EDP/FDP/SONMP alongside LLDP. */
+  lldp_enabled: boolean;
+  lldp_tx_interval: number;
+  lldp_tx_hold: number;
+  lldp_protocols: LldpProtocol[];
+  lldp_interface_pattern: string;
+  lldp_management_pattern: string;
+  lldp_sys_name: string;
+  lldp_sys_description: string;
+  lldp_med_location: Record<string, unknown>;
+  lldp_snmp_agentx: boolean;
 }
 
 export type NtpSourceMode = "pool" | "servers" | "mixed";
+export type LldpProtocol = "cdp" | "edp" | "fdp" | "sonmp";
 
 export interface NtpCustomServer {
   host: string;

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -37,6 +37,7 @@ import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { useSessionState } from "@/lib/useSessionState";
 import { cn } from "@/lib/utils";
+import { LLDPTab } from "./LLDPTab";
 import { NTPTab } from "./NTPTab";
 import { PairingTab } from "./PairingTab";
 import { SNMPTab } from "./SNMPTab";
@@ -679,7 +680,7 @@ export function FleetTab({
   // persists the operator's pick so a refresh inside the same tab
   // lands them back on the same section.
   const [view, setView] = useSessionState<
-    "appliances" | "pairing" | "slot-images" | "ntp" | "snmp"
+    "appliances" | "pairing" | "slot-images" | "lldp" | "ntp" | "snmp"
   >("appliance.fleet.section", "appliances");
 
   const [drilldown, setDrilldown] = useState<ApplianceRow | null>(null);
@@ -896,7 +897,7 @@ export function FleetTab({
   // host-OS surfaces (#155-#166 — APT proxy, syslog forwarder, SSH
   // authorized_keys, etc.) drop into Services without restructuring.
   type NavItem = {
-    key: "appliances" | "pairing" | "slot-images" | "ntp" | "snmp";
+    key: "appliances" | "pairing" | "slot-images" | "lldp" | "ntp" | "snmp";
     label: string;
     summary: string;
     badge?: string | number;
@@ -929,6 +930,11 @@ export function FleetTab({
     {
       heading: "Services",
       items: [
+        {
+          key: "lldp",
+          label: "LLDP",
+          summary: "Fleet-wide lldpd config.",
+        },
         {
           key: "ntp",
           label: "NTP",
@@ -1038,6 +1044,19 @@ export function FleetTab({
                 upgrade points at the uploaded row.
               </p>
               <SlotImageManager />
+            </div>
+          )}
+
+          {view === "lldp" && (
+            <div>
+              <h2 className="mb-1 text-base font-semibold">LLDP (lldpd)</h2>
+              <p className="mb-4 text-xs text-muted-foreground">
+                Fleet-wide lldpd configuration. The rendered config ships
+                through the ConfigBundle long-poll to every appliance host
+                (local + every registered supervisor). LLDP is raw Layer-2 — no
+                firewall port is opened.
+              </p>
+              <LLDPTab />
             </div>
           )}
 

--- a/frontend/src/pages/appliance/LLDPTab.tsx
+++ b/frontend/src/pages/appliance/LLDPTab.tsx
@@ -1,0 +1,67 @@
+import { useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+
+import { authApi, settingsApi, versionApi } from "@/lib/api";
+import { LLDPSection } from "@/components/LLDPSection";
+
+/**
+ * Appliance → LLDP tab (issue #343).
+ *
+ * Thin wrapper around the shared ``LLDPSection`` form, same shape as the
+ * SNMP / NTP tabs. lldpd runs at the OS level on every appliance host; the
+ * rendered config ships through the ConfigBundle long-poll the same way
+ * SNMP / chrony do. Live neighbour discovery (the supervisor shipping
+ * ``lldpcli show neighbors`` back to IPAM) is Phase 2.
+ */
+export function LLDPTab() {
+  const { data: me } = useQuery({
+    queryKey: ["me"],
+    queryFn: authApi.me,
+    staleTime: 60_000,
+  });
+  const { data: settings, isLoading } = useQuery({
+    queryKey: ["settings"],
+    queryFn: settingsApi.get,
+  });
+  const { data: versionInfo } = useQuery({
+    queryKey: ["version"],
+    queryFn: versionApi.get,
+    staleTime: 60 * 60 * 1000,
+  });
+
+  if (isLoading || !settings) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading LLDP settings…
+      </div>
+    );
+  }
+
+  const isSuperadmin = me?.is_superadmin ?? false;
+  const applianceMode = versionInfo?.appliance_mode ?? true;
+  const inputCls =
+    "rounded-md border bg-background px-3 py-1.5 text-sm disabled:opacity-60";
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <div className="mb-4">
+        <h2 className="text-base font-semibold">LLDP (lldpd)</h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          lldpd runs at the OS level on every SpatiumDDI appliance host. It
+          advertises this node to upstream switches (chassis-id, system name,
+          management IP, capabilities) and learns its L2 neighbours. LLDP is raw
+          Layer-2 (ethertype 0x88cc) — unlike SNMP / NTP it opens no firewall
+          port. The interface allowlist excludes container / k3s vNICs by
+          default so the appliance never advertises into the overlay network.
+        </p>
+      </div>
+      <LLDPSection
+        values={settings}
+        isSuperadmin={isSuperadmin}
+        applianceMode={applianceMode}
+        inputCls={inputCls}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Runs `lldpd` as a host-managed OS package on the appliance, configured from a new **LLDP** tab under **Fleet → Services**, built to exact parity with the SNMP (#153) / NTP (#154) host-config plane: `PlatformSettings` columns → rendered config → ConfigBundle long-poll → supervisor trigger-file → host runner.

## What's here

**Backend**
- `PlatformSettings.lldp_*` columns + migration `b8c3f2a9e147` (chained off the real single head `a7f3c1e85d20`). No Fernet — LLDP advertises public identity, not secrets.
- `services/appliance/lldp.py`: deterministic `render_lldpd_conf` (lldpcli directives) + `render_lldpd_daemon_args` (CDP/EDP/FDP/SONMP reception flags) + `lldp_bundle` (stable `{enabled, config_hash, lldpd_conf, daemon_args}`).
- Folded the `lldp` block into the DHCP-agent ConfigBundle etag + response, next to snmp/ntp.
- Settings API read + update fields with validators (tx ranges, protocol allowlist, interface/management-pattern injection guard, sys-text control-char guard).
- `find_lldp_settings` MCP read tool (default-enabled, `module=None`).

**Supervisor** (`agent/supervisor`)
- `appliance_state.maybe_fire_lldp_reload` (4-section payload — the extra line carries `daemon_args`) + `read_lldpd_running` + `collect()` entry, mirroring the snmp/ntp writers.

**Appliance OS**
- `spatiumddi-lldp-reload` host runner + `.path`/`.service` units; mkosi installs `lldpd`, masks its autostart (opt-in), enables the watcher, chmods the files.
- **Key deviation from SNMP/NTP: NO nftables drop-in.** LLDP is raw L2 multicast (ethertype `0x88cc`) — there is no IP port to open.
- Default interface allowlist excludes docker / k3s vNICs so the appliance never advertises into the overlay network.

**Frontend** — `LLDPSection` form + `LLDPTab` + FleetTab "Services" nav (sorts first: LLDP < NTP < SNMP) + api.ts settings types.

**Docs/NOTICE** — APPLIANCE.md LLDP section; lldpd (ISC) added to NOTICE.

## Verification
- **1271 backend tests pass** (9 new LLDP: renderer / bundle / settings-API round-trip / validators) + **6 supervisor tests** (trigger payload / idempotency / appliance gate / status reader)
- Backend ruff / black / mypy clean (509 / 615 files); frontend build + eslint + prettier clean
- Single Alembic head; migration applies; migration-linter baselined

## Scope notes
- **Parity, not yet runtime-active.** Like SNMP/NTP today, the supervisor heartbeat doesn't yet *call* `maybe_fire_*` or receive these settings — that's the shared in-flight #170 / #155–#166 host-config-delivery plane (the #178 commit is tagged not-for-release). LLDP renders + ships in the ConfigBundle and is ready to activate the moment that plane lands, exactly as ready as SNMP/NTP.
- **Phase 2 (deferred):** the neighbor-discovery feedback loop (`find_lldp_neighbors` → existing `NetworkNeighbour` surface) and a console-dashboard row (SNMP/NTP have no console row either).

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)