### PR TITLE
Fix #407–#411: appliance registration toggle, off-cluster agents, live upgrade UI, reboot regression, SSO reveals

### DIFF
--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -520,11 +520,16 @@ def heartbeat_once(
             headers = build_auth_headers(
                 "POST", url_path, cached_cert, identity.private_key, appliance_id
             )
-            # Once we have a cert the session token shouldn't ride
-            # along — keeps the wire payload clean + makes server-
-            # side cert-only enforcement straightforward when it
-            # lands.
-            body.pop("session_token", None)
+            # #411 — KEEP the session token in the body as a fallback even
+            # when we present a cert. The server prefers the cert; if cert-
+            # auth doesn't validate (the cert pipeline isn't proven in the
+            # field yet), it falls back to the session token rather than
+            # 403ing. Previously we popped the token here in anticipation of
+            # cert-only enforcement — but combined with #400 C1 removing the
+            # approved-state bypass, that left the heartbeat with no usable
+            # credential whenever cert-auth wasn't accepted, silently
+            # killing reboot / fleet-upgrade / role delivery. Re-add the pop
+            # once cert-auth is enforced end-to-end (the #411 follow-up).
         except Exception as exc:  # noqa: BLE001
             log.warning("supervisor.heartbeat.cert_auth_skipped", error=str(exc))
 

--- a/backend/app/api/v1/admin/agent_keys.py
+++ b/backend/app/api/v1/admin/agent_keys.py
@@ -32,13 +32,13 @@ from __future__ import annotations
 
 import structlog
 from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from app.api.deps import DB, CurrentUser
 from app.config import settings
 from app.core.permissions import is_effective_superadmin
-from app.core.security import verify_password
 from app.models.audit import AuditLog
+from app.services.reauth import ReauthOutcome, reverify_operator
 
 logger = structlog.get_logger(__name__)
 
@@ -46,7 +46,11 @@ router = APIRouter()
 
 
 class RevealRequest(BaseModel):
-    password: str = Field(min_length=1)
+    # #408 — local users supply ``password``; external-auth users (no
+    # local password) supply ``totp_code`` (a local user with MFA enrolled
+    # may use either). At least one is required; the reauth helper decides.
+    password: str | None = None
+    totp_code: str | None = None
 
 
 class RevealResponse(BaseModel):
@@ -96,14 +100,14 @@ async def reveal_agent_keys(
             "Only superadmins can reveal agent bootstrap keys",
         )
 
-    # Explicit local-auth gate. External-auth users (LDAP / OIDC /
-    # SAML / RADIUS / TACACS+) don't have a local password to confirm,
-    # so the password-re-verify flow is meaningless for them. Rather
-    # than letting it accidentally pass (or fail with a confusing
-    # "password incorrect" when in fact the user has no local
-    # password), surface the policy explicitly: "log in as a local
-    # admin to reveal these keys."
-    if current_user.auth_source != "local":
+    # #408 — re-confirm the operator. Local users with their password OR a
+    # TOTP code (if enrolled); external-auth users (LDAP / OIDC / SAML /
+    # RADIUS / TACACS+ — no local password) with a TOTP code. MFA enrolment
+    # is now open to all auth sources, so an SSO superadmin can enrol + use
+    # TOTP here instead of the old hard "log in as a local admin" dead-end.
+    outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
+    if outcome is not ReauthOutcome.OK:
+        reason = "mfa_required" if outcome is ReauthOutcome.MFA_REQUIRED else "bad_credential"
         db.add(
             AuditLog(
                 user_id=current_user.id,
@@ -114,39 +118,19 @@ async def reveal_agent_keys(
                 resource_id="agent-keys",
                 resource_display="agent bootstrap keys",
                 result="forbidden",
-                new_value={"reason": "external_auth"},
+                new_value={"reason": reason},
             )
         )
         await db.commit()
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN,
-            "Agent bootstrap keys can only be revealed by a local-auth "
-            "superadmin (your account authenticates via "
-            f"{current_user.auth_source}). Log in as a local admin to "
-            "reveal these keys, or pass them out-of-band — they also "
-            "live in /etc/spatiumddi/.env on the control plane host.",
-        )
-
-    if not current_user.hashed_password or not verify_password(
-        body.password, current_user.hashed_password
-    ):
-        db.add(
-            AuditLog(
-                user_id=current_user.id,
-                user_display_name=current_user.display_name,
-                auth_source=current_user.auth_source,
-                action="agent_keys_reveal_denied",
-                resource_type="platform",
-                resource_id="agent-keys",
-                resource_display="agent bootstrap keys",
-                result="bad_password",
-                new_value={"reason": "password_mismatch"},
+        if outcome is ReauthOutcome.MFA_REQUIRED:
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                "Re-confirmation requires MFA. Your account has no local "
+                "password — enrol TOTP under Settings → Security, then retry.",
             )
-        )
-        await db.commit()
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
-            "Password is incorrect",
+            "Password or TOTP code is incorrect",
         )
 
     # Success — emit an audit row carrying NOTHING about the key

--- a/backend/app/api/v1/appliance/pairing.py
+++ b/backend/app/api/v1/appliance/pairing.py
@@ -55,10 +55,10 @@ from sqlalchemy import func, select
 from app.api.deps import DB, CurrentUser
 from app.core.crypto import decrypt_str, encrypt_str
 from app.core.permissions import is_effective_superadmin, require_permission
-from app.core.security import verify_password
 from app.models.appliance import PairingClaim, PairingCode
 from app.models.audit import AuditLog
 from app.models.auth import User
+from app.services.reauth import ReauthOutcome, reverify_operator
 
 logger = structlog.get_logger(__name__)
 
@@ -158,7 +158,11 @@ class PairingCodeList(BaseModel):
 
 
 class PairingCodeRevealRequest(BaseModel):
-    password: str = Field(min_length=1, description="Caller's current password.")
+    # #408 — local users supply ``password``; external-auth users (no
+    # local password) supply ``totp_code``; a local user with MFA enrolled
+    # may use either. The reauth helper decides; at least one is required.
+    password: str | None = Field(default=None, description="Caller's current password.")
+    totp_code: str | None = Field(default=None, description="Caller's current TOTP code.")
 
 
 class PairingCodeRevealResponse(BaseModel):
