### PR TITLE
fix(auth): honor Superadmin role (not just the column) on all superadmin gates (#351)

### DIFF
--- a/backend/app/api/v1/admin/agent_keys.py
+++ b/backend/app/api/v1/admin/agent_keys.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel, Field
 
 from app.api.deps import DB, CurrentUser
 from app.config import settings
+from app.core.permissions import is_effective_superadmin
 from app.core.security import verify_password
 from app.models.audit import AuditLog
 
@@ -74,7 +75,7 @@ async def reveal_agent_keys(
     surface — anyone who has them can register a rogue agent and
     inject themselves into the agent-config push.
     """
-    if not current_user.is_superadmin:
+    if not is_effective_superadmin(current_user):
         # Audit even the denied attempts — interesting signal.
         db.add(
             AuditLog(

--- a/backend/app/api/v1/ai/prompts.py
+++ b/backend/app/api/v1/ai/prompts.py
@@ -174,12 +174,15 @@ async def update_prompt(
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     is_owner = row.created_by_user_id == current_user.id
-    if not (is_effective_superadmin(current_user) or is_owner):
+    # Resolve effective-superadmin once — it walks the RBAC group→role graph,
+    # and this handler gates on it three times (#354 review).
+    is_admin = is_effective_superadmin(current_user)
+    if not (is_admin or is_owner):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     # Operators can't promote a private prompt into the shared bucket
     # without superadmin, since shared prompts go in the curated list.
     if body.is_shared is not None and body.is_shared != row.is_shared:
-        if not is_effective_superadmin(current_user):
+        if not is_admin:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only superadmins can change the shared/private flag",
@@ -206,7 +209,7 @@ async def update_prompt(
     )
     await db.commit()
     await db.refresh(row)
-    return _to_response(row, is_owner=is_owner or is_effective_superadmin(current_user))
+    return _to_response(row, is_owner=is_owner or is_admin)
 
 
 @router.delete("/prompts/{prompt_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/ai/prompts.py
+++ b/backend/app/api/v1/ai/prompts.py
@@ -31,6 +31,7 @@ from sqlalchemy.exc import IntegrityError
 
 from app.api.deps import DB, CurrentUser
 from app.api.v1.dhcp._audit import write_audit
+from app.core.permissions import is_effective_superadmin
 from app.models.ai import AIPrompt
 
 logger = structlog.get_logger(__name__)
@@ -115,7 +116,7 @@ async def list_prompts(current_user: CurrentUser, db: DB) -> list[PromptResponse
     status_code=status.HTTP_201_CREATED,
 )
 async def create_prompt(body: PromptCreate, current_user: CurrentUser, db: DB) -> PromptResponse:
-    if body.is_shared and not current_user.is_superadmin:
+    if body.is_shared and not is_effective_superadmin(current_user):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only superadmins can create shared prompts",
@@ -173,12 +174,12 @@ async def update_prompt(
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     is_owner = row.created_by_user_id == current_user.id
-    if not (current_user.is_superadmin or is_owner):
+    if not (is_effective_superadmin(current_user) or is_owner):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     # Operators can't promote a private prompt into the shared bucket
     # without superadmin, since shared prompts go in the curated list.
     if body.is_shared is not None and body.is_shared != row.is_shared:
-        if not current_user.is_superadmin:
+        if not is_effective_superadmin(current_user):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Only superadmins can change the shared/private flag",
@@ -205,7 +206,7 @@ async def update_prompt(
     )
     await db.commit()
     await db.refresh(row)
-    return _to_response(row, is_owner=is_owner or current_user.is_superadmin)
+    return _to_response(row, is_owner=is_owner or is_effective_superadmin(current_user))
 
 
 @router.delete("/prompts/{prompt_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -214,7 +215,7 @@ async def delete_prompt(prompt_id: uuid.UUID, current_user: CurrentUser, db: DB)
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     is_owner = row.created_by_user_id == current_user.id
-    if not (current_user.is_superadmin or is_owner):
+    if not (is_effective_superadmin(current_user) or is_owner):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     name = row.name
     await db.delete(row)

--- a/backend/app/api/v1/api_tokens/router.py
+++ b/backend/app/api/v1/api_tokens/router.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import delete, select
 
 from app.api.deps import DB, CurrentUser
+from app.core.permissions import is_effective_superadmin
 from app.core.security import generate_api_token
 from app.models.audit import AuditLog
 from app.models.auth import APIToken
@@ -139,7 +140,7 @@ def _resolve_expiry(body: ApiTokenCreate) -> datetime | None:
 async def list_tokens(db: DB, current_user: CurrentUser) -> list[APIToken]:
     """List tokens owned by the caller. Superadmin sees everyone's."""
     stmt = select(APIToken).order_by(APIToken.created_at.desc())
-    if not current_user.is_superadmin:
+    if not is_effective_superadmin(current_user):
         stmt = stmt.where(APIToken.user_id == current_user.id)
     return list((await db.execute(stmt)).scalars().all())
 
@@ -277,6 +278,6 @@ async def _require_owned(token_id: uuid.UUID, db: DB, current_user: CurrentUser)
     # Non-superadmins can only see their own tokens. Raising 404 here
     # rather than 403 so we don't leak "this token exists, just not
     # yours".
-    if not current_user.is_superadmin and token.user_id != current_user.id:
+    if not is_effective_superadmin(current_user) and token.user_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found")
     return token

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -4441,7 +4441,7 @@ async def reveal_appliance_kubeconfig(
             )
         )
 
-    if not current_user.is_superadmin:
+    if not is_effective_superadmin(current_user):
         _audit_denied("non_superadmin")
         await db.commit()
         await asyncio.sleep(0.1)

--- a/backend/app/api/v1/auth/router.py
+++ b/backend/app/api/v1/auth/router.py
@@ -42,6 +42,7 @@ from app.core.auth.user_sync import (
 )
 from app.core.auth_throttle import login_rate_limited, mfa_challenge_consume
 from app.core.demo_mode import forbid_in_demo_mode
+from app.core.permissions import is_effective_superadmin
 from app.core.request_meta import clean_user_agent
 from app.core.security import (
     create_access_token,
@@ -802,8 +803,26 @@ async def logout(current_user: CurrentUser, db: DB) -> None:
 
 
 @router.get("/me", response_model=UserResponse)
-async def get_me(current_user: CurrentUser) -> User:
-    return current_user
+async def get_me(current_user: CurrentUser) -> UserResponse:
+    # #351 — ``is_superadmin`` here reports the *effective* status (the legacy
+    # column OR a group → Superadmin-role ``{*, *}`` wildcard), NOT the raw
+    # column. OIDC / LDAP / SAML users mapped into a Superadmin-role group have
+    # ``is_superadmin=False`` on the row (the column is only set on the seeded
+    # ``admin`` account + explicit admin-form flags), so reporting the column
+    # locked them out of every frontend superadmin gate (Fleet, Pairing,
+    # SNMP / NTP / LLDP, Sessions, Settings, …) even though the backend route
+    # gates already admit them via ``is_effective_superadmin``. This aligns what
+    # ``/me`` advertises with what those gates actually allow. The literal
+    # column stays available to admins via the users endpoint.
+    return UserResponse(
+        id=current_user.id,
+        username=current_user.username,
+        email=current_user.email,
+        display_name=current_user.display_name,
+        is_superadmin=is_effective_superadmin(current_user),
+        force_password_change=current_user.force_password_change,
+        auth_source=current_user.auth_source,
+    )
 
 
 # ── MFA — TOTP enrolment + management (issue #69) ───────────────────────────

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -14,7 +14,7 @@ from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
 from app.core.demo_mode import forbid_in_demo_mode
-from app.core.permissions import user_has_permission
+from app.core.permissions import is_effective_superadmin, user_has_permission
 from app.models.audit_forward import AuditForwardTarget
 from app.models.oui import OUIVendor
 from app.models.settings import PlatformSettings
@@ -1039,7 +1039,7 @@ async def reveal_snmp_community(
             )
         )
 
-    if not current_user.is_superadmin:
+    if not is_effective_superadmin(current_user):
         _audit_denied("non_superadmin")
         await db.commit()
         raise HTTPException(
@@ -1344,7 +1344,7 @@ def _apply_body(t: AuditForwardTarget, body: AuditTargetBody) -> None:
 
 @router.get("/audit-forward-targets", response_model=list[AuditTargetResponse])
 async def list_audit_targets(current_user: CurrentUser, db: DB) -> list[AuditTargetResponse]:
-    if not current_user.is_superadmin:
+    if not is_effective_superadmin(current_user):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     res = await db.execute(select(AuditForwardTarget).order_by(AuditForwardTarget.name))
     return [_target_to_response(t) for t in res.scalars().all()]
@@ -1359,7 +1359,7 @@ async def create_audit_target(
     body: AuditTargetBody, current_user: CurrentUser, db: DB
 ) -> AuditTargetResponse:
     forbid_in_demo_mode("Audit-forward target creation is disabled")
-    if not current_user.is_superadmin:
+    if not is_effective_superadmin(current_user):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     row = AuditForwardTarget()
     _apply_body(row, body)
@@ -1378,7 +1378,7 @@ async def update_audit_target(
     target_id: str, body: AuditTargetBody, current_user: CurrentUser, db: DB
 ) -> AuditTargetResponse:
     forbid_in_demo_mode("Audit-forward target updates are disabled")
-    if not current_user.is_superadmin:
+    if not is_effective_superadmin(current_user):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     row = await db.get(AuditForwardTarget, target_id)
     if row is None:
@@ -1395,7 +1395,7 @@ async def update_audit_target(
 
 @router.delete("/audit-forward-targets/{target_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_audit_target(target_id: str, current_user: CurrentUser, db: DB) -> None:
-    if not current_user.is_superadmin:
+    if not is_effective_superadmin(current_user):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     row = await db.get(AuditForwardTarget, target_id)
     if row is None:
@@ -1412,7 +1412,7 @@ async def test_audit_target(target_id: str, current_user: CurrentUser, db: DB) -
     filter it out in the collector if they want. Doesn't land in
     ``audit_log`` — this is explicit probe traffic, not an audit.
     """
-    if not current_user.is_superadmin:
+    if not is_effective_superadmin(current_user):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
     row = await db.get(AuditForwardTarget, target_id)
     if row is None:

--- a/backend/app/services/ai/operations_writes.py
+++ b/backend/app/services/ai/operations_writes.py
@@ -39,6 +39,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.dhcp._audit import write_audit
+from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.services.ai.operations import Operation, PreviewResult, register
 
@@ -329,7 +330,7 @@ register(
 
 def _require_superadmin(user: User) -> None:
     """Apply-time guard — raises so a non-superadmin apply is rejected."""
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         raise ValueError("This operation is restricted to superadmin users")
 
 
@@ -337,7 +338,7 @@ def _superadmin_preview_block(user: User) -> PreviewResult | None:
     """Preview-time guard — returns a clean rejection (never raises, so
     ``_propose_via`` surfaces it as proposal_rejected rather than an
     error)."""
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return PreviewResult(ok=False, detail="This operation is restricted to superadmin users")
     return None
 

--- a/backend/app/services/ai/tools/admin.py
+++ b/backend/app/services/ai/tools/admin.py
@@ -30,6 +30,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.permissions import is_effective_superadmin
 from app.models.auth import Group, Role, User
 from app.services.ai.tools.base import register_tool
 
@@ -47,7 +48,7 @@ def _superadmin_gate(user: User) -> dict[str, Any] | None:
     allowed. Tools wrap their list/dict return as a single-element
     error response so the orchestrator's "tool result" message reads
     as a clear refusal rather than an empty payload."""
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return {
             "error": (
                 "This tool returns security-sensitive RBAC and login "

--- a/backend/app/services/ai/tools/appliance.py
+++ b/backend/app/services/ai/tools/appliance.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.models.appliance import (
     APPLIANCE_STATE_PENDING_APPROVAL,
     Appliance,
@@ -44,7 +45,7 @@ from app.services.ai.tools.proposals import _persist_proposal, _proposal_result
 
 
 def _superadmin_gate(user: User) -> dict[str, Any] | None:
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return {
             "error": (
                 "Appliance fleet management is restricted to superadmin "

--- a/backend/app/services/ai/tools/backup.py
+++ b/backend/app/services/ai/tools/backup.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import desc, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.backup import BackupTarget
@@ -49,7 +50,7 @@ def _superadmin_gate(user: User) -> dict[str, Any] | None:
     superadmin; ``None`` when the call is allowed. Mirrors the
     pattern from ``tools/admin.py`` for the RBAC tools.
     """
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return {
             "error": (
                 "Backup tools expose destination metadata + audit "

--- a/backend/app/services/ai/tools/diagnostics.py
+++ b/backend/app/services/ai/tools/diagnostics.py
@@ -29,13 +29,14 @@ from pydantic import BaseModel, Field
 from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.models.diagnostics import InternalError
 from app.services.ai.tools.base import register_tool
 
 
 def _superadmin_gate(user: User) -> dict[str, Any] | None:
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return {
             "error": (
                 "This tool exposes uncaught exception tracebacks + "

--- a/backend/app/services/ai/tools/firewall.py
+++ b/backend/app/services/ai/tools/firewall.py
@@ -33,6 +33,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.models.firewall import FirewallAlias, FirewallPolicy
 from app.services.ai import operations
@@ -43,7 +44,7 @@ _MODULE = "appliance.firewall"
 
 
 def _superadmin_gate(user: User) -> dict[str, Any] | None:
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return {
             "error": (
                 "Fleet firewall management is restricted to superadmin users. "

--- a/backend/app/services/ai/tools/imports.py
+++ b/backend/app/services/ai/tools/imports.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.services.ai.operations_writes import (
     CommitDHCPImportArgs,
@@ -29,7 +30,7 @@ from app.services.ai.tools.base import register_tool
 
 
 def _superadmin_gate(user: User) -> dict[str, Any] | None:
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return {"error": "Config-import tools are restricted to superadmin users."}
     return None
 

--- a/backend/app/services/ai/tools/pairing.py
+++ b/backend/app/services/ai/tools/pairing.py
@@ -31,13 +31,14 @@ from sqlalchemy import func as sa_func
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.models.appliance import PairingClaim, PairingCode
 from app.models.auth import User
 from app.services.ai.tools.base import register_tool
 
 
 def _superadmin_gate(user: User) -> dict[str, Any] | None:
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return {
             "error": (
                 "Pairing codes contain agent bootstrap secrets, so this "

--- a/backend/app/services/ai/tools/upgrades.py
+++ b/backend/app/services/ai/tools/upgrades.py
@@ -23,13 +23,14 @@ from typing import Any
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.services.ai.tools.base import register_tool
 from app.services.upgrades import mutex, orchestrator, preflight
 
 
 def _superadmin_gate(user: User) -> dict[str, Any] | None:
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return {"error": ("Rolling-upgrade preflight is restricted to superadmin users.")}
     return None
 

--- a/backend/app/services/ai/tools/webhooks.py
+++ b/backend/app/services/ai/tools/webhooks.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.models.event_subscription import EventOutbox, EventSubscription
 from app.services.ai.tools.base import register_tool
@@ -38,7 +39,7 @@ def _superadmin_gate(user: User) -> dict[str, Any] | None:
     auth tokens). Mirror the gate at the MCP layer so a non-
     superadmin's chat session can't read it either.
     """
-    if not user.is_superadmin:
+    if not is_effective_superadmin(user):
         return {
             "error": (
                 "Webhook config is restricted to superadmin users. "

--- a/backend/tests/test_ai_write_operations.py
+++ b/backend/tests/test_ai_write_operations.py
@@ -32,6 +32,7 @@ async def _user(db: AsyncSession, *, superadmin: bool = True, name: str = "ai-wr
         hashed_password=hash_password("x"),
         is_superadmin=superadmin,
     )
+    u.groups = []  # mark loaded — is_effective_superadmin walks .groups (#351)
     db.add(u)
     await db.commit()
     return u

--- a/backend/tests/test_appliance_pairing.py
+++ b/backend/tests/test_appliance_pairing.py
@@ -44,6 +44,7 @@ async def _make_user(
         auth_source=auth_source,
         is_superadmin=superadmin,
     )
+    user.groups = []  # mark loaded — is_effective_superadmin walks .groups (#351)
     db.add(user)
     await db.flush()
     token = create_access_token(str(user.id))

--- a/backend/tests/test_firewall_mcp.py
+++ b/backend/tests/test_firewall_mcp.py
@@ -37,6 +37,7 @@ async def _user(db: AsyncSession, *, superadmin: bool) -> User:
         hashed_password="x",
         is_superadmin=superadmin,
     )
+    u.groups = []  # mark loaded — is_effective_superadmin walks .groups (#351)
     db.add(u)
     await db.flush()
     return u

--- a/backend/tests/test_permissions.py
+++ b/backend/tests/test_permissions.py
@@ -305,3 +305,46 @@ async def test_dns_editor_cannot_touch_ipam(client: AsyncClient, db_session: Asy
     # IPAM: denied
     r = await client.get("/api/v1/ipam/spaces", headers=headers)
     assert r.status_code == 403
+
+
+# ── /auth/me reports EFFECTIVE superadmin (issue #351) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_me_reports_effective_superadmin_for_role_only_user(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An OIDC/LDAP/SAML user mapped to a Superadmin-role group has
+    ``is_superadmin=False`` on the row but the ``{*, *}`` wildcard via the role.
+    ``/auth/me`` must report ``is_superadmin: true`` so the frontend's
+    superadmin gates (Fleet, Pairing, SNMP/NTP/LLDP, Sessions, …) light up —
+    matching what the backend route gates (``is_effective_superadmin``) allow.
+    """
+    user, token = await _persist_user_with_role(
+        db_session,
+        role_name="Superadmin-clone",
+        permissions=[{"action": "*", "resource_type": "*"}],
+        username="oidc-superadmin",
+    )
+    assert user.is_superadmin is False  # the column is NOT set — role only
+    await db_session.commit()
+    r = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    assert r.json()["is_superadmin"] is True
+
+
+@pytest.mark.asyncio
+async def test_me_reports_false_for_plain_user(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # A user with neither the column nor a wildcard role is NOT a superadmin.
+    _, token = await _persist_user_with_role(
+        db_session,
+        role_name="Plain-reader",
+        permissions=[{"action": "read", "resource_type": "subnet"}],
+        username="plain-user",
+    )
+    await db_session.commit()
+    r = await client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    assert r.json()["is_superadmin"] is False


### PR DESCRIPTION
Closes #351

## The bug
OIDC / LDAP / SAML users mapped into a group that grants the built-in **Superadmin role** have the RBAC `{action: "*", resource_type: "*"}` wildcard but `User.is_superadmin = False` on the row (the column is only set on the seeded `admin` account + explicit admin-form flags). `GET /auth/me` reported the **raw column**, and the frontend's superadmin gates all read `me?.is_superadmin ?? false` — so these users were locked out of Fleet (the reported symptom) **and** every sibling gate, even though the route-level backend gates already admitted them via `is_effective_superadmin` (added in #190). The reporter's evidence: `/api/v1/auth/me` → `"is_superadmin": false`.

## Fix — two layers

**1. `/auth/me` reports *effective* superadmin** (column OR `*/*` wildcard role). One backend change fixes every `me?.is_superadmin` frontend gate — Fleet, Pairing, SNMP / NTP / LLDP, Sessions, Settings, Custom Fields, Auth Providers — with **zero frontend changes**, and aligns what `/me` advertises with what the backend gates actually allow. The literal column stays available to admins via the users endpoint.

**2. Same-bug sweep** — every remaining gate that still checked the raw column now uses `is_effective_superadmin`:
- 9 Operator-Copilot MCP `_superadmin_gate`s — `admin` / `appliance` / `backup` / `diagnostics` / `firewall` / `imports` / `pairing` / `upgrades` / `webhooks`
- `operations_writes` ×2 (Copilot write apply-gate + preview-block)
- `settings/router.py` ×6, `api_tokens/router.py` ×2, `ai/prompts.py` ×5, `admin/agent_keys.py`
- `appliance/supervisor.py:4444` (was inconsistent — line 2025 in the same file already used effective)

**Intentionally left as-is:** users-admin column CRUD + self-demotion guard, the `main.py` seed, `user_sync` (sets the column `False` by design — superadmin comes via the role), `admin.py`'s list-users-*by-column* report, and `sessions/router.py` (already role-aware).

## Production safety
`User.groups` / `Group.roles` are `lazy="selectin"`, so every real user-load path (`get_current_user`, API-token resolve, chat) eager-loads groups — the permission walk in `is_effective_superadmin` does no lazy IO. The only test failures were hand-built users that never loaded `.groups`; fixed in 3 test fixtures.

## Testing
- New `/auth/me` regression tests: role-only superadmin → `true`, plain user → `false`.
- **Full backend suite: 1396 passed, 1 skipped** (the known supervisor-leg byte-identity skip in the backend-only test image). ruff + black + mypy clean.

## Known follow-up (not in this PR)
`factory_reset` preserves superadmins by the **column only** (`WHERE is_superadmin = false`) — same column-vs-role shape, but a destructive path whose role semantics are murky (the `auth_rbac` reset wipes the group→role mapping anyway). Flagged for a focused follow-up rather than changing destructive SQL here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
