### PR TITLE
feat(appliance): #402 Cluster tab — fold Pods + etcd, add live Overview dashboard

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -2076,6 +2076,51 @@ def read_cluster_health() -> dict[str, object] | None:
     return summary
 
 
+# Issue #402 — host disk partitions for the Cluster → Overview dashboard.
+# Reported INSIDE the cluster_health dict (which the backend stores verbatim
+# to the appliance.cluster_health JSONB column), so this needs no new
+# heartbeat field / column / migration. statvfs the host filesystems the
+# supervisor can reach: the active root slot (``/`` via the #402 host-root
+# mount), the ``/var`` data partition (via the release-state bind, which
+# itself lives on /var), and the ESP (``/boot/efi-host``). Best-effort per
+# target — a missing mount (e.g. an older supervisor pod without the
+# host-root mount) is skipped, so the list degrades to whatever's reachable.
+_DISK_TARGETS = (
+    ("/", "OS (root slot)", "/host-root"),
+    ("/var", "Data", "/var/lib/spatiumddi-host/release-state"),
+    ("/boot/efi", "ESP", "/boot/efi-host"),
+)
+
+
+def read_host_disk_partitions() -> list[dict[str, object]]:
+    """statvfs the reachable host partitions → used/total bytes per mount.
+
+    Powers the Cluster → Overview node cards (#402). Each entry:
+    ``{"mount", "label", "total_bytes", "used_bytes"}`` — ``df``-style, where
+    ``used = (blocks - free) * fragment_size``. Returns the partitions that
+    could be statvfs'd (skips any whose mount isn't present in this pod).
+    """
+    out: list[dict[str, object]] = []
+    for mount, label, path in _DISK_TARGETS:
+        try:
+            st = os.statvfs(path)
+        except OSError:
+            continue
+        total = st.f_blocks * st.f_frsize
+        if total <= 0:
+            continue
+        used = (st.f_blocks - st.f_bfree) * st.f_frsize
+        out.append(
+            {
+                "mount": mount,
+                "label": label,
+                "total_bytes": int(total),
+                "used_bytes": int(used),
+            }
+        )
+    return out
+
+
 def read_node_ip() -> str | None:
     """Return this node's k3s-registered InternalIP (#272 Phase 7b).
 
@@ -2318,6 +2363,16 @@ def collect() -> dict[str, object]:
 
     slot_a_version, slot_b_version = read_slot_versions()
     cluster_health = read_cluster_health() if is_appliance else None
+    # #402 — fold host disk partitions into the cluster_health dict (stored
+    # verbatim by the backend; no schema change). Only on appliance hosts;
+    # skipped entirely when nothing was reachable so we never ship an empty key.
+    if is_appliance:
+        _partitions = read_host_disk_partitions()
+        if _partitions:
+            cluster_health = {
+                **(cluster_health or {}),
+                "host_disk_partitions": _partitions,
+            }
     k3s_version = read_k3s_version() if is_appliance else None
     kubeconfig = read_kubeconfig() if is_appliance else None
     k3s_api_cert_expires_at = read_k3s_api_cert_expiry() if is_appliance else None

--- a/backend/app/api/v1/appliance/cluster.py
+++ b/backend/app/api/v1/appliance/cluster.py
@@ -16,14 +16,20 @@ from __future__ import annotations
 
 import asyncio
 import json
+from typing import Any
 
 import anyio
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.deps import DB
 from app.core.permissions import require_permission
+from app.db import AsyncSessionLocal
+from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
 from app.services.appliance import k8s
 from app.services.appliance.cluster_health import cluster_unavailable, get_cluster_health
 
@@ -35,6 +41,13 @@ router = APIRouter()
 # spot: kubelet's Summary API itself only refreshes every ~1–10 s, and a
 # handful of kubeapi calls per tick is cheap, but it feels live in the UI.
 _STREAM_INTERVAL_S = 2.0
+
+
+class HostPartition(BaseModel):
+    mount: str
+    label: str
+    total_bytes: int
+    used_bytes: int
 
 
 class NodeVitals(BaseModel):
@@ -61,6 +74,8 @@ class NodeVitals(BaseModel):
     memory_available_bytes: int | None = None
     fs_used_bytes: int | None = None
     fs_capacity_bytes: int | None = None
+    # #402 — host partitions (root slot / var / ESP) from the supervisor.
+    host_disk_partitions: list[HostPartition] = []
 
 
 class PodSummary(BaseModel):
@@ -108,13 +123,40 @@ class ClusterHealth(BaseModel):
     top_pods_mem: list[PodSummary]
 
 
+async def _merge_host_partitions(db: AsyncSession, snap: dict[str, Any]) -> None:
+    """Attach supervisor-reported host partitions to each node in ``snap``.
+
+    The api pod is a container and can't see host partitions — the supervisor
+    statvfs's them and ships them inside its ``cluster_health`` JSONB (#402).
+    We match by hostname == kube node name. Mutates ``snap`` in place.
+    """
+    if not snap.get("available") or not snap.get("nodes"):
+        return
+    rows = (
+        await db.execute(
+            select(Appliance.hostname, Appliance.cluster_health).where(
+                Appliance.state == APPLIANCE_STATE_APPROVED
+            )
+        )
+    ).all()
+    pmap: dict[str, list[dict[str, Any]]] = {}
+    for hostname, ch in rows:
+        if hostname and isinstance(ch, dict):
+            parts = ch.get("host_disk_partitions")
+            if isinstance(parts, list) and parts:
+                pmap[hostname] = parts
+    for node in snap["nodes"]:
+        if node["name"] in pmap:
+            node["host_disk_partitions"] = pmap[node["name"]]
+
+
 @router.get(
     "/health",
     response_model=ClusterHealth,
     dependencies=[Depends(require_permission("read", "appliance"))],
     summary="Cluster health snapshot (nodes + pods + live usage)",
 )
-async def cluster_health() -> ClusterHealth:
+async def cluster_health(db: DB) -> ClusterHealth:
     try:
         # Off-loop: the gather is a handful of blocking stdlib kubeapi calls.
         snap = await anyio.to_thread.run_sync(get_cluster_health)
@@ -123,6 +165,7 @@ async def cluster_health() -> ClusterHealth:
             status.HTTP_503_SERVICE_UNAVAILABLE,
             f"kubeapi unreachable from api: {exc}",
         )
+    await _merge_host_partitions(db, snap)
     return ClusterHealth(**snap)
 
 
@@ -146,6 +189,10 @@ async def cluster_health_stream(request: Request) -> StreamingResponse:
                 break
             try:
                 snap = await anyio.to_thread.run_sync(get_cluster_health)
+                # Short-lived session per tick (don't hold a connection open
+                # for the whole stream); cheap single-row-per-node lookup.
+                async with AsyncSessionLocal() as db:
+                    await _merge_host_partitions(db, snap)
             except k8s.KubeapiUnavailableError as exc:
                 snap = cluster_unavailable(f"kubeapi unreachable: {exc}")
             except Exception as exc:  # noqa: BLE001 — never let the stream die

--- a/backend/app/api/v1/appliance/cluster.py
+++ b/backend/app/api/v1/appliance/cluster.py
@@ -1,0 +1,166 @@
+"""Cluster health endpoints — issue #402 ("Cluster → Overview" dashboard).
+
+Mounted at ``/api/v1/appliance/cluster``:
+
+    GET  /health          one-shot snapshot (initial paint, MCP, scripting)
+    GET  /health/stream   SSE — a fresh snapshot every ~2 s (live dashboard)
+
+Both read the k3s cluster *underneath* the appliance via the api pod's
+ServiceAccount (nodes + pods + kubelet Summary API). Live CPU / memory come
+from the kubelet Summary API (``nodes/proxy``) because the appliance ships no
+metrics-server / Prometheus — same source the TTY console uses. See
+``services/appliance/cluster_health.py`` for the gather.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import anyio
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from app.core.permissions import require_permission
+from app.services.appliance import k8s
+from app.services.appliance.cluster_health import cluster_unavailable, get_cluster_health
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+# How often the SSE stream re-gathers + pushes a snapshot. 2 s is the sweet
+# spot: kubelet's Summary API itself only refreshes every ~1–10 s, and a
+# handful of kubeapi calls per tick is cheap, but it feels live in the UI.
+_STREAM_INTERVAL_S = 2.0
+
+
+class NodeVitals(BaseModel):
+    name: str
+    ready: bool
+    roles: list[str]
+    schedulable: bool
+    kubelet_version: str | None = None
+    os_image: str | None = None
+    kernel: str | None = None
+    container_runtime: str | None = None
+    architecture: str | None = None
+    internal_ip: str | None = None
+    age_seconds: int | None = None
+    memory_pressure: bool = False
+    disk_pressure: bool = False
+    pid_pressure: bool = False
+    cpu_capacity_cores: float | None = None
+    memory_capacity_bytes: int | None = None
+    pods_capacity: int | None = None
+    pods_running: int = 0
+    cpu_usage_cores: float | None = None
+    memory_working_set_bytes: int | None = None
+    memory_available_bytes: int | None = None
+    fs_used_bytes: int | None = None
+    fs_capacity_bytes: int | None = None
+
+
+class PodSummary(BaseModel):
+    name: str
+    namespace: str
+    component: str | None = None
+    node: str | None = None
+    phase: str
+    state: str
+    ready: str
+    restarts: int
+    age_seconds: int | None = None
+    cpu_usage_cores: float | None = None
+    memory_working_set_bytes: int | None = None
+
+
+class WorkloadHealth(BaseModel):
+    component: str
+    kind: str | None = None
+    ready: int
+    total: int
+    restarts: int
+    status: str
+
+
+class ClusterHealth(BaseModel):
+    available: bool
+    detail: str | None = None
+    nodes_total: int
+    nodes_ready: int
+    pods_total: int
+    pods_running: int
+    pods_by_phase: dict[str, int]
+    kubelet_version: str | None = None
+    is_ha: bool
+    control_plane_nodes: int
+    metrics_available: bool
+    cpu_usage_cores: float | None = None
+    cpu_capacity_cores: float | None = None
+    memory_working_set_bytes: int | None = None
+    memory_capacity_bytes: int | None = None
+    nodes: list[NodeVitals]
+    workloads: list[WorkloadHealth]
+    top_pods_cpu: list[PodSummary]
+    top_pods_mem: list[PodSummary]
+
+
+@router.get(
+    "/health",
+    response_model=ClusterHealth,
+    dependencies=[Depends(require_permission("read", "appliance"))],
+    summary="Cluster health snapshot (nodes + pods + live usage)",
+)
+async def cluster_health() -> ClusterHealth:
+    try:
+        # Off-loop: the gather is a handful of blocking stdlib kubeapi calls.
+        snap = await anyio.to_thread.run_sync(get_cluster_health)
+    except k8s.KubeapiUnavailableError as exc:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            f"kubeapi unreachable from api: {exc}",
+        )
+    return ClusterHealth(**snap)
+
+
+@router.get(
+    "/health/stream",
+    dependencies=[Depends(require_permission("read", "appliance"))],
+    summary="Stream cluster health snapshots as SSE (~2s cadence)",
+)
+async def cluster_health_stream(request: Request) -> StreamingResponse:
+    """Push a fresh cluster snapshot every ``_STREAM_INTERVAL_S`` seconds.
+
+    Server-driven (no client polling): the browser opens one connection and
+    animates each frame. A momentarily-unreachable kubeapi emits an
+    ``available: false`` frame (with a reason) rather than dropping the
+    stream, so the dashboard self-heals when the control plane settles.
+    """
+
+    async def event_source():
+        while True:
+            if await request.is_disconnected():
+                break
+            try:
+                snap = await anyio.to_thread.run_sync(get_cluster_health)
+            except k8s.KubeapiUnavailableError as exc:
+                snap = cluster_unavailable(f"kubeapi unreachable: {exc}")
+            except Exception as exc:  # noqa: BLE001 — never let the stream die
+                logger.warning("cluster_health_stream_gather_failed", error=str(exc))
+                snap = cluster_unavailable("health gather failed; retrying")
+            yield f"data: {json.dumps(snap)}\n\n"
+            await asyncio.sleep(_STREAM_INTERVAL_S)
+
+    # X-Accel-Buffering disables nginx buffering so each frame arrives ASAP —
+    # same pattern as the container-log + AI-chat SSE surfaces.
+    return StreamingResponse(
+        event_source(),
+        media_type="text/event-stream",
+        headers={
+            "X-Accel-Buffering": "no",
+            "Cache-Control": "no-cache",
+        },
+    )

--- a/backend/app/api/v1/appliance/router.py
+++ b/backend/app/api/v1/appliance/router.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
+from app.api.v1.appliance.cluster import router as cluster_router
 from app.api.v1.appliance.containers import router as containers_router
 from app.api.v1.appliance.diagnostics import router as diagnostics_router
 from app.api.v1.appliance.pairing import router as pairing_router
@@ -62,6 +63,8 @@ if settings.slot_image_mirror_mode:
         prefix="/internal/slot-images",
     )
 router.include_router(containers_router, prefix="/containers")
+# #402 — Cluster health dashboard (nodes + pods + live kubelet usage).
+router.include_router(cluster_router, prefix="/cluster")
 router.include_router(diagnostics_router, prefix="/diagnostics")
 router.include_router(system_router, prefix="/system")
 # Pairing routes use no nested prefix so the URLs are

