### PR TITLE
Sidebar reorg + appliance verbose-boot console toggle

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -312,6 +312,15 @@ _SLOT_VERSIONS_FILE = Path("/var/lib/spatiumddi-host/release-state/slot-versions
 # supervisor short-circuits the next heartbeat's trigger write.
 _TZ_TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/tz-pending")
 _TZ_APPLIED_HASH_FILE = Path("/var/lib/spatiumddi-host/release-state/tz-hash")
+# Verbose-boot console toggle. The runner flips a grubenv variable
+# (spatium_verbose) the grub.cfg menuentries read; trigger body is a single
+# "1" (standard Linux console) or "0" (quiet boot + dashboard).
+_VERBOSE_TRIGGER_FILE = Path(
+    "/var/lib/spatiumddi-host/release-state/verbose-boot-pending"
+)
+_VERBOSE_APPLIED_FILE = Path(
+    "/var/lib/spatiumddi-host/release-state/verbose-boot-applied"
+)
 # Per-slot boot-control trigger files. Each carries a single line:
 # the target slot name (``slot_a`` / ``slot_b``). The host-side
 # ``spatiumddi-slot-set-next-boot.path`` / ``spatiumddi-slot-set-
@@ -524,6 +533,39 @@ def maybe_fire_timezone(desired_timezone: str | None) -> bool:
         # rename ensures the runner sees the complete trigger file
         # rather than a half-written one.
         tmp.replace(_TZ_TRIGGER_FILE)
+        return True
+    except OSError:
+        return False
+
+
+def maybe_fire_verbose_boot(desired_verbose_boot: bool | None) -> bool:
+    """Write the verbose-boot trigger when the operator's desired console
+    verbosity (``platform_settings.verbose_boot``) differs from what the host
+    runner last applied. The runner flips a grubenv variable the grub.cfg
+    menuentries read, so it takes effect on the NEXT reboot.
+
+    Body is a single line: ``1`` (standard Linux console — drop the loglevel
+    cap + systemd.show_status + spatium-console=off) or ``0`` (today's quiet
+    boot + Talos dashboard). Idempotent via the ``verbose-boot-applied``
+    sidecar; a missing sidecar is treated as ``0`` because the installer seeds
+    ``grub-editenv … spatium_verbose=0`` at install time, so the default state
+    is already applied and needs no trigger. Strict appliance-only gate
+    (mirrors ``maybe_fire_timezone`` / ``maybe_fire_reboot``).
+    """
+    if detect_deployment_kind() != "appliance":
+        return False
+    desired = "1" if desired_verbose_boot else "0"
+    try:
+        applied = _VERBOSE_APPLIED_FILE.read_text(encoding="utf-8").strip()
+    except OSError:
+        applied = "0"  # install seeds grubenv spatium_verbose=0 — default is live
+    if applied == desired:
+        return False
+    try:
+        _VERBOSE_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _VERBOSE_TRIGGER_FILE.with_suffix(".new")
+        tmp.write_text(desired + "\n", encoding="utf-8")
+        tmp.replace(_VERBOSE_TRIGGER_FILE)
         return True
     except OSError:
         return False

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -653,6 +653,17 @@ def heartbeat_once(
                 desired_timezone=desired_timezone,
             )
 
+    # Verbose-boot console toggle. Always evaluated (it's a definite bool, not
+    # an opt-in override like timezone); maybe_fire_verbose_boot short-circuits
+    # against its applied sidecar so it only writes the grubenv trigger on a
+    # real change. Applies next reboot.
+    desired_verbose_boot = body_out.get("desired_verbose_boot")
+    if appliance_state.maybe_fire_verbose_boot(bool(desired_verbose_boot)):
+        log.info(
+            "supervisor.heartbeat.verbose_boot_trigger_fired",
+            desired_verbose_boot=bool(desired_verbose_boot),
+        )
+
     # Issue #346 — appliance host-config (snmp / chrony / lldp). The control
     # plane ships each rendered block + its config_hash; the maybe_fire_*
     # writers compare against their applied-hash sidecar and fire the matching

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-verbose-boot-reload.path
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-verbose-boot-reload.path
@@ -1,0 +1,14 @@
+[Unit]
+Description=Watch for SpatiumDDI verbose-boot toggle trigger
+# Skip on the live ISO — the installer environment doesn't drive boot
+# verbosity through the SpatiumDDI host-config plane.
+ConditionKernelCommandLine=!boot=live
+
+[Path]
+# Same atomic-rename trigger pattern the tz / chrony / SNMP units use:
+# the supervisor writes <name>.new then mv → <name>; PathChanged fires
+# once per applied toggle (close-after-write semantics).
+PathChanged=/var/lib/spatiumddi/release-state/verbose-boot-pending
+
+[Install]
+WantedBy=multi-user.target

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-verbose-boot-reload.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-verbose-boot-reload.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Apply pending SpatiumDDI verbose-boot toggle (grubenv spatium_verbose)
+# The runner reads /var/lib/spatiumddi/release-state/verbose-boot-pending
+# (available after local-fs.target) and runs grub-editenv against the grubenv
+# on the ESP (/boot/efi), so the ESP must be mounted first.
+After=local-fs.target boot-efi.mount
+Requires=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/spatiumddi-verbose-boot-reload
+# No Install section — only invoked by the matching .path unit, never
+# directly enabled at boot.

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-verbose-boot-reload.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-verbose-boot-reload.service
@@ -1,10 +1,13 @@
 [Unit]
 Description=Apply pending SpatiumDDI verbose-boot toggle (grubenv spatium_verbose)
-# The runner reads /var/lib/spatiumddi/release-state/verbose-boot-pending
-# (available after local-fs.target) and runs grub-editenv against the grubenv
-# on the ESP (/boot/efi), so the ESP must be mounted first.
-After=local-fs.target boot-efi.mount
-Requires=local-fs.target
+# The runner reads the trigger under /var/lib/spatiumddi/release-state and runs
+# grub-editenv against the grubenv on the ESP (/boot/efi). RequiresMountsFor
+# both PULLS IN and orders-after the mount units covering those paths — robust
+# to the ESP mount-unit's generated name (vs a bare After=boot-efi.mount, which
+# only orders if that unit happens to run). Without /boot/efi mounted the runner
+# can't find grubenv.
+RequiresMountsFor=/boot/efi /var/lib/spatiumddi/release-state
+After=local-fs.target
 
 [Service]
 Type=oneshot

--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -1475,6 +1475,24 @@ else
 fi
 if [ -z "\${default}" ]; then set default=slot_a; fi
 
+# Verbose-boot console toggle (grubenv \`spatium_verbose\`, flipped by the
+# Fleet UI → supervisor → spatiumddi-verbose-boot-reload). Loaded by the
+# \`load_env\` above. "1" = standard Linux console: drop the loglevel=3 cap so
+# all kernel messages scroll, add systemd.show_status=1 for the per-unit
+# [ OK ] lines, and pass spatium-console=off so a normal getty login replaces
+# the Talos dashboard. Empty / "0" = today's quiet boot (loglevel=3) + the
+# console dashboard. Unset (old grubenv) falls through to the quiet default —
+# fail-closed, never a brick.
+if [ "\${spatium_verbose}" = "1" ]; then
+    set sp_log=""
+    set sp_systemd="systemd.show_status=1"
+    set sp_console="spatium-console=off"
+else
+    set sp_log="loglevel=3"
+    set sp_systemd=""
+    set sp_console=""
+fi
+
 # Serial console mirror for headless installs.
 serial --unit=0 --speed=115200
 terminal_input  console serial
@@ -1488,7 +1506,7 @@ insmod search_fs_uuid
 menuentry "$SLOT_TITLE_PREFIX (slot A)" --id=slot_a {
     search --no-floppy --fs-uuid --set=root $ROOT_A_UUID
     linux /boot/vmlinuz root=UUID=$ROOT_A_UUID rw \\
-        loglevel=3 audit=0 \\
+        \${sp_log} audit=0 \${sp_systemd} \${sp_console} \\
         console=tty0 console=ttyS0,115200n8
     initrd /boot/initrd.img
 }
@@ -1496,7 +1514,7 @@ menuentry "$SLOT_TITLE_PREFIX (slot A)" --id=slot_a {
 menuentry "$SLOT_TITLE_PREFIX (slot B)" --id=slot_b {
     search --no-floppy --fs-uuid --set=root $ROOT_B_UUID
     linux /boot/vmlinuz root=UUID=$ROOT_B_UUID rw \\
-        loglevel=3 audit=0 \\
+        \${sp_log} audit=0 \${sp_systemd} \${sp_console} \\
         console=tty0 console=ttyS0,115200n8
     initrd /boot/initrd.img
 }
@@ -1525,6 +1543,12 @@ EOF
         # the very first boot lands on slot_a unambiguously. grub-editenv
         # creates the file with the right size (1024 bytes, zero-padded).
         chroot "$MOUNT" /usr/bin/grub-editenv /boot/efi/grub/grubenv set saved_entry=slot_a \
+            >> "$INSTALL_LOG" 2>&1
+        # Seed the verbose-boot toggle OFF (quiet boot + dashboard) so the
+        # menuentry's ${spatium_verbose} conditional resolves to the default
+        # branch from the very first boot. The Fleet UI flips it to 1 later via
+        # spatiumddi-verbose-boot-reload.
+        chroot "$MOUNT" /usr/bin/grub-editenv /boot/efi/grub/grubenv set spatium_verbose=0 \
             >> "$INSTALL_LOG" 2>&1
 
         echo "XXX"; echo "88"; echo "Installing bootloader (BIOS + UEFI to ESP)..."; echo "XXX"

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-verbose-boot-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-verbose-boot-reload
@@ -1,0 +1,97 @@
+#!/bin/bash
+# spatiumddi-verbose-boot-reload — host-side verbose-boot toggle runner.
+#
+# The supervisor writes /var/lib/spatiumddi/release-state/verbose-boot-pending
+# whenever the operator's desired console verbosity (platform_settings.
+# verbose_boot) differs from what this runner last applied. File format:
+#
+#   line 1: "1" (standard Linux console) or "0" (quiet boot + dashboard)
+#
+# Apply flow — flip the grubenv variable ``spatium_verbose`` that the installed
+# grub.cfg menuentries read (see spatium-install's grub.cfg heredoc). We do NOT
+# regenerate grub.cfg or reboot — only set the env var the conditional already
+# consumes:
+#   spatium_verbose=1  -> menuentry drops the loglevel=3 cap, adds
+#                         systemd.show_status=1, and passes spatium-console=off
+#                         (normal getty console, no Talos dashboard) — i.e. the
+#                         box boots like a regular Linux server.
+#   spatium_verbose=0  -> today's quiet boot (loglevel=3) + console dashboard.
+#
+# Takes effect on the NEXT REBOOT (GRUB only reads the cmdline at boot). The
+# Fleet UI says so + offers the reboot affordance.
+#
+# Persistence across A/B slot swaps (Phase 8): grubenv lives on the shared ESP
+# (/boot/efi/grub/grubenv), NOT in /etc (which a slot swap resets) and NOT in a
+# file the running kernel re-reads — so the toggle survives slot upgrades +
+# rollbacks verbatim, the same reasoning that puts saved_entry/next_entry there.
+# The release-state sidecars live on /var directly.
+#
+# Anti-brick: only changes log verbosity + which process owns the TTY; never
+# the slot, root UUID, or kernel. A missing/corrupt grubenv makes the
+# menuentry's conditional fail closed to loglevel=3 (today's behaviour). The
+# always-present GRUB debug menuentry remains the zero-config fallback.
+
+set -euo pipefail
+
+TRIGGER=/var/lib/spatiumddi/release-state/verbose-boot-pending
+APPLIED_SIDECAR=/var/lib/spatiumddi/release-state/verbose-boot-applied
+STATUS_SIDECAR=/var/lib/spatiumddi/release-state/verbose-boot-status
+LOG_DIR=/var/log/spatiumddi
+LOG="$LOG_DIR/verbose-boot-reload.log"
+LOCK=/run/spatiumddi-verbose-boot-reload.lock
+
+mkdir -p "$LOG_DIR" "$(dirname "$APPLIED_SIDECAR")"
+
+log() { printf '%s spatiumddi-verbose-boot-reload: %s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$LOG"; }
+
+exec 9>"$LOCK"
+if ! flock -n 9; then
+    log "another instance is running — exiting"
+    exit 0
+fi
+
+if [ ! -f "$TRIGGER" ]; then
+    log "no trigger file — nothing to do"
+    exit 0
+fi
+
+val="$(head -n1 "$TRIGGER" | tr -d '[:space:]')"
+if [ "$val" != "0" ] && [ "$val" != "1" ]; then
+    log "REJECT: trigger value '$val' is not 0 or 1"
+    printf 'state=failed\nreason=invalid_value\nrequested=%s\napplied_at=%s\n' \
+        "$val" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+    exit 1
+fi
+
+# Locate grubenv. The appliance installs an EFI grub with grubenv on the ESP;
+# fall back to the BIOS paths for completeness. Must match where spatium-install
+# seeds spatium_verbose=0 + where the menuentries load_env from.
+GRUBENV=""
+for cand in /boot/efi/grub/grubenv /boot/grub/grubenv /boot/grub2/grubenv; do
+    if [ -f "$cand" ]; then GRUBENV="$cand"; break; fi
+done
+if [ -z "$GRUBENV" ]; then
+    log "ERROR: no grubenv found (looked in /boot/efi/grub, /boot/grub, /boot/grub2)"
+    printf 'state=failed\nreason=grubenv_not_found\nrequested=%s\napplied_at=%s\n' \
+        "$val" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+    exit 1
+fi
+
+log "apply: spatium_verbose=$val into $GRUBENV"
+if ! grub-editenv "$GRUBENV" set spatium_verbose="$val" 2>&1 | tee -a "$LOG"; then
+    log "ERROR: grub-editenv failed"
+    printf 'state=failed\nreason=grub_editenv_failed\nrequested=%s\napplied_at=%s\n' \
+        "$val" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+    exit 1
+fi
+
+# Apply landed. Record it so the supervisor short-circuits the next heartbeat's
+# trigger write, and surface a "reboot to take effect" status for the Fleet UI.
+printf '%s\n' "$val" > "$APPLIED_SIDECAR"
+printf 'state=ok\nrequested=%s\napplied=%s\npending_reboot=1\napplied_at=%s\n' \
+    "$val" "$val" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+
+# Drop the trigger so the .path unit doesn't re-fire.
+rm -f "$TRIGGER"
+
+log "OK (spatium_verbose=$val — effective on next reboot)"

--- a/appliance/mkosi.postinst
+++ b/appliance/mkosi.postinst
@@ -52,6 +52,7 @@ for unit in chrony.service ssh.service \
             spatiumddi-chrony-reload.path \
             spatiumddi-lldp-reload.path \
             spatiumddi-tz-reload.path \
+            spatiumddi-verbose-boot-reload.path \
             spatium-firewall-reload.path \
             spatiumddi-firewall-revert.timer \
             spatium-install.service \
@@ -245,6 +246,9 @@ chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-chrony-reload.service"
 chmod 0755 "$BUILDROOT/usr/local/bin/spatiumddi-lldp-reload"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-lldp-reload.path"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-lldp-reload.service"
+chmod 0755 "$BUILDROOT/usr/local/bin/spatiumddi-verbose-boot-reload"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-verbose-boot-reload.path"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-verbose-boot-reload.service"
 chmod 0755 "$BUILDROOT/usr/local/bin/spatium-firewall-reload"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatium-firewall-reload.path"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatium-firewall-reload.service"

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -98,6 +98,7 @@ backend/alembic/versions/a3c8e5d61b94_subnet_classification_tags.py:drop_column:
 backend/alembic/versions/a3c8e5d61b94_subnet_classification_tags.py:drop_column:85
 backend/alembic/versions/a3f1d9e07c52_firewall_apply_state.py:drop_column:66
 backend/alembic/versions/a3f1d9e07c52_firewall_apply_state.py:drop_table:67
+backend/alembic/versions/a3f1e9c47b20_platform_settings_verbose_boot.py:drop_column:37
 backend/alembic/versions/a3f7b2c8d419_add_name_description_to_dhcp_scope.py:drop_column:33
 backend/alembic/versions/a3f7b2c8d419_add_name_description_to_dhcp_scope.py:drop_column:34
 backend/alembic/versions/a4b8c2d619e7_ai_provider.py:drop_table:92

--- a/backend/alembic/versions/a3f1e9c47b20_platform_settings_verbose_boot.py
+++ b/backend/alembic/versions/a3f1e9c47b20_platform_settings_verbose_boot.py
@@ -1,0 +1,37 @@
+"""Appliance verbose-boot console toggle — platform_settings.verbose_boot.
+
+When true, the appliance boots a standard Linux console (drop the loglevel=3
+cap + systemd.show_status=1 + spatium-console=off) instead of the quiet boot +
+Talos dashboard. Additive, defaults false → no-op on every existing install.
+
+Revision ID: a3f1e9c47b20
+Revises: c1e7f3a90b4d
+Create Date: 2026-06-04
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a3f1e9c47b20"
+down_revision: str | None = "c1e7f3a90b4d"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "verbose_boot",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_settings", "verbose_boot")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1219,6 +1219,11 @@ class SupervisorHeartbeatResponse(BaseModel):
     # against the host's current tz on every heartbeat + writes the
     # ``spatium-tz-reload`` trigger file when they differ.
     desired_timezone: str = ""
+    # Verbose-boot console toggle. The supervisor flips a grubenv variable
+    # (spatium_verbose) the grub.cfg menuentries read, so it survives A/B slot
+    # swaps + the /etc overlay and applies on next reboot. Mirrors the
+    # desired_timezone delivery exactly.
+    desired_verbose_boot: bool = False
     # Issue #346 — appliance host-config blocks delivered to the supervisor,
     # which compares each block's ``config_hash`` against its applied sidecar
     # and fires the matching ``spatium-{snmp,chrony,lldp}-reload`` trigger when
@@ -1716,6 +1721,8 @@ async def supervisor_heartbeat(
     metallb_vip = (cfg_row.control_plane_vip or "") if cfg_row else ""
     # Issue #165 — operator-set timezone. Empty string = no override.
     desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
+    # Verbose-boot console toggle (grubenv-driven, applies next reboot).
+    desired_verbose_boot = bool(cfg_row.verbose_boot) if cfg_row else False
     # Issue #346 — host-config blocks for snmp / chrony / lldp. Built from the
     # same ``*_bundle`` helpers the DHCP-agent ConfigBundle uses; the
     # disabled-shape fallback keeps a stable key set when no settings row
@@ -1815,6 +1822,7 @@ async def supervisor_heartbeat(
         desired_control_plane_vip=metallb_vip,
         evict_node_names=evict_names,
         desired_timezone=desired_timezone,
+        desired_verbose_boot=desired_verbose_boot,
         snmp_settings=snmp_block,
         ntp_settings=ntp_block,
         lldp_settings=lldp_block,

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -150,6 +150,10 @@ class SettingsResponse(BaseModel):
     # ── Appliance timezone (issue #165) ───────────────────────────
     # Empty string means "follow install-time default" (no override).
     timezone: str = ""
+    # ── Appliance verbose boot console ────────────────────────────
+    # True = standard Linux console on boot (kernel messages + systemd
+    # status + getty, no dashboard); False = quiet boot + dashboard.
+    verbose_boot: bool = False
     # ── Appliance LLDP (issue #343) ───────────────────────────────
     # No secrets — LLDP advertises public identity, so the read shape
     # mirrors the stored shape directly (like NTP).
@@ -413,6 +417,8 @@ class SettingsUpdate(BaseModel):
     ntp_allow_client_networks: list[str] | None = None
     # ── Appliance timezone (issue #165) ───────────────────────────
     timezone: str | None = None
+    # ── Appliance verbose boot console ────────────────────────────
+    verbose_boot: bool | None = None
     # ── Appliance LLDP (issue #343) ───────────────────────────────
     lldp_enabled: bool | None = None
     lldp_tx_interval: int | None = None

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -443,6 +443,20 @@ class PlatformSettings(Base):
         String(64), nullable=False, default="", server_default=sa_text("''")
     )
 
+    # ── Appliance verbose boot console (issue: console-and-sidebar) ──
+    # When True, the appliance boots with a STANDARD Linux console: the
+    # kernel ``loglevel=3`` cap is dropped (all kernel messages scroll),
+    # ``systemd.show_status=1`` shows the per-unit ``[ OK ]`` lines, and
+    # ``spatium-console=off`` is passed so a normal getty login replaces
+    # the Talos-style dashboard — i.e. boot/reboot/shutdown look like a
+    # regular Linux box. False (default) keeps today's quiet boot
+    # (``loglevel=3``) + the console dashboard. Flows through the same
+    # heartbeat → grubenv → host-runner plane as timezone / NTP / SNMP;
+    # the kernel cmdline lives in grub.cfg, so it applies on next reboot.
+    verbose_boot: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+
     # ── Appliance LLDP support (issue #343) ─────────────────────────
     # lldpd runs at the Debian host level on every appliance host (same
     # host-config plane as SNMP / chrony) so it can see the host's real

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -434,6 +434,15 @@ The Talos-style console got a wave of usability fixes:
 - New `Watchdog` header line surfacing the external watchdog state — green `Loop ticking · Ns ago`, yellow `Loop stale · Ns ago`, red `Restart cap hit` when the rate-limit alert trigger is present.
 - Services panel unions whichever supervisor-managed service is either in `docker ps` or listed in `role-compose.env`'s `COMPOSE_PROFILES`, so a crashed / removed container surfaces as `(not running)` rather than disappearing entirely.
 
+### Verbose boot console (standard Linux console)
+
+By default the appliance boots quietly (`loglevel=3` — only kernel errors reach the console) and the Talos-style dashboard claims tty1, so operators see almost no kernel / systemd output during boot / reboot / shutdown. A **Boot console** toggle on **Appliance → Network & Host** switches the box to a *standard Linux console*: it drops the `loglevel=3` cap (all kernel messages scroll), adds `systemd.show_status=1` (the per-unit `[ OK ]` lines), and passes `spatium-console=off` (a normal getty login replaces the dashboard) — i.e. boot looks like a regular Linux server, which is invaluable for diagnosing a boot hang or panic.
+
+- **Mechanism.** Backed by `platform_settings.verbose_boot`; it rides the same host-config plane as timezone / NTP / SNMP (PlatformSettings → supervisor heartbeat `desired_verbose_boot` → `spatiumddi-verbose-boot-reload` host runner). Because the kernel cmdline lives in `grub.cfg` (not a file the running OS re-reads), the runner flips a **grubenv variable** (`spatium_verbose`) that a conditional in the per-slot menuentries reads. grubenv lives on the shared ESP, so the setting **survives A/B slot upgrades + rollbacks + the /etc overlay** verbatim.
+- **Applies on the next reboot** (GRUB only reads the cmdline at boot) — the UI says so and points at the Maintenance-tab reboot.
+- **Default off, opt-in per box.** Doesn't regress the polished quiet-boot experience for appliances that don't want it.
+- **Anti-brick.** Only changes log verbosity + which process owns the TTY — never the slot / root UUID / kernel. A missing or corrupt grubenv makes the menuentry's conditional fail closed to `loglevel=3` (today's behaviour). The always-present GRUB **`(slot A, verbose boot)`** menuentry remains the zero-config one-shot fallback (drops the loglevel cap + `spatium-console=off` for a single boot, selectable from the boot menu with no reinstall).
+
 ### Fleet UI updates
 
 - File rename `frontend/src/pages/appliance/ApprovalsTab.tsx` → `FleetTab.tsx` (component + React-Query keys + URL hash all migrated from `approvals` → `fleet`). The original "Approvals" framing predates the full Fleet management surface that now lives in the tab.

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -63,19 +63,44 @@ import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { useSessionState } from "@/lib/useSessionState";
 import logoIcon from "@/assets/logo-icon.svg";
 
+// Core section. The flat list had grown to 11 rows — the four canonical
+// anchors (Dashboard / IPAM / DHCP / DNS) plus seven grown-in sub-features
+// that mixed daily-driver surfaces with mis-filed child resources (e.g.
+// "Domains" routing under /admin). Reorganised (sidebar IA pass): the four
+// anchors stay first + prominent, then the grown-in items group under
+// lightweight ``SubNavLabel`` sub-headings by family — IPAM-family under
+// "IPAM", DNS-family under "DNS" — reusing the same primitive Network +
+// Administration already use. Routes + module-gating are unchanged; only
+// sidebar adjacency moves. (Logs left Core entirely → its own "Operations"
+// section below, since it's cross-cutting telemetry, not an IPAM/DNS child.)
 const baseMainNav = [
   { label: "Dashboard", icon: LayoutDashboard, to: "/dashboard" },
   { label: "IPAM", icon: Network, to: "/ipam", end: true },
   { label: "DHCP", icon: Server, to: "/dhcp" },
   { label: "DNS", icon: Globe, to: "/dns", end: true },
-  { label: "DNS Pools", icon: Workflow, to: "/dns/pools" },
-  { label: "DNSSEC Policies", icon: KeyRound, to: "/dns/dnssec-policies" },
-  { label: "Domains", icon: Earth, to: "/admin/domains" },
-  { label: "Logs", icon: ScrollText, to: "/logs" },
+];
+// IPAM-family children (all route under /ipam/*). Alphabetised, matching the
+// Network/Administration sub-group convention.
+const coreIpamNav = [
   { label: "NAT Mappings", icon: Shuffle, to: "/ipam/nat" },
   { label: "Stale IPs", icon: History, to: "/ipam/stale" },
   { label: "Subnet Planner", icon: Workflow, to: "/ipam/plans" },
 ];
+// DNS-family children. "Domains" keeps its /admin/domains route — it's the
+// registrar/expiry/RDAP registry side of a name (linked to dns_zone.domain_id),
+// so it belongs beside DNS in the sidebar even though the route lives under
+// /admin.
+const coreDnsNav = [
+  { label: "DNS Pools", icon: Workflow, to: "/dns/pools" },
+  { label: "DNSSEC Policies", icon: KeyRound, to: "/dns/dnssec-policies" },
+  { label: "Domains", icon: Earth, to: "/admin/domains" },
+];
+// Operations — cross-cutting live telemetry. Logs aggregates DNS query logs,
+// DHCP activity, Windows event log + DHCP audit, so it's not an IPAM/DNS child;
+// it gets its own small top-level section (future home for the pending
+// operational-triage surfaces: PCAP trigger #59, config-drift #61, time-travel
+// #56).
+const operationsNav = [{ label: "Logs", icon: ScrollText, to: "/logs" }];
 
 // Network section — grouped under a collapsible header. As the
 // section grew (4 → 8 items, with #94/#95 still to come), a flat
@@ -573,6 +598,40 @@ export function Sidebar({
             collapsed={effectiveCollapsed}
           >
             {mainNav.map((item) => (
+              <NavItem
+                key={item.to}
+                {...item}
+                collapsed={effectiveCollapsed}
+                onNavigate={mobileOpen ? onMobileClose : undefined}
+              />
+            ))}
+            <SubNavLabel label="IPAM" collapsed={effectiveCollapsed} />
+            {coreIpamNav.map((item) => (
+              <NavItem
+                key={item.to}
+                {...item}
+                collapsed={effectiveCollapsed}
+                onNavigate={mobileOpen ? onMobileClose : undefined}
+              />
+            ))}
+            <SubNavLabel label="DNS" collapsed={effectiveCollapsed} />
+            {coreDnsNav.map((item) => (
+              <NavItem
+                key={item.to}
+                {...item}
+                collapsed={effectiveCollapsed}
+                onNavigate={mobileOpen ? onMobileClose : undefined}
+              />
+            ))}
+          </NavSection>
+
+          <NavSection
+            label="Operations"
+            storageKey="sidebar-section-operations-open"
+            collapsed={effectiveCollapsed}
+            showDivider
+          >
+            {operationsNav.map((item) => (
               <NavItem
                 key={item.to}
                 {...item}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2911,6 +2911,11 @@ export interface PlatformSettings {
   // Issue #165 — operator-set IANA timezone. Empty = no override
   // (host falls back to install-time default).
   timezone: string;
+  /** Appliance verbose-boot console. true = standard Linux console on
+   *  boot/reboot/shutdown (kernel messages + systemd status + getty, no
+   *  dashboard); false (default) = quiet boot + Talos dashboard. Appliance
+   *  hosts only; applies on next reboot (grubenv-driven). */
+  verbose_boot: boolean;
   /** Appliance LLDP (issue #343). No secrets — LLDP advertises public
    *  identity, so read + write shapes match. ``lldp_protocols`` enables
    *  reception of CDP/EDP/FDP/SONMP alongside LLDP. */

--- a/frontend/src/pages/appliance/NetworkTab.tsx
+++ b/frontend/src/pages/appliance/NetworkTab.tsx
@@ -160,6 +160,7 @@ function VerboseBootCard() {
           type="button"
           role="switch"
           aria-checked={verbose}
+          aria-label="Verbose boot console (standard Linux boot)"
           disabled={!isSuperadmin || save.isPending || !settings}
           onClick={() => save.mutate(!verbose)}
           className={cn(

--- a/frontend/src/pages/appliance/NetworkTab.tsx
+++ b/frontend/src/pages/appliance/NetworkTab.tsx
@@ -7,12 +7,15 @@ import {
   Network,
   RefreshCw,
   Server,
+  TerminalSquare,
 } from "lucide-react";
 
 import {
   applianceApprovalApi,
   applianceSystemApi,
+  authApi,
   formatApiError,
+  settingsApi,
   type MetalLBConfig,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -106,7 +109,87 @@ export function NetworkTab() {
       </section>
 
       <MetalLBConfigCard />
+      <VerboseBootCard />
     </div>
+  );
+}
+
+// Verbose-boot console toggle. Off (default) = quiet boot + the Talos-style
+// console dashboard; On = a standard Linux console (kernel messages + systemd
+// [ OK ] lines scroll on boot/reboot/shutdown, and a normal getty login
+// replaces the dashboard). Backed by platform_settings.verbose_boot, which the
+// supervisor flips into the grubenv `spatium_verbose` variable the grub.cfg
+// menuentries read — so it applies on the NEXT reboot. Appliance hosts only
+// (this tab is already selfOnly).
+function VerboseBootCard() {
+  const qc = useQueryClient();
+  const { data: me } = useQuery({
+    queryKey: ["me"],
+    queryFn: authApi.me,
+    staleTime: 60_000,
+  });
+  const { data: settings } = useQuery({
+    queryKey: ["settings"],
+    queryFn: settingsApi.get,
+  });
+  const isSuperadmin = me?.is_superadmin ?? false;
+  const verbose = settings?.verbose_boot ?? false;
+  const save = useMutation({
+    mutationFn: (v: boolean) => settingsApi.update({ verbose_boot: v }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["settings"] }),
+  });
+
+  return (
+    <section className="space-y-3 rounded-lg border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="flex items-center gap-2 text-sm font-medium">
+            <TerminalSquare className="h-4 w-4 text-muted-foreground" />
+            Boot console
+          </h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            <strong>Off</strong> (default): quiet boot, then the SpatiumDDI
+            console dashboard. <strong>On</strong>: a standard Linux console —
+            kernel messages and systemd <code>[ OK ]</code> lines scroll during
+            boot / reboot / shutdown, and a normal login prompt replaces the
+            dashboard. Useful for diagnosing boot hangs. Takes effect on the{" "}
+            <strong>next reboot</strong>.
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={verbose}
+          disabled={!isSuperadmin || save.isPending || !settings}
+          onClick={() => save.mutate(!verbose)}
+          className={cn(
+            "relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50",
+            verbose ? "bg-primary" : "bg-muted",
+          )}
+        >
+          <span
+            className={cn(
+              "inline-block h-5 w-5 transform rounded-full bg-background shadow transition-transform",
+              verbose ? "translate-x-5" : "translate-x-0.5",
+            )}
+          />
+        </button>
+      </div>
+      {save.isError && (
+        <p className="text-xs text-destructive">{formatApiError(save.error)}</p>
+      )}
+      {save.isSuccess && (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+          Saved — applies on the next reboot. Reboot the appliance (Maintenance
+          tab) to switch the boot console now.
+        </p>
+      )}
+      {!isSuperadmin && (
+        <p className="text-xs text-muted-foreground">
+          Changing the boot console is restricted to superadmins.
+        </p>
+      )}
+    </section>
   );
 }
 


### PR DESCRIPTION
Two independent operator-UX improvements on one branch (two commits).

## 1. Sidebar reorganization (`27d10d9`)

The flat **Core** list had grown from the 4 canonical anchors to 11 rows, mixing daily-driver surfaces with grown-in sub-features — several mis-filed (e.g. **Domains** routing under `/admin`). A 5-lens IA panel (domain-grouping / task-frequency / DDI-tool-parity / newcomer-discoverability / minimal-churn) + a judge converged on a small, surgical fix.

**Before → After (Core only):**
```
BEFORE — Core (flat, 11 rows)        AFTER — Core
  Dashboard / IPAM / DHCP / DNS        Dashboard / IPAM / DHCP / DNS   (anchors, pinned)
  DNS Pools                            ── IPAM ──
  DNSSEC Policies                        NAT Mappings · Stale IPs · Subnet Planner
  Domains (→/admin/domains)            ── DNS ──
  Logs                                   DNS Pools · DNSSEC Policies · Domains
  NAT Mappings                       Operations  ← NEW section
  Stale IPs                            Logs
  Subnet Planner
```
- Dashboard/IPAM/DHCP/DNS stay pinned at top, unchanged.
- Grown-in items group under lightweight `SubNavLabel` sub-headings by family (the primitive Network + Administration already use).
- **Logs** → new top-level **Operations** section (cross-cutting telemetry; future home for #59/#61/#56).
- Network / Tools / Integrations / Administration / Footer untouched. **Zero route changes, zero module-gating changes** — only sidebar adjacency.

## 2. Verbose boot console (`fd58d89`) — appliance-only

Appliances boot quietly (`loglevel=3`) + the Talos dashboard claims tty1, so operators see almost no kernel/systemd output during boot/reboot/shutdown. Adds a **Boot console** toggle on **Appliance → Network & Host**:
- **Off** (default): today's quiet boot + dashboard — no regression.
- **On**: a *standard Linux console* — drop the `loglevel=3` cap (kernel messages scroll) + `systemd.show_status=1` (the `[ OK ]` lines) + `spatium-console=off` (normal getty login instead of the dashboard).

**Mechanism:** mirrors the timezone/NTP/SNMP host-config plane — `platform_settings.verbose_boot` → supervisor heartbeat `desired_verbose_boot` → `maybe_fire_verbose_boot` writes a trigger → host-side `spatiumddi-verbose-boot-reload` runs `grub-editenv`. Because the kernel cmdline lives in `grub.cfg`, the runner flips a **grubenv** var (`spatium_verbose`) a menuentry conditional reads. grubenv is on the shared ESP → the toggle **survives A/B slot upgrades + rollbacks + the /etc overlay**. **Applies on next reboot** (UI says so).

**Anti-brick:** only changes log verbosity + TTY ownership — never slot/root/kernel; missing/corrupt grubenv fails closed to `loglevel=3`; runner validates `0|1`; strict appliance-only gate. The pre-existing `(slot A, verbose boot)` GRUB menuentry remains the zero-config one-shot fallback. Migration `a3f1e9c47b20` is additive (bool, default false).

## Testing
- ruff + black + mypy clean (backend + supervisor); tsc + eslint + prettier clean (frontend); frontend production build passes.
- Migration applies on a fresh DB (column present); downgrade `drop_column` baselined in the migration linter.
- `bash -n` clean on the new host runner + `spatium-install` + `mkosi.postinst`.
- 16 heartbeat/supervisor tests pass.
- Sidebar verified live in the local docker frontend.

## Notes
- The verbose-boot **toggle is appliance-only** (its Network & Host tab is `selfOnly`) — not visible on docker/k8s control planes. The boot behavior itself needs an **appliance ISO build + install** to field-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
