### PR TITLE
feat(appliance): #404 Firewall left-nav + nav consolidation + realtime firewall logs

### DIFF
--- a/agent/supervisor/spatium_supervisor/__main__.py
+++ b/agent/supervisor/spatium_supervisor/__main__.py
@@ -344,6 +344,14 @@ def main() -> int:
     identity_for_nettool, _ = load_or_generate(cfg.state_dir)
     start_nettool_thread(cfg, identity_for_nettool)
 
+    # #404 — tail /dev/kmsg for nftables drop logs so the firewall_logs
+    # nettool can serve them to the Firewall → Logs viewer. Harmless if no
+    # drops are ever logged (firewall logging off) — the buffer just stays
+    # empty. Daemon thread; no-op if /dev/kmsg can't be opened.
+    from .kmsg_reader import start as start_kmsg_reader  # noqa: PLC0415
+
+    start_kmsg_reader()
+
     stop = False
 
     def _handle_signal(signum: int, _frame: object) -> None:

--- a/agent/supervisor/spatium_supervisor/kmsg_reader.py
+++ b/agent/supervisor/spatium_supervisor/kmsg_reader.py
@@ -1,0 +1,135 @@
+"""Realtime nftables-drop log reader for the Firewall → Logs viewer (#404).
+
+nft `log` statements land in the kernel ring buffer; `/dev/kmsg` exposes it.
+This module runs a daemon thread that tails `/dev/kmsg`, keeps only the lines
+our firewall renderer prefixes with ``spatium-fw: `` (#404 — a rate-limited
+catch-all log before the chain's policy drop), and buffers them with their
+kernel sequence number so the ``firewall_logs`` nettool can serve incremental
+batches (since-cursor) to the control plane.
+
+The supervisor pod runs privileged + as root, so `/dev/kmsg` (host kernel log)
+is readable. We seek to the end on open so we only surface NEW drops — i.e. the
+operator flips logging on, reproduces the blocked connection, and watches it
+appear — rather than replaying the whole boot-time kernel buffer.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import threading
+import time
+from collections import deque
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# Only buffer lines our renderer tags — keeps boot/kernel noise out and the
+# buffer cheap. Matches the prefix in backend firewall._FIREWALL_LOG_RULE.
+_PREFIX = "spatium-fw:"
+_KMSG = "/dev/kmsg"
+_MAX = 1000
+
+_buf: deque[tuple[int, int, str]] = deque(maxlen=_MAX)  # (seq, ts_us, text)
+_lock = threading.Lock()
+_available = False
+_started = False
+
+
+def is_available() -> bool:
+    """True once the reader has opened /dev/kmsg successfully."""
+    return _available
+
+
+def get_since(since_seq: int, limit: int) -> tuple[list[tuple[int, int, str]], int]:
+    """Return buffered entries with ``seq > since_seq`` (oldest-first, capped at
+    ``limit``) plus the newest seq seen (the next since-cursor)."""
+    with _lock:
+        snapshot = list(_buf)
+    fresh = [e for e in snapshot if e[0] > since_seq][:limit]
+    cursor = snapshot[-1][0] if snapshot else since_seq
+    return fresh, cursor
+
+
+def _parse(raw: str) -> tuple[int, int, str] | None:
+    """Parse a /dev/kmsg record ``prio,seq,ts_us,flags;message`` → (seq, ts, msg).
+
+    Continuation/dictionary lines (``\\n KEY=val``) are dropped to the first
+    line; a malformed header yields None.
+    """
+    header, sep, message = raw.partition(";")
+    if not sep:
+        return None
+    parts = header.split(",")
+    if len(parts) < 3:
+        return None
+    try:
+        seq = int(parts[1])
+        ts_us = int(parts[2])
+    except ValueError:
+        return None
+    return seq, ts_us, message.split("\n", 1)[0].strip()
+
+
+def _loop() -> None:
+    global _available
+    # Open /dev/kmsg, retrying — a privileged container can briefly see EPERM
+    # on /dev/kmsg right at pod start (before the device settles), and we must
+    # not let that transient failure kill the reader for the life of the pod.
+    fd = -1
+    for attempt in range(60):  # ~5 min of retries, then give up
+        try:
+            fd = os.open(_KMSG, os.O_RDONLY | os.O_NONBLOCK)
+            break
+        except OSError as exc:
+            if attempt == 0:
+                log.warning("supervisor.kmsg.open_retry", error=str(exc))
+            time.sleep(5.0)
+    if fd < 0:
+        log.warning("supervisor.kmsg.open_gave_up")
+        return
+    # Skip to the newest record — surface only drops logged from now on.
+    try:
+        os.lseek(fd, 0, os.SEEK_END)
+    except OSError:
+        pass
+    _available = True
+    log.info("supervisor.kmsg.reader_started")
+    try:
+        while True:
+            try:
+                data = os.read(fd, 8192)
+            except BlockingIOError:
+                time.sleep(0.5)
+                continue
+            except OSError as exc:
+                # EPIPE: records were overwritten between reads — the fd auto-
+                # advances to the next available record, so just keep going.
+                if exc.errno == errno.EPIPE:
+                    continue
+                log.warning("supervisor.kmsg.read_failed", error=str(exc))
+                time.sleep(1.0)
+                continue
+            if not data:
+                time.sleep(0.5)
+                continue
+            raw = data.decode("utf-8", "replace").rstrip("\n")
+            if _PREFIX not in raw:
+                continue
+            parsed = _parse(raw)
+            if parsed is not None:
+                with _lock:
+                    _buf.append(parsed)
+    finally:
+        os.close(fd)
+        _available = False
+
+
+def start() -> None:
+    """Spawn the kmsg reader daemon thread (idempotent)."""
+    global _started
+    if _started:
+        return
+    _started = True
+    threading.Thread(target=_loop, name="spatium-fw-kmsg", daemon=True).start()

--- a/agent/supervisor/spatium_supervisor/kmsg_reader.py
+++ b/agent/supervisor/spatium_supervisor/kmsg_reader.py
@@ -33,13 +33,17 @@ _MAX = 1000
 
 _buf: deque[tuple[int, int, str]] = deque(maxlen=_MAX)  # (seq, ts_us, text)
 _lock = threading.Lock()
-_available = False
-_started = False
+# Reader state as threading primitives rather than rebound module globals:
+# ``_ready`` is set once /dev/kmsg is open (cleared if the reader exits), and
+# ``_spawned`` guards the idempotent single-thread start.
+_ready = threading.Event()
+_spawn_lock = threading.Lock()
+_spawned = threading.Event()
 
 
 def is_available() -> bool:
     """True once the reader has opened /dev/kmsg successfully."""
-    return _available
+    return _ready.is_set()
 
 
 def get_since(since_seq: int, limit: int) -> tuple[list[tuple[int, int, str]], int]:
@@ -73,7 +77,6 @@ def _parse(raw: str) -> tuple[int, int, str] | None:
 
 
 def _loop() -> None:
-    global _available
     # Open /dev/kmsg, retrying — a privileged container can briefly see EPERM
     # on /dev/kmsg right at pod start (before the device settles), and we must
     # not let that transient failure kill the reader for the life of the pod.
@@ -93,8 +96,10 @@ def _loop() -> None:
     try:
         os.lseek(fd, 0, os.SEEK_END)
     except OSError:
+        # Non-fatal: if the seek fails we just read from the current position
+        # (some backlog may show), so there's nothing to handle — keep going.
         pass
-    _available = True
+    _ready.set()
     log.info("supervisor.kmsg.reader_started")
     try:
         while True:
@@ -123,13 +128,13 @@ def _loop() -> None:
                     _buf.append(parsed)
     finally:
         os.close(fd)
-        _available = False
+        _ready.clear()
 
 
 def start() -> None:
-    """Spawn the kmsg reader daemon thread (idempotent)."""
-    global _started
-    if _started:
-        return
-    _started = True
+    """Spawn the kmsg reader daemon thread (idempotent + race-safe)."""
+    with _spawn_lock:
+        if _spawned.is_set():
+            return
+        _spawned.set()
     threading.Thread(target=_loop, name="spatium-fw-kmsg", daemon=True).start()

--- a/agent/supervisor/spatium_supervisor/nettools.py
+++ b/agent/supervisor/spatium_supervisor/nettools.py
@@ -684,10 +684,40 @@ async def _run_tls_cert(params: dict[str, Any]) -> dict[str, Any]:
             pass
 
 
+# ── firewall logs (#404) ─────────────────────────────────────────────
+
+
+async def _run_firewall_logs(params: dict[str, Any]) -> dict[str, Any]:
+    """Serve buffered nftables drop-log lines from the kmsg reader.
+
+    Not a reachability probe — this reads the local kmsg ring buffer
+    (#404) for lines our firewall renderer tagged ``spatium-fw: ``.
+    ``since_seq`` is the incremental cursor; the result carries the new
+    cursor so the UI can poll for just-arrived lines.
+    """
+    from . import kmsg_reader  # noqa: PLC0415
+
+    try:
+        since_seq = int(params.get("since_seq", 0) or 0)
+    except (TypeError, ValueError):
+        since_seq = 0
+    try:
+        limit = int(params.get("limit", 200) or 200)
+    except (TypeError, ValueError):
+        limit = 200
+    limit = max(1, min(limit, 1000))
+    lines, cursor = kmsg_reader.get_since(since_seq, limit)
+    return {
+        "available": kmsg_reader.is_available(),
+        "lines": [{"seq": s, "ts_us": t, "text": txt} for (s, t, txt) in lines],
+        "cursor": cursor,
+    }
+
+
 # ── dispatch ─────────────────────────────────────────────────────────
 
-# The five reachability tools this executor knows how to run. Mirrors
-# the backend's ``agent_cmd.REACHABILITY_TOOLS`` set — a job for any tool
+# The reachability tools this executor knows how to run. Mirrors the
+# backend's ``agent_cmd.REACHABILITY_TOOLS`` set — a job for any tool
 # outside it is rejected (the control plane never enqueues one, but we
 # guard defensively so a malformed command can't crash the loop).
 _RUNNERS: Final[dict[str, Any]] = {
@@ -696,9 +726,16 @@ _RUNNERS: Final[dict[str, Any]] = {
     "dig": _run_dig,
     "port-test": _run_port_test,
     "tls-cert": _run_tls_cert,
+    # #404 — appliance-diagnostic tool (not a reachability probe), dispatched
+    # the same way; the backend allows it via an explicit allow-set.
+    "firewall_logs": _run_firewall_logs,
 }
 
-REACHABILITY_TOOLS: Final[frozenset[str]] = frozenset(_RUNNERS)
+# True reachability probes only — keep firewall_logs out of this so the set
+# keeps its meaning (the backend gates appliance dispatch on its own set).
+REACHABILITY_TOOLS: Final[frozenset[str]] = frozenset(
+    {"ping", "traceroute", "dig", "port-test", "tls-cert"}
+)
 
 
 async def execute(tool: str, params: dict[str, Any]) -> dict[str, Any]:

--- a/appliance/mkosi.extra/etc/sysctl.d/99-spatium-firewall-log.conf
+++ b/appliance/mkosi.extra/etc/sysctl.d/99-spatium-firewall-log.conf
@@ -1,0 +1,11 @@
+# #404 — allow the supervisor to read the kernel ring buffer (/dev/kmsg) for
+# the Firewall → Logs viewer.
+#
+# nftables `log` statements land in the kernel log. The supervisor runs as a
+# non-root user inside its (privileged) pod and so lacks CAP_SYSLOG, which the
+# default dmesg_restrict=1 requires to read /dev/kmsg. The SpatiumDDI appliance
+# is a single-purpose, single-tenant box — the kernel log is already visible to
+# the operator on the console + diagnostic bundle, and there are no untrusted
+# local users — so lifting the restriction here is low-risk and lets the
+# firewall-log tail work without granting the supervisor extra capabilities.
+kernel.dmesg_restrict = 0

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -245,6 +245,7 @@ backend/alembic/versions/c4f7e92d3a18_sdwan_overlay.py:drop_table:282
 backend/alembic/versions/c4f7e92d3a18_sdwan_overlay.py:drop_table:285
 backend/alembic/versions/c4f7e92d3a18_sdwan_overlay.py:drop_table:289
 backend/alembic/versions/c4f7e92d3a18_sdwan_overlay.py:drop_table:297
+backend/alembic/versions/c5f1a2b3d4e6_firewall_logging_enabled.py:drop_column:37
 backend/alembic/versions/c5f2a9b18e34_ipam_linkage_subnet_domains_bulk.py:drop_column:110
 backend/alembic/versions/c5f2a9b18e34_ipam_linkage_subnet_domains_bulk.py:drop_column:111
 backend/alembic/versions/c5f2a9b18e34_ipam_linkage_subnet_domains_bulk.py:drop_column:112

--- a/backend/alembic/versions/c5f1a2b3d4e6_firewall_logging_enabled.py
+++ b/backend/alembic/versions/c5f1a2b3d4e6_firewall_logging_enabled.py
@@ -1,0 +1,37 @@
+"""#404 — firewall_logging_enabled platform setting
+
+Adds the opt-in firewall-logging master switch. When on (and firewall_enabled
+is on), the rendered nft drop-in carries a rate-limited catch-all
+``log prefix "spatium-fw: "`` so dropped packets land in the kernel log for the
+Firewall → Logs realtime viewer.
+
+Revision ID: c5f1a2b3d4e6
+Revises: b3e7d1f9a204
+Create Date: 2026-06-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c5f1a2b3d4e6"
+down_revision = "b3e7d1f9a204"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "firewall_logging_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_settings", "firewall_logging_enabled")