--- a/backend/app/services/ai/tools/appliance.py
+++ b/backend/app/services/ai/tools/appliance.py
@@ -425,6 +425,100 @@ async def find_cluster_health(
     }
 
 
+# ── find_cluster_metrics ───────────────────────────────────────────
+
+
+class FindClusterMetricsArgs(BaseModel):
+    pass
+
+
+@register_tool(
+    name="find_cluster_metrics",
+    description=(
+        "Live resource metrics for the appliance k3s cluster (superadmin "
+        "only, #402). Unlike ``find_cluster_health`` (control-plane "
+        "membership from heartbeats), this reads the cluster *now* via the "
+        "api pod's ServiceAccount: per-node CPU / memory / disk from the "
+        "kubelet Summary API, pod counts by phase, a per-component workload "
+        "health rollup, and the top pods by CPU + memory. Use to answer "
+        "'how loaded is the appliance?', 'what's eating memory?', or 'are "
+        "all workloads healthy?'. Appliance control plane only; read-only — "
+        "the same data the Cluster → Overview dashboard renders."
+    ),
+    args_model=FindClusterMetricsArgs,
+    category="admin",
+    default_enabled=True,
+    module="appliance.cluster",
+)
+async def find_cluster_metrics(
+    db: AsyncSession, user: User, args: FindClusterMetricsArgs
+) -> dict[str, Any]:
+    if (err := _superadmin_gate(user)) is not None:
+        return err
+    import asyncio  # noqa: PLC0415
+
+    from app.config import settings  # noqa: PLC0415
+    from app.services.appliance import cluster_health, k8s  # noqa: PLC0415
+
+    if not settings.appliance_mode:
+        return {
+            "error": (
+                "Cluster metrics are only available on the SpatiumDDI OS "
+                "appliance control plane."
+            )
+        }
+    try:
+        snap = await asyncio.to_thread(cluster_health.get_cluster_health)
+    except k8s.KubeapiUnavailableError as exc:
+        return {"error": f"kubeapi unreachable: {exc}"}
+    if not snap.get("available"):
+        return {"available": False, "detail": snap.get("detail")}
+
+    def _pct(used: float | None, cap: float | None) -> float | None:
+        return round(100.0 * used / cap, 1) if used is not None and cap else None
+
+    nodes = [
+        {
+            "name": n["name"],
+            "ready": n["ready"],
+            "roles": n["roles"],
+            "cpu_pct": _pct(n.get("cpu_usage_cores"), n.get("cpu_capacity_cores")),
+            "mem_pct": _pct(n.get("memory_working_set_bytes"), n.get("memory_capacity_bytes")),
+            "pods_running": n.get("pods_running"),
+        }
+        for n in snap.get("nodes", [])
+    ]
+    return {
+        "available": True,
+        "nodes_ready": snap["nodes_ready"],
+        "nodes_total": snap["nodes_total"],
+        "pods_running": snap["pods_running"],
+        "pods_total": snap["pods_total"],
+        "pods_by_phase": snap["pods_by_phase"],
+        "kubelet_version": snap["kubelet_version"],
+        "is_ha": snap["is_ha"],
+        "metrics_available": snap["metrics_available"],
+        "cluster_cpu_pct": _pct(snap.get("cpu_usage_cores"), snap.get("cpu_capacity_cores")),
+        "cluster_mem_pct": _pct(
+            snap.get("memory_working_set_bytes"), snap.get("memory_capacity_bytes")
+        ),
+        "nodes": nodes,
+        "workloads": snap["workloads"],
+        "top_pods_cpu": [
+            {"name": p["name"], "namespace": p["namespace"], "cpu_cores": p["cpu_usage_cores"]}
+            for p in snap.get("top_pods_cpu", [])[:5]
+        ],
+        "top_pods_mem": [
+            {
+                "name": p["name"],
+                "namespace": p["namespace"],
+                "mem_bytes": p["memory_working_set_bytes"],
+            }
+            for p in snap.get("top_pods_mem", [])[:5]
+        ],
+    }
+
+
 # ── find_etcd_snapshots ────────────────────────────────────────────
 
 

--- a/backend/app/services/appliance/cluster_health.py
+++ b/backend/app/services/appliance/cluster_health.py
@@ -105,12 +105,22 @@ def _age_seconds(iso: str | None) -> int | None:
 # ── per-resource extractors ────────────────────────────────────────────────
 
 
+_ROLE_LABEL_NS = "node-role.kubernetes.io"
+
+
 def _node_roles(node: dict[str, Any]) -> list[str]:
+    """Roles from ``node-role.kubernetes.io/<role>`` label keys (k3s sets
+    control-plane / etcd / master). Match the label *namespace* exactly via
+    ``partition`` rather than a prefix ``startswith`` — the latter is an
+    incomplete-substring check (CodeQL py/incomplete-url-substring-sanitization)
+    and an exact equality is also more precise."""
     labels = (node.get("metadata") or {}).get("labels") or {}
-    roles = sorted(
-        k.split("/", 1)[1] for k in labels if k.startswith("node-role.kubernetes.io/") and "/" in k
-    )
-    return roles or ["worker"]
+    roles: list[str] = []
+    for key in labels:
+        ns, sep, role = key.partition("/")
+        if sep and ns == _ROLE_LABEL_NS and role:
+            roles.append(role)
+    return sorted(roles) or ["worker"]
 
 
 def _node_condition(node: dict[str, Any], kind: str) -> bool:

