### PR TITLE
fix(dhcp): #383 Kea raw sockets fail under su-exec (no cap_net_raw) — directly-attached DHCP dead on 2026.06.11-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,45 @@ the formatter handles the rest.
 
 ---
 
+## 2026.06.11-2 — 2026-06-11
+
+Hotfix for **directly-attached DHCP dead on 2026.06.11-1** (#383).
+The prior release switched Kea's default socket mode to `raw`
+(AF_PACKET) so it hears directly-attached broadcast DISCOVERs
+(#365 / #366), but the Kea binaries only carried the
+`cap_net_bind_service` file capability — not `cap_net_raw`. The
+container's `NET_RAW` (from `securityContext.capabilities.add`)
+only sets the bounding set and is dropped when the entrypoint
+`su-exec`s to the unprivileged `spatium` user, so `kea-dhcp4`
+failed to open the raw LPF socket (`DHCPSRV_OPEN_SOCKET_FAIL` /
+`DHCPSRV_NO_SOCKETS_OPEN`) and served no leases on any
+non-relayed network. The same missing-capability gap left the
+opt-in scapy rogue-DHCP probe (#370) and passive fingerprint
+sniffer with zero effective caps. Image-only change — no schema,
+no API, no frontend.
+
+### Fixed
+
+- **Kea raw sockets under `su-exec` (#383).** The Kea image now
+  grants `cap_net_raw` alongside `cap_net_bind_service` as a
+  *file* capability on `/usr/sbin/kea-dhcp4` + `/usr/sbin/kea-dhcp6`
+  (`setcap cap_net_bind_service,cap_net_raw=+ep`). File caps
+  survive the `su-exec` 0→non-root privilege drop, where the
+  container-level bounding-set capability does not — so the raw
+  AF_PACKET/LPF socket opens and Kea serves leases on
+  directly-attached networks again. Same fix shape as `named` /
+  `pdns_server` in the DNS image family.
+- **Python agent rogue-probe / fingerprint sniffer caps (#383).**
+  The entrypoint now launches `spatium-dhcp-agent` via util-linux
+  `setpriv --reuid spatium --regid spatium --init-groups
+  --inh-caps +net_raw --ambient-caps +net_raw` so `CAP_NET_RAW`
+  lands in the *ambient* set — which survives setuid + execve into
+  the unprivileged user (a Python interpreter can't carry a file
+  cap the way the Kea binaries can). The opt-in rogue-DHCP probe
+  (`DHCP_ROGUE_PROBE_ENABLED=1`) and passive fingerprint sniffer
+  (`DHCP_FINGERPRINT_ENABLED=1`) can now bind their scapy
+  AF_PACKET sockets.
+
 ## 2026.06.11-1 — 2026-06-11
 
 The **roadmap-batch + control-plane-HA-finish** release. Three

--- a/agent/dhcp/images/kea/Dockerfile
+++ b/agent/dhcp/images/kea/Dockerfile
@@ -32,6 +32,12 @@ FROM alpine:3.22 AS runtime
 # live on the binary as a file cap to survive the privilege drop. Same
 # fix as named + pdns_server in the DNS image family.
 #
+# ``setpriv`` (util-linux) is added for the python agent's launch: the
+# opt-in scapy rogue-DHCP probe + fingerprint sniffer need CAP_NET_RAW,
+# but a python interpreter can't carry a file cap, so the entrypoint
+# raises NET_RAW into the *ambient* set via setpriv (survives the
+# setuid + execve into ``spatium``). See entrypoint.sh (#383).
+#
 # ``kea>=2.6.5-r0`` ships the CVE-2026-3608 (HIGH) fix that Trivy flags
 # in 2.6.3-r0; the explicit ``>=`` lower-bound both pulls the patched
 # package AND busts the BuildKit ``cache-from`` layer so a stale
@@ -55,7 +61,7 @@ RUN apk upgrade --no-cache \
  && apk add --no-cache \
       'kea>=2.6.5-r0' kea-dhcp4 kea-dhcp6 kea-ctrl-agent kea-admin \
       kea-hook-lease-cmds kea-hook-ha \
-      tini su-exec \
+      tini su-exec setpriv \
       python3 py3-pip libpcap \
       libcap \
       ca-certificates tzdata \

--- a/agent/dhcp/images/kea/Dockerfile
+++ b/agent/dhcp/images/kea/Dockerfile
@@ -19,13 +19,18 @@ FROM alpine:3.22 AS runtime
 # for the sniffer to bind the socket — see docs/deployment/DOCKER.md.
 #
 # ``libcap`` brings in ``setcap`` so we can grant ``kea-dhcp4`` /
-# ``kea-dhcp6`` the CAP_NET_BIND_SERVICE file capability — without it,
-# the unprivileged ``spatium`` user the entrypoint drops to can't bind
-# UDP/67 (the DHCPv4 server port) or UDP/547 (the DHCPv6 server port).
-# Compose-side ``cap_add: NET_BIND_SERVICE`` only sets the container
-# bounding set; for a non-root process to actually use the cap, the
-# binary needs file caps. Same fix as named + pdns_server in the DNS
-# image family.
+# ``kea-dhcp6`` the CAP_NET_BIND_SERVICE + CAP_NET_RAW file capabilities.
+# NET_BIND_SERVICE: bind UDP/67 (DHCPv4) + UDP/547 (DHCPv6) as the
+# unprivileged ``spatium`` user the entrypoint drops to. NET_RAW: open
+# the AF_PACKET/LPF raw socket for ``dhcp-socket-type: raw`` (the
+# #365/#366 default — required to hear directly-attached broadcast
+# DISCOVERs); without it kea-dhcp4 fails with "Failed to create raw LPF
+# socket" on the real NIC and serves no leases (#383). Crucially:
+# container-level ``cap_add`` / ``securityContext.capabilities.add:
+# [NET_RAW]`` only sets the bounding set — it's DROPPED when the
+# entrypoint ``su-exec``s to the non-root user, so the capability has to
+# live on the binary as a file cap to survive the privilege drop. Same
+# fix as named + pdns_server in the DNS image family.
 #
 # ``kea>=2.6.5-r0`` ships the CVE-2026-3608 (HIGH) fix that Trivy flags
 # in 2.6.3-r0; the explicit ``>=`` lower-bound both pulls the patched
@@ -55,8 +60,8 @@ RUN apk upgrade --no-cache \
       libcap \
       ca-certificates tzdata \
       'libcrypto3>=3.5.7-r0' 'libssl3>=3.5.7-r0' \
- && setcap cap_net_bind_service=+ep /usr/sbin/kea-dhcp4 \
- && setcap cap_net_bind_service=+ep /usr/sbin/kea-dhcp6 \
+ && setcap cap_net_bind_service,cap_net_raw=+ep /usr/sbin/kea-dhcp4 \
+ && setcap cap_net_bind_service,cap_net_raw=+ep /usr/sbin/kea-dhcp6 \
  && addgroup -S spatium \
  && adduser -S -G spatium spatium \
  && mkdir -p /var/lib/spatium-dhcp-agent /var/lib/kea /run/kea /etc/kea /var/log/kea \

--- a/agent/dhcp/images/kea/entrypoint.sh
+++ b/agent/dhcp/images/kea/entrypoint.sh
@@ -165,7 +165,16 @@ _term() {
 }
 trap _term TERM INT
 
-su-exec spatium:spatium spatium-dhcp-agent &
+# The python agent runs the opt-in scapy rogue-DHCP probe (#370) +
+# passive fingerprint sniffer, which need CAP_NET_RAW to open
+# AF_PACKET sockets. ``su-exec``'s setuid clears the container's
+# NET_RAW on the 0→non-root privilege drop, and a python interpreter
+# can't carry a file capability the way kea-dhcp4/6 do — so use
+# ``setpriv`` to raise NET_RAW into the *ambient* set, which survives
+# setuid + execve into the unprivileged ``spatium`` user (#383).
+setpriv --reuid spatium --regid spatium --init-groups \
+        --inh-caps +net_raw --ambient-caps +net_raw \
+        spatium-dhcp-agent &
 AGENT_PID=$!
 
 # wait -n is a bash-ism; busybox ash accepts it too as of 1.30+


### PR DESCRIPTION
Closes #383

## Regression in 2026.06.11-1

`#365`/`#366` made `dhcp-socket-type: raw` the default so Kea hears directly-attached broadcast DISCOVERs. `raw` mode (and the opt-in scapy probes) need **`CAP_NET_RAW` on the process**, but the Kea image runs everything as the non-root `spatium` user (`su-exec`). The chart/compose `securityContext.capabilities.add: [NET_RAW]` only sets the container *bounding* set, which is **dropped on the `su-exec` privilege drop** — so:

- **`kea-dhcp4` couldn't open the raw socket** → `Failed to create raw LPF socket` → pod `0/1` → **no DHCP** on any deploy with a scope.
- **The scapy rogue-DHCP probe (#370) + fingerprint sniffer couldn't open AF_PACKET sockets** (the Python agent had `CapEff=0`).

## Fix — two parts, both needed

1. **Kea binaries (file caps):** `setcap cap_net_bind_service,cap_net_raw=+ep /usr/sbin/kea-dhcp{4,6}`. The container bounding set already permits `NET_RAW`, so the file cap makes it effective for the non-root process — same mechanism that already let it bind `:67` via `cap_net_bind_service`.
2. **Python agent (ambient caps):** a Python interpreter can't carry a file cap, so launch the agent via `setpriv --reuid spatium --regid spatium --init-groups --inh-caps +net_raw --ambient-caps +net_raw spatium-dhcp-agent` — ambient `NET_RAW` survives the setuid + execve. (busybox `setpriv` can't change uid; `capsh` hardcodes `/bin/bash`, absent on alpine — so util-linux `setpriv` is added.)

## Validated live on a real appliance (not just render/unit tests)

- `getcap` → `cap_net_bind_service,cap_net_raw=ep`; runtime `kea-dhcp4 CapEff=0x2400`, Python agent (uid `spatium`) `CapEff/CapAmb=0x2000`.
- **DHCP serving:** created an IPAM subnet + scope via the API → Kea reloaded, opened the raw socket on the real NIC (no `Failed to create raw LPF socket`, no `NO_SOCKETS_OPEN`, 13 AF_PACKET sockets), pod `1/1`.
- **Rogue detection:** enabled the probe → it broadcast DISCOVERs and detected the LAN router (`192.168.0.1`) as a `rogue` responder via `POST /dhcp/agents/dhcp-offers`, no scapy/permission errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)