### PR TITLE
Control-plane HA — #272 Phase 9b (etcd restore) + Phase 10 (data-plane VIPs) + follow-ups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,8 +376,12 @@ appliance-bake-control-chart:
 appliance-bake-metallb-chart:
 	@CHART_NAME=spatiumddi-metallb bash $(APPLIANCE_DIR)/scripts/bake-chart.sh
 
+# BAKE_FLAGS lets an operator pass --allow-stale-images to bypass the
+# >24h stale-source-image guard (#272 follow-up): make appliance-baked-iso
+# BAKE_FLAGS=--allow-stale-images  (or ALLOW_STALE_IMAGES=1, which the
+# script also honours from the environment).
 appliance-bake-images: build-supervisor
-	@bash $(APPLIANCE_DIR)/scripts/bake-images.sh
+	@bash $(APPLIANCE_DIR)/scripts/bake-images.sh $(BAKE_FLAGS)
 
 # Convenience for fast laptop iteration on appliance-level changes
 # (installer, firstboot, console dashboard, partition layout,

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -429,6 +429,21 @@ _CLUSTER_JOIN_STATE_SIDECAR = Path(
 )
 _K3S_JOIN_TOKEN_SIDECAR = Path("/var/lib/spatiumddi-host/release-state/k3s-join-token")
 
