### PR TITLE
fix(appliance): #386 single-appliance OS upgrade — TLS download, silent loop, full status + persistent image store

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -253,17 +253,16 @@ def _last_upgrade_state_from_sidecar() -> tuple[str | None, datetime | None]:
     runner maintains. Returns (state, when) or (None, None) when no
     upgrade has ever run on this agent.
 
-    Auto-heals stale ``failed`` states: the host runner renames the
-    pending trigger to ``.failed.<ts>`` once it finishes, so the
-    presence of the un-suffixed trigger file is the marker of an
-    in-flight apply. If state == failed AND the un-suffixed trigger
-    isn't present, the failure has already been recorded + processed
-    — by definition the operator has had time to observe it (typical
-    heartbeat cadence is 30 s) so the Fleet view's State pill
-    shouldn't stick on ``failed`` forever. Flip back to ``ready`` so
-    the agent's heartbeat naturally clears the chip on the control
-    plane within one cycle. The ``.failed.<ts>`` sidecar file still
-    exists on disk for forensic / audit lookup.
+    Reports ``failed`` honestly (#386). The earlier behaviour flipped a
+    stale ``failed`` back to ``ready`` the instant the trigger was
+    renamed to ``.failed.<ts>`` — which made a failing upgrade read as
+    ``ready`` on the Fleet chip within one heartbeat, hiding the failure
+    (and, paired with the silent re-fire loop, hiding it forever). A
+    failure now sticks until the operator clears or re-applies: the
+    backend's success auto-clear nulls ``desired_*`` once installed
+    matches, and ``clear_fleet_upgrade_marker`` resets a stale ``failed``
+    to ``ready`` when the control plane reports no upgrade desired (the
+    Cancel button / a cleared attempt).
 
     Fresh appliances that have never run an upgrade have no .state
     file at all — return ``ready`` rather than ``None`` so the Fleet
@@ -282,11 +281,6 @@ def _last_upgrade_state_from_sidecar() -> tuple[str | None, datetime | None]:
     state = parts[0] if parts else None
     if state not in ("ready", "in-flight", "done", "failed"):
         return None, None
-    # Stale-failed auto-heal — only when no apply is currently in
-    # flight (trigger file is the "in-flight" marker; rename to
-    # .failed.<ts> on finish).
-    if state == "failed" and not _TRIGGER_FILE.exists():
-        return "ready", None
     stamp = None
     if len(parts) > 1:
         try:
@@ -298,6 +292,27 @@ def _last_upgrade_state_from_sidecar() -> tuple[str | None, datetime | None]:
 
 _TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/slot-upgrade-pending")
 _REBOOT_TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/reboot-pending")
+# Issue #386 Part B — fire-once marker. Records the last
+# ``desired_slot_image_url`` the supervisor wrote a trigger for, so a
+# failed apply (which renames the trigger to ``.failed.<ts>`` and would
+# otherwise look "no trigger present → fire again") isn't silently
+# re-fired every heartbeat. We re-fire only when the desired URL
+# differs — the backend appends a per-apply nonce fragment, so a fresh
+# "Apply" of the same image re-triggers while a stuck failure does not.
+_FIRED_URL_MARKER = Path(
+    "/var/lib/spatiumddi-host/release-state/slot-upgrade-fired-url"
+)
+# Issue #386 Part C — host slot-upgrade log, mounted read-only into the
+# supervisor (charts/spatiumddi-appliance/templates/supervisor.yaml) so
+# the heartbeat can ship a tail to the Fleet drilldown while an apply is
+# in-flight / failed.
+_SLOT_UPGRADE_LOG = Path("/var/log/spatiumddi-host/slot-upgrade.log")
+# Issue #386 Part C — structured per-phase progress the host runner
+# writes (step / pct / detail / at). Lives in release-state (already
+# mounted into the supervisor), so it works without the log mount.
+_SLOT_UPGRADE_PROGRESS = Path(
+    "/var/lib/spatiumddi-host/release-state/slot-upgrade.progress"
+)
 # Per-slot installed-version sidecar maintained by ``spatium-upgrade-
 # slot sync-versions`` (called by spatiumddi-firstboot at every boot
 # + at the end of every apply). Shape: ``{"slot_a": "<version>",
@@ -448,66 +463,169 @@ _CLUSTER_RESTORE_STATE_SIDECAR = Path(
 def maybe_fire_fleet_upgrade(
     desired_version: str | None,
     desired_url: str | None,
+    desired_sha256: str | None = None,
+    desired_tls_insecure: bool = False,
 ) -> bool:
     """Phase 8f-4 — write the slot-upgrade trigger when the control
     plane's desired version doesn't match what's installed.
 
     Returns True if a trigger was fired (caller should log it), False
-    otherwise. Idempotent — multiple long-poll cycles with the same
-    desired_version produce one trigger, not many: we check whether
-    the trigger file already exists (the host-side path unit hasn't
-    picked it up yet) before writing a fresh one. We also skip when
-    the desired version equals what's already installed.
+    otherwise.
+
+    **Fire-once (#386 Part B).** A failed apply renames the trigger to
+    ``.failed.<ts>``, so the old "trigger file absent → fire" guard
+    re-fired the SAME desired-state every heartbeat — a silent
+    crash-loop that flooded ``.failed.*`` sidecars and never surfaced.
+    We now record the fired ``desired_slot_image_url`` (which carries a
+    per-apply nonce fragment) in ``_FIRED_URL_MARKER`` and skip when it
+    already matches: a stuck failure does NOT re-fire; a fresh Apply
+    (new nonce → different URL) does.
+
+    **Download hints (#386 Part A).** ``desired_sha256`` is written into
+    the trigger so the host runner verifies the bytes against it;
+    ``desired_tls_insecure`` adds an ``insecure-tls`` marker so the
+    runner skips cert-verify for the appliance's OWN self-served URL —
+    but ONLY when a sha256 is also present (verified bytes are the real
+    integrity guarantee).
 
     Conditions for firing:
       - Not running on an appliance (no /etc/spatiumddi-host) → skip.
-      - desired_version is None / empty → skip.
+      - desired_version / desired_url is None / empty → skip.
       - desired_version equals installed_appliance_version → skip.
+      - URL already fired (marker match) → skip (no re-fire loop).
       - Trigger file already present → skip (path unit hasn't picked
         it up yet; don't stack).
-      - desired_url is missing → skip (nothing to apply).
     """
     if detect_deployment_kind() != "appliance":
         return False
     if not desired_version or not desired_url:
         return False
-    # Issue #242 — only accept ``https://`` (preferred) or ``file://``
-    # (sneakernet / air-gap). Reject ``http://`` so a misconfigured
-    # control plane can't downgrade the OS-image fetch to cleartext
-    # over the WAN; reject unknown / unscheme'd URLs entirely so a
-    # tampered payload can't slip past as a relative path the host
-    # runner would resolve.
     desired_url_str = str(desired_url).strip()
     if not desired_url_str:
         return False
+    # Strip the #386 fire-once nonce fragment before any scheme / fetch
+    # work — URL fragments are client-side only and must never reach the
+    # host runner's ``urllib`` fetch. The UNSTRIPPED URL is the
+    # fire-once key (so a new nonce re-fires); the stripped URL is what
+    # the runner downloads.
+    fetch_url = desired_url_str.split("#", 1)[0]
+    # Issue #242 — only accept ``https://`` (preferred) or ``file://``
+    # (sneakernet / air-gap). Reject ``http://`` so a misconfigured
+    # control plane can't downgrade the OS-image fetch to cleartext
+    # over the WAN; reject unknown / unscheme'd URLs entirely.
     allowed_schemes = ("https://", "file://")
-    if not any(desired_url_str.lower().startswith(s) for s in allowed_schemes):
+    if not any(fetch_url.lower().startswith(s) for s in allowed_schemes):
         log.warning(
             "supervisor.appliance_state.rejected_upgrade_url_scheme",
-            url_prefix=desired_url_str.split("://", 1)[0][:32],
+            url_prefix=fetch_url.split("://", 1)[0][:32],
         )
         return False
     installed = read_installed_version()
     if installed and installed == desired_version:
         return False
+    # Fire-once: skip if we already wrote a trigger for this exact
+    # desired-state (same URL incl. nonce).
+    try:
+        if _FIRED_URL_MARKER.read_text(encoding="utf-8").strip() == desired_url_str:
+            return False
+    except OSError:
+        pass
     if _TRIGGER_FILE.exists():
         return False
+    # Only relax TLS when we also have a hash to verify the bytes.
+    insecure = bool(desired_tls_insecure) and bool(desired_sha256)
     # The trigger file's parent should already exist on the appliance
     # (firstboot creates /var/lib/spatiumddi/release-state). Bail
-    # silently if it doesn't — host setup is broken; the operator
-    # will see "upgrade requested but agent couldn't write trigger"
-    # in the audit log on the control plane side once the heartbeat
-    # comes back without a state change.
+    # silently if it doesn't — host setup is broken; the control plane
+    # sees the heartbeat come back without a state change.
     try:
         _TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
+        # Trigger format the host runner parses: line 1 = image URL (or
+        # path, fragment stripped); optional ``sha256=<hex>`` +
+        # ``insecure-tls`` marker lines. Legacy two-line (line 2 = bare
+        # checksum URL) is still accepted by the runner for the
+        # self-panel apply path.
+        lines = [fetch_url]
+        if desired_sha256:
+            lines.append(f"sha256={desired_sha256.strip().lower()}")
+        if insecure:
+            lines.append("insecure-tls")
         tmp = _TRIGGER_FILE.with_suffix(".new")
-        # Two-line format the host runner expects (Phase 8b-3 contract):
-        # line 1 = image URL (or path), line 2 = optional checksum URL.
-        tmp.write_text(desired_url + "\n", encoding="utf-8")
+        tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
         tmp.replace(_TRIGGER_FILE)
+        try:
+            _FIRED_URL_MARKER.write_text(desired_url_str + "\n", encoding="utf-8")
+        except OSError:
+            pass
+        _prune_failed_sidecars()
         return True
     except OSError:
         return False
+
+
+def clear_fleet_upgrade_marker() -> None:
+    """#386 Part B — the control plane reports no upgrade desired
+    (cleared via the Cancel button, or never set). Drop the fire-once
+    marker so a future Apply of the same URL re-fires, and reset a stale
+    ``failed`` state back to ``ready`` so a cancelled failure stops
+    sticking on the Fleet chip. No-op off-appliance, and never touches
+    an in-flight apply (trigger file present)."""
+    if detect_deployment_kind() != "appliance":
+        return
+    try:
+        _FIRED_URL_MARKER.unlink(missing_ok=True)
+    except OSError:
+        pass
+    if _TRIGGER_FILE.exists():
+        return
+    try:
+        if _HOST_SLOT_STATE.exists():
+            parts = _HOST_SLOT_STATE.read_text(encoding="utf-8").split(maxsplit=1)
+            if parts and parts[0] == "failed":
+                _HOST_SLOT_STATE.write_text(
+                    f"ready {datetime.now(UTC).isoformat()}\n", encoding="utf-8"
+                )
+    except OSError:
+        pass
+
+
+def _prune_failed_sidecars(keep: int = 5) -> None:
+    """#386 Part B — keep only the most recent ``.failed.<ts>`` /
+    ``.done.<ts>`` / ``.invalid.<ts>`` slot-upgrade sidecars so churn
+    (or a pre-#386 re-fire loop) doesn't accumulate hundreds of files
+    in release-state. Sidecar suffixes are unix timestamps, so a
+    lexicographic sort is chronological."""
+    try:
+        parent = _TRIGGER_FILE.parent
+        for suffix in ("failed", "done", "invalid"):
+            stale = sorted(parent.glob(f"{_TRIGGER_FILE.name}.{suffix}.*"))
+            for path in stale[:-keep]:
+                path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _read_slot_upgrade_log_tail(lines: int = 40, max_chars: int = 8000) -> str:
+    """#386 Part C — last ``lines`` of the host slot-upgrade.log, capped
+    at ``max_chars``. Empty string when the log is unreadable / absent
+    (e.g. the log dir isn't mounted into the supervisor)."""
+    try:
+        text = _SLOT_UPGRADE_LOG.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    tail = "\n".join(text.splitlines()[-lines:])
+    return tail[-max_chars:] if len(tail) > max_chars else tail
+
+
+def _read_slot_upgrade_progress() -> dict[str, object] | None:
+    """#386 Part C — structured per-phase progress the host runner
+    writes to the progress sidecar (step / pct / detail / at). None when
+    absent / unreadable / malformed."""
+    try:
+        data = json.loads(_SLOT_UPGRADE_PROGRESS.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
 
 
 def maybe_fire_reboot(reboot_requested: bool) -> bool:
@@ -906,7 +1024,8 @@ def maybe_fire_cluster_restore(desired_restore_snapshot: str | None) -> bool:
         _CLUSTER_RESTORE_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
         tmp = _CLUSTER_RESTORE_TRIGGER_FILE.with_suffix(".new")
         tmp.write_text(
-            f"{_CLUSTER_RESTORE_CONFIRM}\n{desired_restore_snapshot}\n", encoding="utf-8"
+            f"{_CLUSTER_RESTORE_CONFIRM}\n{desired_restore_snapshot}\n",
+            encoding="utf-8",
         )
         tmp.replace(_CLUSTER_RESTORE_TRIGGER_FILE)
         return True
@@ -1975,6 +2094,20 @@ def collect() -> dict[str, object]:
     last_state, last_state_at = (
         _last_upgrade_state_from_sidecar() if is_appliance else (None, None)
     )
+    # #386 Part C — ship the log tail + structured progress while an
+    # upgrade is in-flight / failed / awaiting-reboot (done). For idle
+    # appliances ship empty so a stale tail/progress is cleared; None
+    # off-appliance so the backend leaves the columns alone.
+    _show_progress = is_appliance and last_state in ("in-flight", "failed", "done")
+    if not is_appliance:
+        last_upgrade_log_tail = None
+        last_upgrade_progress: dict[str, object] | None = None
+    elif _show_progress:
+        last_upgrade_log_tail = _read_slot_upgrade_log_tail()
+        last_upgrade_progress = _read_slot_upgrade_progress() or {}
+    else:
+        last_upgrade_log_tail = ""
+        last_upgrade_progress = {}
 
     slot_a_version, slot_b_version = read_slot_versions()
     cluster_health = read_cluster_health() if is_appliance else None
@@ -2008,6 +2141,9 @@ def collect() -> dict[str, object]:
         "is_trial_boot": is_trial_boot,
         "last_upgrade_state": last_state,
         "last_upgrade_state_at": last_state_at.isoformat() if last_state_at else None,
+        # #386 Part C — full upgrade status for the Fleet UI.
+        "last_upgrade_log_tail": last_upgrade_log_tail,
+        "last_upgrade_progress": last_upgrade_progress,
         # Issue #153 — surfaces in the Fleet view next to deployment
         # kind so operators see at a glance which appliances actually
         # have snmpd running. None on non-appliance deploys.

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -529,6 +529,8 @@ def maybe_fire_fleet_upgrade(
         if _FIRED_URL_MARKER.read_text(encoding="utf-8").strip() == desired_url_str:
             return False
     except OSError:
+        # No marker yet / unreadable → treat as not-yet-fired and fall
+        # through to write the trigger. Never fatal.
         pass
     if _TRIGGER_FILE.exists():
         return False
@@ -556,6 +558,9 @@ def maybe_fire_fleet_upgrade(
         try:
             _FIRED_URL_MARKER.write_text(desired_url_str + "\n", encoding="utf-8")
         except OSError:
+            # Best-effort fire-once bookkeeping — a failed marker write at
+            # worst costs one extra re-fire next heartbeat, never a crash,
+            # so don't abort the (already-written) trigger.
             pass
         _prune_failed_sidecars()
         return True
@@ -575,6 +580,8 @@ def clear_fleet_upgrade_marker() -> None:
     try:
         _FIRED_URL_MARKER.unlink(missing_ok=True)
     except OSError:
+        # Best-effort cleanup — a stale marker only risks suppressing one
+        # re-fire of an identical URL; not worth failing the loop.
         pass
     if _TRIGGER_FILE.exists():
         return
@@ -586,6 +593,8 @@ def clear_fleet_upgrade_marker() -> None:
                     f"ready {datetime.now(UTC).isoformat()}\n", encoding="utf-8"
                 )
     except OSError:
+        # Best-effort heal — if the state sidecar can't be read/rewritten
+        # the chip just keeps its last value; the next apply overwrites it.
         pass
 
 
@@ -602,6 +611,8 @@ def _prune_failed_sidecars(keep: int = 5) -> None:
             for path in stale[:-keep]:
                 path.unlink(missing_ok=True)
     except OSError:
+        # Best-effort housekeeping — leftover sidecars are cosmetic; a
+        # prune failure must never block the upgrade trigger.
         pass
 
 

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -630,16 +630,29 @@ def heartbeat_once(
 
     desired_version = body_out.get("desired_appliance_version")
     desired_url = body_out.get("desired_slot_image_url")
+    desired_sha256 = body_out.get("desired_slot_image_sha256")
+    desired_tls_insecure = bool(body_out.get("desired_slot_image_tls_insecure"))
     desired_next_boot_slot = body_out.get("desired_next_boot_slot")
     desired_default_slot = body_out.get("desired_default_slot")
     reboot_requested = bool(body_out.get("reboot_requested"))
 
     if desired_version and desired_url:
-        if appliance_state.maybe_fire_fleet_upgrade(desired_version, desired_url):
+        if appliance_state.maybe_fire_fleet_upgrade(
+            desired_version,
+            desired_url,
+            desired_sha256,  # type: ignore[arg-type]
+            desired_tls_insecure,
+        ):
             log.info(
                 "supervisor.heartbeat.upgrade_trigger_fired",
                 desired_version=desired_version,
             )
+    else:
+        # #386 Part B — no upgrade desired (cleared via Cancel, or never
+        # set). Drop the fire-once marker so a future Apply re-fires, and
+        # heal a stale ``failed`` state so a cancelled attempt stops
+        # sticking on the Fleet chip.
+        appliance_state.clear_fleet_upgrade_marker()
     # Per-slot boot intents. Both compare against the freshly-collected
     # local state (snapshotted at the top of this function) so a
     # supervisor that just rebooted into the requested slot doesn't
@@ -834,7 +847,9 @@ def heartbeat_once(
                 dhcp_relay_vip=relay_vip,
             )
         elif dp_err:
-            log.warning("supervisor.heartbeat.dataplane_vip_overrides_failed", error=dp_err)
+            log.warning(
+                "supervisor.heartbeat.dataplane_vip_overrides_failed", error=dp_err
+            )
 
         # #272 Phase 9 — dead-node replacement. The seed deletes each k8s
         # Node the backend flagged for eviction (deleting the Node makes

--- a/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
@@ -28,9 +28,11 @@ import json
 import os
 import re
 import shutil
+import ssl
 import subprocess
 import sys
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -157,13 +159,74 @@ def cmd_status(_args) -> int:
     return 0
 
 
-def fetch_to(src: str, dst: Path) -> None:
-    """Stream-copy from URL or local file path into dst."""
+# Issue #386 Part C — structured per-phase progress for the Fleet UI.
+# The host wrapper (spatiumddi-slot-upgrade) owns the terminal steps
+# (queued / arming / reboot-pending / failed); this script writes the
+# in-apply steps (downloading + pct, verifying, writing, bootloader).
+# The supervisor reads this sidecar (it lives in release-state, which is
+# bind-mounted into the supervisor) and ships it on the heartbeat.
+_PROGRESS_FILE = Path("/var/lib/spatiumddi/release-state/slot-upgrade.progress")
+
+
+def _write_progress(step: str, pct: int | None = None, detail: str = "") -> None:
+    """Atomically write the progress sidecar. Best-effort — never let a
+    progress-write failure abort the upgrade itself."""
+    try:
+        _PROGRESS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            {
+                "step": step,
+                "pct": pct,
+                "detail": detail,
+                "at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        tmp = _PROGRESS_FILE.with_name(_PROGRESS_FILE.name + ".new")
+        tmp.write_text(payload, encoding="utf-8")
+        tmp.replace(_PROGRESS_FILE)
+    except OSError:
+        pass
+
+
+def fetch_to(src: str, dst: Path, *, insecure: bool = False, report: bool = False) -> None:
+    """Stream-copy from URL or local file path into dst.
+
+    ``insecure`` (#386 Part A) skips TLS cert-verification — used ONLY
+    for the appliance's own self-served upgrade-image URL behind its
+    self-signed web cert, and only when the caller will verify the bytes
+    against an expected sha256. ``report`` (#386 Part C) emits download
+    percentage into the progress sidecar from the Content-Length header.
+    """
     dst.parent.mkdir(parents=True, exist_ok=True)
     if src.startswith(("http://", "https://")):
+        ctx: ssl.SSLContext | None = None
+        if insecure and src.startswith("https://"):
+            print("  (TLS cert verification disabled for this self-served fetch)")
+            ctx = ssl._create_unverified_context()
         print(f"  fetching {src}")
-        with urllib.request.urlopen(src) as r, open(dst, "wb") as f:
-            shutil.copyfileobj(r, f, length=1024 * 1024)
+        with urllib.request.urlopen(src, context=ctx) as r, open(dst, "wb") as f:
+            total = 0
+            try:
+                total = int(r.headers.get("Content-Length") or 0)
+            except (TypeError, ValueError):
+                total = 0
+            done = 0
+            last_pct = -5
+            while True:
+                chunk = r.read(1024 * 1024)
+                if not chunk:
+                    break
+                f.write(chunk)
+                done += len(chunk)
+                if report and total > 0:
+                    pct = int(done * 100 / total)
+                    if pct - last_pct >= 2 or pct >= 100:
+                        last_pct = pct
+                        _write_progress(
+                            "downloading",
+                            pct,
+                            f"{done // (1024 * 1024)} / {total // (1024 * 1024)} MB",
+                        )
     else:
         srcpath = Path(src)
         if not srcpath.exists():
@@ -202,28 +265,50 @@ def cmd_apply(args) -> int:
     # /var/persist/etc/ssh, hostname stamp into the new slot's
     # /etc.image) are no longer needed and have been removed.
 
+    # Issue #386 Part A — relaxing TLS verification is only safe when we
+    # also verify the downloaded bytes against an expected hash. Refuse
+    # ``--insecure`` without one rather than fetch an unauthenticated,
+    # unverified image onto a block device.
+    insecure = getattr(args, "insecure", False)
+    expected_sha256 = (getattr(args, "expected_sha256", None) or "").strip().lower()
+    if insecure and not (expected_sha256 or args.checksum):
+        print(
+            "ERROR: --insecure requires --expected-sha256 or --checksum "
+            "(bytes must be verified when TLS verification is off)",
+            file=sys.stderr,
+        )
+        return 2
+
     workdir = Path("/var/lib/spatiumddi/slot-staging")
     workdir.mkdir(parents=True, exist_ok=True)
     staged = workdir / "slot.raw.xz"
 
     # Fetch.
-    fetch_to(args.image, staged)
+    _write_progress("downloading", 0, f"fetching {args.image}")
+    fetch_to(args.image, staged, insecure=insecure, report=True)
 
-    # Verify SHA256 if a sidecar checksum file is present (URL only).
-    if args.checksum:
-        sha_path = workdir / "slot.sha256"
-        fetch_to(args.checksum, sha_path)
-        expected = sha_path.read_text().strip().split()[0]
+    # Verify SHA256 against an expected literal (#386 — passed by the
+    # control plane for self-served images, no second fetch) or a sidecar
+    # checksum file (legacy / external URLs).
+    if expected_sha256 or args.checksum:
+        _write_progress("verifying", None, "verifying sha256")
+        if not expected_sha256:
+            sha_path = workdir / "slot.sha256"
+            fetch_to(args.checksum, sha_path, insecure=insecure)
+            expected_sha256 = sha_path.read_text().strip().split()[0].lower()
         actual = sha256_file(staged)
-        if expected.lower() != actual.lower():
-            print(f"ERROR: checksum mismatch (expected {expected}, got {actual})",
-                  file=sys.stderr)
+        if expected_sha256 != actual.lower():
+            print(
+                f"ERROR: checksum mismatch (expected {expected_sha256}, got {actual})",
+                file=sys.stderr,
+            )
             return 3
         print(f"  checksum OK: {actual}")
 
     # Decompress + dd directly into the inactive partition. xz can
     # stream-decompress so we don't need disk space for an intermediate
     # uncompressed file.
+    _write_progress("writing", None, f"writing image to {inactive['partlabel']}")
     print(f"  writing → {target_dev}")
     xz = subprocess.Popen(["xz", "--decompress", "--stdout", str(staged)],
                           stdout=subprocess.PIPE)
@@ -235,6 +320,7 @@ def cmd_apply(args) -> int:
         print("ERROR: xz exited non-zero", file=sys.stderr)
         return 4
 
+    _write_progress("bootloader", None, "updating bootloader + slot versions")
     print("  flushing kernel buffers + re-reading filesystem metadata…")
     subprocess.run(["partprobe", "/dev/" + os.path.basename(target_dev).rstrip("0123456789p")],
                    check=False)
@@ -709,6 +795,20 @@ def main() -> int:
     apply_p = sub.add_parser("apply", help="write a slot image to the inactive slot")
     apply_p.add_argument("image", help="URL or local file path to a slot .raw.xz image")
     apply_p.add_argument("--checksum", help="URL or path to a SHA-256 sidecar file")
+    # Issue #386 Part A.
+    apply_p.add_argument(
+        "--expected-sha256",
+        dest="expected_sha256",
+        help="expected SHA-256 hex of the image (verify against this literal — no "
+        "second fetch). Takes precedence over --checksum.",
+    )
+    apply_p.add_argument(
+        "--insecure",
+        action="store_true",
+        help="skip TLS cert verification for an https:// fetch (self-served upgrade "
+        "image behind the appliance's self-signed cert). Requires --expected-sha256 "
+        "or --checksum so the bytes are still verified.",
+    )
 
     nxt = sub.add_parser("set-next-boot",
                          help="set the next boot to a slot ONCE (grub-reboot — auto-reverts on failure)")

--- a/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
@@ -185,6 +185,8 @@ def _write_progress(step: str, pct: int | None = None, detail: str = "") -> None
         tmp.write_text(payload, encoding="utf-8")
         tmp.replace(_PROGRESS_FILE)
     except OSError:
+        # Progress reporting is cosmetic — a write failure must never
+        # abort the slot apply itself, so swallow it.
         pass
 
 

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-slot-upgrade
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-slot-upgrade
@@ -1,27 +1,38 @@
 #!/bin/bash
 # spatiumddi-slot-upgrade — host-side slot-image upgrade runner
-# (Phase 8b-3, issue #138).
+# (Phase 8b-3, issue #138; extended in #386).
 #
-# The api container writes /var/lib/spatiumddi/release-state/
-# slot-upgrade-pending with one line: either a URL or a local file
-# path to a slot .raw.xz image. Optionally a second line carries
-# the SHA-256 checksum URL or path.
+# The supervisor (or api container) writes /var/lib/spatiumddi/
+# release-state/slot-upgrade-pending. Format:
+#   line 1: URL or absolute path to slot .raw.xz (any #fragment is
+#           stripped — #386 fire-once nonce, client-side only)
+#   then any of these directive lines (order-independent):
+#     sha256=<hex>   — expected image hash; verified with no 2nd fetch
+#     insecure-tls   — skip TLS cert-verify for the https:// fetch
+#                      (self-served image behind the appliance's
+#                      self-signed cert); only honoured WITH a hash
+#     checksum=<src> — URL/path to a .sha256 sidecar (legacy / external)
+#   A bare URL/path on line 2 is still accepted as a legacy checksum src.
 #
 # Then `spatiumddi-slot-upgrade.path` notices the file and runs this
 # script as root. It:
-#   1. Reads the trigger file
-#   2. Invokes /usr/local/bin/spatium-upgrade-slot apply <url>
-#      [--checksum <url>]
+#   1. Reads + parses the trigger file
+#   2. Invokes /usr/local/bin/spatium-upgrade-slot apply <url> [flags]
 #   3. On success, invokes spatium-upgrade-slot set-next-boot
-#   4. Renames the trigger to .done or .failed so the .path unit
-#      doesn't re-fire on the next watch
+#   4. Renames the trigger to .done / .failed so the .path unit doesn't
+#      re-fire on the next watch
 #
-# The api / UI then polls /api/v1/appliance/slot-upgrade/status to
-# show progress + result (parses /var/log/spatiumddi/slot-upgrade.log).
+# Throughout, it maintains two sidecars the supervisor ships on its
+# heartbeat so the Fleet UI shows full status (#386 Part C):
+#   slot-upgrade-pending.state  — coarse state (in-flight/done/failed)
+#   slot-upgrade.progress       — structured {step,pct,detail,at}; this
+#       wrapper owns the terminal steps, spatium-upgrade-slot writes the
+#       in-apply steps (downloading/verifying/writing/bootloader).
 
 set -euo pipefail
 
 TRIGGER=/var/lib/spatiumddi/release-state/slot-upgrade-pending
+PROGRESS=/var/lib/spatiumddi/release-state/slot-upgrade.progress
 LOG_DIR=/var/log/spatiumddi
 LOG="$LOG_DIR/slot-upgrade.log"
 
@@ -30,16 +41,49 @@ exec >> "$LOG" 2>&1
 echo
 echo "[$(date -Iseconds)] === spatiumddi-slot-upgrade fired ==="
 
+# Structured progress for the Fleet UI. Best-effort — never abort the
+# upgrade on a progress-write hiccup.
+write_progress() {  # $1 = step, $2 = human detail
+    local detail
+    detail=$(printf '%s' "${2:-}" | tr -d '"\\\r\n')
+    printf '{"step":"%s","pct":null,"detail":"%s","at":"%s"}' \
+        "$1" "$detail" "$(date -Iseconds)" > "${PROGRESS}.new" 2>/dev/null \
+        && mv "${PROGRESS}.new" "$PROGRESS" 2>/dev/null || true
+}
+
+fail() {  # $1 = human reason
+    echo
+    echo "  ✗ $1"
+    echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
+    write_progress "failed" "$1"
+    mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" 2>/dev/null || true
+    exit 1
+}
+
 if [ ! -f "$TRIGGER" ]; then
     echo "  no trigger file at $TRIGGER, nothing to do"
     exit 0
 fi
 
-# Trigger file format:
-#   line 1: URL or absolute path to slot .raw.xz
-#   line 2 (optional): URL or absolute path to .sha256 sidecar
+# Line 1 = image source, fragment stripped.
 IMAGE_SRC=$(sed -n '1p' "$TRIGGER" | tr -d '\r\n')
-CHECKSUM_SRC=$(sed -n '2p' "$TRIGGER" | tr -d '\r\n' || true)
+IMAGE_SRC=${IMAGE_SRC%%#*}
+
+# Remaining lines = directives (#386) or a legacy bare checksum URL.
+EXPECTED_SHA256=
+INSECURE=
+CHECKSUM_SRC=
+while IFS= read -r line; do
+    line=$(printf '%s' "$line" | tr -d '\r\n')
+    [ -z "$line" ] && continue
+    case "$line" in
+        sha256=*)              EXPECTED_SHA256=${line#sha256=} ;;
+        insecure-tls)          INSECURE=1 ;;
+        checksum=*)            CHECKSUM_SRC=${line#checksum=} ;;
+        https://*|http://*|/*) CHECKSUM_SRC=$line ;;   # legacy bare line 2
+        *) echo "  WARN: ignoring unrecognised trigger line: $line" ;;
+    esac
+done < <(tail -n +2 "$TRIGGER")
 
 if [ -z "$IMAGE_SRC" ]; then
     echo "  ERROR: trigger file empty, aborting"
@@ -47,8 +91,8 @@ if [ -z "$IMAGE_SRC" ]; then
     exit 1
 fi
 
-# Reject anything that doesn't look like a URL or absolute path —
-# basic guard against shell metachars.
+# Reject anything that doesn't look like a URL or absolute path — basic
+# guard against shell metachars.
 case "$IMAGE_SRC" in
     https://*|http://*|/*)  ;;
     *)
@@ -67,43 +111,47 @@ if [ -n "$CHECKSUM_SRC" ]; then
             ;;
     esac
 fi
+if [ -n "$EXPECTED_SHA256" ]; then
+    case "$EXPECTED_SHA256" in
+        *[!0-9a-fA-F]*)
+            echo "  ERROR: sha256 directive is not hex: $EXPECTED_SHA256"
+            mv "$TRIGGER" "${TRIGGER}.invalid.$(date +%s)"
+            exit 1
+            ;;
+    esac
+fi
 
 echo "  image:    $IMAGE_SRC"
-if [ -n "$CHECKSUM_SRC" ]; then
-    echo "  checksum: $CHECKSUM_SRC"
-fi
+[ -n "$EXPECTED_SHA256" ] && echo "  sha256:   $EXPECTED_SHA256"
+[ -n "$CHECKSUM_SRC" ] && echo "  checksum: $CHECKSUM_SRC"
+[ -n "$INSECURE" ] && echo "  insecure-tls: yes (self-served URL; bytes verified by hash)"
 echo
 
-# Mark trigger as in-flight so the UI can show "applying" state.
-# We don't rename it (the .path unit fires on close-after-write,
-# not on every read) but we do touch a sibling marker.
+# Mark trigger as in-flight so the UI can show "applying" state. We
+# don't rename it (the .path unit fires on close-after-write, not on
+# every read) but we do touch a sibling marker + progress.
 echo "in-flight $(date -Iseconds)" > "${TRIGGER}.state"
+write_progress "queued" "starting slot upgrade"
 
 APPLY_ARGS=("apply" "$IMAGE_SRC")
-if [ -n "$CHECKSUM_SRC" ]; then
-    APPLY_ARGS+=("--checksum" "$CHECKSUM_SRC")
-fi
+[ -n "$EXPECTED_SHA256" ] && APPLY_ARGS+=("--expected-sha256" "$EXPECTED_SHA256")
+[ -n "$CHECKSUM_SRC" ] && APPLY_ARGS+=("--checksum" "$CHECKSUM_SRC")
+[ -n "$INSECURE" ] && APPLY_ARGS+=("--insecure")
 
 echo "  → /usr/local/bin/spatium-upgrade-slot ${APPLY_ARGS[*]}"
 if /usr/local/bin/spatium-upgrade-slot "${APPLY_ARGS[@]}"; then
     echo
     echo "  apply succeeded — calling set-next-boot"
+    write_progress "arming" "arming next-boot"
     if /usr/local/bin/spatium-upgrade-slot set-next-boot; then
         echo
         echo "  ✓ next-boot armed. Operator needs to reboot to switch slots."
         echo "done $(date -Iseconds)" > "${TRIGGER}.state"
+        write_progress "reboot-pending" "upgrade staged — reboot to boot the new slot"
         mv "$TRIGGER" "${TRIGGER}.done.$(date +%s)"
     else
-        echo
-        echo "  ✗ set-next-boot failed (image is written but next-boot not armed)"
-        echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
-        mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
-        exit 1
+        fail "set-next-boot failed (image is written but next-boot not armed)"
     fi
 else
-    echo
-    echo "  ✗ apply failed — inactive slot may be partially written"
-    echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
-    mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
-    exit 1
+    fail "apply failed — see slot-upgrade.log for the cause (download / verify / write)"
 fi

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -380,6 +380,10 @@ backend/alembic/versions/d9a4c3b7e812_add_dhcp_models.py:drop_table:357
 backend/alembic/versions/d9a4c3b7e812_add_dhcp_models.py:drop_table:359
 backend/alembic/versions/d9e4c12a7f85_aggregation_snooze.py:drop_column:39
 backend/alembic/versions/d9f3b21e8c54_wan_circuits.py:drop_table:187
+backend/alembic/versions/e1c4a9d27b63_appliance_upgrade_download_monitoring.py:drop_column:61
+backend/alembic/versions/e1c4a9d27b63_appliance_upgrade_download_monitoring.py:drop_column:62
+backend/alembic/versions/e1c4a9d27b63_appliance_upgrade_download_monitoring.py:drop_column:63
+backend/alembic/versions/e1c4a9d27b63_appliance_upgrade_download_monitoring.py:drop_column:64
 backend/alembic/versions/e1d8c92a4f73_network_service_catalog.py:drop_table:182
 backend/alembic/versions/e1d8c92a4f73_network_service_catalog.py:drop_table:190
 backend/alembic/versions/e1f2a3b4c5d6_subnet_ddns_fields.py:drop_column:63

--- a/backend/alembic/versions/e1c4a9d27b63_appliance_upgrade_download_monitoring.py
+++ b/backend/alembic/versions/e1c4a9d27b63_appliance_upgrade_download_monitoring.py
@@ -1,0 +1,64 @@
+"""appliance upgrade: download integrity hints + log-tail monitoring
+
+Issue #386. Adds three columns to ``appliance`` so a single-appliance
+OS slot-upgrade (a) can be fetched when the image is served by the
+appliance's own self-signed control plane, and (b) is observable in
+the Fleet UI instead of failing silently:
+
+* ``desired_slot_image_sha256`` — expected hash the host-side runner
+  verifies the downloaded image against (Part A).
+* ``desired_slot_image_tls_insecure`` — allow the runner to skip TLS
+  cert-verify for the appliance's own self-served URL (Part A); only
+  honoured host-side when an expected sha256 is present.
+* ``last_upgrade_log_tail`` — tail of the host ``slot-upgrade.log``
+  the supervisor ships while an apply is in-flight / failed, surfaced
+  in the Fleet drilldown (Part C).
+
+Revision ID: e1c4a9d27b63
+Revises: c3f7a1d9b486
+Create Date: 2026-06-12
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e1c4a9d27b63"
+down_revision: str | None = "c3f7a1d9b486"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "appliance",
+        sa.Column("desired_slot_image_sha256", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "appliance",
+        sa.Column(
+            "desired_slot_image_tls_insecure",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "appliance",
+        sa.Column("last_upgrade_log_tail", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "appliance",
+        sa.Column("last_upgrade_progress", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("appliance", "last_upgrade_progress")
+    op.drop_column("appliance", "last_upgrade_log_tail")
+    op.drop_column("appliance", "desired_slot_image_tls_insecure")
+    op.drop_column("appliance", "desired_slot_image_sha256")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -987,6 +987,16 @@ class SupervisorHeartbeatRequest(BaseModel):
     is_trial_boot: bool | None = None
     last_upgrade_state: Literal["ready", "in-flight", "done", "failed"] | None = None
     last_upgrade_state_at: datetime | None = None
+    # Issue #386 Part C — tail of the host ``slot-upgrade.log`` so the
+    # Fleet drilldown can show what an in-flight / failed apply is doing.
+    # The supervisor ships the last lines while state is in-flight/failed
+    # and ``""`` once ready/done (clears a stale tail); None on
+    # non-appliance so the handler leaves the column alone.
+    last_upgrade_log_tail: str | None = None
+    # Issue #386 Part C — structured per-phase progress (step / pct /
+    # detail / at) so the Fleet UI renders a real status stepper. ``{}``
+    # once no longer in-flight (clear); None on non-appliance.
+    last_upgrade_progress: dict[str, Any] | None = None
     snmpd_running: bool | None = None
     ntp_sync_state: Literal["synchronized", "unsynchronized", "unknown"] | None = None
     # Issue #156 — best-effort rsyslog-forwarding status. None = not
@@ -1171,6 +1181,14 @@ class SupervisorHeartbeatResponse(BaseModel):
     long_poll: bool = False
     desired_appliance_version: str | None = None
     desired_slot_image_url: str | None = None
+    # Issue #386 Part A — integrity + transport hints the host-side
+    # ``spatium-upgrade-slot`` runner uses for the fetch. ``sha256`` is
+    # the image's stored hash (the runner verifies bytes against it);
+    # ``tls_insecure`` allows skipping cert-verify for the appliance's
+    # OWN self-served URL only — honoured host-side ONLY when a sha256
+    # is also present. External (public-CA) URLs leave both unset.
+    desired_slot_image_sha256: str | None = None
+    desired_slot_image_tls_insecure: bool = False
     # Operator's per-slot boot intents. The supervisor writes the
     # matching trigger file when non-null + the current state doesn't
     # already satisfy the request. Both auto-clear in the heartbeat
@@ -1514,6 +1532,13 @@ async def supervisor_heartbeat(
         row.last_upgrade_state = body.last_upgrade_state
     if body.last_upgrade_state_at is not None:
         row.last_upgrade_state_at = body.last_upgrade_state_at
+    # #386 Part C — empty string is a meaningful value here ("no
+    # in-flight upgrade, clear any stale tail"), so persist on
+    # ``is not None`` rather than truthiness.
+    if body.last_upgrade_log_tail is not None:
+        row.last_upgrade_log_tail = body.last_upgrade_log_tail or None
+    if body.last_upgrade_progress is not None:
+        row.last_upgrade_progress = body.last_upgrade_progress or None
     if body.snmpd_running is not None:
         row.snmpd_running = body.snmpd_running
     if body.ntp_sync_state is not None:
@@ -1730,6 +1755,8 @@ async def supervisor_heartbeat(
     ):
         row.desired_appliance_version = None
         row.desired_slot_image_url = None
+        row.desired_slot_image_sha256 = None
+        row.desired_slot_image_tls_insecure = False
 
     # Auto-clear desired_next_boot_slot once the supervisor reports
     # the requested slot as ``current_slot`` — the operator's intent
@@ -1843,7 +1870,8 @@ async def supervisor_heartbeat(
             desired_join_token = decrypt_str(row.desired_k3s_join_token_encrypted)
         except Exception:  # noqa: BLE001
             logger.warning(
-                "supervisor_heartbeat_join_token_decrypt_failed", appliance_id=str(row.id)
+                "supervisor_heartbeat_join_token_decrypt_failed",
+                appliance_id=str(row.id),
             )
 
     # #272 Phase 7b — the cross-node firewall peer set this node must
@@ -1894,7 +1922,12 @@ async def supervisor_heartbeat(
     ntp_block = (
         ntp_bundle(cfg_row)
         if cfg_row is not None
-        else {"enabled": False, "allow_clients": False, "config_hash": "", "chrony_conf": ""}
+        else {
+            "enabled": False,
+            "allow_clients": False,
+            "config_hash": "",
+            "chrony_conf": "",
+        }
     )
     lldp_block = (
         lldp_bundle(cfg_row)
@@ -1994,6 +2027,8 @@ async def supervisor_heartbeat(
         state=row.state,  # type: ignore[arg-type]
         desired_appliance_version=row.desired_appliance_version,
         desired_slot_image_url=row.desired_slot_image_url,
+        desired_slot_image_sha256=row.desired_slot_image_sha256,
+        desired_slot_image_tls_insecure=row.desired_slot_image_tls_insecure,
         desired_next_boot_slot=row.desired_next_boot_slot,  # type: ignore[arg-type]
         desired_default_slot=row.desired_default_slot,  # type: ignore[arg-type]
         reboot_requested=row.reboot_requested,
@@ -2166,6 +2201,12 @@ class ApplianceRow(BaseModel):
     is_trial_boot: bool
     last_upgrade_state: str | None
     last_upgrade_state_at: datetime | None
+    # Issue #386 Part C — tail of the host slot-upgrade.log + structured
+    # per-phase progress while an apply is in-flight / failed, so the
+    # Fleet drilldown shows a real status stepper + the failure reason
+    # instead of just the coarse state chip.
+    last_upgrade_log_tail: str | None
+    last_upgrade_progress: dict[str, Any] | None
     snmpd_running: bool | None
     ntp_sync_state: str | None
     # Issue #156 — best-effort rsyslog-forwarding status surfaced from
@@ -2180,6 +2221,11 @@ class ApplianceRow(BaseModel):
     resolver_status: str | None
     desired_appliance_version: str | None
     desired_slot_image_url: str | None
+    # #386 Part A — integrity + transport hints surfaced for the UI /
+    # debugging (not secret). sha256 the host verifies the bytes against;
+    # tls_insecure is true only for the appliance's own self-served URL.
+    desired_slot_image_sha256: str | None
+    desired_slot_image_tls_insecure: bool
     desired_next_boot_slot: str | None
     desired_default_slot: str | None
     reboot_requested: bool
@@ -2274,6 +2320,8 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
         is_trial_boot=row.is_trial_boot,
         last_upgrade_state=row.last_upgrade_state,
         last_upgrade_state_at=row.last_upgrade_state_at,
+        last_upgrade_log_tail=row.last_upgrade_log_tail,
+        last_upgrade_progress=row.last_upgrade_progress,
         snmpd_running=row.snmpd_running,
         ntp_sync_state=row.ntp_sync_state,
         syslog_forwarding=row.syslog_forwarding,
@@ -2281,6 +2329,8 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
         resolver_status=row.resolver_status,
         desired_appliance_version=row.desired_appliance_version,
         desired_slot_image_url=row.desired_slot_image_url,
+        desired_slot_image_sha256=row.desired_slot_image_sha256,
+        desired_slot_image_tls_insecure=row.desired_slot_image_tls_insecure,
         desired_next_boot_slot=row.desired_next_boot_slot,
         desired_default_slot=row.desired_default_slot,
         reboot_requested=row.reboot_requested,
@@ -3673,7 +3723,10 @@ async def replace_control_plane_member(
             resource_id=str(row.id),
             resource_display=row.hostname,
             result="success",
-            new_value={"pairing_code_id": str(pc_id), "pairing_expires_at": expires_at.isoformat()},
+            new_value={
+                "pairing_code_id": str(pc_id),
+                "pairing_expires_at": expires_at.isoformat(),
+            },
         )
     )
     await db.commit()
@@ -4067,7 +4120,10 @@ class MetalLBConfigUpdate(BaseModel):
         # exists without it) and can't reuse the control-plane VIP or each
         # other — MetalLB hands a given address to exactly one Service, so
         # two services sharing one VIP would leave one perpetually Pending.
-        dp_vips = {"DNS resolver VIP": self.dns_vip, "DHCP relay VIP": self.dhcp_relay_vip}
+        dp_vips = {
+            "DNS resolver VIP": self.dns_vip,
+            "DHCP relay VIP": self.dhcp_relay_vip,
+        }
         for label, vip in dp_vips.items():
             if vip and not self.enabled:
                 raise ValueError(f"{label} requires MetalLB to be enabled")
@@ -4078,7 +4134,10 @@ class MetalLBConfigUpdate(BaseModel):
         if self.dns_vip and self.dns_vip == self.dhcp_relay_vip:
             raise ValueError("DNS resolver VIP and DHCP relay VIP must differ")
         # Every configured VIP must fall inside the pool.
-        for label, vip in {"control-plane VIP": self.control_plane_vip, **dp_vips}.items():
+        for label, vip in {
+            "control-plane VIP": self.control_plane_vip,
+            **dp_vips,
+        }.items():
             if vip and self.pool_addresses and not _vip_in_pool(vip, self.pool_addresses):
                 raise ValueError(
                     f"{label} {vip} is not inside the address pool "
@@ -4269,6 +4328,12 @@ async def schedule_appliance_upgrade(
     from app.models.appliance import ApplianceUpgradeImage  # noqa: PLC0415
 
     resolved_url: str
+    # Issue #386 Part A — integrity + transport hints stamped alongside
+    # the URL. For an internal (self-served) image we know the sha256 and
+    # that the URL points at our own self-signed cert; for an external
+    # operator-pasted URL we trust public-CA TLS and have no hash.
+    image_sha256: str | None = None
+    tls_insecure = False
     if body.slot_image_id is not None:
         image = await db.get(ApplianceUpgradeImage, body.slot_image_id)
         if image is None:
@@ -4299,12 +4364,32 @@ async def schedule_appliance_upgrade(
             f"{str(request.base_url).rstrip('/')}"
             f"/api/v1/appliance/upgrade-images/{image.id}/raw.xz?t={token}"
         )
+        # The image is served by our OWN control plane behind the
+        # self-signed web cert, so the host runner's bare urllib fetch
+        # would fail TLS verify (#386). Hand it the stored sha256 to
+        # verify bytes against + flag the self-served URL so it skips
+        # cert-verify for this fetch only.
+        image_sha256 = image.sha256
+        tls_insecure = True
     else:
         assert body.desired_slot_image_url is not None
         resolved_url = body.desired_slot_image_url
 
+    # Issue #386 Part B — append a per-apply nonce as a URL *fragment* so
+    # each schedule yields a distinct ``desired_slot_image_url``. The
+    # supervisor fires the slot-upgrade trigger exactly once per distinct
+    # URL (no silent re-fire loop on a failed apply); a fresh apply of the
+    # same image re-fires because the fragment differs. Fragments are
+    # client-side only — the host runner strips it before fetching and
+    # HTTP never sends it — so it's safe to graft onto any URL, including
+    # query-signed ones.
+    nonce = uuid.uuid4().hex[:12]
+    resolved_url = f"{resolved_url}#a={nonce}"
+
     row.desired_appliance_version = body.desired_appliance_version
     row.desired_slot_image_url = resolved_url
+    row.desired_slot_image_sha256 = image_sha256
+    row.desired_slot_image_tls_insecure = tls_insecure
     db.add(
         AuditLog(
             user_id=current_user.id,
@@ -4356,6 +4441,8 @@ async def clear_appliance_upgrade(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Appliance not found.")
     row.desired_appliance_version = None
     row.desired_slot_image_url = None
+    row.desired_slot_image_sha256 = None
+    row.desired_slot_image_tls_insecure = False
     db.add(
         AuditLog(
             user_id=current_user.id,

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -61,7 +61,9 @@ class ApplianceCertificate(Base):
 
     __tablename__ = "appliance_certificate"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
 
     # Operator-chosen label. Unique so audit log lines + UI cards can
     # refer to "letsencrypt-2026.05" without ambiguity. Distinct from
@@ -98,7 +100,9 @@ class ApplianceCertificate(Base):
     # the most recent activation timestamp so the UI can show "active
     # since X" without consulting the audit log.
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    activated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    activated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Identity extracted from the cert at upload time (so listing
     # doesn't need to re-parse every PEM on every request). subject_cn
@@ -123,8 +127,12 @@ class ApplianceCertificate(Base):
     # render "expires in N days" badges and by a future renewal task
     # (Phase 4b.4) to schedule Let's Encrypt rotations. NULL on
     # CSR-pending rows.
-    valid_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    valid_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    valid_from: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    valid_to: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Operator notes — purely descriptive. UI shows them on the card
     # for context ("Let's Encrypt prod cert — renew script in cron").
@@ -184,11 +192,15 @@ class PairingCode(Base):
 
     __tablename__ = "pairing_code"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
 
     # sha256 hex digest of the cleartext code. UNIQUE so the consume
     # endpoint can look up by hash in O(log n) without collision risk.
-    code_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    code_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True, index=True
+    )
 
     # Last two digits of the cleartext code. Surfaced in the list
     # endpoint for visual correlation ("which row is the code I just
@@ -242,7 +254,9 @@ class PairingCode(Base):
     # revoking a code is permanent ("dead row"), disabling is
     # reversible ("paused"). Revoking a claimed code is a no-op for
     # already-issued certs but still useful audit signal.
-    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     revoked_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -277,7 +291,9 @@ class PairingClaim(Base):
 
     __tablename__ = "pairing_claim"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     pairing_code_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("pairing_code.id", ondelete="CASCADE"),
@@ -379,7 +395,9 @@ class Appliance(Base):
 
     __tablename__ = "appliance"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
 
     hostname: Mapped[str] = mapped_column(String(255), nullable=False)
 
@@ -421,11 +439,15 @@ class Appliance(Base):
     # an admin can Re-authorize (clear ``revoked_at`` + state back
     # to ``approved``). A retention cron hard-deletes after
     # ``platform_settings.appliance_revoked_retention_days``.
-    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Updated by Wave A2+'s supervisor heartbeat path. Stays NULL
     # until the supervisor's first post-register check-in.
-    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     last_seen_ip: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     # Wave B1 — supervisor-reported capabilities (can_run_dns_bind9,
@@ -451,16 +473,24 @@ class Appliance(Base):
     # supervisor auto-renews 30 days before expiry (Wave C polish).
     cert_pem: Mapped[str | None] = mapped_column(Text, nullable=True)
     cert_serial: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    cert_issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    cert_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cert_issued_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    cert_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Approval audit columns (the canonical state is still `state` —
     # these timestamps are for UI relative-time chips).
-    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    approved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     approved_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
-    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rejected_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     rejected_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -484,7 +514,9 @@ class Appliance(Base):
     # shape — the handler leaves the column untouched when the field
     # is missing so a stale supervisor doesn't null out its variant.
     appliance_variant: Mapped[str | None] = mapped_column(String(32), nullable=True)
-    installed_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    installed_appliance_version: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     current_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
     durable_default: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Per-slot installed version — supervisor reads the
@@ -502,6 +534,25 @@ class Appliance(Base):
     last_upgrade_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
     last_upgrade_state_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
+    )
+    # Issue #386 Part C — tail of the host-side ``slot-upgrade.log`` the
+    # supervisor ships while a slot apply is in-flight or has failed, so
+    # the Fleet drilldown can show what the upgrade is actually doing
+    # (download → decompress → dd → grub-patch) and the failure reason —
+    # previously only the coarse ``last_upgrade_state`` chip was visible,
+    # which made a failing upgrade indistinguishable from a pending one.
+    # The supervisor ships ``""`` once state is ready/done so a stale tail
+    # doesn't linger; NULL on non-appliance / never-reported rows.
+    last_upgrade_log_tail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Issue #386 Part C — structured per-phase progress the host runner
+    # emits so the Fleet UI can render a real step-by-step status (not
+    # just a log dump): ``{"step": "downloading"|"verifying"|"writing"|
+    # "bootloader"|"arming"|"reboot-pending"|"done"|"failed",
+    # "pct": <int|null>, "detail": "<human line>", "at": "<iso8601>"}``.
+    # NULL on non-appliance / never-reported rows; the supervisor ships
+    # ``{}`` once an upgrade is no longer in-flight to clear it.
+    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
     )
     snmpd_running: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     ntp_sync_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
@@ -537,8 +588,27 @@ class Appliance(Base):
     # trigger files on the appliance host. Heartbeat handler auto-
     # clears once installed catches up (upgrade) or a fresh heartbeat
     # arrives post-reboot.
-    desired_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    desired_appliance_version: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     desired_slot_image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Issue #386 Part A — integrity + transport hints for the host-side
+    # ``spatium-upgrade-slot`` runner. When the scheduler points
+    # ``desired_slot_image_url`` at the appliance's OWN control-plane API
+    # (an imported/uploaded upgrade image served behind the self-signed
+    # web cert), the runner's bare ``urllib.urlopen`` fails TLS verify and
+    # the upgrade never applies. We stamp the image's stored sha256 here +
+    # set ``tls_insecure`` so the runner verifies bytes against the hash
+    # (the real integrity guarantee) and skips cert-verify ONLY for that
+    # self-served URL. External (public-CA) URLs leave both NULL/false and
+    # stay fully verified. ``tls_insecure`` is refused host-side unless an
+    # expected sha256 is present.
+    desired_slot_image_sha256: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    desired_slot_image_tls_insecure: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
     reboot_requested: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
@@ -558,7 +628,9 @@ class Appliance(Base):
     #
     # Both auto-clear in the heartbeat handler once the supervisor's
     # reported state matches what was requested.
-    desired_next_boot_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    desired_next_boot_slot: Mapped[str | None] = mapped_column(
+        String(16), nullable=True
+    )
     desired_default_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     # Role assignment — #170 Wave C2. Operator picks a subset of
@@ -653,7 +725,9 @@ class Appliance(Base):
     # ships one (legacy compose / pre-#183 supervisors / k3s not yet
     # started).
     k3s_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True
+    )
 
     # Issue #183 Phase 6 — k3s server-cert expiry + direct-kubeapi
     # firewall allowlist.
@@ -708,7 +782,9 @@ class Appliance(Base):
     # heartbeat (read from ``/var/lib/rancher/k3s/server/token``), Fernet-
     # encrypted at rest. The promote endpoint reads this off the primary
     # row to populate ``desired_k3s_join_token_encrypted`` on each joiner.
-    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True
+    )
     # Supervisor-reported progress of the in-flight join/leave:
     # ``joining`` | ``ready`` | ``leaving`` | ``failed`` | NULL (idle).
     cluster_join_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
@@ -828,7 +904,9 @@ class ApplianceCA(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
 
 
 class ApplianceUpgradeImage(Base):
@@ -859,7 +937,9 @@ class ApplianceUpgradeImage(Base):
 
     __tablename__ = "appliance_upgrade_image"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     filename: Mapped[str] = mapped_column(String(255), nullable=False)
     size_bytes: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
     sha256: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -61,9 +61,7 @@ class ApplianceCertificate(Base):
 
     __tablename__ = "appliance_certificate"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     # Operator-chosen label. Unique so audit log lines + UI cards can
     # refer to "letsencrypt-2026.05" without ambiguity. Distinct from
@@ -100,9 +98,7 @@ class ApplianceCertificate(Base):
     # the most recent activation timestamp so the UI can show "active
     # since X" without consulting the audit log.
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    activated_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    activated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Identity extracted from the cert at upload time (so listing
     # doesn't need to re-parse every PEM on every request). subject_cn
@@ -127,12 +123,8 @@ class ApplianceCertificate(Base):
     # render "expires in N days" badges and by a future renewal task
     # (Phase 4b.4) to schedule Let's Encrypt rotations. NULL on
     # CSR-pending rows.
-    valid_from: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    valid_to: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    valid_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    valid_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Operator notes — purely descriptive. UI shows them on the card
     # for context ("Let's Encrypt prod cert — renew script in cron").
@@ -192,15 +184,11 @@ class PairingCode(Base):
 
     __tablename__ = "pairing_code"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     # sha256 hex digest of the cleartext code. UNIQUE so the consume
     # endpoint can look up by hash in O(log n) without collision risk.
-    code_hash: Mapped[str] = mapped_column(
-        String(64), nullable=False, unique=True, index=True
-    )
+    code_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
 
     # Last two digits of the cleartext code. Surfaced in the list
     # endpoint for visual correlation ("which row is the code I just
@@ -254,9 +242,7 @@ class PairingCode(Base):
     # revoking a code is permanent ("dead row"), disabling is
     # reversible ("paused"). Revoking a claimed code is a no-op for
     # already-issued certs but still useful audit signal.
-    revoked_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     revoked_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -291,9 +277,7 @@ class PairingClaim(Base):
 
     __tablename__ = "pairing_claim"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     pairing_code_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("pairing_code.id", ondelete="CASCADE"),
@@ -395,9 +379,7 @@ class Appliance(Base):
 
     __tablename__ = "appliance"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     hostname: Mapped[str] = mapped_column(String(255), nullable=False)
 
@@ -439,15 +421,11 @@ class Appliance(Base):
     # an admin can Re-authorize (clear ``revoked_at`` + state back
     # to ``approved``). A retention cron hard-deletes after
     # ``platform_settings.appliance_revoked_retention_days``.
-    revoked_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Updated by Wave A2+'s supervisor heartbeat path. Stays NULL
     # until the supervisor's first post-register check-in.
-    last_seen_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_seen_ip: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     # Wave B1 — supervisor-reported capabilities (can_run_dns_bind9,
@@ -473,24 +451,16 @@ class Appliance(Base):
     # supervisor auto-renews 30 days before expiry (Wave C polish).
     cert_pem: Mapped[str | None] = mapped_column(Text, nullable=True)
     cert_serial: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    cert_issued_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    cert_expires_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    cert_issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cert_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Approval audit columns (the canonical state is still `state` —
     # these timestamps are for UI relative-time chips).
-    approved_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     approved_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
-    rejected_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     rejected_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -514,9 +484,7 @@ class Appliance(Base):
     # shape — the handler leaves the column untouched when the field
     # is missing so a stale supervisor doesn't null out its variant.
     appliance_variant: Mapped[str | None] = mapped_column(String(32), nullable=True)
-    installed_appliance_version: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    installed_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
     current_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
     durable_default: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Per-slot installed version — supervisor reads the
@@ -551,9 +519,7 @@ class Appliance(Base):
     # "pct": <int|null>, "detail": "<human line>", "at": "<iso8601>"}``.
     # NULL on non-appliance / never-reported rows; the supervisor ships
     # ``{}`` once an upgrade is no longer in-flight to clear it.
-    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, nullable=True
-    )
+    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     snmpd_running: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     ntp_sync_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Issue #156 — best-effort rsyslog-forwarding status the supervisor
@@ -588,9 +554,7 @@ class Appliance(Base):
     # trigger files on the appliance host. Heartbeat handler auto-
     # clears once installed catches up (upgrade) or a fresh heartbeat
     # arrives post-reboot.
-    desired_appliance_version: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    desired_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
     desired_slot_image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Issue #386 Part A — integrity + transport hints for the host-side
     # ``spatium-upgrade-slot`` runner. When the scheduler points
@@ -603,9 +567,7 @@ class Appliance(Base):
     # self-served URL. External (public-CA) URLs leave both NULL/false and
     # stay fully verified. ``tls_insecure`` is refused host-side unless an
     # expected sha256 is present.
-    desired_slot_image_sha256: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    desired_slot_image_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
     desired_slot_image_tls_insecure: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
@@ -628,9 +590,7 @@ class Appliance(Base):
     #
     # Both auto-clear in the heartbeat handler once the supervisor's
     # reported state matches what was requested.
-    desired_next_boot_slot: Mapped[str | None] = mapped_column(
-        String(16), nullable=True
-    )
+    desired_next_boot_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
     desired_default_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     # Role assignment — #170 Wave C2. Operator picks a subset of
@@ -725,9 +685,7 @@ class Appliance(Base):
     # ships one (legacy compose / pre-#183 supervisors / k3s not yet
     # started).
     k3s_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(
-        LargeBinary, nullable=True
-    )
+    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
 
     # Issue #183 Phase 6 — k3s server-cert expiry + direct-kubeapi
     # firewall allowlist.
@@ -782,9 +740,7 @@ class Appliance(Base):
     # heartbeat (read from ``/var/lib/rancher/k3s/server/token``), Fernet-
     # encrypted at rest. The promote endpoint reads this off the primary
     # row to populate ``desired_k3s_join_token_encrypted`` on each joiner.
-    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(
-        LargeBinary, nullable=True
-    )
+    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     # Supervisor-reported progress of the in-flight join/leave:
     # ``joining`` | ``ready`` | ``leaving`` | ``failed`` | NULL (idle).
     cluster_join_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
@@ -904,9 +860,7 @@ class ApplianceCA(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    expires_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
 class ApplianceUpgradeImage(Base):
@@ -937,9 +891,7 @@ class ApplianceUpgradeImage(Base):
 
     __tablename__ = "appliance_upgrade_image"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     filename: Mapped[str] = mapped_column(String(255), nullable=False)
     size_bytes: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
     sha256: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)

--- a/backend/tests/test_appliance_upgrade_download.py
+++ b/backend/tests/test_appliance_upgrade_download.py
@@ -1,0 +1,202 @@
+"""Appliance OS upgrade — download integrity hints + fire-once nonce (#386).
+
+Covers the backend half of the #386 fix:
+
+* Scheduling an upgrade from an internal (uploaded/imported) upgrade
+  image stamps the image's sha256 + ``tls_insecure=True`` on the
+  appliance row, and appends a per-apply nonce fragment to
+  ``desired_slot_image_url`` so the supervisor fires the slot-upgrade
+  trigger exactly once per distinct desired-state (no silent re-fire
+  loop). The bytes are verified against the hash host-side, which is
+  what makes relaxing TLS for the self-served URL safe.
+* Each apply mints a fresh nonce (same fetch URL, different fragment).
+* An external operator-pasted URL stays fully verified (no sha256, no
+  insecure flag) but still gets a nonce.
+* ``clear-upgrade`` nulls the download hints.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.appliance import (
+    APPLIANCE_STATE_APPROVED,
+    Appliance,
+    ApplianceUpgradeImage,
+)
+from app.models.auth import User
+
+_SHA = "a" * 64
+
+
+async def _make_superadmin(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"admin-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test Admin",
+        hashed_password=hash_password("test-pw-386"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _seed_appliance(db: AsyncSession) -> Appliance:
+    appliance = Appliance(
+        id=uuid.uuid4(),
+        hostname=f"ddi-{uuid.uuid4().hex[:8]}",
+        state=APPLIANCE_STATE_APPROVED,
+        public_key_der=b"fake-key",
+        public_key_fingerprint="ff" * 32,
+        cert_serial="0000",
+        deployment_kind="appliance",
+        installed_appliance_version="2026.06.11-1",
+    )
+    db.add(appliance)
+    await db.flush()
+    return appliance
+
+
+async def _seed_image(db: AsyncSession) -> ApplianceUpgradeImage:
+    image = ApplianceUpgradeImage(
+        id=uuid.uuid4(),
+        filename="spatiumddi-appliance-slot-2026.06.12-1-amd64.raw.xz",
+        size_bytes=1234,
+        sha256=_SHA,
+        appliance_version="2026.06.12-1",
+    )
+    db.add(image)
+    await db.flush()
+    return image
+
+
+@pytest.mark.asyncio
+async def test_apply_internal_image_stamps_sha256_and_insecure(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _make_superadmin(db_session)
+    appliance = await _seed_appliance(db_session)
+    image = await _seed_image(db_session)
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/appliance/appliances/{appliance.id}/upgrade",
+        headers=headers,
+        json={
+            "desired_appliance_version": "2026.06.12-1",
+            "slot_image_id": str(image.id),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # The bytes are verified against the stored hash, and the self-served
+    # URL is flagged insecure so the host runner skips cert-verify for it.
+    assert body["desired_slot_image_sha256"] == _SHA
+    assert body["desired_slot_image_tls_insecure"] is True
+    url = body["desired_slot_image_url"]
+    assert f"/api/v1/appliance/upgrade-images/{image.id}/raw.xz" in url
+    assert "?t=" in url
+    # Fire-once nonce fragment.
+    assert "#a=" in url
+
+
+@pytest.mark.asyncio
+async def test_apply_mints_unique_nonce_each_time(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _make_superadmin(db_session)
+    appliance = await _seed_appliance(db_session)
+    image = await _seed_image(db_session)
+    await db_session.commit()
+
+    payload = {
+        "desired_appliance_version": "2026.06.12-1",
+        "slot_image_id": str(image.id),
+    }
+    r1 = await client.post(
+        f"/api/v1/appliance/appliances/{appliance.id}/upgrade",
+        headers=headers,
+        json=payload,
+    )
+    r2 = await client.post(
+        f"/api/v1/appliance/appliances/{appliance.id}/upgrade",
+        headers=headers,
+        json=payload,
+    )
+    assert r1.status_code == 200 and r2.status_code == 200
+    u1 = r1.json()["desired_slot_image_url"]
+    u2 = r2.json()["desired_slot_image_url"]
+    # Different nonce → the supervisor treats the re-apply as a fresh
+    # desired-state and re-fires, even though the underlying image is
+    # identical. The fetch URL (everything before the fragment) matches.
+    assert u1 != u2
+    assert u1.split("#", 1)[0] == u2.split("#", 1)[0]
+
+
+@pytest.mark.asyncio
+async def test_apply_external_url_stays_verified(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _make_superadmin(db_session)
+    appliance = await _seed_appliance(db_session)
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/appliance/appliances/{appliance.id}/upgrade",
+        headers=headers,
+        json={
+            "desired_appliance_version": "2026.06.12-1",
+            "desired_slot_image_url": (
+                "https://example.com/spatiumddi-appliance-slot-amd64.raw.xz"
+            ),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # External public-CA URL — no hash, fully verified TLS.
+    assert body["desired_slot_image_sha256"] is None
+    assert body["desired_slot_image_tls_insecure"] is False
+    assert "#a=" in body["desired_slot_image_url"]
+
+
+@pytest.mark.asyncio
+async def test_clear_upgrade_nulls_download_hints(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _make_superadmin(db_session)
+    appliance = await _seed_appliance(db_session)
+    image = await _seed_image(db_session)
+    await db_session.commit()
+
+    await client.post(
+        f"/api/v1/appliance/appliances/{appliance.id}/upgrade",
+        headers=headers,
+        json={
+            "desired_appliance_version": "2026.06.12-1",
+            "slot_image_id": str(image.id),
+        },
+    )
+    resp = await client.post(
+        f"/api/v1/appliance/appliances/{appliance.id}/clear-upgrade",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["desired_appliance_version"] is None
+    assert body["desired_slot_image_url"] is None
+    assert body["desired_slot_image_sha256"] is None
+    assert body["desired_slot_image_tls_insecure"] is False
+
+    # Confirm at the DB layer too.
+    refreshed = (
+        await db_session.execute(select(Appliance).where(Appliance.id == appliance.id))
+    ).scalar_one()
+    assert refreshed.desired_slot_image_sha256 is None
+    assert refreshed.desired_slot_image_tls_insecure is False

--- a/charts/spatiumddi-appliance/templates/supervisor.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor.yaml
@@ -96,6 +96,14 @@ spec:
             - name: nftables-conf
               mountPath: /etc/nftables-host.conf
               readOnly: true
+            # Issue #386 Part C — host slot-upgrade.log, read-only, so the
+            # heartbeat can ship a tail to the Fleet drilldown for full
+            # upgrade status (download → verify → write → bootloader).
+            # The structured progress sidecar lives in release-state
+            # (already mounted); this adds the raw log for detail.
+            - name: slot-upgrade-log
+              mountPath: /var/log/spatiumddi-host
+              readOnly: true
       volumes:
         - name: etc-spatiumddi-host
           hostPath:
@@ -125,6 +133,12 @@ spec:
           hostPath:
             path: /etc/rancher/k3s
             type: Directory
+        - name: slot-upgrade-log
+          hostPath:
+            path: /var/log/spatiumddi
+            # DirectoryOrCreate so a node that hasn't run an upgrade yet
+            # (no log dir) can never block the supervisor from scheduling.
+            type: DirectoryOrCreate
         - name: nftables-conf
           hostPath:
             path: {{ .Values.supervisor.hostMounts.nftablesConf }}

--- a/charts/spatiumddi/templates/api.yaml
+++ b/charts/spatiumddi/templates/api.yaml
@@ -118,6 +118,18 @@ spec:
             - name: spatiumddi-host-etc
               mountPath: /etc/spatiumddi-host
               readOnly: true
+            {{- if not .Values.slotImageMirror.enabled }}
+            # #386 — uploaded / GitHub-imported upgrade-image bytes. Without
+            # a persistent mount these live in the api's ephemeral container
+            # layer and vanish on every api restart: the DB row survives but
+            # the bytes 404 ("Upgrade image bytes missing on disk — re-upload
+            # required"), so a scheduled upgrade fails on download. The
+            # multi-node slot-image mirror (#296) holds these on its own PVC
+            # and the api proxies byte ops there, so this single-node hostPath
+            # only applies when the mirror is off. api WRITES here.
+            - name: slot-images
+              mountPath: /var/lib/spatiumddi/slot-images
+            {{- end }}
           {{- end }}
       {{- if .Values.api.applianceHostMounts.enabled }}
       volumes:
@@ -133,6 +145,14 @@ spec:
           hostPath:
             path: {{ .Values.api.applianceHostMounts.hostEtcDir }}
             type: DirectoryOrCreate
+        {{- if not .Values.slotImageMirror.enabled }}
+        # #386 — persist upgrade-image bytes across api restarts (single
+        # node; the mirror's PVC handles the multi-node case).
+        - name: slot-images
+          hostPath:
+            path: {{ .Values.api.applianceHostMounts.slotImagesDir }}
+            type: DirectoryOrCreate
+        {{- end }}
       {{- end }}
       {{- include "spatiumddi.controlPlaneNodeSelector" (merge (dict "componentNodeSelector" .Values.api.nodeSelector) .) | nindent 6 }}
       {{- with .Values.api.tolerations }}

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -115,6 +115,12 @@ api:
     releaseStateDir: /var/lib/spatiumddi/release-state
     hostLogDir: /var/log/spatiumddi
     hostEtcDir: /etc/spatiumddi
+    # #386 — host dir backing the api's upgrade-image store
+    # (SPATIUM_SLOT_IMAGE_DIR, default /var/lib/spatiumddi/slot-images).
+    # Persists uploaded / GitHub-imported images across api restarts so
+    # they don't 404 with "bytes missing on disk" on the next upgrade.
+    # Only mounted when the multi-node slot-image mirror is off.
+    slotImagesDir: /var/lib/spatiumddi/slot-images
 
 # ── Slot-image mirror (#296 Phase B) ────────────────────────────────────────
 # A single-replica Deployment + node-pinned local-path PVC + ClusterIP

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8471,6 +8471,29 @@ export interface SupervisorCapabilities {
   [k: string]: unknown;
 }
 
+// #386 Part C — structured per-phase progress the host slot-upgrade
+// runner emits, surfaced on the appliance row so the Fleet drilldown
+// can render a real step-by-step status instead of just a coarse chip.
+export type ApplianceUpgradeStep =
+  | "queued"
+  | "downloading"
+  | "verifying"
+  | "writing"
+  | "bootloader"
+  | "arming"
+  | "reboot-pending"
+  | "done"
+  | "failed";
+
+export interface ApplianceUpgradeProgress {
+  step: ApplianceUpgradeStep | string;
+  /** 0–100 during download; null for steps without a measurable %. */
+  pct: number | null;
+  detail: string;
+  /** ISO-8601 timestamp the step was entered. */
+  at: string;
+}
+
 export interface ApplianceRow {
   id: string;
   hostname: string;
@@ -8511,6 +8534,11 @@ export interface ApplianceRow {
   is_trial_boot: boolean;
   last_upgrade_state: string | null;
   last_upgrade_state_at: string | null;
+  // #386 Part C — full upgrade status: tail of the host slot-upgrade.log
+  // + structured per-phase progress, shipped by the supervisor while an
+  // apply is in-flight / failed / awaiting-reboot.
+  last_upgrade_log_tail: string | null;
+  last_upgrade_progress: ApplianceUpgradeProgress | null;
   snmpd_running: boolean | null;
   ntp_sync_state: string | null;
   /** Issue #156 — best-effort rsyslog forwarding status:
@@ -8527,6 +8555,11 @@ export interface ApplianceRow {
   resolver_status: string | null;
   desired_appliance_version: string | null;
   desired_slot_image_url: string | null;
+  // #386 Part A — integrity + transport hints (not secret). sha256 the
+  // host verifies the image bytes against; tls_insecure is true only for
+  // the appliance's own self-served URL.
+  desired_slot_image_sha256: string | null;
+  desired_slot_image_tls_insecure: boolean;
   // Operator's per-slot boot intents. Non-null means the Fleet UI
   // has asked the appliance to switch boot slots; the supervisor's
   // next heartbeat picks the field up + writes a host-side trigger.

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -29,6 +29,7 @@ import {
   dnsApi,
   type ApplianceRow,
   type ApplianceState,
+  type ApplianceUpgradeStep,
   type ControlPlaneReplaceResult,
   type SupervisorCapabilities,
   type UpgradeImage,
@@ -3639,6 +3640,226 @@ function ApplianceSlotCard({
   );
 }
 
+// #386 Part C — the ordered phases a slot upgrade walks through, for the
+// Fleet drilldown's status stepper. ``done`` / ``failed`` are terminal
+// states carried on ``last_upgrade_state``, not stepper rows.
+const UPGRADE_STEPS: { key: ApplianceUpgradeStep; label: string }[] = [
+  { key: "queued", label: "Queued" },
+  { key: "downloading", label: "Downloading image" },
+  { key: "verifying", label: "Verifying checksum" },
+  { key: "writing", label: "Writing to inactive slot" },
+  { key: "bootloader", label: "Updating bootloader" },
+  { key: "arming", label: "Arming next-boot" },
+  { key: "reboot-pending", label: "Reboot to boot the new slot" },
+];
+
+function UpgradeLogTail({ text }: { text: string }) {
+  return (
+    <details className="mt-2">
+      <summary className="cursor-pointer select-none text-muted-foreground hover:text-foreground">
+        <FileText className="mr-1 inline h-3 w-3" />
+        Show upgrade log
+      </summary>
+      <pre className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap rounded bg-muted/60 p-2 font-mono text-[10px] leading-tight">
+        {text}
+      </pre>
+    </details>
+  );
+}
+
+/**
+ * #386 Part C — full upgrade status for the Fleet drilldown. Driven by
+ * the supervisor-shipped ``last_upgrade_progress`` (per-phase step + %)
+ * + ``last_upgrade_log_tail`` + ``last_upgrade_state``. Renders three
+ * shapes: a red failure card (with the reason + log), a live stepper
+ * while an apply is downloading / writing / etc., and a green
+ * "staged — reboot to finish" card once next-boot is armed.
+ */
+function UpgradeStatusPanel({
+  row,
+  onCancel,
+  cancelPending,
+  onReboot,
+}: {
+  row: ApplianceRow;
+  onCancel: () => void;
+  cancelPending: boolean;
+  onReboot: () => void;
+}) {
+  const progress = row.last_upgrade_progress;
+  const state = row.last_upgrade_state;
+  const failed = state === "failed" || progress?.step === "failed";
+  const target = row.desired_appliance_version;
+
+  if (failed) {
+    return (
+      <div className="mt-3 rounded-md border border-rose-500/40 bg-rose-500/5 p-3 text-xs">
+        <div className="flex items-center gap-2">
+          <AlertCircle className="h-3.5 w-3.5 text-rose-600 dark:text-rose-400" />
+          <span className="font-medium">Upgrade failed</span>
+          {target && (
+            <code className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px]">
+              → {target}
+            </code>
+          )}
+        </div>
+        <p className="mt-1 text-rose-700 dark:text-rose-300">
+          {progress?.detail || "The slot apply failed."} See the log for the
+          cause, fix it, then re-apply.
+        </p>
+        {row.last_upgrade_log_tail && (
+          <UpgradeLogTail text={row.last_upgrade_log_tail} />
+        )}
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={cancelPending}
+          className="mt-2 inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-[11px] hover:bg-muted disabled:opacity-50"
+        >
+          {cancelPending ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <XCircle className="h-3 w-3" />
+          )}
+          Clear failed upgrade
+        </button>
+      </div>
+    );
+  }
+
+  const rebootPending = progress?.step === "reboot-pending" || state === "done";
+  // Where are we? -1 = desired set but no progress reported yet (the
+  // supervisor hasn't fired the trigger). Otherwise the index of the
+  // current phase in UPGRADE_STEPS.
+  const stepIndex = progress
+    ? UPGRADE_STEPS.findIndex((s) => s.key === progress.step)
+    : -1;
+
+  return (
+    <div
+      className={cn(
+        "mt-3 rounded-md border p-3 text-xs",
+        rebootPending
+          ? "border-emerald-500/40 bg-emerald-500/5"
+          : "border-amber-500/40 bg-amber-500/5",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        {rebootPending ? (
+          <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+        ) : (
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-amber-600 dark:text-amber-400" />
+        )}
+        <span className="font-medium">
+          {rebootPending
+            ? "Upgrade staged — reboot to finish"
+            : stepIndex === -1
+              ? "Upgrade pending"
+              : "Upgrade in progress"}
+        </span>
+        {target && (
+          <code className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px]">
+            → {target}
+          </code>
+        )}
+      </div>
+
+      {stepIndex === -1 && (
+        <p className="mt-1 text-muted-foreground">
+          Supervisor will fire the slot-upgrade trigger on its next heartbeat (≤
+          30 s).
+        </p>
+      )}
+
+      <ol className="mt-2 space-y-1">
+        {UPGRADE_STEPS.map((s, i) => {
+          const done =
+            i < stepIndex || (rebootPending && s.key !== "reboot-pending");
+          const active = !rebootPending && i === stepIndex;
+          const rebootCta = rebootPending && s.key === "reboot-pending";
+          return (
+            <li key={s.key} className="flex items-center gap-2">
+              {done ? (
+                <CheckCircle2 className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+              ) : active ? (
+                <Loader2 className="h-3 w-3 animate-spin text-amber-600 dark:text-amber-400" />
+              ) : rebootCta ? (
+                <Power className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+              ) : (
+                <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground/40" />
+              )}
+              <span
+                className={cn(
+                  done || rebootCta
+                    ? "text-foreground"
+                    : active
+                      ? "font-medium text-foreground"
+                      : "text-muted-foreground",
+                )}
+              >
+                {s.label}
+              </span>
+              {active && progress?.pct != null && (
+                <span className="ml-auto tabular-nums text-muted-foreground">
+                  {progress.pct}%
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      {progress?.detail && !rebootPending && (
+        <p
+          className="mt-2 truncate text-muted-foreground"
+          title={progress.detail}
+        >
+          {progress.detail}
+        </p>
+      )}
+      {progress?.step === "downloading" && progress.pct != null && (
+        <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full bg-amber-500 transition-all"
+            style={{ width: `${Math.min(100, Math.max(0, progress.pct))}%` }}
+          />
+        </div>
+      )}
+
+      {row.last_upgrade_log_tail && (
+        <UpgradeLogTail text={row.last_upgrade_log_tail} />
+      )}
+
+      <div className="mt-2 flex flex-wrap gap-2">
+        {rebootPending && (
+          <button
+            type="button"
+            onClick={onReboot}
+            className="inline-flex items-center gap-1 rounded-md border border-emerald-500/50 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 hover:bg-emerald-500/20 dark:text-emerald-300"
+          >
+            <Power className="h-3 w-3" /> Reboot to boot new slot
+          </button>
+        )}
+        {target && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={cancelPending}
+            className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-[11px] hover:bg-muted disabled:opacity-50"
+          >
+            {cancelPending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <XCircle className="h-3 w-3" />
+            )}
+            Cancel pending upgrade
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function ApplianceOsUpgradeSection({ row }: { row: ApplianceRow }) {
   const qc = useQueryClient();
   const [sourceKind, setSourceKind] = useState<"url" | "uploaded">("uploaded");
@@ -3650,6 +3871,13 @@ function ApplianceOsUpgradeSection({ row }: { row: ApplianceRow }) {
   const isApplianceHost =
     row.deployment_kind === "appliance" || row.deployment_kind === null;
   const upgradeInFlight = row.desired_appliance_version !== null;
+  // #386 Part C — show the full status panel whenever there's upgrade
+  // activity: a pending/in-flight desired version, or a terminal
+  // in-flight/failed state the supervisor is still reporting.
+  const showUpgradeStatus =
+    upgradeInFlight ||
+    row.last_upgrade_state === "in-flight" ||
+    row.last_upgrade_state === "failed";
 
   // Staged upgrade images — fetched only when the operator picks the
   // ``uploaded`` source, so non-air-gapped flows skip the round trip.
@@ -3780,31 +4008,13 @@ function ApplianceOsUpgradeSection({ row }: { row: ApplianceRow }) {
           appliance OS. Use the docker compose / helm upgrade flow for{" "}
           <code>{row.deployment_kind}</code> deployments.
         </p>
-      ) : upgradeInFlight ? (
-        <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
-          <div className="flex items-center gap-2">
-            <Upload className="h-3.5 w-3.5 text-amber-700 dark:text-amber-300" />
-            <span className="font-medium">Upgrade pending</span>
-          </div>
-          <p className="mt-1 text-muted-foreground">
-            Target version <code>{row.desired_appliance_version}</code>.
-            Supervisor will fire the slot-upgrade trigger on its next heartbeat
-            (≤ 30 s).
-          </p>
-          <button
-            type="button"
-            onClick={() => clearUpgrade.mutate()}
-            disabled={clearUpgrade.isPending}
-            className="mt-2 inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-[11px] hover:bg-muted disabled:opacity-50"
-          >
-            {clearUpgrade.isPending ? (
-              <Loader2 className="h-3 w-3 animate-spin" />
-            ) : (
-              <XCircle className="h-3 w-3" />
-            )}
-            Cancel pending upgrade
-          </button>
-        </div>
+      ) : showUpgradeStatus ? (
+        <UpgradeStatusPanel
+          row={row}
+          onCancel={() => clearUpgrade.mutate()}
+          cancelPending={clearUpgrade.isPending}
+          onReboot={() => setRebootConfirm(true)}
+        />
       ) : (
         <div className="mt-3 space-y-2">
           {/* Source picker — uploaded image (air-gap-friendly) vs


### PR DESCRIPTION
Closes #386.

A single-appliance OS slot upgrade from an imported/uploaded upgrade
image (the #199 flow) failed every time, retried silently forever, and
showed nothing useful in the Fleet UI. Four fixes, validated end-to-end
on a real appliance (ddi1).

## A — download failed on self-signed TLS *(the headline)*
The scheduler points `desired_slot_image_url` at the appliance's **own**
control plane (`https://<self>/api/v1/appliance/upgrade-images/<id>/raw.xz`),
behind the self-signed web cert. The host runner fetched it with bare
`urllib.urlopen` → `CERTIFICATE_VERIFY_FAILED` every time.

Now the scheduler stamps the image's stored **sha256** + a `tls_insecure`
flag; the host runner verifies the bytes against the hash (the real
integrity guarantee) and skips cert-verify **only** for the self-served
URL. External public-CA URLs stay fully verified; insecure-TLS is refused
host-side unless an expected hash is present.

## B — silent crash-loop + masked failures
A failed apply renamed the trigger away but left `desired_version` set, so
the supervisor re-fired every heartbeat (~30 s), flooding `.failed.<ts>`
sidecars; the `failed→ready` auto-heal then masked it so the Fleet chip
read "ready" mid-failure. Now: a per-apply **nonce fragment** on the URL
makes each schedule a distinct desired-state, the supervisor fires exactly
once per URL (fire-once marker), a cleared/cancelled upgrade resets the
marker + heals a stale failed, the masking is removed (failures reported
honestly), and old sidecars are pruned.

## C — full status in the Fleet UI
The host runner emits structured per-phase progress (`queued → downloading
[+%] → verifying → writing → bootloader → arming → reboot-pending`) to a
sidecar the supervisor ships on heartbeat, plus a tail of
`slot-upgrade.log`. The Fleet drilldown renders a live **status stepper**
with the download %, an expandable log, a failure card with the reason,
and a reboot-to-finish CTA — replacing the opaque "Upgrade pending" chip.

## D — persist the upgrade-image store across api restarts
Found live: uploaded/imported image **bytes** lived in the api container's
ephemeral layer, so an api restart wiped them (the row survived; the next
upgrade 404'd "bytes missing on disk"). The api Deployment now hostPath-
mounts the slot-image dir (appliance-gated, single-node only — the
multi-node mirror's PVC handles that case).

## Schema / infra
Migration `e1c4a9d27b63` adds `appliance.{desired_slot_image_sha256,
desired_slot_image_tls_insecure,last_upgrade_log_tail,last_upgrade_progress}`.
The supervisor gains a read-only `/var/log/spatiumddi` mount for the log tail.

## Validation
- 4 new backend tests (apply stamps sha256/insecure + unique nonce;
  external stays verified; clear nulls) — pass.
- ruff + black + mypy + tsc + eslint + prettier + vite build + helm lint — clean.
- **Live on ddi1:** deployed all images + host scripts + migration, re-ran
  the upgrade → downloaded over the self-signed cert (no TLS error),
  sha256-verified, wrote `2026.06.12-1` to the inactive slot, reached
  `done`/`reboot-pending` without looping; progress + state surfaced
  exactly as the new stepper renders.

Follow-up: #387 (NTP + other host-config runners share the same silent-loop
anti-pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)