### PR TITLE
Roadmap quick wins — #67 #76 #48 #44 (full) + #29 #195 #61 (partial)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -242,6 +242,7 @@ backend/alembic/versions/c5f2a9b18e34_ipam_linkage_subnet_domains_bulk.py:drop_c
 backend/alembic/versions/c5f2a9b18e34_ipam_linkage_subnet_domains_bulk.py:drop_constraint_fk:109
 backend/alembic/versions/c5f2a9b18e34_ipam_linkage_subnet_domains_bulk.py:drop_table:105
 backend/alembic/versions/c6c3137e3554_appliance_slot_image_upload.py:drop_table:110
+backend/alembic/versions/c7a3e1f90d24_subnet_utilization_history.py:drop_table:47
 backend/alembic/versions/c7e2f5a91d48_audit_forward_targets.py:drop_table:172
 backend/alembic/versions/c7e5d918a3f2_appliance_cluster_health.py:drop_column:42
 backend/alembic/versions/c7e9b3a481f2_appliance_approval_workflow.py:drop_column:152

--- a/backend/alembic/versions/c7a3e1f90d24_subnet_utilization_history.py
+++ b/backend/alembic/versions/c7a3e1f90d24_subnet_utilization_history.py
@@ -1,0 +1,47 @@
+"""subnet_utilization_history — per-subnet daily IP-utilization snapshots (#44).
+
+Powers the 30 / 90-day "% used over time" chart on the subnet detail. A
+daily beat task records ``Subnet.allocated_ips`` / ``total_ips`` per subnet
+and prunes rows older than 90 days, so the table stays bounded.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision: str = "c7a3e1f90d24"
+down_revision: str | None = "a3f1e9c47b20"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "subnet_utilization_history",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "subnet_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("subnet.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("sampled_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("allocated_ips", sa.Integer(), nullable=False),
+        sa.Column("total_ips", sa.BigInteger(), nullable=False),
+    )
+    op.create_index(
+        "ix_subnet_util_hist_subnet_sampled",
+        "subnet_utilization_history",
+        ["subnet_id", "sampled_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_subnet_util_hist_subnet_sampled",
+        table_name="subnet_utilization_history",
+    )
+    op.drop_table("subnet_utilization_history")

--- a/backend/app/api/v1/ansible/__init__.py
+++ b/backend/app/api/v1/ansible/__init__.py
@@ -1,0 +1,5 @@
+"""Ansible dynamic-inventory endpoint (#67)."""
+
+from app.api.v1.ansible.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/ansible/router.py
+++ b/backend/app/api/v1/ansible/router.py
@@ -94,7 +94,10 @@ async def ansible_inventory(
         block = blocks.get(subnet.block_id) if subnet and subnet.block_id else None
         space_id = (subnet.space_id if subnet else None) or (block.space_id if block else None)
         space = spaces.get(space_id) if space_id else None
-        tags = list(ip.tags or [])
+        # IPAddress.tags is a JSONB dict ({key: value}), not a list — group
+        # by key+value (like custom fields) so distinct values don't collide
+        # into one group and values aren't dropped.
+        tags = dict(ip.tags or {})
         custom = dict(ip.custom_fields or {})
 
         hostvars[name] = {
@@ -121,8 +124,8 @@ async def ansible_inventory(
             groups[_group("block", block.name)]["hosts"].append(name)
         if subnet:
             groups[_group("subnet", subnet.name or str(subnet.network))]["hosts"].append(name)
-        for tag in tags:
-            groups[_group("tag", str(tag))]["hosts"].append(name)
+        for key, value in tags.items():
+            groups[_group("tag", str(key), str(value))]["hosts"].append(name)
         for field, value in custom.items():
             groups[_group("cf", str(field), str(value))]["hosts"].append(name)
 

--- a/backend/app/api/v1/ansible/router.py
+++ b/backend/app/api/v1/ansible/router.py
@@ -1,0 +1,138 @@
+"""Ansible dynamic-inventory endpoint (#67).
+
+``GET /api/v1/ansible/inventory`` returns a standard Ansible dynamic
+inventory JSON document built from IPAM data — a drop-in replacement for
+a static inventory file or an inventory script. Hosts are grouped by IP
+space, IP block, subnet, every tag, and every custom-field value, and
+each host's metadata is exposed under ``_meta.hostvars`` so Ansible
+needs only the single ``--list`` call (no per-host round-trips).
+
+Read-only and gated on ``read``/``ip_address`` — point Ansible at it with
+an API token scoped to read. Non-negotiables:
+* #13 (MCP): no dedicated MCP tool — this is a machine-format *export* of
+  data the copilot already reads via ``find_ip`` / ``find_subnet``; adding
+  a ``get_ansible_inventory`` tool would duplicate that surface. Explicit
+  decision: skip.
+* #14 (feature module): not a togglable module — it's a single read-only
+  projection endpoint gated by the existing IPAM read permission, not a
+  new top-level resource family / sidebar section / tool cluster.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+
+from app.api.deps import DB
+from app.core.permissions import require_permission
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+router = APIRouter()
+
+# Roles that are placeholder rows (the network / broadcast addresses IPAM
+# auto-creates), not manageable hosts — never emit them as Ansible hosts.
+_NON_HOST_ROLES = frozenset({"network", "broadcast"})
+
+_INVALID_GROUP_CHARS = re.compile(r"[^A-Za-z0-9_]+")
+
+
+def _group(*parts: str) -> str:
+    """Sanitise a group name to Ansible's ``[A-Za-z0-9_]`` grammar."""
+    raw = "_".join(p for p in parts if p)
+    cleaned = _INVALID_GROUP_CHARS.sub("_", raw).strip("_")
+    return cleaned or "ungrouped"
+
+
+@router.get(
+    "/inventory",
+    summary="Ansible dynamic inventory (JSON)",
+    dependencies=[Depends(require_permission("read", "ip_address"))],
+    response_model=None,
+)
+async def ansible_inventory(
+    db: DB,
+    host: str | None = Query(
+        default=None,
+        description="Ansible ``--host`` compatibility: return just this host's vars.",
+    ),
+    status: str | None = Query(
+        default=None,
+        description="Optional: only include addresses with this lifecycle status.",
+    ),
+) -> dict[str, Any]:
+    """Return the full ``--list`` inventory (with ``_meta.hostvars``), or a
+    single host's vars when ``?host=`` is supplied."""
+    addresses = (await db.execute(select(IPAddress))).scalars().all()
+    subnets = {s.id: s for s in (await db.execute(select(Subnet))).scalars().all()}
+    blocks = {b.id: b for b in (await db.execute(select(IPBlock))).scalars().all()}
+    spaces = {sp.id: sp for sp in (await db.execute(select(IPSpace))).scalars().all()}
+
+    groups: dict[str, dict[str, list[str]]] = defaultdict(lambda: {"hosts": []})
+    hostvars: dict[str, dict[str, Any]] = {}
+    all_hosts: list[str] = []
+    seen: dict[str, Any] = {}
+
+    for ip in addresses:
+        if (ip.role or "") in _NON_HOST_ROLES:
+            continue
+        if status is not None and (ip.status or "") != status:
+            continue
+
+        addr = str(ip.address)
+        name = ip.hostname or ip.fqdn or addr
+        # Inventory hostnames must be unique — fall back to the (unique) IP
+        # when a hostname is shared by more than one address.
+        if name in seen and seen[name] != ip.id:
+            name = addr
+        seen[name] = ip.id
+
+        subnet = subnets.get(ip.subnet_id)
+        block = blocks.get(subnet.block_id) if subnet and subnet.block_id else None
+        space_id = (subnet.space_id if subnet else None) or (block.space_id if block else None)
+        space = spaces.get(space_id) if space_id else None
+        tags = list(ip.tags or [])
+        custom = dict(ip.custom_fields or {})
+
+        hostvars[name] = {
+            "ansible_host": addr,
+            "spatium_address": addr,
+            "spatium_status": ip.status,
+            "spatium_role": ip.role,
+            "spatium_mac": ip.mac_address,
+            "spatium_hostname": ip.hostname,
+            "spatium_fqdn": ip.fqdn,
+            "spatium_description": ip.description,
+            "spatium_subnet": str(subnet.network) if subnet else None,
+            "spatium_subnet_name": subnet.name if subnet else None,
+            "spatium_block": block.name if block else None,
+            "spatium_space": space.name if space else None,
+            "spatium_tags": tags,
+            "spatium_custom_fields": custom,
+        }
+
+        all_hosts.append(name)
+        if space:
+            groups[_group("space", space.name)]["hosts"].append(name)
+        if block:
+            groups[_group("block", block.name)]["hosts"].append(name)
+        if subnet:
+            groups[_group("subnet", subnet.name or str(subnet.network))]["hosts"].append(name)
+        for tag in tags:
+            groups[_group("tag", str(tag))]["hosts"].append(name)
+        for field, value in custom.items():
+            groups[_group("cf", str(field), str(value))]["hosts"].append(name)
+
+    # ``--host`` compatibility — Ansible may still probe individual hosts.
+    if host is not None:
+        return hostvars.get(host, {})
+
+    inventory: dict[str, Any] = {
+        "_meta": {"hostvars": hostvars},
+        "all": {"hosts": all_hosts},
+    }
+    inventory.update(groups)
+    return inventory

--- a/backend/app/api/v1/ansible/router.py
+++ b/backend/app/api/v1/ansible/router.py
@@ -24,6 +24,7 @@ import re
 from collections import defaultdict
 from typing import Any
 
+import structlog
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
 
@@ -31,7 +32,16 @@ from app.api.deps import DB
 from app.core.permissions import require_permission
 from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
 
+logger = structlog.get_logger(__name__)
+
 router = APIRouter()
+
+# The Ansible ``--list`` contract requires the *complete* inventory in one
+# response, so this endpoint deliberately loads every address (capping would
+# silently drop hosts from automation — far worse than the latency). This is
+# the soft size past which we log a heads-up so an operator on a very large
+# install has a breadcrumb if the call gets slow / memory-heavy.
+_LARGE_INVENTORY_WARN = 50_000
 
 # Roles that are placeholder rows (the network / broadcast addresses IPAM
 # auto-creates), not manageable hosts — never emit them as Ansible hosts.
@@ -67,6 +77,12 @@ async def ansible_inventory(
     """Return the full ``--list`` inventory (with ``_meta.hostvars``), or a
     single host's vars when ``?host=`` is supplied."""
     addresses = (await db.execute(select(IPAddress))).scalars().all()
+    if len(addresses) >= _LARGE_INVENTORY_WARN:
+        logger.warning(
+            "ansible.inventory.large",
+            address_count=len(addresses),
+            threshold=_LARGE_INVENTORY_WARN,
+        )
     subnets = {s.id: s for s in (await db.execute(select(Subnet))).scalars().all()}
     blocks = {b.id: b for b in (await db.execute(select(IPBlock))).scalars().all()}
     spaces = {sp.id: sp for sp in (await db.execute(select(IPSpace))).scalars().all()}

--- a/backend/app/api/v1/audit/router.py
+++ b/backend/app/api/v1/audit/router.py
@@ -1,8 +1,8 @@
 """Audit log read endpoints (superadmin or users with `read:audit_log`)."""
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Response
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func, select
 
@@ -10,6 +10,7 @@ from app.api.deps import DB
 from app.core.permissions import require_permission
 from app.models.audit import AuditLog
 from app.services.audit_chain import verify_chain
+from app.services.audit_report import generate_change_report_pdf
 
 router = APIRouter(dependencies=[Depends(require_permission("read", "audit_log"))])
 
@@ -80,6 +81,37 @@ async def list_audit_log(
     rows = (await db.execute(q)).scalars().all()
 
     return AuditLogPage(total=total, items=list(rows))
+
+
+# ── Compliance / change report PDF (issue #48) ──────────────────────
+
+
+@router.get("/export.pdf")
+async def export_change_report_pdf(
+    db: DB,
+    since: datetime | None = Query(default=None),
+    until: datetime | None = Query(default=None),
+) -> Response:
+    """Auditor-facing PDF rollup of every audit-log mutation in a date
+    range, grouped by user / resource type / action, with a SHA-256
+    tamper-evidence trailer. Defaults to the last 30 days. Gated by the
+    router-level ``read:audit_log`` permission."""
+    now = datetime.now(UTC)
+    until = until or now
+    since = since or (until - timedelta(days=30))
+    # Coerce naive client-supplied datetimes to UTC so the comparison
+    # against the timezone-aware ``timestamp`` column is well-defined.
+    if since.tzinfo is None:
+        since = since.replace(tzinfo=UTC)
+    if until.tzinfo is None:
+        until = until.replace(tzinfo=UTC)
+    pdf_bytes = await generate_change_report_pdf(db, since=since, until=until)
+    fname = f"spatiumddi-change-report-{now.strftime('%Y%m%d-%H%M%S')}.pdf"
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{fname}"'},
+    )
 
 
 # ── Tamper-evidence verifier (issue #73) ────────────────────────────

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -2772,6 +2772,86 @@ async def get_zone_server_state(
     )
 
 
+# ── Config-drift report (#61) ───────────────────────────────────────
+
+
+class DriftRecordEntry(BaseModel):
+    name: str
+    record_type: str
+    value: str
+    ttl: int | None = None
+
+
+class ServerDriftEntry(BaseModel):
+    server_id: str
+    server_name: str
+    driver: str
+    status: str  # "ok" | "error" | "unsupported"
+    error: str | None = None
+    in_sync: int
+    drift_count: int
+    extra_on_server: list[DriftRecordEntry]
+    missing_on_server: list[DriftRecordEntry]
+
+
+class ZoneDriftResponse(BaseModel):
+    zone_id: str
+    zone_name: str
+    db_record_count: int
+    servers: list[ServerDriftEntry]
+
+
+@router.get(
+    "/groups/{group_id}/zones/{zone_id}/drift",
+    response_model=ZoneDriftResponse,
+)
+async def get_zone_drift(
+    group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, _: CurrentUser
+) -> ZoneDriftResponse:
+    """Per-server record-level config-drift report (#61).
+
+    AXFRs / pulls the live zone from every server in the group and diffs
+    it against the DB source of truth, surfacing per server what's *extra
+    on the server* (manual on-host changes) and *missing on the server*
+    (DB rows not being served). Read-only — never applies. A record whose
+    value changed shows as a missing+extra pair (the identity key includes
+    the value, matching the additive-sync path).
+    """
+    from app.services.dns.drift import compute_zone_drift  # noqa: PLC0415
+
+    zone = await _require_zone(group_id, zone_id, db)
+    report = await compute_zone_drift(db, group_id=group_id, zone=zone)
+    return ZoneDriftResponse(
+        zone_id=report.zone_id,
+        zone_name=report.zone_name,
+        db_record_count=report.db_record_count,
+        servers=[
+            ServerDriftEntry(
+                server_id=s.server_id,
+                server_name=s.server_name,
+                driver=s.driver,
+                status=s.status,
+                error=s.error,
+                in_sync=s.in_sync,
+                drift_count=s.drift_count,
+                extra_on_server=[
+                    DriftRecordEntry(
+                        name=r.name, record_type=r.record_type, value=r.value, ttl=r.ttl
+                    )
+                    for r in s.extra_on_server
+                ],
+                missing_on_server=[
+                    DriftRecordEntry(
+                        name=r.name, record_type=r.record_type, value=r.value, ttl=r.ttl
+                    )
+                    for r in s.missing_on_server
+                ],
+            )
+            for s in report.servers
+        ],
+    )
+
+
 # ── Per-server detail endpoints (powering the Server Detail modal) ──
 
 

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -36,6 +36,7 @@ from app.models.ipam import (
     IPSpace,
     Subnet,
     SubnetDomain,
+    SubnetUtilizationHistory,
 )
 from app.models.settings import PlatformSettings
 from app.models.vlans import VLAN
@@ -3715,6 +3716,56 @@ async def get_subnet(subnet_id: uuid.UUID, current_user: CurrentUser, db: DB) ->
     if subnet is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
     return subnet
+
+
+class UtilizationHistoryPoint(BaseModel):
+    sampled_at: datetime
+    allocated_ips: int
+    total_ips: int
+    utilization_percent: float
+
+
+@router.get(
+    "/subnets/{subnet_id}/utilization-history",
+    response_model=list[UtilizationHistoryPoint],
+)
+async def get_subnet_utilization_history(
+    subnet_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: DB,
+    days: int = Query(default=90, ge=1, le=365),
+) -> list[UtilizationHistoryPoint]:
+    """Per-subnet IP-utilization over the last ``days`` (#44).
+
+    Daily samples are captured by the ``subnet_utilization_snapshot`` beat
+    task (90-day retention), so this is read-only history — it powers the
+    "% used over time" chart on the subnet detail. Empty until the first
+    nightly snapshot runs.
+    """
+    since = datetime.now(UTC) - timedelta(days=days)
+    rows = (
+        (
+            await db.execute(
+                select(SubnetUtilizationHistory)
+                .where(SubnetUtilizationHistory.subnet_id == subnet_id)
+                .where(SubnetUtilizationHistory.sampled_at >= since)
+                .order_by(SubnetUtilizationHistory.sampled_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [
+        UtilizationHistoryPoint(
+            sampled_at=r.sampled_at,
+            allocated_ips=r.allocated_ips,
+            total_ips=r.total_ips,
+            utilization_percent=(
+                round(r.allocated_ips / r.total_ips * 100, 2) if r.total_ips > 0 else 0.0
+            ),
+        )
+        for r in rows
+    ]
 
 
 @router.get("/subnets/{subnet_id}/reconciliation")

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -3742,6 +3742,9 @@ async def get_subnet_utilization_history(
     "% used over time" chart on the subnet detail. Empty until the first
     nightly snapshot runs.
     """
+    subnet = await db.get(Subnet, subnet_id)
+    if subnet is None or subnet.deleted_at is not None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
     since = datetime.now(UTC) - timedelta(days=days)
     rows = (
         (

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -9,6 +9,7 @@ from app.api.v1.admin.redis import router as redis_admin_router
 from app.api.v1.admin.trash import router as trash_router
 from app.api.v1.ai import router as ai_router
 from app.api.v1.alerts.router import router as alerts_router
+from app.api.v1.ansible import router as ansible_router
 from app.api.v1.api_tokens.router import router as api_tokens_router
 from app.api.v1.appliance import router as appliance_router
 from app.api.v1.appliance.firewall import router as firewall_policy_router
@@ -88,6 +89,7 @@ api_v1_router.include_router(postgres_router, prefix="/admin", tags=["admin-post
 api_v1_router.include_router(redis_admin_router, prefix="/admin", tags=["admin-redis"])
 api_v1_router.include_router(trash_router, prefix="/admin", tags=["admin-trash"])
 api_v1_router.include_router(alerts_router, prefix="/alerts", tags=["alerts"])
+api_v1_router.include_router(ansible_router, prefix="/ansible", tags=["ansible"])
 api_v1_router.include_router(api_tokens_router, prefix="/api-tokens", tags=["api-tokens"])
 api_v1_router.include_router(appliance_router, prefix="/appliance", tags=["appliance"])
 # #285 Phase 3c — firewall policy CRUD. Separate include (NOT folded into

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -30,6 +30,7 @@ celery_app = Celery(
         "app.tasks.trash_purge",
         "app.tasks.ipam_reservation_sweep",
         "app.tasks.ipam_discovery",
+        "app.tasks.subnet_utilization_snapshot",
         "app.tasks.reverse_dns",
         "app.tasks.dhcp_lease_history_prune",
         "app.tasks.update_check",
@@ -77,6 +78,7 @@ celery_app.conf.update(
         "app.tasks.prune_internal_errors.*": {"queue": "default"},
         "app.tasks.prune_logs.*": {"queue": "default"},
         "app.tasks.prune_metrics.*": {"queue": "default"},
+        "app.tasks.subnet_utilization_snapshot.*": {"queue": "default"},
         "app.tasks.prune_multicast_memberships.*": {"queue": "default"},
         "app.tasks.prune_pairing_codes.*": {"queue": "default"},
         "app.tasks.firewall_lint_scan.*": {"queue": "default"},
@@ -230,6 +232,12 @@ celery_app.conf.update(
         # pruning more often just burns cycles.
         "metric-samples-prune": {
             "task": "app.tasks.prune_metrics.prune_metric_samples",
+            "schedule": schedule(run_every=24 * 3600.0),
+        },
+        # #44 — daily per-subnet utilization snapshot + 90-day prune,
+        # powering the "% used over time" chart on the subnet detail.
+        "subnet-utilization-snapshot": {
+            "task": "app.tasks.subnet_utilization_snapshot.snapshot_subnet_utilization",
             "schedule": schedule(run_every=24 * 3600.0),
         },
         # Nightly prune of agent-shipped query / activity log entries

--- a/backend/app/drivers/dns/azuredns.py
+++ b/backend/app/drivers/dns/azuredns.py
@@ -544,7 +544,9 @@ class AzureDNSDriver(CloudDNSDriverBase):
             "views": False,
             "rpz": False,
             "dnssec_online": False,
-            "alias_records": True,
+            # #29 — Azure DNS alias records target Azure resources and have no
+            # apply path via the generic ALIAS type here; authoring deferred.
+            "alias_records": False,
             "record_types": [
                 "A",
                 "AAAA",

--- a/backend/app/drivers/dns/cloudflare.py
+++ b/backend/app/drivers/dns/cloudflare.py
@@ -361,7 +361,9 @@ class CloudflareDNSDriver(CloudDNSDriverBase):
             "manages_zones": True,
             "views": False,
             "rpz": False,
-            "dnssec_online": True,
+            # #29 — Cloudflare DNSSEC is a zone-level enable (PATCH /dnssec),
+            # not the per-record online signing these ops model; deferred.
+            "dnssec_online": False,
             "record_types": [
                 "A",
                 "AAAA",

--- a/backend/app/drivers/dns/googledns.py
+++ b/backend/app/drivers/dns/googledns.py
@@ -421,7 +421,9 @@ class GoogleCloudDNSDriver(CloudDNSDriverBase):
             "manages_zones": True,
             "views": False,
             "rpz": False,
-            "dnssec_online": True,
+            # #29 — Google Cloud DNS DNSSEC is a managed-zone toggle, not the
+            # per-record online signing these ops model; deferred.
+            "dnssec_online": False,
             "record_types": [
                 "A",
                 "AAAA",

--- a/backend/app/drivers/dns/route53.py
+++ b/backend/app/drivers/dns/route53.py
@@ -506,8 +506,15 @@ class Route53DNSDriver(CloudDNSDriverBase):
             "manages_zones": True,
             "views": False,
             "rpz": False,
-            "dnssec_online": True,
-            "alias_records": True,
+            # #29 — cloud DNSSEC is a provider zone-toggle (Route 53 needs a
+            # KMS asymmetric key), not the per-record online signing the
+            # dnssec_sign/unsign ops model; gated to powerdns/bind9. Deferred.
+            "dnssec_online": False,
+            # #29 — Route 53 ALIAS targets need an AWS resource + HostedZoneId
+            # the generic ALIAS record type can't express, so authoring is not
+            # supported via this driver yet (existing alias rrsets still read
+            # back). Deferred.
+            "alias_records": False,
             "record_types": [
                 "A",
                 "AAAA",
@@ -519,7 +526,6 @@ class Route53DNSDriver(CloudDNSDriverBase):
                 "CAA",
                 "PTR",
                 "SOA",
-                "ALIAS",
             ],
             "notes": (
                 "Agentless Amazon Route 53 driver. Zone + record CRUD via "

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -1170,3 +1170,28 @@ class IPAMTemplate(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # name_template supports the same {n} / {oct1}–{oct4} tokens as
     # bulk-allocate.
     child_layout: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+
+class SubnetUtilizationHistory(UUIDPrimaryKeyMixin, Base):
+    """Daily snapshot of a subnet's IP utilization (#44).
+
+    One row per subnet per daily sample; powers the 30 / 90-day "% used
+    over time" chart on the subnet detail. Storage piggy-backs on the
+    already-maintained ``Subnet.allocated_ips`` / ``total_ips`` columns —
+    the snapshot beat task just records them. 90-day retention is enforced
+    by that task's prune pass, so the table stays bounded
+    (subnets × ~90 rows).
+    """
+
+    __tablename__ = "subnet_utilization_history"
+
+    subnet_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("subnet.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    sampled_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    allocated_ips: Mapped[int] = mapped_column(Integer, nullable=False)
+    total_ips: Mapped[int] = mapped_column(BigInteger, nullable=False)
+
+    __table_args__ = (Index("ix_subnet_util_hist_subnet_sampled", "subnet_id", "sampled_at"),)

--- a/backend/app/services/ai/tools/dns.py
+++ b/backend/app/services/ai/tools/dns.py
@@ -679,6 +679,62 @@ async def find_zone_dnssec_info(
     }
 
 
+class FindZoneDriftArgs(BaseModel):
+    zone_id: uuid.UUID = Field(
+        description="UUID of the dns_zone to check for per-server config drift.",
+    )
+
+
+@register_tool(
+    name="find_dns_zone_drift",
+    description=(
+        "Per-server config-drift report for one DNS zone (#61): AXFRs / "
+        "pulls the live zone from every server in the zone's group and "
+        "diffs it against the SpatiumDDI DB source of truth. Returns, per "
+        "server, how many records are 'extra on the server' (a manual "
+        "change made directly on the host), 'missing on the server' (DB "
+        "rows the server isn't serving), and in-sync — plus a sample of the "
+        "drifting records. A value change shows as a missing+extra pair. "
+        "Use to answer 'is example.com drifting?' or 'did someone edit "
+        "records directly on the BIND9 host?'. Read-only."
+    ),
+    args_model=FindZoneDriftArgs,
+    category="dns",
+    module="dns",
+)
+async def find_dns_zone_drift(
+    db: AsyncSession, user: User, args: FindZoneDriftArgs
+) -> dict[str, Any]:
+    from app.services.dns.drift import compute_zone_drift  # noqa: PLC0415
+
+    zone = await db.get(DNSZone, args.zone_id)
+    if zone is None:
+        return {"error": "DNS zone not found", "zone_id": str(args.zone_id)}
+    report = await compute_zone_drift(db, group_id=zone.group_id, zone=zone)
+    return {
+        "zone_id": report.zone_id,
+        "name": report.zone_name,
+        "db_record_count": report.db_record_count,
+        "servers": [
+            {
+                "server_name": s.server_name,
+                "driver": s.driver,
+                "status": s.status,
+                "error": s.error,
+                "in_sync": s.in_sync,
+                "drift_count": s.drift_count,
+                "extra_on_server": [
+                    f"{r.name} {r.record_type} {r.value}" for r in s.extra_on_server[:20]
+                ],
+                "missing_on_server": [
+                    f"{r.name} {r.record_type} {r.value}" for r in s.missing_on_server[:20]
+                ],
+            }
+            for s in report.servers
+        ],
+    }
+
+
 class ListDNSSECPoliciesArgs(BaseModel):
     pass
 

--- a/backend/app/services/ai/tools/ipam.py
+++ b/backend/app/services/ai/tools/ipam.py
@@ -27,7 +27,13 @@ from app.models.circuit import Circuit
 from app.models.dhcp import DHCPScope, DHCPStaticAssignment
 from app.models.dns import DNSRecord, DNSZone
 from app.models.domain import Domain
-from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.models.ipam import (
+    IPAddress,
+    IPBlock,
+    IPSpace,
+    Subnet,
+    SubnetUtilizationHistory,
+)
 from app.models.network import NetworkDevice
 from app.models.network_service import NetworkService
 from app.models.overlay import OverlayNetwork
@@ -368,6 +374,81 @@ async def find_subnet_reconciliation(
         return {"error": "subnet not found", "subnet_id": args.subnet_id}
     stale = max(1, min(args.stale_minutes, 525600))
     return await build_reconciliation_report(db, subnet, stale_minutes=stale)
+
+
+# ── get_subnet_utilization_trend ──────────────────────────────────────
+
+
+class SubnetUtilizationTrendArgs(BaseModel):
+    subnet_id: str = Field(description="Subnet UUID.")
+    days: int = Field(
+        default=90,
+        description="How many days of history to return (1–365, default 90).",
+    )
+
+
+@register_tool(
+    name="get_subnet_utilization_trend",
+    description=(
+        "Daily IP-utilization history for one subnet (issue #44): a "
+        "time-ordered series of allocated / total / percent snapshots plus "
+        "first→last delta. Use when the operator asks 'is X filling up?', "
+        "'how fast is X growing?', or 'what was utilization last month?'. "
+        "Snapshots are recorded nightly and retained 90 days."
+    ),
+    args_model=SubnetUtilizationTrendArgs,
+    category="ipam",
+)
+async def get_subnet_utilization_trend(
+    db: AsyncSession, user: User, args: SubnetUtilizationTrendArgs
+) -> dict[str, Any]:
+    from datetime import UTC, datetime, timedelta
+
+    try:
+        subnet_uuid = uuid.UUID(args.subnet_id)
+    except (ValueError, TypeError):
+        return {"error": "subnet_id must be a UUID", "subnet_id": args.subnet_id}
+    subnet = await db.get(Subnet, subnet_uuid)
+    if subnet is None or subnet.deleted_at is not None:
+        return {"error": "subnet not found", "subnet_id": args.subnet_id}
+    days = max(1, min(args.days, 365))
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    rows = (
+        (
+            await db.execute(
+                select(SubnetUtilizationHistory)
+                .where(
+                    SubnetUtilizationHistory.subnet_id == subnet_uuid,
+                    SubnetUtilizationHistory.sampled_at >= cutoff,
+                )
+                .order_by(SubnetUtilizationHistory.sampled_at.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    points = [
+        {
+            "sampled_at": r.sampled_at.isoformat(),
+            "allocated_ips": r.allocated_ips,
+            "total_ips": r.total_ips,
+            "utilization_percent": (
+                round(r.allocated_ips / r.total_ips * 100, 2) if r.total_ips else 0.0
+            ),
+        }
+        for r in rows
+    ]
+    delta = None
+    if len(points) >= 2:
+        delta = round(points[-1]["utilization_percent"] - points[0]["utilization_percent"], 2)
+    return {
+        "subnet_id": str(subnet.id),
+        "network": str(subnet.network),
+        "days": days,
+        "points": points,
+        "current_utilization_percent": float(subnet.utilization_percent or 0.0),
+        "delta_percent_over_window": delta,
+    }
 
 
 # ── find_stale_ips ─────────────────────────────────────────────────────

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -117,6 +117,15 @@ RULE_TYPE_DHCP_POOL_EXHAUSTION = "dhcp_pool_exhaustion"
 # to say whether the supervisor itself is stale or just the host runner.
 RULE_TYPE_FIREWALL_APPLY_STALLED = "firewall.apply_stalled"
 
+# Issue #76 — internal cert / API-token / secret expiry. One rule spans
+# multiple credential tables (supervisor mTLS certs + API tokens with an
+# expiry), so the subject_type is the generic "secret" and the subject_id
+# encodes the source + row id (``appliance_cert:<id>`` / ``api_token:<id>``)
+# to keep each credential's event distinct. Severity escalates like the
+# other ``*_expiring`` rules (threshold/4 → warning, threshold/12 →
+# critical). Catches the "we forgot to rotate" 3am-page failure mode.
+RULE_TYPE_SECRET_EXPIRING = "secret_expiring"
+
 RULE_TYPES = frozenset(
     {
         RULE_TYPE_SUBNET_UTILIZATION,
@@ -140,6 +149,7 @@ RULE_TYPES = frozenset(
         RULE_TYPE_STALE_IP_COUNT,
         RULE_TYPE_DHCP_POOL_EXHAUSTION,
         RULE_TYPE_FIREWALL_APPLY_STALLED,
+        RULE_TYPE_SECRET_EXPIRING,
     }
 )
 
@@ -934,6 +944,100 @@ async def _matching_k3s_api_cert_expiring_subjects(
             f"a restart of k3s.service should pick up a refreshed cert."
         )
         matches.append((str(a.id), a.hostname, message, sev))
+    return matches
+
+
+async def _matching_secret_expiring_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+    now: datetime,
+) -> list[tuple[str, str, str, str]]:
+    """Return ``[(subject_id, display, message, severity)]`` for the
+    ``secret_expiring`` rule type (#76). Scans every internal credential
+    that carries an expiry and fires once per credential expiring within
+    ``threshold_days``:
+
+    * **Supervisor mTLS certs** (``appliance.cert_expires_at``) — the
+      internal-CA-signed cert each appliance's supervisor presents on the
+      agent-comms channel. (The k3s API-server cert has its own
+      ``k3s_api_cert_expiring`` rule and is intentionally NOT duplicated.)
+    * **API tokens** (``api_token.expires_at``) — active tokens with an
+      expiry.
+
+    ``subject_id`` is ``appliance_cert:<id>`` / ``api_token:<id>`` so each
+    credential latches its own event; severity escalates per ``threshold/4``
+    (warning) / ``threshold/12`` (critical). TSIG keys and ACME *accounts*
+    carry no expiry of their own (their issued certs do — out of scope), so
+    they contribute no subjects here.
+    """
+    from app.models.appliance import Appliance  # noqa: PLC0415
+    from app.models.auth import APIToken  # noqa: PLC0415
+
+    threshold_days = rule.threshold_days or _DEFAULT_EXPIRING_THRESHOLD_DAYS
+    cutoff = now + timedelta(days=threshold_days)
+    matches: list[tuple[str, str, str, str]] = []
+
+    def _descriptor(days: int) -> str:
+        if days <= 0:
+            return "has expired"
+        if days == 1:
+            return "expires tomorrow"
+        return f"expires in {days} day(s)"
+
+    # 1. Supervisor mTLS certs (internal CA-signed; agent-comms channel).
+    certs = (
+        (
+            await db.execute(
+                select(Appliance)
+                .where(Appliance.revoked_at.is_(None))
+                .where(Appliance.cert_expires_at.is_not(None))
+                .where(Appliance.cert_expires_at <= cutoff)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for a in certs:
+        if a.cert_expires_at is None:
+            continue
+        days = (a.cert_expires_at - now).days
+        sev = _escalate_severity_for_expiring(
+            rule.severity, threshold_days=threshold_days, days_to_expiry=days
+        )
+        message = (
+            f"Supervisor mTLS certificate for appliance {a.hostname} "
+            f"{_descriptor(days)} ({a.cert_expires_at.isoformat()}, threshold "
+            f"{threshold_days} d). Re-key it from the Fleet drilldown."
+        )
+        matches.append((f"appliance_cert:{a.id}", f"{a.hostname} supervisor cert", message, sev))
+
+    # 2. API tokens with an expiry (active only).
+    tokens = (
+        (
+            await db.execute(
+                select(APIToken)
+                .where(APIToken.is_active.is_(True))
+                .where(APIToken.expires_at.is_not(None))
+                .where(APIToken.expires_at <= cutoff)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for t in tokens:
+        if t.expires_at is None:
+            continue
+        days = (t.expires_at - now).days
+        sev = _escalate_severity_for_expiring(
+            rule.severity, threshold_days=threshold_days, days_to_expiry=days
+        )
+        message = (
+            f"API token '{t.name}' ({t.prefix}…) {_descriptor(days)} "
+            f"({t.expires_at.isoformat()}, threshold {threshold_days} d). "
+            f"Rotate it from Settings → API Tokens."
+        )
+        matches.append((f"api_token:{t.id}", f"{t.name} API token", message, sev))
+
     return matches
 
 
@@ -1796,6 +1900,10 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 expiring = await _matching_k3s_api_cert_expiring_subjects(db, rule, now)
                 matches = [(sid, disp, msg, sev) for sid, disp, msg, sev in expiring]
                 subject_type = "appliance"
+            elif rule.rule_type == RULE_TYPE_SECRET_EXPIRING:
+                expiring = await _matching_secret_expiring_subjects(db, rule, now)
+                matches = [(sid, disp, msg, sev) for sid, disp, msg, sev in expiring]
+                subject_type = "secret"
             elif rule.rule_type == RULE_TYPE_FIREWALL_APPLY_STALLED:
                 stalled = await _matching_firewall_apply_stalled_subjects(db, rule, now)
                 matches = [(sid, disp, msg, sev) for sid, disp, msg, sev in stalled]

--- a/backend/app/services/audit_report.py
+++ b/backend/app/services/audit_report.py
@@ -53,12 +53,12 @@ def _grid(header: list[str], rows: list[list[str]], col_widths: list[float]) -> 
 
 
 def _rows_hash(rows: list[AuditLog]) -> str:
-    """SHA-256 over each row's (seq, timestamp, action, resource) so the
-    trailer is recomputable and tamper-evident — reusing the audit chain's
-    own ``hash`` column when present keeps it cheap and stable."""
+    """SHA-256 over each row's tamper-evidence ``row_hash`` (issue #73's audit
+    chain) so the trailer is itself tamper-evident — falls back to the row id
+    only for rows predating the chain."""
     digest = hashlib.sha256()
     for r in rows:
-        digest.update((getattr(r, "hash", "") or str(r.id)).encode("utf-8"))
+        digest.update((getattr(r, "row_hash", "") or str(r.id)).encode("utf-8"))
         digest.update(b"\x00")
     return digest.hexdigest()
 

--- a/backend/app/services/audit_report.py
+++ b/backend/app/services/audit_report.py
@@ -1,0 +1,190 @@
+"""Compliance / change-report PDF (#48).
+
+An auditor-facing PDF rollup of every ``audit_log`` mutation in a date
+range, grouped by user / resource type / action, with a SHA-256
+tamper-evidence trailer over the included rows. Mirrors the
+``services/conformity/pdf.py`` reportlab pattern (synchronous render after
+async DB queries; small enough to render inline, no ``asyncio.to_thread``
+needed at our scale).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+from datetime import UTC, datetime
+from typing import Any
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import LETTER
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import AuditLog
+
+# Hard cap on detail rows in a single report so a huge range can't blow up
+# memory / the PDF. The summary counts are computed over the full range; the
+# detail table is the most-recent ``_DETAIL_CAP`` rows, with a note when the
+# range exceeds it.
+_DETAIL_CAP = 2000
+
+
+def _grid(header: list[str], rows: list[list[str]], col_widths: list[float]) -> Table:
+    t = Table([header, *rows], colWidths=col_widths, repeatRows=1)
+    t.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#1f2937")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("FONTSIZE", (0, 0), (-1, -1), 8),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#f3f4f6")]),
+                ("GRID", (0, 0), (-1, -1), 0.25, colors.HexColor("#d1d5db")),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("TOPPADDING", (0, 0), (-1, -1), 2),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+            ]
+        )
+    )
+    return t
+
+
+def _rows_hash(rows: list[AuditLog]) -> str:
+    """SHA-256 over each row's (seq, timestamp, action, resource) so the
+    trailer is recomputable and tamper-evident — reusing the audit chain's
+    own ``hash`` column when present keeps it cheap and stable."""
+    digest = hashlib.sha256()
+    for r in rows:
+        digest.update((getattr(r, "hash", "") or str(r.id)).encode("utf-8"))
+        digest.update(b"\x00")
+    return digest.hexdigest()
+
+
+async def generate_change_report_pdf(
+    db: AsyncSession,
+    *,
+    since: datetime,
+    until: datetime,
+    title: str | None = None,
+) -> bytes:
+    """Render the audit-log change report for ``[since, until]`` as a PDF.
+
+    Summary counts (by user / resource type / action) are computed over the
+    whole range; the detail table lists the most-recent ``_DETAIL_CAP`` rows.
+    """
+    base = select(AuditLog).where(AuditLog.timestamp >= since).where(AuditLog.timestamp <= until)
+    total = (await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
+    rows = list(
+        (await db.execute(base.order_by(AuditLog.timestamp.desc()).limit(_DETAIL_CAP)))
+        .scalars()
+        .all()
+    )
+
+    # Summary counters over the FULL range (group-by in the DB so a huge
+    # range doesn't have to be materialised for the rollup).
+    async def _counts(col: Any) -> list[tuple[str, int]]:
+        stmt = (
+            select(col, func.count())
+            .where(AuditLog.timestamp >= since)
+            .where(AuditLog.timestamp <= until)
+            .group_by(col)
+            .order_by(func.count().desc())
+        )
+        return [
+            (str(v if v is not None else "—"), int(n)) for v, n in (await db.execute(stmt)).all()
+        ]
+
+    by_user = await _counts(AuditLog.user_display_name)
+    by_type = await _counts(AuditLog.resource_type)
+    by_action = await _counts(AuditLog.action)
+
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buf,
+        pagesize=LETTER,
+        leftMargin=0.75 * inch,
+        rightMargin=0.75 * inch,
+        topMargin=0.75 * inch,
+        bottomMargin=0.75 * inch,
+        title=title or "SpatiumDDI change report",
+    )
+    styles = getSampleStyleSheet()
+    h1, h2, body = styles["Heading1"], styles["Heading2"], styles["BodyText"]
+    small = ParagraphStyle("small", parent=body, fontSize=8, leading=10)
+    now = datetime.now(UTC)
+
+    story: list = [
+        Paragraph(title or "SpatiumDDI change report", h1),
+        Paragraph(
+            f"Generated {now.isoformat()} UTC · range "
+            f"{since.isoformat()} → {until.isoformat()} · {total} audit events",
+            small,
+        ),
+        Spacer(1, 0.2 * inch),
+    ]
+
+    if total == 0:
+        story.append(
+            Paragraph(
+                "No audit-log mutations recorded in this range.",
+                body,
+            )
+        )
+        doc.build(story)
+        return buf.getvalue()
+
+    def _section(heading: str, label: str, counts: list[tuple[str, int]]) -> None:
+        story.append(Paragraph(heading, h2))
+        story.append(
+            _grid(
+                [label, "Events"],
+                [[k, str(n)] for k, n in counts],
+                [4.5 * inch, 1.5 * inch],
+            )
+        )
+        story.append(Spacer(1, 0.18 * inch))
+
+    _section("By user", "User", by_user)
+    _section("By resource type", "Resource type", by_type)
+    _section("By action", "Action", by_action)
+
+    story.append(Paragraph("Detail", h2))
+    if total > len(rows):
+        story.append(
+            Paragraph(
+                f"Showing the most recent {len(rows)} of {total} events "
+                f"(detail capped at {_DETAIL_CAP}; narrow the range for the rest).",
+                small,
+            )
+        )
+    detail_rows = [
+        [
+            r.timestamp.strftime("%Y-%m-%d %H:%M:%S") if r.timestamp else "—",
+            (r.user_display_name or "—")[:24],
+            (r.action or "—")[:28],
+            (r.resource_type or "—")[:18],
+            (r.resource_display or "—")[:28],
+            (r.result or "—")[:10],
+        ]
+        for r in rows
+    ]
+    story.append(
+        _grid(
+            ["Time (UTC)", "User", "Action", "Type", "Resource", "Result"],
+            detail_rows,
+            [1.15 * inch, 1.1 * inch, 1.4 * inch, 0.9 * inch, 1.4 * inch, 0.65 * inch],
+        )
+    )
+
+    story.append(Spacer(1, 0.18 * inch))
+    story.append(
+        Paragraph(
+            f"Integrity (SHA-256 over {len(rows)} detail rows): {_rows_hash(rows)}",
+            small,
+        )
+    )
+    doc.build(story)
+    return buf.getvalue()

--- a/backend/app/services/dns/drift.py
+++ b/backend/app/services/dns/drift.py
@@ -16,6 +16,7 @@ includes the value.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from dataclasses import dataclass, field
 
@@ -97,7 +98,8 @@ async def compute_zone_drift(
     report = ZoneDriftReport(
         zone_id=str(zone.id), zone_name=zone.name, db_record_count=len(db_rows)
     )
-    for srv in servers:
+
+    async def _drift_for_server(srv: DNSServer) -> ServerDrift:
         entry = ServerDrift(
             server_id=str(srv.id),
             server_name=srv.name,
@@ -108,8 +110,7 @@ async def compute_zone_drift(
         if not hasattr(driver, "pull_zone_records"):
             entry.status = "unsupported"
             entry.error = f"Driver {srv.driver!r} can't pull live records for drift."
-            report.servers.append(entry)
-            continue
+            return entry
         try:
             on_wire: list[RecordData] = await driver.pull_zone_records(srv, zone.name)
         except Exception as exc:  # noqa: BLE001 — per-server, never fail the whole report
@@ -122,8 +123,7 @@ async def compute_zone_drift(
                 driver=srv.driver,
                 error=str(exc),
             )
-            report.servers.append(entry)
-            continue
+            return entry
 
         wire_by_key = {_key(r, zone.name): r for r in on_wire}
         entry.extra_on_server = [
@@ -133,6 +133,12 @@ async def compute_zone_drift(
             _to_drift_record(r) for k, r in db_by_key.items() if k not in wire_by_key
         ]
         entry.in_sync = len(set(db_by_key) & set(wire_by_key))
-        report.servers.append(entry)
+        return entry
+
+    # Pull every server concurrently — a slow/unreachable host shouldn't add
+    # its full AXFR timeout serially to the request latency. Each coroutine
+    # only touches the driver (network), never the shared AsyncSession, and
+    # isolates its own failures, so gather() is safe. Order is preserved.
+    report.servers = list(await asyncio.gather(*(_drift_for_server(s) for s in servers)))
 
     return report

--- a/backend/app/services/dns/drift.py
+++ b/backend/app/services/dns/drift.py
@@ -1,0 +1,138 @@
+"""Per-server DNS config-drift report (#61).
+
+Extends the zone-serial drift surface with a full record-level diff: for
+every server in the zone's group, AXFR / pull the live zone and diff it
+against the SpatiumDDI DB source of truth, surfacing per server what's
+**extra on the server** (records present on the wire but not in the DB —
+a manual change made directly on the host) and what's **missing on the
+server** (DB rows the server isn't serving). Read-only — never applies.
+
+Reuses ``pull_from_server._key`` for the identity/normalisation so the
+comparison matches the additive-sync path exactly (relative-vs-FQDN and
+TTL-only differences don't register as drift). A record whose *value*
+changed on a server surfaces as a missing+extra pair, since the key
+includes the value.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.drivers.dns import get_driver
+from app.drivers.dns.base import RecordData
+from app.models.dns import DNSRecord, DNSServer, DNSZone
+from app.services.dns.pull_from_server import _key
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class DriftRecord:
+    name: str
+    record_type: str
+    value: str
+    ttl: int | None = None
+
+
+@dataclass
+class ServerDrift:
+    server_id: str
+    server_name: str
+    driver: str
+    status: str  # "ok" | "error" | "unsupported"
+    error: str | None = None
+    in_sync: int = 0
+    extra_on_server: list[DriftRecord] = field(default_factory=list)
+    missing_on_server: list[DriftRecord] = field(default_factory=list)
+
+    @property
+    def drift_count(self) -> int:
+        return len(self.extra_on_server) + len(self.missing_on_server)
+
+
+@dataclass
+class ZoneDriftReport:
+    zone_id: str
+    zone_name: str
+    db_record_count: int
+    servers: list[ServerDrift] = field(default_factory=list)
+
+
+def _to_drift_record(r: RecordData | DNSRecord) -> DriftRecord:
+    return DriftRecord(
+        name=r.name or "@",
+        record_type=r.record_type,
+        value=r.value,
+        ttl=r.ttl,
+    )
+
+
+async def compute_zone_drift(
+    db: AsyncSession, *, group_id: uuid.UUID, zone: DNSZone
+) -> ZoneDriftReport:
+    """Compute per-server record-level drift for ``zone`` across every
+    server in ``group_id``. Each server is pulled independently; a pull
+    failure (unreachable / paused / driver can't AXFR) is surfaced as an
+    ``error`` entry rather than failing the whole report."""
+    db_rows = list(
+        (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == zone.id))).scalars().all()
+    )
+    db_by_key = {_key(r, zone.name): r for r in db_rows}
+
+    servers = list(
+        (
+            await db.execute(
+                select(DNSServer).where(DNSServer.group_id == group_id).order_by(DNSServer.name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    report = ZoneDriftReport(
+        zone_id=str(zone.id), zone_name=zone.name, db_record_count=len(db_rows)
+    )
+    for srv in servers:
+        entry = ServerDrift(
+            server_id=str(srv.id),
+            server_name=srv.name,
+            driver=srv.driver,
+            status="ok",
+        )
+        driver = get_driver(srv.driver)
+        if not hasattr(driver, "pull_zone_records"):
+            entry.status = "unsupported"
+            entry.error = f"Driver {srv.driver!r} can't pull live records for drift."
+            report.servers.append(entry)
+            continue
+        try:
+            on_wire: list[RecordData] = await driver.pull_zone_records(srv, zone.name)
+        except Exception as exc:  # noqa: BLE001 — per-server, never fail the whole report
+            entry.status = "error"
+            entry.error = str(exc)
+            logger.warning(
+                "dns.drift.pull_failed",
+                zone=zone.name,
+                server=str(srv.id),
+                driver=srv.driver,
+                error=str(exc),
+            )
+            report.servers.append(entry)
+            continue
+
+        wire_by_key = {_key(r, zone.name): r for r in on_wire}
+        entry.extra_on_server = [
+            _to_drift_record(r) for k, r in wire_by_key.items() if k not in db_by_key
+        ]
+        entry.missing_on_server = [
+            _to_drift_record(r) for k, r in db_by_key.items() if k not in wire_by_key
+        ]
+        entry.in_sync = len(set(db_by_key) & set(wire_by_key))
+        report.servers.append(entry)
+
+    return report

--- a/backend/app/tasks/subnet_utilization_snapshot.py
+++ b/backend/app/tasks/subnet_utilization_snapshot.py
@@ -1,0 +1,55 @@
+"""Daily per-subnet utilization snapshot + 90-day retention prune (#44).
+
+Records each (non-deleted) subnet's already-maintained
+``allocated_ips`` / ``total_ips`` into ``subnet_utilization_history`` once a
+day, then deletes rows older than the retention window. Powers the
+30 / 90-day "% used over time" chart on the subnet detail. Idempotent at
+the day granularity isn't enforced (a manual re-run just adds another
+sample); the chart tolerates multiple same-day points.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import delete, select
+
+from app.celery_app import celery_app
+from app.db import task_session
+from app.models.ipam import Subnet, SubnetUtilizationHistory
+
+logger = structlog.get_logger(__name__)
+
+RETENTION_DAYS = 90
+
+
+async def _snapshot() -> dict[str, int]:
+    async with task_session() as db:
+        now = datetime.now(UTC)
+        subnets = list(
+            (await db.execute(select(Subnet).where(Subnet.deleted_at.is_(None)))).scalars().all()
+        )
+        for s in subnets:
+            db.add(
+                SubnetUtilizationHistory(
+                    subnet_id=s.id,
+                    sampled_at=now,
+                    allocated_ips=int(s.allocated_ips or 0),
+                    total_ips=int(s.total_ips or 0),
+                )
+            )
+        cutoff = now - timedelta(days=RETENTION_DAYS)
+        pruned = await db.execute(
+            delete(SubnetUtilizationHistory).where(SubnetUtilizationHistory.sampled_at < cutoff)
+        )
+        await db.commit()
+        return {"sampled": len(subnets), "pruned": pruned.rowcount or 0}
+
+
+@celery_app.task(name="app.tasks.subnet_utilization_snapshot.snapshot_subnet_utilization")
+def snapshot_subnet_utilization() -> dict[str, int]:
+    result = asyncio.run(_snapshot())
+    logger.info("subnet_utilization_snapshot", **result)
+    return result

--- a/backend/tests/test_alert_secret_expiring.py
+++ b/backend/tests/test_alert_secret_expiring.py
@@ -1,0 +1,92 @@
+"""``secret_expiring`` alert rule (#76).
+
+Verifies the matcher surfaces internal credentials within the threshold
+(supervisor mTLS certs + active API tokens with an expiry), keys each to a
+distinct subject_id, escalates severity as expiry nears, and excludes
+far-future / revoked / inactive credentials.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.alerts import AlertRule
+from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
+from app.models.auth import APIToken, User
+from app.services.alerts import _matching_secret_expiring_subjects
+
+
+def _appliance(hostname: str, *, expires_in_days: int) -> Appliance:
+    der = os.urandom(32)
+    return Appliance(
+        id=uuid.uuid4(),
+        hostname=hostname,
+        public_key_der=der,
+        public_key_fingerprint=hashlib.sha256(der).hexdigest(),
+        state=APPLIANCE_STATE_APPROVED,
+        cert_expires_at=datetime.now(UTC) + timedelta(days=expires_in_days),
+    )
+
+
+async def test_secret_expiring_matches_certs_and_tokens(db_session: AsyncSession) -> None:
+    now = datetime.now(UTC)
+    rule = AlertRule(
+        name="Secret expiry",
+        rule_type="secret_expiring",
+        severity="warning",
+        threshold_days=30,
+        enabled=True,
+    )
+    db_session.add(rule)
+
+    near_cert = _appliance("appl-near", expires_in_days=5)  # inside threshold
+    far_cert = _appliance("appl-far", expires_in_days=365)  # must NOT match
+    db_session.add_all([near_cert, far_cert])
+
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="u",
+        hashed_password="x",
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    live_token = APIToken(
+        name="ci-deploy",
+        token_hash=uuid.uuid4().hex,
+        prefix="abc123",
+        created_by_user_id=user.id,
+        scope="user",
+        is_active=True,
+        expires_at=now + timedelta(days=10),
+    )
+    inactive_token = APIToken(
+        name="retired",
+        token_hash=uuid.uuid4().hex,
+        prefix="dead00",
+        created_by_user_id=user.id,
+        scope="user",
+        is_active=False,  # must NOT match
+        expires_at=now + timedelta(days=3),
+    )
+    db_session.add_all([live_token, inactive_token])
+    await db_session.commit()
+
+    subjects = await _matching_secret_expiring_subjects(db_session, rule, now)
+    ids = {sid for sid, _disp, _msg, _sev in subjects}
+
+    assert f"appliance_cert:{near_cert.id}" in ids
+    assert f"api_token:{live_token.id}" in ids
+    assert f"appliance_cert:{far_cert.id}" not in ids
+    assert f"api_token:{inactive_token.id}" not in ids
+
+    # 5 days left is well inside threshold/12 (30/12 = 2.5) → escalates above the
+    # base "warning"; assert it's at least warning and a known severity.
+    sev_by_id = {sid: sev for sid, _disp, _msg, sev in subjects}
+    assert sev_by_id[f"appliance_cert:{near_cert.id}"] in ("warning", "critical")

--- a/backend/tests/test_ansible_inventory.py
+++ b/backend/tests/test_ansible_inventory.py
@@ -1,0 +1,135 @@
+"""Ansible dynamic-inventory endpoint tests (#67)."""
+
+from __future__ import annotations
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+
+async def _admin_token(db: AsyncSession) -> str:
+    user = User(
+        username=f"ans-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="Ansible Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _space_block_subnet(
+    db: AsyncSession, *, space_name: str, block_name: str, subnet_name: str, cidr: str
+) -> Subnet:
+    space = IPSpace(name=space_name, description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/8", name=block_name)
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network=cidr,
+        name=subnet_name,
+        total_ips=254,
+    )
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def test_inventory_groups_hostvars_and_excludes_placeholders(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _admin_token(db_session)
+    subnet = await _space_block_subnet(
+        db_session,
+        space_name="Prod Space",
+        block_name="Core Block",
+        subnet_name="web-subnet",
+        cidr="10.0.0.0/24",
+    )
+    db_session.add(
+        IPAddress(
+            subnet_id=subnet.id,
+            address="10.0.0.5",
+            status="allocated",
+            role="host",
+            hostname="web01",
+            tags=["web", "prod"],
+            custom_fields={"env": "prod"},
+        )
+    )
+    # A placeholder network row must NOT surface as a manageable host.
+    db_session.add(
+        IPAddress(
+            subnet_id=subnet.id,
+            address="10.0.0.0",
+            status="reserved",
+            role="network",
+        )
+    )
+    await db_session.commit()
+
+    r = await client.get("/api/v1/ansible/inventory", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    inv = r.json()
+
+    # Host present under its hostname with ansible_host = the IP.
+    hv = inv["_meta"]["hostvars"]
+    assert "web01" in hv
+    assert hv["web01"]["ansible_host"] == "10.0.0.5"
+    assert hv["web01"]["spatium_space"] == "Prod Space"
+    assert "web01" in inv["all"]["hosts"]
+
+    # Grouped by space / block / subnet / tag / custom-field (names sanitised).
+    assert "web01" in inv["space_Prod_Space"]["hosts"]
+    assert "web01" in inv["block_Core_Block"]["hosts"]
+    assert "web01" in inv["subnet_web_subnet"]["hosts"]
+    assert "web01" in inv["tag_web"]["hosts"]
+    assert "web01" in inv["tag_prod"]["hosts"]
+    assert "web01" in inv["cf_env_prod"]["hosts"]
+
+    # Placeholder network row excluded entirely.
+    assert "10.0.0.0" not in hv
+    assert "10.0.0.0" not in inv["all"]["hosts"]
+
+
+async def test_inventory_host_query_returns_single_hostvars(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _admin_token(db_session)
+    subnet = await _space_block_subnet(
+        db_session,
+        space_name="S2",
+        block_name="B2",
+        subnet_name="s2",
+        cidr="10.1.0.0/24",
+    )
+    db_session.add(
+        IPAddress(
+            subnet_id=subnet.id,
+            address="10.1.0.9",
+            status="allocated",
+            role="host",
+            hostname="h9",
+        )
+    )
+    await db_session.commit()
+
+    r = await client.get(
+        "/api/v1/ansible/inventory?host=h9",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ansible_host"] == "10.1.0.9"
+    assert "_meta" not in body  # --host returns just the vars

--- a/backend/tests/test_ansible_inventory.py
+++ b/backend/tests/test_ansible_inventory.py
@@ -64,7 +64,7 @@ async def test_inventory_groups_hostvars_and_excludes_placeholders(
             status="allocated",
             role="host",
             hostname="web01",
-            tags=["web", "prod"],
+            tags={"role": "web", "tier": "prod"},
             custom_fields={"env": "prod"},
         )
     )
@@ -94,8 +94,11 @@ async def test_inventory_groups_hostvars_and_excludes_placeholders(
     assert "web01" in inv["space_Prod_Space"]["hosts"]
     assert "web01" in inv["block_Core_Block"]["hosts"]
     assert "web01" in inv["subnet_web_subnet"]["hosts"]
-    assert "web01" in inv["tag_web"]["hosts"]
-    assert "web01" in inv["tag_prod"]["hosts"]
+    # Tags are key+value (a JSONB dict) — grouped by both so distinct
+    # values don't collide and values aren't dropped.
+    assert "web01" in inv["tag_role_web"]["hosts"]
+    assert "web01" in inv["tag_tier_prod"]["hosts"]
+    assert hv["web01"]["spatium_tags"] == {"role": "web", "tier": "prod"}
     assert "web01" in inv["cf_env_prod"]["hosts"]
 
     # Placeholder network row excluded entirely.

--- a/backend/tests/test_audit_change_report.py
+++ b/backend/tests/test_audit_change_report.py
@@ -1,0 +1,69 @@
+"""Compliance / change report PDF (#48)."""
+
+from __future__ import annotations
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import User
+
+
+async def _admin_token(db: AsyncSession) -> str:
+    user = User(
+        username=f"aud-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="Audit Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+def _audit(action: str, rtype: str, who: str) -> AuditLog:
+    return AuditLog(
+        action=action,
+        resource_type=rtype,
+        resource_id=str(uuid.uuid4()),
+        resource_display="10.0.0.0/24",
+        user_display_name=who,
+        auth_source="local",
+        result="success",
+    )
+
+
+async def test_change_report_pdf_renders(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _admin_token(db_session)
+    db_session.add_all(
+        [
+            _audit("subnet.create", "subnet", "alice"),
+            _audit("subnet.update", "subnet", "alice"),
+            _audit("dns.zone.delete", "dns_zone", "bob"),
+        ]
+    )
+    await db_session.commit()
+
+    r = await client.get("/api/v1/audit/export.pdf", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"] == "application/pdf"
+    assert "attachment" in r.headers["content-disposition"]
+    assert r.content.startswith(b"%PDF")  # a real PDF, with content
+
+
+async def test_change_report_pdf_empty_range_is_valid(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _admin_token(db_session)
+    await db_session.commit()
+    # A future window with no events still renders a valid (empty-state) PDF.
+    r = await client.get(
+        "/api/v1/audit/export.pdf?since=2999-01-01T00:00:00&until=2999-02-01T00:00:00",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.content.startswith(b"%PDF")

--- a/backend/tests/test_dns_azure_dns.py
+++ b/backend/tests/test_dns_azure_dns.py
@@ -78,7 +78,7 @@ def test_capabilities_shape() -> None:
     assert caps["name"] == "azure_dns"
     assert caps["agentless"] is True
     assert caps["manages_zones"] is True
-    assert caps["alias_records"] is True
+    assert caps["alias_records"] is False  # #29 — alias authoring deferred
     assert caps["dnssec_online"] is False
     assert "SOA" in caps["record_types"]
     assert "online DNSSEC" in caps["notes"]

--- a/backend/tests/test_dns_cloudflare.py
+++ b/backend/tests/test_dns_cloudflare.py
@@ -537,6 +537,6 @@ def test_capabilities_shape() -> None:
     assert caps["name"] == "cloudflare"
     assert caps["agentless"] is True
     assert caps["manages_zones"] is True
-    assert caps["dnssec_online"] is True
+    assert caps["dnssec_online"] is False  # #29 — cloud DNSSEC deferred
     assert caps["apex_cname"] == "flatten"
     assert "CAA" in caps["record_types"]

--- a/backend/tests/test_dns_drift.py
+++ b/backend/tests/test_dns_drift.py
@@ -1,0 +1,94 @@
+"""DNS config-drift report (#61)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.drivers.dns.base import RecordData
+from app.models.dns import DNSRecord, DNSServer, DNSServerGroup, DNSZone
+from app.services.dns import drift as drift_mod
+
+
+class _FakeDriver:
+    def __init__(self, records: list[RecordData]) -> None:
+        self._records = records
+
+    async def pull_zone_records(self, server: Any, zone_name: str) -> list[RecordData]:
+        return list(self._records)
+
+
+async def _group_server_zone(
+    db: AsyncSession, *, server_name: str, zone_name: str
+) -> tuple[DNSServerGroup, DNSServer, DNSZone]:
+    group = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(group)
+    await db.flush()
+    server = DNSServer(
+        group_id=group.id,
+        name=server_name,
+        driver="bind9",
+        host="10.0.0.53",
+        port=53,
+        is_enabled=True,
+    )
+    db.add(server)
+    zone = DNSZone(group_id=group.id, name=zone_name, zone_type="primary", kind="forward")
+    db.add(zone)
+    await db.flush()
+    return group, server, zone
+
+
+async def test_zone_drift_categorises(db_session: AsyncSession, monkeypatch: Any) -> None:
+    group, _server, zone = await _group_server_zone(
+        db_session, server_name="ns1", zone_name="drift.example.com."
+    )
+    db_session.add_all(
+        [
+            DNSRecord(zone_id=zone.id, name="www", record_type="A", value="10.0.0.1", ttl=300),
+            DNSRecord(zone_id=zone.id, name="mail", record_type="A", value="10.0.0.2", ttl=300),
+        ]
+    )
+    await db_session.commit()
+
+    # Live server: www in sync, a rogue record added directly on the host,
+    # mail not being served.
+    live = [
+        RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        RecordData(name="rogue", record_type="A", value="10.0.0.9", ttl=300),
+    ]
+    monkeypatch.setattr(drift_mod, "get_driver", lambda _d: _FakeDriver(live))
+
+    report = await drift_mod.compute_zone_drift(db_session, group_id=group.id, zone=zone)
+    assert report.db_record_count == 2
+    assert len(report.servers) == 1
+    s = report.servers[0]
+    assert s.status == "ok"
+    assert s.in_sync == 1  # www matches
+    assert {(r.name, r.value) for r in s.extra_on_server} == {("rogue", "10.0.0.9")}
+    assert {(r.name, r.value) for r in s.missing_on_server} == {("mail", "10.0.0.2")}
+    assert s.drift_count == 2
+
+
+async def test_zone_drift_pull_failure_is_surfaced(
+    db_session: AsyncSession, monkeypatch: Any
+) -> None:
+    group, _server, zone = await _group_server_zone(
+        db_session, server_name="ns-down", zone_name="down.example.com."
+    )
+    await db_session.commit()
+
+    class _BoomDriver:
+        async def pull_zone_records(self, server: Any, zone_name: str) -> list[RecordData]:
+            raise RuntimeError("AXFR refused")
+
+    monkeypatch.setattr(drift_mod, "get_driver", lambda _d: _BoomDriver())
+
+    report = await drift_mod.compute_zone_drift(db_session, group_id=group.id, zone=zone)
+    assert len(report.servers) == 1
+    s = report.servers[0]
+    assert s.status == "error"
+    assert "AXFR refused" in (s.error or "")
+    assert s.drift_count == 0

--- a/backend/tests/test_dns_google_dns.py
+++ b/backend/tests/test_dns_google_dns.py
@@ -650,7 +650,7 @@ def test_capabilities_shape() -> None:
     assert caps["name"] == "google_dns"
     assert caps["agentless"] is True
     assert caps["manages_zones"] is True
-    assert caps["dnssec_online"] is True
+    assert caps["dnssec_online"] is False  # #29 — cloud DNSSEC deferred
     assert caps["views"] is False
     assert caps["rpz"] is False
     assert "A" in caps["record_types"]

--- a/backend/tests/test_dns_route53.py
+++ b/backend/tests/test_dns_route53.py
@@ -766,9 +766,9 @@ def test_capabilities_shape() -> None:
     assert caps["name"] == "route53"
     assert caps["agentless"] is True
     assert caps["manages_zones"] is True
-    assert caps["dnssec_online"] is True
-    assert caps["alias_records"] is True
-    assert "ALIAS" in caps["record_types"]
+    assert caps["dnssec_online"] is False  # #29 — cloud DNSSEC deferred
+    assert caps["alias_records"] is False  # #29 — R53 alias authoring deferred
+    assert "ALIAS" not in caps["record_types"]  # #29 — authoring deferred
     assert caps["views"] is False
     assert caps["rpz"] is False
 

--- a/backend/tests/test_subnet_utilization_history.py
+++ b/backend/tests/test_subnet_utilization_history.py
@@ -101,3 +101,16 @@ async def test_utilization_history_empty(client: AsyncClient, db_session: AsyncS
     )
     assert r.status_code == 200, r.text
     assert r.json() == []
+
+
+async def test_utilization_history_missing_subnet_404(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _admin_token(db_session)
+    await db_session.commit()
+    r = await client.get(
+        f"/api/v1/ipam/subnets/{uuid.uuid4()}/utilization-history",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # A missing subnet is distinguishable from "no history yet" (empty list).
+    assert r.status_code == 404, r.text

--- a/backend/tests/test_subnet_utilization_history.py
+++ b/backend/tests/test_subnet_utilization_history.py
@@ -1,0 +1,103 @@
+"""Per-subnet utilization history endpoint (#44)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.ipam import IPBlock, IPSpace, Subnet, SubnetUtilizationHistory
+
+
+async def _admin_token(db: AsyncSession) -> str:
+    user = User(
+        username=f"uh-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="Util Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _subnet(db: AsyncSession) -> Subnet:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/8", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network="10.0.0.0/24",
+        name="s",
+        total_ips=254,
+        allocated_ips=100,
+    )
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def test_utilization_history_window_and_shape(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _admin_token(db_session)
+    subnet = await _subnet(db_session)
+    now = datetime.now(UTC)
+    db_session.add_all(
+        [
+            SubnetUtilizationHistory(
+                subnet_id=subnet.id,
+                sampled_at=now - timedelta(days=2),
+                allocated_ips=50,
+                total_ips=254,
+            ),
+            SubnetUtilizationHistory(
+                subnet_id=subnet.id,
+                sampled_at=now - timedelta(days=1),
+                allocated_ips=100,
+                total_ips=254,
+            ),
+            # Outside the 90-day window — must be excluded.
+            SubnetUtilizationHistory(
+                subnet_id=subnet.id,
+                sampled_at=now - timedelta(days=200),
+                allocated_ips=10,
+                total_ips=254,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    r = await client.get(
+        f"/api/v1/ipam/subnets/{subnet.id}/utilization-history?days=90",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    pts = r.json()
+    assert len(pts) == 2  # the 200-day-old sample is filtered out
+    # Ordered ascending by sampled_at.
+    assert pts[0]["allocated_ips"] == 50
+    assert pts[1]["allocated_ips"] == 100
+    # utilization_percent is computed from allocated/total.
+    assert pts[1]["utilization_percent"] == round(100 / 254 * 100, 2)
+
+
+async def test_utilization_history_empty(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _admin_token(db_session)
+    subnet = await _subnet(db_session)
+    await db_session.commit()
+    r = await client.get(
+        f"/api/v1/ipam/subnets/{subnet.id}/utilization-history",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json() == []

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -472,11 +472,11 @@ Each driver's `capabilities()` returns the same dict shape Windows / PowerDNS us
 
 | | Cloudflare | Route 53 | Azure DNS | Google Cloud DNS |
 |---|:---:|:---:|:---:|:---:|
-| `dnssec_online` | ✅ | ✅ | ❌ | ✅ |
-| ALIAS records | apex CNAME auto-flattened | ✅ (`AliasTarget`, null TTL) | ✅ | — |
+| `dnssec_online` | ❌ | ❌ | ❌ | ❌ |
+| ALIAS records | apex CNAME auto-flattened | read-only (`AliasTarget`, null TTL; authoring deferred) | deferred | — |
 | Apex handling | Cloudflare flattens CNAME-at-apex | apex SOA / NS provider-managed | apex SOA Azure-managed (skipped on read) | apex SOA provider-managed |
 
-`azure_dns` is the only cloud driver without online DNSSEC support — its capability dict carries `dnssec_online: False` and the notes call it out. The DNSSEC sign/unsign/rollover operations stay gated server-side by `_DRIVER_GATED_OPERATIONS` as for every other driver.
+**No cloud driver advertises online DNSSEC sign/unsign (#29).** Cloud DNSSEC is a zone-level *provider* toggle — Route 53 needs a KMS asymmetric key, Cloudflare/Google a managed-zone enable — not the per-record online signing the `dnssec_sign`/`unsign` ops model, so every cloud driver's capability dict carries `dnssec_online: False` and the DNSSEC sign/unsign/rollover operations stay gated server-side by `_DRIVER_GATED_OPERATIONS` to PowerDNS / BIND9. Likewise **cloud ALIAS authoring is deferred** — Route 53 / Azure alias targets need a provider resource id the generic `ALIAS` record type can't express (so `alias_records: False` and `ALIAS` is gated to PowerDNS), though existing alias rrsets are still read back. Wiring real cloud DNSSEC (provider enable + DS retrieval) and cloud ALIAS authoring is a #29 follow-up.
 
 ### 4A.4 Provider-specific wrinkles the hooks paper over
 

--- a/frontend/src/components/MetricsCharts.tsx
+++ b/frontend/src/components/MetricsCharts.tsx
@@ -233,12 +233,17 @@ export function DNSQueryRateCard({
 
 export function DHCPTrafficCard({
   dhcpServers = [],
+  pinnedServerId,
 }: {
   dhcpServers?: DHCPServer[];
+  // #195 — when set (e.g. from the DHCP server detail modal's Stats tab),
+  // the card is scoped to this one server and the server picker is hidden.
+  pinnedServerId?: string;
 }) {
   const [win, setWin] = useState<MetricsWindow>("24h");
   const [serverId, setServerId] = useState<string>(ALL_SERVERS);
-  const scopedId = serverId === ALL_SERVERS ? undefined : serverId;
+  const scopedId =
+    pinnedServerId ?? (serverId === ALL_SERVERS ? undefined : serverId);
   const { data, isLoading } = useQuery({
     queryKey: ["metrics", "dhcp", win, scopedId ?? ""],
     queryFn: () =>
@@ -264,11 +269,13 @@ export function DHCPTrafficCard({
           </h3>
         </div>
         <div className="flex items-center gap-2">
-          <ServerPicker
-            value={serverId}
-            onChange={setServerId}
-            servers={dhcpServers}
-          />
+          {!pinnedServerId && (
+            <ServerPicker
+              value={serverId}
+              onChange={setServerId}
+              servers={dhcpServers}
+            />
+          )}
           <WindowPicker value={win} onChange={setWin} />
         </div>
       </div>

--- a/frontend/src/components/ipam/SubnetUtilizationHistory.tsx
+++ b/frontend/src/components/ipam/SubnetUtilizationHistory.tsx
@@ -1,0 +1,114 @@
+// Per-subnet utilization trend (#44).
+//
+// Renders the daily allocated/total snapshots recorded by the
+// `snapshot_subnet_utilization` beat task as a "% used over time" line
+// chart with a 30 / 90-day window toggle. Self-contained so it can be
+// dropped onto the subnet detail without bloating IPAMPage.
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { TrendingUp } from "lucide-react";
+
+import { ipamApi } from "@/lib/api";
+
+const WINDOWS = [30, 90] as const;
+
+export function SubnetUtilizationHistory({ subnetId }: { subnetId: string }) {
+  const [days, setDays] = useState<(typeof WINDOWS)[number]>(90);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["subnet-utilization-history", subnetId, days],
+    queryFn: () => ipamApi.getUtilizationHistory(subnetId, days),
+  });
+
+  const points = (data ?? []).map((p) => ({
+    t: new Date(p.sampled_at).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    }),
+    util: p.utilization_percent,
+    allocated: p.allocated_ips,
+    total: p.total_ips,
+  }));
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="flex items-center justify-between border-b px-4 py-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <TrendingUp className="h-4 w-4 text-muted-foreground" />
+          Utilization history
+        </div>
+        <div className="flex items-center gap-1">
+          {WINDOWS.map((w) => (
+            <button
+              key={w}
+              type="button"
+              onClick={() => setDays(w)}
+              className={`rounded-md px-2 py-0.5 text-xs ${
+                days === w
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              {w}d
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="h-44 px-2 py-3">
+        {isLoading ? (
+          <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
+            Loading…
+          </div>
+        ) : points.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-1 text-center text-xs text-muted-foreground">
+            <span>No utilization history yet.</span>
+            <span className="text-[11px]">
+              A daily snapshot is recorded each night — check back tomorrow.
+            </span>
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart
+              data={points}
+              margin={{ top: 5, right: 12, left: 0, bottom: 0 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+              <XAxis dataKey="t" tick={{ fontSize: 10 }} minTickGap={32} />
+              <YAxis
+                tick={{ fontSize: 10 }}
+                width={40}
+                domain={[0, 100]}
+                tickFormatter={(v) => `${v}%`}
+              />
+              <Tooltip
+                contentStyle={{ fontSize: 11, borderRadius: 6 }}
+                labelStyle={{ fontWeight: 600 }}
+                formatter={(value, _name, item) => [
+                  `${Number(value).toFixed(1)}% (${item.payload.allocated} / ${item.payload.total})`,
+                  "Utilization",
+                ]}
+              />
+              <Line
+                type="monotone"
+                dataKey="util"
+                stroke="#3b82f6"
+                strokeWidth={2}
+                dot={false}
+                name="Utilization"
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -477,6 +477,13 @@ export const SUBNET_ROLE_LABELS: Record<SubnetRole, string> = {
   guest: "Guest",
 };
 
+export interface SubnetUtilizationPoint {
+  sampled_at: string;
+  allocated_ips: number;
+  total_ips: number;
+  utilization_percent: number;
+}
+
 export interface Subnet {
   id: string;
   space_id: string;
@@ -1377,6 +1384,13 @@ export const ipamApi = {
   }) => api.get<Subnet[]>("/ipam/subnets", { params }).then((r) => r.data),
   getSubnet: (id: string) =>
     api.get<Subnet>(`/ipam/subnets/${id}`).then((r) => r.data),
+  // Per-subnet utilization history — daily snapshots for the trend chart (#44).
+  getUtilizationHistory: (id: string, days = 90) =>
+    api
+      .get<
+        SubnetUtilizationPoint[]
+      >(`/ipam/subnets/${id}/utilization-history`, { params: { days } })
+      .then((r) => r.data),
   // IP discovery reconciliation report (issue #23).
   getReconciliation: (id: string, staleMinutes?: number) =>
     api

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2248,10 +2248,29 @@ export const auditApi = {
     since?: string;
     until?: string;
   }): Promise<void> => {
-    const res = await api.get<Blob>("/audit/export.pdf", {
-      params,
-      responseType: "blob",
-    });
+    let res;
+    try {
+      res = await api.get<Blob>("/audit/export.pdf", {
+        params,
+        responseType: "blob",
+      });
+    } catch (err) {
+      // With responseType: "blob" the error body also arrives as a Blob, so
+      // the usual response.data.detail is unreadable — unwrap it to text
+      // first and re-throw a real Error the caller can show inline.
+      const data = (err as { response?: { data?: unknown } })?.response?.data;
+      if (data instanceof Blob) {
+        const text = await data.text();
+        let detail = text || "PDF export failed";
+        try {
+          detail = JSON.parse(text)?.detail || detail;
+        } catch {
+          // body wasn't JSON — fall back to the raw text
+        }
+        throw new Error(detail);
+      }
+      throw err;
+    }
     const disp = (res.headers["content-disposition"] as string) || "";
     const match = disp.match(/filename="?([^";]+)"?/i);
     const ts = new Date()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6663,7 +6663,8 @@ export type AlertRuleType =
   | "compliance_change"
   | "voice_lease_count_below"
   | "stale_ip_count"
-  | "dhcp_pool_exhaustion";
+  | "dhcp_pool_exhaustion"
+  | "secret_expiring";
 export type AlertSeverity = "info" | "warning" | "critical";
 export type AlertServerType = "dns" | "dhcp" | "any";
 // ``compliance_change`` rule type — keep in lock-step with

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2227,6 +2227,35 @@ export const auditApi = {
         params: maxRows ? { max_rows: maxRows } : undefined,
       })
       .then((r) => r.data),
+  /** Compliance / change report PDF (#48) — auditor-facing rollup of every
+   *  audit-log mutation in a date range, grouped by user / type / action.
+   *  Defaults to the last 30 days; pass ISO ``since``/``until`` to narrow. */
+  exportPdf: async (params?: {
+    since?: string;
+    until?: string;
+  }): Promise<void> => {
+    const res = await api.get<Blob>("/audit/export.pdf", {
+      params,
+      responseType: "blob",
+    });
+    const disp = (res.headers["content-disposition"] as string) || "";
+    const match = disp.match(/filename="?([^";]+)"?/i);
+    const ts = new Date()
+      .toISOString()
+      .slice(0, 19)
+      .replace(/[-:]/g, "")
+      .replace("T", "-");
+    const filename = match ? match[1] : `spatiumddi-change-report-${ts}.pdf`;
+    const blob = new Blob([res.data as BlobPart], { type: "application/pdf" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  },
 };
 
 // ── Backup + restore (issue #117 Phase 1a) ────────────────────────────────────

--- a/frontend/src/pages/admin/AlertsPage.tsx
+++ b/frontend/src/pages/admin/AlertsPage.tsx
@@ -40,6 +40,7 @@ const RULE_TYPE_PARAM_DEFAULTS: Partial<
   domain_expiring: { thresholdDays: 30 },
   circuit_term_expiring: { thresholdDays: 30 },
   service_term_expiring: { thresholdDays: 30 },
+  secret_expiring: { thresholdDays: 30 },
 };
 
 function Field({
@@ -132,6 +133,7 @@ function RuleEditorModal({
           ruleType === "domain_expiring" ||
           ruleType === "circuit_term_expiring" ||
           ruleType === "service_term_expiring" ||
+          ruleType === "secret_expiring" ||
           ruleType === "stale_ip_count"
             ? thresholdDays
             : null,
@@ -249,6 +251,11 @@ function RuleEditorModal({
                   Voice VLAN lease count below threshold
                 </option>
               </optgroup>
+              <optgroup label="Security">
+                <option value="secret_expiring">
+                  Secret / certificate expiring
+                </option>
+              </optgroup>
             </select>
           </Field>
         )}
@@ -354,7 +361,8 @@ function RuleEditorModal({
         )}
         {(ruleType === "domain_expiring" ||
           ruleType === "circuit_term_expiring" ||
-          ruleType === "service_term_expiring") && (
+          ruleType === "service_term_expiring" ||
+          ruleType === "secret_expiring") && (
           <Field
             label="Threshold (days)"
             hint="Soft fire at threshold; severity escalates to warning at threshold/4 and critical at threshold/12 (e.g. 30 → 7.5 → 2.5 d)."

--- a/frontend/src/pages/admin/AuditPage.tsx
+++ b/frontend/src/pages/admin/AuditPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   ClipboardList,
   ChevronLeft,
@@ -116,6 +116,10 @@ export function AuditPage() {
 
   const hasActiveFilter = Object.values(colFilters).some(Boolean);
 
+  const exportPdfMut = useMutation({
+    mutationFn: () => auditApi.exportPdf(),
+  });
+
   const queryParams = {
     limit: PAGE_SIZE,
     offset: page * PAGE_SIZE,
@@ -160,17 +164,25 @@ export function AuditPage() {
           </div>
           <ChainIntegrityBadge />
           <button
-            onClick={() => auditApi.exportPdf()}
+            onClick={() => exportPdfMut.mutate()}
+            disabled={exportPdfMut.isPending}
             title="Download a compliance / change report PDF (last 30 days)"
-            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
           >
             <Download className="h-3.5 w-3.5" />
-            Export PDF
+            {exportPdfMut.isPending ? "Exporting…" : "Export PDF"}
           </button>
           <span className="text-sm text-muted-foreground">
             {total.toLocaleString()} {total === 1 ? "event" : "events"}
           </span>
         </div>
+
+        {exportPdfMut.isError && (
+          <div className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-600 dark:text-red-400">
+            PDF export failed:{" "}
+            {(exportPdfMut.error as Error)?.message ?? "unknown error"}
+          </div>
+        )}
 
         {/* Table */}
         <div className="overflow-x-auto rounded-lg border">

--- a/frontend/src/pages/admin/AuditPage.tsx
+++ b/frontend/src/pages/admin/AuditPage.tsx
@@ -4,6 +4,7 @@ import {
   ClipboardList,
   ChevronLeft,
   ChevronRight,
+  Download,
   ShieldCheck,
   ShieldAlert,
   X,
@@ -158,6 +159,14 @@ export function AuditPage() {
             </p>
           </div>
           <ChainIntegrityBadge />
+          <button
+            onClick={() => auditApi.exportPdf()}
+            title="Download a compliance / change report PDF (last 30 days)"
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            <Download className="h-3.5 w-3.5" />
+            Export PDF
+          </button>
           <span className="text-sm text-muted-foreground">
             {total.toLocaleString()} {total === 1 ? "event" : "events"}
           </span>

--- a/frontend/src/pages/dhcp/ServerDetailModal.tsx
+++ b/frontend/src/pages/dhcp/ServerDetailModal.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Activity,
+  BarChart3,
   Copy,
   Cpu,
   FileText,
@@ -13,6 +14,7 @@ import {
   ScrollText,
   Server,
 } from "lucide-react";
+import { DHCPTrafficCard } from "@/components/MetricsCharts";
 import { Modal } from "@/components/ui/modal";
 import { PauseServerModal } from "@/components/ui/pause-server-modal";
 import {
@@ -42,7 +44,7 @@ import {
  * Read-only Windows DHCP servers hide the Logs + Config tabs (the
  * driver doesn't push a Kea log pipeline and has no rendered config).
  */
-type Tab = "overview" | "sync" | "events" | "logs" | "config";
+type Tab = "overview" | "sync" | "events" | "logs" | "config" | "stats";
 
 const READ_ONLY_DRIVERS = new Set(["windows_dhcp"]);
 
@@ -166,6 +168,12 @@ export function ServerDetailModal({
                 icon={<FileText className="h-3.5 w-3.5" />}
                 label="Config"
               />
+              <TabButton
+                active={tab === "stats"}
+                onClick={() => setTab("stats")}
+                icon={<BarChart3 className="h-3.5 w-3.5" />}
+                label="Stats"
+              />
             </>
           )}
         </div>
@@ -177,6 +185,17 @@ export function ServerDetailModal({
           {tab === "logs" && !isReadOnly && <LogsTab serverId={server.id} />}
           {tab === "config" && !isReadOnly && (
             <ConfigTab serverId={server.id} />
+          )}
+          {/* #195 — DHCP lease-rate timeseries (DISCOVER/OFFER/REQUEST/ACK/
+              NAK/…), scoped to this server. Reuses the dashboard's
+              DHCPTrafficCard pinned to server.id — symmetric with how the
+              DNS modal's Stats tab reuses metricsApi.dnsTimeseries. Gated on
+              !isReadOnly like Logs/Config (Windows DHCP has no Kea metric
+              stream). */}
+          {tab === "stats" && !isReadOnly && (
+            <div className="p-3">
+              <DHCPTrafficCard pinnedServerId={server.id} />
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -126,6 +126,7 @@ import { FreeSpaceBand } from "@/components/ipam/FreeSpaceBand";
 import { PlanAllocationModal } from "@/components/ipam/PlanAllocationModal";
 import { AggregationCandidatesBadge } from "@/components/ipam/AggregationSuggestions";
 import { FreeSpaceTreemap } from "@/components/ipam/FreeSpaceTreemap";
+import { SubnetUtilizationHistory } from "@/components/ipam/SubnetUtilizationHistory";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -3698,7 +3699,7 @@ function SubnetDetail({
   const [scanFromDetail, setScanFromDetail] = useState<IPAddress | null>(null);
   const [showFilters, setShowFilters] = useState(false);
   const [activeSubnetTab, setActiveSubnetTab] = useState<
-    "addresses" | "dhcp" | "aliases" | "nat"
+    "addresses" | "dhcp" | "aliases" | "nat" | "trend"
   >("addresses");
   const [natModalIp, setNatModalIp] = useState<IPAddress | null>(null);
   const [selectedIpIds, setSelectedIpIds] = useState<Set<string>>(new Set());
@@ -4351,6 +4352,18 @@ function SubnetDetail({
           >
             NAT
           </button>
+          <button
+            onClick={() => setActiveSubnetTab("trend")}
+            className={cn(
+              "px-3 py-2 text-xs font-medium border-b-2 -mb-px transition-colors",
+              activeSubnetTab === "trend"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+            title="Utilization over time"
+          >
+            Trend
+          </button>
           {activeSubnetTab === "addresses" && selectedIpIds.size > 0 && (
             <div className="ml-auto flex items-center gap-2 py-1">
               <span className="text-xs font-medium text-muted-foreground">
@@ -4398,6 +4411,12 @@ function SubnetDetail({
       {activeSubnetTab === "nat" && (
         <div className="flex-1 overflow-auto">
           <NatSubnetPanel subnetId={subnet.id} />
+        </div>
+      )}
+
+      {activeSubnetTab === "trend" && (
+        <div className="flex-1 overflow-auto p-4">
+          <SubnetUtilizationHistory subnetId={subnet.id} />
         </div>
       )}
 


### PR DESCRIPTION
Batch of roadmap quick-win issues on a single branch (9 commits). Each feature is one commit; the last two commits are a full self-review pass + fixes (no Copilot this cycle).

## Issues

**Fully addressed (Closes):**
- **#67** — Ansible dynamic-inventory endpoint (`GET /api/v1/ansible/inventory`): `_meta.hostvars` + groups by space / block / subnet / tag / custom-field, gated on `read`/`ip_address`.
- **#76** — `secret_expiring` alert rule (appliance cert + API-token expiry, severity escalation, no migration).
- **#48** — Compliance / change-report PDF (`GET /api/v1/audit/export.pdf`, reportlab, SHA-256 integrity trailer over the audit-chain `row_hash`).
- **#44** — Per-subnet utilization history: new table + nightly snapshot beat task (90-day retention) + API + "Trend" tab line chart + `get_subnet_utilization_trend` MCP tool.

**Partial — please close deliberately, not auto-closed (Refs):**
- **#29** — Cloud DNS driver *capability honesty*: stop advertising DNSSEC/ALIAS ops the API gate already 422s. Real cloud DNSSEC/ALIAS *authoring* is still deferred.
- **#195** — DHCP server-detail Stats tab — reuses the existing DHCP timeseries (no new metrics pipeline).
- **#61** — DNS config-drift report — backend service + endpoint + `find_dns_zone_drift` MCP tool shipped; the drift **UI** is deferred.

**Deferred (not in this PR):**
- **#132** — PowerDNS DNSSEC smoke test is blocked by the 300s LMDB zone-cache; findings posted to the issue.

## Self-review (Copilot credits exhausted this cycle)

Four adversarial review passes across all ~1,770 LOC against the project non-negotiables. Findings fixed in `7d1118c` + `c11b8a7`:

- **BLOCKER** #67 — `IPAddress.tags` is a JSONB **dict**; the inventory iterated it as a list, dropping tag values and colliding distinct values into one group. Now groups by key+value. (Test was masking it with list-shaped tags — fixed.)
- **SHOULD-FIX** #48 — integrity trailer read `getattr(r,"hash")` but the column is `row_hash` → now actually tamper-evident.
- **SHOULD-FIX** #61 — per-server AXFR ran serially (20s × N worst case); now `asyncio.gather` concurrent (each coroutine touches only the driver, isolates failures).
- **NIT** #48 — PDF Export button swallowed blob errors → now unwraps to a real `Error` + inline banner.
- **NIT** #44 — `utilization-history` returned `[]` for a missing subnet → now 404 (+ regression test).
- **NIT** #67 — documented the inherent unbounded `--list` load + added a `>50k` warning log.

Verified correct without change: #76 (columns real, dispatch wired, `subject_id` safe), #29 (flags match `_DRIVER_GATED_*`), #195 (optional prop, query-key isolation, server-side filter), #44 (single alembic head, beat entry inside `conf.update` per #217/#218). All new endpoints are GETs with server-side permission gates (#3); no un-audited mutations (#4); drift goes through the driver ABC (#10).

## Verification
- ruff / black / mypy clean on all touched files; `ruff check app/` + `black --check app/` clean branch-wide.
- `npm run build` (tsc + vite) clean.
- Per-issue test suites pass; full `make test` run attached separately.

Closes #67
Closes #76
Closes #48
Closes #44

Refs #29
Refs #195
Refs #61
Refs #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)