### PR TITLE
fix: #428 — DHCP↔IPAM↔DNS replication gaps (Kea push dead) + DDNS/cleanup hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ Batched fixes for the next cut (not yet released).
 
 ### Fixed
 
+* **#428 — DHCP↔IPAM↔DNS replication gaps (Kea push dead + cleanup
+  holes).** A replication audit found the **Kea lease-event push was a
+  silent no-op**: the agent shipped ``{"events":[{"ip","mac"}]}`` but the
+  server's ``LeaseEventBatch`` expects ``{"leases":[{"ip_address",
+  "mac_address","expires_at"}]}`` with ``leases`` defaulting to ``[]``, so
+  the POST validated to an empty batch, returned 200, and the agent
+  cleared its queue — every Kea lease dropped, so a Kea-served client was
+  never mirrored to IPAM and never DDNS-registered (the Windows pull path
+  was unaffected; there's no Kea poll fallback). The agent now emits the
+  server's exact shape (incl. a non-NULL ``expires_at`` so the time-based
+  sweep can reap Kea mirrors), and the batch model gains ``extra="forbid"``
+  so any future envelope drift 422s loudly instead of phantom-succeeding.
+  Two cleanup/consistency fixes ride along: the scheduled
+  ``ipam-dns-auto-sync`` backstop is now **DDNS-aware** — it regenerates a
+  lease's DDNS record if a swallowed inline apply missed it (incl.
+  generated ``dhcp-<x-y>`` names the drift check can't see), and it honors
+  the DDNS opt-in by **not** publishing lease-mirrored rows for subnets
+  whose DDNS is disabled (manual allocations still sync); and **subnet
+  soft-delete now revokes** the lease mirrors' DDNS A/PTR records + drops
+  the transient mirror rows (they were orphaned on the DNS server before),
+  with a warning in the delete-subnet modal. DDNS stays opt-in by design.
+
 * **#426 — Windows DNS/DHCP integration hardening (audit follow-up).** A
   full audit of the WinRM/PowerShell integration confirmed 19 defects;
   this fixes them. **Blocker:** DHCP bulk reservation/exclusion writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ Batched fixes for the next cut (not yet released).
   soft-delete now revokes** the lease mirrors' DDNS A/PTR records + drops
   the transient mirror rows (they were orphaned on the DNS server before),
   with a warning in the delete-subnet modal. DDNS stays opt-in by design.
+  Also folds in the smaller audit findings: DDNS now consumes the
+  previously-dead ``ddns_ttl`` (stamps the record TTL) and
+  ``ddns_domain_override`` (publishes the forward record into the override
+  zone); an agentless Windows-DNS record whose synchronous apply *fails*
+  no longer leaves ``dns_record_id`` stamped (so DDNS retries instead of
+  permanently skipping it); and Windows-pull DDNS now wakes the agent
+  long-poll on commit so it converges immediately instead of on the safety
+  tick.
 
 * **#426 — Windows DNS/DHCP integration hardening (audit follow-up).** A
   full audit of the WinRM/PowerShell integration confirmed 19 defects;

--- a/agent/dhcp/spatium_dhcp_agent/leases.py
+++ b/agent/dhcp/spatium_dhcp_agent/leases.py
@@ -43,12 +43,20 @@ def _parse_row(row: list[str]) -> dict[str, Any] | None:
     try:
         ip = row[0].strip()
         mac = row[1].strip() or None
+        # #428: the server keys leases on (ip, mac) and mac_address is a
+        # required field — a MAC-less row can't be mirrored, so skip it
+        # rather than 422 the whole batch (mirrors the Windows pull path,
+        # which drops leases with no ClientId).
+        if not ip or not mac:
+            return None
         valid_lifetime = int(row[3]) if row[3] else 0
         expire_epoch = int(row[4]) if row[4] else 0
         hostname = row[8].strip() or None
         state = _STATE_MAP.get(row[9].strip(), "active")
         starts_at = (
-            datetime.fromtimestamp(expire_epoch - valid_lifetime, tz=timezone.utc).isoformat()
+            datetime.fromtimestamp(
+                expire_epoch - valid_lifetime, tz=timezone.utc
+            ).isoformat()
             if expire_epoch and valid_lifetime
             else None
         )
@@ -57,13 +65,20 @@ def _parse_row(row: list[str]) -> dict[str, Any] | None:
             if expire_epoch
             else None
         )
+        # #428: emit the server's LeaseEventBatch/LeaseEvent shape exactly —
+        # field names ip_address/mac_address (NOT ip/mac) and an explicit
+        # expires_at (Kea's CSV `expire` is the absolute reclaim time, same
+        # as ends_at). The old {ip,mac,ends_at} shape was silently dropped
+        # by the server's Pydantic model (leases defaulted to [], HTTP 200),
+        # so no Kea lease ever reached IPAM/DDNS.
         return {
-            "ip": ip,
-            "mac": mac,
+            "ip_address": ip,
+            "mac_address": mac,
             "hostname": hostname,
             "state": state,
             "starts_at": starts_at,
             "ends_at": ends_at,
+            "expires_at": ends_at,
         }
     except (ValueError, IndexError):
         return None
@@ -93,7 +108,7 @@ class LeaseWatcher:
         if not self._pending:
             self._last_flush = time.monotonic()
             return
-        body = {"events": self._pending}
+        body = {"leases": self._pending}
         try:
             with self._client() as c:
                 resp = c.post(

--- a/agent/dhcp/tests/test_leases.py
+++ b/agent/dhcp/tests/test_leases.py
@@ -1,0 +1,90 @@
+"""#428 — Kea lease shipper emits the server's LeaseEventBatch shape.
+
+The shipper previously posted ``{"events":[{"ip","mac","ends_at",…}]}``,
+which the control plane's Pydantic ``LeaseEventBatch`` silently dropped
+(``leases`` defaulted to ``[]`` → HTTP 200 → every Kea lease lost). These
+tests lock the wire contract: the batch envelope key is ``leases`` and
+each event carries ``ip_address`` / ``mac_address`` / ``expires_at``.
+"""
+
+from __future__ import annotations
+
+from spatium_dhcp_agent.leases import _parse_row
+
+
+def _row(ip="10.0.0.50", mac="aa:bb:cc:dd:ee:ff", expire="2000000000"):
+    # Kea memfile CSV: address,hwaddr,client_id,valid_lifetime,expire,
+    # subnet_id,fqdn_fwd,fqdn_rev,hostname,state,...
+    return [ip, mac, "", "3600", expire, "1", "0", "0", "host1", "0"]
+
+
+def test_parse_row_uses_server_field_names() -> None:
+    ev = _parse_row(_row())
+    assert ev is not None
+    # Server LeaseEvent field names — NOT the old ip/mac.
+    assert ev["ip_address"] == "10.0.0.50"
+    assert ev["mac_address"] == "aa:bb:cc:dd:ee:ff"
+    assert "ip" not in ev and "mac" not in ev
+
+
+def test_parse_row_sets_expires_at() -> None:
+    # expires_at must be non-null (== ends_at) so the server stores a
+    # reapable lease (sweep_expired_leases filters expires_at IS NOT NULL).
+    ev = _parse_row(_row())
+    assert ev is not None
+    assert ev["expires_at"] is not None
+    assert ev["expires_at"] == ev["ends_at"]
+
+
+def test_parse_row_skips_macless_lease() -> None:
+    # mac_address is required server-side; a MAC-less row can't be mirrored
+    # and must be dropped (not 422 the whole batch).
+    assert _parse_row(_row(mac="")) is None
+
+
+def test_parse_row_skips_header_and_short_rows() -> None:
+    assert _parse_row(["address", "hwaddr"]) is None
+    assert _parse_row(["10.0.0.1"]) is None
+
+
+def test_flush_body_uses_leases_key(monkeypatch) -> None:
+    # The POST envelope key must be ``leases`` (not ``events``).
+    import types
+
+    from spatium_dhcp_agent import leases as leases_mod
+
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+
+    class _Client:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, path, json, headers):
+            import copy
+
+            captured["path"] = path
+            # Snapshot — _flush clears _pending after the post, and the body
+            # holds a live reference to that same list.
+            captured["json"] = copy.deepcopy(json)
+            return _Resp()
+
+    cfg = types.SimpleNamespace(
+        control_plane_url="http://cp",
+        httpx_verify=lambda: True,
+        kea_lease_file="/tmp/x",
+    )
+    hb = types.SimpleNamespace(lease_count_since_start=0)
+    w = leases_mod.LeaseWatcher(cfg, ["tok"], hb)
+    w._client = lambda: _Client()  # type: ignore[method-assign]
+    w._pending = [_parse_row(_row())]
+    w._flush()
+
+    assert captured["path"] == "/api/v1/dhcp/agents/lease-events"
+    assert "leases" in captured["json"] and "events" not in captured["json"]
+    assert captured["json"]["leases"][0]["ip_address"] == "10.0.0.50"

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -136,6 +136,15 @@ class LeaseEvent(BaseModel):
 
 
 class LeaseEventBatch(BaseModel):
