### PR TITLE
fix(appliance): #387 host-config runners crash-loop silently + #389 etcd-snapshot RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,79 @@ the formatter handles the rest.
 
 ---
 
+## 2026.06.12-2 — 2026-06-12
+
+Appliance **host-config reliability** — closes the silent NTP
+crash-loop (#387) and the always-empty Fleet etcd-snapshot list
+(#389). On a field appliance the GUI-configured NTP settings had
+**never** applied: the host-side `spatiumddi-chrony-reload` runner
+validated the staged config with `chronyd -t -f <file>`, but `-t`
+is chrony's *timeout* flag (it takes a numeric argument), so chrony
+parsed `-f` as the timeout value and died with `Fatal error :
+Invalid argument -f` on every apply. Because each host-config
+runner only writes its applied-hash sidecar on SUCCESS, the
+supervisor re-derived "desired ≠ applied → fire the trigger" every
+~30 s heartbeat and re-fired forever — accumulating **2374**
+`ntp-config-pending.failed.<ts>` sidecars (and a parallel 2021
+`slot-set-next-boot-pending.done` from the same re-fire shape) with
+nothing surfaced in the UI. This release fixes the chrony flag and
+generalises #386's slot-upgrade fire-once/backoff/prune pattern to
+every hash-keyed host-config runner so none of them can silently
+loop again, and surfaces a stuck apply honestly in the Fleet
+drilldown. Builds on the slot-upgrade guard shipped in #386.
+
+### Fixed
+
+* **#387 — NTP config never applied on the appliance.** The chrony
+  config-apply runner's syntax check used `chronyd -t -f <file>`;
+  `-t` is the *timeout* option (numeric arg), not a "test config"
+  flag, so the check died with `Fatal error : Invalid argument -f`
+  and every operator-pushed NTP change silently failed to apply
+  (chrony kept running on the image-baked pool config, so time sync
+  itself was unaffected — only GUI NTP changes were dropped). Now
+  uses `chronyd -p -f <file>` (parse-and-print, exits 0/non-0
+  without touching the running daemon), with a comment documenting
+  the `-t` vs `-p` trap so it isn't reintroduced.
+* **#387 — host-config runners crash-loop silently.** A shared
+  bounded-retry fire-guard now gates every hash-keyed host-config
+  runner (snmp / ntp / lldp / syslog / ssh / resolver / firewall /
+  timezone): a persistently-failing apply re-fires with exponential
+  backoff (60 s → … → 15 min ceiling) per distinct config hash
+  instead of every heartbeat, a fresh config hash resets the budget,
+  and the guard never permanently gives up so a fixed runner
+  auto-recovers. Stale timestamped trigger sidecars
+  (`.failed` / `.done` / `.invalid.<ts>`) are pruned to the newest
+  5 per family on every heartbeat, which culls the existing ddi1
+  backlog on the first post-upgrade tick.
+* **#389 — Fleet etcd-snapshot inventory always empty.** The
+  supervisor reports recoverable snapshots by listing the k3s
+  `ETCDSnapshotFile` CRs over the kubeapi, but its ServiceAccount
+  lacked a `k3s.cattle.io/etcdsnapshotfiles` read grant, so the
+  `GET` 403'd and the list reported empty every heartbeat even
+  though k3s was taking snapshots on schedule. Added the read-only
+  rule to the supervisor's `spatium-supervisor-nodes` ClusterRole;
+  `list_etcd_snapshots()` now logs a warning on a 403 (was a silent
+  empty list) so a future RBAC gap is self-diagnosing.
+
+### Added
+
+* **#387 — host-config apply health in the Fleet UI.** The
+  supervisor heartbeat ships `host_config_health` — per-plane
+  `{state, attempts, at}` for any host-config runner whose desired
+  config isn't applied yet (`retrying` while transient, `failing`
+  once the apply keeps failing) — persisted to the new
+  `appliance.host_config_health` column and rendered as a
+  "Host-config apply health" table in the appliance drilldown, so a
+  stuck apply is visible instead of looping invisibly. An
+  all-healthy appliance reports `{}` and the section stays hidden.
+
+### Migrations
+
+* `f4a1c9e7b2d8` — adds `appliance.host_config_health` (JSONB, not
+  null, default `{}`).
+
+---
+
 ## 2026.06.12-1 — 2026-06-12
 
 Hotfix for **directly-attached DHCP dead on 2026.06.11-1** (#383).

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -598,22 +598,228 @@ def clear_fleet_upgrade_marker() -> None:
         pass
 
 
-def _prune_failed_sidecars(keep: int = 5) -> None:
-    """#386 Part B — keep only the most recent ``.failed.<ts>`` /
-    ``.done.<ts>`` / ``.invalid.<ts>`` slot-upgrade sidecars so churn
-    (or a pre-#386 re-fire loop) doesn't accumulate hundreds of files
-    in release-state. Sidecar suffixes are unix timestamps, so a
-    lexicographic sort is chronological."""
+def _prune_host_config_sidecars(trigger_file: Path, keep: int = 5) -> None:
+    """(#387) Keep only the newest ``.failed.<ts>`` / ``.done.<ts>`` /
+    ``.invalid.<ts>`` sidecars for ONE trigger family, so a (pre-fix)
+    re-fire loop or normal churn can't accumulate thousands of files in
+    release-state (2374 ntp + 2021 set-next-boot observed on ddi1, #387).
+    Sidecar suffixes are unix timestamps, so a lexicographic sort is
+    chronological. Generalises the slot-upgrade-only #386 pruner."""
     try:
-        parent = _TRIGGER_FILE.parent
+        parent = trigger_file.parent
         for suffix in ("failed", "done", "invalid"):
-            stale = sorted(parent.glob(f"{_TRIGGER_FILE.name}.{suffix}.*"))
+            stale = sorted(parent.glob(f"{trigger_file.name}.{suffix}.*"))
             for path in stale[:-keep]:
                 path.unlink(missing_ok=True)
     except OSError:
         # Best-effort housekeeping — leftover sidecars are cosmetic; a
-        # prune failure must never block the upgrade trigger.
+        # prune failure must never block a trigger write.
         pass
+
+
+def _prune_failed_sidecars(keep: int = 5) -> None:
+    """#386 — slot-upgrade sidecar prune. Thin wrapper over the
+    generalised #387 pruner, kept as a named entry point for
+    ``maybe_fire_fleet_upgrade``."""
+    _prune_host_config_sidecars(_TRIGGER_FILE, keep)
+
+
+# ── #387 — shared bounded-retry fire-guard for the hash-keyed host-
+#    config runners (snmp / ntp / lldp / syslog / ssh / resolver /
+#    firewall / timezone) ──────────────────────────────────────────────
+#
+# Each runner applies a control-plane-rendered config and writes its
+# applied-hash sidecar ONLY on success. The naive fire test — "desired
+# config_hash != applied_hash → write the trigger" — therefore re-fires
+# the SAME desired-state every heartbeat whenever an apply persistently
+# fails (the sidecar never advances), flooding ``<trigger>.failed.<ts>``
+# sidecars (2374 observed on ddi1 for a single bad chrony flag, #387) and
+# never surfacing the failure.
+#
+# The guard caps the RATE of re-fires per distinct config_hash with
+# exponential backoff (a fresh hash — operator pushed new config —
+# resets the budget). A stuck apply retries at a decreasing cadence
+# (60 s → 120 s → … → 15 min ceiling) instead of every ~30 s tick, and
+# NEVER permanently gives up, so a fixed runner (e.g. the #387 chrony
+# flag fix) auto-recovers on the next backoff window with no operator
+# action. ``read_host_config_health()`` surfaces the per-plane
+# stuck/failing state on the heartbeat for the Fleet UI.
+
+_HOSTCFG_BACKOFF_BASE_S = 60.0
+_HOSTCFG_BACKOFF_MAX_S = 900.0  # 15-min ceiling between retries of a stuck apply
+_HOSTCFG_FAILING_ATTEMPTS = 3  # at/after this many fires of one hash → "failing"
+
+# (plane name, trigger file, applied-hash sidecar). The per-plane
+# fire-state sidecar is derived as ``<trigger>.fire-state`` so there's
+# one source of truth and no extra path consts to keep in sync.
+_HOST_CONFIG_PLANES: list[tuple[str, Path, Path]] = [
+    ("snmp", _SNMP_TRIGGER_FILE, _SNMP_HASH_SIDECAR),
+    ("ntp", _NTP_TRIGGER_FILE, _NTP_HASH_SIDECAR),
+    ("lldp", _LLDP_TRIGGER_FILE, _LLDP_HASH_SIDECAR),
+    ("syslog", _SYSLOG_TRIGGER_FILE, _SYSLOG_HASH_SIDECAR),
+    ("ssh", _SSH_TRIGGER_FILE, _SSH_HASH_SIDECAR),
+    ("resolver", _RESOLVER_TRIGGER_FILE, _RESOLVER_HASH_SIDECAR),
+    ("firewall", _FIREWALL_TRIGGER_FILE, _FIREWALL_APPLIED_HASH_SIDECAR),
+    ("timezone", _TZ_TRIGGER_FILE, _TZ_APPLIED_HASH_FILE),
+]
+
+
+def _fire_state_path(trigger_file: Path) -> Path:
+    return trigger_file.with_name(trigger_file.name + ".fire-state")
+
+
+def _read_fire_state(fire_state_file: Path) -> tuple[str, int, datetime | None]:
+    """Read ``<hash>\\t<attempts>\\t<iso>`` → (hash, attempts, when).
+    Missing / malformed → ``("", 0, None)``."""
+    try:
+        text = fire_state_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return "", 0, None
+    parts = text.split("\t")
+    if not parts or not parts[0]:
+        return "", 0, None
+    try:
+        attempts = int(parts[1]) if len(parts) > 1 else 0
+    except ValueError:
+        attempts = 0
+    when: datetime | None = None
+    if len(parts) > 2:
+        try:
+            when = datetime.fromisoformat(parts[2])
+        except ValueError:
+            when = None
+    return parts[0], attempts, when
+
+
+def _write_fire_state(
+    fire_state_file: Path, config_hash: str, attempts: int, when: datetime
+) -> None:
+    try:
+        tmp = fire_state_file.with_suffix(".new")
+        tmp.write_text(
+            f"{config_hash}\t{attempts}\t{when.isoformat()}\n", encoding="utf-8"
+        )
+        tmp.replace(fire_state_file)
+    except OSError:
+        # Best-effort bookkeeping — a failed fire-state write at worst
+        # costs the backoff its memory for one tick; never fatal.
+        pass
+
+
+def _hostcfg_backoff_seconds(attempts: int) -> float:
+    # ``attempts`` = number of prior fires for this hash (>= 1).
+    expo = _HOSTCFG_BACKOFF_BASE_S * (2 ** max(0, attempts - 1))
+    return min(expo, _HOSTCFG_BACKOFF_MAX_S)
+
+
+def _hostcfg_should_fire(
+    fire_state_file: Path, config_hash: str, *, now: datetime | None = None
+) -> tuple[bool, int]:
+    """(#387) Decide whether to (re-)fire a hash-keyed host-config
+    trigger, applying per-hash exponential backoff. Returns
+    ``(should_fire, attempt_to_record)``. The caller has already
+    confirmed ``config_hash != applied_hash`` and that the trigger file
+    is absent — so reaching here with the SAME hash means the prior
+    attempt has not succeeded yet (failed, or still mid-apply)."""
+    now = now or datetime.now(UTC)
+    prev_hash, attempts, last_at = _read_fire_state(fire_state_file)
+    if config_hash != prev_hash:
+        return True, 1  # fresh desired-state → reset budget, fire now
+    if last_at is not None and (
+        now - last_at
+    ).total_seconds() < _hostcfg_backoff_seconds(attempts):
+        return False, attempts  # still inside the backoff window
+    return True, attempts + 1
+
+
+def _fire_host_config(
+    trigger_file: Path,
+    applied_hash_sidecar: Path,
+    config_hash: str,
+    payload: str,
+) -> bool:
+    """(#387) Shared write path for the hash-keyed host-config runners.
+
+    Replaces the per-function "compare hash → check trigger presence →
+    write trigger" boilerplate AND adds the bounded-retry guard + the
+    per-plane sidecar prune in one place. Returns True iff a trigger was
+    written. The caller owns the appliance-only gate + payload assembly
+    (+ any plane-specific guard, e.g. the SSH lockout refusal)."""
+    applied_hash = _read_release_state_line(applied_hash_sidecar) or ""
+    if config_hash == applied_hash:
+        return False  # already applied — idempotent no-op
+    if trigger_file.exists():
+        return False  # path unit hasn't consumed the last trigger — don't stack
+    fire_state = _fire_state_path(trigger_file)
+    now = datetime.now(UTC)
+    should_fire, attempt = _hostcfg_should_fire(fire_state, config_hash, now=now)
+    if not should_fire:
+        return False  # backing off a stuck apply (#387) — no silent flood
+    try:
+        trigger_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp = trigger_file.with_suffix(".new")
+        tmp.write_text(payload, encoding="utf-8")
+        tmp.replace(trigger_file)
+    except OSError:
+        return False
+    _write_fire_state(fire_state, config_hash, attempt, now)
+    _prune_host_config_sidecars(trigger_file)
+    return True
+
+
+def read_host_config_health() -> dict[str, dict[str, object]]:
+    """(#387) Per-plane apply health for the hash-keyed host-config
+    runners, surfaced on the heartbeat so the Fleet UI shows a stuck
+    apply honestly instead of leaving the operator with a silent re-fire
+    loop. Only planes whose last-fired config has NOT been applied are
+    reported::
+
+        {"ntp": {"state": "failing", "attempts": 7, "at": "<iso>"}, ...}
+
+    ``state`` is ``failing`` once the same hash has been fired
+    ``_HOSTCFG_FAILING_ATTEMPTS`` times (apply keeps failing), else
+    ``retrying``. A plane whose applied-hash matches its last-fired hash
+    (success) — or that was never fired — is omitted, so a healthy box
+    reports ``{}`` (which clears any stale server-side entry)."""
+    out: dict[str, dict[str, object]] = {}
+    for name, trigger, applied_sidecar in _HOST_CONFIG_PLANES:
+        fhash, attempts, when = _read_fire_state(_fire_state_path(trigger))
+        if not fhash:
+            continue  # never fired → nothing to report
+        applied = _read_release_state_line(applied_sidecar) or ""
+        if applied == fhash:
+            continue  # last-fired config is applied → healthy, omit
+        out[name] = {
+            "state": (
+                "failing" if attempts >= _HOSTCFG_FAILING_ATTEMPTS else "retrying"
+            ),
+            "attempts": attempts,
+            "at": when.isoformat() if when else None,
+        }
+    return out
+
+
+# Trigger families whose host runners rename the consumed trigger to a
+# timestamped ``.done`` / ``.failed`` / ``.invalid`` sidecar. The
+# collect() sweep prunes each every heartbeat so the existing ddi1
+# backlog (2374 ntp + 2021 set-next-boot) is culled on the first
+# post-upgrade heartbeat regardless of whether anything fires this tick.
+# Globbing a family that never timestamp-renames is a harmless no-op.
+_PRUNABLE_TRIGGERS: list[Path] = [
+    _TRIGGER_FILE,
+    _SET_NEXT_BOOT_TRIGGER_FILE,
+    _SET_DEFAULT_TRIGGER_FILE,
+    _VERBOSE_TRIGGER_FILE,
+    _REBOOT_TRIGGER_FILE,
+] + [trigger for _name, trigger, _applied in _HOST_CONFIG_PLANES]
+
+
+def prune_all_trigger_sidecars(keep: int = 5) -> None:
+    """(#387) Sweep every known trigger family's stale timestamped
+    sidecars. Called once per ``collect()`` so a pre-fix backlog is
+    bounded immediately on upgrade, independent of any fire this tick."""
+    for trigger in _PRUNABLE_TRIGGERS:
+        _prune_host_config_sidecars(trigger, keep)
 
 
 def _read_slot_upgrade_log_tail(lines: int = 40, max_chars: int = 8000) -> str:
@@ -695,26 +901,14 @@ def maybe_fire_timezone(desired_timezone: str | None) -> bool:
     if not desired_timezone or not desired_timezone.strip():
         return False
     desired = desired_timezone.strip()
-    # Read the applied-hash sidecar (single-line IANA name) the host
-    # runner writes after a successful apply.
-    try:
-        applied = _TZ_APPLIED_HASH_FILE.read_text(encoding="utf-8").strip()
-    except OSError:
-        applied = ""
-    if applied == desired:
-        return False
-    try:
-        _TZ_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-        tmp = _TZ_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(desired + "\n", encoding="utf-8")
-        # Atomic rename — the .path unit watches PathChanged which
-        # fires on close-after-write of the final path, so the
-        # rename ensures the runner sees the complete trigger file
-        # rather than a half-written one.
-        tmp.replace(_TZ_TRIGGER_FILE)
-        return True
-    except OSError:
-        return False
+    # #387 — fire through the shared bounded-retry guard. The "applied
+    # IANA name" sidecar plays the role of the applied-hash, and the
+    # desired IANA name plays the config_hash, so a tz the host runner
+    # can't apply (e.g. a name ``timedatectl`` rejects) backs off
+    # instead of re-firing every heartbeat. Payload = the IANA name.
+    return _fire_host_config(
+        _TZ_TRIGGER_FILE, _TZ_APPLIED_HASH_FILE, desired, desired + "\n"
+    )
 
 
 def maybe_fire_verbose_boot(desired_verbose_boot: bool | None) -> bool:
@@ -883,37 +1077,24 @@ def maybe_fire_snmp_reload(bundle_block: object) -> bool:
     # disable trigger if the agent previously applied a non-empty
     # config (sidecar present and non-empty) — otherwise this is the
     # default "never configured" state and there's nothing to undo.
-    last_hash = ""
-    if _SNMP_HASH_SIDECAR.exists():
-        try:
-            last_hash = _SNMP_HASH_SIDECAR.read_text(encoding="utf-8").strip()
-        except OSError:
-            last_hash = ""
-    if config_hash == last_hash:
-        return False
-    if _SNMP_TRIGGER_FILE.exists():
-        return False
-    try:
-        _SNMP_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-        # Three-section payload the host runner reads:
-        #   line 1:    ``enabled`` | ``disabled`` marker
-        #   line 2:    config_hash (sha256 hex, blank when disabled)
-        #   line 3+:   rendered snmpd.conf body (already ends with \n)
-        # The hash is on the wire (rather than recomputed by the
-        # runner) so the agent and host agree on exactly which body
-        # was applied — useful when the runner writes the sidecar
-        # the agent reads on next bundle to short-circuit re-firing.
-        payload = (
-            ("enabled\n" if enabled else "disabled\n")
-            + (config_hash + "\n")
-            + snmpd_conf
-        )
-        tmp = _SNMP_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(payload, encoding="utf-8")
-        tmp.replace(_SNMP_TRIGGER_FILE)
-        return True
-    except OSError:
-        return False
+    # Three-section payload the host runner reads:
+    #   line 1:   ``enabled`` | ``disabled`` marker
+    #   line 2:   config_hash (sha256 hex, blank when disabled)
+    #   line 3+:  rendered snmpd.conf body (already ends with \n)
+    # The hash is on the wire (rather than recomputed by the runner) so
+    # the agent and host agree on exactly which body was applied. An
+    # empty config_hash (SNMP disabled) only fires a disable trigger if
+    # a non-empty config was previously applied — handled by the
+    # ``config_hash == applied_hash`` short-circuit inside the guard.
+    payload = (
+        ("enabled\n" if enabled else "disabled\n") + (config_hash + "\n") + snmpd_conf
+    )
+    # #387 — fire through the shared bounded-retry guard so a
+    # persistently-failing apply backs off instead of re-firing every
+    # heartbeat (which flooded thousands of .failed sidecars).
+    return _fire_host_config(
+        _SNMP_TRIGGER_FILE, _SNMP_HASH_SIDECAR, config_hash, payload
+    )
 
 
 # ── #272 Phase 7b — control-plane cluster join/leave ────────────────
@@ -1132,30 +1313,16 @@ def maybe_fire_syslog_reload(bundle_block: object) -> bool:
     ca_certs = bundle_block.get("ca_certs")
     if not isinstance(ca_certs, dict):
         ca_certs = {}
-    last_hash = ""
-    if _SYSLOG_HASH_SIDECAR.exists():
-        try:
-            last_hash = _SYSLOG_HASH_SIDECAR.read_text(encoding="utf-8").strip()
-        except OSError:
-            last_hash = ""
-    if config_hash == last_hash:
-        return False
-    if _SYSLOG_TRIGGER_FILE.exists():
-        return False
-    try:
-        _SYSLOG_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-        payload = (
-            ("enabled\n" if enabled else "disabled\n")
-            + (config_hash + "\n")
-            + (json.dumps(ca_certs) + "\n")
-            + rsyslog_conf
-        )
-        tmp = _SYSLOG_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(payload, encoding="utf-8")
-        tmp.replace(_SYSLOG_TRIGGER_FILE)
-        return True
-    except OSError:
-        return False
+    payload = (
+        ("enabled\n" if enabled else "disabled\n")
+        + (config_hash + "\n")
+        + (json.dumps(ca_certs) + "\n")
+        + rsyslog_conf
+    )
+    # #387 — shared bounded-retry guard (see maybe_fire_snmp_reload).
+    return _fire_host_config(
+        _SYSLOG_TRIGGER_FILE, _SYSLOG_HASH_SIDECAR, config_hash, payload
+    )
 
 
 def read_syslog_forwarding() -> str | None:
@@ -1237,35 +1404,19 @@ def maybe_fire_ssh_reload(bundle_block: object) -> bool:
         )
         return False
 
-    last_hash = ""
-    if _SSH_HASH_SIDECAR.exists():
-        try:
-            last_hash = _SSH_HASH_SIDECAR.read_text(encoding="utf-8").strip()
-        except OSError:
-            last_hash = ""
-    if config_hash == last_hash:
-        return False
-    if _SSH_TRIGGER_FILE.exists():
-        return False
-    try:
-        _SSH_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-        ak_bytes = authorized_keys.encode("utf-8")
-        payload = (
-            ("enabled\n" if enabled else "disabled\n")
-            + (config_hash + "\n")
-            + (str(ssh_port) + "\n")
-            + (json.dumps(allowed) + "\n")
-            + (("1" if password_auth else "0") + "\n")
-            + (str(len(ak_bytes)) + "\n")
-            + authorized_keys
-            + sshd_conf
-        )
-        tmp = _SSH_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(payload, encoding="utf-8")
-        tmp.replace(_SSH_TRIGGER_FILE)
-        return True
-    except OSError:
-        return False
+    ak_bytes = authorized_keys.encode("utf-8")
+    payload = (
+        ("enabled\n" if enabled else "disabled\n")
+        + (config_hash + "\n")
+        + (str(ssh_port) + "\n")
+        + (json.dumps(allowed) + "\n")
+        + (("1" if password_auth else "0") + "\n")
+        + (str(len(ak_bytes)) + "\n")
+        + authorized_keys
+        + sshd_conf
+    )
+    # #387 — shared bounded-retry guard (see maybe_fire_snmp_reload).
+    return _fire_host_config(_SSH_TRIGGER_FILE, _SSH_HASH_SIDECAR, config_hash, payload)
 
 
 def read_ssh_key_count() -> int | None:
@@ -1314,29 +1465,15 @@ def maybe_fire_resolver_reload(bundle_block: object) -> bool:
     config_hash = str(bundle_block.get("config_hash") or "")
     resolved_conf = str(bundle_block.get("resolved_conf") or "")
     enabled = bool(bundle_block.get("enabled"))
-    last_hash = ""
-    if _RESOLVER_HASH_SIDECAR.exists():
-        try:
-            last_hash = _RESOLVER_HASH_SIDECAR.read_text(encoding="utf-8").strip()
-        except OSError:
-            last_hash = ""
-    if config_hash == last_hash:
-        return False
-    if _RESOLVER_TRIGGER_FILE.exists():
-        return False
-    try:
-        _RESOLVER_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-        payload = (
-            ("enabled\n" if enabled else "disabled\n")
-            + (config_hash + "\n")
-            + resolved_conf
-        )
-        tmp = _RESOLVER_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(payload, encoding="utf-8")
-        tmp.replace(_RESOLVER_TRIGGER_FILE)
-        return True
-    except OSError:
-        return False
+    payload = (
+        ("enabled\n" if enabled else "disabled\n")
+        + (config_hash + "\n")
+        + resolved_conf
+    )
+    # #387 — shared bounded-retry guard (see maybe_fire_snmp_reload).
+    return _fire_host_config(
+        _RESOLVER_TRIGGER_FILE, _RESOLVER_HASH_SIDECAR, config_hash, payload
+    )
 
 
 def read_resolver_status() -> str | None:
@@ -1380,30 +1517,16 @@ def maybe_fire_lldp_reload(bundle_block: object) -> bool:
     lldpd_conf = str(bundle_block.get("lldpd_conf") or "")
     daemon_args = str(bundle_block.get("daemon_args") or "")
     enabled = bool(bundle_block.get("enabled"))
-    last_hash = ""
-    if _LLDP_HASH_SIDECAR.exists():
-        try:
-            last_hash = _LLDP_HASH_SIDECAR.read_text(encoding="utf-8").strip()
-        except OSError:
-            last_hash = ""
-    if config_hash == last_hash:
-        return False
-    if _LLDP_TRIGGER_FILE.exists():
-        return False
-    try:
-        _LLDP_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-        payload = (
-            ("enabled\n" if enabled else "disabled\n")
-            + (config_hash + "\n")
-            + (daemon_args + "\n")
-            + lldpd_conf
-        )
-        tmp = _LLDP_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(payload, encoding="utf-8")
-        tmp.replace(_LLDP_TRIGGER_FILE)
-        return True
-    except OSError:
-        return False
+    payload = (
+        ("enabled\n" if enabled else "disabled\n")
+        + (config_hash + "\n")
+        + (daemon_args + "\n")
+        + lldpd_conf
+    )
+    # #387 — shared bounded-retry guard (see maybe_fire_snmp_reload).
+    return _fire_host_config(
+        _LLDP_TRIGGER_FILE, _LLDP_HASH_SIDECAR, config_hash, payload
+    )
 
 
 def read_lldpd_running() -> bool | None:
@@ -1487,22 +1610,17 @@ def maybe_fire_firewall_reload(bundle_block: object) -> bool:
     firewall_conf = str(bundle_block.get("firewall_conf") or "")
     if not config_hash or not firewall_conf:
         return False  # no server-side authority → fall back / no-op
-    # Short-circuit against the runner's applied-hash sidecar. A body the
-    # Phase-1 in-pod path already applied short-circuits on upgrade because
-    # the server render is byte-identical → same hash.
-    last_hash = _read_release_state_line(_FIREWALL_APPLIED_HASH_SIDECAR) or ""
-    if config_hash == last_hash:
-        return False
-    if _FIREWALL_TRIGGER_FILE.exists():
-        return False
-    try:
-        _FIREWALL_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-        tmp = _FIREWALL_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(f"{config_hash}\n{firewall_conf}", encoding="utf-8")
-        tmp.replace(_FIREWALL_TRIGGER_FILE)
-        return True
-    except OSError:
-        return False
+    # #387 — shared bounded-retry guard. The short-circuit against the
+    # runner's applied-hash sidecar (a body the Phase-1 in-pod path
+    # already applied → byte-identical server render → same hash) now
+    # lives inside _fire_host_config, along with backoff on a stuck apply
+    # (see maybe_fire_snmp_reload).
+    return _fire_host_config(
+        _FIREWALL_TRIGGER_FILE,
+        _FIREWALL_APPLIED_HASH_SIDECAR,
+        config_hash,
+        f"{config_hash}\n{firewall_conf}",
+    )
 
 
 # ── LLDP neighbour discovery (#347) ──────────────────────────────────
@@ -1636,39 +1754,25 @@ def maybe_fire_ntp_reload(bundle_block: object) -> bool:
     config_hash = str(bundle_block.get("config_hash") or "")
     chrony_conf = str(bundle_block.get("chrony_conf") or "")
     allow_clients = bool(bundle_block.get("allow_clients"))
-    last_hash = ""
-    if _NTP_HASH_SIDECAR.exists():
-        try:
-            last_hash = _NTP_HASH_SIDECAR.read_text(encoding="utf-8").strip()
-        except OSError:
-            last_hash = ""
-    if config_hash == last_hash:
-        return False
-    if _NTP_TRIGGER_FILE.exists():
-        return False
-    try:
-        _NTP_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-        # Four-line header:
-        #   line 1: marker — ``enabled`` is always the case for
-        #           chrony (it's always running on the appliance);
-        #           kept for shape-parity with the SNMP runner.
-        #   line 2: ``allow_clients`` — ``true`` / ``false`` so the
-        #           runner knows whether to open the UDP 123 nft
-        #           drop-in.
-        #   line 3: config_hash (sha256 hex)
-        #   line 4+: rendered chrony.conf body
-        payload = (
-            "enabled\n"
-            + ("true\n" if allow_clients else "false\n")
-            + (config_hash + "\n")
-            + chrony_conf
-        )
-        tmp = _NTP_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(payload, encoding="utf-8")
-        tmp.replace(_NTP_TRIGGER_FILE)
-        return True
-    except OSError:
-        return False
+    # Four-line header:
+    #   line 1:  marker — ``enabled`` is always the case for chrony
+    #            (it's always running on the appliance); kept for
+    #            shape-parity with the SNMP runner.
+    #   line 2:  ``allow_clients`` — ``true`` / ``false`` so the runner
+    #            knows whether to open the UDP 123 nft drop-in.
+    #   line 3:  config_hash (sha256 hex)
+    #   line 4+: rendered chrony.conf body
+    payload = (
+        "enabled\n"
+        + ("true\n" if allow_clients else "false\n")
+        + (config_hash + "\n")
+        + chrony_conf
+    )
+    # #387 — shared bounded-retry guard. Before this, the bad
+    # ``chronyd -t -f`` validate flag made every apply fail, and the
+    # naive re-fire flooded 2374 .failed sidecars on ddi1. The guard
+    # backs off a stuck apply; the chrony runner fix makes it succeed.
+    return _fire_host_config(_NTP_TRIGGER_FILE, _NTP_HASH_SIDECAR, config_hash, payload)
 
 
 def read_ntp_sync_state() -> str | None:
@@ -2096,6 +2200,13 @@ def collect() -> dict[str, object]:
     deployment_kind = detect_deployment_kind()
     is_appliance = deployment_kind == "appliance"
 
+    # #387 — cull any stale timestamped trigger sidecars every tick so a
+    # pre-fix backlog (2374 ntp + 2021 set-next-boot observed on ddi1)
+    # is bounded on the first post-upgrade heartbeat, independent of
+    # whether any trigger fires this tick. Cheap (a handful of globs).
+    if is_appliance:
+        prune_all_trigger_sidecars()
+
     current_slot = _current_slot_from_cmdline() if is_appliance else None
     durable_default = _durable_default_from_grubenv() if is_appliance else None
     is_trial_boot: bool | None = None
@@ -2165,6 +2276,13 @@ def collect() -> dict[str, object]:
         # reference / stratum >= 16; ``unknown`` = chronyc unreadable
         # (transient at boot). None on non-appliance deploys.
         "ntp_sync_state": read_ntp_sync_state() if is_appliance else None,
+        # #387 — per-plane host-config apply health (snmp / ntp / lldp /
+        # syslog / ssh / resolver / firewall / timezone). Surfaces a
+        # stuck apply (the bounded-retry guard is backing it off) so the
+        # Fleet UI shows it honestly instead of a silent re-fire loop.
+        # ``{}`` when every plane is applied / unconfigured — clears any
+        # stale server-side entry; None off-appliance leaves it untouched.
+        "host_config_health": read_host_config_health() if is_appliance else None,
         # Issue #343 — lldpd running state from the host-side runner's
         # status sidecar. None on non-appliance deploys.
         "lldpd_running": read_lldpd_running() if is_appliance else None,

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -448,6 +448,18 @@ def list_etcd_snapshots() -> list[dict[str, Any]]:
     except RuntimeError:
         return []
     if status != 200:
+        # #389 — a 403 here is the common cause of an empty Fleet → etcd
+        # snapshots list: the supervisor ServiceAccount needs a
+        # ``k3s.cattle.io/etcdsnapshotfiles`` read grant
+        # (supervisor-rbac.yaml). Log it so a missing grant is
+        # self-diagnosing instead of an invisible empty list. A 404
+        # (older k3s without the CRD) is benign → debug, not warning.
+        emit = log.warning if status == 403 else log.debug
+        emit(
+            "supervisor.k8s_api.list_etcd_snapshots_status",
+            status=status,
+            body=resp[:200],
+        )
         return []
     try:
         items = (json.loads(resp) or {}).get("items") or []
@@ -459,7 +471,9 @@ def list_etcd_snapshots() -> list[dict[str, Any]]:
         st = it.get("status") or {}
         out.append(
             {
-                "name": spec.get("snapshotName") or (it.get("metadata") or {}).get("name") or "",
+                "name": spec.get("snapshotName")
+                or (it.get("metadata") or {}).get("name")
+                or "",
                 "location": spec.get("location") or "",
                 "node_name": spec.get("nodeName") or "",
                 "size": st.get("size"),

--- a/agent/supervisor/tests/test_host_config_fire_guard.py
+++ b/agent/supervisor/tests/test_host_config_fire_guard.py
@@ -1,0 +1,209 @@
+"""Bounded-retry fire-guard for hash-keyed host-config runners (#387).
+
+Before #387 each host-config runner (snmp / ntp / lldp / syslog / ssh /
+resolver / firewall / timezone) re-fired its trigger every heartbeat
+whenever ``config_hash != applied_hash`` — and since the runner only
+writes the applied-hash sidecar on SUCCESS, a persistently-failing apply
+(e.g. the bad ``chronyd -t -f`` validate flag) looped forever, flooding
+thousands of ``.failed.<ts>`` sidecars and surfacing nothing. These
+tests cover the guard that caps the re-fire RATE per distinct
+config_hash with exponential backoff, the per-plane health reader that
+surfaces a stuck apply, and the generalised sidecar prune.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from spatium_supervisor import appliance_state
+
+# ── _hostcfg_should_fire: backoff logic (pure, time-injected) ─────────
+
+
+def _fire_state(tmp_path: Path) -> Path:
+    return tmp_path / "ntp-config-pending.fire-state"
+
+
+def test_fresh_hash_fires_immediately(tmp_path: Path) -> None:
+    # No fire-state yet → fire now, recorded as attempt 1.
+    should, attempt = appliance_state._hostcfg_should_fire(
+        _fire_state(tmp_path), "hashA", now=datetime.now(UTC)
+    )
+    assert should is True
+    assert attempt == 1
+
+
+def test_same_hash_backs_off_then_retries(tmp_path: Path) -> None:
+    fs = _fire_state(tmp_path)
+    t0 = datetime(2026, 6, 12, 12, 0, 0, tzinfo=UTC)
+    appliance_state._write_fire_state(fs, "hashA", 1, t0)
+    # Within the 60 s backoff window for attempt 1 → no re-fire.
+    should, attempt = appliance_state._hostcfg_should_fire(
+        fs, "hashA", now=t0 + timedelta(seconds=30)
+    )
+    assert should is False
+    assert attempt == 1
+    # Past the window → re-fire, attempt advances to 2.
+    should, attempt = appliance_state._hostcfg_should_fire(
+        fs, "hashA", now=t0 + timedelta(seconds=61)
+    )
+    assert should is True
+    assert attempt == 2
+
+
+def test_backoff_grows_exponentially(tmp_path: Path) -> None:
+    fs = _fire_state(tmp_path)
+    t0 = datetime(2026, 6, 12, 12, 0, 0, tzinfo=UTC)
+    # 3 prior attempts → backoff = 60 * 2**2 = 240 s.
+    appliance_state._write_fire_state(fs, "hashA", 3, t0)
+    assert (
+        appliance_state._hostcfg_should_fire(
+            fs, "hashA", now=t0 + timedelta(seconds=239)
+        )[0]
+        is False
+    )
+    assert (
+        appliance_state._hostcfg_should_fire(
+            fs, "hashA", now=t0 + timedelta(seconds=241)
+        )[0]
+        is True
+    )
+
+
+def test_backoff_capped_at_ceiling(tmp_path: Path) -> None:
+    fs = _fire_state(tmp_path)
+    t0 = datetime(2026, 6, 12, 12, 0, 0, tzinfo=UTC)
+    # A huge attempt count must not push the interval past the 15-min
+    # ceiling — a stuck apply still retries (never permanently gives up),
+    # so a fixed runner auto-recovers.
+    appliance_state._write_fire_state(fs, "hashA", 50, t0)
+    assert (
+        appliance_state._hostcfg_should_fire(
+            fs, "hashA", now=t0 + timedelta(seconds=899)
+        )[0]
+        is False
+    )
+    assert (
+        appliance_state._hostcfg_should_fire(
+            fs, "hashA", now=t0 + timedelta(seconds=901)
+        )[0]
+        is True
+    )
+
+
+def test_new_hash_resets_budget(tmp_path: Path) -> None:
+    fs = _fire_state(tmp_path)
+    t0 = datetime(2026, 6, 12, 12, 0, 0, tzinfo=UTC)
+    appliance_state._write_fire_state(fs, "hashA", 9, t0)
+    # Operator pushed a fresh config (new hash) → fire immediately,
+    # attempt counter reset to 1, regardless of hashA's backoff.
+    should, attempt = appliance_state._hostcfg_should_fire(
+        fs, "hashB", now=t0 + timedelta(seconds=1)
+    )
+    assert should is True
+    assert attempt == 1
+
+
+def test_read_fire_state_tolerates_garbage(tmp_path: Path) -> None:
+    fs = tmp_path / "fs"
+    assert appliance_state._read_fire_state(fs) == ("", 0, None)  # missing
+    fs.write_text("hashA\tnotanint\tnotadate\n")
+    h, attempts, when = appliance_state._read_fire_state(fs)
+    assert h == "hashA"
+    assert attempts == 0
+    assert when is None
+
+
+# ── _fire_host_config: write path + short-circuits ────────────────────
+
+
+def test_fire_writes_trigger_and_fire_state(tmp_path: Path) -> None:
+    trigger = tmp_path / "ntp-config-pending"
+    applied = tmp_path / "ntp-config-hash"
+    fired = appliance_state._fire_host_config(trigger, applied, "h1", "payload\n")
+    assert fired is True
+    assert trigger.read_text() == "payload\n"
+    fs = appliance_state._fire_state_path(trigger)
+    assert fs.exists()
+    assert appliance_state._read_fire_state(fs)[0] == "h1"
+
+
+def test_fire_short_circuits_when_applied(tmp_path: Path) -> None:
+    trigger = tmp_path / "ntp-config-pending"
+    applied = tmp_path / "ntp-config-hash"
+    applied.write_text("h1\n")
+    # Desired hash already applied → no trigger, no fire.
+    assert appliance_state._fire_host_config(trigger, applied, "h1", "x\n") is False
+    assert not trigger.exists()
+
+
+def test_fire_does_not_stack_on_pending_trigger(tmp_path: Path) -> None:
+    trigger = tmp_path / "ntp-config-pending"
+    applied = tmp_path / "ntp-config-hash"
+    trigger.write_text("old\n")  # path unit hasn't consumed it yet
+    assert appliance_state._fire_host_config(trigger, applied, "h2", "new\n") is False
+    assert trigger.read_text() == "old\n"
+
+
+# ── read_host_config_health: honest surfacing ─────────────────────────
+
+
+def test_health_reports_stuck_and_clears_on_apply(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    trigger = tmp_path / "ntp-config-pending"
+    applied = tmp_path / "ntp-config-hash"
+    monkeypatch.setattr(
+        appliance_state, "_HOST_CONFIG_PLANES", [("ntp", trigger, applied)]
+    )
+    # Never fired → nothing to report.
+    assert appliance_state.read_host_config_health() == {}
+
+    # Fired once, not yet applied → "retrying".
+    appliance_state._write_fire_state(
+        appliance_state._fire_state_path(trigger), "h1", 1, datetime.now(UTC)
+    )
+    health = appliance_state.read_host_config_health()
+    assert health["ntp"]["state"] == "retrying"
+    assert health["ntp"]["attempts"] == 1
+
+    # Many failed attempts → "failing".
+    appliance_state._write_fire_state(
+        appliance_state._fire_state_path(trigger), "h1", 4, datetime.now(UTC)
+    )
+    assert appliance_state.read_host_config_health()["ntp"]["state"] == "failing"
+
+    # Runner finally applied h1 → plane omitted (healthy).
+    applied.write_text("h1\n")
+    assert appliance_state.read_host_config_health() == {}
+
+
+# ── prune ─────────────────────────────────────────────────────────────
+
+
+def test_prune_keeps_newest_n(tmp_path: Path) -> None:
+    trigger = tmp_path / "ntp-config-pending"
+    for ts in range(1000, 1012):  # 12 stale .failed sidecars
+        (tmp_path / f"ntp-config-pending.failed.{ts}").write_text("x")
+    appliance_state._prune_host_config_sidecars(trigger, keep=5)
+    remaining = sorted(p.name for p in tmp_path.glob("ntp-config-pending.failed.*"))
+    assert len(remaining) == 5
+    # Newest (highest timestamps) survive.
+    assert remaining == [f"ntp-config-pending.failed.{ts}" for ts in range(1007, 1012)]
+
+
+def test_prune_all_sweeps_every_family(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ntp = tmp_path / "ntp-config-pending"
+    setnext = tmp_path / "slot-set-next-boot-pending"
+    monkeypatch.setattr(appliance_state, "_PRUNABLE_TRIGGERS", [ntp, setnext])
+    for ts in range(2000, 2010):
+        (tmp_path / f"ntp-config-pending.failed.{ts}").write_text("x")
+        (tmp_path / f"slot-set-next-boot-pending.done.{ts}").write_text("x")
+    appliance_state.prune_all_trigger_sidecars(keep=3)
+    assert len(list(tmp_path.glob("ntp-config-pending.failed.*"))) == 3
+    assert len(list(tmp_path.glob("slot-set-next-boot-pending.done.*"))) == 3

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-chrony-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-chrony-reload
@@ -16,7 +16,7 @@
 #
 # Apply flow:
 #   1. Extract body, write to /tmp staging
-#   2. ``chronyd -t -f <tmp>`` — chrony's syntax check; abort on fail
+#   2. ``chronyd -p -f <tmp>`` — chrony's syntax check; abort on fail
 #   3. Atomically swap /etc/chrony/chrony.conf
 #   4. ``systemctl reload chrony`` (in-place re-read of conf)
 #   5. Manage /etc/nftables.d/50-spatium-ntp.nft per allow_clients
@@ -128,16 +128,21 @@ if [ "$MARKER" != "enabled" ]; then
 fi
 
 # Syntax-check the staged config against chrony's own parser.
-# ``chronyd -t -f <file>`` reads the config + exits 0 / non-0 on
-# parse success / failure without touching the running daemon.
+# ``chronyd -p -f <file>`` parses the config, prints it, and exits
+# 0 / non-0 on parse success / failure WITHOUT detaching or touching
+# the running daemon. NB: ``-t`` is chrony's *timeout* flag (it takes
+# a numeric argument), NOT a "test" flag — ``chronyd -t -f <file>``
+# parses ``-f`` as the timeout value and dies with "Fatal error :
+# Invalid argument -f", which is why every NTP apply silently failed
+# on the appliance before #387.
 if ! command -v chronyd >/dev/null 2>&1; then
     echo "  ✗ chronyd binary not found — is chrony installed?"
     echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
     mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
     exit 1
 fi
-if ! chronyd -t -f "$TMP_BODY" >/tmp/spatium-chrony-validate.log 2>&1; then
-    echo "  ✗ chronyd -t failed for staged config:"
+if ! chronyd -p -f "$TMP_BODY" >/tmp/spatium-chrony-validate.log 2>&1; then
+    echo "  ✗ chronyd -p failed for staged config:"
     sed 's/^/      /' /tmp/spatium-chrony-validate.log
     echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
     mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-chrony-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-chrony-reload
@@ -148,7 +148,7 @@ if ! chronyd -p -f "$TMP_BODY" >/tmp/spatium-chrony-validate.log 2>&1; then
     mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
     exit 1
 fi
-echo "  ✓ chronyd -t passed"
+echo "  ✓ chronyd -p passed"
 
 # Atomic swap. Owner root, group root, mode 0644 — chrony reads as
 # root + the file has no secrets (server hostnames are operator-

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -510,6 +510,7 @@ backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:139
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:140
 backend/alembic/versions/f3b8d24a1c70_appliance_evict_requested.py:drop_column:39
 backend/alembic/versions/f3b9c1d6a274_dhcp_group_socket_mode.py:drop_column:49
+backend/alembic/versions/f4a1c9e7b2d8_appliance_host_config_health.py:drop_column:43
 backend/alembic/versions/f4a6c8b2e571_bgp_communities.py:drop_table:83
 backend/alembic/versions/f4a9c1b2d6e7_dns_zone_color.py:drop_column:33
 backend/alembic/versions/f4e1d2a09b75_lease_history_and_nat.py:drop_column:171

--- a/backend/alembic/versions/f4a1c9e7b2d8_appliance_host_config_health.py
+++ b/backend/alembic/versions/f4a1c9e7b2d8_appliance_host_config_health.py
@@ -1,0 +1,43 @@
+"""appliance: per-plane host-config apply health (#387)
+
+Adds ``appliance.host_config_health`` — the supervisor's bounded-retry
+fire-guard reports, per hash-keyed host-config plane (snmp / ntp / lldp
+/ syslog / ssh / resolver / firewall / timezone), whether the desired
+config is applied or stuck. ``{<plane>: {state, attempts, at}}`` where
+``state`` ∈ {retrying, failing}; only unapplied planes appear, so an
+all-healthy box reports ``{}``. Surfaced in the Fleet drilldown so a
+stuck apply (the pre-#387 silently-looping NTP bug) is visible.
+
+Revision ID: f4a1c9e7b2d8
+Revises: e1c4a9d27b63
+Create Date: 2026-06-12
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "f4a1c9e7b2d8"
+down_revision: str | None = "e1c4a9d27b63"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "appliance",
+        sa.Column(
+            "host_config_health",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("appliance", "host_config_health")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -617,7 +617,9 @@ async def supervisor_register(
     # force a fresh registration they delete the row in the fleet UI,
     # which causes the supervisor to clear its identity + claim a new
     # pairing code on next boot.
-    existing_stmt = select(Appliance).where(Appliance.public_key_fingerprint == pubkey_fingerprint)
+    existing_stmt = select(Appliance).where(
+        Appliance.public_key_fingerprint == pubkey_fingerprint
+    )
     existing = (await db.execute(existing_stmt)).scalar_one_or_none()
     if existing is not None:
         # Idempotent re-register. Touch last_seen_at so the heartbeat
@@ -703,7 +705,9 @@ async def supervisor_register(
                 resource_type="pairing_code",
                 resource_id=str(code_row.id) if code_row is not None else "unknown",
                 resource_display=(
-                    "supervisor pairing code" if code_row is not None else "unknown pairing code"
+                    "supervisor pairing code"
+                    if code_row is not None
+                    else "unknown pairing code"
                 ),
                 result="forbidden",
                 new_value={
@@ -748,7 +752,9 @@ async def supervisor_register(
     # operator to open the role-picker.
     initial_assigned_roles: list[str] = []
     if body.appliance_variant is not None:
-        initial_assigned_roles = list(_REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, []))
+        initial_assigned_roles = list(
+            _REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, [])
+        )
     appliance_row = Appliance(
         id=appliance_id,
         hostname=body.hostname,
@@ -895,7 +901,9 @@ async def supervisor_poll(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Not found.")
 
     row = await db.get(Appliance, body.appliance_id)
-    valid = row is not None and verify_session_token(body.session_token, row.session_token_hash)
+    valid = row is not None and verify_session_token(
+        body.session_token, row.session_token_hash
+    )
     if not valid:
         await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
@@ -1035,6 +1043,12 @@ class SupervisorHeartbeatRequest(BaseModel):
     # None / omitted = supervisor didn't run the watchdog this tick
     # (typical on docker / k8s deployments or before the first probe).
     role_health: dict[str, dict[str, Any]] | None = None
+    # #387 — per-plane host-config apply health from the supervisor's
+    # bounded-retry fire-guard. ``{<plane>: {state, attempts, at}}`` for
+    # the hash-keyed runners (snmp / ntp / lldp / syslog / ssh /
+    # resolver / firewall / timezone). Empty dict = all applied / healthy
+    # (clears stale entries); None / omitted = pre-#387 supervisor.
+    host_config_health: dict[str, dict[str, Any]] | None = None
     # Issue #183 Phase 4 — local k3s cluster health summary. Shape:
     # ``{"kubeapi_ready": bool, "nodes_total": int, "nodes_ready":
     # int, "pods_total": int, "pods_by_phase": {<phase>: count}}``.
@@ -1220,7 +1234,9 @@ class SupervisorHeartbeatResponse(BaseModel):
     # uses this to bring up dns-bind9 / dns-powerdns / dhcp-kea
     # service containers via docker compose. Empty roles list = idle
     # (approved but no service running).
-    role_assignment: SupervisorRoleAssignment = Field(default_factory=SupervisorRoleAssignment)
+    role_assignment: SupervisorRoleAssignment = Field(
+        default_factory=SupervisorRoleAssignment
+    )
     # #272 Phase 7 — control-plane promote/demote desired state.
     # ``desired_cluster_role`` = "member" → join the seed via
     # ``desired_k3s_server_url`` + ``desired_k3s_join_token``; "none" →
@@ -1364,7 +1380,9 @@ async def _ingest_lldp_neighbours(
         .scalars()
         .all()
     )
-    by_key = {(e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing}
+    by_key = {
+        (e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing
+    }
     now = datetime.now(UTC)
 
     for key, n in desired.items():
@@ -1485,7 +1503,9 @@ async def supervisor_heartbeat(
         )
         if not valid:
             await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
-            raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN, "Invalid appliance or session."
+            )
 
     assert row is not None
     # Issue #170 Wave E follow-up — reject heartbeats from soft-deleted
@@ -1578,6 +1598,13 @@ async def supervisor_heartbeat(
         # supervisor's ``since`` timestamp is the canonical "first
         # observed in this status" anchor across heartbeats.
         row.role_health = dict(body.role_health)
+    if body.host_config_health is not None:
+        # #387 — supervisor's per-plane host-config apply health.
+        # Overwrite verbatim every tick: empty dict clears stale stuck-
+        # apply entries once a plane converges; a non-empty dict means
+        # at least one plane's desired config isn't applied (the guard
+        # is backing it off), which the Fleet UI surfaces as a banner.
+        row.host_config_health = dict(body.host_config_health)
     if body.cluster_health is not None:
         # Issue #183 Phase 4 — supervisor's local-k3s health summary.
         # Same overwrite-verbatim shape as role_health. Empty dict
@@ -1706,7 +1733,9 @@ async def supervisor_heartbeat(
         for ev in evicted:
             ev.evict_requested = False
             ev.cluster_join_state = CLUSTER_JOIN_STATE_LEFT
-            logger.info("control_plane_node_evicted", hostname=ev.hostname, by=str(row.id))
+            logger.info(
+                "control_plane_node_evicted", hostname=ev.hostname, by=str(row.id)
+            )
 
     # Auto-clear the promote desired-state once the join landed: the
     # supervisor reports ``ready`` → the node IS a member now, so settle
@@ -1762,13 +1791,19 @@ async def supervisor_heartbeat(
     # the requested slot as ``current_slot`` — the operator's intent
     # was "boot into this slot next", and we got there. ``durable_
     # default`` is irrelevant here (next-boot is one-shot by design).
-    if row.desired_next_boot_slot is not None and row.current_slot == row.desired_next_boot_slot:
+    if (
+        row.desired_next_boot_slot is not None
+        and row.current_slot == row.desired_next_boot_slot
+    ):
         row.desired_next_boot_slot = None
 
     # Auto-clear desired_default_slot once the supervisor reports the
     # requested slot as ``durable_default`` — grub-set-default landed
     # and survives subsequent reboots.
-    if row.desired_default_slot is not None and row.durable_default == row.desired_default_slot:
+    if (
+        row.desired_default_slot is not None
+        and row.durable_default == row.desired_default_slot
+    ):
         row.desired_default_slot = None
 
     # Auto-clear reboot_requested 15 s after the stamp — by that
@@ -1818,12 +1853,17 @@ async def supervisor_heartbeat(
             long_poll = True
             hold_for = min(float(body.wait_seconds), _HEARTBEAT_HOLD_CAP_S)
             deadline = asyncio.get_running_loop().time() + hold_for
-            async with wake_subscription([*appliance_wake_channels(row), HOSTCONFIG_ALL]) as wake:
+            async with wake_subscription(
+                [*appliance_wake_channels(row), HOSTCONFIG_ALL]
+            ) as wake:
                 while True:
                     remaining = deadline - asyncio.get_running_loop().time()
                     if remaining <= 0:
                         break
-                    if await wake.wait(min(WAKE_TICK_SECONDS, remaining)) == WakeResult.WAKE:
+                    if (
+                        await wake.wait(min(WAKE_TICK_SECONDS, remaining))
+                        == WakeResult.WAKE
+                    ):
                         break
             # Pick up anything that committed during the hold (role /
             # firewall / desired-state edits land on other requests) before
@@ -1983,7 +2023,9 @@ async def supervisor_heartbeat(
         vip_configured=bool(metallb_vip),
         firewall_enabled=bool(cfg_row.firewall_enabled) if cfg_row else False,
         appliance_id=row.id,
-        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        web_ui_allowed_cidrs=(
+            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
+        ),
     )
     # Persist the rendered hash so 2d's apply-stalled alarm + the Fleet drift
     # chip can compare it against the runner's reported applied_hash. Only
@@ -2042,7 +2084,9 @@ async def supervisor_heartbeat(
         cluster_peer_cidrs=cluster_peer_cidrs,
         firewall_pod_cidrs=firewall_pod_cidrs,
         firewall_service_cidrs=firewall_service_cidrs,
-        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        web_ui_allowed_cidrs=(
+            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
+        ),
         control_plane_size=control_plane_size,
         desired_metallb_enabled=metallb_enabled,
         desired_metallb_pool_addresses=metallb_pool,
@@ -2101,7 +2145,9 @@ async def firewall_render_inputs(db: DB, row: Appliance) -> dict[str, Any]:
         "cp_member_count": await _committed_cp_count(db),
         "vip_configured": bool((cfg_row.control_plane_vip or "") if cfg_row else ""),
         "firewall_enabled": bool(cfg_row.firewall_enabled) if cfg_row else False,
-        "web_ui_allowed_cidrs": (list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        "web_ui_allowed_cidrs": (
+            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
+        ),
     }
 
 
@@ -2115,7 +2161,9 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     from app.models.dns import DNSServerGroup
 
     assigned_roles = list(row.assigned_roles or [])
-    dns_role_assigned = "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
+    dns_role_assigned = (
+        "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
+    )
     dhcp_role_assigned = "dhcp" in assigned_roles
 
     dns_engine: str | None = None
@@ -2249,6 +2297,11 @@ class ApplianceRow(BaseModel):
     # ``dhcp-kea``); values carry ``{role, status, since,
     # container_id}``.
     role_health: dict[str, dict[str, Any]]
+    # #387 — per-plane host-config apply health (snmp / ntp / lldp /
+    # syslog / ssh / resolver / firewall / timezone). ``{<plane>:
+    # {state, attempts, at}}``; only planes with an unapplied desired
+    # config appear. Empty when all healthy.
+    host_config_health: dict[str, dict[str, Any]]
     # Issue #183 Phase 4 — local k3s cluster health summary.
     cluster_health: dict[str, Any]
     # Issue #183 Phase 5 — installed k3s version (plain text, public).
@@ -2344,6 +2397,7 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
         role_switch_state=row.role_switch_state,
         role_switch_reason=row.role_switch_reason,
         role_health=dict(row.role_health or {}),
+        host_config_health=dict(row.host_config_health or {}),
         cluster_health=dict(row.cluster_health or {}),
         k3s_version=row.k3s_version,
         kubeconfig_set=row.kubeconfig_encrypted is not None,
@@ -2367,7 +2421,9 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
 async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     _require_superadmin(current_user)
     rows = (
-        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc()))).scalars().all()
+        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc())))
+        .scalars()
+        .all()
     )
     return ApplianceList(appliances=[_row_to_schema(r) for r in rows])
 
@@ -2378,7 +2434,9 @@ async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Fetch a single appliance (superadmin)",
 )
-async def get_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> ApplianceRow:
+async def get_appliance(
+    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
+) -> ApplianceRow:
     _require_superadmin(current_user)
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -2503,7 +2561,9 @@ async def approve_appliance(
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Reject a pending appliance (deletes the row, superadmin)",
 )
-async def reject_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> None:
+async def reject_appliance(
+    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
+) -> None:
     """Reject = DELETE the row. Supervisor's next poll gets 403 +
     falls back to bootstrapping. Distinct from delete (next endpoint)
     only in the audit verb — operationally identical."""
@@ -2636,7 +2696,9 @@ async def _find_appliance_dependents(
 
     return ApplianceDependents(
         dns=[
-            ApplianceDependentServer(kind="dns", id=r.id, name=r.name, host=r.host, status=r.status)
+            ApplianceDependentServer(
+                kind="dns", id=r.id, name=r.name, host=r.host, status=r.status
+            )
             for r in dns_rows
         ],
         dhcp=[
@@ -2746,8 +2808,12 @@ async def delete_appliance(
                     Appliance.id != row.id,
                     Appliance.state != APPLIANCE_STATE_REVOKED,
                     or_(
-                        Appliance.appliance_variant.in_(tuple(_SELF_BOOTSTRAP_VARIANTS)),
-                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
+                        Appliance.appliance_variant.in_(
+                            tuple(_SELF_BOOTSTRAP_VARIANTS)
+                        ),
+                        Appliance.cluster_role.in_(
+                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
+                        ),
                     ),
                 )
             )
@@ -3197,10 +3263,14 @@ async def update_appliance_roles(
             new_value={
                 "roles": list(row.assigned_roles or []),
                 "dns_group_id": (
-                    str(row.assigned_dns_group_id) if row.assigned_dns_group_id else None
+                    str(row.assigned_dns_group_id)
+                    if row.assigned_dns_group_id
+                    else None
                 ),
                 "dhcp_group_id": (
-                    str(row.assigned_dhcp_group_id) if row.assigned_dhcp_group_id else None
+                    str(row.assigned_dhcp_group_id)
+                    if row.assigned_dhcp_group_id
+                    else None
                 ),
                 "tags": dict(row.tags or {}),
             },
@@ -3252,7 +3322,9 @@ async def _effective_cp_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
+                        Appliance.cluster_role.in_(
+                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
+                        ),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3340,7 +3412,9 @@ async def _firewall_peer_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
+                        Appliance.cluster_role.in_(
+                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
+                        ),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3466,7 +3540,9 @@ async def promote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
+            )
         if row.id == primary.id:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3477,7 +3553,10 @@ async def promote_control_plane(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is in state {row.state!r}; approve it first.",
             )
-        if row.cluster_role is not None or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER:
+        if (
+            row.cluster_role is not None
+            or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
+        ):
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is already a control-plane member (or joining).",
@@ -3573,7 +3652,9 @@ async def demote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
+            )
         if row.cluster_role == CLUSTER_ROLE_PRIMARY:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3671,7 +3752,9 @@ async def replace_control_plane_member(
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found.")
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found."
+        )
     if row.cluster_role == CLUSTER_ROLE_PRIMARY:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3900,7 +3983,9 @@ async def restore_etcd_snapshot(
             "destructive cluster-reset restore.",
         )
     known = {
-        s.get("name") for s in (seed.etcd_snapshots or []) if isinstance(s, dict) and s.get("name")
+        s.get("name")
+        for s in (seed.etcd_snapshots or [])
+        if isinstance(s, dict) and s.get("name")
     }
     if body.snapshot_name not in known:
         raise HTTPException(
@@ -4017,7 +4102,9 @@ def _metallb_pod_status() -> tuple[bool, int, int]:
 
     def _ready(pod: dict[str, Any]) -> bool:
         conds = (pod.get("status") or {}).get("conditions") or []
-        return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conds)
+        return any(
+            c.get("type") == "Ready" and c.get("status") == "True" for c in conds
+        )
 
     try:
         # #272 / #286 — MetalLB lives in its own metallb-system namespace
@@ -4103,7 +4190,9 @@ class MetalLBConfigUpdate(BaseModel):
     def _cross_field(self) -> MetalLBConfigUpdate:
         if self.enabled:
             if not self.control_plane_vip:
-                raise ValueError("a control-plane VIP is required when MetalLB is enabled")
+                raise ValueError(
+                    "a control-plane VIP is required when MetalLB is enabled"
+                )
             # #272 — auto-derive a single-address pool from the VIP when
             # no explicit pool is given. This is the common case: the
             # operator just wants one floating IP for the Web UI and
@@ -4114,7 +4203,11 @@ class MetalLBConfigUpdate(BaseModel):
             # supply one explicitly, and the VIP-in-pool check below
             # applies to it.
             if not self.pool_addresses:
-                prefix = 32 if ipaddress.ip_address(self.control_plane_vip).version == 4 else 128
+                prefix = (
+                    32
+                    if ipaddress.ip_address(self.control_plane_vip).version == 4
+                    else 128
+                )
                 self.pool_addresses = [f"{self.control_plane_vip}/{prefix}"]
         # #272 Phase 10 — data-plane VIPs require MetalLB on (no VIP path
         # exists without it) and can't reuse the control-plane VIP or each
@@ -4138,7 +4231,11 @@ class MetalLBConfigUpdate(BaseModel):
             "control-plane VIP": self.control_plane_vip,
             **dp_vips,
         }.items():
-            if vip and self.pool_addresses and not _vip_in_pool(vip, self.pool_addresses):
+            if (
+                vip
+                and self.pool_addresses
+                and not _vip_in_pool(vip, self.pool_addresses)
+            ):
                 raise ValueError(
                     f"{label} {vip} is not inside the address pool "
                     "(widen metallb_pool_addresses to include every VIP)"
@@ -4403,7 +4500,9 @@ async def schedule_appliance_upgrade(
             new_value={
                 "desired_appliance_version": body.desired_appliance_version,
                 "desired_slot_image_url": resolved_url,
-                "slot_image_id": (str(body.slot_image_id) if body.slot_image_id else None),
+                "slot_image_id": (
+                    str(body.slot_image_id) if body.slot_image_id else None
+                ),
             },
         )
     )
@@ -4720,7 +4819,9 @@ async def _require_cert_auth(request: Request, db: DB) -> Appliance:
         principal = await authenticate_cert(request, db)
     except CertAuthFailed as exc:
         logger.warning("appliance.k8s_proxy.cert_auth_failed", reason=exc.reason)
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance client cert.") from exc
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "Invalid appliance client cert."
+        ) from exc
     if principal is None:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
@@ -4759,7 +4860,9 @@ async def k8s_proxy_poll(request: Request, db: DB) -> K8sProxyPollResponse:
         # No request within the timeout — return an empty shape so
         # the supervisor loop just re-polls. 200 (not 204) so the
         # supervisor doesn't have to special-case "no body".
-        return K8sProxyPollResponse(request_id="", method="", path="", headers={}, body_b64="")
+        return K8sProxyPollResponse(
+            request_id="", method="", path="", headers={}, body_b64=""
+        )
     return K8sProxyPollResponse(
         request_id=queued.request_id,
         method=queued.method,
@@ -4987,13 +5090,18 @@ async def k8s_rollout_restart(
     # Strategic-merge patch that bumps the pod template's
     # ``restartedAt`` annotation. Standard kubectl rollout-restart
     # shape — same JSON kubectl sends.
-    api_path = f"/apis/apps/v1/namespaces/{body.namespace}/" f"{body.kind.lower()}s/{body.name}"
+    api_path = (
+        f"/apis/apps/v1/namespaces/{body.namespace}/"
+        f"{body.kind.lower()}s/{body.name}"
+    )
     patch_body = {
         "spec": {
             "template": {
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/restartedAt": datetime.now(UTC).isoformat()
+                        "kubectl.kubernetes.io/restartedAt": datetime.now(
+                            UTC
+                        ).isoformat()
                     }
                 }
             }
@@ -5154,7 +5262,9 @@ async def reveal_appliance_kubeconfig(
         # Clean "nothing to reveal" — supervisor hasn't shipped a
         # kubeconfig yet (legacy compose / pre-Phase-5 / k3s not
         # started). Surface as a friendly state, not an error.
-        return RevealKubeconfigResponse(configured=False, kubeconfig=None, hostname=row.hostname)
+        return RevealKubeconfigResponse(
+            configured=False, kubeconfig=None, hostname=row.hostname
+        )
 
     try:
         plaintext = decrypt_str(row.kubeconfig_encrypted)
@@ -5186,7 +5296,9 @@ async def reveal_appliance_kubeconfig(
         hostname=row.hostname,
         user=current_user.username,
     )
-    return RevealKubeconfigResponse(configured=True, kubeconfig=plaintext, hostname=row.hostname)
+    return RevealKubeconfigResponse(
+        configured=True, kubeconfig=plaintext, hostname=row.hostname
+    )
 
 
 # ── Issue #183 Phase 6 — kubeapi-expose CIDR editor ──
@@ -5365,7 +5477,9 @@ async def k8s_list_pods(
         spec = item.get("spec") or {}
         st = item.get("status") or {}
         container_statuses = st.get("containerStatuses") or []
-        ready = bool(container_statuses) and all(cs.get("ready") for cs in container_statuses)
+        ready = bool(container_statuses) and all(
+            cs.get("ready") for cs in container_statuses
+        )
         pods.append(
             K8sPodSummary(
                 name=meta.get("name") or "",
@@ -5373,7 +5487,9 @@ async def k8s_list_pods(
                 phase=st.get("phase") or "Unknown",
                 ready=ready,
                 containers=[
-                    c.get("name") or "" for c in (spec.get("containers") or []) if c.get("name")
+                    c.get("name") or ""
+                    for c in (spec.get("containers") or [])
+                    if c.get("name")
                 ],
                 labels=dict(meta.get("labels") or {}),
             )

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -617,9 +617,7 @@ async def supervisor_register(
     # force a fresh registration they delete the row in the fleet UI,
     # which causes the supervisor to clear its identity + claim a new
     # pairing code on next boot.
-    existing_stmt = select(Appliance).where(
-        Appliance.public_key_fingerprint == pubkey_fingerprint
-    )
+    existing_stmt = select(Appliance).where(Appliance.public_key_fingerprint == pubkey_fingerprint)
     existing = (await db.execute(existing_stmt)).scalar_one_or_none()
     if existing is not None:
         # Idempotent re-register. Touch last_seen_at so the heartbeat
@@ -705,9 +703,7 @@ async def supervisor_register(
                 resource_type="pairing_code",
                 resource_id=str(code_row.id) if code_row is not None else "unknown",
                 resource_display=(
-                    "supervisor pairing code"
-                    if code_row is not None
-                    else "unknown pairing code"
+                    "supervisor pairing code" if code_row is not None else "unknown pairing code"
                 ),
                 result="forbidden",
                 new_value={
@@ -752,9 +748,7 @@ async def supervisor_register(
     # operator to open the role-picker.
     initial_assigned_roles: list[str] = []
     if body.appliance_variant is not None:
-        initial_assigned_roles = list(
-            _REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, [])
-        )
+        initial_assigned_roles = list(_REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, []))
     appliance_row = Appliance(
         id=appliance_id,
         hostname=body.hostname,
@@ -901,9 +895,7 @@ async def supervisor_poll(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Not found.")
 
     row = await db.get(Appliance, body.appliance_id)
-    valid = row is not None and verify_session_token(
-        body.session_token, row.session_token_hash
-    )
+    valid = row is not None and verify_session_token(body.session_token, row.session_token_hash)
     if not valid:
         await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
@@ -1234,9 +1226,7 @@ class SupervisorHeartbeatResponse(BaseModel):
     # uses this to bring up dns-bind9 / dns-powerdns / dhcp-kea
     # service containers via docker compose. Empty roles list = idle
     # (approved but no service running).
-    role_assignment: SupervisorRoleAssignment = Field(
-        default_factory=SupervisorRoleAssignment
-    )
+    role_assignment: SupervisorRoleAssignment = Field(default_factory=SupervisorRoleAssignment)
     # #272 Phase 7 — control-plane promote/demote desired state.
     # ``desired_cluster_role`` = "member" → join the seed via
     # ``desired_k3s_server_url`` + ``desired_k3s_join_token``; "none" →
@@ -1380,9 +1370,7 @@ async def _ingest_lldp_neighbours(
         .scalars()
         .all()
     )
-    by_key = {
-        (e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing
-    }
+    by_key = {(e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing}
     now = datetime.now(UTC)
 
     for key, n in desired.items():
@@ -1503,9 +1491,7 @@ async def supervisor_heartbeat(
         )
         if not valid:
             await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
-            raise HTTPException(
-                status.HTTP_403_FORBIDDEN, "Invalid appliance or session."
-            )
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
 
     assert row is not None
     # Issue #170 Wave E follow-up — reject heartbeats from soft-deleted
@@ -1733,9 +1719,7 @@ async def supervisor_heartbeat(
         for ev in evicted:
             ev.evict_requested = False
             ev.cluster_join_state = CLUSTER_JOIN_STATE_LEFT
-            logger.info(
-                "control_plane_node_evicted", hostname=ev.hostname, by=str(row.id)
-            )
+            logger.info("control_plane_node_evicted", hostname=ev.hostname, by=str(row.id))
 
     # Auto-clear the promote desired-state once the join landed: the
     # supervisor reports ``ready`` → the node IS a member now, so settle
@@ -1791,19 +1775,13 @@ async def supervisor_heartbeat(
     # the requested slot as ``current_slot`` — the operator's intent
     # was "boot into this slot next", and we got there. ``durable_
     # default`` is irrelevant here (next-boot is one-shot by design).
-    if (
-        row.desired_next_boot_slot is not None
-        and row.current_slot == row.desired_next_boot_slot
-    ):
+    if row.desired_next_boot_slot is not None and row.current_slot == row.desired_next_boot_slot:
         row.desired_next_boot_slot = None
 
     # Auto-clear desired_default_slot once the supervisor reports the
     # requested slot as ``durable_default`` — grub-set-default landed
     # and survives subsequent reboots.
-    if (
-        row.desired_default_slot is not None
-        and row.durable_default == row.desired_default_slot
-    ):
+    if row.desired_default_slot is not None and row.durable_default == row.desired_default_slot:
         row.desired_default_slot = None
 
     # Auto-clear reboot_requested 15 s after the stamp — by that
@@ -1853,17 +1831,12 @@ async def supervisor_heartbeat(
             long_poll = True
             hold_for = min(float(body.wait_seconds), _HEARTBEAT_HOLD_CAP_S)
             deadline = asyncio.get_running_loop().time() + hold_for
-            async with wake_subscription(
-                [*appliance_wake_channels(row), HOSTCONFIG_ALL]
-            ) as wake:
+            async with wake_subscription([*appliance_wake_channels(row), HOSTCONFIG_ALL]) as wake:
                 while True:
                     remaining = deadline - asyncio.get_running_loop().time()
                     if remaining <= 0:
                         break
-                    if (
-                        await wake.wait(min(WAKE_TICK_SECONDS, remaining))
-                        == WakeResult.WAKE
-                    ):
+                    if await wake.wait(min(WAKE_TICK_SECONDS, remaining)) == WakeResult.WAKE:
                         break
             # Pick up anything that committed during the hold (role /
             # firewall / desired-state edits land on other requests) before
@@ -2023,9 +1996,7 @@ async def supervisor_heartbeat(
         vip_configured=bool(metallb_vip),
         firewall_enabled=bool(cfg_row.firewall_enabled) if cfg_row else False,
         appliance_id=row.id,
-        web_ui_allowed_cidrs=(
-            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
-        ),
+        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
     )
     # Persist the rendered hash so 2d's apply-stalled alarm + the Fleet drift
     # chip can compare it against the runner's reported applied_hash. Only
@@ -2084,9 +2055,7 @@ async def supervisor_heartbeat(
         cluster_peer_cidrs=cluster_peer_cidrs,
         firewall_pod_cidrs=firewall_pod_cidrs,
         firewall_service_cidrs=firewall_service_cidrs,
-        web_ui_allowed_cidrs=(
-            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
-        ),
+        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
         control_plane_size=control_plane_size,
         desired_metallb_enabled=metallb_enabled,
         desired_metallb_pool_addresses=metallb_pool,
@@ -2145,9 +2114,7 @@ async def firewall_render_inputs(db: DB, row: Appliance) -> dict[str, Any]:
         "cp_member_count": await _committed_cp_count(db),
         "vip_configured": bool((cfg_row.control_plane_vip or "") if cfg_row else ""),
         "firewall_enabled": bool(cfg_row.firewall_enabled) if cfg_row else False,
-        "web_ui_allowed_cidrs": (
-            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
-        ),
+        "web_ui_allowed_cidrs": (list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
     }
 
 
@@ -2161,9 +2128,7 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     from app.models.dns import DNSServerGroup
 
     assigned_roles = list(row.assigned_roles or [])
-    dns_role_assigned = (
-        "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
-    )
+    dns_role_assigned = "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
     dhcp_role_assigned = "dhcp" in assigned_roles
 
     dns_engine: str | None = None
@@ -2421,9 +2386,7 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
 async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     _require_superadmin(current_user)
     rows = (
-        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc())))
-        .scalars()
-        .all()
+        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc()))).scalars().all()
     )
     return ApplianceList(appliances=[_row_to_schema(r) for r in rows])
 
@@ -2434,9 +2397,7 @@ async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Fetch a single appliance (superadmin)",
 )
-async def get_appliance(
-    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
-) -> ApplianceRow:
+async def get_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> ApplianceRow:
     _require_superadmin(current_user)
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -2561,9 +2522,7 @@ async def approve_appliance(
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Reject a pending appliance (deletes the row, superadmin)",
 )
-async def reject_appliance(
-    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
-) -> None:
+async def reject_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> None:
     """Reject = DELETE the row. Supervisor's next poll gets 403 +
     falls back to bootstrapping. Distinct from delete (next endpoint)
     only in the audit verb — operationally identical."""
@@ -2696,9 +2655,7 @@ async def _find_appliance_dependents(
 
     return ApplianceDependents(
         dns=[
-            ApplianceDependentServer(
-                kind="dns", id=r.id, name=r.name, host=r.host, status=r.status
-            )
+            ApplianceDependentServer(kind="dns", id=r.id, name=r.name, host=r.host, status=r.status)
             for r in dns_rows
         ],
         dhcp=[
@@ -2808,12 +2765,8 @@ async def delete_appliance(
                     Appliance.id != row.id,
                     Appliance.state != APPLIANCE_STATE_REVOKED,
                     or_(
-                        Appliance.appliance_variant.in_(
-                            tuple(_SELF_BOOTSTRAP_VARIANTS)
-                        ),
-                        Appliance.cluster_role.in_(
-                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
-                        ),
+                        Appliance.appliance_variant.in_(tuple(_SELF_BOOTSTRAP_VARIANTS)),
+                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
                     ),
                 )
             )
@@ -3263,14 +3216,10 @@ async def update_appliance_roles(
             new_value={
                 "roles": list(row.assigned_roles or []),
                 "dns_group_id": (
-                    str(row.assigned_dns_group_id)
-                    if row.assigned_dns_group_id
-                    else None
+                    str(row.assigned_dns_group_id) if row.assigned_dns_group_id else None
                 ),
                 "dhcp_group_id": (
-                    str(row.assigned_dhcp_group_id)
-                    if row.assigned_dhcp_group_id
-                    else None
+                    str(row.assigned_dhcp_group_id) if row.assigned_dhcp_group_id else None
                 ),
                 "tags": dict(row.tags or {}),
             },
@@ -3322,9 +3271,7 @@ async def _effective_cp_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_(
-                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
-                        ),
+                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3412,9 +3359,7 @@ async def _firewall_peer_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_(
-                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
-                        ),
+                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3540,9 +3485,7 @@ async def promote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
-            )
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
         if row.id == primary.id:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3553,10 +3496,7 @@ async def promote_control_plane(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is in state {row.state!r}; approve it first.",
             )
-        if (
-            row.cluster_role is not None
-            or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
-        ):
+        if row.cluster_role is not None or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is already a control-plane member (or joining).",
@@ -3652,9 +3592,7 @@ async def demote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
-            )
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
         if row.cluster_role == CLUSTER_ROLE_PRIMARY:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3752,9 +3690,7 @@ async def replace_control_plane_member(
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found."
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found.")
     if row.cluster_role == CLUSTER_ROLE_PRIMARY:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3983,9 +3919,7 @@ async def restore_etcd_snapshot(
             "destructive cluster-reset restore.",
         )
     known = {
-        s.get("name")
-        for s in (seed.etcd_snapshots or [])
-        if isinstance(s, dict) and s.get("name")
+        s.get("name") for s in (seed.etcd_snapshots or []) if isinstance(s, dict) and s.get("name")
     }
     if body.snapshot_name not in known:
         raise HTTPException(
@@ -4102,9 +4036,7 @@ def _metallb_pod_status() -> tuple[bool, int, int]:
 
     def _ready(pod: dict[str, Any]) -> bool:
         conds = (pod.get("status") or {}).get("conditions") or []
-        return any(
-            c.get("type") == "Ready" and c.get("status") == "True" for c in conds
-        )
+        return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conds)
 
     try:
         # #272 / #286 — MetalLB lives in its own metallb-system namespace
@@ -4190,9 +4122,7 @@ class MetalLBConfigUpdate(BaseModel):
     def _cross_field(self) -> MetalLBConfigUpdate:
         if self.enabled:
             if not self.control_plane_vip:
-                raise ValueError(
-                    "a control-plane VIP is required when MetalLB is enabled"
-                )
+                raise ValueError("a control-plane VIP is required when MetalLB is enabled")
             # #272 — auto-derive a single-address pool from the VIP when
             # no explicit pool is given. This is the common case: the
             # operator just wants one floating IP for the Web UI and
@@ -4203,11 +4133,7 @@ class MetalLBConfigUpdate(BaseModel):
             # supply one explicitly, and the VIP-in-pool check below
             # applies to it.
             if not self.pool_addresses:
-                prefix = (
-                    32
-                    if ipaddress.ip_address(self.control_plane_vip).version == 4
-                    else 128
-                )
+                prefix = 32 if ipaddress.ip_address(self.control_plane_vip).version == 4 else 128
                 self.pool_addresses = [f"{self.control_plane_vip}/{prefix}"]
         # #272 Phase 10 — data-plane VIPs require MetalLB on (no VIP path
         # exists without it) and can't reuse the control-plane VIP or each
@@ -4231,11 +4157,7 @@ class MetalLBConfigUpdate(BaseModel):
             "control-plane VIP": self.control_plane_vip,
             **dp_vips,
         }.items():
-            if (
-                vip
-                and self.pool_addresses
-                and not _vip_in_pool(vip, self.pool_addresses)
-            ):
+            if vip and self.pool_addresses and not _vip_in_pool(vip, self.pool_addresses):
                 raise ValueError(
                     f"{label} {vip} is not inside the address pool "
                     "(widen metallb_pool_addresses to include every VIP)"
@@ -4500,9 +4422,7 @@ async def schedule_appliance_upgrade(
             new_value={
                 "desired_appliance_version": body.desired_appliance_version,
                 "desired_slot_image_url": resolved_url,
-                "slot_image_id": (
-                    str(body.slot_image_id) if body.slot_image_id else None
-                ),
+                "slot_image_id": (str(body.slot_image_id) if body.slot_image_id else None),
             },
         )
     )
@@ -4819,9 +4739,7 @@ async def _require_cert_auth(request: Request, db: DB) -> Appliance:
         principal = await authenticate_cert(request, db)
     except CertAuthFailed as exc:
         logger.warning("appliance.k8s_proxy.cert_auth_failed", reason=exc.reason)
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN, "Invalid appliance client cert."
-        ) from exc
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance client cert.") from exc
     if principal is None:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
@@ -4860,9 +4778,7 @@ async def k8s_proxy_poll(request: Request, db: DB) -> K8sProxyPollResponse:
         # No request within the timeout — return an empty shape so
         # the supervisor loop just re-polls. 200 (not 204) so the
         # supervisor doesn't have to special-case "no body".
-        return K8sProxyPollResponse(
-            request_id="", method="", path="", headers={}, body_b64=""
-        )
+        return K8sProxyPollResponse(request_id="", method="", path="", headers={}, body_b64="")
     return K8sProxyPollResponse(
         request_id=queued.request_id,
         method=queued.method,
@@ -5090,18 +5006,13 @@ async def k8s_rollout_restart(
     # Strategic-merge patch that bumps the pod template's
     # ``restartedAt`` annotation. Standard kubectl rollout-restart
     # shape — same JSON kubectl sends.
-    api_path = (
-        f"/apis/apps/v1/namespaces/{body.namespace}/"
-        f"{body.kind.lower()}s/{body.name}"
-    )
+    api_path = f"/apis/apps/v1/namespaces/{body.namespace}/" f"{body.kind.lower()}s/{body.name}"
     patch_body = {
         "spec": {
             "template": {
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/restartedAt": datetime.now(
-                            UTC
-                        ).isoformat()
+                        "kubectl.kubernetes.io/restartedAt": datetime.now(UTC).isoformat()
                     }
                 }
             }
@@ -5262,9 +5173,7 @@ async def reveal_appliance_kubeconfig(
         # Clean "nothing to reveal" — supervisor hasn't shipped a
         # kubeconfig yet (legacy compose / pre-Phase-5 / k3s not
         # started). Surface as a friendly state, not an error.
-        return RevealKubeconfigResponse(
-            configured=False, kubeconfig=None, hostname=row.hostname
-        )
+        return RevealKubeconfigResponse(configured=False, kubeconfig=None, hostname=row.hostname)
 
     try:
         plaintext = decrypt_str(row.kubeconfig_encrypted)
@@ -5296,9 +5205,7 @@ async def reveal_appliance_kubeconfig(
         hostname=row.hostname,
         user=current_user.username,
     )
-    return RevealKubeconfigResponse(
-        configured=True, kubeconfig=plaintext, hostname=row.hostname
-    )
+    return RevealKubeconfigResponse(configured=True, kubeconfig=plaintext, hostname=row.hostname)
 
 
 # ── Issue #183 Phase 6 — kubeapi-expose CIDR editor ──
@@ -5477,9 +5384,7 @@ async def k8s_list_pods(
         spec = item.get("spec") or {}
         st = item.get("status") or {}
         container_statuses = st.get("containerStatuses") or []
-        ready = bool(container_statuses) and all(
-            cs.get("ready") for cs in container_statuses
-        )
+        ready = bool(container_statuses) and all(cs.get("ready") for cs in container_statuses)
         pods.append(
             K8sPodSummary(
                 name=meta.get("name") or "",
@@ -5487,9 +5392,7 @@ async def k8s_list_pods(
                 phase=st.get("phase") or "Unknown",
                 ready=ready,
                 containers=[
-                    c.get("name") or ""
-                    for c in (spec.get("containers") or [])
-                    if c.get("name")
+                    c.get("name") or "" for c in (spec.get("containers") or []) if c.get("name")
                 ],
                 labels=dict(meta.get("labels") or {}),
             )

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -61,7 +61,9 @@ class ApplianceCertificate(Base):
 
     __tablename__ = "appliance_certificate"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
 
     # Operator-chosen label. Unique so audit log lines + UI cards can
     # refer to "letsencrypt-2026.05" without ambiguity. Distinct from
@@ -98,7 +100,9 @@ class ApplianceCertificate(Base):
     # the most recent activation timestamp so the UI can show "active
     # since X" without consulting the audit log.
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    activated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    activated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Identity extracted from the cert at upload time (so listing
     # doesn't need to re-parse every PEM on every request). subject_cn
@@ -123,8 +127,12 @@ class ApplianceCertificate(Base):
     # render "expires in N days" badges and by a future renewal task
     # (Phase 4b.4) to schedule Let's Encrypt rotations. NULL on
     # CSR-pending rows.
-    valid_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    valid_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    valid_from: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    valid_to: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Operator notes — purely descriptive. UI shows them on the card
     # for context ("Let's Encrypt prod cert — renew script in cron").
@@ -184,11 +192,15 @@ class PairingCode(Base):
 
     __tablename__ = "pairing_code"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
 
     # sha256 hex digest of the cleartext code. UNIQUE so the consume
     # endpoint can look up by hash in O(log n) without collision risk.
-    code_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    code_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True, index=True
+    )
 
     # Last two digits of the cleartext code. Surfaced in the list
     # endpoint for visual correlation ("which row is the code I just
@@ -242,7 +254,9 @@ class PairingCode(Base):
     # revoking a code is permanent ("dead row"), disabling is
     # reversible ("paused"). Revoking a claimed code is a no-op for
     # already-issued certs but still useful audit signal.
-    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     revoked_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -277,7 +291,9 @@ class PairingClaim(Base):
 
     __tablename__ = "pairing_claim"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     pairing_code_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("pairing_code.id", ondelete="CASCADE"),
@@ -379,7 +395,9 @@ class Appliance(Base):
 
     __tablename__ = "appliance"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
 
     hostname: Mapped[str] = mapped_column(String(255), nullable=False)
 
@@ -421,11 +439,15 @@ class Appliance(Base):
     # an admin can Re-authorize (clear ``revoked_at`` + state back
     # to ``approved``). A retention cron hard-deletes after
     # ``platform_settings.appliance_revoked_retention_days``.
-    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Updated by Wave A2+'s supervisor heartbeat path. Stays NULL
     # until the supervisor's first post-register check-in.
-    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     last_seen_ip: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     # Wave B1 — supervisor-reported capabilities (can_run_dns_bind9,
@@ -451,16 +473,24 @@ class Appliance(Base):
     # supervisor auto-renews 30 days before expiry (Wave C polish).
     cert_pem: Mapped[str | None] = mapped_column(Text, nullable=True)
     cert_serial: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    cert_issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    cert_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cert_issued_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    cert_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Approval audit columns (the canonical state is still `state` —
     # these timestamps are for UI relative-time chips).
-    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    approved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     approved_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
-    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rejected_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     rejected_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -484,7 +514,9 @@ class Appliance(Base):
     # shape — the handler leaves the column untouched when the field
     # is missing so a stale supervisor doesn't null out its variant.
     appliance_variant: Mapped[str | None] = mapped_column(String(32), nullable=True)
-    installed_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    installed_appliance_version: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     current_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
     durable_default: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Per-slot installed version — supervisor reads the
@@ -519,7 +551,9 @@ class Appliance(Base):
     # "pct": <int|null>, "detail": "<human line>", "at": "<iso8601>"}``.
     # NULL on non-appliance / never-reported rows; the supervisor ships
     # ``{}`` once an upgrade is no longer in-flight to clear it.
-    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
     snmpd_running: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     ntp_sync_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Issue #156 — best-effort rsyslog-forwarding status the supervisor
@@ -554,7 +588,9 @@ class Appliance(Base):
     # trigger files on the appliance host. Heartbeat handler auto-
     # clears once installed catches up (upgrade) or a fresh heartbeat
     # arrives post-reboot.
-    desired_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    desired_appliance_version: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     desired_slot_image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Issue #386 Part A — integrity + transport hints for the host-side
     # ``spatium-upgrade-slot`` runner. When the scheduler points
@@ -567,7 +603,9 @@ class Appliance(Base):
     # self-served URL. External (public-CA) URLs leave both NULL/false and
     # stay fully verified. ``tls_insecure`` is refused host-side unless an
     # expected sha256 is present.
-    desired_slot_image_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    desired_slot_image_sha256: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     desired_slot_image_tls_insecure: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
@@ -590,7 +628,9 @@ class Appliance(Base):
     #
     # Both auto-clear in the heartbeat handler once the supervisor's
     # reported state matches what was requested.
-    desired_next_boot_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    desired_next_boot_slot: Mapped[str | None] = mapped_column(
+        String(16), nullable=True
+    )
     desired_default_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     # Role assignment — #170 Wave C2. Operator picks a subset of
@@ -663,6 +703,22 @@ class Appliance(Base):
         server_default="{}",
     )
 
+    # #387 — per-plane host-config apply health from the supervisor's
+    # bounded-retry fire-guard. ``{<plane>: {state, attempts, at}}`` for
+    # the hash-keyed host-config runners (snmp / ntp / lldp / syslog /
+    # ssh / resolver / firewall / timezone), keyed by plane name; only
+    # planes whose desired config is NOT yet applied appear. ``state`` is
+    # ``retrying`` (transient) or ``failing`` (apply keeps failing).
+    # Empty dict when every plane is applied — the Fleet drilldown shows
+    # an amber/red banner only when non-empty, so a stuck apply is
+    # visible instead of looping silently (the pre-#387 NTP bug).
+    host_config_health: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
+
     # Issue #183 Phase 4 — local k3s cluster health summary, supplied
     # by the supervisor on every heartbeat. Shape:
     # ``{"kubeapi_ready": bool, "nodes_total": int, "nodes_ready":
@@ -685,7 +741,9 @@ class Appliance(Base):
     # ships one (legacy compose / pre-#183 supervisors / k3s not yet
     # started).
     k3s_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True
+    )
 
     # Issue #183 Phase 6 — k3s server-cert expiry + direct-kubeapi
     # firewall allowlist.
@@ -740,7 +798,9 @@ class Appliance(Base):
     # heartbeat (read from ``/var/lib/rancher/k3s/server/token``), Fernet-
     # encrypted at rest. The promote endpoint reads this off the primary
     # row to populate ``desired_k3s_join_token_encrypted`` on each joiner.
-    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True
+    )
     # Supervisor-reported progress of the in-flight join/leave:
     # ``joining`` | ``ready`` | ``leaving`` | ``failed`` | NULL (idle).
     cluster_join_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
@@ -860,7 +920,9 @@ class ApplianceCA(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
 
 
 class ApplianceUpgradeImage(Base):
@@ -891,7 +953,9 @@ class ApplianceUpgradeImage(Base):
 
     __tablename__ = "appliance_upgrade_image"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     filename: Mapped[str] = mapped_column(String(255), nullable=False)
     size_bytes: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
     sha256: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -61,9 +61,7 @@ class ApplianceCertificate(Base):
 
     __tablename__ = "appliance_certificate"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     # Operator-chosen label. Unique so audit log lines + UI cards can
     # refer to "letsencrypt-2026.05" without ambiguity. Distinct from
@@ -100,9 +98,7 @@ class ApplianceCertificate(Base):
     # the most recent activation timestamp so the UI can show "active
     # since X" without consulting the audit log.
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    activated_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    activated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Identity extracted from the cert at upload time (so listing
     # doesn't need to re-parse every PEM on every request). subject_cn
@@ -127,12 +123,8 @@ class ApplianceCertificate(Base):
     # render "expires in N days" badges and by a future renewal task
     # (Phase 4b.4) to schedule Let's Encrypt rotations. NULL on
     # CSR-pending rows.
-    valid_from: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    valid_to: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    valid_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    valid_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Operator notes — purely descriptive. UI shows them on the card
     # for context ("Let's Encrypt prod cert — renew script in cron").
@@ -192,15 +184,11 @@ class PairingCode(Base):
 
     __tablename__ = "pairing_code"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     # sha256 hex digest of the cleartext code. UNIQUE so the consume
     # endpoint can look up by hash in O(log n) without collision risk.
-    code_hash: Mapped[str] = mapped_column(
-        String(64), nullable=False, unique=True, index=True
-    )
+    code_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
 
     # Last two digits of the cleartext code. Surfaced in the list
     # endpoint for visual correlation ("which row is the code I just
@@ -254,9 +242,7 @@ class PairingCode(Base):
     # revoking a code is permanent ("dead row"), disabling is
     # reversible ("paused"). Revoking a claimed code is a no-op for
     # already-issued certs but still useful audit signal.
-    revoked_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     revoked_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -291,9 +277,7 @@ class PairingClaim(Base):
 
     __tablename__ = "pairing_claim"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     pairing_code_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("pairing_code.id", ondelete="CASCADE"),
@@ -395,9 +379,7 @@ class Appliance(Base):
 
     __tablename__ = "appliance"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     hostname: Mapped[str] = mapped_column(String(255), nullable=False)
 
@@ -439,15 +421,11 @@ class Appliance(Base):
     # an admin can Re-authorize (clear ``revoked_at`` + state back
     # to ``approved``). A retention cron hard-deletes after
     # ``platform_settings.appliance_revoked_retention_days``.
-    revoked_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Updated by Wave A2+'s supervisor heartbeat path. Stays NULL
     # until the supervisor's first post-register check-in.
-    last_seen_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_seen_ip: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     # Wave B1 — supervisor-reported capabilities (can_run_dns_bind9,
@@ -473,24 +451,16 @@ class Appliance(Base):
     # supervisor auto-renews 30 days before expiry (Wave C polish).
     cert_pem: Mapped[str | None] = mapped_column(Text, nullable=True)
     cert_serial: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    cert_issued_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    cert_expires_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    cert_issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cert_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Approval audit columns (the canonical state is still `state` —
     # these timestamps are for UI relative-time chips).
-    approved_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     approved_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
-    rejected_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     rejected_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -514,9 +484,7 @@ class Appliance(Base):
     # shape — the handler leaves the column untouched when the field
     # is missing so a stale supervisor doesn't null out its variant.
     appliance_variant: Mapped[str | None] = mapped_column(String(32), nullable=True)
-    installed_appliance_version: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    installed_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
     current_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
     durable_default: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Per-slot installed version — supervisor reads the
@@ -551,9 +519,7 @@ class Appliance(Base):
     # "pct": <int|null>, "detail": "<human line>", "at": "<iso8601>"}``.
     # NULL on non-appliance / never-reported rows; the supervisor ships
     # ``{}`` once an upgrade is no longer in-flight to clear it.
-    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, nullable=True
-    )
+    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     snmpd_running: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     ntp_sync_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Issue #156 — best-effort rsyslog-forwarding status the supervisor
@@ -588,9 +554,7 @@ class Appliance(Base):
     # trigger files on the appliance host. Heartbeat handler auto-
     # clears once installed catches up (upgrade) or a fresh heartbeat
     # arrives post-reboot.
-    desired_appliance_version: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    desired_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
     desired_slot_image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Issue #386 Part A — integrity + transport hints for the host-side
     # ``spatium-upgrade-slot`` runner. When the scheduler points
@@ -603,9 +567,7 @@ class Appliance(Base):
     # self-served URL. External (public-CA) URLs leave both NULL/false and
     # stay fully verified. ``tls_insecure`` is refused host-side unless an
     # expected sha256 is present.
-    desired_slot_image_sha256: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    desired_slot_image_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
     desired_slot_image_tls_insecure: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
@@ -628,9 +590,7 @@ class Appliance(Base):
     #
     # Both auto-clear in the heartbeat handler once the supervisor's
     # reported state matches what was requested.
-    desired_next_boot_slot: Mapped[str | None] = mapped_column(
-        String(16), nullable=True
-    )
+    desired_next_boot_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
     desired_default_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     # Role assignment — #170 Wave C2. Operator picks a subset of
@@ -741,9 +701,7 @@ class Appliance(Base):
     # ships one (legacy compose / pre-#183 supervisors / k3s not yet
     # started).
     k3s_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(
-        LargeBinary, nullable=True
-    )
+    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
 
     # Issue #183 Phase 6 — k3s server-cert expiry + direct-kubeapi
     # firewall allowlist.
@@ -798,9 +756,7 @@ class Appliance(Base):
     # heartbeat (read from ``/var/lib/rancher/k3s/server/token``), Fernet-
     # encrypted at rest. The promote endpoint reads this off the primary
     # row to populate ``desired_k3s_join_token_encrypted`` on each joiner.
-    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(
-        LargeBinary, nullable=True
-    )
+    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     # Supervisor-reported progress of the in-flight join/leave:
     # ``joining`` | ``ready`` | ``leaving`` | ``failed`` | NULL (idle).
     cluster_join_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
@@ -920,9 +876,7 @@ class ApplianceCA(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    expires_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
 class ApplianceUpgradeImage(Base):
@@ -953,9 +907,7 @@ class ApplianceUpgradeImage(Base):
 
     __tablename__ = "appliance_upgrade_image"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     filename: Mapped[str] = mapped_column(String(255), nullable=False)
     size_bytes: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
     sha256: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)

--- a/backend/tests/test_appliance_host_config_health.py
+++ b/backend/tests/test_appliance_host_config_health.py
@@ -1,0 +1,125 @@
+"""Heartbeat persists per-plane host-config apply health (#387).
+
+The supervisor's bounded-retry fire-guard reports, per hash-keyed
+host-config plane (ntp / snmp / …), whether the desired config is
+applied or stuck. The heartbeat carries ``host_config_health`` and the
+handler overwrites the ``appliance.host_config_health`` column verbatim
+(empty dict clears stale entries; field omitted → untouched), and
+``ApplianceRow`` exposes it so the Fleet drilldown can surface a stuck
+apply instead of the pre-#387 silent re-fire loop.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
+from app.models.auth import User
+from app.models.settings import PlatformSettings
+from app.services.appliance.ca import generate_session_token
+
+_STUCK = {"ntp": {"state": "failing", "attempts": 4, "at": "2026-06-12T12:00:00+00:00"}}
+
+
+async def _approved_supervisor(db: AsyncSession) -> tuple[Appliance, str]:
+    s = await db.get(PlatformSettings, 1)
+    if s is None:
+        s = PlatformSettings(id=1)
+        db.add(s)
+    s.supervisor_registration_enabled = True
+    token, token_hash = generate_session_token()
+    der = os.urandom(32)
+    row = Appliance(
+        id=uuid.uuid4(),
+        hostname="cp-1",
+        public_key_der=der,
+        public_key_fingerprint=hashlib.sha256(der).hexdigest(),
+        state=APPLIANCE_STATE_APPROVED,
+        deployment_kind="appliance",
+        session_token_hash=token_hash,
+    )
+    db.add(row)
+    await db.flush()
+    return row, token
+
+
+async def _hb(
+    client: AsyncClient, row: Appliance, token: str, **fields: object
+) -> None:
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={"appliance_id": str(row.id), "session_token": token, **fields},
+    )
+    assert r.status_code == 200, r.text
+
+
+async def _reload(db: AsyncSession, appliance_id: uuid.UUID) -> Appliance:
+    db.expunge_all()
+    return await db.get(Appliance, appliance_id)  # type: ignore[return-value]
+
+
+async def test_heartbeat_persists_stuck_plane(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    row, token = await _approved_supervisor(db_session)
+    await db_session.commit()
+
+    await _hb(client, row, token, host_config_health=_STUCK)
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.host_config_health == _STUCK
+
+
+async def test_empty_dict_clears_stale_entries(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    row, token = await _approved_supervisor(db_session)
+    await db_session.commit()
+
+    await _hb(client, row, token, host_config_health=_STUCK)
+    # Plane converged → supervisor ships {} → must clear (overwrite verbatim).
+    await _hb(client, row, token, host_config_health={})
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.host_config_health == {}
+
+
+async def test_omitted_field_left_untouched(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    row, token = await _approved_supervisor(db_session)
+    await db_session.commit()
+
+    await _hb(client, row, token, host_config_health=_STUCK)
+    # A pre-#387 supervisor omits the field entirely → None → don't clobber.
+    await _hb(client, row, token)
+    refreshed = await _reload(db_session, row.id)
+    assert refreshed.host_config_health == _STUCK
+
+
+async def test_appliance_row_exposes_host_config_health(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    row, token = await _approved_supervisor(db_session)
+    admin = User(
+        username=f"admin-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Admin",
+        hashed_password=hash_password("pw-387"),
+        is_superadmin=True,
+    )
+    db_session.add(admin)
+    await db_session.commit()
+
+    await _hb(client, row, token, host_config_health=_STUCK)
+    resp = await client.get(
+        "/api/v1/appliance/appliances",
+        headers={"Authorization": f"Bearer {create_access_token(str(admin.id))}"},
+    )
+    assert resp.status_code == 200, resp.text
+    found = next(a for a in resp.json()["appliances"] if a["id"] == str(row.id))
+    assert found["host_config_health"] == _STUCK

--- a/backend/tests/test_appliance_host_config_health.py
+++ b/backend/tests/test_appliance_host_config_health.py
@@ -49,9 +49,7 @@ async def _approved_supervisor(db: AsyncSession) -> tuple[Appliance, str]:
     return row, token
 
 
-async def _hb(
-    client: AsyncClient, row: Appliance, token: str, **fields: object
-) -> None:
+async def _hb(client: AsyncClient, row: Appliance, token: str, **fields: object) -> None:
     r = await client.post(
         "/api/v1/appliance/supervisor/heartbeat",
         json={"appliance_id": str(row.id), "session_token": token, **fields},
@@ -88,9 +86,7 @@ async def test_empty_dict_clears_stale_entries(
     assert refreshed.host_config_health == {}
 
 
-async def test_omitted_field_left_untouched(
-    client: AsyncClient, db_session: AsyncSession
-) -> None:
+async def test_omitted_field_left_untouched(client: AsyncClient, db_session: AsyncSession) -> None:
     row, token = await _approved_supervisor(db_session)
     await db_session.commit()
 

--- a/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
@@ -159,6 +159,18 @@ rules:
     # k8s_api.patch_node_labels and a fallback strategic-merge if we
     # ever switch.
     verbs: ["get", "list", "watch", "patch", "update"]
+    # #389 — read-only on the k3s ETCDSnapshotFile CRs so the
+    # heartbeat's ``list_etcd_snapshots()`` can populate the Fleet →
+    # etcd snapshots inventory. Without this grant the
+    # ``GET /apis/k3s.cattle.io/v1/etcdsnapshotfiles`` 403s and the
+    # list reports empty every heartbeat even though k3s is taking
+    # snapshots on schedule. Cluster-scoped because the CRs are;
+    # read-only because snapshot create / delete / restore go through
+    # the host ``k3s`` binary + the cluster-restore trigger plane, not
+    # the kubeapi.
+  - apiGroups: ["k3s.cattle.io"]
+    resources: ["etcdsnapshotfiles"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8601,6 +8601,20 @@ export interface ApplianceRow {
       container_id: string | null;
     }
   >;
+  // #387 — per-plane host-config apply health from the supervisor's
+  // bounded-retry fire-guard. Keyed by plane name (``ntp`` / ``snmp`` /
+  // ``lldp`` / ``syslog`` / ``ssh`` / ``resolver`` / ``firewall`` /
+  // ``timezone``); only planes whose desired config isn't applied appear,
+  // so an all-healthy appliance reports ``{}``. ``failing`` = the apply
+  // keeps failing (the guard is backing it off); ``retrying`` = transient.
+  host_config_health: Record<
+    string,
+    {
+      state: "retrying" | "failing";
+      attempts: number;
+      at: string | null;
+    }
+  >;
   // Issue #183 Phase 4 — local k3s cluster health summary, supplied
   // by the supervisor on every heartbeat. Empty object on legacy
   // compose appliances or pre-#183 supervisors.

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -2262,6 +2262,11 @@ function ApplianceDrilldownModal({
             <ApplianceRoleHealthSection row={row} />
           )}
 
+        {row.state === "approved" &&
+          Object.keys(row.host_config_health ?? {}).length > 0 && (
+            <ApplianceHostConfigHealthSection row={row} />
+          )}
+
         {row.state === "approved" && (
           <ApplianceClusterHealthSection row={row} />
         )}
@@ -2505,6 +2510,102 @@ function ApplianceRoleHealthSection({ row }: { row: ApplianceRow }) {
                   </td>
                   <td className="px-3 py-1.5 font-mono text-muted-foreground">
                     {h.container_id ?? "—"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// #387 — per-plane host-config apply health. Renders only when at
+// least one host-config plane (ntp / snmp / lldp / syslog / ssh /
+// resolver / firewall / timezone) has a desired config that isn't
+// applied — i.e. the supervisor's bounded-retry guard is backing off a
+// stuck apply. A healthy appliance reports an empty dict, so this
+// section quietly hides. Before #387 these stuck applies looped
+// silently (the NTP runner failed every ~30 s, flooding thousands of
+// .failed sidecars) with nothing surfaced in the UI.
+const HOSTCFG_PLANE_LABELS: Record<string, string> = {
+  ntp: "NTP (chrony)",
+  snmp: "SNMP",
+  lldp: "LLDP",
+  syslog: "Syslog forwarding",
+  ssh: "SSH keys / sshd",
+  resolver: "DNS resolver",
+  firewall: "Firewall",
+  timezone: "Timezone",
+};
+
+function ApplianceHostConfigHealthSection({ row }: { row: ApplianceRow }) {
+  const entries = Object.entries(row.host_config_health ?? {});
+  entries.sort(([a], [b]) => a.localeCompare(b));
+  const anyFailing = entries.some(([, h]) => h.state === "failing");
+  return (
+    <div className="border-t pt-4">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Host-config apply health
+      </h3>
+      <p
+        className={cn(
+          "mt-1 text-xs",
+          anyFailing
+            ? "text-rose-700 dark:text-rose-300"
+            : "text-amber-700 dark:text-amber-400",
+        )}
+      >
+        {anyFailing
+          ? "A host-config change keeps failing to apply on this appliance — the supervisor is retrying with backoff. Check the host runner log (e.g. /var/log/spatiumddi/chrony-reload.log) for the cause."
+          : "A host-config change is still being applied (retrying)."}
+      </p>
+      <div className="mt-2 overflow-hidden rounded-md border">
+        <table className="w-full text-xs">
+          <thead className="bg-muted/40 text-[10px] uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className="px-3 py-1.5 text-left font-medium">Config</th>
+              <th className="px-3 py-1.5 text-left font-medium">State</th>
+              <th className="px-3 py-1.5 text-left font-medium">Attempts</th>
+              <th className="px-3 py-1.5 text-left font-medium">Last try</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {entries.map(([plane, h]) => {
+              const failing = h.state === "failing";
+              const Icon = failing ? AlertCircle : Loader2;
+              return (
+                <tr key={plane}>
+                  <td className="px-3 py-1.5">
+                    {HOSTCFG_PLANE_LABELS[plane] ?? plane}
+                  </td>
+                  <td className="px-3 py-1.5">
+                    <span
+                      className={cn(
+                        "inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium",
+                        failing
+                          ? "bg-rose-500/15 text-rose-700 border-rose-500/40 dark:text-rose-300"
+                          : "bg-amber-500/15 text-amber-700 border-amber-500/40 dark:text-amber-300",
+                      )}
+                    >
+                      <Icon
+                        className={cn(
+                          "h-2.5 w-2.5",
+                          !failing && "animate-spin",
+                        )}
+                      />
+                      {h.state}
+                    </span>
+                  </td>
+                  <td className="px-3 py-1.5 text-muted-foreground">
+                    {h.attempts}
+                  </td>
+                  <td
+                    className="px-3 py-1.5 text-muted-foreground"
+                    title={h.at ?? undefined}
+                  >
+                    {h.at ? formatRelativeSince(h.at) : "—"}
                   </td>
                 </tr>
               );


### PR DESCRIPTION
## Summary

Two appliance fixes, both surfaced + field-validated on the ddi1
single-node appliance.

**#387 — host-config runners crash-loop silently (NTP never applied).**
On a field appliance the GUI-configured NTP settings had *never*
applied: the host-side `spatiumddi-chrony-reload` runner validated the
staged config with `chronyd -t -f <file>`, but `-t` is chrony's
*timeout* flag (numeric arg), so chrony parsed `-f` as the value and
died with `Fatal error : Invalid argument -f` on every apply. Because
each hash-keyed host-config runner only writes its applied-hash sidecar
on **success**, the supervisor re-derived "desired ≠ applied → fire"
every ~30 s heartbeat and re-fired forever — **2374**
`ntp-config-pending.failed.<ts>` sidecars on ddi1 (and a parallel 2021
`slot-set-next-boot-pending.done` from the same shape) — with nothing
surfaced in the UI.

**#389 — Fleet etcd-snapshot inventory always empty.** The supervisor
lists k3s `ETCDSnapshotFile` CRs over the kubeapi, but its
ServiceAccount lacked a `k3s.cattle.io/etcdsnapshotfiles` read grant,
so the GET 403'd and reported empty every heartbeat even though k3s was
taking snapshots on schedule.

## #387 changes

1. **Root cause** — chrony validate flag `-t -f` → `-p -f`
   (parse-and-print, exits 0/non-0 without touching the running daemon),
   with a comment documenting the trap.
2. **Bounded-retry fire-guard** (`_fire_host_config` /
   `_hostcfg_should_fire`) that every hash-keyed runner now routes
   through (snmp / ntp / lldp / syslog / ssh / resolver / firewall /
   timezone): a stuck apply re-fires with exponential backoff
   (60 s → … → 15 min ceiling) per distinct config hash instead of every
   tick; a fresh hash resets the budget; it never permanently gives up,
   so a fixed runner auto-recovers.
3. **Generalised sidecar prune** — the #386 slot-upgrade pruner now
   covers every trigger family and is swept from `collect()` each
   heartbeat, so a pre-fix backlog is culled on the first post-upgrade
   tick.
4. **Honest-error surfacing** — `collect()` ships `host_config_health`
   (per-plane `{state, attempts, at}`), persisted to the new
   `appliance.host_config_health` column and rendered as a "Host-config
   apply health" table in the Fleet drilldown.

## #389 changes

* Added the read-only `k3s.cattle.io/etcdsnapshotfiles` rule to the
  `spatium-supervisor-nodes` ClusterRole.
* `list_etcd_snapshots()` now logs a warning on a 403 (was a silent
  empty list) so a future RBAC gap is self-diagnosing.

## Testing

* **Unit** — 10 supervisor fire-guard tests (`test_host_config_fire_guard.py`)
  + 4 backend `host_config_health` persist/expose tests; existing
  trigger tests still pass. `make ci` green (ruff/black/mypy `app tests`,
  frontend typecheck/lint/format/build). Migration-lint baseline updated
  for the additive-column downgrade drop.
* **ddi1 (single-node appliance), full deploy:**
  * chrony fix: `chronyd -p` validates the real pushed config; the NTP
    apply succeeds; the re-fire loop stops (`applied == desired`);
    `chronyc tracking` shows `Leap status = Normal` (synced).
  * supervisor rollout: the `collect()` prune swept the **2444** `.failed`
    + **2021** `.done` backlog → 5 each (release-state files ~4400 → 37).
  * migration `c3f7a1d9b486 → e1c4a9d27b63 → f4a1c9e7b2d8` applied;
    `host_config_health: {}` surfaces on the appliance row (healthy).
  * #389: `kubectl auth can-i list etcdsnapshotfiles … → yes`; the
    `/fleet/control-plane/etcd-snapshots` endpoint now returns all 3
    snapshots (was empty).

## Migrations

`f4a1c9e7b2d8` — adds `appliance.host_config_health` (JSONB, not null,
default `{}`).

## Follow-up (not in scope here)

`ntp_sync_state` is captured only at apply-time, so the Fleet sync chip
can read a stale "unsynchronized" while chrony is actually synced — a
pre-existing limitation now more visible once applies succeed. Worth a
periodic host-side refresh of the `ntp-status` sidecar.

Closes #387
Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)