### PR TITLE
feat(appliance): Cluster console + slot-image perm fix + release-asset retention + Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         run: npm install
@@ -166,7 +166,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/prune-release-assets.yml
+++ b/.github/workflows/prune-release-assets.yml
@@ -1,0 +1,52 @@
+name: Prune release assets
+
+# Version-aware retention sweep for the heavy appliance release assets
+# (#392). The release workflow runs the same script as a post-publish step
+# so the window rolls forward on every cut; this scheduled run is the
+# safety net (catches the backlog of releases cut before #392, and any
+# release where the post-step was skipped) plus an on-demand / dry-run
+# knob via workflow_dispatch.
+#
+# Deletes ASSETS only — never a release, tag, or notes. See
+# scripts/prune-release-assets.sh for the two-tier retention rules.
+
+on:
+  schedule:
+    # Weekly, Monday 04:17 UTC. Off-the-hour minute to avoid the
+    # top-of-hour cron stampede on GitHub's shared schedulers.
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      keep_versioned:
+        description: "Newest releases to keep versioned heavy assets on"
+        required: false
+        default: "15"
+      dry_run:
+        description: "Log only — delete nothing"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+
+# Never let two prune runs race on the same release set.
+concurrency:
+  group: prune-release-assets
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Prune old appliance release assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prune
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          KEEP_VERSIONED: ${{ github.event.inputs.keep_versioned || '15' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: |
+          chmod +x scripts/prune-release-assets.sh
+          scripts/prune-release-assets.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -490,6 +490,14 @@ jobs:
           # correct (renamed) filename — important for `sha256sum -c`.
           ( cd appliance/build && sha256sum "$(basename "$VERSIONED_XZ")" > "$(basename "$VERSIONED_SHA")" )
           ( cd appliance/build && sha256sum "$(basename "$STABLE_XZ")" > "$(basename "$STABLE_SHA")" )
+          # Drop the mkosi-ImageVersion-named sha sidecar that
+          # build-slot-image.sh wrote next to the original .raw.xz (e.g.
+          # spatiumddi-appliance-slot-0.1.0.sha256). The .raw.xz itself was
+          # renamed by the mv above; only this stray sha is left, and the
+          # upload globs below would otherwise attach the bogus 0.1.0 name
+          # to every release (#392).
+          SRC_SHA="${SRC_XZ%.raw.xz}.sha256"
+          rm -f "$SRC_SHA"
           ls -lh "$VERSIONED_XZ" "$STABLE_XZ" "$VERSIONED_SHA" "$STABLE_SHA"
           echo "slot_name=spatiumddi-appliance-slot-${VERSION}-amd64.raw.xz" >> "$GITHUB_OUTPUT"
       - name: Upload appliance artifacts (ISO + slot image)
@@ -701,3 +709,24 @@ jobs:
             ## Full Changelog
             ${{ env.PREV_TAG && format('https://github.com/{0}/compare/{1}...{2}', github.repository, env.PREV_TAG, needs.meta.outputs.version) || format('https://github.com/{0}/commits/{1}', github.repository, needs.meta.outputs.version) }}
           generate_release_notes: false
+
+      # ── Prune heavy assets off old releases (#392) ───────────────────────
+      # Version-aware retention: drop the generic-named duplicate ISO / slot
+      # assets from every non-latest release, plus the heavy *versioned*
+      # .iso + slot .raw.xz beyond the keep window. The release, tag, notes,
+      # and versioned .sha256 provenance sidecars are ALWAYS kept. Runs after
+      # the release is published, so the just-cut tag is "latest" and the
+      # keep window rolls forward on its own. A weekly scheduled run
+      # (.github/workflows/prune-release-assets.yml) is the safety net + the
+      # ad-hoc / dry-run knob; both call the same script.
+      - name: Prune old appliance release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          KEEP_VERSIONED: "15"
+          # Never prune the just-cut release's generic /latest/-backing
+          # assets even if GitHub hasn't propagated isLatest=true to it yet.
+          PROTECT_TAG: ${{ needs.meta.outputs.version }}
+        run: |
+          chmod +x scripts/prune-release-assets.sh
+          scripts/prune-release-assets.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,10 @@ changes.
   OS + app version, A/B slot + durable-default + trial-boot, upgrade
   state, nodes-ready + HA, supervisor approval + last-seen), the
   CPU / memory / nodes / workloads health ribbon and charts, and a
-  streaming pod-log tail with a workload picker, plus Reboot-host and
-  View-pods actions. Backed by a new `self_appliance` block on
+  live log tail that follows a **workload** (deployment / daemonset) —
+  resolved server-side to the current pod *and* container, so it survives
+  pod rolls, never shows churny pod names, and handles multi-container
+  pods (e.g. redis) — plus Reboot-host and View-pods actions. Backed by a new `self_appliance` block on
   `GET /appliance/info` sourced from the supervisor heartbeat — a pure
   DB read, so the api never touches host journald or files. Reproduced
   in React rather than bridging a PTY, so it re-exposes no shell / root
@@ -102,6 +104,18 @@ changes.
   empty-state told operators to open a section that had moved; it now
   offers a button that closes the dialog and jumps straight to the
   Upgrade-images view.
+* **celery-beat platform health check failed on HA Redis.** The beat
+  probe used a raw `aioredis.from_url`, which rejects the `sentinel://`
+  scheme used by HA Redis (`Redis URL must specify one of redis:// …`),
+  so the Platform Health card showed beat as errored on a Sentinel
+  deployment. It now uses the same Sentinel-aware helper as the redis +
+  workers probes.
+* **Fleet "Upgrade pending" no longer promises a fire that can't come.**
+  When an appliance's supervisor predates the 2026.06.12 upgrade-progress
+  telemetry it can't report progress, so the panel sat on "supervisor
+  will fire the trigger in ≤30 s" forever. It now detects the old version
+  and explains it, pointing at the host-side check / recovery
+  (`spatium-upgrade-slot status`, `journalctl -u spatiumddi-slot-upgrade`).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,100 @@ the formatter handles the rest.
 
 ---
 
+## 2026.06.14-1 — 2026-06-14
+
+An **appliance polish + ops** release rolling up four issues (#392 /
+#415 / #416 / #417) plus a Cluster-dashboard redesign, a comprehensive
+demo-seeder refresh, and a CodeQL fix. The headline is a browser
+**Cluster console**: the appliance's Talos-style physical-console
+dashboard reproduced in the web UI and merged into the Cluster → Overview
+screen — an identity ribbon (role / host / version / A-B slot / pairing /
+supervisor health), live node + workload health, and a streaming pod-log
+tail, all over the existing authenticated SSE feed (no shell, no new
+privilege). It also fixes a Permission-denied that blocked OS-upgrade
+image uploads on the k3s appliance, stops old releases from hoarding
+multi-GB binaries, and moves the frontend build to Node 22. No schema
+changes.
+
+### Added
+
+* **#416 — browser Cluster console.** The appliance's physical-console
+  dashboard, reproduced in the web UI and folded into Cluster → Overview
+  as a single view: a live identity header (role, hostname, host IP,
+  OS + app version, A/B slot + durable-default + trial-boot, upgrade
+  state, nodes-ready + HA, supervisor approval + last-seen), the
+  CPU / memory / nodes / workloads health ribbon and charts, and a
+  streaming pod-log tail with a workload picker, plus Reboot-host and
+  View-pods actions. Backed by a new `self_appliance` block on
+  `GET /appliance/info` sourced from the supervisor heartbeat — a pure
+  DB read, so the api never touches host journald or files. Reproduced
+  in React rather than bridging a PTY, so it re-exposes no shell / root
+  surface and works for remote agents too; the standalone TTY
+  `spatium-console` is unchanged.
+
+### Changed
+
+* **#417 — frontend build moves to Node 22.** CI and the frontend
+  Dockerfile build on `node:22-alpine` (Node 20 reached end-of-life in
+  April 2026; the Vite 8 toolchain prefers 22.12+). Runtime is
+  unaffected — Node is build-time only.
+* **#392 — version-aware release-asset retention.** A new prune step
+  (post-release plus a weekly scheduled workflow) trims the heavy
+  appliance binaries every release attaches: the generic-named duplicate
+  ISO / slot images come off every non-latest release, and the versioned
+  `.iso` + slot `.raw.xz` come off releases beyond a configurable keep
+  window (default 15). The release, tag, notes, and the versioned
+  `.sha256` provenance sidecars are always kept, and a freshly-cut
+  release is guarded against propagation races so its `/latest/`
+  download URLs never break. The OS-upgrade picker already hides any
+  release missing its slot image, so it stays honest after a prune.
+* **Cluster "Pods" KPI no longer counts completed Jobs.** The dashboard
+  tile divided running by *total* pods, so a healthy box read `10/14`
+  (the four being finished migrate / helm-install Jobs) and looked
+  broken. It now divides by *active* pods, excluding the `Succeeded`
+  phase: a healthy box reads `10/10` with a small "N completed" note,
+  and the tile turns rose only on a genuine shortfall.
+* **`scripts/seed_demo.py` catches up to the data model.** The demo
+  seeder gained the 17 resource families it had drifted behind on — NAT
+  mappings, multicast domains / groups, customers / sites / providers,
+  WAN circuits, the service catalog, SD-WAN overlays, DNS sub-resources
+  (DNSSEC / blocklists / views / GSLB / catalog zones), DHCP
+  sub-resources (classes / statics / MAC blocks / option templates /
+  PXE profiles), a sample RBAC role + user + group, a scoped API token,
+  a conformity policy, and a webhook subscription.
+* **Appliance README gains a "Why k3s, not Docker Compose?" rationale**
+  (declarative reconciliation, growing one box into an HA cluster, no
+  hand-run container commands), cross-linked from the main README for
+  readers wary of Kubernetes.
+
+### Fixed
+
+* **#415 — OS-upgrade image upload failed with Permission denied on
+  k3s.** The api pod runs as uid 1000, but kubelet created the
+  `/var/lib/spatiumddi/slot-images` hostPath as `root:root 0755`, so
+  every upload / GitHub import died with `EACCES`. The
+  `spatiumddi-firstboot` boot step now creates and owns that directory
+  (1000:1000, mode 0700) on every boot — mirroring the existing
+  release-state fix — and the api container pins its runtime uid for
+  good measure. Also corrects a cosmetic `pathlib` bug that wrote the
+  in-flight temp file with a doubled suffix
+  (`<id>.raw.raw.xz.partial`) instead of `<id>.raw.xz.partial`.
+* **Stale "upgrade images" pointer in the fleet upgrade modal.** The
+  empty-state told operators to open a section that had moved; it now
+  offers a button that closes the dialog and jumps straight to the
+  Upgrade-images view.
+
+### Security
+
+* **Stack-trace exposure on the Cluster health endpoints (CodeQL
+  `py/stack-trace-exposure`, alert #68).** The one-shot and SSE
+  cluster-health handlers echoed the raw kubeapi exception text into the
+  client-facing error (`kubeapi unreachable: <exc>`), which could leak
+  internal detail to the operator's browser. Both now log the exception
+  server-side and return a generic reason.
+
+---
+
 ## 2026.06.13-2 — 2026-06-13
 
 A focused **field-fix release** — five issues (#407–#411) surfaced while

--- a/README.md
+++ b/README.md
@@ -682,6 +682,15 @@ SpatiumDDI containers that ship as a Helm chart deploy on the
 appliance via [HelmChart CRDs](https://docs.k3s.io/helm).
 Operators get a real Kubernetes node without managing one.
 
+> **New to Kubernetes? Don't let that stop you.** You never have to
+> touch it — the six-question installer, the `/appliance` web UI, and
+> one-click atomic upgrades hide k3s completely; there are no `kubectl`
+> or `docker` commands to learn. If you're curious *why* we picked
+> embedded k3s over plain Docker Compose — flexibility, growing a single
+> box into a real high-availability cluster, and never hand-running
+> container commands — here's the plain-English rationale:
+> [**Why k3s, not Docker Compose?**](appliance/README.md#why-k3s-not-docker-compose)
+
 #### What you get out of the box
 
 - Single-node [k3s](https://k3s.io/) cluster (~70 MB static

--- a/appliance/README.md
+++ b/appliance/README.md
@@ -28,6 +28,73 @@ the supervisor PATCHes onto the chart on heartbeat.
 >
 > Spec context: [`docs/deployment/APPLIANCE.md`](../docs/deployment/APPLIANCE.md).
 
+## Why k3s, not Docker Compose?
+
+Early appliance builds (pre-#183) ran the stack with `docker compose`
+driven from a boot script. It was fine for one box doing one job — but
+the whole point of the appliance is to *grow* with the operator, and
+Compose fought that at every turn. We moved to **embedded k3s** (a single
+~70 MB static Kubernetes binary) because it turns the appliance from "a
+box running some containers" into "a node you can build a cluster out
+of." Concretely:
+
+- **A declarative target, not a script of CLI commands.** Under Compose,
+  "make this box a DNS node" meant `docker compose down` one service,
+  `up -d` another, juggle an `--env-file`, and pray nothing failed
+  halfway (recovery was usually "delete the state file and reboot").
+  Under k3s the desired state is a *document* — a HelmChart custom
+  resource — and the bundled helm-controller continuously reconciles
+  reality to match it. A crashed pod comes back on its own; a role change
+  is a fact you assert once, not a sequence of imperative steps you have
+  to babysit and unwind by hand when one fails.
+
+- **One box today, a real HA cluster tomorrow — in place.** This is the
+  big one. Docker Compose has no native concept of a multi-machine
+  cluster; you'd be bolting on Swarm or hand-rolling orchestration. k3s
+  ships embedded etcd, so a single-VM appliance can be **promoted** into
+  a 3 / 5 / 7-node high-availability control plane (Postgres via
+  CloudNativePG, Redis via Sentinel, a MetalLB virtual IP) right from the
+  Fleet UI — no reinstall, no re-architecting. The same image that runs a
+  homelab-in-a-box scales up to a fault-tolerant production control
+  plane.
+
+- **Roles are labels, not file edits.** Which services a node runs
+  (control plane / DNS-BIND9 / DNS-PowerDNS / DHCP) is decided by a
+  per-node Kubernetes label. Flipping a role from the web UI is a single
+  `kubectl label node` — the workload schedules or drains as a
+  *consequence* of the label. No editing compose files on the box, no
+  SSH, no remembering which `COMPOSE_PROFILES` were set where. HA agents
+  run as DaemonSets, so "exactly one DNS pod per DNS-labelled node" is
+  something the platform guarantees rather than something the operator
+  maintains.
+
+- **The operator never touches raw container CLI.** Everything is driven
+  from the `/appliance` web surface (Fleet, Cluster, OS Versions tabs)
+  talking to the kube-API, or through the pre-`KUBECONFIG`'d `kubectl`
+  for anyone who wants a shell. Both are standard, documented, widely
+  understood tools — versus a pile of project-specific `docker compose`
+  incantations and hand-maintained `.env` / state files.
+
+- **One deployment model everywhere.** The appliance installs the very
+  same umbrella + appliance Helm charts that ship for standalone
+  Kubernetes deployments. There is no separate Compose path to keep in
+  sync: what we test on Kubernetes is what runs on the appliance, and
+  what you learn operating the appliance transfers to any cluster.
+
+- **Upgrades that can't drift.** k3s keeps its state in kine (SQLite)
+  under `/var/lib/rancher/`, which lives on the persistent `/var`
+  partition and so survives an atomic A/B slot swap. Container images are
+  baked into the slot and reconciled by helm-controller, so an OS upgrade
+  and a container upgrade land as **one unit** — gone is the Compose-era
+  trap where a new rootfs carried a different compose schema while old
+  containers were still running against the old one.
+
+The cost is honest and small: k3s adds ~70 MB to the slot image and a
+steady ~150 MB of RAM for the server process, both comfortably inside the
+appliance's disk and memory floor. For a deeper, change-by-change account
+of the migration, see the **"Why k3s"** section in
+[`docs/deployment/APPLIANCE.md`](../docs/deployment/APPLIANCE.md).
+
 ## What it ships
 
 - Debian 13 (trixie) amd64, `linux-image-cloud-amd64` kernel

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -86,6 +86,18 @@ mkdir -p /var/lib/spatiumddi/release-state /var/log/spatiumddi
 chmod 1777 /var/lib/spatiumddi/release-state
 chmod 0755 /var/log/spatiumddi
 
+# /var/lib/spatiumddi/slot-images — OS A/B upgrade images uploaded /
+# imported through the api before the host-side slot-upgrade runner
+# applies them. The api pod mounts this as a hostPath and runs as
+# uid 1000 (app). kubelet's DirectoryOrCreate would otherwise create
+# it root:root 0755, so the api's upload write fails EACCES (#415).
+# Own it to the api uid; 0700 because the bytes stream back through
+# the api's auth gate, never directly off disk. Idempotent + on every
+# boot, so it survives A/B slot swaps and repairs an already-wrong dir.
+mkdir -p /var/lib/spatiumddi/slot-images
+chown 1000:1000 /var/lib/spatiumddi/slot-images
+chmod 0700 /var/lib/spatiumddi/slot-images
+
 # Detect the host's root block device's rotational flag so the
 # supervisor pod (which can't see the host's /proc/mounts properly —
 # its container view shows ``overlay`` mounted at /) can surface

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -381,12 +381,14 @@ async def platform_health() -> JSONResponse:
     # beat is stopped or has been stopped for >5 min. Present but older
     # than 90 s → degraded (two beat intervals missed).
     try:
-        import redis.asyncio as aioredis
-
         from app.config import settings
+        from app.core.redis_client import make_async_redis
         from app.tasks.heartbeat import BEAT_HEARTBEAT_KEY  # noqa: PLC0415
 
-        r = aioredis.from_url(settings.redis_url, socket_connect_timeout=2)
+        # Sentinel-aware (HA Redis uses ``sentinel://``, which raw
+        # ``aioredis.from_url`` rejects with "must specify one of redis:// …"
+        # — the same helper the redis + workers checks above use).
+        r = make_async_redis(settings.redis_url, socket_connect_timeout=2)
         raw = await r.get(BEAT_HEARTBEAT_KEY)
         await r.aclose()
         if raw is None:

--- a/backend/app/api/v1/appliance/cluster.py
+++ b/backend/app/api/v1/appliance/cluster.py
@@ -161,10 +161,14 @@ async def cluster_health(db: DB) -> ClusterHealth:
         # Off-loop: the gather is a handful of blocking stdlib kubeapi calls.
         snap = await anyio.to_thread.run_sync(get_cluster_health)
     except k8s.KubeapiUnavailableError as exc:
+        # Generic client-facing detail; log the exception text server-side so
+        # an internal error message can't reach the operator's browser
+        # (CodeQL py/stack-trace-exposure).
+        logger.info("cluster_health_kubeapi_unreachable", error=str(exc))
         raise HTTPException(
             status.HTTP_503_SERVICE_UNAVAILABLE,
-            f"kubeapi unreachable from api: {exc}",
-        )
+            "kubeapi unreachable from api; retry shortly.",
+        ) from exc
     await _merge_host_partitions(db, snap)
     return ClusterHealth(**snap)
 
@@ -194,7 +198,11 @@ async def cluster_health_stream(request: Request) -> StreamingResponse:
                 async with AsyncSessionLocal() as db:
                     await _merge_host_partitions(db, snap)
             except k8s.KubeapiUnavailableError as exc:
-                snap = cluster_unavailable(f"kubeapi unreachable: {exc}")
+                # Log detail server-side; keep the client-facing reason generic
+                # so an exception message can't leak internals to the browser
+                # (CodeQL py/stack-trace-exposure).
+                logger.info("cluster_health_stream_kubeapi_unreachable", error=str(exc))
+                snap = cluster_unavailable("kubeapi unreachable; retrying")
             except Exception as exc:  # noqa: BLE001 — never let the stream die
                 logger.warning("cluster_health_stream_gather_failed", error=str(exc))
                 snap = cluster_unavailable("health gather failed; retrying")

--- a/backend/app/api/v1/appliance/containers.py
+++ b/backend/app/api/v1/appliance/containers.py
@@ -169,16 +169,17 @@ async def stream_workload_logs(component: str, tail: int = 100):
     (re)connect lands on the fresh pod.
     """
     try:
-        pod = resolve_workload_pod(component)
+        resolved = resolve_workload_pod(component)
     except DockerUnavailableError as exc:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc))
-    if pod is None:
+    if resolved is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
             f"no running pod for workload {component!r}",
         )
+    pod, container = resolved
     try:
-        gen = stream_container_logs(pod, tail=tail)
+        gen = stream_container_logs(pod, tail=tail, container=container)
     except DockerUnavailableError as exc:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc))
     return _sse_log_response(gen)

--- a/backend/app/api/v1/appliance/containers.py
+++ b/backend/app/api/v1/appliance/containers.py
@@ -25,6 +25,7 @@ from app.services.appliance.containers import (
     DockerUnavailableError,
     container_action,
     get_container_logs,
+    resolve_workload_pod,
     stream_container_logs,
 )
 from app.services.appliance.containers import (
@@ -119,38 +120,65 @@ async def get_logs(name: str, tail: int = 200) -> dict[str, str]:
     return {"name": name, "tail": text}
 
 
-@router.get(
-    "/{name}/logs/stream",
-    dependencies=[Depends(require_permission("read", "appliance"))],
-    summary="Stream container logs as SSE (follow=true)",
-)
-async def stream_logs(name: str, tail: int = 100):
-    """Yields SSE ``data:`` frames with each log chunk as it arrives.
+def _sse_log_response(gen) -> StreamingResponse:
+    """Wrap a log-chunk generator as an SSE response.
 
-    Client disconnects close the underlying docker stream. Chunks
-    are JSON-encoded ``{"line": "..."}`` so embedded newlines /
+    Chunks are JSON-encoded ``{"line": "..."}`` so embedded newlines /
     quotes round-trip cleanly through the SSE wire format.
+    ``X-Accel-Buffering: no`` disables nginx response buffering so each
+    line reaches the browser ASAP (same pattern as the AI-chat stream).
     """
-    try:
-        gen = stream_container_logs(name, tail=tail)
-    except DockerUnavailableError as exc:
-        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc))
 
     async def event_source():
         async for chunk in gen:
             for line in chunk.splitlines():
-                # SSE frame format — ``data:`` + payload + double newline
-                payload = json.dumps({"line": line})
-                yield f"data: {payload}\n\n"
+                yield f"data: {json.dumps({'line': line})}\n\n"
 
-    # X-Accel-Buffering disables nginx response buffering so each log
-    # line arrives at the browser ASAP. Same pattern as the AI chat
-    # streaming endpoint.
     return StreamingResponse(
         event_source(),
         media_type="text/event-stream",
-        headers={
-            "X-Accel-Buffering": "no",
-            "Cache-Control": "no-cache",
-        },
+        headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
     )
+
+
+@router.get(
+    "/{name}/logs/stream",
+    dependencies=[Depends(require_permission("read", "appliance"))],
+    summary="Stream a single pod's logs as SSE (follow=true)",
+)
+async def stream_logs(name: str, tail: int = 100):
+    """Stream one pod's logs by exact pod name; closes on client disconnect."""
+    try:
+        gen = stream_container_logs(name, tail=tail)
+    except DockerUnavailableError as exc:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc))
+    return _sse_log_response(gen)
+
+
+@router.get(
+    "/workloads/{component}/logs/stream",
+    dependencies=[Depends(require_permission("read", "appliance"))],
+    summary="Stream a workload's logs as SSE — resolves component → current pod",
+)
+async def stream_workload_logs(component: str, tail: int = 100):
+    """Tail a workload (deployment / daemonset) by its component label
+    (api / worker / frontend / …) instead of a churny pod name (#416).
+
+    Resolves the component to its current running pod server-side, so the
+    operator picks a stable workload and a pod roll just means the next
+    (re)connect lands on the fresh pod.
+    """
+    try:
+        pod = resolve_workload_pod(component)
+    except DockerUnavailableError as exc:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc))
+    if pod is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"no running pod for workload {component!r}",
+        )
+    try:
+        gen = stream_container_logs(pod, tail=tail)
+    except DockerUnavailableError as exc:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc))
+    return _sse_log_response(gen)