+# #272 Phase 9b — guided etcd restore. Same trigger-file + confirm-marker
+# shape as join/leave, but for the MOST destructive cluster op: a
+# single-node cluster-reset that restores etcd from a snapshot. The
+# host-side spatium-cluster-restore runner refuses any trigger whose
+# first line isn't this exact marker. The payload is two lines: the
+# marker then the snapshot name. The runner writes the same .state sidecar
+# shape (``state\treason``) the supervisor reports back.
+_CLUSTER_RESTORE_TRIGGER_FILE = Path(
+    "/var/lib/spatiumddi-host/release-state/cluster-restore-pending"
+)
+_CLUSTER_RESTORE_CONFIRM = "SPATIUMDDI-CLUSTER-RESTORE-CONFIRM-V1"
+_CLUSTER_RESTORE_STATE_SIDECAR = Path(
+    "/var/lib/spatiumddi-host/release-state/cluster-restore.state"
+)
+
 
 def maybe_fire_fleet_upgrade(
     desired_version: str | None,
@@ -858,6 +873,60 @@ def read_cluster_join_state() -> tuple[str | None, str | None]:
         return None, None
     try:
         raw = _CLUSTER_JOIN_STATE_SIDECAR.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None, None
+    if not raw:
+        return None, None
+    state, _, reason = raw.partition("\t")
+    return (state or None), (reason or None)
+
+
+def maybe_fire_cluster_restore(desired_restore_snapshot: str | None) -> bool:
+    """Write the cluster-restore trigger when the control plane asks this
+    seed to restore etcd from a snapshot (#272 Phase 9b).
+
+    ⚠️ The MOST destructive trigger: the host runner stops k3s and runs
+    ``k3s server --cluster-reset --cluster-reset-restore-path=…``, which
+    collapses the cluster to a 1-member etcd and orphans every other
+    control-plane node. The backend already gates this hard (superadmin +
+    typed-hostname confirm + snapshot-in-inventory); here we re-assert the
+    appliance-only gate and stamp the ``_CLUSTER_RESTORE_CONFIRM`` marker
+    so a stray file can't fire a cluster reset.
+
+    Payload is two lines: the marker then the snapshot name. Idempotent
+    via trigger-file presence — once written we don't stack until the host
+    runner consumes it (rename to ``.done`` / ``.failed``)."""
+    if detect_deployment_kind() != "appliance":
+        return False
+    if not desired_restore_snapshot:
+        return False
+    if _CLUSTER_RESTORE_TRIGGER_FILE.exists():
+        return False
+    try:
+        _CLUSTER_RESTORE_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _CLUSTER_RESTORE_TRIGGER_FILE.with_suffix(".new")
+        tmp.write_text(
+            f"{_CLUSTER_RESTORE_CONFIRM}\n{desired_restore_snapshot}\n", encoding="utf-8"
+        )
+        tmp.replace(_CLUSTER_RESTORE_TRIGGER_FILE)
+        return True
+    except OSError:
+        return False
+
+
+def read_cluster_restore_state() -> tuple[str | None, str | None]:
+    """Return ``(restore_state, restore_reason)`` from the ``.state``
+    sidecar the host restore runner writes (``state\\treason``).
+
+    Appliance-only; ``(None, None)`` when the sidecar is missing so the
+    backend's "only update when not None" semantics leave the columns
+    alone on nodes that have never run a restore."""
+    if detect_deployment_kind() != "appliance":
+        return None, None
+    if not _CLUSTER_RESTORE_STATE_SIDECAR.exists():
+        return None, None
+    try:
+        raw = _CLUSTER_RESTORE_STATE_SIDECAR.read_text(encoding="utf-8").strip()
     except OSError:
         return None, None
     if not raw:

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -485,6 +485,22 @@ def heartbeat_once(
                 log.warning("supervisor.watchdog.crashed", error=str(exc))
         if _cached_role_health:
             body["role_health"] = _cached_role_health
+
+        # #272 Phase 9b — report the seed's etcd snapshot inventory (read
+        # from the k3s ETCDSnapshotFile CRs over the kubeapi, no host k3s
+        # binary needed) so Fleet can show recoverable snapshots without an
+        # operator SSH. Seed-only: the kubeapi read on a non-control-plane
+        # node 403s / returns [] (the helper swallows it). Plus the
+        # guided-restore .state sidecar, so the backend can settle the
+        # desired snapshot once the runner reports ``done``.
+        if appliance_state.detect_appliance_variant() == "control-plane":
+            from . import k8s_api  # noqa: PLC0415
+
+            body["etcd_snapshots"] = k8s_api.list_etcd_snapshots()
+        restore_state, restore_reason = appliance_state.read_cluster_restore_state()
+        if restore_state is not None:
+            body["restore_state"] = restore_state
+            body["restore_reason"] = restore_reason
     url_path = "/api/v1/appliance/supervisor/heartbeat"
     # #272 — cluster members POST to the in-cluster api Service; remote
     # agents to their configured CONTROL_PLANE_URL. See
@@ -716,6 +732,19 @@ def heartbeat_once(
         if appliance_state.maybe_fire_cluster_leave(desired_cluster_role):
             log.info("supervisor.heartbeat.cluster_leave_trigger_fired")
 
+    # #272 Phase 9b — guided etcd restore. The backend stamps
+    # ``desired_restore_snapshot`` only on the seed row (after a superadmin
+    # + typed-hostname confirm), so this fires only on the seed. The
+    # host-side spatium-cluster-restore runner does the destructive
+    # cluster-reset; collect() ships the .state sidecar back so the backend
+    # clears the desired-state once it lands ``done``.
+    restore_snapshot = body_out.get("desired_restore_snapshot")
+    if appliance_state.maybe_fire_cluster_restore(restore_snapshot):  # type: ignore[arg-type]
+        log.warning(
+            "supervisor.heartbeat.cluster_restore_trigger_fired",
+            snapshot=restore_snapshot,
+        )
+
     # #277 — scale the CNPG postgres cluster + control-plane workload
     # replicas to the committed member count. Only the SEED acts (the
     # spatium-control HelmChart lives there; on members the GET 404s and
@@ -788,6 +817,24 @@ def heartbeat_once(
             )
         elif bs_err:
             log.warning("supervisor.heartbeat.metallb_overrides_failed", error=bs_err)
+
+        # #272 Phase 10 — data-plane resolver VIPs. Patches
+        # dns.useMetalLBVIP / dns.vip / dhcpKea.relayVIP onto the
+        # spatiumddi-appliance HelmChartConfig (a no-op merge until the
+        # chart exists, i.e. until a DNS/DHCP role is assigned somewhere).
+        dns_vip = body_out.get("desired_dns_vip") or ""
+        relay_vip = body_out.get("desired_dhcp_relay_vip") or ""
+        dp_changed, dp_err = k8s_api.apply_dataplane_vip_overrides(
+            dns_vip=str(dns_vip), dhcp_relay_vip=str(relay_vip)
+        )
+        if dp_changed:
+            log.info(
+                "supervisor.heartbeat.dataplane_vip_overrides_applied",
+                dns_vip=dns_vip,
+                dhcp_relay_vip=relay_vip,
+            )
+        elif dp_err:
+            log.warning("supervisor.heartbeat.dataplane_vip_overrides_failed", error=dp_err)
 
         # #272 Phase 9 — dead-node replacement. The seed deletes each k8s
         # Node the backend flagged for eviction (deleting the Node makes

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -430,6 +430,47 @@ def delete_helmchart(
     return False, f"kubeapi status {status}: {resp[:200]!r}"
 
 
+def list_etcd_snapshots() -> list[dict[str, Any]]:
+    """List recoverable etcd snapshots from the k3s ``ETCDSnapshotFile``
+    cluster-scoped CRs (#272 Phase 9b).
+
+    k3s ≥ 1.26 materialises one ``etcdsnapshotfile.k3s.cattle.io`` object
+    per on-disk (and S3) snapshot — the same source ``k3s etcd-snapshot
+    list`` reads — so the supervisor reads them over the kubeapi it
+    already talks to, with NO host ``k3s`` binary or etcd access needed.
+
+    Returns ``[{name, location, node_name, size, created_at}]`` sorted
+    newest-first, or ``[]`` on any error (older k3s without the CRD, a
+    kubeapi blip, or a non-seed node whose read 403s)."""
+    path = "/apis/k3s.cattle.io/v1/etcdsnapshotfiles"
+    try:
+        status, resp = _request("GET", path)
+    except RuntimeError:
+        return []
+    if status != 200:
+        return []
+    try:
+        items = (json.loads(resp) or {}).get("items") or []
+    except (json.JSONDecodeError, ValueError):
+        return []
+    out: list[dict[str, Any]] = []
+    for it in items:
+        spec = it.get("spec") or {}
+        st = it.get("status") or {}
+        out.append(
+            {
+                "name": spec.get("snapshotName") or (it.get("metadata") or {}).get("name") or "",
+                "location": spec.get("location") or "",
+                "node_name": spec.get("nodeName") or "",
+                "size": st.get("size"),
+                "created_at": st.get("creationTime"),
+            }
+        )
+    # Newest-first by created_at (ISO 8601 sorts lexically); blanks last.
+    out.sort(key=lambda s: s.get("created_at") or "", reverse=True)
+    return out
+
+
 def delete_node(name: str) -> tuple[bool, str | None]:
     """Delete a k8s Node. On k3s, deleting a server Node object makes
     the cluster drop its etcd member — so this is how a dead
@@ -567,6 +608,35 @@ def apply_metallb_overrides(
         f"  ipPool:\n    addresses: {pool_json}\n"
     )
     return _helmchartconfig_upsert("spatium-metallb", values)
+
+
+def apply_dataplane_vip_overrides(
+    *, dns_vip: str, dhcp_relay_vip: str
+) -> tuple[bool, str | None]:
+    """Durably set the data-plane resolver VIPs (#272 Phase 10) on the
+    spatiumddi-appliance HelmChartConfig.
+
+    ``dns_vip`` (non-empty) flips the bind9 / powerdns DaemonSets OFF
+    hostNetwork and behind a single L2 LoadBalancer Service at the VIP
+    (``dns.useMetalLBVIP`` + ``dns.vip``); empty keeps hostNetwork :53.
+    ``dhcp_relay_vip`` adds the relay→server LoadBalancer Service on :67
+    (``dhcpKea.relayVIP``) without touching Kea's hostNetwork broadcast
+    path; empty renders no relay Service.
+
+    Written to the HelmChartConfig (not the HelmChart CR) so it survives
+    a k3s restart's manifest re-apply, exactly like the cp-size + VIP
+    overrides. helm-controller merges it on top of the role-assignment
+    values the supervisor PATCHes onto the same-named HelmChart, so this
+    overlay only carries the VIP keys and never fights for ownership of
+    the per-role ``enabled`` flags. Idempotent — only writes on change."""
+    dns_vip = (dns_vip or "").strip()
+    relay_vip = (dhcp_relay_vip or "").strip()
+    values = (
+        f"dns:\n  useMetalLBVIP: {'true' if dns_vip else 'false'}\n"
+        f'  vip: "{dns_vip}"\n'
+        f'dhcpKea:\n  relayVIP: "{relay_vip}"\n'
+    )
+    return _helmchartconfig_upsert("spatiumddi-appliance", values)
 
 
 def patch_node_labels(

--- a/agent/supervisor/tests/test_cluster_join_triggers.py
+++ b/agent/supervisor/tests/test_cluster_join_triggers.py
@@ -37,7 +37,10 @@ def test_join_writes_trigger_with_payload(appliance_paths: Path) -> None:
     fired = appliance_state.maybe_fire_cluster_join("member", "https://10.0.0.1:6443", "K10::tok")
     assert fired is True
     body = (appliance_paths / "cluster-join-pending").read_text()
-    assert body == "https://10.0.0.1:6443\nK10::tok\n"
+    # Three lines: the guardrail confirm marker, then server_url + token.
+    assert body == (
+        f"{appliance_state._CLUSTER_JOIN_CONFIRM}\nhttps://10.0.0.1:6443\nK10::tok\n"
+    )
 
 
 def test_join_idempotent_until_consumed(appliance_paths: Path) -> None:
@@ -88,3 +91,57 @@ def test_read_k3s_join_token(appliance_paths: Path) -> None:
     assert appliance_state.read_k3s_join_token() is None
     (appliance_paths / "k3s-join-token").write_text("K10::servertoken\n")
     assert appliance_state.read_k3s_join_token() == "K10::servertoken"
+
+
+# ── guided etcd restore (#272 Phase 9b) ──────────────────────────────
+
+
+@pytest.fixture
+def restore_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the restore trigger + state sidecar at a tmp dir + force the
+    appliance deployment kind so the gate passes."""
+    monkeypatch.setattr(appliance_state, "detect_deployment_kind", lambda: "appliance")
+    monkeypatch.setattr(
+        appliance_state, "_CLUSTER_RESTORE_TRIGGER_FILE", tmp_path / "cluster-restore-pending"
+    )
+    monkeypatch.setattr(
+        appliance_state, "_CLUSTER_RESTORE_STATE_SIDECAR", tmp_path / "cluster-restore.state"
+    )
+    return tmp_path
+
+
+def test_restore_writes_trigger_with_marker(restore_paths: Path) -> None:
+    assert appliance_state.maybe_fire_cluster_restore("snap-A") is True
+    body = (restore_paths / "cluster-restore-pending").read_text()
+    # Two lines: the guardrail confirm marker, then the snapshot name.
+    assert body == f"{appliance_state._CLUSTER_RESTORE_CONFIRM}\nsnap-A\n"
+
+
+def test_restore_idempotent_until_consumed(restore_paths: Path) -> None:
+    assert appliance_state.maybe_fire_cluster_restore("snap-A") is True
+    assert appliance_state.maybe_fire_cluster_restore("snap-A") is False
+
+
+def test_restore_requires_snapshot(restore_paths: Path) -> None:
+    assert appliance_state.maybe_fire_cluster_restore(None) is False
+    assert appliance_state.maybe_fire_cluster_restore("") is False
+    assert not (restore_paths / "cluster-restore-pending").exists()
+
+
+def test_restore_skipped_off_appliance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(appliance_state, "detect_deployment_kind", lambda: "docker")
+    monkeypatch.setattr(
+        appliance_state, "_CLUSTER_RESTORE_TRIGGER_FILE", tmp_path / "cluster-restore-pending"
+    )
+    assert appliance_state.maybe_fire_cluster_restore("snap-A") is False
+    assert not (tmp_path / "cluster-restore-pending").exists()
+
+
+def test_read_cluster_restore_state(restore_paths: Path) -> None:
+    assert appliance_state.read_cluster_restore_state() == (None, None)
+    (restore_paths / "cluster-restore.state").write_text("restoring\tsnap-A")
+    assert appliance_state.read_cluster_restore_state() == ("restoring", "snap-A")
+    (restore_paths / "cluster-restore.state").write_text("done\t")
+    assert appliance_state.read_cluster_restore_state() == ("done", None)

--- a/agent/supervisor/tests/test_cnpg_scale.py
+++ b/agent/supervisor/tests/test_cnpg_scale.py
@@ -83,3 +83,36 @@ def test_rejects_sub_one_size(monkeypatch) -> None:
     assert changed is False
     assert err == "instances < 1"
     assert not rec.calls  # guard short-circuits before any kubeapi call
+
+
+# ── #272 Phase 10 — data-plane VIP overrides (HelmChartConfig render) ──
+
+
+def test_dataplane_vip_overrides_render(monkeypatch) -> None:
+    # No existing HelmChartConfig (404) → create POST carrying the values.
+    rec = _Recorder(404, "")
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.apply_dataplane_vip_overrides(
+        dns_vip="192.168.0.242", dhcp_relay_vip="192.168.0.243"
+    )
+
+    assert (changed, err) == (True, None)
+    body = next(json.loads(b) for m, _, b in rec.calls if m == "POST" and b)
+    vals = body["spec"]["valuesContent"]
+    assert "useMetalLBVIP: true" in vals
+    assert 'vip: "192.168.0.242"' in vals
+    assert 'relayVIP: "192.168.0.243"' in vals
+
+
+def test_dataplane_vip_overrides_empty_disables(monkeypatch) -> None:
+    rec = _Recorder(404, "")
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    k8s_api.apply_dataplane_vip_overrides(dns_vip="", dhcp_relay_vip="")
+
+    body = next(json.loads(b) for m, _, b in rec.calls if m == "POST" and b)
+    vals = body["spec"]["valuesContent"]
+    assert "useMetalLBVIP: false" in vals
+    assert 'vip: ""' in vals
+    assert 'relayVIP: ""' in vals

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-cluster-restore.path
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-cluster-restore.path
@@ -1,0 +1,16 @@
+[Unit]
+Description=Watch for SpatiumDDI etcd-restore trigger (#272 Phase 9b)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/272
+# Installed appliances only — the trigger is written by the seed
+# supervisor via its release-state bind mount; never present on the
+# live ISO.
+ConditionKernelCommandLine=!boot=live
+
+[Path]
+# PathChanged fires on close-after-write. The supervisor atomically
+# renames a .new sibling onto the trigger, so this fires once per
+# restore request, not on every incremental write.
+PathChanged=/var/lib/spatiumddi/release-state/cluster-restore-pending
+
+[Install]
+WantedBy=multi-user.target

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-cluster-restore.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-cluster-restore.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Restore etcd from a snapshot — single-node cluster-reset (#272 Phase 9b)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/272
+# k3s --cluster-reset surgery; the runner stops/starts k3s itself.
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/spatium-cluster-restore
+# No Install section — only invoked by the matching .path unit.

--- a/appliance/mkosi.extra/usr/local/bin/spatium-cluster-restore
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-cluster-restore
@@ -1,0 +1,179 @@
+#!/bin/bash
+# spatium-cluster-restore — host-side k3s etcd restore runner
+# (#272 Phase 9b).
+#
+# ┌─────────────────────────────────────────────────────────────────┐
+# │ ⚠️  THE MOST DESTRUCTIVE host runner. It runs                     │
+# │ ``k3s server --cluster-reset --cluster-reset-restore-path=…``,   │
+# │ which COLLAPSES the cluster to a single-member etcd restored     │
+# │ from the snapshot. Every OTHER control-plane node is ORPHANED    │
+# │ (it still references the old etcd cluster) and must be re-paired  │
+# │ via the Fleet Replace flow afterwards. Disaster recovery only —  │
+# │ never a routine operation. UNVALIDATED on a multi-node cluster;  │
+# │ shake out on throwaway VMs before trusting it in the field.      │
+# └─────────────────────────────────────────────────────────────────┘
+#
+# Flow (mirrors spatium-cluster-join):
+#   1. Operator picks a snapshot in Fleet → Control plane and confirms
+#      (superadmin + typed seed hostname) → backend stamps
+#      desired_restore_snapshot on the seed row.
+#   2. The seed supervisor's heartbeat picks it up + writes the trigger
+#      file via its release-state bind mount:
+#        /var/lib/spatiumddi/release-state/cluster-restore-pending
+#        (2 lines: confirm marker, snapshot name)
+#   3. The spatiumddi-cluster-restore.path unit notices the file + runs
+#      this script as root.
+#   4. This script reset-restores etcd, writes the cluster-restore.state
+#      sidecar (state<TAB>reason) the supervisor reads back + reports,
+#      and renames the trigger to .done / .failed so the .path unit
+#      doesn't re-fire.
+#
+# k3s restore model: with k3s stopped, ``k3s server --cluster-reset
+# --cluster-reset-restore-path=<file>`` rebuilds etcd as a fresh
+# 1-member cluster from the snapshot and exits; a normal
+# ``systemctl start k3s`` then brings the restored single-node cluster
+# up. We only restore from a LOCAL snapshot file (S3 restore is a
+# follow-up); a snapshot whose file isn't on this node is refused.
+
+set -uo pipefail
+
+RELEASE_STATE=/var/lib/spatiumddi/release-state
+TRIGGER="$RELEASE_STATE/cluster-restore-pending"
+STATE="$RELEASE_STATE/cluster-restore.state"
+
+# Guardrail confirmation marker. This script is fired by a systemd .path
+# unit watching the trigger file — so a stray / leftover / hand-touched
+# file could otherwise reset the cluster by accident. The supervisor
+# stamps this magic first line into every trigger it writes; we refuse
+# to act on any trigger whose first line isn't an exact match. Must stay
+# byte-identical to _CLUSTER_RESTORE_CONFIRM in the supervisor's
+# appliance_state.py.
+RESTORE_CONFIRM="SPATIUMDDI-CLUSTER-RESTORE-CONFIRM-V1"
+
+K3S_SERVER_DIR=/var/lib/rancher/k3s/server
+SNAP_DIR="$K3S_SERVER_DIR/db/snapshots"
+
+LOG_DIR=/var/log/spatiumddi
+LOG="$LOG_DIR/cluster-restore.log"
+READY_TIMEOUT=240  # seconds to wait for the node to report Ready
+
+mkdir -p "$LOG_DIR" "$RELEASE_STATE"
+
+log() { printf '[%s] %s\n' "$(date -Iseconds)" "$*" | tee -a "$LOG"; }
+
+# State sidecar the supervisor reads (state<TAB>reason). Keep the
+# vocabulary in lock-step with the supervisor's appliance_state.py +
+# the backend's restore_state handling: restoring | done | failed.
+write_state() { printf '%s\t%s\n' "$1" "${2:-}" > "$STATE"; }
+
+# Reap orphaned containerd-shims + reset the systemd start counter before
+# a (re)start — identical rationale to spatium-cluster-join's helper
+# (k3s stop leaves shims behind; rapid restarts trip StartLimitBurst).
+clean_k3s_runtime() {
+    systemctl reset-failed k3s 2>/dev/null || true
+    pkill -9 -f 'containerd-shim' 2>/dev/null || true
+    pkill -9 -f 'k3s/data' 2>/dev/null || true
+    awk '$2 ~ "/var/lib/kubelet/pods|/run/k3s|/var/lib/rancher/k3s" {print $2}' /proc/mounts \
+        | sort -r | while read -r m; do umount "$m" 2>/dev/null || true; done
+}
+
+require_appliance() {
+    if [ ! -f /etc/spatiumddi/role-config ]; then
+        log "not a SpatiumDDI appliance (no role-config) — refusing"
+        exit 0
+    fi
+    if ! command -v k3s >/dev/null 2>&1; then
+        log "k3s not installed — refusing"
+        exit 0
+    fi
+}
+
+wait_ready() {
+    local deadline=$(( $(date +%s) + READY_TIMEOUT )) node
+    node="$(hostname)"
+    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        if k3s kubectl get node "$node" \
+                -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' \
+                2>/dev/null | grep -q True; then
+            return 0
+        fi
+        sleep 5
+    done
+    return 1
+}
+
+do_restore() {
+    if [ ! -f "$TRIGGER" ]; then
+        log "restore invoked without a trigger file — nothing to do"
+        exit 0
+    fi
+    local confirm snapshot
+    confirm="$(sed -n '1p' "$TRIGGER" | tr -d '\r\n')"
+    snapshot="$(sed -n '2p' "$TRIGGER" | tr -d '\r\n')"
+
+    # Guardrail — refuse anything not stamped by the supervisor.
+    if [ "$confirm" != "$RESTORE_CONFIRM" ]; then
+        log "restore trigger missing confirmation marker (got: '${confirm:-<empty>}') — refusing, not touching k3s"
+        mv -f "$TRIGGER" "${TRIGGER}.rejected.$(date +%s)" || true
+        exit 0
+    fi
+
+    # Sanitise the snapshot name: a bare filename only, no path traversal.
+    # The supervisor sources it from the ETCDSnapshotFile CR, but this is
+    # the file we feed to a root k3s invocation — defend in depth.
+    if [ -z "$snapshot" ] || printf '%s' "$snapshot" | grep -q '[/]'; then
+        log "invalid snapshot name ('${snapshot:-<empty>}') — refusing"
+        write_state failed "invalid snapshot name"
+        mv -f "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" || true
+        exit 1
+    fi
+
+    local snap_path="$SNAP_DIR/$snapshot"
+    if [ ! -f "$snap_path" ]; then
+        log "snapshot file not found locally: $snap_path (S3 restore unsupported in v1)"
+        write_state failed "snapshot not found on this node: $snapshot"
+        mv -f "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" || true
+        exit 1
+    fi
+
+    log "RESTORE: resetting cluster to single-node etcd from $snapshot"
+    write_state restoring "$snapshot"
+
+    systemctl stop k3s || true
+    clean_k3s_runtime
+
+    # One-shot reset-restore. k3s rebuilds etcd as a 1-member cluster from
+    # the snapshot and EXITS (it is NOT the long-running server here); a
+    # normal ``systemctl start k3s`` afterwards brings the restored cluster
+    # up. We capture its output to the log for forensics.
+    if k3s server \
+            --cluster-reset \
+            --cluster-reset-restore-path="$snap_path" >>"$LOG" 2>&1; then
+        log "cluster-reset-restore completed — restarting k3s"
+    else
+        log "cluster-reset-restore FAILED — see $LOG; attempting to restart k3s as-is"
+        clean_k3s_runtime
+        systemctl start k3s || true
+        write_state failed "k3s --cluster-reset-restore failed; cluster left as-is"
+        mv -f "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" || true
+        exit 1
+    fi
+
+    clean_k3s_runtime
+    if systemctl start k3s && wait_ready; then
+        log "RESTORE ok — single-node cluster is Ready on the restored snapshot."
+        log "NOTE: other control-plane members are now orphaned — re-pair them via Fleet → Replace."
+        write_state done "$snapshot"
+        mv -f "$TRIGGER" "${TRIGGER}.done.$(date +%s)" || true
+        exit 0
+    fi
+
+    log "RESTORE: k3s did not come Ready after restore — manual recovery needed"
+    write_state failed "k3s not Ready after restore"
+    mv -f "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" || true
+    exit 1
+}
+
+require_appliance
+do_restore

--- a/appliance/mkosi.postinst
+++ b/appliance/mkosi.postinst
@@ -46,6 +46,7 @@ for unit in chrony.service ssh.service \
             spatiumddi-reboot-agent.path \
             spatiumddi-cluster-join.path \
             spatiumddi-cluster-leave.path \
+            spatiumddi-cluster-restore.path \
             spatiumddi-publish-k3s-token.service \
             k3s.service \
             spatiumddi-snmp-reload.path \
@@ -286,6 +287,10 @@ chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-cluster-join.path"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-cluster-join.service"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-cluster-leave.path"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-cluster-leave.service"
+# #272 Phase 9b — guided etcd-restore host runner (single-node cluster-reset).
+chmod 0755 "$BUILDROOT/usr/local/bin/spatium-cluster-restore"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-cluster-restore.path"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-cluster-restore.service"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-publish-k3s-token.service"
 
 # Issue #276 — spatium-etc-render runs in the sysinit phase (it must

--- a/appliance/scripts/bake-images.sh
+++ b/appliance/scripts/bake-images.sh
@@ -30,6 +30,20 @@ VERSION_FILE="$APPLIANCE_DIR/mkosi.extra/usr/lib/spatiumddi/spatiumddi-version"
 SPATIUMDDI_VERSION="${SPATIUMDDI_VERSION:-dev}"
 BAKE_SOURCE="${BAKE_SOURCE:-local}"  # local (docker :dev) | ghcr (pull from ghcr.io)
 
+# #272 follow-up — stale-source-image guard. A local bake saves whatever
+# ``make build`` last produced; if the operator edited code but forgot to
+# rebuild, the ISO silently ships stale images. Refuse when any SpatiumDDI
+# source image is older than STALE_MAX_AGE_S unless explicitly allowed.
+# ghcr pulls are always fresh, so this only applies to BAKE_SOURCE=local.
+ALLOW_STALE_IMAGES="${ALLOW_STALE_IMAGES:-0}"
+STALE_MAX_AGE_S="${STALE_MAX_AGE_S:-86400}"  # 24h
+for arg in "$@"; do
+    case "$arg" in
+        --allow-stale-images) ALLOW_STALE_IMAGES=1 ;;
+        *) echo "WARN: ignoring unknown arg '$arg'" >&2 ;;
+    esac
+done
+
 # SpatiumDDI service images. Tagged with SPATIUMDDI_VERSION so the
 # chart's ``image: ghcr.io/spatiumddi/<name>:${SPATIUMDDI_VERSION}``
 # reference resolves locally without a pull.
@@ -186,6 +200,35 @@ resolve_source_tag() {
             ;;
     esac
 }
+
+# Stale-source-image pre-scan (local only). Fails BEFORE baking anything
+# so the operator fixes it in one rebuild rather than discovering a stale
+# image after a 10-minute ISO build. Missing images aren't flagged here —
+# the main loop's inspect handles those with a more specific error.
+image_age_seconds() {
+    local created created_epoch
+    created="$(docker image inspect "$1" --format '{{.Created}}' 2>/dev/null)" || return 1
+    created_epoch="$(date -d "$created" +%s 2>/dev/null)" || return 1
+    echo $(( $(date +%s) - created_epoch ))
+}
+if [ "$BAKE_SOURCE" = "local" ] && [ "$ALLOW_STALE_IMAGES" != "1" ]; then
+    stale=()
+    for repo in "${IMAGES[@]}"; do
+        src="$(resolve_source_tag "$repo")"
+        docker image inspect "$src" >/dev/null 2>&1 || continue
+        age="$(image_age_seconds "$src")" || continue
+        if [ "$age" -gt "$STALE_MAX_AGE_S" ]; then
+            stale+=("$src ($(( age / 3600 ))h old)")
+        fi
+    done
+    if [ "${#stale[@]}" -gt 0 ]; then
+        echo "ERROR: stale local source image(s) older than $(( STALE_MAX_AGE_S / 3600 ))h:" >&2
+        for s in "${stale[@]}"; do echo "         $s" >&2; done
+        echo "       Rebuild with 'make build' (+ 'make build-supervisor'), or bake them" >&2
+        echo "       as-is with --allow-stale-images (or ALLOW_STALE_IMAGES=1)." >&2
+        exit 4
+    fi
+fi
 
 for repo in "${IMAGES[@]}"; do
     short="$(basename "$repo")"

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -468,6 +468,12 @@ backend/alembic/versions/ee86cea94cf5_appliance_role_assignment.py:drop_column:1
 backend/alembic/versions/ee86cea94cf5_appliance_role_assignment.py:drop_column:104
 backend/alembic/versions/ee86cea94cf5_appliance_role_assignment.py:drop_column:105
 backend/alembic/versions/f1a3b8c52d04_subnet_role.py:drop_column:39
+backend/alembic/versions/f1a4c7b2e9d6_cp_ha_dataplane_vip_etcd_restore.py:drop_column:71
+backend/alembic/versions/f1a4c7b2e9d6_cp_ha_dataplane_vip_etcd_restore.py:drop_column:72
+backend/alembic/versions/f1a4c7b2e9d6_cp_ha_dataplane_vip_etcd_restore.py:drop_column:73
+backend/alembic/versions/f1a4c7b2e9d6_cp_ha_dataplane_vip_etcd_restore.py:drop_column:74
+backend/alembic/versions/f1a4c7b2e9d6_cp_ha_dataplane_vip_etcd_restore.py:drop_column:75
+backend/alembic/versions/f1a4c7b2e9d6_cp_ha_dataplane_vip_etcd_restore.py:drop_column:76
 backend/alembic/versions/f1a8d2c5e413_dns_pull_from_server_settings.py:drop_column:56
 backend/alembic/versions/f1a8d2c5e413_dns_pull_from_server_settings.py:drop_column:57
 backend/alembic/versions/f1a8d2c5e413_dns_pull_from_server_settings.py:drop_column:58

--- a/backend/alembic/versions/f1a4c7b2e9d6_cp_ha_dataplane_vip_etcd_restore.py
+++ b/backend/alembic/versions/f1a4c7b2e9d6_cp_ha_dataplane_vip_etcd_restore.py
@@ -1,0 +1,76 @@
+"""Control-plane HA: data-plane VIPs (#272 Phase 10) + etcd restore (#272 Phase 9b)
+
+Phase 10 — adds ``platform_settings.dns_vip`` + ``dhcp_relay_vip`` (the
+cluster-wide data-plane resolver VIPs, same MetalLB pool as the
+control-plane VIP). Phase 9b — adds ``appliance.etcd_snapshots`` (the
+seed-reported snapshot inventory), ``desired_restore_snapshot`` (guided
+restore desired-state), and ``restore_state`` / ``restore_reason``
+(runner-reported progress).
+
+All additive + nullable / defaulted, so existing rows backfill to the
+single-node defaults (no VIP, no snapshots, no restore in flight).
+
+Revision ID: f1a4c7b2e9d6
+Revises: e7a3c0d519f4
+Create Date: 2026-06-11
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "f1a4c7b2e9d6"
+down_revision = "e7a3c0d519f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── #272 Phase 10 — data-plane resolver VIPs (platform_settings) ──
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "dns_vip", sa.String(length=64), nullable=False, server_default=""
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "dhcp_relay_vip", sa.String(length=64), nullable=False, server_default=""
+        ),
+    )
+
+    # ── #272 Phase 9b — etcd snapshot inventory + guided restore (appliance) ──
+    op.add_column(
+        "appliance",
+        sa.Column(
+            "etcd_snapshots",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "appliance",
+        sa.Column("desired_restore_snapshot", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "appliance",
+        sa.Column("restore_state", sa.String(length=16), nullable=True),
+    )
+    op.add_column(
+        "appliance",
+        sa.Column("restore_reason", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("appliance", "restore_reason")
+    op.drop_column("appliance", "restore_state")
+    op.drop_column("appliance", "desired_restore_snapshot")
+    op.drop_column("appliance", "etcd_snapshots")
+    op.drop_column("platform_settings", "dhcp_relay_vip")
+    op.drop_column("platform_settings", "dns_vip")

--- a/backend/app/api/v1/admin/postgres.py
+++ b/backend/app/api/v1/admin/postgres.py
@@ -181,6 +181,73 @@ async def postgres_overview(db: DB, _: SuperAdmin) -> OverviewResponse:
     )
 
 
+class SchemaHealthResponse(BaseModel):
+    """Alembic schema-head divergence (#272 follow-up).
+
+    ``status`` is ``ok`` (DB at the head this image expects),
+    ``behind`` (a migration is pending — the migrate Job hasn't run the
+    new head yet, the real-world failure mode on a cold multi-node boot
+    or a bundled image that's behind), or ``error`` (couldn't read the
+    head / alembic_version). The readiness probe already gates pod
+    membership on this; surfacing it here gives operators a non-502 way
+    to see *why* a fresh install or rolling upgrade is mid-converge."""
+
+    status: str  # "ok" | "behind" | "error"
+    expected_head: str | None = None
+    db_revision: str | None = None
+    detail: str
+
+
+@router.get("/postgres/schema-health", response_model=SchemaHealthResponse)
+async def postgres_schema_health(db: DB, _: SuperAdmin) -> SchemaHealthResponse:
+    """Compare the DB's ``alembic_version`` against the alembic head this
+    api image bundles. Reuses the readiness probe's cached head reader so
+    there's a single source of truth for "is the schema where this image
+    expects it?". Cheap — the head is read+cached once, then it's one
+    ``SELECT version_num``."""
+    from app.api.health import _expected_alembic_head  # noqa: PLC0415
+
+    expected, head_err = _expected_alembic_head()
+    if head_err is not None:
+        return SchemaHealthResponse(
+            status="error", expected_head=None, db_revision=None, detail=head_err
+        )
+    try:
+        row = (await db.execute(text("SELECT version_num FROM alembic_version"))).first()
+    except Exception as exc:  # noqa: BLE001 — surface, never 500 the panel
+        return SchemaHealthResponse(
+            status="error",
+            expected_head=expected,
+            db_revision=None,
+            detail=f"could not read alembic_version: {exc}",
+        )
+    actual = str(row[0]) if row else None
+    if actual is None:
+        return SchemaHealthResponse(
+            status="error",
+            expected_head=expected,
+            db_revision=None,
+            detail="alembic_version table is empty (migrations never ran)",
+        )
+    if actual != expected:
+        return SchemaHealthResponse(
+            status="behind",
+            expected_head=expected,
+            db_revision=actual,
+            detail=(
+                f"DB schema is at {actual}; this api image expects {expected}. "
+                "A migration is pending — the migrate Job should advance it "
+                "(cold-boot / mid-rolling-upgrade window)."
+            ),
+        )
+    return SchemaHealthResponse(
+        status="ok",
+        expected_head=expected,
+        db_revision=actual,
+        detail=f"Schema at head {expected}.",
+    )
+
+
 @router.get("/postgres/tables", response_model=TableSizesResponse)
 async def postgres_table_sizes(
     db: DB,

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -54,7 +54,7 @@ from cryptography.hazmat.primitives.serialization import (
     load_der_public_key,
 )
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 from sqlalchemy import func as sa_func
 from sqlalchemy import or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -1096,6 +1096,16 @@ class SupervisorHeartbeatRequest(BaseModel):
     # ``evict_requested`` + settles those rows to ``left``. Empty on
     # every non-seed heartbeat + when there's nothing to evict.
     evicted_node_names: list[str] = Field(default_factory=list)
+    # #272 Phase 9b — etcd snapshot inventory + restore progress. The
+    # SEED reports its local ``k3s etcd-snapshot list`` so the Fleet tab
+    # can show recoverable snapshots; ``restore_state`` /
+    # ``restore_reason`` mirror the host runner's ``.state`` sidecar
+    # while a guided restore is in flight. All "only update when not
+    # None / non-empty-on-seed" so a member heartbeat never blanks the
+    # seed's inventory. None = no report this tick (leave the row as-is).
+    etcd_snapshots: list[dict[str, Any]] | None = None
+    restore_state: str | None = None
+    restore_reason: str | None = None
 
 
 class SupervisorRoleAssignment(BaseModel):
@@ -1241,6 +1251,12 @@ class SupervisorHeartbeatResponse(BaseModel):
     desired_metallb_enabled: bool = False
     desired_metallb_pool_addresses: list[str] = Field(default_factory=list)
     desired_control_plane_vip: str = ""
+    # #272 Phase 10 — data-plane resolver VIPs. Acted on only by the seed:
+    # it patches ``dns.useMetalLBVIP`` / ``dns.vip`` / ``dhcpKea.relayVIP``
+    # on the spatiumddi-appliance HelmChartConfig overlay. Empty = the
+    # hostNetwork data plane (single-node default).
+    desired_dns_vip: str = ""
+    desired_dhcp_relay_vip: str = ""
     # #272 Phase 9 — dead-node replacement. Hostnames of k8s Nodes the
     # SEED should evict (delete the Node → k3s removes the etcd member).
     # Populated from rows flagged ``evict_requested``; only the
@@ -1600,6 +1616,13 @@ async def supervisor_heartbeat(
     if body.node_ip is not None:
         row.node_ip = body.node_ip
 
+    # #272 Phase 9b — etcd snapshot inventory (seed-reported). "Only
+    # update when not None" so a member / pre-9b supervisor never blanks
+    # the seed's list. Cap the stored list defensively (the runner already
+    # sorts newest-first; a runaway snapshot dir shouldn't bloat the row).
+    if body.etcd_snapshots is not None:
+        row.etcd_snapshots = list(body.etcd_snapshots)[:200]
+
     # Issue #285 Phase 1 — fleet-firewall prerequisites. "Only update when
     # not None" so a legacy / pre-#285 supervisor never blanks them.
     if body.node_ips is not None:
@@ -1680,6 +1703,22 @@ async def supervisor_heartbeat(
     ):
         row.cluster_role = None
         row.desired_cluster_role = None
+
+    # #272 Phase 9b — guided etcd restore. Persist the runner-reported
+    # progress, and auto-clear the desired snapshot once it lands ``done``
+    # (so a converged restore stops re-firing the trigger). A ``failed``
+    # restore keeps ``desired_restore_snapshot`` set so the operator sees
+    # the failure on the row and can retry / pick another snapshot.
+    if body.restore_state is not None:
+        row.restore_state = body.restore_state
+        row.restore_reason = body.restore_reason
+    if row.desired_restore_snapshot is not None and row.restore_state == "done":
+        logger.info(
+            "control_plane_restore_done",
+            appliance_id=str(row.id),
+            snapshot=row.desired_restore_snapshot,
+        )
+        row.desired_restore_snapshot = None
 
     # Auto-clear desired_appliance_version once installed matches +
     # the upgrade landed cleanly. Same shape as #138 Phase 8f-4's
@@ -1836,6 +1875,9 @@ async def supervisor_heartbeat(
     metallb_enabled = bool(cfg_row.metallb_enabled) if cfg_row else False
     metallb_pool = list(cfg_row.metallb_pool_addresses or []) if cfg_row else []
     metallb_vip = (cfg_row.control_plane_vip or "") if cfg_row else ""
+    # #272 Phase 10 — data-plane resolver VIPs (only the seed acts).
+    dns_vip = (cfg_row.dns_vip or "") if cfg_row else ""
+    dhcp_relay_vip = (cfg_row.dhcp_relay_vip or "") if cfg_row else ""
     # Issue #165 — operator-set timezone. Empty string = no override.
     desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
     # Verbose-boot console toggle (grubenv-driven, applies next reboot).
@@ -1970,6 +2012,8 @@ async def supervisor_heartbeat(
         desired_metallb_enabled=metallb_enabled,
         desired_metallb_pool_addresses=metallb_pool,
         desired_control_plane_vip=metallb_vip,
+        desired_dns_vip=dns_vip,
+        desired_dhcp_relay_vip=dhcp_relay_vip,
         evict_node_names=evict_names,
         desired_timezone=desired_timezone,
         desired_verbose_boot=desired_verbose_boot,
@@ -3647,6 +3691,205 @@ async def replace_control_plane_member(
     )
 
 
+# ── Admin: etcd snapshot list + guided restore (#272 Phase 9b) ───────
+
+
+class EtcdSnapshotRow(BaseModel):
+    """One recoverable etcd snapshot, mapped from a k3s
+    ``ETCDSnapshotFile`` CR. All fields tolerant of a partial wire shape
+    (a future k3s schema change shouldn't 500 the panel)."""
+
+    name: str = ""
+    location: str = ""
+    node_name: str = ""
+    size: int | None = None
+    created_at: str | None = None
+
+
+class EtcdSnapshotsResponse(BaseModel):
+    """Cluster etcd snapshot inventory + in-flight restore state.
+
+    ``available`` is False on a docker / k8s control plane (no appliance
+    seed row) — the Fleet panel then shows a "not an appliance" note
+    instead of an empty table that reads as broken.
+    """
+
+    available: bool = False
+    seed_id: uuid.UUID | None = None
+    seed_hostname: str | None = None
+    reported_at: datetime | None = None
+    snapshots: list[EtcdSnapshotRow] = Field(default_factory=list)
+    # In-flight guided restore (#272 Phase 9b).
+    desired_restore_snapshot: str | None = None
+    restore_state: str | None = None
+    restore_reason: str | None = None
+
+
+class ClusterRestoreRequest(BaseModel):
+    """POST body for a guided etcd restore. ``confirm_hostname`` must
+    match the seed's hostname exactly — a typed-confirmation guardrail
+    on top of the superadmin gate, because the restore is a single-node
+    cluster-reset (every other control-plane node is orphaned)."""
+
+    snapshot_name: str
+    confirm_hostname: str
+
+
+async def _find_seed_row(db: DB) -> Appliance | None:
+    """Resolve the etcd seed appliance row — the control-plane node that
+    holds the snapshots + drives a guided restore.
+
+    Multi-node: the row with ``cluster_role == 'primary'``. Single-node
+    (pre-promote, cluster_role still NULL): the lone control-plane-variant
+    appliance. None on a docker / k8s control plane (no appliance rows)."""
+    primary = (
+        (
+            await db.execute(
+                select(Appliance).where(
+                    Appliance.state == APPLIANCE_STATE_APPROVED,
+                    Appliance.cluster_role == CLUSTER_ROLE_PRIMARY,
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if primary is not None:
+        return primary
+    return (
+        (
+            await db.execute(
+                select(Appliance)
+                .where(
+                    Appliance.state == APPLIANCE_STATE_APPROVED,
+                    Appliance.appliance_variant.in_(tuple(_SELF_BOOTSTRAP_VARIANTS)),
+                    Appliance.last_seen_at.is_not(None),
+                )
+                .order_by(Appliance.created_at.asc())
+            )
+        )
+        .scalars()
+        .first()
+    )
+
+
+def _etcd_snapshots_response(seed: Appliance | None) -> EtcdSnapshotsResponse:
+    if seed is None:
+        return EtcdSnapshotsResponse(available=False)
+    rows: list[EtcdSnapshotRow] = []
+    for s in seed.etcd_snapshots or []:
+        if isinstance(s, dict):
+            rows.append(EtcdSnapshotRow(**s))
+    return EtcdSnapshotsResponse(
+        available=True,
+        seed_id=seed.id,
+        seed_hostname=seed.hostname,
+        reported_at=seed.last_seen_at,
+        snapshots=rows,
+        desired_restore_snapshot=seed.desired_restore_snapshot,
+        restore_state=seed.restore_state,
+        restore_reason=seed.restore_reason,
+    )
+
+
+@router.get(
+    "/fleet/control-plane/etcd-snapshots",
+    response_model=EtcdSnapshotsResponse,
+    dependencies=[Depends(require_permission("admin", "appliance"))],
+    summary="List recoverable etcd snapshots from the cluster seed (superadmin)",
+)
+async def list_etcd_snapshots(
+    current_user: CurrentUser,
+    db: DB,
+) -> EtcdSnapshotsResponse:
+    """Read the seed's reported ``k3s etcd-snapshot list`` + any in-flight
+    restore state. Read-only — the seed reports its local snapshots on
+    every heartbeat, so this is just the last-reported inventory."""
+    _require_superadmin(current_user)
+    return _etcd_snapshots_response(await _find_seed_row(db))
+
+
+@router.post(
+    "/fleet/control-plane/restore",
+    response_model=EtcdSnapshotsResponse,
+    dependencies=[Depends(require_permission("admin", "appliance"))],
+    summary="Guided etcd restore — stamp the seed to cluster-reset-restore (superadmin)",
+)
+async def restore_etcd_snapshot(
+    body: ClusterRestoreRequest,
+    current_user: CurrentUser,
+    db: DB,
+) -> EtcdSnapshotsResponse:
+    """Stamp the seed row to perform a guided etcd restore.
+
+    ⚠️ DESTRUCTIVE — single-node cluster-reset. The seed supervisor reads
+    ``desired_restore_snapshot`` on its next heartbeat and fires the
+    host-side ``spatium-cluster-restore`` trigger (guarded by a confirm
+    marker): k3s stops, resets etcd to a 1-member cluster from the
+    snapshot, and restarts. Every OTHER control-plane node is orphaned
+    and must be re-paired (Replace flow). Disaster recovery only.
+
+    Guardrails: superadmin + the snapshot must exist in the seed's
+    last-reported inventory + ``confirm_hostname`` must match the seed's
+    hostname exactly. Refuses a second restore while one is in flight."""
+    _require_superadmin(current_user)
+    seed = await _find_seed_row(db)
+    if seed is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            "No appliance control-plane seed found — etcd restore is appliance-only "
+            "(a docker / k8s control plane manages its own database).",
+        )
+    if (body.confirm_hostname or "").strip() != (seed.hostname or ""):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            f"Type the seed hostname ({seed.hostname!r}) exactly to confirm this "
+            "destructive cluster-reset restore.",
+        )
+    known = {
+        s.get("name")
+        for s in (seed.etcd_snapshots or [])
+        if isinstance(s, dict) and s.get("name")
+    }
+    if body.snapshot_name not in known:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            f"Snapshot {body.snapshot_name!r} is not in the seed's reported inventory.",
+        )
+    if seed.desired_restore_snapshot is not None and seed.restore_state != "failed":
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"A restore is already in flight ({seed.desired_restore_snapshot!r}, "
+            f"state={seed.restore_state or 'pending'}). Wait for it to settle.",
+        )
+    seed.desired_restore_snapshot = body.snapshot_name
+    seed.restore_state = None
+    seed.restore_reason = None
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="appliance.control_plane_etcd_restore_requested",
+            resource_type="appliance",
+            resource_id=str(seed.id),
+            resource_display=seed.hostname,
+            result="success",
+            new_value={"snapshot_name": body.snapshot_name},
+        )
+    )
+    await db.commit()
+    await db.refresh(seed)
+    logger.warning(
+        "control_plane_etcd_restore_requested",
+        appliance_id=str(seed.id),
+        hostname=seed.hostname,
+        snapshot=body.snapshot_name,
+        user=current_user.username,
+    )
+    return _etcd_snapshots_response(seed)
+
+
 # ── Admin: MetalLB control-plane VIP (#272 Phase 7c) ─────────────
 
 
@@ -3694,6 +3937,11 @@ class MetalLBConfigResponse(BaseModel):
     enabled: bool = False
     pool_addresses: list[str] = Field(default_factory=list)
     control_plane_vip: str = ""
+    # #272 Phase 10 — data-plane resolver VIPs (same pool). Empty = the
+    # hostNetwork data plane (no VIP). ``dns_vip`` fronts bind9/powerdns
+    # :53; ``dhcp_relay_vip`` fronts the Kea relay→server :67 forward.
+    dns_vip: str = ""
+    dhcp_relay_vip: str = ""
     # #272 — live readiness, best-effort from the spatium-namespace pod
     # list (reuses the api's existing pod-read RBAC). All zero/false when
     # kubeapi is unreachable (docker/k8s control plane) or MetalLB is off.
@@ -3749,6 +3997,8 @@ def _metallb_response(row: PlatformSettings) -> MetalLBConfigResponse:
         enabled=row.metallb_enabled,
         pool_addresses=list(row.metallb_pool_addresses or []),
         control_plane_vip=row.control_plane_vip or "",
+        dns_vip=row.dns_vip or "",
+        dhcp_relay_vip=row.dhcp_relay_vip or "",
         controller_ready=controller_ready,
         speakers_ready=speakers_ready,
         speakers_total=speakers_total,
@@ -3767,6 +4017,9 @@ class MetalLBConfigUpdate(BaseModel):
     enabled: bool = False
     pool_addresses: list[str] = Field(default_factory=list)
     control_plane_vip: str = ""
+    # #272 Phase 10 — data-plane resolver VIPs (optional; same pool).
+    dns_vip: str = ""
+    dhcp_relay_vip: str = ""
 
     @field_validator("pool_addresses")
     @classmethod
@@ -3783,16 +4036,16 @@ class MetalLBConfigUpdate(BaseModel):
             out.append(s)
         return out
 
-    @field_validator("control_plane_vip")
+    @field_validator("control_plane_vip", "dns_vip", "dhcp_relay_vip")
     @classmethod
-    def _valid_vip(cls, v: str) -> str:
+    def _valid_vip(cls, v: str, info: ValidationInfo) -> str:
         s = v.strip()
         if not s:
             return ""
         try:
             ipaddress.ip_address(s)
         except ValueError as exc:
-            raise ValueError(f"control_plane_vip must be a single IP: {exc}") from exc
+            raise ValueError(f"{info.field_name} must be a single IP: {exc}") from exc
         return s
 
     @model_validator(mode="after")
@@ -3812,10 +4065,26 @@ class MetalLBConfigUpdate(BaseModel):
             if not self.pool_addresses:
                 prefix = 32 if ipaddress.ip_address(self.control_plane_vip).version == 4 else 128
                 self.pool_addresses = [f"{self.control_plane_vip}/{prefix}"]
-        if self.control_plane_vip and self.pool_addresses:
-            if not _vip_in_pool(self.control_plane_vip, self.pool_addresses):
+        # #272 Phase 10 — data-plane VIPs require MetalLB on (no VIP path
+        # exists without it) and can't reuse the control-plane VIP or each
+        # other — MetalLB hands a given address to exactly one Service, so
+        # two services sharing one VIP would leave one perpetually Pending.
+        dp_vips = {"DNS resolver VIP": self.dns_vip, "DHCP relay VIP": self.dhcp_relay_vip}
+        for label, vip in dp_vips.items():
+            if vip and not self.enabled:
+                raise ValueError(f"{label} requires MetalLB to be enabled")
+        if self.dns_vip and self.dns_vip == self.control_plane_vip:
+            raise ValueError("DNS resolver VIP must differ from the control-plane VIP")
+        if self.dhcp_relay_vip and self.dhcp_relay_vip == self.control_plane_vip:
+            raise ValueError("DHCP relay VIP must differ from the control-plane VIP")
+        if self.dns_vip and self.dns_vip == self.dhcp_relay_vip:
+            raise ValueError("DNS resolver VIP and DHCP relay VIP must differ")
+        # Every configured VIP must fall inside the pool.
+        for label, vip in {"control-plane VIP": self.control_plane_vip, **dp_vips}.items():
+            if vip and self.pool_addresses and not _vip_in_pool(vip, self.pool_addresses):
                 raise ValueError(
-                    f"control-plane VIP {self.control_plane_vip} is not inside the " "address pool"
+                    f"{label} {vip} is not inside the address pool "
+                    "(widen metallb_pool_addresses to include every VIP)"
                 )
         return self
 
@@ -3872,14 +4141,20 @@ async def put_metallb_config(
         "enabled": row.metallb_enabled,
         "pool_addresses": list(row.metallb_pool_addresses or []),
         "control_plane_vip": row.control_plane_vip or "",
+        "dns_vip": row.dns_vip or "",
+        "dhcp_relay_vip": row.dhcp_relay_vip or "",
     }
     row.metallb_enabled = body.enabled
     row.metallb_pool_addresses = body.pool_addresses
     row.control_plane_vip = body.control_plane_vip
+    row.dns_vip = body.dns_vip
+    row.dhcp_relay_vip = body.dhcp_relay_vip
     new = {
         "enabled": body.enabled,
         "pool_addresses": body.pool_addresses,
         "control_plane_vip": body.control_plane_vip,
+        "dns_vip": body.dns_vip,
+        "dhcp_relay_vip": body.dhcp_relay_vip,
     }
     db.add(
         AuditLog(

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -3847,9 +3847,7 @@ async def restore_etcd_snapshot(
             "destructive cluster-reset restore.",
         )
     known = {
-        s.get("name")
-        for s in (seed.etcd_snapshots or [])
-        if isinstance(s, dict) and s.get("name")
+        s.get("name") for s in (seed.etcd_snapshots or []) if isinstance(s, dict) and s.get("name")
     }
     if body.snapshot_name not in known:
         raise HTTPException(

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -769,6 +769,33 @@ class Appliance(Base):
         Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
 
+    # ── #272 Phase 9b — etcd snapshot inventory + guided restore ─────
+    # The SEED (primary) reports its local ``k3s etcd-snapshot list`` on
+    # every heartbeat so the Fleet tab can show recoverable snapshots
+    # without an operator SSH. Each entry:
+    #   {"name", "location", "size" (bytes, int|null), "created_at" (ISO)}.
+    # Populated only on the primary row; member / application rows stay [].
+    etcd_snapshots: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa.text("'[]'::jsonb")
+    )
+    # The snapshot the operator asked to restore (its ``name`` from the
+    # inventory). Stamped by ``POST …/control-plane/restore`` on the seed
+    # row; the seed supervisor reads it on heartbeat and fires the
+    # destructive host-side ``spatium-cluster-restore`` trigger (guarded
+    # by a confirm marker). NULL except while a restore is in flight; the
+    # heartbeat handler clears it once the runner reports ``done``.
+    #
+    # ⚠️ A restore is a single-node cluster-reset: k3s collapses to a
+    # 1-member etcd from the snapshot and every OTHER control-plane node
+    # is orphaned and must be re-paired (Replace flow). Disaster recovery
+    # only — never a routine op.
+    desired_restore_snapshot: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Supervisor-reported progress of the in-flight restore:
+    # ``restoring`` | ``done`` | ``failed`` | NULL (idle), read from the
+    # host runner's ``.state`` sidecar (mirrors ``cluster_join_state``).
+    restore_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    restore_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -724,3 +724,29 @@ class PlatformSettings(Base):
     control_plane_vip: Mapped[str] = mapped_column(
         String(64), nullable=False, default="", server_default=sa_text("''")
     )
+
+    # ── Data-plane resolver VIPs (issue #272 Phase 10) ──────────────
+    # Same cluster-wide singleton + same MetalLB pool as the control-
+    # plane VIP. Both default empty = the single-node hostNetwork data
+    # plane (no VIP), and both require ``metallb_enabled`` + a value
+    # inside ``metallb_pool_addresses`` that differs from every other
+    # VIP. The seed supervisor applies them on heartbeat (same desired-
+    # state path as ``control_plane_vip``): it writes ``dns.useMetalLBVIP``
+    # / ``dns.vip`` / ``dhcpKea.relayVIP`` onto the spatiumddi-appliance
+    # HelmChartConfig overlay, and helm-controller flips the resolver
+    # Pods off hostNetwork behind an L2 LoadBalancer Service.
+    #
+    # ``dns_vip`` — one floating :53 resolver IP that follows whichever
+    # node is up (bind9 / powerdns drop hostNetwork and sit behind the
+    # LoadBalancer Service). Empty = each node answers on its own IP.
+    #
+    # ``dhcp_relay_vip`` — fronts the relay→server unicast forward on
+    # :67 so a DHCP relay's ``forward-to`` target outlives a single Kea
+    # node. Kea KEEPS hostNetwork:67 for direct-attached broadcast reach
+    # — this VIP does NOT replace client-facing :67. Empty = no relay VIP.
+    dns_vip: Mapped[str] = mapped_column(
+        String(64), nullable=False, default="", server_default=sa_text("''")
+    )
+    dhcp_relay_vip: Mapped[str] = mapped_column(
+        String(64), nullable=False, default="", server_default=sa_text("''")
+    )

--- a/backend/app/services/ai/tools/appliance.py
+++ b/backend/app/services/ai/tools/appliance.py
@@ -231,13 +231,14 @@ class FindControlPlaneVipArgs(BaseModel):
 @register_tool(
     name="find_control_plane_vip",
     description=(
-        "Read the cluster-wide MetalLB control-plane VIP config "
-        "(superadmin only, #272 Phase 7c). Returns whether MetalLB is "
-        "enabled, the L2 address pool, and the floating VIP that fronts "
-        "the Web UI across control-plane nodes. Read-only — changing the "
-        "VIP is a high-blast-radius operation (it can sever Web UI / "
-        "agent reachability) and is done in Fleet → Control plane, not "
-        "via the Copilot."
+        "Read the cluster-wide MetalLB VIP config (superadmin only, "
+        "#272). Returns whether MetalLB is enabled, the L2 address pool, "
+        "the floating control-plane VIP that fronts the Web UI across "
+        "control-plane nodes, and the data-plane resolver VIPs (DNS :53 "
+        "and DHCP relay :67, #272 Phase 10). Read-only — changing a VIP "
+        "is a high-blast-radius operation (it can sever Web UI / agent / "
+        "resolver reachability) and is done in Fleet → Control plane, "
+        "not via the Copilot."
     ),
     args_model=FindControlPlaneVipArgs,
     category="admin",
@@ -255,11 +256,19 @@ async def find_control_plane_vip(
         await db.execute(select(PlatformSettings).where(PlatformSettings.id == 1))
     ).scalar_one_or_none()
     if row is None:
-        return {"enabled": False, "pool_addresses": [], "control_plane_vip": ""}
+        return {
+            "enabled": False,
+            "pool_addresses": [],
+            "control_plane_vip": "",
+            "dns_vip": "",
+            "dhcp_relay_vip": "",
+        }
     return {
         "enabled": bool(row.metallb_enabled),
         "pool_addresses": list(row.metallb_pool_addresses or []),
         "control_plane_vip": row.control_plane_vip or "",
+        "dns_vip": row.dns_vip or "",
+        "dhcp_relay_vip": row.dhcp_relay_vip or "",
     }
 
 
@@ -412,6 +421,87 @@ async def find_cluster_health(
             "tolerates_node_loss": max(0, (member_count - 1) // 2),
         },
         "nodes": nodes,
+    }
+
+
+# ── find_etcd_snapshots ────────────────────────────────────────────
+
+
+class FindEtcdSnapshotsArgs(BaseModel):
+    pass
+
+
+@register_tool(
+    name="find_etcd_snapshots",
+    description=(
+        "List recoverable etcd snapshots reported by the appliance "
+        "control-plane seed (superadmin only, #272 Phase 9b). Returns "
+        "each snapshot's name / node / size / creation time, plus any "
+        "in-flight restore state. Use to answer 'what etcd snapshots can "
+        "we recover from?' or 'is a restore running?'. Read-only — a "
+        "restore is a destructive single-node cluster-reset and is done "
+        "in Fleet → Control plane, never via the Copilot."
+    ),
+    args_model=FindEtcdSnapshotsArgs,
+    category="admin",
+    default_enabled=True,
+    module="appliance.cluster",
+)
+async def find_etcd_snapshots(
+    db: AsyncSession, user: User, args: FindEtcdSnapshotsArgs
+) -> dict[str, Any]:
+    if (err := _superadmin_gate(user)) is not None:
+        return err
+    from app.models.appliance import (  # noqa: PLC0415
+        APPLIANCE_STATE_APPROVED,
+        CLUSTER_ROLE_PRIMARY,
+    )
+
+    # Resolve the seed: prefer the etcd primary, else the lone
+    # control-plane-variant appliance (single-node, pre-promote).
+    seed = (
+        (
+            await db.execute(
+                select(Appliance).where(
+                    Appliance.state == APPLIANCE_STATE_APPROVED,
+                    Appliance.cluster_role == CLUSTER_ROLE_PRIMARY,
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if seed is None:
+        seed = (
+            (
+                await db.execute(
+                    select(Appliance)
+                    .where(
+                        Appliance.state == APPLIANCE_STATE_APPROVED,
+                        Appliance.appliance_variant.in_(
+                            ("control-plane", "full-stack", "frontend-core")
+                        ),
+                        Appliance.last_seen_at.is_not(None),
+                    )
+                    .order_by(Appliance.created_at.asc())
+                )
+            )
+            .scalars()
+            .first()
+        )
+    if seed is None:
+        return {
+            "available": False,
+            "snapshots": [],
+            "note": "No appliance control-plane seed found (docker / k8s control plane).",
+        }
+    return {
+        "available": True,
+        "seed_hostname": seed.hostname,
+        "snapshots": list(seed.etcd_snapshots or []),
+        "desired_restore_snapshot": seed.desired_restore_snapshot,
+        "restore_state": seed.restore_state,
+        "restore_reason": seed.restore_reason,
     }
 
 

--- a/backend/tests/test_appliance_control_plane_promote.py
+++ b/backend/tests/test_appliance_control_plane_promote.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import os
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
@@ -443,4 +444,229 @@ async def test_metallb_non_superadmin_refused(
     token = await _admin(db_session, superadmin=False, username="plainuser")
     await db_session.commit()
     resp = await client.get(_METALLB_URL, headers=_hdr(token))
+    assert resp.status_code == 403
+
+
+# ── data-plane resolver VIPs (Phase 10) ──────────────────────────────
+
+
+async def test_dataplane_vips_put_and_get(db_session: AsyncSession, client: AsyncClient) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": True,
+            "pool_addresses": ["192.168.0.240/29"],
+            "control_plane_vip": "192.168.0.241",
+            "dns_vip": "192.168.0.242",
+            "dhcp_relay_vip": "192.168.0.243",
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["dns_vip"] == "192.168.0.242"
+    assert body["dhcp_relay_vip"] == "192.168.0.243"
+    got = (await client.get(_METALLB_URL, headers=_hdr(token))).json()
+    assert got["dns_vip"] == "192.168.0.242"
+    assert got["dhcp_relay_vip"] == "192.168.0.243"
+
+
+async def test_dataplane_vip_outside_pool_refused(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": True,
+            "pool_addresses": ["192.168.0.240/29"],
+            "control_plane_vip": "192.168.0.241",
+            "dns_vip": "10.0.0.9",
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 422
+    assert "not inside" in resp.text
+
+
+async def test_dataplane_vip_requires_metallb_enabled(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": False,
+            "pool_addresses": [],
+            "control_plane_vip": "",
+            "dns_vip": "192.168.0.242",
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 422
+    assert "requires MetalLB" in resp.text
+
+
+async def test_dataplane_vip_must_differ_from_control_plane(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": True,
+            "pool_addresses": ["192.168.0.240/29"],
+            "control_plane_vip": "192.168.0.241",
+            "dns_vip": "192.168.0.241",
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 422
+    assert "differ from the control-plane VIP" in resp.text
+
+
+async def test_dataplane_dns_and_dhcp_vips_must_differ(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": True,
+            "pool_addresses": ["192.168.0.240/29"],
+            "control_plane_vip": "192.168.0.241",
+            "dns_vip": "192.168.0.242",
+            "dhcp_relay_vip": "192.168.0.242",
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 422
+    assert "must differ" in resp.text
+
+
+# ── etcd snapshots + guided restore (Phase 9b) ───────────────────────
+
+_SNAP_URL = "/api/v1/appliance/fleet/control-plane/etcd-snapshots"
+_RESTORE_URL = "/api/v1/appliance/fleet/control-plane/restore"
+
+
+async def test_etcd_snapshots_unavailable_without_seed(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.get(_SNAP_URL, headers=_hdr(token))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["available"] is False
+
+
+async def test_etcd_snapshots_lists_seed_inventory(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    seed = await _seed(db_session)
+    seed.last_seen_at = datetime.now(UTC)
+    seed.etcd_snapshots = [
+        {
+            "name": "on-demand-seed-1700000000",
+            "location": "file:///var/lib/rancher/k3s/server/db/snapshots/on-demand-seed-1700000000",
+            "node_name": "seed",
+            "size": 1234567,
+            "created_at": "2026-06-10T00:00:00Z",
+        }
+    ]
+    await db_session.commit()
+    resp = await client.get(_SNAP_URL, headers=_hdr(token))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["available"] is True
+    assert body["seed_hostname"] == "seed"
+    assert len(body["snapshots"]) == 1
+    assert body["snapshots"][0]["name"] == "on-demand-seed-1700000000"
+
+
+async def test_restore_stamps_desired_snapshot(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    seed = await _seed(db_session)
+    seed.etcd_snapshots = [{"name": "snap-A", "node_name": "seed"}]
+    await db_session.commit()
+    resp = await client.post(
+        _RESTORE_URL,
+        json={"snapshot_name": "snap-A", "confirm_hostname": "seed"},
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 200, resp.text
+    await db_session.refresh(seed)
+    assert seed.desired_restore_snapshot == "snap-A"
+
+
+async def test_restore_wrong_hostname_refused(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    seed = await _seed(db_session)
+    seed.etcd_snapshots = [{"name": "snap-A", "node_name": "seed"}]
+    await db_session.commit()
+    resp = await client.post(
+        _RESTORE_URL,
+        json={"snapshot_name": "snap-A", "confirm_hostname": "wrong"},
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 422
+    assert "hostname" in resp.text
+    await db_session.refresh(seed)
+    assert seed.desired_restore_snapshot is None
+
+
+async def test_restore_unknown_snapshot_refused(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session)
+    seed = await _seed(db_session)
+    seed.etcd_snapshots = [{"name": "snap-A", "node_name": "seed"}]
+    await db_session.commit()
+    resp = await client.post(
+        _RESTORE_URL,
+        json={"snapshot_name": "does-not-exist", "confirm_hostname": "seed"},
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 422
+    assert "inventory" in resp.text
+
+
+async def test_restore_in_flight_conflict(db_session: AsyncSession, client: AsyncClient) -> None:
+    token = await _admin(db_session)
+    seed = await _seed(db_session)
+    seed.etcd_snapshots = [{"name": "snap-A", "node_name": "seed"}]
+    seed.desired_restore_snapshot = "snap-A"
+    seed.restore_state = "restoring"
+    await db_session.commit()
+    resp = await client.post(
+        _RESTORE_URL,
+        json={"snapshot_name": "snap-A", "confirm_hostname": "seed"},
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 409
+    assert "already in flight" in resp.text
+
+
+async def test_restore_non_superadmin_refused(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session, superadmin=False, username="plain2")
+    await _seed(db_session)
+    await db_session.commit()
+    resp = await client.post(
+        _RESTORE_URL,
+        json={"snapshot_name": "snap-A", "confirm_hostname": "seed"},
+        headers=_hdr(token),
+    )
     assert resp.status_code == 403

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -177,6 +177,19 @@ state on its heartbeat:
   `frontend.controlPlaneVIP` rides the `spatium-control` override above.
   The VIP also auto-threads into the api's `APPLIANCE_EXTRA_CERT_SANS` so
   the served cert validates on it.
+- **Data-plane VIPs (Phase 10).** Two optional resolver VIPs share the
+  same pool: `dns_vip` (one floating :53 the bind9/powerdns DaemonSets
+  drop `hostNetwork` to sit behind, an L2 LoadBalancer Service) and
+  `dhcp_relay_vip` (an additional :67 LoadBalancer fronting the Kea
+  relay→server unicast forward — Kea keeps `hostNetwork` for
+  direct-attached broadcast). Both live on the same `platform_settings`
+  singleton + the `…/control-plane/metallb` endpoint; the seed upserts
+  the `spatiumddi-appliance` HelmChartConfig (`dns.useMetalLBVIP` /
+  `dns.vip` / `dhcpKea.relayVIP`) via
+  `k8s_api.apply_dataplane_vip_overrides()`. Each must fall in the pool
+  and differ from the control-plane VIP + each other; empty = the
+  hostNetwork data plane (the single-node default). Configured under
+  Network & Host → MetalLB → **Advanced**.
 - **Cert SAN reconcile (Phase 7c).** A periodic loop in the api lifespan
   (`reconcile_cluster_cert_sans`, advisory-locked across the api
   replicas, appliance-mode only) grows the self-signed cert as members
@@ -215,6 +228,35 @@ agents have no in-cluster DNS to resolve that name, so they keep using
 their configured `CONTROL_PLANE_URL` — which should be the **VIP** on an
 HA cluster (see `_effective_control_plane_url` in the supervisor's
 `heartbeat.py`).
+
+### Guided etcd restore (Phase 9b)
+
+`/appliance → Fleet → Control plane` carries an **etcd snapshots**
+disaster-recovery card. The seed reports its local
+`k3s etcd-snapshot list` on every heartbeat — read from the
+`ETCDSnapshotFile` CRs over the kubeapi (no host `k3s` binary needed),
+stored on the seed's `appliance.etcd_snapshots` column — so the card
+lists recoverable snapshots (name / node / size / created) without an
+operator SSH. k3s takes one every 6 h and retains 8 (baked into the k3s
+config).
+
+A **Restore…** action stamps `appliance.desired_restore_snapshot` on the
+seed after a typed-hostname confirm (on top of the superadmin gate). The
+seed supervisor reads it on the next heartbeat and fires the host-side
+`spatium-cluster-restore` trigger (guarded by the
+`SPATIUMDDI-CLUSTER-RESTORE-CONFIRM-V1` marker, mirroring join/leave); the
+runner stops k3s, runs `k3s server --cluster-reset
+--cluster-reset-restore-path=<local snapshot>`, restarts, and writes a
+`.state` sidecar the supervisor reports back (`restoring` → `done` /
+`failed`). The backend clears the desired snapshot once it lands `done`.
+
+⚠️ **A restore is a single-node cluster-reset** — etcd collapses to one
+member from the snapshot, and every *other* control-plane node is
+orphaned and must be re-paired via the **Replace** flow afterward.
+Disaster recovery only, never routine; only local snapshots are
+restorable in v1 (S3 restore is a follow-up). The read-only
+`find_etcd_snapshots` MCP tool surfaces the inventory to the Operator
+Copilot (restore itself is UI-only).
 
 ### Storage note
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8089,6 +8089,11 @@ export interface MetalLBConfig {
   enabled: boolean;
   pool_addresses: string[];
   control_plane_vip: string;
+  // #272 Phase 10 — optional data-plane resolver VIPs (same pool).
+  // Empty = the hostNetwork data plane (no VIP). dns_vip fronts
+  // bind9/powerdns :53; dhcp_relay_vip fronts the Kea relay→server :67.
+  dns_vip?: string;
+  dhcp_relay_vip?: string;
   // #272 — live readiness from the GET (best-effort; absent/zero when
   // kubeapi is unreachable). Not sent on PUT.
   controller_ready?: boolean;
@@ -8101,6 +8106,25 @@ export interface ControlPlaneReplaceResult {
   evicted: ApplianceRow;
   pairing_code: string;
   pairing_expires_at: string;
+}
+
+// #272 Phase 9b — etcd snapshot inventory + guided restore.
+export interface EtcdSnapshotRow {
+  name: string;
+  location: string;
+  node_name: string;
+  size: number | null;
+  created_at: string | null;
+}
+export interface EtcdSnapshots {
+  available: boolean;
+  seed_id: string | null;
+  seed_hostname: string | null;
+  reported_at: string | null;
+  snapshots: EtcdSnapshotRow[];
+  desired_restore_snapshot: string | null;
+  restore_state: string | null;
+  restore_reason: string | null;
 }
 
 export const applianceFleetApi = {
@@ -8694,6 +8718,21 @@ export const applianceApprovalApi = {
   setMetalLBConfig: (body: MetalLBConfig) =>
     api
       .put<MetalLBConfig>("/appliance/fleet/control-plane/metallb", body)
+      .then((r) => r.data),
+  // #272 Phase 9b — etcd snapshot inventory + guided restore. The seed
+  // reports its local snapshots on heartbeat; restore stamps the seed
+  // row (superadmin + typed-hostname confirm) and the host runner does a
+  // destructive single-node cluster-reset.
+  listEtcdSnapshots: () =>
+    api
+      .get<EtcdSnapshots>("/appliance/fleet/control-plane/etcd-snapshots")
+      .then((r) => r.data),
+  restoreEtcdSnapshot: (snapshot_name: string, confirm_hostname: string) =>
+    api
+      .post<EtcdSnapshots>("/appliance/fleet/control-plane/restore", {
+        snapshot_name,
+        confirm_hostname,
+      })
       .then((r) => r.data),
   // #170 Wave D1 — OS slot upgrade + reboot affordances on the
   // Fleet drilldown. Appliance-only deployments; the API surfaces a
@@ -10152,7 +10191,20 @@ export const postgresApi = {
         params: { limit },
       })
       .then((r) => r.data),
+  // #272 follow-up — alembic schema-head divergence (cold-boot / rolling
+  // upgrade visibility; the readiness probe gates on the same check).
+  schemaHealth: () =>
+    api
+      .get<PostgresSchemaHealth>("/admin/postgres/schema-health")
+      .then((r) => r.data),
 };
+
+export interface PostgresSchemaHealth {
+  status: "ok" | "behind" | "error";
+  expected_head: string | null;
+  db_revision: string | null;
+  detail: string;
+}
 
 // ── Redis insights (#358) ─────────────────────────────────────────────
 export interface RedisReplica {

--- a/frontend/src/pages/admin/PlatformInsightsPage.tsx
+++ b/frontend/src/pages/admin/PlatformInsightsPage.tsx
@@ -115,6 +115,14 @@ function PostgresPanel() {
     queryFn: () => postgresApi.slowQueries(20),
     refetchInterval: 60_000,
   });
+  // #272 follow-up — alembic schema-head divergence (cold-boot / rolling
+  // upgrade visibility). Polls a touch faster than the rest so a pending
+  // migration clears from the banner soon after the migrate Job runs.
+  const schema = useQuery({
+    queryKey: ["pg-schema-health"],
+    queryFn: () => postgresApi.schemaHealth(),
+    refetchInterval: 15_000,
+  });
 
   const ov: PostgresOverview | undefined = overview.data;
 
@@ -162,6 +170,57 @@ function PostgresPanel() {
           icon={HardDrive}
         />
       </div>
+
+      {/* #272 follow-up — alembic schema-head divergence. Compact OK row;
+        prominent banner when behind / errored (the actionable cases). */}
+      {schema.data &&
+        (schema.data.status === "ok" ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <ShieldCheck className="h-3.5 w-3.5 text-emerald-500" />
+            Schema at alembic head{" "}
+            <span className="font-mono">{schema.data.expected_head}</span>.
+          </div>
+        ) : (
+          <div
+            className={cn(
+              "rounded-md border p-3",
+              schema.data.status === "behind"
+                ? "border-amber-500/40 bg-amber-500/5"
+                : "border-rose-500/40 bg-rose-500/5",
+            )}
+          >
+            <div
+              className={cn(
+                "flex items-center gap-2 text-sm font-medium",
+                schema.data.status === "behind"
+                  ? "text-amber-800 dark:text-amber-300"
+                  : "text-rose-800 dark:text-rose-300",
+              )}
+            >
+              <AlertTriangle className="h-4 w-4" />
+              {schema.data.status === "behind"
+                ? "Database schema is behind this image"
+                : "Schema-head check failed"}
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {schema.data.detail}
+            </p>
+            <div className="mt-2 flex flex-wrap gap-x-6 gap-y-1 text-xs">
+              <div>
+                <span className="text-muted-foreground">Image expects</span>{" "}
+                <span className="font-mono">
+                  {schema.data.expected_head ?? "—"}
+                </span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">DB revision</span>{" "}
+                <span className="font-mono">
+                  {schema.data.db_revision ?? "—"}
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
 
       {ov?.longest_transaction && (
         <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3">

--- a/frontend/src/pages/appliance/EtcdSnapshotsCard.tsx
+++ b/frontend/src/pages/appliance/EtcdSnapshotsCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  applianceFleetApi,
+  applianceApprovalApi,
   formatApiError,
   type EtcdSnapshotRow,
 } from "@/lib/api";
@@ -39,7 +39,7 @@ export function EtcdSnapshotsCard() {
   const qc = useQueryClient();
   const { data, isLoading } = useQuery({
     queryKey: ["appliance", "etcd-snapshots"],
-    queryFn: applianceFleetApi.listEtcdSnapshots,
+    queryFn: applianceApprovalApi.listEtcdSnapshots,
     staleTime: 20_000,
     // Poll faster while a restore is in flight so the state banner tracks
     // the host runner; idle otherwise.
@@ -57,7 +57,7 @@ export function EtcdSnapshotsCard() {
 
   const restore = useMutation({
     mutationFn: ({ name, hostname }: { name: string; hostname: string }) =>
-      applianceFleetApi.restoreEtcdSnapshot(name, hostname),
+      applianceApprovalApi.restoreEtcdSnapshot(name, hostname),
     onSuccess: (res) => {
       qc.setQueryData(["appliance", "etcd-snapshots"], res);
       setRestoreTarget(null);

--- a/frontend/src/pages/appliance/EtcdSnapshotsCard.tsx
+++ b/frontend/src/pages/appliance/EtcdSnapshotsCard.tsx
@@ -1,0 +1,250 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  applianceFleetApi,
+  formatApiError,
+  type EtcdSnapshotRow,
+} from "@/lib/api";
+import { Modal } from "@/components/ui/modal";
+
+// #272 Phase 9b — etcd snapshot inventory + guided restore.
+//
+// Self-contained card rendered in Fleet → Control plane. The seed
+// reports its local ``k3s etcd-snapshot list`` (via the ETCDSnapshotFile
+// CRs) on heartbeat; this lists them and offers a guided restore. The
+// restore is the MOST destructive control-plane op — a single-node
+// cluster-reset that orphans every other member — so it's gated behind a
+// typed-hostname confirm on top of the superadmin API gate.
+
+function fmtBytes(n: number | null): string {
+  if (n == null) return "—";
+  if (n < 1024) return `${n} B`;
+  const units = ["KiB", "MiB", "GiB", "TiB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(1)} ${units[i]}`;
+}
+
+function fmtTime(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+export function EtcdSnapshotsCard() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery({
+    queryKey: ["appliance", "etcd-snapshots"],
+    queryFn: applianceFleetApi.listEtcdSnapshots,
+    staleTime: 20_000,
+    // Poll faster while a restore is in flight so the state banner tracks
+    // the host runner; idle otherwise.
+    refetchInterval: (q) =>
+      q.state.data?.desired_restore_snapshot ||
+      q.state.data?.restore_state === "restoring"
+        ? 5_000
+        : 30_000,
+  });
+
+  const [restoreTarget, setRestoreTarget] = useState<EtcdSnapshotRow | null>(
+    null,
+  );
+  const [typed, setTyped] = useState("");
+
+  const restore = useMutation({
+    mutationFn: ({ name, hostname }: { name: string; hostname: string }) =>
+      applianceFleetApi.restoreEtcdSnapshot(name, hostname),
+    onSuccess: (res) => {
+      qc.setQueryData(["appliance", "etcd-snapshots"], res);
+      setRestoreTarget(null);
+      setTyped("");
+    },
+  });
+
+  // Hide entirely on a docker / k8s control plane (no appliance seed).
+  if (!isLoading && !data?.available) return null;
+
+  const inFlight = !!data?.desired_restore_snapshot;
+  const failed = data?.restore_state === "failed";
+  const seedHostname = data?.seed_hostname ?? "";
+
+  return (
+    <section className="rounded-lg border bg-card p-4 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">
+          etcd snapshots — disaster recovery
+        </h3>
+        {seedHostname && (
+          <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+            seed: {seedHostname}
+          </span>
+        )}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Recoverable etcd snapshots from the cluster seed (k3s takes one every
+        6&nbsp;h, retains 8). Restoring is{" "}
+        <strong className="text-rose-600 dark:text-rose-400">
+          destructive
+        </strong>{" "}
+        — it resets the cluster to a single etcd member from the snapshot, and
+        every other control-plane node is orphaned and must be re-paired via{" "}
+        <strong>Replace</strong>. Use only for recovery from a bad cluster
+        state, never routinely.
+      </p>
+
+      {/* In-flight / failed restore banner. */}
+      {inFlight && (
+        <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-xs text-amber-700 dark:text-amber-400">
+          <strong>Restore in progress</strong> —{" "}
+          <span className="font-mono">{data?.desired_restore_snapshot}</span>{" "}
+          (state: {data?.restore_state || "pending"}). The seed will reset +
+          restart k3s; the Web UI may blip while it converges.
+        </div>
+      )}
+      {failed && !inFlight && (
+        <div className="mt-3 rounded-md border border-rose-500/40 bg-rose-500/10 p-2.5 text-xs text-rose-700 dark:text-rose-400">
+          <strong>Last restore failed</strong>
+          {data?.restore_reason ? <> — {data.restore_reason}</> : null}. Pick a
+          snapshot to retry.
+        </div>
+      )}
+
+      {isLoading ? (
+        <p className="mt-3 text-sm text-muted-foreground">Loading…</p>
+      ) : (data?.snapshots.length ?? 0) === 0 ? (
+        <p className="mt-3 text-sm text-muted-foreground">
+          No snapshots reported yet (the seed reports them on heartbeat; a fresh
+          cluster takes its first within ~6&nbsp;h, or run{" "}
+          <code>k3s etcd-snapshot save</code> on the seed for one now).
+        </p>
+      ) : (
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full min-w-[36rem] text-left text-xs">
+            <thead className="text-muted-foreground">
+              <tr className="border-b">
+                <th className="py-1.5 pr-3 font-medium">Snapshot</th>
+                <th className="py-1.5 pr-3 font-medium">Node</th>
+                <th className="py-1.5 pr-3 font-medium">Size</th>
+                <th className="py-1.5 pr-3 font-medium">Created</th>
+                <th className="py-1.5" />
+              </tr>
+            </thead>
+            <tbody>
+              {data?.snapshots.map((s) => (
+                <tr
+                  key={`${s.node_name}/${s.name}`}
+                  className="border-b last:border-0"
+                >
+                  <td className="py-1.5 pr-3 font-mono break-all">{s.name}</td>
+                  <td className="py-1.5 pr-3">{s.node_name || "—"}</td>
+                  <td className="py-1.5 pr-3 tabular-nums">
+                    {fmtBytes(s.size)}
+                  </td>
+                  <td className="py-1.5 pr-3 whitespace-nowrap">
+                    {fmtTime(s.created_at)}
+                  </td>
+                  <td className="py-1.5 text-right">
+                    <button
+                      type="button"
+                      disabled={inFlight}
+                      onClick={() => {
+                        setRestoreTarget(s);
+                        setTyped("");
+                      }}
+                      className="rounded-md border border-rose-500/40 px-2 py-1 text-rose-600 hover:bg-rose-500/10 disabled:opacity-40 dark:text-rose-400"
+                    >
+                      Restore…
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Guided restore confirm — typed-hostname gate on the destructive op. */}
+      {restoreTarget && (
+        <Modal
+          title="Restore etcd snapshot?"
+          onClose={() => {
+            setRestoreTarget(null);
+            setTyped("");
+          }}
+        >
+          <div className="space-y-3 text-sm">
+            <div className="rounded-md border border-rose-500/40 bg-rose-500/10 p-3 text-xs text-rose-700 dark:text-rose-400">
+              <p className="font-semibold">
+                This is a destructive, single-node cluster-reset.
+              </p>
+              <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                <li>
+                  The seed resets etcd to a 1-member cluster restored from this
+                  snapshot, then restarts k3s.
+                </li>
+                <li>
+                  Every <strong>other</strong> control-plane member is orphaned
+                  and must be re-paired afterwards via <strong>Replace</strong>.
+                </li>
+                <li>The Web UI / API will blip while the seed converges.</li>
+              </ul>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Restoring{" "}
+              <span className="font-mono break-all">{restoreTarget.name}</span>{" "}
+              (node {restoreTarget.node_name || "—"},{" "}
+              {fmtTime(restoreTarget.created_at)}).
+            </p>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-muted-foreground">
+                Type the seed hostname{" "}
+                <span className="font-mono">{seedHostname}</span> to confirm
+              </span>
+              <input
+                value={typed}
+                onChange={(e) => setTyped(e.target.value)}
+                placeholder={seedHostname}
+                className="w-full rounded-md border bg-background px-2 py-1 font-mono text-xs"
+                autoFocus
+              />
+            </div>
+            {restore.isError && (
+              <p className="text-xs text-rose-600">
+                {formatApiError(restore.error)}
+              </p>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setRestoreTarget(null);
+                  setTyped("");
+                }}
+                className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={typed.trim() !== seedHostname || restore.isPending}
+                onClick={() =>
+                  restore.mutate({
+                    name: restoreTarget.name,
+                    hostname: typed.trim(),
+                  })
+                }
+                className="rounded-md border border-rose-500/50 bg-rose-600 px-3 py-1.5 text-sm text-white hover:bg-rose-700 disabled:opacity-40"
+              >
+                {restore.isPending ? "Restoring…" : "Restore snapshot"}
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -37,6 +37,7 @@ import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { useSessionState } from "@/lib/useSessionState";
 import { cn } from "@/lib/utils";
+import { EtcdSnapshotsCard } from "./EtcdSnapshotsCard";
 import { LLDPTab } from "./LLDPTab";
 import { NTPTab } from "./NTPTab";
 import { PairingTab } from "./PairingTab";
@@ -1333,6 +1334,9 @@ export function FleetTab({
                     onPermanentDelete={(row) => setPermanentDeleteTarget(row)}
                     onReplace={(row) => setReplaceTarget(row)}
                   />
+                  {/* #272 Phase 9b — etcd snapshot list + guided restore.
+                    Self-hides on docker / k8s control planes (no seed). */}
+                  <EtcdSnapshotsCard />
                   <ApplianceTableSection
                     title="Service agents"
                     subtitle="Appliance nodes running DNS / DHCP service containers paired to a remote control plane."

--- a/frontend/src/pages/appliance/NetworkTab.tsx
+++ b/frontend/src/pages/appliance/NetworkTab.tsx
@@ -312,6 +312,9 @@ function MetalLBConfigCard() {
   const [enabled, setEnabled] = useState(false);
   const [poolText, setPoolText] = useState("");
   const [vip, setVip] = useState("");
+  // #272 Phase 10 — data-plane resolver VIPs (optional; live in Advanced).
+  const [dnsVip, setDnsVip] = useState("");
+  const [dhcpRelayVip, setDhcpRelayVip] = useState("");
   const [dirty, setDirty] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
 
@@ -323,15 +326,19 @@ function MetalLBConfigCard() {
       const pool = data.pool_addresses ?? [];
       setPoolText(pool.join("\n"));
       setVip(data.control_plane_vip ?? "");
+      setDnsVip(data.dns_vip ?? "");
+      setDhcpRelayVip(data.dhcp_relay_vip ?? "");
       // Auto-reveal the Advanced pool field when the saved pool is a
       // real range (not just the auto-derived <vip>/32) so editing an
-      // existing custom pool isn't hidden behind the disclosure.
+      // existing custom pool isn't hidden behind the disclosure. A
+      // data-plane VIP also lives in Advanced, so reveal for those too.
       const autoPool = data.control_plane_vip
         ? [`${data.control_plane_vip}/32`, `${data.control_plane_vip}/128`]
         : [];
       const isCustom =
         pool.length > 1 || (pool.length === 1 && !autoPool.includes(pool[0]));
-      if (isCustom) setShowAdvanced(true);
+      if (isCustom || data.dns_vip || data.dhcp_relay_vip)
+        setShowAdvanced(true);
     }
   }, [data, dirty]);
 
@@ -372,6 +379,11 @@ function MetalLBConfigCard() {
       // range is only sent when Advanced is open.
       pool_addresses: showAdvanced ? poolAddresses : [],
       control_plane_vip: vip.trim(),
+      // Data-plane VIPs are sent unconditionally (no auto-derive); the
+      // seeded value carries through even if Advanced is collapsed, so a
+      // pool-only edit can't silently drop a configured resolver VIP.
+      dns_vip: dnsVip.trim(),
+      dhcp_relay_vip: dhcpRelayVip.trim(),
     });
   };
 
@@ -417,7 +429,9 @@ function MetalLBConfigCard() {
           one address regardless of which control-plane node is up (multi-node
           HA). Just enter the VIP — a matching <code>/32</code> pool is created
           for you. Applied across the cluster by the seed within ~60&nbsp;s; the
-          served certificate auto-adds the VIP to its SANs.
+          served certificate auto-adds the VIP to its SANs. Open{" "}
+          <strong>Advanced</strong> to widen the pool and add data-plane
+          resolver VIPs (DNS&nbsp;:53 / DHCP relay&nbsp;:67).
         </p>
 
         {/* Live status — only meaningful once enabled. */}
@@ -490,25 +504,71 @@ function MetalLBConfigCard() {
                 {showAdvanced ? "▾" : "▸"} Advanced — custom address pool
               </button>
               {showAdvanced && (
-                <div className="flex flex-col gap-1">
-                  <textarea
-                    value={poolText}
-                    onChange={(e) => {
-                      setPoolText(e.target.value);
-                      setDirty(true);
-                    }}
-                    rows={2}
-                    placeholder={
-                      "192.168.0.240/29\n192.168.0.240-192.168.0.247"
-                    }
-                    className="w-full rounded-md border bg-background px-2 py-1 font-mono text-xs"
-                  />
-                  <span className="text-[11px] text-muted-foreground">
-                    One CIDR or range per line. Leave blank to auto-create a{" "}
-                    <code>/32</code> from the VIP. Provide a range only for
-                    headroom, data-plane VIPs, or BGP. The VIP must fall inside
-                    the pool.
-                  </span>
+                <div className="flex flex-col gap-3">
+                  <div className="flex flex-col gap-1">
+                    <textarea
+                      value={poolText}
+                      onChange={(e) => {
+                        setPoolText(e.target.value);
+                        setDirty(true);
+                      }}
+                      rows={2}
+                      placeholder={
+                        "192.168.0.240/29\n192.168.0.240-192.168.0.247"
+                      }
+                      className="w-full rounded-md border bg-background px-2 py-1 font-mono text-xs"
+                    />
+                    <span className="text-[11px] text-muted-foreground">
+                      One CIDR or range per line. Leave blank to auto-create a{" "}
+                      <code>/32</code> from the VIP. Provide a range only for
+                      headroom, data-plane VIPs, or BGP. Every VIP must fall
+                      inside the pool.
+                    </span>
+                  </div>
+
+                  {/* #272 Phase 10 — data-plane resolver VIPs. Optional;
+                    need a pool wide enough to hold them alongside the
+                    control-plane VIP. Empty = the hostNetwork data plane. */}
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      DNS resolver VIP (:53) — optional
+                    </span>
+                    <input
+                      value={dnsVip}
+                      onChange={(e) => {
+                        setDnsVip(e.target.value);
+                        setDirty(true);
+                      }}
+                      placeholder="192.168.0.241"
+                      className="w-full rounded-md border bg-background px-2 py-1 font-mono text-xs"
+                    />
+                    <span className="text-[11px] text-muted-foreground">
+                      One floating IP for BIND9 / PowerDNS so clients use a
+                      single resolver address that follows whichever node is up
+                      (the resolver Pods drop <code>hostNetwork</code> behind an
+                      L2 LoadBalancer). Must differ from the control-plane VIP.
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      DHCP relay VIP (:67) — optional
+                    </span>
+                    <input
+                      value={dhcpRelayVip}
+                      onChange={(e) => {
+                        setDhcpRelayVip(e.target.value);
+                        setDirty(true);
+                      }}
+                      placeholder="192.168.0.242"
+                      className="w-full rounded-md border bg-background px-2 py-1 font-mono text-xs"
+                    />
+                    <span className="text-[11px] text-muted-foreground">
+                      Stabilises a DHCP relay's <code>forward-to</code> target
+                      so it outlives a single Kea node. Kea keeps{" "}
+                      <code>hostNetwork</code>:67 for direct-attached broadcast
+                      — this VIP only fronts the relay→server unicast forward.
+                    </span>
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Finishes the remaining **code** for control-plane HA (#272). The two open code phases (9b + 10) plus the two non-blocking deferred follow-ups. **Live multi-node VM testing (promote → restore → VIP claim) remains the gate to actually close #272** — the destructive cluster-reset path can't be exercised in CI.

## Phase 10 — data-plane resolver VIPs
Phase 5 shipped the chart gates; this wires the operator-facing config (mirroring the 7c control-plane-VIP path exactly).
- `dns_vip` (:53) drops bind9/powerdns off `hostNetwork` behind an L2 LoadBalancer; `dhcp_relay_vip` (:67) fronts the Kea relay→server unicast forward (Kea keeps `hostNetwork` for broadcast).
- New `platform_settings.dns_vip` / `dhcp_relay_vip`; `…/control-plane/metallb` carries them with **VIP-in-pool + distinct-VIP** validation.
- Seed upserts the `spatiumddi-appliance` HelmChartConfig (`dns.useMetalLBVIP`/`dns.vip`/`dhcpKea.relayVIP`) via `apply_dataplane_vip_overrides` — same reboot-safe overlay mechanism as cp-size + the control-plane VIP.
- Fleet → **Network & Host → MetalLB → Advanced** gains the two pickers; `find_control_plane_vip` MCP tool widened to report them.

## Phase 9b — guided etcd snapshot restore
- The seed reports its `k3s etcd-snapshot list` (read from the `ETCDSnapshotFile` CRs over the kubeapi — **no host `k3s` binary needed**) on heartbeat → `appliance.etcd_snapshots`.
- **Fleet → Control plane** gains an etcd-snapshots card; **Restore** is gated behind a typed-hostname confirm (on top of superadmin), stamps `desired_restore_snapshot`, and fires the host-side `spatium-cluster-restore` runner (`k3s server --cluster-reset --cluster-reset-restore-path=…`, `SPATIUMDDI-CLUSTER-RESTORE-CONFIRM-V1`-guarded, `.path`/`.service` units + postinst).
- ⚠️ A restore is a **single-node cluster-reset** — other members are orphaned and re-paired via Replace. Disaster recovery only; local snapshots only (S3 restore deferred).
- Read-only `find_etcd_snapshots` MCP tool.

## Deferred follow-ups (non-blocking, from the #272 issue)
- **Schema-head divergence panel** on Platform Insights → Postgres (`/postgres/schema-health`), reusing the readiness probe's cached alembic-head reader — cold-boot / mid-rolling-upgrade visibility without a 502 guess.
- **Stale-source-image guard** on `make appliance-baked-iso`: refuses `>24h`-old local images unless `--allow-stale-images` / `ALLOW_STALE_IMAGES=1`.

## Migration
`f1a4c7b2e9d6` — additive (2 `platform_settings` + 4 `appliance` columns); applies cleanly on the dev DB; downgrade-drops baselined for the #296 migration-shape linter.

## Testing
- New backend tests (12) for the data-plane VIP validation + the etcd snapshot list / restore guards — **pass** alongside the existing control-plane suite (32 total).
- New supervisor unit tests for the restore trigger writer + the VIP-override rendering — **pass** (122 total). Also fixed a **stale #272 Phase 7b test** (the cluster-join trigger payload gained a confirm marker; the assertion predated it).
- ruff + black + mypy + eslint + prettier + tsc all clean.
- ⚠️ 4 pre-existing supervisor-suite failures (`test_register` ×2, `test_smoke` ×2) are **#170** drift (register reshape + the documented `su-exec spatium:spatium`→`su-exec spatium` docker.sock fix), unrelated to this PR, in a non-CI-gated suite — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
