### PR TITLE
fix(dns): #424 — SRV weight/port in the UI + per-type structured-field rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,27 @@ Batched fixes for the next cut (not yet released).
 
 ### Fixed
 
+* **#424 — couldn't define SRV records in the UI; MX priority could be
+  NULL.** The Add/Edit DNS Record form only exposed a Priority field, so
+  SRV records were created with NULL ``weight`` and ``port`` — and every
+  driver (bind9 / powerdns / windows) substitutes ``0`` for a NULL,
+  rendering a meaningless ``priority 0 0 target``. The form now shows
+  Priority + Weight + Port for SRV (all required) and a clean
+  Priority-only field for MX, and every record type gained a wire-format
+  placeholder for its Value (CAA / NAPTR / SSHFP / TLSA / LOC / SVCB /
+  HTTPS show the expected RDATA shape). The API enforces the per-type
+  rules server-side: SRV requires priority + weight + port, MX takes only
+  a priority and defaults it to 10 (no more NULL MX priority), and every
+  other type rejects stray priority/weight/port with a 422. A one-shot data
+  migration backfills existing rows the old UI left NULL (SRV
+  priority/weight/port → 0, MX priority → 10 — the values the drivers
+  already substitute, so wire output is unchanged) so those rows stay
+  editable under the new validation. The Operator Copilot's
+  ``create_dns_record`` proposal gained ``weight`` + ``port`` so the
+  assistant can create valid SRV records too — and now correctly enqueues a
+  record op so a Copilot-created record actually propagates to the agents
+  (previously it landed in the DB but was never pushed).
+
 * **#419 — slot-upgrade wedged at "in-flight" on pre-2026.06.12
   appliances.** The control plane appends a per-apply re-fire nonce to the
   slot-image URL as a ``#fragment``; the host runner only strips that