--- a/backend/app/api/v1/appliance/router.py
+++ b/backend/app/api/v1/appliance/router.py
@@ -19,9 +19,14 @@ Gating model:
 
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Any
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
+from sqlalchemy import select
 
+from app.api.deps import DB
 from app.api.v1.appliance.cluster import router as cluster_router
 from app.api.v1.appliance.containers import router as containers_router
 from app.api.v1.appliance.diagnostics import router as diagnostics_router
@@ -35,6 +40,7 @@ from app.api.v1.appliance.tls import router as tls_router
 from app.api.v1.appliance.upgrade_images import router as upgrade_images_router
 from app.config import settings
 from app.core.permissions import require_permission
+from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
 
 router = APIRouter()
 
@@ -77,10 +83,41 @@ router.include_router(pairing_router)
 router.include_router(supervisor_router)
 
 
+class SelfApplianceInfo(BaseModel):
+    """Identity + lifecycle of the LOCAL appliance for the browser Console
+    view (#416), sourced from the self ``Appliance`` row the supervisor
+    populates on heartbeat (matched by hostname, exactly as the Cluster
+    Overview merge does in ``appliance/cluster.py``).
+
+    Pure DB read — the api pod never touches host files or journald for
+    this; every field rides the supervisor heartbeat. ``None`` on docker /
+    k8s control planes (no supervisor) or before the local supervisor has
+    registered + been approved.
+    """
+
+    state: str
+    deployment_kind: str | None
+    supervisor_version: str | None
+    installed_appliance_version: str | None
+    current_slot: str | None
+    durable_default: str | None
+    is_trial_boot: bool
+    last_upgrade_state: str | None
+    node_ip: str | None
+    # ``{<compose-service>: {role, status, since, …}}`` — the supervisor's
+    # service-container watchdog rollup; drives the Console's per-role
+    # health chips.
+    role_health: dict[str, Any]
+    role_switch_state: str | None
+    last_seen_at: datetime | None
+
+
 class ApplianceInfo(BaseModel):
     appliance_mode: bool
     appliance_version: str | None
     appliance_hostname: str | None
+    # #416 — local appliance lifecycle for the Console view; None off-box.
+    self_appliance: SelfApplianceInfo | None = None
 
 
 @router.get(
@@ -89,17 +126,51 @@ class ApplianceInfo(BaseModel):
     dependencies=[Depends(require_permission("read", "appliance"))],
     summary="Appliance identity + capabilities",
 )
-async def get_appliance_info() -> ApplianceInfo:
+async def get_appliance_info(db: DB) -> ApplianceInfo:
     """Return the appliance's own self-description.
 
     Distinct from ``/api/v1/version`` (which is public so the sidebar
     can render before login). This endpoint sits behind the appliance
-    read permission because once 4b-4g land it grows into a richer
-    payload (capability flags, supervised container set, host network
-    digest, …) that the unauthenticated surface shouldn't expose.
+    read permission because it grows into a richer payload (capability
+    flags, supervised container set, host network digest, the Console
+    view's local lifecycle block, …) that the unauthenticated surface
+    shouldn't expose.
     """
