### PR TITLE
fix: #430 DDI hardening sweep — integration-mirror mass-delete + agent wire-contract + wake gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,52 @@ Batched fixes for the next cut (not yet released).
 
 ### Fixed
 
+* **#430 — DDI hardening sweep: integration-mirror mass-delete on
+  degraded reads + agent wire-contract + ConfigBundle/wake gaps.** A
+  three-area audit (integration mirrors, agent↔control-plane wire
+  contracts, ConfigBundle ETag + wake coverage) surfaced one systemic
+  data-loss class plus a batch of wire/lifecycle gaps. **Systemic
+  (highest value):** every read-only integration mirror (Kubernetes,
+  Docker, Proxmox, Cloud AWS/Azure/GCP, UniFi, OPNsense, Tailscale)
+  could **mass-delete the entire mirror on a degraded read** — a 200
+  with a wrong-shape body (proxy/auth error page, envelope change,
+  ``data: null``) or a partial multi-scope pull collapsed to "zero
+  items", and the unconditional absence-delete pass purged every
+  mirrored IPAM/DNS row while reporting ``ok=True``. UniFi was the
+  worst: a routine ``stat/sta`` 429 on one site mass-deleted that
+  site's subnets + client addresses. Fixed in two layers — a shared
+  shape guard (``app/services/_mirror_shape.py``) makes each client
+  **raise** its typed error on a wrong-shape 200 (a legitimately-empty
+  upstream like ``{"items": []}`` still returns ``[]``), and the
+  reconcilers now **skip the absence-delete pass on a partial pull**
+  (cloud connectors record ``failed_scopes`` + the reconciler upserts
+  but doesn't delete + records the partial pull in ``last_sync_error``;
+  UniFi aborts the whole reconcile on a per-site fetch failure like the
+  Proxmox per-node pattern). **Agent wire-contract / bundle fixes:**
+  DNS per-zone TTL was pinned to a constant 3600 (a ``default_ttl``
+  getattr typo — the column is ``ttl``) so editing a zone's TTL never
+  re-rendered; DNS per-server convergence (the ZoneSyncPill) never
+  reported because the bundle shipped no per-zone serial, so the agent
+  skipped every zone; DHCP static reservations dropped ``client_id`` +
+  ``options_override`` on the wire (a client-id-keyed reservation
+  silently fell back to MAC); DHCP scope ``min/max_lease_time`` were
+  settable + in the ETag but never reached the agent (now rendered as
+  Kea ``min/max-valid-lifetime``); and a DNS **view's
+  ``allow_query`` / ``allow_query_cache`` ACL** round-tripped through
+  the API but was never carried in the bundle or emitted by the BIND9
+  renderer, so a view-scoped query ACL silently never took effect.
+  **Wake / hardening:** the appliance fleet-firewall master switch
+  (``PUT /enforcement``) and mgmt-UI CIDR lock (``PUT /web-ui-access``)
+  published no agent wake, so security changes converged only when the
+  parked heartbeat hold timed out (≤28 s) — they now wake immediately;
+  DHCP server create/delete now wake the group (an HA-membership change
+  re-renders peers); the DHCP lease shipper caps its pending buffer
+  (was unbounded on a persistent reject); and the DNS heartbeat model
+  gains ``extra="forbid"`` + a bounded ``ops_ack`` so a wrong-envelope
+  ACK batch 422s loudly instead of silently clearing the agent's ACK
+  queue. The supervisor's ``lldpd_running`` (shipped every heartbeat
+  since #347 but silently dropped) is now persisted.
+
 * **#428 — DHCP↔IPAM↔DNS replication gaps (Kea push dead + cleanup
   holes).** A replication audit found the **Kea lease-event push was a
   silent no-op**: the agent shipped ``{"events":[{"ip","mac"}]}`` but the
@@ -134,6 +180,21 @@ Batched fixes for the next cut (not yet released).
   operator can clear + re-apply from the Fleet drilldown. The drilldown
   also shows a "looks stuck — check the host or re-apply" hint if an
   apply sits in-flight past ~6 min.
+
+### Migrations
+
+* **#430 — ``appliance.lldpd_running``** (``a3f7c1e84d59``). Adds a
+  nullable Boolean column persisting the supervisor's LLDP daemon
+  up/down status (companion to the already-wired ``lldp_neighbours``
+  set). Additive + nullable; no backfill.
+
+### Deprecated
+
+* **#430 — DNS heartbeat ``zone_serials``.** Serial convergence is
+  reported via the dedicated ``/dns/agents/zone-state`` endpoint; the
+  current agent no longer sends ``zone_serials`` in its heartbeat. The
+  field is retained (default ``{}``) on the request model so pre-#430
+  agents still validate under the new ``extra="forbid"``.
 
 ---
 

--- a/agent/dhcp/spatium_dhcp_agent/leases.py
+++ b/agent/dhcp/spatium_dhcp_agent/leases.py
@@ -31,6 +31,11 @@ log = structlog.get_logger(__name__)
 
 _BATCH_MAX_EVENTS = 100
 _BATCH_MAX_SECONDS = 5.0
+# #430 — hard cap on the pending buffer. A persistent reject (422/500/401)
+# leaves _pending unflushed while run() keeps appending new lease rows, so
+# without a cap the buffer (and the re-POSTed body) grows without bound.
+# Trim-half on overflow, mirroring the log + fingerprint shippers.
+_BATCH_MAX_BUFFER = 5000
 
 _STATE_MAP = {"0": "active", "1": "declined", "2": "expired"}
 
@@ -153,6 +158,10 @@ class LeaseWatcher:
             for row in rows:
                 evt = _parse_row(row)
                 if evt is not None:
+                    if len(self._pending) >= _BATCH_MAX_BUFFER:
+                        drop = _BATCH_MAX_BUFFER // 2
+                        self._pending = self._pending[drop:]
+                        log.warning("lease_events_buffer_trimmed", dropped=drop)
                     self._pending.append(evt)
                 if len(self._pending) >= _BATCH_MAX_EVENTS:
                     self._flush()

--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -134,12 +134,18 @@ def _options_from_mapping(options: dict[str, Any] | None) -> list[dict[str, Any]
             return
         out.append(_opt(name, val))
 
-    _put("domain-name-servers", options.get("dns_servers") or options.get("domain-name-servers"))
+    _put(
+        "domain-name-servers",
+        options.get("dns_servers") or options.get("domain-name-servers"),
+    )
     _put("ntp-servers", options.get("ntp_servers") or options.get("ntp-servers"))
     _put("routers", options.get("routers") or options.get("gateway"))
     _put("domain-name", options.get("domain_name") or options.get("domain-name"))
     _put("domain-search", options.get("domain_search") or options.get("domain-search"))
-    _put("tftp-server-name", options.get("tftp_server") or options.get("tftp-server-name"))
+    _put(
+        "tftp-server-name",
+        options.get("tftp_server") or options.get("tftp-server-name"),
+    )
     _put("boot-file-name", options.get("boot_file") or options.get("boot-file-name"))
 
     # Pass through any raw Kea-style list already shaped correctly.
@@ -324,6 +330,12 @@ def _scope_to_subnet6(scope: dict[str, Any]) -> dict[str, Any]:
             out["reservations"] = resv
     if scope.get("lease_time"):
         out["valid-lifetime"] = int(scope["lease_time"])
+    # #430 — honour the per-scope min/max lease bounds (Kea clamps the
+    # client-requested lease into [min, max]). Omitted → Kea defaults.
+    if scope.get("min_lease_time"):
+        out["min-valid-lifetime"] = int(scope["min_lease_time"])
+    if scope.get("max_lease_time"):
+        out["max-valid-lifetime"] = int(scope["max_lease_time"])
     relay = scope.get("relay_addresses")
     if relay:
         out["relay"] = {"ip-addresses": list(relay)}
@@ -397,7 +409,8 @@ def _subnet(subnet: dict[str, Any]) -> dict[str, Any]:
     pools = subnet.get("pools") or []
     if pools:
         out["pools"] = [
-            {"pool": p["pool"]} if isinstance(p, dict) else {"pool": str(p)} for p in pools
+            {"pool": p["pool"]} if isinstance(p, dict) else {"pool": str(p)}
+            for p in pools
         ]
     opts = _options_from_mapping(subnet.get("options"))
     if opts:
@@ -475,6 +488,12 @@ def _scope_to_subnet(scope: dict[str, Any]) -> dict[str, Any]:
         out["reservations"] = resv
     if scope.get("lease_time"):
         out["valid-lifetime"] = int(scope["lease_time"])
+    # #430 — honour the per-scope min/max lease bounds (Kea clamps the
+    # client-requested lease into [min, max]). Omitted → Kea defaults.
+    if scope.get("min_lease_time"):
+        out["min-valid-lifetime"] = int(scope["min_lease_time"])
+    if scope.get("max_lease_time"):
+        out["max-valid-lifetime"] = int(scope["max_lease_time"])
     # Relay-agent matching (issue #337) — Kea selects this subnet for
     # packets whose giaddr is one of these relay IPs. Required for
     # subnets not directly attached to a centralized server.
@@ -616,7 +635,9 @@ def render(
             "max-reclaim-time": 250,
             "unwarned-reclaim-cycles": 5,
         },
-        "valid-lifetime": int(bundle.get("global_options", {}).get("lease_time") or 3600),
+        "valid-lifetime": int(
+            bundle.get("global_options", {}).get("lease_time") or 3600
+        ),
         "renew-timer": 900,
         "rebind-timer": 1800,
         "hooks-libraries": [

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -410,11 +410,28 @@ class Bind9Driver(DriverBase):
                     if md
                     else ""
                 )
+                # #430 — per-view query ACLs. When the control plane sets
+                # allow_query / allow_query_cache on a view, enforce it here;
+                # a null/empty value inherits the server-options allow-query.
+                aq = view.get("allow_query")
+                aq_line = (
+                    f"    allow-query {{ {'; '.join(str(c) for c in aq)}; }};\n"
+                    if aq
+                    else ""
+                )
+                aqc = view.get("allow_query_cache")
+                aqc_line = (
+                    f"    allow-query-cache {{ {'; '.join(str(c) for c in aqc)}; }};\n"
+                    if aqc
+                    else ""
+                )
                 conf += (
                     f'view "{vname}" {{\n'
                     f"    match-clients {{ {match_clients}; }};\n"
                     f"{md_line}"
                     f"    recursion {recursion_v};\n"
+                    f"{aq_line}"
+                    f"{aqc_line}"
                     f"{_indent(body)}"
                     f"}};\n"
                 )

--- a/agent/dns/spatium_dns_agent/heartbeat.py
+++ b/agent/dns/spatium_dns_agent/heartbeat.py
@@ -24,7 +24,6 @@ class HeartbeatClient:
         self._stop = threading.Event()
         self.pending_acks: list[dict[str, Any]] = []
         self.daemon_status: dict[str, Any] = {}
-        self.zone_serials: dict[str, int] = {}
         self.failed_ops_count = 0
 
     def stop(self) -> None:
@@ -36,7 +35,9 @@ class HeartbeatClient:
             verify = False
         elif self.cfg.tls_ca_path:
             verify = self.cfg.tls_ca_path
-        return httpx.Client(base_url=self.cfg.control_plane_url, verify=verify, timeout=15.0)
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url, verify=verify, timeout=15.0
+        )
 
     def send_once(self) -> None:
         body: dict[str, Any] = {
@@ -45,7 +46,6 @@ class HeartbeatClient:
             "config": {},
             "ops_ack": self.pending_acks,
             "failed_ops_count": self.failed_ops_count,
-            "zone_serials": self.zone_serials,
         }
         # #170 Wave C1 — slot / deployment / upgrade-state telemetry
         # used to ship here per Phase 8f-2; now lives on the
@@ -80,7 +80,9 @@ class HeartbeatClient:
                 log.warning(
                     "heartbeat_will_rebootstrap",
                     status=resp.status_code,
-                    reason="token_invalid" if resp.status_code == 401 else "server_missing",
+                    reason=(
+                        "token_invalid" if resp.status_code == 401 else "server_missing"
+                    ),
                 )
                 save_token(self.cfg.state_dir, "")
                 self._stop.set()

--- a/agent/dns/tests/test_views_render.py
+++ b/agent/dns/tests/test_views_render.py
@@ -148,6 +148,35 @@ def test_per_view_zone_files_hold_view_scoped_records(tmp_path: Path) -> None:
     assert "mail.example.com." in external_zone
 
 
+def test_per_view_allow_query_acl_is_enforced(tmp_path: Path) -> None:
+    """#430 — a view's allow_query / allow_query_cache render into its block.
+
+    Previously these round-tripped through the API but were never emitted,
+    so a view-scoped query ACL silently never took effect."""
+    bundle = _split_horizon_bundle()
+    # internal: restrict queries to the RFC 1918 client range + cache to it.
+    bundle["views"][0]["allow_query"] = ["10.0.0.0/8", "localhost"]
+    bundle["views"][0]["allow_query_cache"] = ["10.0.0.0/8"]
+    # external: leave both unset → inherit server-options allow-query.
+    bundle["views"][1]["allow_query"] = None
+    bundle["views"][1]["allow_query_cache"] = None
+
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(bundle)
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+
+    internal_block = conf.split('view "internal" {', 1)[1].split(
+        'view "external" {', 1
+    )[0]
+    external_block = conf.split('view "external" {', 1)[1]
+
+    assert "allow-query { 10.0.0.0/8; localhost; };" in internal_block
+    assert "allow-query-cache { 10.0.0.0/8; };" in internal_block
+    # The unset view emits neither line (inherits server options).
+    assert "allow-query {" not in external_block
+    assert "allow-query-cache {" not in external_block
+
+
 def test_no_views_keeps_flat_render(tmp_path: Path) -> None:
     # Backward-compat: a bundle with no views renders flat (no view {}
     # blocks, zone file at zones/<name>.db).

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -103,6 +103,7 @@ backend/alembic/versions/a3f1d9e07c52_firewall_apply_state.py:drop_table:67
 backend/alembic/versions/a3f1e9c47b20_platform_settings_verbose_boot.py:drop_column:37
 backend/alembic/versions/a3f7b2c8d419_add_name_description_to_dhcp_scope.py:drop_column:33
 backend/alembic/versions/a3f7b2c8d419_add_name_description_to_dhcp_scope.py:drop_column:34
+backend/alembic/versions/a3f7c1e84d59_appliance_lldpd_running.py:drop_column:35
 backend/alembic/versions/a3f7c1e92b48_decom_date_awareness.py:drop_column:38
 backend/alembic/versions/a3f7c1e92b48_decom_date_awareness.py:drop_column:41
 backend/alembic/versions/a4b8c2d619e7_ai_provider.py:drop_table:92

--- a/backend/alembic/versions/a3f7c1e84d59_appliance_lldpd_running.py
+++ b/backend/alembic/versions/a3f7c1e84d59_appliance_lldpd_running.py
@@ -1,0 +1,35 @@
+"""appliance.lldpd_running — persist the LLDP daemon up/down bool (#430)
+
+The supervisor has shipped ``lldpd_running`` in every heartbeat since #347
+(appliance_state lldpd sidecar), but the backend had no field / column /
+handler, so ``extra="ignore"`` silently dropped it (a #428-shape defect).
+This adds the column so it persists alongside the already-wired
+``lldp_neighbours`` set — an empty neighbour set is "no neighbours" only
+when lldpd is up, "lldpd down" otherwise.
+
+Revision ID: a3f7c1e84d59
+Revises: f4a1c8e92b07
+Create Date: 2026-06-14
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a3f7c1e84d59"
+down_revision: str | None = "f4a1c8e92b07"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "appliance",
+        sa.Column("lldpd_running", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("appliance", "lldpd_running")

--- a/backend/app/api/v1/appliance/firewall.py
+++ b/backend/app/api/v1/appliance/firewall.py
@@ -42,6 +42,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser
+from app.core.agent_wake import HOSTCONFIG_ALL, publish_wake
 from app.core.permissions import user_has_permission
 from app.core.request_meta import client_ip
 from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
@@ -1099,6 +1100,10 @@ async def set_enforcement(
             )
         )
     await db.commit()
+    # Wake every supervisor's heartbeat hold so the enforcement flip converges
+    # at ~0 s instead of waiting out the parked long-poll (≤28 s). Firewall
+    # state feeds firewall_render_inputs() in the heartbeat.
+    await publish_wake(HOSTCONFIG_ALL)
     return await _enforcement_status(db)
 
 
@@ -1371,6 +1376,9 @@ async def set_web_ui_access(
             )
         )
     await db.commit()
+    # Mgmt-UI CIDR lock is security-critical — wake the fleet so the new
+    # allow-list lands immediately rather than at the next heartbeat tick.
+    await publish_wake(HOSTCONFIG_ALL)
     cidrs = list(cfg.web_ui_allowed_cidrs or [])
     return WebUIAccessResponse(
         allowed_cidrs=cidrs,

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -156,7 +156,8 @@ def _supervisor_strips_url_fragment(row: Appliance) -> bool:
     changes the URL), never the ability to upgrade (#419)."""
     ver = row.supervisor_version or row.installed_appliance_version or ""
     return (
-        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
+        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None
+        and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
     )
 
 
