### PR TITLE
chore: prep release 2026.06.12-1 (#383 DHCP raw-socket hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ the formatter handles the rest.
 
 ---
 
-## 2026.06.11-2 — 2026-06-11
+## 2026.06.12-1 — 2026-06-12
 
 Hotfix for **directly-attached DHCP dead on 2026.06.11-1** (#383).
 The prior release switched Kea's default socket mode to `raw`


### PR DESCRIPTION
Retitles the #383 hotfix CHANGELOG entry from `2026.06.11-2` to
`2026.06.12-1` so the release is cut under today's date.

The fix itself (Kea `cap_net_raw` file caps + `setpriv` ambient
NET_RAW for the Python agent) already merged in #384. This is a
docs-only one-line heading change so `release.yml` extracts the
correct `## 2026.06.12-1` CHANGELOG section into the GitHub release
body when the tag is pushed.

No code, schema, API, or frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)