--- a/backend/app/api/v1/appliance/firewall.py
+++ b/backend/app/api/v1/appliance/firewall.py
@@ -974,6 +974,9 @@ class EnforcementNode(BaseModel):
 
 class EnforcementStatus(BaseModel):
     enabled: bool
+    # #404 — opt-in firewall logging master switch (independent of the
+    # enforcement gate; logging is harmless so it has no hardened-node guard).
+    logging_enabled: bool = False
     reported_count: int
     hardened_count: int
     lanwide_count: int
@@ -987,9 +990,14 @@ class SetEnforcementRequest(BaseModel):
     override_unhardened: bool = False
 
 
+class SetFirewallLoggingRequest(BaseModel):
+    enabled: bool
+
+
 async def _enforcement_status(db: DB) -> EnforcementStatus:
     cfg = await db.get(PlatformSettings, 1)
     enabled = bool(cfg.firewall_enabled) if cfg else False
+    logging_enabled = bool(cfg.firewall_logging_enabled) if cfg else False
     rows = list(
         (
             await db.execute(
@@ -1026,6 +1034,7 @@ async def _enforcement_status(db: DB) -> EnforcementStatus:
     all_hardened = reported > 0 and hardened == reported
     return EnforcementStatus(
         enabled=enabled,
+        logging_enabled=logging_enabled,
         reported_count=reported,
         hardened_count=hardened,
         lanwide_count=lanwide,
@@ -1087,6 +1096,40 @@ async def set_enforcement(
                     "hardened_count": status.hardened_count,
                     "reported_count": status.reported_count,
                 },
+            )
+        )
+    await db.commit()
+    return await _enforcement_status(db)
+
+
+@router.put("/logging", response_model=EnforcementStatus)
+async def set_logging(
+    body: SetFirewallLoggingRequest, db: DB, current_user: CurrentUser
+) -> EnforcementStatus:
+    """#404 — toggle opt-in firewall drop-logging. Independent of the
+    enforcement master switch + hardened gate (logging is harmless): it just
+    makes the rendered nft drop-in carry a rate-limited catch-all log rule, so
+    the Firewall → Logs viewer has something to tail. Takes effect on the next
+    supervisor heartbeat render (only matters while firewall_enabled is on)."""
+    _require_admin(current_user)
+    cfg = await db.get(PlatformSettings, 1)
+    if cfg is None:
+        cfg = PlatformSettings(id=1)
+        db.add(cfg)
+        await db.flush()
+    if cfg.firewall_logging_enabled != body.enabled:
+        cfg.firewall_logging_enabled = body.enabled
+        db.add(
+            AuditLog(
+                action="update",
+                resource_type="platform_settings",
+                resource_id="1",
+                resource_display="firewall logging",
+                user_id=current_user.id,
+                user_display_name=current_user.username,
+                result="success",
+                changed_fields=["firewall_logging_enabled"],
+                new_value={"firewall_logging_enabled": body.enabled},
             )
         )
     await db.commit()

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -2031,6 +2031,7 @@ async def supervisor_heartbeat(
         firewall_enabled=bool(cfg_row.firewall_enabled) if cfg_row else False,
         appliance_id=row.id,
         web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        firewall_logging_enabled=(bool(cfg_row.firewall_logging_enabled) if cfg_row else False),
     )
     # Persist the rendered hash so 2d's apply-stalled alarm + the Fleet drift
     # chip can compare it against the runner's reported applied_hash. Only

--- a/backend/app/api/v1/tools/router.py
+++ b/backend/app/api/v1/tools/router.py
@@ -44,6 +44,8 @@ from app.api.v1.dns_tools import (
 from app.api.v1.tools.schemas import (
     CommandResult,
     DigRequest,
+    FirewallLogsRequest,
+    FirewallLogsResult,
     HostRequest,
     MacVendorEntry,
     MacVendorRequest,
@@ -100,6 +102,7 @@ async def _dispatch_to_appliance[ResultT: BaseModel](
     target: NetToolTarget,
     db: DB,
     current_user: CurrentUser,
+    allowed: frozenset[str] = agent_cmd.REACHABILITY_TOOLS,
 ) -> ResultT:
     """Run a reachability tool FROM a Fleet appliance's vantage.
 
@@ -120,8 +123,9 @@ async def _dispatch_to_appliance[ResultT: BaseModel](
     Every appliance-targeted run is audit-logged (non-negotiable #4)
     with the tool, the target appliance id+name, and the target host.
     """
-    # (a) reachability gate.
-    if tool not in agent_cmd.REACHABILITY_TOOLS:
+    # (a) dispatch gate — reachability tools by default; callers pass an
+    # explicit allow-set for appliance-diagnostic tools (e.g. firewall_logs).
+    if tool not in allowed:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
             f"Tool {tool!r} cannot be run from an appliance vantage.",
@@ -352,6 +356,40 @@ async def tls_cert(
             current_user=current_user,
         )
     return await inspect_tls_cert(body.host, body.port, body.server_name, body.timeout_seconds)
+
+
+# ── firewall logs (appliance-diagnostic, #404) ──────────────────────
+
+
+@router.post("/firewall-logs", response_model=FirewallLogsResult, dependencies=[_RequirePerm])
+async def firewall_logs(
+    body: FirewallLogsRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
+) -> FirewallLogsResult:
+    """Tail an appliance's nftables drop logs (#404).
+
+    Always runs from an appliance vantage — the api container can't read host
+    kernel logs, so a server target is rejected. Dispatched over the same
+    supervisor poll/reply channel the reachability tools use, so it works for
+    the local control-plane appliance AND remote fleet appliances. The UI polls
+    this with the returned ``cursor`` for a near-realtime tail.
+    """
+    if _server_target(body.target):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "firewall-logs requires an appliance target — the control plane "
+            "can't read host kernel logs itself.",
+        )
+    assert body.target is not None
+    return await _dispatch_to_appliance(
+        tool="firewall_logs",
+        params=body.model_dump(mode="json"),
+        request_model=FirewallLogsRequest,
+        result_model=FirewallLogsResult,
+        target=body.target,
+        db=db,
+        current_user=current_user,
+        allowed=frozenset({"firewall_logs"}),
+    )
 
 
 # ── DNS propagation (reuses the dns_tools helper; off-prem budget) ──

--- a/backend/app/api/v1/tools/schemas.py
+++ b/backend/app/api/v1/tools/schemas.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 from app.services.nettools.schemas import (
     CommandResult,
     DigRequest,
+    FirewallLogLine,
+    FirewallLogsRequest,
+    FirewallLogsResult,
     HostRequest,
     MacVendorEntry,
     MacVendorRequest,
@@ -29,6 +32,9 @@ from app.services.nettools.schemas import (
 __all__ = [
     "CommandResult",
     "DigRequest",
+    "FirewallLogLine",
+    "FirewallLogsRequest",
+    "FirewallLogsResult",
     "HostRequest",
     "MacVendorEntry",
     "MacVendorRequest",

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -661,6 +661,15 @@ class PlatformSettings(Base):
     firewall_enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=sa_text("false")
     )
+    # #404 — opt-in firewall logging. When on (and firewall_enabled is on),
+    # the rendered nft drop-in gets a rate-limited catch-all `log prefix
+    # "spatium-fw: "` before the chain's policy drop, so dropped/rejected
+    # packets land in the kernel log. The supervisor tails /dev/kmsg for that
+    # prefix and serves it to the Firewall → Logs viewer. Off by default
+    # (log volume); flip on for troubleshooting, off when done.
+    firewall_logging_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
     # #285 Phase 6 — source-scope the Web UI (frontend hostPort 80/443 + the
     # MetalLB control-plane VIP). Empty = open (today's behaviour). When set,
     # both firewall renderers emit a peer-scoped 80/443 accept (requires the

--- a/backend/app/services/appliance/firewall.py
+++ b/backend/app/services/appliance/firewall.py
@@ -233,6 +233,7 @@ async def firewall_bundle(
     firewall_enabled: bool,
     appliance_id: Any = None,
     web_ui_allowed_cidrs: list[Any] | None = None,
+    firewall_logging_enabled: bool = False,
 ) -> dict[str, Any]:
     """The ``firewall_settings`` block shipped on the supervisor heartbeat.
 
@@ -270,11 +271,27 @@ async def firewall_bundle(
         appliance_policy=appliance_policy,
         web_ui_allowed_cidrs=web_ui_allowed_cidrs,
     )
+    if firewall_logging_enabled:
+        # #404 — a rate-limited catch-all log just before the chain's
+        # policy drop. The drop-in's accept rules terminate first; anything
+        # falling through gets logged (≤10/s so a scan can't flood dmesg)
+        # then hits the base chain's `policy drop`. The supervisor tails
+        # /dev/kmsg for this prefix → Firewall → Logs viewer.
+        body = body.rstrip("\n") + "\n" + _FIREWALL_LOG_RULE + "\n"
     return {
         "enabled": True,
         "config_hash": hashlib.sha256(body.encode("utf-8")).hexdigest(),
         "firewall_conf": body,
     }
+
+
+# nft rule appended to the rendered drop-in when firewall logging is on. No
+# verdict → it logs + continues, so the base chain's `policy drop` still drops.
+_FIREWALL_LOG_RULE = (
+    "limit rate 10/second burst 20 packets "
+    'log prefix "spatium-fw: " level info '
+    'comment "spatiumddi dropped-packet log (#404)"'
+)
 
 
 __all__ = ["compile_firewall_body", "firewall_bundle"]

--- a/backend/app/services/nettools/schemas.py
+++ b/backend/app/services/nettools/schemas.py
@@ -456,9 +456,44 @@ class MacVendorResult(BaseModel):
     entries: list[MacVendorEntry]
 
 
+# ── firewall logs (appliance-diagnostic, #404) ──────────────────────
+#
+# Not a reachability probe: it serves the supervisor's kmsg-tailed
+# nftables drop-log buffer. The api container can't read host kernel
+# logs, so this ALWAYS runs from an appliance vantage (the router rejects
+# a server target). ``since_seq`` is the incremental cursor.
+
+
+class FirewallLogsRequest(BaseModel):
+    target: NetToolTarget | None = None
+    since_seq: int = Field(default=0, ge=0)
+    limit: int = Field(default=200, ge=1, le=1000)
+
+
+class FirewallLogLine(BaseModel):
+    seq: int
+    ts_us: int
+    text: str
+
+
+class FirewallLogsResult(BaseModel):
+    # False when the supervisor couldn't open /dev/kmsg.
+    available: bool = False
+    lines: list[FirewallLogLine] = []
+    # Newest kernel sequence seen — pass back as ``since_seq`` to poll for
+    # just-arrived lines.
+    cursor: int = 0
+    error: str | None = None
+    # See CommandResult.ran_from — stamped "appliance:<name>" after dispatch.
+    ran_from: str = "server"
+
+
 __all__ = [
     "CommandResult",
     "DigRequest",
+    "FirewallLogLine",
+    "FirewallLogsRequest",
+    "FirewallLogsResult",
     "HostRequest",
     "MacVendorEntry",
     "MacVendorRequest",

--- a/backend/tests/test_firewall_logging.py
+++ b/backend/tests/test_firewall_logging.py
@@ -1,0 +1,56 @@
+"""Tests for the #404 opt-in firewall drop-logging render injection.
+
+When ``firewall_logging_enabled`` is on (and ``firewall_enabled`` is on), the
+rendered nft drop-in body gains a single rate-limited catch-all ``log prefix
+"spatium-fw: "`` rule at the very end (after the accept rules), so dropped
+packets land in the kernel log for the Firewall → Logs viewer. The flag is a
+no-op when enforcement is off (the bundle short-circuits to the disabled
+shape).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.appliance.firewall import _FIREWALL_LOG_RULE, firewall_bundle
+
+_COMMON = dict(
+    role_assignment={"roles": []},
+    cluster_peer_cidrs=[],
+    pod_cidrs=[],
+    service_cidrs=[],
+    cp_member_count=1,
+    vip_configured=False,
+)
+
+
+async def test_logging_off_has_no_log_rule(db_session: AsyncSession) -> None:
+    bundle = await firewall_bundle(db_session, firewall_enabled=True, **_COMMON)
+    assert bundle["enabled"] is True
+    assert _FIREWALL_LOG_RULE not in bundle["firewall_conf"]
+    assert "spatium-fw:" not in bundle["firewall_conf"]
+
+
+async def test_logging_on_appends_single_log_rule(db_session: AsyncSession) -> None:
+    base = await firewall_bundle(db_session, firewall_enabled=True, **_COMMON)
+    logged = await firewall_bundle(
+        db_session, firewall_enabled=True, firewall_logging_enabled=True, **_COMMON
+    )
+    # The rule lands once, at the end (accepts terminate first; the catch-all
+    # logs whatever falls through before the base chain's policy drop).
+    assert logged["firewall_conf"].count("spatium-fw:") == 1
+    assert logged["firewall_conf"].rstrip().endswith(_FIREWALL_LOG_RULE)
+    # Body changed → hash shifts → the supervisor re-applies + picks up logging.
+    assert logged["config_hash"] != base["config_hash"]
+    # Rate limit is present so a scan can't flood the kernel log.
+    assert "limit rate" in _FIREWALL_LOG_RULE
+
+
+async def test_logging_ignored_when_enforcement_off(db_session: AsyncSession) -> None:
+    # firewall_enabled off → disabled shape regardless of the logging flag.
+    bundle = await firewall_bundle(
+        db_session, firewall_enabled=False, firewall_logging_enabled=True, **_COMMON
+    )
+    assert bundle["enabled"] is False
+    assert bundle["firewall_conf"] == ""
+    assert bundle["config_hash"] == ""

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7803,6 +7803,8 @@ export interface FirewallEnforcementNode {
 
 export interface FirewallEnforcement {
   enabled: boolean;
+  /** #404 — opt-in firewall drop-logging master switch. */
+  logging_enabled: boolean;
   reported_count: number;
   hardened_count: number;
   lanwide_count: number;
@@ -7881,6 +7883,11 @@ export const firewallApi = {
   setEnforcement: (body: { enabled: boolean; override_unhardened?: boolean }) =>
     api
       .put<FirewallEnforcement>(`${_FW}/enforcement`, body)
+      .then((r) => r.data),
+  // #404 — opt-in firewall drop-logging toggle (independent of enforcement).
+  setLogging: (enabled: boolean) =>
+    api
+      .put<FirewallEnforcement>(`${_FW}/logging`, { enabled })
       .then((r) => r.data),
   applyPosture: (preset: "locked" | "balanced" | "open") =>
     api.post<FirewallPolicy>(`${_FW}/posture`, { preset }).then((r) => r.data),
@@ -11278,7 +11285,32 @@ export const networkToolsApi = {
     api
       .post<NetToolMacVendorResult>("/tools/mac-vendor", { macs })
       .then((r) => r.data),
+  // #404 — tail an appliance's nftables drop logs. Always appliance-targeted
+  // (the api can't read host kernel logs); poll with the returned cursor.
+  firewallLogs: (
+    body: { since_seq?: number; limit?: number },
+    target: NetToolTarget,
+  ) =>
+    api
+      .post<FirewallLogsResult>("/tools/firewall-logs", { ...body, target })
+      .then((r) => r.data),
 };
+
+// #404 — firewall drop-log line + result (Firewall → Logs viewer).
+export interface FirewallLogLine {
+  seq: number;
+  ts_us: number;
+  text: string;
+}
+
+export interface FirewallLogsResult {
+  available: boolean;
+  lines: FirewallLogLine[];
+  cursor: number;
+  error: string | null;
+  /** Vantage the run executed from — "appliance:<name>". */
+  ran_from?: string;
+}
 
 // ── ASN management ──────────────────────────────────────────────────
 

--- a/frontend/src/pages/admin/PlatformInsightsPage.tsx
+++ b/frontend/src/pages/admin/PlatformInsightsPage.tsx
@@ -443,7 +443,7 @@ function ContainersPanel() {
 
   // On a k3s appliance the control-plane workloads run as Kubernetes pods,
   // not Docker containers, so this docker-stats view is empty/irrelevant.
-  // Send the operator to the Appliance → Pods surface (live logs + restart).
+  // Send the operator to Appliance → Cluster → Pods (live logs + restart).
   if (isAppliance) {
     return (
       <div className="rounded border border-blue-500/40 bg-blue-500/5 p-4">
@@ -455,10 +455,10 @@ function ContainersPanel() {
           Control-plane workloads run as Kubernetes pods, not Docker containers.
           View and manage them — with restart and live log streaming — under{" "}
           <Link
-            to="/appliance?tab=containers"
+            to="/appliance?tab=cluster&section=pods"
             className="font-medium text-primary hover:underline"
           >
-            Appliance → Pods
+            Appliance → Cluster → Pods
           </Link>
           .
         </p>

--- a/frontend/src/pages/appliance/AppliancePage.tsx
+++ b/frontend/src/pages/appliance/AppliancePage.tsx
@@ -1,12 +1,10 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
-  Box,
   Boxes,
   Network,
-  Rocket,
   ScrollText,
   ShieldAlert,
   ShieldCheck,
@@ -18,14 +16,22 @@ import { applianceApi } from "@/lib/api";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { useSessionState } from "@/lib/useSessionState";
 import { FleetTab } from "./FleetTab";
-import { CertificatesTab } from "./CertificatesTab";
 import { ClusterTab } from "./ClusterTab";
-import { ClusterUpgradeTab } from "./ClusterUpgradeTab";
 import { FirewallTab } from "./FirewallTab";
 import { LogsTab } from "./LogsTab";
 import { MaintenanceTab } from "./MaintenanceTab";
 import { NetworkTab } from "./NetworkTab";
-import { ReleasesTab } from "./ReleasesTab";
+
+// #404 — Rolling Upgrade, Releases, and Web UI Certificate moved OUT of the
+// top-level tab bar and INTO the Fleet tab's left sidebar (Rolling Upgrade now
+// also hosts the Releases catalog). The legacy ?tab= deep-links + the Fleet
+// drilldown's onNavigateTab calls for those keys are remapped to the Fleet tab
+// + the matching sidebar section via LEGACY_TAB_TO_FLEET_SECTION below.
+const LEGACY_TAB_TO_FLEET_SECTION: Record<string, string> = {
+  tls: "web-ui-certificate",
+  releases: "cluster-upgrade",
+  "cluster-upgrade": "cluster-upgrade",
+};
 
 /**
  * SpatiumDDI OS appliance management hub (issue #134, Phase 4).
@@ -43,15 +49,12 @@ import { ReleasesTab } from "./ReleasesTab";
  * then releases / containers / logs / network / wizard in any order.
  */
 type Tab =
-  | "tls"
   | "fleet"
   | "firewall"
-  | "releases"
   | "cluster"
   | "logs"
   | "network"
-  | "maintenance"
-  | "cluster-upgrade";
+  | "maintenance";
 
 interface TabSpec {
   key: Tab;
@@ -96,19 +99,6 @@ const TABS: TabSpec[] = [
     icon: Stamp,
     summary:
       "Manage the Application appliance fleet — approve / reject pending pairings, assign roles + groups, schedule OS slot upgrades + reboots, re-key + delete. Pending rows pin at the top; approved rows open a per-appliance drilldown with capability detail + role assignment + firewall preview + OS upgrade controls.",
-  },
-  {
-    // #296 Phase G — Rolling Upgrade tab. Multi-node cluster upgrade
-    // orchestrator surface; consumes the Phase A-F endpoints under
-    // /api/v1/upgrades. selfOnly because the orchestrator requires
-    // kubeapi access (no docker-compose path).
-    key: "cluster-upgrade",
-    label: "Rolling Upgrade",
-    phase: "296",
-    icon: Rocket,
-    selfOnly: true,
-    summary:
-      "Multi-node rolling upgrade orchestrator — walks the cluster from version N-1 to N one node at a time with preflight gate, CNPG cordon-triggered switchover, drain, slot apply + reboot, health gate, DS-Ready gate, uncordon. Post-loop chart bump + migrate Job close the mixed-version window once every node commits the new slot.",
   },
   {
     // #402 — Cluster tab. Combines the Pods view + the etcd snapshot /
@@ -166,23 +156,6 @@ const TABS: TabSpec[] = [
     summary:
       "Declarative per-role / per-appliance nftables policy compiled into each node's drop-in. Edit fleet / role / appliance policies + rules + aliases, and preview any node's effective merged ruleset (dark until the firewall_enabled master switch is on). The seeded builtin role policies reproduce the hardcoded Phase-2 renderer byte-for-byte.",
   },
-  {
-    key: "releases",
-    label: "Releases",
-    phase: "4c",
-    icon: Box,
-    summary:
-      "GitHub Releases list with one-click pull-and-recycle, a rollback target picker, and the release notes inline so operators see what they're applying before they apply it.",
-  },
-  {
-    key: "tls",
-    label: "Web UI Certificate",
-    phase: "4b",
-    icon: ShieldCheck,
-    selfOnly: true,
-    summary:
-      "Upload an existing certificate + key, generate a CSR, or have the appliance issue a Let's Encrypt cert against a public DNS name. Reuses the existing ACME service (app/services/acme/).",
-  },
 ];
 
 export function AppliancePage() {
@@ -212,12 +185,25 @@ export function AppliancePage() {
     return a.label.localeCompare(b.label, undefined, { sensitivity: "base" });
   });
 
-  // Default tab — first self-only tab on appliance hosts (TLS),
-  // first universal tab (Releases) otherwise. Keeps the session-stored
-  // value if it's still in the visible set; falls back if the operator
-  // last visited a now-hidden tab (e.g. after a deployment-kind change).
-  const defaultTab: Tab = isApplianceHost ? "tls" : "releases";
+  // Default tab — Fleet (pinned first, always visible on every deployment
+  // shape). Keeps the session-stored value if it's still in the visible set;
+  // falls back here if the operator last visited a now-removed tab (#404 moved
+  // Rolling Upgrade / Releases / Web UI Certificate into the Fleet sidebar).
+  const defaultTab: Tab = "fleet";
   const [tab, setTab] = useSessionState<Tab>("appliance.tab", defaultTab);
+
+  // #404 — a deep-link / onNavigateTab target that now lives in the Fleet
+  // sidebar jumps to Fleet and hands the section down for FleetTab to select.
+  const [fleetSection, setFleetSection] = useState<string | null>(null);
+  const navigate = (t: string) => {
+    const target = LEGACY_TAB_TO_FLEET_SECTION[t];
+    if (target) {
+      setTab("fleet");
+      setFleetSection(target);
+    } else {
+      setTab(t as Tab);
+    }
+  };
 
   // Deep-link support: ``/appliance?tab=<key>`` forces a specific tab on
   // arrival regardless of the session-stored last-active tab — e.g. the
@@ -232,7 +218,13 @@ export function AppliancePage() {
   const requestedTab = searchParams.get("tab");
   useEffect(() => {
     if (!requestedTab) return;
-    if (TABS.some((t) => t.key === requestedTab)) {
+    const target = LEGACY_TAB_TO_FLEET_SECTION[requestedTab];
+    if (target) {
+      // Legacy ?tab=tls / ?tab=releases / ?tab=cluster-upgrade now resolve to
+      // the Fleet tab + the matching sidebar section (#404).
+      setTab("fleet");
+      setFleetSection(target);
+    } else if (TABS.some((t) => t.key === requestedTab)) {
       setTab(requestedTab as Tab);
     }
     const next = new URLSearchParams(searchParams);
@@ -266,7 +258,7 @@ export function AppliancePage() {
           {!isApplianceHost && (
             <span
               className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
-              title="This control plane is running on Docker or Kubernetes. Host-level tabs (TLS, Cluster, Logs, Network, Maintenance) are hidden — the OS Versions tab still drives slot upgrades on any registered appliance agents."
+              title="This control plane is running on Docker or Kubernetes. Host-level tabs (Cluster, Logs, Network, Maintenance) are hidden — the OS Versions tab still drives slot upgrades on any registered appliance agents."
             >
               docker/k8s
             </span>
@@ -275,14 +267,14 @@ export function AppliancePage() {
         <p className="mt-1 text-xs text-muted-foreground">
           {isApplianceHost ? (
             <>
-              Manage the SpatiumDDI OS appliance — TLS, releases, cluster, logs,
-              host network, and lifecycle. The OS Versions tab also drives slot
-              upgrades on every registered remote DNS + DHCP agent.
+              Manage the SpatiumDDI OS appliance — fleet, firewall, cluster,
+              logs, host network, and lifecycle. Releases, rolling OS upgrades,
+              and the Web UI certificate now live under the Fleet sidebar.
             </>
           ) : (
             <>
               This control plane is running on Docker / Kubernetes. Host-level
-              tabs (TLS, Cluster, Logs, Network, Maintenance) only apply to an
+              tabs (Cluster, Logs, Network, Maintenance) only apply to an
               appliance-hosted control plane and are hidden here. The OS
               Versions tab still drives slot upgrades on any registered
               appliance agents.
@@ -312,22 +304,15 @@ export function AppliancePage() {
       </div>
 
       <div className="flex-1 overflow-auto bg-background p-6">
-        {effectiveTab === "tls" ? (
-          <CertificatesTab />
-        ) : effectiveTab === "fleet" ? (
+        {effectiveTab === "fleet" ? (
           <FleetTab
-            onNavigateTab={(t) => setTab(t as Tab)}
+            onNavigateTab={navigate}
             isApplianceHost={isApplianceHost}
-          />
-        ) : effectiveTab === "releases" ? (
-          <ReleasesTab
-            applianceMode={isApplianceHost}
-            onNavigateTab={(t) => setTab(t as Tab)}
+            initialSection={fleetSection}
+            onSectionApplied={() => setFleetSection(null)}
           />
         ) : effectiveTab === "firewall" ? (
           <FirewallTab />
-        ) : effectiveTab === "cluster-upgrade" ? (
-          <ClusterUpgradeTab />
         ) : effectiveTab === "cluster" ? (
           <ClusterTab />
         ) : effectiveTab === "logs" ? (

--- a/frontend/src/pages/appliance/AppliancePage.tsx
+++ b/frontend/src/pages/appliance/AppliancePage.tsx
@@ -195,6 +195,9 @@ export function AppliancePage() {
   // #404 — a deep-link / onNavigateTab target that now lives in the Fleet
   // sidebar jumps to Fleet and hands the section down for FleetTab to select.
   const [fleetSection, setFleetSection] = useState<string | null>(null);
+  // Deep-linked sub-section for the Cluster tab (e.g. Platform Insights →
+  // Containers links to ?tab=cluster&section=pods, #404 follow-up).
+  const [clusterSection, setClusterSection] = useState<string | null>(null);
   const navigate = (t: string) => {
     const target = LEGACY_TAB_TO_FLEET_SECTION[t];
     if (target) {
@@ -216,6 +219,7 @@ export function AppliancePage() {
   // deep-linked tab turns out to be hidden on a docker/k8s control plane.
   const [searchParams, setSearchParams] = useSearchParams();
   const requestedTab = searchParams.get("tab");
+  const requestedSection = searchParams.get("section");
   useEffect(() => {
     if (!requestedTab) return;
     const target = LEGACY_TAB_TO_FLEET_SECTION[requestedTab];
@@ -226,11 +230,17 @@ export function AppliancePage() {
       setFleetSection(target);
     } else if (TABS.some((t) => t.key === requestedTab)) {
       setTab(requestedTab as Tab);
+      // ?section= deep-links a tab's left sub-section (Cluster: Platform
+      // Insights → Containers points at ?tab=cluster&section=pods).
+      if (requestedTab === "cluster" && requestedSection) {
+        setClusterSection(requestedSection);
+      }
     }
     const next = new URLSearchParams(searchParams);
     next.delete("tab");
+    next.delete("section");
     setSearchParams(next, { replace: true });
-  }, [requestedTab, searchParams, setSearchParams, setTab]);
+  }, [requestedTab, requestedSection, searchParams, setSearchParams, setTab]);
 
   const effectiveTab: Tab = visibleTabs.some((t) => t.key === tab)
     ? tab
@@ -314,7 +324,10 @@ export function AppliancePage() {
         ) : effectiveTab === "firewall" ? (
           <FirewallTab />
         ) : effectiveTab === "cluster" ? (
-          <ClusterTab />
+          <ClusterTab
+            initialSection={clusterSection}
+            onSectionApplied={() => setClusterSection(null)}
+          />
         ) : effectiveTab === "logs" ? (
           <LogsTab />
         ) : effectiveTab === "network" ? (

--- a/frontend/src/pages/appliance/ClusterTab.tsx
+++ b/frontend/src/pages/appliance/ClusterTab.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Boxes,
@@ -62,11 +63,29 @@ const SECTIONS: {
   },
 ];
 
-export function ClusterTab() {
+export function ClusterTab({
+  initialSection = null,
+  onSectionApplied,
+}: {
+  // #404 follow-up — a deep-link (?tab=cluster&section=pods, e.g. from Platform
+  // Insights → Containers) selects a sub-section on arrival; cleared via
+  // onSectionApplied so re-navigating to the same section fires again.
+  initialSection?: string | null;
+  onSectionApplied?: () => void;
+} = {}) {
   const [section, setSection] = useSessionState<ClusterSection>(
     "appliance.cluster.section",
     "overview",
   );
+
+  useEffect(() => {
+    if (initialSection) {
+      setSection(initialSection as ClusterSection);
+      onSectionApplied?.();
+    }
+    // Gate purely on the prop; setSection/onSectionApplied identities are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialSection]);
 
   // Shared with EtcdSnapshotsCard (same query key → React Query dedupes)
   // purely so the etcd section can show a friendly placeholder instead of

--- a/frontend/src/pages/appliance/FirewallTab.tsx
+++ b/frontend/src/pages/appliance/FirewallTab.tsx
@@ -6,7 +6,14 @@
 // tab itself is gated in AppliancePage on the appliance.firewall feature
 // module — #14's NavItem clause is satisfied by tab-level gating because the
 // firewall family lives under the always-visible /appliance parent.
-import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
@@ -29,6 +36,8 @@ import {
   applianceApprovalApi,
   firewallApi,
   formatApiError,
+  networkToolsApi,
+  type FirewallLogLine,
   type FirewallAction,
   type FirewallEffective,
   type FirewallFamily,
@@ -208,22 +217,211 @@ export function FirewallTab() {
   );
 }
 
-// #404 Phase 2 — realtime nftables firewall-log viewer. Placeholder until the
-// supervisor-side log stream lands (nft rules don't log today; the api pod
-// can't read host kernel logs, so the supervisor tails them and streams via
-// the proxy — local node first, remote appliances via the same seam).
+// #404 Phase 2 — realtime nftables firewall-log viewer.
+//
+// nft rules don't log by default, so logging is an opt-in toggle: when on, the
+// renderer adds a rate-limited catch-all `log prefix "spatium-fw: "` before the
+// chain's policy drop. The api pod can't read host kernel logs, so the
+// supervisor tails /dev/kmsg and serves the lines over the nettool proxy —
+// which routes per-appliance, so any appliance in the fleet is selectable. We
+// poll ~2s with a since-cursor for a near-realtime tail.
+function recentlySeen(iso: string | null | undefined): boolean {
+  if (!iso) return false;
+  const t = new Date(iso).getTime();
+  return Number.isFinite(t) && Date.now() - t < 120_000;
+}
+
 function FirewallLogsSection() {
+  const qc = useQueryClient();
+  const { data: enf } = useQuery({
+    queryKey: ["firewall", "enforcement"],
+    queryFn: firewallApi.getEnforcement,
+  });
+  const setLogging = useMutation({
+    mutationFn: firewallApi.setLogging,
+    onSuccess: (d) => qc.setQueryData(["firewall", "enforcement"], d),
+  });
+
+  const { data: appliances } = useQuery({
+    queryKey: ["appliance", "fleet", "fw-logs"],
+    queryFn: applianceApprovalApi.list,
+    refetchInterval: 30_000,
+  });
+  const online = useMemo(
+    () =>
+      (appliances ?? []).filter(
+        (a) =>
+          a.state === "approved" &&
+          a.deployment_kind === "appliance" &&
+          recentlySeen(a.last_seen_at),
+      ),
+    [appliances],
+  );
+
+  const [selected, setSelected] = useState<string>("");
+  useEffect(() => {
+    if (!selected && online.length) setSelected(online[0].id);
+  }, [online, selected]);
+
+  const [lines, setLines] = useState<FirewallLogLine[]>([]);
+  const [paused, setPaused] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const cursorRef = useRef(0);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Reset the buffer when the target appliance changes.
+  useEffect(() => {
+    setLines([]);
+    cursorRef.current = 0;
+    setErr(null);
+  }, [selected]);
+
+  // Poll the appliance's firewall_logs nettool for new lines (~2s).
+  useEffect(() => {
+    if (!selected || paused) return;
+    let stop = false;
+    const tick = async () => {
+      try {
+        const res = await networkToolsApi.firewallLogs(
+          { since_seq: cursorRef.current, limit: 500 },
+          { kind: "appliance", id: selected },
+        );
+        if (stop) return;
+        setErr(
+          res.available ? null : "kernel log not readable on this appliance",
+        );
+        if (res.cursor) cursorRef.current = res.cursor;
+        if (res.lines.length) {
+          setLines((prev) => {
+            const next = [...prev, ...res.lines];
+            return next.length > 2000 ? next.slice(next.length - 2000) : next;
+          });
+        }
+      } catch (e) {
+        if (!stop) setErr(formatApiError(e));
+      }
+    };
+    void tick();
+    const h = setInterval(tick, 2000);
+    return () => {
+      stop = true;
+      clearInterval(h);
+    };
+  }, [selected, paused]);
+
+  // Auto-scroll to the bottom as lines arrive (unless paused).
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && !paused) el.scrollTop = el.scrollHeight;
+  }, [lines, paused]);
+
+  const loggingOn = !!enf?.logging_enabled;
+  const enforcementOff = enf ? !enf.enabled : false;
+
   return (
-    <div className="mx-auto max-w-2xl rounded-xl border border-dashed bg-muted/30 px-6 py-12 text-center">
-      <ScrollText className="mx-auto h-8 w-8 text-muted-foreground" />
-      <p className="mt-3 text-sm font-medium">Realtime firewall logs</p>
-      <p className="mt-1 text-xs text-muted-foreground">
-        A live tail of nftables drop / reject events for troubleshooting "why is
-        this blocked?" — including remote appliances in a multi-node fleet.
-        Lands in Phase 2 of this change: an opt-in logging toggle on the
-        firewall rules, with the supervisor streaming the host kernel log
-        through the control plane.
-      </p>
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="flex items-center gap-2 text-sm font-semibold">
+            <ScrollText className="h-4 w-4 text-muted-foreground" />
+            Firewall logs
+          </h3>
+          <p className="mt-1 max-w-xl text-xs text-muted-foreground">
+            Live tail of nftables drop events (prefix <code>spatium-fw:</code>)
+            for troubleshooting "why is this blocked?". Logging is opt-in; the
+            supervisor streams its host kernel log here, so you can watch any
+            appliance in the fleet.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setLogging.mutate(!loggingOn)}
+          disabled={setLogging.isPending}
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm",
+            loggingOn
+              ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+              : "bg-background hover:bg-accent",
+          )}
+        >
+          {setLogging.isPending && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          )}
+          Logging: {loggingOn ? "On" : "Off"}
+        </button>
+      </div>
+
+      {loggingOn && enforcementOff && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5 text-xs text-amber-700 dark:text-amber-400">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          Logging is on, but firewall enforcement is off — no packets are being
+          dropped, so there's nothing to log yet. Turn on enforcement from the
+          Policies section.
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <label className="text-xs text-muted-foreground">Appliance</label>
+        <select
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        >
+          {online.length === 0 && (
+            <option value="">No online appliances</option>
+          )}
+          {online.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.hostname}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => setPaused((p) => !p)}
+          className="rounded-md border bg-background px-2 py-1 text-xs hover:bg-accent"
+        >
+          {paused ? "Resume" : "Pause"}
+        </button>
+        <button
+          type="button"
+          onClick={() => setLines([])}
+          className="rounded-md border bg-background px-2 py-1 text-xs hover:bg-accent"
+        >
+          Clear
+        </button>
+        <span className="ml-auto text-[11px] text-muted-foreground">
+          {lines.length} line{lines.length === 1 ? "" : "s"}
+          {!paused && selected ? " · live" : ""}
+        </span>
+      </div>
+
+      {err && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
+          {err}
+        </div>
+      )}
+
+      <div
+        ref={scrollRef}
+        className="h-[28rem] overflow-auto rounded-md border bg-muted/30 px-3 py-2 font-mono text-[11px] leading-tight"
+      >
+        {lines.length === 0 ? (
+          <span className="text-muted-foreground">
+            {selected
+              ? loggingOn
+                ? "Waiting for dropped packets…"
+                : "Enable logging above, then reproduce the blocked connection."
+              : "Select an appliance to tail its firewall log."}
+          </span>
+        ) : (
+          lines.map((l) => (
+            <div key={l.seq} className="whitespace-pre-wrap break-all">
+              {l.text}
+            </div>
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/appliance/FirewallTab.tsx
+++ b/frontend/src/pages/appliance/FirewallTab.tsx
@@ -11,12 +11,14 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
   CheckCircle2,
+  Eye,
   Globe,
   Layers,
   Loader2,
   Lock,
   Plus,
   RefreshCw,
+  ScrollText,
   ShieldAlert,
   ShieldCheck,
   Tags,
@@ -86,7 +88,50 @@ const POSTURE_PRESETS: {
   },
 ];
 
-type SubTab = "policies" | "aliases" | "preview" | "effective";
+type FirewallSection =
+  | "policies"
+  | "aliases"
+  | "preview"
+  | "effective"
+  | "logs";
+
+const FW_SECTIONS: {
+  key: FirewallSection;
+  label: string;
+  icon: typeof ShieldAlert;
+  hint: string;
+}[] = [
+  {
+    key: "policies",
+    label: "Policies",
+    icon: ShieldAlert,
+    hint: "Fleet / role / appliance rules",
+  },
+  {
+    key: "aliases",
+    label: "Aliases",
+    icon: Tags,
+    hint: "Named CIDR / port sets",
+  },
+  {
+    key: "preview",
+    label: "Preview changes",
+    icon: Eye,
+    hint: "Stage & diff before save",
+  },
+  {
+    key: "effective",
+    label: "Effective render",
+    icon: Layers,
+    hint: "Per-node merged ruleset",
+  },
+  {
+    key: "logs",
+    label: "Logs",
+    icon: ScrollText,
+    hint: "Realtime nft drop log",
+  },
+];
 
 function scopeLabel(p: FirewallPolicy): string {
   if (p.scope_kind === "fleet") return "Fleet";
@@ -95,16 +140,10 @@ function scopeLabel(p: FirewallPolicy): string {
 }
 
 export function FirewallTab() {
-  const [sub, setSub] = useSessionState<SubTab>(
-    "appliance.firewall.subtab",
+  const [section, setSection] = useSessionState<FirewallSection>(
+    "appliance.firewall.section",
     "policies",
   );
-  const tabs: { key: SubTab; label: string }[] = [
-    { key: "policies", label: "Policies" },
-    { key: "aliases", label: "Aliases" },
-    { key: "preview", label: "Preview changes" },
-    { key: "effective", label: "Effective render" },
-  ];
   return (
     <div className="space-y-4">
       <div className="flex items-start gap-2">
@@ -115,7 +154,7 @@ export function FirewallTab() {
             Declarative per-role / per-appliance nftables policy. Edits stay
             dark until the <code>firewall_enabled</code> master switch is on AND
             the next supervisor heartbeat renders — preview any node's effective
-            ruleset below before you flip enforcement on.
+            ruleset before you flip enforcement on.
           </p>
         </div>
       </div>
@@ -123,28 +162,68 @@ export function FirewallTab() {
       <EnforcementCard />
       <WebUIAccessCard />
 
-      <div className="flex flex-wrap gap-1 border-b">
-        {tabs.map((t) => (
-          <button
-            key={t.key}
-            type="button"
-            onClick={() => setSub(t.key)}
-            className={cn(
-              "-mb-px border-b-2 px-3 py-1.5 text-sm",
-              sub === t.key
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
-            )}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
+      {/* #404 — left sub-nav (Cluster-style) replacing the old top sub-tabs. */}
+      <div className="flex gap-6">
+        <nav className="w-48 shrink-0 space-y-1">
+          <div className="mb-2 flex items-center gap-1.5 px-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            <ShieldAlert className="h-3.5 w-3.5" />
+            Firewall
+          </div>
+          {FW_SECTIONS.map((s) => {
+            const Icon = s.icon;
+            const active = section === s.key;
+            return (
+              <button
+                key={s.key}
+                type="button"
+                onClick={() => setSection(s.key)}
+                className={cn(
+                  "flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left",
+                  active
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                )}
+              >
+                <span className="flex items-center gap-1.5 text-sm">
+                  <Icon className="h-3.5 w-3.5" />
+                  {s.label}
+                </span>
+                <span className="pl-5 text-[11px] text-muted-foreground">
+                  {s.hint}
+                </span>
+              </button>
+            );
+          })}
+        </nav>
 
-      {sub === "policies" && <PoliciesSection />}
-      {sub === "aliases" && <AliasesSection />}
-      {sub === "preview" && <PreviewSection />}
-      {sub === "effective" && <EffectiveSection />}
+        <div className="min-w-0 flex-1">
+          {section === "policies" && <PoliciesSection />}
+          {section === "aliases" && <AliasesSection />}
+          {section === "preview" && <PreviewSection />}
+          {section === "effective" && <EffectiveSection />}
+          {section === "logs" && <FirewallLogsSection />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// #404 Phase 2 — realtime nftables firewall-log viewer. Placeholder until the
+// supervisor-side log stream lands (nft rules don't log today; the api pod
+// can't read host kernel logs, so the supervisor tails them and streams via
+// the proxy — local node first, remote appliances via the same seam).
+function FirewallLogsSection() {
+  return (
+    <div className="mx-auto max-w-2xl rounded-xl border border-dashed bg-muted/30 px-6 py-12 text-center">
+      <ScrollText className="mx-auto h-8 w-8 text-muted-foreground" />
+      <p className="mt-3 text-sm font-medium">Realtime firewall logs</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        A live tail of nftables drop / reject events for troubleshooting "why is
+        this blocked?" — including remote appliances in a multi-node fleet.
+        Lands in Phase 2 of this change: an opt-in logging toggle on the
+        firewall rules, with the supervisor streaming the host kernel log
+        through the control plane.
+      </p>
     </div>
   );
 }

--- a/frontend/src/pages/appliance/FirewallTab.tsx
+++ b/frontend/src/pages/appliance/FirewallTab.tsx
@@ -168,10 +168,9 @@ export function FirewallTab() {
         </div>
       </div>
 
-      <EnforcementCard />
-      <WebUIAccessCard />
-
-      {/* #404 — left sub-nav (Cluster-style) replacing the old top sub-tabs. */}
+      {/* #404 — left sub-nav (Cluster-style) replacing the old top sub-tabs.
+          Enforcement + Web-UI-access cards moved into the Policies section
+          (they were confusing full-width bars up here). */}
       <div className="flex gap-6">
         <nav className="w-48 shrink-0 space-y-1">
           <div className="mb-2 flex items-center gap-1.5 px-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
@@ -837,6 +836,13 @@ function PoliciesSection() {
 
   return (
     <div className="space-y-3">
+      {/* #404 — firewall master controls (enforcement + Web UI access),
+          nested here with the policies they govern instead of as full-width
+          bars above the whole tab. Two columns so they stay compact. */}
+      <div className="grid gap-3 xl:grid-cols-2">
+        <EnforcementCard />
+        <WebUIAccessCard />
+      </div>
       <div className="grid gap-2 sm:grid-cols-3">
         {POSTURE_PRESETS.map((p) => (
           <div key={p.key} className="rounded-md border p-2.5">

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -46,6 +46,10 @@ import { ResolverTab } from "./ResolverTab";
 import { SNMPTab } from "./SNMPTab";
 import { SSHTab } from "./SSHTab";
 import { SyslogTab } from "./SyslogTab";
+// #404 — these three moved out of the top-level tab bar into this sidebar.
+import { CertificatesTab } from "./CertificatesTab";
+import { ClusterUpgradeTab } from "./ClusterUpgradeTab";
+import { ReleasesTab } from "./ReleasesTab";
 
 /**
  * Appliance → Fleet tab (#170 Wave D1; supersedes Wave B3 "Approvals").
@@ -639,6 +643,8 @@ const VIP_ADVISORY_DISMISS_KEY = "spatium.fleet.vipAdvisoryDismissed";
 export function FleetTab({
   onNavigateTab,
   isApplianceHost = false,
+  initialSection = null,
+  onSectionApplied,
 }: {
   // #272 Phase 6 — lets the cert card jump to the "Web UI Certificate"
   // tab. Optional so the component still renders standalone.
@@ -646,6 +652,12 @@ export function FleetTab({
   // Only appliance hosts have a local Web UI cert to manage; docker/k8s
   // control planes hide the cert tab, so we hide the card there too.
   isApplianceHost?: boolean;
+  // #404 — a legacy ?tab=tls / ?tab=releases deep-link (or the drilldown's
+  // onNavigateTab) resolves to a Fleet sidebar section; AppliancePage hands
+  // it down here so we select it on arrival, then clears it via
+  // onSectionApplied so re-navigating to the same section fires again.
+  initialSection?: string | null;
+  onSectionApplied?: () => void;
 }) {
   const qc = useQueryClient();
   const { data: me } = useQuery({
@@ -687,7 +699,9 @@ export function FleetTab({
   const [view, setView] = useSessionState<
     | "appliances"
     | "pairing"
+    | "cluster-upgrade"
     | "upgrade-images"
+    | "web-ui-certificate"
     | "lldp"
     | "ntp"
     | "resolver"
@@ -695,6 +709,18 @@ export function FleetTab({
     | "ssh"
     | "syslog"
   >("appliance.fleet.section", "appliances");
+
+  // #404 — apply a deep-linked sidebar section handed down from AppliancePage
+  // (legacy ?tab=tls / ?tab=releases / drilldown onNavigateTab). Runs whenever
+  // the prop changes to a non-null value; a later manual click won't re-fire it.
+  useEffect(() => {
+    if (initialSection) {
+      setView(initialSection as typeof view);
+      onSectionApplied?.();
+    }
+    // Gate purely on the prop; setView/onSectionApplied identities are stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialSection]);
 
   const [drilldown, setDrilldown] = useState<ApplianceRow | null>(null);
   const [showCluster, setShowCluster] = useState(false);
@@ -913,7 +939,9 @@ export function FleetTab({
     key:
       | "appliances"
       | "pairing"
+      | "cluster-upgrade"
       | "upgrade-images"
+      | "web-ui-certificate"
       | "lldp"
       | "ntp"
       | "resolver"
@@ -942,11 +970,32 @@ export function FleetTab({
           label: "Pairing codes",
           summary: "Mint codes for new appliances.",
         },
+        // #404 — Rolling Upgrade (releases catalog + multi-node A/B
+        // orchestrator) moved here from a top-level tab. Always shown: the
+        // releases catalog is universal; the orchestrator self-gates to
+        // appliance hosts inside the section.
+        {
+          key: "cluster-upgrade",
+          label: "Rolling Upgrade",
+          summary: "Releases + multi-node A/B slot upgrade.",
+        },
         {
           key: "upgrade-images",
           label: "Upgrade images",
           summary: "GitHub import or air-gap .raw.xz upload.",
         },
+        // #404 — Web UI Certificate moved here from a top-level tab.
+        // Appliance-host only (a docker/k8s control plane has no local cert
+        // to manage).
+        ...(isApplianceHost
+          ? [
+              {
+                key: "web-ui-certificate" as const,
+                label: "Web UI Certificate",
+                summary: "TLS upload / CSR / Let's Encrypt.",
+              },
+            ]
+          : []),
       ],
     },
     {
@@ -1086,6 +1135,20 @@ export function FleetTab({
               </p>
               <UpgradeImageManager />
             </div>
+          )}
+
+          {/* #404 — Rolling Upgrade orchestrator (appliance hosts) + the
+              releases catalog (universal), merged from two old top-level tabs. */}
+          {view === "cluster-upgrade" && (
+            <div className="space-y-6">
+              {isApplianceHost && <ClusterUpgradeTab />}
+              <ReleasesTab applianceMode={isApplianceHost} />
+            </div>
+          )}
+
+          {/* #404 — Web UI Certificate, moved from a top-level tab. */}
+          {view === "web-ui-certificate" && isApplianceHost && (
+            <CertificatesTab />
           )}
 
           {view === "lldp" && (

--- a/frontend/src/pages/appliance/ReleasesTab.tsx
+++ b/frontend/src/pages/appliance/ReleasesTab.tsx
@@ -6,7 +6,6 @@ import {
   ChevronRight,
   Download,
   ExternalLink,
-  Info,
   RefreshCw,
 } from "lucide-react";
 
@@ -40,12 +39,8 @@ const FULL_CARDS = 3;
  */
 export function ReleasesTab({
   applianceMode = false,
-  onNavigateTab,
 }: {
   applianceMode?: boolean;
-  // Lets the appliance-mode banner deep-link to the Fleet tab where OS
-  // slot upgrades actually live.
-  onNavigateTab?: (tab: string) => void;
 }) {
   const { data, isLoading, error } = useQuery({
     queryKey: ["appliance", "releases"],
@@ -75,35 +70,10 @@ export function ReleasesTab({
         </div>
       </div>
 
-      {/* #294 — on the appliance, OS upgrades are NOT applied from here;
-          they go through the A/B slot image flow on the Fleet tab. This
-          list is read-only. */}
-      {applianceMode && (
-        <div className="rounded-md border border-sky-500/40 bg-sky-500/10 p-3">
-          <div className="flex items-start gap-2 text-xs">
-            <Info className="mt-0.5 h-4 w-4 shrink-0 text-sky-600 dark:text-sky-400" />
-            <div className="flex-1">
-              <p className="font-medium text-sky-700 dark:text-sky-300">
-                This list is informational
-              </p>
-              <p className="mt-0.5 text-sky-700/80 dark:text-sky-300/80">
-                OS upgrades on the appliance are applied as atomic A/B slot
-                images from the Fleet tab — not from here.
-              </p>
-              {onNavigateTab && (
-                <button
-                  type="button"
-                  onClick={() => onNavigateTab("fleet")}
-                  className="mt-1.5 inline-flex items-center gap-1 rounded-md border border-sky-500/50 bg-background px-2 py-1 text-xs font-medium text-sky-700 hover:bg-sky-500/10 dark:text-sky-300"
-                >
-                  Go to Fleet → OS upgrades
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
+      {/* #404 — Releases now live alongside the Rolling Upgrade orchestrator
+          in the Fleet sidebar, so the old "go to Fleet for OS upgrades"
+          banner is gone; on the appliance this catalog stays read-only
+          (upgrades are driven by the orchestrator above / OS Versions). */}
       {error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
           Failed to load releases: {formatApiError(error)}


### PR DESCRIPTION
Closes #404

Operator-requested cleanup of the Appliance management surface plus a new realtime firewall-log viewer.

## Phase 1 — IA cleanup (`88c2214`)
- **Firewall** tab → Cluster-style **left sub-nav** (Policies / Aliases / Preview / Effective / Logs).
- **Rolling Upgrade** + **Web UI Certificate** moved out of the top tab bar into the **Fleet sidebar** (Rolling Upgrade between Pairing codes & Upgrade images; Web UI Certificate after, appliance-host only).
- **Releases** folded into the Rolling Upgrade surface (the old "go to Fleet" banner removed). The releases catalog stays universal (docker/k8s too); the multi-node orchestrator self-gates to appliance hosts.
- Legacy `?tab=tls` / `?tab=releases` deep-links + the Fleet "Manage certificates" button remapped to the Fleet tab + the matching sidebar section (via an `initialSection` prop, cleared after apply so repeat navigation re-fires).

Top-level Appliance tabs are now: Fleet · Firewall · Logs & Diagnostics · Maintenance · Network & Host · Cluster.

## Phase 2 — realtime nftables firewall-log viewer (`2efb5ad`)
A live tail of nftables drop events for "why is this blocked?" troubleshooting, including **remote appliances** in a multi-node fleet.

- **Opt-in toggle**: `PlatformSettings.firewall_logging_enabled` (migration `c5f1a2b3d4e6`) flows to the supervisor on the heartbeat like `firewall_enabled`. When on, `firewall_bundle` appends one rate-limited catch-all `log prefix "spatium-fw: "` (≤10/s) before the chain's policy drop. `PUT /appliance/firewall/logging` toggles it; `EnforcementStatus` carries `logging_enabled`.
- The supervisor (`kmsg_reader.py`) tails `/dev/kmsg` for `spatium-fw:` lines into a since-cursor ring buffer, served by a new `firewall_logs` nettool. The api can't read host kernel logs, so it always runs from a supervisor vantage — dispatched over the existing nettool poll/reply proxy, which routes **per-appliance**, so any appliance in the fleet is selectable.
- `/tools/firewall-logs` dispatches it; the UI's **Firewall → Logs** section polls ~2s with the returned cursor (appliance picker + logging toggle + "logging on but enforcement off" hint).
- The non-root supervisor lacks `CAP_SYSLOG` and `dmesg_restrict=1` blocks `/dev/kmsg`, so a sysctl drop-in sets `kernel.dmesg_restrict=0` (single-tenant appliance; kernel log already operator-visible); the reader also retries the open to ride out the privileged-container device-cgroup settle at pod start.

## Follow-up fix (`dc64dec`)
Platform Insights → Containers linked to the dead `?tab=containers`; now points to `?tab=cluster&section=pods` via a new `?section=` cluster sub-section deep-link.

## Verification
- Backend ruff / black / mypy clean; new tests (`test_firewall_logging.py`); migration-shape linter baselined; affected firewall/tools tests pass per-file.
- Frontend ESLint (`--max-warnings 0`) + production build clean.
- **Field-validated on the ddi1 appliance**: the reorg renders; the logging toggle flips; the nettool reaches the supervisor (`ran_from=appliance:ddi1`); an injected `spatium-fw:` kernel line streams end-to-end with a working since-cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)