### PR TITLE
test(appliance): fix red main — align upgrade-download tests with #419 nonce gate

### DIFF
--- a/backend/tests/test_appliance_upgrade_download.py
+++ b/backend/tests/test_appliance_upgrade_download.py
@@ -57,7 +57,11 @@ async def _seed_appliance(db: AsyncSession) -> Appliance:
         public_key_fingerprint="ff" * 32,
         cert_serial="0000",
         deployment_kind="appliance",
-        installed_appliance_version="2026.06.11-1",
+        # The fire-once nonce fragment is gated on a supervisor new enough to
+        # strip it before fetching (#419 / >= 2026.06.12). These tests assert
+        # the nonce IS appended, so the fixture must present a capable box.
+        supervisor_version="2026.06.13-2",
+        installed_appliance_version="2026.06.13-2",
     )
     db.add(appliance)
     await db.flush()


### PR DESCRIPTION
## Why

PR #420 merged to main with Backend Tests failing — the merge watch reported *completion*, not *pass*, and the broken commit (e11a600) landed. This fixes main forward.

## The break

#420 gated the slot-upgrade re-fire nonce on a supervisor new enough to strip the URL `#fragment` (`>= 2026.06.12`, the #419 fix). The pre-existing `test_appliance_upgrade_download.py` fixture seeded the appliance at `installed_appliance_version="2026.06.11-1"` — below the threshold — so the gate now (correctly) returns a clean nonce-free URL, breaking three assertions:

- `test_apply_internal_image_stamps_sha256_and_insecure` — `assert "#a=" in url`
- `test_apply_mints_unique_nonce_each_time` — `assert u1 != u2`
- `test_apply_external_url_stays_verified` — `assert "#a=" in body["desired_slot_image_url"]`

## The fix

These tests exercise nonce behaviour, which legitimately now requires a fragment-stripping-capable supervisor. The fixture is bumped to present one (`supervisor_version` + `installed_appliance_version` both `2026.06.13-2`). One file, +5/-1. The version-gate logic itself stays independently covered by `test_appliance_upgrade_url_gate.py`.

Verified locally: 17 passed (both `test_appliance_upgrade_download.py` + `test_appliance_upgrade_url_gate.py`), ruff + black clean.