### PR TITLE
fix(dhcp): #365 group socket-mode (raw/udp) so directly-attached clients get leases

### DIFF
--- a/agent/dhcp/images/kea/Dockerfile
+++ b/agent/dhcp/images/kea/Dockerfile
@@ -41,6 +41,11 @@ FROM alpine:3.22 AS runtime
 # re-resolved against the current alpine 3.22 index. GitHub Actions
 # Docker layer cache (``cache-from: type=gha``) is otherwise happy
 # to serve a 30-day-old ``apk add`` layer that Trivy will then flag.
+#
+# ``libcrypto3``/``libssl3`` pinned ``>=3.5.7-r0`` for CVE-2026-45447
+# (HIGH, OpenSSL — alpine 3.22 base ships 3.5.6-r0, fixed in 3.5.7-r0):
+# the explicit lower bound installs the patched openssl libs AND busts
+# the ``cache-from`` layer so a stale apk add can't reintroduce 3.5.6-r0.
 RUN apk upgrade --no-cache \
  && apk add --no-cache \
       'kea>=2.6.5-r0' kea-dhcp4 kea-dhcp6 kea-ctrl-agent kea-admin \
@@ -49,6 +54,7 @@ RUN apk upgrade --no-cache \
       python3 py3-pip libpcap \
       libcap \
       ca-certificates tzdata \
+      'libcrypto3>=3.5.7-r0' 'libssl3>=3.5.7-r0' \
  && setcap cap_net_bind_service=+ep /usr/sbin/kea-dhcp4 \
  && setcap cap_net_bind_service=+ep /usr/sbin/kea-dhcp6 \
  && addgroup -S spatium \

