### PR TITLE
fix(ui): alphabetize Fleet → Services menu items

### DIFF
--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -949,7 +949,14 @@ export function FleetTab({
     },
     {
       heading: "Services",
+      // Keep these alphabetical by label so new host-config services slot
+      // in by position rather than append-order.
       items: [
+        {
+          key: "resolver",
+          label: "DNS Resolver",
+          summary: "Fleet-wide systemd-resolved config.",
+        },
         {
           key: "lldp",
           label: "LLDP",
@@ -964,11 +971,6 @@ export function FleetTab({
           key: "snmp",
           label: "SNMP",
           summary: "Fleet-wide snmpd config.",
-        },
-        {
-          key: "resolver",
-          label: "DNS Resolver",
-          summary: "Fleet-wide systemd-resolved config.",
         },
         {
           key: "ssh",


### PR DESCRIPTION
The **Fleet → Services** nav listed the original three host-config services (LLDP / NTP / SNMP) alphabetically, but the newer ones (#156 Syslog, #157 SSH, #158 DNS Resolver) were appended in issue order, so the menu read LLDP · NTP · SNMP · DNS Resolver · SSH · Syslog.

Reordered the `navGroups` Services items alphabetically by label → **DNS Resolver · LLDP · NTP · SNMP · SSH · Syslog**, and added a keep-alphabetical comment so future services slot in by position.

UI-only; no behaviour change. prettier + eslint + `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)