@@ -516,18 +520,22 @@ async def reveal_pairing_code(
     no encrypted cleartext (shown once on create); reveal 422s on
     them.
 
-    Gated: superadmin + local-auth + current-password re-check +
-    audited. Mirrors agent-bootstrap-keys reveal.
+    Gated: superadmin + password-or-TOTP re-confirm (#408) + audited.
+    Mirrors agent-bootstrap-keys reveal.
     """
     _require_superadmin(current_user)
 
-    if current_user.auth_source != "local":
+    # #408 — local users re-confirm with password or TOTP; external-auth
+    # users with TOTP (enrol under Settings → Security if not yet enrolled).
+    outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
+    if outcome is ReauthOutcome.MFA_REQUIRED:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
-            "Reveal requires a local-auth account; SSO accounts cannot re-verify password.",
+            "Re-confirmation requires MFA. Your account has no local password "
+            "— enrol TOTP under Settings → Security, then retry.",
         )
-    if not verify_password(body.password, current_user.hashed_password or ""):
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password verification failed.")
+    if outcome is not ReauthOutcome.OK:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password or TOTP verification failed.")
 
     row = await db.get(PairingCode, code_id)
     if row is None:

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -632,13 +632,18 @@ async def supervisor_register(
             existing.capabilities = body.capabilities.model_dump()
         # Rotate the session token — supervisor must use the fresh one
         # for subsequent polls. Old cached tokens fail hash compare.
-        # Skip when the row already has a cert (approval-complete; the
-        # supervisor is using mTLS not session tokens at that point).
-        if existing.cert_pem is None:
-            cleartext, digest = generate_session_token()
-            existing.session_token_hash = digest
-        else:
-            cleartext = ""  # no longer needed; supervisor uses mTLS
+        # #411 — ALWAYS mint + return a fresh token, even for a cert'd
+        # (approved) row. Previously this blanked the token for cert'd
+        # rows ("supervisor uses mTLS"), but the heartbeat's mTLS verifier
+        # is not yet enforced — it's a fallback that supersedes the token
+        # only when the cert actually validates. Once #400 C1 removed the
+        # approved-state heartbeat bypass, an approved box whose cert isn't
+        # validating in the field had NO usable credential and 403'd every
+        # heartbeat (no reboot / upgrade / role delivery). The session
+        # token stays the dependable heartbeat credential until cert-auth
+        # is proven + enforced in the field.
+        cleartext, digest = generate_session_token()
+        existing.session_token_hash = digest
         await db.commit()
         logger.info(
             "supervisor_register_idempotent",
@@ -1467,13 +1472,23 @@ async def supervisor_heartbeat(
     try:
         cert_principal = await authenticate_cert(request, db)
     except CertAuthFailed as exc:
-        await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
+        # #411 — a cert-auth FAILURE no longer hard-403s. The mTLS verifier
+        # is a fallback that supersedes the session token only when the cert
+        # actually validates; when it doesn't (no cert delivered yet, clock
+        # skew, chain mismatch), fall through to the session-token path below
+        # so an approved supervisor can still authenticate its heartbeat.
+        # The session token is a real per-appliance secret (stored as a
+        # hash), so this is NOT the credential-less UUID-only bypass #400 C1
+        # closed — the no-cert branch still REQUIRES a valid token. The
+        # cluster-admin k3s join token stays gated on ``cert_principal is not
+        # None`` below, so a token-only heartbeat can never harvest it. The
+        # warning is kept for the cert-auth-steady-state follow-up.
         logger.warning(
             "supervisor_heartbeat_cert_auth_failed",
             appliance_id=str(body.appliance_id),
             reason=exc.reason,
         )
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance client cert.")
+        cert_principal = None
 
     if cert_principal is not None:
         # Cert subject CN must match the body's appliance_id (defence-

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -5131,11 +5131,13 @@ async def k8s_rollout_restart(
 
 
 class RevealKubeconfigRequest(BaseModel):
-    """Operator's local-auth password — re-verified before we hand
-    back the cleartext kubeconfig. Same gate the SNMP-community and
-    agent-bootstrap-key reveals use."""
+    """Operator re-confirmation before we hand back the cleartext
+    kubeconfig. Same gate the SNMP-community and agent-bootstrap-key
+    reveals use: local users supply ``password``, external-auth users
+    (no local password, #408) supply ``totp_code``."""
 
-    password: str
+    password: str | None = None
+    totp_code: str | None = None
 
 
 class RevealKubeconfigResponse(BaseModel):
@@ -5177,7 +5179,10 @@ async def reveal_appliance_kubeconfig(
     need to edit the server line to a reachable address.
     """
     from app.core.crypto import decrypt_str  # noqa: PLC0415
-    from app.core.security import verify_password  # noqa: PLC0415
+    from app.services.reauth import (  # noqa: PLC0415
+        ReauthOutcome,
+        reverify_operator,
+    )
 
     def _audit_denied(reason: str, *, row: Appliance | None = None) -> None:
         db.add(
@@ -5202,23 +5207,22 @@ async def reveal_appliance_kubeconfig(
             status.HTTP_403_FORBIDDEN,
             "Only superadmins can reveal an appliance kubeconfig.",
         )
-    if current_user.auth_source != "local":
-        _audit_denied("external_auth")
-        await db.commit()
+    # #408 — local users re-confirm with password or TOTP; external-auth
+    # users with TOTP (enrol under Settings → Security if not yet enrolled).
+    outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
+    if outcome is not ReauthOutcome.OK:
         await asyncio.sleep(0.1)
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN,
-            "Kubeconfig reveal requires a local-auth superadmin "
-            f"(your account authenticates via {current_user.auth_source}). "
-            "Log in as a local admin to reveal the kubeconfig.",
-        )
-    if not current_user.hashed_password or not verify_password(
-        body.password, current_user.hashed_password
-    ):
-        _audit_denied("password_mismatch")
+        if outcome is ReauthOutcome.MFA_REQUIRED:
+            _audit_denied("mfa_required")
+            await db.commit()
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                "Re-confirmation requires MFA. Your account has no local "
+                "password — enrol TOTP under Settings → Security, then retry.",
+            )
+        _audit_denied("bad_credential")
         await db.commit()
-        await asyncio.sleep(0.1)
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password is incorrect.")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect.")
 
     row = await db.get(Appliance, appliance_id)
     if row is None:

--- a/backend/app/api/v1/auth/router.py
+++ b/backend/app/api/v1/auth/router.py
@@ -898,10 +898,12 @@ class MfaEnrolVerifyRequest(BaseModel):
 
 
 class MfaPasswordCodeRequest(BaseModel):
-    """Body shape for disable + recovery-code regen — both gated on the
-    same two-factor reauth (current password + current TOTP code)."""
+    """Body shape for disable + recovery-code regen. Local users supply
+    their current password AND a current TOTP code (two-factor reauth);
+    external-auth users (no local password, #408) supply just the TOTP
+    code, so ``password`` is optional."""
 
-    password: str
+    password: str | None = None
     code: str
 
 
@@ -932,12 +934,12 @@ async def mfa_enroll_begin(current_user: CurrentUser, db: DB) -> MfaEnrolBeginRe
     over the wire twice) but leaves ``totp_enabled`` false.
 
     Calling begin a second time before verify replaces the candidate —
-    operator scanned a half-broken QR code, fine, just start over."""
-    if current_user.auth_source != "local":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="MFA enrolment is for local users only",
-        )
+    operator scanned a half-broken QR code, fine, just start over.
+
+    #408 — open to every auth source (was local-only). An external-auth
+    (OIDC / SAML / LDAP / …) superadmin needs TOTP to re-confirm sensitive
+    reveals, since they have no local password; the authenticated session
+    is the enrolment auth (begin only mints a candidate secret)."""
     if current_user.totp_enabled:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -964,12 +966,9 @@ async def mfa_enroll_verify(
 ) -> None:
     """Confirm enrolment by submitting the first 6-digit TOTP code. Until
     this succeeds ``totp_enabled`` stays false and login skips the MFA
-    gate. On success we audit-log and the next ``/login`` will MFA-gate."""
-    if current_user.auth_source != "local":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="MFA enrolment is for local users only",
-        )
+    gate. On success we audit-log and the next ``/login`` will MFA-gate.
+
+    #408 — open to every auth source (was local-only)."""
     if current_user.totp_enabled:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="MFA already enabled")
     if current_user.totp_secret_encrypted is None:
@@ -985,7 +984,7 @@ async def mfa_enroll_verify(
         AuditLog(
             user_id=current_user.id,
             user_display_name=current_user.display_name,
-            auth_source="local",
+            auth_source=current_user.auth_source,
             source_ip=_client_ip(request),
             user_agent=clean_user_agent(request.headers.get("user-agent")),
             action="mfa.enabled",
@@ -1002,22 +1001,21 @@ async def mfa_enroll_verify(
 async def mfa_disable(
     body: MfaPasswordCodeRequest, current_user: CurrentUser, request: Request, db: DB
 ) -> None:
-    """Disable MFA. Requires both the current password AND a current TOTP
-    code — neither alone is sufficient. Clears the secret and recovery
-    codes."""
-    if current_user.auth_source != "local":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="MFA management is for local users only",
-        )
+    """Disable MFA. Local users supply the current password AND a current
+    TOTP code (neither alone suffices); external-auth users (no local
+    password, #408) supply just the current TOTP code. Clears the secret
+    and recovery codes."""
     if not current_user.totp_enabled or current_user.totp_secret_encrypted is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="MFA is not currently enabled"
         )
-    if not current_user.hashed_password or not verify_password(
-        body.password, current_user.hashed_password
-    ):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    # Password is required + checked ONLY for local accounts (which have
+    # one). External-auth accounts re-confirm with the TOTP code alone.
+    if current_user.auth_source == "local" and current_user.hashed_password:
+        if not body.password or not verify_password(body.password, current_user.hashed_password):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+            )
     secret = decrypt_secret(current_user.totp_secret_encrypted)
     if not verify_totp(secret, body.code):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid TOTP code")
@@ -1028,7 +1026,7 @@ async def mfa_disable(
         AuditLog(
             user_id=current_user.id,
             user_display_name=current_user.display_name,
-            auth_source="local",
+            auth_source=current_user.auth_source,
             source_ip=_client_ip(request),
             user_agent=clean_user_agent(request.headers.get("user-agent")),
             action="mfa.disabled",
@@ -1051,20 +1049,18 @@ async def mfa_regenerate_recovery_codes(
     """Replace the recovery-code list. Same two-factor reauth as
     ``/disable``. Returns the new codes ONCE — operator must record them.
     The existing ``secret`` is kept so the authenticator app entry stays
-    valid; only the recovery-code list rotates."""
-    if current_user.auth_source != "local":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="MFA management is for local users only",
-        )
+    valid; only the recovery-code list rotates. Same reauth shape as
+    ``/disable``: local users supply password + TOTP, external-auth users
+    (no local password, #408) supply just the TOTP code."""
     if not current_user.totp_enabled or current_user.totp_secret_encrypted is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="MFA is not currently enabled"
         )
-    if not current_user.hashed_password or not verify_password(
-        body.password, current_user.hashed_password
-    ):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    if current_user.auth_source == "local" and current_user.hashed_password:
+        if not body.password or not verify_password(body.password, current_user.hashed_password):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+            )
     secret = decrypt_secret(current_user.totp_secret_encrypted)
     if not verify_totp(secret, body.code):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid TOTP code")
@@ -1074,7 +1070,7 @@ async def mfa_regenerate_recovery_codes(
         AuditLog(
             user_id=current_user.id,
             user_display_name=current_user.display_name,
-            auth_source="local",
+            auth_source=current_user.auth_source,
             source_ip=_client_ip(request),
             user_agent=clean_user_agent(request.headers.get("user-agent")),
             action="mfa.recovery_regenerated",

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -1986,7 +1986,10 @@ async def get_oui_status(current_user: CurrentUser, db: DB) -> OUIStatusResponse
 
 
 class RevealCommunityRequest(BaseModel):
-    password: str
+    # #408 — local users supply ``password``; external-auth users (no
+    # local password) supply ``totp_code``. The reauth helper decides.
+    password: str | None = None
+    totp_code: str | None = None
 
 
 class RevealCommunityResponse(BaseModel):
@@ -2012,8 +2015,8 @@ async def reveal_snmp_community(
     no local password to re-confirm.
     """
     from app.core.crypto import decrypt_str
-    from app.core.security import verify_password
     from app.models.audit import AuditLog
+    from app.services.reauth import ReauthOutcome, reverify_operator
 
     def _audit_denied(reason: str) -> None:
         db.add(
@@ -2038,22 +2041,21 @@ async def reveal_snmp_community(
             "Only superadmins can reveal the SNMP community",
         )
 
-    if current_user.auth_source != "local":
-        _audit_denied("external_auth")
+    # #408 — local users re-confirm with password or TOTP; external-auth
+    # users with TOTP (enrol under Settings → Security if not yet enrolled).
+    outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
+    if outcome is not ReauthOutcome.OK:
+        if outcome is ReauthOutcome.MFA_REQUIRED:
+            _audit_denied("mfa_required")
+            await db.commit()
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                "Re-confirmation requires MFA. Your account has no local "
+                "password — enrol TOTP under Settings → Security, then retry.",
+            )
+        _audit_denied("bad_credential")
         await db.commit()
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN,
-            "SNMP community reveal requires a local-auth superadmin "
-            f"(your account authenticates via {current_user.auth_source}). "
-            "Log in as a local admin to reveal the community.",
-        )
-
-    if not current_user.hashed_password or not verify_password(
-        body.password, current_user.hashed_password
-    ):
-        _audit_denied("password_mismatch")
-        await db.commit()
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password is incorrect")
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect")
 
     settings = await _get_or_create(db)
     if not settings.snmp_community_encrypted:

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -176,6 +176,13 @@ class SettingsResponse(BaseModel):
     # ``verbose_dashboard`` = verbose boot output then dashboard;
     # ``text_console`` = verbose boot + plain getty login (no dashboard).
     console_mode: str = "dashboard"
+    # ── Supervisor (appliance) registration gate (#170 Wave A / #407) ──
+    # When false, POST /appliance/supervisor/register 404s so a remote
+    # supervisor cannot pair. OS-appliance control-plane installs self-
+    # enable this on first boot; generic Kubernetes/Helm control planes
+    # have no such auto-enable, so an operator must flip it on (here or
+    # via the Fleet → Pairing toggle) before an appliance can register.
+    supervisor_registration_enabled: bool = False
     # ── Maintenance mode (issue #57) ──────────────────────────────
     # System-wide read-only switch. ``maintenance_started_at`` is
     # server-managed (stamped on enable / cleared on disable) and so is
@@ -649,6 +656,10 @@ class SettingsUpdate(BaseModel):
     timezone: str | None = None
     # ── Appliance console mode (#393) ─────────────────────────────
     console_mode: Literal["dashboard", "verbose_dashboard", "text_console"] | None = None
+    # ── Supervisor (appliance) registration gate (#170 Wave A / #407) ──
+    # Not a host-config field (no supervisor wake needed) — it's read
+    # fresh by the register endpoint's module gate on the next pairing.
+    supervisor_registration_enabled: bool | None = None
     # ── Maintenance mode (issue #57) ──────────────────────────────
     # ``maintenance_started_at`` is intentionally NOT settable here —
     # it's server-stamped in ``update_settings`` when the enable flag
@@ -1386,6 +1397,18 @@ async def update_settings(
             detail="Maintenance mode can only be changed by a superadmin",
         )
 
+    # Supervisor (appliance) registration is a SECURITY gate (#407): while
+    # true, POST /appliance/supervisor/register accepts pairing codes; while
+    # false it 404s. Opening it widens the appliance-pairing attack surface,
+    # so it is superadmin-only — a delegated ``write:settings`` editor must
+    # not be able to flip it. Matches the superadmin-only Fleet → Pairing
+    # toggle in the UI.
+    if "supervisor_registration_enabled" in changes and not is_effective_superadmin(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Appliance registration can only be changed by a superadmin",
+        )
+
     # Maintenance mode (issue #57). Capture the prior enabled state before
     # the setattr loop mutates it so we can detect an actual flip (and
     # server-stamp / clear ``maintenance_started_at`` accordingly + write
@@ -1395,6 +1418,11 @@ async def update_settings(
     _maintenance_requested = changes.get("maintenance_mode_enabled")
     _maintenance_message_prev = settings.maintenance_message or ""
     _maintenance_message_requested = changes.get("maintenance_message")
+
+    # #407 — capture the prior registration-gate state before the setattr
+    # loop so we can detect an actual flip and write a dedicated audit row.
+    _supervisor_reg_prev = bool(settings.supervisor_registration_enabled)
+    _supervisor_reg_requested = changes.get("supervisor_registration_enabled")
 
     # Whether this update touches any host-config field a HOSTCONFIG_ALL
     # subscriber acts on. The DHCP-agent /config long-poll folds SNMP /
@@ -1701,6 +1729,31 @@ async def update_settings(
                     "enabled": bool(settings.maintenance_mode_enabled),
                     "message": settings.maintenance_message or "",
                 },
+            )
+        )
+
+    # #407 — audit the supervisor-registration gate flip (non-negotiable #4).
+    # Security-relevant: enabling it opens the appliance-pairing endpoint.
+    if (
+        _supervisor_reg_requested is not None
+        and bool(_supervisor_reg_requested) != _supervisor_reg_prev
+    ):
+        _reg_now = bool(_supervisor_reg_requested)
+        db.add(
+            AuditLog(
+                user_id=current_user.id,
+                user_display_name=current_user.display_name,
+                auth_source=current_user.auth_source,
+                action=(
+                    "supervisor_registration.enabled"
+                    if _reg_now
+                    else "supervisor_registration.disabled"
+                ),
+                resource_type="platform_settings",
+                resource_id="supervisor_registration",
+                resource_display="Appliance registration",
+                result="success",
+                new_value={"enabled": _reg_now},
             )
         )
 

--- a/backend/app/services/reauth.py
+++ b/backend/app/services/reauth.py
@@ -9,9 +9,11 @@ bootstrap key, or the SNMP community.
 
 This helper unifies the re-confirmation:
 
-* **Local users** (have a password): a correct password OR a correct TOTP code
-  (when MFA is enrolled) passes — the password stays the primary, TOTP is an
-  added option.
+* **Local users** (have a password): only a correct password passes — TOTP is
+  NOT accepted in lieu of it. Local users already hold the strongest factor,
+  and accepting TOTP-instead-of-password would downgrade the reveal step-up
+  (MFA enrolment needs only a session, so a hijacked session could self-enrol
+  and reveal without the password). See the SECURITY note in reverify_operator.
 * **External-auth users** (no local password): a correct TOTP code passes. MFA
   enrolment is now open to every auth source (#408), so an SSO superadmin can
   enrol TOTP and then re-confirm with it. If they have NOT enrolled, the helper
@@ -70,14 +72,24 @@ def reverify_operator(
     """
     has_local_password = bool(user.auth_source == "local" and user.hashed_password)
     if has_local_password:
+        # SECURITY (review of #408): a local user must prove their PASSWORD —
+        # TOTP is NOT accepted as a substitute here. Accepting TOTP-in-lieu-of-
+        # password would be a defense-in-depth downgrade: MFA enrolment only
+        # needs an authenticated session, so a hijacked session of a local
+        # superadmin who hasn't enrolled could self-enrol TOTP and then reveal
+        # secrets without ever proving the password the reveal step-up exists
+        # to demand. Local users already hold the strongest factor (password);
+        # only password-less SSO users fall back to TOTP below.
         assert user.hashed_password is not None  # narrowed by has_local_password
         if password and verify_password(password, user.hashed_password):
             return ReauthOutcome.OK
-        if _totp_ok(user, totp_code):
-            return ReauthOutcome.OK
         return ReauthOutcome.BAD_CREDENTIAL
 
-    # External-auth (or a local account with no password set) — TOTP only.
+    # External-auth (or a local account with no password set) — TOTP only,
+    # since there is no password to prove. A "local" row with a NULL password
+    # is a misconfiguration that cannot hold a session today (login rejects
+    # it); it falls here and still requires enrolled MFA + a valid code, so
+    # the password check is never silently skipped for a credentialed account.
     if not user.totp_enabled:
         return ReauthOutcome.MFA_REQUIRED
     if _totp_ok(user, totp_code):

--- a/backend/app/services/reauth.py
+++ b/backend/app/services/reauth.py
@@ -1,0 +1,85 @@
+"""Operator re-confirmation for sensitive actions (#408).
+
+Sensitive surfaces (secret reveals, and — later — destructive ops) re-confirm
+the operator's identity right before proceeding. Historically each did a local
+``verify_password`` and hard-rejected any ``auth_source != "local"`` account —
+so an OIDC / SAML / LDAP / RADIUS / TACACS+ superadmin (who has no local
+password) could never reveal an appliance kubeconfig, a pairing code, an agent
+bootstrap key, or the SNMP community.
+
+This helper unifies the re-confirmation:
+
+* **Local users** (have a password): a correct password OR a correct TOTP code
+  (when MFA is enrolled) passes — the password stays the primary, TOTP is an
+  added option.
+* **External-auth users** (no local password): a correct TOTP code passes. MFA
+  enrolment is now open to every auth source (#408), so an SSO superadmin can
+  enrol TOTP and then re-confirm with it. If they have NOT enrolled, the helper
+  returns ``MFA_REQUIRED`` so the caller can tell them to enrol rather than
+  dead-ending on a password they don't have.
+
+The helper is intentionally stateless: it verifies a live TOTP code only (no
+recovery-code consumption, which would mutate the user row) — recovery codes
+are the lost-authenticator path for *login*, not per-action re-confirmation.
+A single-use replay guard on the reveal TOTP (mirroring the login MFA
+challenge) is a possible follow-up; the reveal endpoints are superadmin-gated
+and audited, so a 30 s TOTP window is low-risk in the meantime.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from app.core.security import verify_password
+from app.services.mfa import decrypt_secret, verify_totp
+
+if TYPE_CHECKING:
+    from app.models.auth import User
+
+
+class ReauthOutcome(Enum):
+    """Result of an operator re-confirmation attempt. Compared by identity
+    (``is``) at the call sites, so plain ``Enum`` (no ``str`` mixin)."""
+
+    OK = "ok"
+    BAD_CREDENTIAL = "bad_credential"  # wrong password / wrong or missing TOTP
+    MFA_REQUIRED = "mfa_required"  # external-auth user with no MFA enrolled
+
+
+def _totp_ok(user: User, code: str | None) -> bool:
+    """True iff ``code`` is a currently-valid TOTP for an MFA-enrolled user."""
+    if not code or not user.totp_enabled or user.totp_secret_encrypted is None:
+        return False
+    try:
+        return verify_totp(decrypt_secret(user.totp_secret_encrypted), code)
+    except Exception:  # noqa: BLE001 — a decrypt/parse failure is just "no"
+        return False
+
+
+def reverify_operator(
+    user: User,
+    *,
+    password: str | None = None,
+    totp_code: str | None = None,
+) -> ReauthOutcome:
+    """Re-confirm ``user`` for a sensitive action. See module docstring.
+
+    Never raises on a bad credential — returns an outcome so the caller keeps
+    its own audit-on-denial + friction-sleep behaviour.
+    """
+    has_local_password = bool(user.auth_source == "local" and user.hashed_password)
+    if has_local_password:
+        assert user.hashed_password is not None  # narrowed by has_local_password
+        if password and verify_password(password, user.hashed_password):
+            return ReauthOutcome.OK
+        if _totp_ok(user, totp_code):
+            return ReauthOutcome.OK
+        return ReauthOutcome.BAD_CREDENTIAL
+
+    # External-auth (or a local account with no password set) — TOTP only.
+    if not user.totp_enabled:
+        return ReauthOutcome.MFA_REQUIRED
+    if _totp_ok(user, totp_code):
+        return ReauthOutcome.OK
+    return ReauthOutcome.BAD_CREDENTIAL

--- a/backend/tests/test_appliance_pairing.py
+++ b/backend/tests/test_appliance_pairing.py
@@ -347,12 +347,14 @@ async def test_reveal_rejects_ephemeral_code(db_session: AsyncSession, client: A
 
 
 @pytest.mark.asyncio
-async def test_reveal_rejects_external_auth_user(
+async def test_reveal_external_auth_without_mfa_must_enrol(
     db_session: AsyncSession, client: AsyncClient
 ) -> None:
-    """External-auth users (LDAP / OIDC / SAML) can't re-confirm a
-    local password. The endpoint refuses cleanly rather than failing
-    with a confusing 'password incorrect'."""
+    """#408 — external-auth users (LDAP / OIDC / SAML) have no local
+    password, so reveal re-confirmation requires TOTP. A user who hasn't
+    enrolled MFA gets a clear 'enrol MFA' 403 (not a confusing password
+    rejection); enrolling + supplying a TOTP code is covered in
+    test_reveal_mfa_reauth.py."""
     _, token = await _make_user(
         db_session,
         username="pcldap",
@@ -375,6 +377,7 @@ async def test_reveal_rejects_external_auth_user(
         json={"password": "anything"},
     )
     assert resp.status_code == 403
+    assert "mfa" in resp.json()["detail"].lower()
 
 
 # ── MCP tool ────────────────────────────────────────────────────────

--- a/backend/tests/test_appliance_supervisor_register.py
+++ b/backend/tests/test_appliance_supervisor_register.py
@@ -295,6 +295,49 @@ async def test_register_is_idempotent_for_same_pubkey(
 
 
 @pytest.mark.asyncio
+async def test_reregister_mints_token_for_certd_row(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """#411 — re-register-from-cache returns a FRESH session token even after
+    the row has a cert (post-approval), so an approved supervisor that lost
+    its token can recover it. Pre-#411 this returned "" for cert'd rows, which
+    — once #400 C1 removed the approved-state heartbeat bypass — left such a
+    box with no usable credential and 403'd every heartbeat."""
+    await _enable_supervisor_registration(db_session)
+    await _make_pairing_code(db_session, code="55555555")
+    await db_session.commit()
+
+    _, _, _, pubkey_b64 = _new_keypair()
+    first = await client.post(
+        "/api/v1/appliance/supervisor/register",
+        json={
+            "pairing_code": "55555555",
+            "hostname": "cp-recover",
+            "public_key_der_b64": pubkey_b64,
+        },
+    )
+    assert first.status_code == 200, first.text
+
+    # Simulate approval having issued a cert on the row.
+    appliance = await db_session.get(Appliance, uuid.UUID(first.json()["appliance_id"]))
+    assert appliance is not None
+    appliance.cert_pem = "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"
+    await db_session.commit()
+
+    # Re-register the SAME pubkey — must hand back a usable (non-empty) token.
+    second = await client.post(
+        "/api/v1/appliance/supervisor/register",
+        json={
+            "pairing_code": "55555555",
+            "hostname": "cp-recover",
+            "public_key_der_b64": pubkey_b64,
+        },
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["session_token"], "re-register must mint a fresh token for a cert'd row"
+
+
+@pytest.mark.asyncio
 async def test_register_rejects_malformed_pubkey_without_burning_code(
     db_session: AsyncSession, client: AsyncClient
 ) -> None:

--- a/backend/tests/test_reveal_mfa_reauth.py
+++ b/backend/tests/test_reveal_mfa_reauth.py
@@ -58,11 +58,16 @@ def test_local_wrong_password_is_bad_credential() -> None:
     assert out is ReauthOutcome.BAD_CREDENTIAL
 
 
-def test_local_user_may_use_totp_when_enrolled() -> None:
+def test_local_user_totp_is_not_a_password_substitute() -> None:
+    # SECURITY (review of #408): a local user must prove their PASSWORD —
+    # a valid TOTP alone must NOT pass, else a hijacked session could
+    # self-enrol MFA and reveal secrets without the password.
     secret = generate_secret()
     u = _user(password="pw", totp_secret=secret)
     out = reverify_operator(u, totp_code=pyotp.TOTP(secret).now())
-    assert out is ReauthOutcome.OK
+    assert out is ReauthOutcome.BAD_CREDENTIAL
+    # ...and the password still works for that same enrolled local user.
+    assert reverify_operator(u, password="pw") is ReauthOutcome.OK
 
 
 def test_sso_user_with_totp_ok() -> None:
@@ -101,6 +106,37 @@ async def _sso_superadmin(db: AsyncSession, username: str = "ssoadmin") -> tuple
     db.add(user)
     await db.flush()
     return user, create_access_token(str(user.id))
+
+
+async def _local_superadmin(
+    db: AsyncSession, username: str = "localadmin", password: str = "password123"
+) -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=hash_password(password),
+        auth_source="local",
+        is_superadmin=True,
+    )
+    user.groups = []
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _enrol_mfa(client: AsyncClient, headers: dict[str, str]) -> str:
+    """Enrol TOTP via begin + verify; return the secret for code generation."""
+    begin = await client.post("/api/v1/auth/mfa/enroll/begin", headers=headers)
+    assert begin.status_code == 200, begin.text
+    secret = begin.json()["secret"]
+    verify = await client.post(
+        "/api/v1/auth/mfa/enroll/verify",
+        headers=headers,
+        json={"code": pyotp.TOTP(secret).now()},
+    )
+    assert verify.status_code == 204, verify.text
+    return secret
 
 
 @pytest.mark.asyncio
@@ -158,3 +194,52 @@ async def test_sso_user_without_mfa_is_told_to_enrol(
     )
     assert resp.status_code == 403, resp.text
     assert "mfa" in resp.json()["detail"].lower()
+
+
+# ── MFA disable: password conditional (local needs it, SSO doesn't) ──
+
+
+@pytest.mark.asyncio
+async def test_sso_user_disables_mfa_with_totp_only(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """#408 — an SSO user (no local password) disables MFA with just a current
+    TOTP code; the disable endpoint no longer demands a password they lack."""
+    _, token = await _sso_superadmin(db_session, username="ssodisable")
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    secret = await _enrol_mfa(client, headers)
+    resp = await client.post(
+        "/api/v1/auth/mfa/disable",
+        headers=headers,
+        json={"code": pyotp.TOTP(secret).now()},
+    )
+    assert resp.status_code == 204, resp.text
+
+
+@pytest.mark.asyncio
+async def test_local_user_disable_still_requires_password(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """#408 — a LOCAL user still must supply their password to disable MFA;
+    a TOTP-only disable is rejected (the password step-up is preserved)."""
+    _, token = await _local_superadmin(db_session, username="localdisable")
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    secret = await _enrol_mfa(client, headers)
+
+    # TOTP only, no password → rejected.
+    no_pw = await client.post(
+        "/api/v1/auth/mfa/disable",
+        headers=headers,
+        json={"code": pyotp.TOTP(secret).now()},
+    )
+    assert no_pw.status_code == 401, no_pw.text
+
+    # Password + code → disabled.
+    ok = await client.post(
+        "/api/v1/auth/mfa/disable",
+        headers=headers,
+        json={"password": "password123", "code": pyotp.TOTP(secret).now()},
+    )
+    assert ok.status_code == 204, ok.text

--- a/backend/tests/test_reveal_mfa_reauth.py
+++ b/backend/tests/test_reveal_mfa_reauth.py
@@ -1,0 +1,160 @@
+"""#408 — SSO operators can re-confirm sensitive reveals via TOTP.
+
+Historically the reveal endpoints (agent keys, SNMP community, appliance
+kubeconfig, pairing codes) hard-rejected any ``auth_source != "local"``
+account because they re-verified a *local password* an SSO user doesn't
+have. #408 unifies re-confirmation through ``reverify_operator``: local
+users use a password (or TOTP if enrolled), external-auth users use TOTP
+— and MFA enrolment is now open to every auth source.
+
+Covers:
+
+* The ``reverify_operator`` contract (unit).
+* MFA enrolment open to an external-auth (OIDC) user (integration).
+* An SSO superadmin revealing agent keys with a TOTP code (integration),
+  and the no-MFA dead-end returning MFA_REQUIRED.
+"""
+
+from __future__ import annotations
+
+import pyotp
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.services.mfa import encrypt_secret, generate_secret
+from app.services.reauth import ReauthOutcome, reverify_operator
+
+# ── reverify_operator unit contract ────────────────────────────────
+
+
+def _user(
+    *,
+    auth_source: str = "local",
+    password: str | None = None,
+    totp_secret: str | None = None,
+) -> User:
+    u = User(
+        username="u",
+        email="u@example.com",
+        display_name="u",
+        auth_source=auth_source,
+        hashed_password=hash_password(password) if password else None,
+    )
+    if totp_secret is not None:
+        u.totp_enabled = True
+        u.totp_secret_encrypted = encrypt_secret(totp_secret)
+    return u
+
+
+def test_local_password_ok() -> None:
+    assert reverify_operator(_user(password="pw"), password="pw") is ReauthOutcome.OK
+
+
+def test_local_wrong_password_is_bad_credential() -> None:
+    out = reverify_operator(_user(password="pw"), password="nope")
+    assert out is ReauthOutcome.BAD_CREDENTIAL
+
+
+def test_local_user_may_use_totp_when_enrolled() -> None:
+    secret = generate_secret()
+    u = _user(password="pw", totp_secret=secret)
+    out = reverify_operator(u, totp_code=pyotp.TOTP(secret).now())
+    assert out is ReauthOutcome.OK
+
+
+def test_sso_user_with_totp_ok() -> None:
+    secret = generate_secret()
+    u = _user(auth_source="oidc", totp_secret=secret)
+    out = reverify_operator(u, totp_code=pyotp.TOTP(secret).now())
+    assert out is ReauthOutcome.OK
+
+
+def test_sso_user_without_mfa_requires_enrolment() -> None:
+    # Even with a password supplied, an SSO account has no local password
+    # to check against — the helper steers them to enrol MFA.
+    out = reverify_operator(_user(auth_source="oidc"), password="anything")
+    assert out is ReauthOutcome.MFA_REQUIRED
+
+
+def test_sso_user_wrong_totp_is_bad_credential() -> None:
+    secret = generate_secret()
+    u = _user(auth_source="saml", totp_secret=secret)
+    assert reverify_operator(u, totp_code="000000") is ReauthOutcome.BAD_CREDENTIAL
+
+
+# ── integration: SSO enrol MFA → reveal agent keys with TOTP ────────
+
+
+async def _sso_superadmin(db: AsyncSession, username: str = "ssoadmin") -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=None,  # external-auth — no local password
+        auth_source="oidc",
+        is_superadmin=True,
+    )
+    user.groups = []
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+@pytest.mark.asyncio
+async def test_sso_user_can_enrol_mfa_and_reveal(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """#408 end-to-end: an OIDC superadmin enrols TOTP (was local-only) and
+    then reveals the agent bootstrap keys with a TOTP code."""
+    _, token = await _sso_superadmin(db_session)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Enrolment is now open to external-auth users.
+    begin = await client.post("/api/v1/auth/mfa/enroll/begin", headers=headers)
+    assert begin.status_code == 200, begin.text
+    secret = begin.json()["secret"]
+    verify = await client.post(
+        "/api/v1/auth/mfa/enroll/verify",
+        headers=headers,
+        json={"code": pyotp.TOTP(secret).now()},
+    )
+    assert verify.status_code == 204, verify.text
+
+    # Reveal with a current TOTP code → accepted.
+    reveal = await client.post(
+        "/api/v1/admin/agent-keys/reveal",
+        headers=headers,
+        json={"totp_code": pyotp.TOTP(secret).now()},
+    )
+    assert reveal.status_code == 200, reveal.text
+
+    # A wrong TOTP is rejected (the gate still requires a real credential).
+    bad = await client.post(
+        "/api/v1/admin/agent-keys/reveal",
+        headers=headers,
+        json={"totp_code": "000000"},
+    )
+    assert bad.status_code == 403, bad.text
+
+
+@pytest.mark.asyncio
+async def test_sso_user_without_mfa_is_told_to_enrol(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """#408 — an SSO superadmin who hasn't enrolled MFA gets a clear
+    'enrol MFA' 403 instead of a dead-end password rejection."""
+    _, token = await _sso_superadmin(db_session, username="ssonomfa")
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.post(
+        "/api/v1/admin/agent-keys/reveal",
+        headers=headers,
+        json={"password": "irrelevant"},
+    )
+    assert resp.status_code == 403, resp.text
+    assert "mfa" in resp.json()["detail"].lower()

--- a/backend/tests/test_settings_supervisor_registration.py
+++ b/backend/tests/test_settings_supervisor_registration.py
@@ -1,0 +1,148 @@
+"""Settings-router tests for the supervisor-registration gate (#407).
+
+``platform_settings.supervisor_registration_enabled`` gates appliance
+(supervisor) pairing, but before #407 it was absent from both
+``SettingsResponse`` and ``SettingsUpdate`` — so an operator on a generic
+Kubernetes/Helm control plane (where the OS-appliance self-bootstrap never
+fires) had no way to enable it short of hand-editing the database.
+
+These tests pin the now-exposed round-trip:
+
+* GET /settings surfaces the field (defaults False).
+* PUT /settings can flip it on and back off; GET reflects the change.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import Group, Role, User
+
+
+async def _make_superadmin(db: AsyncSession, username: str = "srsuper") -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        auth_source="local",
+        is_superadmin=True,
+    )
+    user.groups = []
+    db.add(user)
+    await db.flush()
+    token = create_access_token(str(user.id))
+    return user, token
+
+
+async def _make_settings_editor(db: AsyncSession, username: str = "srsettings") -> tuple[User, str]:
+    """A non-superadmin granted exactly ``write`` on ``settings`` — passes the
+    generic write:settings gate but NOT the #407 superadmin gate on the
+    registration flag."""
+    role = Role(
+        name=f"settings-editor-{uuid.uuid4().hex[:6]}",
+        description="",
+        permissions=[{"action": "write", "resource_type": "settings"}],
+    )
+    group = Group(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    group.roles = [role]
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        auth_source="local",
+        is_superadmin=False,
+    )
+    user.groups = [group]
+    db.add_all([role, group, user])
+    await db.flush()
+    token = create_access_token(str(user.id))
+    return user, token
+
+
+@pytest.mark.asyncio
+async def test_get_settings_exposes_field_default_false(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    await db_session.commit()
+    resp = await client.get("/api/v1/settings", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "supervisor_registration_enabled" in body
+    # Deliberate Wave-A security posture: off by default.
+    assert body["supervisor_registration_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_put_enables_then_disables_registration(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, token = await _make_superadmin(db_session, username="srtoggle")
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Enable.
+    resp = await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={"supervisor_registration_enabled": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["supervisor_registration_enabled"] is True
+    # GET reflects the persisted change.
+    resp = await client.get("/api/v1/settings", headers=headers)
+    assert resp.json()["supervisor_registration_enabled"] is True
+
+    # Disable again.
+    resp = await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={"supervisor_registration_enabled": False},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["supervisor_registration_enabled"] is False
+    resp = await client.get("/api/v1/settings", headers=headers)
+    assert resp.json()["supervisor_registration_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_non_superadmin_cannot_change_registration(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """#407 — enabling appliance registration is a security gate, so a
+    delegated ``write:settings`` editor is 403'd (mirrors maintenance mode);
+    the superadmin-only Fleet → Pairing toggle matches this."""
+    _, token = await _make_settings_editor(db_session)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={"supervisor_registration_enabled": True},
+    )
+    assert resp.status_code == 403, resp.text
+    assert "superadmin" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_settings_editor_can_still_write_other_fields(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """#407 — the gate is field-scoped: a write:settings editor can still
+    write non-registration settings."""
+    _, token = await _make_settings_editor(db_session, username="srotherok")
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={"dns_auto_sync_enabled": True},
+    )
+    assert resp.status_code == 200, resp.text

--- a/backend/tests/test_supervisor_heartbeat_authz.py
+++ b/backend/tests/test_supervisor_heartbeat_authz.py
@@ -123,3 +123,45 @@ async def test_join_token_not_returned_over_session_token_path(
     )
     assert r.status_code == 200, r.text
     assert r.json()["desired_k3s_join_token"] is None
+
+
+# ── #411 — cert-auth failure falls back to the session-token path ──────────
+# Cert headers PRESENT but failing to validate (the field condition where the
+# cert pipeline isn't proven yet) must not hard-403 an approved supervisor —
+# it falls back to its valid session token so reboot / upgrade / role delivery
+# keep working. This is NOT the C1 bypass: the token is still required.
+
+_GARBAGE_CERT_HEADERS = {
+    "X-Appliance-Cert": "not-a-real-base64-cert",
+    "X-Appliance-Signature": "x",
+    "X-Appliance-Timestamp": "2026-06-13T00:00:00Z",
+}
+
+
+async def test_heartbeat_cert_failure_falls_back_to_valid_session_token(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#411 — invalid cert headers + a VALID session token → accepted (the
+    cert-auth fallback). Pre-#411 this hard-403'd on the cert failure."""
+    row, token = await _approved_appliance(db_session)
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        headers=_GARBAGE_CERT_HEADERS,
+        json={"appliance_id": str(row.id), "session_token": token},
+    )
+    assert r.status_code == 200, r.text
+
+
+async def test_heartbeat_cert_failure_without_valid_token_still_rejected(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#411 — the fallback does NOT open a hole: invalid cert headers + no
+    valid session token is still rejected (a real credential is still
+    required — the C1 invariant holds)."""
+    row, _token = await _approved_appliance(db_session)
+    r = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        headers=_GARBAGE_CERT_HEADERS,
+        json={"appliance_id": str(row.id), "session_token": "wrong-token"},
+    )
+    assert r.status_code == 403, r.text

--- a/charts/spatiumddi-appliance/templates/dhcp-kea.yaml
+++ b/charts/spatiumddi-appliance/templates/dhcp-kea.yaml
@@ -68,14 +68,17 @@ spec:
             # Kea entrypoint env contract (agent/dhcp/images/kea/
             # entrypoint.sh): SPATIUM_API_URL + SPATIUM_AGENT_KEY +
             # AGENT_GROUP.
-            # #292 — co-located DaemonSet agent reaches the control plane
-            # via the in-cluster API Service over plain HTTP. The external
-            # operator-facing URL (dhcpKea.controlPlaneUrl) carries the
-            # appliance's self-signed cert, which the agent can't verify
-            # → registration fails with CERTIFICATE_VERIFY_FAILED. See
-            # dns-bind9.yaml for the full rationale.
+            # #292 / #409 — in-cluster API Service over HTTP by default;
+            # prefer the supervisor-supplied external controlPlaneUrl when
+            # set (Application appliance with its own k3s — no in-cluster
+            # control Service), skipping TLS verify on that self-signed
+            # path. See dns-bind9.yaml for the full rationale.
             - name: SPATIUM_API_URL
-              value: {{ .Values.dhcpKea.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
+              value: {{ .Values.dhcpKea.controlPlaneUrl | default .Values.dhcpKea.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
+            {{- if .Values.dhcpKea.controlPlaneUrl }}
+            - name: SPATIUM_INSECURE_SKIP_TLS_VERIFY
+              value: "1"
+            {{- end }}
             - name: SPATIUM_AGENT_KEY
               value: {{ .Values.dhcpKea.agentKey | quote }}
             - name: AGENT_GROUP

--- a/charts/spatiumddi-appliance/templates/dns-bind9.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-bind9.yaml
@@ -73,17 +73,26 @@ spec:
           image: {{ include "spatiumddi-appliance.imageRef" (dict "global" .Values.global "repository" .Values.dnsBind9.image.repository) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
-            # #292 — co-located DaemonSet agents reach the control plane
-            # via the in-cluster API Service over plain HTTP. The external
-            # operator-facing URL (dnsBind9.controlPlaneUrl) carries the
-            # appliance's self-signed cert, which the agent can't verify
-            # → registration fails with CERTIFICATE_VERIFY_FAILED. Intra-
-            # cluster traffic needs no TLS, so point at the api Service
-            # directly (same repoint as the #272 supervisor heartbeat).
-            # ``inClusterApiUrl`` overrides the default if a deployment
-            # uses a non-standard control-release name/namespace.
+            # #292 — a co-located DaemonSet agent (control-plane / full-
+            # stack appliance) reaches the control plane via the in-cluster
+            # API Service over plain HTTP; intra-cluster traffic needs no
+            # TLS, so the in-cluster Service is the default.
+            # #409 — but an Application appliance is its OWN single-node k3s
+            # with no in-cluster control Service, so when the supervisor
+            # supplies the external operator-facing URL it must be used.
+            # Precedence: controlPlaneUrl (external; set by the supervisor
+            # only on off-cluster Application appliances) → inClusterApiUrl
+            # (override for non-standard control-release name/ns) → the in-
+            # cluster api Service default. The external URL carries the
+            # appliance's self-signed cert, so the TLS-skip env below is
+            # emitted on that path (same TOFU model as the supervisor pod —
+            # the pairing code + mTLS client cert are the real auth).
             - name: CONTROL_PLANE_URL
-              value: {{ .Values.dnsBind9.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
+              value: {{ .Values.dnsBind9.controlPlaneUrl | default .Values.dnsBind9.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
+            {{- if .Values.dnsBind9.controlPlaneUrl }}
+            - name: SPATIUM_INSECURE_SKIP_TLS_VERIFY
+              value: "1"
+            {{- end }}
             - name: DNS_AGENT_KEY
               value: {{ .Values.dnsBind9.agentKey | quote }}
             - name: AGENT_GROUP

--- a/charts/spatiumddi-appliance/templates/dns-powerdns.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-powerdns.yaml
@@ -52,10 +52,17 @@ spec:
           image: {{ include "spatiumddi-appliance.imageRef" (dict "global" .Values.global "repository" .Values.dnsPowerdns.image.repository) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
-            # #292 — in-cluster API Service over HTTP; see dns-bind9.yaml
-            # (the external URL's self-signed cert fails agent registration).
+            # #292 / #409 — in-cluster API Service over HTTP by default;
+            # prefer the supervisor-supplied external controlPlaneUrl when
+            # set (Application appliance with its own k3s — no in-cluster
+            # control Service), skipping TLS verify on that self-signed
+            # path. See dns-bind9.yaml for the full rationale.
             - name: CONTROL_PLANE_URL
-              value: {{ .Values.dnsPowerdns.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
+              value: {{ .Values.dnsPowerdns.controlPlaneUrl | default .Values.dnsPowerdns.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
+            {{- if .Values.dnsPowerdns.controlPlaneUrl }}
+            - name: SPATIUM_INSECURE_SKIP_TLS_VERIFY
+              value: "1"
+            {{- end }}
             - name: DNS_AGENT_KEY
               value: {{ .Values.dnsPowerdns.agentKey | quote }}
             - name: AGENT_GROUP

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -38,10 +38,18 @@ dnsBind9:
     repository: ghcr.io/spatiumddi/dns-bind9
   # Pass-through to the agent via env. The supervisor fills these in
   # when assigning the DNS role.
-  # NOTE (#292): controlPlaneUrl is the EXTERNAL operator-facing URL
-  # (self-signed cert) — no longer used by the co-located DaemonSet
-  # agent, which registers against the in-cluster Service instead. Kept
-  # for the standalone docker-compose agent path.
+  # controlPlaneUrl is the EXTERNAL operator-facing URL (self-signed
+  # cert). #409 — the co-located DaemonSet agent now PREFERS this when
+  # the supervisor sets it (an Application appliance is its own single-
+  # node k3s with no in-cluster control Service, so the in-cluster name
+  # does not resolve), skipping TLS verify on that self-signed path.
+  # Empty on a control-plane/full-stack appliance → falls through to
+  # inClusterApiUrl (the #292 in-cluster verified-HTTP path).
+  # KNOWN LIMITATION: a promoted Application member keeps its baked
+  # external URL here (service_lifecycle._build_values is not yet member-
+  # aware), so its role pods stay on the external + TLS-skip path rather
+  # than the in-cluster path the heartbeat switches to — uncommon
+  # topology, tracked as a #409 follow-up.
   controlPlaneUrl: ""
   # #292 — in-cluster API Service URL the co-located DaemonSet agent
   # registers against (plain HTTP — no TLS to verify intra-cluster, so

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -1258,6 +1258,15 @@ The control-plane operator generates a short-lived 8-digit code on
 the web UI; the agent's installer prompts for that code instead of
 the long ``DNS_AGENT_KEY`` / ``DHCP_AGENT_KEY`` hex string.
 
+> **Generic Kubernetes / Helm control planes:** appliance registration
+> is **disabled by default** — only OS-appliance control-plane installs
+> self-enable it on first boot. Flip it on once at **Appliance →
+> Pairing** ("Appliance registration → Enable"), or set
+> ``supervisor_registration_enabled: true`` via ``PUT /api/v1/settings``,
+> *before* the first pairing — otherwise
+> ``POST /api/v1/appliance/supervisor/register`` returns 404 and the
+> supervisor idles (#407).
+
 1. On the control plane, open **Appliance → Pairing**.
 2. Click **New pairing code**, pick the agent kind (DNS / DHCP /
    DNS+DHCP for combined boxes), optionally pre-assign a server

--- a/frontend/src/components/AgentBootstrapKeysSection.tsx
+++ b/frontend/src/components/AgentBootstrapKeysSection.tsx
@@ -10,6 +10,7 @@ import {
   ShieldAlert,
 } from "lucide-react";
 
+import { ReauthFields } from "@/components/ReauthFields";
 import {
   agentBootstrapKeysApi,
   type AgentBootstrapKeysReveal,
@@ -33,6 +34,7 @@ import {
  */
 export function AgentBootstrapKeysSection() {
   const [password, setPassword] = useState("");
+  const [totp, setTotp] = useState("");
   const [data, setData] = useState<AgentBootstrapKeysReveal | null>(null);
   const [shown, setShown] = useState<{ dns: boolean; dhcp: boolean }>({
     dns: false,
@@ -41,10 +43,12 @@ export function AgentBootstrapKeysSection() {
   const [copied, setCopied] = useState<"dns" | "dhcp" | null>(null);
 
   const reveal = useMutation({
-    mutationFn: agentBootstrapKeysApi.reveal,
+    mutationFn: () =>
+      agentBootstrapKeysApi.reveal(password || undefined, totp || undefined),
     onSuccess: (resp) => {
       setData(resp);
       setPassword("");
+      setTotp("");
       // Show both as masked by default — operator chooses which to
       // uncover. Reduces shoulder-surf risk when only one is needed.
       setShown({ dns: false, dhcp: false });
@@ -86,21 +90,17 @@ export function AgentBootstrapKeysSection() {
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            reveal.mutate(password);
+            reveal.mutate();
           }}
           className="max-w-md space-y-3 rounded-lg border bg-card p-4 shadow-sm"
         >
-          <label className="block text-xs font-medium text-muted-foreground">
-            Confirm your password
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              autoComplete="current-password"
-              className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
-            />
-          </label>
+          <ReauthFields
+            password={password}
+            onPassword={setPassword}
+            totp={totp}
+            onTotp={setTotp}
+            autoFocus
+          />
           {reveal.isError && (
             <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
               <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
@@ -109,7 +109,7 @@ export function AgentBootstrapKeysSection() {
           )}
           <button
             type="submit"
-            disabled={reveal.isPending || !password}
+            disabled={reveal.isPending || (!password && !totp)}
             className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
           >
             <Eye className="h-3.5 w-3.5" />

--- a/frontend/src/components/ReauthFields.tsx
+++ b/frontend/src/components/ReauthFields.tsx
@@ -1,0 +1,65 @@
+/**
+ * #408 — shared re-confirmation inputs for sensitive reveals.
+ *
+ * Local users confirm with their password; external-auth (LDAP / OIDC /
+ * SAML / RADIUS / TACACS+) users have no local password, so they confirm
+ * with a TOTP code from their authenticator (a local user with MFA enrolled
+ * may use either). The backend `reverify_operator` helper decides; the UI
+ * just offers both fields and lets the operator fill whichever applies.
+ */
+
+const inputCls =
+  "mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+export function ReauthFields({
+  password,
+  onPassword,
+  totp,
+  onTotp,
+  autoFocus = false,
+}: {
+  password: string;
+  onPassword: (v: string) => void;
+  totp: string;
+  onTotp: (v: string) => void;
+  autoFocus?: boolean;
+}) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-xs font-medium">
+        Password{" "}
+        <span className="font-normal text-muted-foreground">
+          (local accounts)
+        </span>
+        <input
+          type="password"
+          autoComplete="current-password"
+          autoFocus={autoFocus}
+          value={password}
+          onChange={(e) => onPassword(e.target.value)}
+          className={inputCls}
+        />
+      </label>
+      <label className="block text-xs font-medium">
+        Authenticator code{" "}
+        <span className="font-normal text-muted-foreground">
+          (SSO accounts)
+        </span>
+        <input
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          placeholder="123456"
+          value={totp}
+          onChange={(e) => onTotp(e.target.value)}
+          className={inputCls}
+        />
+      </label>
+      <p className="text-[11px] text-muted-foreground">
+        Local users: enter your password. SSO users (LDAP / OIDC / SAML / RADIUS
+        / TACACS+): enter a code from your authenticator — enrol under{" "}
+        <span className="font-medium">Account → Two-factor</span> first if you
+        haven't.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/SNMPSection.tsx
+++ b/frontend/src/components/SNMPSection.tsx
@@ -40,6 +40,7 @@ function CommunityField({
   const [replacing, setReplacing] = useState(false);
   const [revealing, setRevealing] = useState(false);
   const [revealPassword, setRevealPassword] = useState("");
+  const [revealTotp, setRevealTotp] = useState("");
   const [revealed, setRevealed] = useState<string | null>(null);
 
   // Operator-driven reveal — gated server-side on password +
@@ -48,12 +49,19 @@ function CommunityField({
   // the operator clicks Hide; we deliberately don't auto-hide on a
   // timer because the operator just typed a password to get here and
   // wants the value long enough to paste it into an NMS / snmpwalk.
+  // #408 — re-confirm with a local password OR a TOTP code (SSO accounts
+  // have no local password; enrol under Account → Two-factor).
   const revealMutation = useMutation({
-    mutationFn: (password: string) => settingsApi.revealSnmpCommunity(password),
+    mutationFn: () =>
+      settingsApi.revealSnmpCommunity(
+        revealPassword || undefined,
+        revealTotp || undefined,
+      ),
     onSuccess: (data) => {
       setRevealed(data.community ?? "(no community configured)");
       setRevealing(false);
       setRevealPassword("");
+      setRevealTotp("");
     },
   });
 
@@ -158,7 +166,7 @@ function CommunityField({
             className="flex items-center gap-2"
             onSubmit={(e) => {
               e.preventDefault();
-              if (revealPassword) revealMutation.mutate(revealPassword);
+              if (revealPassword || revealTotp) revealMutation.mutate();
             }}
           >
             <input
@@ -166,13 +174,24 @@ function CommunityField({
               autoComplete="current-password"
               value={revealPassword}
               onChange={(e) => setRevealPassword(e.target.value)}
-              placeholder="Confirm your password"
-              className={cn(inputCls, "w-56 font-mono")}
+              placeholder="Password"
+              className={cn(inputCls, "w-40 font-mono")}
               autoFocus
+            />
+            <input
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              value={revealTotp}
+              onChange={(e) => setRevealTotp(e.target.value)}
+              placeholder="or 6-digit code"
+              className={cn(inputCls, "w-32 font-mono")}
+              title="SSO accounts: enter an authenticator code instead of a password"
             />
             <button
               type="submit"
-              disabled={!revealPassword || revealMutation.isPending}
+              disabled={
+                (!revealPassword && !revealTotp) || revealMutation.isPending
+              }
               className="rounded-md border bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-40"
             >
               {revealMutation.isPending ? "Verifying…" : "Reveal"}
@@ -182,6 +201,7 @@ function CommunityField({
               onClick={() => {
                 setRevealing(false);
                 setRevealPassword("");
+                setRevealTotp("");
                 revealMutation.reset();
               }}
               className="rounded-md border px-2 py-1 text-xs hover:bg-accent"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3261,12 +3261,15 @@ export const settingsApi = {
    *  password re-verify. Superadmin + local-auth only; every reveal
    *  is audit-logged. ``community`` is null when nothing is
    *  configured (in which case ``configured`` is false). */
-  revealSnmpCommunity: (password: string) =>
+  revealSnmpCommunity: (password?: string, totpCode?: string) =>
     api
       .post<{
         configured: boolean;
         community: string | null;
-      }>("/settings/snmp/reveal-community", { password })
+      }>("/settings/snmp/reveal-community", {
+        password,
+        totp_code: totpCode,
+      })
       .then((r) => r.data),
   getOUIStatus: () =>
     api.get<OUIStatus>("/settings/oui/status").then((r) => r.data),
@@ -6612,9 +6615,9 @@ export const authApi = {
       .then((r) => r.data),
   mfaEnrollVerify: (code: string) =>
     api.post("/auth/mfa/enroll/verify", { code }),
-  mfaDisable: (password: string, code: string) =>
+  mfaDisable: (password: string | undefined, code: string) =>
     api.post("/auth/mfa/disable", { password, code }),
-  mfaRegenerateRecoveryCodes: (password: string, code: string) =>
+  mfaRegenerateRecoveryCodes: (password: string | undefined, code: string) =>
     api
       .post<MfaEnrolBeginResponse>("/auth/mfa/recovery-codes/regenerate", {
         password,
@@ -8448,11 +8451,11 @@ export const appliancePairingApi = {
     api
       .post<void>(`/appliance/pairing-codes/${id}/disable`)
       .then((r) => r.data),
-  reveal: (id: string, password: string) =>
+  reveal: (id: string, password?: string, totpCode?: string) =>
     api
       .post<PairingCodeRevealResponse>(
         `/appliance/pairing-codes/${id}/reveal`,
-        { password },
+        { password, totp_code: totpCode },
       )
       .then((r) => r.data),
 };
@@ -8880,13 +8883,16 @@ export const applianceApprovalApi = {
   // Issue #183 Phase 5 — reveal the stored kubeconfig after a
   // password re-confirmation. Same shape as the SNMP-community and
   // agent-bootstrap-key reveal endpoints.
-  revealKubeconfig: (id: string, password: string) =>
+  revealKubeconfig: (id: string, password?: string, totpCode?: string) =>
     api
       .post<{
         configured: boolean;
         kubeconfig: string | null;
         hostname: string;
-      }>(`/appliance/appliances/${id}/k8s/kubeconfig/reveal`, { password })
+      }>(`/appliance/appliances/${id}/k8s/kubeconfig/reveal`, {
+        password,
+        totp_code: totpCode,
+      })
       .then((r) => r.data),
   // Issue #183 Phase 6 — operator-controlled CIDR allowlist for
   // direct kubeapi access. Empty = proxy-only (default).
@@ -9161,9 +9167,12 @@ export interface AgentBootstrapKeysReveal {
 }
 
 export const agentBootstrapKeysApi = {
-  reveal: (password: string) =>
+  reveal: (password?: string, totpCode?: string) =>
     api
-      .post<AgentBootstrapKeysReveal>("/admin/agent-keys/reveal", { password })
+      .post<AgentBootstrapKeysReveal>("/admin/agent-keys/reveal", {
+        password,
+        totp_code: totpCode,
+      })
       .then((r) => r.data),
 };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3004,6 +3004,12 @@ export interface PlatformSettings {
    *  verbose boot + a plain getty login (no dashboard). Appliance hosts only;
    *  applies on the next reboot (grubenv-driven). */
   console_mode: "dashboard" | "verbose_dashboard" | "text_console";
+  /** Supervisor (appliance) registration gate (#170 Wave A / #407).
+   *  When false, a remote supervisor cannot pair (register 404s).
+   *  OS-appliance control-plane installs self-enable this on first boot;
+   *  generic Kubernetes/Helm control planes must flip it on (here or via
+   *  the Fleet → Pairing toggle) before an appliance can register. */
+  supervisor_registration_enabled: boolean;
   /** Maintenance mode (issue #57). System-wide read-only switch.
    *  ``maintenance_started_at`` is server-managed (stamped on enable /
    *  cleared on disable) and is therefore read-only — not sent on PUT. */

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -16,10 +16,12 @@ export function AccountPage() {
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Account</h1>
           <p className="mt-1 text-xs text-muted-foreground">
-            Manage your password and two-factor authentication. SpatiumDDI users
-            authenticated through LDAP / OIDC / SAML / RADIUS / TACACS+ should
-            update their credentials in their identity provider — these settings
-            only apply to local accounts.
+            Manage your password and two-factor authentication. Password changes
+            apply to local accounts only — SSO users (LDAP / OIDC / SAML /
+            RADIUS / TACACS+) manage credentials in their identity provider.
+            Two-factor authentication is available to every account, and SSO
+            superadmins must enrol it to re-confirm sensitive reveals (appliance
+            kubeconfig, pairing codes, agent bootstrap keys).
           </p>
         </div>
 
@@ -351,11 +353,13 @@ function PasswordCodePrompt({
           <>
             <p className="text-xs text-muted-foreground">
               <Smartphone className="mr-1 inline h-3 w-3" />
-              Confirm with your password and a current authenticator code.
+              Confirm with a current authenticator code. Local accounts also
+              enter their password; SSO accounts can leave it blank.
             </p>
             <div className="space-y-2">
               <label className="text-xs font-medium text-muted-foreground">
-                Current password
+                Current password{" "}
+                <span className="font-normal">(local accounts)</span>
               </label>
               <input
                 type="password"
@@ -401,7 +405,7 @@ function PasswordCodePrompt({
             <button
               type="button"
               onClick={() => onSubmit(password, code)}
-              disabled={!password || code.length !== 6 || isPending}
+              disabled={code.length !== 6 || isPending}
               className={
                 destructive
                   ? "rounded-md bg-destructive px-3 py-1.5 text-sm text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -672,8 +672,22 @@ export function FleetTab({
     queryFn: applianceApprovalApi.list,
     refetchInterval: (query) => {
       const rows = query.state.data ?? [];
-      const hasPending = rows.some((r) => r.state === "pending_approval");
-      return hasPending ? 2_000 : 15_000;
+      // #410 — also fast-poll while any appliance has an upgrade or
+      // reboot in flight, so the drilldown's UpgradeStatusPanel shows
+      // download progress within ~2 s instead of the 15 s idle cadence.
+      // A terminal ``failed`` upgrade is excluded from the desired-version
+      // arm so a stale failure doesn't pin every superadmin's browser at
+      // 2 s until it's cleared (it still fast-polls while actually
+      // in-flight, and a reboot is caught by reboot_requested).
+      const busy = rows.some(
+        (r) =>
+          r.state === "pending_approval" ||
+          (r.desired_appliance_version !== null &&
+            r.last_upgrade_state !== "failed") ||
+          r.last_upgrade_state === "in-flight" ||
+          r.reboot_requested === true,
+      );
+      return busy ? 2_000 : 15_000;
     },
     enabled: isSuperadmin,
   });
@@ -1439,7 +1453,12 @@ export function FleetTab({
 
       {drilldown && (
         <ApplianceDrilldownModal
-          row={drilldown}
+          // #410 — render the freshly-polled row (matched by id) rather
+          // than the frozen open-time snapshot, so live upgrade progress
+          // shipped via the supervisor heartbeat updates the drilldown
+          // without a hard page reload. Falls back to the snapshot if the
+          // row briefly drops out of the list (e.g. mid-refetch).
+          row={data?.find((r) => r.id === drilldown.id) ?? drilldown}
           onClose={() => setDrilldown(null)}
           onApprove={() => approve.mutate(drilldown.id)}
           approving={approve.isPending}

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { ReauthFields } from "@/components/ReauthFields";
 import { useSessionState } from "@/lib/useSessionState";
 import { cn } from "@/lib/utils";
 import { LLDPTab } from "./LLDPTab";
@@ -3258,10 +3259,15 @@ function RevealKubeconfigModal({
   onClose: () => void;
 }) {
   const [password, setPassword] = useState("");
+  const [totp, setTotp] = useState("");
   const [shown, setShown] = useState<string | null>(null);
   const reveal = useMutation({
     mutationFn: () =>
-      applianceApprovalApi.revealKubeconfig(appliance.id, password),
+      applianceApprovalApi.revealKubeconfig(
+        appliance.id,
+        password || undefined,
+        totp || undefined,
+      ),
     onSuccess: (data) => {
       setShown(data.kubeconfig ?? "");
     },
@@ -3283,20 +3289,20 @@ function RevealKubeconfigModal({
     >
       <div className="space-y-3 text-sm">
         <p className="text-xs text-muted-foreground">
-          Re-confirm your password to reveal the admin kubeconfig the supervisor
-          shipped for this appliance. The reveal is audit-logged and
-          local-auth-only. The downloaded file works against the appliance from
-          its current network; for cross-network use, edit the{" "}
-          <code>server:</code> line to a reachable address.
+          Re-confirm to reveal the admin kubeconfig the supervisor shipped for
+          this appliance — with your password (local accounts) or an
+          authenticator code (SSO). The reveal is audit-logged. The downloaded
+          file works against the appliance from its current network; for
+          cross-network use, edit the <code>server:</code> line to a reachable
+          address.
         </p>
         {!shown && (
           <>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Your password"
-              className="w-full rounded-md border bg-background px-2 py-1 text-sm"
+            <ReauthFields
+              password={password}
+              onPassword={setPassword}
+              totp={totp}
+              onTotp={setTotp}
               autoFocus
             />
             <div className="flex items-center justify-end gap-2">
@@ -3310,7 +3316,9 @@ function RevealKubeconfigModal({
               <button
                 type="button"
                 onClick={() => reveal.mutate()}
-                disabled={!password.trim() || reveal.isPending}
+                disabled={
+                  (!password.trim() && !totp.trim()) || reveal.isPending
+                }
                 className="inline-flex items-center gap-1 rounded-md border border-primary bg-primary/10 px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {reveal.isPending ? (

--- a/frontend/src/pages/appliance/PairingTab.tsx
+++ b/frontend/src/pages/appliance/PairingTab.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { ReauthFields } from "@/components/ReauthFields";
 import { cn } from "@/lib/utils";
 
 /**
@@ -711,11 +712,17 @@ function RevealModal({
   onClose: () => void;
 }) {
   const [password, setPassword] = useState("");
+  const [totp, setTotp] = useState("");
   const [revealed, setRevealed] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
   const mutation = useMutation({
-    mutationFn: () => appliancePairingApi.reveal(row.id, password),
+    mutationFn: () =>
+      appliancePairingApi.reveal(
+        row.id,
+        password || undefined,
+        totp || undefined,
+      ),
     onSuccess: (body) => setRevealed(body.code),
   });
 
@@ -767,19 +774,16 @@ function RevealModal({
           className="flex flex-col gap-3"
         >
           <p className="text-xs text-muted-foreground">
-            Re-display the cleartext of this persistent code. Requires
-            confirming your current password (local-auth only).
+            Re-display the cleartext of this persistent code. Re-confirm with
+            your password (local accounts) or an authenticator code (SSO).
           </p>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="text-xs font-medium">Current password</span>
-            <input
-              type="password"
-              className={inputCls}
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              autoFocus
-            />
-          </label>
+          <ReauthFields
+            password={password}
+            onPassword={setPassword}
+            totp={totp}
+            onTotp={setTotp}
+            autoFocus
+          />
           {mutation.error && (
             <div className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive">
               {formatApiError(mutation.error)}
@@ -795,7 +799,7 @@ function RevealModal({
             </button>
             <button
               type="submit"
-              disabled={mutation.isPending || password.length === 0}
+              disabled={mutation.isPending || (!password && !totp)}
               className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
             >
               {mutation.isPending && (

--- a/frontend/src/pages/appliance/PairingTab.tsx
+++ b/frontend/src/pages/appliance/PairingTab.tsx
@@ -17,6 +17,7 @@ import {
 import {
   appliancePairingApi,
   authApi,
+  settingsApi,
   type PairingCodeCreated,
   type PairingCodeRow,
   formatApiError,
@@ -94,6 +95,25 @@ export function PairingTab() {
     },
   });
 
+  // #407 — supervisor (appliance) registration gate. When OFF, the
+  // register endpoint 404s so no supervisor can pair, no matter how many
+  // pairing codes exist. OS-appliance control-plane installs self-enable
+  // this on first boot; generic Kubernetes/Helm control planes do not, so
+  // the operator must flip it on here before pairing the first appliance.
+  const settingsQuery = useQuery({
+    queryKey: ["settings"],
+    queryFn: settingsApi.get,
+    enabled: isSuperadmin,
+    staleTime: 30_000,
+  });
+  const registrationEnabled =
+    settingsQuery.data?.supervisor_registration_enabled ?? null;
+  const registrationToggle = useMutation({
+    mutationFn: (enabled: boolean) =>
+      settingsApi.update({ supervisor_registration_enabled: enabled }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["settings"] }),
+  });
+
   if (!isSuperadmin) {
     return (
       <div className="mx-auto max-w-4xl">
@@ -155,6 +175,65 @@ export function PairingTab() {
             New pairing code
           </button>
         </div>
+      </div>
+
+      {/* #407 — registration gate. Surfaces + toggles
+          ``supervisor_registration_enabled`` so an operator can enable
+          appliance pairing from the UI instead of hand-editing the DB.
+          Generic Kubernetes/Helm control planes ship with it OFF. */}
+      <div
+        className={cn(
+          "mb-4 rounded-md border p-3",
+          registrationEnabled === false &&
+            "border-amber-500/40 bg-amber-500/10",
+        )}
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-sm font-medium">
+              Appliance registration{" "}
+              {registrationEnabled === null ? (
+                <span className="text-muted-foreground">…</span>
+              ) : registrationEnabled ? (
+                <span className="text-emerald-600 dark:text-emerald-400">
+                  enabled
+                </span>
+              ) : (
+                <span className="text-amber-700 dark:text-amber-400">
+                  disabled
+                </span>
+              )}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {registrationEnabled === false
+                ? "New supervisors cannot pair while this is off — the register endpoint returns 404. Enable it before pairing an appliance."
+                : "Remote supervisors may register with a valid pairing code. Turn this off to refuse all new pairings."}
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled={
+              registrationEnabled === null || registrationToggle.isPending
+            }
+            onClick={() => registrationToggle.mutate(!registrationEnabled)}
+            className={cn(
+              "inline-flex flex-shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium disabled:opacity-60",
+              registrationEnabled
+                ? "border hover:bg-muted"
+                : "bg-primary text-primary-foreground hover:bg-primary/90",
+            )}
+          >
+            {registrationToggle.isPending && (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            )}
+            {registrationEnabled ? "Disable" : "Enable"} registration
+          </button>
+        </div>
+        {registrationToggle.isError && (
+          <p className="mt-2 text-xs text-rose-700 dark:text-rose-300">
+            {formatApiError(registrationToggle.error)}
+          </p>
+        )}
       </div>
 
       {isLoading ? (


### PR DESCRIPTION
Fixes the five issues #407–#411 reported by @waza-ari. One branch, six logical fixes (one per issue + a security follow-up), each tested.

## Fixes

- **#407 — no UI to enable `supervisor_registration_enabled`.** The gate that allows appliance pairing defaulted false and was never exposed in the settings API, so operators on generic Kubernetes/Helm control planes (where the OS-appliance self-bootstrap never fires) had to hand-edit the DB. Exposed it on the settings API + a **superadmin-only** toggle on the Fleet → Pairing tab; kept the default FALSE, gated the write to superadmin (mirroring maintenance mode), and write a dedicated audit row on flip.

- **#409 — DNS/DHCP agents fail to register (`[Errno -2] Name does not resolve`).** An Application appliance is its own single-node k3s with no in-cluster `spatium-control` Service, so the #292 hardcoded in-cluster URL didn't resolve. The three role-pod chart templates now prefer the supervisor-supplied external `controlPlaneUrl` (→ `inClusterApiUrl` → in-cluster default), emitting `SPATIUM_INSECURE_SKIP_TLS_VERIFY=1` only on the external self-signed path — same trust-on-first-use model the supervisor pod already uses. Control-plane/full-stack appliances send `controlPlaneUrl=""` and fall through to the unchanged in-cluster path. Verified by rendering all three templates in both modes.

- **#410 — appliance upgrade progress needs a hard refresh.** The Fleet drilldown rendered a frozen open-time `useState` snapshot, so OS-upgrade progress shipped via the supervisor heartbeat never updated. It now renders the freshly-polled row by id (pure derivation — no flicker) and fast-polls (2 s) while any upgrade or reboot is in flight.

- **#411 — reboot-to-slot AND normal reboot do nothing (regression in 2026.06.13-1).** #400 C1 hardened the supervisor `/heartbeat` to require a cert or a valid session token, removing the old `state==APPROVED` bypass. An approved supervisor whose cert isn't validating in the field rode that bypass; once removed, every heartbeat 403'd — silently killing reboot **and** fleet-upgrade **and** role delivery. Restored the session-token path: cert-auth failure now falls back to the token (still a real per-appliance secret; the cluster-admin k3s join token stays cert-only), the supervisor keeps sending its token alongside the cert, and re-register mints a fresh token for cert'd rows. Preserves every #400 C1 invariant (verified by the existing authz tests + new coverage). *The cert-auth steady-state + auto-recover-on-403 is deferred as a follow-up (see below).*

- **#408 — sensitive reveals don't work with SSO.** The agent-keys / SNMP-community / kubeconfig / pairing-code reveals re-verified a local password and hard-rejected external-auth users; MFA enrolment was also local-only, so there was no fallback. New `reverify_operator` helper + opened MFA enrolment to every auth source: **local users prove their password; password-less SSO users prove a TOTP code** (enrol under Account → Two-factor). Shared `<ReauthFields>` on all four reveal modals.

## Security review note (#408)

An adversarial review caught a defense-in-depth **downgrade** in the first #408 cut: accepting TOTP *in lieu of* the local password meant a hijacked session of a local superadmin who hadn't enrolled MFA could self-enrol TOTP and reveal secrets without proving the password. Fixed in `610894b` — local accounts must prove their password; only password-less SSO accounts use TOTP.

## Verification

`ruff check app tests` ✓ · `black --check app tests` ✓ · **`mypy app` ✓ (564 files)** · **full backend `pytest` ✓ (1908 passed, 2 skipped)** · frontend `eslint`/`prettier`/`tsc`/`vite build` ✓ · `helm template` (both #409 paths) ✓ · no new migration. New tests: #407 settings round-trip + authz, #411 cert-auth fallback + re-register, #408 reverify contract + SSO enrol-then-reveal + disable contract.

## Deferred follow-ups (not blocking)

- Apply the login path's single-use TOTP replay guard to the reveal endpoints.
- Widen the Security-dashboard MFA-coverage rollup to include SSO enrollees.
- Gate local MFA enrolment on password re-auth (closes a pre-existing session-can-enrol gap).
- #411 cert-auth steady-state (make mTLS reliably engage) + supervisor auto-recover-on-403 so a blanked-token box recovers without a manual re-pair.
- delete-appliance / factory-reset can adopt the same `reverify_operator` helper.

Closes #407
Closes #408
Closes #409
Closes #410
Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
