### PR TITLE
Appliance host-config delivery plane + LLDP Phase 2/3 (#346, #347, #348)

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -855,6 +856,118 @@ def read_lldpd_running() -> bool | None:
     return None
 
 
+# ── LLDP neighbour discovery (#347) ──────────────────────────────────
+
+
+def _lldp_list(x: object) -> list:
+    """lldpd's json0 wraps even single items in arrays; tolerate both."""
+    if isinstance(x, list):
+        return x
+    return [x] if x is not None else []
+
+
+def _lldp_scalar(x: object) -> str:
+    """Pull a leaf string from a json0 node — ``[{"value": v}]`` / ``{"value":
+    v}`` / a bare scalar all collapse to ``str(v)``."""
+    items = _lldp_list(x)
+    if not items:
+        return ""
+    first = items[0]
+    if isinstance(first, dict):
+        return str(first.get("value", "")).strip()
+    return str(first).strip()
+
+
+def _lldp_chassis(iface: dict) -> dict:
+    """Return the chassis object for an interface entry, tolerating both the
+    json0 array shape (``"chassis": [{"id": ...}]``) and the name-keyed
+    ``json`` shape (``"chassis": {"sw1": {"id": ...}}``)."""
+    raw = iface.get("chassis")
+    items = _lldp_list(raw)
+    if items and isinstance(items[0], dict):
+        c = items[0]
+        # Name-keyed single-entry dict (no "id" key) → unwrap the inner value.
+        if "id" not in c and len(c) == 1:
+            inner = next(iter(c.values()))
+            if isinstance(inner, dict):
+                return inner
+        return c
+    return {}
+
+
+def _parse_lldp_neighbours(doc: object) -> list[dict]:
+    """Flatten ``lldpcli show neighbors -f json0`` into neutral neighbour
+    dicts the control plane ingests. Defensive — skips malformed entries
+    rather than raising, so one weird neighbour can't drop the whole batch.
+    """
+    out: list[dict] = []
+    if not isinstance(doc, dict):
+        return out
+    for lldp in _lldp_list(doc.get("lldp")):
+        if not isinstance(lldp, dict):
+            continue
+        for iface in _lldp_list(lldp.get("interface")):
+            if not isinstance(iface, dict):
+                continue
+            # ``_lldp_scalar`` handles both a plain ``"eth0"`` and json0's
+            # array-wrapped ``[{"value": "eth0"}]`` forms uniformly.
+            local = _lldp_scalar(iface.get("name"))
+            chassis = _lldp_chassis(iface)
+            ports = _lldp_list(iface.get("port"))
+            port = ports[0] if ports and isinstance(ports[0], dict) else {}
+
+            chassis_id = _lldp_scalar(chassis.get("id"))
+            port_id = _lldp_scalar(port.get("id"))
+            if not local or not chassis_id or not port_id:
+                continue  # the identity tuple must be complete
+
+            caps = [
+                str(c.get("type"))
+                for c in _lldp_list(chassis.get("capability"))
+                if isinstance(c, dict) and c.get("enabled") and c.get("type")
+            ]
+            out.append(
+                {
+                    "local_iface": local[:64],
+                    "remote_chassis_id": chassis_id[:255],
+                    "remote_port_id": port_id[:255],
+                    "remote_port_descr": (_lldp_scalar(port.get("descr")) or None),
+                    "remote_sys_name": (_lldp_scalar(chassis.get("name")) or None),
+                    "remote_sys_descr": (_lldp_scalar(chassis.get("descr")) or None),
+                    "remote_mgmt_ip": (_lldp_scalar(chassis.get("mgmt-ip")) or None),
+                    "remote_caps": (",".join(caps) or None),
+                }
+            )
+    return out
+
+
+def read_lldp_neighbours() -> list[dict] | None:
+    """Run ``lldpcli show neighbors -f json0`` + parse it (#347).
+
+    Returns the neighbour list (possibly empty) on a successful run, or
+    ``None`` when not on an appliance / lldpcli is unavailable or errors — so
+    the control plane leaves the stored set alone rather than wiping it on a
+    transient failure. An empty list DOES wipe (lldpd ran, saw nothing)."""
+    if detect_deployment_kind() != "appliance":
+        return None
+    try:
+        proc = subprocess.run(
+            ["lldpcli", "-f", "json0", "show", "neighbors"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        doc = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    return _parse_lldp_neighbours(doc)
+
+
 def maybe_fire_ntp_reload(bundle_block: object) -> bool:
     """Issue #154 — write the ntp-config trigger when the control
     plane's rendered chrony.conf hash differs from the last applied.
@@ -1208,6 +1321,10 @@ def collect() -> dict[str, object]:
         # Issue #343 — lldpd running state from the host-side runner's
         # status sidecar. None on non-appliance deploys.
         "lldpd_running": read_lldpd_running() if is_appliance else None,
+        # Issue #347 — LLDP neighbours discovered by local lldpd. None when
+        # not collected (off-appliance / lldpcli error) so the backend leaves
+        # the stored set alone; an empty list means "ran, saw none" (wipe).
+        "lldp_neighbours": read_lldp_neighbours() if is_appliance else None,
         # Issue #183 Phase 4 — local k3s health summary. Slow drift
         # signals that ride the heartbeat (fast actions go through
         # the proxy). Empty dict on non-k3s appliances; never None

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -887,10 +887,13 @@ def _lldp_chassis(iface: dict) -> dict:
     if items and isinstance(items[0], dict):
         c = items[0]
         # Name-keyed single-entry dict (no "id" key) → unwrap the inner value.
+        # The KEY is the chassis sys-name in this shape, so fold it in as
+        # ``name`` (unless the inner dict already carries one) — otherwise
+        # remote_sys_name is silently lost for those lldpd builds.
         if "id" not in c and len(c) == 1:
-            inner = next(iter(c.values()))
+            key, inner = next(iter(c.items()))
             if isinstance(inner, dict):
-                return inner
+                return inner if "name" in inner else {**inner, "name": key}
         return c
     return {}
 

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -79,9 +79,7 @@ _ROLE_ENV_FILENAME = "role-compose.env"
 # used by snmp / chrony / slot-upgrade triggers). Writing to this
 # path = "host runner please re-render".
 _NFT_TRIGGER_PATH = Path("/var/lib/spatiumddi-host/release-state/firewall-pending")
-_NFT_APPLIED_HASH_PATH = Path(
-    "/var/lib/spatiumddi-host/release-state/firewall-applied-hash"
-)
+_NFT_APPLIED_HASH_PATH = Path("/var/lib/spatiumddi-host/release-state/firewall-applied-hash")
 
 # #272 — in-cluster control-plane API Service. Every control-plane
 # node runs the api Deployment behind this headless-routable
@@ -616,6 +614,19 @@ def heartbeat_once(
                 desired_timezone=desired_timezone,
             )
 
+    # Issue #346 — appliance host-config (snmp / chrony / lldp). The control
+    # plane ships each rendered block + its config_hash; the maybe_fire_*
+    # writers compare against their applied-hash sidecar and fire the matching
+    # host-side reload trigger only when it differs (appliance-only, idempotent
+    # — safe to call every heartbeat). This is the runtime-activation path for
+    # #153 / #154 / #343.
+    if appliance_state.maybe_fire_snmp_reload(body_out.get("snmp_settings")):
+        log.info("supervisor.heartbeat.snmp_trigger_fired")
+    if appliance_state.maybe_fire_ntp_reload(body_out.get("ntp_settings")):
+        log.info("supervisor.heartbeat.ntp_trigger_fired")
+    if appliance_state.maybe_fire_lldp_reload(body_out.get("lldp_settings")):
+        log.info("supervisor.heartbeat.lldp_trigger_fired")
+
     # #272 Phase 7b — control-plane promote/demote. The host-side runner
     # (spatium-cluster-join) reconfigures k3s + reports back via the
     # .state sidecar that collect() ships on the next heartbeat; the
@@ -719,9 +730,7 @@ def heartbeat_once(
                 _evicted_pending.add(str(name))
                 log.info("supervisor.heartbeat.node_evicted", node=name)
             else:
-                log.warning(
-                    "supervisor.heartbeat.node_evict_failed", node=name, error=evict_err
-                )
+                log.warning("supervisor.heartbeat.node_evict_failed", node=name, error=evict_err)
         _evicted_pending.intersection_update({str(n) for n in evict_names})
 
     # #170 Wave C2 — render the role-driven compose env. C3 will

--- a/agent/supervisor/tests/test_lldp_neighbours.py
+++ b/agent/supervisor/tests/test_lldp_neighbours.py
@@ -1,0 +1,92 @@
+"""Supervisor lldpcli json0 neighbour parser (#347).
+
+``read_lldp_neighbours`` shells to ``lldpcli`` (validated on real appliances);
+this covers the pure parsing of its json0 output — the fiddly bit — against a
+representative document, plus the defensive skip of incomplete entries.
+"""
+
+from __future__ import annotations
+
+from spatium_supervisor.appliance_state import _parse_lldp_neighbours
+
+# Representative ``lldpcli show neighbors -f json0`` document — json0 wraps
+# every node in arrays and nests leaf values as ``{"value": ...}``.
+_JSON0 = {
+    "lldp": [
+        {
+            "interface": [
+                {
+                    "name": "eth0",
+                    "chassis": [
+                        {
+                            "id": [{"type": "mac", "value": "00:11:22:33:44:55"}],
+                            "name": [{"value": "switch1"}],
+                            "descr": [{"value": "Cisco IOS"}],
+                            "mgmt-ip": [{"value": "10.0.0.1"}],
+                            "capability": [
+                                {"type": "Bridge", "enabled": True},
+                                {"type": "Router", "enabled": False},
+                                {"type": "Wlan", "enabled": True},
+                            ],
+                        }
+                    ],
+                    "port": [
+                        {
+                            "id": [{"type": "ifname", "value": "Gi0/1"}],
+                            "descr": [{"value": "uplink"}],
+                        }
+                    ],
+                },
+                {
+                    # Incomplete entry (no port id) → skipped.
+                    "name": "eth1",
+                    "chassis": [{"id": [{"type": "mac", "value": "aa:bb:cc:dd:ee:ff"}]}],
+                    "port": [{"descr": [{"value": "nope"}]}],
+                },
+            ]
+        }
+    ]
+}
+
+
+def test_parse_json0_neighbour() -> None:
+    out = _parse_lldp_neighbours(_JSON0)
+    assert len(out) == 1  # the incomplete eth1 entry was skipped
+    n = out[0]
+    assert n["local_iface"] == "eth0"
+    assert n["remote_chassis_id"] == "00:11:22:33:44:55"
+    assert n["remote_port_id"] == "Gi0/1"
+    assert n["remote_port_descr"] == "uplink"
+    assert n["remote_sys_name"] == "switch1"
+    assert n["remote_sys_descr"] == "Cisco IOS"
+    assert n["remote_mgmt_ip"] == "10.0.0.1"
+    # Only enabled capabilities, in document order.
+    assert n["remote_caps"] == "Bridge,Wlan"
+
+
+def test_parse_handles_name_keyed_chassis() -> None:
+    # Some lldpd builds key chassis by sys-name with no "id" sibling.
+    doc = {
+        "lldp": [
+            {
+                "interface": [
+                    {
+                        "name": "eno1",
+                        "chassis": {"sw2": {"id": [{"type": "mac", "value": "de:ad:be:ef:00:01"}]}},
+                        "port": {"id": [{"type": "local", "value": "7"}]},
+                    }
+                ]
+            }
+        ]
+    }
+    out = _parse_lldp_neighbours(doc)
+    assert len(out) == 1
+    assert out[0]["remote_chassis_id"] == "de:ad:be:ef:00:01"
+    assert out[0]["remote_port_id"] == "7"
+
+
+def test_parse_empty_and_garbage() -> None:
+    assert _parse_lldp_neighbours({}) == []
+    assert _parse_lldp_neighbours({"lldp": []}) == []
+    assert _parse_lldp_neighbours("not a dict") == []
+    assert _parse_lldp_neighbours({"lldp": [{"interface": []}]}) == []

--- a/agent/supervisor/tests/test_lldp_neighbours.py
+++ b/agent/supervisor/tests/test_lldp_neighbours.py
@@ -83,6 +83,8 @@ def test_parse_handles_name_keyed_chassis() -> None:
     assert len(out) == 1
     assert out[0]["remote_chassis_id"] == "de:ad:be:ef:00:01"
     assert out[0]["remote_port_id"] == "7"
+    # The chassis KEY is the sys-name in this shape — must be preserved (#349).
+    assert out[0]["remote_sys_name"] == "sw2"
 
 
 def test_parse_empty_and_garbage() -> None:

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -183,6 +183,7 @@ backend/alembic/versions/c1f4a8b27d09_soft_delete.py:drop_column:100
 backend/alembic/versions/c1f4a8b27d09_soft_delete.py:drop_column:93
 backend/alembic/versions/c1f4a8b27d09_soft_delete.py:drop_column:98
 backend/alembic/versions/c1f4a8b27d09_soft_delete.py:drop_column:99
+backend/alembic/versions/c1f4a8e3b29d_appliance_lldp_neighbour.py:drop_table:66
 backend/alembic/versions/c263ae1d381a_appliance_cluster_columns.py:drop_column:54
 backend/alembic/versions/c263ae1d381a_appliance_cluster_columns.py:drop_column:55
 backend/alembic/versions/c263ae1d381a_appliance_cluster_columns.py:drop_column:56

--- a/backend/alembic/versions/c1f4a8e3b29d_appliance_lldp_neighbour.py
+++ b/backend/alembic/versions/c1f4a8e3b29d_appliance_lldp_neighbour.py
@@ -1,0 +1,66 @@
+"""appliance_lldp_neighbour — LLDP neighbour discovery (issue #347)
+
+Dedicated table for LLDP neighbours an appliance host discovers via its local
+lldpd (``lldpcli show neighbors``). Distinct from ``network_neighbour`` (the
+SNMP-MIB-shaped switch-polled table) — this matches lldpcli's output directly.
+Absence-deleted on every supervisor heartbeat ingest.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c1f4a8e3b29d"
+down_revision: str | None = "b8c3f2a9e147"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "appliance_lldp_neighbour",
+        sa.Column(
+            "id",
+            sa.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column(
+            "appliance_id",
+            sa.UUID(as_uuid=True),
+            sa.ForeignKey("appliance.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("local_iface", sa.String(length=64), nullable=False),
+        sa.Column("remote_chassis_id", sa.String(length=255), nullable=False),
+        sa.Column("remote_port_id", sa.String(length=255), nullable=False),
+        sa.Column("remote_port_descr", sa.String(length=255), nullable=True),
+        sa.Column("remote_sys_name", sa.String(length=255), nullable=True),
+        sa.Column("remote_sys_descr", sa.Text(), nullable=True),
+        sa.Column("remote_mgmt_ip", sa.String(length=64), nullable=True),
+        sa.Column("remote_caps", sa.String(length=255), nullable=True),
+        sa.Column(
+            "first_seen", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "last_seen", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.UniqueConstraint(
+            "appliance_id",
+            "local_iface",
+            "remote_chassis_id",
+            "remote_port_id",
+            name="uq_appliance_lldp_neighbour",
+        ),
+    )
+    op.create_index(
+        "ix_appliance_lldp_neighbour_appliance",
+        "appliance_lldp_neighbour",
+        ["appliance_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_appliance_lldp_neighbour_appliance", table_name="appliance_lldp_neighbour")
+    op.drop_table("appliance_lldp_neighbour")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -968,6 +968,10 @@ class SupervisorHeartbeatRequest(BaseModel):
     last_upgrade_state_at: datetime | None = None
     snmpd_running: bool | None = None
     ntp_sync_state: Literal["synchronized", "unsynchronized", "unknown"] | None = None
+    # Issue #347 — LLDP neighbours the local lldpd discovered. ``None`` = not
+    # collected (leave the stored set alone); a list (possibly empty) is the
+    # authoritative current set the handler upserts + absence-deletes against.
+    lldp_neighbours: list[dict[str, Any]] | None = None
     # #170 Phase E2 — host-side port conflicts probed by the
     # supervisor. Free-form dict keyed by ``<proto>_<port>``; values
     # are the ``users`` string from ``ss -p`` (process name / pid).
@@ -1181,6 +1185,81 @@ class SupervisorHeartbeatResponse(BaseModel):
     lldp_settings: dict[str, Any] = Field(default_factory=dict)
 
 
+def _s(v: object, limit: int = 255) -> str | None:
+    """Normalise a neighbour string field — trim, truncate, empty → None."""
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s[:limit] if s else None
+
+
+async def _ingest_lldp_neighbours(
+    db: DB, appliance_id: uuid.UUID, neighbours: list[dict[str, Any]]
+) -> None:
+    """Upsert the appliance's LLDP neighbours + absence-delete the rest (#347).
+
+    ``neighbours`` is the authoritative current set from the supervisor's local
+    lldpd. Keyed on ``(local_iface, remote_chassis_id, remote_port_id)`` — the
+    same identity the model's unique constraint uses. Rows no longer present
+    are deleted, mirroring how the switch-polled NetworkNeighbour table behaves.
+    """
+    from app.models.network import ApplianceLldpNeighbour
+
+    desired: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for n in neighbours:
+        if not isinstance(n, dict):
+            continue
+        li = _s(n.get("local_iface"), 64)
+        ch = _s(n.get("remote_chassis_id"))
+        pt = _s(n.get("remote_port_id"))
+        if not (li and ch and pt):
+            continue
+        desired[(li, ch, pt)] = n
+
+    existing = (
+        (
+            await db.execute(
+                select(ApplianceLldpNeighbour).where(
+                    ApplianceLldpNeighbour.appliance_id == appliance_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_key = {(e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing}
+    now = datetime.now(UTC)
+
+    for key, n in desired.items():
+        row = by_key.get(key)
+        if row is None:
+            db.add(
+                ApplianceLldpNeighbour(
+                    appliance_id=appliance_id,
+                    local_iface=key[0],
+                    remote_chassis_id=key[1],
+                    remote_port_id=key[2],
+                    remote_port_descr=_s(n.get("remote_port_descr")),
+                    remote_sys_name=_s(n.get("remote_sys_name")),
+                    remote_sys_descr=_s(n.get("remote_sys_descr"), 4096),
+                    remote_mgmt_ip=_s(n.get("remote_mgmt_ip"), 64),
+                    remote_caps=_s(n.get("remote_caps")),
+                    last_seen=now,
+                )
+            )
+        else:
+            row.remote_port_descr = _s(n.get("remote_port_descr"))
+            row.remote_sys_name = _s(n.get("remote_sys_name"))
+            row.remote_sys_descr = _s(n.get("remote_sys_descr"), 4096)
+            row.remote_mgmt_ip = _s(n.get("remote_mgmt_ip"), 64)
+            row.remote_caps = _s(n.get("remote_caps"))
+            row.last_seen = now
+
+    for key, row in by_key.items():
+        if key not in desired:
+            await db.delete(row)
+
+
 @router.post(
     "/supervisor/heartbeat",
     response_model=SupervisorHeartbeatResponse,
@@ -1314,6 +1393,10 @@ async def supervisor_heartbeat(
         row.snmpd_running = body.snmpd_running
     if body.ntp_sync_state is not None:
         row.ntp_sync_state = body.ntp_sync_state
+    # Issue #347 — ingest the supervisor's local LLDP neighbours (upsert +
+    # absence-delete). None = not collected (leave the set alone).
+    if body.lldp_neighbours is not None:
+        await _ingest_lldp_neighbours(db, row.id, body.lldp_neighbours)
     if body.port_conflicts is not None:
         # Overwrite verbatim — the supervisor's probe is the source of
         # truth. Empty dict explicitly clears prior conflicts; the

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -84,6 +84,9 @@ from app.services.appliance.ca import (
     sign_supervisor_cert,
     verify_session_token,
 )
+from app.services.appliance.lldp import lldp_bundle
+from app.services.appliance.ntp import ntp_bundle
+from app.services.appliance.snmp import snmp_bundle
 
 logger = structlog.get_logger(__name__)
 
@@ -1167,6 +1170,15 @@ class SupervisorHeartbeatResponse(BaseModel):
     # against the host's current tz on every heartbeat + writes the
     # ``spatium-tz-reload`` trigger file when they differ.
     desired_timezone: str = ""
+    # Issue #346 — appliance host-config blocks delivered to the supervisor,
+    # which compares each block's ``config_hash`` against its applied sidecar
+    # and fires the matching ``spatium-{snmp,chrony,lldp}-reload`` trigger when
+    # it differs. Same shape the DHCP-agent ConfigBundle ships; rendered from
+    # ``platform_settings`` via the ``*_bundle`` helpers. Empty/disabled blocks
+    # are still sent (stable key set) so the supervisor can retract config.
+    snmp_settings: dict[str, Any] = Field(default_factory=dict)
+    ntp_settings: dict[str, Any] = Field(default_factory=dict)
+    lldp_settings: dict[str, Any] = Field(default_factory=dict)
 
 
 @router.post(
@@ -1523,6 +1535,25 @@ async def supervisor_heartbeat(
     metallb_vip = (cfg_row.control_plane_vip or "") if cfg_row else ""
     # Issue #165 — operator-set timezone. Empty string = no override.
     desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
+    # Issue #346 — host-config blocks for snmp / chrony / lldp. Built from the
+    # same ``*_bundle`` helpers the DHCP-agent ConfigBundle uses; the
+    # disabled-shape fallback keeps a stable key set when no settings row
+    # exists yet so the supervisor's hash compare never KeyErrors.
+    snmp_block = (
+        snmp_bundle(cfg_row)
+        if cfg_row is not None
+        else {"enabled": False, "config_hash": "", "snmpd_conf": ""}
+    )
+    ntp_block = (
+        ntp_bundle(cfg_row)
+        if cfg_row is not None
+        else {"enabled": False, "allow_clients": False, "config_hash": "", "chrony_conf": ""}
+    )
+    lldp_block = (
+        lldp_bundle(cfg_row)
+        if cfg_row is not None
+        else {"enabled": False, "config_hash": "", "lldpd_conf": "", "daemon_args": ""}
+    )
 
     # #272 Phase 9 — dead k8s Nodes the seed should evict. Returned to
     # every CP supervisor but only the control-plane-variant seed acts.
@@ -1560,6 +1591,9 @@ async def supervisor_heartbeat(
         desired_control_plane_vip=metallb_vip,
         evict_node_names=evict_names,
         desired_timezone=desired_timezone,
+        snmp_settings=snmp_block,
+        ntp_settings=ntp_block,
+        lldp_settings=lldp_block,
     )
 
 

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -478,6 +478,20 @@ class SettingsUpdate(BaseModel):
             raise ValueError("must not contain control characters or newlines")
         return v
 
+    @field_validator("lldp_med_location")
+    @classmethod
+    def _valid_lldp_med_location(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        # LLDP-MED location (issue #348). The only rendered form today is ELIN
+        # (E911 number) — must be digits, since it's rendered bare into
+        # ``configure med location elin <n>``. Other keys are accepted + stored
+        # for future coordinate/civic support but not yet rendered.
+        if v is None:
+            return None
+        elin = v.get("elin")
+        if elin is not None and not str(elin).strip().isdigit():
+            raise ValueError("lldp_med_location.elin must be a numeric E911 ELIN")
+        return v
+
     @field_validator("timezone")
     @classmethod
     def _validate_timezone(cls, v: str | None) -> str | None:

--- a/backend/app/models/network.py
+++ b/backend/app/models/network.py
@@ -407,10 +407,63 @@ class NetworkNeighbour(UUIDPrimaryKeyMixin, Base):
     device: Mapped[NetworkDevice] = relationship("NetworkDevice", back_populates="neighbours")
 
 
+class ApplianceLldpNeighbour(UUIDPrimaryKeyMixin, Base):
+    """An LLDP neighbour an appliance host discovered via its local lldpd.
+
+    Distinct from :class:`NetworkNeighbour` (the SNMP-MIB-shaped table for
+    switch-polled neighbours): this matches ``lldpcli show neighbors -f json0``
+    output directly — local interface *name* + the remote's string-decoded
+    chassis/port — so there is no MIB-subtype impedance and no synthesised
+    ``NetworkDevice`` row. Issue #347.
+
+    Keyed on ``(appliance, local_iface, remote_chassis_id, remote_port_id)`` —
+    the same identity lldpd uses to dedupe. Absence-deleted on every supervisor
+    heartbeat ingest, mirroring how ``NetworkNeighbour`` / FDB rows behave; the
+    audit log is the place to look for historical "what used to be here".
+    """
+
+    __tablename__ = "appliance_lldp_neighbour"
+    __table_args__ = (
+        UniqueConstraint(
+            "appliance_id",
+            "local_iface",
+            "remote_chassis_id",
+            "remote_port_id",
+            name="uq_appliance_lldp_neighbour",
+        ),
+        Index("ix_appliance_lldp_neighbour_appliance", "appliance_id"),
+    )
+
+    appliance_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("appliance.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    local_iface: Mapped[str] = mapped_column(String(64), nullable=False)
+    remote_chassis_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    remote_port_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    remote_port_descr: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    remote_sys_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    remote_sys_descr: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Management IP as a plain string (v4 / v6 / absent) — lldpcli reports it
+    # verbatim and we don't index/range-query it, so no INET typing needed.
+    remote_mgmt_ip: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Comma-joined capability names (e.g. "Bridge,Router") straight from lldpcli.
+    remote_caps: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    first_seen: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_seen: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
 __all__ = [
     "NetworkDevice",
     "NetworkInterface",
     "NetworkArpEntry",
     "NetworkFdbEntry",
     "NetworkNeighbour",
+    "ApplianceLldpNeighbour",
 ]

--- a/backend/app/services/ai/tools/lldp.py
+++ b/backend/app/services/ai/tools/lldp.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.appliance import Appliance
 from app.models.auth import User
+from app.models.network import ApplianceLldpNeighbour
 from app.models.settings import PlatformSettings
 from app.services.ai.tools.base import register_tool
 
@@ -68,3 +71,52 @@ async def find_lldp_settings(
         "system_name_override": settings.lldp_sys_name or None,
         "system_description_override": settings.lldp_sys_description or None,
     }
+
+
+class FindLLDPNeighborsArgs(BaseModel):
+    appliance_id: str | None = Field(
+        default=None, description="Filter to one appliance UUID (the host that saw the neighbour)."
+    )
+    limit: int = Field(default=200, ge=1, le=1000)
+
+
+@register_tool(
+    name="find_lldp_neighbors",
+    description=(
+        "List LLDP neighbours discovered by SpatiumDDI appliance hosts via their "
+        "local lldpd — local interface, the remote switch/device's chassis-id, "
+        "port-id, system name, management IP, and capabilities. Use to answer "
+        "'what is appliance X plugged into?', 'which switch/port is it on?', or "
+        "'what are my appliances' L2 neighbours?'. Populated by the supervisor "
+        "heartbeat (issue #347), absence-deleted when a neighbour ages out."
+    ),
+    args_model=FindLLDPNeighborsArgs,
+    category="network",
+    default_enabled=True,
+    module=None,
+)
+async def find_lldp_neighbors(
+    db: AsyncSession, user: User, args: FindLLDPNeighborsArgs
+) -> list[dict[str, Any]]:
+    stmt = select(ApplianceLldpNeighbour, Appliance.hostname).join(
+        Appliance, Appliance.id == ApplianceLldpNeighbour.appliance_id
+    )
+    if args.appliance_id:
+        stmt = stmt.where(ApplianceLldpNeighbour.appliance_id == args.appliance_id)
+    stmt = stmt.order_by(ApplianceLldpNeighbour.last_seen.desc()).limit(args.limit)
+    rows = (await db.execute(stmt)).all()
+    return [
+        {
+            "appliance_id": str(n.appliance_id),
+            "appliance_hostname": hostname,
+            "local_iface": n.local_iface,
+            "remote_chassis_id": n.remote_chassis_id,
+            "remote_port_id": n.remote_port_id,
+            "remote_port_descr": n.remote_port_descr,
+            "remote_sys_name": n.remote_sys_name,
+            "remote_mgmt_ip": n.remote_mgmt_ip,
+            "remote_caps": n.remote_caps,
+            "last_seen": n.last_seen.isoformat() if n.last_seen else None,
+        }
+        for n, hostname in rows
+    ]

--- a/backend/app/services/ai/tools/lldp.py
+++ b/backend/app/services/ai/tools/lldp.py
@@ -13,6 +13,7 @@ the Phase-1 config-visibility counterpart, matching ``find_snmp_settings``.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -102,7 +103,13 @@ async def find_lldp_neighbors(
         Appliance, Appliance.id == ApplianceLldpNeighbour.appliance_id
     )
     if args.appliance_id:
-        stmt = stmt.where(ApplianceLldpNeighbour.appliance_id == args.appliance_id)
+        try:
+            aid = uuid.UUID(args.appliance_id)
+        except ValueError:
+            # Malformed UUID — return empty rather than letting a bad value
+            # hit the UUID column (driver-dependent error).
+            return []
+        stmt = stmt.where(ApplianceLldpNeighbour.appliance_id == aid)
     stmt = stmt.order_by(ApplianceLldpNeighbour.last_seen.desc()).limit(args.limit)
     rows = (await db.execute(stmt)).all()
     return [

--- a/backend/app/services/appliance/lldp.py
+++ b/backend/app/services/appliance/lldp.py
@@ -97,6 +97,15 @@ def render_lldpd_conf(settings: PlatformSettings) -> str:
     lines.append("configure lldp management-addresses-advertisements enable")
     lines.append("configure lldp capabilities-advertisements enable")
 
+    # LLDP-MED ELIN location (issue #348) — Emergency Location Identification
+    # Number, advertised to MED-capable endpoints (IP phones) for E911 routing.
+    # Coordinate / civic forms are richer and stay API-only for now; ELIN is a
+    # single value with the clearest operator use.
+    med = settings.lldp_med_location or {}
+    elin = str(med.get("elin") or "").strip() if isinstance(med, dict) else ""
+    if elin:
+        lines.append(f"configure med location elin {elin}")
+
     return "\n".join(lines) + "\n"
 
 
@@ -104,10 +113,17 @@ def render_lldpd_daemon_args(settings: PlatformSettings) -> str:
     """Return the ``DAEMON_ARGS`` value for ``/etc/default/lldpd``.
 
     Enables reception of the operator-selected legacy/vendor protocols on top
-    of LLDP. Deterministic flag order so the bundle hash is stable.
+    of LLDP, plus the SNMP AgentX subagent (``-x``) when requested. Deterministic
+    flag order so the bundle hash is stable.
     """
     protocols = {str(p).strip().lower() for p in (settings.lldp_protocols or [])}
     flags = [_PROTOCOL_FLAGS[p] for p in ("cdp", "edp", "fdp", "sonmp") if p in protocols]
+    # ``-x`` registers lldpd as an AgentX subagent so LLDP-MIB (lldpRemTable)
+    # is queryable through the host's snmpd when both are enabled (issue #348).
+    # Loopback AgentX socket — still no firewall change. Harmless if snmpd is
+    # off (lldpd just can't connect to the master and logs a warning).
+    if bool(getattr(settings, "lldp_snmp_agentx", False)):
+        flags.append("-x")
     return " ".join(flags)
 
 

--- a/backend/tests/test_appliance_host_config_delivery.py
+++ b/backend/tests/test_appliance_host_config_delivery.py
@@ -1,0 +1,82 @@
+"""Supervisor heartbeat delivers host-config blocks (issue #346).
+
+The keystone for the appliance host-config plane: the supervisor heartbeat
+response must carry the rendered snmp / chrony / lldp blocks so the
+supervisor can fire the host-side reload triggers. Before #346 the response
+omitted them entirely (SNMP #153 / NTP #154 / LLDP #343 rendered config that
+never reached the supervisor).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
+from app.models.settings import PlatformSettings
+from app.services.appliance.ca import generate_session_token
+
+
+async def _settings(db: AsyncSession) -> PlatformSettings:
+    s = await db.get(PlatformSettings, 1)
+    if s is None:
+        s = PlatformSettings(id=1)
+        db.add(s)
+    # The supervisor endpoints 404 unless the feature flag is on.
+    s.supervisor_registration_enabled = True
+    s.lldp_enabled = True
+    s.lldp_tx_interval = 30
+    s.lldp_tx_hold = 4
+    s.lldp_protocols = ["cdp"]
+    s.snmp_enabled = False
+    await db.flush()
+    return s
+
+
+async def _approved_supervisor(db: AsyncSession) -> tuple[Appliance, str]:
+    token, token_hash = generate_session_token()
+    der = os.urandom(32)
+    row = Appliance(
+        id=uuid.uuid4(),
+        hostname="agent-1",
+        public_key_der=der,
+        public_key_fingerprint=hashlib.sha256(der).hexdigest(),
+        state=APPLIANCE_STATE_APPROVED,
+        deployment_kind="appliance",
+        session_token_hash=token_hash,
+    )
+    db.add(row)
+    await db.flush()
+    return row, token
+
+
+async def test_heartbeat_delivers_host_config_blocks(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _settings(db_session)
+    row, token = await _approved_supervisor(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={"appliance_id": str(row.id), "session_token": token},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    # All three host-config blocks are present with their stable key set.
+    assert "snmp_settings" in body and "ntp_settings" in body and "lldp_settings" in body
+    lldp = body["lldp_settings"]
+    assert lldp["enabled"] is True
+    assert lldp["config_hash"]  # non-empty when enabled
+    assert "configure lldp tx-interval 30" in lldp["lldpd_conf"]
+    assert lldp["daemon_args"] == "-c"  # cdp reception
+    # SNMP is off → disabled-shape block (still present, empty hash).
+    assert body["snmp_settings"]["enabled"] is False
+    assert body["snmp_settings"]["config_hash"] == ""
+    # NTP block carries its stable keys too.
+    assert "config_hash" in body["ntp_settings"]

--- a/backend/tests/test_appliance_lldp.py
+++ b/backend/tests/test_appliance_lldp.py
@@ -88,6 +88,23 @@ def test_daemon_args_flags_in_deterministic_order() -> None:
     assert render_lldpd_daemon_args(s) == ""
 
 
+def test_agentx_appends_x_flag() -> None:
+    s = _bare_settings()
+    s.lldp_protocols = ["cdp"]
+    assert render_lldpd_daemon_args(s) == "-c"
+    s.lldp_snmp_agentx = True
+    assert render_lldpd_daemon_args(s) == "-c -x"  # issue #348
+    s.lldp_protocols = []
+    assert render_lldpd_daemon_args(s) == "-x"
+
+
+def test_med_elin_renders() -> None:
+    s = _bare_settings()
+    assert "med location" not in render_lldpd_conf(s)  # none by default
+    s.lldp_med_location = {"elin": "911"}
+    assert "configure med location elin 911" in render_lldpd_conf(s)
+
+
 def test_renderer_is_deterministic() -> None:
     s = _bare_settings()
     s.lldp_protocols = ["cdp"]
@@ -187,3 +204,24 @@ async def test_settings_lldp_validators(client: AsyncClient, db_session: AsyncSe
     assert (
         await client.put("/api/v1/settings", headers=h, json={"lldp_sys_name": "a\nb"})
     ).status_code == 422
+    # non-numeric MED ELIN (issue #348).
+    assert (
+        await client.put(
+            "/api/v1/settings", headers=h, json={"lldp_med_location": {"elin": "nope"}}
+        )
+    ).status_code == 422
+
+
+async def test_settings_lldp_agentx_and_elin_round_trip(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    r = await client.put(
+        "/api/v1/settings",
+        headers=h,
+        json={"lldp_snmp_agentx": True, "lldp_med_location": {"elin": "911"}},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["lldp_snmp_agentx"] is True
+    assert body["lldp_med_location"] == {"elin": "911"}

--- a/backend/tests/test_appliance_lldp_neighbours.py
+++ b/backend/tests/test_appliance_lldp_neighbours.py
@@ -1,0 +1,168 @@
+"""LLDP neighbour ingest + find_lldp_neighbors MCP tool (issue #347).
+
+The supervisor ships its local lldpd neighbours on the heartbeat; the handler
+upserts them into ``appliance_lldp_neighbour`` and absence-deletes the rest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import hash_password
+from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
+from app.models.auth import User
+from app.models.network import ApplianceLldpNeighbour
+from app.models.settings import PlatformSettings
+from app.services.appliance.ca import generate_session_token
+
+
+async def _approved_supervisor(db: AsyncSession) -> tuple[Appliance, str]:
+    s = await db.get(PlatformSettings, 1)
+    if s is None:
+        s = PlatformSettings(id=1)
+        db.add(s)
+    s.supervisor_registration_enabled = True
+    token, token_hash = generate_session_token()
+    der = os.urandom(32)
+    row = Appliance(
+        id=uuid.uuid4(),
+        hostname="agent-1",
+        public_key_der=der,
+        public_key_fingerprint=hashlib.sha256(der).hexdigest(),
+        state=APPLIANCE_STATE_APPROVED,
+        deployment_kind="appliance",
+        session_token_hash=token_hash,
+    )
+    db.add(row)
+    await db.flush()
+    return row, token
+
+
+def _nbr(iface: str, chassis: str, port: str, **kw: object) -> dict:
+    return {
+        "local_iface": iface,
+        "remote_chassis_id": chassis,
+        "remote_port_id": port,
+        **kw,
+    }
+
+
+async def _heartbeat(client: AsyncClient, row: Appliance, token: str, neighbours: list) -> None:
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={
+            "appliance_id": str(row.id),
+            "session_token": token,
+            "lldp_neighbours": neighbours,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+async def _rows(db: AsyncSession, appliance_id: uuid.UUID) -> list[ApplianceLldpNeighbour]:
+    res = await db.execute(
+        select(ApplianceLldpNeighbour).where(ApplianceLldpNeighbour.appliance_id == appliance_id)
+    )
+    return list(res.scalars().all())
+
+
+async def test_heartbeat_ingests_and_absence_deletes(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    row, token = await _approved_supervisor(db_session)
+    await db_session.commit()
+
+    # First heartbeat — two neighbours.
+    await _heartbeat(
+        client,
+        row,
+        token,
+        [
+            _nbr(
+                "eth0",
+                "aa:bb:cc:00:00:01",
+                "Gi0/1",
+                remote_sys_name="sw1",
+                remote_mgmt_ip="10.0.0.1",
+            ),
+            _nbr("eth1", "aa:bb:cc:00:00:02", "Gi0/2", remote_sys_name="sw2"),
+        ],
+    )
+    db_session.expunge_all()
+    rows = await _rows(db_session, row.id)
+    assert len(rows) == 2
+    by_iface = {r.local_iface: r for r in rows}
+    assert by_iface["eth0"].remote_sys_name == "sw1"
+    assert by_iface["eth0"].remote_mgmt_ip == "10.0.0.1"
+
+    # Second heartbeat — eth0 updated, eth1 gone, eth2 new.
+    await _heartbeat(
+        client,
+        row,
+        token,
+        [
+            _nbr("eth0", "aa:bb:cc:00:00:01", "Gi0/1", remote_sys_name="sw1-renamed"),
+            _nbr("eth2", "aa:bb:cc:00:00:09", "Gi0/9"),
+        ],
+    )
+    db_session.expunge_all()
+    rows2 = await _rows(db_session, row.id)
+    ifaces = {r.local_iface for r in rows2}
+    assert ifaces == {"eth0", "eth2"}  # eth1 absence-deleted
+    eth0 = next(r for r in rows2 if r.local_iface == "eth0")
+    assert eth0.remote_sys_name == "sw1-renamed"  # upserted
+
+
+async def test_heartbeat_none_leaves_rows_alone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    row, token = await _approved_supervisor(db_session)
+    await db_session.commit()
+    await _heartbeat(client, row, token, [_nbr("eth0", "aa:bb:cc:00:00:01", "Gi0/1")])
+    db_session.expunge_all()
+    assert len(await _rows(db_session, row.id)) == 1
+
+    # Heartbeat with lldp_neighbours omitted (None) → existing rows untouched.
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={"appliance_id": str(row.id), "session_token": token},
+    )
+    assert r.status_code == 200, r.text
+    db_session.expunge_all()
+    assert len(await _rows(db_session, row.id)) == 1
+
+
+async def test_find_lldp_neighbors_tool(client: AsyncClient, db_session: AsyncSession) -> None:
+    from app.services.ai.tools.lldp import FindLLDPNeighborsArgs, find_lldp_neighbors
+
+    row, token = await _approved_supervisor(db_session)
+    await db_session.commit()
+    await _heartbeat(
+        client,
+        row,
+        token,
+        [_nbr("eth0", "aa:bb:cc:00:00:01", "Gi0/1", remote_sys_name="sw1")],
+    )
+
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="t",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    out = await find_lldp_neighbors(db_session, user, FindLLDPNeighborsArgs())
+    mine = [n for n in out if n["appliance_id"] == str(row.id)]
+    assert len(mine) == 1
+    assert mine[0]["remote_sys_name"] == "sw1"
+    assert mine[0]["appliance_hostname"] == "agent-1"
+    assert mine[0]["local_iface"] == "eth0"

--- a/backend/tests/test_appliance_lldp_neighbours.py
+++ b/backend/tests/test_appliance_lldp_neighbours.py
@@ -166,3 +166,15 @@ async def test_find_lldp_neighbors_tool(client: AsyncClient, db_session: AsyncSe
     assert mine[0]["remote_sys_name"] == "sw1"
     assert mine[0]["appliance_hostname"] == "agent-1"
     assert mine[0]["local_iface"] == "eth0"
+
+    # Filter by the appliance UUID works…
+    filtered = await find_lldp_neighbors(
+        db_session, user, FindLLDPNeighborsArgs(appliance_id=str(row.id))
+    )
+    assert len(filtered) == 1
+    # …and a malformed UUID returns empty rather than erroring at the DB layer.
+    assert (
+        await find_lldp_neighbors(
+            db_session, user, FindLLDPNeighborsArgs(appliance_id="not-a-uuid")
+        )
+    ) == []

--- a/frontend/src/components/LLDPSection.tsx
+++ b/frontend/src/components/LLDPSection.tsx
@@ -84,7 +84,9 @@ export function LLDPSection({
     sysDesc !== values.lldp_sys_description ||
     agentx !== values.lldp_snmp_agentx ||
     elin !==
-      String((values.lldp_med_location as { elin?: unknown } | null)?.elin ?? "");
+      String(
+        (values.lldp_med_location as { elin?: unknown } | null)?.elin ?? "",
+      );
 
   const [saveErr, setSaveErr] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
@@ -278,7 +280,11 @@ export function LLDPSection({
         label="SNMP AgentX (LLDP-MIB)"
         description="Register lldpd as an AgentX subagent of the host snmpd so LLDP-MIB (lldpRemTable) is queryable over SNMP. Only meaningful when SNMP is also enabled. Loopback only — no firewall change."
       >
-        <Toggle checked={agentx} onChange={setAgentx} disabled={!isSuperadmin} />
+        <Toggle
+          checked={agentx}
+          onChange={setAgentx}
+          disabled={!isSuperadmin}
+        />
       </Field>
 
       <Field

--- a/frontend/src/components/LLDPSection.tsx
+++ b/frontend/src/components/LLDPSection.tsx
@@ -67,6 +67,10 @@ export function LLDPSection({
   );
   const [sysName, setSysName] = useState<string>(values.lldp_sys_name);
   const [sysDesc, setSysDesc] = useState<string>(values.lldp_sys_description);
+  const [agentx, setAgentx] = useState<boolean>(values.lldp_snmp_agentx);
+  const [elin, setElin] = useState<string>(
+    String((values.lldp_med_location as { elin?: unknown } | null)?.elin ?? ""),
+  );
 
   const dirty =
     enabled !== values.lldp_enabled ||
@@ -77,7 +81,10 @@ export function LLDPSection({
     ifacePattern !== values.lldp_interface_pattern ||
     mgmtPattern !== values.lldp_management_pattern ||
     sysName !== values.lldp_sys_name ||
-    sysDesc !== values.lldp_sys_description;
+    sysDesc !== values.lldp_sys_description ||
+    agentx !== values.lldp_snmp_agentx ||
+    elin !==
+      String((values.lldp_med_location as { elin?: unknown } | null)?.elin ?? "");
 
   const [saveErr, setSaveErr] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
@@ -94,6 +101,12 @@ export function LLDPSection({
       setMgmtPattern(updated.lldp_management_pattern);
       setSysName(updated.lldp_sys_name);
       setSysDesc(updated.lldp_sys_description);
+      setAgentx(updated.lldp_snmp_agentx);
+      setElin(
+        String(
+          (updated.lldp_med_location as { elin?: unknown } | null)?.elin ?? "",
+        ),
+      );
       setSaveErr(null);
       setSavedAt(Date.now());
       setTimeout(() => setSavedAt(null), 2500);
@@ -119,6 +132,8 @@ export function LLDPSection({
       lldp_management_pattern: mgmtPattern.trim(),
       lldp_sys_name: sysName,
       lldp_sys_description: sysDesc,
+      lldp_snmp_agentx: agentx,
+      lldp_med_location: elin.trim() ? { elin: elin.trim() } : {},
     });
   }
 
@@ -256,6 +271,28 @@ export function LLDPSection({
           placeholder="(default)"
           disabled={!isSuperadmin}
           className={cn(inputCls, "w-96 max-w-full")}
+        />
+      </Field>
+
+      <Field
+        label="SNMP AgentX (LLDP-MIB)"
+        description="Register lldpd as an AgentX subagent of the host snmpd so LLDP-MIB (lldpRemTable) is queryable over SNMP. Only meaningful when SNMP is also enabled. Loopback only — no firewall change."
+      >
+        <Toggle checked={agentx} onChange={setAgentx} disabled={!isSuperadmin} />
+      </Field>
+
+      <Field
+        label="MED location (ELIN)"
+        description="LLDP-MED Emergency Location Identification Number advertised to MED endpoints (IP phones) for E911 routing. Digits only; empty = none. Coordinate / civic forms are API-only for now."
+      >
+        <input
+          type="text"
+          inputMode="numeric"
+          value={elin}
+          onChange={(e) => setElin(e.target.value)}
+          placeholder="(none)"
+          disabled={!isSuperadmin}
+          className={cn(inputCls, "w-48")}
         />
       </Field>
 


### PR DESCRIPTION
The three #343 follow-ups, dependency-ordered on one branch.

## #346 — supervisor host-config delivery plane (the keystone)
The render + bundle + host-runner halves of the appliance host-config plane shipped (SNMP #153, NTP #154, LLDP #343), but the **delivery** half was unwired under #170: the supervisor heartbeat response never carried the settings and the heartbeat loop never called the `maybe_fire_*_reload` writers — so none of the three actually applied on a supervisor-based appliance.

- Backend `SupervisorHeartbeatResponse` + builder now include `snmp_settings` / `ntp_settings` / `lldp_settings` blocks (from the existing `*_bundle` helpers; disabled-shape fallback when no settings row).
- Supervisor heartbeat loop calls `appliance_state.maybe_fire_snmp_reload` / `ntp` / `lldp` with each block — hash-compare against the applied sidecar, fire the host-side reload only on change. Mirrors the path that already works for `desired_timezone`.
- E2e test: an authed supervisor heartbeat returns all three blocks.

## #347 — LLDP Phase 2: neighbour discovery feedback loop
Dedicated `ApplianceLldpNeighbour` model (chosen over forcing lldpcli output through the SNMP-MIB-shaped `NetworkNeighbour` — no local-interface-name field, integer MIB subtypes, NOT-NULL `local_port_num`).

- Supervisor `read_lldp_neighbours` runs `lldpcli show neighbors -f json0`; `_parse_lldp_neighbours` flattens it (tolerates json0 array-wrapping + name-keyed chassis; skips incomplete entries). Shipped on the heartbeat (None off-appliance / on error).
- Heartbeat handler upserts the set + absence-deletes the rest (None = leave alone; [] = wipe).
- `find_lldp_neighbors` MCP tool (read, default-enabled).

## #348 — LLDP Phase 3: MED ELIN + AgentX
Wires the two columns #343 added but left unrendered: `lldp_snmp_agentx` → `-x` daemon arg (LLDP-MIB via the host snmpd, loopback, no firewall change); `lldp_med_location` → `configure med location elin <n>` (numeric-validated). Frontend AgentX toggle + ELIN input.

## Verification
- **Backend suite green** (targeted: heartbeat delivery, LLDP neighbour ingest/absence-delete, MCP tool, renderer/validators) + **9 supervisor LLDP tests** (json0 parser, name-keyed chassis, trigger payload/idempotency)
- ruff / black / mypy clean; frontend build + prettier clean
- Single Alembic head `c1f4a8e3b29d`; both migrations apply; linter baselined

## Scope notes
- #347 console neighbour-count row deferred — consistent with #343/#346 (no host-config feature has a Talos-console row yet; won't add an untested subprocess to that render loop). A unified host-config console row is a fair future follow-up.
- LLDP-MED coordinate/civic forms accepted + stored but API-only for now (ELIN is the rendered form).

Closes #346
Closes #347
Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)