### PR TITLE
fix(security): #400 — auth-bypass + privilege-boundary + hardening review (1 critical, 3 high, 12 hardening)

### DIFF
--- a/appliance/mkosi.extra/usr/local/share/spatiumddi/nginx-appliance.conf
+++ b/appliance/mkosi.extra/usr/local/share/spatiumddi/nginx-appliance.conf
@@ -65,11 +65,31 @@ server {
     ssl_session_timeout 1d;
     ssl_session_tickets off;
 
-    # HSTS — once a browser sees the appliance over HTTPS, refuse
-    # downgrade for 1 year. Apply only after we've shipped a real
-    # cert workflow (4b.4 / operator upload) so self-signed boots
-    # don't pin themselves into permanent "site insecure" prompts.
-    # add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # ── Security response headers (SECURITY #400, L2) ──────────────
+    # HSTS — once a browser sees the appliance over HTTPS, refuse a
+    # downgrade for 1 year. The appliance always terminates TLS on
+    # :443 (the :80 block 301s to HTTPS), and operators get a real
+    # cert via the 4b.4 / upload workflow, so it's safe to pin. A
+    # self-signed first boot only ever produces a one-time browser
+    # trust prompt, not a permanent HSTS lock, because HSTS is honoured
+    # only after the cert validates — browsers ignore the header on a
+    # connection the user had to click through. ``includeSubDomains``
+    # is intentionally omitted: the appliance may be reached by bare
+    # IP or a host that owns sibling sub-domains.
+    add_header Strict-Transport-Security "max-age=31536000" always;
+
+    # CSP + clickjacking + sniffing + referrer hardening. Rationale
+    # matches frontend/default.conf.template (same Vite build): script
+    # locked to 'self' (no inline/eval), style-src needs 'unsafe-inline'
+    # for runtime-injected <style> (recharts) + React inline styles,
+    # connect-src 'self' (LLM providers are proxied through the api),
+    # img-src adds data: for favicon/logo data URIs, frame-ancestors
+    # 'none' blocks framing.
+    set $spatium_csp "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'";
+    add_header Content-Security-Policy $spatium_csp always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
 
     root /usr/share/nginx/html;
     index index.html;
@@ -142,6 +162,13 @@ server {
     location ~* \.(js|css|woff2?|png|svg|ico)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        # Re-emit security headers (SECURITY #400, L2) — a location
+        # with its own add_header does NOT inherit the server-level set.
+        add_header Strict-Transport-Security "max-age=31536000" always;
+        add_header Content-Security-Policy $spatium_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer" always;
     }
 
     gzip on;

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -24,6 +24,29 @@ _bearer = HTTPBearer(auto_error=False)
 # on every request. See ``app.core.security.generate_api_token``.
 _API_TOKEN_PREFIX = "sddi_"
 
+# SECURITY (#400 / M4): when ``User.force_password_change`` is set (a fresh
+# account, an admin-forced reset, or a max-age-expired password), the user
+# must be barred from every authenticated endpoint EXCEPT the handful needed
+# to actually rotate the password and read enough state to do so. Without
+# this gate the flag was advisory only — the frontend honoured it, but the
+# API happily served every other request to a token minted for a
+# must-change-password account. These suffixes are matched against the
+# request path so a forced user can still reach the recovery flow.
+_FORCE_PW_CHANGE_ALLOWLIST: tuple[str, ...] = (
+    "/auth/change-password",
+    "/auth/logout",
+    "/auth/me",
+    "/auth/password-policy",
+)
+
+
+def _path_in_recovery_allowlist(path: str) -> bool:
+    """True when ``path`` ends with one of the password-recovery endpoints
+    a ``force_password_change`` user is still allowed to reach. Suffix match
+    so the API ``/api/v1`` prefix (and any mount-point reverse-proxy rewrite)
+    doesn't matter — the allowlisted set is unambiguous on its tail."""
+    return any(path.rstrip("/").endswith(suffix) for suffix in _FORCE_PW_CHANGE_ALLOWLIST)
+
 
 async def _resolve_api_token(db: AsyncSession, raw: str, request: Request) -> User:
     """Validate an ``sddi_*`` bearer and return the owning user.
@@ -77,6 +100,16 @@ async def _resolve_api_token(db: AsyncSession, raw: str, request: Request) -> Us
     if not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="User account is disabled"
+        )
+    # SECURITY (#400 / M4): the must-change-password gate applies to API
+    # tokens too — a token minted for an account that later gets a forced
+    # reset (or whose password expires) must not be a bypass around the
+    # interactive lockout. Same recovery allowlist (the recovery endpoints
+    # are session-only, so in practice this just 403s the token).
+    if user.force_password_change and not _path_in_recovery_allowlist(request.url.path):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Password change required before continuing",
         )
     # Fire-and-forget last-used bump. Failure to write this shouldn't
     # 500 the request — we commit on the caller's session so if the
@@ -158,6 +191,18 @@ async def get_current_user(
     if not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="User account is disabled"
+        )
+
+    # SECURITY (#400 / M4): enforce the must-change-password gate server-side.
+    # ``force_password_change`` is set on fresh accounts, on admin resets, and
+    # is flipped on by the login-time max-age check (issue #70), so honouring
+    # it here closes both the "must change" and the "password expired" cases.
+    # We reject every request EXCEPT the password-recovery allowlist so the
+    # user can still rotate their password and log out — anything else 403s.
+    if user.force_password_change and not _path_in_recovery_allowlist(request.url.path):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Password change required before continuing",
         )
 
     await _load_time_bound_grants(db, user)

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -271,15 +271,25 @@ async def startup() -> JSONResponse:
 async def platform_health() -> JSONResponse:
     """Dashboard-oriented rollup of every control-plane component.
 
-    Distinct from ``/health/ready`` in that this one is authenticated-
-    dashboard-facing rather than an orchestrator probe: it enumerates
-    the individual pieces (db, redis, celery workers, celery beat)
-    instead of returning a single binary verdict, so the UI can show a
+    Distinct from ``/health/ready`` in that this one is dashboard-
+    facing rather than an orchestrator probe: it enumerates the
+    individual pieces (db, redis, celery workers, celery beat) instead
+    of returning a single binary verdict, so the UI can show a
     per-component status dot and explain what's wrong. Individual
     failures never make the endpoint itself fail — the caller always
     gets a 200 with the rollup. The top-level ``status`` folds the
     components into a single ``ok`` / ``degraded`` verdict for headline
     display.
+
+    SECURITY (#400 / M5): this endpoint is mounted UNAUTHENTICATED
+    (the AppLayout polls it before login for the demo-mode /
+    maintenance banner), so component ``detail`` fields must never echo
+    raw backend exception strings — those can leak DSNs, internal
+    hostnames, driver versions, and stack-frame paths to an anonymous
+    caller. On error we log the full ``str(exc)`` server-side (where
+    operators can see it) and return only a fixed, generic detail
+    string. The ``ok`` / ``error`` / ``warn`` status semantics are
+    unchanged, so the per-component dots still render correctly.
     """
     components: list[dict[str, Any]] = [{"name": "api", "status": "ok", "detail": "responding"}]
 
@@ -296,7 +306,10 @@ async def platform_health() -> JSONResponse:
             }
         )
     except Exception as exc:
-        components.append({"name": "postgres", "status": "error", "detail": str(exc)})
+        # SECURITY (#400 / M5): never echo str(exc) to this unauthenticated
+        # endpoint — it can leak the Postgres DSN / host. Log it server-side.
+        logger.warning("platform_health_check_failed", component="postgres", error=str(exc))
+        components.append({"name": "postgres", "status": "error", "detail": "postgres error"})
 
     # Redis
     t0 = monotonic()
@@ -315,7 +328,10 @@ async def platform_health() -> JSONResponse:
             }
         )
     except Exception as exc:
-        components.append({"name": "redis", "status": "error", "detail": str(exc)})
+        # SECURITY (#400 / M5): generic detail only — str(exc) would leak the
+        # Redis URL / host to an unauthenticated caller.
+        logger.warning("platform_health_check_failed", component="redis", error=str(exc))
+        components.append({"name": "redis", "status": "error", "detail": "redis error"})
 
     # Celery workers — `inspect().ping()` is a sync, broker-backed RPC
     # that can hang, so run it in a threadpool with a short overall
@@ -332,8 +348,11 @@ async def platform_health() -> JSONResponse:
         ping = None
         workers_detail = "inspect timed out"
     except Exception as exc:  # noqa: BLE001
+        # SECURITY (#400 / M5): generic detail only — str(exc) here can carry
+        # the broker URL / host. Log the real error server-side.
+        logger.warning("platform_health_check_failed", component="celery-workers", error=str(exc))
         ping = None
-        workers_detail = f"inspect error: {exc}"
+        workers_detail = "inspect error"
     else:
         workers_detail = None
 
@@ -397,7 +416,10 @@ async def platform_health() -> JSONResponse:
                 }
             )
     except Exception as exc:
-        components.append({"name": "celery-beat", "status": "error", "detail": str(exc)})
+        # SECURITY (#400 / M5): generic detail only — str(exc) would leak the
+        # Redis URL / internal state to an unauthenticated caller.
+        logger.warning("platform_health_check_failed", component="celery-beat", error=str(exc))
+        components.append({"name": "celery-beat", "status": "error", "detail": "celery-beat error"})
 
     rollup = "ok"
     for c in components:

--- a/backend/app/api/v1/ai/mcp.py
+++ b/backend/app/api/v1/ai/mcp.py
@@ -38,6 +38,7 @@ from app.api.deps import DB, CurrentUser
 from app.services.ai.tools import (
     REGISTRY,
     ToolArgumentError,
+    ToolDisabled,
     ToolNotFound,
 )
 
@@ -79,6 +80,25 @@ def _err(req_id: int | str | None, code: int, message: str, data: Any = None) ->
     return {"jsonrpc": "2.0", "id": req_id, "error": payload}
 
 
+def _mcp_tools() -> list[Any]:
+    """The tools the MCP transport exposes — genuinely read-only only.
+
+    SECURITY (#400, M1): ``REGISTRY.read_only()`` keys off the ``writes``
+    flag, but every ``propose_*`` tool is registered ``writes=False``
+    (the propose call itself only previews + persists a proposal row;
+    the mutation runs later through the C2-gated /apply endpoint). We
+    therefore additionally drop ``propose_*`` tools so the MCP surface
+    never previews/stages a write either. ``tools/list`` (advertised
+    set) and ``tools/call`` (dispatch gate) both consume this single
+    source of truth so they can never drift apart.
+    """
+    return [t for t in REGISTRY.read_only() if not t.name.startswith("propose_")]
+
+
+def _mcp_tool_names() -> set[str]:
+    return {t.name for t in _mcp_tools()}
+
+
 # Standard JSON-RPC error codes
 _PARSE_ERROR = -32700
 _INVALID_REQUEST = -32600
@@ -97,7 +117,7 @@ async def mcp_get(current_user: CurrentUser) -> dict[str, Any]:
     return {
         "server": _SERVER_INFO,
         "protocol_version": _PROTOCOL_VERSION,
-        "available_tools": len(REGISTRY.read_only()),
+        "available_tools": len(_mcp_tools()),
         "transport": "streamable_http",
     }
 
@@ -178,7 +198,7 @@ async def _dispatch_one(raw: Any, db: Any, user: Any) -> dict[str, Any]:
         if method == "tools/list":
             return _ok(
                 req.id,
-                {"tools": [t.to_mcp_tool() for t in REGISTRY.read_only()]},
+                {"tools": [t.to_mcp_tool() for t in _mcp_tools()]},
             )
 
         if method == "tools/call":
@@ -190,9 +210,26 @@ async def _dispatch_one(raw: Any, db: Any, user: Any) -> dict[str, Any]:
                     _INVALID_PARAMS,
                     "tools/call requires string `name`",
                 )
+            # SECURITY (#400, M1): the MCP transport only advertises the
+            # read-only tool set via tools/list, so tools/call must refuse
+            # anything outside it. Passing effective={MCP tool names} makes
+            # the registry raise ToolDisabled for write/propose tools —
+            # without this, a read-scoped API-token client could invoke any
+            # registered tool (including propose_* proposals) by name.
             try:
-                result = await REGISTRY.call(name, arguments, db=db, user=user)
+                result = await REGISTRY.call(
+                    name, arguments, db=db, user=user, effective=_mcp_tool_names()
+                )
             except ToolNotFound as exc:
+                return _err(
+                    req.id,
+                    _METHOD_NOT_FOUND,
+                    f"tool not found: {exc.name!r}",
+                )
+            except ToolDisabled as exc:
+                # A registered tool the MCP surface doesn't expose (write /
+                # propose). Report it as method-not-found so we don't leak
+                # the existence of tools outside the advertised set.
                 return _err(
                     req.id,
                     _METHOD_NOT_FOUND,

--- a/backend/app/api/v1/ai/proposals.py
+++ b/backend/app/api/v1/ai/proposals.py
@@ -135,6 +135,23 @@ async def apply_proposal(
             detail=f"Operation {row.operation!r} is not registered",
         )
 
+    # SECURITY (#400, C2): authoritative RBAC backstop. The propose→apply
+    # flow has NO router-level require_*_permission dependency, so without
+    # this gate an authenticated Viewer who owns a proposal row could apply
+    # it and write IPAM / DNS / DHCP / multicast / alert rows the equivalent
+    # REST route would 403. We enforce the operation's declared
+    # (action, resource_type) here, before re-validating args or dispatching
+    # — matching the permission the equivalent REST route requires. The
+    # per-_apply_ checks in services/ai/operations.py are defense in depth;
+    # this endpoint is the primary gate.
+    try:
+        operations.enforce_operation_permission(current_user, op)
+    except operations.OperationPermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+
     # Re-validate args through the operation's pydantic model — guards
     # against the rare case where the model schema changed between
     # propose and apply (a redeploy mid-flight).
@@ -156,6 +173,16 @@ async def apply_proposal(
 
     try:
         result = await op.apply(db, current_user, args)
+    except operations.OperationPermissionError as exc:
+        # SECURITY (#400, C2): a permission failure raised by the op's
+        # own defense-in-depth check surfaces as a clean 403, not a
+        # rolled-back ok=False result. (The authoritative gate above
+        # should already have caught the common case.)
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
     except Exception as exc:  # noqa: BLE001
         # Apply rolled back its own transaction; reload the proposal
         # from a fresh state and stamp the error.

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1487,14 +1487,26 @@ async def supervisor_heartbeat(
             )
         row = cert_principal.appliance
     else:
-        # Session-token fallback for pending_approval rows.
+        # No client cert presented — authenticate via the session token
+        # (minted at register, stored only as a hash, held by the real
+        # supervisor). This is the legitimate non-mTLS path: a not-yet-cert
+        # supervisor and HTTP-only remote supervisors heartbeat with it.
+        #
+        # SECURITY (GHSA-mj4g-hw3m-62rm / #400 C1): this previously read
+        # ``row.state == APPROVED or (session_token ...)``. Python ``or``
+        # short-circuits, so for ANY approved row (the steady state of every
+        # registered appliance) it returned valid with NO cert AND NO session
+        # token — i.e. anyone who knew an appliance UUID (UUIDs leak via logs /
+        # UI / audit) could drive the heartbeat. We now REQUIRE a valid
+        # credential (the session token) on every no-cert heartbeat — the
+        # UUID alone is no longer sufficient. The cluster-admin k3s join token
+        # is additionally gated on mTLS below, so even a leaked session token
+        # cannot harvest it.
         row = await db.get(Appliance, body.appliance_id)
-        valid = row is not None and (
-            row.state == APPLIANCE_STATE_APPROVED
-            or (
-                body.session_token is not None
-                and verify_session_token(body.session_token, row.session_token_hash)
-            )
+        valid = (
+            row is not None
+            and body.session_token is not None
+            and verify_session_token(body.session_token, row.session_token_hash)
         )
         if not valid:
             await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
@@ -1887,9 +1899,16 @@ async def supervisor_heartbeat(
         ca_chain_pem = ca.cert_pem
 
     # #272 Phase 7 — decrypt the join token for the joiner (mTLS channel).
+    # SECURITY (GHSA-mj4g-hw3m-62rm / #400 C1, defence-in-depth): the k3s
+    # join token is cluster-admin-equivalent, so only ever hand it back over a
+    # cert-authenticated (mTLS) request — never the credential-less /
+    # session-token path. The auth gate above already closes the no-cert path
+    # for approved rows; this is the belt-and-braces so the secret can't leak
+    # even if that gate is later loosened.
     desired_join_token: str | None = None
     if (
-        row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
+        cert_principal is not None
+        and row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
         and row.desired_k3s_join_token_encrypted is not None
     ):
         from app.core.crypto import decrypt_str  # noqa: PLC0415

--- a/backend/app/api/v1/auth/router.py
+++ b/backend/app/api/v1/auth/router.py
@@ -48,6 +48,7 @@ from app.core.security import (
     create_access_token,
     create_mfa_challenge_token,
     create_refresh_token,
+    decode_access_token,
     decode_mfa_challenge_token,
     hash_password,
     hash_refresh_token,
@@ -720,10 +721,31 @@ async def get_password_policy(db: DB) -> PasswordPolicyResponse:
     )
 
 
+def _current_session_jti(request: Request) -> str | None:
+    """Best-effort extraction of the access token's ``jti`` from the
+    incoming Authorization header, so the self-service change-password
+    path can spare the caller's own session when it revokes the rest.
+
+    Returns None for API-token auth, legacy (no-jti) tokens, or anything
+    that fails to decode — in which case we simply revoke every session,
+    which is the safe direction (the caller just has to log in again)."""
+    header = request.headers.get("authorization") or ""
+    scheme, _, raw = header.partition(" ")
+    if scheme.lower() != "bearer" or not raw:
+        return None
+    try:
+        payload = decode_access_token(raw)
+    except JWTError:
+        return None
+    jti = payload.get("jti")
+    return str(jti) if jti is not None else None
+
+
 @router.post("/change-password", status_code=status.HTTP_204_NO_CONTENT)
 async def change_password(
     body: ChangePasswordRequest,
     current_user: CurrentUser,
+    request: Request,
     db: DB,
 ) -> None:
     forbid_in_demo_mode("Password change is disabled")
@@ -764,6 +786,21 @@ async def change_password(
     current_user.force_password_change = False
     current_user.password_changed_at = datetime.now(UTC)
     current_user.password_history_encrypted = new_history
+
+    # SECURITY (#400 / M3): a password change must revoke every other
+    # outstanding session + refresh token for this user. Without this a
+    # stolen/leaked session that triggered the rotation (or any old session
+    # that existed before the change) keeps working — defeating the whole
+    # point of changing the password. Reuses the exact revocation statement
+    # ``/auth/logout`` uses; we spare the caller's *current* session so a
+    # routine self-service change doesn't immediately log the user out.
+    current_jti = _current_session_jti(request)
+    revoke_stmt = update(UserSession).where(
+        UserSession.user_id == current_user.id, UserSession.revoked.is_(False)
+    )
+    if current_jti is not None:
+        revoke_stmt = revoke_stmt.where(UserSession.id != current_jti)
+    await db.execute(revoke_stmt.values(revoked=True))
 
     audit = AuditLog(
         user_id=current_user.id,

--- a/backend/app/api/v1/cloud/router.py
+++ b/backend/app/api/v1/cloud/router.py
@@ -427,6 +427,13 @@ async def test_connection(
             detail="credentials are required (either in the body or via a stored endpoint_id)",
         )
 
+    # SECURITY (#400, L5): no SSRF guard call here — the AWS / Azure /
+    # GCP connectors dial each cloud's FIXED SDK service endpoints
+    # (derived from subscription / project / region IDs), not an
+    # operator-supplied host, so there is no operator-controlled connect
+    # target to resolve. If a custom ``endpoint_url`` field is ever added
+    # to ``provider_config``, route it through
+    # ``app.core.ssrf.assert_safe_target`` here. See app/core/ssrf.py.
     try:
         connector = get_connector(
             provider,

--- a/backend/app/api/v1/dashboards/security.py
+++ b/backend/app/api/v1/dashboards/security.py
@@ -28,7 +28,8 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 from sqlalchemy import desc, func, select
 
-from app.api.deps import DB, CurrentUser  # noqa: F401
+from app.api.deps import DB, CurrentUser
+from app.core.permissions import is_effective_superadmin, user_has_permission
 from app.models.audit import AuditLog
 from app.models.auth import APIToken, User
 
@@ -127,10 +128,24 @@ _PERMISSION_RESOURCE_TYPES: frozenset[str] = frozenset(
 
 
 @router.get("/security/summary", response_model=SecurityDashboardSummary)
-async def security_summary(
-    db: DB, current_user: CurrentUser  # noqa: ARG001
-) -> SecurityDashboardSummary:
-    """Single-shot rollup for the Security dashboard tab."""
+async def security_summary(db: DB, current_user: CurrentUser) -> SecurityDashboardSummary:
+    """Single-shot rollup for the Security dashboard tab.
+
+    SECURITY (#400 / M2): this rollup surfaces user/MFA/token/login
+    telemetry (per-user last-login times, failed-login source IPs,
+    permission-change actor history) that must not be exposed to any
+    authenticated caller. Privileged callers — an effective superadmin
+    or anyone holding ``read`` on ``audit_log`` *or* ``user`` — get the
+    full per-row detail. Everyone else still gets the aggregate
+    headline counts (so the dashboard tile renders) but the per-user
+    PII-bearing detail lists are stripped. This keeps the legitimate
+    operator flow intact while closing the unauthenticated-PII leak.
+    """
+    privileged = (
+        is_effective_superadmin(current_user)
+        or user_has_permission(current_user, "read", "audit_log")
+        or user_has_permission(current_user, "read", "user")
+    )
     now = datetime.now(UTC)
 
     # ── MFA coverage (local-auth users only) ────────────────────
@@ -260,19 +275,24 @@ async def security_summary(
         for r in perm_rows[:_DETAIL_LIMIT]
     ]
 
+    # SECURITY (#400 / M2): aggregate counts are safe for any
+    # authenticated viewer, but the per-row detail lists carry PII
+    # (usernames, last-login timestamps, failed-login source IPs,
+    # permission-change actors). Withhold those from non-privileged
+    # callers — the tile still renders from the headline counts.
     return SecurityDashboardSummary(
         generated_at=now,
         mfa_total_local_users=mfa_total,
         mfa_enrolled_count=mfa_enrolled,
         mfa_coverage_pct=round(mfa_pct, 1),
-        mfa_unenrolled=mfa_unenrolled_rows,
+        mfa_unenrolled=mfa_unenrolled_rows if privileged else [],
         api_tokens_total=int(tokens_total),
         api_tokens_expiring_count=len(expiring_tokens),
-        api_tokens_expiring=expiring_rows,
+        api_tokens_expiring=expiring_rows if privileged else [],
         failed_login_window_hours=_FAILED_LOGIN_WINDOW_HOURS,
         failed_login_total=len(failed_rows),
-        failed_login_top_sources=grouped[:_DETAIL_LIMIT],
+        failed_login_top_sources=grouped[:_DETAIL_LIMIT] if privileged else [],
         permission_change_window_days=_PERMISSION_CHANGE_WINDOW_DAYS,
         permission_change_count=len(perm_rows),
-        permission_changes=perm_change_rows,
+        permission_changes=perm_change_rows if privileged else [],
     )

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -20,7 +20,11 @@ from sqlalchemy.orm import selectinload
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.agent_wake import collect_wake, dns_group_channel, dns_server_channel
 from app.core.crypto import decrypt_dict, encrypt_dict, encrypt_str
-from app.core.permissions import require_any_resource_permission, token_scope_allows
+from app.core.permissions import (
+    _token_grants_for,
+    require_any_resource_permission,
+    token_scope_allows,
+)
 from app.drivers.dns import _DRIVERS as _DNS_DRIVERS
 from app.drivers.dns import CLOUD_DNS_DRIVERS, is_agentless
 from app.drivers.dns.windows import test_winrm_credentials
@@ -2585,7 +2589,7 @@ async def delete_view(
 async def list_zones(
     group_id: uuid.UUID,
     db: DB,
-    _: CurrentUser,
+    current_user: CurrentUser,
     customer_id: uuid.UUID | None = None,
     tag: list[str] = Query(default_factory=list),
 ) -> list[DNSZone]:
@@ -2594,6 +2598,12 @@ async def list_zones(
     if customer_id is not None:
         stmt = stmt.where(DNSZone.customer_id == customer_id)
     stmt = apply_tag_filter(stmt, DNSZone.tags, tag)
+    # SECURITY (#400 / C3 — IDOR): a dns_zone-scoped token must only enumerate
+    # the zone(s) it's bound to; otherwise it could list every zone in the
+    # group. No-op (None) for sessions / unscoped / wildcard-grant tokens.
+    zone_ids = _zone_token_id_filter(current_user)
+    if zone_ids is not None:
+        stmt = stmt.where(DNSZone.id.in_(zone_ids))
     result = await db.execute(stmt)
     return list(result.scalars().all())
 
@@ -2648,7 +2658,7 @@ async def create_zone(
 async def export_all_zones(
     group_id: uuid.UUID,
     db: DB,
-    _: CurrentUser,
+    current_user: CurrentUser,
     view_id: uuid.UUID | None = None,
 ) -> StreamingResponse:
     """Return all zones in a group (optionally filtered by view) as a zip.
@@ -2662,6 +2672,12 @@ async def export_all_zones(
     stmt = select(DNSZone).where(DNSZone.group_id == group_id)
     if view_id is not None:
         stmt = stmt.where(DNSZone.view_id == view_id)
+    # SECURITY (#400 / C3 — IDOR): bulk export must respect a dns_zone-scoped
+    # token's binding — without this a single-zone token could zip-export every
+    # zone in the group. No-op for sessions / unscoped / wildcard-grant tokens.
+    zone_ids = _zone_token_id_filter(current_user)
+    if zone_ids is not None:
+        stmt = stmt.where(DNSZone.id.in_(zone_ids))
     result = await db.execute(stmt.order_by(DNSZone.name))
     zones = list(result.scalars().all())
 
@@ -2685,8 +2701,10 @@ async def export_all_zones(
 
 
 @router.get("/groups/{group_id}/zones/{zone_id}", response_model=ZoneResponse)
-async def get_zone(group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, _: CurrentUser) -> DNSZone:
-    return await _require_zone(group_id, zone_id, db)
+async def get_zone(
+    group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, current_user: CurrentUser
+) -> DNSZone:
+    return await _require_zone(group_id, zone_id, db, current_user)
 
 
 class ServerZoneStateEntry(BaseModel):
@@ -2710,7 +2728,7 @@ class ServerZoneStateResponse(BaseModel):
     response_model=ServerZoneStateResponse,
 )
 async def get_zone_server_state(
-    group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, _: CurrentUser
+    group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, current_user: CurrentUser
 ) -> ServerZoneStateResponse:
     """Per-server serial snapshot for a zone.
 
@@ -2723,7 +2741,7 @@ async def get_zone_server_state(
     """
     from app.models.dns import DNSServer, DNSServerZoneState  # noqa: PLC0415
 
-    zone = await _require_zone(group_id, zone_id, db)
+    zone = await _require_zone(group_id, zone_id, db, current_user)
 
     # All servers in the group.
     servers_res = await db.execute(
@@ -2806,7 +2824,7 @@ class ZoneDriftResponse(BaseModel):
     response_model=ZoneDriftResponse,
 )
 async def get_zone_drift(
-    group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, _: CurrentUser
+    group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, current_user: CurrentUser
 ) -> ZoneDriftResponse:
     """Per-server record-level config-drift report (#61).
 
@@ -2819,7 +2837,7 @@ async def get_zone_drift(
     """
     from app.services.dns.drift import compute_zone_drift  # noqa: PLC0415
 
-    zone = await _require_zone(group_id, zone_id, db)
+    zone = await _require_zone(group_id, zone_id, db, current_user)
     report = await compute_zone_drift(db, group_id=group_id, zone=zone)
     return ZoneDriftResponse(
         zone_id=report.zone_id,
@@ -3401,7 +3419,7 @@ async def get_zone_dnssec_info(
     group_id: uuid.UUID,
     zone_id: uuid.UUID,
     db: DB,
-    _: CurrentUser,
+    current_user: CurrentUser,
 ) -> dict[str, Any]:
     """DNSSEC state + DS records for the zone-edit DNSSEC card.
 
@@ -3411,7 +3429,7 @@ async def get_zone_dnssec_info(
     sign / unsign op, so it tracks ground truth within one config
     sync cycle (typically <30s after the operator clicks Sign).
     """
-    zone = await _require_zone(group_id, zone_id, db)
+    zone = await _require_zone(group_id, zone_id, db, current_user)
     keys = (
         (
             await db.execute(
@@ -3830,7 +3848,7 @@ async def create_zone_from_template(
 
 @router.get("/groups/{group_id}/zones/{zone_id}/delegation-preview")
 async def get_delegation_preview(
-    group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, _: CurrentUser
+    group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, current_user: CurrentUser
 ) -> dict[str, Any]:
     """Compute the NS + glue records needed to delegate this zone from its parent.
 
@@ -3838,7 +3856,7 @@ async def get_delegation_preview(
     the same group; otherwise the dict is the full preview shape from
     ``preview_to_dict`` plus ``has_parent: true``.
     """
-    child = await _require_zone(group_id, zone_id, db)
+    child = await _require_zone(group_id, zone_id, db, current_user)
     parent = await find_parent_zone(db, group_id, child.name)
     if parent is None:
         return {"has_parent": False}
@@ -3861,7 +3879,7 @@ async def apply_delegation(
     flows through ``enqueue_record_op`` so the parent zone's serial bumps
     once and the agent / Windows-driver push happens uniformly.
     """
-    child = await _require_zone(group_id, zone_id, db)
+    child = await _require_zone(group_id, zone_id, db, current_user)
     parent = await find_parent_zone(db, group_id, child.name)
     if parent is None:
         raise HTTPException(
@@ -4335,7 +4353,7 @@ async def bulk_delete_records(
     if not body.record_ids:
         return BulkDeleteRecordsResponse(deleted=0, skipped=[])
 
-    zone = await _require_zone(group_id, zone_id, db)
+    zone = await _require_zone(group_id, zone_id, db, current_user)
 
     res = await db.execute(select(DNSRecord).where(DNSRecord.id.in_(body.record_ids)))
     records = list(res.scalars().all())
@@ -4536,13 +4554,13 @@ async def import_zone_preview(
     zone_id: uuid.UUID,
     body: ImportPreviewRequest,
     db: DB,
-    _: CurrentUser,
+    current_user: CurrentUser,
 ) -> ImportPreviewResponse:
     """Parse a zone file and return the diff against an existing zone.
 
     Non-mutating: this endpoint never writes to the database.
     """
-    zone = await _require_zone(group_id, zone_id, db)
+    zone = await _require_zone(group_id, zone_id, db, current_user)
     zone_name = _resolve_zone_name(body, zone)
 
     try:
@@ -4764,7 +4782,7 @@ async def sync_zone_with_server_endpoint(
     """
     from app.services.dns.pull_from_server import sync_zone_with_server
 
-    zone = await _require_zone(group_id, zone_id, db)
+    zone = await _require_zone(group_id, zone_id, db, current_user)
     try:
         result = await sync_zone_with_server(db, zone, apply=body.apply)
     except ValueError as exc:
@@ -4823,10 +4841,10 @@ async def export_zone(
     group_id: uuid.UUID,
     zone_id: uuid.UUID,
     db: DB,
-    _: CurrentUser,
+    current_user: CurrentUser,
 ) -> Response:
     """Return the zone as an RFC 1035 zone file."""
-    zone = await _require_zone(group_id, zone_id, db)
+    zone = await _require_zone(group_id, zone_id, db, current_user)
     records = await _load_zone_records(zone_id, db)
     text = write_zone_file(zone, records)
     ts = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
@@ -4889,13 +4907,53 @@ def _enforce_zone_token_scope(user: Any, zone_id: uuid.UUID) -> None:
         )
 
 
-async def _require_zone(group_id: uuid.UUID, zone_id: uuid.UUID, db: DB) -> DNSZone:
+def _zone_token_id_filter(user: Any) -> set[uuid.UUID] | None:
+    """Zone-ids a resource-scoped API token (#374) may enumerate, or ``None``.
+
+    SECURITY (#400 / C3 — IDOR): list / export-all handlers don't run through
+    ``_require_zone``, so the per-row gate never fires for them. Without this a
+    ``dns_zone``-scoped token could enumerate / bulk-export EVERY zone. Returns:
+
+    * ``None`` — caller is a session / unscoped token, OR holds a wildcard
+      ``dns_zone`` grant (resource_id ``*``/missing): no id-narrowing needed.
+    * a (possibly empty) set — the concrete zone-ids the token is bound to.
+      An empty set means a scoped token with no ``dns_zone`` binding at all, so
+      the list must come back empty rather than leaking every zone.
+    """
+    grants = _token_grants_for(user)
+    if not grants:
+        return None  # session / unscoped token — full visibility
+    bound: set[uuid.UUID] = set()
+    for g in grants:
+        if g.get("resource_type") != "dns_zone":
+            continue
+        rid = g.get("resource_id")
+        if rid in (None, "", "*"):
+            return None  # wildcard dns_zone grant — every zone in scope
+        try:
+            bound.add(uuid.UUID(str(rid)))
+        except (ValueError, TypeError):
+            continue
+    return bound
+
+
+async def _require_zone(
+    group_id: uuid.UUID, zone_id: uuid.UUID, db: DB, user: Any | None = None
+) -> DNSZone:
     result = await db.execute(
         select(DNSZone).where(DNSZone.id == zone_id, DNSZone.group_id == group_id)
     )
     zone = result.scalar_one_or_none()
     if not zone:
         raise HTTPException(status_code=404, detail="Zone not found")
+    # SECURITY (#400 / C3 — IDOR): when the caller is supplied, enforce the
+    # per-row API-token binding here so every single-zone consumer (get/export/
+    # server-state/dnssec/delegation-preview) inherits the scope check. The
+    # coarse router gate only matches on type (req_rid=None), so without this a
+    # dns_zone-scoped token could read/export ANY zone. No-op for sessions /
+    # unscoped tokens. 404-before-403 keeps zone-existence non-leaky.
+    if user is not None:
+        _enforce_zone_token_scope(user, zone_id)
     return zone
 
 

--- a/backend/app/api/v1/dns_import/router.py
+++ b/backend/app/api/v1/dns_import/router.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 
 from app.api.deps import DB, SuperAdmin
 from app.core.agent_wake import collect_wake, dns_group_channel
+from app.core.ssrf import assert_safe_target
 from app.models.dns import DNSServer, DNSServerGroup
 from app.services.dns_import import (
     CLOUD_DRIVERS,
@@ -634,6 +635,12 @@ async def powerdns_test_connection(
     """Probe the PowerDNS REST API and return the daemon's
     identifying info. Operator clicks this before kicking off a
     full pull on a giant server."""
+
+    # SECURITY (#400, L5): advisory SSRF guard — log the resolved
+    # PowerDNS API IP so operators can audit the connect target. Not
+    # hard-blocked: a co-located / LAN PowerDNS daemon is a legitimate
+    # import source.
+    assert_safe_target(body.api_url, label="dns_import_powerdns")
 
     try:
         info = await test_powerdns_connection(

--- a/backend/app/api/v1/docker/router.py
+++ b/backend/app/api/v1/docker/router.py
@@ -24,6 +24,7 @@ from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.crypto import decrypt_str, encrypt_str
 from app.core.demo_mode import forbid_in_demo_mode
 from app.core.permissions import require_resource_permission
+from app.core.ssrf import assert_safe_target
 from app.models.audit import AuditLog
 from app.models.dns import DNSServerGroup
 from app.models.docker import DockerHost
@@ -453,6 +454,11 @@ async def test_connection(
             status_code=422,
             detail="connection_type and endpoint are required (either in body or via stored host_id)",
         )
+
+    # SECURITY (#400, L5): advisory SSRF guard — log the resolved docker
+    # daemon IP. Not hard-blocked: docker hosts are routinely on the LAN
+    # (RFC1918) or a unix-socket endpoint (no network host to resolve).
+    assert_safe_target(endpoint, label="docker")
 
     result = await _probe(
         connection_type=connection_type,

--- a/backend/app/api/v1/groups/router.py
+++ b/backend/app/api/v1/groups/router.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser
-from app.core.permissions import require_permission
+from app.core.permissions import caller_can_grant, require_permission
 from app.models.audit import AuditLog
 from app.models.auth import Group, Role, User
 
@@ -131,6 +131,33 @@ async def _resolve_roles(db: DB, role_ids: list[uuid.UUID]) -> list[Role]:
     return roles
 
 
+def _enforce_attach_ceiling(actor: User, roles: list[Role]) -> None:
+    """SECURITY (#400, finding C4): privilege ceiling on role attachment.
+
+    Attaching a role to a group grants its members the role's permissions. A
+    non-superadmin holding delegated ``admin:group`` could otherwise attach a
+    Superadmin-equivalent role (e.g. one carrying ``{*, *}``) to a group they
+    belong to → effective superadmin. The union of every attached role's
+    permissions must be a subset of the caller's own effective permissions
+    (and may carry no wildcard) unless the caller is an effective superadmin —
+    ``caller_can_grant`` enforces both. Members keep whatever else they hold;
+    this only bounds what THIS mutation can add.
+    """
+    union: list[dict] = []
+    for role in roles:
+        for perm in role.permissions or []:
+            if isinstance(perm, dict):
+                union.append(perm)
+    if not caller_can_grant(actor, union):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "You can only attach roles whose permissions you already hold, and "
+                "only a superadmin can attach a role carrying wildcard ('*') permissions."
+            ),
+        )
+
+
 async def _resolve_users(db: DB, user_ids: list[uuid.UUID]) -> list[User]:
     if not user_ids:
         return []
@@ -177,6 +204,7 @@ async def create_group(body: GroupCreate, current_user: CurrentUser, db: DB) -> 
         )
 
     roles = await _resolve_roles(db, body.role_ids)
+    _enforce_attach_ceiling(current_user, roles)
     users = await _resolve_users(db, body.user_ids)
 
     g = Group(
@@ -225,7 +253,15 @@ async def update_group(
     if body.external_dn is not None:
         g.external_dn = body.external_dn
     if body.role_ids is not None:
-        g.roles = await _resolve_roles(db, body.role_ids)
+        new_roles = await _resolve_roles(db, body.role_ids)
+        # SECURITY (#400, C4): only bound roles NEWLY added by this mutation, so
+        # editing a group that already carries an over-privileged role (name /
+        # user-list edits) isn't blocked — but a delegated admin can't introduce
+        # a role above their own ceiling.
+        existing_role_ids = {r.id for r in g.roles}
+        added = [r for r in new_roles if r.id not in existing_role_ids]
+        _enforce_attach_ceiling(current_user, added)
+        g.roles = new_roles
     if body.user_ids is not None:
         g.users = await _resolve_users(db, body.user_ids)
 

--- a/backend/app/api/v1/groups/time_bound_grants.py
+++ b/backend/app/api/v1/groups/time_bound_grants.py
@@ -6,9 +6,15 @@ to a group until ``expires_at``; ``user_has_permission`` unions live grants
 over the static role grants.
 
 Authorization mirrors how role permissions are edited today: ``admin`` on
-``group`` is sufficient to create / revoke a grant (no extra
-privilege-escalation guard — see issue #65 resolved decisions). Listing
-needs only ``read`` on ``group``.
+``group`` is sufficient to create / revoke a grant. Listing needs only
+``read`` on ``group``.
+
+SECURITY (#400, finding C4): creating a grant adds a temporary permission to a
+group, so it must respect the same privilege ceiling as role authoring — a
+non-superadmin may only grant a triple they already hold, never a wildcard.
+``caller_can_grant`` (in ``app.core.permissions``) enforces this; effective
+superadmins bypass it. The pre-#400 "no extra privilege-escalation guard"
+stance (issue #65) is superseded.
 
 Every mutation writes an ``audit_log`` row with ``action='permission_change'``
 before the response is returned (CLAUDE.md non-negotiable #4).
@@ -26,7 +32,7 @@ from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
 from app.api.v1.roles.router import _VALID_ACTIONS
-from app.core.permissions import require_permission
+from app.core.permissions import caller_can_grant, require_permission
 from app.models.audit import AuditLog
 from app.models.auth import Group
 from app.models.time_bound_grant import TimeBoundGrant
@@ -163,6 +169,25 @@ async def create_time_bound_grant(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="expires_at must be in the future",
+        )
+
+    # SECURITY (#400, finding C4): privilege ceiling. A grant unions a temporary
+    # permission onto a group, so a non-superadmin may only grant a triple they
+    # already hold and may never mint a wildcard — same rule as role authoring.
+    requested = [
+        {
+            "action": body.action,
+            "resource_type": body.resource_type,
+            "resource_id": body.resource_id,
+        }
+    ]
+    if not caller_can_grant(current_user, requested):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "You can only grant a permission you already hold, and only a "
+                "superadmin can grant wildcard ('*') permissions."
+            ),
         )
 
     grant = TimeBoundGrant(

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -2346,6 +2346,15 @@ async def create_space(body: IPSpaceCreate, current_user: CurrentUser, db: DB) -
 
 @router.get("/spaces/{space_id}", response_model=IPSpaceResponse)
 async def get_space(space_id: uuid.UUID, current_user: CurrentUser, db: DB) -> IPSpace:
+    # SECURITY TODO (#400 / L4): no per-row token-scope re-check here. This is
+    # currently safe ONLY because ``ip_space`` is NOT in
+    # ``services/api_token_scopes.TOKEN_GRANT_RESOURCE_TYPES`` (today: subnet,
+    # dns_zone), so a resource-scoped token can never bind to a space and
+    # ``token_scope_allows`` is irrelevant. IF ``ip_space`` is ever added to
+    # that vocabulary, this handler MUST gain a
+    # ``token_scope_allows(current_user, "ip_space", space_id)`` 403 gate (see
+    # ``_enforce_subnet_token_scope``) or a space-scoped token would read any
+    # space. Keep this in lockstep with the vocabulary so the two can't drift.
     space = await db.get(IPSpace, space_id)
     if space is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP space not found")
@@ -2773,6 +2782,15 @@ async def create_block(body: IPBlockCreate, current_user: CurrentUser, db: DB) -
 
 @router.get("/blocks/{block_id}", response_model=IPBlockResponse)
 async def get_block(block_id: uuid.UUID, current_user: CurrentUser, db: DB) -> dict[str, Any]:
+    # SECURITY TODO (#400 / L4): no per-row token-scope re-check here. This is
+    # currently safe ONLY because ``ip_block`` is NOT in
+    # ``services/api_token_scopes.TOKEN_GRANT_RESOURCE_TYPES`` (today: subnet,
+    # dns_zone), so a resource-scoped token can never bind to a block and
+    # ``token_scope_allows`` is irrelevant. IF ``ip_block`` is ever added to
+    # that vocabulary, this handler MUST gain a
+    # ``token_scope_allows(current_user, "ip_block", block_id)`` 403 gate (see
+    # ``_enforce_subnet_token_scope``) or a block-scoped token would read any
+    # block. Keep this in lockstep with the vocabulary so the two can't drift.
     block = await db.get(IPBlock, block_id)
     if block is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP block not found")

--- a/backend/app/api/v1/kubernetes/router.py
+++ b/backend/app/api/v1/kubernetes/router.py
@@ -31,6 +31,7 @@ from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.crypto import decrypt_str, encrypt_str
 from app.core.demo_mode import forbid_in_demo_mode
 from app.core.permissions import require_resource_permission
+from app.core.ssrf import assert_safe_target
 from app.models.audit import AuditLog
 from app.models.dns import DNSServerGroup
 from app.models.ipam import IPSpace
@@ -670,6 +671,12 @@ async def test_connection(
             status_code=422,
             detail="api_server_url and token are required (either in body or via stored cluster_id)",
         )
+
+    # SECURITY (#400, L5): advisory SSRF guard — log the resolved API
+    # server IP so operators can audit what the control plane dialed.
+    # Not hard-blocked: a co-located k3s appliance legitimately points
+    # at an on-box / RFC1918 API server.
+    assert_safe_target(api_server_url, label="kubernetes")
 
     result = await _probe_cluster(
         api_server_url=api_server_url,

--- a/backend/app/api/v1/nmap/router.py
+++ b/backend/app/api/v1/nmap/router.py
@@ -10,8 +10,13 @@ follow-ups). Endpoints:
   ``target_ip`` / ``status``.
 * ``GET /scans/{id}`` — full record (incl. raw XML on completion).
 * ``GET /scans/{id}/stream`` — Server-Sent Events relaying the live
-  ``raw_stdout`` buffer. Auth via ``?token=<jwt-or-api-token>`` query
-  arg because ``EventSource`` can't set Authorization headers.
+  ``raw_stdout`` buffer. Auth preferred via the ``Authorization:
+  Bearer <jwt-or-api-token>`` header (the frontend consumes this
+  stream with ``fetch()`` + ``ReadableStream``, which — unlike
+  ``EventSource`` — can set request headers). A ``?token=`` query
+  arg is still accepted as a back-compat fallback, but is
+  discouraged: SECURITY (#400, M8) tokens in the URL leak via proxy
+  access logs, browser history, and the ``Referer`` header.
 * ``DELETE /scans/{id}`` — operator cancel; flips status to
   ``cancelled`` so the runner self-terminates on its next poll.
 
@@ -486,16 +491,40 @@ async def stamp_discovered(
 # ── SSE stream ──────────────────────────────────────────────────────
 
 
-async def _resolve_user_from_query_token(db: AsyncSession, token: str, request: Request) -> User:
-    """Validate a JWT or API token passed as a query parameter.
+def _extract_stream_token(request: Request, query_token: str | None) -> str:
+    """Resolve the SSE auth token, preferring the Authorization header.
 
-    EventSource can't set ``Authorization`` headers, so the SSE
-    endpoint accepts ``?token=<...>``. We re-implement the relevant
-    branches of :func:`app.api.deps.get_current_user` here rather
-    than reach into Security() — that dep is wired to the Bearer
-    extractor which won't see a query arg. ``request`` is forwarded
-    into ``_resolve_api_token`` so the scope guard (issue #74) can
-    inspect the SSE endpoint's path before allowing the connection.
+    SECURITY (#400, M8): the live nmap stream is consumed by the
+    frontend with ``fetch()`` + ``ReadableStream`` (not
+    ``EventSource``), so the access token now rides the standard
+    ``Authorization: Bearer <token>`` header where it never lands in
+    a URL — keeping it out of nginx/proxy access logs, browser
+    history, and the ``Referer`` header. The legacy ``?token=`` query
+    arg is still honoured as a fallback so older clients / bookmarked
+    URLs keep working, but the header takes precedence.
+    """
+    auth = request.headers.get("Authorization") or request.headers.get("authorization")
+    if auth and auth.lower().startswith("bearer "):
+        header_token = auth[len("bearer ") :].strip()
+        if header_token:
+            return header_token
+    if query_token:
+        return query_token
+    raise HTTPException(status_code=401, detail="Missing authentication token")
+
+
+async def _resolve_user_from_query_token(db: AsyncSession, token: str, request: Request) -> User:
+    """Validate a JWT or API token presented to the SSE endpoint.
+
+    The token is sourced by :func:`_extract_stream_token` (header
+    preferred, ``?token=`` query arg as a back-compat fallback). We
+    re-implement the relevant branches of
+    :func:`app.api.deps.get_current_user` here rather than reach into
+    Security() — that dep is wired to the Bearer extractor and would
+    have 401'd the connection before our header/query resolution
+    runs. ``request`` is forwarded into ``_resolve_api_token`` so the
+    scope guard (issue #74) can inspect the SSE endpoint's path
+    before allowing the connection.
     """
     if token.startswith("sddi_"):
         # API tokens — re-use the deps helper.
@@ -521,17 +550,20 @@ async def _resolve_user_from_query_token(db: AsyncSession, token: str, request: 
 async def stream_scan(
     scan_id: uuid.UUID,
     request: Request,
-    token: Annotated[str, Query(...)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    token: Annotated[str | None, Query()] = None,
 ) -> StreamingResponse:
     """Server-Sent Events relay for a running scan.
 
-    Auth is via ``?token=`` query arg (EventSource can't send
-    Authorization headers). Each ``data:`` frame carries one line of
-    nmap stdout. On terminal status we emit one final
-    ``event: done`` frame and close.
+    SECURITY (#400, M8): auth is preferred via the ``Authorization:
+    Bearer`` header (the frontend uses ``fetch()`` + ``ReadableStream``
+    so the token stays out of the URL). The ``?token=`` query arg is
+    accepted only as a back-compat fallback. Each ``data:`` frame
+    carries one line of nmap stdout. On terminal status we emit one
+    final ``event: done`` frame and close.
     """
-    user = await _resolve_user_from_query_token(db, token, request)
+    resolved_token = _extract_stream_token(request, token)
+    user = await _resolve_user_from_query_token(db, resolved_token, request)
     if not user_has_permission(user, "read", PERMISSION):
         raise HTTPException(status_code=403, detail="Permission denied")
 
@@ -574,6 +606,10 @@ async def stream_scan(
         "Cache-Control": "no-cache",
         "X-Accel-Buffering": "no",
         "Connection": "keep-alive",
+        # SECURITY (#400, M8): defence-in-depth for any back-compat
+        # ``?token=`` callers — never leak the request URL (which may
+        # still carry the token) onward via the Referer header.
+        "Referrer-Policy": "no-referrer",
     }
     return StreamingResponse(_event_stream(), media_type="text/event-stream", headers=headers)
 

--- a/backend/app/api/v1/opnsense/router.py
+++ b/backend/app/api/v1/opnsense/router.py
@@ -20,6 +20,7 @@ from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.crypto import decrypt_str, encrypt_str
 from app.core.demo_mode import forbid_in_demo_mode
 from app.core.permissions import require_resource_permission
+from app.core.ssrf import assert_safe_target
 from app.models.audit import AuditLog
 from app.models.dns import DNSServerGroup
 from app.models.ipam import IPSpace
@@ -452,6 +453,11 @@ async def test_connection(
             status_code=422,
             detail="host, api_key, and api_secret are required (either in body or via stored router_id)",
         )
+
+    # SECURITY (#400, L5): advisory SSRF guard — log the resolved
+    # OPNsense host IP. Not hard-blocked: firewalls live on the
+    # RFC1918 LAN by definition.
+    assert_safe_target(host, label="opnsense")
 
     result = await _probe(
         host=host,

--- a/backend/app/api/v1/proxmox/router.py
+++ b/backend/app/api/v1/proxmox/router.py
@@ -20,6 +20,7 @@ from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.crypto import decrypt_str, encrypt_str
 from app.core.demo_mode import forbid_in_demo_mode
 from app.core.permissions import require_resource_permission
+from app.core.ssrf import assert_safe_target
 from app.models.audit import AuditLog
 from app.models.dns import DNSServerGroup
 from app.models.ipam import IPSpace
@@ -490,6 +491,11 @@ async def test_connection(
             status_code=422,
             detail="host, token_id, and token_secret are required (either in body or via stored node_id)",
         )
+
+    # SECURITY (#400, L5): advisory SSRF guard — log the resolved
+    # Proxmox host IP. Not hard-blocked: PVE hosts are almost always on
+    # the RFC1918 LAN.
+    assert_safe_target(host, label="proxmox")
 
     result = await _probe(
         host=host,

--- a/backend/app/api/v1/roles/router.py
+++ b/backend/app/api/v1/roles/router.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
-from app.core.permissions import require_permission
+from app.core.permissions import caller_can_grant, require_permission
 from app.models.audit import AuditLog
 from app.models.auth import Role, User
 
@@ -130,6 +130,25 @@ def _perm_list_to_dicts(perms: list[PermissionEntry]) -> list[dict[str, Any]]:
     return out
 
 
+def _enforce_grant_ceiling(actor: User, perms: list[PermissionEntry]) -> None:
+    """SECURITY (#400, finding C4): privilege ceiling on role authoring.
+
+    A non-superadmin holding delegated ``admin:role`` could otherwise mint a
+    ``{action:"*", resource_type:"*"}`` role (or any permission they don't hold)
+    and self-assign it → effective superadmin. ``caller_can_grant`` rejects
+    wildcard minting and any triple the caller doesn't already hold. Effective
+    superadmins bypass so the platform owner can still build arbitrary roles.
+    """
+    if not caller_can_grant(actor, perms):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "You can only grant permissions you already hold, and only a "
+                "superadmin can grant wildcard ('*') permissions."
+            ),
+        )
+
+
 def _audit(actor: User, action: str, role: Role, summary: str) -> AuditLog:
     return AuditLog(
         user_id=actor.id,
@@ -163,6 +182,7 @@ async def create_role(body: RoleCreate, current_user: CurrentUser, db: DB) -> Ro
     existing = await db.scalar(select(Role).where(Role.name == body.name))
     if existing is not None:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Role name already in use")
+    _enforce_grant_ceiling(current_user, body.permissions)
     r = Role(
         name=body.name,
         description=body.description,
@@ -212,6 +232,7 @@ async def update_role(
     if body.description is not None:
         r.description = body.description
     if body.permissions is not None:
+        _enforce_grant_ceiling(current_user, body.permissions)
         r.permissions = _perm_list_to_dicts(body.permissions)
     db.add(_audit(current_user, "update", r, f"Updated role {r.name}"))
     await db.commit()
@@ -255,6 +276,17 @@ async def clone_role(
     existing = await db.scalar(select(Role).where(Role.name == body.name))
     if existing is not None:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Role name already in use")
+    # SECURITY (#400, C4): cloning copies the source permissions verbatim into a
+    # role the caller controls — apply the same ceiling so a non-superadmin can't
+    # clone a Superadmin (or any over-privileged) role and self-assign the clone.
+    if not caller_can_grant(current_user, list(src.permissions or [])):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "You can only clone a role whose permissions you already hold, and "
+                "only a superadmin can clone a role carrying wildcard ('*') permissions."
+            ),
+        )
     clone = Role(
         name=body.name,
         description=f"Cloned from '{src.name}'",

--- a/backend/app/api/v1/tailscale/router.py
+++ b/backend/app/api/v1/tailscale/router.py
@@ -390,6 +390,11 @@ async def test_connection(
             detail="tailnet and api_key are required (either in body or via stored tenant_id)",
         )
 
+    # SECURITY (#400, L5): no SSRF guard call here — ``_probe`` dials a
+    # FIXED host (``api.tailscale.com``) with ``tailnet`` only as a URL
+    # path segment, so there is no operator-controlled connect target to
+    # resolve (unlike the proxmox / unifi / opnsense / docker / k8s LAN
+    # integrations). See app/core/ssrf.py.
     result = await _probe(tailnet=tailnet, api_key=api_key)
 
     if body.tenant_id is not None and result.ok:

--- a/backend/app/api/v1/unifi/router.py
+++ b/backend/app/api/v1/unifi/router.py
@@ -29,6 +29,7 @@ from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.crypto import decrypt_str, encrypt_str
 from app.core.demo_mode import forbid_in_demo_mode
 from app.core.permissions import require_resource_permission
+from app.core.ssrf import assert_safe_target
 from app.models.audit import AuditLog
 from app.models.dns import DNSServerGroup
 from app.models.ipam import IPAddress, IPSpace, Subnet
@@ -853,6 +854,13 @@ async def test_connection(
             status_code=422,
             detail="username + password required for auth_kind='user_password'",
         )
+
+    # SECURITY (#400, L5): advisory SSRF guard — log the resolved
+    # controller IP for local-mode probes (cloud mode dials UniFi's
+    # hosted API, not an operator-supplied host). Not hard-blocked:
+    # local controllers sit on the RFC1918 LAN.
+    if mode == "local" and host:
+        assert_safe_target(host, label="unifi")
 
     result = await _probe(
         mode=mode,

--- a/backend/app/api/v1/users/router.py
+++ b/backend/app/api/v1/users/router.py
@@ -8,12 +8,12 @@ import bcrypt
 import structlog
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, field_validator, model_validator
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from app.api.deps import DB, SuperAdmin
 from app.core.demo_mode import forbid_in_demo_mode
 from app.models.audit import AuditLog
-from app.models.auth import User
+from app.models.auth import User, UserSession
 from app.models.settings import PlatformSettings
 from app.services.account_lockout import (
     is_locked as is_user_locked,
@@ -286,6 +286,19 @@ async def reset_password(
     user.password_changed_at = datetime.now(UTC)
     user.password_history_encrypted = push_history(
         hashed, user.password_history_encrypted, policy.history_count
+    )
+    # SECURITY (#400 / M3): an admin password reset must revoke every
+    # outstanding session + refresh token for the target user — the whole
+    # reason an admin resets a password is usually that the account is
+    # compromised or being handed over, so leaving live sessions running
+    # against the old credential defeats the reset. No session is spared
+    # here (unlike the self-service path): the admin is acting on someone
+    # else's account, so all of the target's sessions die. Same revocation
+    # statement ``/auth/logout`` uses.
+    await db.execute(
+        update(UserSession)
+        .where(UserSession.user_id == user.id, UserSession.revoked.is_(False))
+        .values(revoked=True)
     )
     db.add(
         _audit(current_user, "reset_password", str(user.id), f"Reset password for {user.username}")

--- a/backend/app/api/v1/version/router.py
+++ b/backend/app/api/v1/version/router.py
@@ -5,22 +5,62 @@ release-check banner is visible even on the login screen. The response
 is tiny and cacheable; no sensitive data leaks beyond the version
 string itself — which is also stamped on every Docker image's OCI
 label anyway.
+
+SECURITY (#400 / L6): the appliance-specific fields
+(``appliance_version`` / ``appliance_hostname``) DO leak operational
+detail — most notably the host's configured hostname — so they are
+withheld from unauthenticated callers. The endpoint stays public for
+the bare ``version`` + release-check banner; appliance fields populate
+only when a valid Bearer credential is presented.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Annotated
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Request, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import DB
+from app.api.deps import DB, get_current_user
 from app.config import settings
+from app.db import get_db
+from app.models.auth import User
 from app.models.settings import PlatformSettings
 
 router = APIRouter(tags=["version"])
 
 _SINGLETON_ID = 1
+
+# Optional-auth bearer — ``auto_error=False`` so an anonymous caller
+# (login screen / sidebar pre-login) still gets a 200 with the public
+# fields. A *present* credential is fully validated; only on success do
+# the appliance fields populate.
+_optional_bearer = HTTPBearer(auto_error=False)
+
+
+async def _maybe_current_user(
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Security(_optional_bearer)],
+) -> User | None:
+    """Return the authenticated user if a valid Bearer is presented, else None.
+
+    SECURITY (#400 / L6): never raises — an absent / invalid / expired
+    credential resolves to ``None`` so the version endpoint stays public,
+    but the appliance fields are gated on a non-None return.
+    """
+    if credentials is None:
+        return None
+    try:
+        return await get_current_user(request, db, credentials)
+    except Exception:  # noqa: BLE001 — any auth failure = treat as anonymous
+        return None
+
+
+MaybeUser = Annotated[User | None, Depends(_maybe_current_user)]
 
 
 class VersionResponse(BaseModel):
@@ -49,16 +89,26 @@ class VersionResponse(BaseModel):
     appliance_hostname: str | None
 
 
-def _appliance_fields() -> dict[str, str | bool | None]:
+def _appliance_fields(authenticated: bool) -> dict[str, str | bool | None]:
+    """Appliance-mode signals.
+
+    SECURITY (#400 / L6): ``appliance_mode`` is a harmless boolean the
+    login page needs to decide whether to even hint at the appliance
+    surface, so it's always returned. ``appliance_version`` and
+    ``appliance_hostname`` disclose the host identity / patch level and
+    are returned ONLY to authenticated callers; anonymous callers get
+    ``None`` for both.
+    """
     return {
         "appliance_mode": settings.appliance_mode,
-        "appliance_version": settings.appliance_version or None,
-        "appliance_hostname": settings.appliance_hostname or None,
+        "appliance_version": (settings.appliance_version or None) if authenticated else None,
+        "appliance_hostname": (settings.appliance_hostname or None) if authenticated else None,
     }
 
 
 @router.get("", response_model=VersionResponse)
-async def get_version(db: DB) -> VersionResponse:
+async def get_version(db: DB, current_user: MaybeUser) -> VersionResponse:
+    authenticated = current_user is not None
     ps = await db.get(PlatformSettings, _SINGLETON_ID)
     if ps is None:
         # Settings row hasn't been seeded yet (first boot before
@@ -72,7 +122,7 @@ async def get_version(db: DB) -> VersionResponse:
             latest_checked_at=None,
             release_check_enabled=True,
             latest_check_error=None,
-            **_appliance_fields(),
+            **_appliance_fields(authenticated),
         )
     return VersionResponse(
         version=settings.version,
@@ -82,5 +132,5 @@ async def get_version(db: DB) -> VersionResponse:
         latest_checked_at=ps.latest_checked_at,
         release_check_enabled=ps.github_release_check_enabled,
         latest_check_error=ps.latest_check_error,
-        **_appliance_fields(),
+        **_appliance_fields(authenticated),
     )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -47,7 +47,25 @@ class Settings(BaseSettings):
     # allow credentials" combo Starlette produces for ``["*"]`` +
     # ``allow_credentials=True``. Set explicit origins to lock the API
     # down to your frontend(s); credentials are then enabled for them.
+    #
+    # SECURITY (#400 / M6): if ``"*"`` appears MIXED with explicit
+    # origins (e.g. ``"*,https://app.example.com"``) we treat the whole
+    # list as a wildcard (``cors_origins_list`` collapses to ``["*"]``),
+    # which forces ``allow_credentials=False`` at the middleware. Without
+    # this, the explicit entries would flip credentials on while the
+    # ``"*"`` still reflected every Origin — the exact "trust any site +
+    # send credentials" combo we guard against above.
     cors_origins: str = "*"
+
+    # TrustedHostMiddleware allow-list (#400 / L3). Comma-separated host
+    # patterns (e.g. "ddi.example.com,*.example.com"). Default "*"
+    # accepts any Host header so existing deploys behind a trusted
+    # reverse proxy / on the appliance keep working out of the box.
+    # Operators who terminate TLS directly on the API (or want defence
+    # against Host-header injection / DNS-rebinding / cache-poisoning)
+    # set this to their real hostnames. Starlette's TrustedHostMiddleware
+    # treats ``["*"]`` as "allow everything".
+    trusted_hosts: str = "*"
 
     # External auth providers (LDAP / OIDC / SAML) are configured via the GUI at
     # /admin/auth-providers — see backend/app/models/auth_provider.py. Secrets are
@@ -183,11 +201,37 @@ class Settings(BaseSettings):
     def cors_origins_list(self) -> list[str]:
         """``cors_origins`` parsed into a list. ``"*"`` (the default)
         yields ``["*"]``; a comma-separated value yields the trimmed,
-        non-empty entries."""
+        non-empty entries.
+
+        SECURITY (#400 / M6): if ``"*"`` is present ANYWHERE in the list
+        (even mixed with explicit origins), the whole list collapses to
+        ``["*"]``. The middleware keys ``allow_credentials`` off this
+        result being exactly ``["*"]``, so a wildcard always disables
+        credentials regardless of any explicit entries the operator
+        also listed. This closes the "explicit origin enables creds while
+        ``*`` still reflects every Origin" combo.
+        """
         raw = self.cors_origins.strip()
         if raw == "*" or not raw:
             return ["*"]
-        return [o.strip() for o in raw.split(",") if o.strip()]
+        entries = [o.strip() for o in raw.split(",") if o.strip()]
+        if "*" in entries:
+            return ["*"]
+        return entries
+
+    @property
+    def trusted_hosts_list(self) -> list[str]:
+        """``trusted_hosts`` parsed into a list for TrustedHostMiddleware
+        (#400 / L3). ``"*"`` (the default) yields ``["*"]`` — accept any
+        Host header; a comma-separated value yields the trimmed,
+        non-empty patterns."""
+        raw = self.trusted_hosts.strip()
+        if raw == "*" or not raw:
+            return ["*"]
+        entries = [h.strip() for h in raw.split(",") if h.strip()]
+        if "*" in entries:
+            return ["*"]
+        return entries or ["*"]
 
     @model_validator(mode="after")
     def _check_secret_key_default(self) -> "Settings":

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -261,6 +261,83 @@ def _user_rbac_allows(user: User, action: str, resource_type: str, req_rid: str 
     return False
 
 
+# ── Privilege ceiling for delegated role / group editing ──────────────────────
+#
+# SECURITY (#400, finding C4): a non-superadmin holding a delegated
+# ``admin:role`` (+``admin:group``) capability could previously mint a role
+# carrying ``{action:"*", resource_type:"*"}`` (or any permission the caller
+# does not themselves hold) and self-assign it, escalating to effective
+# superadmin. The default install does not delegate ``admin:role`` to
+# non-superadmins, so it is not exploitable out of the box — but the delegated
+# capability was silently unbounded.
+#
+# ``caller_can_grant`` enforces a privilege ceiling: a non-superadmin may only
+# author / attach permission triples they already hold themselves, and may
+# never mint a wildcard (``*`` action OR ``*`` resource_type) permission.
+# Effective superadmins bypass the ceiling entirely so the platform owner can
+# still build arbitrary roles. Callers (roles + groups routers) pre-screen the
+# requested permission set with this helper and 403 on any entry that exceeds
+# the caller's own grants.
+
+
+def _perm_triple(perm: object) -> tuple[str, str, str | None] | None:
+    """Normalise a permission entry (dict or grant-like object) into a
+    ``(action, resource_type, resource_id)`` triple, or ``None`` if the shape
+    is unrecognised. Empty-string / ``"*"`` resource_id collapses to ``None``
+    (any-instance)."""
+    if isinstance(perm, dict):
+        action = perm.get("action", "")
+        resource_type = perm.get("resource_type", "")
+        resource_id = perm.get("resource_id")
+    else:
+        action = getattr(perm, "action", "")
+        resource_type = getattr(perm, "resource_type", "")
+        resource_id = getattr(perm, "resource_id", None)
+    if not isinstance(action, str) or not isinstance(resource_type, str):
+        return None
+    rid = resource_id if isinstance(resource_id, str) and resource_id not in ("", "*") else None
+    return (action, resource_type, rid)
+
+
+def caller_can_grant(user: User, perms: object) -> bool:
+    """Whether ``user`` is allowed to author / attach the permission set ``perms``.
+
+    ``perms`` is an iterable of permission entries — either ``dict``s in the
+    ``Role.permissions`` JSONB shape or objects exposing ``action`` /
+    ``resource_type`` / ``resource_id`` attributes (Pydantic
+    ``PermissionEntry``, ``TimeBoundGrant`` rows).
+
+    Rules (privilege ceiling, #400 / C4):
+
+    * Effective superadmins may grant anything — return ``True`` immediately.
+    * Any wildcard permission (``action == "*"`` OR ``resource_type == "*"``)
+      may only be granted by an effective superadmin → ``False`` for everyone
+      else.
+    * Every other entry must be one the caller *already holds* (verified via
+      :func:`user_has_permission` with the same triple). A caller cannot grant
+      a permission they don't possess, so the resulting role can never widen
+      the caller's own effective access.
+
+    A malformed / unrecognised entry is treated as un-grantable (``False``) so
+    a bad shape can't sneak past the ceiling.
+    """
+    if is_effective_superadmin(user):
+        return True
+    for perm in perms:
+        triple = _perm_triple(perm)
+        if triple is None:
+            return False
+        action, resource_type, rid = triple
+        # No wildcard minting for non-superadmins — a `*` on either axis would
+        # grant access beyond what the caller can express via concrete holds.
+        if action == "*" or resource_type == "*":
+            return False
+        # The caller must already hold this exact (action, resource_type[, id]).
+        if not user_has_permission(user, action, resource_type, rid):
+            return False
+    return True
+
+
 async def _record_denial(
     db: AsyncSession,
     user: User,
@@ -445,6 +522,8 @@ KNOWN_MANAGE_PERMISSIONS: frozenset[str] = frozenset(
 
 __all__ = [
     "KNOWN_MANAGE_PERMISSIONS",
+    "caller_can_grant",
+    "is_effective_superadmin",
     "require_any_permission",
     "require_any_resource_permission",
     "require_permission",

--- a/backend/app/core/ssrf.py
+++ b/backend/app/core/ssrf.py
@@ -136,7 +136,9 @@ def assert_safe_target(
     except ValueError:
         try:
             infos = socket.getaddrinfo(host, None)
-            resolved = sorted({info[4][0] for info in infos})
+            # sockaddr[0] is the address string (AF_INET: (host, port);
+            # AF_INET6: (host, port, flow, scope)) — str() pins the type.
+            resolved = sorted({str(info[4][0]) for info in infos})
         except OSError as exc:
             # Resolution failed — let the downstream connect surface the
             # real error; we just record that we tried.

--- a/backend/app/core/ssrf.py
+++ b/backend/app/core/ssrf.py
@@ -1,0 +1,176 @@
+"""Defense-in-depth SSRF guard for operator-supplied integration targets.
+
+SECURITY (#400 / GHSA-mj4g-hw3m-62rm, finding L5):
+    The integration "Test Connection" endpoints (kubernetes / docker /
+    proxmox / unifi / opnsense / tailscale / cloud / dns-import) take an
+    operator-supplied host / URL and have the *server* open a connection
+    to it. That is a server-side request — an authenticated SSRF surface.
+    Because reaching these endpoints already requires the
+    integration-write resource permission (or superadmin), the blast
+    radius is small, so this is a LOW / defense-in-depth control rather
+    than a primary fix.
+
+    The honest constraint here is that almost every one of these
+    integrations *legitimately* points at an RFC1918 LAN host — a
+    Proxmox box on ``192.168.x.x``, a UniFi controller on ``10.x``, a
+    docker daemon at ``unix:///var/run/docker.sock`` or a LAN TLS
+    endpoint. We therefore MUST NOT blanket-block private ranges; doing
+    so would break the product's core on-prem use case.
+
+    What we *can* safely flag is the classic SSRF pivot targets that no
+    legitimate integration target should ever resolve to:
+
+        * loopback         127.0.0.0/8, ::1
+        * link-local       169.254.0.0/16, fe80::/10
+        * cloud metadata   169.254.169.254 (a link-local address; called
+                           out explicitly because it is the canonical
+                           SSRF-to-cloud-creds pivot)
+
+    ``assert_safe_target`` resolves the host and, by default, *logs* the
+    resolved IP plus a ``ssrf_guard_*`` structured event so an operator
+    grepping the audit/log trail can see exactly what the control plane
+    was asked to dial. Loopback / link-local / metadata resolutions are
+    logged at WARNING. Hard blocking is opt-in (``block=True``) and is
+    deliberately NOT used by the on-box-capable integrations, because a
+    full-stack appliance can legitimately reach a service on
+    ``127.0.0.1`` (e.g. a co-located daemon) and we will not break that.
+
+This module is intentionally dependency-light (stdlib ``ipaddress`` +
+``socket`` + ``structlog``) and has no import-time side effects.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# Cloud-metadata service address — the canonical SSRF-to-creds pivot.
+_CLOUD_METADATA = ipaddress.ip_address("169.254.169.254")
+
+
+class SSRFBlockedError(Exception):
+    """Raised by ``assert_safe_target(..., block=True)`` when an
+    operator-supplied target resolves to a forbidden address."""
+
+
+def _classify(ip: ipaddress._BaseAddress) -> str | None:
+    """Return a short reason string if ``ip`` is a known SSRF-pivot
+    target, else ``None``. Note RFC1918 / unique-local are intentionally
+    NOT classified — those are legitimate on-prem integration targets."""
+
+    if ip == _CLOUD_METADATA:
+        return "cloud_metadata"
+    if ip.is_loopback:  # 127.0.0.0/8, ::1
+        return "loopback"
+    if ip.is_link_local:  # 169.254.0.0/16, fe80::/10
+        return "link_local"
+    return None
+
+
+def extract_host(target: str) -> str:
+    """Best-effort pull of the bare hostname from a URL or ``host[:port]``.
+
+    Accepts bare hostnames, ``host:port``, and full URLs. Returns the
+    input stripped of scheme / port / path so it can be fed to
+    ``socket.getaddrinfo``. Returns an empty string for inputs we cannot
+    make sense of (e.g. a unix-socket ``unix://`` docker endpoint, which
+    has no network host to resolve)."""
+
+    if not target:
+        return ""
+    raw = target.strip()
+    if "://" in raw:
+        parts = urlsplit(raw)
+        if parts.scheme in {"unix", "npipe"}:
+            return ""  # no network host to resolve
+        host = parts.hostname or ""
+        return host
+    # Bracketed IPv6 literal — ``[2001:db8::1]`` or ``[2001:db8::1]:443``.
+    if raw.startswith("["):
+        end = raw.find("]")
+        if end != -1:
+            return raw[1:end]
+    # bare ``host`` or ``host:port`` — split off a trailing :port only
+    # when it is unambiguous (not an IPv6 literal full of colons).
+    if raw.count(":") == 1:
+        return raw.split(":", 1)[0]
+    return raw
+
+
+def assert_safe_target(
+    target: str, *, label: str = "integration", block: bool = False
+) -> list[str]:
+    """Resolve ``target`` and log the resolved IP(s); flag SSRF pivots.
+
+    SECURITY (#400, L5): advisory-by-default guard. ``target`` may be a
+    bare host, ``host:port``, or a full URL. The host is resolved via
+    ``socket.getaddrinfo`` and every resolved address is logged so the
+    operator can audit what the control plane was asked to dial.
+
+    Loopback / link-local / cloud-metadata resolutions are logged at
+    WARNING. When ``block=True`` such a resolution raises
+    ``SSRFBlockedError`` — callers that can legitimately reach on-box
+    services leave ``block=False`` (the default) so this never breaks a
+    valid flow.
+
+    Returns the list of resolved IP strings (possibly empty when the
+    target has no network host, e.g. a unix-socket docker endpoint, or
+    when DNS resolution fails — resolution failure is non-fatal here
+    because the downstream connect will surface the real error).
+    """
+
+    host = extract_host(target)
+    if not host:
+        logger.debug("ssrf_guard_no_host", label=label, target=target)
+        return []
+
+    # A bare IP literal needs no DNS; classify it directly.
+    try:
+        literal = ipaddress.ip_address(host)
+        resolved = [str(literal)]
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(host, None)
+            resolved = sorted({info[4][0] for info in infos})
+        except OSError as exc:
+            # Resolution failed — let the downstream connect surface the
+            # real error; we just record that we tried.
+            logger.debug("ssrf_guard_resolve_failed", label=label, host=host, error=str(exc))
+            return []
+
+    flagged: list[str] = []
+    for ip_str in resolved:
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        reason = _classify(ip)
+        if reason is not None:
+            flagged.append(f"{ip_str} ({reason})")
+
+    if flagged:
+        logger.warning(
+            "ssrf_guard_flagged_target",
+            label=label,
+            host=host,
+            resolved=resolved,
+            flagged=flagged,
+            blocked=block,
+        )
+        if block:
+            raise SSRFBlockedError(
+                f"{label}: target {host!r} resolves to a forbidden address "
+                f"({', '.join(flagged)})"
+            )
+    else:
+        logger.info("ssrf_guard_target", label=label, host=host, resolved=resolved)
+
+    return resolved
+
+
+__all__ = ["assert_safe_target", "extract_host", "SSRFBlockedError"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ import structlog.contextvars
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from app.api.health import router as health_router
 from app.api.v1.router import api_v1_router
@@ -28,6 +29,79 @@ from app.services import (
 logger = structlog.get_logger(__name__)
 
 
+async def _assert_demo_mode_not_on_prod_data() -> None:
+    """SECURITY (#400 / M7): DEMO_MODE seeds an unlocked admin/admin
+    superadmin (``force_password_change`` skipped) and unlocks abusable
+    surfaces — it must NEVER land on a production image. Detect the
+    tell-tale signs of a real deployment (configured backup targets,
+    integration mirror targets, or external auth providers) and fail
+    fast so the demo flag can't silently leak onto prod.
+
+    No-op unless ``DEMO_MODE=1``. On a genuine demo image these tables
+    are empty, so the legitimate demo flow is untouched. Failure-tolerant
+    on the pre-migration / missing-table case — we can't assert against a
+    schema that isn't there yet, and that's not a prod install anyway.
+    """
+    if not settings.demo_mode:
+        return
+
+    from sqlalchemy import text  # noqa: PLC0415
+
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+
+    # Tables whose presence of ANY row means "this is a real deployment".
+    # Fixed allow-list of literal identifiers (no user input) — the only
+    # values ever interpolated below are these constants, so the count
+    # query carries no injection surface. A missing table (pre-migration)
+    # degrades to the failure-tolerant skip path rather than crashing boot.
+    prod_signal_tables = (
+        "backup_target",
+        "audit_forward_target",
+        "auth_provider",
+        "kubernetes_cluster",
+        "docker_host",
+        "proxmox_node",
+        "tailscale_tenant",
+        "unifi_controller",
+        "cloud_endpoint",
+    )
+    offenders: list[str] = []
+    try:
+        async with AsyncSessionLocal() as session:
+            for table in prod_signal_tables:
+                try:
+                    # ``table`` is a hardcoded constant from the tuple
+                    # above, never request-derived — safe to interpolate.
+                    n = await session.scalar(text(f"SELECT count(*) FROM {table}"))  # noqa: S608
+                except Exception as exc:  # noqa: BLE001
+                    # Table missing (pre-migration) or unreadable — can't
+                    # be a populated prod install; skip this signal.
+                    logger.debug("demo_mode_prod_check_skipped", table=table, reason=str(exc))
+                    continue
+                if n and n > 0:
+                    offenders.append(f"{table}={n}")
+    except RuntimeError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        # DB unreachable at boot — can't prove prod data either way.
+        # Don't crash the (possibly legitimate) demo boot on transient
+        # connectivity; the offender check below simply finds nothing.
+        logger.debug("demo_mode_prod_check_db_unavailable", reason=str(exc))
+
+    if offenders:
+        # SECURITY (#400 / M7): a demo image with real deployment data is
+        # a leaked demo flag on prod — refuse to boot rather than serve an
+        # unlocked admin/admin superadmin.
+        raise RuntimeError(
+            "DEMO_MODE=1 is set but real configured deployment data was "
+            "found ("
+            + ", ".join(offenders)
+            + "). DEMO_MODE seeds an unlocked admin/admin superadmin and "
+            "must NOT run against a production install. Unset DEMO_MODE "
+            "(or wipe the demo data) before booting."
+        )
+
+
 async def _seed_default_admin() -> None:
     """Create the default admin user if no users exist yet."""
     from sqlalchemy import func, select
@@ -35,6 +109,11 @@ async def _seed_default_admin() -> None:
     from app.core.security import hash_password
     from app.db import AsyncSessionLocal
     from app.models.auth import User
+
+    # SECURITY (#400 / M7): hard-stop the demo flag from booting on a real
+    # install BEFORE we (possibly) seed an unlocked admin. Raises on a
+    # prod-data collision; no-op otherwise.
+    await _assert_demo_mode_not_on_prod_data()
 
     async with AsyncSessionLocal() as session:
         try:
@@ -466,8 +545,8 @@ def create_app() -> FastAPI:
 
     # Middleware (outermost first). Note Starlette wraps in REVERSE add
     # order: the LAST-added middleware runs outermost. So the request
-    # flows in as CORS → Prometheus → Maintenance → RequestContext, and
-    # the response unwinds the other way.
+    # flows in as TrustedHost → CORS → Prometheus → Maintenance →
+    # RequestContext, and the response unwinds the other way.
     app.add_middleware(RequestContextMiddleware)
 
     # Maintenance mode (issue #57). Added AFTER RequestContextMiddleware so
@@ -489,6 +568,12 @@ def create_app() -> FastAPI:
     # (not cookies), so wildcard-without-credentials is correct + safe.
     # When the operator pins explicit origins we enable credentials for
     # them (future cookie-based flows / withCredentials fetches).
+    #
+    # SECURITY (#400 / M6): ``cors_origins_list`` collapses to ``["*"]``
+    # whenever a wildcard is present — even mixed with explicit origins
+    # ("*,https://app.example.com"). So ``allow_credentials`` below can
+    # never be True while any wildcard is in play; the dangerous
+    # "reflect every Origin + send credentials" combo is impossible.
     _cors_origins = settings.cors_origins_list
     app.add_middleware(
         CORSMiddleware,
@@ -496,6 +581,19 @@ def create_app() -> FastAPI:
         allow_credentials=_cors_origins != ["*"],
         allow_methods=["*"],
         allow_headers=["*"],
+    )
+
+    # SECURITY (#400 / L3): Host-header allow-list. Added LAST so — given
+    # Starlette's reverse wrap — it runs OUTERMOST and rejects a forged /
+    # unexpected Host header (Host-header injection, DNS-rebinding, cache
+    # poisoning) before any other middleware or handler sees the request.
+    # Default ``["*"]`` accepts any host so existing reverse-proxy /
+    # appliance deploys are unaffected; operators set TRUSTED_HOSTS to
+    # lock the API to their real hostnames. (TrustedHostMiddleware
+    # short-circuits ``["*"]`` so there's no per-request cost when open.)
+    app.add_middleware(
+        TrustedHostMiddleware,
+        allowed_hosts=settings.trusted_hosts_list,
     )
 
     # Routes

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -69,6 +69,18 @@ class Operation:
     # Free-form category for grouping in the admin UI — same vocabulary
     # as the read-only tool registry ("ipam", "dns", "dhcp").
     category: str = "ops"
+    # SECURITY (#400, C2): the RBAC gate the apply endpoint enforces
+    # before dispatching this operation. An ``(action, resource_type)``
+    # tuple matching the equivalent REST route's ``require_*_permission``
+    # — e.g. ``("write", "ip_address")``. ``apply_proposal`` calls
+    # ``user_has_permission(user, action, resource_type)`` and raises 403
+    # when the caller lacks it, so the AI propose→apply flow can never
+    # write a row the operator couldn't write through the REST API. The
+    # field is the authoritative backstop; declaring it on every write
+    # operation is mandatory. ``None`` is reserved for self-scoped ops
+    # (e.g. archiving your own chat session) that gate on ownership
+    # inside their own apply rather than on a coarse RBAC permission.
+    required_permission: tuple[str, str] | None = None
 
 
 @dataclass(frozen=True)
@@ -101,6 +113,40 @@ def get_operation(name: str) -> Operation | None:
 
 def all_operations() -> list[Operation]:
     return sorted(_OPERATIONS.values(), key=lambda o: o.name)
+
+
+class OperationPermissionError(PermissionError):
+    """Raised when the calling user lacks the RBAC permission an
+    operation declares. ``apply_proposal`` translates this into a 403.
+
+    SECURITY (#400, C2): the AI propose→apply flow has no router-level
+    ``require_*_permission`` dependency, so the operation layer is the
+    authoritative authorization gate — without it an authenticated
+    Viewer could apply a proposal that writes IPAM/DNS/DHCP/multicast/
+    alert rows the equivalent REST route would 403.
+    """
+
+    def __init__(self, action: str, resource_type: str) -> None:
+        super().__init__(f"Permission denied: need '{action}' on '{resource_type}'")
+        self.action = action
+        self.resource_type = resource_type
+
+
+def enforce_operation_permission(user: User, op: Operation) -> None:
+    """Backstop an operation's declared RBAC gate (#400, C2).
+
+    Called both by ``apply_proposal`` (the authoritative gate) and by
+    each ``_apply_*`` (defense in depth, so the gate holds even if the
+    op is ever dispatched outside the apply endpoint). No-op when the
+    operation declares ``required_permission=None`` (self-scoped ops).
+    """
+    from app.core.permissions import user_has_permission  # noqa: PLC0415 — avoid cycle
+
+    if op.required_permission is None:
+        return
+    action, resource_type = op.required_permission
+    if not user_has_permission(user, action, resource_type):
+        raise OperationPermissionError(action, resource_type)
 
 
 def expires_at_default() -> datetime:
@@ -204,6 +250,10 @@ async def _apply_create_ip_address(
     is the simpler alternative until the apply set grows.
     """
     from app.api.v1.dhcp._audit import write_audit  # local import to avoid cycle
+
+    # SECURITY (#400, C2): RBAC backstop — the apply path has no
+    # router-level permission dependency.
+    enforce_operation_permission(user, _OPERATIONS["create_ip_address"])
 
     subnet = await db.get(Subnet, args.subnet_id)
     if subnet is None:
@@ -364,6 +414,10 @@ async def _apply_run_nmap_scan(
     from app.models.audit import AuditLog  # local import to avoid cycle
     from app.models.nmap import NmapScan  # local import to avoid cycle
 
+    # SECURITY (#400, C2): RBAC backstop — matches the REST route's
+    # require_permission("write", "manage_nmap_scans").
+    enforce_operation_permission(user, _OPERATIONS["run_nmap_scan"])
+
     target = args.target_ip.strip()
     # Re-validate at apply time too — argv builder gates dangerous flags.
     try:
@@ -436,6 +490,7 @@ register(
         preview=_preview_run_nmap_scan,
         apply=_apply_run_nmap_scan,
         category="network",
+        required_permission=("write", "manage_nmap_scans"),
     )
 )
 
@@ -553,6 +608,10 @@ async def _apply_allocate_subnet(
         allocate_subnet,
     )
 
+    # SECURITY (#400, C2): RBAC backstop — matches the IPAM router's
+    # require_any_resource_permission("subnet", ...) write gate.
+    enforce_operation_permission(user, _OPERATIONS["allocate_subnet"])
+
     alloc = SubnetAllocate(
         prefix_len=args.prefix_len,
         name=args.name or "",
@@ -582,6 +641,7 @@ register(
         preview=_preview_allocate_subnet,
         apply=_apply_allocate_subnet,
         category="ipam",
+        required_permission=("write", "subnet"),
     )
 )
 
@@ -601,6 +661,7 @@ register(
         preview=_preview_create_ip_address,
         apply=_apply_create_ip_address,
         category="ipam",
+        required_permission=("write", "ip_address"),
     )
 )
 
@@ -729,6 +790,10 @@ async def _apply_create_dns_record(
     from app.api.v1.dhcp._audit import write_audit  # local import to avoid cycle
     from app.models.dns import DNSRecord, DNSZone
 
+    # SECURITY (#400, C2): RBAC backstop — matches the DNS router's
+    # require_any_resource_permission("dns_record", ...) write gate.
+    enforce_operation_permission(user, _OPERATIONS["create_dns_record"])
+
     rtype = args.record_type.strip().upper()
     if rtype not in _DNS_RECORD_TYPES:
         raise ValueError(f"Unsupported record type {rtype!r}.")
@@ -800,6 +865,7 @@ register(
         preview=_preview_create_dns_record,
         apply=_apply_create_dns_record,
         category="dns",
+        required_permission=("write", "dns_record"),
     )
 )
 
@@ -1046,6 +1112,10 @@ async def _apply_create_dns_zone(
     from app.models.audit import AuditLog  # noqa: PLC0415
     from app.models.dns import DNSZone  # noqa: PLC0415
 
+    # SECURITY (#400, C2): RBAC backstop — matches the DNS router's
+    # require_any_resource_permission("dns_zone", ...) write gate.
+    enforce_operation_permission(user, _OPERATIONS["create_dns_zone"])
+
     name = _normalize_zone_name(args.name)
     grp, _drivers, err = await _resolve_group_for_zone(
         db, group_id=args.group_id, driver_hint=args.driver_hint
@@ -1111,6 +1181,7 @@ register(
         preview=_preview_create_dns_zone,
         apply=_apply_create_dns_zone,
         category="dns",
+        required_permission=("write", "dns_zone"),
     )
 )
 
@@ -1188,6 +1259,10 @@ async def _apply_create_dhcp_static(
     from app.api.v1.dhcp._audit import write_audit
     from app.models.dhcp import DHCPScope, DHCPStaticAssignment
 
+    # SECURITY (#400, C2): RBAC backstop — matches the DHCP statics
+    # router's require_resource_permission("dhcp_static") write gate.
+    enforce_operation_permission(user, _OPERATIONS["create_dhcp_static"])
+
     scope = await db.get(DHCPScope, args.scope_id)
     if scope is None:
         raise ValueError(f"DHCP scope {args.scope_id} not found.")
@@ -1246,6 +1321,7 @@ register(
         preview=_preview_create_dhcp_static,
         apply=_apply_create_dhcp_static,
         category="dhcp",
+        required_permission=("write", "dhcp_static"),
     )
 )
 
@@ -1295,7 +1371,13 @@ async def _apply_create_alert_rule(
     db: AsyncSession, user: User, args: CreateAlertRuleArgs
 ) -> dict[str, Any]:
     from app.api.v1.dhcp._audit import write_audit
+    from app.core.permissions import is_effective_superadmin  # noqa: PLC0415
     from app.models.alerts import AlertRule
+
+    # SECURITY (#400, C2): RBAC backstop — the REST POST /alerts/rules
+    # route gates on _require_superadmin, so the AI apply does too.
+    if not is_effective_superadmin(user):
+        raise OperationPermissionError("admin", "alert_rule")
 
     row = AlertRule(
         name=args.name,
@@ -1551,6 +1633,10 @@ async def _apply_create_multicast_group(
     from app.models.audit import AuditLog  # noqa: PLC0415
     from app.models.multicast import MulticastGroup  # noqa: PLC0415
 
+    # SECURITY (#400, C2): RBAC backstop — matches the multicast
+    # router's require_resource_permission("multicast") write gate.
+    enforce_operation_permission(user, _OPERATIONS["create_multicast_group"])
+
     err = _validate_multicast_address(args.address)
     if err is not None:
         raise ValueError(err)
@@ -1610,6 +1696,7 @@ register(
         preview=_preview_create_multicast_group,
         apply=_apply_create_multicast_group,
         category="multicast",
+        required_permission=("write", "multicast"),
     )
 )
 
@@ -1773,6 +1860,10 @@ async def _apply_allocate_multicast_groups(
     from app.models.audit import AuditLog  # noqa: PLC0415
     from app.models.multicast import MulticastGroup  # noqa: PLC0415
 
+    # SECURITY (#400, C2): RBAC backstop — matches the multicast
+    # router's require_resource_permission("multicast") write gate.
+    enforce_operation_permission(user, _OPERATIONS["allocate_multicast_groups"])
+
     items, conflict_count, err = await _bulk_allocate_helper(db, args)
     if err is not None:
         raise ValueError(err)
@@ -1836,6 +1927,7 @@ register(
         preview=_preview_allocate_multicast_groups,
         apply=_apply_allocate_multicast_groups,
         category="multicast",
+        required_permission=("write", "multicast"),
     )
 )
 
@@ -1921,6 +2013,11 @@ async def _apply_approve_appliance(
         sign_supervisor_cert,
     )
 
+    # SECURITY (#400, C2): RBAC backstop — matches the REST approve
+    # route's require_permission("admin", "appliance"). High-blast-
+    # radius (mints a cert), so the gate is mandatory at apply.
+    enforce_operation_permission(user, _OPERATIONS["approve_appliance"])
+
     appliance_uuid = UUID(args.appliance_id)
     row = await db.get(Appliance, appliance_uuid)
     if row is None:
@@ -1985,6 +2082,7 @@ register(
         preview=_preview_approve_appliance,
         apply=_apply_approve_appliance,
         category="admin",
+        required_permission=("admin", "appliance"),
     )
 )
 
@@ -2083,6 +2181,10 @@ async def _apply_assign_appliance_role(
     from app.models.dhcp import DHCPServerGroup  # noqa: PLC0415
     from app.models.dns import DNSServerGroup  # noqa: PLC0415
 
+    # SECURITY (#400, C2): RBAC backstop — matches the REST role-assign
+    # route's require_permission("admin", "appliance").
+    enforce_operation_permission(user, _OPERATIONS["assign_appliance_role"])
+
     appliance_uuid = UUID(args.appliance_id)
     row = await db.get(Appliance, appliance_uuid)
     if row is None:
@@ -2136,6 +2238,7 @@ register(
         preview=_preview_assign_appliance_role,
         apply=_apply_assign_appliance_role,
         category="admin",
+        required_permission=("admin", "appliance"),
     )
 )
 
@@ -2187,6 +2290,10 @@ async def _apply_toggle_firewall_policy(
     from app.models.firewall import FirewallPolicy  # noqa: PLC0415
     from app.services.appliance.firewall_merge import reset_policy_cache  # noqa: PLC0415
 
+    # SECURITY (#400, C2): RBAC backstop — the fleet-firewall routes
+    # gate on require_permission("admin", "appliance").
+    enforce_operation_permission(user, _OPERATIONS["toggle_firewall_policy"])
+
     p = await db.get(FirewallPolicy, UUID(args.policy_id))
     if p is None:
         return {"error": f"No firewall policy with id {args.policy_id}."}
@@ -2218,6 +2325,7 @@ register(
         preview=_preview_toggle_firewall_policy,
         apply=_apply_toggle_firewall_policy,
         category="admin",
+        required_permission=("admin", "appliance"),
     )
 )
 

--- a/backend/tests/test_fix_c2_ai_rbac.py
+++ b/backend/tests/test_fix_c2_ai_rbac.py
@@ -1,0 +1,305 @@
+"""Regression tests for #400 / GHSA-mj4g-hw3m-62rm.
+
+C2 (HIGH) — AI proposal apply RBAC backstop. The Operator Copilot
+``propose_*`` → ``apply`` flow has no router-level
+``require_*_permission`` dependency, so before the fix an authenticated
+Viewer who owned a proposal row could apply it and write IPAM / DNS /
+DHCP / multicast / alert rows the equivalent REST route would 403. The
+fix declares an ``(action, resource_type)`` gate on every write
+``Operation`` and enforces it in ``apply_proposal`` (authoritative) plus
+each ``_apply_*`` (defense in depth).
+
+M1 (MEDIUM) — MCP ``tools/call`` read-only gating. ``mcp_post`` dispatched
+ANY registered tool by name (including ``propose_*`` writes) ignoring the
+read-only advertised set. The fix passes ``effective={read-only names}``
+so a read-scoped MCP caller can't invoke a write/propose tool.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.ai import mcp as mcp_mod
+from app.api.v1.ai.proposals import apply_proposal
+from app.core.security import hash_password
+from app.models.ai import AIOperationProposal
+from app.models.auth import Group, Role, User
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.ai import operations
+from app.services.ai.operations import (
+    CreateIPAddressArgs,
+    OperationPermissionError,
+    enforce_operation_permission,
+    get_operation,
+)
+from app.services.ai.tools import REGISTRY
+
+
+async def _user(
+    db: AsyncSession,
+    *,
+    superadmin: bool = False,
+    name: str = "rbac",
+    permissions: list[dict] | None = None,
+) -> User:
+    """Create a user. ``permissions`` (a list of RBAC permission dicts)
+    is attached via a fresh Group+Role so the user passes
+    ``user_has_permission`` for exactly those grants — mirroring how a
+    real Viewer / IPAM-Editor is provisioned."""
+    u = User(
+        username=f"{name}-{uuid.uuid4().hex[:8]}",
+        email=f"{name}-{uuid.uuid4().hex[:8]}@example.test",
+        display_name="RBAC Tester",
+        hashed_password=hash_password("x"),
+        is_superadmin=superadmin,
+    )
+    u.groups = []  # mark loaded — is_effective_superadmin walks .groups
+    if permissions:
+        role = Role(name=f"role-{uuid.uuid4().hex[:8]}", permissions=permissions)
+        group = Group(name=f"grp-{uuid.uuid4().hex[:8]}")
+        group.roles = [role]
+        u.groups = [group]
+        db.add_all([role, group])
+    db.add(u)
+    await db.commit()
+    return u
+
+
+async def _subnet(db: AsyncSession) -> Subnet:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/16", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.0.5.0/24", name="s")
+    db.add(subnet)
+    await db.commit()
+    await db.refresh(subnet)
+    return subnet
+
+
+async def _make_proposal(
+    db: AsyncSession, *, user: User, operation: str, args: dict
+) -> AIOperationProposal:
+    row = AIOperationProposal(
+        session_id=None,
+        user_id=user.id,
+        operation=operation,
+        args=args,
+        preview_text="preview",
+        expires_at=operations.expires_at_default(),
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+# ── C2: operation-level gate declared on every write op ────────────────
+
+
+def test_core_write_ops_declare_a_gate() -> None:
+    """The IPAM / DNS / DHCP / multicast / appliance write operations
+    must each declare a coarse RBAC gate so apply_proposal can enforce it
+    (#400 C2). Self-scoped ops (archive_session — own session only) and
+    inline-superadmin ops (create_alert_rule, grant_temporary_access)
+    gate inside their own apply instead and are excluded here."""
+    expected = {
+        "create_ip_address": ("write", "ip_address"),
+        "allocate_subnet": ("write", "subnet"),
+        "run_nmap_scan": ("write", "manage_nmap_scans"),
+        "create_dns_record": ("write", "dns_record"),
+        "create_dns_zone": ("write", "dns_zone"),
+        "create_dhcp_static": ("write", "dhcp_static"),
+        "create_multicast_group": ("write", "multicast"),
+        "allocate_multicast_groups": ("write", "multicast"),
+        "approve_appliance": ("admin", "appliance"),
+        "assign_appliance_role": ("admin", "appliance"),
+        "toggle_firewall_policy": ("admin", "appliance"),
+    }
+    for name, gate in expected.items():
+        op = get_operation(name)
+        assert op is not None, f"operation {name!r} not registered"
+        assert op.required_permission == gate, f"{name}: {op.required_permission!r} != {gate!r}"
+
+
+@pytest.mark.asyncio
+async def test_enforce_operation_permission_raises_for_viewer(db_session: AsyncSession) -> None:
+    op = get_operation("create_ip_address")
+    assert op is not None
+    # A bare user with no groups → no write on ip_address.
+    viewer = await _user(db_session)
+    with pytest.raises(OperationPermissionError):
+        enforce_operation_permission(viewer, op)
+
+
+# ── C2: apply_proposal is the authoritative backstop ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_proposal_403_for_unprivileged_owner(db_session: AsyncSession) -> None:
+    """A Viewer who OWNS the proposal still cannot apply it — the apply
+    endpoint enforces the op's RBAC gate, not just ownership."""
+    subnet = await _subnet(db_session)
+    viewer = await _user(db_session, name="viewer")
+    proposal = await _make_proposal(
+        db_session,
+        user=viewer,
+        operation="create_ip_address",
+        args=CreateIPAddressArgs(subnet_id=str(subnet.id), address="10.0.5.10").model_dump(),
+    )
+
+    with pytest.raises(HTTPException) as ei:
+        await apply_proposal(proposal.id, viewer, db_session)
+    assert ei.value.status_code == 403
+
+    # And no IPAddress row was written.
+    rows = (
+        (await db_session.execute(select(IPAddress).where(IPAddress.subnet_id == subnet.id)))
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_apply_proposal_succeeds_for_authorized_writer(db_session: AsyncSession) -> None:
+    """A user granted ('write','ip_address') — the same grant the REST
+    route requires — can apply the proposal and the row lands."""
+    subnet = await _subnet(db_session)
+    writer = await _user(
+        db_session,
+        name="ipam-editor",
+        permissions=[{"action": "write", "resource_type": "ip_address"}],
+    )
+    proposal = await _make_proposal(
+        db_session,
+        user=writer,
+        operation="create_ip_address",
+        args=CreateIPAddressArgs(subnet_id=str(subnet.id), address="10.0.5.11").model_dump(),
+    )
+
+    resp = await apply_proposal(proposal.id, writer, db_session)
+    assert resp.ok is True
+    rows = (
+        (
+            await db_session.execute(
+                select(IPAddress).where(
+                    IPAddress.subnet_id == subnet.id, IPAddress.address == "10.0.5.11"
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_proposal_succeeds_for_superadmin(db_session: AsyncSession) -> None:
+    subnet = await _subnet(db_session)
+    admin = await _user(db_session, superadmin=True, name="admin")
+    proposal = await _make_proposal(
+        db_session,
+        user=admin,
+        operation="create_ip_address",
+        args=CreateIPAddressArgs(subnet_id=str(subnet.id), address="10.0.5.12").model_dump(),
+    )
+    resp = await apply_proposal(proposal.id, admin, db_session)
+    assert resp.ok is True
+
+
+@pytest.mark.asyncio
+async def test_apply_proposal_wrong_resource_type_perm_still_403(db_session: AsyncSession) -> None:
+    """A grant on a DIFFERENT resource_type (dns_record) must NOT let the
+    caller apply a create_ip_address proposal."""
+    subnet = await _subnet(db_session)
+    user = await _user(
+        db_session,
+        name="dns-only",
+        permissions=[{"action": "write", "resource_type": "dns_record"}],
+    )
+    proposal = await _make_proposal(
+        db_session,
+        user=user,
+        operation="create_ip_address",
+        args=CreateIPAddressArgs(subnet_id=str(subnet.id), address="10.0.5.20").model_dump(),
+    )
+    with pytest.raises(HTTPException) as ei:
+        await apply_proposal(proposal.id, user, db_session)
+    assert ei.value.status_code == 403
+
+
+# ── M1: MCP tools/call refuses write / propose tools ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_call_rejects_propose_tool(db_session: AsyncSession) -> None:
+    """A propose_* tool is NOT in the MCP-exposed set (propose tools are
+    registered writes=False but still stage a write), so tools/call must
+    report method-not-found and must NOT persist a proposal row."""
+    user = await _user(db_session, superadmin=True, name="mcp")
+
+    propose_names = sorted(t.name for t in REGISTRY.all() if t.name.startswith("propose_"))
+    assert propose_names, "expected at least one propose_* tool registered"
+    target = propose_names[0]
+
+    frame = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": target, "arguments": {}},
+    }
+    resp = await mcp_mod._dispatch_one(frame, db_session, user)
+    assert "error" in resp, resp
+    # -32601 = method not found (we deliberately mask disabled→not-found
+    # so the existence of non-exposed tools doesn't leak).
+    assert resp["error"]["code"] == mcp_mod._METHOD_NOT_FOUND
+    # No proposal row was staged.
+    rows = (
+        (
+            await db_session.execute(
+                select(AIOperationProposal).where(AIOperationProposal.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_call_rejects_write_tool(db_session: AsyncSession) -> None:
+    """A genuine writes=True tool must be rejected by tools/call too."""
+    user = await _user(db_session, superadmin=True, name="mcpw")
+    write_names = sorted(t.name for t in REGISTRY.all() if t.writes)
+    if not write_names:
+        pytest.skip("no writes=True tool registered")
+    frame = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {"name": write_names[0], "arguments": {}},
+    }
+    resp = await mcp_mod._dispatch_one(frame, db_session, user)
+    assert resp["error"]["code"] == mcp_mod._METHOD_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_list_excludes_write_and_propose(db_session: AsyncSession) -> None:
+    """The advertised tools/list must never include a write or propose
+    tool — keeps the call-gate's effective set in sync with what's
+    advertised (single source of truth: _mcp_tools)."""
+    user = await _user(db_session, superadmin=True, name="mcp2")
+    frame = {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+    resp = await mcp_mod._dispatch_one(frame, db_session, user)
+    listed = {t["name"] for t in resp["result"]["tools"]}
+    excluded = {t.name for t in REGISTRY.all() if t.writes or t.name.startswith("propose_")}
+    assert listed.isdisjoint(excluded)
+    assert listed == mcp_mod._mcp_tool_names()

--- a/backend/tests/test_fix_c3_dns_token_scope.py
+++ b/backend/tests/test_fix_c3_dns_token_scope.py
@@ -1,0 +1,198 @@
+"""Regression: dns_zone-scoped API token must not read/enumerate/export
+foreign zones (issue #400 / GHSA-mj4g-hw3m-62rm finding C3 — IDOR).
+
+Before the fix the coarse router gate passed a dns_zone-scoped token on type
+match (req_rid=None) and the single-zone READ handlers (get_zone / export_zone /
+server-state / dnssec-info / delegation-preview / drift) plus the list/export-all
+handlers never re-checked the per-row binding, so a token bound to zone A could
+read or bulk-export ANY zone in the group. The record handlers already enforced
+``_enforce_zone_token_scope``; this mirrors that for every zone READ surface.
+
+The fix:
+* ``_require_zone`` now runs ``_enforce_zone_token_scope`` when the caller is
+  supplied, so every single-zone consumer inherits the per-row check.
+* ``list_zones`` / ``export_all_zones`` narrow their result set to the token's
+  bound zone(s) via ``_zone_token_id_filter``.
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+import zipfile
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, generate_api_token, hash_password
+from app.models.auth import APIToken, User
+from app.models.dns import DNSServerGroup, DNSZone
+
+
+async def _make_user(db: AsyncSession, *, superadmin: bool) -> tuple[User, str]:
+    user = User(
+        username=f"tok-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="Token User",
+        hashed_password=hash_password("x"),
+        is_superadmin=superadmin,
+    )
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_token(db: AsyncSession, owner: User, grants: list[dict] | None) -> str:
+    raw, _prefix, token_hash = generate_api_token()
+    db.add(
+        APIToken(
+            name=f"t-{uuid.uuid4().hex[:6]}",
+            token_hash=token_hash,
+            prefix=raw[:10],
+            scope="user",
+            scopes=[],
+            resource_grants=grants,
+            user_id=owner.id,
+            created_by_user_id=owner.id,
+            is_active=True,
+        )
+    )
+    await db.flush()
+    return raw
+
+
+async def _group_with_two_zones(
+    db: AsyncSession,
+) -> tuple[DNSServerGroup, DNSZone, DNSZone]:
+    group = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    db.add(group)
+    await db.flush()
+    zone_a = DNSZone(group_id=group.id, name=f"a-{uuid.uuid4().hex[:6]}.test", kind="forward")
+    zone_b = DNSZone(group_id=group.id, name=f"b-{uuid.uuid4().hex[:6]}.test", kind="forward")
+    db.add_all([zone_a, zone_b])
+    await db.flush()
+    return group, zone_a, zone_b
+
+
+@pytest.mark.asyncio
+async def test_zone_token_cannot_read_foreign_zone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A read grant bound to zone A reads A (200) but 403s on zone B —
+    across get_zone / export_zone / server-state / dnssec / delegation-preview /
+    drift (all of which route through _require_zone)."""
+    owner, _ = await _make_user(db_session, superadmin=True)
+    group, zone_a, zone_b = await _group_with_two_zones(db_session)
+    raw = await _make_token(
+        db_session,
+        owner,
+        [{"action": "read", "resource_type": "dns_zone", "resource_id": str(zone_a.id)}],
+    )
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {raw}"}
+    base = f"/api/v1/dns/groups/{group.id}/zones"
+
+    # In-scope: every single-zone read on the bound zone works.
+    assert (await client.get(f"{base}/{zone_a.id}", headers=hdr)).status_code == 200
+    assert (await client.get(f"{base}/{zone_a.id}/export", headers=hdr)).status_code == 200
+
+    # Out-of-scope: same token, foreign zone → 403 on every read surface.
+    for suffix in (
+        "",
+        "/export",
+        "/server-state",
+        "/dnssec/info",
+        "/delegation-preview",
+        "/drift",
+    ):
+        r = await client.get(f"{base}/{zone_b.id}{suffix}", headers=hdr)
+        assert r.status_code == 403, f"{suffix or '<get_zone>'} leaked: {r.status_code} {r.text}"
+
+
+@pytest.mark.asyncio
+async def test_list_zones_filtered_to_bound_zone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """list_zones returns only the token's bound zone — not the whole group."""
+    owner, _ = await _make_user(db_session, superadmin=True)
+    group, zone_a, zone_b = await _group_with_two_zones(db_session)
+    raw = await _make_token(
+        db_session,
+        owner,
+        [{"action": "read", "resource_type": "dns_zone", "resource_id": str(zone_a.id)}],
+    )
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {raw}"}
+
+    r = await client.get(f"/api/v1/dns/groups/{group.id}/zones", headers=hdr)
+    assert r.status_code == 200, r.text
+    returned_ids = {row["id"] for row in r.json()}
+    assert returned_ids == {str(zone_a.id)}
+    assert str(zone_b.id) not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_export_all_zones_filtered_to_bound_zone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """export_all_zones zips only the bound zone, never the foreign one."""
+    owner, _ = await _make_user(db_session, superadmin=True)
+    group, zone_a, zone_b = await _group_with_two_zones(db_session)
+    raw = await _make_token(
+        db_session,
+        owner,
+        [{"action": "read", "resource_type": "dns_zone", "resource_id": str(zone_a.id)}],
+    )
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {raw}"}
+
+    r = await client.get(f"/api/v1/dns/groups/{group.id}/zones/export", headers=hdr)
+    assert r.status_code == 200, r.text
+    names = set(zipfile.ZipFile(io.BytesIO(r.content)).namelist())
+    assert zone_a.name.rstrip(".") + ".zone" in names
+    assert zone_b.name.rstrip(".") + ".zone" not in names
+
+
+@pytest.mark.asyncio
+async def test_unscoped_session_still_sees_all_zones(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Legitimate flow guard: a normal (non-token) superadmin session is
+    unaffected — it lists both zones and reads either one."""
+    _, token = await _make_user(db_session, superadmin=True)
+    group, zone_a, zone_b = await _group_with_two_zones(db_session)
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {token}"}
+    base = f"/api/v1/dns/groups/{group.id}/zones"
+
+    r_list = await client.get(base, headers=hdr)
+    assert r_list.status_code == 200, r_list.text
+    ids = {row["id"] for row in r_list.json()}
+    assert {str(zone_a.id), str(zone_b.id)} <= ids
+
+    assert (await client.get(f"{base}/{zone_a.id}", headers=hdr)).status_code == 200
+    assert (await client.get(f"{base}/{zone_b.id}", headers=hdr)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_write_scoped_token_can_still_read_own_zone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A write grant implies read on the bound zone (#374 write-implies-read),
+    so a dns:write-scoped token bound to zone A can still GET zone A — the fix
+    must not regress that legitimate path."""
+    owner, _ = await _make_user(db_session, superadmin=True)
+    group, zone_a, zone_b = await _group_with_two_zones(db_session)
+    raw = await _make_token(
+        db_session,
+        owner,
+        [{"action": "write", "resource_type": "dns_zone", "resource_id": str(zone_a.id)}],
+    )
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {raw}"}
+    base = f"/api/v1/dns/groups/{group.id}/zones"
+
+    assert (await client.get(f"{base}/{zone_a.id}", headers=hdr)).status_code == 200
+    # ...but a foreign zone is still 403.
+    assert (await client.get(f"{base}/{zone_b.id}", headers=hdr)).status_code == 403

--- a/backend/tests/test_fix_c4_rbac_ceiling.py
+++ b/backend/tests/test_fix_c4_rbac_ceiling.py
@@ -1,0 +1,413 @@
+"""Regression tests for finding C4 (GHSA-mj4g-hw3m-62rm / issue #400).
+
+Privilege ceiling on delegated role / group editing.
+
+Before the fix, a non-superadmin holding a delegated ``admin:role``
+(+``admin:group``) capability could mint a role carrying
+``{action:"*", resource_type:"*"}`` (or any permission they don't themselves
+hold) and self-assign it, escalating to effective superadmin. The fix adds
+``app.core.permissions.caller_can_grant`` and enforces it in:
+
+* roles router — ``create_role`` / ``update_role`` / ``clone_role``
+* groups router — role attachment in ``create_group`` / ``update_group``
+* time-bound grants — ``create_time_bound_grant``
+
+These tests cover the helper directly plus the end-to-end HTTP enforcement,
+and confirm legitimate flows (superadmin builds anything; a delegated admin
+grants within their own ceiling) are NOT broken.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permissions import caller_can_grant
+from app.core.security import create_access_token, hash_password
+from app.models.auth import Group, Role, User
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _user(superadmin: bool = False, is_active: bool = True) -> User:
+    u = User(
+        username=f"u{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@t.io",
+        display_name="Test",
+        hashed_password="x",
+        is_superadmin=superadmin,
+        is_active=is_active,
+    )
+    u.groups = []
+    return u
+
+
+def _role(perms: list[dict[str, Any]]) -> Role:
+    return Role(name=f"r{uuid.uuid4().hex[:6]}", description="", permissions=perms)
+
+
+def _group(roles: list[Role]) -> Group:
+    g = Group(name=f"g{uuid.uuid4().hex[:6]}", description="")
+    g.roles = roles
+    g.users = []
+    return g
+
+
+async def _persist_user_with_role(
+    db: AsyncSession,
+    *,
+    role_name: str,
+    permissions: list[dict[str, Any]],
+    username: str,
+    superadmin: bool = False,
+) -> tuple[User, str]:
+    role = Role(name=role_name, description="", is_builtin=False, permissions=permissions)
+    group = Group(name=f"{role_name}-grp-{uuid.uuid4().hex[:6]}", description="")
+    user = User(
+        username=username,
+        email=f"{username}@t.io",
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        is_superadmin=superadmin,
+    )
+    group.roles = [role]
+    group.users = [user]
+    db.add_all([role, group, user])
+    await db.flush()
+    token = create_access_token(str(user.id))
+    return user, token
+
+
+# ── caller_can_grant unit tests ───────────────────────────────────────────────
+
+
+def test_superadmin_can_grant_anything() -> None:
+    u = _user(superadmin=True)
+    assert caller_can_grant(u, [{"action": "*", "resource_type": "*"}]) is True
+    assert caller_can_grant(u, [{"action": "admin", "resource_type": "anything"}]) is True
+
+
+def test_effective_superadmin_via_wildcard_can_grant_anything() -> None:
+    u = _user(superadmin=False)
+    u.groups = [_group([_role([{"action": "*", "resource_type": "*"}])])]
+    assert caller_can_grant(u, [{"action": "*", "resource_type": "*"}]) is True
+
+
+def test_nonsuperadmin_cannot_grant_full_wildcard() -> None:
+    """The core C4 escalation: a delegated admin minting {*, *}."""
+    u = _user(superadmin=False)
+    u.groups = [_group([_role([{"action": "admin", "resource_type": "role"}])])]
+    assert caller_can_grant(u, [{"action": "*", "resource_type": "*"}]) is False
+
+
+def test_nonsuperadmin_cannot_grant_action_wildcard() -> None:
+    u = _user(superadmin=False)
+    u.groups = [_group([_role([{"action": "admin", "resource_type": "subnet"}])])]
+    # `{*, subnet}` would let the role do anything to subnets — wider than the
+    # `admin` the caller holds in the action axis sense; still wildcard-minting.
+    assert caller_can_grant(u, [{"action": "*", "resource_type": "subnet"}]) is False
+
+
+def test_nonsuperadmin_cannot_grant_resource_wildcard() -> None:
+    u = _user(superadmin=False)
+    u.groups = [_group([_role([{"action": "read", "resource_type": "subnet"}])])]
+    assert caller_can_grant(u, [{"action": "read", "resource_type": "*"}]) is False
+
+
+def test_nonsuperadmin_cannot_grant_permission_they_lack() -> None:
+    u = _user(superadmin=False)
+    u.groups = [_group([_role([{"action": "admin", "resource_type": "subnet"}])])]
+    # Caller has subnet admin but NOT dns_zone — cannot grant dns_zone.
+    assert caller_can_grant(u, [{"action": "write", "resource_type": "dns_zone"}]) is False
+
+
+def test_nonsuperadmin_can_grant_subset_of_own_perms() -> None:
+    u = _user(superadmin=False)
+    u.groups = [
+        _group(
+            [
+                _role(
+                    [
+                        {"action": "admin", "resource_type": "subnet"},
+                        {"action": "read", "resource_type": "dns_zone"},
+                    ]
+                )
+            ]
+        )
+    ]
+    # admin implies read/write/delete on subnet, so granting write:subnet is OK.
+    assert caller_can_grant(u, [{"action": "write", "resource_type": "subnet"}]) is True
+    assert caller_can_grant(u, [{"action": "read", "resource_type": "dns_zone"}]) is True
+    # ...but anything outside the held set fails.
+    assert (
+        caller_can_grant(
+            u,
+            [
+                {"action": "write", "resource_type": "subnet"},
+                {"action": "write", "resource_type": "dns_zone"},  # not held
+            ],
+        )
+        is False
+    )
+
+
+def test_malformed_entry_is_not_grantable() -> None:
+    u = _user(superadmin=False)
+    u.groups = [_group([_role([{"action": "*", "resource_type": "*"}])])]
+    # Even an effective superadmin short-circuits to True, so use a plain admin.
+    u2 = _user(superadmin=False)
+    u2.groups = [_group([_role([{"action": "admin", "resource_type": "subnet"}])])]
+    assert caller_can_grant(u2, ["not-a-dict"]) is False  # type: ignore[list-item]
+
+
+def test_empty_perms_is_grantable() -> None:
+    u = _user(superadmin=False)
+    u.groups = [_group([_role([{"action": "admin", "resource_type": "subnet"}])])]
+    assert caller_can_grant(u, []) is True
+
+
+# ── HTTP enforcement — roles router ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delegated_admin_cannot_create_wildcard_role(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """C4 end-to-end: a non-superadmin with delegated admin:role is blocked
+    from minting a {*, *} role."""
+    _, token = await _persist_user_with_role(
+        db_session,
+        role_name="RoleAdmin-T",
+        permissions=[{"action": "admin", "resource_type": "role"}],
+        username="role-admin",
+    )
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        "/api/v1/roles",
+        json={
+            "name": "Sneaky-Superadmin",
+            "permissions": [{"action": "*", "resource_type": "*"}],
+        },
+        headers=headers,
+    )
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.asyncio
+async def test_delegated_admin_cannot_create_role_with_unheld_perm(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _persist_user_with_role(
+        db_session,
+        role_name="RoleAdmin-Subnet-T",
+        permissions=[
+            {"action": "admin", "resource_type": "role"},
+            {"action": "admin", "resource_type": "subnet"},
+        ],
+        username="role-admin-subnet",
+    )
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    # Caller has no dns_zone permission → cannot author a role that grants it.
+    r = await client.post(
+        "/api/v1/roles",
+        json={
+            "name": "DNS-Grab",
+            "permissions": [{"action": "admin", "resource_type": "dns_zone"}],
+        },
+        headers=headers,
+    )
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.asyncio
+async def test_delegated_admin_can_create_role_within_ceiling(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Legitimate delegation still works: a delegated admin authors a role
+    carrying only perms they themselves hold."""
+    _, token = await _persist_user_with_role(
+        db_session,
+        role_name="RoleAdmin-WithSubnet-T",
+        permissions=[
+            {"action": "admin", "resource_type": "role"},
+            {"action": "admin", "resource_type": "subnet"},
+        ],
+        username="role-admin-ok",
+    )
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        "/api/v1/roles",
+        json={
+            "name": "Subnet-Reader",
+            "permissions": [{"action": "read", "resource_type": "subnet"}],
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_superadmin_can_create_wildcard_role(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The platform owner is unbounded — the ceiling must not break this."""
+    _, token = await _persist_user_with_role(
+        db_session,
+        role_name="Real-Superadmin-T",
+        permissions=[{"action": "*", "resource_type": "*"}],
+        username="real-superadmin",
+        superadmin=True,
+    )
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        "/api/v1/roles",
+        json={
+            "name": "Custom-Superadmin",
+            "permissions": [{"action": "*", "resource_type": "*"}],
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+
+
+# ── HTTP enforcement — groups router (role attachment) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delegated_group_admin_cannot_attach_superadmin_role(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """C4 via the groups path: a non-superadmin with admin:group cannot attach
+    a pre-existing {*, *} (Superadmin-equivalent) role to a group."""
+    _, token = await _persist_user_with_role(
+        db_session,
+        role_name="GroupAdmin-T",
+        permissions=[{"action": "admin", "resource_type": "group"}],
+        username="group-admin",
+    )
+    # A wildcard role already exists in the system (e.g. built-in Superadmin).
+    wildcard_role = Role(
+        name=f"Wildcard-{uuid.uuid4().hex[:6]}",
+        description="",
+        is_builtin=False,
+        permissions=[{"action": "*", "resource_type": "*"}],
+    )
+    db_session.add(wildcard_role)
+    await db_session.flush()
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        "/api/v1/groups",
+        json={
+            "name": "Escalation-Group",
+            "role_ids": [str(wildcard_role.id)],
+        },
+        headers=headers,
+    )
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.asyncio
+async def test_superadmin_can_attach_wildcard_role_to_group(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _persist_user_with_role(
+        db_session,
+        role_name="GroupSuperadmin-T",
+        permissions=[{"action": "*", "resource_type": "*"}],
+        username="group-superadmin",
+        superadmin=True,
+    )
+    wildcard_role = Role(
+        name=f"Wildcard2-{uuid.uuid4().hex[:6]}",
+        description="",
+        is_builtin=False,
+        permissions=[{"action": "*", "resource_type": "*"}],
+    )
+    db_session.add(wildcard_role)
+    await db_session.flush()
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        "/api/v1/groups",
+        json={
+            "name": "Legit-Admin-Group",
+            "role_ids": [str(wildcard_role.id)],
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+
+
+# ── HTTP enforcement — time-bound grants ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delegated_admin_cannot_mint_wildcard_time_bound_grant(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """C4 via the time-bound-grant path (docstring previously noted no
+    escalation guard)."""
+    _, token = await _persist_user_with_role(
+        db_session,
+        role_name="GrantAdmin-T",
+        permissions=[{"action": "admin", "resource_type": "group"}],
+        username="grant-admin",
+    )
+    target_group = Group(name=f"Target-{uuid.uuid4().hex[:6]}", description="")
+    db_session.add(target_group)
+    await db_session.flush()
+    gid = str(target_group.id)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        "/api/v1/groups/time-bound-grants",
+        json={
+            "group_id": gid,
+            "action": "*",
+            "resource_type": "*",
+            "expires_at": "2099-01-01T00:00:00Z",
+            "reason": "escalation attempt",
+        },
+        headers=headers,
+    )
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.asyncio
+async def test_superadmin_can_mint_time_bound_grant(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _persist_user_with_role(
+        db_session,
+        role_name="GrantSuperadmin-T",
+        permissions=[{"action": "*", "resource_type": "*"}],
+        username="grant-superadmin",
+        superadmin=True,
+    )
+    target_group = Group(name=f"Target2-{uuid.uuid4().hex[:6]}", description="")
+    db_session.add(target_group)
+    await db_session.flush()
+    gid = str(target_group.id)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        "/api/v1/groups/time-bound-grants",
+        json={
+            "group_id": gid,
+            "action": "admin",
+            "resource_type": "subnet",
+            "expires_at": "2099-01-01T00:00:00Z",
+            "reason": "legit temporary access",
+        },
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text

--- a/backend/tests/test_fix_l5_ssrf.py
+++ b/backend/tests/test_fix_l5_ssrf.py
@@ -1,0 +1,156 @@
+"""Regression tests for the L5 defense-in-depth SSRF guard.
+
+SECURITY (#400 / GHSA-mj4g-hw3m-62rm, finding L5):
+    The integration "Test Connection" endpoints have the control plane
+    dial an operator-supplied host. ``app.core.ssrf.assert_safe_target``
+    resolves the host, logs the resolved IP, and flags the classic SSRF
+    pivot targets (loopback / link-local / cloud-metadata) while
+    deliberately treating RFC1918 LAN hosts as legitimate (proxmox /
+    unifi / opnsense / docker / k8s on the LAN must keep working).
+
+These tests pin that behaviour with no DB and a mocked resolver so they
+stay hermetic (no real DNS / network).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.ssrf import (
+    SSRFBlockedError,
+    assert_safe_target,
+    extract_host,
+)
+
+
+@pytest.mark.parametrize(
+    "target,expected",
+    [
+        ("192.168.1.10", "192.168.1.10"),
+        ("https://192.168.1.10:8006/", "192.168.1.10"),
+        ("https://pve.lan:8006/api2/json", "pve.lan"),
+        ("tcp://docker.example.com:2376", "docker.example.com"),
+        ("controller.lan:8443", "controller.lan"),
+        ("unix:///var/run/docker.sock", ""),  # no network host
+        ("npipe:////./pipe/docker_engine", ""),
+        ("", ""),
+        ("[2001:db8::1]:443", "2001:db8::1"),
+    ],
+)
+def test_extract_host(target: str, expected: str) -> None:
+    assert extract_host(target) == expected
+
+
+def test_rfc1918_target_is_allowed_not_flagged(monkeypatch) -> None:
+    """A LAN (RFC1918) target is the legitimate common case — it must
+    resolve cleanly, be logged, and NOT be flagged or blocked."""
+
+    warned: list[tuple] = []
+    monkeypatch.setattr(
+        "app.core.ssrf.logger.warning",
+        lambda *a, **k: warned.append((a, k)),
+    )
+
+    # Bare IP literal — no DNS needed.
+    resolved = assert_safe_target("10.0.5.20", label="proxmox", block=True)
+    assert resolved == ["10.0.5.20"]
+    assert warned == []  # RFC1918 is never flagged
+
+
+def test_loopback_is_flagged_but_not_blocked_by_default(monkeypatch) -> None:
+    """Loopback is flagged (WARNING) but the advisory default never
+    raises — co-located on-box services must keep working."""
+
+    warned: list[tuple] = []
+    monkeypatch.setattr(
+        "app.core.ssrf.logger.warning",
+        lambda *a, **k: warned.append((a, k)),
+    )
+
+    resolved = assert_safe_target("127.0.0.1", label="docker")
+    assert resolved == ["127.0.0.1"]
+    assert len(warned) == 1
+    kwargs = warned[0][1]
+    assert kwargs["blocked"] is False
+    assert any("loopback" in f for f in kwargs["flagged"])
+
+
+def test_cloud_metadata_is_flagged(monkeypatch) -> None:
+    """169.254.169.254 — the canonical cloud-creds SSRF pivot — is
+    flagged with the dedicated reason string."""
+
+    warned: list[tuple] = []
+    monkeypatch.setattr(
+        "app.core.ssrf.logger.warning",
+        lambda *a, **k: warned.append((a, k)),
+    )
+
+    assert_safe_target("http://169.254.169.254/latest/meta-data/", label="k8s")
+    assert len(warned) == 1
+    assert any("cloud_metadata" in f for f in warned[0][1]["flagged"])
+
+
+def test_link_local_is_flagged(monkeypatch) -> None:
+    warned: list[tuple] = []
+    monkeypatch.setattr(
+        "app.core.ssrf.logger.warning",
+        lambda *a, **k: warned.append((a, k)),
+    )
+
+    assert_safe_target("169.254.10.10", label="opnsense")
+    assert len(warned) == 1
+    assert any("link_local" in f for f in warned[0][1]["flagged"])
+
+
+def test_block_true_raises_on_pivot() -> None:
+    """When a caller opts into hard blocking, a pivot target raises."""
+
+    with pytest.raises(SSRFBlockedError):
+        assert_safe_target("127.0.0.1", label="test", block=True)
+    with pytest.raises(SSRFBlockedError):
+        assert_safe_target("169.254.169.254", label="test", block=True)
+
+
+def test_hostname_resolving_to_loopback_is_flagged(monkeypatch) -> None:
+    """A hostname (not a literal) that resolves to loopback is flagged —
+    this is the DNS-rebind / localhost-alias SSRF case."""
+
+    def fake_getaddrinfo(host, *a, **k):
+        return [(2, 1, 6, "", ("127.0.0.1", 0))]
+
+    monkeypatch.setattr("app.core.ssrf.socket.getaddrinfo", fake_getaddrinfo)
+    warned: list[tuple] = []
+    monkeypatch.setattr(
+        "app.core.ssrf.logger.warning",
+        lambda *a, **k: warned.append((a, k)),
+    )
+
+    resolved = assert_safe_target("evil.lanalias.example", label="proxmox")
+    assert resolved == ["127.0.0.1"]
+    assert len(warned) == 1
+    assert any("loopback" in f for f in warned[0][1]["flagged"])
+
+
+def test_resolution_failure_is_non_fatal(monkeypatch) -> None:
+    """If DNS resolution fails, the guard returns [] and does NOT raise —
+    the downstream connect surfaces the real error."""
+
+    def boom(host, *a, **k):
+        raise OSError("name resolution failed")
+
+    monkeypatch.setattr("app.core.ssrf.socket.getaddrinfo", boom)
+
+    resolved = assert_safe_target("nonexistent.invalid", label="proxmox", block=True)
+    assert resolved == []  # non-fatal
+
+
+def test_unix_socket_endpoint_short_circuits(monkeypatch) -> None:
+    """A unix-socket docker endpoint has no network host — the guard
+    returns [] without attempting resolution or flagging."""
+
+    def should_not_run(*a, **k):  # pragma: no cover
+        raise AssertionError("getaddrinfo must not be called for unix://")
+
+    monkeypatch.setattr("app.core.ssrf.socket.getaddrinfo", should_not_run)
+
+    assert assert_safe_target("unix:///var/run/docker.sock", label="docker") == []

--- a/backend/tests/test_fix_m2_m5_l6_info.py
+++ b/backend/tests/test_fix_m2_m5_l6_info.py
@@ -1,0 +1,271 @@
+"""Regression tests for #400 / GHSA-mj4g-hw3m-62rm — M2 + M5 + L6.
+
+M2: ``GET /api/v1/dashboards/security/summary`` returned per-user
+    user/MFA/token/login telemetry (usernames, last-login times,
+    failed-login source IPs, permission-change actors) to ANY
+    authenticated caller — no permission gate. After the fix the
+    per-row detail lists populate only for an effective superadmin or a
+    caller holding ``read`` on ``audit_log`` / ``user``; everyone else
+    gets the aggregate headline counts with the PII lists stripped.
+
+M5: ``GET /api/v1/health/platform`` is mounted UNAUTHENTICATED and
+    echoed raw ``str(exc)`` backend exception strings (DSNs, internal
+    hosts, driver versions) in each component's ``detail`` on error.
+    After the fix error details are fixed generic strings; the
+    ``ok`` / ``error`` / ``warn`` status semantics are unchanged.
+
+L6: ``GET /api/v1/version`` disclosed the appliance hostname +
+    appliance version to UNAUTHENTICATED callers. After the fix those
+    two fields are returned only to authenticated callers; the bare
+    ``version`` + release-check banner stay public.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.api.health as health_module
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import Group, Role, User
+from app.models.settings import PlatformSettings
+
+_SECURITY_URL = "/api/v1/dashboards/security/summary"
+
+
+async def _ensure_settings(db: AsyncSession) -> None:
+    if await db.get(PlatformSettings, 1) is None:
+        db.add(PlatformSettings(id=1))
+        await db.flush()
+
+
+async def _user(
+    db: AsyncSession,
+    *,
+    is_superadmin: bool = False,
+    last_login: datetime | None = None,
+) -> User:
+    u = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@x.com",
+        display_name="T",
+        hashed_password=hash_password("OldPass123!"),
+        auth_source="local",
+        is_active=True,
+        is_superadmin=is_superadmin,
+        force_password_change=False,
+        password_changed_at=datetime.now(UTC),
+        last_login_at=last_login,
+    )
+    db.add(u)
+    await db.flush()
+    return u
+
+
+async def _grant_role(db: AsyncSession, user: User, perms: list[dict]) -> None:
+    """Attach a fresh group + role carrying ``perms`` to ``user``."""
+    role = Role(name=f"r-{uuid.uuid4().hex[:8]}", permissions=perms)
+    group = Group(name=f"g-{uuid.uuid4().hex[:8]}")
+    group.roles.append(role)
+    group.users.append(user)
+    db.add_all([role, group])
+    await db.flush()
+
+
+def _bearer(user: User) -> dict[str, str]:
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _seed_security_signals(db: AsyncSession) -> None:
+    """Seed one PII-bearing row in each panel so the detail lists are
+    non-empty for a privileged caller (and provably stripped otherwise)."""
+    # An unenrolled local user (MFA panel) — its last_login_at is PII.
+    await _user(db, last_login=datetime.now(UTC))
+    # A failed-login burst (source_ip is PII).
+    db.add(
+        AuditLog(
+            user_display_name="victim",
+            auth_source="local",
+            source_ip="203.0.113.7",
+            action="login",
+            resource_type="user",
+            resource_id="",
+            resource_display="victim",
+            result="denied",
+            timestamp=datetime.now(UTC),
+        )
+    )
+    # A permission change (actor is PII).
+    db.add(
+        AuditLog(
+            user_display_name="some-admin",
+            auth_source="local",
+            action="update",
+            resource_type="role",
+            resource_id=str(uuid.uuid4()),
+            resource_display="editor",
+            result="success",
+            timestamp=datetime.now(UTC),
+        )
+    )
+
+
+# ── M2: per-user PII is withheld from non-privileged callers ────────────────
+
+
+async def test_security_summary_strips_pii_for_unprivileged(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _ensure_settings(db_session)
+    await _seed_security_signals(db_session)
+    # A plain authenticated user with no groups / roles → not privileged.
+    plain = await _user(db_session)
+    await db_session.commit()
+
+    r = await client.get(_SECURITY_URL, headers=_bearer(plain))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Aggregate counts still render (tile not blank)...
+    assert body["mfa_total_local_users"] >= 1
+    assert body["failed_login_total"] >= 1
+    assert body["permission_change_count"] >= 1
+    # ...but every PII-bearing detail list is empty.
+    assert body["mfa_unenrolled"] == []
+    assert body["api_tokens_expiring"] == []
+    assert body["failed_login_top_sources"] == []
+    assert body["permission_changes"] == []
+
+
+async def test_security_summary_full_detail_for_superadmin(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _ensure_settings(db_session)
+    await _seed_security_signals(db_session)
+    admin = await _user(db_session, is_superadmin=True)
+    await db_session.commit()
+
+    r = await client.get(_SECURITY_URL, headers=_bearer(admin))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # The superadmin sees the source IP + actor that were stripped above.
+    assert any(row["source_ip"] == "203.0.113.7" for row in body["failed_login_top_sources"])
+    assert any(row["actor"] == "some-admin" for row in body["permission_changes"])
+    assert len(body["mfa_unenrolled"]) >= 1
+
+
+async def test_security_summary_full_detail_for_audit_reader(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A non-superadmin holding read/audit_log is privileged (no 403)."""
+    await _ensure_settings(db_session)
+    await _seed_security_signals(db_session)
+    reader = await _user(db_session)
+    await _grant_role(db_session, reader, [{"action": "read", "resource_type": "audit_log"}])
+    await db_session.commit()
+
+    r = await client.get(_SECURITY_URL, headers=_bearer(reader))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["failed_login_top_sources"], "audit reader should see the detail"
+
+
+async def test_security_summary_requires_auth(client: AsyncClient) -> None:
+    """The endpoint still requires authentication (CurrentUser)."""
+    r = await client.get(_SECURITY_URL)
+    assert r.status_code == 401, r.text
+
+
+# ── M5: unauthenticated platform-health never leaks str(exc) ────────────────
+
+
+async def test_platform_health_sanitises_error_details(client: AsyncClient, monkeypatch) -> None:
+    """Force every component check to raise with a secret-bearing message
+    and confirm none of it reaches the unauthenticated response body."""
+    secret = "postgresql://spatium:SUPERSECRET@db-internal.prod.local:5432/ddi"
+
+    class _BoomSession:
+        async def __aenter__(self):  # noqa: ANN001
+            raise RuntimeError(secret)
+
+        async def __aexit__(self, *a):  # noqa: ANN001
+            return False
+
+    # Postgres + the maintenance read both go through AsyncSessionLocal.
+    monkeypatch.setattr(health_module, "AsyncSessionLocal", lambda: _BoomSession())
+
+    # No Authorization header — this is the anonymous attack surface.
+    r = await client.get("/health/platform")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # The DSN must not appear anywhere in the serialised response.
+    assert secret not in r.text
+    pg = next(c for c in body["components"] if c["name"] == "postgres")
+    assert pg["status"] == "error"
+    assert pg["detail"] == "postgres error"
+    # Status semantics intact — an errored component degrades the rollup.
+    assert body["status"] == "degraded"
+
+
+# ── L6: appliance hostname/version gated behind auth ────────────────────────
+
+
+async def test_version_hides_appliance_fields_when_anonymous(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+) -> None:
+    from app.config import settings
+
+    await _ensure_settings(db_session)
+    await db_session.commit()
+    monkeypatch.setattr(settings, "appliance_mode", True)
+    monkeypatch.setattr(settings, "appliance_version", "2026.06.12-1")
+    monkeypatch.setattr(settings, "appliance_hostname", "ddi-prod-01")
+
+    r = await client.get("/api/v1/version")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Bare version + appliance_mode flag stay public...
+    assert body["version"]
+    assert body["appliance_mode"] is True
+    # ...but the host identity / patch level is withheld from anonymous callers.
+    assert body["appliance_hostname"] is None
+    assert body["appliance_version"] is None
+
+
+async def test_version_reveals_appliance_fields_when_authenticated(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+) -> None:
+    from app.config import settings
+
+    await _ensure_settings(db_session)
+    user = await _user(db_session)
+    await db_session.commit()
+    monkeypatch.setattr(settings, "appliance_mode", True)
+    monkeypatch.setattr(settings, "appliance_version", "2026.06.12-1")
+    monkeypatch.setattr(settings, "appliance_hostname", "ddi-prod-01")
+
+    r = await client.get("/api/v1/version", headers=_bearer(user))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["appliance_hostname"] == "ddi-prod-01"
+    assert body["appliance_version"] == "2026.06.12-1"
+
+
+async def test_version_invalid_token_treated_as_anonymous(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+) -> None:
+    """A garbage Bearer must not 401 the public endpoint — it falls back to
+    anonymous (appliance fields withheld), keeping the login-screen flow."""
+    from app.config import settings
+
+    await _ensure_settings(db_session)
+    await db_session.commit()
+    monkeypatch.setattr(settings, "appliance_mode", True)
+    monkeypatch.setattr(settings, "appliance_hostname", "ddi-prod-01")
+
+    r = await client.get("/api/v1/version", headers={"Authorization": "Bearer not-a-real-token"})
+    assert r.status_code == 200, r.text
+    assert r.json()["appliance_hostname"] is None

--- a/backend/tests/test_fix_m3_m4_auth_session.py
+++ b/backend/tests/test_fix_m3_m4_auth_session.py
@@ -1,0 +1,215 @@
+"""Regression tests for #400 / GHSA-mj4g-hw3m-62rm — M3 + M4.
+
+M3: changing a password (self-service AND admin reset) must revoke the
+    user's other outstanding sessions / refresh tokens. Before the fix a
+    session that existed before the change kept working, defeating the
+    point of rotating the credential.
+
+M4: ``force_password_change`` (set on fresh accounts, admin resets, and
+    flipped on by the login-time max-age check) was advisory only — the
+    API served every authenticated request to a must-change-password
+    token. After the fix every endpoint 403s EXCEPT the password-recovery
+    allowlist (change-password / logout / me / password-policy).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import (
+    create_access_token,
+    create_refresh_token,
+    hash_password,
+)
+from app.models.auth import User, UserSession
+from app.models.settings import PlatformSettings
+
+
+async def _ensure_settings(db: AsyncSession) -> None:
+    if await db.get(PlatformSettings, 1) is None:
+        db.add(PlatformSettings(id=1))
+        await db.flush()
+
+
+async def _user(
+    db: AsyncSession,
+    *,
+    password: str = "OldPass123!",
+    force_change: bool = False,
+    is_superadmin: bool = False,
+) -> User:
+    u = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@x.com",
+        display_name="T",
+        hashed_password=hash_password(password),
+        auth_source="local",
+        is_active=True,
+        is_superadmin=is_superadmin,
+        force_password_change=force_change,
+        password_changed_at=datetime.now(UTC),
+    )
+    db.add(u)
+    await db.flush()
+    return u
+
+
+async def _session(db: AsyncSession, user: User) -> UserSession:
+    """Create a real ``UserSession`` row and return it (its id is the jti)."""
+    _raw, refresh_hash = create_refresh_token(str(user.id))
+    now = datetime.now(UTC)
+    s = UserSession(
+        user_id=user.id,
+        refresh_token_hash=refresh_hash,
+        created_at=now,
+        last_seen_at=now,
+        expires_at=now + timedelta(days=7),
+        revoked=False,
+    )
+    db.add(s)
+    await db.flush()
+    return s
+
+
+def _bearer(user: User, session: UserSession | None = None) -> dict[str, str]:
+    jti = str(session.id) if session is not None else None
+    return {"Authorization": f"Bearer {create_access_token(str(user.id), jti=jti)}"}
+
+
+# ── M3: self-service change-password revokes OTHER sessions, spares caller ──
+
+
+async def test_change_password_revokes_other_sessions_spares_caller(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _ensure_settings(db_session)
+    user = await _user(db_session)
+    caller_session = await _session(db_session, user)
+    other_session = await _session(db_session, user)
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/auth/change-password",
+        json={"current_password": "OldPass123!", "new_password": "BrandNewPass1!"},
+        headers=_bearer(user, caller_session),
+    )
+    assert r.status_code == 204, r.text
+
+    await db_session.refresh(other_session)
+    await db_session.refresh(caller_session)
+    # The other session is revoked; the caller's own session survives.
+    assert other_session.revoked is True
+    assert caller_session.revoked is False
+
+
+async def test_change_password_wrong_current_does_not_revoke(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A failed change (wrong current password) must not touch sessions."""
+    await _ensure_settings(db_session)
+    user = await _user(db_session)
+    caller_session = await _session(db_session, user)
+    other_session = await _session(db_session, user)
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/auth/change-password",
+        json={"current_password": "WRONG-pass", "new_password": "BrandNewPass1!"},
+        headers=_bearer(user, caller_session),
+    )
+    assert r.status_code == 400, r.text
+    await db_session.refresh(other_session)
+    assert other_session.revoked is False
+
+
+# ── M3: admin reset revokes ALL of the target's sessions ────────────────────
+
+
+async def test_admin_reset_revokes_all_target_sessions(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _ensure_settings(db_session)
+    admin = await _user(db_session, is_superadmin=True)
+    target = await _user(db_session)
+    await _session(db_session, target)
+    await _session(db_session, target)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/users/{target.id}/reset-password",
+        json={"new_password": "AdminSetPass1!"},
+        headers=_bearer(admin),
+    )
+    assert r.status_code == 204, r.text
+
+    rows = (
+        (await db_session.execute(select(UserSession).where(UserSession.user_id == target.id)))
+        .scalars()
+        .all()
+    )
+    assert rows, "expected the target's sessions to still exist (just revoked)"
+    assert all(s.revoked for s in rows)
+    # The admin reset forces the target to change their password again.
+    await db_session.refresh(target)
+    assert target.force_password_change is True
+
+
+# ── M4: force_password_change gates every non-recovery endpoint ─────────────
+
+
+async def test_force_change_blocks_normal_endpoint(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _ensure_settings(db_session)
+    user = await _user(db_session, force_change=True, is_superadmin=True)
+    session = await _session(db_session, user)
+    await db_session.commit()
+
+    # A normal authenticated endpoint must 403 while the flag is set, even
+    # for a superadmin (the flag is independent of RBAC).
+    r = await client.get("/api/v1/users", headers=_bearer(user, session))
+    assert r.status_code == 403, r.text
+    assert "Password change required" in r.text
+
+
+async def test_force_change_allows_recovery_endpoints(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _ensure_settings(db_session)
+    user = await _user(db_session, force_change=True)
+    session = await _session(db_session, user)
+    await db_session.commit()
+    headers = _bearer(user, session)
+
+    # GET /auth/me must still work so the UI can render the change-password screen.
+    me = await client.get("/api/v1/auth/me", headers=headers)
+    assert me.status_code == 200, me.text
+    assert me.json()["force_password_change"] is True
+
+    # And the change-password endpoint itself must be reachable + clear the flag.
+    changed = await client.post(
+        "/api/v1/auth/change-password",
+        json={"current_password": "OldPass123!", "new_password": "RecoverPass1!"},
+        headers=headers,
+    )
+    assert changed.status_code == 204, changed.text
+    await db_session.refresh(user)
+    assert user.force_password_change is False
+
+
+async def test_cleared_flag_unblocks_endpoints(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Once the flag is cleared a fresh token reaches normal endpoints."""
+    await _ensure_settings(db_session)
+    user = await _user(db_session, force_change=False, is_superadmin=True)
+    session = await _session(db_session, user)
+    await db_session.commit()
+
+    r = await client.get("/api/v1/users", headers=_bearer(user, session))
+    assert r.status_code == 200, r.text

--- a/backend/tests/test_fix_m6_m7_l3_wiring.py
+++ b/backend/tests/test_fix_m6_m7_l3_wiring.py
@@ -1,0 +1,142 @@
+"""Regression tests for #400 / GHSA-mj4g-hw3m-62rm — global-wiring
+hardening cluster (M6 CORS, M7 demo-mode prod guard, L3 TrustedHost).
+
+M6: a wildcard ``*`` mixed with explicit CORS origins must NOT enable
+    credentials (the "reflect every Origin + send credentials" combo).
+M7: ``DEMO_MODE=1`` must hard-fail if real configured deployment data
+    (backup targets / integrations / auth providers) is present, so the
+    unlocked admin/admin demo seed can't silently leak onto prod.
+L3: TrustedHostMiddleware is wired from ``TRUSTED_HOSTS`` config and
+    rejects forged Host headers when restricted, while the ``["*"]``
+    default keeps existing deploys working.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import Settings, settings
+
+
+# --------------------------------------------------------------------------
+# M6 — CORS wildcard never co-exists with credentials
+# --------------------------------------------------------------------------
+def test_m6_plain_wildcard_collapses_and_disables_credentials() -> None:
+    s = Settings(cors_origins="*")
+    assert s.cors_origins_list == ["*"]
+    # Middleware keys allow_credentials off (list == ["*"]) → disabled.
+    assert (s.cors_origins_list != ["*"]) is False
+
+
+def test_m6_explicit_origins_enable_credentials() -> None:
+    s = Settings(cors_origins="https://a.example.com,https://b.example.com")
+    assert s.cors_origins_list == [
+        "https://a.example.com",
+        "https://b.example.com",
+    ]
+    # No wildcard present → credentials may be enabled for the pinned origins.
+    assert (s.cors_origins_list != ["*"]) is True
+
+
+def test_m6_wildcard_mixed_with_explicit_collapses_to_wildcard() -> None:
+    """The core M6 vuln: ``*`` mixed with an explicit origin previously
+    produced ``["*", "https://app"]`` (!= ["*"]) which flipped credentials
+    ON while ``*`` still reflected every Origin. Must collapse to ``["*"]``
+    so credentials stay OFF."""
+    for raw in (
+        "*,https://app.example.com",
+        "https://app.example.com,*",
+        "https://a.example.com, * ,https://b.example.com",
+    ):
+        s = Settings(cors_origins=raw)
+        assert s.cors_origins_list == ["*"], raw
+        # Therefore the middleware computes allow_credentials=False.
+        assert (s.cors_origins_list != ["*"]) is False, raw
+
+
+# --------------------------------------------------------------------------
+# L3 — TrustedHosts config + middleware wiring
+# --------------------------------------------------------------------------
+def test_l3_trusted_hosts_default_is_open() -> None:
+    s = Settings()
+    assert s.trusted_hosts_list == ["*"]
+
+
+def test_l3_trusted_hosts_explicit_list() -> None:
+    s = Settings(trusted_hosts="ddi.example.com, *.example.com")
+    assert s.trusted_hosts_list == ["ddi.example.com", "*.example.com"]
+
+
+def test_l3_trusted_hosts_wildcard_mixed_collapses() -> None:
+    s = Settings(trusted_hosts="ddi.example.com,*")
+    assert s.trusted_hosts_list == ["*"]
+
+
+def test_l3_trustedhost_middleware_is_wired() -> None:
+    """The middleware must actually be installed on the app stack."""
+    from starlette.middleware.trustedhost import TrustedHostMiddleware
+
+    from app.main import create_app
+
+    app = create_app()
+    classes = {m.cls for m in app.user_middleware}
+    assert TrustedHostMiddleware in classes
+
+
+async def test_l3_forged_host_rejected_when_restricted(monkeypatch) -> None:
+    """With TRUSTED_HOSTS pinned, a request carrying a foreign Host header
+    is 400'd by TrustedHostMiddleware; the allowed host still passes."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.main import create_app
+
+    monkeypatch.setattr(settings, "trusted_hosts", "allowed.example.com")
+    app = create_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://allowed.example.com") as ac:
+        ok = await ac.get("/health/live")
+        assert ok.status_code == 200
+        bad = await ac.get("/health/live", headers={"host": "evil.example.com"})
+        assert bad.status_code == 400
+
+
+# --------------------------------------------------------------------------
+# M7 — DEMO_MODE may not boot on a real install
+# --------------------------------------------------------------------------
+async def test_m7_demo_guard_noop_when_demo_off(db_session, monkeypatch) -> None:
+    """Guard is a no-op when DEMO_MODE is off, regardless of data."""
+    from app.main import _assert_demo_mode_not_on_prod_data
+
+    monkeypatch.setattr(settings, "demo_mode", False)
+    # Must not raise even if prod-signal tables hold rows.
+    await _assert_demo_mode_not_on_prod_data()
+
+
+async def test_m7_demo_guard_passes_on_empty_demo_install(monkeypatch) -> None:
+    """A genuine demo image has empty prod-signal tables — the guard must
+    let it boot (legitimate demo flow preserved)."""
+    from app.main import _assert_demo_mode_not_on_prod_data
+
+    monkeypatch.setattr(settings, "demo_mode", True)
+    await _assert_demo_mode_not_on_prod_data()
+
+
+async def test_m7_demo_guard_fails_on_prod_backup_target(db_session, monkeypatch) -> None:
+    """DEMO_MODE=1 with a configured backup target = a leaked demo flag on
+    a real install. Must hard-fail boot."""
+    from app.main import _assert_demo_mode_not_on_prod_data
+    from app.models.backup import BackupTarget
+
+    db_session.add(
+        BackupTarget(
+            name="prod-s3",
+            kind="s3",
+            config={"bucket": "prod"},
+            passphrase_encrypted=b"x",
+        )
+    )
+    await db_session.commit()
+
+    monkeypatch.setattr(settings, "demo_mode", True)
+    with pytest.raises(RuntimeError, match="DEMO_MODE=1"):
+        await _assert_demo_mode_not_on_prod_data()

--- a/backend/tests/test_fix_m8_l1_l2_frontend.py
+++ b/backend/tests/test_fix_m8_l1_l2_frontend.py
@@ -1,0 +1,86 @@
+"""Regression tests for SECURITY #400 / GHSA-mj4g-hw3m-62rm — cluster M8.
+
+M8: the nmap live-scan SSE endpoint used to authenticate ONLY via a
+``?token=<jwt>`` query argument. Tokens in URLs leak through nginx /
+proxy access logs, browser history, and the ``Referer`` header. The
+fix switches the frontend consumer to ``fetch()`` + ``ReadableStream``
+so the token rides the ``Authorization: Bearer`` header, and the
+server (``app.api.v1.nmap.router._extract_stream_token``) now prefers
+that header — keeping ``?token=`` only as a back-compat fallback.
+
+These tests pin the resolver's precedence + failure behaviour so a
+future refactor can't silently re-open the URL-token-only path.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException, Request
+
+from app.api.v1.nmap.router import _extract_stream_token
+
+
+def _request(headers: dict[str, str] | None = None) -> Request:
+    """Build a minimal Starlette Request carrying the given headers.
+
+    ``_extract_stream_token`` only ever reads ``request.headers``, so a
+    bare ASGI ``http`` scope with an encoded header list is enough — no
+    app, DB, or event loop required.
+    """
+    raw = [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/v1/nmap/scans/x/stream",
+        "headers": raw,
+    }
+    return Request(scope)
+
+
+def test_authorization_header_is_preferred_over_query_token() -> None:
+    # When both are present the header wins — the legacy URL token is
+    # never the one that gets used if a header is supplied.
+    req = _request({"Authorization": "Bearer header-token"})
+    assert _extract_stream_token(req, "query-token") == "header-token"
+
+
+def test_authorization_header_is_case_insensitive() -> None:
+    # HTTP header names are case-insensitive; the scheme match must be too.
+    req = _request({"authorization": "bearer mixed-case-token"})
+    assert _extract_stream_token(req, None) == "mixed-case-token"
+
+
+def test_query_token_is_accepted_as_back_compat_fallback() -> None:
+    # No header → fall back to the query arg so older clients / bookmarks
+    # keep working.
+    req = _request({})
+    assert _extract_stream_token(req, "query-token") == "query-token"
+
+
+def test_blank_bearer_header_falls_through_to_query_token() -> None:
+    # A header of literally ``Bearer `` (empty token) must not be taken as
+    # a valid credential — fall through to the query arg.
+    req = _request({"Authorization": "Bearer    "})
+    assert _extract_stream_token(req, "query-token") == "query-token"
+
+
+def test_non_bearer_authorization_scheme_is_ignored() -> None:
+    # A Basic / other scheme isn't a bearer token; fall back to the query.
+    req = _request({"Authorization": "Basic Zm9vOmJhcg=="})
+    assert _extract_stream_token(req, "query-token") == "query-token"
+
+
+def test_missing_both_header_and_query_raises_401() -> None:
+    # No header AND no query token → 401, not a silent anonymous stream.
+    req = _request({})
+    with pytest.raises(HTTPException) as exc:
+        _extract_stream_token(req, None)
+    assert exc.value.status_code == 401
+
+
+def test_empty_query_token_with_no_header_raises_401() -> None:
+    # ``?token=`` with an empty value is not a credential.
+    req = _request({})
+    with pytest.raises(HTTPException) as exc:
+        _extract_stream_token(req, "")
+    assert exc.value.status_code == 401

--- a/backend/tests/test_supervisor_heartbeat_authz.py
+++ b/backend/tests/test_supervisor_heartbeat_authz.py
@@ -1,0 +1,125 @@
+"""Regression tests for the supervisor /heartbeat authentication gate
+(GHSA-mj4g-hw3m-62rm / #400 C1).
+
+The vulnerability: the no-cert fallback validity check was
+``row.state == APPROVED or (session_token and verify(...))``. Python ``or``
+short-circuits, so any APPROVED appliance was accepted with NO cert AND NO
+session token — anyone who knew an appliance UUID could drive the heartbeat,
+read the decrypted k3s cluster-join token, and overwrite control-plane state.
+
+The fix: every no-cert heartbeat now REQUIRES a valid session token (UUID
+alone is insufficient), and the cluster-admin join token is only returned over
+a cert-authenticated (mTLS) request.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import encrypt_str
+from app.models.appliance import (
+    APPLIANCE_STATE_APPROVED,
+    DESIRED_CLUSTER_ROLE_MEMBER,
+    Appliance,
+)
+from app.models.settings import PlatformSettings
+from app.services.appliance.ca import generate_session_token
+
+
+async def _approved_appliance(
+    db: AsyncSession, *, member_join: bool = False
+) -> tuple[Appliance, str]:
+    s = await db.get(PlatformSettings, 1)
+    if s is None:
+        s = PlatformSettings(id=1)
+        db.add(s)
+    s.supervisor_registration_enabled = True
+    token, token_hash = generate_session_token()
+    der = os.urandom(32)
+    row = Appliance(
+        id=uuid.uuid4(),
+        hostname="cp-1",
+        public_key_der=der,
+        public_key_fingerprint=hashlib.sha256(der).hexdigest(),
+        state=APPLIANCE_STATE_APPROVED,
+        deployment_kind="appliance",
+        appliance_variant="control-plane",
+        session_token_hash=token_hash,
+    )
+    if member_join:
+        row.desired_cluster_role = DESIRED_CLUSTER_ROLE_MEMBER
+        row.desired_k3s_join_token_encrypted = encrypt_str("K10deadbeef::node:abc123")
+    db.add(row)
+    await db.flush()
+    await db.commit()
+    return row, token
+
+
+async def test_heartbeat_with_valid_session_token_succeeds(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The legitimate non-mTLS path: an approved appliance heartbeating with
+    its valid session token is accepted (this is the path the host-config
+    delivery tests rely on)."""
+    row, token = await _approved_appliance(db_session)
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={"appliance_id": str(row.id), "session_token": token},
+    )
+    assert r.status_code == 200, r.text
+
+
+async def test_heartbeat_uuid_only_is_rejected(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """C1: an APPROVED appliance UUID with NO cert and NO session token must
+    be rejected — the credential-less short-circuit is gone."""
+    row, _token = await _approved_appliance(db_session)
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={"appliance_id": str(row.id)},
+    )
+    assert r.status_code == 403, r.text
+
+
+async def test_heartbeat_wrong_session_token_is_rejected(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    row, _token = await _approved_appliance(db_session)
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={"appliance_id": str(row.id), "session_token": "not-the-real-token"},
+    )
+    assert r.status_code == 403, r.text
+
+
+async def test_unknown_appliance_uuid_is_rejected(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # Module must be enabled or the endpoint 404s for an unrelated reason.
+    await _approved_appliance(db_session)
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={"appliance_id": str(uuid.uuid4()), "session_token": "x"},
+    )
+    assert r.status_code == 403, r.text
+
+
+async def test_join_token_not_returned_over_session_token_path(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """C1 defence-in-depth: the cluster-admin k3s join token must NOT be
+    handed back over the credential-but-non-cert (session-token) path — only
+    over an mTLS (cert-authenticated) heartbeat."""
+    row, token = await _approved_appliance(db_session, member_join=True)
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={"appliance_id": str(row.id), "session_token": token},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["desired_k3s_join_token"] is None

--- a/backend/tests/test_time_bound_grants_api.py
+++ b/backend/tests/test_time_bound_grants_api.py
@@ -77,8 +77,18 @@ async def test_create_requires_admin_on_group(
 
 
 async def test_create_and_audit(client: AsyncClient, db_session: AsyncSession) -> None:
+    # The caller needs ``admin`` on ``group`` to reach the endpoint AND must
+    # itself hold the permission it grants — the #400/C4 privilege ceiling
+    # (caller_can_grant) forbids a delegated group-admin from minting a
+    # time-bound grant for a permission they don't possess (an escalation
+    # path). So admin1 holds ``write:subnet`` too.
     user, token = await _user_with_perms(
-        db_session, permissions=[{"action": "admin", "resource_type": "group"}], username="admin1"
+        db_session,
+        permissions=[
+            {"action": "admin", "resource_type": "group"},
+            {"action": "write", "resource_type": "subnet"},
+        ],
+        username="admin1",
     )
     target = await _target_group(db_session)
     r = await client.post(

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -31,6 +31,44 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # ── Security response headers (SECURITY #400, L2) ──────────────
+    # Applied at the server level so they cover the SPA, static
+    # assets, and proxied /api responses. NOTE: nginx ``add_header``
+    # does NOT inherit into a location that declares its own
+    # ``add_header`` — the @starting + static-asset locations below
+    # re-emit these via ``include`` of the same snippet.
+    #
+    # CSP rationale (verified against the Vite build):
+    #   * default-src 'self'    — lock everything to same origin.
+    #   * script-src 'self'     — Vite emits external module scripts
+    #                             only (no inline <script>, no eval /
+    #                             new Function in the bundle), so NO
+    #                             'unsafe-inline' / 'unsafe-eval'.
+    #   * style-src 'self' 'unsafe-inline'
+    #                           — Tailwind ships an external stylesheet,
+    #                             but recharts / transition deps inject
+    #                             <style> elements at runtime and React
+    #                             style props set inline styles. Those
+    #                             genuinely need 'unsafe-inline' for
+    #                             STYLES ONLY (style injection can't
+    #                             execute script, so the risk is low).
+    #   * img-src 'self' data:  — favicons / small logos are data URIs.
+    #   * connect-src 'self'    — all XHR/fetch/SSE go to same-origin
+    #                             /api (LLM providers are proxied through
+    #                             the backend, never called from the SPA).
+    #   * font-src 'self'       — fonts are self-hosted.
+    #   * frame-ancestors 'none'— clickjacking defence (pairs with
+    #                             X-Frame-Options: DENY for old browsers).
+    #   * base-uri / form-action / object-src locked down.
+    set $spatium_csp "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'";
+    add_header Content-Security-Policy $spatium_csp always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+    # HSTS is intentionally NOT set here: this image's server block is
+    # plain HTTP (TLS terminates upstream at an ingress / the appliance
+    # nginx). The appliance HTTPS server block sets HSTS itself.
+
     # Re-resolve the upstream periodically so a container / Pod restart
     # that hands out a new IP doesn't strand nginx on the old one. The
     # nameserver list comes from /etc/resolv.conf at container start —
@@ -87,6 +125,12 @@ server {
         # Surface what the upstream said so a curl debugger can tell
         # "upstream is unreachable" from "upstream timed out".
         add_header X-Upstream-Status $upstream_status always;
+        # Re-emit security headers (SECURITY #400, L2) — a location
+        # with its own add_header does NOT inherit the server-level set.
+        add_header Content-Security-Policy $spatium_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer" always;
         try_files /_starting.html =503;
     }
 
@@ -190,6 +234,12 @@ server {
     location ~* \.(js|css|woff2?|png|svg|ico)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        # Re-emit security headers (SECURITY #400, L2) — a location
+        # with its own add_header does NOT inherit the server-level set.
+        add_header Content-Security-Policy $spatium_csp always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "no-referrer" always;
     }
 
     gzip on;

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,26 @@
 import { useState, useCallback } from "react";
 import { authApi, type LoginResponse } from "@/lib/api";
 
+// SECURITY (#400, L1): both the JWT access token and the refresh
+// token are persisted in localStorage. This is XSS-stealable —
+// any script injected into the SPA's origin can read
+// localStorage.getItem("access_token") / "refresh_token" and
+// exfiltrate a full session (including the long-lived refresh
+// token). The CSP added in #400/L2 (script-src 'self', no
+// 'unsafe-inline'/'unsafe-eval') is the primary mitigation, but
+// localStorage remains the weak link.
+//
+// INTENDED FIX (deferred — too large for this PR): move the refresh
+// token into an HttpOnly + Secure + SameSite=Strict cookie issued by
+// the backend (/auth/login + /auth/refresh), and keep ONLY the
+// short-lived access token in JS memory (a module-level variable /
+// React context), never localStorage. The axios interceptor in
+// lib/api.ts would then call /auth/refresh with credentials:'include'
+// and read the new access token from the JSON body, with the cookie
+// invisible to JS. That refactor touches the backend auth router,
+// the login/callback pages, and this hook together, so it's tracked
+// as a follow-up rather than bundled into the #400 hardening pass.
+
 export function useAuth() {
   const [isAuthenticated, setIsAuthenticated] = useState(
     () => !!localStorage.getItem("access_token"),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -15,7 +15,12 @@ function createClient(): AxiosInstance {
     paramsSerializer: { indexes: null },
   });
 
-  // Attach Bearer token from localStorage on every request
+  // Attach Bearer token from localStorage on every request.
+  // SECURITY (#400, L1): access + refresh tokens live in
+  // localStorage and are therefore XSS-stealable. The CSP shipped in
+  // #400/L2 is the primary mitigation; the intended structural fix
+  // (refresh token -> HttpOnly cookie, access token in memory only)
+  // is documented in hooks/useAuth.ts and deferred to a follow-up.
   client.interceptors.request.use((config) => {
     const token = localStorage.getItem("access_token");
     if (token) {
@@ -10929,15 +10934,68 @@ export const nmapApi = {
         skipped_addresses: string[];
       }>(`/nmap/scans/${scanId}/stamp-discovered`)
       .then((r) => r.data),
-  // The SSE stream isn't fetched via axios — callers use `EventSource`
-  // pointed at the URL returned here. Auth piggybacks on a query
-  // token because EventSource can't set Authorization headers.
+  // SECURITY (#400, M8): the SSE stream is consumed via `streamScan`
+  // (fetch + ReadableStream) so the access token rides the
+  // Authorization header instead of a `?token=` query arg that would
+  // leak through proxy access logs / browser history / Referer.
+  // `streamUrl` is kept only for callers that build the path; it no
+  // longer embeds the token.
   streamUrl: (id: string) => {
-    const token = localStorage.getItem("access_token") ?? "";
     const base = API_BASE.replace(/\/$/, "");
-    return `${base}/nmap/scans/${id}/stream?token=${encodeURIComponent(token)}`;
+    return `${base}/nmap/scans/${id}/stream`;
   },
 };
+
+/**
+ * Stream live nmap scan output as SSE. Mirrors `streamChatTurn` /
+ * `streamApplianceContainerLogs` — uses `fetch` (not `EventSource`)
+ * so the Bearer token rides the Authorization header rather than a
+ * `?token=` query arg (SECURITY #400, M8). Yields `{ data, done }`
+ * for each frame: `done` carries the terminal event payload (the
+ * scan's final status) when the server emits `event: done`. Cancel
+ * via the AbortSignal.
+ */
+export async function* streamNmapScan(
+  scanId: string,
+  signal?: AbortSignal,
+): AsyncIterable<{ data: string; done: boolean }> {
+  const token = localStorage.getItem("access_token");
+  const url = nmapApi.streamUrl(scanId);
+  const res = await fetch(url, {
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      Accept: "text/event-stream",
+    },
+    signal,
+  });
+  if (!res.ok || !res.body) {
+    throw new Error(`scan stream failed: HTTP ${res.status}`);
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const frames = buffer.split("\n\n");
+    buffer = frames.pop() ?? "";
+    for (const frame of frames) {
+      if (!frame.trim() || frame.startsWith(":")) continue; // skip heartbeats
+      let isDone = false;
+      let data = "";
+      for (const line of frame.split("\n")) {
+        if (line.startsWith("event:") && line.slice(6).trim() === "done") {
+          isDone = true;
+        } else if (line.startsWith("data:")) {
+          data += line.slice(5).replace(/^ /, "");
+        }
+      }
+      yield { data, done: isDone };
+      if (isDone) return;
+    }
+  }
+}
 
 // ── Built-in network tools (issue #58) ──────────────────────────────
 //

--- a/frontend/src/pages/nmap/NmapScanLiveViewer.tsx
+++ b/frontend/src/pages/nmap/NmapScanLiveViewer.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, StopCircle } from "lucide-react";
-import { type NmapScanRead, type NmapScanStatus, nmapApi } from "@/lib/api";
+import {
+  type NmapScanRead,
+  type NmapScanStatus,
+  nmapApi,
+  streamNmapScan,
+} from "@/lib/api";
 import { HeaderButton } from "@/components/ui/header-button";
 import { cn } from "@/lib/utils";
 import { NmapResultPanel } from "./NmapResultPanel";
@@ -42,12 +47,15 @@ export interface NmapScanLiveViewerProps {
 /**
  * Live SSE-driven output viewer plus parsed-summary panel.
  *
- * The viewer opens an EventSource against
- * ``/api/v1/nmap/scans/{id}/stream`` and appends every ``data:``
- * frame to a rolling buffer. When the ``done`` event arrives we
- * refetch the full scan record so the parsed summary (open ports,
- * OS guess, exit code) and final stdout buffer are rendered from
- * the persisted row.
+ * The viewer streams ``/api/v1/nmap/scans/{id}/stream`` via
+ * ``fetch()`` + ``ReadableStream`` (not ``EventSource``) so the
+ * access token rides the ``Authorization`` header instead of a
+ * ``?token=`` query arg — SECURITY (#400, M8): tokens in URLs leak
+ * through proxy logs / browser history / Referer. Every ``data:``
+ * frame is appended to a rolling buffer. When the ``done`` event
+ * arrives we refetch the full scan record so the parsed summary
+ * (open ports, OS guess, exit code) and final stdout buffer are
+ * rendered from the persisted row.
  */
 export function NmapScanLiveViewer({
   scanId,
@@ -84,28 +92,40 @@ export function NmapScanLiveViewer({
     setLines([]);
     setStreamStatus("connecting");
 
-    const url = nmapApi.streamUrl(scanId);
-    const es = new EventSource(url);
+    // SECURITY (#400, M8): stream via fetch() so the access token
+    // rides the Authorization header (see streamNmapScan) instead of
+    // a leak-prone ``?token=`` query arg. Cancel via AbortController
+    // on unmount / scanId change.
+    const ctrl = new AbortController();
 
-    es.onopen = () => setStreamStatus("open");
-    es.onmessage = (ev) => {
-      setLines((prev) => [...prev, ev.data]);
-    };
-    es.addEventListener("done", () => {
-      setStreamStatus("done");
-      es.close();
-      qc.invalidateQueries({ queryKey: ["nmap-scan", scanId] });
-      qc.invalidateQueries({ queryKey: ["nmap-scans"] });
-    });
-    es.onerror = () => {
-      // EventSource auto-reconnects; surface the state once but don't
-      // tear it down — server-side close after `done` fires onerror
-      // too in some browsers.
-      setStreamStatus((s) => (s === "done" ? s : "error"));
-    };
+    (async () => {
+      try {
+        for await (const { data, done } of streamNmapScan(
+          scanId,
+          ctrl.signal,
+        )) {
+          if (ctrl.signal.aborted) return;
+          setStreamStatus((s) => (s === "connecting" ? "open" : s));
+          if (done) {
+            setStreamStatus("done");
+            qc.invalidateQueries({ queryKey: ["nmap-scan", scanId] });
+            qc.invalidateQueries({ queryKey: ["nmap-scans"] });
+            return;
+          }
+          if (data) setLines((prev) => [...prev, data]);
+        }
+      } catch {
+        // Aborting the fetch on unmount throws — swallow it. Any real
+        // network/HTTP failure surfaces as the "error" badge; the
+        // polling refetch above still drives the final summary.
+        if (!ctrl.signal.aborted) {
+          setStreamStatus((s) => (s === "done" ? s : "error"));
+        }
+      }
+    })();
 
     return () => {
-      es.close();
+      ctrl.abort();
     };
   }, [scanId, qc]);
 


### PR DESCRIPTION
Remediates the findings from the internal auth-bypass / unauthenticated-access review tracked in #400. **Closes #400.**

Pre-prod project, no field deployments, so this ships as one public PR (no coordinated-disclosure split, no CVE) — the draft advisory has been closed.

## Critical
- **C1 — supervisor `/heartbeat`** accepted any approved appliance UUID with no cert and no session token (an `or row.state == APPROVED` short-circuit), then returned the decrypted k3s cluster-join token + let the caller overwrite control-plane state → unauthenticated cluster-admin. Now a valid credential (session token) is required on every no-cert heartbeat, and the join token is returned only over mTLS. Legitimate paths unchanged (approved → mTLS cert; pending → session token).

## High (post-auth privilege boundaries)
- **C2 — AI proposal apply** had no RBAC gate (a Viewer could write IPAM/DNS/DHCP via propose→apply). `apply_proposal` now enforces the operation's declared `(action, resource_type)`; MCP `tools/call` is restricted to the read-only tool set (M1).
- **C3 — `dns_zone`-scoped API token** could read/export any zone (IDOR). Scope is now enforced in the shared `_require_zone` path + list/export filtering (and an adjacent bulk-delete gap was closed).
- **C4 — role/group editing** had no privilege ceiling (a delegated `admin:role` could mint `{*,*}` and self-escalate). New `caller_can_grant` ceiling: a non-superadmin may only grant permissions they hold, never a wildcard — wired into roles, group role-attachment, and time-bound grants.

## Hardening (medium / low)
- **M3/M4** revoke sessions on password change/reset; enforce `force_password_change`/expiry as a real access gate (with a recovery allowlist).
- **M2/M5/L6/L4** gate the security dashboard + strip PII; sanitise `/health/platform` for anonymous callers; hide `/version` appliance fields from anonymous; document the latent ip_space/ip_block token-scope TODO.
- **M6/M7/L3** wildcard-mixed CORS can't enable credentials; demo-mode prod-coexistence boot guard; `TrustedHostMiddleware` (default open, operator-restrictable).
- **L5** shared SSRF advisory guard on integration test-connection paths (loopback/link-local/metadata; RFC1918 LAN stays allowed).
- **M8/L1/L2** nmap SSE token moves to the `Authorization` header; localStorage-XSS risk documented; CSP / X-Frame-Options / Referrer-Policy / nosniff / HSTS on the frontend + appliance nginx.

## Tests & verification
~55 new regression tests across the findings (incl. a C1 test that an approved UUID with no cert/token is rejected). Verified locally: backend suite green, `ruff` + `black` + `mypy app` clean, frontend typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)