### PR TITLE
Release 2026.06.13-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,165 @@ the formatter handles the rest.
 
 ---
 
+## 2026.06.13-1 — 2026-06-13
+
+The **appliance console + security-hardening** release. Six PRs: a
+Talos-style operations cockpit and a live Cluster dashboard for the
+appliance console / UI, a 3-mode console selector that fixes a
+no-login regression, an in-place host-migration framework so
+install-time / ESP changes reach already-installed boxes on a slot
+upgrade, a firewall navigation refresh with a realtime
+dropped-packet log viewer, and a full internal auth-bypass /
+privilege-boundary review (#400) that remediates 1 critical, 3
+high, and 12 medium / low findings with ~55 regression tests.
+
+**#400 — auth-bypass / privilege-boundary review (#401).** The
+headline security item. **C1 (critical):** the supervisor
+`/heartbeat` endpoint was unauthenticated, so anyone who could
+reach the control plane could register a fake appliance and pull a
+signed supervisor cert → k3s cluster-admin; it now requires the
+supervisor session token. **C2–C4 (high):** AI-apply re-checks the
+caller's RBAC at apply time (not only at propose), the `dns_zone`
+token path no longer trusts a caller-supplied zone id (IDOR), and
+role / group edits are capped by the editor's own permission
+ceiling so an admin can't grant beyond what they themselves hold.
+Plus 12 medium / low hardening items spanning sessions, the
+force-password-change gate, response info-leak trimming,
+CORS / TrustedHost tightening, an SSRF guard on outbound-fetch
+surfaces, and frontend token-handling + security-header fixes.
+
+**Appliance console & Cluster UI.** The serial / VGA console gains
+a Talos-style operations cockpit (#398) and the web UI gains a
+consolidated **Cluster** tab with a live SSE-fed Overview dashboard
+(#402) — both grounded in kubelet stats + node / pod listings since
+there is no Prometheus on the appliance. A new firewall navigation
+layout adds a realtime nftables dropped-packet log viewer that
+works across remote appliances too (#404).
+
+### Security
+
+* **C1 (critical) — unauthenticated supervisor heartbeat → k3s
+  cluster-admin (#400).** The `/api/v1/appliance/supervisor/heartbeat`
+  endpoint accepted any caller, so anyone able to reach the control
+  plane could impersonate a supervisor, get approved, and receive a
+  signed supervisor certificate that grants k3s cluster-admin. The
+  endpoint now requires the supervisor session token (regression
+  test in `test_supervisor_heartbeat_authz.py`).
+* **C2 (high) — AI-apply skipped the apply-time RBAC re-check.** A
+  `propose_*` plan that passed the proposer's permissions could be
+  applied by a caller who no longer (or never) held them; apply now
+  re-validates the caller's RBAC against the concrete mutation.
+* **C3 (high) — `dns_zone` token-scope IDOR.** The DNS token path
+  trusted a caller-supplied zone id instead of deriving scope from
+  the authenticated token, letting a scoped token act outside its
+  zone. Scope is now resolved server-side.
+* **C4 (high) — role / group edits could exceed the editor's
+  ceiling.** Role and group mutations are now bounded by the
+  editing user's own effective permissions, so an admin cannot
+  grant a permission they do not themselves hold.
+* **12 medium / low hardening items.** Session fixation + idle
+  timeout, the force-password-change gate, response info-leak
+  trimming, CORS / TrustedHost allow-list tightening, a new SSRF
+  guard (`backend/app/core/ssrf.py`) on outbound-fetch surfaces, and
+  frontend token-handling + security-header fixes. ~55 regression
+  tests across `test_fix_c*` / `test_fix_m*` / `test_fix_l*`.
+
+### Added
+
+* **#398 — Talos-style operations cockpit on the appliance
+  console.** Replaces the prior console with a 6-box KPI ribbon
+  (Cluster / etcd / Postgres / API / Platform / Slot) fed by
+  concurrent 5 s-tier collectors, an F7 Health drill-down with
+  guarded recovery actions, multi-node quorum + auto pod-filter +
+  cluster-wide Top-pods + a MetalLB speaker check, font-safe glyphs,
+  content-sized panels, and level-token log colouring. Field-tested
+  on ddi1 at ~2.5 % CPU.
+* **#402 — live Cluster Overview dashboard.** The Overview section
+  of the new Cluster tab streams cluster health over SSE (2 s) into
+  a KPI ribbon, a Recharts CPU / memory hero chart, animated
+  per-node radial gauges, a workload-health panel, and a top-pods
+  leaderboard — all from kubelet stats + node / pod listings (no
+  Prometheus on the appliance). Per-node disk shows the host's real
+  partition list (supervisor-reported, with a kubelet `/var`
+  fallback). Needs a `nodes/proxy [get]` RBAC grant and a read-only
+  host-root mount on the supervisor, both shipped in the charts.
+* **#404 — realtime nftables firewall-log viewer.** An opt-in global
+  toggle appends a rate-limited `log` rule to the rendered input
+  policy; the supervisor tails `/dev/kmsg` for `spatium-fw:` drops
+  into a ring buffer, surfaced through a new `firewall_logs` nettool
+  so the Firewall tab streams dropped / rejected packets live —
+  including for remote appliances via the per-appliance nettool
+  proxy. Ships a `kernel.dmesg_restrict=0` sysctl drop-in so the
+  unprivileged supervisor can read the kernel ring buffer.
+* **#395 — in-place host-migration framework.** A/B slot upgrades
+  replace the rootfs but not the install-time, shared-ESP
+  `grub.cfg`, so menu-structure or kernel-cmdline changes (such as
+  #393's verbose branch) previously required a full reinstall to
+  reach an installed box. New `spatium-grub-render` (idempotent,
+  single source of truth for grub.cfg, shared by the install + live
+  paths) and `spatium-host-migrate` (version-gated, every-boot
+  reconcile of numbered idempotent host-patches run before the
+  health-commit, so a failed render blocks the slot commit and the
+  A/B one-shot reverts) close that gap; failures surface as
+  `host_migration_health` in the Fleet UI.
+
+### Changed
+
+* **#393 — 3-mode console selector replaces the verbose-boot
+  toggle.** The old binary toggle conflated boot verbosity with the
+  post-boot console (dashboard vs. plain login) and couldn't express
+  "verbose boot, then dashboard". `console_mode` ∈ {`dashboard`
+  (default), `verbose_dashboard`, `text_console`} maps to the
+  grubenv `spatium_verbose` 0 / 2 / 1 the grub menuentries read
+  (keeping dashboard = 0 + text_console = 1 so old grubenv values
+  still resolve fail-closed); the NetworkTab toggle becomes a
+  3-option radio.
+* **#402 — Cluster tab consolidation.** The standalone Pods tab and
+  the etcd-snapshots section fold into a single **Cluster** tab
+  (Overview / Pods / etcd left sub-nav) — named "Cluster" rather
+  than "Kubernetes" for operator clarity.
+* **#404 — Firewall + Fleet navigation refresh.** The Firewall tab's
+  top sub-tabs become a left sub-nav (Policies / Aliases / Preview /
+  Effective / Logs), with the Enforcement + Web-UI-access cards
+  nested compactly inside Policies; Rolling Upgrade, Releases (folded
+  into Rolling Upgrade), and Web UI Certificate move into the Fleet
+  sidebar, with legacy `?tab=` deep-links remapped.
+
+### Fixed
+
+* **#394 — helm-stuck-recover crashed on every boot.**
+  `spatiumddi-helm-stuck-recover` (the #183 Phase 9 safety net) died
+  with `JSONDecodeError: Invalid control character` because it
+  shell-interpolated kubectl JSON into a Python heredoc parsed in
+  strict mode, so a genuinely wedged HelmChart would never
+  auto-clear. Now passes the JSON via an env var and parses with
+  `strict=False`.
+* **#393 — `text_console` mode left the appliance with no console
+  login.** `spatium-console.service` still declared
+  `Conflicts=getty@tty1.service`, which is registered at unit-load
+  time, so even with the dashboard correctly inactive in
+  `text_console` mode the recorded conflict dropped `getty@tty1`
+  from the boot transaction — bare kernel text, no prompt. Removed
+  the `Conflicts=` (dashboard and getty are already mutually
+  exclusive via opposite `spatium-console=off` conditions);
+  field-validated end-to-end on slot B.
+* **#404 — dead Platform Insights → Containers link.** The Platform
+  Insights card linked to the removed `?tab=containers`; it now
+  points at `Cluster → Pods`.
+
+### Migrations
+
+* `a7c3e9f1b405` (#393) — adds `platform_settings.console_mode`,
+  backfills it from the old `verbose_boot` flag (`True` →
+  `text_console`), then drops `verbose_boot`.
+* `b3e7d1f9a204` (#395) — adds `appliance.host_migration_health`
+  (JSONB, not null, default `{}`).
+* `c5f1a2b3d4e6` (#404) — adds
+  `platform_settings.firewall_logging_enabled` (bool, default
+  `false`).
+
+---
+
 ## 2026.06.12-2 — 2026-06-12
 
 Appliance **upgrade + host-config reliability** — three appliance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,9 +112,9 @@ works across remote appliances too (#404).
   unprivileged supervisor can read the kernel ring buffer.
 * **#395 — in-place host-migration framework.** A/B slot upgrades
   replace the rootfs but not the install-time, shared-ESP
-  `grub.cfg`, so menu-structure or kernel-cmdline changes (such as
-  #393's verbose branch) previously required a full reinstall to
-  reach an installed box. New `spatium-grub-render` (idempotent,
+  `grub.cfg`, so menu-structure or kernel-cmdline changes (like the
+  verbose-boot branch from #393) previously required a full
+  reinstall to reach an installed box. New `spatium-grub-render` (idempotent,
   single source of truth for grub.cfg, shared by the install + live
   paths) and `spatium-host-migrate` (version-gated, every-boot
   reconcile of numbered idempotent host-patches run before the

--- a/README.md
+++ b/README.md
@@ -693,15 +693,19 @@ Operators get a real Kubernetes node without managing one.
   your own pasted PEM / CSR-on-server / Let's Encrypt cert
   whenever you're ready.
 - A **dedicated `/appliance` management hub** that handles
-  everything you'd otherwise need SSH for: pod inspection +
-  live log streaming, TLS cert manager, atomic A/B OS slot
-  upgrades, firmware-pending banner, fleet management for
-  remote agents, NTP / SNMP host config, journalctl viewer,
-  self-test runner, one-click diagnostic bundle, maintenance
-  mode, host reboot / shutdown.
-- A Talos-style **console dashboard** on the appliance's
-  physical / serial console showing live vitals, pod health,
-  and a journalctl tail — useful when the web UI is down.
+  everything you'd otherwise need SSH for: a live **Cluster
+  health dashboard** (pod inspection + log streaming + node
+  vitals + etcd snapshots), TLS cert manager, atomic A/B OS
+  slot upgrades, firmware-pending banner, fleet management for
+  remote agents, NTP / SNMP host config, a realtime
+  **firewall-log viewer**, journalctl viewer, self-test
+  runner, one-click diagnostic bundle, maintenance mode, host
+  reboot / shutdown.
+- A Talos-style **operations cockpit** on the appliance's
+  physical / serial console — a KPI ribbon (cluster / etcd /
+  Postgres / API / platform / slot), live vitals, pod health,
+  a journalctl tail, and an F7 health drill-down with guarded
+  recovery actions — useful when the web UI is down.
 - **Atomic A/B slot OS upgrades**: every appliance has two
   identical root partitions; an upgrade dd's the new image
   into the inactive one, reboots, and auto-reverts on
@@ -914,12 +918,16 @@ concern:
   presence), one-click diagnostic bundle (secrets redacted).
 - **Maintenance** — drain traffic, reboot, shutdown.
 
-The **console dashboard** on the appliance's physical or
-serial console shows live vitals, pod health, and a
-journalctl tail. F-keys give you local-login (F1), htop
-(F2), `kubectl get pods -A` (F3 — pod log viewer), `nmtui`
-for networking (F4), and confirmed reboot / shutdown
-(F5 / F6).
+The **console cockpit** on the appliance's physical or
+serial console shows a 6-box KPI ribbon (cluster / etcd /
+Postgres / API / platform / slot), live vitals, pod health,
+and a journalctl tail. F-keys give you local-login (F1),
+htop (F2), `kubectl get pods -A` (F3 — pod log viewer),
+`nmtui` for networking (F4), confirmed reboot / shutdown
+(F5 / F6), and a health drill-down with guarded recovery
+actions (F7). The post-boot console (dashboard / verbose
+dashboard / plain login) is selectable from **Appliance →
+Network & Host**.
 
 Stuck without a working web UI? SSH in as the OS admin user
 you created during install. `kubectl` is on PATH (with bash
@@ -1115,7 +1123,7 @@ Full docs at **[spatiumddi.github.io](https://spatiumddi.github.io)** (coming so
 | Phase 1 | Core IPAM, auth, user management, audit log, Docker Compose | ✅ Done — LDAP/OIDC/SAML + RADIUS/TACACS+, group-based RBAC, bulk-edit, inheritance, mobile-responsive UI, and full IPv6 `/next-address` (EUI-64 + random /128 + sequential) all shipped |
 | Phase 2 | DHCP (Kea), DNS (BIND9), DDNS, zone/subnet tree UI | ✅ Done — DNS, Kea DHCPv4, subnet-level DDNS, agent-side Kea DDNS, block/space DDNS inheritance, per-server zone serial reporting all shipped |
 | Phase 3 | DNS views, server groups, blocking lists, VLAN/VXLAN, system admin, Kea HA | 🔄 DNS features + health dashboard + alerts framework + group-centric Kea HA (self-healing peer-IP drift + supervised daemons) + DNS Views end-to-end split-horizon landed; HA state-transition actions still pending |
-| Phase 4 | OS appliance, Terraform provider, SAML, backup/restore, ACME | 🔄 SAML + full backup/restore + factory-reset + OS appliance beta (Debian 13 ISO + embedded [k3s](https://k3s.io/) + Helm orchestration, `/appliance` management hub with TLS upload + CSR-on-server, GitHub release apply, kubeapi-driven Pods tab + live SSE logs, host log viewer + self-test + diagnostic bundle, maintenance mode + reboot, web first-boot wizard, atomic A/B slot upgrades, **multi-node rolling cluster upgrade** with CNPG switchover + lease-mutex + preflight + air-gap mirror PVC) all landed. Terraform/Ansible providers + ACME embedded client (Let's Encrypt auto-issue) still pending |
+| Phase 4 | OS appliance, Terraform provider, SAML, backup/restore, ACME | 🔄 SAML + full backup/restore + factory-reset + OS appliance beta (Debian 13 ISO + embedded [k3s](https://k3s.io/) + Helm orchestration, `/appliance` management hub with TLS upload + CSR-on-server, GitHub release apply, kubeapi-driven Pods tab + live SSE logs, host log viewer + self-test + diagnostic bundle, maintenance mode + reboot, web first-boot wizard, atomic A/B slot upgrades, **multi-node rolling cluster upgrade** with CNPG switchover + lease-mutex + preflight + air-gap mirror PVC, consolidated **Cluster tab** (Pods + etcd + live SSE health dashboard), realtime **firewall-log viewer**, Talos-style **console cockpit**) all landed. Terraform/Ansible providers + ACME embedded client (Let's Encrypt auto-issue) still pending |
 | Phase 5 | Multi-tenancy, IP request workflows, advanced reporting | 📋 Planned |
 
 See [CHANGELOG.md](CHANGELOG.md) for the per-release feature list and

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -116,6 +116,13 @@ on inactive.
    satisfy an unscoped check (one passed without `resource_id`). This prevents
    "I have write on *this one* subnet" from accidentally granting "write on
    subnets in general".
+5. **Privilege ceiling on role / group edits (#400 C4).** When a non-superadmin
+   creates or edits a role's permission set (or assigns roles to a group), every
+   permission they add must be one they *themselves* effectively hold —
+   `user_has_permission(editor, entry)` must pass for each entry in the new set.
+   This stops, say, an IPAM editor from minting a `{*, *}` role and assigning it
+   to their own group to escalate. Superadmins (either path in the section
+   above) are exempt by rule 1.
 
 ## Built-in roles (seeded on first start)
 

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -84,13 +84,13 @@ The installer's **hard disk floor is 32 GiB** for every role (raised from 24 GiB
 
 The `/appliance` section in the SpatiumDDI UI talks to k3s directly via the api pod's mounted ServiceAccount:
 
-- **Pods tab** (`/appliance/containers` API surface, renamed Containers → Pods in the UI). Lists every pod in the spatium namespace via kubeapi `GET /api/v1/namespaces/spatium/pods`. Restart = `DELETE` the pod (owning Deployment / DaemonSet recreates it). Logs = SSE wrapping kubeapi's `?follow=true` pod-log endpoint.
+- **Cluster tab** (#402 — folds the former Containers/Pods tab + the etcd-snapshots section into one tab via a left sub-nav, named *Cluster* rather than *Kubernetes* for operator clarity). Three sub-sections: **Overview** — a live SSE-fed (2 s) health dashboard (KPI ribbon, CPU / memory hero chart, per-node radial gauges with the host's real partition list, workload-health panel, top-pods leaderboard) built from kubeapi node / pod listings + per-node kubelet `stats/summary` (there is no Prometheus on the appliance); **Pods** — lists every pod in the spatium namespace via kubeapi `GET /api/v1/namespaces/spatium/pods`, restart = `DELETE` the pod (owning Deployment / DaemonSet recreates it), logs = SSE wrapping kubeapi's `?follow=true` pod-log endpoint; **etcd** — the recoverable `ETCDSnapshotFile` inventory.
 - **TLS cert manager**. Patches the `spatium-appliance-tls` Secret in place via `kubectl patch secret`. Bumps a checksum annotation on the frontend Deployment to trigger a rollout (k8s doesn't auto-roll on Secret changes — the annotation acts as the trigger).
 - **Logs & Diagnostics → Self-test**. Five-check battery: external DNS resolution, kubeapi reachability via the ServiceAccount, every spatium pod's health (Running + healthy / Succeeded Jobs OK), informational DHCP + DNS role presence (OK when not assigned).
 - **Diagnostic bundle**. Per-pod log tails (last 500 lines via kubeapi) + host logs + system info + redacted env, zipped for support tickets.
 - **OS Versions**. Atomic A/B slot upgrades — same machinery as pre-#183 (Phase 8); the slot raw.xz carries a complete rootfs with k3s + baked images + chart tarballs. A slot upgrade is also an effective container upgrade because images are baked. For an upgrade scheduled from an imported/uploaded image (#199), the download is **verified by the stored sha256** (the integrity guarantee), which lets the host runner relax TLS cert-verify *only* for the appliance's own self-served URL behind the self-signed web cert — external public-CA URLs stay fully verified (#386). The Fleet drilldown shows a **live per-phase progress stepper** (download % → verify → write → bootloader → reboot-pending) with an expandable `slot-upgrade.log` tail and an honest failure card, and a stuck apply re-fires once per distinct desired-state rather than looping (#386). Uploaded/imported image bytes are persisted on a host-path mount so they survive an api restart (#386).
 
-The api pod's ServiceAccount is namespace-scoped with minimal RBAC: pods + pods/log read, the specific `spatium-appliance-tls` Secret patch, and the frontend Deployment annotation patch. Nothing cluster-wide, nothing destructive.
+The api pod's ServiceAccount keeps minimal RBAC: namespace-scoped pods + pods/log read, the specific `spatium-appliance-tls` Secret patch, and the frontend Deployment annotation patch. The only cluster-scoped grant is **read-only** `nodes` + `nodes/proxy [get]` (added in #402) so the Cluster Overview dashboard can read per-node kubelet stats. Nothing destructive.
 
 ### From-zero operator flow
 
@@ -296,12 +296,28 @@ Seeded **builtin** role policies reproduce the Phase-2 hardcoded renderer
 byte-for-byte; operators tune their rules (the floor — ssh/22, ICMP, loopback —
 is un-removable, and no rule may `drop` 22).
 
-**Fleet → Firewall tab.** An **Enforcement** card (turn it on, gated — see
-below) over four sub-tabs: **Policies** (fleet/role/appliance list + rule
-editor), **Aliases** (named CIDR/port sets), **Preview changes** (stage
-fleet-overlay rules → per-node line diff + accept↔drop conflict / redundancy
-warnings, read-only), and **Effective render** (any node's merged drop-in +
-layer breakdown + rendered-vs-applied drift; works while still dark).
+**Fleet → Firewall tab.** A **left sub-nav** (#404 — was top sub-tabs) over
+five sections: **Policies** (fleet/role/appliance list + rule editor, with the
+**Enforcement** + **Web-UI-access** cards nested compactly at the top rather
+than as full-width bars), **Aliases** (named CIDR/port sets), **Preview
+changes** (stage fleet-overlay rules → per-node line diff + accept↔drop conflict
+/ redundancy warnings, read-only), **Effective render** (any node's merged
+drop-in + layer breakdown + rendered-vs-applied drift; works while still dark),
+and **Logs** (realtime dropped-packet viewer — see below).
+
+**Realtime firewall logs (#404).** An opt-in
+`platform_settings.firewall_logging_enabled` toggle (off by default; `PUT
+/appliance/firewall/logging`, migration `c5f1a2b3d4e6`) appends a rate-limited
+`log prefix "spatium-fw: "` rule to the rendered input chain just before the
+`policy drop`, so dropped / rejected packets are logged to the kernel ring
+buffer. The supervisor tails `/dev/kmsg` for `spatium-fw:` lines into a ring
+buffer (`kmsg_reader.py`), exposed through a new `firewall_logs` nettool; the
+**Logs** section streams them live (2 s poll) and — because it routes through
+the per-appliance nettool proxy — works for **remote** appliances too, not just
+the local control plane. Needs `kernel.dmesg_restrict=0` (a baked sysctl
+drop-in ships it) so the unprivileged supervisor can read the ring buffer; the
+rule is folded into the body before the bundle hash, so toggling it re-fires
+each node's `spatium-firewall-reload`.
 
 **Turning enforcement on (the field-test recipe).** `PUT
 /appliance/firewall/enforcement {enabled:true}` flips the master switch — but
@@ -476,14 +492,18 @@ The Talos-style console got a wave of usability fixes:
 - New `Watchdog` header line surfacing the external watchdog state — green `Loop ticking · Ns ago`, yellow `Loop stale · Ns ago`, red `Restart cap hit` when the rate-limit alert trigger is present.
 - Services panel unions whichever supervisor-managed service is either in `docker ps` or listed in `role-compose.env`'s `COMPOSE_PROFILES`, so a crashed / removed container surfaces as `(not running)` rather than disappearing entirely.
 
-### Verbose boot console (standard Linux console)
+### Console mode (dashboard / verbose dashboard / text login)
 
-By default the appliance boots quietly (`loglevel=3` — only kernel errors reach the console) and the Talos-style dashboard claims tty1, so operators see almost no kernel / systemd output during boot / reboot / shutdown. A **Boot console** toggle on **Appliance → Network & Host** switches the box to a *standard Linux console*: it drops the `loglevel=3` cap (all kernel messages scroll), adds `systemd.show_status=1` (the per-unit `[ OK ]` lines), and passes `spatium-console=off` (a normal getty login replaces the dashboard) — i.e. boot looks like a regular Linux server, which is invaluable for diagnosing a boot hang or panic.
+By default the appliance boots quietly (`loglevel=3` — only kernel errors reach the console) and the Talos-style cockpit claims tty1, so operators see almost no kernel / systemd output during boot. A **Boot console** selector on **Appliance → Network & Host** (#393 — replacing the old binary verbose-boot toggle, which conflated boot verbosity with the post-boot console and couldn't express "verbose boot, then dashboard") picks one of three modes:
 
-- **Mechanism.** Backed by `platform_settings.verbose_boot`; it rides the same host-config plane as timezone / NTP / SNMP (PlatformSettings → supervisor heartbeat `desired_verbose_boot` → `spatiumddi-verbose-boot-reload` host runner). Because the kernel cmdline lives in `grub.cfg` (not a file the running OS re-reads), the runner flips a **grubenv variable** (`spatium_verbose`) that a conditional in the per-slot menuentries reads. grubenv lives on the shared ESP, so the setting **survives A/B slot upgrades + rollbacks + the /etc overlay** verbatim.
+- **`dashboard`** (default) — quiet boot, then the cockpit on tty1.
+- **`verbose_dashboard`** — full kernel + `systemd.show_status=1` boot output (invaluable for diagnosing a boot hang / panic), *then* the cockpit. This is the combination the old toggle couldn't reach.
+- **`text_console`** — verbose boot, then a standard getty login (`spatium-console=off`) instead of the cockpit — boot looks like a regular Linux server end-to-end.
+
+- **Mechanism.** Backed by `platform_settings.console_mode` (Literal-validated to the three values; migration `a7c3e9f1b405` adds it, backfills from the old `verbose_boot` flag — `True` → `text_console` — then drops `verbose_boot`). It rides the same host-config plane as timezone / NTP / SNMP (PlatformSettings → supervisor heartbeat `console_mode` → `maybe_fire_console_mode` → host runner). Because the kernel cmdline lives in `grub.cfg` (not a file the running OS re-reads), the runner flips a **grubenv variable** (`spatium_verbose`) that a `0` / `1` / `2` conditional in the per-slot menuentries reads (rendered by #395's `spatium-grub-render`). The mode → grubenv map keeps `dashboard = 0` + `text_console = 1` so pre-#393 grubenv values still resolve fail-closed; `verbose_dashboard = 2` is the new branch. grubenv lives on the shared ESP, so the setting **survives A/B slot upgrades + rollbacks + the /etc overlay** verbatim.
 - **Applies on the next reboot** (GRUB only reads the cmdline at boot) — the UI says so and points at the Maintenance-tab reboot.
-- **Default off, opt-in per box.** Doesn't regress the polished quiet-boot experience for appliances that don't want it.
-- **Anti-brick.** Only changes log verbosity + which process owns the TTY — never the slot / root UUID / kernel. A missing or corrupt grubenv makes the menuentry's conditional fail closed to `loglevel=3` (today's behaviour). The always-present GRUB **`(slot A, verbose boot)`** menuentry remains the zero-config one-shot fallback (drops the loglevel cap + `spatium-console=off` for a single boot, selectable from the boot menu with no reinstall).
+- **`text_console` gets a real login.** `getty@tty1` is gated on `spatium-console=off` (the mirror of the dashboard's gate) and enabled into `getty.target.wants`, so the dashboard and getty are mutually exclusive by their opposite conditions and `text_console` lands a standard agetty login. (A unit-load-time `Conflicts=getty` leak that left `text_console` with *no* login was fixed in #393 / #394 — see CHANGELOG.)
+- **Anti-brick.** Only changes log verbosity + which process owns the TTY — never the slot / root UUID / kernel. A missing or corrupt grubenv makes the menuentry's conditional fail closed to `loglevel=3` + the dashboard. The always-present GRUB verbose-boot menuentry remains the zero-config one-shot fallback (drops the loglevel cap for a single boot, selectable from the boot menu with no reinstall).
 
 ### Fleet UI updates
 


### PR DESCRIPTION
## 2026.06.13-1 — 2026-06-13

The **appliance console + security-hardening** release. Six PRs: a Talos-style operations cockpit and a live Cluster dashboard for the appliance console / UI, a 3-mode console selector that fixes a no-login regression, an in-place host-migration framework so install-time / ESP changes reach already-installed boxes on a slot upgrade, a firewall navigation refresh with a realtime dropped-packet log viewer, and a full internal auth-bypass / privilege-boundary review (#400) that remediates 1 critical, 3 high, and 12 medium / low findings with ~55 regression tests.

**#400 — auth-bypass / privilege-boundary review (#401).** The headline security item. **C1 (critical):** the supervisor `/heartbeat` endpoint was unauthenticated, so anyone who could reach the control plane could register a fake appliance and pull a signed supervisor cert → k3s cluster-admin; it now requires the supervisor session token. **C2–C4 (high):** AI-apply re-checks the caller's RBAC at apply time (not only at propose), the `dns_zone` token path no longer trusts a caller-supplied zone id (IDOR), and role / group edits are capped by the editor's own permission ceiling so an admin can't grant beyond what they themselves hold. Plus 12 medium / low hardening items spanning sessions, the force-password-change gate, response info-leak trimming, CORS / TrustedHost tightening, an SSRF guard on outbound-fetch surfaces, and frontend token-handling + security-header fixes.

**Appliance console & Cluster UI.** The serial / VGA console gains a Talos-style operations cockpit (#398) and the web UI gains a consolidated **Cluster** tab with a live SSE-fed Overview dashboard (#402) — both grounded in kubelet stats + node / pod listings since there is no Prometheus on the appliance. A new firewall navigation layout adds a realtime nftables dropped-packet log viewer that works across remote appliances too (#404).

### 🔒 Security

* **C1 (critical) — unauthenticated supervisor heartbeat → k3s cluster-admin (#400).** The `/api/v1/appliance/supervisor/heartbeat` endpoint accepted any caller, so anyone able to reach the control plane could impersonate a supervisor, get approved, and receive a signed supervisor certificate that grants k3s cluster-admin. The endpoint now requires the supervisor session token (regression test in `test_supervisor_heartbeat_authz.py`).
* **C2 (high) — AI-apply skipped the apply-time RBAC re-check.** A `propose_*` plan that passed the proposer's permissions could be applied by a caller who no longer (or never) held them; apply now re-validates the caller's RBAC against the concrete mutation.
* **C3 (high) — `dns_zone` token-scope IDOR.** The DNS token path trusted a caller-supplied zone id instead of deriving scope from the authenticated token, letting a scoped token act outside its zone. Scope is now resolved server-side.
* **C4 (high) — role / group edits could exceed the editor's ceiling.** Role and group mutations are now bounded by the editing user's own effective permissions, so an admin cannot grant a permission they do not themselves hold.
* **12 medium / low hardening items.** Session fixation + idle timeout, the force-password-change gate, response info-leak trimming, CORS / TrustedHost allow-list tightening, a new SSRF guard (`backend/app/core/ssrf.py`) on outbound-fetch surfaces, and frontend token-handling + security-header fixes. ~55 regression tests across `test_fix_c*` / `test_fix_m*` / `test_fix_l*`.

### ✨ Added

* **#398 — Talos-style operations cockpit on the appliance console.** Replaces the prior console with a 6-box KPI ribbon (Cluster / etcd / Postgres / API / Platform / Slot) fed by concurrent 5 s-tier collectors, an F7 Health drill-down with guarded recovery actions, multi-node quorum + auto pod-filter + cluster-wide Top-pods + a MetalLB speaker check, font-safe glyphs, content-sized panels, and level-token log colouring. Field-tested on ddi1 at ~2.5 % CPU.
* **#402 — live Cluster Overview dashboard.** The Overview section of the new Cluster tab streams cluster health over SSE (2 s) into a KPI ribbon, a Recharts CPU / memory hero chart, animated per-node radial gauges, a workload-health panel, and a top-pods leaderboard — all from kubelet stats + node / pod listings (no Prometheus on the appliance). Per-node disk shows the host's real partition list (supervisor-reported, with a kubelet `/var` fallback). Needs a `nodes/proxy [get]` RBAC grant and a read-only host-root mount on the supervisor, both shipped in the charts.
* **#404 — realtime nftables firewall-log viewer.** An opt-in global toggle appends a rate-limited `log` rule to the rendered input policy; the supervisor tails `/dev/kmsg` for `spatium-fw:` drops into a ring buffer, surfaced through a new `firewall_logs` nettool so the Firewall tab streams dropped / rejected packets live — including for remote appliances via the per-appliance nettool proxy. Ships a `kernel.dmesg_restrict=0` sysctl drop-in so the unprivileged supervisor can read the kernel ring buffer.
* **#395 — in-place host-migration framework.** A/B slot upgrades replace the rootfs but not the install-time, shared-ESP `grub.cfg`, so menu-structure or kernel-cmdline changes (like the verbose-boot branch from #393) previously required a full reinstall to reach an installed box. New `spatium-grub-render` (idempotent, single source of truth for grub.cfg, shared by the install + live paths) and `spatium-host-migrate` (version-gated, every-boot reconcile of numbered idempotent host-patches run before the health-commit, so a failed render blocks the slot commit and the A/B one-shot reverts) close that gap; failures surface as `host_migration_health` in the Fleet UI.

### 🔧 Changed

* **#393 — 3-mode console selector replaces the verbose-boot toggle.** The old binary toggle conflated boot verbosity with the post-boot console (dashboard vs. plain login) and couldn't express "verbose boot, then dashboard". `console_mode` ∈ {`dashboard` (default), `verbose_dashboard`, `text_console`} maps to the grubenv `spatium_verbose` 0 / 2 / 1 the grub menuentries read (keeping dashboard = 0 + text_console = 1 so old grubenv values still resolve fail-closed); the NetworkTab toggle becomes a 3-option radio.
* **#402 — Cluster tab consolidation.** The standalone Pods tab and the etcd-snapshots section fold into a single **Cluster** tab (Overview / Pods / etcd left sub-nav) — named "Cluster" rather than "Kubernetes" for operator clarity.
* **#404 — Firewall + Fleet navigation refresh.** The Firewall tab's top sub-tabs become a left sub-nav (Policies / Aliases / Preview / Effective / Logs), with the Enforcement + Web-UI-access cards nested compactly inside Policies; Rolling Upgrade, Releases (folded into Rolling Upgrade), and Web UI Certificate move into the Fleet sidebar, with legacy `?tab=` deep-links remapped.

### 🐛 Fixed

* **#394 — helm-stuck-recover crashed on every boot.** `spatiumddi-helm-stuck-recover` (the #183 Phase 9 safety net) died with `JSONDecodeError: Invalid control character` because it shell-interpolated kubectl JSON into a Python heredoc parsed in strict mode, so a genuinely wedged HelmChart would never auto-clear. Now passes the JSON via an env var and parses with `strict=False`.
* **#393 — `text_console` mode left the appliance with no console login.** `spatium-console.service` still declared `Conflicts=getty@tty1.service`, which is registered at unit-load time, so even with the dashboard correctly inactive in `text_console` mode the recorded conflict dropped `getty@tty1` from the boot transaction — bare kernel text, no prompt. Removed the `Conflicts=` (dashboard and getty are already mutually exclusive via opposite `spatium-console=off` conditions); field-validated end-to-end on slot B.
* **#404 — dead Platform Insights → Containers link.** The Platform Insights card linked to the removed `?tab=containers`; it now points at `Cluster → Pods`.

### 🗃️ Migrations

* `a7c3e9f1b405` (#393) — adds `platform_settings.console_mode`, backfills it from the old `verbose_boot` flag (`True` → `text_console`), then drops `verbose_boot`.
* `b3e7d1f9a204` (#395) — adds `appliance.host_migration_health` (JSONB, not null, default `{}`).
* `c5f1a2b3d4e6` (#404) — adds `platform_settings.firewall_logging_enabled` (bool, default `false`).
