### PR TITLE
feat(ui): #380 point Platform Insights → Containers to Appliance → Pods on k3s appliances

### DIFF
--- a/frontend/src/pages/admin/PlatformInsightsPage.tsx
+++ b/frontend/src/pages/admin/PlatformInsightsPage.tsx
@@ -20,6 +20,7 @@ import {
   postgresApi,
   containersApi,
   redisApi,
+  versionApi,
   type PostgresOverview,
   type PostgresTableSize,
   type PostgresConnection,
@@ -426,6 +427,8 @@ function PostgresPanel() {
 }
 
 function ContainersPanel() {
+  const version = useQuery({ queryKey: ["version"], queryFn: versionApi.get });
+  const isAppliance = !!version.data?.appliance_mode;
   const [prefix, setPrefix] = useState("spatiumddi-");
   const [includeStopped, setIncludeStopped] = useState(false);
   const stats = useQuery({
@@ -433,7 +436,35 @@ function ContainersPanel() {
     queryFn: () =>
       containersApi.stats({ prefix, include_stopped: includeStopped }),
     refetchInterval: 5_000,
+    // No operator-facing Docker socket on the k3s appliance — don't poll it;
+    // we point at Appliance → Pods instead (below).
+    enabled: !isAppliance,
   });
+
+  // On a k3s appliance the control-plane workloads run as Kubernetes pods,
+  // not Docker containers, so this docker-stats view is empty/irrelevant.
+  // Send the operator to the Appliance → Pods surface (live logs + restart).
+  if (isAppliance) {
+    return (
+      <div className="rounded border border-blue-500/40 bg-blue-500/5 p-4">
+        <div className="flex items-center gap-2 text-sm font-medium text-blue-800 dark:text-blue-300">
+          <Box className="h-4 w-4" />
+          This appliance runs on k3s
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Control-plane workloads run as Kubernetes pods, not Docker containers.
+          View and manage them — with restart and live log streaming — under{" "}
+          <Link
+            to="/appliance?tab=containers"
+            className="font-medium text-primary hover:underline"
+          >
+            Appliance → Pods
+          </Link>
+          .
+        </p>
+      </div>
+    );
+  }
 
   if (stats.data && !stats.data.available) {
     return (


### PR DESCRIPTION
Closes #380.

## Problem

On a k3s appliance, **Platform Insights → Containers** shows the Docker-`ps`-style view, which is empty / irrelevant there — the control-plane workloads (api / frontend / worker / agents / …) run as **Kubernetes pods**, surfaced under **Appliance → Pods**. Operators landing on the Containers tab got an empty/"Docker socket not mounted" panel with no signpost to the right place.

## Change

In `ContainersPanel` (`frontend/src/pages/admin/PlatformInsightsPage.tsx`):

- When `appliance_mode` is true (read from `versionApi.get`), render an info card — _"This appliance runs on k3s — control-plane workloads run as Kubernetes pods, not Docker containers"_ — with a deep-link to **Appliance → Pods** (`/appliance?tab=containers`, which already has restart + live log streaming).
- Gate the docker-stats query with `enabled: !isAppliance` so an appliance doesn't poll a non-existent Docker socket every 5 s.
- **Non-appliance (docker / k8s) control planes are unchanged** — same Docker container table as before.

The Pods tab is `selfOnly` (visible on appliance hosts) and not feature-gated, so the deep-link lands correctly.

## Verification

- eslint, `tsc`, Prettier — clean
- `npm run build` (CI-parity Frontend Build) — ✓ built clean

Note: the appliance branch can't be exercised on the docker-compose dev stack (`appliance_mode` is false there, so the existing Docker view renders unchanged); the logic is a simple `if (appliance_mode) return <pointer>` and the deep-link target is verified against the Pods tab key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