--- a/backend/alembic/versions/f4a1c8e92b07_backfill_srv_mx_struct_fields.py
+++ b/backend/alembic/versions/f4a1c8e92b07_backfill_srv_mx_struct_fields.py
@@ -1,0 +1,55 @@
+"""#424 — backfill SRV/MX structured fields that the old UI left NULL
+
+Before #424 the Add/Edit Record form couldn't set an SRV's weight/port (and
+could leave an MX priority NULL), so existing rows carry NULLs that every
+driver silently renders as 0 (SRV) / 10 (MX). #424 now *requires* those
+fields on create and validates the merged row on update — which would make a
+pre-existing NULL-weight SRV un-editable (any edit 422s "SRV records require
+weight, port"). This one-shot data migration backfills those rows to the
+exact values the drivers already substitute, so:
+
+  * the rendered wire output is unchanged (bind9/powerdns/windows all map a
+    NULL SRV field → 0 and a NULL MX priority → 10 today), and
+  * post-upgrade edits validate instead of 422-ing.
+
+Data-only; the downgrade is a no-op (a backfilled 0/10 is indistinguishable
+from an operator-set 0/10, so there is nothing safe to revert).
+
+Revision ID: f4a1c8e92b07
+Revises: c5f1a2b3d4e6
+Create Date: 2026-06-14
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "f4a1c8e92b07"
+down_revision = "c5f1a2b3d4e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # SRV uses priority + weight + port; a NULL renders as 0.
+    op.execute("""
+        UPDATE dns_record
+           SET priority = COALESCE(priority, 0),
+               weight   = COALESCE(weight, 0),
+               port     = COALESCE(port, 0)
+         WHERE record_type = 'SRV'
+           AND (priority IS NULL OR weight IS NULL OR port IS NULL)
+        """)
+    # MX uses priority (the preference); a NULL renders as 10.
+    op.execute("""
+        UPDATE dns_record
+           SET priority = 10
+         WHERE record_type = 'MX'
+           AND priority IS NULL
+        """)
+
+
+def downgrade() -> None:
+    # No-op: a backfilled 0/10 can't be told apart from an operator-set
+    # value, so there is nothing safe to undo.
+    pass

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -853,6 +853,80 @@ class RecordResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+def _normalize_record_struct_fields(
+    record_type: str,
+    priority: int | None,
+    weight: int | None,
+    port: int | None,
+) -> tuple[int | None, int | None, int | None]:
+    """Enforce per-type rules for the structured columns and return the
+    normalized ``(priority, weight, port)`` (#424).
+
+    These three columns are the source of truth — every driver
+    (bind9 / powerdns / windows) stitches them into the wire format and
+    silently substitutes ``0`` for a NULL. So a NULL weight/port on an
+    SRV renders as a meaningless ``prio 0 0 target``; the UI bug that
+    left them unset is what this guards against.
+
+    - **SRV** uses all three (RFC 2782 ``priority weight port target``);
+      all are required.
+    - **MX** uses ``priority`` (the preference); defaults to ``10`` when
+      omitted so the column is never NULL. Weight/port are not part of an
+      MX record.
+    - Every other type carries none of the three.
+
+    Raises ``HTTPException(422)`` on a type/field mismatch or out-of-range
+    value.
+    """
+    rtype = record_type.upper()
+
+    def _check_range(label: str, v: int | None) -> None:
+        if v is not None and not 0 <= v <= 65535:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{label} must be between 0 and 65535",
+            )
+
+    if rtype == "SRV":
+        missing = [
+            n for n, v in (("priority", priority), ("weight", weight), ("port", port)) if v is None
+        ]
+        if missing:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "SRV records require "
+                    + ", ".join(missing)
+                    + " (an SRV is priority + weight + port + target)"
+                ),
+            )
+        _check_range("priority", priority)
+        _check_range("weight", weight)
+        _check_range("port", port)
+        return priority, weight, port
+
+    if rtype == "MX":
+        extra = [n for n, v in (("weight", weight), ("port", port)) if v is not None]
+        if extra:
+            raise HTTPException(
+                status_code=422,
+                detail=f"MX records take only a priority, not {', '.join(extra)}",
+            )
+        prio = priority if priority is not None else 10
+        _check_range("priority", prio)
+        return prio, None, None
+
+    extra = [
+        n for n, v in (("priority", priority), ("weight", weight), ("port", port)) if v is not None
+    ]
+    if extra:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{rtype} records do not take {', '.join(extra)}",
+        )
+    return None, None, None
+
+
 # ── Server Group endpoints ──────────────────────────────────────────────────
 
 
@@ -4139,6 +4213,11 @@ async def create_record(
     _enforce_zone_token_scope(current_user, zone_id)
     _reject_if_synthesised_zone(zone, "add records to")
     await _check_driver_gated_record_type(body.record_type, group_id, db)
+    # #424 — per-type structured-field rules (SRV needs priority+weight+port,
+    # MX takes only priority and defaults it to 10, others take none).
+    body.priority, body.weight, body.port = _normalize_record_struct_fields(
+        body.record_type, body.priority, body.weight, body.port
+    )
     fqdn = f"{body.name}.{zone.name}" if body.name != "@" else zone.name
 
     record = DNSRecord(
@@ -4201,6 +4280,12 @@ async def update_record(
     changes = body.model_dump(exclude_none=True)
     for k, v in changes.items():
         setattr(record, k, v)
+    # #424 — validate the merged per-type fields (record_type is immutable on
+    # update, so this checks the final priority/weight/port against the row's
+    # type and normalizes, e.g. defaulting MX priority to 10).
+    record.priority, record.weight, record.port = _normalize_record_struct_fields(
+        record.record_type, record.priority, record.weight, record.port
+    )
     if "name" in changes and zone:
         record.fqdn = f"{record.name}.{zone.name}" if record.name != "@" else zone.name
     target_serial = bump_zone_serial(zone) if zone is not None else None

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -716,7 +716,8 @@ class CreateDNSRecordArgs(BaseModel):
         description=(
             "Right-hand-side value. For A/AAAA an IP; for CNAME / NS "
             "a target FQDN; for TXT the quoted text; for MX the "
-            "target host (priority is a separate arg)."
+            "target host (priority is a separate arg); for SRV the "
+            "target host (priority/weight/port are separate args)."
         )
     )
     ttl: int | None = Field(
@@ -730,7 +731,19 @@ class CreateDNSRecordArgs(BaseModel):
     )
     priority: int | None = Field(
         default=None,
-        description="MX/SRV priority. Required for MX records.",
+        description="MX/SRV priority. Required for MX and SRV records.",
+        ge=0,
+        le=65_535,
+    )
+    weight: int | None = Field(
+        default=None,
+        description="SRV weight. Required for SRV records (not used elsewhere).",
+        ge=0,
+        le=65_535,
+    )
+    port: int | None = Field(
+        default=None,
+        description="SRV port. Required for SRV records (not used elsewhere).",
         ge=0,
         le=65_535,
     )
@@ -746,6 +759,21 @@ async def _preview_create_dns_record(
         return PreviewResult(ok=False, detail=f"Unsupported record type {rtype!r}.")
     if rtype == "MX" and args.priority is None:
         return PreviewResult(ok=False, detail="MX records require a priority.")
+    if rtype == "SRV":
+        missing = [
+            n
+            for n, v in (
+                ("priority", args.priority),
+                ("weight", args.weight),
+                ("port", args.port),
+            )
+            if v is None
+        ]
+        if missing:
+            return PreviewResult(
+                ok=False,
+                detail="SRV records require " + ", ".join(missing) + ".",
+            )
 
     zone = await db.get(DNSZone, args.zone_id)
     if zone is None:
@@ -781,6 +809,10 @@ async def _preview_create_dns_record(
         parts.append(f"ttl={args.ttl}")
     if args.priority is not None:
         parts.append(f"priority={args.priority}")
+    if args.weight is not None:
+        parts.append(f"weight={args.weight}")
+    if args.port is not None:
+        parts.append(f"port={args.port}")
     return PreviewResult(ok=True, detail="ready", preview_text=", ".join(parts) + suffix)
 
 
@@ -788,7 +820,10 @@ async def _apply_create_dns_record(
     db: AsyncSession, user: User, args: CreateDNSRecordArgs
 ) -> dict[str, Any]:
     from app.api.v1.dhcp._audit import write_audit  # local import to avoid cycle
+    from app.core.agent_wake import dns_group_channel, publish_wake
     from app.models.dns import DNSRecord, DNSZone
+    from app.services.dns.record_ops import enqueue_record_op
+    from app.services.dns.serial import bump_zone_serial
 
     # SECURITY (#400, C2): RBAC backstop — matches the DNS router's
     # require_any_resource_permission("dns_record", ...) write gate.
@@ -799,6 +834,8 @@ async def _apply_create_dns_record(
         raise ValueError(f"Unsupported record type {rtype!r}.")
     if rtype == "MX" and args.priority is None:
         raise ValueError("MX records require a priority.")
+    if rtype == "SRV" and (args.priority is None or args.weight is None or args.port is None):
+        raise ValueError("SRV records require priority, weight, and port.")
 
     zone = await db.get(DNSZone, args.zone_id)
     if zone is None:
@@ -819,10 +856,34 @@ async def _apply_create_dns_record(
         value=args.value,
         ttl=args.ttl,
         priority=args.priority,
+        weight=args.weight if rtype == "SRV" else None,
+        port=args.port if rtype == "SRV" else None,
         created_by_user_id=user.id,
     )
     db.add(row)
+    # Mirror the REST create path so a Copilot-created record actually
+    # propagates: bump the zone serial and queue a record op for every
+    # agent in the group. Without this the row lands in the DB but never
+    # reaches BIND9/PowerDNS (the agent only converges on the next ETag
+    # shift). enqueue_record_op collects a Redis wake; flush it explicitly
+    # here since this runs outside the router's wake_publishing dependency.
+    target_serial = bump_zone_serial(zone)
     await db.flush()
+    await enqueue_record_op(
+        db,
+        zone,
+        "create",
+        {
+            "name": row.name,
+            "type": row.record_type,
+            "value": row.value,
+            "ttl": row.ttl,
+            "priority": row.priority,
+            "weight": row.weight,
+            "port": row.port,
+        },
+        target_serial=target_serial,
+    )
 
     write_audit(
         db,
@@ -839,11 +900,16 @@ async def _apply_create_dns_record(
             "value": args.value,
             "ttl": args.ttl,
             "priority": args.priority,
+            "weight": args.weight if rtype == "SRV" else None,
+            "port": args.port if rtype == "SRV" else None,
             "via": "ai_proposal",
         },
     )
     await db.commit()
     await db.refresh(row)
+    # Instant wake (advisory — the ETag compare is still the source of
+    # truth; if Redis is down the agent converges on its poll/safety tick).
+    await publish_wake(dns_group_channel(zone.group_id))
     return {
         "id": str(row.id),
         "zone_id": str(zone.id),

--- a/backend/tests/test_ai_dns_record_srv.py
+++ b/backend/tests/test_ai_dns_record_srv.py
@@ -1,0 +1,152 @@
+"""#424 — MCP create_dns_record gained weight + port for SRV records.
+
+The Operator Copilot's ``create_dns_record`` proposal previously accepted
+only ``priority``, so it could not create a valid SRV (weight + port stayed
+NULL → rendered as 0). It now takes weight + port and rejects an SRV that
+omits any of priority / weight / port, mirroring the REST API guard.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import hash_password
+from app.models.auth import User
+from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSServerGroup, DNSZone
+from app.services.ai.operations import CreateDNSRecordArgs, get_operation
+
+
+async def _user(db: AsyncSession) -> User:
+    u = User(
+        username=f"ai-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="AI Writer",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    u.groups = []  # mark loaded — is_effective_superadmin walks .groups
+    db.add(u)
+    await db.flush()
+    return u
+
+
+async def _zone(db: AsyncSession) -> DNSZone:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    # An agent-based server so enqueue_record_op has somewhere to queue to
+    # (proves the MCP apply now propagates — issue #424 / pre-existing gap).
+    db.add(
+        DNSServer(
+            group_id=grp.id,
+            driver="bind9",
+            host="bind9.example.com",
+            name=f"srv-{uuid.uuid4().hex[:6]}",
+            # enqueue_record_op requires a primary server in the group (it
+            # gates "is this group configured?" before fanning out to every
+            # agent-based server — same as the REST path).
+            is_primary=True,
+        )
+    )
+    zone = DNSZone(
+        group_id=grp.id,
+        name="example.com.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.com.",
+        admin_email="admin.example.com.",
+    )
+    db.add(zone)
+    await db.flush()
+    return zone
+
+
+@pytest.mark.asyncio
+async def test_srv_preview_apply_sets_weight_and_port(db_session: AsyncSession) -> None:
+    user = await _user(db_session)
+    zone = await _zone(db_session)
+    await db_session.commit()
+
+    op = get_operation("create_dns_record")
+    assert op is not None
+    args = CreateDNSRecordArgs(
+        zone_id=str(zone.id),
+        name="_sip._tcp",
+        record_type="SRV",
+        value="sip.example.com.",
+        priority=10,
+        weight=20,
+        port=5060,
+    )
+    preview = await op.preview(db_session, user, args)
+    assert preview.ok, preview.detail
+    assert "weight=20" in preview.preview_text and "port=5060" in preview.preview_text
+
+    result = await op.apply(db_session, user, args)
+    row = await db_session.get(DNSRecord, uuid.UUID(result["id"]))
+    assert row is not None
+    assert (row.priority, row.weight, row.port) == (10, 20, 5060)
+
+    # The apply must propagate: a record op is queued for the agent with
+    # the structured fields intact (without this the Copilot's SRV lands
+    # in the DB but never reaches BIND9).
+    op_row = (
+        (await db_session.execute(select(DNSRecordOp).where(DNSRecordOp.op == "create")))
+        .scalars()
+        .first()
+    )
+    assert op_row is not None
+    assert (
+        op_row.record["weight"] == 20
+        and op_row.record["port"] == 5060
+        and op_row.record["priority"] == 10
+    )
+
+
+@pytest.mark.asyncio
+async def test_srv_preview_rejects_missing_port(db_session: AsyncSession) -> None:
+    user = await _user(db_session)
+    zone = await _zone(db_session)
+    await db_session.commit()
+
+    op = get_operation("create_dns_record")
+    assert op is not None
+    args = CreateDNSRecordArgs(
+        zone_id=str(zone.id),
+        name="_sip._tcp",
+        record_type="SRV",
+        value="sip.example.com.",
+        priority=10,
+        weight=20,
+    )
+    preview = await op.preview(db_session, user, args)
+    assert not preview.ok
+    assert "SRV records require" in preview.detail
+    with pytest.raises(ValueError, match="SRV records require"):
+        await op.apply(db_session, user, args)
+
+
+@pytest.mark.asyncio
+async def test_non_srv_record_ignores_weight_port(db_session: AsyncSession) -> None:
+    user = await _user(db_session)
+    zone = await _zone(db_session)
+    await db_session.commit()
+
+    op = get_operation("create_dns_record")
+    assert op is not None
+    # An A record never carries weight/port even if the model accepts the
+    # fields — apply nulls them for non-SRV types.
+    args = CreateDNSRecordArgs(
+        zone_id=str(zone.id),
+        name="www",
+        record_type="A",
+        value="10.0.0.1",
+    )
+    result = await op.apply(db_session, user, args)
+    row = await db_session.get(DNSRecord, uuid.UUID(result["id"]))
+    assert row is not None
+    assert row.weight is None and row.port is None

--- a/backend/tests/test_dns_record_struct_fields.py
+++ b/backend/tests/test_dns_record_struct_fields.py
@@ -1,0 +1,302 @@
+"""#424 — per-type structured fields on DNS records (priority/weight/port).
+
+The three columns are the source of truth — every driver stitches them
+into the wire format and silently substitutes 0 for a NULL, so a NULL
+weight/port on an SRV renders as a meaningless ``prio 0 0 target`` (the UI
+bug this issue fixes). The API now enforces the per-type rules:
+
+* SRV requires priority + weight + port,
+* MX takes only priority and defaults it to 10,
+* every other type takes none of the three.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import DNSServer, DNSServerGroup, DNSZone
+
+
+async def _admin_headers(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _bind9_group(db: AsyncSession) -> tuple[DNSServerGroup, DNSZone]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    db.add(
+        DNSServer(
+            group_id=grp.id,
+            driver="bind9",
+            host="bind9.example.com",
+            name=f"srv-{uuid.uuid4().hex[:6]}",
+        )
+    )
+    zone = DNSZone(
+        group_id=grp.id,
+        name="example.com.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.com.",
+        admin_email="admin.example.com.",
+    )
+    db.add(zone)
+    await db.flush()
+    return grp, zone
+
+
+# ── SRV ──────────────────────────────────────────────────────────────────
+
+
+async def test_srv_with_all_fields_succeeds(client: AsyncClient, db_session: AsyncSession) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={
+            "name": "_sip._tcp",
+            "record_type": "SRV",
+            "value": "sipserver.example.com.",
+            "priority": 10,
+            "weight": 20,
+            "port": 5060,
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert (body["priority"], body["weight"], body["port"]) == (10, 20, 5060)
+
+
+async def test_srv_zero_values_are_kept_not_treated_as_missing(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # 0 is a legitimate SRV priority/weight — the guard must check for
+    # None, not falsiness.
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={
+            "name": "_sip._udp",
+            "record_type": "SRV",
+            "value": "sip.example.com.",
+            "priority": 0,
+            "weight": 0,
+            "port": 5060,
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["weight"] == 0
+
+
+async def test_srv_missing_weight_or_port_is_422(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    for payload in (
+        {"priority": 10, "port": 5060},  # missing weight
+        {"priority": 10, "weight": 20},  # missing port
+        {"weight": 20, "port": 5060},  # missing priority
+        {},  # missing all three
+    ):
+        r = await client.post(
+            f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+            headers=h,
+            json={
+                "name": "_x._tcp",
+                "record_type": "SRV",
+                "value": "host.example.com.",
+                **payload,
+            },
+        )
+        assert r.status_code == 422, f"{payload}: {r.text}"
+        assert "SRV records require" in r.text
+
+
+# ── MX ───────────────────────────────────────────────────────────────────
+
+
+async def test_mx_with_priority_succeeds(client: AsyncClient, db_session: AsyncSession) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={
+            "name": "@",
+            "record_type": "MX",
+            "value": "mail.example.com.",
+            "priority": 5,
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["priority"] == 5
+
+
+async def test_mx_without_priority_defaults_to_10(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={"name": "@", "record_type": "MX", "value": "mail2.example.com."},
+    )
+    assert r.status_code == 201, r.text
+    # No more NULL priority on MX (the original bug); defaults to 10.
+    assert r.json()["priority"] == 10
+
+
+async def test_mx_with_weight_or_port_is_422(client: AsyncClient, db_session: AsyncSession) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={
+            "name": "@",
+            "record_type": "MX",
+            "value": "mail.example.com.",
+            "priority": 10,
+            "weight": 5,
+        },
+    )
+    assert r.status_code == 422, r.text
+    assert "MX records take only a priority" in r.text
+
+
+# ── Non-MX/SRV types reject stray structured fields ────────────────────────
+
+
+async def test_a_record_rejects_priority(client: AsyncClient, db_session: AsyncSession) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={
+            "name": "www",
+            "record_type": "A",
+            "value": "10.0.0.1",
+            "priority": 10,
+        },
+    )
+    assert r.status_code == 422, r.text
+    assert "do not take" in r.text
+
+
+async def test_a_record_with_no_struct_fields_succeeds(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={"name": "www", "record_type": "A", "value": "10.0.0.1"},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["priority"] is None and body["weight"] is None and body["port"] is None
+
+
+# ── Update path ────────────────────────────────────────────────────────────
+
+
+async def test_update_srv_port_succeeds(client: AsyncClient, db_session: AsyncSession) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    created = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={
+            "name": "_sip._tcp",
+            "record_type": "SRV",
+            "value": "sip.example.com.",
+            "priority": 10,
+            "weight": 20,
+            "port": 5060,
+        },
+    )
+    rid = created.json()["id"]
+    r = await client.put(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records/{rid}",
+        headers=h,
+        json={"port": 5061},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # The merged record keeps its other fields and applies the new port.
+    assert (body["priority"], body["weight"], body["port"]) == (10, 20, 5061)
+
+
+async def test_update_srv_unrelated_field_does_not_422(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # Editing an unrelated field (TTL) on a fully-specified SRV must NOT
+    # trip the per-type validation. This is the post-backfill guarantee
+    # (migration f4a1c8e92b07 fills legacy NULL weight/port → 0 so every
+    # existing SRV row stays editable).
+    h = await _admin_headers(db_session)
+    grp, zone = await _bind9_group(db_session)
+    await db_session.commit()
+
+    created = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records",
+        headers=h,
+        json={
+            "name": "_sip._tcp",
+            "record_type": "SRV",
+            "value": "sip.example.com.",
+            "priority": 0,
+            "weight": 0,
+            "port": 5060,
+        },
+    )
+    rid = created.json()["id"]
+    r = await client.put(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records/{rid}",
+        headers=h,
+        json={"ttl": 7200},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ttl"] == 7200
+    assert (body["priority"], body["weight"], body["port"]) == (0, 0, 5060)

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -2340,6 +2340,32 @@ const RECORD_TYPES = [
   "DNAME",
 ];
 
+// Per-type placeholder for the Value field. For MX / SRV the Value is the
+// *target host* only — priority/weight/port are entered in their own
+// fields and stitched into the wire format by the driver. The
+// packed-value types (CAA / NAPTR / SSHFP / TLSA / LOC / SVCB / HTTPS)
+// carry their whole RDATA in Value, so the hint shows the wire format so
+// operators know what to type (#424 — sweep of every record type).
+const RECORD_VALUE_PLACEHOLDER: Record<string, string> = {
+  A: "10.0.0.1",
+  AAAA: "2001:db8::1",
+  CNAME: "other.example.com.",
+  ALIAS: "lb.elsewhere.example.net.",
+  PTR: "host.example.com.",
+  NS: "ns1.example.com.",
+  MX: "mail.example.com.  (target host — set Priority below)",
+  SRV: "target host, e.g. sipserver.example.com.",
+  TXT: '"v=spf1 include:_spf.example.com ~all"',
+  CAA: '0 issue "letsencrypt.org"',
+  NAPTR: '100 10 "U" "E2U+sip" "!^.*$!sip:info@ex.com!" .',
+  SSHFP: "2 1 123456789abcdef67890...",
+  TLSA: "3 1 1 0123456789abcdef...",
+  LOC: "37 23 30.900 N 121 59 19.000 W 7m",
+  SVCB: '1 . alpn="h2,h3"',
+  HTTPS: '1 . alpn="h2,h3"',
+  DNAME: "target.example.net.",
+};
+
 function RecordModal({
   groupId,
   zoneId,
@@ -2363,6 +2389,8 @@ function RecordModal({
   const [value, setValue] = useState(record?.value ?? "");
   const [ttl, setTtl] = useState(String(record?.ttl ?? ""));
   const [priority, setPriority] = useState(String(record?.priority ?? ""));
+  const [weight, setWeight] = useState(String(record?.weight ?? ""));
+  const [port, setPort] = useState(String(record?.port ?? ""));
   const [viewId, setViewId] = useState<string>(record?.view_id ?? "");
   const [error, setError] = useState("");
 
@@ -2371,7 +2399,10 @@ function RecordModal({
     queryFn: () => dnsApi.listViews(groupId),
   });
 
-  const showPriority = ["MX", "SRV"].includes(type);
+  // SRV carries priority + weight + port (RFC 2782); MX carries only a
+  // priority (the preference). Everything else carries none. (#424)
+  const isSrv = type === "SRV";
+  const usesPriority = type === "MX" || isSrv;
 
   const mut = useMutation({
     mutationFn: (d: Record<string, unknown>) =>
@@ -2388,12 +2419,22 @@ function RecordModal({
   function submit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+    // Client-side guard mirroring the API's per-type rules so the operator
+    // gets an inline message instead of a round-trip 422 (#424).
+    if (isSrv && (priority === "" || weight === "" || port === "")) {
+      setError("SRV records require priority, weight, and port.");
+      return;
+    }
     mut.mutate({
       name,
       record_type: type,
       value,
       ttl: ttl ? parseInt(ttl, 10) : null,
-      priority: priority ? parseInt(priority, 10) : null,
+      // Only send the structured fields the type actually uses, so the API
+      // never sees a stray weight/port on a non-SRV record.
+      priority: usesPriority && priority !== "" ? parseInt(priority, 10) : null,
+      weight: isSrv && weight !== "" ? parseInt(weight, 10) : null,
+      port: isSrv && port !== "" ? parseInt(port, 10) : null,
       view_id: viewId || null,
     });
   }
@@ -2417,6 +2458,10 @@ function RecordModal({
               className={inputCls}
               value={type}
               onChange={(e) => setType(e.target.value)}
+              // record_type is immutable on update (the API ignores it), so
+              // lock it in edit mode rather than let the per-type fields
+              // shift around a Type that won't actually change (#424).
+              disabled={!!record}
             >
               {RECORD_TYPES.map((t) => (
                 <option key={t} value={t}>
@@ -2487,19 +2532,15 @@ function RecordModal({
               className={inputCls}
               value={value}
               onChange={(e) => setValue(e.target.value)}
-              placeholder={
-                type === "A"
-                  ? "10.0.0.1"
-                  : type === "CNAME"
-                    ? "other.example.com."
-                    : type === "ALIAS"
-                      ? "lb.elsewhere.example.net."
-                      : type === "PTR"
-                        ? "host.example.com."
-                        : "record value"
-              }
+              placeholder={RECORD_VALUE_PLACEHOLDER[type] ?? "record value"}
               required
             />
+          )}
+          {isSrv && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Value is the <strong>target host</strong> only — set priority,
+              weight, and port in the fields below.
+            </p>
           )}
         </Field>
         {type === "ALIAS" && (
@@ -2549,9 +2590,12 @@ function RecordModal({
               placeholder="zone default"
             />
           </Field>
-          {showPriority && (
+          {type === "MX" && (
             <Field label="Priority">
               <input
+                type="number"
+                min={0}
+                max={65535}
                 className={inputCls}
                 value={priority}
                 onChange={(e) => setPriority(e.target.value)}
@@ -2560,6 +2604,46 @@ function RecordModal({
             </Field>
           )}
         </div>
+        {isSrv && (
+          <div className="grid grid-cols-3 gap-3">
+            <Field label="Priority">
+              <input
+                type="number"
+                min={0}
+                max={65535}
+                className={inputCls}
+                value={priority}
+                onChange={(e) => setPriority(e.target.value)}
+                placeholder="0"
+                required
+              />
+            </Field>
+            <Field label="Weight">
+              <input
+                type="number"
+                min={0}
+                max={65535}
+                className={inputCls}
+                value={weight}
+                onChange={(e) => setWeight(e.target.value)}
+                placeholder="0"
+                required
+              />
+            </Field>
+            <Field label="Port">
+              <input
+                type="number"
+                min={0}
+                max={65535}
+                className={inputCls}
+                value={port}
+                onChange={(e) => setPort(e.target.value)}
+                placeholder="e.g. 5060"
+                required
+              />
+            </Field>
+          </div>
+        )}
         <Field label="View (optional — scope record to a split-horizon view)">
           <select
             className={inputCls}


### PR DESCRIPTION
Closes #424

## Problem

The Add/Edit DNS Record form only exposed a **Priority** field, so SRV records were created with NULL `weight` + `port` — and every driver (bind9 / powerdns / windows) substitutes `0` for a NULL, rendering a meaningless `priority 0 0 target`. MX priority could also be left NULL/misaligned. (Screenshots in the issue.)

The columns `priority` / `weight` / `port` are the source of truth; the fix closes the gaps end-to-end.

## Frontend (`RecordModal`)

- **SRV** now shows **Priority + Weight + Port** (all required, numeric); **MX** shows a clean Priority-only field — fixing the layout the issue called out.
- Every record type gained a wire-format **Value placeholder** (CAA / NAPTR / SSHFP / TLSA / LOC / SVCB / HTTPS show the expected RDATA shape — the "sweep all record types" ask).
- `submit()` only sends the structured fields a type actually uses, so switching Type never leaks a stray weight/port; client-validates SRV.
- The Type `<select>` is locked in edit mode (`record_type` is immutable on update).

## Backend API (server-side per-type validation)

- `_normalize_record_struct_fields`: **SRV** requires priority+weight+port; **MX** takes only priority and **defaults it to 10** (no more NULL MX priority); every other type rejects stray priority/weight/port with a **422**. Wired into `create_record` (pre-build) and `update_record` (validates the merged row).

## Migration `f4a1c8e92b07` (data-only)

- Backfills rows the old UI left NULL — SRV priority/weight/port → 0, MX priority → 10 (the values the drivers already substitute, so **wire output is unchanged**) — so pre-existing rows stay editable under the new rules. No-op downgrade.

## Operator Copilot (`create_dns_record`)

- `CreateDNSRecordArgs` gained `weight` + `port` with SRV validation in **preview AND apply**.
- `apply` now bumps the zone serial + **enqueues a record op** + publishes the agent wake, mirroring the REST path — previously an MCP-created record landed in the DB but never propagated (pre-existing gap for all MCP DNS writes, surfaced by enabling SRV here).

## Verification

- New tests: `test_dns_record_struct_fields.py` (10 REST cases) + `test_ai_dns_record_srv.py` (3 MCP cases incl. propagation). **85 existing DNS tests still pass.**
- ruff / black / mypy (564 files) / tsc / eslint / prettier all clean; migration applies (single head); migration-shape linter OK.
- **Live-verified on a real k3s appliance**: a full **19/19** all-record-types API sweep (SRV requires p/w/p with 422s, zeros kept, MX defaults to 10 + rejects weight, A rejects stray priority, all packed types store correctly).
- Adversarially reviewed across backend / frontend / MCP+compat lenses (fix-first → both majors — the legacy-edit regression and the MCP propagation gap — fixed in this PR).