@@ -638,7 +639,9 @@ async def supervisor_register(
     # force a fresh registration they delete the row in the fleet UI,
     # which causes the supervisor to clear its identity + claim a new
     # pairing code on next boot.
-    existing_stmt = select(Appliance).where(Appliance.public_key_fingerprint == pubkey_fingerprint)
+    existing_stmt = select(Appliance).where(
+        Appliance.public_key_fingerprint == pubkey_fingerprint
+    )
     existing = (await db.execute(existing_stmt)).scalar_one_or_none()
     if existing is not None:
         # Idempotent re-register. Touch last_seen_at so the heartbeat
@@ -729,7 +732,9 @@ async def supervisor_register(
                 resource_type="pairing_code",
                 resource_id=str(code_row.id) if code_row is not None else "unknown",
                 resource_display=(
-                    "supervisor pairing code" if code_row is not None else "unknown pairing code"
+                    "supervisor pairing code"
+                    if code_row is not None
+                    else "unknown pairing code"
                 ),
                 result="forbidden",
                 new_value={
@@ -774,7 +779,9 @@ async def supervisor_register(
     # operator to open the role-picker.
     initial_assigned_roles: list[str] = []
     if body.appliance_variant is not None:
-        initial_assigned_roles = list(_REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, []))
+        initial_assigned_roles = list(
+            _REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, [])
+        )
     appliance_row = Appliance(
         id=appliance_id,
         hostname=body.hostname,
@@ -921,7 +928,9 @@ async def supervisor_poll(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Not found.")
 
     row = await db.get(Appliance, body.appliance_id)
-    valid = row is not None and verify_session_token(body.session_token, row.session_token_hash)
+    valid = row is not None and verify_session_token(
+        body.session_token, row.session_token_hash
+    )
     if not valid:
         await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
@@ -1024,6 +1033,10 @@ class SupervisorHeartbeatRequest(BaseModel):
     # once no longer in-flight (clear); None on non-appliance.
     last_upgrade_progress: dict[str, Any] | None = None
     snmpd_running: bool | None = None
+    # Issue #430 — the supervisor already ships this every heartbeat
+    # (appliance_state lldpd sidecar); it was silently dropped (no field /
+    # column / handler). Now persisted alongside lldp_neighbours.
+    lldpd_running: bool | None = None
     ntp_sync_state: Literal["synchronized", "unsynchronized", "unknown"] | None = None
     # Issue #156 — best-effort rsyslog-forwarding status. None = not
     # collected (leave the stored column alone); a value persists.
@@ -1258,7 +1271,9 @@ class SupervisorHeartbeatResponse(BaseModel):
     # uses this to bring up dns-bind9 / dns-powerdns / dhcp-kea
     # service containers via docker compose. Empty roles list = idle
     # (approved but no service running).
-    role_assignment: SupervisorRoleAssignment = Field(default_factory=SupervisorRoleAssignment)
+    role_assignment: SupervisorRoleAssignment = Field(
+        default_factory=SupervisorRoleAssignment
+    )
     # #272 Phase 7 — control-plane promote/demote desired state.
     # ``desired_cluster_role`` = "member" → join the seed via
     # ``desired_k3s_server_url`` + ``desired_k3s_join_token``; "none" →
@@ -1403,7 +1418,9 @@ async def _ingest_lldp_neighbours(
         .scalars()
         .all()
     )
-    by_key = {(e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing}
+    by_key = {
+        (e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing
+    }
     now = datetime.now(UTC)
 
     for key, n in desired.items():
@@ -1546,7 +1563,9 @@ async def supervisor_heartbeat(
         )
         if not valid:
             await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
-            raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN, "Invalid appliance or session."
+            )
 
     assert row is not None
     # Issue #170 Wave E follow-up — reject heartbeats from soft-deleted
@@ -1602,6 +1621,8 @@ async def supervisor_heartbeat(
         row.last_upgrade_progress = body.last_upgrade_progress or None
     if body.snmpd_running is not None:
         row.snmpd_running = body.snmpd_running
+    if body.lldpd_running is not None:
+        row.lldpd_running = body.lldpd_running
     if body.ntp_sync_state is not None:
         row.ntp_sync_state = body.ntp_sync_state
     if body.syslog_forwarding is not None:
@@ -1782,7 +1803,9 @@ async def supervisor_heartbeat(
         for ev in evicted:
             ev.evict_requested = False
             ev.cluster_join_state = CLUSTER_JOIN_STATE_LEFT
-            logger.info("control_plane_node_evicted", hostname=ev.hostname, by=str(row.id))
+            logger.info(
+                "control_plane_node_evicted", hostname=ev.hostname, by=str(row.id)
+            )
 
     # Auto-clear the promote desired-state once the join landed: the
     # supervisor reports ``ready`` → the node IS a member now, so settle
@@ -1838,13 +1861,19 @@ async def supervisor_heartbeat(
     # the requested slot as ``current_slot`` — the operator's intent
     # was "boot into this slot next", and we got there. ``durable_
     # default`` is irrelevant here (next-boot is one-shot by design).
-    if row.desired_next_boot_slot is not None and row.current_slot == row.desired_next_boot_slot:
+    if (
+        row.desired_next_boot_slot is not None
+        and row.current_slot == row.desired_next_boot_slot
+    ):
         row.desired_next_boot_slot = None
 
     # Auto-clear desired_default_slot once the supervisor reports the
     # requested slot as ``durable_default`` — grub-set-default landed
     # and survives subsequent reboots.
-    if row.desired_default_slot is not None and row.durable_default == row.desired_default_slot:
+    if (
+        row.desired_default_slot is not None
+        and row.durable_default == row.desired_default_slot
+    ):
         row.desired_default_slot = None
 
     # Auto-clear reboot_requested 15 s after the stamp — by that
@@ -1894,12 +1923,17 @@ async def supervisor_heartbeat(
             long_poll = True
             hold_for = min(float(body.wait_seconds), _HEARTBEAT_HOLD_CAP_S)
             deadline = asyncio.get_running_loop().time() + hold_for
-            async with wake_subscription([*appliance_wake_channels(row), HOSTCONFIG_ALL]) as wake:
+            async with wake_subscription(
+                [*appliance_wake_channels(row), HOSTCONFIG_ALL]
+            ) as wake:
                 while True:
                     remaining = deadline - asyncio.get_running_loop().time()
                     if remaining <= 0:
                         break
-                    if await wake.wait(min(WAKE_TICK_SECONDS, remaining)) == WakeResult.WAKE:
+                    if (
+                        await wake.wait(min(WAKE_TICK_SECONDS, remaining))
+                        == WakeResult.WAKE
+                    ):
                         break
             # Pick up anything that committed during the hold (role /
             # firewall / desired-state edits land on other requests) before
@@ -1992,7 +2026,9 @@ async def supervisor_heartbeat(
     # Issue #165 — operator-set timezone. Empty string = no override.
     desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
     # #393 — appliance console mode (grubenv-driven, applies next reboot).
-    desired_console_mode = (cfg_row.console_mode or "dashboard") if cfg_row else "dashboard"
+    desired_console_mode = (
+        (cfg_row.console_mode or "dashboard") if cfg_row else "dashboard"
+    )
     # Issue #346 — host-config blocks for snmp / chrony / lldp. Built from the
     # same ``*_bundle`` helpers the DHCP-agent ConfigBundle uses; the
     # disabled-shape fallback keeps a stable key set when no settings row
@@ -2066,8 +2102,12 @@ async def supervisor_heartbeat(
         vip_configured=bool(metallb_vip),
         firewall_enabled=bool(cfg_row.firewall_enabled) if cfg_row else False,
         appliance_id=row.id,
-        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
-        firewall_logging_enabled=(bool(cfg_row.firewall_logging_enabled) if cfg_row else False),
+        web_ui_allowed_cidrs=(
+            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
+        ),
+        firewall_logging_enabled=(
+            bool(cfg_row.firewall_logging_enabled) if cfg_row else False
+        ),
     )
     # Persist the rendered hash so 2d's apply-stalled alarm + the Fleet drift
     # chip can compare it against the runner's reported applied_hash. Only
@@ -2126,7 +2166,9 @@ async def supervisor_heartbeat(
         cluster_peer_cidrs=cluster_peer_cidrs,
         firewall_pod_cidrs=firewall_pod_cidrs,
         firewall_service_cidrs=firewall_service_cidrs,
-        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        web_ui_allowed_cidrs=(
+            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
+        ),
         control_plane_size=control_plane_size,
         desired_metallb_enabled=metallb_enabled,
         desired_metallb_pool_addresses=metallb_pool,
@@ -2185,7 +2227,9 @@ async def firewall_render_inputs(db: DB, row: Appliance) -> dict[str, Any]:
         "cp_member_count": await _committed_cp_count(db),
         "vip_configured": bool((cfg_row.control_plane_vip or "") if cfg_row else ""),
         "firewall_enabled": bool(cfg_row.firewall_enabled) if cfg_row else False,
-        "web_ui_allowed_cidrs": (list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        "web_ui_allowed_cidrs": (
+            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
+        ),
     }
 
 
@@ -2199,7 +2243,9 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     from app.models.dns import DNSServerGroup
 
     assigned_roles = list(row.assigned_roles or [])
-    dns_role_assigned = "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
+    dns_role_assigned = (
+        "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
+    )
     dhcp_role_assigned = "dhcp" in assigned_roles
 
     dns_engine: str | None = None
@@ -2292,6 +2338,7 @@ class ApplianceRow(BaseModel):
     last_upgrade_log_tail: str | None
     last_upgrade_progress: dict[str, Any] | None
     snmpd_running: bool | None
+    lldpd_running: bool | None
     ntp_sync_state: str | None
     # Issue #156 — best-effort rsyslog-forwarding status surfaced from
     # the appliance row (forwarding / unreachable / disabled).
@@ -2417,6 +2464,7 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
         last_upgrade_log_tail=row.last_upgrade_log_tail,
         last_upgrade_progress=row.last_upgrade_progress,
         snmpd_running=row.snmpd_running,
+        lldpd_running=row.lldpd_running,
         ntp_sync_state=row.ntp_sync_state,
         syslog_forwarding=row.syslog_forwarding,
         ssh_key_count=row.ssh_key_count,
@@ -2463,7 +2511,9 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
 async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     _require_superadmin(current_user)
     rows = (
-        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc()))).scalars().all()
+        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc())))
+        .scalars()
+        .all()
     )
     return ApplianceList(appliances=[_row_to_schema(r) for r in rows])
 
@@ -2474,7 +2524,9 @@ async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Fetch a single appliance (superadmin)",
 )
-async def get_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> ApplianceRow:
+async def get_appliance(
+    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
+) -> ApplianceRow:
     _require_superadmin(current_user)
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -2599,7 +2651,9 @@ async def approve_appliance(
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Reject a pending appliance (deletes the row, superadmin)",
 )
-async def reject_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> None:
+async def reject_appliance(
+    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
+) -> None:
     """Reject = DELETE the row. Supervisor's next poll gets 403 +
     falls back to bootstrapping. Distinct from delete (next endpoint)
     only in the audit verb — operationally identical."""
@@ -2732,7 +2786,9 @@ async def _find_appliance_dependents(
 
     return ApplianceDependents(
         dns=[
-            ApplianceDependentServer(kind="dns", id=r.id, name=r.name, host=r.host, status=r.status)
+            ApplianceDependentServer(
+                kind="dns", id=r.id, name=r.name, host=r.host, status=r.status
+            )
             for r in dns_rows
         ],
         dhcp=[
@@ -2842,8 +2898,12 @@ async def delete_appliance(
                     Appliance.id != row.id,
                     Appliance.state != APPLIANCE_STATE_REVOKED,
                     or_(
-                        Appliance.appliance_variant.in_(tuple(_SELF_BOOTSTRAP_VARIANTS)),
-                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
+                        Appliance.appliance_variant.in_(
+                            tuple(_SELF_BOOTSTRAP_VARIANTS)
+                        ),
+                        Appliance.cluster_role.in_(
+                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
+                        ),
                     ),
                 )
             )
@@ -3293,10 +3353,14 @@ async def update_appliance_roles(
             new_value={
                 "roles": list(row.assigned_roles or []),
                 "dns_group_id": (
-                    str(row.assigned_dns_group_id) if row.assigned_dns_group_id else None
+                    str(row.assigned_dns_group_id)
+                    if row.assigned_dns_group_id
+                    else None
                 ),
                 "dhcp_group_id": (
-                    str(row.assigned_dhcp_group_id) if row.assigned_dhcp_group_id else None
+                    str(row.assigned_dhcp_group_id)
+                    if row.assigned_dhcp_group_id
+                    else None
                 ),
                 "tags": dict(row.tags or {}),
             },
@@ -3348,7 +3412,9 @@ async def _effective_cp_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
+                        Appliance.cluster_role.in_(
+                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
+                        ),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3436,7 +3502,9 @@ async def _firewall_peer_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
+                        Appliance.cluster_role.in_(
+                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
+                        ),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3562,7 +3630,9 @@ async def promote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
+            )
         if row.id == primary.id:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3573,7 +3643,10 @@ async def promote_control_plane(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is in state {row.state!r}; approve it first.",
             )
-        if row.cluster_role is not None or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER:
+        if (
+            row.cluster_role is not None
+            or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
+        ):
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is already a control-plane member (or joining).",
@@ -3669,7 +3742,9 @@ async def demote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
+            )
         if row.cluster_role == CLUSTER_ROLE_PRIMARY:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3767,7 +3842,9 @@ async def replace_control_plane_member(
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found.")
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found."
+        )
     if row.cluster_role == CLUSTER_ROLE_PRIMARY:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3996,7 +4073,9 @@ async def restore_etcd_snapshot(
             "destructive cluster-reset restore.",
         )
     known = {
-        s.get("name") for s in (seed.etcd_snapshots or []) if isinstance(s, dict) and s.get("name")
+        s.get("name")
+        for s in (seed.etcd_snapshots or [])
+        if isinstance(s, dict) and s.get("name")
     }
     if body.snapshot_name not in known:
         raise HTTPException(
@@ -4113,7 +4192,9 @@ def _metallb_pod_status() -> tuple[bool, int, int]:
 
     def _ready(pod: dict[str, Any]) -> bool:
         conds = (pod.get("status") or {}).get("conditions") or []
-        return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conds)
+        return any(
+            c.get("type") == "Ready" and c.get("status") == "True" for c in conds
+        )
 
     try:
         # #272 / #286 — MetalLB lives in its own metallb-system namespace
@@ -4199,7 +4280,9 @@ class MetalLBConfigUpdate(BaseModel):
     def _cross_field(self) -> MetalLBConfigUpdate:
         if self.enabled:
             if not self.control_plane_vip:
-                raise ValueError("a control-plane VIP is required when MetalLB is enabled")
+                raise ValueError(
+                    "a control-plane VIP is required when MetalLB is enabled"
+                )
             # #272 — auto-derive a single-address pool from the VIP when
             # no explicit pool is given. This is the common case: the
             # operator just wants one floating IP for the Web UI and
@@ -4210,7 +4293,11 @@ class MetalLBConfigUpdate(BaseModel):
             # supply one explicitly, and the VIP-in-pool check below
             # applies to it.
             if not self.pool_addresses:
-                prefix = 32 if ipaddress.ip_address(self.control_plane_vip).version == 4 else 128
+                prefix = (
+                    32
+                    if ipaddress.ip_address(self.control_plane_vip).version == 4
+                    else 128
+                )
                 self.pool_addresses = [f"{self.control_plane_vip}/{prefix}"]
         # #272 Phase 10 — data-plane VIPs require MetalLB on (no VIP path
         # exists without it) and can't reuse the control-plane VIP or each
@@ -4234,7 +4321,11 @@ class MetalLBConfigUpdate(BaseModel):
             "control-plane VIP": self.control_plane_vip,
             **dp_vips,
         }.items():
-            if vip and self.pool_addresses and not _vip_in_pool(vip, self.pool_addresses):
+            if (
+                vip
+                and self.pool_addresses
+                and not _vip_in_pool(vip, self.pool_addresses)
+            ):
                 raise ValueError(
                     f"{label} {vip} is not inside the address pool "
                     "(widen metallb_pool_addresses to include every VIP)"
@@ -4503,7 +4594,9 @@ async def schedule_appliance_upgrade(
             new_value={
                 "desired_appliance_version": body.desired_appliance_version,
                 "desired_slot_image_url": resolved_url,
-                "slot_image_id": (str(body.slot_image_id) if body.slot_image_id else None),
+                "slot_image_id": (
+                    str(body.slot_image_id) if body.slot_image_id else None
+                ),
             },
         )
     )
@@ -4820,7 +4913,9 @@ async def _require_cert_auth(request: Request, db: DB) -> Appliance:
         principal = await authenticate_cert(request, db)
     except CertAuthFailed as exc:
         logger.warning("appliance.k8s_proxy.cert_auth_failed", reason=exc.reason)
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance client cert.") from exc
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "Invalid appliance client cert."
+        ) from exc
     if principal is None:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
@@ -4859,7 +4954,9 @@ async def k8s_proxy_poll(request: Request, db: DB) -> K8sProxyPollResponse:
         # No request within the timeout — return an empty shape so
         # the supervisor loop just re-polls. 200 (not 204) so the
         # supervisor doesn't have to special-case "no body".
-        return K8sProxyPollResponse(request_id="", method="", path="", headers={}, body_b64="")
+        return K8sProxyPollResponse(
+            request_id="", method="", path="", headers={}, body_b64=""
+        )
     return K8sProxyPollResponse(
         request_id=queued.request_id,
         method=queued.method,
@@ -5087,13 +5184,18 @@ async def k8s_rollout_restart(
     # Strategic-merge patch that bumps the pod template's
     # ``restartedAt`` annotation. Standard kubectl rollout-restart
     # shape — same JSON kubectl sends.
-    api_path = f"/apis/apps/v1/namespaces/{body.namespace}/" f"{body.kind.lower()}s/{body.name}"
+    api_path = (
+        f"/apis/apps/v1/namespaces/{body.namespace}/"
+        f"{body.kind.lower()}s/{body.name}"
+    )
     patch_body = {
         "spec": {
             "template": {
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/restartedAt": datetime.now(UTC).isoformat()
+                        "kubectl.kubernetes.io/restartedAt": datetime.now(
+                            UTC
+                        ).isoformat()
                     }
                 }
             }
@@ -5234,7 +5336,9 @@ async def reveal_appliance_kubeconfig(
         )
     # #408 — local users re-confirm with password or TOTP; external-auth
     # users with TOTP (enrol under Settings → Security if not yet enrolled).
-    outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
+    outcome = reverify_operator(
+        current_user, password=body.password, totp_code=body.totp_code
+    )
     if outcome is not ReauthOutcome.OK:
         await asyncio.sleep(0.1)
         if outcome is ReauthOutcome.MFA_REQUIRED:
@@ -5247,7 +5351,9 @@ async def reveal_appliance_kubeconfig(
             )
         _audit_denied("bad_credential")
         await db.commit()
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect.")
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect."
+        )
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -5258,7 +5364,9 @@ async def reveal_appliance_kubeconfig(
         # Clean "nothing to reveal" — supervisor hasn't shipped a
         # kubeconfig yet (legacy compose / pre-Phase-5 / k3s not
         # started). Surface as a friendly state, not an error.
-        return RevealKubeconfigResponse(configured=False, kubeconfig=None, hostname=row.hostname)
+        return RevealKubeconfigResponse(
+            configured=False, kubeconfig=None, hostname=row.hostname
+        )
 
     try:
         plaintext = decrypt_str(row.kubeconfig_encrypted)
@@ -5290,7 +5398,9 @@ async def reveal_appliance_kubeconfig(
         hostname=row.hostname,
         user=current_user.username,
     )
-    return RevealKubeconfigResponse(configured=True, kubeconfig=plaintext, hostname=row.hostname)
+    return RevealKubeconfigResponse(
+        configured=True, kubeconfig=plaintext, hostname=row.hostname
+    )
 
 
 # ── Issue #183 Phase 6 — kubeapi-expose CIDR editor ──
@@ -5469,7 +5579,9 @@ async def k8s_list_pods(
         spec = item.get("spec") or {}
         st = item.get("status") or {}
         container_statuses = st.get("containerStatuses") or []
-        ready = bool(container_statuses) and all(cs.get("ready") for cs in container_statuses)
+        ready = bool(container_statuses) and all(
+            cs.get("ready") for cs in container_statuses
+        )
         pods.append(
             K8sPodSummary(
                 name=meta.get("name") or "",
@@ -5477,7 +5589,9 @@ async def k8s_list_pods(
                 phase=st.get("phase") or "Unknown",
                 ready=ready,
                 containers=[
-                    c.get("name") or "" for c in (spec.get("containers") or []) if c.get("name")
+                    c.get("name") or ""
+                    for c in (spec.get("containers") or [])
+                    if c.get("name")
                 ],
                 labels=dict(meta.get("labels") or {}),
             )

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -156,8 +156,7 @@ def _supervisor_strips_url_fragment(row: Appliance) -> bool:
     changes the URL), never the ability to upgrade (#419)."""
     ver = row.supervisor_version or row.installed_appliance_version or ""
     return (
-        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None
-        and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
+        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
     )
 
 
@@ -639,9 +638,7 @@ async def supervisor_register(
     # force a fresh registration they delete the row in the fleet UI,
     # which causes the supervisor to clear its identity + claim a new
     # pairing code on next boot.
-    existing_stmt = select(Appliance).where(
-        Appliance.public_key_fingerprint == pubkey_fingerprint
-    )
+    existing_stmt = select(Appliance).where(Appliance.public_key_fingerprint == pubkey_fingerprint)
     existing = (await db.execute(existing_stmt)).scalar_one_or_none()
     if existing is not None:
         # Idempotent re-register. Touch last_seen_at so the heartbeat
@@ -732,9 +729,7 @@ async def supervisor_register(
                 resource_type="pairing_code",
                 resource_id=str(code_row.id) if code_row is not None else "unknown",
                 resource_display=(
-                    "supervisor pairing code"
-                    if code_row is not None
-                    else "unknown pairing code"
+                    "supervisor pairing code" if code_row is not None else "unknown pairing code"
                 ),
                 result="forbidden",
                 new_value={
@@ -779,9 +774,7 @@ async def supervisor_register(
     # operator to open the role-picker.
     initial_assigned_roles: list[str] = []
     if body.appliance_variant is not None:
-        initial_assigned_roles = list(
-            _REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, [])
-        )
+        initial_assigned_roles = list(_REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, []))
     appliance_row = Appliance(
         id=appliance_id,
         hostname=body.hostname,
@@ -928,9 +921,7 @@ async def supervisor_poll(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Not found.")
 
     row = await db.get(Appliance, body.appliance_id)
-    valid = row is not None and verify_session_token(
-        body.session_token, row.session_token_hash
-    )
+    valid = row is not None and verify_session_token(body.session_token, row.session_token_hash)
     if not valid:
         await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
@@ -1271,9 +1262,7 @@ class SupervisorHeartbeatResponse(BaseModel):
     # uses this to bring up dns-bind9 / dns-powerdns / dhcp-kea
     # service containers via docker compose. Empty roles list = idle
     # (approved but no service running).
-    role_assignment: SupervisorRoleAssignment = Field(
-        default_factory=SupervisorRoleAssignment
-    )
+    role_assignment: SupervisorRoleAssignment = Field(default_factory=SupervisorRoleAssignment)
     # #272 Phase 7 — control-plane promote/demote desired state.
     # ``desired_cluster_role`` = "member" → join the seed via
     # ``desired_k3s_server_url`` + ``desired_k3s_join_token``; "none" →
@@ -1418,9 +1407,7 @@ async def _ingest_lldp_neighbours(
         .scalars()
         .all()
     )
-    by_key = {
-        (e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing
-    }
+    by_key = {(e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing}
     now = datetime.now(UTC)
 
     for key, n in desired.items():
@@ -1563,9 +1550,7 @@ async def supervisor_heartbeat(
         )
         if not valid:
             await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
-            raise HTTPException(
-                status.HTTP_403_FORBIDDEN, "Invalid appliance or session."
-            )
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
 
     assert row is not None
     # Issue #170 Wave E follow-up — reject heartbeats from soft-deleted
@@ -1803,9 +1788,7 @@ async def supervisor_heartbeat(
         for ev in evicted:
             ev.evict_requested = False
             ev.cluster_join_state = CLUSTER_JOIN_STATE_LEFT
-            logger.info(
-                "control_plane_node_evicted", hostname=ev.hostname, by=str(row.id)
-            )
+            logger.info("control_plane_node_evicted", hostname=ev.hostname, by=str(row.id))
 
     # Auto-clear the promote desired-state once the join landed: the
     # supervisor reports ``ready`` → the node IS a member now, so settle
@@ -1861,19 +1844,13 @@ async def supervisor_heartbeat(
     # the requested slot as ``current_slot`` — the operator's intent
     # was "boot into this slot next", and we got there. ``durable_
     # default`` is irrelevant here (next-boot is one-shot by design).
-    if (
-        row.desired_next_boot_slot is not None
-        and row.current_slot == row.desired_next_boot_slot
-    ):
+    if row.desired_next_boot_slot is not None and row.current_slot == row.desired_next_boot_slot:
         row.desired_next_boot_slot = None
 
     # Auto-clear desired_default_slot once the supervisor reports the
     # requested slot as ``durable_default`` — grub-set-default landed
     # and survives subsequent reboots.
-    if (
-        row.desired_default_slot is not None
-        and row.durable_default == row.desired_default_slot
-    ):
+    if row.desired_default_slot is not None and row.durable_default == row.desired_default_slot:
         row.desired_default_slot = None
 
     # Auto-clear reboot_requested 15 s after the stamp — by that
@@ -1923,17 +1900,12 @@ async def supervisor_heartbeat(
             long_poll = True
             hold_for = min(float(body.wait_seconds), _HEARTBEAT_HOLD_CAP_S)
             deadline = asyncio.get_running_loop().time() + hold_for
-            async with wake_subscription(
-                [*appliance_wake_channels(row), HOSTCONFIG_ALL]
-            ) as wake:
+            async with wake_subscription([*appliance_wake_channels(row), HOSTCONFIG_ALL]) as wake:
                 while True:
                     remaining = deadline - asyncio.get_running_loop().time()
                     if remaining <= 0:
                         break
-                    if (
-                        await wake.wait(min(WAKE_TICK_SECONDS, remaining))
-                        == WakeResult.WAKE
-                    ):
+                    if await wake.wait(min(WAKE_TICK_SECONDS, remaining)) == WakeResult.WAKE:
                         break
             # Pick up anything that committed during the hold (role /
             # firewall / desired-state edits land on other requests) before
@@ -2026,9 +1998,7 @@ async def supervisor_heartbeat(
     # Issue #165 — operator-set timezone. Empty string = no override.
     desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
     # #393 — appliance console mode (grubenv-driven, applies next reboot).
-    desired_console_mode = (
-        (cfg_row.console_mode or "dashboard") if cfg_row else "dashboard"
-    )
+    desired_console_mode = (cfg_row.console_mode or "dashboard") if cfg_row else "dashboard"
     # Issue #346 — host-config blocks for snmp / chrony / lldp. Built from the
     # same ``*_bundle`` helpers the DHCP-agent ConfigBundle uses; the
     # disabled-shape fallback keeps a stable key set when no settings row
@@ -2102,12 +2072,8 @@ async def supervisor_heartbeat(
         vip_configured=bool(metallb_vip),
         firewall_enabled=bool(cfg_row.firewall_enabled) if cfg_row else False,
         appliance_id=row.id,
-        web_ui_allowed_cidrs=(
-            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
-        ),
-        firewall_logging_enabled=(
-            bool(cfg_row.firewall_logging_enabled) if cfg_row else False
-        ),
+        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        firewall_logging_enabled=(bool(cfg_row.firewall_logging_enabled) if cfg_row else False),
     )
     # Persist the rendered hash so 2d's apply-stalled alarm + the Fleet drift
     # chip can compare it against the runner's reported applied_hash. Only
@@ -2166,9 +2132,7 @@ async def supervisor_heartbeat(
         cluster_peer_cidrs=cluster_peer_cidrs,
         firewall_pod_cidrs=firewall_pod_cidrs,
         firewall_service_cidrs=firewall_service_cidrs,
-        web_ui_allowed_cidrs=(
-            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
-        ),
+        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
         control_plane_size=control_plane_size,
         desired_metallb_enabled=metallb_enabled,
         desired_metallb_pool_addresses=metallb_pool,
@@ -2227,9 +2191,7 @@ async def firewall_render_inputs(db: DB, row: Appliance) -> dict[str, Any]:
         "cp_member_count": await _committed_cp_count(db),
         "vip_configured": bool((cfg_row.control_plane_vip or "") if cfg_row else ""),
         "firewall_enabled": bool(cfg_row.firewall_enabled) if cfg_row else False,
-        "web_ui_allowed_cidrs": (
-            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
-        ),
+        "web_ui_allowed_cidrs": (list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
     }
 
 
@@ -2243,9 +2205,7 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     from app.models.dns import DNSServerGroup
 
     assigned_roles = list(row.assigned_roles or [])
-    dns_role_assigned = (
-        "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
-    )
+    dns_role_assigned = "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
     dhcp_role_assigned = "dhcp" in assigned_roles
 
     dns_engine: str | None = None
@@ -2511,9 +2471,7 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
 async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     _require_superadmin(current_user)
     rows = (
-        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc())))
-        .scalars()
-        .all()
+        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc()))).scalars().all()
     )
     return ApplianceList(appliances=[_row_to_schema(r) for r in rows])
 
@@ -2524,9 +2482,7 @@ async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Fetch a single appliance (superadmin)",
 )
-async def get_appliance(
-    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
-) -> ApplianceRow:
+async def get_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> ApplianceRow:
     _require_superadmin(current_user)
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -2651,9 +2607,7 @@ async def approve_appliance(
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Reject a pending appliance (deletes the row, superadmin)",
 )
-async def reject_appliance(
-    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
-) -> None:
+async def reject_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> None:
     """Reject = DELETE the row. Supervisor's next poll gets 403 +
     falls back to bootstrapping. Distinct from delete (next endpoint)
     only in the audit verb — operationally identical."""
@@ -2786,9 +2740,7 @@ async def _find_appliance_dependents(
 
     return ApplianceDependents(
         dns=[
-            ApplianceDependentServer(
-                kind="dns", id=r.id, name=r.name, host=r.host, status=r.status
-            )
+            ApplianceDependentServer(kind="dns", id=r.id, name=r.name, host=r.host, status=r.status)
             for r in dns_rows
         ],
         dhcp=[
@@ -2898,12 +2850,8 @@ async def delete_appliance(
                     Appliance.id != row.id,
                     Appliance.state != APPLIANCE_STATE_REVOKED,
                     or_(
-                        Appliance.appliance_variant.in_(
-                            tuple(_SELF_BOOTSTRAP_VARIANTS)
-                        ),
-                        Appliance.cluster_role.in_(
-                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
-                        ),
+                        Appliance.appliance_variant.in_(tuple(_SELF_BOOTSTRAP_VARIANTS)),
+                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
                     ),
                 )
             )
@@ -3353,14 +3301,10 @@ async def update_appliance_roles(
             new_value={
                 "roles": list(row.assigned_roles or []),
                 "dns_group_id": (
-                    str(row.assigned_dns_group_id)
-                    if row.assigned_dns_group_id
-                    else None
+                    str(row.assigned_dns_group_id) if row.assigned_dns_group_id else None
                 ),
                 "dhcp_group_id": (
-                    str(row.assigned_dhcp_group_id)
-                    if row.assigned_dhcp_group_id
-                    else None
+                    str(row.assigned_dhcp_group_id) if row.assigned_dhcp_group_id else None
                 ),
                 "tags": dict(row.tags or {}),
             },
@@ -3412,9 +3356,7 @@ async def _effective_cp_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_(
-                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
-                        ),
+                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3502,9 +3444,7 @@ async def _firewall_peer_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_(
-                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
-                        ),
+                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3630,9 +3570,7 @@ async def promote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
-            )
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
         if row.id == primary.id:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3643,10 +3581,7 @@ async def promote_control_plane(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is in state {row.state!r}; approve it first.",
             )
-        if (
-            row.cluster_role is not None
-            or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
-        ):
+        if row.cluster_role is not None or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is already a control-plane member (or joining).",
@@ -3742,9 +3677,7 @@ async def demote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
-            )
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
         if row.cluster_role == CLUSTER_ROLE_PRIMARY:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3842,9 +3775,7 @@ async def replace_control_plane_member(
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found."
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found.")
     if row.cluster_role == CLUSTER_ROLE_PRIMARY:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -4073,9 +4004,7 @@ async def restore_etcd_snapshot(
             "destructive cluster-reset restore.",
         )
     known = {
-        s.get("name")
-        for s in (seed.etcd_snapshots or [])
-        if isinstance(s, dict) and s.get("name")
+        s.get("name") for s in (seed.etcd_snapshots or []) if isinstance(s, dict) and s.get("name")
     }
     if body.snapshot_name not in known:
         raise HTTPException(
@@ -4192,9 +4121,7 @@ def _metallb_pod_status() -> tuple[bool, int, int]:
 
     def _ready(pod: dict[str, Any]) -> bool:
         conds = (pod.get("status") or {}).get("conditions") or []
-        return any(
-            c.get("type") == "Ready" and c.get("status") == "True" for c in conds
-        )
+        return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conds)
 
     try:
         # #272 / #286 — MetalLB lives in its own metallb-system namespace
@@ -4280,9 +4207,7 @@ class MetalLBConfigUpdate(BaseModel):
     def _cross_field(self) -> MetalLBConfigUpdate:
         if self.enabled:
             if not self.control_plane_vip:
-                raise ValueError(
-                    "a control-plane VIP is required when MetalLB is enabled"
-                )
+                raise ValueError("a control-plane VIP is required when MetalLB is enabled")
             # #272 — auto-derive a single-address pool from the VIP when
             # no explicit pool is given. This is the common case: the
             # operator just wants one floating IP for the Web UI and
@@ -4293,11 +4218,7 @@ class MetalLBConfigUpdate(BaseModel):
             # supply one explicitly, and the VIP-in-pool check below
             # applies to it.
             if not self.pool_addresses:
-                prefix = (
-                    32
-                    if ipaddress.ip_address(self.control_plane_vip).version == 4
-                    else 128
-                )
+                prefix = 32 if ipaddress.ip_address(self.control_plane_vip).version == 4 else 128
                 self.pool_addresses = [f"{self.control_plane_vip}/{prefix}"]
         # #272 Phase 10 — data-plane VIPs require MetalLB on (no VIP path
         # exists without it) and can't reuse the control-plane VIP or each
@@ -4321,11 +4242,7 @@ class MetalLBConfigUpdate(BaseModel):
             "control-plane VIP": self.control_plane_vip,
             **dp_vips,
         }.items():
-            if (
-                vip
-                and self.pool_addresses
-                and not _vip_in_pool(vip, self.pool_addresses)
-            ):
+            if vip and self.pool_addresses and not _vip_in_pool(vip, self.pool_addresses):
                 raise ValueError(
                     f"{label} {vip} is not inside the address pool "
                     "(widen metallb_pool_addresses to include every VIP)"
@@ -4594,9 +4511,7 @@ async def schedule_appliance_upgrade(
             new_value={
                 "desired_appliance_version": body.desired_appliance_version,
                 "desired_slot_image_url": resolved_url,
-                "slot_image_id": (
-                    str(body.slot_image_id) if body.slot_image_id else None
-                ),
+                "slot_image_id": (str(body.slot_image_id) if body.slot_image_id else None),
             },
         )
     )
@@ -4913,9 +4828,7 @@ async def _require_cert_auth(request: Request, db: DB) -> Appliance:
         principal = await authenticate_cert(request, db)
     except CertAuthFailed as exc:
         logger.warning("appliance.k8s_proxy.cert_auth_failed", reason=exc.reason)
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN, "Invalid appliance client cert."
-        ) from exc
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance client cert.") from exc
     if principal is None:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
@@ -4954,9 +4867,7 @@ async def k8s_proxy_poll(request: Request, db: DB) -> K8sProxyPollResponse:
         # No request within the timeout — return an empty shape so
         # the supervisor loop just re-polls. 200 (not 204) so the
         # supervisor doesn't have to special-case "no body".
-        return K8sProxyPollResponse(
-            request_id="", method="", path="", headers={}, body_b64=""
-        )
+        return K8sProxyPollResponse(request_id="", method="", path="", headers={}, body_b64="")
     return K8sProxyPollResponse(
         request_id=queued.request_id,
         method=queued.method,
@@ -5184,18 +5095,13 @@ async def k8s_rollout_restart(
     # Strategic-merge patch that bumps the pod template's
     # ``restartedAt`` annotation. Standard kubectl rollout-restart
     # shape — same JSON kubectl sends.
-    api_path = (
-        f"/apis/apps/v1/namespaces/{body.namespace}/"
-        f"{body.kind.lower()}s/{body.name}"
-    )
+    api_path = f"/apis/apps/v1/namespaces/{body.namespace}/" f"{body.kind.lower()}s/{body.name}"
     patch_body = {
         "spec": {
             "template": {
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/restartedAt": datetime.now(
-                            UTC
-                        ).isoformat()
+                        "kubectl.kubernetes.io/restartedAt": datetime.now(UTC).isoformat()
                     }
                 }
             }
@@ -5336,9 +5242,7 @@ async def reveal_appliance_kubeconfig(
         )
     # #408 — local users re-confirm with password or TOTP; external-auth
     # users with TOTP (enrol under Settings → Security if not yet enrolled).
-    outcome = reverify_operator(
-        current_user, password=body.password, totp_code=body.totp_code
-    )
+    outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
     if outcome is not ReauthOutcome.OK:
         await asyncio.sleep(0.1)
         if outcome is ReauthOutcome.MFA_REQUIRED:
@@ -5351,9 +5255,7 @@ async def reveal_appliance_kubeconfig(
             )
         _audit_denied("bad_credential")
         await db.commit()
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect."
-        )
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect.")
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -5364,9 +5266,7 @@ async def reveal_appliance_kubeconfig(
         # Clean "nothing to reveal" — supervisor hasn't shipped a
         # kubeconfig yet (legacy compose / pre-Phase-5 / k3s not
         # started). Surface as a friendly state, not an error.
-        return RevealKubeconfigResponse(
-            configured=False, kubeconfig=None, hostname=row.hostname
-        )
+        return RevealKubeconfigResponse(configured=False, kubeconfig=None, hostname=row.hostname)
 
     try:
         plaintext = decrypt_str(row.kubeconfig_encrypted)
@@ -5398,9 +5298,7 @@ async def reveal_appliance_kubeconfig(
         hostname=row.hostname,
         user=current_user.username,
     )
-    return RevealKubeconfigResponse(
-        configured=True, kubeconfig=plaintext, hostname=row.hostname
-    )
+    return RevealKubeconfigResponse(configured=True, kubeconfig=plaintext, hostname=row.hostname)
 
 
 # ── Issue #183 Phase 6 — kubeapi-expose CIDR editor ──
@@ -5579,9 +5477,7 @@ async def k8s_list_pods(
         spec = item.get("spec") or {}
         st = item.get("status") or {}
         container_statuses = st.get("containerStatuses") or []
-        ready = bool(container_statuses) and all(
-            cs.get("ready") for cs in container_statuses
-        )
+        ready = bool(container_statuses) and all(cs.get("ready") for cs in container_statuses)
         pods.append(
             K8sPodSummary(
                 name=meta.get("name") or "",
@@ -5589,9 +5485,7 @@ async def k8s_list_pods(
                 phase=st.get("phase") or "Unknown",
                 ready=ready,
                 containers=[
-                    c.get("name") or ""
-                    for c in (spec.get("containers") or [])
-                    if c.get("name")
+                    c.get("name") or "" for c in (spec.get("containers") or []) if c.get("name")
                 ],
                 labels=dict(meta.get("labels") or {}),
             )

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -532,6 +532,14 @@ async def agent_config_longpoll(
                                         "ip_address": st.ip_address,
                                         "mac_address": st.mac_address,
                                         "hostname": st.hostname,
+                                        # #430 — client_id + options_override
+                                        # are settable, ETag-hashed, and the
+                                        # agent renderer reads them, but were
+                                        # omitted here: a client-id-keyed
+                                        # reservation silently fell back to MAC
+                                        # and per-host options were dropped.
+                                        "client_id": st.client_id,
+                                        "options_override": st.options_override,
                                         # DHCPv6 DUID (#368) — keys the v6
                                         # reservation instead of the MAC.
                                         "duid": st.duid,

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -255,14 +255,10 @@ async def agent_register(
         res = await db.execute(select(DHCPServer).where(DHCPServer.agent_id == aid))
         server = res.scalar_one_or_none()
     if server is None:
-        res = await db.execute(
-            select(DHCPServer).where(DHCPServer.name == body.hostname)
-        )
+        res = await db.execute(select(DHCPServer).where(DHCPServer.name == body.hostname))
         server = res.scalar_one_or_none()
 
-    require_approval = (
-        os.environ.get("DHCP_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
-    )
+    require_approval = os.environ.get("DHCP_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
     pending_approval = False
     if server is None:
         agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
@@ -280,9 +276,7 @@ async def agent_register(
             agent_fingerprint=body.fingerprint,
             agent_version=body.version,
             description=(
-                f"auto-registered agent v{body.version}"
-                if body.version
-                else "auto-registered"
+                f"auto-registered agent v{body.version}" if body.version else "auto-registered"
             ),
         )
         pending_approval = require_approval
@@ -300,9 +294,7 @@ async def agent_register(
         server.agent_version = body.version
         server.agent_registered = True
         if server.agent_id is None:
-            server.agent_id = (
-                uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
-            )
+            server.agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
 
     token, exp = mint_agent_token(
         server_id=str(server.id),
@@ -453,10 +445,7 @@ async def agent_config_longpoll(
                 f"|resolver:{int(bool(resolver_block.get('enabled')))}"
                 f":{resolver_block.get('config_hash', '')}"
             )
-            etag = (
-                "sha256:"
-                + hashlib.sha256(f"{bundle.etag}|{fleet_marker}".encode()).hexdigest()
-            )
+            etag = "sha256:" + hashlib.sha256(f"{bundle.etag}|{fleet_marker}".encode()).hexdigest()
 
             # Pending ops fast-path. Issue #182: paused servers don't ship
             # ops — they accumulate as ``pending`` and dispatch as soon as
@@ -846,9 +835,7 @@ async def agent_lease_events(
     subnets = await _load_subnet_cache(db)
     subnet_for_ip = {ip: _find_containing_subnet(ip, subnets) for ip in ips}
     ipam_existing = (
-        (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips))))
-        .scalars()
-        .all()
+        (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips)))).scalars().all()
     )
     ipam_by_key: dict[tuple[Any, str], IPAddress] = {
         (row.subnet_id, row.address): row for row in ipam_existing
@@ -1010,9 +997,7 @@ async def agent_metrics(
     }
     existing = await db.get(DHCPMetricSample, (server.id, body.bucket_at))
     if existing is None:
-        db.add(
-            DHCPMetricSample(server_id=server.id, bucket_at=body.bucket_at, **values)
-        )
+        db.add(DHCPMetricSample(server_id=server.id, bucket_at=body.bucket_at, **values))
     else:
         for k, v in values.items():
             setattr(existing, k, v)

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -255,10 +255,14 @@ async def agent_register(
         res = await db.execute(select(DHCPServer).where(DHCPServer.agent_id == aid))
         server = res.scalar_one_or_none()
     if server is None:
-        res = await db.execute(select(DHCPServer).where(DHCPServer.name == body.hostname))
+        res = await db.execute(
+            select(DHCPServer).where(DHCPServer.name == body.hostname)
+        )
         server = res.scalar_one_or_none()
 
-    require_approval = os.environ.get("DHCP_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
+    require_approval = (
+        os.environ.get("DHCP_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
+    )
     pending_approval = False
     if server is None:
         agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
@@ -276,7 +280,9 @@ async def agent_register(
             agent_fingerprint=body.fingerprint,
             agent_version=body.version,
             description=(
-                f"auto-registered agent v{body.version}" if body.version else "auto-registered"
+                f"auto-registered agent v{body.version}"
+                if body.version
+                else "auto-registered"
             ),
         )
         pending_approval = require_approval
@@ -294,7 +300,9 @@ async def agent_register(
         server.agent_version = body.version
         server.agent_registered = True
         if server.agent_id is None:
-            server.agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
+            server.agent_id = (
+                uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
+            )
 
     token, exp = mint_agent_token(
         server_id=str(server.id),
@@ -445,7 +453,10 @@ async def agent_config_longpoll(
                 f"|resolver:{int(bool(resolver_block.get('enabled')))}"
                 f":{resolver_block.get('config_hash', '')}"
             )
-            etag = "sha256:" + hashlib.sha256(f"{bundle.etag}|{fleet_marker}".encode()).hexdigest()
+            etag = (
+                "sha256:"
+                + hashlib.sha256(f"{bundle.etag}|{fleet_marker}".encode()).hexdigest()
+            )
 
             # Pending ops fast-path. Issue #182: paused servers don't ship
             # ops — they accumulate as ``pending`` and dispatch as soon as
@@ -497,6 +508,11 @@ async def agent_config_longpoll(
                             {
                                 "subnet_cidr": s.subnet_cidr,
                                 "lease_time": s.lease_time,
+                                # #430 — min/max were settable + in the ETag but
+                                # never shipped, so the agent never rendered
+                                # min/max-valid-lifetime (silent no-op).
+                                "min_lease_time": s.min_lease_time,
+                                "max_lease_time": s.max_lease_time,
                                 "options": s.options,
                                 # Issue #330 — the agent's render_kea branches on
                                 # these to emit a Dhcp6/subnet6 entry for v6
@@ -830,7 +846,9 @@ async def agent_lease_events(
     subnets = await _load_subnet_cache(db)
     subnet_for_ip = {ip: _find_containing_subnet(ip, subnets) for ip in ips}
     ipam_existing = (
-        (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips)))).scalars().all()
+        (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips))))
+        .scalars()
+        .all()
     )
     ipam_by_key: dict[tuple[Any, str], IPAddress] = {
         (row.subnet_id, row.address): row for row in ipam_existing
@@ -992,7 +1010,9 @@ async def agent_metrics(
     }
     existing = await db.get(DHCPMetricSample, (server.id, body.bucket_at))
     if existing is None:
-        db.add(DHCPMetricSample(server_id=server.id, bucket_at=body.bucket_at, **values))
+        db.add(
+            DHCPMetricSample(server_id=server.id, bucket_at=body.bucket_at, **values)
+        )
     else:
         for k, v in values.items():
             setattr(existing, k, v)

--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -25,7 +25,11 @@ from app.models.dhcp import DHCPConfigOp, DHCPLease, DHCPMACBlock, DHCPServer
 from app.models.dhcp_fingerprint import DHCPFingerprint
 from app.services.dhcp.config_bundle import build_config_bundle
 from app.services.dhcp.pull_leases import pull_leases_from_server
-from app.services.oui import bulk_lookup_vendors, is_voip_phone_vendor, normalize_mac_key
+from app.services.oui import (
+    bulk_lookup_vendors,
+    is_voip_phone_vendor,
+    normalize_mac_key,
+)
 
 router = APIRouter(
     prefix="/servers",
@@ -286,7 +290,9 @@ async def list_servers(db: DB, _: CurrentUser) -> list[ServerResponse]:
 async def create_server(body: ServerCreate, db: DB, user: SuperAdmin) -> ServerResponse:
     existing = await db.execute(select(DHCPServer).where(DHCPServer.name == body.name))
     if existing.scalar_one_or_none():
-        raise HTTPException(status_code=409, detail="A DHCP server with that name exists")
+        raise HTTPException(
+            status_code=409, detail="A DHCP server with that name exists"
+        )
 
     payload = body.model_dump(exclude={"windows_credentials"})
     s = DHCPServer(**payload)
@@ -323,6 +329,11 @@ async def create_server(body: ServerCreate, db: DB, user: SuperAdmin) -> ServerR
         resource_display=s.name,
         new_value=audit_payload,
     )
+    # #430 — a new member can flip a group from standalone to HA (≥2 Kea
+    # members), re-rendering every peer's failover block. Wake the group so
+    # survivors converge at ~0 s instead of the 12 s safety tick.
+    if s.server_group_id is not None:
+        collect_wake(dhcp_group_channel(s.server_group_id))
     await db.commit()
     await db.refresh(s)
     return ServerResponse.from_model(s)
@@ -401,7 +412,9 @@ async def update_server(
             s.credentials_encrypted = None
             changes["windows_credentials_cleared"] = True
 
-    audit_payload = body.model_dump(mode="json", exclude_none=True, exclude={"windows_credentials"})
+    audit_payload = body.model_dump(
+        mode="json", exclude_none=True, exclude={"windows_credentials"}
+    )
     if "windows_credentials_set" in changes:
         audit_payload["windows_credentials_set"] = True
     if "windows_credentials_cleared" in changes:
@@ -435,7 +448,12 @@ async def delete_server(server_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
         resource_id=str(s.id),
         resource_display=s.name,
     )
+    # #430 — capture the group before delete; removing a member can drop a
+    # group out of HA, re-rendering the survivors' failover block. Wake it.
+    gid = s.server_group_id
     await db.delete(s)
+    if gid is not None:
+        collect_wake(dhcp_group_channel(gid))
     await db.commit()
 
 
@@ -539,7 +557,9 @@ async def test_windows_credentials_endpoint(
         if s is None:
             raise HTTPException(status_code=404, detail="Server not found")
         if not s.credentials_encrypted:
-            raise HTTPException(status_code=400, detail="Server has no stored credentials to test")
+            raise HTTPException(
+                status_code=400, detail="Server has no stored credentials to test"
+            )
         creds = decrypt_dict(s.credentials_encrypted)
         host = body.host or s.host
     else:
@@ -553,7 +573,9 @@ async def test_windows_credentials_endpoint(
 
 
 @router.post("/{server_id}/sync-leases", response_model=SyncLeasesResponse)
-async def sync_leases_now(server_id: uuid.UUID, db: DB, user: SuperAdmin) -> SyncLeasesResponse:
+async def sync_leases_now(
+    server_id: uuid.UUID, db: DB, user: SuperAdmin
+) -> SyncLeasesResponse:
     """Poll the DHCP server for current leases and reconcile into the DB.
 
     Only valid for agentless drivers (windows_dhcp today). Agent-based
@@ -656,7 +678,9 @@ async def sync_leases_now(server_id: uuid.UUID, db: DB, user: SuperAdmin) -> Syn
 
 
 @router.post("/{server_id}/approve", response_model=ServerResponse)
-async def approve_server(server_id: uuid.UUID, db: DB, user: SuperAdmin) -> ServerResponse:
+async def approve_server(
+    server_id: uuid.UUID, db: DB, user: SuperAdmin
+) -> ServerResponse:
     s = await db.get(DHCPServer, server_id)
     if s is None:
         raise HTTPException(status_code=404, detail="Server not found")
@@ -996,9 +1020,9 @@ async def list_leases(
     q = select(DHCPLease).where(DHCPLease.server_id == server_id)
     if device_class:
         # Inner-join the fingerprint table so the limit lands on matching rows.
-        q = q.join(DHCPFingerprint, DHCPFingerprint.mac_address == DHCPLease.mac_address).where(
-            DHCPFingerprint.fingerbank_device_class == device_class
-        )
+        q = q.join(
+            DHCPFingerprint, DHCPFingerprint.mac_address == DHCPLease.mac_address
+        ).where(DHCPFingerprint.fingerbank_device_class == device_class)
     q = q.order_by(DHCPLease.last_seen_at.desc()).limit(min(limit, 5000))
     rows = list((await db.execute(q)).scalars().all())
 
@@ -1012,7 +1036,9 @@ async def list_leases(
     fps: dict[str, DHCPFingerprint] = {}
     if macs:
         fp_rows = (
-            await db.execute(select(DHCPFingerprint).where(DHCPFingerprint.mac_address.in_(macs)))
+            await db.execute(
+                select(DHCPFingerprint).where(DHCPFingerprint.mac_address.in_(macs))
+            )
         ).scalars()
         for fp in fp_rows:
             fps[normalize_mac_key(str(fp.mac_address))] = fp

--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -290,9 +290,7 @@ async def list_servers(db: DB, _: CurrentUser) -> list[ServerResponse]:
 async def create_server(body: ServerCreate, db: DB, user: SuperAdmin) -> ServerResponse:
     existing = await db.execute(select(DHCPServer).where(DHCPServer.name == body.name))
     if existing.scalar_one_or_none():
-        raise HTTPException(
-            status_code=409, detail="A DHCP server with that name exists"
-        )
+        raise HTTPException(status_code=409, detail="A DHCP server with that name exists")
 
     payload = body.model_dump(exclude={"windows_credentials"})
     s = DHCPServer(**payload)
@@ -412,9 +410,7 @@ async def update_server(
             s.credentials_encrypted = None
             changes["windows_credentials_cleared"] = True
 
-    audit_payload = body.model_dump(
-        mode="json", exclude_none=True, exclude={"windows_credentials"}
-    )
+    audit_payload = body.model_dump(mode="json", exclude_none=True, exclude={"windows_credentials"})
     if "windows_credentials_set" in changes:
         audit_payload["windows_credentials_set"] = True
     if "windows_credentials_cleared" in changes:
@@ -557,9 +553,7 @@ async def test_windows_credentials_endpoint(
         if s is None:
             raise HTTPException(status_code=404, detail="Server not found")
         if not s.credentials_encrypted:
-            raise HTTPException(
-                status_code=400, detail="Server has no stored credentials to test"
-            )
+            raise HTTPException(status_code=400, detail="Server has no stored credentials to test")
         creds = decrypt_dict(s.credentials_encrypted)
         host = body.host or s.host
     else:
@@ -573,9 +567,7 @@ async def test_windows_credentials_endpoint(
 
 
 @router.post("/{server_id}/sync-leases", response_model=SyncLeasesResponse)
-async def sync_leases_now(
-    server_id: uuid.UUID, db: DB, user: SuperAdmin
-) -> SyncLeasesResponse:
+async def sync_leases_now(server_id: uuid.UUID, db: DB, user: SuperAdmin) -> SyncLeasesResponse:
     """Poll the DHCP server for current leases and reconcile into the DB.
 
     Only valid for agentless drivers (windows_dhcp today). Agent-based
@@ -678,9 +670,7 @@ async def sync_leases_now(
 
 
 @router.post("/{server_id}/approve", response_model=ServerResponse)
-async def approve_server(
-    server_id: uuid.UUID, db: DB, user: SuperAdmin
-) -> ServerResponse:
+async def approve_server(server_id: uuid.UUID, db: DB, user: SuperAdmin) -> ServerResponse:
     s = await db.get(DHCPServer, server_id)
     if s is None:
         raise HTTPException(status_code=404, detail="Server not found")
@@ -1020,9 +1010,9 @@ async def list_leases(
     q = select(DHCPLease).where(DHCPLease.server_id == server_id)
     if device_class:
         # Inner-join the fingerprint table so the limit lands on matching rows.
-        q = q.join(
-            DHCPFingerprint, DHCPFingerprint.mac_address == DHCPLease.mac_address
-        ).where(DHCPFingerprint.fingerbank_device_class == device_class)
+        q = q.join(DHCPFingerprint, DHCPFingerprint.mac_address == DHCPLease.mac_address).where(
+            DHCPFingerprint.fingerbank_device_class == device_class
+        )
     q = q.order_by(DHCPLease.last_seen_at.desc()).limit(min(limit, 5000))
     rows = list((await db.execute(q)).scalars().all())
 
@@ -1036,9 +1026,7 @@ async def list_leases(
     fps: dict[str, DHCPFingerprint] = {}
     if macs:
         fp_rows = (
-            await db.execute(
-                select(DHCPFingerprint).where(DHCPFingerprint.mac_address.in_(macs))
-            )
+            await db.execute(select(DHCPFingerprint).where(DHCPFingerprint.mac_address.in_(macs)))
         ).scalars()
         for fp in fp_rows:
             fps[normalize_mac_key(str(fp.mac_address))] = fp

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -169,9 +169,7 @@ async def agent_register(
     """Bootstrap registration: PSK-authenticated; returns a per-server JWT."""
     # Resolve or create group
     if body.group_name:
-        res = await db.execute(
-            select(DNSServerGroup).where(DNSServerGroup.name == body.group_name)
-        )
+        res = await db.execute(select(DNSServerGroup).where(DNSServerGroup.name == body.group_name))
         group = res.scalar_one_or_none()
         if group is None:
             group = DNSServerGroup(
@@ -180,14 +178,10 @@ async def agent_register(
             db.add(group)
             await db.flush()
     else:
-        res = await db.execute(
-            select(DNSServerGroup).order_by(DNSServerGroup.created_at).limit(1)
-        )
+        res = await db.execute(select(DNSServerGroup).order_by(DNSServerGroup.created_at).limit(1))
         group = res.scalar_one_or_none()
         if group is None:
-            group = DNSServerGroup(
-                name="default", description="Auto-created by agent registration"
-            )
+            group = DNSServerGroup(name="default", description="Auto-created by agent registration")
             db.add(group)
             await db.flush()
 
@@ -203,9 +197,7 @@ async def agent_register(
 
     if server is None:
         res = await db.execute(
-            select(DNSServer).where(
-                DNSServer.group_id == group.id, DNSServer.name == body.hostname
-            )
+            select(DNSServer).where(DNSServer.group_id == group.id, DNSServer.name == body.hostname)
         )
         server = res.scalar_one_or_none()
 
@@ -236,9 +228,7 @@ async def agent_register(
     # high-trust environments flip this to true, which engages the
     # anti-hijack behaviour: any fingerprint mismatch on re-registration
     # forces a manual approval step before the agent can pull config.
-    require_approval = (
-        os.environ.get("DNS_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
-    )
+    require_approval = os.environ.get("DNS_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
 
     pending_approval = False
     if server is None:
@@ -279,9 +269,7 @@ async def agent_register(
         server.roles = body.roles
         server.status = "active"
         if server.agent_id is None:
-            server.agent_id = (
-                uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
-            )
+            server.agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
 
     # Mint token
     token, exp = mint_agent_token(
@@ -668,9 +656,7 @@ async def agent_dnssec_state(
         if not n.endswith("."):
             name_set.add(n + ".")
     res = await db.execute(select(DNSZone).where(DNSZone.name.in_(name_set)))
-    zones_by_name: dict[str, DNSZone] = {
-        z.name.rstrip("."): z for z in res.scalars().all()
-    }
+    zones_by_name: dict[str, DNSZone] = {z.name.rstrip("."): z for z in res.scalars().all()}
 
     for entry in body.zones:
         zone = zones_by_name.get(entry.zone_name.rstrip("."))
@@ -882,10 +868,7 @@ async def agent_rendered_config(
         if len(f.content) > _RENDERED_FILE_SIZE_MAX:
             # Truncate rather than reject — operator wants to *see*
             # something even if a single file blew the cap.
-            content = (
-                f.content[:_RENDERED_FILE_SIZE_MAX]
-                + "\n... [truncated by control plane]\n"
-            )
+            content = f.content[:_RENDERED_FILE_SIZE_MAX] + "\n... [truncated by control plane]\n"
         else:
             content = f.content
         total += len(content)

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -15,7 +15,7 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from jose import JWTError
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
 
@@ -76,12 +76,23 @@ class AgentRegisterResponseV2(BaseModel):
 
 
 class AgentHeartbeatRequest(BaseModel):
+    # #430 (D4) — reject a wrong-envelope heartbeat loudly instead of
+    # validating into an all-default body (ops_ack=[] → ACK loop runs 0× →
+    # 200 → agent clears its ACK buffer). The model is a strict superset of
+    # what the DNS agent sends (the slot/deployment fields below are still
+    # accepted from pre-Wave-C1 agents), so forbid is backward-compatible.
+    model_config = ConfigDict(extra="forbid")
+
     agent_version: str | None = None
     daemon: dict[str, Any] = {}
     config: dict[str, Any] = {}
-    ops_ack: list[dict[str, Any]] = []
+    # Bound the ACK list so a malformed/hostile heartbeat can't pin memory.
+    ops_ack: list[dict[str, Any]] = Field(default_factory=list, max_length=5000)
     failed_ops_count: int = 0
     disk_free_bytes: int | None = None
+    # #430 (D6) — deprecated: serial convergence is reported via the
+    # dedicated /zone-state endpoint. The current agent no longer sends this;
+    # retained (default {}) so pre-#430 agents still validate under forbid.
     zone_serials: dict[str, int] = {}
     # Phase 8f-2 — agent reports its slot state + deployment environment.
     # All optional so older agents that haven't been upgraded keep
@@ -158,7 +169,9 @@ async def agent_register(
     """Bootstrap registration: PSK-authenticated; returns a per-server JWT."""
     # Resolve or create group
     if body.group_name:
-        res = await db.execute(select(DNSServerGroup).where(DNSServerGroup.name == body.group_name))
+        res = await db.execute(
+            select(DNSServerGroup).where(DNSServerGroup.name == body.group_name)
+        )
         group = res.scalar_one_or_none()
         if group is None:
             group = DNSServerGroup(
@@ -167,10 +180,14 @@ async def agent_register(
             db.add(group)
             await db.flush()
     else:
-        res = await db.execute(select(DNSServerGroup).order_by(DNSServerGroup.created_at).limit(1))
+        res = await db.execute(
+            select(DNSServerGroup).order_by(DNSServerGroup.created_at).limit(1)
+        )
         group = res.scalar_one_or_none()
         if group is None:
-            group = DNSServerGroup(name="default", description="Auto-created by agent registration")
+            group = DNSServerGroup(
+                name="default", description="Auto-created by agent registration"
+            )
             db.add(group)
             await db.flush()
 
@@ -186,7 +203,9 @@ async def agent_register(
 
     if server is None:
         res = await db.execute(
-            select(DNSServer).where(DNSServer.group_id == group.id, DNSServer.name == body.hostname)
+            select(DNSServer).where(
+                DNSServer.group_id == group.id, DNSServer.name == body.hostname
+            )
         )
         server = res.scalar_one_or_none()
 
@@ -217,7 +236,9 @@ async def agent_register(
     # high-trust environments flip this to true, which engages the
     # anti-hijack behaviour: any fingerprint mismatch on re-registration
     # forces a manual approval step before the agent can pull config.
-    require_approval = os.environ.get("DNS_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
+    require_approval = (
+        os.environ.get("DNS_REQUIRE_AGENT_APPROVAL", "false").lower() == "true"
+    )
 
     pending_approval = False
     if server is None:
@@ -258,7 +279,9 @@ async def agent_register(
         server.roles = body.roles
         server.status = "active"
         if server.agent_id is None:
-            server.agent_id = uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
+            server.agent_id = (
+                uuid.UUID(body.agent_id) if body.agent_id else uuid.uuid4()
+            )
 
     # Mint token
     token, exp = mint_agent_token(
@@ -645,7 +668,9 @@ async def agent_dnssec_state(
         if not n.endswith("."):
             name_set.add(n + ".")
     res = await db.execute(select(DNSZone).where(DNSZone.name.in_(name_set)))
-    zones_by_name: dict[str, DNSZone] = {z.name.rstrip("."): z for z in res.scalars().all()}
+    zones_by_name: dict[str, DNSZone] = {
+        z.name.rstrip("."): z for z in res.scalars().all()
+    }
 
     for entry in body.zones:
         zone = zones_by_name.get(entry.zone_name.rstrip("."))
@@ -857,7 +882,10 @@ async def agent_rendered_config(
         if len(f.content) > _RENDERED_FILE_SIZE_MAX:
             # Truncate rather than reject — operator wants to *see*
             # something even if a single file blew the cap.
-            content = f.content[:_RENDERED_FILE_SIZE_MAX] + "\n... [truncated by control plane]\n"
+            content = (
+                f.content[:_RENDERED_FILE_SIZE_MAX]
+                + "\n... [truncated by control plane]\n"
+            )
         else:
             content = f.content
         total += len(content)

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -61,7 +61,9 @@ class ApplianceCertificate(Base):
 
     __tablename__ = "appliance_certificate"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
 
     # Operator-chosen label. Unique so audit log lines + UI cards can
     # refer to "letsencrypt-2026.05" without ambiguity. Distinct from
@@ -98,7 +100,9 @@ class ApplianceCertificate(Base):
     # the most recent activation timestamp so the UI can show "active
     # since X" without consulting the audit log.
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    activated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    activated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Identity extracted from the cert at upload time (so listing
     # doesn't need to re-parse every PEM on every request). subject_cn
@@ -123,8 +127,12 @@ class ApplianceCertificate(Base):
     # render "expires in N days" badges and by a future renewal task
     # (Phase 4b.4) to schedule Let's Encrypt rotations. NULL on
     # CSR-pending rows.
-    valid_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    valid_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    valid_from: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    valid_to: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Operator notes — purely descriptive. UI shows them on the card
     # for context ("Let's Encrypt prod cert — renew script in cron").
@@ -184,11 +192,15 @@ class PairingCode(Base):
 
     __tablename__ = "pairing_code"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
 
     # sha256 hex digest of the cleartext code. UNIQUE so the consume
     # endpoint can look up by hash in O(log n) without collision risk.
-    code_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    code_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, unique=True, index=True
+    )
 
     # Last two digits of the cleartext code. Surfaced in the list
     # endpoint for visual correlation ("which row is the code I just
@@ -242,7 +254,9 @@ class PairingCode(Base):
     # revoking a code is permanent ("dead row"), disabling is
     # reversible ("paused"). Revoking a claimed code is a no-op for
     # already-issued certs but still useful audit signal.
-    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     revoked_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -277,7 +291,9 @@ class PairingClaim(Base):
 
     __tablename__ = "pairing_claim"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     pairing_code_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("pairing_code.id", ondelete="CASCADE"),
@@ -379,7 +395,9 @@ class Appliance(Base):
 
     __tablename__ = "appliance"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
 
     hostname: Mapped[str] = mapped_column(String(255), nullable=False)
 
@@ -421,11 +439,15 @@ class Appliance(Base):
     # an admin can Re-authorize (clear ``revoked_at`` + state back
     # to ``approved``). A retention cron hard-deletes after
     # ``platform_settings.appliance_revoked_retention_days``.
-    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Updated by Wave A2+'s supervisor heartbeat path. Stays NULL
     # until the supervisor's first post-register check-in.
-    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     last_seen_ip: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     # Wave B1 — supervisor-reported capabilities (can_run_dns_bind9,
@@ -451,16 +473,24 @@ class Appliance(Base):
     # supervisor auto-renews 30 days before expiry (Wave C polish).
     cert_pem: Mapped[str | None] = mapped_column(Text, nullable=True)
     cert_serial: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    cert_issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    cert_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cert_issued_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    cert_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Approval audit columns (the canonical state is still `state` —
     # these timestamps are for UI relative-time chips).
-    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    approved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     approved_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
-    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rejected_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     rejected_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -484,7 +514,9 @@ class Appliance(Base):
     # shape — the handler leaves the column untouched when the field
     # is missing so a stale supervisor doesn't null out its variant.
     appliance_variant: Mapped[str | None] = mapped_column(String(32), nullable=True)
-    installed_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    installed_appliance_version: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     current_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
     durable_default: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Per-slot installed version — supervisor reads the
@@ -519,8 +551,15 @@ class Appliance(Base):
     # "pct": <int|null>, "detail": "<human line>", "at": "<iso8601>"}``.
     # NULL on non-appliance / never-reported rows; the supervisor ships
     # ``{}`` once an upgrade is no longer in-flight to clear it.
-    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
     snmpd_running: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    # Issue #347 / #430 — whether the host lldpd daemon is running. Companion
+    # to the lldp_neighbours set (an empty set means "no neighbours" only when
+    # lldpd is up; "lldpd down" otherwise). NULL on non-appliance / pre-#430
+    # rows; the heartbeat handler only overwrites on a non-None value.
+    lldpd_running: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     ntp_sync_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Issue #156 — best-effort rsyslog-forwarding status the supervisor
     # reports from ``systemctl is-active rsyslog`` + config-applied
@@ -554,7 +593,9 @@ class Appliance(Base):
     # trigger files on the appliance host. Heartbeat handler auto-
     # clears once installed catches up (upgrade) or a fresh heartbeat
     # arrives post-reboot.
-    desired_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    desired_appliance_version: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     desired_slot_image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Issue #386 Part A — integrity + transport hints for the host-side
     # ``spatium-upgrade-slot`` runner. When the scheduler points
@@ -567,7 +608,9 @@ class Appliance(Base):
     # self-served URL. External (public-CA) URLs leave both NULL/false and
     # stay fully verified. ``tls_insecure`` is refused host-side unless an
     # expected sha256 is present.
-    desired_slot_image_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    desired_slot_image_sha256: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
     desired_slot_image_tls_insecure: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
@@ -590,7 +633,9 @@ class Appliance(Base):
     #
     # Both auto-clear in the heartbeat handler once the supervisor's
     # reported state matches what was requested.
-    desired_next_boot_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    desired_next_boot_slot: Mapped[str | None] = mapped_column(
+        String(16), nullable=True
+    )
     desired_default_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     # Role assignment — #170 Wave C2. Operator picks a subset of
@@ -716,7 +761,9 @@ class Appliance(Base):
     # ships one (legacy compose / pre-#183 supervisors / k3s not yet
     # started).
     k3s_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True
+    )
 
     # Issue #183 Phase 6 — k3s server-cert expiry + direct-kubeapi
     # firewall allowlist.
@@ -771,7 +818,9 @@ class Appliance(Base):
     # heartbeat (read from ``/var/lib/rancher/k3s/server/token``), Fernet-
     # encrypted at rest. The promote endpoint reads this off the primary
     # row to populate ``desired_k3s_join_token_encrypted`` on each joiner.
-    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True
+    )
     # Supervisor-reported progress of the in-flight join/leave:
     # ``joining`` | ``ready`` | ``leaving`` | ``failed`` | NULL (idle).
     cluster_join_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
@@ -891,7 +940,9 @@ class ApplianceCA(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
 
 
 class ApplianceUpgradeImage(Base):
@@ -922,7 +973,9 @@ class ApplianceUpgradeImage(Base):
 
     __tablename__ = "appliance_upgrade_image"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
     filename: Mapped[str] = mapped_column(String(255), nullable=False)
     size_bytes: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
     sha256: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -61,9 +61,7 @@ class ApplianceCertificate(Base):
 
     __tablename__ = "appliance_certificate"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     # Operator-chosen label. Unique so audit log lines + UI cards can
     # refer to "letsencrypt-2026.05" without ambiguity. Distinct from
@@ -100,9 +98,7 @@ class ApplianceCertificate(Base):
     # the most recent activation timestamp so the UI can show "active
     # since X" without consulting the audit log.
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    activated_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    activated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Identity extracted from the cert at upload time (so listing
     # doesn't need to re-parse every PEM on every request). subject_cn
@@ -127,12 +123,8 @@ class ApplianceCertificate(Base):
     # render "expires in N days" badges and by a future renewal task
     # (Phase 4b.4) to schedule Let's Encrypt rotations. NULL on
     # CSR-pending rows.
-    valid_from: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    valid_to: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    valid_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    valid_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Operator notes — purely descriptive. UI shows them on the card
     # for context ("Let's Encrypt prod cert — renew script in cron").
@@ -192,15 +184,11 @@ class PairingCode(Base):
 
     __tablename__ = "pairing_code"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     # sha256 hex digest of the cleartext code. UNIQUE so the consume
     # endpoint can look up by hash in O(log n) without collision risk.
-    code_hash: Mapped[str] = mapped_column(
-        String(64), nullable=False, unique=True, index=True
-    )
+    code_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
 
     # Last two digits of the cleartext code. Surfaced in the list
     # endpoint for visual correlation ("which row is the code I just
@@ -254,9 +242,7 @@ class PairingCode(Base):
     # revoking a code is permanent ("dead row"), disabling is
     # reversible ("paused"). Revoking a claimed code is a no-op for
     # already-issued certs but still useful audit signal.
-    revoked_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     revoked_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -291,9 +277,7 @@ class PairingClaim(Base):
 
     __tablename__ = "pairing_claim"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     pairing_code_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("pairing_code.id", ondelete="CASCADE"),
@@ -395,9 +379,7 @@ class Appliance(Base):
 
     __tablename__ = "appliance"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
 
     hostname: Mapped[str] = mapped_column(String(255), nullable=False)
 
@@ -439,15 +421,11 @@ class Appliance(Base):
     # an admin can Re-authorize (clear ``revoked_at`` + state back
     # to ``approved``). A retention cron hard-deletes after
     # ``platform_settings.appliance_revoked_retention_days``.
-    revoked_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Updated by Wave A2+'s supervisor heartbeat path. Stays NULL
     # until the supervisor's first post-register check-in.
-    last_seen_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_seen_ip: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     # Wave B1 — supervisor-reported capabilities (can_run_dns_bind9,
@@ -473,24 +451,16 @@ class Appliance(Base):
     # supervisor auto-renews 30 days before expiry (Wave C polish).
     cert_pem: Mapped[str | None] = mapped_column(Text, nullable=True)
     cert_serial: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    cert_issued_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    cert_expires_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    cert_issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cert_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # Approval audit columns (the canonical state is still `state` —
     # these timestamps are for UI relative-time chips).
-    approved_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     approved_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
-    rejected_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     rejected_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
@@ -514,9 +484,7 @@ class Appliance(Base):
     # shape — the handler leaves the column untouched when the field
     # is missing so a stale supervisor doesn't null out its variant.
     appliance_variant: Mapped[str | None] = mapped_column(String(32), nullable=True)
-    installed_appliance_version: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    installed_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
     current_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
     durable_default: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Per-slot installed version — supervisor reads the
@@ -551,9 +519,7 @@ class Appliance(Base):
     # "pct": <int|null>, "detail": "<human line>", "at": "<iso8601>"}``.
     # NULL on non-appliance / never-reported rows; the supervisor ships
     # ``{}`` once an upgrade is no longer in-flight to clear it.
-    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, nullable=True
-    )
+    last_upgrade_progress: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     snmpd_running: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     # Issue #347 / #430 — whether the host lldpd daemon is running. Companion
     # to the lldp_neighbours set (an empty set means "no neighbours" only when
@@ -593,9 +559,7 @@ class Appliance(Base):
     # trigger files on the appliance host. Heartbeat handler auto-
     # clears once installed catches up (upgrade) or a fresh heartbeat
     # arrives post-reboot.
-    desired_appliance_version: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    desired_appliance_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
     desired_slot_image_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Issue #386 Part A — integrity + transport hints for the host-side
     # ``spatium-upgrade-slot`` runner. When the scheduler points
@@ -608,9 +572,7 @@ class Appliance(Base):
     # self-served URL. External (public-CA) URLs leave both NULL/false and
     # stay fully verified. ``tls_insecure`` is refused host-side unless an
     # expected sha256 is present.
-    desired_slot_image_sha256: Mapped[str | None] = mapped_column(
-        String(64), nullable=True
-    )
+    desired_slot_image_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
     desired_slot_image_tls_insecure: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=sa.text("false")
     )
@@ -633,9 +595,7 @@ class Appliance(Base):
     #
     # Both auto-clear in the heartbeat handler once the supervisor's
     # reported state matches what was requested.
-    desired_next_boot_slot: Mapped[str | None] = mapped_column(
-        String(16), nullable=True
-    )
+    desired_next_boot_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
     desired_default_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     # Role assignment — #170 Wave C2. Operator picks a subset of
@@ -761,9 +721,7 @@ class Appliance(Base):
     # ships one (legacy compose / pre-#183 supervisors / k3s not yet
     # started).
     k3s_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(
-        LargeBinary, nullable=True
-    )
+    kubeconfig_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
 
     # Issue #183 Phase 6 — k3s server-cert expiry + direct-kubeapi
     # firewall allowlist.
@@ -818,9 +776,7 @@ class Appliance(Base):
     # heartbeat (read from ``/var/lib/rancher/k3s/server/token``), Fernet-
     # encrypted at rest. The promote endpoint reads this off the primary
     # row to populate ``desired_k3s_join_token_encrypted`` on each joiner.
-    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(
-        LargeBinary, nullable=True
-    )
+    k3s_join_token_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
     # Supervisor-reported progress of the in-flight join/leave:
     # ``joining`` | ``ready`` | ``leaving`` | ``failed`` | NULL (idle).
     cluster_join_state: Mapped[str | None] = mapped_column(String(16), nullable=True)
@@ -940,9 +896,7 @@ class ApplianceCA(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    expires_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
 class ApplianceUpgradeImage(Base):
@@ -973,9 +927,7 @@ class ApplianceUpgradeImage(Base):
 
     __tablename__ = "appliance_upgrade_image"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     filename: Mapped[str] = mapped_column(String(255), nullable=False)
     size_bytes: Mapped[int] = mapped_column(sa.BigInteger, nullable=False)
     sha256: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)

--- a/backend/app/services/_mirror_shape.py
+++ b/backend/app/services/_mirror_shape.py
@@ -1,0 +1,60 @@
+"""Shape guards for integration-mirror reads (#430 / #426).
+
+A read-only integration mirror (Kubernetes / Docker / Proxmox / Cloud /
+UniFi / OPNsense / Tailscale) pulls the upstream inventory and then runs an
+*absence-delete* pass: any mirrored IPAM/DNS row whose source object is no
+longer present gets removed. That makes the parse step safety-critical.
+
+A 200 response whose body is the **wrong shape** — a proxy/gateway error
+page served 200, an auth-downgrade landing page, an envelope change, a
+``data: null`` from a momentarily-confused upstream — must be treated as a
+*fetch failure*: raise the integration's typed ``*ClientError`` so the
+reconciler aborts and keeps the last-known mirror rows. The dangerous
+anti-pattern (the #426 defect class) is collapsing such a body to ``[]`` /
+zero items, which looks like "everything was deleted upstream" and purges
+the entire mirror while reporting ``ok=True``.
+
+A *legitimately empty* result — the documented envelope present, just no
+rows (an empty cluster ``{"items": []}``, an empty tailnet
+``{"devices": []}``) — stays valid and returns an empty list.
+
+Each client passes its own error factory so the raised exception is the
+type its reconciler already catches; no new catch wiring is required.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+def require_list(value: Any, *, make_error: Callable[[str], Exception], context: str) -> list[Any]:
+    """Return ``value`` if it is a list, else raise ``make_error(...)``.
+
+    Use when the upstream returns a bare JSON array on success (Docker
+    ``/networks``, Proxmox ``data`` for list endpoints).
+    """
+    if not isinstance(value, list):
+        raise make_error(
+            f"{context}: expected a JSON array but got {type(value).__name__} "
+            f"— treating as a degraded read, not zero items"
+        )
+    return value
+
+
+def require_keyed_list(
+    body: Any, key: str, *, make_error: Callable[[str], Exception], context: str
+) -> list[Any]:
+    """Return ``body[key]`` if it is a list, else raise ``make_error(...)``.
+
+    Use when the upstream wraps the collection in an object under a known
+    key (Kubernetes ``{"items": [...]}``, Tailscale ``{"devices": [...]}``).
+    A missing key, a non-dict body, or a non-list value are all degraded
+    reads. An explicitly-empty list (``{"items": []}``) is legitimate.
+    """
+    if not isinstance(body, dict) or key not in body:
+        raise make_error(
+            f"{context}: response is not an object with a '{key}' key "
+            f"({type(body).__name__}) — treating as a degraded read, not zero items"
+        )
+    return require_list(body[key], make_error=make_error, context=f"{context}.{key}")

--- a/backend/app/services/cloud/aws.py
+++ b/backend/app/services/cloud/aws.py
@@ -225,6 +225,10 @@ class AWSConnector(CloudConnector):
                 # region) shouldn't sink the whole sweep — warn + move on.
                 logger.warning("aws_region_fetch_failed", region=region, error=str(exc))
                 inv.warnings.append(f"region {region}: {exc}")
+                # #430 — mark this scope failed so the reconciler skips the
+                # absence-delete pass; a region throttle after subnets land
+                # must not purge the region's instance IPs.
+                inv.failed_scopes.append(f"region {region}")
 
         return inv
 

--- a/backend/app/services/cloud/azure.py
+++ b/backend/app/services/cloud/azure.py
@@ -186,6 +186,10 @@ class AzureConnector(CloudConnector):
                     subscription_id=subscription_id,
                     error=str(exc),
                 )
+                # #430 — mark this scope failed so the reconciler skips the
+                # absence-delete pass; a failed subscription in a multi-sub
+                # endpoint must not purge that subscription's rows.
+                inventory.failed_scopes.append(f"subscription {subscription_id}")
 
         if succeeded == 0:
             raise CloudConnectorError(

--- a/backend/app/services/cloud/base.py
+++ b/backend/app/services/cloud/base.py
@@ -127,6 +127,11 @@ class CloudInventory:
     # Non-fatal connector notes (a region that failed, an unsupported
     # resource skipped) surfaced into the reconcile summary warnings.
     warnings: list[str] = field(default_factory=list)
+    # #430 — scopes (project / region / subscription) whose fetch failed
+    # mid-pull. When non-empty the inventory is INCOMPLETE: the reconciler
+    # still upserts what it got but MUST skip the absence-delete pass, or a
+    # partial read would mass-delete rows for the missing scope.
+    failed_scopes: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/cloud/gcp.py
+++ b/backend/app/services/cloud/gcp.py
@@ -250,6 +250,10 @@ class GCPConnector(CloudConnector):
                 msg = f"GCP project {project}: {self._describe_error(exc)}"
                 logger.warning("cloud.gcp.project_failed", project=project, error=str(exc))
                 inventory.warnings.append(msg)
+                # #430 — mark this scope failed so the reconciler skips the
+                # absence-delete pass; a partial walk (subnets landed,
+                # instances denied) must not purge the project's rows.
+                inventory.failed_scopes.append(f"project {project}")
 
         return inventory
 

--- a/backend/app/services/cloud/reconcile.py
+++ b/backend/app/services/cloud/reconcile.py
@@ -384,6 +384,8 @@ async def _apply_blocks_and_subnets(
     desired_blocks: list[_DesiredBlock],
     desired_subnets: list[_DesiredSubnet],
     summary: ReconcileSummary,
+    *,
+    allow_delete: bool = True,
 ) -> None:
     block_rows = (
         (await db.execute(select(IPBlock).where(IPBlock.space_id == endpoint.ipam_space_id)))
@@ -459,12 +461,14 @@ async def _apply_blocks_and_subnets(
 
     desired_map = {d.network: d for d in desired_subnets}
 
-    # Prune endpoint-owned subnets no longer in the desired set.
-    for net_str, row in current_subnets.items():
-        if net_str in desired_map:
-            continue
-        await db.delete(row)
-        summary.subnets_deleted += 1
+    # Prune endpoint-owned subnets no longer in the desired set. Skipped on a
+    # partial pull (#430) — a failed scope makes "absent" unreliable.
+    if allow_delete:
+        for net_str, row in current_subnets.items():
+            if net_str in desired_map:
+                continue
+            await db.delete(row)
+            summary.subnets_deleted += 1
 
     for net_str, d in desired_map.items():
         # An operator subnet at this exact CIDR wins — reused untouched.
@@ -545,14 +549,16 @@ async def _apply_blocks_and_subnets(
 
     await db.flush()
 
-    # Drop endpoint-owned blocks that no longer back any subnet.
-    for net_str, block in endpoint_blocks.items():
-        if net_str in desired_block_cidrs:
-            continue
-        refs = await db.execute(select(Subnet).where(Subnet.block_id == block.id))
-        if refs.scalar_one_or_none() is None:
-            await db.delete(block)
-            summary.blocks_deleted += 1
+    # Drop endpoint-owned blocks that no longer back any subnet. Skipped on a
+    # partial pull (#430).
+    if allow_delete:
+        for net_str, block in endpoint_blocks.items():
+            if net_str in desired_block_cidrs:
+                continue
+            refs = await db.execute(select(Subnet).where(Subnet.block_id == block.id))
+            if refs.scalar_one_or_none() is None:
+                await db.delete(block)
+                summary.blocks_deleted += 1
 
 
 # ── Apply: addresses ──────────────────────────────────────────────────
@@ -563,6 +569,8 @@ async def _apply_addresses(
     endpoint: CloudEndpoint,
     desired: list[_DesiredAddress],
     summary: ReconcileSummary,
+    *,
+    allow_delete: bool = True,
 ) -> None:
     subnet_rows = (
         (await db.execute(select(Subnet).where(Subnet.cloud_endpoint_id == endpoint.id)))
@@ -634,16 +642,18 @@ async def _apply_addresses(
     dirty_subnets: set[Any] = set(endpoint_subnet_ids)
 
     # Prune endpoint-owned rows no longer desired (preserve operator-edited
-    # rows by releasing the FK instead of deleting).
-    for addr, row in current.items():
-        if addr not in desired_map:
-            dirty_subnets.add(row.subnet_id)
-            if row.user_modified_at is not None:
-                row.cloud_endpoint_id = None
-                summary.addresses_updated += 1
-            else:
-                await db.delete(row)
-                summary.addresses_deleted += 1
+    # rows by releasing the FK instead of deleting). Skipped on a partial
+    # pull (#430) — a failed scope makes "no longer desired" unreliable.
+    if allow_delete:
+        for addr, row in current.items():
+            if addr not in desired_map:
+                dirty_subnets.add(row.subnet_id)
+                if row.user_modified_at is not None:
+                    row.cloud_endpoint_id = None
+                    summary.addresses_updated += 1
+                else:
+                    await db.delete(row)
+                    summary.addresses_deleted += 1
 
     for addr, d in desired_map.items():
         subnet = _find_subnet_for_ip(subnets, d.address)
@@ -834,13 +844,28 @@ async def reconcile_endpoint(db: AsyncSession, endpoint: CloudEndpoint) -> Recon
 
     desired_blocks, desired_subnets, desired_addresses = _compute_desired(endpoint, inv)
 
-    await _apply_blocks_and_subnets(db, endpoint, desired_blocks, desired_subnets, summary)
-    await _apply_addresses(db, endpoint, desired_addresses, summary)
+    # #430 — a partial pull (one or more scopes failed mid-fetch) yields an
+    # incomplete desired set. Upsert what we got, but suppress the
+    # absence-delete pass so a transient scope failure can't mass-delete the
+    # rows for the missing project/region/subscription.
+    allow_delete = not inv.failed_scopes
+    await _apply_blocks_and_subnets(
+        db, endpoint, desired_blocks, desired_subnets, summary, allow_delete=allow_delete
+    )
+    await _apply_addresses(db, endpoint, desired_addresses, summary, allow_delete=allow_delete)
 
     summary.warnings.extend(inv.warnings)
 
     endpoint.last_synced_at = datetime.now(UTC)
-    endpoint.last_sync_error = None
+    # On a partial pull, record the failed scopes so the operator sees the
+    # mirror is incomplete (and the interval backoff treats it as an error)
+    # rather than a misleading green "last sync OK".
+    if inv.failed_scopes:
+        partial_msg = "partial pull — absence-delete skipped for: " + ", ".join(inv.failed_scopes)
+        endpoint.last_sync_error = partial_msg
+        summary.warnings.append(partial_msg)
+    else:
+        endpoint.last_sync_error = None
     endpoint.provider_account_id = inv.account_id
     endpoint.network_count = summary.network_count
     endpoint.instance_count = summary.instance_count

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -96,7 +96,9 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     opts = opts_res.scalar_one_or_none()
 
     # Views
-    views_res = await db.execute(select(DNSView).where(DNSView.group_id == server.group_id))
+    views_res = await db.execute(
+        select(DNSView).where(DNSView.group_id == server.group_id)
+    )
     views = views_res.scalars().all()
     # Split-horizon (issue #24). When the group defines views, every zone is
     # rendered INSIDE a ``view { match-clients … }`` block and records are
@@ -114,7 +116,9 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     acls = acls_res.scalars().all()
 
     # Zones (+ records for primary only)
-    zones_res = await db.execute(select(DNSZone).where(DNSZone.group_id == server.group_id))
+    zones_res = await db.execute(
+        select(DNSZone).where(DNSZone.group_id == server.group_id)
+    )
     zones = zones_res.scalars().all()
 
     def _rec_dict(r: DNSRecord) -> dict[str, Any]:
@@ -174,13 +178,19 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         # files for serving — primary/secondary distinction matters for
         # accepting RFC 2136 updates, not for which server gets the data.
         rec_rows = list(
-            (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == z.id))).scalars().all()
+            (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == z.id)))
+            .scalars()
+            .all()
         )
 
         if not has_views:
             # Flat render — one zone copy, all records, no view (today's path).
             zone_payload.append(
-                {**base_zp, "view_name": None, "records": [_rec_dict(r) for r in rec_rows]}
+                {
+                    **base_zp,
+                    "view_name": None,
+                    "records": [_rec_dict(r) for r in rec_rows],
+                }
             )
             continue
 
@@ -206,7 +216,11 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
                 else rec_rows
             )
             zone_payload.append(
-                {**base_zp, "view_name": v.name, "records": [_rec_dict(r) for r in recs]}
+                {
+                    **base_zp,
+                    "view_name": v.name,
+                    "records": [_rec_dict(r) for r in recs],
+                }
             )
 
     # Pending record ops — every agent-based server in the group
@@ -295,7 +309,11 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     # auto-generated single key on DNSServerGroup. Both kinds end up in
     # the same `key { … };` block via the named.conf template.
     op_keys = (
-        (await db.execute(select(DNSTSIGKey).where(DNSTSIGKey.group_id == server.group_id)))
+        (
+            await db.execute(
+                select(DNSTSIGKey).where(DNSTSIGKey.group_id == server.group_id)
+            )
+        )
         .scalars()
         .all()
     )
@@ -313,15 +331,21 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         "forwarders": getattr(opts, "forwarders", []) if opts else [],
         "forward_policy": getattr(opts, "forward_policy", "first") if opts else "first",
         "recursion_enabled": getattr(opts, "recursion_enabled", True) if opts else True,
-        "dnssec_validation": (getattr(opts, "dnssec_validation", "auto") if opts else "auto"),
+        "dnssec_validation": (
+            getattr(opts, "dnssec_validation", "auto") if opts else "auto"
+        ),
         "allow_query": getattr(opts, "allow_query", ["any"]) if opts else ["any"],
-        "allow_transfer": (getattr(opts, "allow_transfer", ["none"]) if opts else ["none"]),
+        "allow_transfer": (
+            getattr(opts, "allow_transfer", ["none"]) if opts else ["none"]
+        ),
         # Query logging — surfaced to BIND9's named.conf via template
         # render and to PowerDNS's pdns.conf via the agent's
         # ``_render_conf``. Keep ``query_log_enabled`` in the
         # structural fingerprint so toggling it in the UI reliably
         # triggers a daemon reload.
-        "query_log_enabled": (bool(getattr(opts, "query_log_enabled", False)) if opts else False),
+        "query_log_enabled": (
+            bool(getattr(opts, "query_log_enabled", False)) if opts else False
+        ),
     }
     views_block = [
         {
@@ -331,6 +355,12 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             "match_destinations": getattr(v, "match_destinations", []) or [],
             "recursion": bool(getattr(v, "recursion", True)),
             "order": getattr(v, "order", 0),
+            # #430 — per-view query ACL overrides. None → inherit the
+            # server-options allow-query (the agent renderer omits the line).
+            # Carried in views_block, which is part of the structural
+            # fingerprint, so editing a view ACL re-renders named.conf.
+            "allow_query": getattr(v, "allow_query", None),
+            "allow_query_cache": getattr(v, "allow_query_cache", None),
         }
         # Ordered low→high so the rendered view blocks honour BIND's
         # first-match-wins precedence (issue #24).
@@ -375,7 +405,9 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             # Members are every primary zone in the group. Forward / stub
             # zones don't belong in a catalog (they're lookups, not
             # served data); secondaries are the consumer's responsibility.
-            member_names = sorted(z.name for z in zones if z.zone_type in ("primary", "master"))
+            member_names = sorted(
+                z.name for z in zones if z.zone_type in ("primary", "master")
+            )
             if server.id == producer.id:
                 catalog_block = {
                     "mode": "producer",
@@ -520,7 +552,8 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         # shifts the structural etag and triggers a full, view-correct
         # re-render. ``view_name`` is always retained either way.
         "zones_structural": [
-            {k: val for k, val in z.items() if (k != "records" or has_views)} for z in zone_payload
+            {k: val for k, val in z.items() if (k != "records" or has_views)}
+            for z in zone_payload
         ],
         # DNSSEC signing intent / policy params rewrite named.conf, so a
         # change must trigger a full reload (issue #49).

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -96,9 +96,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     opts = opts_res.scalar_one_or_none()
 
     # Views
-    views_res = await db.execute(
-        select(DNSView).where(DNSView.group_id == server.group_id)
-    )
+    views_res = await db.execute(select(DNSView).where(DNSView.group_id == server.group_id))
     views = views_res.scalars().all()
     # Split-horizon (issue #24). When the group defines views, every zone is
     # rendered INSIDE a ``view { match-clients … }`` block and records are
@@ -116,9 +114,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     acls = acls_res.scalars().all()
 
     # Zones (+ records for primary only)
-    zones_res = await db.execute(
-        select(DNSZone).where(DNSZone.group_id == server.group_id)
-    )
+    zones_res = await db.execute(select(DNSZone).where(DNSZone.group_id == server.group_id))
     zones = zones_res.scalars().all()
 
     def _rec_dict(r: DNSRecord) -> dict[str, Any]:
@@ -178,9 +174,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         # files for serving — primary/secondary distinction matters for
         # accepting RFC 2136 updates, not for which server gets the data.
         rec_rows = list(
-            (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == z.id)))
-            .scalars()
-            .all()
+            (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == z.id))).scalars().all()
         )
 
         if not has_views:
@@ -309,11 +303,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     # auto-generated single key on DNSServerGroup. Both kinds end up in
     # the same `key { … };` block via the named.conf template.
     op_keys = (
-        (
-            await db.execute(
-                select(DNSTSIGKey).where(DNSTSIGKey.group_id == server.group_id)
-            )
-        )
+        (await db.execute(select(DNSTSIGKey).where(DNSTSIGKey.group_id == server.group_id)))
         .scalars()
         .all()
     )
@@ -331,21 +321,15 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         "forwarders": getattr(opts, "forwarders", []) if opts else [],
         "forward_policy": getattr(opts, "forward_policy", "first") if opts else "first",
         "recursion_enabled": getattr(opts, "recursion_enabled", True) if opts else True,
-        "dnssec_validation": (
-            getattr(opts, "dnssec_validation", "auto") if opts else "auto"
-        ),
+        "dnssec_validation": (getattr(opts, "dnssec_validation", "auto") if opts else "auto"),
         "allow_query": getattr(opts, "allow_query", ["any"]) if opts else ["any"],
-        "allow_transfer": (
-            getattr(opts, "allow_transfer", ["none"]) if opts else ["none"]
-        ),
+        "allow_transfer": (getattr(opts, "allow_transfer", ["none"]) if opts else ["none"]),
         # Query logging — surfaced to BIND9's named.conf via template
         # render and to PowerDNS's pdns.conf via the agent's
         # ``_render_conf``. Keep ``query_log_enabled`` in the
         # structural fingerprint so toggling it in the UI reliably
         # triggers a daemon reload.
-        "query_log_enabled": (
-            bool(getattr(opts, "query_log_enabled", False)) if opts else False
-        ),
+        "query_log_enabled": (bool(getattr(opts, "query_log_enabled", False)) if opts else False),
     }
     views_block = [
         {
@@ -405,9 +389,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             # Members are every primary zone in the group. Forward / stub
             # zones don't belong in a catalog (they're lookups, not
             # served data); secondaries are the consumer's responsibility.
-            member_names = sorted(
-                z.name for z in zones if z.zone_type in ("primary", "master")
-            )
+            member_names = sorted(z.name for z in zones if z.zone_type in ("primary", "master"))
             if server.id == producer.id:
                 catalog_block = {
                     "mode": "producer",
@@ -552,8 +534,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         # shifts the structural etag and triggers a full, view-correct
         # re-render. ``view_name`` is always retained either way.
         "zones_structural": [
-            {k: val for k, val in z.items() if (k != "records" or has_views)}
-            for z in zone_payload
+            {k: val for k, val in z.items() if (k != "records" or has_views)} for z in zone_payload
         ],
         # DNSSEC signing intent / policy params rewrite named.conf, so a
         # change must trigger a full reload (issue #49).

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -148,7 +148,15 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             "id": str(z.id),
             "name": getattr(z, "name", None) or getattr(z, "fqdn", None),
             "type": getattr(z, "zone_type", "primary"),
-            "ttl": getattr(z, "default_ttl", 3600),
+            # #430 — was getattr(z, "default_ttl", 3600): DNSZone has no
+            # default_ttl, so this silently pinned every zone's $TTL to the
+            # literal 3600 and editing a zone's TTL never re-rendered.
+            "ttl": getattr(z, "ttl", 3600),
+            # #430 (D1) — the agent's zone-state reporter skips any zone with
+            # serial=None, so omitting this made it report nothing for every
+            # zone and the per-server ZoneSyncPill stayed empty. Ship the
+            # authoritative serial the agent renders from.
+            "serial": getattr(z, "last_serial", 0),
             # Forward-zone-only fields (ignored by the agent for other types).
             "forwarders": list(getattr(z, "forwarders", []) or []),
             "forward_only": bool(getattr(z, "forward_only", True)),

--- a/backend/app/services/docker/client.py
+++ b/backend/app/services/docker/client.py
@@ -38,6 +38,8 @@ from typing import Any
 import httpx
 import structlog
 
+from app.services._mirror_shape import require_list
+
 logger = structlog.get_logger(__name__)
 
 
@@ -192,7 +194,12 @@ class DockerClient:
         are returned; the reconciler filters them based on
         ``include_default_networks`` / driver.
         """
-        items = await self._get("/networks")
+        # #430 — Docker returns a JSON array on success; a 200 that decodes
+        # to {} (proxy/gateway error in front of a tcp:// daemon) must raise,
+        # not iterate-to-empty and purge every mirrored Docker subnet/row.
+        items = require_list(
+            await self._get("/networks"), make_error=DockerClientError, context="/networks"
+        )
         out: list[_DockerNetwork] = []
         for item in items:
             ipam = (item.get("IPAM") or {}).get("Config") or []
@@ -218,7 +225,11 @@ class DockerClient:
 
     async def list_containers(self, *, include_stopped: bool) -> list[_DockerContainer]:
         """Every container that has at least one network IP assigned."""
-        items = await self._get("/containers/json", all=str(include_stopped).lower())
+        items = require_list(
+            await self._get("/containers/json", all=str(include_stopped).lower()),
+            make_error=DockerClientError,
+            context="/containers/json",
+        )
         out: list[_DockerContainer] = []
         for item in items:
             # ``Names`` is a list with a leading slash each. Take the

--- a/backend/app/services/kubernetes/client.py
+++ b/backend/app/services/kubernetes/client.py
@@ -20,6 +20,8 @@ from typing import Any
 import httpx
 import structlog
 
+from app.services._mirror_shape import require_keyed_list
+
 logger = structlog.get_logger(__name__)
 
 
@@ -141,7 +143,12 @@ class KubernetesClient:
             raise KubernetesClientError(f"{path}: HTTP {resp.status_code} — RBAC or token issue")
         if resp.status_code >= 400:
             raise KubernetesClientError(f"{path}: HTTP {resp.status_code} {resp.text[:200]}")
-        return resp.json().get("items") or []
+        # #430 — a 200 that isn't a List object (auth-proxy page, Status
+        # object, envelope change) must raise, not collapse to [] and purge
+        # the whole cluster mirror. A real empty cluster is {"items": []}.
+        return require_keyed_list(
+            resp.json(), "items", make_error=KubernetesClientError, context=path
+        )
 
     # ── Public surface ───────────────────────────────────────────────
 

--- a/backend/app/services/opnsense/client.py
+++ b/backend/app/services/opnsense/client.py
@@ -286,9 +286,17 @@ class OPNsenseClient:
         contribute nothing.
         """
         data = await self._get("/api/diagnostics/interface/getInterfaceConfig")
+        # #430 — getInterfaceConfig always returns a non-empty dict keyed by
+        # logical interface name; a non-dict or empty-dict 200 (proxy error
+        # body, envelope change) is a degraded read. Returning [] here would
+        # absence-delete every router-owned interface subnet. Matches the
+        # #426 reasoning already applied to list_leases/list_arp.
+        if not isinstance(data, dict) or not data:
+            raise OPNsenseClientError(
+                "getInterfaceConfig returned no interfaces — treating as a "
+                "degraded read, not zero interfaces"
+            )
         out: list[_OPNInterface] = []
-        if not isinstance(data, dict):
-            return out
         for logical, cfg in data.items():
             if not isinstance(cfg, dict):
                 continue
@@ -326,13 +334,18 @@ class OPNsenseClient:
         except OPNsenseClientError as exc:
             logger.debug("opnsense_vlans_unavailable", error=str(exc))
             return []
-        rows: dict[str, Any] = {}
-        if isinstance(data, dict):
-            outer = data.get("vlan")
-            if isinstance(outer, dict):
-                inner = outer.get("vlan")
-                if isinstance(inner, dict):
-                    rows = inner
+        # #430 — distinguish a legitimately-empty VLAN set (envelope present,
+        # inner {}) from a degraded read (envelope absent). Returning [] on a
+        # degraded read would absence-delete VLAN-derived subnets. The 404 /
+        # plugin-absent case is already handled by the except above.
+        outer = data.get("vlan") if isinstance(data, dict) else None
+        inner = outer.get("vlan") if isinstance(outer, dict) else None
+        if not isinstance(inner, dict):
+            raise OPNsenseClientError(
+                "vlan_settings/get missing the vlan.vlan envelope — treating "
+                "as a degraded read, not zero VLANs"
+            )
+        rows: dict[str, Any] = inner
         out: list[_OPNVlan] = []
         for _uuid, row in rows.items():
             if not isinstance(row, dict):

--- a/backend/app/services/proxmox/client.py
+++ b/backend/app/services/proxmox/client.py
@@ -34,6 +34,8 @@ from typing import Any
 import httpx
 import structlog
 
+from app.services._mirror_shape import require_list
+
 logger = structlog.get_logger(__name__)
 
 
@@ -374,10 +376,13 @@ class ProxmoxClient:
         )
 
     async def list_nodes(self) -> list[_ProxmoxNodeInfo]:
-        items = await self._get("/nodes")
+        # #430 — a data:null / non-list body (confused PVE, proxy error page)
+        # must raise, not yield zero nodes — zero nodes collects zero guests
+        # and absence-deletes every Proxmox-owned IP. Empty cluster → [].
+        items = require_list(
+            await self._get("/nodes"), make_error=ProxmoxClientError, context="/nodes"
+        )
         out: list[_ProxmoxNodeInfo] = []
-        if not isinstance(items, list):
-            return out
         for item in items:
             if not isinstance(item, dict):
                 continue
@@ -391,10 +396,12 @@ class ProxmoxClient:
         """Bridges / VLAN interfaces / bonds — the stuff with a CIDR is
         what we mirror into IPAM as a subnet.
         """
-        items = await self._get(f"/nodes/{node}/network")
+        items = require_list(
+            await self._get(f"/nodes/{node}/network"),
+            make_error=ProxmoxClientError,
+            context=f"/nodes/{node}/network",
+        )
         out: list[_ProxmoxNetworkIface] = []
-        if not isinstance(items, list):
-            return out
         for item in items:
             if not isinstance(item, dict):
                 continue
@@ -530,9 +537,11 @@ class ProxmoxClient:
         return out
 
     async def list_qemu(self, node: str, *, include_stopped: bool) -> list[_ProxmoxGuest]:
-        items = await self._get(f"/nodes/{node}/qemu")
-        if not isinstance(items, list):
-            return []
+        items = require_list(
+            await self._get(f"/nodes/{node}/qemu"),
+            make_error=ProxmoxClientError,
+            context=f"/nodes/{node}/qemu",
+        )
         guests: list[_ProxmoxGuest] = []
         for item in items:
             if not isinstance(item, dict):
@@ -569,9 +578,11 @@ class ProxmoxClient:
         return guests
 
     async def list_lxc(self, node: str, *, include_stopped: bool) -> list[_ProxmoxGuest]:
-        items = await self._get(f"/nodes/{node}/lxc")
-        if not isinstance(items, list):
-            return []
+        items = require_list(
+            await self._get(f"/nodes/{node}/lxc"),
+            make_error=ProxmoxClientError,
+            context=f"/nodes/{node}/lxc",
+        )
         guests: list[_ProxmoxGuest] = []
         for item in items:
             if not isinstance(item, dict):

--- a/backend/app/services/tailscale/client.py
+++ b/backend/app/services/tailscale/client.py
@@ -30,6 +30,8 @@ from typing import Any
 import httpx
 import structlog
 
+from app.services._mirror_shape import require_keyed_list
+
 logger = structlog.get_logger(__name__)
 
 _BASE_URL = "https://api.tailscale.com/api/v2"
@@ -146,7 +148,13 @@ class TailscaleClient:
         from the default ``?fields=default`` shape.
         """
         data = await self._get(f"/tailnet/{self._tailnet}/devices", fields="all")
-        items = data.get("devices") or []
+        # #430 — a 200 without a "devices" list (CDN/auth maintenance page,
+        # envelope change) must raise so the reconciler keeps existing rows,
+        # not collapse to [] and mass-delete the tailnet. Empty tailnet is
+        # {"devices": []}.
+        items = require_keyed_list(
+            data, "devices", make_error=TailscaleClientError, context="list_devices"
+        )
         out: list[_TailscaleDevice] = []
         for d in items:
             out.append(

--- a/backend/app/services/unifi/reconcile.py
+++ b/backend/app/services/unifi/reconcile.py
@@ -1021,8 +1021,16 @@ async def reconcile_controller(db: AsyncSession, controller: UnifiController) ->
                     try:
                         nets = await client.list_networks(site.name)
                     except UnifiClientError as exc:
-                        summary.warnings.append(f"site {site.name}: list_networks failed — {exc}")
-                        nets = []
+                        # #430 — abort the whole reconcile on a per-site fetch
+                        # failure (matches the Proxmox per-node pattern). The
+                        # absence-delete pass is controller-wide and unions
+                        # desired rows across ALL sites, so treating one
+                        # throttled/5xx site as "zero networks" would
+                        # mass-delete that site's subnets (and cascade its
+                        # addresses). A transient 429 self-heals next pass.
+                        raise UnifiClientError(
+                            f"site {site.name}: list_networks failed — {exc}"
+                        ) from exc
                     nets = [n for n in nets if _network_allowed(n, site, net_allow)]
                     site_to_networks[site] = nets
                 else:
@@ -1033,18 +1041,23 @@ async def reconcile_controller(db: AsyncSession, controller: UnifiController) ->
                     try:
                         clients_combined.extend(await client.list_active_clients(site.name))
                     except UnifiClientError as exc:
-                        summary.warnings.append(
+                        # #430 — abort, don't swallow (see list_networks above).
+                        # list_active_clients (stat/sta) is the heaviest, most
+                        # rate-limited call; a routine 429 here would otherwise
+                        # mass-delete every active-client address on the site.
+                        raise UnifiClientError(
                             f"site {site.name}: list_active_clients failed — {exc}"
-                        )
+                        ) from exc
                 if controller.mirror_fixed_ips:
                     try:
                         for known in await client.list_known_clients(site.name):
                             if known.fixed_ip and known.ip:
                                 clients_combined.append(known)
                     except UnifiClientError as exc:
-                        summary.warnings.append(
+                        # #430 — abort, don't swallow (see list_networks above).
+                        raise UnifiClientError(
                             f"site {site.name}: list_known_clients failed — {exc}"
-                        )
+                        ) from exc
                 site_to_clients[site] = clients_combined
     except UnifiClientError as exc:
         summary.error = str(exc)

--- a/backend/tests/test_cloud_reconcile.py
+++ b/backend/tests/test_cloud_reconcile.py
@@ -420,6 +420,43 @@ async def test_removed_instance_prunes_its_row(db_session: AsyncSession) -> None
 
 
 @pytest.mark.asyncio
+async def test_partial_pull_suppresses_absence_delete(db_session: AsyncSession) -> None:
+    """#430 — when a scope failed mid-fetch (failed_scopes non-empty), the
+    reconciler upserts what it got but must NOT run the absence-delete pass.
+
+    A region throttle that drops db-1 from the inventory would otherwise
+    purge its mirrored row even though the row still exists upstream."""
+    space = await _make_space(db_session)
+    endpoint = await _make_endpoint(db_session, space)
+    await db_session.commit()
+
+    # First (clean) pass mirrors both instances.
+    with _patch_connector(_FakeConnector(inventory=_aws_inventory())):
+        await reconcile_endpoint(db_session, endpoint)
+    assert (
+        await db_session.scalar(select(IPAddress).where(IPAddress.address == "10.0.2.20"))
+    ) is not None
+
+    # Second pass: db-1 (10.0.2.20) is missing, but ONLY because a region
+    # failed mid-pull — the inventory is incomplete, not authoritatively empty.
+    inv = _aws_inventory()
+    inv.instances = [inv.instances[0]]  # db-1 absent from the partial inventory
+    inv.failed_scopes = ["region us-east-1"]
+    with _patch_connector(_FakeConnector(inventory=inv)):
+        summary = await reconcile_endpoint(db_session, endpoint)
+
+    # No deletes ran; the row the partial pull "lost" is preserved.
+    assert summary.addresses_deleted == 0
+    assert summary.subnets_deleted == 0
+    assert (
+        await db_session.scalar(select(IPAddress).where(IPAddress.address == "10.0.2.20"))
+    ) is not None
+    # The incompleteness is surfaced, not reported as a clean sync.
+    assert endpoint.last_sync_error is not None
+    assert "region us-east-1" in endpoint.last_sync_error
+
+
+@pytest.mark.asyncio
 async def test_public_ip_lands_when_enclosing_subnet_mirrored(
     db_session: AsyncSession,
 ) -> None:

--- a/backend/tests/test_fix_430_mirror_guards.py
+++ b/backend/tests/test_fix_430_mirror_guards.py
@@ -142,9 +142,7 @@ async def test_proxmox_data_null_raises(body: Any) -> None:
 
 
 def _opnsense() -> OPNsenseClient:
-    return OPNsenseClient(
-        host="fw.test", port=443, api_key="k", api_secret="s", verify_tls=False
-    )
+    return OPNsenseClient(host="fw.test", port=443, api_key="k", api_secret="s", verify_tls=False)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_fix_430_mirror_guards.py
+++ b/backend/tests/test_fix_430_mirror_guards.py
@@ -1,0 +1,182 @@
+"""#430 — integration-mirror clients raise on a wrong-shape 200.
+
+The #426 defect class: a degraded read that LOOKS successful (HTTP 200 with
+a wrong-shape body — a proxy error page, an envelope change, ``data: null``)
+collapses to zero items and the reconciler's absence-delete pass purges the
+whole mirror while reporting ``ok=True``. These tests pin the per-client
+guards: a degraded 200 raises the client's typed error (so the reconciler
+aborts and keeps last-known rows), while a *legitimately empty* upstream
+(documented envelope present, no rows) returns an empty list.
+
+The list methods that hit HTTP are tested by feeding the parse layer a
+canned body: ``_get`` is stubbed for the clients that parse after ``_get``
+(docker / tailscale / proxmox / opnsense); Kubernetes raises inside
+``_list`` itself, so it gets a real ``httpx.MockTransport``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from app.services.docker.client import DockerClient, DockerClientError
+from app.services.kubernetes.client import KubernetesClient, KubernetesClientError
+from app.services.opnsense.client import OPNsenseClient, OPNsenseClientError
+from app.services.proxmox.client import ProxmoxClient, ProxmoxClientError
+from app.services.tailscale.client import TailscaleClient, TailscaleClientError
+
+
+def _stub_get(client: Any, value: Any) -> None:
+    """Replace the instance's async ``_get`` with one that returns ``value``."""
+
+    async def _fake(*_a: Any, **_k: Any) -> Any:
+        return value
+
+    client._get = _fake  # type: ignore[assignment]
+
+
+# ── Kubernetes (require_keyed_list inside _list) ──────────────────────
+
+
+def _k8s_with_body(body: Any) -> KubernetesClient:
+    client = KubernetesClient(api_server_url="https://k8s.test", token="t")
+
+    def handler(_req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=body)
+
+    client._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="https://k8s.test"
+    )
+    return client
+
+
+@pytest.mark.asyncio
+async def test_k8s_empty_cluster_is_legitimate() -> None:
+    client = _k8s_with_body({"items": []})
+    assert await client.list_nodes() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [{}, {"items": None}, {"kind": "Status"}, []])
+async def test_k8s_wrong_shape_200_raises(body: Any) -> None:
+    client = _k8s_with_body(body)
+    with pytest.raises(KubernetesClientError):
+        await client.list_nodes()
+
+
+# ── Docker (require_list after _get) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_docker_empty_arrays_are_legitimate() -> None:
+    client = DockerClient(connection_type="tcp", endpoint="localhost:2375")
+    _stub_get(client, [])
+    assert await client.list_networks() == []
+    assert await client.list_containers(include_stopped=False) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [{}, {"message": "bad gateway"}, None])
+async def test_docker_non_array_200_raises(body: Any) -> None:
+    client = DockerClient(connection_type="tcp", endpoint="localhost:2375")
+    _stub_get(client, body)
+    with pytest.raises(DockerClientError):
+        await client.list_networks()
+    with pytest.raises(DockerClientError):
+        await client.list_containers(include_stopped=True)
+
+
+# ── Tailscale (require_keyed_list after _get) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tailscale_empty_tailnet_is_legitimate() -> None:
+    client = TailscaleClient(api_key="k", tailnet="-")
+    _stub_get(client, {"devices": []})
+    assert await client.list_devices() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [{}, {"devices": None}, {"foo": 1}])
+async def test_tailscale_missing_devices_raises(body: Any) -> None:
+    client = TailscaleClient(api_key="k", tailnet="-")
+    _stub_get(client, body)
+    with pytest.raises(TailscaleClientError):
+        await client.list_devices()
+
+
+# ── Proxmox (require_list after _get unwraps data) ────────────────────
+
+
+def _proxmox() -> ProxmoxClient:
+    return ProxmoxClient(
+        host="pve.test", port=8006, token_id="root@pam!t", token_secret="s", verify_tls=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_proxmox_empty_lists_are_legitimate() -> None:
+    client = _proxmox()
+    _stub_get(client, [])  # data:[] → _get returns []
+    assert await client.list_nodes() == []
+    assert await client.list_qemu("pve", include_stopped=True) == []
+    assert await client.list_lxc("pve", include_stopped=True) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [None, {}, {"foo": "bar"}])
+async def test_proxmox_data_null_raises(body: Any) -> None:
+    # data:null → _get returns None; data:{} → returns a dict. Either is a
+    # degraded read for a list endpoint and must raise, not yield zero nodes.
+    client = _proxmox()
+    _stub_get(client, body)
+    with pytest.raises(ProxmoxClientError):
+        await client.list_nodes()
+    with pytest.raises(ProxmoxClientError):
+        await client.list_qemu("pve", include_stopped=False)
+
+
+# ── OPNsense (bespoke envelope guards) ────────────────────────────────
+
+
+def _opnsense() -> OPNsenseClient:
+    return OPNsenseClient(
+        host="fw.test", port=443, api_key="k", api_secret="s", verify_tls=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_opnsense_interfaces_real_data_parses() -> None:
+    client = _opnsense()
+    _stub_get(client, {"lan": {"device": "igb0", "ipaddr": "10.0.0.1", "subnet": "24"}})
+    out = await client.list_interfaces()
+    assert len(out) == 1 and out[0].cidr == "10.0.0.0/24"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [{}, [], None, "oops"])
+async def test_opnsense_interfaces_degraded_200_raises(body: Any) -> None:
+    # getInterfaceConfig always returns a non-empty keyed dict; empty/non-dict
+    # is a degraded read that would otherwise delete every interface subnet.
+    client = _opnsense()
+    _stub_get(client, body)
+    with pytest.raises(OPNsenseClientError):
+        await client.list_interfaces()
+
+
+@pytest.mark.asyncio
+async def test_opnsense_vlans_empty_envelope_is_legitimate() -> None:
+    client = _opnsense()
+    _stub_get(client, {"vlan": {"vlan": {}}})  # box with zero VLANs
+    assert await client.list_vlans() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [{}, [], None, {"vlan": {}}])
+async def test_opnsense_vlans_missing_envelope_raises(body: Any) -> None:
+    client = _opnsense()
+    _stub_get(client, body)
+    with pytest.raises(OPNsenseClientError):
+        await client.list_vlans()

--- a/backend/tests/test_fix_430_wire_contracts.py
+++ b/backend/tests/test_fix_430_wire_contracts.py
@@ -1,0 +1,55 @@
+"""#430 (D4 / D8) — DNS agent heartbeat wire contract is hardened.
+
+The DNS ``AgentHeartbeatRequest`` was all-optional with no ``extra=forbid``,
+so a wrong-envelope ACK batch (a typo'd key) validated into an all-default
+body (ops_ack=[]), the ACK loop ran zero times, the endpoint returned 200,
+and the agent cleared its ACK buffer — losing the ACK. These tests pin the
+forbid behaviour and prove the model stays a superset of every agent shape
+(so forbid is backward-compatible).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.v1.dns.agents import AgentHeartbeatRequest
+
+
+def test_current_dns_agent_heartbeat_body_validates() -> None:
+    # The exact shape agent/dns/spatium_dns_agent/heartbeat.py ships today.
+    body = {
+        "agent_version": "1.2.3",
+        "daemon": {"status": "ok"},
+        "config": {},
+        "ops_ack": [{"op_id": "x", "status": "applied"}],
+        "failed_ops_count": 0,
+    }
+    m = AgentHeartbeatRequest.model_validate(body)
+    assert m.agent_version == "1.2.3"
+    assert len(m.ops_ack) == 1
+
+
+def test_wrong_envelope_is_rejected() -> None:
+    # A typo'd ACK key ("ops_acks") used to silently validate into ops_ack=[].
+    with pytest.raises(ValidationError):
+        AgentHeartbeatRequest.model_validate({"ops_acks": [{"op_id": "x"}]})
+
+
+def test_legacy_agent_fields_still_accepted() -> None:
+    # Pre-Wave-C1 agents shipped slot/deployment telemetry + zone_serials.
+    # forbid must NOT 422 them — the model is a deliberate superset.
+    body = {
+        "agent_version": "old",
+        "zone_serials": {"example.com.": 5},
+        "deployment_kind": "appliance",
+        "current_slot": "A",
+        "is_trial_boot": False,
+    }
+    AgentHeartbeatRequest.model_validate(body)
+
+
+def test_ops_ack_over_cap_rejected() -> None:
+    # The ACK list is bounded so a malformed/hostile heartbeat can't pin memory.
+    with pytest.raises(ValidationError):
+        AgentHeartbeatRequest.model_validate({"ops_ack": [{} for _ in range(5001)]})

--- a/backend/tests/test_mirror_shape.py
+++ b/backend/tests/test_mirror_shape.py
@@ -1,0 +1,73 @@
+"""#430 — shared shape guards for integration-mirror reads.
+
+``require_list`` / ``require_keyed_list`` turn a wrong-shape 200 (proxy
+error page, envelope change, ``data: null``) into a raised error so the
+reconciler aborts and keeps last-known rows, instead of collapsing to zero
+items and triggering the absence-delete mass-purge (the #426 defect class).
+A legitimately-empty result stays valid and returns an empty list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services._mirror_shape import require_keyed_list, require_list
+
+
+class _Boom(Exception):
+    pass
+
+
+def _err(msg: str) -> _Boom:
+    return _Boom(msg)
+
+
+# ── require_list ──────────────────────────────────────────────────────
+
+
+def test_require_list_passes_through_a_list() -> None:
+    assert require_list([1, 2], make_error=_err, context="x") == [1, 2]
+
+
+def test_require_list_allows_empty_list() -> None:
+    # A genuinely-empty collection is legitimate — must NOT raise.
+    assert require_list([], make_error=_err, context="x") == []
+
+
+@pytest.mark.parametrize("bad", [{}, {"a": 1}, None, "string", 0, 3.5])
+def test_require_list_raises_on_non_list(bad: object) -> None:
+    with pytest.raises(_Boom):
+        require_list(bad, make_error=_err, context="ctx")
+
+
+def test_require_list_raises_the_factory_type_with_context() -> None:
+    with pytest.raises(_Boom, match="ctx"):
+        require_list({}, make_error=_err, context="ctx")
+
+
+# ── require_keyed_list ────────────────────────────────────────────────
+
+
+def test_require_keyed_list_returns_the_keyed_list() -> None:
+    assert require_keyed_list({"items": [1]}, "items", make_error=_err, context="x") == [1]
+
+
+def test_require_keyed_list_allows_empty_keyed_list() -> None:
+    # {"items": []} — a real empty cluster / tailnet — is legitimate.
+    assert require_keyed_list({"items": []}, "items", make_error=_err, context="x") == []
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {},  # key missing entirely (degraded)
+        {"items": None},  # null instead of list
+        {"items": {}},  # object instead of list
+        [],  # not even a dict
+        None,
+        "string",
+    ],
+)
+def test_require_keyed_list_raises_on_bad_shape(bad: object) -> None:
+    with pytest.raises(_Boom):
+        require_keyed_list(bad, "items", make_error=_err, context="ctx")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8589,6 +8589,7 @@ export interface ApplianceRow {
   last_upgrade_log_tail: string | null;
   last_upgrade_progress: ApplianceUpgradeProgress | null;
   snmpd_running: boolean | null;
+  lldpd_running: boolean | null;
   ntp_sync_state: string | null;
   /** Issue #156 — best-effort rsyslog forwarding status:
    *  "forwarding" / "unreachable" / "disabled", or null on


### PR DESCRIPTION
Closes #430

A three-area audit (integration mirrors, agent↔control-plane wire contracts, ConfigBundle ETag + wake coverage) surfaced one systemic data-loss class plus a batch of wire/lifecycle gaps. Fixed across four clusters.

## Cluster B — systemic (highest value): degraded-read mass-delete in every mirror
All 8 read-only integration mirrors (Kubernetes, Docker, Proxmox, Cloud AWS/Azure/GCP, UniFi, OPNsense, Tailscale) could **purge the entire mirror on a degraded read** — a 200 with a wrong-shape body (proxy/auth error page, envelope change, `data: null`) or a partial multi-scope pull collapsed to "zero items", and the unconditional absence-delete pass deleted every mirrored IPAM/DNS row while reporting `ok=True`. UniFi was worst: a routine `stat/sta` 429 on one site mass-deleted that site's subnets + client addresses.

Two layers:
- **Client shape guard** (`app/services/_mirror_shape.py`) — each client now **raises** its typed error on a wrong-shape 200; a legitimately-empty upstream (`{"items": []}`, `{"devices": []}`, `data:[]`) still returns `[]`. Wired into k8s/docker/proxmox/tailscale/opnsense.
- **Reconciler partial-pull guard** — cloud connectors record `failed_scopes`; the reconciler upserts what it got but **skips the absence-delete pass** and records the partial pull in `last_sync_error`. UniFi aborts the whole reconcile on a per-site fetch failure (Proxmox per-node pattern).

## Cluster A — agent wire-contract + wake
- DNS per-zone TTL pinned to a constant 3600 (`default_ttl` getattr typo; column is `ttl`) → editing a zone's TTL never re-rendered.
- DNS per-server convergence (ZoneSyncPill) never reported — bundle shipped no per-zone serial, so the agent skipped every zone.
- DHCP static reservations dropped `client_id` + `options_override` on the wire (client-id-keyed reservation silently fell back to MAC).
- Appliance fleet-firewall master switch + mgmt-UI CIDR lock published no agent wake (security changes converged only on the ≤28 s heartbeat-hold timeout) — now wake immediately.

## Cluster C — DNS view ACL never enforced
A view's `allow_query`/`allow_query_cache` round-tripped through the API but were never carried in the bundle or emitted by the BIND9 renderer — a view-scoped query ACL silently never took effect. Now threaded into `views_block` (part of the structural fingerprint) + the agent renderer.

## Cluster D — wire hardening + lifecycle
- DHCP lease shipper caps its pending buffer at 5000 (was unbounded on a persistent reject).
- DNS heartbeat model gains `extra="forbid"` + bounded `ops_ack` (a wrong-envelope ACK batch used to validate into an all-default body → 200 → agent cleared its ACK queue). Model stays a strict superset of every agent shape, so forbid is backward-compatible. Dropped the dead `zone_serials` producer.
- DHCP create/delete now wake the group (HA-membership change re-renders peers).
- DHCP scope `min/max_lease_time` shipped + rendered as Kea `min/max-valid-lifetime` (were settable + in the ETag but never reached the agent).
- Supervisor `lldpd_running` (shipped since #347, silently dropped) now persisted — column + migration `a3f7c1e84d59`.

## Verification
- `ruff check app tests`, `black --check app tests`, `mypy app` (566 files), migration-shape linter, frontend eslint + build — all green.
- 45 new tests (mirror shape guards per client, cloud partial-pull gate, DNS heartbeat contract) + 145 existing reconcile suites + supervisor/firewall/wake/agent suites — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)