### PR TITLE
fix(appliance): #393 console-mode selector + no-login fix, #394 helm-recover crash

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -911,23 +911,36 @@ def maybe_fire_timezone(desired_timezone: str | None) -> bool:
     )
 
 
-def maybe_fire_verbose_boot(desired_verbose_boot: bool | None) -> bool:
-    """Write the verbose-boot trigger when the operator's desired console
-    verbosity (``platform_settings.verbose_boot``) differs from what the host
-    runner last applied. The runner flips a grubenv variable the grub.cfg
-    menuentries read, so it takes effect on the NEXT reboot.
+# #393 — console_mode → grubenv ``spatium_verbose`` numeric. Keeping
+# dashboard=0 + text_console=1 preserves the pre-#393 grubenv meaning,
+# so an old grubenv (or an unknown mode → ``"0"`` fallback) still
+# resolves to the safe dashboard default in grub.cfg (fail-closed).
+_CONSOLE_MODE_TO_GRUBENV = {
+    "dashboard": "0",
+    "text_console": "1",
+    "verbose_dashboard": "2",
+}
 
-    Body is a single line: ``1`` (standard Linux console — drop the loglevel
-    cap + systemd.show_status + spatium-console=off) or ``0`` (today's quiet
-    boot + Talos dashboard). Idempotent via the ``verbose-boot-applied``
-    sidecar; a missing sidecar is treated as ``0`` because the installer seeds
-    ``grub-editenv … spatium_verbose=0`` at install time, so the default state
-    is already applied and needs no trigger. Strict appliance-only gate
-    (mirrors ``maybe_fire_timezone`` / ``maybe_fire_reboot``).
+
+def maybe_fire_console_mode(desired_console_mode: str | None) -> bool:
+    """(#393) Write the verbose-boot trigger when the operator's desired
+    console mode (``platform_settings.console_mode``) differs from what the
+    host runner last applied. The runner flips the grubenv ``spatium_verbose``
+    variable the grub.cfg menuentries read, so it takes effect on the NEXT
+    reboot.
+
+    Maps the mode to the grubenv numeric the runner + grub.cfg understand:
+    ``dashboard``→0 (quiet boot + dashboard), ``text_console``→1 (verbose boot
+    + a plain getty login, no dashboard), ``verbose_dashboard``→2 (verbose
+    boot output, then the dashboard). An unknown / missing mode falls back to
+    ``0`` (dashboard) — fail-closed. Idempotent via the
+    ``verbose-boot-applied`` sidecar; a missing sidecar is treated as ``0``
+    (the installer seeds ``grub-editenv … spatium_verbose=0``). Strict
+    appliance-only gate (mirrors ``maybe_fire_timezone`` / ``maybe_fire_reboot``).
     """
     if detect_deployment_kind() != "appliance":
         return False
-    desired = "1" if desired_verbose_boot else "0"
+    desired = _CONSOLE_MODE_TO_GRUBENV.get(desired_console_mode or "dashboard", "0")
     try:
         applied = _VERBOSE_APPLIED_FILE.read_text(encoding="utf-8").strip()
     except OSError:

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -693,15 +693,17 @@ def heartbeat_once(
                 desired_timezone=desired_timezone,
             )
 
-    # Verbose-boot console toggle. Always evaluated (it's a definite bool, not
-    # an opt-in override like timezone); maybe_fire_verbose_boot short-circuits
+    # #393 — appliance console mode. Always evaluated (a definite value, not an
+    # opt-in override like timezone); maybe_fire_console_mode short-circuits
     # against its applied sidecar so it only writes the grubenv trigger on a
     # real change. Applies next reboot.
-    desired_verbose_boot = body_out.get("desired_verbose_boot")
-    if appliance_state.maybe_fire_verbose_boot(bool(desired_verbose_boot)):
+    desired_console_mode = body_out.get("desired_console_mode")
+    if appliance_state.maybe_fire_console_mode(
+        desired_console_mode if isinstance(desired_console_mode, str) else None
+    ):
         log.info(
-            "supervisor.heartbeat.verbose_boot_trigger_fired",
-            desired_verbose_boot=bool(desired_verbose_boot),
+            "supervisor.heartbeat.console_mode_trigger_fired",
+            desired_console_mode=desired_console_mode,
         )
 
     # Issue #346 — appliance host-config (snmp / chrony / lldp). The control

--- a/agent/supervisor/tests/test_console_mode_triggers.py
+++ b/agent/supervisor/tests/test_console_mode_triggers.py
@@ -1,0 +1,74 @@
+"""Supervisor console-mode trigger writer (#393).
+
+``maybe_fire_console_mode`` maps platform_settings.console_mode →
+the grubenv ``spatium_verbose`` numeric the host runner + grub.cfg
+consume (dashboard→0 / text_console→1 / verbose_dashboard→2), and
+writes the verbose-boot trigger only on a real change (idempotent via
+the applied sidecar). Replaces the pre-#393 boolean verbose_boot path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from spatium_supervisor import appliance_state
+
+
+@pytest.fixture
+def cm_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(appliance_state, "detect_deployment_kind", lambda: "appliance")
+    monkeypatch.setattr(
+        appliance_state, "_VERBOSE_TRIGGER_FILE", tmp_path / "verbose-boot-pending"
+    )
+    monkeypatch.setattr(
+        appliance_state, "_VERBOSE_APPLIED_FILE", tmp_path / "verbose-boot-applied"
+    )
+    return tmp_path
+
+
+def _trigger(p: Path) -> str:
+    return (p / "verbose-boot-pending").read_text().strip()
+
+
+def test_text_console_maps_to_1(cm_paths: Path) -> None:
+    assert appliance_state.maybe_fire_console_mode("text_console") is True
+    assert _trigger(cm_paths) == "1"
+
+
+def test_verbose_dashboard_maps_to_2(cm_paths: Path) -> None:
+    assert appliance_state.maybe_fire_console_mode("verbose_dashboard") is True
+    assert _trigger(cm_paths) == "2"
+
+
+def test_dashboard_is_default_no_fire_from_fresh(cm_paths: Path) -> None:
+    # Fresh box: applied sidecar missing → treated as "0"; dashboard → "0",
+    # so there's nothing to change.
+    assert appliance_state.maybe_fire_console_mode("dashboard") is False
+    assert not (cm_paths / "verbose-boot-pending").exists()
+
+
+def test_unknown_mode_falls_back_to_dashboard(cm_paths: Path) -> None:
+    # Fail-closed: an unknown / None mode maps to "0" (dashboard).
+    assert appliance_state.maybe_fire_console_mode("bogus") is False
+    assert appliance_state.maybe_fire_console_mode(None) is False
+
+
+def test_idempotent_against_applied_sidecar(cm_paths: Path) -> None:
+    (cm_paths / "verbose-boot-applied").write_text("1\n")
+    # Already applied text_console (1) → no re-fire.
+    assert appliance_state.maybe_fire_console_mode("text_console") is False
+    assert not (cm_paths / "verbose-boot-pending").exists()
+    # But switching to verbose_dashboard (2) fires.
+    assert appliance_state.maybe_fire_console_mode("verbose_dashboard") is True
+    assert _trigger(cm_paths) == "2"
+
+
+def test_non_appliance_no_op(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(appliance_state, "detect_deployment_kind", lambda: "docker")
+    monkeypatch.setattr(
+        appliance_state, "_VERBOSE_TRIGGER_FILE", tmp_path / "verbose-boot-pending"
+    )
+    assert appliance_state.maybe_fire_console_mode("text_console") is False
+    assert not (tmp_path / "verbose-boot-pending").exists()

--- a/appliance/mkosi.extra/etc/systemd/system/getty@tty1.service.d/spatium-console-gate.conf
+++ b/appliance/mkosi.extra/etc/systemd/system/getty@tty1.service.d/spatium-console-gate.conf
@@ -1,0 +1,24 @@
+# #393 — gate getty@tty1 on the appliance console mode.
+#
+# The Talos console dashboard (spatium-console.service) is a getty
+# REPLACEMENT on tty1: it runs when the kernel cmdline does NOT carry
+# spatium-console=off (its ConditionKernelCommandLine=!spatium-console=off),
+# and Conflicts=getty@tty1.service. In the "text_console" console mode the
+# grub menuentry passes spatium-console=off, so the dashboard's condition
+# fails and it doesn't start — but pre-#393 NOTHING claimed tty1 then, so an
+# operator who picked the plain-console mode was left at bare kernel text with
+# NO login prompt at all.
+#
+# This drop-in makes getty@tty1 the mirror image of the dashboard: it runs
+# ONLY when spatium-console=off is present. Combined with the
+# getty.target.wants symlink (added in mkosi.postinst), that means:
+#   * dashboard / verbose_dashboard mode (no spatium-console=off) → this
+#     condition fails → getty@tty1 stays inactive → the dashboard owns tty1.
+#   * text_console mode (spatium-console=off) → the dashboard's condition
+#     fails, THIS condition passes → getty@tty1 starts → a normal login.
+# The two are mutually exclusive by condition, so they never fight over tty1.
+#
+# tty2..tty6 are unaffected (this is the tty1 instance drop-in only), so the
+# Alt+F2..F6 shell escape hatch via logind autovt still works in every mode.
+[Unit]
+ConditionKernelCommandLine=spatium-console=off

--- a/appliance/mkosi.extra/etc/systemd/system/serial-getty@ttyS0.service.d/spatium-console-gate.conf
+++ b/appliance/mkosi.extra/etc/systemd/system/serial-getty@ttyS0.service.d/spatium-console-gate.conf
@@ -1,0 +1,18 @@
+# #393 — gate serial-getty@ttyS0 on the appliance console mode, the serial
+# mirror of getty@tty1.service.d/spatium-console-gate.conf.
+#
+# systemd-getty-generator auto-wants serial-getty@ttyS0 from the kernel
+# cmdline `console=ttyS0,115200n8`. The serial console dashboard
+# (spatium-console@ttyS0.service) runs when spatium-console=off is NOT set
+# and owns ttyS0. This drop-in makes serial-getty its mirror image — it runs
+# ONLY when spatium-console=off — so the two are mutually exclusive by
+# condition and never race over ttyS0:
+#   * dashboard / verbose_dashboard mode → this condition fails → the serial
+#     dashboard owns ttyS0.
+#   * text_console mode → the serial dashboard's condition fails, this passes
+#     → a normal serial login.
+# Without it (and without the now-removed Conflicts=), serial-getty would
+# race the dashboard for ttyS0 in dashboard mode. NB: only validated on a box
+# with a real serial port — the dev VM has none.
+[Unit]
+ConditionKernelCommandLine=spatium-console=off

--- a/appliance/mkosi.extra/etc/systemd/system/spatium-console.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatium-console.service
@@ -20,7 +20,17 @@ ConditionKernelCommandLine=!spatium-console=off
 # in the meantime.
 After=systemd-user-sessions.service getty-pre.target
 Before=getty.target
-Conflicts=getty@tty1.service
+# #393 — NO Conflicts=getty@tty1.service. Conflicts= is registered at
+# unit-load time and leaks: even though this unit's
+# ConditionKernelCommandLine=!spatium-console=off makes it inactive in
+# the text_console mode, the recorded conflict still drops getty@tty1
+# from the boot transaction (ConflictedBy), so the operator who picked
+# the plain-console mode was left with NO login at all. The dashboard and
+# getty@tty1 are now mutually exclusive purely by their opposite
+# spatium-console=off conditions (getty's gate is in
+# getty@tty1.service.d/spatium-console-gate.conf), which needs no
+# Conflicts. The ExecStartPre `systemctl stop getty@tty1` below stays as
+# belt-and-braces for the rare case getty somehow raced up first.
 
 [Service]
 # `idle` defers ExecStart until pending jobs settle — same trick

--- a/appliance/mkosi.extra/etc/systemd/system/spatium-console@.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatium-console@.service
@@ -14,10 +14,15 @@ ConditionPathExists=/dev/%I
 # dashboard during boot, when they can't yet ssh in.
 After=systemd-user-sessions.service getty-pre.target
 Before=getty.target
-# Replace the serial-getty systemd-getty-generator auto-spawns from
-# the kernel cmdline `console=ttyS0,115200n8`. Same Conflicts pattern
-# as the tty1 unit.
-Conflicts=serial-getty@%i.service
+# #393 — NO Conflicts=serial-getty@%i.service. Same fix + reasoning as
+# spatium-console.service: a load-time Conflicts= leaks (ConflictedBy)
+# and drops serial-getty from the boot transaction even when this unit
+# stays inactive in text_console mode, leaving a serial-only box with no
+# login. The dashboard and serial-getty are now mutually exclusive purely
+# by their opposite spatium-console=off conditions (serial-getty's gate is
+# in serial-getty@ttyS0.service.d/spatium-console-gate.conf). The
+# ExecStartPre `systemctl stop serial-getty@%i` below stays as
+# belt-and-braces.
 
 [Service]
 Type=idle

--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -1475,18 +1475,27 @@ else
 fi
 if [ -z "\${default}" ]; then set default=slot_a; fi
 
-# Verbose-boot console toggle (grubenv \`spatium_verbose\`, flipped by the
-# Fleet UI → supervisor → spatiumddi-verbose-boot-reload). Loaded by the
-# \`load_env\` above. "1" = standard Linux console: drop the loglevel=3 cap so
-# all kernel messages scroll, add systemd.show_status=1 for the per-unit
-# [ OK ] lines, and pass spatium-console=off so a normal getty login replaces
-# the Talos dashboard. Empty / "0" = today's quiet boot (loglevel=3) + the
-# console dashboard. Unset (old grubenv) falls through to the quiet default —
+# Console-mode toggle (#393) — grubenv \`spatium_verbose\`, flipped by the
+# Fleet UI → supervisor → spatiumddi-verbose-boot-reload, loaded by \`load_env\`
+# above. The supervisor maps platform_settings.console_mode → this numeric:
+#   "1" text_console      — drop the loglevel=3 cap so all kernel messages
+#                           scroll, add systemd.show_status=1 for the per-unit
+#                           [ OK ] lines, and pass spatium-console=off so a
+#                           normal getty LOGIN replaces the Talos dashboard
+#                           (regular Linux server console).
+#   "2" verbose_dashboard — same verbose boot output, but NO spatium-console=off
+#                           so the dashboard still claims tty1 after boot.
+#   "0"/empty dashboard   — today's quiet boot (loglevel=3) + the dashboard.
+# Unset / unknown (old grubenv) falls through to the quiet dashboard default —
 # fail-closed, never a brick.
 if [ "\${spatium_verbose}" = "1" ]; then
     set sp_log=""
     set sp_systemd="systemd.show_status=1"
     set sp_console="spatium-console=off"
+elif [ "\${spatium_verbose}" = "2" ]; then
+    set sp_log=""
+    set sp_systemd="systemd.show_status=1"
+    set sp_console=""
 else
     set sp_log="loglevel=3"
     set sp_systemd=""

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-helm-stuck-recover
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-helm-stuck-recover
@@ -62,10 +62,20 @@ charts_json=$($KUBECTL --request-timeout=10s get helmchart -A -o json 2>/dev/nul
 # Walk each item, pull (namespace, name, conditions). We use python3
 # because jq isn't guaranteed (it's in the slot image but the runner
 # stays dep-free in case a future slot trims it).
-python3 - <<PY
-import json, sys, subprocess, time
+#
+# #394 — pass the kubectl JSON via an env var, NOT shell-interpolated
+# into the heredoc (``'''$charts_json'''``): a HelmChart's
+# ``spec.valuesContent`` can carry a literal control char that Python's
+# default strict json.loads rejects ("Invalid control character"),
+# crashing the whole recovery runner on every boot — and interpolating
+# ~280 KB of operator-influenced data straight into the Python source
+# is fragile besides (JSON containing ``'''`` would break the literal).
+# ``strict=False`` tolerates the control char (we only read the CRs to
+# find Failed conditions, so lossy value bytes don't matter).
+CHARTS_JSON="$charts_json" python3 - <<PY
+import json, os, subprocess, time
 
-data = json.loads('''$charts_json''')
+data = json.loads(os.environ["CHARTS_JSON"], strict=False)
 now = int(time.time())
 
 def kubectl(*args):

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-verbose-boot-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-verbose-boot-reload
@@ -2,20 +2,24 @@
 # spatiumddi-verbose-boot-reload — host-side verbose-boot toggle runner.
 #
 # The supervisor writes /var/lib/spatiumddi/release-state/verbose-boot-pending
-# whenever the operator's desired console verbosity (platform_settings.
-# verbose_boot) differs from what this runner last applied. File format:
+# whenever the operator's desired console mode (platform_settings.console_mode,
+# #393) differs from what this runner last applied. File format:
 #
-#   line 1: "1" (standard Linux console) or "0" (quiet boot + dashboard)
+#   line 1: "0" | "1" | "2" — the grubenv spatium_verbose value (the supervisor
+#           maps console_mode → this numeric: dashboard→0 / text_console→1 /
+#           verbose_dashboard→2)
 #
 # Apply flow — flip the grubenv variable ``spatium_verbose`` that the installed
 # grub.cfg menuentries read (see spatium-install's grub.cfg heredoc). We do NOT
 # regenerate grub.cfg or reboot — only set the env var the conditional already
 # consumes:
-#   spatium_verbose=1  -> menuentry drops the loglevel=3 cap, adds
-#                         systemd.show_status=1, and passes spatium-console=off
-#                         (normal getty console, no Talos dashboard) — i.e. the
-#                         box boots like a regular Linux server.
-#   spatium_verbose=0  -> today's quiet boot (loglevel=3) + console dashboard.
+#   spatium_verbose=0  -> quiet boot (loglevel=3) + the Talos console dashboard.
+#   spatium_verbose=1  -> drops the loglevel=3 cap, adds systemd.show_status=1,
+#                         and passes spatium-console=off so a normal getty LOGIN
+#                         replaces the dashboard (regular Linux server console).
+#   spatium_verbose=2  -> verbose boot output (no loglevel cap +
+#                         systemd.show_status=1) but the dashboard still claims
+#                         tty1 after boot (no spatium-console=off).
 #
 # Takes effect on the NEXT REBOOT (GRUB only reads the cmdline at boot). The
 # Fleet UI says so + offers the reboot affordance.
@@ -56,12 +60,18 @@ if [ ! -f "$TRIGGER" ]; then
 fi
 
 val="$(head -n1 "$TRIGGER" | tr -d '[:space:]')"
-if [ "$val" != "0" ] && [ "$val" != "1" ]; then
-    log "REJECT: trigger value '$val' is not 0 or 1"
-    printf 'state=failed\nreason=invalid_value\nrequested=%s\napplied_at=%s\n' \
-        "$val" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
-    exit 1
-fi
+# #393 — 0 = dashboard (quiet boot + dashboard), 1 = text_console
+# (verbose boot + plain getty login, no dashboard), 2 = verbose_dashboard
+# (verbose boot output, then the dashboard claims tty1).
+case "$val" in
+    0 | 1 | 2) ;;
+    *)
+        log "REJECT: trigger value '$val' is not 0, 1 or 2"
+        printf 'state=failed\nreason=invalid_value\nrequested=%s\napplied_at=%s\n' \
+            "$val" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+        exit 1
+        ;;
+esac
 
 # Locate grubenv. The appliance installs an EFI grub with grubenv on the ESP;
 # fall back to the BIOS paths for completeness. Must match where spatium-install

--- a/appliance/mkosi.postinst
+++ b/appliance/mkosi.postinst
@@ -19,15 +19,16 @@ set -eu
 # for cloud-init-local / cloud-init / cloud-config / cloud-final.
 mkdir -p "$BUILDROOT/etc/systemd/system/multi-user.target.wants"
 
-# NOTE on tty1: we deliberately do NOT force-enable getty@tty1.service
-# here anymore. Phase 4h ships spatium-console.service which claims
-# tty1 on the installed system (Conflicts=getty@tty1.service +
-# ConditionKernelCommandLine gates that match getty's drop-in). For
-# the installer and live ISO modes the existing spatium-install /
-# spatium-live-banner units own tty1 — both still gate themselves via
-# kernel cmdline. Operators who want stock getty back can pass
-# `spatium-console=off` on the kernel cmdline or
-# `systemctl disable spatium-console.service && systemctl enable getty@tty1.service`.
+# NOTE on tty1 (#393): getty@tty1.service IS enabled (getty.target.wants
+# symlink below), but a drop-in (getty@tty1.service.d/spatium-console-gate.conf)
+# gates it on ConditionKernelCommandLine=spatium-console=off — the exact
+# mirror of spatium-console.service's !spatium-console=off gate. So the two
+# are mutually exclusive: in dashboard / verbose_dashboard console mode the
+# dashboard owns tty1 (getty's condition fails); in text_console mode the
+# dashboard's condition fails and getty@tty1 runs → a real login. Pre-#393
+# getty@tty1 was NOT enabled, so picking the plain-console mode left tty1 with
+# no login at all. Install + live ISO modes still gate themselves via
+# spatium-mode= so only the wizard/banner owns tty1 there.
 #
 # Alt+F2..F6 still spawn getty on demand via systemd-logind's NAutoVTs
 # (Debian default = 6), so the operator always has a shell escape hatch
@@ -82,6 +83,15 @@ for unit in chrony.service ssh.service \
     fi
     ln -sfn "$src" "$BUILDROOT/etc/systemd/system/multi-user.target.wants/$unit"
 done
+
+# #393 — enable getty@tty1 into getty.target.wants (its [Install] is
+# WantedBy=getty.target, NOT multi-user.target, so the loop above can't do it).
+# The spatium-console-gate.conf drop-in gates it on spatium-console=off, so it
+# only actually starts in the text_console mode; in dashboard /
+# verbose_dashboard mode its condition fails and the dashboard owns tty1.
+mkdir -p "$BUILDROOT/etc/systemd/system/getty.target.wants"
+ln -sfn /lib/systemd/system/getty@.service \
+    "$BUILDROOT/etc/systemd/system/getty.target.wants/getty@tty1.service"
 
 # Issue #153 — snmpd is installed but NOT auto-started. The Debian
 # net-snmp package's postinst symlinks snmpd.service into

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -118,6 +118,8 @@ backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:91
 backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:92
 backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:93
 backend/alembic/versions/a7b3c8d92e14_account_lockout.py:drop_column:94
+backend/alembic/versions/a7c3e9f1b405_console_mode.py:drop_column:48
+backend/alembic/versions/a7c3e9f1b405_console_mode.py:drop_column:65
 backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py:drop_column:54
 backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py:drop_column:55
 backend/alembic/versions/a7e3c1f49d20_subnet_ip_discovery.py:drop_column:56

--- a/backend/alembic/versions/a7c3e9f1b405_console_mode.py
+++ b/backend/alembic/versions/a7c3e9f1b405_console_mode.py
@@ -1,0 +1,65 @@
+"""appliance console mode — replace verbose_boot with console_mode (#393)
+
+Replaces the boolean ``platform_settings.verbose_boot`` with a
+``console_mode`` enum-string so the operator can pick between three
+console behaviours instead of a single on/off:
+
+* ``dashboard``         — quiet boot + Talos console dashboard (default)
+* ``verbose_dashboard`` — verbose boot output, then the dashboard
+* ``text_console``      — verbose boot + a plain getty login (no dashboard)
+
+Backfills the old boolean: ``verbose_boot=True`` → ``text_console``
+(the old "standard Linux console" behaviour), ``False`` → ``dashboard``.
+
+Revision ID: a7c3e9f1b405
+Revises: f4a1c9e7b2d8
+Create Date: 2026-06-12
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a7c3e9f1b405"
+down_revision: str | None = "f4a1c9e7b2d8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "console_mode",
+            sa.String(length=20),
+            nullable=False,
+            server_default="dashboard",
+        ),
+    )
+    # Backfill from the old boolean before dropping it.
+    op.execute(
+        "UPDATE platform_settings "
+        "SET console_mode = CASE WHEN verbose_boot THEN 'text_console' "
+        "ELSE 'dashboard' END"
+    )
+    op.drop_column("platform_settings", "verbose_boot")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "verbose_boot",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.execute(
+        "UPDATE platform_settings "
+        "SET verbose_boot = (console_mode <> 'dashboard')"
+    )
+    op.drop_column("platform_settings", "console_mode")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1294,11 +1294,12 @@ class SupervisorHeartbeatResponse(BaseModel):
     # against the host's current tz on every heartbeat + writes the
     # ``spatium-tz-reload`` trigger file when they differ.
     desired_timezone: str = ""
-    # Verbose-boot console toggle. The supervisor flips a grubenv variable
+    # #393 — appliance console mode (dashboard / verbose_dashboard /
+    # text_console). The supervisor maps it to the grubenv variable
     # (spatium_verbose) the grub.cfg menuentries read, so it survives A/B slot
     # swaps + the /etc overlay and applies on next reboot. Mirrors the
     # desired_timezone delivery exactly.
-    desired_verbose_boot: bool = False
+    desired_console_mode: str = "dashboard"
     # Issue #346 — appliance host-config blocks delivered to the supervisor,
     # which compares each block's ``config_hash`` against its applied sidecar
     # and fires the matching ``spatium-{snmp,chrony,lldp}-reload`` trigger when
@@ -1921,8 +1922,8 @@ async def supervisor_heartbeat(
     dhcp_relay_vip = (cfg_row.dhcp_relay_vip or "") if cfg_row else ""
     # Issue #165 — operator-set timezone. Empty string = no override.
     desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
-    # Verbose-boot console toggle (grubenv-driven, applies next reboot).
-    desired_verbose_boot = bool(cfg_row.verbose_boot) if cfg_row else False
+    # #393 — appliance console mode (grubenv-driven, applies next reboot).
+    desired_console_mode = (cfg_row.console_mode or "dashboard") if cfg_row else "dashboard"
     # Issue #346 — host-config blocks for snmp / chrony / lldp. Built from the
     # same ``*_bundle`` helpers the DHCP-agent ConfigBundle uses; the
     # disabled-shape fallback keeps a stable key set when no settings row
@@ -2064,7 +2065,7 @@ async def supervisor_heartbeat(
         desired_dhcp_relay_vip=dhcp_relay_vip,
         evict_node_names=evict_names,
         desired_timezone=desired_timezone,
-        desired_verbose_boot=desired_verbose_boot,
+        desired_console_mode=desired_console_mode,
         snmp_settings=snmp_block,
         ntp_settings=ntp_block,
         lldp_settings=lldp_block,

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 from ipaddress import ip_network
-from typing import Any
+from typing import Any, Literal
 
 import structlog
 from fastapi import APIRouter, HTTPException, status
@@ -171,10 +171,11 @@ class SettingsResponse(BaseModel):
     # ── Appliance timezone (issue #165) ───────────────────────────
     # Empty string means "follow install-time default" (no override).
     timezone: str = ""
-    # ── Appliance verbose boot console ────────────────────────────
-    # True = standard Linux console on boot (kernel messages + systemd
-    # status + getty, no dashboard); False = quiet boot + dashboard.
-    verbose_boot: bool = False
+    # ── Appliance console mode (#393) ─────────────────────────────
+    # ``dashboard`` (default) = quiet boot + Talos dashboard;
+    # ``verbose_dashboard`` = verbose boot output then dashboard;
+    # ``text_console`` = verbose boot + plain getty login (no dashboard).
+    console_mode: str = "dashboard"
     # ── Maintenance mode (issue #57) ──────────────────────────────
     # System-wide read-only switch. ``maintenance_started_at`` is
     # server-managed (stamped on enable / cleared on disable) and so is
@@ -646,8 +647,8 @@ class SettingsUpdate(BaseModel):
     ntp_allow_client_networks: list[str] | None = None
     # ── Appliance timezone (issue #165) ───────────────────────────
     timezone: str | None = None
-    # ── Appliance verbose boot console ────────────────────────────
-    verbose_boot: bool | None = None
+    # ── Appliance console mode (#393) ─────────────────────────────
+    console_mode: Literal["dashboard", "verbose_dashboard", "text_console"] | None = None
     # ── Maintenance mode (issue #57) ──────────────────────────────
     # ``maintenance_started_at`` is intentionally NOT settable here —
     # it's server-stamped in ``update_settings`` when the enable flag
@@ -1407,7 +1408,7 @@ async def update_settings(
     # popped / rewritten so detection is order-independent.
     _supervisor_host_config_fields = {
         "timezone",
-        "verbose_boot",
+        "console_mode",
         "firewall_enabled",
         "metallb_enabled",
         "metallb_pool_addresses",

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -446,18 +446,24 @@ class PlatformSettings(Base):
         String(64), nullable=False, default="", server_default=sa_text("''")
     )
 
-    # ── Appliance verbose boot console (issue: console-and-sidebar) ──
-    # When True, the appliance boots with a STANDARD Linux console: the
-    # kernel ``loglevel=3`` cap is dropped (all kernel messages scroll),
-    # ``systemd.show_status=1`` shows the per-unit ``[ OK ]`` lines, and
-    # ``spatium-console=off`` is passed so a normal getty login replaces
-    # the Talos-style dashboard — i.e. boot/reboot/shutdown look like a
-    # regular Linux box. False (default) keeps today's quiet boot
-    # (``loglevel=3``) + the console dashboard. Flows through the same
-    # heartbeat → grubenv → host-runner plane as timezone / NTP / SNMP;
-    # the kernel cmdline lives in grub.cfg, so it applies on next reboot.
-    verbose_boot: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    # ── Appliance console mode (#393) ──────────────────────────────
+    # How the appliance's physical/serial console behaves, one of:
+    #   ``dashboard``         (default) — quiet boot (``loglevel=3``) +
+    #                         the Talos-style console dashboard on tty1.
+    #   ``verbose_dashboard`` — show kernel + systemd boot output during
+    #                         boot, THEN the dashboard takes over tty1.
+    #   ``text_console``      — verbose boot + a plain getty LOGIN on
+    #                         tty1 (no dashboard), i.e. a regular Linux
+    #                         box (``spatium-console=off``).
+    # The supervisor maps this to the grubenv ``spatium_verbose`` value
+    # the grub.cfg menuentries read (dashboard→0 / text_console→1 /
+    # verbose_dashboard→2); applies on the next reboot. Flows through
+    # the same heartbeat → grubenv → host-runner plane as timezone /
+    # NTP / SNMP. Replaces the pre-#393 boolean ``verbose_boot`` (which
+    # mapped True→text_console, False→dashboard — backfilled in the
+    # migration).
+    console_mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="dashboard", server_default="dashboard"
     )
 
     # ── Maintenance mode (issue #57) ────────────────────────────────

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2993,11 +2993,12 @@ export interface PlatformSettings {
   // Issue #165 — operator-set IANA timezone. Empty = no override
   // (host falls back to install-time default).
   timezone: string;
-  /** Appliance verbose-boot console. true = standard Linux console on
-   *  boot/reboot/shutdown (kernel messages + systemd status + getty, no
-   *  dashboard); false (default) = quiet boot + Talos dashboard. Appliance
-   *  hosts only; applies on next reboot (grubenv-driven). */
-  verbose_boot: boolean;
+  /** Appliance console mode (#393): "dashboard" (default) = quiet boot +
+   *  the Talos console dashboard; "verbose_dashboard" = verbose kernel /
+   *  systemd boot output, then the dashboard takes over; "text_console" =
+   *  verbose boot + a plain getty login (no dashboard). Appliance hosts only;
+   *  applies on the next reboot (grubenv-driven). */
+  console_mode: "dashboard" | "verbose_dashboard" | "text_console";
   /** Maintenance mode (issue #57). System-wide read-only switch.
    *  ``maintenance_started_at`` is server-managed (stamped on enable /
    *  cleared on disable) and is therefore read-only — not sent on PUT. */

--- a/frontend/src/pages/appliance/NetworkTab.tsx
+++ b/frontend/src/pages/appliance/NetworkTab.tsx
@@ -114,13 +114,34 @@ export function NetworkTab() {
   );
 }
 
-// Verbose-boot console toggle. Off (default) = quiet boot + the Talos-style
-// console dashboard; On = a standard Linux console (kernel messages + systemd
-// [ OK ] lines scroll on boot/reboot/shutdown, and a normal getty login
-// replaces the dashboard). Backed by platform_settings.verbose_boot, which the
-// supervisor flips into the grubenv `spatium_verbose` variable the grub.cfg
+// Console-mode selector (#393). Picks what the appliance's physical / serial
+// console shows: the Talos dashboard, verbose boot output then the dashboard,
+// or a plain text login. Backed by platform_settings.console_mode, which the
+// supervisor maps to the grubenv `spatium_verbose` value the grub.cfg
 // menuentries read — so it applies on the NEXT reboot. Appliance hosts only
 // (this tab is already selfOnly).
+const CONSOLE_MODES: {
+  value: "dashboard" | "verbose_dashboard" | "text_console";
+  label: string;
+  desc: string;
+}[] = [
+  {
+    value: "dashboard",
+    label: "Dashboard (default)",
+    desc: "Quiet boot, then the SpatiumDDI console dashboard on screen.",
+  },
+  {
+    value: "verbose_dashboard",
+    label: "Verbose boot, then dashboard",
+    desc: "Kernel + systemd [ OK ] lines scroll during boot, then the dashboard takes over the console.",
+  },
+  {
+    value: "text_console",
+    label: "Plain text console",
+    desc: "Verbose boot + a standard Linux login prompt, no dashboard. Best for diagnosing boot hangs or working at the console directly.",
+  },
+];
+
 function VerboseBootCard() {
   const qc = useQueryClient();
   const { data: me } = useQuery({
@@ -133,48 +154,60 @@ function VerboseBootCard() {
     queryFn: settingsApi.get,
   });
   const isSuperadmin = me?.is_superadmin ?? false;
-  const verbose = settings?.verbose_boot ?? false;
+  const mode = settings?.console_mode ?? "dashboard";
   const save = useMutation({
-    mutationFn: (v: boolean) => settingsApi.update({ verbose_boot: v }),
+    mutationFn: (v: "dashboard" | "verbose_dashboard" | "text_console") =>
+      settingsApi.update({ console_mode: v }),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["settings"] }),
   });
 
   return (
     <section className="space-y-3 rounded-lg border bg-card p-4 shadow-sm">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <h3 className="flex items-center gap-2 text-sm font-medium">
-            <TerminalSquare className="h-4 w-4 text-muted-foreground" />
-            Boot console
-          </h3>
-          <p className="mt-1 text-xs text-muted-foreground">
-            <strong>Off</strong> (default): quiet boot, then the SpatiumDDI
-            console dashboard. <strong>On</strong>: a standard Linux console —
-            kernel messages and systemd <code>[ OK ]</code> lines scroll during
-            boot / reboot / shutdown, and a normal login prompt replaces the
-            dashboard. Useful for diagnosing boot hangs. Takes effect on the{" "}
-            <strong>next reboot</strong>.
-          </p>
-        </div>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={verbose}
-          aria-label="Verbose boot console (standard Linux boot)"
-          disabled={!isSuperadmin || save.isPending || !settings}
-          onClick={() => save.mutate(!verbose)}
-          className={cn(
-            "relative mt-0.5 inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50",
-            verbose ? "bg-primary" : "bg-muted",
-          )}
-        >
-          <span
-            className={cn(
-              "inline-block h-5 w-5 transform rounded-full bg-background shadow transition-transform",
-              verbose ? "translate-x-5" : "translate-x-0.5",
-            )}
-          />
-        </button>
+      <div>
+        <h3 className="flex items-center gap-2 text-sm font-medium">
+          <TerminalSquare className="h-4 w-4 text-muted-foreground" />
+          Boot console
+        </h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          What the appliance&apos;s physical / serial console shows. Takes
+          effect on the <strong>next reboot</strong>.
+        </p>
+      </div>
+      <div className="space-y-2">
+        {CONSOLE_MODES.map((opt) => {
+          const active = mode === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              disabled={!isSuperadmin || save.isPending || !settings}
+              onClick={() => save.mutate(opt.value)}
+              className={cn(
+                "flex w-full items-start gap-3 rounded-md border p-2.5 text-left transition-colors disabled:opacity-50",
+                active
+                  ? "border-primary bg-primary/5"
+                  : "border-border hover:bg-muted/50",
+              )}
+            >
+              <span
+                className={cn(
+                  "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border",
+                  active ? "border-primary" : "border-muted-foreground/40",
+                )}
+              >
+                {active && <span className="h-2 w-2 rounded-full bg-primary" />}
+              </span>
+              <span className="min-w-0">
+                <span className="block text-sm font-medium">{opt.label}</span>
+                <span className="block text-xs text-muted-foreground">
+                  {opt.desc}
+                </span>
+              </span>
+            </button>
+          );
+        })}
       </div>
       {save.isError && (
         <p className="text-xs text-destructive">{formatApiError(save.error)}</p>
@@ -182,7 +215,7 @@ function VerboseBootCard() {
       {save.isSuccess && (
         <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
           Saved — applies on the next reboot. Reboot the appliance (Maintenance
-          tab) to switch the boot console now.
+          tab) to switch the console now.
         </p>
       )}
       {!isSuperadmin && (


### PR DESCRIPTION
## Summary

Two appliance fixes, both surfaced/validated during the 2026.06.12-2 field test. Safe to ship in the next release — no rush.

### #393 — console-mode selector + fix missing login in verbose mode
Replaces the boolean `verbose_boot` platform setting with a 3-mode `console_mode` enum and fixes a field-discovered bug where picking the non-dashboard mode left the box with **no login at all**.

- **Three modes** (`dashboard` / `verbose_dashboard` / `text_console`) drive the grubenv `spatium_verbose` numeric (`0` / `2` / `1`) consumed by `grub.cfg` + the host runner.
- **Model/API:** `PlatformSettings.console_mode` (`String(20)`, default `dashboard`) replaces `verbose_boot`; migration `a7c3e9f1b405` backfills (`verbose_boot=True → text_console`) and drops the old column; settings router uses a `Literal` type; supervisor heartbeat carries `desired_console_mode` → `maybe_fire_console_mode`.
- **Frontend:** `NetworkTab` toggle → 3-option radio; `console_mode` type on `PlatformSettings`.
- **Boot wiring:** new `grub.cfg` `spatium_verbose=2` branch (verbose_dashboard = systemd status + dashboard); `spatium-install` + `spatiumddi-verbose-boot-reload` accept `0/1/2`; new `spatium-console=off` console-gate drop-ins for `getty@tty1` + `serial-getty@ttyS0`; `mkosi.postinst` stamps the `getty@tty1` wants-symlink.
- **The no-login fix (field-discovered):** removed `Conflicts=getty@tty1.service` / `Conflicts=serial-getty@%i.service` from the dashboard units. A load-time `Conflicts=` **leaks** via `ConflictedBy` and drops getty from the boot transaction even when the dashboard stays inactive (its `ConditionKernelCommandLine=!spatium-console=off` fails in text_console mode) — so the operator who picked the plain console was left with no login. The dashboard and getty are now mutually exclusive purely by their opposite `spatium-console=off` conditions.

### #394 — helm-stuck-recover crashes on boot (JSONDecodeError)
`spatiumddi-helm-stuck-recover` shell-interpolated a `helm list -o json` blob straight into a Python heredoc (`json.loads('''$charts_json''')`); an embedded control char tripped `json.loads`' strict mode and the recovery step crashed on every boot — helm auto-recovery was non-functional. Fixed by passing the blob through an env var (`CHARTS_JSON=...`) and `json.loads(..., strict=False)`.

## Validation
- **`text_console` no-login fix:** field-validated on real 3-node hardware (ddi1) via slot-upgrade — `getty@tty1` active + agetty login confirmed at the physical console.
- **#394:** reproduced the crash + proved the fix with a standalone `python3` repro of the original control-char payload.
- ⚠️ Not yet validated on a fresh ISO install (vs slot-upgrade): the new `verbose_dashboard` grub branch and the full UI → `console_mode` → supervisor → grubenv chain. Recommend a fresh-ISO smoke before relying on `verbose_dashboard` in the field.

Closes #393
Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)
