### PR TITLE
fix(appliance): gate slot-upgrade re-fire nonce on supervisor version (#419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@ the formatter handles the rest.
 
 ---
 
+## Unreleased
+
+Batched fixes for the next cut (not yet released).
+
+### Fixed
+
+* **#419 — slot-upgrade wedged at "in-flight" on pre-2026.06.12
+  appliances.** The control plane appends a per-apply re-fire nonce to the
+  slot-image URL as a ``#fragment``; the host runner only strips that
+  fragment before fetching as of #386 (2026-06-12), so an appliance on an
+  older supervisor handed the fragment straight to the downloader and the
+  apply hung at "in-flight" forever. The nonce is now gated on the target
+  supervisor's reported version — pre-2026.06.12 and unknown supervisors
+  get a clean URL their runner can fetch, while current ones keep the
+  nonce for same-image re-fire. (Recover an already-stuck box on the host
+  with ``spatium-upgrade-slot apply <url> --checksum <url>`` then reboot.)
+
+---
+
 ## 2026.06.14-1 — 2026-06-14
 
 An **appliance polish + ops** release rolling up four issues (#392 /

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -138,6 +138,28 @@ _HOST_ROLE_CONFIG = Path("/etc/spatiumddi-host/role-config")
 _SELF_BOOTSTRAP_VARIANTS = frozenset({"control-plane", "full-stack", "frontend-core"})
 _SELF_BOOTSTRAP_CODE_TTL = timedelta(minutes=10)
 
+# The slot-upgrade host runner only strips a URL ``#fragment`` before
+# fetching as of #386 (shipped 2026-06-12). An appliance on an older
+# supervisor hands the fragment straight to the downloader and the apply
+# wedges at "in-flight" forever (#419). Gate the re-fire nonce on the
+# target supervisor's reported version so older fleets get a clean URL.
+_URL_FRAGMENT_STRIP_MIN_VERSION = "2026.06.12"
+
+
+def _supervisor_strips_url_fragment(row: Appliance) -> bool:
+    """True if the appliance's supervisor / slot-upgrade runner strips a URL
+    ``#fragment`` before fetching (≥ 2026.06.12, i.e. has the #386 strip).
+
+    CalVer (``YYYY.MM.DD-N``) sorts lexicographically, so a string compare is
+    correct. A dev / unknown / pre-CalVer version stays on the safe clean-URL
+    path — losing only auto-re-fire of the *same* image (a new version already
+    changes the URL), never the ability to upgrade (#419)."""
+    ver = row.supervisor_version or row.installed_appliance_version or ""
+    return (
+        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None
+        and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
+    )
+
 
 def _read_host_role() -> str | None:
     """Parse ``ROLE=`` out of ``/etc/spatiumddi-host/role-config``.
@@ -4451,15 +4473,19 @@ async def schedule_appliance_upgrade(
         resolved_url = body.desired_slot_image_url
 
     # Issue #386 Part B — append a per-apply nonce as a URL *fragment* so
-    # each schedule yields a distinct ``desired_slot_image_url``. The
-    # supervisor fires the slot-upgrade trigger exactly once per distinct
-    # URL (no silent re-fire loop on a failed apply); a fresh apply of the
-    # same image re-fires because the fragment differs. Fragments are
-    # client-side only — the host runner strips it before fetching and
-    # HTTP never sends it — so it's safe to graft onto any URL, including
-    # query-signed ones.
-    nonce = uuid.uuid4().hex[:12]
-    resolved_url = f"{resolved_url}#a={nonce}"
+    # each schedule yields a distinct ``desired_slot_image_url`` and the
+    # supervisor re-fires the trigger on a fresh apply of the same image
+    # (it fires once per distinct URL — no silent re-fire loop on failure).
+    # The host runner strips the fragment before fetching, but only since
+    # #386 (2026-06-12); an older appliance passes it straight to the
+    # downloader and the apply wedges at "in-flight" forever (#419). So only
+    # add the nonce when the target supervisor is known to strip it — older
+    # / unknown supervisors get a clean URL (a new version already changes
+    # the URL, so re-fire still works; only re-applying the *same* version
+    # loses auto-re-fire on those boxes).
+    if _supervisor_strips_url_fragment(row):
+        nonce = uuid.uuid4().hex[:12]
+        resolved_url = f"{resolved_url}#a={nonce}"
 
     row.desired_appliance_version = body.desired_appliance_version
     row.desired_slot_image_url = resolved_url

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -156,8 +156,7 @@ def _supervisor_strips_url_fragment(row: Appliance) -> bool:
     changes the URL), never the ability to upgrade (#419)."""
     ver = row.supervisor_version or row.installed_appliance_version or ""
     return (
-        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None
-        and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
+        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
     )
 
 

--- a/backend/tests/test_appliance_upgrade_url_gate.py
+++ b/backend/tests/test_appliance_upgrade_url_gate.py
@@ -1,0 +1,52 @@
+"""Slot-image URL re-fire-nonce version gate (#419).
+
+The control plane appends a per-apply nonce as a URL ``#fragment`` so a fresh
+apply of the same image re-fires the supervisor trigger. The host runner only
+strips that fragment before fetching as of #386 (2026-06-12); an older
+appliance hands it straight to the downloader and the apply wedges at
+"in-flight" forever. ``_supervisor_strips_url_fragment`` gates the nonce so
+only known-capable supervisors get it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.v1.appliance import supervisor as sup
+
+
+@pytest.mark.parametrize(
+    ("supervisor_version", "installed_version", "expected"),
+    [
+        # ≥ 2026.06.12 strips the fragment → nonce is safe.
+        ("2026.06.13-2", None, True),
+        ("2026.06.12-1", None, True),
+        ("2026.06.12", None, True),  # exactly the threshold
+        ("2026.07.01-1", None, True),
+        ("2027.01.01-1", None, True),
+        # Pre-2026.06.12 does NOT strip → must get a clean URL.
+        ("2026.06.11-1", None, False),  # Nuvopact's box
+        ("2026.05.30-1", None, False),
+        ("2025.12.31-9", None, False),
+        # Falls back to installed_appliance_version when supervisor_version
+        # is absent (older heartbeats).
+        (None, "2026.06.14-1", True),
+        (None, "2026.06.11-1", False),
+        # Unknown / dev / empty → safe clean-URL path.
+        (None, None, False),
+        ("dev-abc1234", None, False),
+        ("", "", False),
+    ],
+)
+def test_supervisor_strips_url_fragment(
+    supervisor_version: str | None,
+    installed_version: str | None,
+    expected: bool,
+) -> None:
+    row = SimpleNamespace(
+        supervisor_version=supervisor_version,
+        installed_appliance_version=installed_version,
+    )
+    assert sup._supervisor_strips_url_fragment(row) is expected  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Fixes the **root cause** of #419 — a fleet/UI-scheduled slot upgrade wedging at `in-flight` forever on appliances running a pre-2026.06.12 supervisor.

The control plane appends a per-apply re-fire nonce to the slot-image URL as a `#fragment` (#386 Part B), so re-applying the *same* image re-fires the supervisor trigger. The host runner only learned to **strip** that fragment before fetching in #386 (2026-06-12) — the day after the `2026.06.11-1` tag. An older runner hands the fragmented URL (`…raw.xz#a=<nonce>`) straight to the downloader and the apply never completes.

**Field-confirmed** (Nuvopact, #419): the trigger fired, `.state` stuck at `in-flight` since Jun 12, `slot-upgrade.log`/journal empty (rotated), and a manual **clean-URL** `spatium-upgrade-slot apply` worked perfectly → the fragment is the differentiator.

## The fix

`_supervisor_strips_url_fragment(row)` gates the nonce on the target supervisor's reported version (`supervisor_version` / `installed_appliance_version`, CalVer sorts lexicographically): append `#a=<nonce>` only when **≥ 2026.06.12**. Older / unknown supervisors get a **clean URL** their runner can fetch; current ones keep the nonce for same-image re-fire.

- Upgrading to a *new* version already changes the URL, so cross-version re-fire is unaffected on every fleet.
- Only re-applying the *exact same* version on a pre-2026.06.12 box loses auto-re-fire — an acceptable trade vs. a wedged upgrade.
- Unblocks auto-upgrade for the **already-deployed** pre-2026.06.12 fleet (the only path that can help boxes whose supervisor code is already fixed).

## Not in this PR (tracked in #419)

The **stale-`in-flight` recovery** — a runner that dies mid-apply leaves a permanent `in-flight` that never surfaces as failed — is a supervisor-side robustness follow-up and stays open in #419. (2026.06.14-1 already made the UI honest about a supervisor too old to report progress, which covers the *display* side of the field report.)

## Test plan

- `backend/tests/test_appliance_upgrade_url_gate.py` — 13 cases over the version gate (≥/< 2026.06.12, installed-version fallback, dev/unknown/empty → clean URL). All pass.
- ruff / black / mypy clean on the changed files.
- No schema changes.

Refs #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)