+    self_info: SelfApplianceInfo | None = None
+    hostname = settings.appliance_hostname or None
+    if hostname:
+        # Match the LOCAL appliance the same way cluster.py merges host
+        # partitions: approved row whose hostname equals ours. Pick the
+        # most-recently-seen if a stale re-register left duplicates.
+        row = (
+            await db.execute(
+                select(Appliance)
+                .where(
+                    Appliance.hostname == hostname,
+                    Appliance.state == APPLIANCE_STATE_APPROVED,
+                )
+                .order_by(Appliance.last_seen_at.desc().nullslast())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if row is not None:
+            self_info = SelfApplianceInfo(
+                state=row.state,
+                deployment_kind=row.deployment_kind,
+                supervisor_version=row.supervisor_version,
+                installed_appliance_version=row.installed_appliance_version,
+                current_slot=row.current_slot,
+                durable_default=row.durable_default,
+                is_trial_boot=row.is_trial_boot,
+                last_upgrade_state=row.last_upgrade_state,
+                node_ip=row.node_ip,
+                role_health=row.role_health or {},
+                role_switch_state=row.role_switch_state,
+                last_seen_at=row.last_seen_at,
+            )
     return ApplianceInfo(
         appliance_mode=settings.appliance_mode,
         appliance_version=settings.appliance_version or None,
-        appliance_hostname=settings.appliance_hostname or None,
+        appliance_hostname=hostname,
+        self_appliance=self_info,
     )

--- a/backend/app/api/v1/appliance/slot_image_mirror.py
+++ b/backend/app/api/v1/appliance/slot_image_mirror.py
@@ -191,7 +191,10 @@ async def put_image(image_id: uuid.UUID, request: Request) -> None:
     _verify_auth("put", image_id, request.headers.get(_AUTH_HEADER))
     _ensure_dir()
     target = _image_path(image_id)
-    tmp = target.with_suffix(".raw.xz.partial")
+    # Append ".partial" to the full ``<id>.raw.xz`` name — NOT
+    # ``with_suffix(".raw.xz.partial")``, which replaces only the final
+    # ``.xz`` and doubles the ``.raw`` into ``<id>.raw.raw.xz.partial`` (#415).
+    tmp = target.with_name(target.name + ".partial")
     # ``streamed`` flips True after the stream-loop completes; the
     # ``finally`` block uses it to decide whether to atomic-rename or
     # clean up the partial. Catches client disconnects + asyncio

--- a/backend/app/api/v1/appliance/upgrade_images.py
+++ b/backend/app/api/v1/appliance/upgrade_images.py
@@ -125,6 +125,16 @@ def _image_path(image_id: uuid.UUID) -> Path:
     return SLOT_IMAGE_DIR / f"{image_id}.raw.xz"
 
 
+def _partial_path(image_id: uuid.UUID) -> Path:
+    # In-flight upload temp file, atomically renamed to ``_image_path``
+    # on success. Append ".partial" to the full ``<id>.raw.xz`` name —
+    # NOT ``with_suffix(".raw.xz.partial")``, which replaces only the
+    # final ``.xz`` component and doubles the ``.raw`` into the bogus
+    # ``<id>.raw.raw.xz.partial`` (#415).
+    target = _image_path(image_id)
+    return target.with_name(target.name + ".partial")
+
+
 def _ensure_storage_dir() -> None:
     SLOT_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
     try:
@@ -359,7 +369,7 @@ async def _store_verified_image(
     # an atomic .partial → final rename.
     _ensure_storage_dir()
     target_path = _image_path(image_id)
-    tmp_path = target_path.with_suffix(".raw.xz.partial")
+    tmp_path = _partial_path(image_id)
     try:
         with tmp_path.open("wb") as out:
             async for chunk in source:

--- a/backend/app/services/appliance/containers.py
+++ b/backend/app/services/appliance/containers.py
@@ -188,23 +188,76 @@ def list_containers() -> list[ContainerSummary]:
     return out
 
 
-def resolve_workload_pod(component: str) -> str | None:
-    """Resolve a workload component (api/worker/frontend/…) to its current
-    running SpatiumDDI pod name — the newest, so a just-rolled Deployment
-    resolves to the fresh pod. Lets the log surface tail a stable workload
-    instead of a churny pod name (#416). None if nothing running matches."""
-    running = [
-        c
-        for c in list_containers()
-        if c.is_spatium and c.state == "running" and c.component == component
+# Container names that are never the workload's "main" log source — skip
+# them when a multi-container pod has no component-matching or default
+# container (e.g. the redis pod ships a render-config sidecar).
+_LOG_SIDECAR_NAMES = frozenset({"render-config"})
+
+
+def _pick_log_container(pod: dict[str, Any], prefer: str | None = None) -> str | None:
+    """Which container's logs to tail for a (possibly multi-container) pod.
+
+    kubeapi 400s a logs request on a multi-container pod unless a container
+    is named (#416 follow-up: the redis pod is render-config + redis +
+    sentinel). Returns None for a single-container pod — kubeapi defaults to
+    the only one. Otherwise prefer the component-matching container (redis →
+    redis), then the ``kubectl.kubernetes.io/default-container`` annotation,
+    then the first non-sidecar, then the first."""
+    names = [
+        c.get("name") for c in (pod.get("spec") or {}).get("containers") or [] if c.get("name")
     ]
-    if not running:
+    if len(names) <= 1:
         return None
-    running.sort(
-        key=lambda c: c.started_at or datetime.min.replace(tzinfo=UTC),
+    if prefer and prefer in names:
+        return prefer
+    ann = (pod.get("metadata") or {}).get("annotations") or {}
+    default_c = ann.get("kubectl.kubernetes.io/default-container")
+    if default_c in names:
+        return default_c
+    for n in names:
+        if n not in _LOG_SIDECAR_NAMES:
+            return n
+    return names[0]
+
+
+def _default_log_container(name: str) -> str | None:
+    """Default log container for a bare pod name (the Pods-tab path), so a
+    multi-container pod doesn't 400. None if the pod isn't found / single."""
+    try:
+        pods = k8s.list_pods()
+    except k8s.KubeapiUnavailableError:
+        return None
+    for p in pods:
+        if (p.get("metadata") or {}).get("name") == name:
+            return _pick_log_container(p)
+    return None
+
+
+def resolve_workload_pod(component: str) -> tuple[str, str | None] | None:
+    """Resolve a workload component (api/worker/frontend/…) to ``(pod_name,
+    container)`` for its current running SpatiumDDI pod — the newest, so a
+    just-rolled Deployment resolves to the fresh pod, and the right container
+    on a multi-container pod (e.g. redis). Lets the log surface tail a stable
+    workload instead of a churny pod name (#416). None if nothing matches."""
+    if not settings.appliance_mode:
+        return None
+    try:
+        pods = k8s.list_pods()
+    except k8s.KubeapiUnavailableError as exc:
+        raise DockerUnavailableError(str(exc)) from exc
+    matches: list[tuple[ContainerSummary, dict[str, Any]]] = []
+    for p in pods:
+        summary = _parse_pod_to_summary(p)
+        if summary.is_spatium and summary.state == "running" and summary.component == component:
+            matches.append((summary, p))
+    if not matches:
+        return None
+    matches.sort(
+        key=lambda sp: sp[0].started_at or datetime.min.replace(tzinfo=UTC),
         reverse=True,
     )
-    return running[0].name
+    summary, pod = matches[0]
+    return summary.name, _pick_log_container(pod, prefer=component)
 
 
 def container_action(name: str, action: str) -> None:
@@ -246,7 +299,9 @@ def get_container_logs(name: str, tail: int = 200, since_seconds: int | None = N
     return body
 
 
-async def stream_container_logs(name: str, tail: int = 100) -> AsyncGenerator[str, None]:
+async def stream_container_logs(
+    name: str, tail: int = 100, container: str | None = None
+) -> AsyncGenerator[str, None]:
     """Yield log lines from the named pod as they arrive.
 
     Wraps ``k8s.stream_pod_logs`` (a sync generator) with
@@ -260,8 +315,13 @@ async def stream_container_logs(name: str, tail: int = 100) -> AsyncGenerator[st
     worker thread is closed via the generator's GeneratorExit
     propagation through the iter wrapper below.
     """
+    if container is None:
+        # A bare pod name (the Pods tab) on a multi-container pod (e.g. redis:
+        # render-config / redis / sentinel) makes kubeapi 400 "a container
+        # name must be specified". Resolve a default from the pod's spec.
+        container = _default_log_container(name)
     try:
-        gen = k8s.stream_pod_logs(name, tail=tail)
+        gen = k8s.stream_pod_logs(name, tail=tail, container=container)
     except k8s.KubeapiUnavailableError as exc:
         raise DockerUnavailableError(str(exc)) from exc
 

--- a/backend/app/services/appliance/containers.py
+++ b/backend/app/services/appliance/containers.py
@@ -63,6 +63,24 @@ class ContainerSummary:
     short_id: str
     started_at: datetime | None
     is_spatium: bool
+    component: str  # workload label (api/worker/frontend/…) — #416 log picker
+
+
+def _pod_component(pod: dict[str, Any]) -> str:
+    """Workload component for a pod — the ``app.kubernetes.io/component``
+    label, else the chart-prefix-stripped pod name. Mirrors
+    ``cluster_health._pod_component`` (kept local to avoid an import cycle)."""
+    labels = (pod.get("metadata") or {}).get("labels") or {}
+    comp = labels.get("app.kubernetes.io/component")
+    if comp:
+        return comp
+    name = (pod.get("metadata") or {}).get("name") or "?"
+    for pre in ("spatium-control-spatiumddi-", "spatium-bootstrap-", "spatium-"):
+        if name.startswith(pre):
+            name = name[len(pre) :]
+            break
+    parts = name.rsplit("-", 2)
+    return parts[0] if len(parts) == 3 else name
 
 
 def _parse_pod_to_summary(pod: dict[str, Any]) -> ContainerSummary:
@@ -153,6 +171,7 @@ def _parse_pod_to_summary(pod: dict[str, Any]) -> ContainerSummary:
         short_id=(meta.get("uid") or "")[:12],
         started_at=started_at,
         is_spatium=is_spatium,
+        component=_pod_component(pod),
     )
 
 
@@ -167,6 +186,25 @@ def list_containers() -> list[ContainerSummary]:
     # Spatium pods first, then alphabetical within each group.
     out.sort(key=lambda c: (not c.is_spatium, c.name))
     return out
+
+
+def resolve_workload_pod(component: str) -> str | None:
+    """Resolve a workload component (api/worker/frontend/…) to its current
+    running SpatiumDDI pod name — the newest, so a just-rolled Deployment
+    resolves to the fresh pod. Lets the log surface tail a stable workload
+    instead of a churny pod name (#416). None if nothing running matches."""
+    running = [
+        c
+        for c in list_containers()
+        if c.is_spatium and c.state == "running" and c.component == component
+    ]
+    if not running:
+        return None
+    running.sort(
+        key=lambda c: c.started_at or datetime.min.replace(tzinfo=UTC),
+        reverse=True,
+    )
+    return running[0].name
 
 
 def container_action(name: str, action: str) -> None:

--- a/backend/tests/test_appliance_containers.py
+++ b/backend/tests/test_appliance_containers.py
@@ -1,9 +1,10 @@
-"""Workload→pod resolver for the Console log picker (#416).
+"""Workload→pod resolver + log-container picker for the Console log picker (#416).
 
 ``resolve_workload_pod`` lets the Cluster dashboard tail a stable workload
-(deployment / daemonset) by its ``app.kubernetes.io/component`` label and
-have the backend pick the current running pod — so the stream survives pod
-rolls and never exposes churny pod names.
+(deployment / daemonset) by its ``app.kubernetes.io/component`` label and have
+the backend pick the current running pod AND the right container — so the
+stream survives pod rolls, never exposes churny pod names, and doesn't 400 on
+a multi-container pod (the redis pod is render-config + redis + sentinel).
 """
 
 from __future__ import annotations
@@ -21,7 +22,9 @@ def _pod(
     *,
     phase: str = "Running",
     start: str = "2026-06-14T10:00:00Z",
+    container_names: list[str] | None = None,
 ) -> dict[str, Any]:
+    names = container_names if container_names is not None else [component]
     return {
         "metadata": {
             "name": name,
@@ -31,7 +34,7 @@ def _pod(
                 "app.kubernetes.io/component": component,
             },
         },
-        "spec": {"containers": [{"image": "ghcr.io/x:dev"}]},
+        "spec": {"containers": [{"name": n, "image": "ghcr.io/x:dev"} for n in names]},
         "status": {
             "phase": phase,
             "startTime": start,
@@ -55,9 +58,38 @@ def test_resolve_picks_newest_running_pod(monkeypatch: pytest.MonkeyPatch) -> No
             _pod("spatium-control-spatiumddi-worker-1", "worker"),
         ],
     )
-    # Newest running pod for the component wins (fresh after a roll).
-    assert containers.resolve_workload_pod("api") == "spatium-control-spatiumddi-api-new"
-    assert containers.resolve_workload_pod("worker") == "spatium-control-spatiumddi-worker-1"
+    # Newest running pod for the component; single-container → no container
+    # needed (kubeapi defaults to the only one).
+    assert containers.resolve_workload_pod("api") == (
+        "spatium-control-spatiumddi-api-new",
+        None,
+    )
+    assert containers.resolve_workload_pod("worker") == (
+        "spatium-control-spatiumddi-worker-1",
+        None,
+    )
+
+
+def test_resolve_multi_container_picks_component_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The redis pod is render-config + redis + sentinel — kubeapi 400s without
+    # a container; the resolver picks the one matching the component.
+    monkeypatch.setattr(
+        containers.k8s,
+        "list_pods",
+        lambda *a, **k: [
+            _pod(
+                "spatium-control-spatiumddi-redis-0",
+                "redis",
+                container_names=["render-config", "redis", "sentinel"],
+            ),
+        ],
+    )
+    assert containers.resolve_workload_pod("redis") == (
+        "spatium-control-spatiumddi-redis-0",
+        "redis",
+    )
 
 
 def test_resolve_skips_completed_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -83,9 +115,10 @@ def test_resolve_unknown_component(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_resolve_component_from_name_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     # No component label → derive from the chart-prefixed pod name.
-    pod = _pod("spatium-control-spatiumddi-frontend-abc-1", "ignored")
+    pod = _pod("spatium-control-spatiumddi-frontend-abc-1", "frontend")
     del pod["metadata"]["labels"]["app.kubernetes.io/component"]
     monkeypatch.setattr(containers.k8s, "list_pods", lambda *a, **k: [pod])
-    assert (
-        containers.resolve_workload_pod("frontend") == "spatium-control-spatiumddi-frontend-abc-1"
+    assert containers.resolve_workload_pod("frontend") == (
+        "spatium-control-spatiumddi-frontend-abc-1",
+        None,
     )

--- a/backend/tests/test_appliance_containers.py
+++ b/backend/tests/test_appliance_containers.py
@@ -1,0 +1,91 @@
+"""Workload→pod resolver for the Console log picker (#416).
+
+``resolve_workload_pod`` lets the Cluster dashboard tail a stable workload
+(deployment / daemonset) by its ``app.kubernetes.io/component`` label and
+have the backend pick the current running pod — so the stream survives pod
+rolls and never exposes churny pod names.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services.appliance import containers
+
+
+def _pod(
+    name: str,
+    component: str,
+    *,
+    phase: str = "Running",
+    start: str = "2026-06-14T10:00:00Z",
+) -> dict[str, Any]:
+    return {
+        "metadata": {
+            "name": name,
+            "uid": "u" * 12,
+            "labels": {
+                "app.kubernetes.io/part-of": "spatiumddi",
+                "app.kubernetes.io/component": component,
+            },
+        },
+        "spec": {"containers": [{"image": "ghcr.io/x:dev"}]},
+        "status": {
+            "phase": phase,
+            "startTime": start,
+            "containerStatuses": [{"ready": True}],
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def _appliance_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(containers.settings, "appliance_mode", True)
+
+
+def test_resolve_picks_newest_running_pod(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        containers.k8s,
+        "list_pods",
+        lambda *a, **k: [
+            _pod("spatium-control-spatiumddi-api-old", "api", start="2026-06-14T09:00:00Z"),
+            _pod("spatium-control-spatiumddi-api-new", "api", start="2026-06-14T10:30:00Z"),
+            _pod("spatium-control-spatiumddi-worker-1", "worker"),
+        ],
+    )
+    # Newest running pod for the component wins (fresh after a roll).
+    assert containers.resolve_workload_pod("api") == "spatium-control-spatiumddi-api-new"
+    assert containers.resolve_workload_pod("worker") == "spatium-control-spatiumddi-worker-1"
+
+
+def test_resolve_skips_completed_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A Succeeded one-shot Job pod is not "running" → no tailable pod.
+    monkeypatch.setattr(
+        containers.k8s,
+        "list_pods",
+        lambda *a, **k: [
+            _pod("spatium-control-spatiumddi-migrate-xyz", "migrate", phase="Succeeded"),
+        ],
+    )
+    assert containers.resolve_workload_pod("migrate") is None
+
+
+def test_resolve_unknown_component(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        containers.k8s,
+        "list_pods",
+        lambda *a, **k: [_pod("spatium-control-spatiumddi-api-1", "api")],
+    )
+    assert containers.resolve_workload_pod("does-not-exist") is None
+
+
+def test_resolve_component_from_name_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No component label → derive from the chart-prefixed pod name.
+    pod = _pod("spatium-control-spatiumddi-frontend-abc-1", "ignored")
+    del pod["metadata"]["labels"]["app.kubernetes.io/component"]
+    monkeypatch.setattr(containers.k8s, "list_pods", lambda *a, **k: [pod])
+    assert (
+        containers.resolve_workload_pod("frontend") == "spatium-control-spatiumddi-frontend-abc-1"
+    )

--- a/backend/tests/test_upgrade_images.py
+++ b/backend/tests/test_upgrade_images.py
@@ -106,6 +106,18 @@ def test_pick_upgrade_assets_prefers_versioned() -> None:
     assert "-2026.05.14-1-amd64.raw.xz" in picked[0]
 
 
+def test_partial_path_does_not_double_suffix() -> None:
+    # #415 regression: with_suffix(".raw.xz.partial") replaces only the
+    # ``.xz`` of ``<id>.raw.xz`` and doubles the ``.raw`` into the bogus
+    # ``<id>.raw.raw.xz.partial``. _partial_path appends instead.
+    img = uuid.UUID("c1ce67bb-e165-44a0-a2fd-1f03b3abcb5f")
+    partial = upgrade_images._partial_path(img)
+    assert partial.name == f"{img}.raw.xz.partial"
+    assert ".raw.raw" not in partial.name
+    # the atomic-rename target is the un-suffixed image path
+    assert upgrade_images._image_path(img).name == f"{img}.raw.xz"
+
+
 async def test_list_available_upgrade_images_filters(monkeypatch: pytest.MonkeyPatch) -> None:
     raw = [
         _release("2026.05.14-1", assets=_image_assets("2026.05.14-1")),

--- a/charts/spatiumddi/templates/api.yaml
+++ b/charts/spatiumddi/templates/api.yaml
@@ -46,6 +46,14 @@ spec:
         - name: api
           image: {{ include "spatiumddi.image" (merge (dict "imageName" "spatiumddi-api") .) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # Pin the runtime uid/gid to the image's ``app`` user (1000) so the
+          # slot-images hostPath — chowned 1000:1000 by spatiumddi-firstboot
+          # (#415) — is writable regardless of any cluster-level PodSecurity
+          # default. Matches the image USER directive: a no-op on a normal
+          # deploy, deterministic belt-and-braces on the appliance.
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
           ports:
             - name: http
               containerPort: 8000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,7 +8,7 @@
 # on one platform lacks the ``@rollup/rollup-linux-arm64-musl`` optional
 # dep needed when ``npm install`` runs on emulated arm64-musl — which
 # was the failure mode on the 2026.04.22-1 release build.
-FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
 
 # Release-pipeline version stamp. The release workflow passes the git
 # tag (e.g. ``2026.04.22-1``); local builds default to ``dev`` so

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7701,10 +7701,37 @@ export const versionApi = {
 // 4b-4g extend this client with the real management surfaces (TLS
 // cert upload, release manager, containers, logs, network/host
 // config, web first-boot wizard).
+// #416 — identity + lifecycle of the LOCAL appliance for the browser
+// Console view, sourced from the self ``Appliance`` row the supervisor
+// populates on heartbeat (matched by hostname). ``null`` on docker / k8s
+// control planes (no supervisor) or before the local supervisor has
+// registered + been approved. Mirrors the backend ``SelfApplianceInfo``.
+export interface SelfApplianceInfo {
+  state: string;
+  deployment_kind: string | null;
+  supervisor_version: string | null;
+  installed_appliance_version: string | null;
+  current_slot: string | null;
+  durable_default: string | null;
+  is_trial_boot: boolean;
+  last_upgrade_state: string | null;
+  node_ip: string | null;
+  // ``{<compose-service>: {role, status, since, …}}`` — the supervisor's
+  // service-container watchdog rollup; drives the Console's per-role chips.
+  role_health: Record<
+    string,
+    { role?: string; status?: string; since?: string; [k: string]: unknown }
+  >;
+  role_switch_state: string | null;
+  last_seen_at: string | null;
+}
+
 export interface ApplianceInfo {
   appliance_mode: boolean;
   appliance_version: string | null;
   appliance_hostname: string | null;
+  // #416 — local appliance lifecycle for the Console view; null off-box.
+  self_appliance: SelfApplianceInfo | null;
 }
 
 export const applianceApi = {
@@ -9275,13 +9302,11 @@ export const applianceDiagnosticsApi = {
  * (not EventSource) so we can send the Bearer token in Authorization.
  * Yields each parsed log line; cancel via the AbortSignal.
  */
-export async function* streamApplianceContainerLogs(
-  name: string,
+async function* _streamApplianceLogSse(
+  url: string,
   signal?: AbortSignal,
-  tail = 100,
 ): AsyncIterable<string> {
   const token = localStorage.getItem("access_token");
-  const url = `/api/v1/appliance/containers/${encodeURIComponent(name)}/logs/stream?tail=${tail}`;
   const res = await fetch(url, {
     headers: {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -9316,6 +9341,32 @@ export async function* streamApplianceContainerLogs(
       }
     }
   }
+}
+
+// Tail one pod's logs by exact pod name (used by the Pods tab).
+export function streamApplianceContainerLogs(
+  name: string,
+  signal?: AbortSignal,
+  tail = 100,
+): AsyncIterable<string> {
+  return _streamApplianceLogSse(
+    `/api/v1/appliance/containers/${encodeURIComponent(name)}/logs/stream?tail=${tail}`,
+    signal,
+  );
+}
+
+// Tail a workload (deployment / daemonset) by its component label
+// (api / worker / frontend / …); the backend resolves it to the current
+// pod, so the stream survives pod rolls without exposing pod names (#416).
+export function streamApplianceWorkloadLogs(
+  component: string,
+  signal?: AbortSignal,
+  tail = 100,
+): AsyncIterable<string> {
+  return _streamApplianceLogSse(
+    `/api/v1/appliance/containers/workloads/${encodeURIComponent(component)}/logs/stream?tail=${tail}`,
+    signal,
+  );
 }
 
 /**

--- a/frontend/src/pages/appliance/ClusterOverview.tsx
+++ b/frontend/src/pages/appliance/ClusterOverview.tsx
@@ -1,17 +1,25 @@
 import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
+  AlertCircle,
   AlertTriangle,
   Boxes,
   CheckCircle2,
+  Clock,
   Cpu,
   Database,
   HardDrive,
   Layers,
   MemoryStick,
+  Network,
+  Pause,
+  Power,
   Radio,
   RotateCcw,
+  ScrollText,
   Server,
+  Tag,
 } from "lucide-react";
 import {
   Area,
@@ -24,17 +32,35 @@ import {
 } from "recharts";
 
 import {
-  applianceClusterApi,
-  streamClusterHealth,
-  type ClusterHealthSnapshot,
+  applianceApi,
+  applianceSystemApi,
+  streamApplianceWorkloadLogs,
+  versionApi,
   type ClusterNodeVitals,
   type ClusterPodSummary,
   type ClusterWorkloadHealth,
+  type SelfApplianceInfo,
 } from "@/lib/api";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import {
+  AMBER,
+  EMERALD,
+  ROSE,
+  SKY,
+  SLATE,
+  VIOLET,
+  fmtAge,
+  fmtBytes,
+  fmtCores,
+  pct,
+  usageColor,
+  useClusterHealthStream,
+  type HistPoint,
+} from "./clusterShared";
 
 /**
- * Cluster → Overview (#402) — a live, near-real-time dashboard for the k3s
- * cluster underneath the appliance.
+ * Cluster → Overview (#402 / #416) — one cohesive, near-real-time dashboard
+ * for the k3s cluster underneath the appliance.
  *
  * Fed by an SSE stream (`/appliance/cluster/health/stream`) that pushes a
  * fresh snapshot every ~2s; each frame animates the gradient CPU/memory hero
@@ -42,64 +68,14 @@ import {
  * leaderboard. There's no metrics-server / Prometheus on the appliance — live
  * usage comes from the kubelet Summary API, the same source the TTY console
  * uses. The stream self-reconnects; a one-shot GET paints instantly on mount.
+ *
+ * The top identity header + live pod-log tail + reboot action fold in what was
+ * a separate "Console" sub-view: identity / lifecycle come from
+ * `applianceApi.getInfo()` (the `self_appliance` block) + the app version from
+ * `versionApi.get()`. Degrades gracefully when `self_appliance` is null
+ * (docker / k8s control plane or pre-registration) — slot / pairing chips drop
+ * out, while hostname / version / cluster / log / actions stay.
  */
-
-const MAX_POINTS = 90; // ~3 min of history at the 2s stream cadence
-
-const EMERALD = "#10b981";
-const SKY = "#0ea5e9";
-const AMBER = "#f59e0b";
-const ROSE = "#f43f5e";
-const VIOLET = "#8b5cf6";
-const SLATE = "#64748b";
-
-interface HistPoint {
-  i: number;
-  cpu: number | null;
-  mem: number | null;
-}
-
-// ── formatting helpers ──────────────────────────────────────────────────────
-
-function fmtBytes(n: number | null | undefined): string {
-  if (n == null) return "—";
-  if (n < 1024) return `${n} B`;
-  const u = ["KiB", "MiB", "GiB", "TiB"];
-  let v = n / 1024;
-  let i = 0;
-  while (v >= 1024 && i < u.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return `${v.toFixed(v < 10 ? 1 : 0)} ${u[i]}`;
-}
-
-function fmtCores(c: number | null | undefined): string {
-  if (c == null) return "—";
-  return c < 1 ? `${Math.round(c * 1000)}m` : c.toFixed(2);
-}
-
-function pct(
-  used: number | null | undefined,
-  cap: number | null | undefined,
-): number | null {
-  if (used == null || !cap) return null;
-  return Math.max(0, Math.min(100, (used / cap) * 100));
-}
-
-function fmtAge(s: number | null | undefined): string {
-  if (s == null) return "—";
-  if (s < 3600) return `${Math.max(1, Math.floor(s / 60))}m`;
-  if (s < 86400) return `${Math.floor(s / 3600)}h`;
-  return `${Math.floor(s / 86400)}d`;
-}
-
-function usageColor(p: number | null): string {
-  if (p == null) return SLATE;
-  if (p < 60) return EMERALD;
-  if (p < 85) return AMBER;
-  return ROSE;
-}
 
 function shortPodName(p: { name: string }): string {
   return p.name
@@ -108,70 +84,16 @@ function shortPodName(p: { name: string }): string {
     .replace(/^spatium-/, "");
 }
 
-// ── live stream hook ─────────────────────────────────────────────────────────
-
-function useClusterHealthStream() {
-  const [snapshot, setSnapshot] = useState<ClusterHealthSnapshot | null>(null);
-  const [history, setHistory] = useState<HistPoint[]>([]);
-  const [connected, setConnected] = useState(false);
-  const seq = useRef(0);
-
-  useEffect(() => {
-    const ctrl = new AbortController();
-    let stopped = false;
-
-    const ingest = (snap: ClusterHealthSnapshot) => {
-      setSnapshot(snap);
-      if (snap.available) {
-        const cpu = pct(snap.cpu_usage_cores, snap.cpu_capacity_cores);
-        const mem = pct(
-          snap.memory_working_set_bytes,
-          snap.memory_capacity_bytes,
-        );
-        setHistory((prev) => {
-          const next = [...prev, { i: seq.current++, cpu, mem }];
-          return next.length > MAX_POINTS
-            ? next.slice(next.length - MAX_POINTS)
-            : next;
-        });
-      }
-    };
-
-    // Instant first paint while the SSE stream warms up.
-    applianceClusterApi
-      .health()
-      .then((s) => {
-        if (!stopped) ingest(s);
-      })
-      .catch(() => {
-        /* stream will deliver shortly */
-      });
-
-    const run = async () => {
-      while (!stopped) {
-        try {
-          for await (const snap of streamClusterHealth(ctrl.signal)) {
-            if (stopped) break;
-            setConnected(true);
-            ingest(snap);
-          }
-        } catch {
-          if (stopped) break;
-        }
-        setConnected(false);
-        if (stopped) break;
-        await new Promise((r) => setTimeout(r, 2000)); // backoff then reconnect
-      }
-    };
-    void run();
-
-    return () => {
-      stopped = true;
-      ctrl.abort();
-    };
-  }, []);
-
-  return { snapshot, history, connected };
+// ── small relative-time helper (no shared util exists) ─────────────────────
+function relTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "—";
+  const s = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (s < 60) return `${s}s ago`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+  return `${Math.floor(s / 86400)}d ago`;
 }
 
 // ── small visual primitives ──────────────────────────────────────────────────
@@ -234,7 +156,7 @@ function RadialGauge({
   );
 }
 
-function Sparkline({
+export function Sparkline({
   data,
   color,
   max,
@@ -302,7 +224,63 @@ function Bar({ value, color }: { value: number; color: string }) {
   );
 }
 
-function KpiTile({
+// ── identity chip ──────────────────────────────────────────────────────────
+function Chip({
+  icon: Icon,
+  children,
+  color,
+  title,
+}: {
+  icon?: typeof Cpu;
+  children: React.ReactNode;
+  color?: string;
+  title?: string;
+}) {
+  return (
+    <span
+      title={title}
+      className="inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium"
+      style={
+        color
+          ? { color, borderColor: `${color}55`, background: `${color}12` }
+          : undefined
+      }
+    >
+      {Icon && <Icon className="h-3 w-3" />}
+      {children}
+    </span>
+  );
+}
+
+function upgradeStateColor(state: string | null | undefined): string {
+  switch (state) {
+    case "ready":
+    case "done":
+      return EMERALD;
+    case "in-flight":
+      return VIOLET;
+    case "failed":
+      return ROSE;
+    default:
+      return SLATE;
+  }
+}
+
+// Derive the list of roles the box runs from the watchdog role_health keys
+// (compose-service names → their reported ``role``), falling back to the
+// deployment kind so a box with no watchdog rollup still labels itself.
+function deriveRoles(self: SelfApplianceInfo | null): string[] {
+  if (self) {
+    const fromHealth = Object.entries(self.role_health)
+      .map(([svc, v]) => v?.role || svc)
+      .filter(Boolean);
+    if (fromHealth.length) return [...new Set(fromHealth)];
+    if (self.deployment_kind) return [self.deployment_kind];
+  }
+  return [];
+}
+
+export function KpiTile({
   icon: Icon,
   label,
   value,
@@ -336,7 +314,7 @@ function KpiTile({
   );
 }
 
-function RoleBadge({ role }: { role: string }) {
+export function RoleBadge({ role }: { role: string }) {
   const color =
     role === "control-plane" || role === "master"
       ? VIOLET
@@ -353,7 +331,7 @@ function RoleBadge({ role }: { role: string }) {
   );
 }
 
-function StatusChip({ status }: { status: string }) {
+export function StatusChip({ status }: { status: string }) {
   const map: Record<string, [string, string]> = {
     healthy: [EMERALD, "Healthy"],
     degraded: [AMBER, "Degraded"],
@@ -605,7 +583,7 @@ function TopPods({
 
 // ── hero live chart ───────────────────────────────────────────────────────────
 
-function HeroChart({
+export function HeroChart({
   history,
   cpuPct,
   memPct,
@@ -725,7 +703,11 @@ function HeroChart({
 
 // ── workload health ───────────────────────────────────────────────────────────
 
-function WorkloadHealth({ workloads }: { workloads: ClusterWorkloadHealth[] }) {
+export function WorkloadHealth({
+  workloads,
+}: {
+  workloads: ClusterWorkloadHealth[];
+}) {
   return (
     <div className="rounded-xl border bg-card p-4 shadow-sm">
       <h3 className="flex items-center gap-1.5 text-sm font-semibold">
@@ -774,10 +756,184 @@ function WorkloadHealth({ workloads }: { workloads: ClusterWorkloadHealth[] }) {
   );
 }
 
+// ── service roles (supervisor watchdog rollup) ─────────────────────────────────
+
+function ServiceRoles({
+  rows,
+}: {
+  rows: { service: string; status: string; since: string | null }[];
+}) {
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+        <Layers className="h-4 w-4 text-muted-foreground" />
+        Service roles
+      </h3>
+      <div className="mt-3 space-y-1.5">
+        {rows.map((r) => (
+          <div
+            key={r.service}
+            className="flex items-center justify-between gap-2 rounded-md px-1 py-1 text-xs"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <StatusChip status={r.status} />
+              <span className="truncate font-medium">{r.service}</span>
+            </div>
+            {r.since && (
+              <span className="shrink-0 text-[10px] text-muted-foreground">
+                since {relTime(r.since)}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── live log pane ──────────────────────────────────────────────────────────
+function LiveLogPane({ workload }: { workload: string }) {
+  const [lines, setLines] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [paused, setPaused] = useState(false);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setLines([]);
+    setError(null);
+    setPaused(false);
+    const ctrl = new AbortController();
+    (async () => {
+      try {
+        for await (const line of streamApplianceWorkloadLogs(
+          workload,
+          ctrl.signal,
+          200,
+        )) {
+          setLines((prev) => {
+            const next = [...prev, line];
+            // Cap at 2000 lines so a chatty pod doesn't blow up memory / DOM.
+            if (next.length > 2000) next.splice(0, next.length - 2000);
+            return next;
+          });
+        }
+      } catch (e) {
+        if (!ctrl.signal.aborted) {
+          setError(e instanceof Error ? e.message : String(e));
+        }
+      }
+    })();
+    return () => ctrl.abort();
+  }, [workload]);
+
+  // Auto-scroll to bottom unless the operator scrolled up (pause).
+  useEffect(() => {
+    if (paused) return;
+    const el = boxRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lines, paused]);
+
+  const onScroll = () => {
+    const el = boxRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+    setPaused(!atBottom);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+        <Activity className="h-3 w-3 text-emerald-500" />
+        Live · {lines.length} line{lines.length === 1 ? "" : "s"}
+        {paused && (
+          <button
+            type="button"
+            onClick={() => setPaused(false)}
+            className="ml-auto inline-flex items-center gap-1 rounded-md border bg-background px-2 py-0.5 text-[11px] hover:bg-accent"
+            title="Jump to bottom + resume auto-scroll"
+          >
+            <Pause className="h-3 w-3" />
+            Paused — click to resume
+          </button>
+        )}
+      </div>
+      {error && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+      <div
+        ref={boxRef}
+        onScroll={onScroll}
+        className="h-80 overflow-auto rounded-md border bg-muted/30 px-3 py-2 font-mono text-[11px] leading-tight"
+      >
+        {lines.length === 0 && !error ? (
+          <span className="text-muted-foreground">Waiting for logs…</span>
+        ) : (
+          lines.map((line, i) => (
+            <div key={i} className="whitespace-pre-wrap">
+              {line}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ── main ──────────────────────────────────────────────────────────────────────
 
-export function ClusterOverview() {
+export function ClusterOverview({
+  onViewPods,
+}: { onViewPods?: () => void } = {}) {
   const { snapshot, history, connected } = useClusterHealthStream();
+
+  // Identity + lifecycle for the header / reboot action (folds in the former
+  // Console view). These hooks run unconditionally — the early returns below
+  // come after them, so no hooks-rule violation.
+  const { data: info } = useQuery({
+    queryKey: ["appliance", "info"],
+    queryFn: applianceApi.getInfo,
+    staleTime: 20_000,
+    refetchInterval: 30_000,
+  });
+  const { data: version } = useQuery({
+    queryKey: ["version"],
+    queryFn: versionApi.get,
+    staleTime: 30_000,
+  });
+
+  const self = info?.self_appliance ?? null;
+  const isApplianceHost = self?.deployment_kind === "appliance";
+
+  const [confirmReboot, setConfirmReboot] = useState(false);
+  const [rebooting, setRebooting] = useState(false);
+
+  // ── log workload picker — tail a deployment/daemonset by its component ──
+  // The operator picks a stable workload (api / worker / frontend / …) and
+  // the backend resolves it to the current pod, so the stream survives pod
+  // rolls and never exposes churny pod names (#416).
+  const workloadNames = (snapshot?.workloads ?? []).map((w) => w.component);
+  const defaultWorkload =
+    workloadNames.find((n) => /api|control/i.test(n)) ?? workloadNames[0] ?? "";
+  const [selectedWorkload, setSelectedWorkload] = useState<string>("");
+  // Honor the explicit pick only while it's still a known workload; else fall
+  // back to the default (deriving avoids a stale picker without an effect).
+  const effectiveWorkload =
+    selectedWorkload && workloadNames.includes(selectedWorkload)
+      ? selectedWorkload
+      : defaultWorkload;
+
+  const doReboot = async () => {
+    setRebooting(true);
+    try {
+      await applianceSystemApi.reboot();
+      setConfirmReboot(false);
+    } finally {
+      setRebooting(false);
+    }
+  };
 
   if (snapshot === null) {
     return (
@@ -809,55 +965,154 @@ export function ClusterOverview() {
   ).length;
   const cpuSpark = history.map((h) => h.cpu ?? 0);
   const memSpark = history.map((h) => h.mem ?? 0);
-  const phaseSummary = Object.entries(s.pods_by_phase)
-    .sort((a, b) => b[1] - a[1])
-    .map(([k, v]) => `${k} ${v}`)
+
+  // Pods KPI — exclude completed Jobs (Succeeded phase: migrate / helm-install
+  // / CNPG bootstrap) from the denominator so a healthy box reads "10/10"
+  // instead of an alarming "10/14". Finished Jobs still surface as a small
+  // "N completed" sub-line; any pending / failed pods are noted too.
+  const succeeded = s.pods_by_phase?.["Succeeded"] ?? 0;
+  const pending = s.pods_by_phase?.["Pending"] ?? 0;
+  const failed = s.pods_by_phase?.["Failed"] ?? 0;
+  const activePods = Math.max(0, s.pods_total - succeeded);
+  const podsSub = [
+    succeeded > 0 ? `${succeeded} completed` : null,
+    pending > 0 ? `${pending} pending` : null,
+    failed > 0 ? `${failed} failed` : null,
+  ]
+    .filter(Boolean)
     .join(" · ");
+
+  // ── derived identity values ─────────────────────────────────────────────
+  const roles = deriveRoles(self);
+  const hostIp =
+    self?.node_ip ?? s.nodes.find((n) => n.internal_ip)?.internal_ip ?? null;
+
+  // role_health → flat list of {service, status, since}; rendered only when
+  // non-empty (a control-plane appliance reports none — no empty placeholder).
+  const roleHealthRows = self
+    ? Object.entries(self.role_health).map(([service, v]) => ({
+        service,
+        status: (v?.status as string | undefined) ?? "unknown",
+        since: (v?.since as string | undefined) ?? null,
+      }))
+    : [];
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex flex-wrap items-center gap-2">
-        <h2 className="flex items-center gap-2 text-base font-semibold">
-          <Boxes className="h-4 w-4 text-muted-foreground" />
-          Cluster overview
-        </h2>
-        <span
-          className="inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium"
-          style={{
-            color: connected ? EMERALD : AMBER,
-            borderColor: `${connected ? EMERALD : AMBER}55`,
-            background: `${connected ? EMERALD : AMBER}12`,
-          }}
-        >
-          <span
-            className={`h-1.5 w-1.5 rounded-full ${connected ? "animate-pulse" : ""}`}
-            style={{ background: connected ? EMERALD : AMBER }}
-          />
-          {connected ? "LIVE" : "reconnecting…"}
-        </span>
-        <span className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
-          {s.kubelet_version && (
-            <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono">
-              {s.kubelet_version}
-            </span>
-          )}
-          <span
-            className="rounded-md px-1.5 py-0.5 font-medium"
-            style={
-              s.is_ha
-                ? { color: EMERALD, background: `${EMERALD}1f` }
-                : { color: SLATE, background: `${SLATE}1f` }
-            }
+      {/* Identity header */}
+      <div className="rounded-xl border bg-card p-4 shadow-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="flex items-center gap-2 text-base font-semibold">
+            <Boxes className="h-4 w-4 text-muted-foreground" />
+            Cluster
+          </h2>
+          <Chip
+            icon={Radio}
+            color={connected ? EMERALD : AMBER}
+            title={connected ? "Streaming live" : "Reconnecting"}
           >
-            {s.is_ha ? `HA · ${s.control_plane_nodes} nodes` : "single node"}
-          </span>
-          {!s.metrics_available && (
-            <span className="rounded-md bg-amber-500/15 px-1.5 py-0.5 text-amber-600 dark:text-amber-400">
-              live usage unavailable
+            {connected ? "LIVE" : "reconnecting…"}
+          </Chip>
+          {self?.last_seen_at && (
+            <span className="ml-auto flex items-center gap-1 text-[11px] text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              supervisor seen {relTime(self.last_seen_at)}
             </span>
           )}
-        </span>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          {roles.map((r) => (
+            <Chip key={r} icon={Layers} color={VIOLET}>
+              {r}
+            </Chip>
+          ))}
+          <Chip icon={Server}>
+            {info?.appliance_hostname ?? s.nodes[0]?.name ?? "unknown"}
+          </Chip>
+          {hostIp && (
+            <Chip icon={Network} title="Host IP">
+              <span className="font-mono">{hostIp}</span>
+            </Chip>
+          )}
+          {(self?.installed_appliance_version ?? info?.appliance_version) && (
+            <Chip icon={Tag} title="Appliance OS version">
+              OS {self?.installed_appliance_version ?? info?.appliance_version}
+            </Chip>
+          )}
+          {version?.version && (
+            <Chip icon={Tag} title="SpatiumDDI app version">
+              app {version.version}
+            </Chip>
+          )}
+
+          {/* A/B slot — appliance only */}
+          {self?.current_slot && (
+            <Chip
+              icon={HardDrive}
+              color={self.is_trial_boot ? AMBER : EMERALD}
+              title={`Running slot ${self.current_slot}; durable default ${self.durable_default ?? "?"}`}
+            >
+              slot {self.current_slot}
+              {self.durable_default && (
+                <span className="opacity-70">
+                  · default {self.durable_default}
+                </span>
+              )}
+            </Chip>
+          )}
+          {self?.is_trial_boot && (
+            <Chip
+              color={AMBER}
+              title="Running slot differs from durable default"
+            >
+              TRIAL BOOT
+            </Chip>
+          )}
+          {self?.last_upgrade_state && (
+            <Chip
+              color={upgradeStateColor(self.last_upgrade_state)}
+              title="Last A/B slot upgrade state"
+            >
+              upgrade: {self.last_upgrade_state}
+            </Chip>
+          )}
+
+          {/* Cluster status */}
+          <Chip
+            color={s.nodes_ready === s.nodes_total ? EMERALD : ROSE}
+            title="Nodes ready / total"
+          >
+            {s.nodes_ready}/{s.nodes_total} nodes
+            {s.is_ha && <span className="opacity-70">· HA</span>}
+          </Chip>
+          {s.kubelet_version && (
+            <Chip title="Kubelet version">
+              <span className="font-mono">{s.kubelet_version}</span>
+            </Chip>
+          )}
+          {!s.metrics_available && (
+            <Chip color={AMBER} title="kubelet Summary API not reporting yet">
+              live usage unavailable
+            </Chip>
+          )}
+          {self?.state && (
+            <Chip
+              color={self.state === "approved" ? EMERALD : AMBER}
+              title="Supervisor approval / pairing lifecycle"
+            >
+              {self.state}
+            </Chip>
+          )}
+        </div>
+
+        {!self && (
+          <p className="mt-3 text-[11px] text-muted-foreground">
+            No local supervisor registered — showing cluster health only. Slot,
+            lifecycle, and per-role chips appear once the local appliance's
+            supervisor is approved.
+          </p>
+        )}
       </div>
 
       {/* KPI ribbon */}
@@ -894,14 +1149,16 @@ export function ClusterOverview() {
         <KpiTile
           icon={Boxes}
           label="Pods running"
-          value={`${s.pods_running}/${s.pods_total}`}
-          accent={VIOLET}
+          value={`${s.pods_running}/${activePods}`}
+          accent={s.pods_running >= activePods ? EMERALD : ROSE}
         >
           <div
             className="truncate text-[11px] text-muted-foreground"
-            title={phaseSummary}
+            title={Object.entries(s.pods_by_phase)
+              .map(([k, v]) => `${k} ${v}`)
+              .join(" · ")}
           >
-            {phaseSummary || "—"}
+            {podsSub || "all running"}
           </div>
         </KpiTile>
         <KpiTile
@@ -941,11 +1198,90 @@ export function ClusterOverview() {
         ))}
       </div>
 
-      {/* Workloads + top pods */}
+      {/* Workloads + top pods (+ service roles when the supervisor reports them) */}
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         <WorkloadHealth workloads={s.workloads} />
         <TopPods cpu={s.top_pods_cpu} mem={s.top_pods_mem} />
+        {roleHealthRows.length > 0 && <ServiceRoles rows={roleHealthRows} />}
       </div>
+
+      {/* Live log pane */}
+      <div className="rounded-xl border bg-card p-4 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+            <ScrollText className="h-4 w-4 text-muted-foreground" />
+            Live log
+          </h3>
+          {workloadNames.length > 0 && (
+            <select
+              value={effectiveWorkload}
+              onChange={(e) => setSelectedWorkload(e.target.value)}
+              className="rounded-md border bg-background px-2 py-1 text-xs"
+            >
+              {workloadNames.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+        <div className="mt-3">
+          {effectiveWorkload ? (
+            <LiveLogPane key={effectiveWorkload} workload={effectiveWorkload} />
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              No workloads to tail yet.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Action bar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setConfirmReboot(true)}
+          disabled={!isApplianceHost}
+          title={
+            isApplianceHost
+              ? "Reboot the appliance host OS"
+              : "Reboot is only available on appliance hosts"
+          }
+          className="inline-flex items-center gap-1.5 rounded-md border border-destructive/40 bg-background px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Power className="h-3.5 w-3.5" />
+          Reboot host
+        </button>
+        {onViewPods && (
+          <button
+            type="button"
+            onClick={onViewPods}
+            className="inline-flex items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            <Boxes className="h-3.5 w-3.5" />
+            View all pods →
+          </button>
+        )}
+      </div>
+
+      <ConfirmModal
+        open={confirmReboot}
+        title="Reboot appliance?"
+        message={
+          <span>
+            The host will power-cycle in ~10 seconds. Existing DHCP leases keep
+            their state (DB-backed); DNS zones reload from the served config;
+            the web UI will be unreachable for ~1 minute.
+          </span>
+        }
+        confirmLabel="Reboot now"
+        tone="destructive"
+        requireCheckboxLabel="I understand the appliance will go offline for ~1 minute."
+        onClose={() => !rebooting && setConfirmReboot(false)}
+        onConfirm={() => void doReboot()}
+        loading={rebooting}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/appliance/ClusterTab.tsx
+++ b/frontend/src/pages/appliance/ClusterTab.tsx
@@ -47,7 +47,7 @@ const SECTIONS: {
     key: "overview",
     label: "Overview",
     icon: Gauge,
-    hint: "Live health & metrics",
+    hint: "Live dashboard & metrics",
   },
   {
     key: "pods",
@@ -132,7 +132,7 @@ export function ClusterTab({
 
       <div className="min-w-0 flex-1">
         {section === "overview" ? (
-          <ClusterOverview />
+          <ClusterOverview onViewPods={() => setSection("pods")} />
         ) : section === "pods" ? (
           <ContainersTab />
         ) : etcdAvailable ? (

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -1467,6 +1467,10 @@ export function FleetTab({
           onRekey={() => setRekeyTarget(drilldown)}
           onDelete={() => setDeleteTarget(drilldown)}
           onRowUpdated={(next) => setDrilldown(next)}
+          onViewUpgradeImages={() => {
+            setDrilldown(null);
+            setView("upgrade-images");
+          }}
         />
       )}
 
@@ -2228,6 +2232,7 @@ function ApplianceDrilldownModal({
   onRekey,
   onDelete,
   onRowUpdated,
+  onViewUpgradeImages,
 }: {
   row: ApplianceRow;
   onClose: () => void;
@@ -2237,6 +2242,11 @@ function ApplianceDrilldownModal({
   onRekey: () => void;
   onDelete: () => void;
   onRowUpdated: (next: ApplianceRow) => void;
+  // Closes this modal and switches the Fleet sub-nav to the
+  // "Upgrade images" view — wired into the OS-upgrade section's
+  // empty state so operators aren't told to look for a section
+  // that moved (#199 renamed slot-images → Upgrade images).
+  onViewUpgradeImages?: () => void;
 }) {
   const caps = row.capabilities ?? {};
   const badge = stateBadge(row.state);
@@ -2357,7 +2367,12 @@ function ApplianceDrilldownModal({
           <ApplianceClusterHealthSection row={row} />
         )}
 
-        {row.state === "approved" && <ApplianceOsUpgradeSection row={row} />}
+        {row.state === "approved" && (
+          <ApplianceOsUpgradeSection
+            row={row}
+            onViewUpgradeImages={onViewUpgradeImages}
+          />
+        )}
 
         {row.state === "approved" && (
           <div>
@@ -4143,7 +4158,13 @@ function UpgradeStatusPanel({
   );
 }
 
-function ApplianceOsUpgradeSection({ row }: { row: ApplianceRow }) {
+function ApplianceOsUpgradeSection({
+  row,
+  onViewUpgradeImages,
+}: {
+  row: ApplianceRow;
+  onViewUpgradeImages?: () => void;
+}) {
   const qc = useQueryClient();
   const [sourceKind, setSourceKind] = useState<"url" | "uploaded">("uploaded");
   const [tag, setTag] = useState("");
@@ -4345,8 +4366,21 @@ function ApplianceOsUpgradeSection({ row }: { row: ApplianceRow }) {
               </select>
               {uploadedQuery.data && uploadedQuery.data.length === 0 && (
                 <p className="text-[11px] text-muted-foreground">
-                  No upgrade images uploaded yet. Open the &ldquo;Upgrade
-                  images&rdquo; section above to upload one.
+                  No upgrade images uploaded yet.{" "}
+                  {onViewUpgradeImages ? (
+                    <button
+                      type="button"
+                      onClick={onViewUpgradeImages}
+                      className="font-medium text-primary underline-offset-2 hover:underline"
+                    >
+                      Go to Upgrade images →
+                    </button>
+                  ) : (
+                    <>
+                      Open <strong>Fleet → Upgrade images</strong> to upload or
+                      import one.
+                    </>
+                  )}
                 </p>
               )}
               <input

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -4077,8 +4077,8 @@ function UpgradeStatusPanel({
             live upgrade-progress reporting, so this dashboard can&rsquo;t show
             the trigger&rsquo;s status &mdash; the upgrade may already have
             fired. Verify on the host (<code>spatium-upgrade-slot status</code>,{" "}
-            <code>journalctl -u spatiumddi-slot-upgrade</code>) or apply the slot
-            image by hand, then reboot. Live progress appears here once the
+            <code>journalctl -u spatiumddi-slot-upgrade</code>) or apply the
+            slot image by hand, then reboot. Live progress appears here once the
             appliance is on &ge; 2026.06.12.
           </p>
         ) : (

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -3988,6 +3988,14 @@ function UpgradeStatusPanel({
   const state = row.last_upgrade_state;
   const failed = state === "failed" || progress?.step === "failed";
   const target = row.desired_appliance_version;
+  // A supervisor older than the #386 (2026.06.12) upgrade-progress telemetry
+  // never reports last_upgrade_progress, so without this the panel sits on
+  // "pending" forever even after the trigger fired. Detect it from the
+  // reported version (CalVer sorts lexicographically) and say so honestly
+  // rather than promising a fire "in ≤30s" that already happened.
+  const supVer = row.supervisor_version ?? row.installed_appliance_version;
+  const predatesProgress =
+    !!supVer && /^\d{4}\.\d{2}\.\d{2}/.test(supVer) && supVer < "2026.06.12";
 
   if (failed) {
     return (
@@ -4062,12 +4070,24 @@ function UpgradeStatusPanel({
         )}
       </div>
 
-      {stepIndex === -1 && (
-        <p className="mt-1 text-muted-foreground">
-          Supervisor will fire the slot-upgrade trigger on its next heartbeat (≤
-          30 s).
-        </p>
-      )}
+      {stepIndex === -1 &&
+        (predatesProgress ? (
+          <p className="mt-1 text-muted-foreground">
+            This appliance&rsquo;s supervisor (<code>{supVer}</code>) predates
+            live upgrade-progress reporting, so this dashboard can&rsquo;t show
+            the trigger&rsquo;s status &mdash; the upgrade may already have
+            fired. Verify on the host (<code>spatium-upgrade-slot status</code>,{" "}
+            <code>journalctl -u spatiumddi-slot-upgrade</code>) or apply the slot
+            image by hand, then reboot. Live progress appears here once the
+            appliance is on &ge; 2026.06.12.
+          </p>
+        ) : (
+          <p className="mt-1 text-muted-foreground">
+            Supervisor will fire the slot-upgrade trigger on its next heartbeat
+            (&le; 30 s). If it stays here, check{" "}
+            <code>journalctl -u spatiumddi-slot-upgrade</code> on the host.
+          </p>
+        ))}
 
       <ol className="mt-2 space-y-1">
         {UPGRADE_STEPS.map((s, i) => {

--- a/frontend/src/pages/appliance/clusterShared.ts
+++ b/frontend/src/pages/appliance/clusterShared.ts
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  applianceClusterApi,
+  streamClusterHealth,
+  type ClusterHealthSnapshot,
+} from "@/lib/api";
+
+/**
+ * Shared, non-component cluster-health primitives (#416).
+ *
+ * Pulled out of ``ClusterOverview.tsx`` so the constants / formatting
+ * helpers / the live SSE hook can be reused by the Console view without
+ * tripping eslint's ``react-refresh/only-export-components`` (a .tsx file
+ * may export multiple components, but mixing component + non-component
+ * exports breaks Vite fast-refresh). Keep this file JSX-free.
+ */
+
+const MAX_POINTS = 90; // ~3 min of history at the 2s stream cadence
+
+// Shared palette — the Console view (#416) reuses these so its chips /
+// charts match the Overview exactly without re-declaring the hex.
+export const EMERALD = "#10b981";
+export const SKY = "#0ea5e9";
+export const AMBER = "#f59e0b";
+export const ROSE = "#f43f5e";
+export const VIOLET = "#8b5cf6";
+export const SLATE = "#64748b";
+
+export interface HistPoint {
+  i: number;
+  cpu: number | null;
+  mem: number | null;
+}
+
+// ── formatting helpers ──────────────────────────────────────────────────────
+
+export function fmtBytes(n: number | null | undefined): string {
+  if (n == null) return "—";
+  if (n < 1024) return `${n} B`;
+  const u = ["KiB", "MiB", "GiB", "TiB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < u.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(v < 10 ? 1 : 0)} ${u[i]}`;
+}
+
+export function fmtCores(c: number | null | undefined): string {
+  if (c == null) return "—";
+  return c < 1 ? `${Math.round(c * 1000)}m` : c.toFixed(2);
+}
+
+export function pct(
+  used: number | null | undefined,
+  cap: number | null | undefined,
+): number | null {
+  if (used == null || !cap) return null;
+  return Math.max(0, Math.min(100, (used / cap) * 100));
+}
+
+export function fmtAge(s: number | null | undefined): string {
+  if (s == null) return "—";
+  if (s < 3600) return `${Math.max(1, Math.floor(s / 60))}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h`;
+  return `${Math.floor(s / 86400)}d`;
+}
+
+export function usageColor(p: number | null): string {
+  if (p == null) return SLATE;
+  if (p < 60) return EMERALD;
+  if (p < 85) return AMBER;
+  return ROSE;
+}
+
+// ── live stream hook ─────────────────────────────────────────────────────────
+
+export function useClusterHealthStream() {
+  const [snapshot, setSnapshot] = useState<ClusterHealthSnapshot | null>(null);
+  const [history, setHistory] = useState<HistPoint[]>([]);
+  const [connected, setConnected] = useState(false);
+  const seq = useRef(0);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    let stopped = false;
+
+    const ingest = (snap: ClusterHealthSnapshot) => {
+      setSnapshot(snap);
+      if (snap.available) {
+        const cpu = pct(snap.cpu_usage_cores, snap.cpu_capacity_cores);
+        const mem = pct(
+          snap.memory_working_set_bytes,
+          snap.memory_capacity_bytes,
+        );
+        setHistory((prev) => {
+          const next = [...prev, { i: seq.current++, cpu, mem }];
+          return next.length > MAX_POINTS
+            ? next.slice(next.length - MAX_POINTS)
+            : next;
+        });
+      }
+    };
+
+    // Instant first paint while the SSE stream warms up.
+    applianceClusterApi
+      .health()
+      .then((s) => {
+        if (!stopped) ingest(s);
+      })
+      .catch(() => {
+        /* stream will deliver shortly */
+      });
+
+    const run = async () => {
+      while (!stopped) {
+        try {
+          for await (const snap of streamClusterHealth(ctrl.signal)) {
+            if (stopped) break;
+            setConnected(true);
+            ingest(snap);
+          }
+        } catch {
+          if (stopped) break;
+        }
+        setConnected(false);
+        if (stopped) break;
+        await new Promise((r) => setTimeout(r, 2000)); // backoff then reconnect
+      }
+    };
+    void run();
+
+    return () => {
+      stopped = true;
+      ctrl.abort();
+    };
+  }, []);
+
+  return { snapshot, history, connected };
+}

--- a/scripts/prune-release-assets.sh
+++ b/scripts/prune-release-assets.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Prune heavy appliance release assets with version-aware retention (#392).
+#
+# Every appliance release attaches ~4.6 GB of large binaries (a versioned
+# + a generic-named ISO, and a versioned + a generic-named slot .raw.xz,
+# plus tiny .sha256 sidecars). Nothing prunes them, so the Releases page
+# grows ~4.6 GB per cut. This script trims that in two tiers:
+#
+#   Tier 1 — on every NON-latest release, delete the generic-named
+#            duplicate assets:
+#              spatiumddi-appliance-amd64.iso
+#              spatiumddi-appliance-slot-amd64.raw.xz
+#              spatiumddi-appliance-slot-amd64.sha256
+#            They exist only to back the stable
+#            releases/latest/download/<name> URLs, which always resolve to
+#            the newest release — so on any older release they are pure
+#            duplication of the versioned copies. Safe to drop everywhere
+#            except the current latest.
+#
+#   Tier 2 — beyond the keep window (the KEEP_VERSIONED newest releases),
+#            also delete the heavy VERSIONED binaries:
+#              spatiumddi-appliance-<tag>.iso
+#              spatiumddi-appliance-slot-<tag>-amd64.raw.xz
+#            The versioned slot .sha256 provenance sidecar, the release,
+#            the tag, and the notes are ALWAYS kept — provenance is tiny
+#            and the binary can be rebuilt from the tag if ever needed.
+#
+# Also drops the stray mkosi-ImageVersion-named slot sha (e.g.
+# spatiumddi-appliance-slot-0.1.0.sha256) from every release — a
+# historical artefact of the pre-#392 release workflow (now fixed at
+# source in release.yml, but old releases still carry it).
+#
+# Version-aware honesty: the appliance OS-upgrade picker
+# (backend releases_service._pick_upgrade_assets) only offers a release
+# that still has BOTH a slot .raw.xz AND its .sha256. A Tier-2-pruned
+# release keeps only the .sha256, so _pick_upgrade_assets returns None and
+# the release auto-drops out of the picker — "Apply" never offers a dead
+# link. Keep KEEP_VERSIONED wide enough to cover the window of releases you
+# want operators to be able to pin / roll back / air-gap to.
+#
+# Deletes ASSETS only — never the release, tag, or notes.
+#
+# Env:
+#   REPO            owner/repo (default: $GITHUB_REPOSITORY)
+#   KEEP_VERSIONED  newest releases to keep versioned heavy assets on
+#                   (default: 15)
+#   DRY_RUN         "true" => log only, delete nothing (default: false)
+#   GH_TOKEN        token with contents:write (delete-asset)
+set -euo pipefail
+
+REPO="${REPO:-${GITHUB_REPOSITORY:?REPO or GITHUB_REPOSITORY required}}"
+KEEP_VERSIONED="${KEEP_VERSIONED:-15}"
+DRY_RUN="${DRY_RUN:-false}"
+# The just-cut tag, passed by release.yml's post-release prune step. Its
+# generic /latest/-backing assets are never pruned even if GitHub hasn't
+# propagated isLatest=true to it yet (the release-time race). Empty on the
+# scheduled run, which correctly keys "latest" off GitHub's isLatest.
+PROTECT_TAG="${PROTECT_TAG:-}"
+
+if ! [[ "$KEEP_VERSIONED" =~ ^[0-9]+$ ]] || [ "$KEEP_VERSIONED" -lt 1 ]; then
+    echo "ERROR: KEEP_VERSIONED must be a positive integer, got '${KEEP_VERSIONED}'" >&2
+    exit 2
+fi
+
+echo "→ Prune release assets on ${REPO}"
+echo "  keep newest ${KEEP_VERSIONED} releases' versioned heavy assets; dry_run=${DRY_RUN}"
+
+# Newest-first list of releases. ``--exclude-drafts``: drafts have no public
+# /latest/ URLs and must NOT consume keep-window index slots — a lingering
+# draft would shift a real release a slot earlier into the prune window.
+# ``isLatest`` marks the single release the /latest/ URLs resolve to (GitHub
+# computes it; not necessarily index 0 if a prerelease was cut afterwards).
+# Limit 1000 covers all foreseeable history. Capture into a var with an
+# explicit rc check so a gh auth/network/rate-limit failure FAILS LOUD
+# instead of looking like "no releases" (which would silently skip pruning).
+# TSV: "<tag>\t<isLatest>".
+if ! releases_tsv=$(
+    gh release list --repo "$REPO" --limit 1000 --exclude-drafts \
+        --json tagName,isLatest,createdAt \
+        -q 'sort_by(.createdAt) | reverse | .[] | [.tagName, (.isLatest|tostring)] | @tsv'
+); then
+    echo "ERROR: 'gh release list' failed (auth / network / rate-limit?)" >&2
+    exit 1
+fi
+if [ -z "$releases_tsv" ]; then
+    echo "  no releases found — nothing to do"
+    exit 0
+fi
+mapfile -t RELEASES <<<"$releases_tsv"
+
+deleted=0
+kept_releases=0
+
+del() {
+    # del <tag> <asset-name>
+    local tag="$1" asset="$2"
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "    [dry-run] would delete ${tag} :: ${asset}"
+        deleted=$((deleted + 1))
+        return
+    fi
+    if gh release delete-asset --repo "$REPO" "$tag" "$asset" --yes 2>/dev/null; then
+        echo "    deleted ${tag} :: ${asset}"
+        deleted=$((deleted + 1))
+    else
+        echo "    WARN: could not delete ${tag} :: ${asset} (already gone?)" >&2
+    fi
+}
+
+idx=0
+for line in "${RELEASES[@]}"; do
+    tag="${line%%$'\t'*}"
+    is_latest="${line##*$'\t'}"
+
+    # release-time race guard: the freshly-published tag IS (about to be)
+    # latest; treat it as latest regardless of isLatest propagation lag so
+    # its generic /latest/-backing assets are never Tier-1 pruned.
+    if [ -n "$PROTECT_TAG" ] && [ "$tag" = "$PROTECT_TAG" ]; then
+        is_latest="true"
+    fi
+
+    # Per-tag asset name conventions (must match release.yml's wrap-iso +
+    # build-slot-image steps).
+    generic_iso="spatiumddi-appliance-amd64.iso"
+    generic_xz="spatiumddi-appliance-slot-amd64.raw.xz"
+    generic_sha="spatiumddi-appliance-slot-amd64.sha256"
+    ver_iso="spatiumddi-appliance-${tag}.iso"
+    ver_xz="spatiumddi-appliance-slot-${tag}-amd64.raw.xz"
+    ver_sha="spatiumddi-appliance-slot-${tag}-amd64.sha256"
+
+    beyond_window="false"
+    [ "$idx" -ge "$KEEP_VERSIONED" ] && beyond_window="true"
+
+    mapfile -t ASSETS < <(
+        gh release view "$tag" --repo "$REPO" --json assets \
+            -q '.assets[].name' 2>/dev/null || true
+    )
+
+    if [ "$is_latest" = "true" ]; then
+        echo "  [${idx}] ${tag} — LATEST: keeping full asset set"
+    elif [ "$beyond_window" = "true" ]; then
+        echo "  [${idx}] ${tag} — beyond keep window: dropping generic + versioned heavy assets"
+    else
+        echo "  [${idx}] ${tag} — within window: dropping generic dupes only"
+    fi
+
+    for a in "${ASSETS[@]}"; do
+        case "$a" in
+            "$generic_iso" | "$generic_xz" | "$generic_sha")
+                # Tier 1 — generic dupes are dead weight on any non-latest.
+                [ "$is_latest" = "true" ] || del "$tag" "$a"
+                ;;
+            "$ver_iso" | "$ver_xz")
+                # Tier 2 — heavy versioned binaries beyond the keep window.
+                if [ "$beyond_window" = "true" ] && [ "$is_latest" != "true" ]; then
+                    del "$tag" "$a"
+                fi
+                ;;
+            "$ver_sha")
+                : # always keep the versioned provenance sidecar
+                ;;
+            spatiumddi-appliance-slot-*.sha256)
+                # Stray mkosi-ImageVersion sha (e.g. …-slot-0.1.0.sha256) —
+                # neither versioned nor generic. Junk on every release.
+                del "$tag" "$a"
+                ;;
+            *)
+                : # unknown / future asset — leave untouched
+                ;;
+        esac
+    done
+
+    idx=$((idx + 1))
+done
+
+kept_releases="${#RELEASES[@]}"
+echo "→ Done. Scanned ${kept_releases} releases; ${deleted} assets $([ "$DRY_RUN" = "true" ] && echo 'would be ' )pruned. All releases, tags, notes, and versioned .sha256 sidecars retained."

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -19,16 +19,33 @@ dynamic context block has real numbers to summarise. Sections:
 * Domains — corp.example.com (matches the DNS zone) + example.com
 * Custom fields — one IP-level + one subnet-level
 * IPAM templates — one block + one subnet template
+* IPAM NAT mappings — 1to1 / pat / hide examples
+* Multicast — PIM domain, multicast-kind subnet, group + ports + membership
+* Subnet plan — a draft planner workspace (not applied)
+* Network modeling — customers / sites / providers / circuits / services /
+  applications / SD-WAN overlays + overlay-sites + routing policies
+* DNS sub-resources — view, ACL, TSIG key, DNSSEC policy, GSLB pool,
+  blocklist + entry + exception, catalog-template zone
+* DHCP sub-resources — client class, static reservation, MAC blocklist,
+  option template, PXE profile, phone profile
+* Governance — custom role, sample group + non-admin user, time-bound
+  grant, scoped API token, custom conformity policy, webhook subscription
 * Alert rules — utilization, server-unreachable, domain-expiring
 * AI prompts — three shared triage prompts (issue #90 Phase 2)
 
 Every section is idempotent — the script swallows 409 from already-
 existing rows, and PATCHes spaces / blocks where the FK targets need
-to converge on a re-run after new entities exist.
+to converge on a re-run after new entities exist. A handful of
+endpoints have no uniqueness constraint (time-bound grants, API
+tokens, conformity policies, webhook subscriptions); those sections
+list-then-skip on a stable key so a re-run doesn't pile up duplicates.
 
-Out of scope: AI providers (secrets), webhooks (per-deployment URLs),
-audit-forward targets (per-deployment endpoints), API tokens
-(operator-scoped). Those need real creds from the operator.
+Out of scope: AI providers (secrets), audit-forward targets
+(per-deployment endpoints), and every read-only-pull integration
+target (Kubernetes / Docker / Proxmox / Tailscale / UniFi / OPNsense /
+Cloud) — those need real creds / live external systems. The webhook
+subscription seeded here points at a deliberately non-resolving host
+and ships disabled so the worker never attempts delivery.
 """
 
 from __future__ import annotations
@@ -170,42 +187,52 @@ def seed_dhcp_group(a: Api) -> str | None:
     return g["id"] if g else None
 
 
-def seed_dhcp_scope(a: Api, group_id: str | None, subnets: list[dict]):
+def seed_dhcp_scope(a: Api, group_id: str | None, subnets: list[dict]) -> str | None:
     """Wire a scope on the Servers subnet so the DHCP page isn't empty.
 
     The subnet has gateway + DDNS already inherited from the space; the
     scope just configures the lease window + a small dynamic pool.
+    Returns the scope id so the DHCP sub-resources section can attach
+    statics / phone-profile scope links to it.
     """
     if not group_id or not subnets:
-        return
+        return None
     target = find(subnets, "name", "Servers")
     if not target:
-        return
+        return None
     print("Creating DHCP scope + pool on Servers subnet…")
     scope = a.call(
         "POST",
         f"/api/v1/dhcp/subnets/{target['id']}/dhcp-scopes",
         json={
-            "server_group_id": group_id,
+            "group_id": group_id,
             "name": "Servers DHCP",
             "lease_time": 86400,
             "enabled": True,
             "ddns_enabled": True,
         },
     )
-    if scope and scope.get("id"):
+    scope_id = scope["id"] if scope and scope.get("id") else None
+    if scope_id is None:
+        # Re-run path: the scope already exists (409 swallowed above). Look
+        # it up so downstream sections still get an id to attach to.
+        scopes = a.call("GET", f"/api/v1/dhcp/server-groups/{group_id}/scopes") or []
+        existing = find(scopes, "name", "Servers DHCP")
+        scope_id = existing["id"] if existing else None
+    if scope_id:
         # Small dynamic pool so screenshots show "▼ start / ▲ end" rows
         # in the IPAM table.
         a.call(
             "POST",
-            f"/api/v1/dhcp/scopes/{scope['id']}/pools",
+            f"/api/v1/dhcp/scopes/{scope_id}/pools",
             json={
                 "name": "Default pool",
-                "start_address": "10.10.10.100",
-                "end_address": "10.10.10.149",
-                "kind": "dynamic",
+                "start_ip": "10.10.10.100",
+                "end_ip": "10.10.10.149",
+                "pool_type": "dynamic",
             },
         )
+    return scope_id
 
 
 # ── Section: ASNs + VRFs ──────────────────────────────────────────────────
@@ -642,10 +669,10 @@ def seed_ipam_templates(a: Api, dns_group_id: str | None, dhcp_group_id: str | N
         "ddns_enabled": True,
         "ddns_hostname_policy": "leave_unchanged",
         "child_layout": {
-            "subnets": [
-                {"prefix": "27", "name_template": "Staff-{n}", "description": ""},
-                {"prefix": "27", "name_template": "Phones-{n}", "description": ""},
-                {"prefix": "27", "name_template": "Servers-{n}", "description": ""},
+            "children": [
+                {"prefix": 27, "name_template": "Staff-{n}", "description": ""},
+                {"prefix": 27, "name_template": "Phones-{n}", "description": ""},
+                {"prefix": 27, "name_template": "Servers-{n}", "description": ""},
             ]
         },
     }
@@ -762,6 +789,981 @@ def seed_ai_prompts(a: Api):
         a.call("POST", "/api/v1/ai/prompts", json=body)
 
 
+# ── Section: IPAM NAT mappings ────────────────────────────────────────────
+
+
+def seed_nat_mappings(a: Api, subnets: list[dict]):
+    """Three NAT mappings — one of each kind (1to1 / pat / hide).
+
+    internal_ip / external_ip are plain strings; the handler auto-resolves
+    them to IPAM rows when they happen to match a seeded address. Each
+    mapping uses a distinct external_ip so the external-slot conflict
+    guard (409) never fires. The hide mapping needs a real Subnet id, so
+    it pins to the seeded Office-LAN subnet when present.
+    """
+    print("Creating NAT mappings…")
+    a.call(
+        "POST",
+        "/api/v1/ipam/nat-mappings",
+        json={
+            "name": "web01 public NAT",
+            "kind": "1to1",
+            "internal_ip": "10.10.10.20",
+            "external_ip": "203.0.113.10",
+            "protocol": "any",
+            "device_label": "edge-fw1",
+            "description": "1:1 NAT for the web server",
+        },
+    )
+    a.call(
+        "POST",
+        "/api/v1/ipam/nat-mappings",
+        json={
+            "name": "app-api 443->8443 PAT",
+            "kind": "pat",
+            "internal_ip": "10.10.10.30",
+            "internal_port_start": 8443,
+            "external_ip": "203.0.113.11",
+            "external_port_start": 443,
+            "protocol": "tcp",
+            "description": "Port-forward HTTPS to app-api",
+        },
+    )
+    office_lan = find(subnets, "name", "Office-LAN")
+    if office_lan:
+        a.call(
+            "POST",
+            "/api/v1/ipam/nat-mappings",
+            json={
+                "name": "Office-LAN hide NAT",
+                "kind": "hide",
+                "internal_subnet_id": office_lan["id"],
+                "external_ip": "203.0.113.1",
+                "protocol": "any",
+                "description": "Masquerade staff LAN behind the edge public IP",
+            },
+        )
+    else:
+        print("  · skipping hide-NAT (no Office-LAN subnet to pin internal_subnet_id)")
+
+
+# ── Section: Multicast ────────────────────────────────────────────────────
+
+
+def seed_multicast(
+    a: Api,
+    space_id: str | None,
+    subnets: list[dict],
+):
+    """PIM domain + multicast-kind subnet + group + ports + membership.
+
+    The whole /multicast surface is feature-module gated (network.multicast,
+    default-enabled) so a non-200 is tolerated. Subnet.kind is auto-detected
+    from the CIDR — a 224.0.0.0/4 network stores as kind='multicast', no
+    operator-settable field. The group create auto-creates its own enclosing
+    block, but we also seed a dedicated multicast subnet so the IPAM tree
+    renders the range like a real subnet.
+    """
+    if not space_id:
+        print("  · skipping multicast (no Corporate space id)")
+        return
+    print("Creating multicast domain + subnet + group…")
+
+    # PIM domain. pim_mode='ssm' needs no rendezvous point, so it's the
+    # zero-FK safe choice (sparse/bidir would 422 without an RP).
+    a.call(
+        "POST",
+        "/api/v1/multicast/domains",
+        json={
+            "name": "HQ PIM-SSM",
+            "description": "Headquarters source-specific multicast domain",
+            "pim_mode": "ssm",
+            "ssm_range": "232.0.0.0/8",
+            "notes": "",
+        },
+    )
+
+    # Multicast-range block (encloses 239.0.0.0/8) so the multicast subnet
+    # has a parent. _assert_no_overlap runs on both, so the ranges are
+    # picked to not collide with the unicast blocks/subnets.
+    a.call(
+        "POST",
+        "/api/v1/ipam/blocks",
+        json={
+            "space_id": space_id,
+            "name": "Multicast 239.0.0.0/8",
+            "network": "239.0.0.0/8",
+            "description": "Administratively-scoped multicast (RFC 2365)",
+        },
+    )
+    blocks = a.call("GET", f"/api/v1/ipam/blocks?space_id={space_id}") or []
+    mcast_block = find(blocks, "name", "Multicast 239.0.0.0/8")
+    if mcast_block:
+        a.call(
+            "POST",
+            "/api/v1/ipam/subnets",
+            json={
+                "space_id": space_id,
+                "block_id": mcast_block["id"],
+                "network": "239.10.0.0/24",
+                "name": "Video multicast",
+                "description": "Administratively-scoped multicast (RFC 2365)",
+            },
+        )
+
+    # Multicast group. Needs only space_id + address (in 224.0.0.0/4); the
+    # handler ensures an enclosing block exists on its own.
+    group = a.call(
+        "POST",
+        "/api/v1/multicast/groups",
+        json={
+            "space_id": space_id,
+            "address": "239.10.0.10",
+            "name": "IPTV-Channel-1",
+            "description": "Set-top-box video stream",
+            "application": "IPTV",
+            "rtp_payload_type": 33,
+        },
+    )
+    group_id = group["id"] if group and group.get("id") else None
+    if group_id is None:
+        # Re-run: resolve the group by address so ports / memberships still
+        # have a parent to attach to.
+        listed = (
+            a.call(
+                "GET",
+                f"/api/v1/multicast/groups?space_id={space_id}&search=239.10.0.10",
+            )
+            or {}
+        )
+        items = listed.get("items", []) if isinstance(listed, dict) else []
+        existing = find(items, "address", "239.10.0.10")
+        group_id = existing["id"] if existing else None
+
+    if not group_id:
+        print(
+            "  · multicast group unavailable (module disabled?); skipping ports + membership"
+        )
+        return
+
+    # RTP + RTCP port pair on the group.
+    a.call(
+        "POST",
+        f"/api/v1/multicast/groups/{group_id}/ports",
+        json={
+            "port_start": 5004,
+            "port_end": 5005,
+            "transport": "rtp",
+            "notes": "RTP + RTCP pair",
+        },
+    )
+
+    # Membership needs a real IPAM address id. Pull one from the Servers
+    # subnet (the seeder already allocated several IPs there).
+    servers = find(subnets, "name", "Servers")
+    addr_id = None
+    if servers:
+        addresses = (
+            a.call("GET", f"/api/v1/ipam/subnets/{servers['id']}/addresses") or []
+        )
+        allocated = next(
+            (
+                ip
+                for ip in addresses
+                if ip.get("status") == "allocated" and ip.get("id")
+            ),
+            None,
+        )
+        if allocated is None and addresses:
+            allocated = next((ip for ip in addresses if ip.get("id")), None)
+        addr_id = allocated["id"] if allocated else None
+    if addr_id:
+        a.call(
+            "POST",
+            f"/api/v1/multicast/groups/{group_id}/memberships",
+            json={
+                "ip_address_id": addr_id,
+                "role": "producer",
+                "seen_via": "manual",
+                "notes": "Encoder feeding the stream",
+            },
+        )
+    else:
+        print("  · skipping multicast membership (no allocated IP in Servers subnet)")
+
+
+# ── Section: Subnet plan ──────────────────────────────────────────────────
+
+
+def seed_subnet_plan(a: Api, space_id: str | None):
+    """A draft planner workspace. The tree is a draft only — it does NOT
+    materialise blocks/subnets until /apply (which the seeder never calls),
+    so it's safe demo data with no side effects.
+    """
+    if not space_id:
+        print("  · skipping subnet plan (no Corporate space id)")
+        return
+    print("Creating subnet plan (draft)…")
+    a.call(
+        "POST",
+        "/api/v1/ipam/plans",
+        json={
+            "name": "Branch office /24 carve",
+            "description": "Draft layout for a new branch — 2x /26",
+            "space_id": space_id,
+            "tree": {
+                "id": "root",
+                "network": "172.16.0.0/24",
+                "name": "Branch aggregate",
+                "kind": "block",
+                "children": [
+                    {
+                        "id": "n1",
+                        "network": "172.16.0.0/26",
+                        "name": "Staff",
+                        "kind": "subnet",
+                        "children": [],
+                    },
+                    {
+                        "id": "n2",
+                        "network": "172.16.0.64/26",
+                        "name": "Phones",
+                        "kind": "subnet",
+                        "children": [],
+                    },
+                ],
+            },
+        },
+    )
+
+
+# ── Section: Network modeling (ownership + circuits + services + overlays) ──
+
+
+def seed_customers(a: Api) -> dict[str, str]:
+    print("Creating customers…")
+    rows = [
+        {
+            "name": "Acme Corp",
+            "account_number": "ACME-001",
+            "contact_email": "netops@acme.example",
+            "status": "active",
+        },
+        {
+            "name": "Globex Retail",
+            "account_number": "GLBX-002",
+            "contact_email": "it@globex.example",
+            "status": "active",
+        },
+    ]
+    for body in rows:
+        a.call("POST", "/api/v1/customers", json=body)
+    listed = a.call("GET", "/api/v1/customers") or {}
+    items = listed.get("items", []) if isinstance(listed, dict) else listed
+    return {row["name"]: row["id"] for row in items if row.get("name")}
+
+
+def seed_sites(a: Api) -> dict[str, str]:
+    print("Creating sites…")
+    rows = [
+        {
+            "name": "HQ Datacenter",
+            "code": "HQ-DC1",
+            "kind": "datacenter",
+            "region": "us-east",
+        },
+        {
+            "name": "Branch — Austin",
+            "code": "BR-AUS",
+            "kind": "branch",
+            "region": "us-central",
+        },
+        {
+            "name": "Branch — Denver",
+            "code": "BR-DEN",
+            "kind": "branch",
+            "region": "us-west",
+        },
+    ]
+    for body in rows:
+        a.call("POST", "/api/v1/sites", json=body)
+    listed = a.call("GET", "/api/v1/sites") or {}
+    items = listed.get("items", []) if isinstance(listed, dict) else listed
+    return {row["name"]: row["id"] for row in items if row.get("name")}
+
+
+def seed_providers(a: Api, asns: dict[str, str]) -> dict[str, str]:
+    print("Creating providers…")
+    rows: list[dict] = [
+        {
+            "name": "Cogent Communications",
+            "kind": "transit",
+            "account_number": "CGT-99",
+            "contact_email": "noc@cogent.example",
+        },
+        {
+            "name": "Lumen Fiber",
+            "kind": "carrier",
+            "account_number": "LMN-44",
+            "contact_email": "noc@lumen.example",
+        },
+    ]
+    # Wire the Cogent provider to the seeded Cogent ASN when available.
+    if asns.get("Cogent"):
+        rows[0]["default_asn_id"] = asns["Cogent"]
+    for body in rows:
+        a.call("POST", "/api/v1/providers", json=body)
+    listed = a.call("GET", "/api/v1/providers") or {}
+    items = listed.get("items", []) if isinstance(listed, dict) else listed
+    return {row["name"]: row["id"] for row in items if row.get("name")}
+
+
+def seed_circuits(
+    a: Api,
+    providers: dict[str, str],
+    customers: dict[str, str],
+    sites: dict[str, str],
+    subnets: list[dict],
+) -> dict[str, str]:
+    """WAN circuits. provider_id is REQUIRED (RESTRICT); a/z-end sites are
+    wired to seeded sites so the topology + by-site views populate.
+    """
+    provider_id = providers.get("Cogent Communications")
+    if not provider_id:
+        print("  · skipping circuits (no provider id)")
+        return {}
+    print("Creating WAN circuits…")
+    hq = sites.get("HQ Datacenter")
+    aus = sites.get("Branch — Austin")
+    den = sites.get("Branch — Denver")
+    acme = customers.get("Acme Corp")
+    servers = find(subnets, "name", "Servers")
+    a_end_subnet = servers["id"] if servers else None
+
+    specs = [
+        {
+            "name": "HQ-Austin MPLS",
+            "ckt_id": "CKT-10042",
+            "transport_class": "mpls",
+            "bandwidth_mbps_down": 100,
+            "bandwidth_mbps_up": 100,
+            "a_end_site_id": hq,
+            "z_end_site_id": aus,
+        },
+        {
+            "name": "HQ-Denver MPLS",
+            "ckt_id": "CKT-10043",
+            "transport_class": "mpls",
+            "bandwidth_mbps_down": 100,
+            "bandwidth_mbps_up": 100,
+            "a_end_site_id": hq,
+            "z_end_site_id": den,
+        },
+        {
+            "name": "HQ Internet DIA",
+            "ckt_id": "CKT-20001",
+            "transport_class": "internet_broadband",
+            "bandwidth_mbps_down": 1000,
+            "bandwidth_mbps_up": 1000,
+            "a_end_site_id": hq,
+        },
+    ]
+    for spec in specs:
+        body: dict = {
+            "provider_id": provider_id,
+            "status": "active",
+            "currency": "USD",
+        }
+        body.update({k: v for k, v in spec.items() if v is not None})
+        if acme:
+            body["customer_id"] = acme
+        if a_end_subnet:
+            body["a_end_subnet_id"] = a_end_subnet
+        a.call("POST", "/api/v1/circuits", json=body)
+
+    listed = a.call("GET", "/api/v1/circuits") or {}
+    items = listed.get("items", []) if isinstance(listed, dict) else listed
+    return {row["name"]: row["id"] for row in items if row.get("name")}
+
+
+def seed_applications(a: Api):
+    """One custom application-category row. Builtins (office365, zoom,
+    microsoft_teams, …) are seeded at startup and already satisfy
+    routing-policy matches; this is demo flavour.
+    """
+    print("Creating custom application category…")
+    a.call(
+        "POST",
+        "/api/v1/applications",
+        json={
+            "name": "Acme ERP",  # normalised server-side to acme_erp
+            "description": "Acme internal ERP",
+            "category": "saas",
+            "default_dscp": 18,
+        },
+    )
+
+
+def seed_services(
+    a: Api,
+    customers: dict[str, str],
+    vrfs: dict[str, str],
+    sites: dict[str, str],
+    circuits: dict[str, str],
+    subnets: list[dict],
+):
+    """A custom-kind service with a few resources attached.
+
+    kind='custom' lets us attach several resource kinds freely (an
+    mpls_l3vpn enforces at-most-one-VRF). Each attach is idempotent —
+    re-attaching the same (kind, id) just updates the role.
+    """
+    customer_id = customers.get("Acme Corp")
+    if not customer_id:
+        print("  · skipping network service (no customer id)")
+        return
+    print("Creating network service + resource attaches…")
+    svc = a.call(
+        "POST",
+        "/api/v1/services",
+        json={
+            "name": "Acme Managed WAN",
+            "kind": "custom",
+            "customer_id": customer_id,
+            "status": "active",
+            "currency": "USD",
+        },
+    )
+    service_id = svc["id"] if svc and svc.get("id") else None
+    if service_id is None:
+        listed = a.call("GET", "/api/v1/services") or {}
+        items = listed.get("items", []) if isinstance(listed, dict) else listed
+        existing = find(items, "name", "Acme Managed WAN")
+        service_id = existing["id"] if existing else None
+    if not service_id:
+        print("  · service unavailable; skipping resource attaches")
+        return
+
+    attaches: list[dict] = []
+    if vrfs.get("default"):
+        attaches.append(
+            {"resource_kind": "vrf", "resource_id": vrfs["default"], "role": "core"}
+        )
+    for site_name in ("HQ Datacenter", "Branch — Austin"):
+        if sites.get(site_name):
+            attaches.append(
+                {
+                    "resource_kind": "site",
+                    "resource_id": sites[site_name],
+                    "role": "edge",
+                }
+            )
+    if circuits.get("HQ-Austin MPLS"):
+        attaches.append(
+            {
+                "resource_kind": "circuit",
+                "resource_id": circuits["HQ-Austin MPLS"],
+                "role": "edge",
+            }
+        )
+    servers = find(subnets, "name", "Servers")
+    if servers:
+        attaches.append(
+            {"resource_kind": "subnet", "resource_id": servers["id"], "role": "lan"}
+        )
+    for body in attaches:
+        a.call("POST", f"/api/v1/services/{service_id}/resources", json=body)
+
+
+def seed_overlays(
+    a: Api,
+    customers: dict[str, str],
+    sites: dict[str, str],
+    circuits: dict[str, str],
+):
+    """SD-WAN overlay + hub/spoke site membership + a routing policy.
+
+    To get topology EDGES, the hub + spokes share one MPLS circuit in
+    their preferred_circuits. The routing policy uses match_kind='dscp'
+    + mark_dscp so it needs no application-catalog or circuit FK.
+    """
+    print("Creating SD-WAN overlay + sites + policy…")
+    body: dict = {
+        "name": "Acme SD-WAN",
+        "kind": "sdwan",
+        "vendor": "cisco_meraki",
+        "default_path_strategy": "active_backup",
+        "status": "active",
+    }
+    if customers.get("Acme Corp"):
+        body["customer_id"] = customers["Acme Corp"]
+    ov = a.call("POST", "/api/v1/overlays", json=body)
+    overlay_id = ov["id"] if ov and ov.get("id") else None
+    if overlay_id is None:
+        listed = a.call("GET", "/api/v1/overlays") or {}
+        items = listed.get("items", []) if isinstance(listed, dict) else listed
+        existing = find(items, "name", "Acme SD-WAN")
+        overlay_id = existing["id"] if existing else None
+    if not overlay_id:
+        print("  · overlay unavailable; skipping sites + policy")
+        return
+
+    hub_circuit = circuits.get("HQ-Austin MPLS")
+    shared = [hub_circuit] if hub_circuit else []
+    members = [
+        ("HQ Datacenter", "hub"),
+        ("Branch — Austin", "spoke"),
+        ("Branch — Denver", "spoke"),
+    ]
+    for site_name, role in members:
+        site_id = sites.get(site_name)
+        if not site_id:
+            continue
+        site_body: dict = {"site_id": site_id, "role": role}
+        if shared:
+            site_body["preferred_circuits"] = shared
+        a.call("POST", f"/api/v1/overlays/{overlay_id}/sites", json=site_body)
+
+    a.call(
+        "POST",
+        f"/api/v1/overlays/{overlay_id}/policies",
+        json={
+            "name": "Mark EF for voice",
+            "priority": 100,
+            "match_kind": "dscp",
+            "match_value": "46",
+            "action": "mark_dscp",
+            "action_target": "46",
+            "enabled": True,
+        },
+    )
+
+
+# ── Section: DNS sub-resources ────────────────────────────────────────────
+
+
+def seed_dns_subresources(
+    a: Api,
+    dns_group_id: str | None,
+    dns_fwd_zone_id: str | None,
+):
+    """View, ACL, TSIG key, DNSSEC policy, GSLB pool, blocklist tree, and a
+    catalog-template zone. All persist without a live agent.
+    """
+    print("Creating DNS sub-resources…")
+
+    # DNSSEC policy is global (not group-scoped) — seed it regardless.
+    a.call(
+        "POST",
+        "/api/v1/dns/dnssec-policies",
+        json={
+            "name": "ecdsa-default",
+            "description": "ECDSA P-256, 90d ZSK rollover",
+            "algorithm": "ecdsap256sha256",
+            "ksk_lifetime_days": 0,
+            "zsk_lifetime_days": 90,
+            "nsec3": False,
+        },
+    )
+
+    # Manual blocklist + entry + exception (no group needed to create).
+    bl = a.call(
+        "POST",
+        "/api/v1/dns/blocklists",
+        json={
+            "name": "Corp custom blocks",
+            "description": "Manually-curated blocked domains",
+            "category": "custom",
+            "source_type": "manual",
+            "feed_format": "hosts",
+            "block_mode": "nxdomain",
+            "enabled": True,
+        },
+    )
+    list_id = bl["id"] if bl and bl.get("id") else None
+    if list_id is None:
+        lists = a.call("GET", "/api/v1/dns/blocklists") or []
+        existing = find(lists, "name", "Corp custom blocks")
+        list_id = existing["id"] if existing else None
+    if list_id:
+        a.call(
+            "POST",
+            f"/api/v1/dns/blocklists/{list_id}/entries",
+            json={
+                "domain": "ads.example-tracker.com",
+                "entry_type": "block",
+                "is_wildcard": True,
+                "reason": "ad/tracking",
+            },
+        )
+        a.call(
+            "POST",
+            f"/api/v1/dns/blocklists/{list_id}/exceptions",
+            json={"domain": "cdn.allowed-partner.com", "reason": "required CDN"},
+        )
+
+    if not dns_group_id:
+        print("  · skipping group-scoped DNS sub-resources (no DNS group id)")
+        return
+
+    # Split-horizon view.
+    a.call(
+        "POST",
+        f"/api/v1/dns/groups/{dns_group_id}/views",
+        json={
+            "name": "internal",
+            "description": "Internal split-horizon view",
+            "match_clients": ["10.0.0.0/8", "192.168.0.0/16"],
+            "recursion": True,
+            "order": 0,
+        },
+    )
+
+    # ACL.
+    a.call(
+        "POST",
+        f"/api/v1/dns/groups/{dns_group_id}/acls",
+        json={
+            "name": "trusted-internal",
+            "description": "RFC1918 trusted ranges",
+            "entries": [
+                {"value": "10.0.0.0/8", "negate": False, "order": 0},
+                {"value": "192.168.0.0/16", "negate": False, "order": 1},
+            ],
+        },
+    )
+
+    # TSIG key — omit 'secret' so the server generates one.
+    a.call(
+        "POST",
+        f"/api/v1/dns/groups/{dns_group_id}/tsig-keys",
+        json={
+            "name": "tsig-update.spatium.local.",
+            "algorithm": "hmac-sha256",
+            "notes": "DDNS update key",
+        },
+    )
+
+    # GSLB pool with two inline members on the forward zone.
+    if dns_fwd_zone_id:
+        a.call(
+            "POST",
+            f"/api/v1/dns/groups/{dns_group_id}/zones/{dns_fwd_zone_id}/pools",
+            json={
+                "name": "web-gslb",
+                "description": "Health-balanced web frontends",
+                "record_name": "app.corp.example.com.",
+                "record_type": "A",
+                "ttl": 30,
+                "hc_type": "tcp",
+                "hc_target_port": 443,
+                "members": [
+                    {"address": "10.10.10.20", "weight": 1, "enabled": True},
+                    {"address": "10.10.10.21", "weight": 1, "enabled": True},
+                ],
+            },
+        )
+
+    # Catalog-template zone — resolve a template with no required params so
+    # the seeder doesn't have to guess parameter values.
+    catalog = a.call("GET", "/api/v1/dns/zone-templates") or {}
+    templates = catalog.get("templates", []) if isinstance(catalog, dict) else []
+    chosen = None
+    for tmpl in templates:
+        params = tmpl.get("parameters", [])
+        if not any(p.get("required") for p in params):
+            chosen = tmpl
+            break
+    if chosen:
+        a.call(
+            "POST",
+            f"/api/v1/dns/groups/{dns_group_id}/zones/from-template",
+            json={
+                "template_id": chosen["id"],
+                "zone_name": "lab.corp.example.com",
+                "params": {},
+                "zone_type": "primary",
+                "kind": "forward",
+            },
+        )
+    else:
+        print("  · skipping template zone (no zero-required-param template in catalog)")
+
+
+# ── Section: DHCP sub-resources ───────────────────────────────────────────
+
+
+def seed_dhcp_subresources(a: Api, dhcp_group_id: str | None, scope_id: str | None):
+    """Client class, static reservation, MAC block, option template, PXE
+    profile, phone profile. All persist without a live Kea agent.
+    """
+    if not dhcp_group_id:
+        print("  · skipping DHCP sub-resources (no DHCP group id)")
+        return
+    print("Creating DHCP sub-resources…")
+
+    a.call(
+        "POST",
+        f"/api/v1/dhcp/server-groups/{dhcp_group_id}/client-classes",
+        json={
+            "name": "voip-phones",
+            "match_expression": "substring(option[60].hex,0,9) == 'PXEClient'",
+            "description": "Match VoIP vendor class",
+            "options": {},
+        },
+    )
+
+    a.call(
+        "POST",
+        f"/api/v1/dhcp/server-groups/{dhcp_group_id}/mac-blocks",
+        json={
+            "mac_address": "00:11:22:33:44:55",
+            "reason": "rogue",
+            "description": "Unauthorized AP",
+            "enabled": True,
+        },
+    )
+
+    a.call(
+        "POST",
+        f"/api/v1/dhcp/server-groups/{dhcp_group_id}/option-templates",
+        json={
+            "name": "Corp DNS+NTP",
+            "description": "Standard resolver + NTP options",
+            "address_family": "ipv4",
+            "options": {
+                "domain-name-servers": "10.10.10.20,10.10.10.21",
+                "ntp-servers": "10.10.10.5",
+            },
+        },
+    )
+
+    a.call(
+        "POST",
+        f"/api/v1/dhcp/server-groups/{dhcp_group_id}/pxe-profiles",
+        json={
+            "name": "netboot-bios+ipxe",
+            "description": "BIOS PXE + iPXE chainload",
+            "next_server": "10.10.10.5",
+            "enabled": True,
+            "matches": [
+                {
+                    "priority": 100,
+                    "match_kind": "first_stage",
+                    "arch_codes": [0],
+                    "boot_filename": "undionly.kpxe",
+                },
+                {
+                    "priority": 50,
+                    "match_kind": "ipxe_chain",
+                    "boot_filename": "http://10.10.10.5/boot.ipxe",
+                },
+            ],
+        },
+    )
+
+    phone_body: dict = {
+        "name": "polycom-voip",
+        "description": "Polycom TFTP provisioning",
+        "enabled": True,
+        "vendor": "Polycom",
+        "vendor_class_match": "Polycom",
+        "option_set": [{"code": 66, "value": "10.10.10.5"}],
+        "scope_ids": [scope_id] if scope_id else [],
+    }
+    a.call(
+        "POST",
+        f"/api/v1/dhcp/server-groups/{dhcp_group_id}/phone-profiles",
+        json=phone_body,
+    )
+
+    # Static reservation needs a scope. The IP must be OUTSIDE the seeded
+    # dynamic pool (10.10.10.100-149) so the in-pool conflict guard (409)
+    # doesn't fire — .50 is clear.
+    if scope_id:
+        a.call(
+            "POST",
+            f"/api/v1/dhcp/scopes/{scope_id}/statics",
+            json={
+                "ip_address": "10.10.10.50",
+                "mac_address": "52:54:00:ab:cd:ef",
+                "hostname": "printer-lobby",
+                "description": "Reserved lobby printer",
+            },
+        )
+    else:
+        print("  · skipping DHCP static (no Servers DHCP scope id)")
+
+
+# ── Section: Governance (RBAC sample + tokens + conformity + webhooks) ─────
+
+
+def seed_rbac_sample(a: Api):
+    """A custom role + non-admin user + group binding them, plus a
+    time-bound grant on the group. Ordered role → user → group so the
+    group's role_ids / user_ids resolve on first POST.
+    """
+    print("Creating sample RBAC role + user + group…")
+
+    a.call(
+        "POST",
+        "/api/v1/roles",
+        json={
+            "name": "Helpdesk (read-only IPAM+DNS)",
+            "description": "Demo delegated role: read-only on IPAM and DNS",
+            "permissions": [
+                {"action": "read", "resource_type": "ipam"},
+                {"action": "read", "resource_type": "dns"},
+            ],
+        },
+    )
+    roles = a.call("GET", "/api/v1/roles") or []
+    role = find(roles, "name", "Helpdesk (read-only IPAM+DNS)")
+    role_id = role["id"] if role else None
+
+    a.call(
+        "POST",
+        "/api/v1/users",
+        json={
+            "username": "helpdesk-demo",
+            "email": "helpdesk-demo@corp.example.com",
+            "display_name": "Helpdesk Demo",
+            "password": "DemoPassw0rd!",
+            "is_superadmin": False,
+            "force_password_change": True,
+        },
+    )
+    users = a.call("GET", "/api/v1/users") or []
+    user = find(users, "username", "helpdesk-demo")
+    user_id = user["id"] if user else None
+
+    group_body: dict = {
+        "name": "Helpdesk",
+        "description": "Demo group — delegated read-only operators",
+        "auth_source": "local",
+        "role_ids": [role_id] if role_id else [],
+        "user_ids": [user_id] if user_id else [],
+    }
+    a.call("POST", "/api/v1/groups", json=group_body)
+    groups = a.call("GET", "/api/v1/groups") or []
+    group = find(groups, "name", "Helpdesk")
+    group_id = group["id"] if group else None
+
+    if not group_id:
+        print("  · skipping time-bound grant (no Helpdesk group id)")
+        return
+
+    # Time-bound grant — NOT idempotent (no unique constraint), so list-then-
+    # skip on a stable (action, resource_type) key to avoid pile-up on re-run.
+    existing_grants = (
+        a.call("GET", f"/api/v1/groups/time-bound-grants?group_id={group_id}") or []
+    )
+    already = any(
+        g.get("action") == "write" and g.get("resource_type") == "dhcp"
+        for g in existing_grants
+    )
+    if already:
+        print("  · time-bound grant already present; skipping")
+    else:
+        a.call(
+            "POST",
+            "/api/v1/groups/time-bound-grants",
+            json={
+                "group_id": group_id,
+                "action": "write",
+                "resource_type": "dhcp",
+                "expires_at": "2030-01-01T00:00:00Z",
+                "reason": "Demo: temporary DHCP write for on-call",
+            },
+        )
+
+
+def seed_api_token(a: Api):
+    """A read-only scoped API token. NOT idempotent (no unique name) — guard
+    via list-then-skip. The raw token is returned once; we discard it (a
+    seeded demo token is never used for real automation).
+    """
+    print("Creating scoped API token…")
+    existing = a.call("GET", "/api/v1/api-tokens") or []
+    if find(existing, "name", "Ansible inventory (read-only)"):
+        print("  · API token already present; skipping")
+        return
+    a.call(
+        "POST",
+        "/api/v1/api-tokens",
+        json={
+            "name": "Ansible inventory (read-only)",
+            "description": "Demo automation token — read scope only",
+            "expires_in_days": 365,
+            "scopes": ["read"],
+            "resource_grants": [],
+        },
+    )
+
+
+def seed_conformity_policy(a: Api):
+    """A custom conformity policy. Gated behind compliance.conformity
+    (default-enabled) — tolerate a 404 if the module is off. NOT idempotent
+    (no unique name) — guard via list-then-skip. Seeded disabled so the beat
+    engine doesn't immediately evaluate it.
+    """
+    print("Creating custom conformity policy…")
+    listed = a.call("GET", "/api/v1/conformity/policies")
+    if listed is None:
+        # Module likely disabled (404) or another non-200 — skip cleanly.
+        print("  · conformity unavailable (module disabled?); skipping")
+        return
+    if find(listed, "name", "Every subnet has an owner field"):
+        print("  · conformity policy already present; skipping")
+        return
+    a.call(
+        "POST",
+        "/api/v1/conformity/policies",
+        json={
+            "name": "Every subnet has an owner field",
+            "description": "Demo custom policy: subnets must set the 'owner' custom field",
+            "framework": "custom",
+            "severity": "warning",
+            "target_kind": "subnet",
+            "target_filter": {},
+            "check_kind": "has_field",
+            "check_args": {"field": "owner"},
+            "enabled": False,
+            "eval_interval_hours": 24,
+        },
+    )
+
+
+def seed_webhook(a: Api):
+    """A typed-event webhook subscription pointed at a non-resolving host,
+    shipped disabled so the worker never attempts delivery. NOT idempotent
+    (no unique name) — guard via list-then-skip. Blocked in DEMO_MODE (403),
+    which the Api wrapper logs and continues past.
+    """
+    print("Creating webhook subscription (disabled)…")
+    existing = a.call("GET", "/api/v1/webhooks")
+    if existing is None:
+        # 403 in DEMO_MODE or another non-200 — skip cleanly.
+        print("  · webhooks unavailable (demo mode?); skipping")
+        return
+    if find(existing, "name", "Demo SIEM forwarder"):
+        print("  · webhook subscription already present; skipping")
+        return
+    a.call(
+        "POST",
+        "/api/v1/webhooks",
+        json={
+            "name": "Demo SIEM forwarder",
+            "description": "Demo typed-event subscription (no live receiver)",
+            "enabled": False,
+            "url": "https://example.invalid/spatiumddi-hook",
+            "event_types": ["subnet.created", "dns.zone.created"],
+            "timeout_seconds": 10,
+            "max_attempts": 8,
+        },
+    )
+
+
 # ── Driver ────────────────────────────────────────────────────────────────
 
 
@@ -788,7 +1790,7 @@ def main(base: str, user: str, pw: str):
         asns=asns,
     )
     seed_addresses(a, subnets)
-    seed_dhcp_scope(a, dhcp_group_id, subnets)
+    dhcp_scope_id = seed_dhcp_scope(a, dhcp_group_id, subnets)
 
     seed_network_devices(a, space_id)
     seed_legacy_vlans(a)
@@ -796,6 +1798,35 @@ def main(base: str, user: str, pw: str):
     seed_domains(a)
     seed_custom_fields(a)
     seed_ipam_templates(a, dns_group_id, dhcp_group_id)
+
+    # IPAM extras — NAT mappings reference seeded subnets/IPs; multicast +
+    # subnet plan need the Corporate space id; multicast membership needs
+    # an allocated IP in the Servers subnet (already seeded above).
+    seed_nat_mappings(a, subnets)
+    seed_multicast(a, space_id, subnets)
+    seed_subnet_plan(a, space_id)
+
+    # Network modeling — ownership entities first (providers need ASNs;
+    # circuits need a provider; services need a customer; overlays + service
+    # attaches reference circuits / sites / vrfs / subnets).
+    customers = seed_customers(a)
+    sites = seed_sites(a)
+    providers = seed_providers(a, asns)
+    circuits = seed_circuits(a, providers, customers, sites, subnets)
+    seed_applications(a)
+    seed_services(a, customers, vrfs, sites, circuits, subnets)
+    seed_overlays(a, customers, sites, circuits)
+
+    # DNS + DHCP sub-resources — both persist without a live agent.
+    seed_dns_subresources(a, dns_group_id, dns_fwd_zone_id)
+    seed_dhcp_subresources(a, dhcp_group_id, dhcp_scope_id)
+
+    # Governance + admin data.
+    seed_rbac_sample(a)
+    seed_api_token(a)
+    seed_conformity_policy(a)
+    seed_webhook(a)
+
     seed_alert_rules(a)
     seed_ai_prompts(a)
 


### PR DESCRIPTION
## Summary

Appliance polish + ops — four issues plus a Cluster-dashboard redesign, a demo-seeder refresh, and a CodeQL fix. No schema changes.

- **#416 — browser Cluster console.** The appliance's TTY dashboard reproduced in the web UI and merged into **Cluster → Overview**: an identity ribbon (role / host / version / A-B slot / pairing / supervisor health), live node + workload health + charts, and a **workload** log tail — the operator picks a deployment/daemonset and the backend resolves it to the current pod, so it survives pod rolls and never shows churny pod names. Backed by a new `self_appliance` block on `GET /appliance/info` (a pure DB read — the api never touches host journald/files). Reproduced in React, **not** a PTY bridge, so it re-exposes no shell/root surface; the standalone TTY `spatium-console` is unchanged.
- **#415 — OS-upgrade image upload failed with Permission denied on k3s.** `spatiumddi-firstboot` now creates + owns `/var/lib/spatiumddi/slot-images` (1000:1000, 0700); the api container pins its runtime uid; the doubled `.raw.raw.xz` temp-file suffix is fixed.
- **#392 — version-aware release-asset retention.** A post-release prune step + a weekly scheduled workflow trim the heavy appliance binaries (generic dupes off every non-latest release; versioned `.iso` + slot `.raw.xz` beyond a keep window of 15). Release / tag / notes / versioned `.sha256` are always kept, and the freshly-cut release is guarded against `isLatest` propagation races so its `/latest/` URLs never break. The stray `slot-0.1.0.sha256` source name is fixed.
- **#417 — frontend build moves to Node 22** (Node 20 EOL; Vite 8 prefers 22.12+). Build-time only.

Also in this PR:
- Cluster **"Pods" KPI excludes completed Jobs** — a healthy box reads `10/10` (+ "N completed") instead of an alarming `10/14`.
- `scripts/seed_demo.py` catches up to the data model — **17 new resource families** (NAT, multicast, ownership, circuits, services, overlays, DNS/DHCP sub-resources, RBAC sample, conformity, webhook).
- **CodeQL alert #68** (`py/stack-trace-exposure`) on the cluster-health endpoints — raw kubeapi exception text no longer reaches the client.
- Appliance README **"Why k3s, not Docker Compose?"** rationale + main-README cross-link.

## Test plan

- Local CI-equivalent green: ruff / black / mypy (564 files) / eslint `--max-warnings 0` / tsc / vite build / migration-shape linter / shellcheck; `resolve_workload_pod` + slot-image-suffix regression tests pass.
- Deployed api + frontend to a live single-node k3s appliance: slot-image upload succeeds (dir now `1000:1000`), merged Cluster dashboard renders, the workload log tail streams and survives a pod roll, the Pods KPI reads `10/10`.

Closes #392, Closes #415, Closes #416, Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)