### PR TITLE
docs: refresh README + redraw architecture diagram for current feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ SpatiumDDI is built on nights and weekends with no commercial backing — every 
 | ☁️ | **Cloud (AWS / Azure / GCP)** | VPCs → IP blocks · subnets · NIC / public / load-balancer IPs · per-provider picker · paired with the agentless Cloud DNS drivers |
 | 🔐 | **Tailscale** | tailnet devices + synthetic `*.ts.net` zone |
 | 📡 | **UniFi Network** | controller sites · networks (VLANs / CIDRs) · clients (with hostnames + MAC) |
+| 🛡 | **OPNsense** | firewall interfaces (LAN / OPT / VLAN → subnets) · VLANs · DHCPv4 leases + static reservations → IPAM |
 
 ### 🛡 Identity & ops
 
@@ -169,10 +170,10 @@ SpatiumDDI is built on nights and weekends with no commercial backing — every 
 | 🛡 | **TOTP MFA** | 2FA on local logins — QR enrolment via `pyotp` + `qrcode` · single-use backup codes · admin force-disable per user (audit-logged) · enrolment also open to SSO accounts so external-auth superadmins can re-confirm sensitive secret reveals (#408) |
 | 🔐 | **Local-auth hardening** | configurable **password policy** (min length · per-class complexity · history depth · max-age) · **account lockout** after N failed logins inside a rolling window (default off; opt-in in Settings) · **active session viewer + force-logout** at `/admin/sessions` — every login carries a `jti` claim that resolves to a `UserSession` row, flip `revoked=True` to 401 the in-flight token on its next call |
 | 🏷 | **Subnet classification tags** | `pci_scope` · `hipaa_scope` · `internet_facing` first-class boolean columns on every subnet · indexed predicates · compliance roll-up card on Platform Insights · feeds the compliance-change alert + conformity policy filters |
-| 🤖 | **Operator Copilot (AI)** | grounded chat over your live IPAM / DNS / DHCP / Network data — multi-vendor (OpenAI / Anthropic / Azure OpenAI / Gemini / OpenAI-compat for Ollama, vLLM, etc.) with automatic failover · **180 tools** spanning IPAM (incl. discovery / stale-IP / reconciliation / utilization trends / hygiene findings), DNS (records / pools / blocklists / views / DNSSEC / query stats / drift), DHCP (pools / statics / classes / option templates / PXE / MAC blocks / pool occupancy / rogue responders), network modeling (ASNs / VRFs / circuits / services / overlays / domains), ownership (customers / sites / providers), admin (users / groups / roles / time-bound grants), reports (top-N), network tools (ping / traceroute / dig / port-test / TLS-cert / whois / MAC-vendor), integration mirrors (K8s / Docker / Proxmox / Tailscale / UniFi / Cloud / OPNsense), appliance fleet (firewall policies / LLDP neighbours / pairing / OS upgrades / upgrade images / etcd snapshots / host-config syslog + SSH + resolver), observability (DNS query / DHCP activity / metrics / Redis stats / global search), compliance (conformity policies + results + framework rollups), maintenance mode, typed-event webhooks (registry + event-type catalog + delivery history), multi-node rolling upgrade state (preflight / runs / lease), and Apply-gated write proposals — `propose_create_ip_address` / `propose_create_dns_record` / `propose_create_dhcp_static` / `propose_create_alert_rule` / `propose_run_nmap_scan` / `propose_archive_session` plus conformity / webhooks / DNSSEC / multicast / SNMP-NTP / DNS + DHCP import commits · MCP HTTP endpoint for Claude Desktop / Cursor / Cline · "Ask AI about this" affordances on every resource · per-provider editable system prompt · per-provider tool allowlist · OUI vendor enrichment baked in · live nmap results in chat · per-message token / latency footer · Markdown + GFM tables in replies · daily digest |
+| 🤖 | **Operator Copilot (AI)** | grounded chat over your live IPAM / DNS / DHCP / Network data — multi-vendor (OpenAI / Anthropic / Azure OpenAI / Gemini / OpenAI-compat for Ollama, vLLM, etc.) with automatic failover · **183 tools** spanning IPAM (incl. discovery / stale-IP / reconciliation / utilization trends / hygiene findings), DNS (records / pools / blocklists / views / DNSSEC / query stats / drift), DHCP (pools / statics / classes / option templates / PXE / MAC blocks / pool occupancy / rogue responders), network modeling (ASNs / VRFs / circuits / services / overlays / domains), ownership (customers / sites / providers), admin (users / groups / roles / time-bound grants), reports (top-N), network tools (ping / traceroute / dig / port-test / TLS-cert / whois / MAC-vendor), integration mirrors (K8s / Docker / Proxmox / Tailscale / UniFi / Cloud / OPNsense), appliance fleet (firewall policies / LLDP neighbours / pairing / OS upgrades / upgrade images / etcd snapshots / host-config syslog + SSH + resolver), observability (DNS query / DHCP activity / metrics / Redis stats / global search), compliance (conformity policies + results + framework rollups), maintenance mode, typed-event webhooks (registry + event-type catalog + delivery history), multi-node rolling upgrade state (preflight / runs / lease), and Apply-gated write proposals — `propose_create_ip_address` / `propose_create_dns_record` / `propose_create_dhcp_static` / `propose_create_alert_rule` / `propose_run_nmap_scan` / `propose_archive_session` plus conformity / webhooks / DNSSEC / multicast / SNMP-NTP / DNS + DHCP import commits · MCP HTTP endpoint for Claude Desktop / Cursor / Cline · "Ask AI about this" affordances on every resource · per-provider editable system prompt · per-provider tool allowlist · OUI vendor enrichment baked in · live nmap results in chat · per-message token / latency footer · Markdown + GFM tables in replies · daily digest |
 | 🔔 | **Alerts + forwarding** | rule-based alerts · `compliance_change` rule type (PCI / HIPAA / internet-facing audit-log scanner with 24 h auto-resolve, three disabled seed rules) · DNS query-anomaly rules (`dns_nxdomain_spike` / `dns_query_rate_spike`) · IP-hygiene rules (`ip_free_but_responding` / `stale_reservation` / `unknown_mac_in_static_range`) · `rogue_dhcp` (unexpected DHCP responder) · multi-target syslog (RFC 5424 / CEF / LEEF / RFC 3164) · HTTP webhooks · SMTP email · Slack / Teams / Discord chat |
-| 📑 | **Conformity evaluations** | declarative policy library scheduled against PCI-DSS / HIPAA / SOC2 frameworks · 6 starter check kinds (`has_field` · `in_separate_vrf` · `no_open_ports` · `alert_rule_covers` · `last_seen_within` · `audit_log_immutable`) · 8 disabled seed policies, opt-in toggle · pass→fail transitions emit alert events · auditor-facing PDF export with SHA-256 integrity hash · `Auditor` + `Compliance Editor` builtin roles |
-| 🪝 | **Typed-event webhooks** | 96 typed events (resource × verb) · HMAC-SHA256 signed · outbox-backed retry with backoff + dead-letter |
+| 📑 | **Conformity evaluations** | declarative policy library scheduled against PCI-DSS / HIPAA / SOC2 frameworks · 9 check kinds (`has_field` · `in_separate_vrf` · `no_open_ports` · `alert_rule_covers` · `last_seen_within` · `audit_log_immutable` · `voice_segment_not_internet_facing` · `no_multicast_collision` · `no_lanwide_control_plane_ports`) · 11 disabled seed policies, opt-in toggle · pass→fail transitions emit alert events · auditor-facing PDF export with SHA-256 integrity hash · `Auditor` + `Compliance Editor` builtin roles |
+| 🪝 | **Typed-event webhooks** | 131 typed events (38 resource namespaces × 3 verbs + 17 special-cased names) · HMAC-SHA256 signed · outbox-backed retry with backoff + dead-letter |
 | 🐛 | **Diagnostics — captured uncaught exceptions** | every uncaught Python exception across API + Celery lands in a queryable `internal_error` table with **fingerprint dedup** (sha256 of class + top-2 frames), occurrence counter, last-seen-at bumping, redaction of headers + secret-shaped payload fields, `context_json` blob capped at 16 KB · admin viewer at `/admin/diagnostics/errors` with Acknowledge / Suppress (1 h / 1 d / 1 w) / Delete / **Submit-bug** (pre-filled GitHub-issue template URL) actions · daily prune sweep against the configured retention window |
 | 🏷 | **Platform-wide tags + filter** | `tags JSONB` columns across IPAM (spaces / blocks / subnets / IPs) · Network modeling (ASNs / VRFs / circuits / services / overlays / customers / sites / providers) · DNS (zones / records) · DHCP (scopes / pools / statics) · `?tag=` filter on every REST list endpoint with multi-tag AND/OR semantics · `/api/v1/tags/autocomplete` ranked by occurrence · tag chips on every list view + clickable pills on the IP detail modal that navigate to a filtered IPAM view |
 | 🔐 | **ACME DNS-01** | `acme-dns`-compatible — certbot / lego / acme.sh issue public certs (wildcards included) |
@@ -187,7 +188,7 @@ SpatiumDDI is built on nights and weekends with no commercial backing — every 
 |---|---|---|
 | 🐳 | **Docker Compose** | `docker compose up -d` |
 | ☸️ | **Kubernetes** | Helm umbrella chart, OCI-published |
-| 🖥 | **Bare metal / OS appliance** | bare metal today · self-contained appliance ISO (beta — Debian 13 + full stack, hybrid USB/CD, see [Getting Started](#quick-start-with-the-os-appliance-iso)) |
+| 🖥 | **Bare metal / OS appliance** | bare metal today · self-contained appliance ISO (beta — Debian 13 + full stack, hybrid USB/CD, see [Getting Started](#quick-start-with-the-os-appliance-iso-recommended)) |
 
 ---
 
@@ -469,14 +470,17 @@ The tables above are the elevator pitch. The bullets here are the same surface w
 
 - 📑 **Conformity evaluations** — proactive: prove steady state and produce the auditor PDF.
   - Declarative `ConformityPolicy` rows pin a `check_kind` against a target set (subnet / IP address / DNS zone / DHCP scope / platform). Beat-driven engine ticks every 60 s and runs every enabled policy on its `eval_interval_hours` cadence (default 24 h). On-demand re-eval via `POST /conformity/policies/{id}/evaluate`
-  - 6 starter check kinds:
+  - 9 check kinds:
     - `has_field` — non-empty value on a named target column (e.g. PCI subnet must have `customer_id`)
     - `in_separate_vrf` — subnet's effective VRF holds only classification-matched siblings (no PCI ↔ non-PCI mixing)
     - `no_open_ports` — latest nmap scan within N days didn't expose forbidden ports (`warn` when no recent scan; never silent-pass)
     - `alert_rule_covers` — at least one enabled alert rule of the named type covers this scope (positive coverage signal — confirms the reactive #105 channel is wired)
     - `last_seen_within` — IP / subnet recency check (catches rows that should be decommissioned)
     - `audit_log_immutable` — platform-level positive-presence signal for the auditor checkbox
-  - 8 disabled seed policies covering PCI-DSS / HIPAA / SOC2: PCI dedicated VRF, PCI owner_assigned, PCI no admin ports, PCI alert coverage, PCI no stale IPs, HIPAA dedicated VRF, internet-facing alert coverage, audit log immutable
+    - `voice_segment_not_internet_facing` — a voice / VoIP-classified subnet must not also carry the `internet_facing` flag
+    - `no_multicast_collision` — no two multicast group registrations in an IPSpace claim the same address
+    - `no_lanwide_control_plane_ports` — no appliance exposes k3s control-plane ports (etcd / kubelet / apiserver) to the LAN
+  - 11 disabled seed policies covering PCI-DSS / HIPAA / SOC2: PCI dedicated VRF, PCI owner_assigned, PCI no admin ports, PCI alert coverage, PCI no stale IPs, HIPAA dedicated VRF, internet-facing alert coverage, voice-not-internet-facing, multicast-collision-free, audit log immutable, no LAN-wide control-plane ports
   - `pass→fail` transitions emit `AlertEvent` rows against the policy's wired alert rule when set, so conformity drift surfaces in the existing alerts dashboard
   - Append-only `ConformityResult` history indexed twice (by policy and by resource) so both natural drilldowns hit an index — answers "every result for this policy" + "every policy that touched this resource" in O(log n)
   - Auditor-facing **PDF export** via `reportlab` — per-framework summary table, per-policy section with pass / warn / fail counts, enumerated failing rows with diagnostic JSON pretty-printed beneath, trailer with a SHA-256 hash over `(result_id, status)` tuples so the auditor can verify post-generation tampering. `GET /conformity/export.pdf` with optional `?framework=` filter
@@ -517,7 +521,7 @@ The tables above are the elevator pitch. The bullets here are the same surface w
   - **Pre-flight backup as warn-only with override** — if no enabled backup target exists, `POST /system/factory-reset/execute` returns 412 unless the operator passes `acknowledge_no_backup=true`. The Backup admin tab surfaces the warning + checkbox up front
   - UI lives as a third tab on the Backup admin page (after Manual + Destinations) — backup snapshots state, factory reset wipes it, two ends of the same lifecycle. Per-section cards in a 2-col grid + red-bordered "Reset everything" card. Modal gates the password field on a green-border phrase match
 
-- 🤖 **Operator Copilot** — AI assistant grounded in your live IPAM / DNS / DHCP / Network data. Hosted-API or fully on-prem (Ollama). One provider config, **180 tools**, real conversations about your network.
+- 🤖 **Operator Copilot** — AI assistant grounded in your live IPAM / DNS / DHCP / Network data. Hosted-API or fully on-prem (Ollama). One provider config, **183 tools**, real conversations about your network.
 
   **Provider + model**
 
@@ -528,11 +532,11 @@ The tables above are the elevator pitch. The bullets here are the same surface w
   - **Reasoning-channel fallback** — `qwen3.5` / DeepSeek-R1 / o1 / o3 family that route their answer to `reasoning` instead of `content` are handled transparently by the driver
   - **Ollama context-window forwarding** — driver forwards `options.num_ctx` / `num_predict` / `extra_body` so Ollama respects the configured context window. Operators can also set `OLLAMA_CONTEXT_LENGTH` env var on the server side (recommended); without one or the other, Ollama silently truncates to 2048 tokens and small models hallucinate tool names from a half-cut tool list
 
-  **Tool registry (180 tools — highlights below)**
+  **Tool registry (183 tools — highlights below)**
 
   Each tool is gated by both the `feature_module` it belongs to (`integrations.unifi` off → UniFi tool disappears from the registry) and an admin-controlled per-tool allowlist at **Admin → AI → Tools**, so operators can trim what the model can see without touching code. Every tool can also be flipped per-provider via the AI Provider modal's Tools tab — the right call for small Ollama models that struggle with 100+ tool schemas.
 
-  The per-category bullets below are a representative tour, not an exhaustive enumeration — the canonical inventory is `backend/app/services/ai/tools/` (one module per category, every `@register_tool(...)` decorator is a live entry) and the live `/api/v1/ai/tools` endpoint on a running install. Categories not surfaced here (multicast, appliance fleet, …) round out the 180 total.
+  The per-category bullets below are a representative tour, not an exhaustive enumeration — the canonical inventory is `backend/app/services/ai/tools/` (one module per category, every `@register_tool(...)` decorator is a live entry) and the live `/api/v1/ai/tools` endpoint on a running install. Categories not surfaced here (multicast, appliance fleet, …) round out the 183 total.
 
   - **IPAM (10)** — `list_ip_spaces`, `list_ip_blocks`, `list_subnets`, `get_subnet_summary`, `find_ip` (returns MAC + **vendor**), `find_by_tag`, `count_ipam_resources`, `find_devices_by_vendor`, `count_devices_by_vendor`, `propose_create_ip_address`. Name-or-UUID resolution on `space_id` / `block_id` so the model can pass `"home"` directly without a UUID-lookup hop
   - **DNS (10)** — `list_dns_server_groups`, `list_dns_zones`, `list_dns_views`, `list_dns_records` (cross-zone substring search), `list_dns_pools` (GSLB pools + per-member health), `list_dns_blocklists` (RPZ rows + sync state), `query_dns_records`, `forward_dns`, `reverse_dns`, `propose_create_dns_record`
@@ -542,7 +546,7 @@ The tables above are the elevator pitch. The bullets here are the same surface w
   - **Admin (3)** — `list_users`, `list_groups`, `list_roles` (superadmin-gated inline; the orchestrator returns an error dict for non-admins)
   - **Appliance fleet config (3)** — `find_snmp_settings`, `find_ntp_settings`, `find_pairing_codes`. All three superadmin-gated; pairing codes also redact the cleartext code + sha256 hash, only the last two digits ever leave the database. No `propose_*` write companions by design — the create response for a pairing code carries the cleartext code, which we don't want in chat transcripts
   - **Backup + factory-reset (3)** — `list_backup_targets` (every configured destination with last-run state, schedule, retention; `config` blob deliberately omitted so destination credentials stay out of the LLM context), `list_backup_archives_at_target` (calls the driver's `list_archives` so the result matches the Backup admin Archives drawer), `find_backup_audit_history` (windowed timeline of backup_created / target-run-success/failed / backup_restored / factory_reset_performed audit rows). All three superadmin-gated. **No `propose_*` writes by design** — restore + factory-reset are password-gated + confirm-phrase-gated, an LLM intermediary in "should I restore?" adds friction without value
-  - **Integration mirrors (5)** — `list_kubernetes_targets`, `list_docker_targets`, `list_proxmox_targets`, `list_tailscale_targets`, `list_unifi_targets` (each tagged with the matching `integrations.*` module so disabling the integration removes the tool in lock-step with the sidebar entry; credentials never enter the response)
+  - **Integration mirrors (7)** — `list_kubernetes_targets`, `list_docker_targets`, `list_proxmox_targets`, `list_tailscale_targets`, `list_unifi_targets`, `list_cloud_targets`, `list_opnsense_targets` (each tagged with the matching `integrations.*` module so disabling the integration removes the tool in lock-step with the sidebar entry; credentials never enter the response)
   - **Ops, observability + audit (18)** — `list_alerts`, `list_alert_rules`, `get_audit_history`, `audit_walk` (paginated chronology), `current_state` (platform health snapshot), `query_dns_query_log`, `query_dhcp_activity_log`, `query_logs`, `get_dns_query_rate` / `get_dhcp_lease_rate` (24-bucket timeseries), `global_search`, `lookup_whois_asn` / `lookup_whois_domain` / `lookup_whois_ip`, `tls_cert_check`, `help_write_permission`, `propose_create_alert_rule`, `propose_archive_session`
   - **Compliance (3)** — `list_conformity_policies` (per-framework registry filter), `find_conformity_results` (append-only evaluation history), `get_conformity_summary` (per-framework rollup of policy + result counts)
   - **Typed-event webhooks (3, superadmin-gated)** — `list_webhooks` (registry; secrets NEVER returned, `secret_set` boolean only), `get_webhook_event_types` (the full typed-event vocabulary so the LLM can validate `event_types[]` references before proposing a subscription), `find_webhook_deliveries` (outbox history — state / attempts / last_error / last_status_code)
@@ -596,7 +600,7 @@ The tables above are the elevator pitch. The bullets here are the same surface w
   - Per-target filters
 
 - 🪝 **Typed-event webhooks** — curated automation surface for downstream consumers.
-  - 96 typed events covering every resource × verb (e.g. `subnet.created`, `dns.zone.updated`, `ip.allocated`)
+  - 131 typed events covering every resource × verb (e.g. `subnet.created`, `dns.zone.updated`, `ip.allocated`)
   - HMAC-SHA256 signed POSTs with reserved `X-SpatiumDDI-*` headers
   - Outbox-backed at-least-once delivery with exponential backoff + dead-letter
   - Per-subscription manual retry, custom headers, and one-time secret reveal
@@ -614,7 +618,7 @@ The tables above are the elevator pitch. The bullets here are the same surface w
   - Docker Compose
   - Kubernetes — Helm umbrella chart, OCI-published
   - Bare metal
-  - OS appliance ISO — beta (Debian 13 + k3s + full stack pre-installed, dedicated `/appliance` management hub with TLS, releases, containers, logs, host config — SNMP / NTP / **LLDP** / timezone driven from the UI; **declarative fleet firewall** — per-role nftables policy with posture presets, staged-preview diffs, an enforcement master switch that cuts LAN-wide etcd / kubelet exposure, and source-scopable Web UI; **multi-node control-plane HA** — promote appliances to a 3/5/7-node cluster with CloudNativePG + Redis Sentinel + a MetalLB VIP; see [Getting Started](#quick-start-with-the-os-appliance-iso) + [`docs/deployment/APPLIANCE.md`](docs/deployment/APPLIANCE.md))
+  - OS appliance ISO — beta (Debian 13 + k3s + full stack pre-installed, dedicated `/appliance` management hub (Fleet · Cluster · Firewall · Logs & Diagnostics · Maintenance · Network & Host) with TLS cert upload, GitHub releases, atomic A/B + rolling cluster upgrades, and host config — SNMP / NTP / **LLDP** / timezone driven from the UI; **declarative fleet firewall** — per-role nftables policy with posture presets, staged-preview diffs, an enforcement master switch that cuts LAN-wide etcd / kubelet exposure, and source-scopable Web UI; **multi-node control-plane HA** — promote appliances to a 3/5/7-node cluster with CloudNativePG + Redis Sentinel + a MetalLB VIP; see [Getting Started](#quick-start-with-the-os-appliance-iso-recommended) + [`docs/deployment/APPLIANCE.md`](docs/deployment/APPLIANCE.md))
 
 ---
 
@@ -640,17 +644,23 @@ _Click any image to open the full-size version._
   <img src="docs/assets/architecture.svg" alt="SpatiumDDI architecture" width="900"/>
 </p>
 
-**Control plane** — FastAPI + PostgreSQL + Redis + Celery. Single source of truth for everything (IPAM tree, DNS records, auth, audit log). Exposes a REST API; the web UI and any Terraform / Ansible / CLI integration all speak the same API.
+**Control plane** — FastAPI + PostgreSQL 16 + Redis 7 + Celery. Single source of truth for everything (IPAM tree, DNS records, DHCP scopes, auth, audit log). Exposes a REST API; the web UI and any Terraform / Ansible / CLI / MCP integration all speak the same API. Runs single-node by default; on the OS appliance it can **scale to a 3/5/7-node HA cluster** — replicated PostgreSQL (CloudNativePG), Redis Sentinel, k3s embedded-etcd quorum, and a MetalLB control-plane VIP. The **Operator Copilot** (multi-vendor LLM + 183-tool registry + MCP HTTP endpoint) is grounded in this same live data.
 
-**Data plane — two shapes:**
+**Data plane — four independent shapes (mix freely):**
 
-- **Agented** (BIND9, Kea) — one container per service. Each bakes in a sidecar agent (`spatium-dns-agent` / `spatium-dhcp-agent`) that (1) bootstraps with a PSK → rotating JWT, (2) long-polls `/config` with an ETag, (3) caches the last-known-good bundle on disk so the service keeps serving if the control plane is unreachable, (4) drains record / config ops over loopback (nsupdate + TSIG for BIND9; Kea Control Agent API for Kea). Structural changes reload named / kea-dhcp4; record changes do not.
+- **Agented, on-prem** (BIND9 *or* PowerDNS, plus Kea) — one container per service. Each bakes in a sidecar agent (`spatium-dns-agent` / `spatium-dhcp-agent`) that (1) bootstraps with a PSK or pairing code → rotating JWT, (2) long-polls `/config` with an ETag (woken over a Redis pub/sub channel), (3) caches the last-known-good bundle on disk so the service keeps serving if the control plane is unreachable, (4) drains record / config ops over loopback (nsupdate + TSIG for BIND9; REST Control Agent for PowerDNS / Kea). Structural changes reload the daemon; record changes do not. The DNS engine is mutually exclusive per server group.
 
-- **Agentless** (Windows DNS, Windows DHCP) — no software on the Windows side. The control plane speaks directly: RFC 2136 over UDP/TCP 53 (DNS record writes + AXFR), WinRM + PowerShell over 5985/5986 (DNS zone CRUD, DHCP lease / scope reads). Credentials are Fernet-encrypted on the server row.
+- **Agentless, on-prem** (Windows DNS, Windows DHCP) — no software on the Windows side. The control plane speaks directly: RFC 2136 over UDP/TCP 53 (DNS record writes + AXFR), WinRM + PowerShell over 5985/5986 (DNS zone CRUD, DHCP lease / scope reads). Credentials are Fernet-encrypted on the server row.
 
-The driver abstraction is backend-neutral — services speak to `DNSDriver` / `DHCPDriver`, never to BIND9 / Kea / PowerShell specifics.
+- **Agentless, cloud DNS** (Cloudflare, Route 53, Azure DNS, Google Cloud DNS, plus DigitalOcean / Hetzner / Linode / Vultr) — first-class drivers that call the provider's REST API / SDK directly, with import-existing-zones. No agent, no daemon.
 
-**Tech stack**: Python 3.12 · FastAPI · SQLAlchemy 2.x (async) · PostgreSQL 16 · Redis 7 · Celery · React 18 · TypeScript · Tailwind · shadcn/ui · pywinrm · dnspython · Docker · Kubernetes + Helm
+- **Read-only integration mirrors** (Kubernetes, Docker, Proxmox VE, Cloud AWS/Azure/GCP, Tailscale, UniFi, OPNsense) — scheduled pulls reconcile external state into IPAM; never written back.
+
+On the **OS appliance**, a host-side **`spatium-supervisor`** (Ed25519 identity, pairing-code onboarding, heartbeat long-poll) orchestrates the local k3s node — it picks up role assignments, atomic A/B OS upgrades, and firewall + host-config (SNMP / NTP / LLDP / syslog / SSH) from the control plane and enforces them on the host.
+
+The driver abstraction is backend-neutral — services speak to `DNSDriver` / `DHCPDriver`, never to BIND9 / PowerDNS / Kea / PowerShell / cloud-SDK specifics.
+
+**Tech stack**: Python 3.12 · FastAPI · SQLAlchemy 2.x (async) · PostgreSQL 16 · Redis 7 · Celery · React 18 · TypeScript · Tailwind · shadcn/ui · pywinrm · dnspython · cloud provider SDKs · Docker · Kubernetes + Helm · k3s (appliance)
 
 ---
 
@@ -666,7 +676,7 @@ The driver abstraction is backend-neutral — services speak to `DNSDriver` / `D
 
 One click brings up a full SpatiumDDI stack in a fresh Codespace, builds the images from `main`, runs migrations, and seeds realistic IPAM / DNS / DHCP / network-modeling demo data so every screen has something to look at. Sign in with **`admin / admin`**.
 
-The demo Codespace runs in **DEMO_MODE** — abusable surfaces are server-side locked: nmap, the AI Copilot, every read-only integration mirror (Kubernetes / Docker / Proxmox / Tailscale / UniFi), webhook subscriptions, audit-forward / SMTP, backup target creation, factory reset, and password change all return 403. IPAM / DNS / DHCP CRUD on the seeded data stays open so you can play with it.
+The demo Codespace runs in **DEMO_MODE** — abusable surfaces are server-side locked: nmap, packet capture, the AI Copilot, every read-only integration mirror (Kubernetes / Docker / Proxmox / Tailscale / UniFi / Cloud / OPNsense), webhook subscriptions, backup target creation, factory reset, and password change all return 403. IPAM / DNS / DHCP CRUD on the seeded data stays open so you can play with it.
 
 Cold start is ~5–8 minutes (image build) on a 4-core machine; the Codespace's free-tier hours come from your own GitHub account, and trashing the data only affects your own copy. To start fresh, delete the Codespace and click the badge again.
 
@@ -887,45 +897,55 @@ schedules Postgres onto it.
 
 #### Managing the appliance
 
-The **Appliance** section in the sidebar groups every host
-concern:
+The **Appliance** section in the sidebar opens a management
+hub with six tabs:
 
-- **Fleet** — every registered appliance in two tables
-  (control-plane nodes + service agents): approve pairings,
-  assign DNS/DHCP roles, watch per-service health, and
-  promote/demote control-plane cluster members + set the
-  MetalLB control-plane VIP (see HA above).
-- **OS Versions** — atomic A/B slot upgrades for this
-  appliance and every registered remote agent. Pick a
-  release, optionally bulk-select agents, click Apply.
-  Failed upgrades auto-revert on the next reboot; rollback
-  is a single click.
-- **Rolling Upgrade** — coordinated, one-node-at-a-time
-  upgrade of every node in the local control-plane cluster
-  (preflight → CNPG cordon-triggered switchover → drain →
-  slot apply → reboot → health-gate → DaemonSet-ready gate
-  → uncordon → chart `image.tag` bump → migrate Job → post-
-  upgrade verification). Two source modes: upload `.raw.xz`
-  to the in-cluster mirror PVC (air-gap) or paste a GitHub
-  release URL (online). Halt / Resume / Abort exposed.
-  Detail: [`docs/deployment/APPLIANCE.md#5d-multi-node-rolling-cluster-upgrade-296`](docs/deployment/APPLIANCE.md#5d-multi-node-rolling-cluster-upgrade-296).
-- **Pairing** — generate single-use codes to onboard agents.
-- **Releases** — GitHub releases list with one-click upgrades.
-- **Web UI Certificate** — replace the self-signed cert with
-  a pasted PEM + key, an in-server CSR, or a Let's Encrypt
-  cert. Modifies the k8s Secret + bumps the frontend pod's
-  rollout annotation; nginx reloads with the new cert in ~15 s.
-- **NTP** — chrony config that propagates to every
-  registered agent appliance.
-- **SNMP** — read-only monitoring access (v2c with community
-  + CIDR allowlist, or v3 USM).
-- **Pods** — live pod list across the spatium namespace via
-  the api's mounted ServiceAccount; per-pod restart (delete
-  → controller recreate) and SSE live log streaming.
-- **Logs & Diagnostics** — journal viewer, self-test runner
-  (DNS resolution + kubeapi reachability + pod health + role
-  presence), one-click diagnostic bundle (secrets redacted).
-- **Maintenance** — drain traffic, reboot, shutdown.
+- **Fleet** — the heart of it: a roster of every registered
+  appliance (control-plane nodes + service agents). Approve /
+  reject pending pairings, assign DNS / DHCP roles + server
+  groups, watch per-service health, schedule per-box atomic
+  A/B OS slot upgrades + reboots, re-key, and delete. Promote
+  / demote control-plane cluster members and set the MetalLB
+  control-plane VIP from the roster drilldown (see HA above).
+  A left sidebar holds the fleet-wide config surfaces:
+  **Pairing codes** (single-use onboarding codes), **Rolling
+  Upgrade** (coordinated one-node-at-a-time OS+app upgrade of
+  the whole cluster — preflight → CNPG switchover → drain →
+  slot apply → reboot → health-gate → uncordon → chart
+  `image.tag` bump → migrate Job; air-gap mirror PVC or
+  GitHub-release source; Halt / Resume / Abort — plus the
+  GitHub release catalog), **Upgrade images** (air-gap
+  slot-image mirror), **Web UI Certificate** (pasted PEM +
+  key, in-server CSR, or Let's Encrypt — nginx reloads in
+  ~15 s), **NTP** (chrony, propagates to every agent), and
+  **SNMP** (v2c community + CIDR allowlist, or v3 USM).
+- **Cluster** — the k3s cluster underneath: a **Pods** view
+  (running workloads with per-pod restart + SSE live logs)
+  and **etcd snapshots** (disaster-recovery state + guided
+  single-node restore), both driven off the in-cluster
+  kube-API via the api pod's ServiceAccount. *(Appliance
+  host only.)*
+- **Firewall** — declarative per-role / per-appliance
+  nftables policy compiled into each node's drop-in, with a
+  staged-preview diff of any node's effective merged ruleset,
+  an enforcement master switch that cuts LAN-wide etcd /
+  kubelet exposure, and a realtime firewall-log viewer.
+  *(Module-gated on `appliance.firewall`.)*
+- **Logs & Diagnostics** — host-log viewer, the self-test
+  runner (DNS resolution + kube-API reachability + pod
+  health + role presence), and a one-click diagnostic bundle
+  (secrets redacted). *(Appliance host only.)*
+- **Maintenance** — maintenance-mode toggle (drains DNS /
+  DHCP traffic before host work) plus reboot / shutdown with
+  confirmation. *(Appliance host only.)*
+- **Network & Host** — hostname, DNS resolvers, IPv4 / IPv6
+  mode (DHCP or static), the nftables drop-in editor, SSH-key
+  upload, proxy config, console-mode selector, and a
+  reboot-pending banner. *(Appliance host only.)*
+
+> On docker / k8s control planes the host-only tabs hide;
+> **Fleet** stays so operators can still drive remote
+> appliance agents.
 
 The **console cockpit** on the appliance's physical or
 serial console shows a 6-box KPI ribbon (cluster / etcd /
@@ -1006,7 +1026,7 @@ docker compose up -d                  # recreate api/worker/beat/frontend on the
 
 ```bash
 # In your .env:
-SPATIUMDDI_VERSION=2026.05.11-1
+SPATIUMDDI_VERSION=2026.06.14-1
 
 # Then:
 docker compose pull
@@ -1112,16 +1132,22 @@ Full docs at **[spatiumddi.github.io](https://spatiumddi.github.io)** (coming so
 | [Getting Started](docs/GETTING_STARTED.md) | Recommended setup order — from server groups down to allocating an IP |
 | [IPAM Features](docs/features/IPAM.md) | IP space, block, subnet, address management |
 | [DHCP Features](docs/features/DHCP.md) | DHCP server management — Kea, Windows DHCP |
-| [DNS Features](docs/features/DNS.md) | DNS zones, views, server groups, blocking lists, Windows DNS |
+| [DNS Features](docs/features/DNS.md) | DNS zones, views, server groups, blocking lists, Windows DNS, PowerDNS, Cloud DNS |
+| [Integrations](docs/features/INTEGRATIONS.md) | Read-only mirrors — Kubernetes, Docker, Proxmox, Cloud, Tailscale, UniFi, OPNsense |
+| [Migration / Import](docs/features/MIGRATION.md) | One-shot DNS + DHCP config importers (BIND9 / Windows / PowerDNS / Kea / ISC dhcpd) |
+| [ACME DNS-01](docs/features/ACME.md) | acme-dns-compatible provider for Let's Encrypt / public-CA cert issuance |
 | [Auth & Permissions](docs/features/AUTH.md) | LDAP, OIDC, SAML, RADIUS, TACACS+, roles, scoped permissions |
+| [Permissions (RBAC)](docs/PERMISSIONS.md) | Permission grammar, builtin roles, wildcards, group-scoped access |
 | [System Admin](docs/features/SYSTEM_ADMIN.md) | Health dashboard, backup, notifications |
 | [Observability](docs/OBSERVABILITY.md) | Logging, metrics, alerting |
 | [Deployment Topologies](docs/deployment/TOPOLOGIES.md) | Six reference topologies — single VM through HA cloud + on-prem hybrid — with diagrams |
 | [Windows Server Setup](docs/deployment/WINDOWS.md) | WinRM, service accounts, firewall — Windows-side checklist |
 | [DNS Agent Design](docs/deployment/DNS_AGENT.md) | Agent protocol, auto-registration, config sync |
-| [DNS Driver Spec](docs/drivers/DNS_DRIVERS.md) | BIND9 + Windows DNS driver internals |
+| [DNS Driver Spec](docs/drivers/DNS_DRIVERS.md) | BIND9 + PowerDNS + Windows DNS + cloud (Route 53 / Azure DNS / Cloudflare / Google) driver internals |
 | [DHCP Driver Spec](docs/drivers/DHCP_DRIVERS.md) | Kea + Windows DHCP driver internals |
+| [Docker Compose](docs/deployment/DOCKER.md) | Compose setup, ports, first-time setup, TLS, HA, password reset |
 | [Appliance Deployment](docs/deployment/APPLIANCE.md) | OS appliance ISO — base OS selection, build pipeline, first-boot orchestration, `/appliance` management hub spec |
+| [Troubleshooting](docs/TROUBLESHOOTING.md) | Recovery recipes — deleted agent rows, password reset, subnet-delete refused |
 
 ---
 
@@ -1131,8 +1157,8 @@ Full docs at **[spatiumddi.github.io](https://spatiumddi.github.io)** (coming so
 |---|---|---|
 | Phase 1 | Core IPAM, auth, user management, audit log, Docker Compose | ✅ Done — LDAP/OIDC/SAML + RADIUS/TACACS+, group-based RBAC, bulk-edit, inheritance, mobile-responsive UI, and full IPv6 `/next-address` (EUI-64 + random /128 + sequential) all shipped |
 | Phase 2 | DHCP (Kea), DNS (BIND9), DDNS, zone/subnet tree UI | ✅ Done — DNS, Kea DHCPv4, subnet-level DDNS, agent-side Kea DDNS, block/space DDNS inheritance, per-server zone serial reporting all shipped |
-| Phase 3 | DNS views, server groups, blocking lists, VLAN/VXLAN, system admin, Kea HA | 🔄 DNS features + health dashboard + alerts framework + group-centric Kea HA (self-healing peer-IP drift + supervised daemons) + DNS Views end-to-end split-horizon landed; HA state-transition actions still pending |
-| Phase 4 | OS appliance, Terraform provider, SAML, backup/restore, ACME | 🔄 SAML + full backup/restore + factory-reset + OS appliance beta (Debian 13 ISO + embedded [k3s](https://k3s.io/) + Helm orchestration, `/appliance` management hub with TLS upload + CSR-on-server, GitHub release apply, kubeapi-driven Pods tab + live SSE logs, host log viewer + self-test + diagnostic bundle, maintenance mode + reboot, web first-boot wizard, atomic A/B slot upgrades, **multi-node rolling cluster upgrade** with CNPG switchover + lease-mutex + preflight + air-gap mirror PVC, consolidated **Cluster tab** (Pods + etcd + live SSE health dashboard), realtime **firewall-log viewer**, Talos-style **console cockpit**) all landed. Terraform/Ansible providers + ACME embedded client (Let's Encrypt auto-issue) still pending |
+| Phase 3 | DNS views, server groups, blocking lists, VLAN/VXLAN, system admin, Kea HA | ✅ Done — DNS features + health dashboard + alerts framework + group-centric Kea HA (self-healing peer-IP drift + supervised daemons) + DNS Views end-to-end split-horizon + **multi-node control-plane HA** (CloudNativePG + Redis Sentinel + MetalLB VIP, operator promote/demote) all shipped |
+| Phase 4 | OS appliance, Terraform provider, SAML, backup/restore, ACME | 🔄 SAML + full backup/restore + factory-reset + OS appliance beta (Debian 13 ISO + embedded [k3s](https://k3s.io/) + Helm orchestration, `/appliance` management hub with TLS upload + CSR-on-server, GitHub release apply, kubeapi-driven Pods tab + live SSE logs, host log viewer + self-test + diagnostic bundle, maintenance mode + reboot, web first-boot wizard, atomic A/B slot upgrades, **multi-node rolling cluster upgrade** with CNPG switchover + lease-mutex + preflight + air-gap mirror PVC, consolidated **Cluster tab** (Pods + etcd + live SSE health dashboard), realtime **firewall-log viewer**, Talos-style **console cockpit**) + the **ACME DNS-01 provider** (acme-dns-compatible, for external certbot / lego / acme.sh clients) all landed. Terraform / Ansible providers + the ACME *embedded client* (auto-issuing TLS for SpatiumDDI's own services) still pending |
 | Phase 5 | Multi-tenancy, IP request workflows, advanced reporting | 📋 Planned |
 
 See [CHANGELOG.md](CHANGELOG.md) for the per-release feature list and

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,40 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1100" viewBox="0 0 1200 1100"
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1310" viewBox="0 0 1400 1310"
      preserveAspectRatio="xMidYMid meet"
      font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
   <defs>
-    <!-- Palette: soft gradients, consistent family -->
     <linearGradient id="g-client" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#60a5fa"/>
-      <stop offset="100%" stop-color="#3b82f6"/>
+      <stop offset="0%" stop-color="#60a5fa"/><stop offset="100%" stop-color="#3b82f6"/>
     </linearGradient>
     <linearGradient id="g-api" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#8b5cf6"/>
-      <stop offset="100%" stop-color="#6d28d9"/>
+      <stop offset="0%" stop-color="#8b5cf6"/><stop offset="100%" stop-color="#6d28d9"/>
     </linearGradient>
     <linearGradient id="g-worker" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="100%" stop-color="#7c3aed"/>
+      <stop offset="0%" stop-color="#a78bfa"/><stop offset="100%" stop-color="#7c3aed"/>
     </linearGradient>
     <linearGradient id="g-store" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#34d399"/>
-      <stop offset="100%" stop-color="#059669"/>
+      <stop offset="0%" stop-color="#34d399"/><stop offset="100%" stop-color="#059669"/>
     </linearGradient>
     <linearGradient id="g-agented" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#fb923c"/>
-      <stop offset="100%" stop-color="#ea580c"/>
+      <stop offset="0%" stop-color="#fb923c"/><stop offset="100%" stop-color="#ea580c"/>
     </linearGradient>
     <linearGradient id="g-agentless" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#22d3ee"/>
-      <stop offset="100%" stop-color="#0891b2"/>
+      <stop offset="0%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="g-cloud" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#818cf8"/><stop offset="100%" stop-color="#4f46e5"/>
     </linearGradient>
     <linearGradient id="g-integrations" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#14b8a6"/>
-      <stop offset="100%" stop-color="#0f766e"/>
-    </linearGradient>
-    <linearGradient id="g-discovery" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#f472b6"/>
-      <stop offset="100%" stop-color="#be185d"/>
+      <stop offset="0%" stop-color="#14b8a6"/><stop offset="100%" stop-color="#0f766e"/>
     </linearGradient>
 
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
@@ -47,290 +38,317 @@
     </marker>
 
     <style>
-      .card {
-        stroke: rgba(15, 23, 42, 0.14);
-        stroke-width: 1;
-        filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.10));
-      }
-      .title-lg { font-size: 22px; font-weight: 700; fill: #0f172a; }
+      .card { stroke: rgba(15,23,42,0.14); stroke-width: 1; filter: drop-shadow(0 2px 4px rgba(15,23,42,0.10)); }
+      .title-lg { font-size: 26px; font-weight: 700; fill: #0f172a; }
       .subtitle { font-size: 13px; fill: #64748b; }
-
-      .card-title { font-size: 16px; font-weight: 700; fill: #ffffff; }
-      .card-sub { font-size: 12px; fill: rgba(255, 255, 255, 0.9); }
-      .card-sub-dim { font-size: 11px; fill: rgba(255, 255, 255, 0.75); }
-
-      .layer-label {
-        font-size: 11px; font-weight: 700; fill: #475569;
-        letter-spacing: 0.12em; text-transform: uppercase;
-      }
-      .band {
-        fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1;
-      }
-      .lane-label {
-        font-size: 12px; font-weight: 600; fill: #334155;
-      }
-
+      .card-title { font-size: 15px; font-weight: 700; fill: #ffffff; }
+      .card-title-sm { font-size: 13px; font-weight: 700; fill: #ffffff; }
+      .card-sub { font-size: 11.5px; fill: rgba(255,255,255,0.92); }
+      .card-sub-dim { font-size: 10.5px; fill: rgba(255,255,255,0.78); }
+      .layer-label { font-size: 11px; font-weight: 700; fill: #475569; letter-spacing: 0.10em; text-transform: uppercase; }
+      .band { fill: #f8fafc; stroke: #e2e8f0; stroke-width: 1; }
+      .subband { fill: #ffffff; stroke: #e2e8f0; stroke-width: 1; }
+      .subband-dash { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1; stroke-dasharray: 5,4; }
+      .lane-label { font-size: 12px; font-weight: 600; fill: #334155; }
       .edge { stroke: #475569; stroke-width: 1.5; fill: none; }
       .edge-dashed { stroke: #94a3b8; stroke-width: 1.5; stroke-dasharray: 5,4; fill: none; }
       .edge-label { font-size: 10.5px; fill: #475569; font-weight: 600; }
-
       .note-box { fill: #f1f5f9; stroke: #cbd5e1; stroke-width: 1; }
       .note-title { font-size: 12px; font-weight: 700; fill: #1e293b; }
-      .note { font-size: 11px; fill: #475569; }
-
-      .pill {
-        fill: rgba(255, 255, 255, 0.22);
-        stroke: rgba(255, 255, 255, 0.35);
-        stroke-width: 0.5;
-      }
-      .pill-text { font-size: 10px; font-weight: 600; fill: #ffffff; }
+      .note { font-size: 10.5px; fill: #475569; }
+      .pill { fill: rgba(255,255,255,0.22); stroke: rgba(255,255,255,0.35); stroke-width: 0.5; }
+      .pill-text { font-size: 10.5px; font-weight: 600; fill: #ffffff; }
+      .divider { stroke: rgba(255,255,255,0.35); stroke-width: 1; }
+      .lane-div { stroke: #e2e8f0; stroke-width: 1; }
     </style>
   </defs>
 
-  <!-- ─────────────────── Title ─────────────────── -->
-  <text x="600" y="36" text-anchor="middle" class="title-lg">SpatiumDDI — Architecture</text>
-  <text x="600" y="58" text-anchor="middle" class="subtitle">
-    Control plane is source of truth · data plane runs either agented (built-in) or agentless (Windows)
-  </text>
+  <!-- ───── Title ───── -->
+  <text x="700" y="38" text-anchor="middle" class="title-lg">SpatiumDDI — Architecture</text>
+  <text x="700" y="62" text-anchor="middle" class="subtitle">Single control plane · four data-plane shapes · single-node or multi-node HA · grounded AI copilot</text>
 
-  <!-- ─────────────────── Clients ─────────────────── -->
-  <text x="40" y="96" class="layer-label">Clients</text>
-
-  <g>
-    <rect x="40" y="108" width="230" height="72" rx="10" ry="10" class="card" fill="url(#g-client)"/>
-    <text x="155" y="136" text-anchor="middle" class="card-title">Browser</text>
-    <text x="155" y="156" text-anchor="middle" class="card-sub">React 18 SPA · served by nginx</text>
-    <text x="155" y="172" text-anchor="middle" class="card-sub-dim">dark / light / system</text>
-  </g>
+  <!-- ───── Clients ───── -->
+  <text x="40" y="92" class="layer-label">Clients</text>
+  <rect x="36" y="100" width="1328" height="104" rx="12" class="band"/>
 
   <g>
-    <rect x="290" y="108" width="230" height="72" rx="10" ry="10" class="card" fill="url(#g-client)" fill-opacity="0.78"/>
-    <text x="405" y="136" text-anchor="middle" class="card-title">CLI &amp; API clients</text>
-    <text x="405" y="156" text-anchor="middle" class="card-sub">curl · Terraform · Ansible</text>
-    <text x="405" y="172" text-anchor="middle" class="card-sub-dim">REST + OpenAPI 3 / Swagger</text>
+    <rect x="56" y="116" width="250" height="72" rx="10" class="card" fill="url(#g-client)"/>
+    <text x="181" y="144" text-anchor="middle" class="card-title">Browser</text>
+    <text x="181" y="164" text-anchor="middle" class="card-sub">React 18 SPA · served by nginx</text>
+    <text x="181" y="180" text-anchor="middle" class="card-sub-dim">dark / light / system</text>
   </g>
-
-  <!-- ─────────────────── Control Plane band ─────────────────── -->
-  <text x="40" y="220" class="layer-label">Control plane</text>
-  <rect x="36" y="228" width="820" height="172" rx="12" ry="12" class="band"/>
-
   <g>
-    <rect x="56" y="248" width="240" height="132" rx="10" ry="10" class="card" fill="url(#g-api)"/>
-    <text x="176" y="278" text-anchor="middle" class="card-title">API</text>
-    <text x="176" y="298" text-anchor="middle" class="card-sub">FastAPI · Python 3.12 · async</text>
-    <text x="176" y="316" text-anchor="middle" class="card-sub">JWT + RBAC · audit log</text>
-    <text x="176" y="334" text-anchor="middle" class="card-sub">/docs (Swagger) · /redoc</text>
-    <text x="176" y="352" text-anchor="middle" class="card-sub-dim">long-poll endpoints for agents</text>
-    <text x="176" y="370" text-anchor="middle" class="card-sub-dim">direct WinRM for agentless</text>
+    <rect x="326" y="116" width="250" height="72" rx="10" class="card" fill="url(#g-client)" fill-opacity="0.82"/>
+    <text x="451" y="144" text-anchor="middle" class="card-title">CLI &amp; API clients</text>
+    <text x="451" y="164" text-anchor="middle" class="card-sub">curl · Terraform · Ansible</text>
+    <text x="451" y="180" text-anchor="middle" class="card-sub-dim">REST + OpenAPI 3 / Swagger</text>
   </g>
-
   <g>
-    <rect x="316" y="248" width="200" height="62" rx="10" ry="10" class="card" fill="url(#g-worker)"/>
-    <text x="416" y="278" text-anchor="middle" class="card-title">Worker</text>
-    <text x="416" y="296" text-anchor="middle" class="card-sub">Celery · ipam / dns / dhcp</text>
+    <rect x="596" y="116" width="250" height="72" rx="10" class="card" fill="url(#g-client)" fill-opacity="0.66"/>
+    <text x="721" y="144" text-anchor="middle" class="card-title">MCP clients</text>
+    <text x="721" y="164" text-anchor="middle" class="card-sub">Claude Desktop · Cursor · Cline</text>
+    <text x="721" y="180" text-anchor="middle" class="card-sub-dim">via /api/v1/ai/mcp</text>
   </g>
 
+  <!-- Non-negotiables legend -->
+  <rect x="946" y="108" width="416" height="90" rx="8" class="note-box"/>
+  <text x="960" y="128" class="note-title">Non-negotiables</text>
+  <text x="960" y="146" class="note">• API-first — UI + CLI + MCP share one REST surface.</text>
+  <text x="960" y="162" class="note">• Agent local cache survives control-plane outage.</text>
+  <text x="960" y="178" class="note">• Every mutation audit-logged · creds Fernet-encrypted.</text>
+  <text x="960" y="194" class="note">• Multi-arch images (amd64 · arm64).</text>
+
+  <!-- ───── Control Plane ───── -->
+  <text x="40" y="246" class="layer-label">Control plane</text>
+  <rect x="36" y="254" width="1328" height="240" rx="12" class="band"/>
+
+  <!-- Core -->
+  <rect x="52" y="266" width="560" height="212" rx="10" class="subband"/>
+  <text x="64" y="286" class="lane-label">Core — all deployments</text>
   <g>
-    <rect x="316" y="318" width="200" height="62" rx="10" ry="10" class="card" fill="url(#g-worker)" fill-opacity="0.85"/>
-    <text x="416" y="348" text-anchor="middle" class="card-title">Beat</text>
-    <text x="416" y="366" text-anchor="middle" class="card-sub">sync jobs · health · cleanup</text>
+    <rect x="66" y="298" width="152" height="172" rx="9" class="card" fill="url(#g-api)"/>
+    <text x="142" y="324" text-anchor="middle" class="card-title">API</text>
+    <text x="142" y="344" text-anchor="middle" class="card-sub">FastAPI · Python 3.12</text>
+    <text x="142" y="362" text-anchor="middle" class="card-sub">async · JWT + RBAC</text>
+    <text x="142" y="380" text-anchor="middle" class="card-sub">audit log · REST/OpenAPI</text>
+    <text x="142" y="402" text-anchor="middle" class="card-sub-dim">long-poll /config (agents)</text>
+    <text x="142" y="420" text-anchor="middle" class="card-sub-dim">WinRM / RFC 2136 (agentless)</text>
+    <text x="142" y="438" text-anchor="middle" class="card-sub-dim">REST/SDK (cloud DNS)</text>
+    <text x="142" y="458" text-anchor="middle" class="card-sub-dim">/api/docs · /api/redoc</text>
   </g>
-
   <g>
-    <rect x="536" y="248" width="200" height="62" rx="10" ry="10" class="card" fill="url(#g-store)"/>
-    <text x="636" y="278" text-anchor="middle" class="card-title">PostgreSQL 16</text>
-    <text x="636" y="296" text-anchor="middle" class="card-sub">IPAM · DNS · DHCP · Audit</text>
+    <rect x="232" y="298" width="160" height="82" rx="9" class="card" fill="url(#g-worker)"/>
+    <text x="312" y="326" text-anchor="middle" class="card-title">Worker</text>
+    <text x="312" y="346" text-anchor="middle" class="card-sub">Celery · ipam / dns / dhcp</text>
+    <text x="312" y="364" text-anchor="middle" class="card-sub-dim">integrations · alerts</text>
   </g>
-
   <g>
-    <rect x="536" y="318" width="200" height="62" rx="10" ry="10" class="card" fill="url(#g-store)" fill-opacity="0.85"/>
-    <text x="636" y="348" text-anchor="middle" class="card-title">Redis 7</text>
-    <text x="636" y="366" text-anchor="middle" class="card-sub">cache · Celery broker</text>
+    <rect x="232" y="388" width="160" height="82" rx="9" class="card" fill="url(#g-worker)" fill-opacity="0.85"/>
+    <text x="312" y="416" text-anchor="middle" class="card-title">Beat</text>
+    <text x="312" y="436" text-anchor="middle" class="card-sub">scheduled: sync · health</text>
+    <text x="312" y="454" text-anchor="middle" class="card-sub-dim">cleanup · reconcile</text>
   </g>
-
-  <!-- ─────────────────── Data plane ─────────────────── -->
-  <text x="40" y="436" class="layer-label">Data plane</text>
-
-  <!-- Lane: Agented (BIND9 + Kea containers) -->
-  <rect x="36" y="452" width="560" height="336" rx="12" ry="12" class="band"/>
-  <text x="52" y="476" class="lane-label">Agented — built-in containers (auto-register)</text>
-
   <g>
-    <rect x="56" y="492" width="250" height="282" rx="10" ry="10" class="card" fill="url(#g-agented)"/>
-    <text x="181" y="520" text-anchor="middle" class="card-title">dns-bind9</text>
-    <text x="181" y="538" text-anchor="middle" class="card-sub-dim">ghcr.io/spatiumddi/dns-bind9</text>
-
-    <line x1="76" y1="552" x2="286" y2="552" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-
-    <!-- agent pill -->
-    <rect x="80" y="566" width="202" height="84" rx="6" ry="6" class="pill"/>
-    <text x="181" y="584" text-anchor="middle" class="pill-text">spatium-dns-agent</text>
-    <text x="181" y="602" text-anchor="middle" class="card-sub-dim">bootstrap (PSK → JWT)</text>
-    <text x="181" y="618" text-anchor="middle" class="card-sub-dim">long-poll /config · ETag</text>
-    <text x="181" y="634" text-anchor="middle" class="card-sub-dim">last-known-good cache</text>
-
-    <line x1="76" y1="668" x2="286" y2="668" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-    <text x="181" y="688" text-anchor="middle" class="card-sub">named (BIND9 9.18)</text>
-    <text x="181" y="706" text-anchor="middle" class="card-sub-dim">loopback nsupdate + TSIG</text>
-    <text x="181" y="724" text-anchor="middle" class="card-sub-dim">53/udp · 53/tcp</text>
-    <text x="181" y="752" text-anchor="middle" class="card-sub-dim">survives control-plane outage</text>
+    <rect x="406" y="298" width="190" height="82" rx="9" class="card" fill="url(#g-store)"/>
+    <text x="501" y="326" text-anchor="middle" class="card-title">PostgreSQL 16</text>
+    <text x="501" y="346" text-anchor="middle" class="card-sub">IPAM · DNS · DHCP</text>
+    <text x="501" y="364" text-anchor="middle" class="card-sub-dim">Network · Audit · Auth</text>
   </g>
-
   <g>
-    <rect x="326" y="492" width="250" height="282" rx="10" ry="10" class="card" fill="url(#g-agented)" fill-opacity="0.9"/>
-    <text x="451" y="520" text-anchor="middle" class="card-title">dhcp-kea</text>
-    <text x="451" y="538" text-anchor="middle" class="card-sub-dim">ghcr.io/spatiumddi/dhcp-kea</text>
-
-    <line x1="346" y1="552" x2="556" y2="552" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-
-    <rect x="350" y="566" width="202" height="84" rx="6" ry="6" class="pill"/>
-    <text x="451" y="584" text-anchor="middle" class="pill-text">spatium-dhcp-agent</text>
-    <text x="451" y="602" text-anchor="middle" class="card-sub-dim">bootstrap (PSK → JWT)</text>
-    <text x="451" y="618" text-anchor="middle" class="card-sub-dim">long-poll /config · ETag</text>
-    <text x="451" y="634" text-anchor="middle" class="card-sub-dim">last-known-good cache</text>
-
-    <line x1="346" y1="668" x2="556" y2="668" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-    <text x="451" y="688" text-anchor="middle" class="card-sub">kea-dhcp4 / kea-dhcp6</text>
-    <text x="451" y="706" text-anchor="middle" class="card-sub-dim">Control Agent · loopback</text>
-    <text x="451" y="724" text-anchor="middle" class="card-sub-dim">67/udp · HA hook library</text>
-    <text x="451" y="752" text-anchor="middle" class="card-sub-dim">survives control-plane outage</text>
+    <rect x="406" y="388" width="190" height="82" rx="9" class="card" fill="url(#g-store)" fill-opacity="0.85"/>
+    <text x="501" y="416" text-anchor="middle" class="card-title">Redis 7</text>
+    <text x="501" y="436" text-anchor="middle" class="card-sub">cache · Celery broker</text>
+    <text x="501" y="454" text-anchor="middle" class="card-sub-dim">pub/sub agent wake</text>
   </g>
 
-  <!-- Lane: Agentless (Windows DC) -->
-  <rect x="612" y="452" width="552" height="336" rx="12" ry="12" class="band"/>
-  <text x="628" y="476" class="lane-label">Agentless — Windows Server (no software installed on the DC)</text>
-
+  <!-- HA add-ons -->
+  <rect x="628" y="266" width="298" height="212" rx="10" class="subband-dash"/>
+  <text x="640" y="286" class="lane-label">Multi-node HA — cluster only</text>
   <g>
-    <rect x="632" y="492" width="252" height="282" rx="10" ry="10" class="card" fill="url(#g-agentless)"/>
-    <text x="758" y="520" text-anchor="middle" class="card-title">Windows DNS</text>
-    <text x="758" y="538" text-anchor="middle" class="card-sub-dim">existing Active Directory DC</text>
-
-    <line x1="652" y1="552" x2="864" y2="552" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-
-    <rect x="656" y="566" width="204" height="36" rx="6" ry="6" class="pill"/>
-    <text x="758" y="582" text-anchor="middle" class="pill-text">Path A — record CRUD</text>
-    <text x="758" y="596" text-anchor="middle" class="card-sub-dim">RFC 2136 + dnspython</text>
-
-    <rect x="656" y="614" width="204" height="36" rx="6" ry="6" class="pill"/>
-    <text x="758" y="630" text-anchor="middle" class="pill-text">Path B — zone CRUD (creds)</text>
-    <text x="758" y="644" text-anchor="middle" class="card-sub-dim">WinRM + DnsServer PS module</text>
-
-    <line x1="652" y1="668" x2="864" y2="668" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-    <text x="758" y="688" text-anchor="middle" class="card-sub">53/udp · 53/tcp (RFC 2136)</text>
-    <text x="758" y="706" text-anchor="middle" class="card-sub">5985/5986 (WinRM)</text>
-    <text x="758" y="728" text-anchor="middle" class="card-sub-dim">AXFR or Get-DnsServerResource…</text>
-    <text x="758" y="752" text-anchor="middle" class="card-sub-dim">zones auto-import on sync</text>
+    <rect x="640" y="298" width="134" height="80" rx="9" class="card" fill="url(#g-store)" fill-opacity="0.62"/>
+    <text x="707" y="322" text-anchor="middle" class="card-title-sm">CloudNativePG</text>
+    <text x="707" y="342" text-anchor="middle" class="card-sub-dim">replicated Postgres</text>
+    <text x="707" y="358" text-anchor="middle" class="card-sub-dim">auto failover</text>
   </g>
-
   <g>
-    <rect x="904" y="492" width="252" height="282" rx="10" ry="10" class="card" fill="url(#g-agentless)" fill-opacity="0.9"/>
-    <text x="1030" y="520" text-anchor="middle" class="card-title">Windows DHCP</text>
-    <text x="1030" y="538" text-anchor="middle" class="card-sub-dim">existing DHCP server</text>
-
-    <line x1="924" y1="552" x2="1136" y2="552" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-
-    <rect x="928" y="566" width="204" height="36" rx="6" ry="6" class="pill"/>
-    <text x="1030" y="582" text-anchor="middle" class="pill-text">Path A — read-only</text>
-    <text x="1030" y="596" text-anchor="middle" class="card-sub-dim">WinRM + DhcpServer PS module</text>
-
-    <rect x="928" y="614" width="204" height="36" rx="6" ry="6" class="pill"/>
-    <text x="1030" y="630" text-anchor="middle" class="pill-text">leases + scopes (polling)</text>
-    <text x="1030" y="644" text-anchor="middle" class="card-sub-dim">Get-DhcpServerv4Lease</text>
-
-    <line x1="924" y1="668" x2="1136" y2="668" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-    <text x="1030" y="688" text-anchor="middle" class="card-sub">5985/5986 (WinRM)</text>
-    <text x="1030" y="710" text-anchor="middle" class="card-sub-dim">mirrors leases into IPAM</text>
-    <text x="1030" y="728" text-anchor="middle" class="card-sub-dim">status=dhcp · auto-cleanup</text>
-    <text x="1030" y="752" text-anchor="middle" class="card-sub-dim">Path B (full CRUD) — roadmap</text>
+    <rect x="784" y="298" width="130" height="80" rx="9" class="card" fill="url(#g-store)" fill-opacity="0.62"/>
+    <text x="849" y="322" text-anchor="middle" class="card-title-sm">Redis Sentinel</text>
+    <text x="849" y="342" text-anchor="middle" class="card-sub-dim">master election</text>
+    <text x="849" y="358" text-anchor="middle" class="card-sub-dim">sentinel:// URL</text>
   </g>
-
-  <!-- ─────────────────── Edges ─────────────────── -->
-  <!-- Browser → API -->
-  <path d="M 155 180 L 155 248" class="edge" marker-end="url(#arrow)"/>
-  <text x="162" y="216" class="edge-label">HTTPS</text>
-  <!-- CLI → API -->
-  <path d="M 405 180 L 240 248" class="edge" marker-end="url(#arrow)"/>
-
-  <!-- API ↔ Worker -->
-  <path d="M 296 278 L 316 278" class="edge" marker-end="url(#arrow)"/>
-  <!-- API ↔ Beat -->
-  <path d="M 296 348 L 316 348" class="edge" marker-end="url(#arrow)"/>
-  <!-- Worker ↔ Redis / PG -->
-  <path d="M 516 278 L 536 278" class="edge" marker-end="url(#arrow)"/>
-  <text x="520" y="270" class="edge-label">async SQL</text>
-  <path d="M 516 348 L 536 348" class="edge" marker-end="url(#arrow)"/>
-  <text x="520" y="340" class="edge-label">broker</text>
-
-  <!-- API → agented lane (via sidecar) -->
-  <path d="M 176 380 L 176 448 Q 176 460 188 460 L 306 460 Q 316 460 316 472 L 316 492" class="edge" marker-end="url(#arrow)"/>
-  <text x="200" y="436" class="edge-label">long-poll /config · heartbeat</text>
-  <!-- dashed return (config bundle) -->
-  <path d="M 181 492 L 181 464 Q 181 456 173 456 L 140 456 Q 132 456 132 448 L 132 380" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
-
-  <!-- API → agentless lane (direct) -->
-  <path d="M 176 380 L 176 428 Q 176 440 188 440 L 744 440 Q 758 440 758 452 L 758 492" class="edge" marker-end="url(#arrow)"/>
-  <text x="430" y="434" class="edge-label">RFC 2136 · AXFR · WinRM (direct from API)</text>
-
-  <!-- Beat → agentless (scheduled sync jobs) -->
-  <path d="M 416 380 L 416 420 Q 416 432 428 432 L 1020 432 Q 1030 432 1030 444 L 1030 492" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
-  <text x="720" y="427" class="edge-label">scheduled: lease pull · zone sync · IPAM→DNS reconcile</text>
-
-  <!-- ─────────────────── Read-only sources band ─────────────────── -->
-  <text x="40" y="824" class="layer-label">Read-only sources — pulled into IPAM (scheduled by Worker)</text>
-  <rect x="36" y="836" width="1128" height="240" rx="12" ry="12" class="band"/>
-
-  <!-- Lane: Integrations -->
   <g>
-    <rect x="56" y="856" width="540" height="200" rx="10" ry="10" class="card" fill="url(#g-integrations)"/>
-    <text x="326" y="884" text-anchor="middle" class="card-title">Integrations (read-only mirrors)</text>
-    <text x="326" y="902" text-anchor="middle" class="card-sub-dim">Settings → Integrations · per-target Sync Now</text>
-
-    <line x1="76" y1="918" x2="576" y2="918" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-
-    <text x="76" y="942" class="card-sub" font-weight="600">Kubernetes</text>
-    <text x="76" y="958" class="card-sub-dim">CIDRs · nodes · LB VIPs · Ingress → DNS</text>
-
-    <text x="76" y="982" class="card-sub" font-weight="600">Docker</text>
-    <text x="76" y="998" class="card-sub-dim">networks · optional container IPs</text>
-
-    <text x="316" y="942" class="card-sub" font-weight="600">Proxmox VE</text>
-    <text x="316" y="958" class="card-sub-dim">bridges · SDN VNets · VM/LXC NICs</text>
-
-    <text x="316" y="982" class="card-sub" font-weight="600">Tailscale</text>
-    <text x="316" y="998" class="card-sub-dim">devices + synthetic *.ts.net zone</text>
-
-    <line x1="76" y1="1014" x2="576" y2="1014" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-    <text x="326" y="1034" text-anchor="middle" class="card-sub-dim">credentials Fernet-encrypted · 30 s default sync</text>
+    <rect x="640" y="388" width="134" height="80" rx="9" class="card" fill="url(#g-store)" fill-opacity="0.62"/>
+    <text x="707" y="412" text-anchor="middle" class="card-title-sm">k3s etcd</text>
+    <text x="707" y="432" text-anchor="middle" class="card-sub-dim">state quorum</text>
+    <text x="707" y="448" text-anchor="middle" class="card-sub-dim">3 / 5 / 7 nodes</text>
   </g>
-
-  <!-- Lane: Network discovery (SNMP) -->
   <g>
-    <rect x="616" y="856" width="540" height="200" rx="10" ry="10" class="card" fill="url(#g-discovery)"/>
-    <text x="886" y="884" text-anchor="middle" class="card-title">Network discovery (SNMP)</text>
-    <text x="886" y="902" text-anchor="middle" class="card-sub-dim">routers + switches · standard MIBs</text>
-
-    <line x1="636" y1="918" x2="1136" y2="918" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-
-    <text x="886" y="942" text-anchor="middle" class="card-sub">v1 · v2c · v3 (USM auth + priv)</text>
-    <text x="886" y="960" text-anchor="middle" class="card-sub-dim">IF-MIB · IP-MIB · Q-BRIDGE-MIB · LLDP-MIB</text>
-
-    <text x="886" y="984" text-anchor="middle" class="card-sub">interfaces · ARP · FDB · LLDP neighbours</text>
-    <text x="886" y="1002" text-anchor="middle" class="card-sub-dim">cross-referenced into IP rows</text>
-
-    <line x1="636" y1="1014" x2="1136" y2="1014" stroke="rgba(255,255,255,0.35)" stroke-width="1"/>
-    <text x="886" y="1034" text-anchor="middle" class="card-sub-dim">per-IP switch-port + VLAN visibility in IPAM</text>
+    <rect x="784" y="388" width="130" height="80" rx="9" class="card" fill="url(#g-store)" fill-opacity="0.62"/>
+    <text x="849" y="412" text-anchor="middle" class="card-title-sm">MetalLB</text>
+    <text x="849" y="432" text-anchor="middle" class="card-sub-dim">control-plane VIP</text>
+    <text x="849" y="448" text-anchor="middle" class="card-sub-dim">one UI address</text>
   </g>
 
-  <!-- Worker → Read-only sources band (scheduled pulls) -->
-  <path d="M 416 380 L 416 412 Q 416 422 426 422 L 580 422 Q 596 422 596 836" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
-  <text x="486" y="416" class="edge-label">scheduled: integration sync · SNMP poll · GSLB health</text>
+  <!-- Operator Copilot -->
+  <rect x="942" y="266" width="402" height="212" rx="10" class="subband"/>
+  <text x="954" y="286" class="lane-label">Operator Copilot — grounded AI</text>
+  <g>
+    <rect x="956" y="298" width="374" height="56" rx="9" class="card" fill="url(#g-api)"/>
+    <text x="1143" y="322" text-anchor="middle" class="card-title">LLM Provider</text>
+    <text x="1143" y="341" text-anchor="middle" class="card-sub">OpenAI · Anthropic · Azure · Gemini · Ollama (auto-failover)</text>
+  </g>
+  <g>
+    <rect x="956" y="364" width="182" height="106" rx="9" class="card" fill="url(#g-worker)"/>
+    <text x="1047" y="390" text-anchor="middle" class="card-title">Tool Registry</text>
+    <text x="1047" y="410" text-anchor="middle" class="card-sub">183 tools</text>
+    <text x="1047" y="428" text-anchor="middle" class="card-sub-dim">IPAM / DNS / DHCP / Net</text>
+    <text x="1047" y="444" text-anchor="middle" class="card-sub-dim">admin / appliance / …</text>
+    <text x="1047" y="460" text-anchor="middle" class="card-sub-dim">Apply-gated writes</text>
+  </g>
+  <g>
+    <rect x="1148" y="364" width="182" height="106" rx="9" class="card" fill="url(#g-api)" fill-opacity="0.82"/>
+    <text x="1239" y="390" text-anchor="middle" class="card-title">MCP Server</text>
+    <text x="1239" y="410" text-anchor="middle" class="card-sub-dim">/api/v1/ai/mcp</text>
+    <text x="1239" y="428" text-anchor="middle" class="card-sub-dim">per-provider prompt</text>
+    <text x="1239" y="446" text-anchor="middle" class="card-sub-dim">+ tool allowlist</text>
+    <text x="1239" y="462" text-anchor="middle" class="card-sub-dim">grounded in live data</text>
+  </g>
 
-  <!-- ─────────────────── Notes / legend ─────────────────── -->
-  <rect x="880" y="96" width="280" height="120" rx="8" ry="8" class="note-box"/>
-  <text x="892" y="118" class="note-title">Non-negotiables</text>
-  <text x="892" y="138" class="note">• API-first (UI + CLI speak the same REST).</text>
-  <text x="892" y="156" class="note">• Agent local cache survives CP outage.</text>
-  <text x="892" y="174" class="note">• Every mutation is audit-logged.</text>
-  <text x="892" y="192" class="note">• Credentials: Fernet-encrypted at rest.</text>
-  <text x="892" y="210" class="note">• Multi-arch images: amd64 · arm64.</text>
+  <!-- ───── Appliance Fleet ───── -->
+  <text x="40" y="512" class="layer-label">OS appliance fleet (optional)</text>
+  <rect x="36" y="520" width="1328" height="158" rx="12" class="band"/>
+  <g>
+    <rect x="56" y="536" width="430" height="126" rx="10" class="card" fill="url(#g-agented)"/>
+    <text x="271" y="562" text-anchor="middle" class="card-title">spatium-supervisor</text>
+    <text x="271" y="582" text-anchor="middle" class="card-sub-dim">Ed25519 identity · pairing-code onboarding</text>
+    <text x="271" y="602" text-anchor="middle" class="card-sub">heartbeat long-poll → control plane</text>
+    <text x="271" y="622" text-anchor="middle" class="card-sub-dim">pulls: roles · A/B OS upgrade · firewall · host-config</text>
+    <text x="271" y="642" text-anchor="middle" class="card-sub-dim">enforces on host (k3s node label · nft · grub)</text>
+  </g>
+  <g>
+    <rect x="506" y="536" width="380" height="126" rx="10" class="card" fill="url(#g-agented)" fill-opacity="0.88"/>
+    <text x="696" y="562" text-anchor="middle" class="card-title">Role pods (DaemonSets)</text>
+    <text x="696" y="582" text-anchor="middle" class="card-sub">dns-bind9 / dns-powerdns / dhcp-kea</text>
+    <text x="696" y="602" text-anchor="middle" class="card-sub-dim">role-picked at fleet promotion</text>
+    <text x="696" y="622" text-anchor="middle" class="card-sub-dim">= the agented data plane (below)</text>
+    <text x="696" y="642" text-anchor="middle" class="card-sub-dim">scheduled by spatium.io/role-* labels</text>
+  </g>
+  <g>
+    <rect x="906" y="536" width="438" height="126" rx="10" class="card" fill="url(#g-agented)"/>
+    <text x="1125" y="562" text-anchor="middle" class="card-title">Host config &amp; firewall</text>
+    <text x="1125" y="582" text-anchor="middle" class="card-sub">SNMP · NTP · LLDP · syslog · SSH · timezone</text>
+    <text x="1125" y="602" text-anchor="middle" class="card-sub-dim">declarative, control-plane-driven</text>
+    <text x="1125" y="622" text-anchor="middle" class="card-sub">per-role nftables firewall enforce</text>
+    <text x="1125" y="642" text-anchor="middle" class="card-sub-dim">systemd / grub / A-B slot management</text>
+  </g>
+
+  <!-- ───── Data Plane ───── -->
+  <text x="40" y="712" class="layer-label">Data plane — independent shapes, mix freely</text>
+  <rect x="36" y="718" width="1328" height="322" rx="12" class="band"/>
+  <line x1="476" y1="730" x2="476" y2="1028" class="lane-div"/>
+  <line x1="916" y1="730" x2="916" y2="1028" class="lane-div"/>
+
+  <!-- Lane A: Agented on-prem -->
+  <text x="52" y="740" class="lane-label">Agented (on-prem) — built-in containers, auto-register</text>
+  <g>
+    <rect x="52" y="750" width="412" height="82" rx="9" class="card" fill="url(#g-agented)"/>
+    <text x="258" y="773" text-anchor="middle" class="card-title">dns-bind9</text>
+    <text x="258" y="791" text-anchor="middle" class="card-sub-dim">ghcr.io/spatiumddi/dns-bind9</text>
+    <text x="258" y="811" text-anchor="middle" class="card-sub">spatium-dns-agent · BIND9 9.18 · nsupdate+TSIG · 53/udp+tcp</text>
+  </g>
+  <g>
+    <rect x="52" y="842" width="412" height="82" rx="9" class="card" fill="url(#g-agented)" fill-opacity="0.9"/>
+    <text x="258" y="865" text-anchor="middle" class="card-title">dns-powerdns</text>
+    <text x="258" y="883" text-anchor="middle" class="card-sub-dim">ghcr.io/spatiumddi/dns-powerdns</text>
+    <text x="258" y="903" text-anchor="middle" class="card-sub">spatium-dns-agent · PowerDNS · REST Control Agent · DNSSEC</text>
+  </g>
+  <g>
+    <rect x="52" y="934" width="412" height="82" rx="9" class="card" fill="url(#g-agented)" fill-opacity="0.8"/>
+    <text x="258" y="957" text-anchor="middle" class="card-title">dhcp-kea</text>
+    <text x="258" y="975" text-anchor="middle" class="card-sub-dim">ghcr.io/spatiumddi/dhcp-kea</text>
+    <text x="258" y="995" text-anchor="middle" class="card-sub">spatium-dhcp-agent · kea-dhcp4/6 · 67/udp · HA hook</text>
+  </g>
+  <text x="258" y="1024" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">PSK/pairing→JWT · long-poll ETag · last-known-good cache · DNS engine mutually exclusive</text>
+
+  <!-- Lane B: Agentless on-prem (Windows) -->
+  <text x="488" y="740" class="lane-label">Agentless (on-prem) — Windows Server, nothing installed</text>
+  <g>
+    <rect x="488" y="750" width="420" height="128" rx="9" class="card" fill="url(#g-agentless)"/>
+    <text x="698" y="773" text-anchor="middle" class="card-title">Windows DNS</text>
+    <text x="698" y="790" text-anchor="middle" class="card-sub-dim">existing Active Directory DC</text>
+    <rect x="508" y="800" width="380" height="28" rx="6" class="pill"/>
+    <text x="698" y="818" text-anchor="middle" class="pill-text">Path A — RFC 2136 record CRUD</text>
+    <rect x="508" y="836" width="380" height="28" rx="6" class="pill"/>
+    <text x="698" y="854" text-anchor="middle" class="pill-text">Path B — WinRM zone CRUD (DnsServer PS)</text>
+  </g>
+  <g>
+    <rect x="488" y="888" width="420" height="128" rx="9" class="card" fill="url(#g-agentless)" fill-opacity="0.9"/>
+    <text x="698" y="911" text-anchor="middle" class="card-title">Windows DHCP</text>
+    <text x="698" y="928" text-anchor="middle" class="card-sub-dim">existing DHCP server</text>
+    <rect x="508" y="938" width="380" height="28" rx="6" class="pill"/>
+    <text x="698" y="956" text-anchor="middle" class="pill-text">read-only WinRM polling → IPAM mirror</text>
+    <text x="698" y="984" text-anchor="middle" class="card-sub-dim">5985/5986 · status=dhcp · Path B (CRUD) roadmap</text>
+  </g>
+  <text x="698" y="1024" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">no software on the DC · credentials Fernet-encrypted on the server row</text>
+
+  <!-- Lane C: Agentless cloud DNS -->
+  <text x="924" y="740" class="lane-label">Agentless (cloud DNS) — provider API, no agent</text>
+  <g>
+    <rect x="924" y="750" width="204" height="70" rx="9" class="card" fill="url(#g-cloud)"/>
+    <text x="1026" y="778" text-anchor="middle" class="card-title">Cloudflare</text>
+    <text x="1026" y="796" text-anchor="middle" class="card-sub-dim">API token · REST</text>
+  </g>
+  <g>
+    <rect x="1140" y="750" width="204" height="70" rx="9" class="card" fill="url(#g-cloud)"/>
+    <text x="1242" y="778" text-anchor="middle" class="card-title">Route 53</text>
+    <text x="1242" y="796" text-anchor="middle" class="card-sub-dim">boto3 · IAM</text>
+  </g>
+  <g>
+    <rect x="924" y="830" width="204" height="70" rx="9" class="card" fill="url(#g-cloud)" fill-opacity="0.9"/>
+    <text x="1026" y="858" text-anchor="middle" class="card-title">Azure DNS</text>
+    <text x="1026" y="876" text-anchor="middle" class="card-sub-dim">Azure SDK</text>
+  </g>
+  <g>
+    <rect x="1140" y="830" width="204" height="70" rx="9" class="card" fill="url(#g-cloud)" fill-opacity="0.9"/>
+    <text x="1242" y="858" text-anchor="middle" class="card-title">Google Cloud DNS</text>
+    <text x="1242" y="876" text-anchor="middle" class="card-sub-dim">service-account JSON</text>
+  </g>
+  <g>
+    <rect x="924" y="910" width="420" height="70" rx="9" class="card" fill="url(#g-cloud)" fill-opacity="0.8"/>
+    <text x="1134" y="938" text-anchor="middle" class="card-title">DigitalOcean · Hetzner · Linode · Vultr</text>
+    <text x="1134" y="956" text-anchor="middle" class="card-sub-dim">single API-token REST</text>
+  </g>
+  <text x="1134" y="1024" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">control plane calls REST/SDK directly · import-existing-zones</text>
+
+  <!-- ───── Integration mirrors ───── -->
+  <text x="40" y="1062" class="layer-label">Read-only integration mirrors — scheduled pull → IPAM (never written back)</text>
+  <rect x="36" y="1068" width="1328" height="186" rx="12" class="band"/>
+  <rect x="52" y="1082" width="1292" height="158" rx="10" class="card" fill="url(#g-integrations)"/>
+
+  <text x="212" y="1116" text-anchor="middle" class="card-title-sm">Kubernetes</text>
+  <text x="212" y="1134" text-anchor="middle" class="card-sub-dim">CIDRs · nodes · LB VIPs · Ingress→DNS</text>
+  <text x="532" y="1116" text-anchor="middle" class="card-title-sm">Docker</text>
+  <text x="532" y="1134" text-anchor="middle" class="card-sub-dim">networks · container IPs</text>
+  <text x="852" y="1116" text-anchor="middle" class="card-title-sm">Proxmox VE</text>
+  <text x="852" y="1134" text-anchor="middle" class="card-sub-dim">bridges · SDN VNets · VM/LXC NICs</text>
+  <text x="1180" y="1116" text-anchor="middle" class="card-title-sm">Cloud (AWS / Azure / GCP)</text>
+  <text x="1180" y="1134" text-anchor="middle" class="card-sub-dim">VPCs→blocks · subnets · NIC/LB IPs</text>
+
+  <line x1="76" y1="1158" x2="1320" y2="1158" class="divider"/>
+
+  <text x="212" y="1190" text-anchor="middle" class="card-title-sm">Tailscale</text>
+  <text x="212" y="1208" text-anchor="middle" class="card-sub-dim">devices · synthetic *.ts.net zone</text>
+  <text x="532" y="1190" text-anchor="middle" class="card-title-sm">UniFi Network</text>
+  <text x="532" y="1208" text-anchor="middle" class="card-sub-dim">sites · VLANs · clients (host+MAC)</text>
+  <text x="852" y="1190" text-anchor="middle" class="card-title-sm">OPNsense</text>
+  <text x="852" y="1208" text-anchor="middle" class="card-sub-dim">interfaces · DHCP leases + reservations</text>
+  <text x="1180" y="1196" text-anchor="middle" class="card-sub">Fernet-encrypted creds · 30 s sync</text>
+  <text x="1180" y="1214" text-anchor="middle" class="card-sub-dim">shape-guarded absence-delete</text>
+
+  <!-- ───── Edges ───── -->
+  <!-- Clients → control plane -->
+  <path d="M 181 188 L 181 254" class="edge" marker-end="url(#arrow)"/>
+  <text x="188" y="228" class="edge-label">HTTPS</text>
+  <path d="M 451 188 L 451 254" class="edge" marker-end="url(#arrow)"/>
+  <text x="458" y="228" class="edge-label">REST / OpenAPI</text>
+  <path d="M 721 188 L 721 254" class="edge" marker-end="url(#arrow)"/>
+  <text x="728" y="228" class="edge-label">MCP</text>
+
+  <!-- Control plane → appliance supervisor -->
+  <path d="M 271 494 L 271 536" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
+  <text x="300" y="511" class="edge-label">supervisor: register · heartbeat · pull desired-state (roles · upgrade · firewall · host-config)</text>
+
+  <!-- Appliance → data plane (supervisor schedules role pods) -->
+  <path d="M 660 662 L 660 718" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
+  <text x="668" y="700" class="edge-label">schedules role pods</text>
+
+  <!-- Control plane → data plane (left spine) -->
+  <path d="M 66 408 L 24 408 L 24 700 L 200 700 L 200 718" class="edge" marker-end="url(#arrow)"/>
+  <text x="34" y="688" class="edge-label">API → data plane (direct): long-poll /config · RFC 2136 / WinRM · REST/SDK</text>
+  <!-- dashed config-bundle return -->
+  <path d="M 120 750 L 120 690 L 14 690 L 14 426 L 66 426" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
+
+  <!-- Beat → integration mirrors (right spine) -->
+  <path d="M 1344 470 L 1378 470 L 1378 1080 L 1344 1080" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
+  <text x="1150" y="1062" class="edge-label" text-anchor="end">Beat: scheduled pull → IPAM ↘</text>
 </svg>


### PR DESCRIPTION
Sweeps README.md against the live codebase and redraws the stale architecture.svg (last touched 2026-04-30).

- Bumps stale version pin (2026.05.11-1 → 2026.06.14-1)
- Corrects counts: AI tools 180→183, typed events 96→131, conformity 6→9 kinds / 8→11 policies
- Adds the OPNsense integration (table, demo-mode list, diagram)
- Restructures the appliance section to the real 6 tabs (Fleet / Cluster / Firewall / Logs & Diagnostics / Maintenance / Network & Host)
- Expands the architecture prose to four data-plane shapes
- Updates Project Status phases; adds Integrations / Migration / ACME / Permissions / Docker / Troubleshooting doc links; fixes a broken appliance-ISO anchor
- Redraws architecture.svg: PowerDNS, the cloud-DNS driver family, the spatium-supervisor + embedded-k3s appliance layer, multi-node HA (CNPG / Sentinel / etcd / MetalLB), the Operator Copilot + MCP layer, and all 7 integration mirrors

Docs-only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)