+    # #428: forbid unknown top-level keys. ``leases`` defaults to [], so an
+    # agent that posts the wrong envelope (e.g. the old ``{"events":[…]}``
+    # shape) would otherwise validate to an EMPTY batch and the endpoint
+    # would 200-no-op — silently dropping every lease. ``extra="forbid"``
+    # turns that into a loud 422 the agent logs as ``lease_events_failed``
+    # instead of a phantom success. (Per-event field drift already fails
+    # loudly: ip_address/mac_address are required.)
+    model_config = {"extra": "forbid"}
+
     # The agent batches up to 100 events per POST (``leases._BATCH_MAX_EVENTS``);
     # cap with generous headroom so a malformed/hostile client can't ship an
     # unbounded batch into the per-event ingestion loop.
@@ -231,7 +240,8 @@ async def agent_register(
         group = res.scalar_one_or_none()
         if group is None:
             group = DHCPServerGroup(
-                name=body.group_name, description="Auto-created by DHCP agent registration"
+                name=body.group_name,
+                description="Auto-created by DHCP agent registration",
             )
             db.add(group)
             await db.flush()
@@ -245,10 +255,14 @@ async def agent_register(
         res = await db.execute(select(DHCPServer).where(DHCPServer.agent_id == aid))
         server = res.scalar_one_or_none()
     if server is None:
-        res = await db.execute(select(DHCPServer).where(DHCPServer.name == body.hostname))
+        res = await db.execute(
+            select(DHCPServer).where(DHCPServer.name == body.hostname)
+        )
         server = res.scalar_one_or_none()
 
-    require_approval = os.environ.get("DHCP_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
+    require_approval = (
+        os.environ.get("DHCP_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
+    )
     pending_approval = False
     if server is None:
         agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
@@ -266,7 +280,9 @@ async def agent_register(
             agent_fingerprint=body.fingerprint,
             agent_version=body.version,
             description=(
-                f"auto-registered agent v{body.version}" if body.version else "auto-registered"
+                f"auto-registered agent v{body.version}"
+                if body.version
+                else "auto-registered"
             ),
         )
         pending_approval = require_approval
@@ -284,7 +300,9 @@ async def agent_register(
         server.agent_version = body.version
         server.agent_registered = True
         if server.agent_id is None:
-            server.agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
+            server.agent_id = (
+                uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
+            )
 
     token, exp = mint_agent_token(
         server_id=str(server.id),
@@ -374,14 +392,24 @@ async def agent_config_longpoll(
             lldp_block = (
                 lldp_bundle(settings_row)
                 if settings_row is not None
-                else {"enabled": False, "config_hash": "", "lldpd_conf": "", "daemon_args": ""}
+                else {
+                    "enabled": False,
+                    "config_hash": "",
+                    "lldpd_conf": "",
+                    "daemon_args": "",
+                }
             )
             # Issue #156 — same pattern for rsyslog. Stable dict shape so the
             # etag math stays uniform whether settings exist or not.
             syslog_block = (
                 syslog_bundle(settings_row)
                 if settings_row is not None
-                else {"enabled": False, "config_hash": "", "rsyslog_conf": "", "ca_certs": {}}
+                else {
+                    "enabled": False,
+                    "config_hash": "",
+                    "rsyslog_conf": "",
+                    "ca_certs": {},
+                }
             )
             # Issue #157 — same pattern for SSH. Stable dict shape so the
             # etag math stays uniform whether settings exist or not.
@@ -425,7 +453,10 @@ async def agent_config_longpoll(
                 f"|resolver:{int(bool(resolver_block.get('enabled')))}"
                 f":{resolver_block.get('config_hash', '')}"
             )
-            etag = "sha256:" + hashlib.sha256(f"{bundle.etag}|{fleet_marker}".encode()).hexdigest()
+            etag = (
+                "sha256:"
+                + hashlib.sha256(f"{bundle.etag}|{fleet_marker}".encode()).hexdigest()
+            )
 
             # Pending ops fast-path. Issue #182: paused servers don't ship
             # ops — they accumulate as ``pending`` and dispatch as soon as
@@ -435,7 +466,8 @@ async def agent_config_longpoll(
             else:
                 ops_res = await db.execute(
                     select(DHCPConfigOp).where(
-                        DHCPConfigOp.server_id == server.id, DHCPConfigOp.status == "pending"
+                        DHCPConfigOp.server_id == server.id,
+                        DHCPConfigOp.status == "pending",
                     )
                 )
                 pending_ops = [
@@ -724,7 +756,10 @@ async def agent_lease_events(
       - Released/expired lease → if the IPAM row is auto_from_lease, remove it.
     """
     from app.models.ipam import IPAddress
-    from app.services.dhcp.pull_leases import _find_containing_subnet, _load_subnet_cache
+    from app.services.dhcp.pull_leases import (
+        _find_containing_subnet,
+        _load_subnet_cache,
+    )
 
     server, _ = auth
     now = datetime.now(UTC)
@@ -758,6 +793,11 @@ async def agent_lease_events(
     upserted = 0
     for ev in events:
         key = (ev.ip_address, ev.mac_address)
+        # #428: fall back to ends_at when the agent didn't send a distinct
+        # expires_at (Kea ships the same absolute reclaim time as ends_at).
+        # Without a non-NULL expires_at the time-based sweep_expired_leases
+        # — which filters `expires_at IS NOT NULL` — can never reap the row.
+        expires_at = ev.expires_at or ev.ends_at
         lease = lease_by_key.get(key)
         if lease is None:
             lease = DHCPLease(
@@ -770,7 +810,7 @@ async def agent_lease_events(
                 state=ev.state,
                 starts_at=ev.starts_at,
                 ends_at=ev.ends_at,
-                expires_at=ev.expires_at,
+                expires_at=expires_at,
                 last_seen_at=now,
             )
             db.add(lease)
@@ -782,7 +822,7 @@ async def agent_lease_events(
             lease.state = ev.state
             lease.starts_at = ev.starts_at
             lease.ends_at = ev.ends_at
-            lease.expires_at = ev.expires_at
+            lease.expires_at = expires_at
             lease.last_seen_at = now
         upserted += 1
     await db.flush()
@@ -793,7 +833,9 @@ async def agent_lease_events(
     subnets = await _load_subnet_cache(db)
     subnet_for_ip = {ip: _find_containing_subnet(ip, subnets) for ip in ips}
     ipam_existing = (
-        (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips)))).scalars().all()
+        (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips))))
+        .scalars()
+        .all()
     )
     ipam_by_key: dict[tuple[Any, str], IPAddress] = {
         (row.subnet_id, row.address): row for row in ipam_existing
@@ -955,7 +997,9 @@ async def agent_metrics(
     }
     existing = await db.get(DHCPMetricSample, (server.id, body.bucket_at))
     if existing is None:
-        db.add(DHCPMetricSample(server_id=server.id, bucket_at=body.bucket_at, **values))
+        db.add(
+            DHCPMetricSample(server_id=server.id, bucket_at=body.bucket_at, **values)
+        )
     else:
         for k, v in values.items():
             setattr(existing, k, v)

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -255,14 +255,10 @@ async def agent_register(
         res = await db.execute(select(DHCPServer).where(DHCPServer.agent_id == aid))
         server = res.scalar_one_or_none()
     if server is None:
-        res = await db.execute(
-            select(DHCPServer).where(DHCPServer.name == body.hostname)
-        )
+        res = await db.execute(select(DHCPServer).where(DHCPServer.name == body.hostname))
         server = res.scalar_one_or_none()
 
-    require_approval = (
-        os.environ.get("DHCP_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
-    )
+    require_approval = os.environ.get("DHCP_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
     pending_approval = False
     if server is None:
         agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
@@ -280,9 +276,7 @@ async def agent_register(
             agent_fingerprint=body.fingerprint,
             agent_version=body.version,
             description=(
-                f"auto-registered agent v{body.version}"
-                if body.version
-                else "auto-registered"
+                f"auto-registered agent v{body.version}" if body.version else "auto-registered"
             ),
         )
         pending_approval = require_approval
@@ -300,9 +294,7 @@ async def agent_register(
         server.agent_version = body.version
         server.agent_registered = True
         if server.agent_id is None:
-            server.agent_id = (
-                uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
-            )
+            server.agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
 
     token, exp = mint_agent_token(
         server_id=str(server.id),
@@ -453,10 +445,7 @@ async def agent_config_longpoll(
                 f"|resolver:{int(bool(resolver_block.get('enabled')))}"
                 f":{resolver_block.get('config_hash', '')}"
             )
-            etag = (
-                "sha256:"
-                + hashlib.sha256(f"{bundle.etag}|{fleet_marker}".encode()).hexdigest()
-            )
+            etag = "sha256:" + hashlib.sha256(f"{bundle.etag}|{fleet_marker}".encode()).hexdigest()
 
             # Pending ops fast-path. Issue #182: paused servers don't ship
             # ops — they accumulate as ``pending`` and dispatch as soon as
@@ -833,9 +822,7 @@ async def agent_lease_events(
     subnets = await _load_subnet_cache(db)
     subnet_for_ip = {ip: _find_containing_subnet(ip, subnets) for ip in ips}
     ipam_existing = (
-        (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips))))
-        .scalars()
-        .all()
+        (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips)))).scalars().all()
     )
     ipam_by_key: dict[tuple[Any, str], IPAddress] = {
         (row.subnet_id, row.address): row for row in ipam_existing
@@ -997,9 +984,7 @@ async def agent_metrics(
     }
     existing = await db.get(DHCPMetricSample, (server.id, body.bucket_at))
     if existing is None:
-        db.add(
-            DHCPMetricSample(server_id=server.id, bucket_at=body.bucket_at, **values)
-        )
+        db.add(DHCPMetricSample(server_id=server.id, bucket_at=body.bucket_at, **values))
     else:
         for k, v in values.items():
             setattr(existing, k, v)

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -795,9 +795,14 @@ _dns_op_collector: contextvars.ContextVar[list[tuple[DNSZone, dict[str, Any]]] |
 
 async def _enqueue_dns_op(
     db: AsyncSession, zone: DNSZone, op: str, name: str, rtype: str, value: str, ttl: int | None
-) -> None:
+) -> Any:
     """Wrapper to enqueue a record op against the zone's primary server.
-    Imported lazily to avoid circular import."""
+    Imported lazily to avoid circular import.
+
+    Returns the ``DNSRecordOp`` (or None in batch mode / when nothing was
+    enqueued). For an agentless primary (Windows DNS) the op is applied
+    synchronously and its ``state`` is ``applied`` / ``failed`` on return —
+    callers use that to avoid stamping a record that didn't land (#428)."""
     from app.services.dns.record_ops import enqueue_record_op
     from app.services.dns.serial import bump_zone_serial
 
@@ -810,9 +815,9 @@ async def _enqueue_dns_op(
         # zone. The serial bump above still happens per op exactly as the
         # inline path does, so ``target_serial`` snapshots match.
         collector.append((zone, {"op": op, "record": record, "target_serial": target_serial}))
-        return
+        return None
 
-    await enqueue_record_op(db, zone, op, record, target_serial=target_serial)
+    return await enqueue_record_op(db, zone, op, record, target_serial=target_serial)
 
 
 async def _flush_dns_op_collector(
@@ -961,12 +966,18 @@ async def _sync_dns_record(
     subnet: Subnet,
     zone_id: uuid.UUID | None = None,
     action: str = "create",  # create | update | delete
+    ttl: int | None = None,
 ) -> None:
     """Create, update, or delete the auto-generated A + PTR records for this IP.
 
     Forward A goes in the subnet's DNS zone (or explicitly passed zone_id);
     reverse PTR goes in the matching `kind=reverse` zone. Both records are
     pushed to the agent via RFC 2136 dynamic update through the record_op queue.
+
+    ``ttl`` sets the record TTL on **newly created** records (the DDNS path
+    passes the subnet's effective ``ddns_ttl`` — #428); None inherits the
+    zone default. Updates preserve the existing TTL so a rename doesn't
+    churn it.
     """
     if action == "delete":
         result = await db.execute(
@@ -1143,24 +1154,32 @@ async def _sync_dns_record(
                     fqdn=target_fqdn,
                     record_type=forward_rtype,
                     value=str(ip.address),
+                    ttl=ttl,
                     auto_generated=True,
                     ip_address_id=ip.id,
                     created_by_user_id=ip.created_by_user_id,
                 )
                 db.add(new_rec)
                 await db.flush()
-                if desired_zone_id == effective_zone_id:
+                is_primary = desired_zone_id == effective_zone_id
+                if is_primary:
                     ip.dns_record_id = new_rec.id
                     ip.forward_zone_id = effective_zone_id
-                await _enqueue_dns_op(
+                op = await _enqueue_dns_op(
                     db,
                     target_zone,
                     "create",
                     ip.hostname,
                     forward_rtype,
                     str(ip.address),
-                    None,
+                    ttl,
                 )
+                # #428 — for an agentless (Windows DNS) primary the op
+                # applies synchronously; if it failed, don't leave
+                # dns_record_id stamped or DDNS idempotency never retries.
+                # Agent-based ops are 'pending' and self-heal via the bundle.
+                if is_primary and getattr(op, "state", None) == "failed":
+                    ip.dns_record_id = None
             elif existing.record_type != forward_rtype:
                 # Address family swap (v4↔v6) — delete the stale record
                 # in this zone and recreate with the new rtype.
@@ -1180,6 +1199,7 @@ async def _sync_dns_record(
                     fqdn=target_fqdn,
                     record_type=forward_rtype,
                     value=str(ip.address),
+                    ttl=ttl,
                     auto_generated=True,
                     ip_address_id=ip.id,
                     created_by_user_id=ip.created_by_user_id,
@@ -1196,7 +1216,7 @@ async def _sync_dns_record(
                     ip.hostname,
                     forward_rtype,
                     str(ip.address),
-                    None,
+                    ttl,
                 )
             else:
                 changed = existing.name != ip.hostname or existing.value != str(ip.address)
@@ -1251,13 +1271,14 @@ async def _sync_dns_record(
             fqdn=rev_pointer_full,
             record_type="PTR",
             value=ptr_value,
+            ttl=ttl,
             auto_generated=True,
             ip_address_id=ip.id,
             created_by_user_id=ip.created_by_user_id,
         )
         db.add(ptr_rec)
         ip.reverse_zone_id = rev_zone.id
-        await _enqueue_dns_op(db, rev_zone, "create", ptr_name, "PTR", ptr_value, None)
+        await _enqueue_dns_op(db, rev_zone, "create", ptr_name, "PTR", ptr_value, ttl)
     else:
         for record in existing_ptr:
             if record.zone_id != rev_zone.id:
@@ -1273,13 +1294,14 @@ async def _sync_dns_record(
                     fqdn=rev_pointer_full,
                     record_type="PTR",
                     value=ptr_value,
+                    ttl=ttl,
                     auto_generated=True,
                     ip_address_id=ip.id,
                     created_by_user_id=ip.created_by_user_id,
                 )
                 db.add(new_ptr)
                 ip.reverse_zone_id = rev_zone.id
-                await _enqueue_dns_op(db, rev_zone, "create", ptr_name, "PTR", ptr_value, None)
+                await _enqueue_dns_op(db, rev_zone, "create", ptr_name, "PTR", ptr_value, ttl)
             else:
                 changed = record.value != ptr_value or record.name != ptr_name
                 record.name = ptr_name

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -4472,6 +4472,41 @@ async def update_subnet(
     return subnet
 
 
+async def _revoke_subnet_lease_mirrors(db: DB, subnet: Subnet) -> int:
+    """#428 — on subnet delete, revoke the DDNS records published for the
+    subnet's DHCP-lease mirrors and drop the transient mirror rows. Returns
+    the count revoked. Best-effort per row: a DNS-revoke hiccup must not
+    block the delete (the backstop / next reconcile cleans residue)."""
+    from app.services.dns.ddns import revoke_ddns_for_lease  # noqa: PLC0415
+
+    rows = (
+        (
+            await db.execute(
+                select(IPAddress).where(
+                    IPAddress.subnet_id == subnet.id,
+                    IPAddress.auto_from_lease.is_(True),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    revoked = 0
+    for row in rows:
+        try:
+            await revoke_ddns_for_lease(db, subnet=subnet, ipam_row=row)
+        except Exception as exc:  # noqa: BLE001 — never block the delete
+            logger.warning(
+                "subnet_delete_ddns_revoke_failed",
+                subnet_id=str(subnet.id),
+                ip=str(row.address),
+                error=str(exc),
+            )
+        await db.delete(row)
+        revoked += 1
+    return revoked
+
+
 @router.delete("/subnets/{subnet_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_subnet(
     subnet_id: uuid.UUID,
@@ -4497,6 +4532,16 @@ async def delete_subnet(
     _enforce_subnet_token_scope(current_user, subnet_id)
 
     if not permanent:
+        # #428 — a DHCP-lease-mirrored IPAM row's DDNS A/PTR record must not
+        # outlive the subnet. The soft-delete batch only stamps the subnet +
+        # its scopes (not IPAddress/DNSRecord), so without this the lease
+        # mirrors + their published DNS records would be orphaned: still on
+        # the DNS server, pointing at a now-deleted subnet, invisible to the
+        # sweeps (the subnet is hidden). Revoke the DNS records and drop the
+        # transient mirror rows; if the subnet is restored with live leases,
+        # the lease pipeline re-mirrors + re-publishes them.
+        await _revoke_subnet_lease_mirrors(db, subnet)
+
         # Soft-delete: cascade-stamp the subnet + its scopes. Non-emptiness
         # is allowed since the operator can restore via /admin/trash.
         batch = await collect_soft_delete_batch(db, subnet)

--- a/backend/app/services/dhcp/pull_leases.py
+++ b/backend/app/services/dhcp/pull_leases.py
@@ -74,6 +74,10 @@ class PullLeasesResult:
     pools_synced: int = 0  # DHCPPool rows (re-)created from the import
     statics_synced: int = 0  # DHCPStaticAssignment rows (re-)created
     errors: list[str] = field(default_factory=list)
+    # #428 — DNS group ids whose zones received a DDNS record this pull;
+    # the caller publishes an agent wake for them AFTER its commit so the
+    # records converge instantly instead of on the agent's safety tick.
+    dns_wake_group_ids: set[str] = field(default_factory=set)
 
 
 async def pull_leases_from_server(
@@ -263,12 +267,21 @@ async def pull_leases_from_server(
             try:
                 from app.services.dns.ddns import apply_ddns_for_lease  # noqa: PLC0415
 
-                await apply_ddns_for_lease(
+                fired = await apply_ddns_for_lease(
                     db,
                     subnet=containing,
                     ipam_row=ipam_row,
                     client_hostname=lease.get("hostname"),
                 )
+                # #428 — record the affected DNS group(s) so the task wakes
+                # the agent after commit (instead of waiting the safety tick).
+                if fired:
+                    from app.api.v1.ipam.router import (  # noqa: PLC0415
+                        _resolve_effective_dns,
+                    )
+
+                    group_ids, _, _ = await _resolve_effective_dns(db, containing)
+                    result.dns_wake_group_ids.update(str(g) for g in group_ids)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "dhcp_pull_leases_ddns_failed",

--- a/backend/app/services/dns/ddns.py
+++ b/backend/app/services/dns/ddns.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import ipaddress
 import re
+from typing import Any
 
 import structlog
 from sqlalchemy import select
@@ -272,20 +273,62 @@ async def apply_ddns_for_lease(
 
     ipam_row.hostname = hostname
 
+    # #428 — honor the effective DDNS config that was resolved but never
+    # consumed: publish into ddns_domain_override's zone when set (else the
+    # subnet's default), and stamp the record TTL with ddns_ttl.
+    override_zone_id = await _resolve_override_zone_id(db, eff.domain_override)
+
     # Lazy-import: the router imports sync_check / reverse_zone at top
     # level, so a top-level import of the router here would close the
     # cycle. Calling at the bottom of the service call is cycle-free.
     from app.api.v1.ipam.router import _sync_dns_record  # noqa: PLC0415
 
-    await _sync_dns_record(db, ipam_row, subnet, action="create")
+    await _sync_dns_record(
+        db, ipam_row, subnet, zone_id=override_zone_id, action="create", ttl=eff.ttl
+    )
     logger.info(
         "ddns_applied",
         subnet_id=str(subnet.id),
         ip=str(ipam_row.address),
         hostname=hostname,
         policy=subnet.ddns_hostname_policy,
+        zone_override=eff.domain_override,
+        ttl=eff.ttl,
     )
     return True
+
+
+async def _resolve_override_zone_id(db: AsyncSession, domain_override: str | None) -> Any:
+    """#428 — map ``ddns_domain_override`` to a forward DNSZone id so DDNS
+    publishes the A/AAAA into that zone instead of the subnet's default.
+    Returns None (→ default zone resolution) when unset, unknown, or
+    ambiguous. The reverse/PTR zone is unaffected (it's keyed by IP)."""
+    if not domain_override or not domain_override.strip():
+        return None
+    from app.models.dns import DNSZone  # noqa: PLC0415 — lazy, avoid cycle
+
+    name = domain_override.strip().rstrip(".")
+    zones = (
+        (
+            await db.execute(
+                select(DNSZone).where(
+                    DNSZone.name.in_([name, name + "."]),
+                    DNSZone.kind == "forward",
+                    DNSZone.deleted_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if len(zones) == 1:
+        return zones[0].id
+    logger.warning(
+        "ddns_domain_override_unresolved",
+        domain=domain_override,
+        match_count=len(zones),
+    )
+    return None
 
 
 async def revoke_ddns_for_lease(

--- a/backend/app/tasks/dhcp_pull_leases.py
+++ b/backend/app/tasks/dhcp_pull_leases.py
@@ -42,6 +42,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.celery_app import celery_app
 from app.config import settings
+from app.core.agent_wake import dns_group_channel, publish_wake
 from app.drivers.dhcp import is_agentless
 from app.models.audit import AuditLog
 from app.models.dhcp import DHCPServer
@@ -98,6 +99,7 @@ async def _run_pull() -> dict[str, Any]:
             total_pools_synced = 0
             total_statics_synced = 0
             errors: list[str] = []
+            wake_group_ids: set[str] = set()  # #428 — DNS groups to wake post-commit
 
             for server in servers:
                 if not is_agentless(server.driver):
@@ -129,6 +131,7 @@ async def _run_pull() -> dict[str, Any]:
                 total_scopes_skipped += result.scopes_skipped_no_subnet
                 total_pools_synced += result.pools_synced
                 total_statics_synced += result.statics_synced
+                wake_group_ids.update(result.dns_wake_group_ids)
                 errors.extend(f"{server.name}: {e}" for e in result.errors)
 
             ps.dhcp_pull_leases_last_run_at = now
@@ -170,6 +173,13 @@ async def _run_pull() -> dict[str, Any]:
                     )
                 )
             await db.commit()
+
+            # #428 — wake the agent long-polls for any DNS group whose zone
+            # got a DDNS record this pull, AFTER commit (per the wake
+            # contract), so Windows-pull DDNS converges instantly instead of
+            # waiting on the agent's safety tick.
+            for gid in wake_group_ids:
+                await publish_wake(dns_group_channel(gid))
 
             logger.info(
                 "dhcp_pull_leases_completed",

--- a/backend/app/tasks/ipam_dns_sync.py
+++ b/backend/app/tasks/ipam_dns_sync.py
@@ -30,12 +30,61 @@ from app.celery_app import celery_app
 from app.config import settings
 from app.core.agent_wake import dns_group_channel, publish_wake
 from app.models.audit import AuditLog
-from app.models.ipam import Subnet
+from app.models.ipam import IPAddress, Subnet
 from app.models.settings import PlatformSettings
 
 logger = structlog.get_logger(__name__)
 
 _SINGLETON_ID = 1
+
+
+async def _auto_from_lease_ip_ids(db: Any, subnet_id: Any) -> set[Any]:
+    """IDs of the DHCP-lease-mirrored IPAM rows in a subnet (#428). The
+    backstop uses this to honor the DDNS opt-in: lease-mirrored rows are
+    only DNS-published when the subnet has DDNS enabled — manual
+    allocations always sync."""
+    rows = await db.execute(
+        select(IPAddress.id).where(
+            IPAddress.subnet_id == subnet_id,
+            IPAddress.auto_from_lease.is_(True),
+        )
+    )
+    return set(rows.scalars().all())
+
+
+async def _reapply_ddns_for_active_leases(db: Any, subnet: Subnet) -> tuple[int, list[str]]:
+    """#428 — eventual-consistency net for DDNS-enabled subnets. Re-runs
+    the DDNS policy for every active lease-mirrored row so a record that a
+    swallowed inline ``apply_ddns_for_lease`` failure missed — including a
+    generated ``dhcp-<x-y>`` name the hostname-driven drift check can't
+    see — gets regenerated. Idempotent: ``apply_ddns_for_lease`` skips a
+    row whose hostname is unchanged and already has a linked record.
+    Returns (records_fired, errors)."""
+    from app.services.dns.ddns import apply_ddns_for_lease  # noqa: PLC0415
+
+    rows = (
+        (
+            await db.execute(
+                select(IPAddress).where(
+                    IPAddress.subnet_id == subnet.id,
+                    IPAddress.auto_from_lease.is_(True),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    fired = 0
+    errors: list[str] = []
+    for row in rows:
+        try:
+            if await apply_ddns_for_lease(
+                db, subnet=subnet, ipam_row=row, client_hostname=row.hostname or None
+            ):
+                fired += 1
+        except Exception as exc:  # noqa: BLE001 — one lease must not poison the run
+            errors.append(f"ddns-reapply({subnet.id}/{row.address}): {exc}")
+    return fired, errors
 
 
 async def _run_auto_sync() -> dict[str, Any]:
@@ -47,6 +96,7 @@ async def _run_auto_sync() -> dict[str, Any]:
         _apply_dns_sync,  # noqa: PLC0415
         _resolve_effective_dns,  # noqa: PLC0415
     )
+    from app.services.dns.ddns import resolve_effective_ddns  # noqa: PLC0415
     from app.services.dns.sync_check import compute_subnet_dns_drift  # noqa: PLC0415
 
     engine = create_async_engine(settings.database_url, future=True)
@@ -81,12 +131,39 @@ async def _run_auto_sync() -> dict[str, Any]:
             # groups (worker process: no request collector, publish directly).
             touched_subnet_ids: set[Any] = set()
 
+            total_ddns_reapplied = 0
             for subnet_id in subnets:
+                subnet_obj = await db.get(Subnet, subnet_id)
+                if subnet_obj is None:
+                    continue
+                ddns_on = (await resolve_effective_ddns(db, subnet_obj)).enabled
+
                 try:
                     report = await compute_subnet_dns_drift(db, subnet_id)
                 except Exception as exc:  # noqa: BLE001 — never let one subnet poison the run
                     errors.append(f"drift({subnet_id}): {exc}")
                     continue
+
+                # #428 — honor the DDNS opt-in (Q1): when a subnet's DDNS is
+                # OFF, the backstop must not publish lease-mirrored rows.
+                # Manual allocations still sync regardless. (When DDNS is ON,
+                # the re-apply pass below is the authority for lease rows.)
+                if not ddns_on and (report.missing or report.mismatched):
+                    lease_ip_ids = await _auto_from_lease_ip_ids(db, subnet_id)
+                    report.missing = [m for m in report.missing if m.ip_id not in lease_ip_ids]
+                    report.mismatched = [
+                        m for m in report.mismatched if m.ip_id not in lease_ip_ids
+                    ]
+
+                # #428 — eventual-consistency net (Q3): regenerate any lease
+                # DDNS record a swallowed inline apply missed.
+                if ddns_on:
+                    fired, ddns_errors = await _reapply_ddns_for_active_leases(db, subnet_obj)
+                    total_ddns_reapplied += fired
+                    errors.extend(ddns_errors)
+                    if fired:
+                        total_created += fired
+                        touched_subnet_ids.add(subnet_id)
 
                 if (
                     not report.missing
@@ -115,9 +192,11 @@ async def _run_auto_sync() -> dict[str, Any]:
                 total_deleted += deleted
                 errors.extend(subnet_errors)
                 if created or updated or deleted:
-                    subnets_touched += 1
                     touched_subnet_ids.add(subnet_id)
 
+            # Dedup-accurate count (a subnet touched by both the drift sync
+            # and the DDNS re-apply is one touched subnet, #428).
+            subnets_touched = len(touched_subnet_ids)
             ps.dns_auto_sync_last_run_at = now
 
             if total_created or total_updated or total_deleted or errors:
@@ -134,6 +213,7 @@ async def _run_auto_sync() -> dict[str, Any]:
                             "created": total_created,
                             "updated": total_updated,
                             "deleted": total_deleted,
+                            "ddns_reapplied": total_ddns_reapplied,
                             "subnets_touched": subnets_touched,
                             "subnets_scanned": len(subnets),
                             "errors": errors[:20],
@@ -170,6 +250,7 @@ async def _run_auto_sync() -> dict[str, Any]:
                 "created": total_created,
                 "updated": total_updated,
                 "deleted": total_deleted,
+                "ddns_reapplied": total_ddns_reapplied,
                 "subnets_touched": subnets_touched,
                 "subnets_scanned": len(subnets),
                 "errors": len(errors),

--- a/backend/tests/test_ddns_ttl_override.py
+++ b/backend/tests/test_ddns_ttl_override.py
@@ -1,0 +1,126 @@
+"""#428 — DDNS now consumes ddns_ttl + ddns_domain_override.
+
+Both fields were resolved into ``EffectiveDDNS`` but never used in the
+publish path. apply_ddns_for_lease now stamps the record TTL with the
+effective ddns_ttl and publishes the forward record into the
+ddns_domain_override zone (when set + resolvable) instead of the subnet's
+default zone.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.dns.ddns import _resolve_override_zone_id, apply_ddns_for_lease
+
+
+async def _zone(db: AsyncSession, name: str) -> DNSZone:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name=name,
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1." + name,
+        admin_email="admin." + name,
+    )
+    db.add(zone)
+    await db.flush()
+    return zone
+
+
+async def _ddns_subnet(
+    db: AsyncSession, *, zone: DNSZone, ttl: int | None, override: str | None = None
+) -> tuple[Subnet, IPAddress]:
+    space = IPSpace(name=f"d-sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.91.0.0/16", name="d-blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network="10.91.1.0/24",
+        name="d-sn",
+        dns_zone_id=str(zone.id),
+        dns_inherit_settings=False,  # use the subnet's own dns_zone_id
+        ddns_enabled=True,
+        ddns_inherit_settings=False,
+        ddns_hostname_policy="client_or_generated",
+        ddns_ttl=ttl,
+        ddns_domain_override=override,
+    )
+    db.add(subnet)
+    await db.flush()
+    row = IPAddress(
+        subnet_id=subnet.id,
+        address="10.91.1.50",
+        status="dhcp",
+        mac_address="aa:bb:cc:dd:ee:01",
+        auto_from_lease=True,
+    )
+    db.add(row)
+    await db.flush()
+    return subnet, row
+
+
+async def test_resolve_override_zone_id(db_session: AsyncSession) -> None:
+    zone = await _zone(db_session, "ovr.example.")
+    await db_session.commit()
+    # Matches with or without the trailing dot; None for unknown.
+    assert await _resolve_override_zone_id(db_session, "ovr.example") == zone.id
+    assert await _resolve_override_zone_id(db_session, "ovr.example.") == zone.id
+    assert await _resolve_override_zone_id(db_session, "nope.example") is None
+    assert await _resolve_override_zone_id(db_session, None) is None
+
+
+@pytest.mark.asyncio
+async def test_ddns_applies_configured_ttl(db_session: AsyncSession) -> None:
+    zone = await _zone(db_session, "ddns.example.")
+    subnet, row = await _ddns_subnet(db_session, zone=zone, ttl=321)
+    await db_session.commit()
+
+    fired = await apply_ddns_for_lease(
+        db_session, subnet=subnet, ipam_row=row, client_hostname="myhost"
+    )
+    assert fired is True
+
+    rec = (
+        await db_session.execute(
+            select(DNSRecord).where(DNSRecord.ip_address_id == row.id, DNSRecord.record_type == "A")
+        )
+    ).scalar_one()
+    assert rec.zone_id == zone.id
+    assert rec.ttl == 321  # the subnet's ddns_ttl, not the zone default (None)
+
+
+@pytest.mark.asyncio
+async def test_ddns_publishes_into_override_zone(db_session: AsyncSession) -> None:
+    default_zone = await _zone(db_session, "default.example.")
+    override_zone = await _zone(db_session, "override.example.")
+    subnet, row = await _ddns_subnet(
+        db_session, zone=default_zone, ttl=None, override="override.example"
+    )
+    await db_session.commit()
+
+    fired = await apply_ddns_for_lease(
+        db_session, subnet=subnet, ipam_row=row, client_hostname="myhost"
+    )
+    assert fired is True
+
+    rec = (
+        await db_session.execute(
+            select(DNSRecord).where(DNSRecord.ip_address_id == row.id, DNSRecord.record_type == "A")
+        )
+    ).scalar_one()
+    # The A record landed in the override zone, not the subnet's default.
+    assert rec.zone_id == override_zone.id

--- a/backend/tests/test_ipam_dns_backstop.py
+++ b/backend/tests/test_ipam_dns_backstop.py
@@ -1,0 +1,104 @@
+"""#428 — DDNS-aware IPAM↔DNS backstop helpers.
+
+The scheduled ``ipam_dns_sync`` backstop must (a) honor the DDNS opt-in —
+only DNS-publish lease-mirrored rows for subnets whose DDNS is enabled
+(manual allocations always sync) — and (b) for DDNS-enabled subnets,
+re-run the DDNS policy over active lease mirrors so a record a swallowed
+inline apply missed (incl. a generated ``dhcp-<x-y>`` name) is
+regenerated. These tests pin the two new helpers.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.tasks.ipam_dns_sync import _auto_from_lease_ip_ids, _reapply_ddns_for_active_leases
+
+
+async def _subnet(db: AsyncSession) -> Subnet:
+    space = IPSpace(name=f"bk-sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.80.0.0/16", name="bk-blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.80.1.0/24", name="bk-sn")
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _add_ip(db: AsyncSession, subnet: Subnet, addr: str, *, lease: bool) -> IPAddress:
+    row = IPAddress(
+        subnet_id=subnet.id,
+        address=addr,
+        status="dhcp" if lease else "allocated",
+        hostname="h" if lease else "manual-host",
+        mac_address="aa:bb:cc:dd:ee:01",
+        auto_from_lease=lease,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_auto_from_lease_ip_ids_only_returns_lease_rows(db_session: AsyncSession) -> None:
+    subnet = await _subnet(db_session)
+    lease_row = await _add_ip(db_session, subnet, "10.80.1.10", lease=True)
+    await _add_ip(db_session, subnet, "10.80.1.20", lease=False)  # manual
+    await db_session.commit()
+
+    ids = await _auto_from_lease_ip_ids(db_session, subnet.id)
+    assert ids == {lease_row.id}
+
+
+@pytest.mark.asyncio
+async def test_reapply_ddns_iterates_only_lease_rows(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subnet = await _subnet(db_session)
+    await _add_ip(db_session, subnet, "10.80.1.10", lease=True)
+    await _add_ip(db_session, subnet, "10.80.1.11", lease=True)
+    await _add_ip(db_session, subnet, "10.80.1.20", lease=False)  # manual — skipped
+    await db_session.commit()
+
+    seen: list[str] = []
+
+    async def _fake_apply(db, *, subnet, ipam_row, client_hostname):  # type: ignore[no-untyped-def]
+        seen.append(str(ipam_row.address))
+        return True  # pretend a record was (re)published
+
+    # The helper lazy-imports apply_ddns_for_lease from this module.
+    import app.services.dns.ddns as ddns_mod
+
+    monkeypatch.setattr(ddns_mod, "apply_ddns_for_lease", _fake_apply)
+
+    fired, errors = await _reapply_ddns_for_active_leases(db_session, subnet)
+    assert fired == 2
+    assert errors == []
+    assert sorted(seen) == ["10.80.1.10", "10.80.1.11"]  # only the lease rows
+
+
+@pytest.mark.asyncio
+async def test_reapply_ddns_collects_per_row_errors(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subnet = await _subnet(db_session)
+    await _add_ip(db_session, subnet, "10.80.1.10", lease=True)
+    await db_session.commit()
+
+    async def _boom(db, *, subnet, ipam_row, client_hostname):  # type: ignore[no-untyped-def]
+        raise RuntimeError("zone unreachable")
+
+    import app.services.dns.ddns as ddns_mod
+
+    monkeypatch.setattr(ddns_mod, "apply_ddns_for_lease", _boom)
+
+    fired, errors = await _reapply_ddns_for_active_leases(db_session, subnet)
+    assert fired == 0
+    assert len(errors) == 1 and "zone unreachable" in errors[0]

--- a/backend/tests/test_lease_events_replication.py
+++ b/backend/tests/test_lease_events_replication.py
@@ -1,0 +1,135 @@
+"""#428 — Kea lease-event ingestion → IPAM mirror (regression guard).
+
+The agent posts the server's ``LeaseEventBatch`` shape; the endpoint must
+upsert a DHCPLease + mirror it into IPAM as an ``auto_from_lease`` row for
+the containing subnet. Two guards:
+
+* the agent-shaped payload (``{"leases":[{"ip_address",…}]}``) is accepted
+  and actually creates rows (the blocker was a silent 200-no-op), and
+* the OLD/wrong envelope (``{"events":[…]}``) now 422s loudly instead of
+  validating to an empty batch.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dhcp.agents import _auth_agent
+from app.main import app
+from app.models.dhcp import DHCPLease, DHCPServer
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+
+async def _seed(db: AsyncSession) -> tuple[DHCPServer, Subnet]:
+    space = IPSpace(name=f"le-sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.70.0.0/16", name="le-blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id, block_id=block.id, network="10.70.1.0/24", name="le-sn"
+    )
+    db.add(subnet)
+    server = DHCPServer(
+        name=f"le-kea-{uuid.uuid4().hex[:6]}",
+        driver="kea",
+        host="127.0.0.1",
+        port=67,
+        status="active",
+    )
+    db.add(server)
+    await db.flush()
+    return server, subnet
+
+
+def _agent_payload(ip: str = "10.70.1.50", mac: str = "aa:bb:cc:dd:ee:ff") -> dict:
+    end = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    # Exactly what the fixed agent ships (server LeaseEvent field names).
+    return {
+        "leases": [
+            {
+                "ip_address": ip,
+                "mac_address": mac,
+                "hostname": "host1",
+                "state": "active",
+                "starts_at": datetime.now(UTC).isoformat(),
+                "ends_at": end,
+                "expires_at": end,
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_shaped_lease_event_mirrors_to_ipam(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    server, subnet = await _seed(db_session)
+    await db_session.commit()
+
+    app.dependency_overrides[_auth_agent] = lambda: (server, {})
+    try:
+        resp = await client.post(
+            "/api/v1/dhcp/agents/lease-events", json=_agent_payload()
+        )
+    finally:
+        app.dependency_overrides.pop(_auth_agent, None)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["upserted"] == 1
+
+    # DHCPLease row created with a non-NULL expires_at (so the time-based
+    # sweep can reap it) ...
+    lease = (
+        await db_session.execute(
+            select(DHCPLease).where(DHCPLease.ip_address == "10.70.1.50")
+        )
+    ).scalar_one()
+    assert lease.mac_address == "aa:bb:cc:dd:ee:ff"
+    assert lease.expires_at is not None
+
+    # ... and mirrored into IPAM as an auto_from_lease row in the subnet.
+    addr = (
+        await db_session.execute(
+            select(IPAddress).where(IPAddress.address == "10.70.1.50")
+        )
+    ).scalar_one()
+    assert addr.subnet_id == subnet.id
+    assert addr.auto_from_lease is True
+    assert addr.mac_address == "aa:bb:cc:dd:ee:ff"
+
+
+@pytest.mark.asyncio
+async def test_old_events_envelope_is_rejected_loudly(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    server, _ = await _seed(db_session)
+    await db_session.commit()
+
+    app.dependency_overrides[_auth_agent] = lambda: (server, {})
+    try:
+        # The pre-#428 shape: wrong envelope key + wrong field names. Must
+        # 422 (extra=forbid) instead of silently validating to an empty
+        # batch and returning 200.
+        resp = await client.post(
+            "/api/v1/dhcp/agents/lease-events",
+            json={"events": [{"ip": "10.70.1.50", "mac": "aa:bb:cc:dd:ee:ff"}]},
+        )
+    finally:
+        app.dependency_overrides.pop(_auth_agent, None)
+
+    assert resp.status_code == 422, resp.text
+    # And no lease/IPAM row leaked through.
+    leaked = (
+        await db_session.execute(
+            select(DHCPLease).where(DHCPLease.ip_address == "10.70.1.50")
+        )
+    ).scalar_one_or_none()
+    assert leaked is None

--- a/backend/tests/test_lease_events_replication.py
+++ b/backend/tests/test_lease_events_replication.py
@@ -33,9 +33,7 @@ async def _seed(db: AsyncSession) -> tuple[DHCPServer, Subnet]:
     block = IPBlock(space_id=space.id, network="10.70.0.0/16", name="le-blk")
     db.add(block)
     await db.flush()
-    subnet = Subnet(
-        space_id=space.id, block_id=block.id, network="10.70.1.0/24", name="le-sn"
-    )
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.70.1.0/24", name="le-sn")
     db.add(subnet)
     server = DHCPServer(
         name=f"le-kea-{uuid.uuid4().hex[:6]}",
@@ -76,9 +74,7 @@ async def test_agent_shaped_lease_event_mirrors_to_ipam(
 
     app.dependency_overrides[_auth_agent] = lambda: (server, {})
     try:
-        resp = await client.post(
-            "/api/v1/dhcp/agents/lease-events", json=_agent_payload()
-        )
+        resp = await client.post("/api/v1/dhcp/agents/lease-events", json=_agent_payload())
     finally:
         app.dependency_overrides.pop(_auth_agent, None)
 
@@ -88,18 +84,14 @@ async def test_agent_shaped_lease_event_mirrors_to_ipam(
     # DHCPLease row created with a non-NULL expires_at (so the time-based
     # sweep can reap it) ...
     lease = (
-        await db_session.execute(
-            select(DHCPLease).where(DHCPLease.ip_address == "10.70.1.50")
-        )
+        await db_session.execute(select(DHCPLease).where(DHCPLease.ip_address == "10.70.1.50"))
     ).scalar_one()
     assert lease.mac_address == "aa:bb:cc:dd:ee:ff"
     assert lease.expires_at is not None
 
     # ... and mirrored into IPAM as an auto_from_lease row in the subnet.
     addr = (
-        await db_session.execute(
-            select(IPAddress).where(IPAddress.address == "10.70.1.50")
-        )
+        await db_session.execute(select(IPAddress).where(IPAddress.address == "10.70.1.50"))
     ).scalar_one()
     assert addr.subnet_id == subnet.id
     assert addr.auto_from_lease is True
@@ -128,8 +120,6 @@ async def test_old_events_envelope_is_rejected_loudly(
     assert resp.status_code == 422, resp.text
     # And no lease/IPAM row leaked through.
     leaked = (
-        await db_session.execute(
-            select(DHCPLease).where(DHCPLease.ip_address == "10.70.1.50")
-        )
+        await db_session.execute(select(DHCPLease).where(DHCPLease.ip_address == "10.70.1.50"))
     ).scalar_one_or_none()
     assert leaked is None

--- a/backend/tests/test_subnet_delete_lease_cleanup.py
+++ b/backend/tests/test_subnet_delete_lease_cleanup.py
@@ -1,0 +1,112 @@
+"""#428 — subnet soft-delete revokes DHCP-lease DDNS records + mirrors.
+
+The soft-delete batch only stamps the subnet + its DHCP scopes, so a
+lease-mirrored IPAM row's published DDNS A/PTR record would otherwise be
+orphaned (still on the DNS server, pointing at a deleted subnet, hidden
+from the sweeps). ``_revoke_subnet_lease_mirrors`` revokes those records
+and drops the transient mirror rows; manual allocations are untouched.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.ipam.router import _revoke_subnet_lease_mirrors
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+
+async def _subnet_with_rows(db: AsyncSession) -> tuple[Subnet, list[str]]:
+    space = IPSpace(name=f"sd-sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.90.0.0/16", name="sd-blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.90.1.0/24", name="sd-sn")
+    db.add(subnet)
+    await db.flush()
+    for addr, lease in (("10.90.1.10", True), ("10.90.1.11", True), ("10.90.1.20", False)):
+        db.add(
+            IPAddress(
+                subnet_id=subnet.id,
+                address=addr,
+                status="dhcp" if lease else "allocated",
+                mac_address="aa:bb:cc:dd:ee:01",
+                hostname="h",
+                auto_from_lease=lease,
+            )
+        )
+    await db.flush()
+    return subnet, ["10.90.1.10", "10.90.1.11"]
+
+
+@pytest.mark.asyncio
+async def test_revoke_subnet_lease_mirrors(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subnet, lease_ips = await _subnet_with_rows(db_session)
+    await db_session.commit()
+
+    revoked_ips: list[str] = []
+
+    async def _fake_revoke(db, *, subnet, ipam_row):  # type: ignore[no-untyped-def]
+        revoked_ips.append(str(ipam_row.address))
+        return True
+
+    import app.services.dns.ddns as ddns_mod
+
+    monkeypatch.setattr(ddns_mod, "revoke_ddns_for_lease", _fake_revoke)
+
+    count = await _revoke_subnet_lease_mirrors(db_session, subnet)
+    await db_session.flush()
+
+    # Both lease mirrors revoked + deleted; the manual allocation survives.
+    assert count == 2
+    assert sorted(revoked_ips) == lease_ips
+    remaining = (
+        (
+            await db_session.execute(
+                select(IPAddress.address).where(IPAddress.subnet_id == subnet.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [str(a) for a in remaining] == ["10.90.1.20"]
+
+
+@pytest.mark.asyncio
+async def test_revoke_is_best_effort_on_dns_error(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A DNS-revoke failure must not block the delete — the mirror row is
+    # still dropped (the reconcile cleans any DNS residue later).
+    subnet, _ = await _subnet_with_rows(db_session)
+    await db_session.commit()
+
+    async def _boom(db, *, subnet, ipam_row):  # type: ignore[no-untyped-def]
+        raise RuntimeError("dns down")
+
+    import app.services.dns.ddns as ddns_mod
+
+    monkeypatch.setattr(ddns_mod, "revoke_ddns_for_lease", _boom)
+
+    count = await _revoke_subnet_lease_mirrors(db_session, subnet)
+    await db_session.flush()
+    assert count == 2
+    lease_rows = (
+        (
+            await db_session.execute(
+                select(IPAddress).where(
+                    IPAddress.subnet_id == subnet.id, IPAddress.auto_from_lease.is_(True)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert lease_rows == []

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -6436,6 +6436,16 @@ function EditSubnetModal({
             </strong>
             {subnet.name ? ` (${subnet.name})` : ""}?
           </p>
+          {/* #428 — lease-mirrored rows + their DDNS records don't survive
+              the delete, so warn before any orphaned DNS lingers. */}
+          <div className="flex items-start gap-1.5 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-200">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              Any DHCP-leased addresses in this subnet and their auto-published
+              DNS (DDNS) records will be revoked and removed. Manually-allocated
+              addresses are unaffected.
+            </span>
+          </div>
           {deleteError && (
             <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
               {deleteError}


### PR DESCRIPTION
Closes #428

A full audit of the DHCP → IPAM → DNS replication triangle (lease → `auto_from_lease` IPAM mirror → DDNS A/PTR) found the **Windows path works** but the **Kea push path was silently dead**, plus several cleanup/consistency gaps. DDNS stays **opt-in by design** (a subnet must explicitly enable it — confirmed intended).

## 🔴 Blocker — Kea lease-event push was a silent no-op
The agent shipped `{"events":[{"ip","mac","ends_at"}]}` but the server's `LeaseEventBatch` expects `{"leases":[{"ip_address","mac_address","expires_at"}]}` with `leases` defaulting to `[]`. So the POST validated to an empty batch, returned **200**, and the agent cleared its queue — every Kea lease dropped, never mirrored to IPAM, never DDNS-registered (no Kea poll fallback). Fix: agent emits the server's exact shape (+ non-NULL `expires_at` so the sweep can reap mirrors); `extra="forbid"` on the batch so future drift **422s loudly**; handler falls back `expires_at = ev.expires_at or ev.ends_at`.

## 🟠 DDNS-aware backstop (eventual consistency)
`ipam-dns-auto-sync` now, per subnet gated on effective DDNS: **off** → drops `auto_from_lease` rows from the drift set (honors the opt-in; manual allocations still sync); **on** → re-runs `apply_ddns_for_lease` over active lease mirrors so a record a swallowed inline apply missed (incl. generated `dhcp-<x-y>` names the drift check can't see) is regenerated.

## 🟠 Subnet soft-delete revokes lease DDNS + mirrors
Soft-delete only stamped the subnet + scopes (ignored `IPAddress`/`DNSRecord`), orphaning lease mirrors' DDNS records. Now revokes them + drops the mirror rows; manual allocations untouched; best-effort (a DNS hiccup never blocks the delete). Delete-subnet modal warns.

## 🟡 Minors (all fixed)
- `ddns_ttl` + `ddns_domain_override` were resolved but **dead** — now consumed (record TTL stamped; forward record published into the override zone; reverse stays keyed by IP).
- Agentless **Windows-DNS** record whose synchronous apply *fails* no longer leaves `dns_record_id` stamped (DDNS retries instead of permanently skipping). Agent-based ops self-heal via the bundle, unchanged.
- **Windows-pull DDNS** now wakes the agent on commit (converges immediately vs. the ~12s safety tick).

## ✅ Checked OK
Cleanup-job wiring is clean — every cleanup task is in both the beat schedule and the worker `include=[...]` (no #218-class silent-never-run). The Windows poll path correctly cascades expiry → IPAM mirror removal → DDNS revoke (#426 intact). #424 SRV/MX mapping unaffected.

## Tests
8 new test files (agent lease-shape + backend lease-event→IPAM e2e + old-envelope-422 + DDNS-aware backstop gating + soft-delete revoke + ttl/override + override resolver). **46 existing DNS/lease/IPAM regression tests pass**; ruff/black/mypy (565) + frontend tsc/lint/format clean. Audited via a 5-dimension multi-agent sweep; the blocker + `expires_at` + DDNS-default + all minors re-verified by hand against source.