### PR TITLE
fix(appliance): #379 stop nftables flush from wiping kube-proxy rules (CNPG crash-loop)

### DIFF
--- a/appliance/mkosi.extra/etc/nftables.conf
+++ b/appliance/mkosi.extra/etc/nftables.conf
@@ -16,8 +16,22 @@
 # Custom additions: drop a *.nft file in /etc/nftables.d/ —
 # `nft -f /etc/nftables.conf` loads the main config first, then
 # appends from /etc/nftables.d/.
-
-flush ruleset
+#
+# Issue #379 — do NOT `flush ruleset` here. On this Debian iptables-nft
+# host, kube-proxy + flannel keep their service / forwarding rules in the
+# `ip`/`ip6` {nat,filter,mangle} tables — the kube-API ClusterIP DNAT
+# (10.43.0.1:443 → node:6443) lives in `ip nat`. `flush ruleset` wipes
+# EVERY family, so each apply of this file — at boot AND on every
+# supervisor role re-render (e.g. enabling DHCP, which rewrites
+# spatium-role.nft and re-runs `nft -f`) — destroyed kube-proxy's rules
+# until it re-synced ~30-60 s later. In that window in-cluster pods can't
+# reach 10.43.0.1:443 and crash-loop (the CNPG operator was the visible
+# victim). Instead, atomically replace ONLY our table: `add`
+# (create-if-absent guard so the `delete` can't fail on first load) +
+# `delete`, then redefine below. kube-proxy / flannel's `ip`/`ip6` tables
+# are never touched.
+add table inet filter
+delete table inet filter
 
 table inet filter {
     chain input {


### PR DESCRIPTION
Closes #379.

## Root cause — and it explains *both* the boot and DHCP-enable crashes

#379 was written up as a cosmetic **early-boot timing** race (the CNPG operator starts before kube-proxy programs the `10.43.0.1` route). Field observation that the **same crash happens when enabling the DHCP server** (not just at boot) pointed at the real, unifying cause:

The appliance firewall apply runs **`nft flush ruleset`** in `/etc/nftables.conf`. On this Debian **iptables-nft** host, kube-proxy + flannel keep their rules in the `ip`/`ip6` `{nat,filter,mangle}` tables — the kube-API ClusterIP DNAT (`10.43.0.1:443 → node:6443`) lives in `ip nat`. `flush ruleset` wipes **every family**, so each `nft -f /etc/nftables.conf` destroys kube-proxy's rules until it re-syncs ~30–60 s later. In that window any in-cluster pod talking to `10.43.0.1` gets `i/o timeout` and crash-loops — the CNPG bootstrap operator was the visible victim.

That apply fires on **every** reload:
- **At boot** — the supervisor's first heartbeats render `spatium-role.nft` and reload, each flush clobbering kube-proxy *after* it programmed → the observed 4 restarts.
- **On DHCP enable** — the role re-render rewrites `spatium-role.nft` and reloads → same flush → same crash (no boot timing involved, which is why this observation was the key clue).

So this is **not** a pure start-ordering race; the `wait-for-apiserver` initContainer proposed in the issue would have masked only the boot case and done nothing for DHCP-enable.

## Fix

In `appliance/mkosi.extra/etc/nftables.conf`, replace `flush ruleset` with an atomic **single-table** replace:

```nft
add table inet filter      # create-if-absent guard so delete can't fail on first load
delete table inet filter
table inet filter { … }
```

Our `inet filter` table is fully replaced on each apply (no stale-rule leak); kube-proxy / flannel's `ip`/`ip6` tables are never touched.

## Verification (live, on a `2026.06.11-1` appliance)

| | `ip nat` 10.43.0.1 rules |
|---|---|
| Before | 8 |
| After applying the fixed config | **8** (old `flush ruleset` → 0) |
| After a 2nd re-apply (simulating the DHCP-role re-render) | **8** |

`nft -c -f` parses clean; reload from the real `/etc/nftables.conf` path keeps kube-proxy intact; the CNPG operator does not restart. Appliance-config only — no Python/TS, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