--- a/backend/app/services/appliance/cluster_health.py
+++ b/backend/app/services/appliance/cluster_health.py
@@ -1,0 +1,436 @@
+"""Cluster health snapshot for the appliance "Cluster → Overview" screen (#402).
+
+Aggregates a live picture of the k3s cluster *underneath* the appliance from
+data the api pod's ServiceAccount can already read (nodes + pods cluster-wide)
+plus the kubelet Summary API via the apiserver proxy (``nodes/proxy [get]``,
+added in the same PR). This is the same data source the TTY console uses — the
+appliance ships **no** metrics-server / Prometheus, so live CPU / memory comes
+from the kubelet Summary API, not ``metrics.k8s.io``.
+
+``get_cluster_health()`` is a synchronous gather (a handful of stdlib kubeapi
+calls); the router runs it in a worker thread so the event loop never blocks,
+and the SSE stream re-runs it every couple of seconds for the near-real-time
+dashboard. The return value is a JSON-safe dict matching the ``ClusterHealth``
+Pydantic model in ``app.api.v1.appliance.cluster`` (so the SSE loop can
+``json.dumps`` it directly without re-validating each tick).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+
+from app.services.appliance import k8s
+
+logger = structlog.get_logger(__name__)
+
+# Components we recognise for the workload-health rollup. Anything else still
+# rolls up under its own ``app.kubernetes.io/component`` label (or a name-
+# derived fallback) — this list only drives nice display ordering.
+_COMPONENT_ORDER = [
+    "api",
+    "worker",
+    "beat",
+    "frontend",
+    "postgresql",
+    "redis",
+    "supervisor",
+    "dns-bind9",
+    "dns-powerdns",
+    "dhcp-kea",
+]
+
+_TOP_POD_LIMIT = 8
+
+
+# ── quantity parsers ───────────────────────────────────────────────────────
+
+
+def _cpu_cores(q: str | None) -> float | None:
+    """k8s CPU quantity → cores. Handles ``n`` / ``u`` / ``m`` / plain."""
+    if not q:
+        return None
+    q = q.strip()
+    try:
+        if q.endswith("n"):
+            return float(q[:-1]) / 1e9
+        if q.endswith("u"):
+            return float(q[:-1]) / 1e6
+        if q.endswith("m"):
+            return float(q[:-1]) / 1e3
+        return float(q)
+    except ValueError:
+        return None
+
+
+_MEM_BIN = {"Ki": 1024, "Mi": 1024**2, "Gi": 1024**3, "Ti": 1024**4, "Pi": 1024**5, "Ei": 1024**6}
+_MEM_DEC = {"k": 1e3, "K": 1e3, "M": 1e6, "G": 1e9, "T": 1e12, "P": 1e15, "E": 1e18}
+
+
+def _mem_bytes(q: str | None) -> int | None:
+    """k8s memory quantity → bytes. Handles Ki/Mi/Gi… (1024) + K/M/G… (1000)."""
+    if not q:
+        return None
+    q = q.strip()
+    for suf, mult in _MEM_BIN.items():
+        if q.endswith(suf):
+            try:
+                return int(float(q[:-2]) * mult)
+            except ValueError:
+                return None
+    for suf, mult in _MEM_DEC.items():
+        if q.endswith(suf):
+            try:
+                return int(float(q[:-1]) * mult)
+            except ValueError:
+                return None
+    try:
+        return int(float(q))
+    except ValueError:
+        return None
+
+
+def _age_seconds(iso: str | None) -> int | None:
+    if not iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return int((datetime.now(UTC) - dt).total_seconds())
+
+
+# ── per-resource extractors ────────────────────────────────────────────────
+
+
+def _node_roles(node: dict[str, Any]) -> list[str]:
+    labels = (node.get("metadata") or {}).get("labels") or {}
+    roles = sorted(
+        k.split("/", 1)[1] for k in labels if k.startswith("node-role.kubernetes.io/") and "/" in k
+    )
+    return roles or ["worker"]
+
+
+def _node_condition(node: dict[str, Any], kind: str) -> bool:
+    for c in (node.get("status") or {}).get("conditions") or []:
+        if c.get("type") == kind:
+            return c.get("status") == "True"
+    return False
+
+
+def _internal_ip(node: dict[str, Any]) -> str | None:
+    for a in (node.get("status") or {}).get("addresses") or []:
+        if a.get("type") == "InternalIP":
+            return a.get("address")
+    return None
+
+
+def _parse_node_stats(summary: dict[str, Any]) -> dict[str, Any]:
+    node = summary.get("node") or {}
+    cpu = node.get("cpu") or {}
+    mem = node.get("memory") or {}
+    fs = node.get("fs") or {}
+    nano = cpu.get("usageNanoCores")
+    return {
+        "cpu_usage_cores": (nano / 1e9) if isinstance(nano, (int, float)) else None,
+        "memory_working_set_bytes": mem.get("workingSetBytes"),
+        "memory_available_bytes": mem.get("availableBytes"),
+        "fs_used_bytes": fs.get("usedBytes"),
+        "fs_capacity_bytes": fs.get("capacityBytes"),
+    }
+
+
+def _parse_pod_stats(summary: dict[str, Any]) -> dict[tuple[str, str], tuple[float, int]]:
+    """``{(namespace, pod): (cpu_cores, mem_bytes)}`` from a kubelet summary."""
+    out: dict[tuple[str, str], tuple[float, int]] = {}
+    for pod in summary.get("pods") or []:
+        ref = pod.get("podRef") or {}
+        ns, nm = ref.get("namespace", ""), ref.get("name", "")
+        if not nm:
+            continue
+        nano = (pod.get("cpu") or {}).get("usageNanoCores") or 0
+        mem = (pod.get("memory") or {}).get("workingSetBytes") or 0
+        out[(ns, nm)] = (nano / 1e9, int(mem))
+    return out
+
+
+def _pod_component(pod: dict[str, Any]) -> str:
+    labels = (pod.get("metadata") or {}).get("labels") or {}
+    comp = labels.get("app.kubernetes.io/component")
+    if comp:
+        return comp
+    # Fallback: strip the chart's release prefixes off the pod name.
+    name = (pod.get("metadata") or {}).get("name") or "?"
+    for pre in ("spatium-control-spatiumddi-", "spatium-bootstrap-", "spatium-"):
+        if name.startswith(pre):
+            name = name[len(pre) :]
+            break
+    # Drop the random replica suffix (…-abc123-x9y2z / …-0).
+    parts = name.rsplit("-", 2)
+    return parts[0] if len(parts) == 3 else name
+
+
+def _pod_state(pod: dict[str, Any]) -> str:
+    """Human state — surfaces a waiting reason (CrashLoopBackOff) over phase."""
+    status = pod.get("status") or {}
+    for cs in status.get("containerStatuses") or []:
+        waiting = (cs.get("state") or {}).get("waiting") or {}
+        reason = waiting.get("reason")
+        if reason:
+            return reason
+    return status.get("phase") or "Unknown"
+
+
+def _pod_owner_kind(pod: dict[str, Any]) -> str | None:
+    owners = (pod.get("metadata") or {}).get("ownerReferences") or []
+    return owners[0].get("kind") if owners else None
+
+
+def _ready_counts(pod: dict[str, Any]) -> tuple[int, int]:
+    css = (pod.get("status") or {}).get("containerStatuses") or []
+    ready = sum(1 for c in css if c.get("ready"))
+    return ready, len(css)
+
+
+# ── assembly ───────────────────────────────────────────────────────────────
+
+
+def _unavailable(detail: str) -> dict[str, Any]:
+    return {
+        "available": False,
+        "detail": detail,
+        "nodes_total": 0,
+        "nodes_ready": 0,
+        "pods_total": 0,
+        "pods_running": 0,
+        "pods_by_phase": {},
+        "kubelet_version": None,
+        "is_ha": False,
+        "control_plane_nodes": 0,
+        "metrics_available": False,
+        "cpu_usage_cores": None,
+        "cpu_capacity_cores": None,
+        "memory_working_set_bytes": None,
+        "memory_capacity_bytes": None,
+        "nodes": [],
+        "workloads": [],
+        "top_pods_cpu": [],
+        "top_pods_mem": [],
+    }
+
+
+def cluster_unavailable(detail: str) -> dict[str, Any]:
+    """Public unavailable snapshot — used by the SSE stream when kubeapi is
+    momentarily unreachable so the live dashboard shows a reason, not a stall."""
+    return _unavailable(detail)
+
+
+def get_cluster_health() -> dict[str, Any]:
+    """Gather a full cluster-health snapshot. Synchronous (stdlib kubeapi).
+
+    Raises ``k8s.KubeapiUnavailableError`` only when the ServiceAccount isn't
+    mounted (non-k8s / non-appliance) — the router maps that to 503. A 403 on
+    the node read (RBAC not granted) is returned as ``available=False`` with a
+    diagnostic ``detail`` rather than an error, so the UI can explain it.
+    """
+    nstatus, nodes_raw = k8s.list_nodes()
+    if nstatus == 403:
+        return _unavailable(
+            "The api ServiceAccount can't read Nodes — enable "
+            "api.upgradeOrchestratorRBAC (the appliance default) and re-apply the chart."
+        )
+    if nstatus != 200:
+        return _unavailable(f"kubeapi node list returned HTTP {nstatus}")
+
+    try:
+        _pstatus, pods_raw = k8s.list_all_pods()
+    except k8s.KubeapiUnavailableError:
+        pods_raw = []
+
+    # Per-node kubelet Summary API (CPU / mem / fs + per-pod usage). Degrades
+    # cleanly to "no live usage" when nodes/proxy isn't granted (403) or a
+    # kubelet is briefly unreachable.
+    node_stats: dict[str, dict[str, Any]] = {}
+    pod_usage: dict[tuple[str, str], tuple[float, int]] = {}
+    metrics_available = False
+    for n in nodes_raw:
+        nm = (n.get("metadata") or {}).get("name")
+        if not nm:
+            continue
+        try:
+            sstatus, summary = k8s.get_node_stats_summary(nm)
+        except k8s.KubeapiUnavailableError:
+            continue
+        if sstatus == 200 and summary:
+            metrics_available = True
+            node_stats[nm] = _parse_node_stats(summary)
+            pod_usage.update(_parse_pod_stats(summary))
+
+    # ── nodes ──
+    nodes: list[dict[str, Any]] = []
+    nodes_ready = 0
+    control_plane_nodes = 0
+    cluster_cpu_used = 0.0
+    cluster_cpu_cap = 0.0
+    cluster_mem_used = 0
+    cluster_mem_cap = 0
+    kubelet_version: str | None = None
+    pods_on_node: dict[str, int] = {}
+    for p in pods_raw:
+        nn = (p.get("spec") or {}).get("nodeName")
+        if nn:
+            pods_on_node[nn] = pods_on_node.get(nn, 0) + 1
+
+    for n in nodes_raw:
+        meta = n.get("metadata") or {}
+        name = meta.get("name") or "?"
+        info = (n.get("status") or {}).get("nodeInfo") or {}
+        cap = (n.get("status") or {}).get("capacity") or {}
+        roles = _node_roles(n)
+        ready = k8s.is_node_ready(n)
+        if ready:
+            nodes_ready += 1
+        if "control-plane" in roles or "master" in roles:
+            control_plane_nodes += 1
+        kubelet_version = kubelet_version or info.get("kubeletVersion")
+        stats = node_stats.get(name) or {}
+        cpu_cap = _cpu_cores(cap.get("cpu"))
+        mem_cap = _mem_bytes(cap.get("memory"))
+        if stats.get("cpu_usage_cores") is not None:
+            cluster_cpu_used += stats["cpu_usage_cores"]
+        if cpu_cap:
+            cluster_cpu_cap += cpu_cap
+        if stats.get("memory_working_set_bytes"):
+            cluster_mem_used += int(stats["memory_working_set_bytes"])
+        if mem_cap:
+            cluster_mem_cap += mem_cap
+        nodes.append(
+            {
+                "name": name,
+                "ready": ready,
+                "roles": roles,
+                "schedulable": not (n.get("spec") or {}).get("unschedulable", False),
+                "kubelet_version": info.get("kubeletVersion"),
+                "os_image": info.get("osImage"),
+                "kernel": info.get("kernelVersion"),
+                "container_runtime": info.get("containerRuntimeVersion"),
+                "architecture": info.get("architecture"),
+                "internal_ip": _internal_ip(n),
+                "age_seconds": _age_seconds(meta.get("creationTimestamp")),
+                "memory_pressure": _node_condition(n, "MemoryPressure"),
+                "disk_pressure": _node_condition(n, "DiskPressure"),
+                "pid_pressure": _node_condition(n, "PIDPressure"),
+                "cpu_capacity_cores": cpu_cap,
+                "memory_capacity_bytes": mem_cap,
+                "pods_capacity": int(cap["pods"]) if cap.get("pods") else None,
+                "pods_running": pods_on_node.get(name, 0),
+                "cpu_usage_cores": stats.get("cpu_usage_cores"),
+                "memory_working_set_bytes": stats.get("memory_working_set_bytes"),
+                "memory_available_bytes": stats.get("memory_available_bytes"),
+                "fs_used_bytes": stats.get("fs_used_bytes"),
+                "fs_capacity_bytes": stats.get("fs_capacity_bytes"),
+            }
+        )
+
+    # ── pods + workload rollup + top pods ──
+    pods_by_phase: dict[str, int] = {}
+    pods_running = 0
+    pod_rows: list[dict[str, Any]] = []
+    rollup: dict[str, dict[str, Any]] = {}
+    for p in pods_raw:
+        meta = p.get("metadata") or {}
+        status = p.get("status") or {}
+        ns = meta.get("namespace") or ""
+        name = meta.get("name") or "?"
+        phase = status.get("phase") or "Unknown"
+        pods_by_phase[phase] = pods_by_phase.get(phase, 0) + 1
+        if phase == "Running":
+            pods_running += 1
+        ready_n, total_n = _ready_counts(p)
+        restarts = sum(c.get("restartCount", 0) for c in status.get("containerStatuses") or [])
+        cpu_u, mem_u = pod_usage.get((ns, name), (None, None))
+        comp = _pod_component(p)
+        owner = _pod_owner_kind(p)
+        terminal = phase in ("Succeeded", "Failed")
+        row = {
+            "name": name,
+            "namespace": ns,
+            "component": comp,
+            "node": (p.get("spec") or {}).get("nodeName"),
+            "phase": phase,
+            "state": _pod_state(p),
+            "ready": f"{ready_n}/{total_n}" if total_n else "0/0",
+            "restarts": restarts,
+            "age_seconds": _age_seconds(meta.get("creationTimestamp")),
+            "cpu_usage_cores": cpu_u,
+            "memory_working_set_bytes": mem_u,
+        }
+        pod_rows.append(row)
+
+        # Workload rollup — skip done Job pods (helm-install Completed etc.).
+        if terminal and owner == "Job":
+            continue
+        agg = rollup.setdefault(
+            comp,
+            {"component": comp, "kind": owner, "ready": 0, "total": 0, "restarts": 0},
+        )
+        agg["total"] += 1
+        agg["restarts"] += restarts
+        fully_ready = (total_n > 0 and ready_n == total_n) or phase == "Succeeded"
+        if fully_ready:
+            agg["ready"] += 1
+        if agg["kind"] is None:
+            agg["kind"] = owner
+
+    workloads: list[dict[str, Any]] = []
+    for comp, agg in rollup.items():
+        if agg["ready"] == agg["total"] and agg["total"] > 0:
+            wstatus = "healthy"
+        elif agg["ready"] > 0:
+            wstatus = "degraded"
+        else:
+            wstatus = "down"
+        workloads.append({**agg, "status": wstatus})
+    workloads.sort(
+        key=lambda w: (
+            (
+                _COMPONENT_ORDER.index(w["component"])
+                if w["component"] in _COMPONENT_ORDER
+                else len(_COMPONENT_ORDER)
+            ),
+            w["component"],
+        )
+    )
+
+    with_cpu = [r for r in pod_rows if r["cpu_usage_cores"] is not None]
+    with_mem = [r for r in pod_rows if r["memory_working_set_bytes"] is not None]
+    top_pods_cpu = sorted(with_cpu, key=lambda r: r["cpu_usage_cores"], reverse=True)[
+        :_TOP_POD_LIMIT
+    ]
+    top_pods_mem = sorted(with_mem, key=lambda r: r["memory_working_set_bytes"], reverse=True)[
+        :_TOP_POD_LIMIT
+    ]
+
+    return {
+        "available": True,
+        "detail": None,
+        "nodes_total": len(nodes_raw),
+        "nodes_ready": nodes_ready,
+        "pods_total": len(pod_rows),
+        "pods_running": pods_running,
+        "pods_by_phase": pods_by_phase,
+        "kubelet_version": kubelet_version,
+        "is_ha": control_plane_nodes > 1,
+        "control_plane_nodes": control_plane_nodes,
+        "metrics_available": metrics_available,
+        "cpu_usage_cores": round(cluster_cpu_used, 4) if metrics_available else None,
+        "cpu_capacity_cores": round(cluster_cpu_cap, 4) if cluster_cpu_cap else None,
+        "memory_working_set_bytes": cluster_mem_used if metrics_available else None,
+        "memory_capacity_bytes": cluster_mem_cap or None,
+        "nodes": nodes,
+        "workloads": workloads,
+        "top_pods_cpu": top_pods_cpu,
+        "top_pods_mem": top_pods_mem,
+    }

--- a/backend/app/services/appliance/cluster_health.py
+++ b/backend/app/services/appliance/cluster_health.py
@@ -331,6 +331,10 @@ def get_cluster_health() -> dict[str, Any]:
                 "memory_available_bytes": stats.get("memory_available_bytes"),
                 "fs_used_bytes": stats.get("fs_used_bytes"),
                 "fs_capacity_bytes": stats.get("fs_capacity_bytes"),
+                # #402 — host disk partitions are merged in by the router from
+                # the supervisor's cluster_health JSONB (the api pod can't see
+                # host partitions itself); empty here so the shape is stable.
+                "host_disk_partitions": [],
             }
         )
 

--- a/backend/app/services/appliance/k8s.py
+++ b/backend/app/services/appliance/k8s.py
@@ -215,6 +215,55 @@ def list_pods(namespace: str | None = None) -> list[dict[str, Any]]:
     return data.get("items") or []
 
 
+def list_all_pods() -> tuple[int, list[dict[str, Any]]]:
+    """List pods across ALL namespaces (cluster-wide).
+
+    Returns (status, items). On non-200 returns the status + empty
+    list so the Cluster-health caller can branch on a 403 (RBAC not
+    granted) without an exception. Distinct from ``list_pods`` (single
+    namespace) — the health screen rolls up control-plane + system +
+    agent pods, which span ``spatium`` / ``kube-system`` / etc.
+    """
+    cfg = get_config()
+    if cfg is None:
+        raise KubeapiUnavailableError("ServiceAccount not mounted; kubeapi unreachable")
+    status, body = _request("GET", "/api/v1/pods")
+    if status != 200:
+        return status, []
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise KubeapiUnavailableError(f"kubeapi list all pods bad json: {exc}") from exc
+    return status, data.get("items") or []
+
+
+def get_node_stats_summary(node_name: str) -> tuple[int, dict[str, Any] | None]:
+    """Fetch the kubelet Summary API for a node via the apiserver proxy.
+
+    ``GET /api/v1/nodes/<n>/proxy/stats/summary`` — per-node + per-pod
+    CPU (``usageNanoCores``) + memory (``workingSetBytes``) + filesystem
+    usage. This is how the appliance surfaces live usage WITHOUT a
+    metrics-server / Prometheus (the TTY console uses the same source).
+
+    Needs the ``nodes/proxy [get]`` grant (#402). Returns
+    (status, parsed_or_None); a 403 (older chart without the grant)
+    comes back as the status so the caller degrades to "no live usage"
+    instead of erroring. A short timeout keeps a wedged kubelet from
+    stalling the health poll.
+    """
+    cfg = get_config()
+    if cfg is None:
+        raise KubeapiUnavailableError("ServiceAccount not mounted; kubeapi unreachable")
+    path = f"/api/v1/nodes/{quote(node_name)}/proxy/stats/summary"
+    status, body = _request("GET", path, timeout=6.0)
+    if status == 200:
+        try:
+            return status, json.loads(body.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return status, None
+    return status, None
+
+
 def get_pod_logs(
     name: str,
     namespace: str | None = None,

--- a/backend/tests/test_cluster_health.py
+++ b/backend/tests/test_cluster_health.py
@@ -100,12 +100,18 @@ def _summary(node: str = "ddi1") -> dict:
         },
         "pods": [
             {
-                "podRef": {"namespace": "spatium", "name": "spatium-control-spatiumddi-api-x"},
+                "podRef": {
+                    "namespace": "spatium",
+                    "name": "spatium-control-spatiumddi-api-x",
+                },
                 "cpu": {"usageNanoCores": 500_000_000},
                 "memory": {"workingSetBytes": 400 * 1024**2},
             },
             {
-                "podRef": {"namespace": "spatium", "name": "spatium-control-spatiumddi-worker-y"},
+                "podRef": {
+                    "namespace": "spatium",
+                    "name": "spatium-control-spatiumddi-worker-y",
+                },
                 "cpu": {"usageNanoCores": 120_000_000},
                 "memory": {"workingSetBytes": 250 * 1024**2},
             },
@@ -128,7 +134,10 @@ def _patch_kube(monkeypatch, *, node_status=200, summary_status=200) -> None:
     ]
     monkeypatch.setattr(
         "app.services.appliance.k8s.list_nodes",
-        lambda label_selector=None: (node_status, [_node()] if node_status == 200 else []),
+        lambda label_selector=None: (
+            node_status,
+            [_node()] if node_status == 200 else [],
+        ),
     )
     monkeypatch.setattr(
         "app.services.appliance.k8s.list_all_pods",
@@ -136,7 +145,10 @@ def _patch_kube(monkeypatch, *, node_status=200, summary_status=200) -> None:
     )
     monkeypatch.setattr(
         "app.services.appliance.k8s.get_node_stats_summary",
-        lambda name: (summary_status, _summary(name) if summary_status == 200 else None),
+        lambda name: (
+            summary_status,
+            _summary(name) if summary_status == 200 else None,
+        ),
     )
 
 
@@ -268,3 +280,67 @@ async def test_health_endpoint_503_when_sa_missing(
 async def test_health_endpoint_requires_auth(client: AsyncClient) -> None:
     r = await client.get(_HEALTH_URL)
     assert r.status_code == 401, r.text
+
+
+async def test_health_endpoint_merges_host_partitions(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+) -> None:
+    """#402 — host partitions the supervisor reports inside its cluster_health
+    JSONB are merged onto the matching node (hostname == kube node name)."""
+    import hashlib
+    import os
+
+    from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
+
+    _patch_kube(monkeypatch)  # kube node is "ddi1"
+    der = os.urandom(32)
+    db_session.add(
+        Appliance(
+            id=uuid.uuid4(),
+            hostname="ddi1",
+            public_key_der=der,
+            public_key_fingerprint=hashlib.sha256(der).hexdigest(),
+            state=APPLIANCE_STATE_APPROVED,
+            deployment_kind="appliance",
+            appliance_variant="control-plane",
+            session_token_hash="deadbeef",
+            cluster_health={
+                "kubeapi_ready": True,
+                "host_disk_partitions": [
+                    {
+                        "mount": "/",
+                        "label": "OS (root slot)",
+                        "total_bytes": 8_000_000_000,
+                        "used_bytes": 3_000_000_000,
+                    },
+                    {
+                        "mount": "/var",
+                        "label": "Data",
+                        "total_bytes": 15_000_000_000,
+                        "used_bytes": 9_800_000_000,
+                    },
+                    {
+                        "mount": "/boot/efi",
+                        "label": "ESP",
+                        "total_bytes": 536_000_000,
+                        "used_bytes": 12_000_000,
+                    },
+                ],
+            },
+        )
+    )
+    admin = await _superadmin(db_session)
+    await db_session.commit()
+
+    r = await client.get(_HEALTH_URL, headers=_bearer(admin))
+    assert r.status_code == 200, r.text
+    node = r.json()["nodes"][0]
+    assert node["name"] == "ddi1"
+    assert {p["mount"] for p in node["host_disk_partitions"]} == {
+        "/",
+        "/var",
+        "/boot/efi",
+    }
+    root = next(p for p in node["host_disk_partitions"] if p["mount"] == "/")
+    assert root["label"] == "OS (root slot)"
+    assert root["total_bytes"] == 8_000_000_000

--- a/backend/tests/test_cluster_health.py
+++ b/backend/tests/test_cluster_health.py
@@ -1,0 +1,270 @@
+"""Tests for the Cluster health snapshot service + endpoint (#402).
+
+The gather reads nodes + pods cluster-wide and the kubelet Summary API via
+the api pod's ServiceAccount. Here we monkeypatch the three ``k8s`` helpers
+with realistic kubeapi-shaped fixtures and assert the rollup (KPIs, per-node
+live usage, workload health, top pods) + the degraded paths (no nodes/proxy
+grant → no live usage; nodes 403 → available=false; SA missing → 503).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.services.appliance import cluster_health
+
+_HEALTH_URL = "/api/v1/appliance/cluster/health"
+
+
+# ── kube-shaped fixtures ────────────────────────────────────────────────────
+
+
+def _node(name: str = "ddi1", *, ready: bool = True, cpu: str = "4", mem: str = "8Gi") -> dict:
+    return {
+        "metadata": {
+            "name": name,
+            "creationTimestamp": "2026-06-12T19:00:00Z",
+            "labels": {
+                "node-role.kubernetes.io/control-plane": "true",
+                "node-role.kubernetes.io/etcd": "true",
+            },
+        },
+        "spec": {"unschedulable": False},
+        "status": {
+            "conditions": [
+                {"type": "Ready", "status": "True" if ready else "False"},
+                {"type": "MemoryPressure", "status": "False"},
+                {"type": "DiskPressure", "status": "False"},
+            ],
+            "addresses": [{"type": "InternalIP", "address": "192.168.0.199"}],
+            "nodeInfo": {
+                "kubeletVersion": "v1.35.5+k3s1",
+                "osImage": "Debian GNU/Linux 13 (trixie)",
+                "kernelVersion": "6.12.90",
+                "containerRuntimeVersion": "containerd://2.2.3-k3s1",
+                "architecture": "amd64",
+            },
+            "capacity": {"cpu": cpu, "memory": mem, "pods": "110"},
+        },
+    }
+
+
+def _pod(
+    name: str,
+    *,
+    ns: str = "spatium",
+    comp: str = "api",
+    node: str = "ddi1",
+    phase: str = "Running",
+    ready: bool = True,
+    restarts: int = 0,
+    owner: str = "ReplicaSet",
+    waiting: str | None = None,
+) -> dict:
+    state: dict = (
+        {"running": {}} if ready else {"waiting": {"reason": waiting or "ContainerCreating"}}
+    )
+    return {
+        "metadata": {
+            "name": name,
+            "namespace": ns,
+            "creationTimestamp": "2026-06-12T19:00:00Z",
+            "labels": {"app.kubernetes.io/component": comp},
+            "ownerReferences": [{"kind": owner}],
+        },
+        "spec": {"nodeName": node},
+        "status": {
+            "phase": phase,
+            "podIP": "10.42.0.5",
+            "containerStatuses": [
+                {"ready": ready, "restartCount": restarts, "state": state},
+            ],
+        },
+    }
+
+
+def _summary(node: str = "ddi1") -> dict:
+    return {
+        "node": {
+            "nodeName": node,
+            "cpu": {"usageNanoCores": 800_000_000},  # 0.8 cores
+            "memory": {"workingSetBytes": 2 * 1024**3, "availableBytes": 6 * 1024**3},
+            "fs": {"usedBytes": 5 * 1024**3, "capacityBytes": 20 * 1024**3},
+        },
+        "pods": [
+            {
+                "podRef": {"namespace": "spatium", "name": "spatium-control-spatiumddi-api-x"},
+                "cpu": {"usageNanoCores": 500_000_000},
+                "memory": {"workingSetBytes": 400 * 1024**2},
+            },
+            {
+                "podRef": {"namespace": "spatium", "name": "spatium-control-spatiumddi-worker-y"},
+                "cpu": {"usageNanoCores": 120_000_000},
+                "memory": {"workingSetBytes": 250 * 1024**2},
+            },
+        ],
+    }
+
+
+def _patch_kube(monkeypatch, *, node_status=200, summary_status=200) -> None:
+    pods = [
+        _pod("spatium-control-spatiumddi-api-x", comp="api"),
+        _pod("spatium-control-spatiumddi-worker-y", comp="worker"),
+        _pod(
+            "helm-install-spatium-bootstrap-z",
+            ns="kube-system",
+            comp="helm-install",
+            phase="Succeeded",
+            ready=False,
+            owner="Job",
+        ),
+    ]
+    monkeypatch.setattr(
+        "app.services.appliance.k8s.list_nodes",
+        lambda label_selector=None: (node_status, [_node()] if node_status == 200 else []),
+    )
+    monkeypatch.setattr(
+        "app.services.appliance.k8s.list_all_pods",
+        lambda: (200, pods),
+    )
+    monkeypatch.setattr(
+        "app.services.appliance.k8s.get_node_stats_summary",
+        lambda name: (summary_status, _summary(name) if summary_status == 200 else None),
+    )
+
+
+# ── service-level ───────────────────────────────────────────────────────────
+
+
+def test_get_cluster_health_rollup(monkeypatch) -> None:
+    _patch_kube(monkeypatch)
+    snap = cluster_health.get_cluster_health()
+
+    assert snap["available"] is True
+    assert snap["nodes_total"] == 1
+    assert snap["nodes_ready"] == 1
+    assert snap["control_plane_nodes"] == 1
+    assert snap["is_ha"] is False
+    assert snap["metrics_available"] is True
+    assert snap["kubelet_version"] == "v1.35.5+k3s1"
+
+    # Live per-node usage flowed through from the kubelet summary.
+    node = snap["nodes"][0]
+    assert node["cpu_usage_cores"] == pytest.approx(0.8)
+    assert node["cpu_capacity_cores"] == pytest.approx(4.0)
+    assert node["memory_working_set_bytes"] == 2 * 1024**3
+    assert node["fs_capacity_bytes"] == 20 * 1024**3
+    assert "control-plane" in node["roles"]
+
+    # Cluster aggregate.
+    assert snap["cpu_usage_cores"] == pytest.approx(0.8)
+    assert snap["cpu_capacity_cores"] == pytest.approx(4.0)
+
+    # Workload rollup: api + worker present + healthy; the Completed Job pod
+    # is excluded (not counted as "down").
+    comps = {w["component"]: w for w in snap["workloads"]}
+    assert comps["api"]["status"] == "healthy"
+    assert comps["worker"]["status"] == "healthy"
+    assert "helm-install" not in comps
+
+    # Top pods by CPU — api (0.5) ahead of worker (0.12).
+    assert snap["top_pods_cpu"][0]["component"] == "api"
+    assert snap["top_pods_cpu"][0]["cpu_usage_cores"] == pytest.approx(0.5)
+
+
+def test_cluster_health_degrades_without_kubelet_proxy(monkeypatch) -> None:
+    # nodes/proxy not granted → 403 on the Summary API → no live usage, but
+    # the node inventory + workload rollup still render.
+    _patch_kube(monkeypatch, summary_status=403)
+    snap = cluster_health.get_cluster_health()
+    assert snap["available"] is True
+    assert snap["metrics_available"] is False
+    assert snap["cpu_usage_cores"] is None
+    assert snap["nodes"][0]["cpu_usage_cores"] is None
+    # Capacity (from the Node object) is still known even without live usage.
+    assert snap["nodes"][0]["cpu_capacity_cores"] == pytest.approx(4.0)
+    assert snap["nodes_total"] == 1
+
+
+def test_cluster_health_unavailable_when_nodes_forbidden(monkeypatch) -> None:
+    _patch_kube(monkeypatch, node_status=403)
+    snap = cluster_health.get_cluster_health()
+    assert snap["available"] is False
+    assert "RBAC" in (snap["detail"] or "") or "ServiceAccount" in (snap["detail"] or "")
+
+
+def test_quantity_parsers() -> None:
+    assert cluster_health._cpu_cores("4") == pytest.approx(4.0)
+    assert cluster_health._cpu_cores("500m") == pytest.approx(0.5)
+    assert cluster_health._cpu_cores("250000000n") == pytest.approx(0.25)
+    assert cluster_health._cpu_cores(None) is None
+    assert cluster_health._mem_bytes("8Gi") == 8 * 1024**3
+    assert cluster_health._mem_bytes("8113280Ki") == 8113280 * 1024
+    assert cluster_health._mem_bytes("2000M") == 2_000_000_000
+    assert cluster_health._mem_bytes(None) is None
+
+
+# ── endpoint-level ──────────────────────────────────────────────────────────
+
+
+async def _superadmin(db: AsyncSession) -> User:
+    u = User(
+        username=f"sa-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@x.com",
+        display_name="SA",
+        hashed_password=hash_password("OldPass123!"),
+        auth_source="local",
+        is_active=True,
+        is_superadmin=True,
+        force_password_change=False,
+        password_changed_at=datetime.now(UTC),
+    )
+    db.add(u)
+    await db.flush()
+    await db.commit()
+    return u
+
+
+def _bearer(user: User) -> dict[str, str]:
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def test_health_endpoint_returns_snapshot(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+) -> None:
+    _patch_kube(monkeypatch)
+    admin = await _superadmin(db_session)
+    r = await client.get(_HEALTH_URL, headers=_bearer(admin))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["available"] is True
+    assert body["nodes_total"] == 1
+    assert body["metrics_available"] is True
+    assert body["nodes"][0]["cpu_usage_cores"] == pytest.approx(0.8)
+
+
+async def test_health_endpoint_503_when_sa_missing(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+) -> None:
+    # No monkeypatch of the SA volume → list_nodes raises KubeapiUnavailable.
+    def _boom(label_selector=None):
+        from app.services.appliance.k8s import KubeapiUnavailableError
+
+        raise KubeapiUnavailableError("ServiceAccount not mounted; kubeapi unreachable")
+
+    monkeypatch.setattr("app.services.appliance.k8s.list_nodes", _boom)
+    admin = await _superadmin(db_session)
+    r = await client.get(_HEALTH_URL, headers=_bearer(admin))
+    assert r.status_code == 503, r.text
+
+
+async def test_health_endpoint_requires_auth(client: AsyncClient) -> None:
+    r = await client.get(_HEALTH_URL)
+    assert r.status_code == 401, r.text

--- a/charts/spatiumddi-appliance/templates/supervisor.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor.yaml
@@ -104,6 +104,14 @@ spec:
             - name: slot-upgrade-log
               mountPath: /var/log/spatiumddi-host
               readOnly: true
+            # Issue #402 — the active root-slot filesystem (read-only), so the
+            # heartbeat can statvfs it for the Cluster → Overview disk panel.
+            # /var + the ESP are already reachable via the release-state +
+            # boot-efi binds above; this adds the OS root slot ("/"). Read-only
+            # — the supervisor never writes here.
+            - name: host-root
+              mountPath: /host-root
+              readOnly: true
       volumes:
         - name: etc-spatiumddi-host
           hostPath:
@@ -148,4 +156,11 @@ spec:
             # created there; the marker reader tolerates an empty/absent
             # file by reporting None.
             type: FileOrCreate
+        # Issue #402 — host root filesystem, read-only, for the disk panel's
+        # root-slot usage. statvfs("/host-root") reports the active root
+        # partition; /var + ESP come from the binds above.
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
 {{- end }}

--- a/charts/spatiumddi/templates/api-rbac.yaml
+++ b/charts/spatiumddi/templates/api-rbac.yaml
@@ -125,6 +125,17 @@ rules:
   - apiGroups: [""]
     resources: ["pods/eviction"]
     verbs: ["create"]
+  # #402 — read-only kubelet Summary API proxy for the Cluster health
+  # screen (per-node + per-pod CPU / memory / fs via
+  # GET /api/v1/nodes/<n>/proxy/stats/summary — the same source the TTY
+  # console uses; the appliance ships no metrics-server / Prometheus).
+  # ``get`` ONLY: this authorizes read GETs to kubelet endpoints, not
+  # exec / attach / run (those need ``create`` on nodes/proxy). Folded
+  # into the orchestrator block because the health screen already needs
+  # the cluster-scoped ``nodes`` read above.
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9046,6 +9046,87 @@ export const applianceContainersApi = {
       .then((r) => r.data),
 };
 
+// ── Appliance: Cluster health dashboard (#402) ─────────────────────
+export interface ClusterNodeVitals {
+  name: string;
+  ready: boolean;
+  roles: string[];
+  schedulable: boolean;
+  kubelet_version: string | null;
+  os_image: string | null;
+  kernel: string | null;
+  container_runtime: string | null;
+  architecture: string | null;
+  internal_ip: string | null;
+  age_seconds: number | null;
+  memory_pressure: boolean;
+  disk_pressure: boolean;
+  pid_pressure: boolean;
+  cpu_capacity_cores: number | null;
+  memory_capacity_bytes: number | null;
+  pods_capacity: number | null;
+  pods_running: number;
+  cpu_usage_cores: number | null;
+  memory_working_set_bytes: number | null;
+  memory_available_bytes: number | null;
+  fs_used_bytes: number | null;
+  fs_capacity_bytes: number | null;
+}
+
+export interface ClusterPodSummary {
+  name: string;
+  namespace: string;
+  component: string | null;
+  node: string | null;
+  phase: string;
+  state: string;
+  ready: string;
+  restarts: number;
+  age_seconds: number | null;
+  cpu_usage_cores: number | null;
+  memory_working_set_bytes: number | null;
+}
+
+export interface ClusterWorkloadHealth {
+  component: string;
+  kind: string | null;
+  ready: number;
+  total: number;
+  restarts: number;
+  status: string;
+}
+
+export interface ClusterHealthSnapshot {
+  available: boolean;
+  detail: string | null;
+  nodes_total: number;
+  nodes_ready: number;
+  pods_total: number;
+  pods_running: number;
+  pods_by_phase: Record<string, number>;
+  kubelet_version: string | null;
+  is_ha: boolean;
+  control_plane_nodes: number;
+  metrics_available: boolean;
+  cpu_usage_cores: number | null;
+  cpu_capacity_cores: number | null;
+  memory_working_set_bytes: number | null;
+  memory_capacity_bytes: number | null;
+  nodes: ClusterNodeVitals[];
+  workloads: ClusterWorkloadHealth[];
+  top_pods_cpu: ClusterPodSummary[];
+  top_pods_mem: ClusterPodSummary[];
+}
+
+export const applianceClusterApi = {
+  // One-shot snapshot — used for the very first paint while the SSE
+  // stream warms up, and as the fallback when SSE can't connect.
+  health: () =>
+    api
+      .get<ClusterHealthSnapshot>("/appliance/cluster/health")
+      .then((r) => r.data),
+};
+
 // ── Agent bootstrap keys (Phase 6 prerequisite) ────────────────────
 // Reveal the DNS_AGENT_KEY + DHCP_AGENT_KEY the control plane uses
 // to validate first-boot agent registration. Applies to every
@@ -9200,6 +9281,55 @@ export async function* streamApplianceContainerLogs(
       try {
         const parsed = JSON.parse(data) as { line: string };
         if (typeof parsed.line === "string") yield parsed.line;
+      } catch {
+        // skip malformed frames
+      }
+    }
+  }
+}
+
+/**
+ * Stream live cluster-health snapshots over SSE (#402).
+ *
+ * Server pushes a fresh `ClusterHealthSnapshot` every ~2s; we yield each
+ * parsed frame so the Cluster → Overview dashboard can animate. Same
+ * `fetch`-not-`EventSource` shape as `streamApplianceContainerLogs` so the
+ * bearer token rides an `Authorization` header (EventSource can't set
+ * headers). Caller passes an `AbortSignal` and re-invokes on error to
+ * reconnect.
+ */
+export async function* streamClusterHealth(
+  signal?: AbortSignal,
+): AsyncIterable<ClusterHealthSnapshot> {
+  const token = localStorage.getItem("access_token");
+  const res = await fetch("/api/v1/appliance/cluster/health/stream", {
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      Accept: "text/event-stream",
+    },
+    signal,
+  });
+  if (!res.ok || !res.body) {
+    throw new Error(`cluster health stream failed: HTTP ${res.status}`);
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const frames = buffer.split("\n\n");
+    buffer = frames.pop() ?? "";
+    for (const frame of frames) {
+      if (!frame.trim()) continue;
+      let data = "";
+      for (const line of frame.split("\n")) {
+        if (line.startsWith("data: ")) data += line.slice(6);
+      }
+      if (!data) continue;
+      try {
+        yield JSON.parse(data) as ClusterHealthSnapshot;
       } catch {
         // skip malformed frames
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9047,6 +9047,13 @@ export const applianceContainersApi = {
 };
 
 // ── Appliance: Cluster health dashboard (#402) ─────────────────────
+export interface HostPartition {
+  mount: string;
+  label: string;
+  total_bytes: number;
+  used_bytes: number;
+}
+
 export interface ClusterNodeVitals {
   name: string;
   ready: boolean;
@@ -9071,6 +9078,7 @@ export interface ClusterNodeVitals {
   memory_available_bytes: number | null;
   fs_used_bytes: number | null;
   fs_capacity_bytes: number | null;
+  host_disk_partitions: HostPartition[];
 }
 
 export interface ClusterPodSummary {

--- a/frontend/src/pages/appliance/AppliancePage.tsx
+++ b/frontend/src/pages/appliance/AppliancePage.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
   Box,
-  Container as ContainerIcon,
+  Boxes,
   Network,
   Rocket,
   ScrollText,
@@ -19,8 +19,8 @@ import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { useSessionState } from "@/lib/useSessionState";
 import { FleetTab } from "./FleetTab";
 import { CertificatesTab } from "./CertificatesTab";
+import { ClusterTab } from "./ClusterTab";
 import { ClusterUpgradeTab } from "./ClusterUpgradeTab";
-import { ContainersTab } from "./ContainersTab";
 import { FirewallTab } from "./FirewallTab";
 import { LogsTab } from "./LogsTab";
 import { MaintenanceTab } from "./MaintenanceTab";
@@ -47,7 +47,7 @@ type Tab =
   | "fleet"
   | "firewall"
   | "releases"
-  | "containers"
+  | "cluster"
   | "logs"
   | "network"
   | "maintenance"
@@ -111,13 +111,20 @@ const TABS: TabSpec[] = [
       "Multi-node rolling upgrade orchestrator — walks the cluster from version N-1 to N one node at a time with preflight gate, CNPG cordon-triggered switchover, drain, slot apply + reboot, health gate, DS-Ready gate, uncordon. Post-loop chart bump + migrate Job close the mixed-version window once every node commits the new slot.",
   },
   {
-    key: "containers",
-    label: "Pods",
-    phase: "11",
-    icon: ContainerIcon,
+    // #402 — Cluster tab. Combines the Pods view + the etcd snapshot /
+    // restore surface (lifted out of Fleet, where it crowded the roster)
+    // into one operator-friendly tab behind a left sub-nav. Named
+    // "Cluster" rather than "Kubernetes" so operators don't need k8s
+    // vocabulary to find pod / etcd controls. selfOnly: both halves need
+    // the in-cluster kubeapi / embedded-etcd seed that only an appliance
+    // host has.
+    key: "cluster",
+    label: "Cluster",
+    phase: "402",
+    icon: Boxes,
     selfOnly: true,
     summary:
-      "Pod list driven off the in-cluster kubeapi via the api pod's ServiceAccount, with restart (delete pod → controller recreate) and live log streaming over SSE. Replaces the pre-Phase-11 docker-socket surface; the appliance is k3s-only.",
+      "The k3s cluster underneath the appliance — Pods (running workloads, with restart + live log streaming over SSE) and etcd snapshots (the cluster's disaster-recovery state + guided single-node restore). Both are driven off the in-cluster kubeapi via the api pod's ServiceAccount.",
   },
   {
     key: "logs",
@@ -259,7 +266,7 @@ export function AppliancePage() {
           {!isApplianceHost && (
             <span
               className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
-              title="This control plane is running on Docker or Kubernetes. Host-level tabs (TLS, Pods, Logs, Network, Maintenance) are hidden — the OS Versions tab still drives slot upgrades on any registered appliance agents."
+              title="This control plane is running on Docker or Kubernetes. Host-level tabs (TLS, Cluster, Logs, Network, Maintenance) are hidden — the OS Versions tab still drives slot upgrades on any registered appliance agents."
             >
               docker/k8s
             </span>
@@ -268,15 +275,15 @@ export function AppliancePage() {
         <p className="mt-1 text-xs text-muted-foreground">
           {isApplianceHost ? (
             <>
-              Manage the SpatiumDDI OS appliance — TLS, releases, containers,
-              logs, host network, and lifecycle. The OS Versions tab also drives
-              slot upgrades on every registered remote DNS + DHCP agent.
+              Manage the SpatiumDDI OS appliance — TLS, releases, cluster, logs,
+              host network, and lifecycle. The OS Versions tab also drives slot
+              upgrades on every registered remote DNS + DHCP agent.
             </>
           ) : (
             <>
               This control plane is running on Docker / Kubernetes. Host-level
-              tabs (TLS, Containers, Logs, Network, Maintenance) only apply to
-              an appliance-hosted control plane and are hidden here. The OS
+              tabs (TLS, Cluster, Logs, Network, Maintenance) only apply to an
+              appliance-hosted control plane and are hidden here. The OS
               Versions tab still drives slot upgrades on any registered
               appliance agents.
             </>
@@ -321,8 +328,8 @@ export function AppliancePage() {
           <FirewallTab />
         ) : effectiveTab === "cluster-upgrade" ? (
           <ClusterUpgradeTab />
-        ) : effectiveTab === "containers" ? (
-          <ContainersTab />
+        ) : effectiveTab === "cluster" ? (
+          <ClusterTab />
         ) : effectiveTab === "logs" ? (
           <LogsTab />
         ) : effectiveTab === "network" ? (

--- a/frontend/src/pages/appliance/ClusterOverview.tsx
+++ b/frontend/src/pages/appliance/ClusterOverview.tsx
@@ -380,6 +380,7 @@ function NodeCard({ node }: { node: ClusterNodeVitals }) {
   const cpuPct = pct(node.cpu_usage_cores, node.cpu_capacity_cores);
   const memPct = pct(node.memory_working_set_bytes, node.memory_capacity_bytes);
   const diskPct = pct(node.fs_used_bytes, node.fs_capacity_bytes);
+  const parts = node.host_disk_partitions ?? [];
   const pressure =
     node.memory_pressure || node.disk_pressure || node.pid_pressure;
   return (
@@ -423,36 +424,74 @@ function NodeCard({ node }: { node: ClusterNodeVitals }) {
           sub={`${fmtBytes(node.memory_working_set_bytes)} / ${fmtBytes(node.memory_capacity_bytes)}`}
         />
         <div className="min-w-0 flex-1 space-y-2 text-[11px]">
-          <div
-            title={
-              "Kubelet node filesystem — container images, pod volumes, and " +
-              "ephemeral storage on the appliance's /var data partition. This " +
-              "is the disk-pressure signal the kubelet evicts on. The OS slot " +
-              "partitions (root A/B) and the ESP are managed separately and " +
-              "aren't shown here."
-            }
-          >
-            <div className="flex justify-between text-muted-foreground">
-              <span className="flex items-center gap-1">
-                <HardDrive className="h-3 w-3" /> Disk
-                <span className="rounded bg-muted px-1 text-[9px] font-medium uppercase tracking-wide">
-                  node /var
-                </span>
-              </span>
-              <span className="tabular-nums">
-                {fmtBytes(node.fs_used_bytes)} /{" "}
-                {fmtBytes(node.fs_capacity_bytes)}
-                {diskPct != null && (
-                  <span className="ml-1 text-foreground">
-                    · {Math.round(diskPct)}%
+          {parts.length > 0 ? (
+            // #402 — full host-partition breakdown from the supervisor
+            // (root slot / var / ESP). statvfs'd host-side; the api pod
+            // can't see host partitions itself.
+            <div
+              className="space-y-1.5"
+              title="Host partitions reported by the supervisor (statvfs of the node's mounted filesystems)."
+            >
+              {parts.map((p) => {
+                const pp = pct(p.used_bytes, p.total_bytes);
+                return (
+                  <div key={p.mount}>
+                    <div className="flex justify-between text-muted-foreground">
+                      <span className="flex items-center gap-1">
+                        <HardDrive className="h-3 w-3" /> {p.label}
+                        <span className="font-mono text-[9px] opacity-70">
+                          {p.mount}
+                        </span>
+                      </span>
+                      <span className="tabular-nums">
+                        {fmtBytes(p.used_bytes)} / {fmtBytes(p.total_bytes)}
+                        {pp != null && (
+                          <span className="ml-1 text-foreground">
+                            · {Math.round(pp)}%
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                    <div className="mt-1">
+                      <Bar value={pp ?? 0} color={usageColor(pp)} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            // Fallback before the supervisor reports: the kubelet node
+            // filesystem (the appliance's /var data partition).
+            <div
+              title={
+                "Kubelet node filesystem — container images, pod volumes, and " +
+                "ephemeral storage on the appliance's /var data partition. This " +
+                "is the disk-pressure signal the kubelet evicts on. The OS slot " +
+                "partitions (root A/B) and the ESP are managed separately."
+              }
+            >
+              <div className="flex justify-between text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <HardDrive className="h-3 w-3" /> Disk
+                  <span className="rounded bg-muted px-1 text-[9px] font-medium uppercase tracking-wide">
+                    node /var
                   </span>
-                )}
-              </span>
+                </span>
+                <span className="tabular-nums">
+                  {fmtBytes(node.fs_used_bytes)} /{" "}
+                  {fmtBytes(node.fs_capacity_bytes)}
+                  {diskPct != null && (
+                    <span className="ml-1 text-foreground">
+                      · {Math.round(diskPct)}%
+                    </span>
+                  )}
+                </span>
+              </div>
+              <div className="mt-1">
+                <Bar value={diskPct ?? 0} color={usageColor(diskPct)} />
+              </div>
             </div>
-            <div className="mt-1">
-              <Bar value={diskPct ?? 0} color={usageColor(diskPct)} />
-            </div>
-          </div>
+          )}
           <div className="flex items-center justify-between text-muted-foreground">
             <span className="flex items-center gap-1">
               <Boxes className="h-3 w-3" /> Pods

--- a/frontend/src/pages/appliance/ClusterOverview.tsx
+++ b/frontend/src/pages/appliance/ClusterOverview.tsx
@@ -1,0 +1,896 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  Boxes,
+  CheckCircle2,
+  Cpu,
+  Database,
+  HardDrive,
+  Layers,
+  MemoryStick,
+  Radio,
+  RotateCcw,
+  Server,
+} from "lucide-react";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  applianceClusterApi,
+  streamClusterHealth,
+  type ClusterHealthSnapshot,
+  type ClusterNodeVitals,
+  type ClusterPodSummary,
+  type ClusterWorkloadHealth,
+} from "@/lib/api";
+
+/**
+ * Cluster → Overview (#402) — a live, near-real-time dashboard for the k3s
+ * cluster underneath the appliance.
+ *
+ * Fed by an SSE stream (`/appliance/cluster/health/stream`) that pushes a
+ * fresh snapshot every ~2s; each frame animates the gradient CPU/memory hero
+ * chart, the per-node radial gauges, the KPI sparklines, and the top-pods
+ * leaderboard. There's no metrics-server / Prometheus on the appliance — live
+ * usage comes from the kubelet Summary API, the same source the TTY console
+ * uses. The stream self-reconnects; a one-shot GET paints instantly on mount.
+ */
+
+const MAX_POINTS = 90; // ~3 min of history at the 2s stream cadence
+
+const EMERALD = "#10b981";
+const SKY = "#0ea5e9";
+const AMBER = "#f59e0b";
+const ROSE = "#f43f5e";
+const VIOLET = "#8b5cf6";
+const SLATE = "#64748b";
+
+interface HistPoint {
+  i: number;
+  cpu: number | null;
+  mem: number | null;
+}
+
+// ── formatting helpers ──────────────────────────────────────────────────────
+
+function fmtBytes(n: number | null | undefined): string {
+  if (n == null) return "—";
+  if (n < 1024) return `${n} B`;
+  const u = ["KiB", "MiB", "GiB", "TiB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < u.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(v < 10 ? 1 : 0)} ${u[i]}`;
+}
+
+function fmtCores(c: number | null | undefined): string {
+  if (c == null) return "—";
+  return c < 1 ? `${Math.round(c * 1000)}m` : c.toFixed(2);
+}
+
+function pct(
+  used: number | null | undefined,
+  cap: number | null | undefined,
+): number | null {
+  if (used == null || !cap) return null;
+  return Math.max(0, Math.min(100, (used / cap) * 100));
+}
+
+function fmtAge(s: number | null | undefined): string {
+  if (s == null) return "—";
+  if (s < 3600) return `${Math.max(1, Math.floor(s / 60))}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h`;
+  return `${Math.floor(s / 86400)}d`;
+}
+
+function usageColor(p: number | null): string {
+  if (p == null) return SLATE;
+  if (p < 60) return EMERALD;
+  if (p < 85) return AMBER;
+  return ROSE;
+}
+
+function shortPodName(p: { name: string }): string {
+  return p.name
+    .replace(/^spatium-control-spatiumddi-/, "")
+    .replace(/^spatium-bootstrap-/, "")
+    .replace(/^spatium-/, "");
+}
+
+// ── live stream hook ─────────────────────────────────────────────────────────
+
+function useClusterHealthStream() {
+  const [snapshot, setSnapshot] = useState<ClusterHealthSnapshot | null>(null);
+  const [history, setHistory] = useState<HistPoint[]>([]);
+  const [connected, setConnected] = useState(false);
+  const seq = useRef(0);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    let stopped = false;
+
+    const ingest = (snap: ClusterHealthSnapshot) => {
+      setSnapshot(snap);
+      if (snap.available) {
+        const cpu = pct(snap.cpu_usage_cores, snap.cpu_capacity_cores);
+        const mem = pct(
+          snap.memory_working_set_bytes,
+          snap.memory_capacity_bytes,
+        );
+        setHistory((prev) => {
+          const next = [...prev, { i: seq.current++, cpu, mem }];
+          return next.length > MAX_POINTS
+            ? next.slice(next.length - MAX_POINTS)
+            : next;
+        });
+      }
+    };
+
+    // Instant first paint while the SSE stream warms up.
+    applianceClusterApi
+      .health()
+      .then((s) => {
+        if (!stopped) ingest(s);
+      })
+      .catch(() => {
+        /* stream will deliver shortly */
+      });
+
+    const run = async () => {
+      while (!stopped) {
+        try {
+          for await (const snap of streamClusterHealth(ctrl.signal)) {
+            if (stopped) break;
+            setConnected(true);
+            ingest(snap);
+          }
+        } catch {
+          if (stopped) break;
+        }
+        setConnected(false);
+        if (stopped) break;
+        await new Promise((r) => setTimeout(r, 2000)); // backoff then reconnect
+      }
+    };
+    void run();
+
+    return () => {
+      stopped = true;
+      ctrl.abort();
+    };
+  }, []);
+
+  return { snapshot, history, connected };
+}
+
+// ── small visual primitives ──────────────────────────────────────────────────
+
+function RadialGauge({
+  value,
+  label,
+  sub,
+}: {
+  value: number | null;
+  label: string;
+  sub?: string;
+}) {
+  const p = value == null ? 0 : Math.max(0, Math.min(100, value));
+  const R = 32;
+  const C = 2 * Math.PI * R;
+  const off = C * (1 - p / 100);
+  const color = usageColor(value);
+  return (
+    <div className="flex flex-col items-center">
+      <div className="relative h-[76px] w-[76px]">
+        <svg viewBox="0 0 80 80" className="h-[76px] w-[76px] -rotate-90">
+          <circle
+            cx="40"
+            cy="40"
+            r={R}
+            fill="none"
+            strokeWidth="7"
+            className="stroke-muted/40"
+          />
+          <circle
+            cx="40"
+            cy="40"
+            r={R}
+            fill="none"
+            stroke={color}
+            strokeWidth="7"
+            strokeLinecap="round"
+            strokeDasharray={C}
+            strokeDashoffset={off}
+            style={{
+              transition: "stroke-dashoffset 0.7s ease, stroke 0.7s ease",
+            }}
+          />
+        </svg>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span
+            className="text-base font-semibold tabular-nums"
+            style={{ color }}
+          >
+            {value == null ? "—" : `${Math.round(value)}%`}
+          </span>
+        </div>
+      </div>
+      <span className="mt-1 text-[11px] font-medium text-muted-foreground">
+        {label}
+      </span>
+      {sub && <span className="text-[10px] text-muted-foreground">{sub}</span>}
+    </div>
+  );
+}
+
+function Sparkline({
+  data,
+  color,
+  max,
+}: {
+  data: number[];
+  color: string;
+  max?: number;
+}) {
+  const w = 100;
+  const h = 28;
+  if (data.length < 2) {
+    return (
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        className="h-7 w-full"
+        preserveAspectRatio="none"
+      />
+    );
+  }
+  const hi = max ?? Math.max(...data, 1);
+  const lo = 0;
+  const range = hi - lo || 1;
+  const x = (i: number) => (i / (data.length - 1)) * w;
+  const y = (v: number) =>
+    h - ((Math.max(lo, Math.min(hi, v)) - lo) / range) * h;
+  const line = data.map((v, i) => `${x(i)},${y(v)}`).join(" ");
+  const area = `0,${h} ${line} ${w},${h}`;
+  const gid = `spark-${color.replace("#", "")}`;
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      className="h-7 w-full"
+      preserveAspectRatio="none"
+    >
+      <defs>
+        <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity={0.35} />
+          <stop offset="100%" stopColor={color} stopOpacity={0} />
+        </linearGradient>
+      </defs>
+      <polygon points={area} fill={`url(#${gid})`} />
+      <polyline
+        points={line}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
+function Bar({ value, color }: { value: number; color: string }) {
+  return (
+    <div className="h-2 w-full overflow-hidden rounded-full bg-muted/40">
+      <div
+        className="h-full rounded-full"
+        style={{
+          width: `${Math.max(2, Math.min(100, value))}%`,
+          background: color,
+          transition: "width 0.7s ease, background 0.7s ease",
+        }}
+      />
+    </div>
+  );
+}
+
+function KpiTile({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  accent,
+  children,
+}: {
+  icon: typeof Cpu;
+  label: string;
+  value: string;
+  sub?: string;
+  accent: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="relative overflow-hidden rounded-xl border bg-card p-3 shadow-sm">
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-0.5"
+        style={{ background: accent }}
+      />
+      <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" style={{ color: accent }} />
+        {label}
+      </div>
+      <div className="mt-1 flex items-baseline gap-1.5">
+        <span className="text-2xl font-semibold tabular-nums">{value}</span>
+        {sub && <span className="text-xs text-muted-foreground">{sub}</span>}
+      </div>
+      {children && <div className="mt-1">{children}</div>}
+    </div>
+  );
+}
+
+function RoleBadge({ role }: { role: string }) {
+  const color =
+    role === "control-plane" || role === "master"
+      ? VIOLET
+      : role === "etcd"
+        ? AMBER
+        : SLATE;
+  return (
+    <span
+      className="rounded px-1.5 py-0.5 text-[10px] font-medium"
+      style={{ color, background: `${color}1f` }}
+    >
+      {role}
+    </span>
+  );
+}
+
+function StatusChip({ status }: { status: string }) {
+  const map: Record<string, [string, string]> = {
+    healthy: [EMERALD, "Healthy"],
+    degraded: [AMBER, "Degraded"],
+    down: [ROSE, "Down"],
+  };
+  const [color, text] = map[status] ?? [SLATE, status];
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium"
+      style={{ color, background: `${color}1f` }}
+    >
+      <span
+        className="h-1.5 w-1.5 rounded-full"
+        style={{ background: color }}
+      />
+      {text}
+    </span>
+  );
+}
+
+// ── node card ────────────────────────────────────────────────────────────────
+
+function NodeCard({ node }: { node: ClusterNodeVitals }) {
+  const cpuPct = pct(node.cpu_usage_cores, node.cpu_capacity_cores);
+  const memPct = pct(node.memory_working_set_bytes, node.memory_capacity_bytes);
+  const diskPct = pct(node.fs_used_bytes, node.fs_capacity_bytes);
+  const pressure =
+    node.memory_pressure || node.disk_pressure || node.pid_pressure;
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span
+              className={`h-2.5 w-2.5 shrink-0 rounded-full ${node.ready ? "animate-pulse" : ""}`}
+              style={{ background: node.ready ? EMERALD : ROSE }}
+              title={node.ready ? "Ready" : "Not Ready"}
+            />
+            <span className="truncate font-semibold">{node.name}</span>
+            {!node.schedulable && (
+              <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
+                cordoned
+              </span>
+            )}
+          </div>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {node.roles.map((r) => (
+              <RoleBadge key={r} role={r} />
+            ))}
+          </div>
+        </div>
+        <div className="shrink-0 text-right text-[10px] text-muted-foreground">
+          <div className="font-mono">{node.internal_ip ?? "—"}</div>
+          <div>up {fmtAge(node.age_seconds)}</div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center gap-4">
+        <RadialGauge
+          value={cpuPct}
+          label="CPU"
+          sub={`${fmtCores(node.cpu_usage_cores)} / ${fmtCores(node.cpu_capacity_cores)}`}
+        />
+        <RadialGauge
+          value={memPct}
+          label="Memory"
+          sub={`${fmtBytes(node.memory_working_set_bytes)} / ${fmtBytes(node.memory_capacity_bytes)}`}
+        />
+        <div className="min-w-0 flex-1 space-y-2 text-[11px]">
+          <div>
+            <div className="flex justify-between text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <HardDrive className="h-3 w-3" /> Disk
+              </span>
+              <span className="tabular-nums">
+                {fmtBytes(node.fs_used_bytes)} /{" "}
+                {fmtBytes(node.fs_capacity_bytes)}
+              </span>
+            </div>
+            <div className="mt-1">
+              <Bar value={diskPct ?? 0} color={usageColor(diskPct)} />
+            </div>
+          </div>
+          <div className="flex items-center justify-between text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <Boxes className="h-3 w-3" /> Pods
+            </span>
+            <span className="tabular-nums text-foreground">
+              {node.pods_running}
+              {node.pods_capacity ? ` / ${node.pods_capacity}` : ""}
+            </span>
+          </div>
+          <div
+            className="truncate text-muted-foreground"
+            title={node.os_image ?? ""}
+          >
+            {node.kubelet_version ?? "—"} · {node.architecture ?? "—"}
+          </div>
+          {pressure && (
+            <div className="flex items-center gap-1 text-rose-500">
+              <AlertTriangle className="h-3 w-3" />
+              {[
+                node.memory_pressure && "memory",
+                node.disk_pressure && "disk",
+                node.pid_pressure && "pid",
+              ]
+                .filter(Boolean)
+                .join(" / ")}{" "}
+              pressure
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── top-pods leaderboard ──────────────────────────────────────────────────────
+
+function TopPods({
+  cpu,
+  mem,
+}: {
+  cpu: ClusterPodSummary[];
+  mem: ClusterPodSummary[];
+}) {
+  const [mode, setMode] = useState<"cpu" | "mem">("cpu");
+  const rows = mode === "cpu" ? cpu : mem;
+  const peak = Math.max(
+    1e-9,
+    ...rows.map((p) =>
+      mode === "cpu"
+        ? (p.cpu_usage_cores ?? 0)
+        : (p.memory_working_set_bytes ?? 0),
+    ),
+  );
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+          <Activity className="h-4 w-4 text-muted-foreground" />
+          Top pods
+        </h3>
+        <div className="flex overflow-hidden rounded-md border text-[11px]">
+          {(["cpu", "mem"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={`px-2 py-1 ${
+                mode === m
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:bg-accent/50"
+              }`}
+            >
+              {m === "cpu" ? "CPU" : "Memory"}
+            </button>
+          ))}
+        </div>
+      </div>
+      {rows.length === 0 ? (
+        <p className="mt-4 text-xs text-muted-foreground">
+          No live pod usage yet (waiting for the kubelet Summary API).
+        </p>
+      ) : (
+        <div className="mt-3 space-y-2">
+          {rows.map((p) => {
+            const v =
+              mode === "cpu"
+                ? (p.cpu_usage_cores ?? 0)
+                : (p.memory_working_set_bytes ?? 0);
+            return (
+              <div key={`${p.namespace}/${p.name}`}>
+                <div className="flex items-baseline justify-between gap-2 text-[11px]">
+                  <span className="truncate font-mono">{shortPodName(p)}</span>
+                  <span className="shrink-0 tabular-nums text-muted-foreground">
+                    {mode === "cpu" ? `${fmtCores(v)} c` : fmtBytes(v)}
+                  </span>
+                </div>
+                <div className="mt-0.5">
+                  <Bar
+                    value={(v / peak) * 100}
+                    color={mode === "cpu" ? EMERALD : SKY}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── hero live chart ───────────────────────────────────────────────────────────
+
+function HeroChart({
+  history,
+  cpuPct,
+  memPct,
+}: {
+  history: HistPoint[];
+  cpuPct: number | null;
+  memPct: number | null;
+}) {
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <div className="flex items-center justify-between">
+        <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+          <Activity className="h-4 w-4 text-muted-foreground" />
+          Cluster load
+          <span className="text-xs font-normal text-muted-foreground">
+            · last ~3 min
+          </span>
+        </h3>
+        <div className="flex items-center gap-4 text-xs">
+          <span className="flex items-center gap-1.5">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ background: EMERALD }}
+            />
+            CPU{" "}
+            <span
+              className="font-semibold tabular-nums"
+              style={{ color: EMERALD }}
+            >
+              {cpuPct == null ? "—" : `${Math.round(cpuPct)}%`}
+            </span>
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ background: SKY }}
+            />
+            Mem{" "}
+            <span className="font-semibold tabular-nums" style={{ color: SKY }}>
+              {memPct == null ? "—" : `${Math.round(memPct)}%`}
+            </span>
+          </span>
+        </div>
+      </div>
+      <div className="mt-3 h-56">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart
+            data={history}
+            margin={{ top: 6, right: 6, bottom: 0, left: -18 }}
+          >
+            <defs>
+              <linearGradient id="cpuGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={EMERALD} stopOpacity={0.45} />
+                <stop offset="100%" stopColor={EMERALD} stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="memGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={SKY} stopOpacity={0.4} />
+                <stop offset="100%" stopColor={SKY} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="#94a3b8"
+              strokeOpacity={0.18}
+              vertical={false}
+            />
+            <XAxis dataKey="i" hide />
+            <YAxis
+              domain={[0, 100]}
+              width={42}
+              tick={{ fill: "#94a3b8", fontSize: 10 }}
+              tickFormatter={(v: number) => `${v}%`}
+              stroke="#94a3b8"
+              strokeOpacity={0.3}
+            />
+            <Tooltip
+              isAnimationActive={false}
+              formatter={(v) => `${Math.round(Number(v))}%`}
+              labelFormatter={() => ""}
+              contentStyle={{
+                background: "hsl(var(--card))",
+                border: "1px solid hsl(var(--border))",
+                borderRadius: 8,
+                fontSize: 12,
+              }}
+            />
+            <Area
+              type="monotone"
+              dataKey="mem"
+              name="Memory"
+              stroke={SKY}
+              strokeWidth={2}
+              fill="url(#memGrad)"
+              isAnimationActive={false}
+              dot={false}
+              connectNulls
+              style={{ filter: "drop-shadow(0 1px 4px rgba(14,165,233,0.4))" }}
+            />
+            <Area
+              type="monotone"
+              dataKey="cpu"
+              name="CPU"
+              stroke={EMERALD}
+              strokeWidth={2}
+              fill="url(#cpuGrad)"
+              isAnimationActive={false}
+              dot={false}
+              connectNulls
+              style={{ filter: "drop-shadow(0 1px 4px rgba(16,185,129,0.45))" }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+// ── workload health ───────────────────────────────────────────────────────────
+
+function WorkloadHealth({ workloads }: { workloads: ClusterWorkloadHealth[] }) {
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+        <Layers className="h-4 w-4 text-muted-foreground" />
+        Workloads
+      </h3>
+      {workloads.length === 0 ? (
+        <p className="mt-4 text-xs text-muted-foreground">
+          No workloads reported.
+        </p>
+      ) : (
+        <div className="mt-3 space-y-1.5">
+          {workloads.map((w) => (
+            <div
+              key={w.component}
+              className="flex items-center justify-between gap-2 rounded-md px-1 py-1 text-xs"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <StatusChip status={w.status} />
+                <span className="truncate font-medium">{w.component}</span>
+                {w.kind && (
+                  <span className="hidden text-[10px] text-muted-foreground sm:inline">
+                    {w.kind}
+                  </span>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-3 text-muted-foreground">
+                {w.restarts > 0 && (
+                  <span
+                    className="flex items-center gap-0.5 text-amber-600 dark:text-amber-400"
+                    title={`${w.restarts} restarts`}
+                  >
+                    <RotateCcw className="h-3 w-3" />
+                    {w.restarts}
+                  </span>
+                )}
+                <span className="tabular-nums text-foreground">
+                  {w.ready}/{w.total}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+export function ClusterOverview() {
+  const { snapshot, history, connected } = useClusterHealthStream();
+
+  if (snapshot === null) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
+        <Radio className="mr-2 h-4 w-4 animate-pulse" />
+        Connecting to the cluster…
+      </div>
+    );
+  }
+
+  if (!snapshot.available) {
+    return (
+      <div className="mx-auto max-w-2xl rounded-xl border border-dashed bg-muted/30 px-6 py-12 text-center">
+        <Server className="mx-auto h-8 w-8 text-muted-foreground" />
+        <p className="mt-3 text-sm font-medium">Cluster metrics unavailable</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {snapshot.detail ??
+            "The api ServiceAccount can't read the cluster yet."}
+        </p>
+      </div>
+    );
+  }
+
+  const s = snapshot;
+  const cpuPct = pct(s.cpu_usage_cores, s.cpu_capacity_cores);
+  const memPct = pct(s.memory_working_set_bytes, s.memory_capacity_bytes);
+  const healthyWorkloads = s.workloads.filter(
+    (w) => w.status === "healthy",
+  ).length;
+  const cpuSpark = history.map((h) => h.cpu ?? 0);
+  const memSpark = history.map((h) => h.mem ?? 0);
+  const phaseSummary = Object.entries(s.pods_by_phase)
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, v]) => `${k} ${v}`)
+    .join(" · ");
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-2">
+        <h2 className="flex items-center gap-2 text-base font-semibold">
+          <Boxes className="h-4 w-4 text-muted-foreground" />
+          Cluster overview
+        </h2>
+        <span
+          className="inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium"
+          style={{
+            color: connected ? EMERALD : AMBER,
+            borderColor: `${connected ? EMERALD : AMBER}55`,
+            background: `${connected ? EMERALD : AMBER}12`,
+          }}
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${connected ? "animate-pulse" : ""}`}
+            style={{ background: connected ? EMERALD : AMBER }}
+          />
+          {connected ? "LIVE" : "reconnecting…"}
+        </span>
+        <span className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+          {s.kubelet_version && (
+            <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono">
+              {s.kubelet_version}
+            </span>
+          )}
+          <span
+            className="rounded-md px-1.5 py-0.5 font-medium"
+            style={
+              s.is_ha
+                ? { color: EMERALD, background: `${EMERALD}1f` }
+                : { color: SLATE, background: `${SLATE}1f` }
+            }
+          >
+            {s.is_ha ? `HA · ${s.control_plane_nodes} nodes` : "single node"}
+          </span>
+          {!s.metrics_available && (
+            <span className="rounded-md bg-amber-500/15 px-1.5 py-0.5 text-amber-600 dark:text-amber-400">
+              live usage unavailable
+            </span>
+          )}
+        </span>
+      </div>
+
+      {/* KPI ribbon */}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
+        <KpiTile
+          icon={Cpu}
+          label="CPU"
+          value={cpuPct == null ? "—" : `${Math.round(cpuPct)}%`}
+          sub={`${fmtCores(s.cpu_usage_cores)} / ${fmtCores(s.cpu_capacity_cores)} c`}
+          accent={EMERALD}
+        >
+          <Sparkline data={cpuSpark} color={EMERALD} max={100} />
+        </KpiTile>
+        <KpiTile
+          icon={MemoryStick}
+          label="Memory"
+          value={memPct == null ? "—" : `${Math.round(memPct)}%`}
+          sub={`${fmtBytes(s.memory_working_set_bytes)} / ${fmtBytes(s.memory_capacity_bytes)}`}
+          accent={SKY}
+        >
+          <Sparkline data={memSpark} color={SKY} max={100} />
+        </KpiTile>
+        <KpiTile
+          icon={Server}
+          label="Nodes ready"
+          value={`${s.nodes_ready}/${s.nodes_total}`}
+          accent={s.nodes_ready === s.nodes_total ? EMERALD : ROSE}
+        >
+          <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+            <CheckCircle2 className="h-3 w-3" style={{ color: EMERALD }} />
+            {s.control_plane_nodes} control-plane
+          </div>
+        </KpiTile>
+        <KpiTile
+          icon={Boxes}
+          label="Pods running"
+          value={`${s.pods_running}/${s.pods_total}`}
+          accent={VIOLET}
+        >
+          <div
+            className="truncate text-[11px] text-muted-foreground"
+            title={phaseSummary}
+          >
+            {phaseSummary || "—"}
+          </div>
+        </KpiTile>
+        <KpiTile
+          icon={Database}
+          label="Workloads"
+          value={`${healthyWorkloads}/${s.workloads.length}`}
+          sub="healthy"
+          accent={healthyWorkloads === s.workloads.length ? EMERALD : AMBER}
+        >
+          <div className="flex flex-wrap gap-0.5">
+            {s.workloads.slice(0, 14).map((w) => (
+              <span
+                key={w.component}
+                className="h-1.5 w-1.5 rounded-full"
+                title={`${w.component}: ${w.status}`}
+                style={{
+                  background:
+                    w.status === "healthy"
+                      ? EMERALD
+                      : w.status === "degraded"
+                        ? AMBER
+                        : ROSE,
+                }}
+              />
+            ))}
+          </div>
+        </KpiTile>
+      </div>
+
+      {/* Hero live chart */}
+      <HeroChart history={history} cpuPct={cpuPct} memPct={memPct} />
+
+      {/* Nodes */}
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        {s.nodes.map((n) => (
+          <NodeCard key={n.name} node={n} />
+        ))}
+      </div>
+
+      {/* Workloads + top pods */}
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <WorkloadHealth workloads={s.workloads} />
+        <TopPods cpu={s.top_pods_cpu} mem={s.top_pods_mem} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/appliance/ClusterOverview.tsx
+++ b/frontend/src/pages/appliance/ClusterOverview.tsx
@@ -423,14 +423,30 @@ function NodeCard({ node }: { node: ClusterNodeVitals }) {
           sub={`${fmtBytes(node.memory_working_set_bytes)} / ${fmtBytes(node.memory_capacity_bytes)}`}
         />
         <div className="min-w-0 flex-1 space-y-2 text-[11px]">
-          <div>
+          <div
+            title={
+              "Kubelet node filesystem — container images, pod volumes, and " +
+              "ephemeral storage on the appliance's /var data partition. This " +
+              "is the disk-pressure signal the kubelet evicts on. The OS slot " +
+              "partitions (root A/B) and the ESP are managed separately and " +
+              "aren't shown here."
+            }
+          >
             <div className="flex justify-between text-muted-foreground">
               <span className="flex items-center gap-1">
                 <HardDrive className="h-3 w-3" /> Disk
+                <span className="rounded bg-muted px-1 text-[9px] font-medium uppercase tracking-wide">
+                  node /var
+                </span>
               </span>
               <span className="tabular-nums">
                 {fmtBytes(node.fs_used_bytes)} /{" "}
                 {fmtBytes(node.fs_capacity_bytes)}
+                {diskPct != null && (
+                  <span className="ml-1 text-foreground">
+                    · {Math.round(diskPct)}%
+                  </span>
+                )}
               </span>
             </div>
             <div className="mt-1">

--- a/frontend/src/pages/appliance/ClusterTab.tsx
+++ b/frontend/src/pages/appliance/ClusterTab.tsx
@@ -3,10 +3,12 @@ import {
   Boxes,
   Container as ContainerIcon,
   DatabaseBackup,
+  Gauge,
 } from "lucide-react";
 
 import { applianceApprovalApi } from "@/lib/api";
 import { useSessionState } from "@/lib/useSessionState";
+import { ClusterOverview } from "./ClusterOverview";
 import { ContainersTab } from "./ContainersTab";
 import { EtcdSnapshotsCard } from "./EtcdSnapshotsCard";
 
@@ -32,7 +34,7 @@ import { EtcdSnapshotsCard } from "./EtcdSnapshotsCard";
  * Pods needs the in-cluster kubeapi and etcd snapshots need the embedded
  * etcd seed — neither exists on a docker / k8s control plane.
  */
-type ClusterSection = "pods" | "etcd";
+type ClusterSection = "overview" | "pods" | "etcd";
 
 const SECTIONS: {
   key: ClusterSection;
@@ -40,6 +42,12 @@ const SECTIONS: {
   icon: typeof ContainerIcon;
   hint: string;
 }[] = [
+  {
+    key: "overview",
+    label: "Overview",
+    icon: Gauge,
+    hint: "Live health & metrics",
+  },
   {
     key: "pods",
     label: "Pods",
@@ -57,7 +65,7 @@ const SECTIONS: {
 export function ClusterTab() {
   const [section, setSection] = useSessionState<ClusterSection>(
     "appliance.cluster.section",
-    "pods",
+    "overview",
   );
 
   // Shared with EtcdSnapshotsCard (same query key → React Query dedupes)
@@ -104,7 +112,9 @@ export function ClusterTab() {
       </nav>
 
       <div className="min-w-0 flex-1">
-        {section === "pods" ? (
+        {section === "overview" ? (
+          <ClusterOverview />
+        ) : section === "pods" ? (
           <ContainersTab />
         ) : etcdAvailable ? (
           <div className="mx-auto max-w-4xl">

--- a/frontend/src/pages/appliance/ClusterTab.tsx
+++ b/frontend/src/pages/appliance/ClusterTab.tsx
@@ -1,0 +1,124 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  Boxes,
+  Container as ContainerIcon,
+  DatabaseBackup,
+} from "lucide-react";
+
+import { applianceApprovalApi } from "@/lib/api";
+import { useSessionState } from "@/lib/useSessionState";
+import { ContainersTab } from "./ContainersTab";
+import { EtcdSnapshotsCard } from "./EtcdSnapshotsCard";
+
+/**
+ * Cluster tab (issue #402).
+ *
+ * Combines two views of the k3s cluster underneath the appliance into a
+ * single operator-friendly tab behind a left sub-nav:
+ *
+ *   - Pods           — the running workloads (logs / restart), formerly
+ *                      its own top-level "Pods" tab (ContainersTab).
+ *   - etcd snapshots — the cluster's disaster-recovery state + guided
+ *                      restore, previously rendered inline on the Fleet
+ *                      tab where it crowded the appliance roster (#402).
+ *
+ * Deliberately named "Cluster", not "Kubernetes" — operators shouldn't
+ * need k8s vocabulary to find pod / etcd controls, but it's still honest
+ * about what it is (a single- or multi-node k3s cluster). The sub-nav
+ * keeps each section full-height so neither competes for vertical space
+ * (the original Fleet-tab complaint).
+ *
+ * Whole tab is gated selfOnly at AppliancePage (appliance hosts only):
+ * Pods needs the in-cluster kubeapi and etcd snapshots need the embedded
+ * etcd seed — neither exists on a docker / k8s control plane.
+ */
+type ClusterSection = "pods" | "etcd";
+
+const SECTIONS: {
+  key: ClusterSection;
+  label: string;
+  icon: typeof ContainerIcon;
+  hint: string;
+}[] = [
+  {
+    key: "pods",
+    label: "Pods",
+    icon: ContainerIcon,
+    hint: "Running workloads",
+  },
+  {
+    key: "etcd",
+    label: "etcd snapshots",
+    icon: DatabaseBackup,
+    hint: "Disaster recovery",
+  },
+];
+
+export function ClusterTab() {
+  const [section, setSection] = useSessionState<ClusterSection>(
+    "appliance.cluster.section",
+    "pods",
+  );
+
+  // Shared with EtcdSnapshotsCard (same query key → React Query dedupes)
+  // purely so the etcd section can show a friendly placeholder instead of
+  // a blank pane before the seed first reports its snapshots on heartbeat.
+  const { data: etcd } = useQuery({
+    queryKey: ["appliance", "etcd-snapshots"],
+    queryFn: applianceApprovalApi.listEtcdSnapshots,
+    staleTime: 20_000,
+  });
+  const etcdAvailable = !!etcd?.available;
+
+  return (
+    <div className="flex gap-6">
+      <nav className="w-48 shrink-0 space-y-1">
+        <div className="mb-2 flex items-center gap-1.5 px-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          <Boxes className="h-3.5 w-3.5" />
+          Cluster
+        </div>
+        {SECTIONS.map((s) => {
+          const Icon = s.icon;
+          const active = section === s.key;
+          return (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() => setSection(s.key)}
+              className={`flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left ${
+                active
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              }`}
+            >
+              <span className="flex items-center gap-1.5 text-sm">
+                <Icon className="h-3.5 w-3.5" />
+                {s.label}
+              </span>
+              <span className="pl-5 text-[11px] text-muted-foreground">
+                {s.hint}
+              </span>
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="min-w-0 flex-1">
+        {section === "pods" ? (
+          <ContainersTab />
+        ) : etcdAvailable ? (
+          <div className="mx-auto max-w-4xl">
+            <EtcdSnapshotsCard />
+          </div>
+        ) : (
+          <div className="mx-auto max-w-2xl rounded-lg border border-dashed bg-muted/30 px-6 py-12 text-center text-sm text-muted-foreground">
+            No recoverable etcd snapshots yet. These appear once the cluster
+            seed reports its embedded-etcd snapshots on heartbeat (k3s takes one
+            every ~6&nbsp;h, retains 8 — or run{" "}
+            <code>k3s etcd-snapshot save</code> on the seed for one now).
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -39,7 +39,6 @@ import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { useSessionState } from "@/lib/useSessionState";
 import { cn } from "@/lib/utils";
-import { EtcdSnapshotsCard } from "./EtcdSnapshotsCard";
 import { LLDPTab } from "./LLDPTab";
 import { NTPTab } from "./NTPTab";
 import { PairingTab } from "./PairingTab";
@@ -1338,9 +1337,8 @@ export function FleetTab({
                     onPermanentDelete={(row) => setPermanentDeleteTarget(row)}
                     onReplace={(row) => setReplaceTarget(row)}
                   />
-                  {/* #272 Phase 9b — etcd snapshot list + guided restore.
-                    Self-hides on docker / k8s control planes (no seed). */}
-                  <EtcdSnapshotsCard />
+                  {/* #402 — the etcd snapshot list + guided restore moved
+                    to the Cluster tab (it crowded the fleet roster here). */}
                   <ApplianceTableSection
                     title="Service agents"
                     subtitle="Appliance nodes running DNS / DHCP service containers paired to a remote control plane."


### PR DESCRIPTION
Closes #402

## What
Replaces the standalone **Pods** tab and the etcd-snapshots block that crowded **Fleet** with a single, operator-friendly **Cluster** tab — and makes its front door a live, near-real-time health/metrics dashboard for the k3s cluster underneath the appliance.

Named "Cluster" (not "Kubernetes") so operators don't need k8s vocabulary; it sorts immediately after the pinned Fleet tab.

### Cluster tab structure
- **Overview** (default) — the live dashboard (below)
- **Pods** — the former `ContainersTab` (workloads / logs / restart), unchanged
- **etcd snapshots** — the former `EtcdSnapshotsCard` lifted out of Fleet (restore guard intact)

### The Overview dashboard
Fed by an **SSE stream** (`/appliance/cluster/health/stream`) pushing a fresh snapshot every ~2s — server-driven, self-reconnecting, through nginx (same pattern as the log/chat SSE):
- Scrolling gradient **CPU/memory hero chart** + KPI ribbon with sparklines
- Animated **SVG radial gauges** per node, workload-health rollup, live **top-pods leaderboard**
- **Full host-partition breakdown** per node (root slot `/` · `/var` · `/boot/efi` ESP)

### Data sources (no Prometheus on the appliance)
- Node/pod inventory + live CPU/mem from the **kubelet Summary API** via the api SA — same source the TTY console uses. One read-only RBAC line (`nodes/proxy [get]`) added to the appliance-gated api ClusterRole.
- Host partitions come from the **supervisor** (`statvfs`, it has the host mounts), folded into the `cluster_health` JSONB it already heartbeats — **no migration / no new column**. One read-only host-root mount added to the supervisor DaemonSet for the root slot.
- New `find_cluster_metrics` MCP tool (non-negotiable #13) surfaces the live usage to the Operator Copilot.

## Commits
1. `87587ea` Cluster tab — fold in Pods + etcd
2. `d7b3410` live Cluster Overview dashboard (SSE node/pod metrics)
3. `e3fe054` clarify the node Disk line is the kubelet /var fs
4. `8928bd6` full host-partition breakdown (supervisor statvfs)

## Verification
- Backend ruff / black / mypy clean; **8** new tests (`test_cluster_health.py`); no new migration.
- Frontend ESLint (`--max-warnings 0`) + production build clean.
- **Field-validated on the ddi1 appliance**: migrate → roll api/worker/beat/frontend/supervisor → live SSE frames with real per-node CPU/mem, and the host-partition breakdown flowing end-to-end through the heartbeat (`/` 0.69/8.35 GB · `/var` 10.8/16 GB · ESP 0.01/0.54 GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)