--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -542,7 +542,14 @@ def render(
     dhcp4: dict[str, Any] = {
         "interfaces-config": {
             "interfaces": list(interfaces),
-            "dhcp-socket-type": server.get("dhcp_socket_type", "udp"),
+            # Issue #365 — default to ``raw`` (AF_PACKET) so Kea hears
+            # broadcast DISCOVERs from directly-attached clients. The
+            # control plane sends the resolved value (``raw`` for group
+            # socket_mode "direct", ``udp`` for "relay"); the ``raw``
+            # fallback only applies to bundles from an older control plane
+            # that predates the ``server`` block. ``raw`` needs CAP_NET_RAW
+            # (granted on the appliance DaemonSet + compose Kea services).
+            "dhcp-socket-type": server.get("dhcp_socket_type", "raw"),
         },
         "control-socket": {
             "socket-type": "unix",

--- a/agent/dns/images/bind9/Dockerfile
+++ b/agent/dns/images/bind9/Dockerfile
@@ -26,6 +26,11 @@ FROM alpine:3.22 AS runtime
 # ``cache-from: type=gha`` on the build workflow) is otherwise
 # perfectly happy to serve a 30-day-old ``apk add`` layer that
 # Trivy will then flag.
+#
+# ``libcrypto3``/``libssl3`` pinned ``>=3.5.7-r0`` for CVE-2026-45447
+# (HIGH, OpenSSL — alpine 3.22 base ships 3.5.6-r0, fixed in 3.5.7-r0):
+# the explicit lower bound installs the patched openssl libs AND busts
+# the ``cache-from`` layer so a stale apk add can't reintroduce 3.5.6-r0.
 RUN apk upgrade --no-cache \
  && apk add --no-cache \
       bind bind-tools \
@@ -33,6 +38,7 @@ RUN apk upgrade --no-cache \
       python3 py3-pip \
       libcap \
       ca-certificates tzdata \
+      'libcrypto3>=3.5.7-r0' 'libssl3>=3.5.7-r0' \
  && setcap cap_net_bind_service=+ep /usr/sbin/named \
  && addgroup -S spatium \
  && adduser -S -G spatium spatium \

--- a/agent/dns/images/powerdns/Dockerfile
+++ b/agent/dns/images/powerdns/Dockerfile
@@ -27,6 +27,11 @@ FROM alpine:3.22 AS runtime
 # index. GitHub Actions Docker layer cache (the ``cache-from:
 # type=gha`` on the build workflow) is otherwise happy to serve a
 # 30-day-old ``apk add`` layer that Trivy will then flag.
+#
+# ``libcrypto3``/``libssl3`` pinned ``>=3.5.7-r0`` for CVE-2026-45447
+# (HIGH, OpenSSL — alpine 3.22 base ships 3.5.6-r0, fixed in 3.5.7-r0):
+# the explicit lower bound installs the patched openssl libs AND busts
+# the ``cache-from`` layer so a stale apk add can't reintroduce 3.5.6-r0.
 RUN apk upgrade --no-cache \
  && apk add --no-cache \
       pdns pdns-backend-lmdb \
@@ -35,6 +40,7 @@ RUN apk upgrade --no-cache \
       python3 py3-pip \
       libcap \
       ca-certificates tzdata \
+      'libcrypto3>=3.5.7-r0' 'libssl3>=3.5.7-r0' \
  && setcap cap_net_bind_service=+ep /usr/sbin/pdns_server \
  && addgroup -S spatium \
  && adduser -S -G spatium spatium \

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -490,6 +490,7 @@ backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:138
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:139
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:140
 backend/alembic/versions/f3b8d24a1c70_appliance_evict_requested.py:drop_column:39
+backend/alembic/versions/f3b9c1d6a274_dhcp_group_socket_mode.py:drop_column:49
 backend/alembic/versions/f4a6c8b2e571_bgp_communities.py:drop_table:83
 backend/alembic/versions/f4a9c1b2d6e7_dns_zone_color.py:drop_column:33
 backend/alembic/versions/f4e1d2a09b75_lease_history_and_nat.py:drop_column:171

--- a/backend/alembic/versions/f3b9c1d6a274_dhcp_group_socket_mode.py
+++ b/backend/alembic/versions/f3b9c1d6a274_dhcp_group_socket_mode.py
@@ -1,0 +1,49 @@
+"""dhcp server group: add dhcp_socket_mode (issue #365)
+
+Adds ``dhcp_server_group.dhcp_socket_mode`` — the Kea ``dhcp-socket-type``
+selector carried on the group (a per-daemon Kea setting, so it can't vary
+per subnet):
+
+  * ``direct`` → ``raw`` sockets (default). Receives broadcast DISCOVERs
+    from directly-attached clients that have no IP yet *and* relayed
+    traffic. Kea's own default.
+  * ``relay`` → ``udp`` sockets. Relay-only; cannot receive direct L2
+    broadcasts.
+
+Existing rows backfill to ``direct`` via the column ``server_default`` so
+upgraded installs switch from the old hardcoded ``udp`` render to ``raw``
+and start answering directly-attached clients with no operator action.
+
+Revision ID: f3b9c1d6a274
+Revises: b6f4d2a91c83
+Create Date: 2026-06-10
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f3b9c1d6a274"
+down_revision: str | None = "b6f4d2a91c83"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # NOT NULL with a server_default → Postgres backfills every existing
+    # row to "direct" as part of the ADD COLUMN, so no separate UPDATE is
+    # needed. The model carries the same server_default.
+    op.add_column(
+        "dhcp_server_group",
+        sa.Column(
+            "dhcp_socket_mode",
+            sa.String(length=16),
+            nullable=False,
+            server_default="direct",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("dhcp_server_group", "dhcp_socket_mode")

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -448,6 +448,16 @@ async def agent_config_longpoll(
                         "server_name": bundle.server_name,
                         "driver": bundle.driver,
                         "roles": list(bundle.roles),
+                        # Issue #365 — server-wide Kea interfaces-config. The
+                        # agent's render_kea reads ``dhcp_socket_type`` here;
+                        # ``raw`` (from group socket_mode "direct") lets Kea
+                        # receive broadcast DISCOVERs from directly-attached
+                        # clients, ``udp`` is relay-only. Folded into the
+                        # bundle ETag so a mode change wakes the long-poll.
+                        "server": {
+                            "interfaces": ["*"],
+                            "dhcp_socket_type": bundle.dhcp_socket_type,
+                        },
                         "scopes": [
                             {
                                 "subnet_cidr": s.subnet_cidr,

--- a/backend/app/api/v1/dhcp/server_groups.py
+++ b/backend/app/api/v1/dhcp/server_groups.py
@@ -29,12 +29,17 @@ router = APIRouter(
 )
 
 VALID_MODES = {"standalone", "load-balancing", "hot-standby"}
+# Issue #365 — Kea dhcp-socket-type selector. "direct" → raw sockets
+# (receives broadcast DISCOVERs from directly-attached clients), "relay"
+# → udp sockets (relay-only).
+VALID_SOCKET_MODES = {"direct", "relay"}
 
 
 class GroupCreate(BaseModel):
     name: str
     description: str = ""
     mode: str = "hot-standby"
+    dhcp_socket_mode: str = "direct"
     heartbeat_delay_ms: int = 10000
     max_response_delay_ms: int = 60000
     max_ack_delay_ms: int = 10000
@@ -48,11 +53,19 @@ class GroupCreate(BaseModel):
             raise ValueError(f"mode must be one of {sorted(VALID_MODES)}")
         return v
 
+    @field_validator("dhcp_socket_mode")
+    @classmethod
+    def _sm(cls, v: str) -> str:
+        if v not in VALID_SOCKET_MODES:
+            raise ValueError(f"dhcp_socket_mode must be one of {sorted(VALID_SOCKET_MODES)}")
+        return v
+
 
 class GroupUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
     mode: str | None = None
+    dhcp_socket_mode: str | None = None
     heartbeat_delay_ms: int | None = None
     max_response_delay_ms: int | None = None
     max_ack_delay_ms: int | None = None
@@ -64,6 +77,13 @@ class GroupUpdate(BaseModel):
     def _m(cls, v: str | None) -> str | None:
         if v is not None and v not in VALID_MODES:
             raise ValueError(f"mode must be one of {sorted(VALID_MODES)}")
+        return v
+
+    @field_validator("dhcp_socket_mode")
+    @classmethod
+    def _sm(cls, v: str | None) -> str | None:
+        if v is not None and v not in VALID_SOCKET_MODES:
+            raise ValueError(f"dhcp_socket_mode must be one of {sorted(VALID_SOCKET_MODES)}")
         return v
 
 
@@ -83,6 +103,7 @@ class GroupResponse(BaseModel):
     name: str
     description: str
     mode: str
+    dhcp_socket_mode: str
     heartbeat_delay_ms: int
     max_response_delay_ms: int
     max_ack_delay_ms: int
@@ -107,6 +128,7 @@ def _group_to_response(g: DHCPServerGroup) -> GroupResponse:
         name=g.name,
         description=g.description,
         mode=g.mode,
+        dhcp_socket_mode=g.dhcp_socket_mode,
         heartbeat_delay_ms=g.heartbeat_delay_ms,
         max_response_delay_ms=g.max_response_delay_ms,
         max_ack_delay_ms=g.max_ack_delay_ms,
@@ -177,8 +199,9 @@ async def update_group(
     changes = body.model_dump(exclude_none=True)
     for k, v in changes.items():
         setattr(g, k, v)
-    # HA tuning (mode / heartbeat / delays / auto-failover) renders into
-    # every member's bundle, so wake the group channel.
+    # HA tuning (mode / heartbeat / delays / auto-failover) and the Kea
+    # socket mode (#365) all render into every member's bundle, so wake the
+    # group channel — the bundle ETag shifts and agents re-render promptly.
     collect_wake(dhcp_group_channel(g.id))
     write_audit(
         db,

--- a/backend/app/drivers/dhcp/base.py
+++ b/backend/app/drivers/dhcp/base.py
@@ -225,6 +225,12 @@ class ConfigBundle:
     # agent's Kea renderer injects ``libdhcp_ha.so`` + the ``high-
     # availability`` config block when this is present.
     failover: FailoverConfig | None = None
+    # Issue #365 — Kea ``dhcp-socket-type`` for the Dhcp4 daemon, derived
+    # from ``DHCPServerGroup.dhcp_socket_mode`` (``direct`` → ``raw``,
+    # ``relay`` → ``udp``). Defaults to ``raw`` so a bundle built without a
+    # group (or by an older control plane) still serves directly-attached
+    # clients. v6 is unaffected — DHCPv6 has no socket-type concept.
+    dhcp_socket_type: str = "raw"
 
     def compute_etag(self) -> str:
         """Compute a stable SHA-256 of the bundle contents (excluding etag/timestamp)."""
@@ -240,6 +246,7 @@ class ConfigBundle:
             "pxe_classes": [asdict(p) for p in self.pxe_classes],
             "phone_classes": [asdict(c) for c in self.phone_classes],
             "failover": asdict(self.failover) if self.failover else None,
+            "dhcp_socket_type": self.dhcp_socket_type,
         }
         blob = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
         return "sha256:" + hashlib.sha256(blob).hexdigest()

--- a/backend/app/drivers/dhcp/kea.py
+++ b/backend/app/drivers/dhcp/kea.py
@@ -268,7 +268,13 @@ class KeaDriver(DHCPDriver):
         if v4_scopes or not v6_scopes:
             out["Dhcp4"] = {
                 "valid-lifetime": bundle.options.lease_time,
-                "interfaces-config": {"interfaces": ["*"]},
+                # Issue #365 — ``raw`` (group socket_mode "direct") receives
+                # broadcast DISCOVERs from directly-attached clients; ``udp``
+                # is relay-only. v6 below has no socket-type concept.
+                "interfaces-config": {
+                    "interfaces": ["*"],
+                    "dhcp-socket-type": bundle.dhcp_socket_type,
+                },
                 "lease-database": {
                     "type": "memfile",
                     "persist": True,

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -71,6 +71,26 @@ class DHCPServerGroup(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         String(16), nullable=False, default="host", server_default="host"
     )
 
+    # Issue #365 — Kea ``dhcp-socket-type`` (inside ``interfaces-config``).
+    # Distinct from ``network_mode`` above: that's the *container* network
+    # namespace; this is how the Kea daemon reads packets off the wire. It
+    # is a per-daemon setting (cannot vary per subnet), so it lives on the
+    # group and applies to every member Kea.
+    #   * ``direct`` → ``raw`` (AF_PACKET). Receives broadcast DISCOVERs
+    #     from directly-attached clients that have no IP yet *and* relayed
+    #     traffic — the superset, and Kea's own default. Needs CAP_NET_RAW
+    #     (granted on the appliance DaemonSet + the compose Kea services).
+    #   * ``relay`` → ``udp`` (datagram). Relay-only; cannot receive direct
+    #     L2 broadcasts. Pick only when Kea sits exclusively behind a DHCP
+    #     relay, or the runtime can't grant raw-socket capability.
+    # Delivered to every deploy path (k8s/compose/appliance) via the
+    # ConfigBundle long-poll — not the supervisor role assignment — so the
+    # agent renders ``interfaces-config`` from it and the ETag shifts on
+    # change.
+    dhcp_socket_mode: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="direct", server_default="direct"
+    )
+
     # Kea HA hook tuning — rendered into libdhcp_ha.so config when the
     # group is an HA pair. Defaults mirror Kea's documented recommendations.
     heartbeat_delay_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=10000)

--- a/backend/app/services/ai/tools/dhcp.py
+++ b/backend/app/services/ai/tools/dhcp.py
@@ -196,7 +196,9 @@ class ListServerGroupsArgs(BaseModel):
     description=(
         "List DHCP server groups (logical bundles of Kea servers, "
         "with HA implicit when the group has ≥ 2 members). Each "
-        "summary includes name, member count, and DDNS toggle."
+        "summary includes name, member count, DDNS toggle, and "
+        "dhcp_socket_mode ('direct' = raw sockets that hear broadcast "
+        "DISCOVERs from on-LAN clients; 'relay' = udp, relay-only)."
     ),
     args_model=ListServerGroupsArgs,
     category="dhcp",
@@ -219,6 +221,10 @@ async def list_dhcp_server_groups(
                 "id": str(g.id),
                 "name": g.name,
                 "ddns_enabled": g.ddns_enabled,
+                # #365 — "direct" (raw sockets, hears broadcast DISCOVERs) or
+                # "relay" (udp sockets, relay-only). Helps the copilot answer
+                # "why isn't this DHCP server replying to direct clients?".
+                "dhcp_socket_mode": g.dhcp_socket_mode,
                 "member_count": int(member_count or 0),
             }
         )

--- a/backend/app/services/dhcp/config_bundle.py
+++ b/backend/app/services/dhcp/config_bundle.py
@@ -258,6 +258,12 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
     phone_classes = await _assemble_phone_classes(db, scope_rows)
 
     failover = await _resolve_failover(db, server, group)
+    # Issue #365 — Kea socket type. ``direct`` (default) → ``raw`` sockets
+    # so Kea hears broadcast DISCOVERs from directly-attached clients;
+    # ``relay`` → ``udp`` for relay-only deployments. Groupless servers
+    # render an empty bundle anyway, but default them to ``raw`` too.
+    socket_mode = getattr(group, "dhcp_socket_mode", "direct") if group else "direct"
+    dhcp_socket_type = "udp" if socket_mode == "relay" else "raw"
     bundle = ConfigBundle(
         server_id=str(server.id),
         server_name=server.name,
@@ -271,6 +277,7 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
         phone_classes=phone_classes,
         generated_at=datetime.now(UTC),
         failover=failover,
+        dhcp_socket_type=dhcp_socket_type,
     )
     bundle.etag = bundle.compute_etag()
     return bundle

--- a/backend/tests/test_dhcp_socket_mode.py
+++ b/backend/tests/test_dhcp_socket_mode.py
@@ -1,0 +1,182 @@
+"""DHCP socket mode — Kea dhcp-socket-type render + group plumbing (#365).
+
+``DHCPServerGroup.dhcp_socket_mode`` ("direct"/"relay") drives Kea's
+``Dhcp4.interfaces-config.dhcp-socket-type`` ("raw"/"udp"). "direct"
+(raw) is the default so Kea hears broadcast DISCOVERs from directly-
+attached clients; "relay" (udp) is for relay-only deployments.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.drivers.dhcp.base import ConfigBundle, PoolDef, ScopeDef, ServerOptionsDef
+from app.drivers.dhcp.kea import KeaDriver
+from app.models.auth import User
+from app.models.dhcp import DHCPServer, DHCPServerGroup
+from app.services.dhcp.config_bundle import build_config_bundle
+
+V4_CIDR = "10.30.0.0/24"
+V6_CIDR = "2001:db8:365::/64"
+
+
+def _bundle(socket_type: str = "raw", *, v6: bool = False) -> ConfigBundle:
+    scope = (
+        ScopeDef(
+            subnet_cidr=V6_CIDR,
+            address_family="ipv6",
+            pools=(PoolDef(start_ip="2001:db8:365::100", end_ip="2001:db8:365::1ff"),),
+        )
+        if v6
+        else ScopeDef(
+            subnet_cidr=V4_CIDR,
+            pools=(PoolDef(start_ip="10.30.0.100", end_ip="10.30.0.200"),),
+        )
+    )
+    return ConfigBundle(
+        server_id="00000000-0000-0000-0000-000000000000",
+        server_name="kea-socket-test",
+        driver="kea",
+        roles=(),
+        options=ServerOptionsDef(options={}, lease_time=3600),
+        scopes=(scope,),
+        client_classes=(),
+        generated_at=datetime.now(UTC),
+        dhcp_socket_type=socket_type,
+    )
+
+
+# ── Kea driver render ────────────────────────────────────────────────────
+
+
+def test_render_raw_socket() -> None:
+    cfg = json.loads(KeaDriver().render_config(_bundle("raw")))
+    assert cfg["Dhcp4"]["interfaces-config"]["dhcp-socket-type"] == "raw"
+
+
+def test_render_udp_socket() -> None:
+    cfg = json.loads(KeaDriver().render_config(_bundle("udp")))
+    assert cfg["Dhcp4"]["interfaces-config"]["dhcp-socket-type"] == "udp"
+
+
+def test_bundle_default_socket_type_is_raw() -> None:
+    # A bundle built without an explicit socket type (older control plane,
+    # groupless server) defaults to raw so directly-attached clients work.
+    bundle = ConfigBundle(
+        server_id="0" * 8,
+        server_name="x",
+        driver="kea",
+        roles=(),
+        options=ServerOptionsDef(options={}, lease_time=3600),
+        scopes=(ScopeDef(subnet_cidr=V4_CIDR),),
+        client_classes=(),
+        generated_at=datetime.now(UTC),
+    )
+    assert bundle.dhcp_socket_type == "raw"
+    cfg = json.loads(KeaDriver().render_config(bundle))
+    assert cfg["Dhcp4"]["interfaces-config"]["dhcp-socket-type"] == "raw"
+
+
+def test_v6_has_no_socket_type() -> None:
+    # dhcp-socket-type is a Dhcp4-only concept; the Dhcp6 daemon must not
+    # carry it (Kea rejects the config otherwise).
+    cfg = json.loads(KeaDriver().render_config(_bundle("raw", v6=True)))
+    assert "Dhcp4" not in cfg
+    assert "dhcp-socket-type" not in cfg["Dhcp6"]["interfaces-config"]
+
+
+def test_socket_type_shifts_etag() -> None:
+    assert _bundle("raw").compute_etag() != _bundle("udp").compute_etag()
+
+
+# ── build_config_bundle: group mode → socket type ───────────────────────
+
+
+async def _group_with_server(db: AsyncSession, socket_mode: str) -> DHCPServer:
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:8]}", dhcp_socket_mode=socket_mode)
+    db.add(grp)
+    await db.flush()
+    srv = DHCPServer(
+        name=f"kea-{uuid.uuid4().hex[:6]}",
+        driver="kea",
+        host="127.0.0.1",
+        port=67,
+        server_group_id=grp.id,
+    )
+    db.add(srv)
+    await db.flush()
+    return srv
+
+
+async def test_direct_group_renders_raw(db_session: AsyncSession) -> None:
+    srv = await _group_with_server(db_session, "direct")
+    bundle = await build_config_bundle(db_session, srv)
+    assert bundle.dhcp_socket_type == "raw"
+
+
+async def test_relay_group_renders_udp(db_session: AsyncSession) -> None:
+    srv = await _group_with_server(db_session, "relay")
+    bundle = await build_config_bundle(db_session, srv)
+    assert bundle.dhcp_socket_type == "udp"
+
+
+# ── Group API round-trip ────────────────────────────────────────────────
+
+
+async def _superadmin(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def test_group_api_persists_socket_mode(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    # Default on create is "direct".
+    r = await client.post(
+        "/api/v1/dhcp/server-groups",
+        headers=h,
+        json={"name": f"g-{uuid.uuid4().hex[:6]}"},
+    )
+    assert r.status_code == 201, r.text
+    gid = r.json()["id"]
+    assert r.json()["dhcp_socket_mode"] == "direct"
+
+    # PUT to relay round-trips.
+    r = await client.put(
+        f"/api/v1/dhcp/server-groups/{gid}",
+        headers=h,
+        json={"dhcp_socket_mode": "relay"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["dhcp_socket_mode"] == "relay"
+
+
+async def test_group_api_rejects_bad_socket_mode(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin(db_session)
+    await db_session.commit()
+    r = await client.post(
+        "/api/v1/dhcp/server-groups",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"name": f"g-{uuid.uuid4().hex[:6]}", "dhcp_socket_mode": "bogus"},
+    )
+    assert r.status_code == 422, r.text

--- a/docker-compose.agent-dhcp.yml
+++ b/docker-compose.agent-dhcp.yml
@@ -81,8 +81,13 @@ services:
       - "${DHCP_HA_HOST_PORT:-8001}:8000/tcp"
       # Optional operator-facing kea-ctrl-agent REST.
       # - "8544:8544/tcp"
+    # NET_BIND_SERVICE binds UDP/67; NET_RAW (#365) lets Kea use raw
+    # AF_PACKET sockets — the default "direct" socket mode. For a
+    # directly-attached LAN switch this to `network_mode: host`; the
+    # bridged default here only sees relayed/port-mapped traffic.
     cap_add:
       - NET_BIND_SERVICE
+      - NET_RAW
 
   # ── DHCP agent (secondary, HA peer) ───────────────────────────────
   # Enable with: ``--profile dhcp-ha``.
@@ -111,6 +116,7 @@ services:
       - "${DHCP_HA_HOST_PORT_2:-8002}:8000/tcp"
     cap_add:
       - NET_BIND_SERVICE
+      - NET_RAW  # #365 — raw sockets for direct-attached DHCP (see dhcp-kea)
 
 networks:
   spatiumddi-agent:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -348,11 +348,15 @@ services:
     depends_on:
       api:
         condition: service_started
-    # Kea runs as non-root and needs to bind UDP/67. No NET_RAW/NET_ADMIN —
-    # this server accepts relayed DHCP (unicast from relay agents), it does
-    # NOT need to listen for L2 broadcasts on the host LAN.
+    # Kea binds UDP/67 (NET_BIND_SERVICE) and, by default, uses raw
+    # AF_PACKET sockets (NET_RAW, #365) so it hears broadcast DISCOVERs
+    # from directly-attached clients on the host LAN. A relay-only group
+    # (socket mode "relay" → udp sockets) doesn't use raw sockets, but
+    # granting NET_RAW is harmless. Pair with `network_mode: host` (or a
+    # macvlan) so the broadcasts actually reach the container.
     cap_add:
       - NET_BIND_SERVICE
+      - NET_RAW
 
   # ── DHCP agent (secondary, HA peer) ───────────────────────────────────
   # Only starts with `--profile dhcp-ha`. Pair dhcp-kea + dhcp-kea-2 in
@@ -398,6 +402,7 @@ services:
         condition: service_started
     cap_add:
       - NET_BIND_SERVICE
+      - NET_RAW  # #365 — raw sockets for direct-attached DHCP (see dhcp-kea)
 
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -310,11 +310,15 @@ services:
     depends_on:
       api:
         condition: service_started
-    # Kea runs as non-root and needs to bind UDP/67. No NET_RAW/NET_ADMIN —
-    # this server accepts relayed DHCP (unicast from relay agents), it does
-    # NOT need to listen for L2 broadcasts on the host LAN.
+    # Kea binds UDP/67 (NET_BIND_SERVICE) and, by default, uses raw
+    # AF_PACKET sockets (NET_RAW, #365) so it hears broadcast DISCOVERs
+    # from directly-attached clients on the host LAN. A relay-only group
+    # (socket mode "relay" → udp sockets) doesn't use raw sockets, but
+    # granting NET_RAW is harmless. Pair with `network_mode: host` (or a
+    # macvlan) so the broadcasts actually reach the container.
     cap_add:
       - NET_BIND_SERVICE
+      - NET_RAW
 
   # ── DHCP agent (secondary, HA peer) ───────────────────────────────────
   # Only starts with `--profile dhcp-ha`. Pair it with dhcp-kea in a
@@ -357,6 +361,7 @@ services:
         condition: service_started
     cap_add:
       - NET_BIND_SERVICE
+      - NET_RAW  # #365 — raw sockets for direct-attached DHCP (see dhcp-kea)
 
 networks:
   spatiumddi:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -134,7 +134,7 @@ Read the result:
 | tcpdump shows DISCOVER | Kea log | Conclusion |
 |---|---|---|
 | yes | logs DISCOVER, no OFFER (often `DHCP4_SUBNET_SELECTION_FAILED` / "no subnet selected") | **(B)** — subnet/scope mismatch. Most common. |
-| yes | logs nothing | **(A)** — firewall is eating it before the socket. |
+| yes | logs nothing | **(A)** — the packet reaches the host but not the Kea socket: the group is in **Relay-only (udp)** socket mode, or the firewall is dropping it. |
 | no  | — | The broadcast isn't reaching the appliance VM at all (vSwitch port-group / VLAN). |
 
 ### Fixing (B) — scope/subnet mismatch (most common)
@@ -177,11 +177,45 @@ pool, then the bundle ETag shifts and the agent re-renders within a
 heartbeat. (The DHCP Activity tab on the **Logs** page surfaces the same
 Kea log lines if you'd rather stay in the UI.)
 
-### Fixing (A) — firewall
+### Fixing (A) — packet reaches the host but not Kea
 
-Kea uses a plain UDP socket (`dhcp-socket-type: udp`), so it **is**
-subject to the host's nftables INPUT chain. The DHCP role opens UDP
-**67 + 68**; confirm the rules are present (and haven't drifted):
+Two causes; check the socket mode first.
+
+**Socket mode (#365).** A directly-attached client can only be heard when
+Kea's Dhcp4 daemon uses **raw** (AF_PACKET) sockets — UDP sockets are
+relay-only and silently miss the broadcast. The DHCP **server group**
+carries a *Client reachability* setting that controls this:
+
+- **Directly attached / mixed** → `dhcp-socket-type: raw` (the default
+  since #365). Hears broadcast DISCOVERs *and* relayed traffic.
+- **Relay-only** → `dhcp-socket-type: udp`. Cannot receive direct L2
+  broadcasts.
+
+If the server is on the same LAN as its clients, the group must be
+**Directly attached** (DHCP → the server group → Edit → *Client
+reachability*). Confirm what's actually rendered:
+
+```bash
+# k3s appliance:
+sudo k3s kubectl exec -n <ns> <kea-pod> -- \
+    cat /var/lib/spatium-dhcp-agent/rendered/kea-dhcp4.json | grep socket-type
+# docker-compose:
+docker compose exec dhcp-kea \
+    cat /var/lib/spatium-dhcp-agent/rendered/kea-dhcp4.json | grep socket-type
+```
+
+`"dhcp-socket-type": "udp"` on a direct-attached LAN is the problem —
+switch the group to *Directly attached*; the agent re-renders within a
+heartbeat. (Raw sockets need the `NET_RAW` capability, which the
+appliance DaemonSet and the shipped compose files grant.)
+
+> Installs predating #365 hardcoded `udp` and had no knob — that was the
+> original bug. Upgraded installs default to `direct` (raw), so this is
+> only a live cause if the group was deliberately set to Relay-only.
+
+**Firewall.** UDP sockets are also subject to the host's nftables INPUT
+chain (raw sockets bypass it). The DHCP role opens UDP **67 + 68**;
+confirm the rules are present (and haven't drifted):
 
 ```bash
 sudo nft list chain inet filter input | grep -E 'dport (67|68)'

--- a/docs/drivers/DHCP_DRIVERS.md
+++ b/docs/drivers/DHCP_DRIVERS.md
@@ -120,6 +120,7 @@ The HTTP envelope returned by `GET /api/v1/dhcp/agents/config` is:
     "server_name": "…",
     "driver": "kea",
     "roles": [...],
+    "server": { "interfaces": ["*"], "dhcp_socket_type": "raw" },
     "scopes": [
       {
         "subnet_cidr": "10.0.0.0/24",
@@ -138,6 +139,8 @@ The HTTP envelope returned by `GET /api/v1/dhcp/agents/config` is:
 ```
 
 Shipped 2026.04.21-2: `render_kea.py:_scope_to_subnet` maps each wire scope to a Kea `subnet4` entry — `subnet_cidr` → `subnet`, `pools[start_ip,end_ip,pool_type]` → `{"pool": "start - end"}` (only `dynamic` pools are emitted; `excluded` / `reserved` are IPAM bookkeeping and must **not** become Kea lease pools), `statics[ip_address,mac_address,hostname]` → `reservations[ip-address,hw-address,hostname]`. Client-class `match_expression` → Kea `test`. Subnet `id` is derived deterministically from the CIDR via truncated SHA-256, so a config reload never orphans active leases by renumbering subnets.
+
+**Socket type (issue #365).** The `server.dhcp_socket_type` field drives `Dhcp4.interfaces-config.dhcp-socket-type`. It is derived from the server group's `dhcp_socket_mode` in `services/dhcp/config_bundle.py` (`direct` → `raw`, `relay` → `udp`) and is part of `ConfigBundle.compute_etag()`, so flipping the mode shifts the ETag and the agent re-renders on its next long-poll. The default is `raw` (AF_PACKET) so Kea hears broadcast `DHCPDISCOVER`s from directly-attached clients; the agent's `render_kea.py` also falls back to `raw` when an older control plane omits the `server` block. `raw` needs `CAP_NET_RAW` (appliance DaemonSet + shipped compose Kea services grant it). DHCPv6 has no socket-type concept — the field applies to `Dhcp4` only.
 
 ### HA coordination
 

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -33,12 +33,32 @@ DHCPServer
 DHCPServerGroup
   id, name, description
   mode: enum(standalone, hot-standby, load-balancing)
+  dhcp_socket_mode: enum(direct, relay)   -- Kea dhcp-socket-type selector
   heartbeat_delay_ms, max_response_delay_ms, max_ack_delay_ms, max_unacked_clients
   auto_failover: bool
   servers: [DHCPServer]          -- 2 Kea members = HA pair
   scopes: [DHCPScope]            -- rendered on every member
   client_classes: [DHCPClientClass]
 ```
+
+**Client reachability (`dhcp_socket_mode`, issue #365).** Kea's
+`dhcp-socket-type` is a *per-daemon* setting — it can't vary per subnet —
+so it lives on the group and applies to every member Kea. Two values,
+surfaced in the create/edit modal as **Client reachability**:
+
+| Mode | Renders | Use when |
+|---|---|---|
+| `direct` *(default)* | `dhcp-socket-type: raw` | The server is on the same L2 as its clients. Raw (AF_PACKET) sockets receive broadcast `DHCPDISCOVER`s from clients that have no IP yet **and** relayed traffic — the superset, and Kea's own default. Needs `CAP_NET_RAW` (granted on the appliance DaemonSet + the shipped compose Kea services). |
+| `relay` | `dhcp-socket-type: udp` | Kea sits exclusively behind a DHCP relay (`ip helper-address` / `dhcrelay`), or the runtime can't grant raw-socket capability. UDP datagram sockets cannot receive direct L2 broadcasts. |
+
+The value flows to every deploy path (k8s / compose / appliance) through
+the ConfigBundle long-poll and is folded into the bundle ETag, so a
+change re-renders the running Kea within a heartbeat. It is distinct from
+`network_mode` (host vs bridged), which controls the *container's* network
+namespace on supervisor-managed appliances — a directly-attached server
+typically wants `network_mode: host` **and** `dhcp_socket_mode: direct`.
+See [TROUBLESHOOTING.md](../TROUBLESHOOTING.md#dhcp-server-kea-doesnt-respond-to-discover)
+for the "no DHCPOFFER" diagnosis flow.
 
 ---
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5745,6 +5745,11 @@ export interface DHCPServerGroup {
   // unicast deployments). Surfaces in the role-assignment UI on
   // the Approvals tab so the operator knows what they're picking.
   network_mode?: string;
+  // #365 — Kea dhcp-socket-type selector. "direct" → raw sockets (hears
+  // broadcast DISCOVERs from directly-attached clients; the default),
+  // "relay" → udp sockets (relay-only). Per-daemon, so it lives on the
+  // group and applies to every member Kea.
+  dhcp_socket_mode?: "direct" | "relay";
   heartbeat_delay_ms: number;
   max_response_delay_ms: number;
   max_ack_delay_ms: number;
@@ -5763,6 +5768,7 @@ export interface DHCPServerGroupCreate {
   name: string;
   description?: string;
   mode?: "standalone" | "hot-standby" | "load-balancing";
+  dhcp_socket_mode?: "direct" | "relay";
   heartbeat_delay_ms?: number;
   max_response_delay_ms?: number;
   max_ack_delay_ms?: number;

--- a/frontend/src/pages/dhcp/CreateServerGroupModal.tsx
+++ b/frontend/src/pages/dhcp/CreateServerGroupModal.tsx
@@ -112,7 +112,9 @@ export function CreateServerGroupModal({
           <select
             className={inputCls}
             value={socketMode}
-            onChange={(e) => setSocketMode(e.target.value as "direct" | "relay")}
+            onChange={(e) =>
+              setSocketMode(e.target.value as "direct" | "relay")
+            }
           >
             <option value="direct">
               Directly attached / mixed (raw sockets) — recommended

--- a/frontend/src/pages/dhcp/CreateServerGroupModal.tsx
+++ b/frontend/src/pages/dhcp/CreateServerGroupModal.tsx
@@ -30,6 +30,9 @@ export function CreateServerGroupModal({
   const [autoFailover, setAutoFailover] = useState(
     group?.auto_failover ?? true,
   );
+  const [socketMode, setSocketMode] = useState<"direct" | "relay">(
+    group?.dhcp_socket_mode ?? "direct",
+  );
   const [error, setError] = useState("");
 
   const isHA = mode === "hot-standby" || mode === "load-balancing";
@@ -40,6 +43,7 @@ export function CreateServerGroupModal({
         name,
         description,
         mode: mode as "standalone" | "hot-standby" | "load-balancing",
+        dhcp_socket_mode: socketMode,
         heartbeat_delay_ms: parseInt(heartbeat, 10) || 10000,
         max_response_delay_ms: parseInt(maxResponse, 10) || 60000,
         max_ack_delay_ms: parseInt(maxAck, 10) || 10000,
@@ -98,6 +102,22 @@ export function CreateServerGroupModal({
               Hot Standby (one active, one passive)
             </option>
             <option value="load-balancing">Load Balancing (both active)</option>
+          </select>
+        </Field>
+
+        <Field
+          label="Client reachability"
+          hint="How Kea receives client traffic. Directly attached uses raw sockets, so Kea hears broadcast DISCOVERs from clients on the same LAN (and also serves relayed clients) — the right choice for an all-in-one / on-LAN server. Relay-only uses UDP sockets; pick it only when every client reaches Kea through a DHCP relay, or the host can't grant raw-socket capability."
+        >
+          <select
+            className={inputCls}
+            value={socketMode}
+            onChange={(e) => setSocketMode(e.target.value as "direct" | "relay")}
+          >
+            <option value="direct">
+              Directly attached / mixed (raw sockets) — recommended
+            </option>
+            <option value="relay">Relay-only (UDP sockets)</option>
           </select>
         </Field>
 


### PR DESCRIPTION
Closes #365.

## Problem

The DHCP agent always rendered Kea with **`dhcp-socket-type: udp`**, with no operator control. UDP datagram sockets are relay-only — they can't receive broadcast `DHCPDISCOVER`s from directly-attached clients that have no IP yet. So on the all-in-one appliance (or any on-LAN DHCP server), Kea was alive and healthy but **deaf to the broadcast**: DISCOVER on the wire, firewall open, no `DHCPOFFER`. Field-reproduced; the smoking gun is `render_kea.py` defaulting to `udp` while the control plane never sent a socket-type and there was no UI/API knob.

## Fix

A per-**group** knob `dhcp_socket_mode` — **`direct` → `raw`** (default) / **`relay` → `udp`**. `dhcp-socket-type` is a per-daemon Kea setting (can't vary per subnet), so it lives on `DHCPServerGroup` and applies to every member Kea. `raw` (AF_PACKET) hears broadcast DISCOVERs **and** relayed traffic — the superset, and Kea's own default; `relay`/`udp` is the restricted opt-out for relay-only or capability-restricted runtimes.

It's delivered to every deploy path (k8s / compose / appliance) through the **ConfigBundle long-poll**, folded into the bundle **ETag** so a change re-renders the running Kea within a heartbeat — not via the supervisor role assignment, since the agent renders `interfaces-config` from the bundle. Distinct from the existing `network_mode` (host/bridged container namespace).

## What changed

- **Model + migration** `f3b9c1d6a274` — backfills existing groups to `direct` (so upgrades start answering directly-attached clients with no action).
- **Bundle** — `config_bundle` maps mode → socket type; new `ConfigBundle.dhcp_socket_type` in `compute_etag()`; agent wire gains a `server` block.
- **Renderers** — agentless `kea.py` Dhcp4 honors it (v6 excluded — DHCPv6 has no socket-type); agent `render_kea.py` fallback flipped `udp` → `raw`.
- **API** — group `Create/Update/Response` + validator + wake-on-change.
- **Compose** — `NET_RAW` granted on all Kea services in `docker-compose{,.dev,.agent-dhcp}.yml` (the appliance DaemonSet already had it); corrected the stale "No NET_RAW" comments.
- **Frontend** — api types + a "Client reachability" toggle on the group modal.
- **MCP** — `list_dhcp_server_groups` surfaces `dhcp_socket_mode`.
- **Docs** — DHCP.md, DHCP_DRIVERS.md, and the TROUBLESHOOTING.md "no DHCPOFFER" matrix.

## Verification

- `ruff` / `black` / `mypy` (backend) clean; frontend `tsc` clean.
- New `test_dhcp_socket_mode.py` — **9/9 pass** (driver render raw/udp, default-raw, v6-excluded, ETag shift, group→bundle mapping, API round-trip + validation).
- Migration applies cleanly (`b6f4d2a91c83 → f3b9c1d6a274`, column default `direct`).
- **Live on a dev stack**: recreated `dhcp-kea` with `NET_RAW`; the agent re-rendered `"dhcp-socket-type": "raw"` and Kea came up running on raw sockets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
