### PR TITLE
feat: #59 packet capture (tcpdump) — server + appliance-host vantages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,31 @@ the formatter handles the rest.
 
 Batched fixes for the next cut (not yet released).
 
+### Added
+
+* **#59 — Packet capture (tcpdump), Phase 1 (server vantage).** On-demand
+  packet capture as a first-class, RBAC-gated, audited platform tool —
+  for troubleshooting an appliance/container where there's no easy shell.
+  A new **Tools → Packet Capture** page starts a capture (interface +
+  BPF filter with presets + stop conditions: packets / duration / bytes +
+  snaplen), watches live byte/packet progress, and downloads the
+  ``.pcap`` for Wireshark. Mirrors the nmap scanner (persisted job rows,
+  5-state lifecycle, history + bulk-delete, ``tools.pcap`` feature
+  module, DEMO_MODE lockdown, ``setcap cap_net_raw`` on the binary) but
+  the deliverable is a binary ``.pcap`` artifact on disk (download-only,
+  auto-pruned after ``pcap_retention_days`` — default 7 — since captures
+  are large + sensitive). The BPF filter is passed as tcpdump's single
+  trailing argv element (never shell-interpolated) + charset-validated.
+  Phase 1 runs tcpdump in the worker container (the control-plane network
+  vantage); a new dedicated ``manage_packet_capture`` permission (seeded
+  to **Network Editor**, not Viewer — captured bytes are a privileged
+  read) gates every endpoint, and every start / download / cancel /
+  delete is audit-logged. Operator Copilot gets read tools
+  (``find_packet_captures`` / ``count_packet_captures`` /
+  ``get_packet_capture`` — metadata only, never bytes) + a gated
+  ``propose_run_packet_capture`` write. Appliance-host capture (the real
+  NICs, via the supervisor host-runner) lands in Phase 2.
+
 ### Fixed
 
 * **#430 — DDI hardening sweep: integration-mirror mass-delete on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Batched fixes for the next cut (not yet released).
 
 ### Added
 
-* **#59 — Packet capture (tcpdump), Phase 1 (server vantage).** On-demand
+* **#59 — Packet capture (tcpdump).** On-demand
   packet capture as a first-class, RBAC-gated, audited platform tool —
   for troubleshooting an appliance/container where there's no easy shell.
   A new **Tools → Packet Capture** page starts a capture (interface +
@@ -46,8 +46,18 @@ Batched fixes for the next cut (not yet released).
   delete is audit-logged. Operator Copilot gets read tools
   (``find_packet_captures`` / ``count_packet_captures`` /
   ``get_packet_capture`` — metadata only, never bytes) + a gated
-  ``propose_run_packet_capture`` write. Appliance-host capture (the real
-  NICs, via the supervisor host-runner) lands in Phase 2.
+  ``propose_run_packet_capture`` write. **Appliance-host vantage (Phase 2)**
+  adds capture on an appliance's *real NICs*: the operator picks the
+  appliance from a vantage dropdown (or the Fleet drilldown's "Packet
+  capture" link), the supervisor's ``pcap_proxy`` long-polls a cert-authed
+  DB-poll dispatch (any api replica can serve it — no in-memory queue to
+  strand the job), drives a host-side ``spatium-pcap-runner`` over the
+  existing trigger-file → systemd ``.path`` pattern (tcpdump runs in the
+  real host net namespace — NOT a privileged ``hostNetwork`` pod), streams
+  progress, and uploads the finished ``.pcap`` back over the supervisor
+  channel. On a single-node appliance the api + worker share the pcap dir
+  via a hostPath; multi-node server-vantage download needs the slot-image
+  mirror proxy (a tracked follow-up).
 
 ### Fixed
 

--- a/NOTICE
+++ b/NOTICE
@@ -54,6 +54,7 @@ components. Grouped by role; license + project URL for each.
 - reportlab (PDF export) — BSD 3-Clause — https://www.reportlab.com
 - Scapy (passive DHCP fingerprinting) — GPL v2 — https://scapy.net
 - nmap (network scanning) — NPSL (Nmap Public Source License) — https://nmap.org
+- tcpdump / libpcap (packet capture) — BSD 3-Clause — https://www.tcpdump.org
 - boto3 / botocore (AWS — infra mirror + Route 53 DNS) — Apache 2.0 — https://github.com/boto/boto3
 - azure-identity / azure-mgmt-network / azure-mgmt-compute / azure-mgmt-dns / azure-mgmt-resource (Azure — infra mirror + Azure DNS) — MIT — https://github.com/Azure/azure-sdk-for-python
 - google-cloud-compute / google-cloud-dns / google-auth (GCP — infra mirror + Cloud DNS) — Apache 2.0 — https://github.com/googleapis/google-cloud-python

--- a/agent/supervisor/spatium_supervisor/__main__.py
+++ b/agent/supervisor/spatium_supervisor/__main__.py
@@ -344,6 +344,16 @@ def main() -> int:
     identity_for_nettool, _ = load_or_generate(cfg.state_dir)
     start_nettool_thread(cfg, identity_for_nettool)
 
+    # #59 Phase 2 — appliance-host packet capture. Daemon thread that
+    # long-polls for queued appliance-vantage captures, drives the host
+    # runner over the trigger-file pattern, and streams the finished
+    # .pcap back. Self-resilient (no cert / registration / 404 → sleep +
+    # retry); dormant when no capture is queued.
+    from .pcap_proxy import start_pcap_thread  # noqa: PLC0415
+
+    identity_for_pcap, _ = load_or_generate(cfg.state_dir)
+    start_pcap_thread(cfg, identity_for_pcap)
+
     # #404 — tail /dev/kmsg for nftables drop logs so the firewall_logs
     # nettool can serve them to the Firewall → Logs viewer. Harmless if no
     # drops are ever logged (firewall logging off) — the buffer just stays

--- a/agent/supervisor/spatium_supervisor/pcap_proxy.py
+++ b/agent/supervisor/spatium_supervisor/pcap_proxy.py
@@ -133,6 +133,8 @@ def _read_state(path: Path) -> dict[str, str]:
             if k:
                 out[k.strip()] = v.strip()
     except (OSError, ValueError):
+        # Unreadable / half-written state file — treat as "no state yet";
+        # the next ~3 s poll re-reads it. Never fatal to the capture.
         pass
     return out
 
@@ -144,6 +146,8 @@ def _cleanup(cid: str) -> None:
         try:
             f.unlink()
         except OSError:
+            # Best-effort cleanup — a file already gone (or briefly locked
+            # by the host runner) is harmless; the next capture overwrites.
             pass
 
 

--- a/agent/supervisor/spatium_supervisor/pcap_proxy.py
+++ b/agent/supervisor/spatium_supervisor/pcap_proxy.py
@@ -1,0 +1,404 @@
+"""Supervisor-side packet-capture proxy thread (#59 Phase 2).
+
+The appliance-host vantage runs tcpdump on the appliance **host** (real
+NICs). The supervisor pod can't (it isn't ``hostNetwork`` — it would only
+see the pod veth), so it drives a **host runner** over the existing
+trigger-file → systemd ``.path`` pattern (same as snmp / chrony / firewall
+reload) and relays progress + the finished ``.pcap`` back to the control
+plane.
+
+Flow (one claimed capture, processed serially — one at a time, so no
+concurrent-capture lock is needed):
+
+  1. Long-poll ``POST /supervisor/pcap/poll`` (cert-authed). The control
+     plane atomically claims the oldest queued appliance-vantage row and
+     returns a structured command (never a shell string).
+  2. Re-validate the BPF filter + interface name (charset; defence in
+     depth — the host runner re-checks the interface against the real
+     ``/sys/class/net`` and is the authoritative membership gate).
+  3. Atomically write the request trigger
+     ``release-state/pcap/<cid>.request.json``. The host ``.path`` unit
+     fires ``spatium-pcap-runner``, which writes ``<cid>.pcap`` (grows) +
+     ``<cid>.state.json`` ({state, packets, bytes, error}).
+  4. Poll the state + pcap size every ~3 s → ``POST /supervisor/pcap/
+     progress/<cid>`` (the response carries the operator cancel flag; on
+     cancel we ``touch <cid>.cancel`` for the runner to stop).
+  5. On ``done`` → stream ``<cid>.pcap`` to ``POST /supervisor/pcap/
+     upload/<cid>?packets=N``. On ``failed`` → ``?error=…`` (empty body).
+  6. Clean up every ``<cid>.*`` file.
+
+A hard self-timeout (``max_duration_s`` + grace) requests cancel and then
+fails the row if the runner never finalizes — backstopped server-side by
+the stuck-capture reaper. Daemon thread; self-resilient (no cert /
+registration / 404 → sleep + retry), dormant when no capture is queued.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+import structlog
+
+from .cert_auth import build_auth_headers, load_cert
+from .config import SupervisorConfig
+from .heartbeat import _effective_control_plane_url
+from .identity import Identity, load_appliance_id
+
+log = structlog.get_logger(__name__)
+
+_BASE = "/api/v1/appliance/supervisor"
+_POLL_PATH = f"{_BASE}/pcap/poll"
+_POLL_TIMEOUT_S = 35.0
+_BACKOFF_S = 10.0
+_REVOKED_BACKOFF_S = 60.0
+_PROGRESS_INTERVAL_S = 3.0
+_GRACE_S = 20.0
+
+# Trigger dir inside the supervisor pod (bind-mounted host release-state).
+# The host .path unit watches the host-side path of this same dir.
+_TRIGGER_DIR = Path("/var/lib/spatiumddi-host/release-state/pcap")
+
+# Charset bounds — byte-identical to the backend's
+# app/services/pcap/runner.py validators (defence in depth; the host
+# runner validates again and is the authoritative interface gate).
+import re  # noqa: E402
+
+_BPF_RE = re.compile(r"^[A-Za-z0-9_ .:\[\]()/&|!=<>+*x-]{0,1024}$")
+_IFACE_RE = re.compile(r"^[A-Za-z0-9_.:@-]{1,64}$")
+
+
+class PcapValidationError(ValueError):
+    pass
+
+
+def _validate(cmd: dict[str, Any]) -> dict[str, Any]:
+    iface = (cmd.get("interface") or "any").strip() or "any"
+    if not _IFACE_RE.match(iface):
+        raise PcapValidationError(f"invalid interface {iface!r}")
+    bpf = cmd.get("bpf_filter")
+    if bpf is not None:
+        bpf = str(bpf).strip()
+        if bpf and not _BPF_RE.match(bpf):
+            raise PcapValidationError("invalid BPF filter")
+        bpf = bpf or None
+    return {
+        "capture_id": str(cmd["capture_id"]),
+        "interface": iface,
+        "bpf_filter": bpf,
+        "snaplen": int(cmd.get("snaplen") or 256),
+        "promiscuous": bool(cmd.get("promiscuous")),
+        "max_packets": cmd.get("max_packets"),
+        "max_duration_s": cmd.get("max_duration_s"),
+        "max_bytes": cmd.get("max_bytes"),
+    }
+
+
+def _atomic_write_request(path: Path, cmd: dict[str, Any]) -> None:
+    """Write the request as a line-based ``key=value`` file (NOT JSON) so
+    the bash host runner stays dependency-free. ``bpf`` is the LAST line
+    (it may contain spaces; it's validated to have no newlines) so the
+    runner can read it as the rest-of-line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _v(k: str) -> str:
+        v = cmd.get(k)
+        return "" if v is None else str(v)
+
+    lines = [
+        f"capture_id={cmd['capture_id']}",
+        f"interface={cmd['interface']}",
+        f"snaplen={cmd['snaplen']}",
+        f"promiscuous={'1' if cmd['promiscuous'] else '0'}",
+        f"max_packets={_v('max_packets')}",
+        f"max_duration_s={_v('max_duration_s')}",
+        f"max_bytes={_v('max_bytes')}",
+        f"bpf={cmd.get('bpf_filter') or ''}",
+    ]
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_state(path: Path) -> dict[str, str]:
+    """Parse the runner's line-based ``key=value`` state file."""
+    out: dict[str, str] = {}
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            k, _, v = line.partition("=")
+            if k:
+                out[k.strip()] = v.strip()
+    except (OSError, ValueError):
+        pass
+    return out
+
+
+def _cleanup(cid: str) -> None:
+    if not _TRIGGER_DIR.exists():
+        return
+    for f in _TRIGGER_DIR.glob(f"{cid}.*"):
+        try:
+            f.unlink()
+        except OSError:
+            pass
+
+
+def pcap_loop_forever(cfg: SupervisorConfig, identity: Identity) -> None:
+    """Run the pcap long-poll loop until the process exits (daemon thread)."""
+    with httpx.Client(timeout=_POLL_TIMEOUT_S + 5.0) as client:
+        while True:
+            try:
+                _pcap_once(cfg, identity, client)
+            except Exception as exc:  # noqa: BLE001 — never let the thread die
+                log.warning("supervisor.pcap.loop_crashed", error=str(exc))
+                time.sleep(_BACKOFF_S)
+
+
+def _pcap_once(cfg: SupervisorConfig, identity: Identity, client: httpx.Client) -> None:
+    appliance_id = load_appliance_id(cfg.state_dir)
+    cert_pem = load_cert(cfg.state_dir)
+    base_url = _effective_control_plane_url(cfg)
+    if appliance_id is None or cert_pem is None or not base_url:
+        time.sleep(_BACKOFF_S)
+        return
+
+    headers = build_auth_headers(
+        "POST", _POLL_PATH, cert_pem, identity.private_key, appliance_id
+    )
+    try:
+        resp = client.post(base_url.rstrip("/") + _POLL_PATH, headers=headers)
+    except httpx.HTTPError as exc:
+        log.warning("supervisor.pcap.poll_failed", error=str(exc))
+        time.sleep(_BACKOFF_S)
+        return
+    if resp.status_code in (403, 404):
+        time.sleep(_REVOKED_BACKOFF_S)
+        return
+    if resp.status_code != 200:
+        log.warning("supervisor.pcap.poll_unexpected", status_code=resp.status_code)
+        time.sleep(_BACKOFF_S)
+        return
+
+    try:
+        cmd = resp.json()
+    except ValueError:
+        time.sleep(_BACKOFF_S)
+        return
+    if not cmd.get("capture_id"):
+        return  # empty long-poll — no queued capture
+
+    _run_capture(cfg, identity, client, appliance_id, cmd)
+
+
+def _run_capture(
+    cfg: SupervisorConfig,
+    identity: Identity,
+    client: httpx.Client,
+    appliance_id: str,
+    raw_cmd: dict[str, Any],
+) -> None:
+    cid = str(raw_cmd.get("capture_id") or "")
+    try:
+        cmd = _validate(raw_cmd)
+    except PcapValidationError as exc:
+        log.warning("supervisor.pcap.validation_failed", capture_id=cid, error=str(exc))
+        _finalize_error(
+            cfg, identity, client, appliance_id, cid, f"validation failed: {exc}"
+        )
+        return
+
+    log.info("supervisor.pcap.starting", capture_id=cid, interface=cmd["interface"])
+    _atomic_write_request(_TRIGGER_DIR / f"{cid}.request", cmd)
+
+    pcap_file = _TRIGGER_DIR / f"{cid}.pcap"
+    state_file = _TRIGGER_DIR / f"{cid}.state"
+    max_dur = int(cmd["max_duration_s"] or 1800)
+    deadline = time.monotonic() + max_dur + _GRACE_S
+    started = time.monotonic()
+    cancel_sent = False
+
+    while True:
+        time.sleep(_PROGRESS_INTERVAL_S)
+        state = _read_state(state_file) if state_file.exists() else {}
+        size = (
+            pcap_file.stat().st_size
+            if pcap_file.exists()
+            else int(state.get("bytes") or 0)
+        )
+        st = state.get("state") or "starting"
+
+        cancel = _post_progress(
+            cfg,
+            identity,
+            client,
+            appliance_id,
+            cid,
+            packets=state.get("packets"),
+            bytes_captured=size,
+            elapsed_s=time.monotonic() - started,
+        )
+        if cancel and not cancel_sent:
+            (_TRIGGER_DIR / f"{cid}.cancel").touch()
+            cancel_sent = True
+
+        if st == "failed":
+            _finalize_error(
+                cfg,
+                identity,
+                client,
+                appliance_id,
+                cid,
+                str(state.get("error") or "host capture failed"),
+            )
+            _cleanup(cid)
+            return
+        if st == "done":
+            break
+        if time.monotonic() > deadline:
+            if not cancel_sent:
+                (_TRIGGER_DIR / f"{cid}.cancel").touch()
+                cancel_sent = True
+            # Give the runner a couple of ticks to finalize, then give up.
+            if time.monotonic() > deadline + _GRACE_S:
+                _finalize_error(
+                    cfg,
+                    identity,
+                    client,
+                    appliance_id,
+                    cid,
+                    "host runner did not finalize before the deadline",
+                )
+                _cleanup(cid)
+                return
+
+    # done → upload the pcap.
+    packets = state.get("packets")
+    _upload_pcap(cfg, identity, client, appliance_id, cid, pcap_file, packets)
+    _cleanup(cid)
+
+
+def _post_progress(
+    cfg: SupervisorConfig,
+    identity: Identity,
+    client: httpx.Client,
+    appliance_id: str,
+    cid: str,
+    *,
+    packets: Any,
+    bytes_captured: int,
+    elapsed_s: float,
+) -> bool:
+    path = f"{_BASE}/pcap/progress/{cid}"
+    base_url = _effective_control_plane_url(cfg)
+    cert_pem = load_cert(cfg.state_dir)
+    if not base_url or cert_pem is None:
+        return False
+    headers = build_auth_headers(
+        "POST", path, cert_pem, identity.private_key, appliance_id
+    )
+    try:
+        resp = client.post(
+            base_url.rstrip("/") + path,
+            headers=headers,
+            json={
+                "packets": int(packets) if packets not in (None, "") else None,
+                "bytes_captured": int(bytes_captured),
+                "elapsed_s": float(elapsed_s),
+            },
+        )
+        if resp.status_code == 200:
+            return bool(resp.json().get("cancel"))
+    except (httpx.HTTPError, ValueError) as exc:
+        log.warning("supervisor.pcap.progress_failed", capture_id=cid, error=str(exc))
+    return False
+
+
+def _upload_pcap(
+    cfg: SupervisorConfig,
+    identity: Identity,
+    client: httpx.Client,
+    appliance_id: str,
+    cid: str,
+    pcap_file: Path,
+    packets: Any,
+) -> None:
+    if not pcap_file.exists() or pcap_file.stat().st_size == 0:
+        _finalize_error(
+            cfg, identity, client, appliance_id, cid, "capture produced no bytes"
+        )
+        return
+    path = f"{_BASE}/pcap/upload/{cid}"
+    base_url = _effective_control_plane_url(cfg)
+    cert_pem = load_cert(cfg.state_dir)
+    if not base_url or cert_pem is None:
+        return
+    # Cert signature is over the bare path (query excluded server-side).
+    headers = build_auth_headers(
+        "POST", path, cert_pem, identity.private_key, appliance_id
+    )
+    headers["Content-Type"] = "application/octet-stream"
+    q = f"?packets={int(packets)}" if packets not in (None, "") else ""
+
+    def _gen() -> Any:
+        with open(pcap_file, "rb") as fh:
+            while True:
+                chunk = fh.read(4 * 1024 * 1024)
+                if not chunk:
+                    break
+                yield chunk
+
+    try:
+        resp = client.post(
+            base_url.rstrip("/") + path + q,
+            headers=headers,
+            content=_gen(),
+            timeout=120.0,
+        )
+        log.info(
+            "supervisor.pcap.uploaded", capture_id=cid, status_code=resp.status_code
+        )
+    except httpx.HTTPError as exc:
+        log.warning("supervisor.pcap.upload_failed", capture_id=cid, error=str(exc))
+
+
+def _finalize_error(
+    cfg: SupervisorConfig,
+    identity: Identity,
+    client: httpx.Client,
+    appliance_id: str,
+    cid: str,
+    message: str,
+) -> None:
+    path = f"{_BASE}/pcap/upload/{cid}"
+    base_url = _effective_control_plane_url(cfg)
+    cert_pem = load_cert(cfg.state_dir)
+    if not base_url or cert_pem is None:
+        return
+    headers = build_auth_headers(
+        "POST", path, cert_pem, identity.private_key, appliance_id
+    )
+    try:
+        client.post(
+            base_url.rstrip("/") + path + f"?error={quote(message[:300])}",
+            headers=headers,
+        )
+    except httpx.HTTPError as exc:
+        log.warning(
+            "supervisor.pcap.finalize_error_failed", capture_id=cid, error=str(exc)
+        )
+
+
+def start_pcap_thread(cfg: SupervisorConfig, identity: Identity) -> threading.Thread:
+    """Spawn the pcap proxy loop as a daemon thread."""
+    t = threading.Thread(
+        target=pcap_loop_forever, args=(cfg, identity), name="pcap-proxy", daemon=True
+    )
+    t.start()
+    return t
+
+
+__all__ = ["pcap_loop_forever", "start_pcap_thread"]

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-pcap.path
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-pcap.path
@@ -1,0 +1,16 @@
+[Unit]
+Description=Watch for SpatiumDDI appliance-host packet-capture requests (issue #59)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/59
+# Skip on the live ISO — tcpdump capture is a post-install operator action.
+ConditionKernelCommandLine=!boot=live
+
+[Path]
+# Fires while a *.request file exists in the trigger dir (level-triggered).
+# The supervisor writes <cid>.request (atomic rename); the runner claims it
+# by renaming to <cid>.request.running, which stops the glob matching, so a
+# capture fires exactly once. A second queued request re-fires the service
+# after the first completes.
+PathExistsGlob=/var/lib/spatiumddi/release-state/pcap/*.request
+
+[Install]
+WantedBy=multi-user.target

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-pcap.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-pcap.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Run a pending SpatiumDDI appliance-host packet capture (issue #59)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/59
+# The trigger dir + the runner's output live under /var/lib/spatiumddi,
+# available after local-fs. No /etc overlay dependency — the runner writes
+# only under /var/lib/spatiumddi/release-state (the pcap is uploaded back
+# to the control plane + the files are cleaned up; nothing persists to /etc).
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/spatium-pcap-runner
+# A capture can run up to the operator's max_duration cap (≤30 min) plus
+# grace — don't let systemd's default start timeout kill a long capture.
+TimeoutStartSec=infinity
+# Raw-socket capture needs CAP_NET_RAW (+ CAP_NET_ADMIN for promiscuous).
+# The runner executes as root on the host via systemd, so caps are present;
+# these are belt-and-braces if the unit is ever hardened with NoNewPrivileges.
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+# No [Install] — invoked only by spatiumddi-pcap.path, never enabled directly.

--- a/appliance/mkosi.extra/usr/local/bin/spatium-pcap-runner
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-pcap-runner
@@ -1,0 +1,172 @@
+#!/bin/bash
+# spatium-pcap-runner — host-side packet-capture runner (#59 Phase 2).
+#
+# The supervisor pod can't run tcpdump against the host's real NICs (it
+# isn't hostNetwork), so it drops a request trigger and this host-side
+# runner does the capture in the real host net namespace.
+#
+# Trigger dir: /var/lib/spatiumddi/release-state/pcap/ (the supervisor
+# writes to it via its release-state bind mount; the spatiumddi-pcap.path
+# unit watches it). Per-capture files (keyed by <cid>):
+#
+#   <cid>.request   supervisor → runner. Line-based key=value (NO json so
+#                   this stays dependency-free). Keys: capture_id,
+#                   interface, snaplen, promiscuous(0|1), max_packets,
+#                   max_duration_s, max_bytes, bpf (LAST line, rest-of-line;
+#                   validated upstream to a safe charset, no newlines).
+#   <cid>.cancel    supervisor → runner. Touch to stop the capture early.
+#   <cid>.pcap      runner → supervisor. The capture (grows during run).
+#   <cid>.state     runner → supervisor. key=value: state(starting|running|
+#                   done|failed), packets, bytes, error.
+#
+# Security: the bpf filter is passed to tcpdump as a SINGLE quoted argv
+# element — never eval'd, never re-split, never through a shell builtin —
+# so a hostile filter can at worst be an invalid BPF expression tcpdump
+# rejects. The interface is membership-checked against /sys/class/net.
+#
+# tcpdump is part of the appliance OS (mkosi.conf). The runner is a
+# oneshot that processes the OLDEST pending *.request and exits; systemd
+# re-fires it (via the .path unit) for the next one.
+set -u
+
+PCAP_DIR=/var/lib/spatiumddi/release-state/pcap
+IFACE_RE='^[A-Za-z0-9_.:@-]{1,64}$'
+# The BPF filter is charset-validated upstream (control plane + supervisor)
+# and passed to tcpdump as a single quoted argv element here — never eval'd
+# or re-split — so it needs no re-validation in the runner.
+POLL_S=1
+GRACE_S=10
+
+log() { logger -t spatium-pcap-runner "$*" 2>/dev/null || echo "spatium-pcap-runner: $*" >&2; }
+
+write_state() {
+  # $1=cid $2=state $3=packets $4=bytes $5=error
+  local cid="$1" tmp
+  tmp="$PCAP_DIR/$cid.state.tmp"
+  {
+    echo "state=$2"
+    echo "packets=${3:-}"
+    echo "bytes=${4:-0}"
+    echo "error=${5:-}"
+  } > "$tmp"
+  mv -f "$tmp" "$PCAP_DIR/$cid.state"
+}
+
+# Pick the oldest pending request (skip already-claimed *.request.running).
+req=""
+if [ -d "$PCAP_DIR" ]; then
+  req=$(ls -1tr "$PCAP_DIR"/*.request 2>/dev/null | head -1)
+fi
+[ -z "$req" ] && exit 0
+
+# Claim it immediately so the .path glob stops matching + a concurrent
+# runner can't double-process.
+running="$req.running"
+mv -f "$req" "$running" 2>/dev/null || exit 0
+
+# Parse the line-based request.
+cid=""; interface="any"; snaplen=256; promiscuous=0
+max_packets=""; max_duration_s=""; max_bytes=""; bpf=""
+while IFS= read -r line; do
+  key=${line%%=*}; val=${line#*=}
+  case "$key" in
+    capture_id) cid="$val" ;;
+    interface) interface="$val" ;;
+    snaplen) snaplen="$val" ;;
+    promiscuous) promiscuous="$val" ;;
+    max_packets) max_packets="$val" ;;
+    max_duration_s) max_duration_s="$val" ;;
+    max_bytes) max_bytes="$val" ;;
+    bpf) bpf="$val" ;;
+  esac
+done < "$running"
+
+[ -z "$cid" ] && { rm -f "$running"; exit 0; }
+pcap="$PCAP_DIR/$cid.pcap"
+cancel="$PCAP_DIR/$cid.cancel"
+write_state "$cid" starting "" 0 ""
+
+# ── Validate (defence in depth; the supervisor + control plane already
+# charset-validated). The interface MUST exist on the host. ──
+if ! [[ "$interface" =~ $IFACE_RE ]]; then
+  write_state "$cid" failed "" 0 "invalid interface name"
+  exit 0
+fi
+if [ "$interface" != "any" ] && [ ! -e "/sys/class/net/$interface" ]; then
+  write_state "$cid" failed "" 0 "interface $interface not found on this host"
+  exit 0
+fi
+[[ -z "$snaplen" || ! "$snaplen" =~ ^[0-9]+$ ]] && snaplen=256
+
+# Free-space pre-check: refuse if free < max_bytes + 64 MiB headroom.
+want_mb=$(( ( ${max_bytes:-52428800} / 1048576 ) + 64 ))
+free_mb=$(df -Pm "$PCAP_DIR" 2>/dev/null | awk 'NR==2{print $4}')
+if [ -n "$free_mb" ] && [ "$free_mb" -lt "$want_mb" ]; then
+  write_state "$cid" failed "" 0 "insufficient disk: ${free_mb}MiB free, need ~${want_mb}MiB"
+  exit 0
+fi
+
+# ── Build the tcpdump argv as an ARRAY (no eval, no shell re-split). ──
+argv=(tcpdump -n -U -i "$interface" -s "$snaplen" -w "$pcap")
+[ "$promiscuous" != "1" ] && argv+=(-p)
+[ -n "$max_packets" ] && [[ "$max_packets" =~ ^[0-9]+$ ]] && argv+=(-c "$max_packets")
+# BPF filter is a single trailing argv element. Empty → omit.
+if [ -n "$bpf" ]; then
+  argv+=("$bpf")
+fi
+
+log "starting capture $cid on $interface (snaplen=$snaplen dur=${max_duration_s:-none} pkts=${max_packets:-none} bytes=${max_bytes:-none})"
+write_state "$cid" running "" 0 ""
+
+# Spawn tcpdump in its own process group so we can kill the whole group.
+errfile="$PCAP_DIR/$cid.stderr"
+setsid "${argv[@]}" 2>"$errfile" &
+pid=$!
+pgid=$pid
+
+start=$(date +%s)
+stopped_reason=""
+while kill -0 "$pid" 2>/dev/null; do
+  sleep "$POLL_S"
+  now=$(date +%s)
+  bytes=0; [ -f "$pcap" ] && bytes=$(stat -c%s "$pcap" 2>/dev/null || echo 0)
+  write_state "$cid" running "" "$bytes" ""
+  # Operator cancel.
+  if [ -e "$cancel" ]; then stopped_reason="cancelled"; break; fi
+  # Wall-clock cap (hard kill independent of any cancel signal).
+  if [ -n "$max_duration_s" ] && [[ "$max_duration_s" =~ ^[0-9]+$ ]] \
+     && [ $(( now - start )) -ge "$max_duration_s" ]; then
+    stopped_reason="duration"; break
+  fi
+  # Byte cap (approximate — checked each ${POLL_S}s).
+  if [ -n "$max_bytes" ] && [[ "$max_bytes" =~ ^[0-9]+$ ]] \
+     && [ "$bytes" -ge "$max_bytes" ]; then
+    stopped_reason="bytes"; break
+  fi
+done
+
+# Stop tcpdump if still running (SIGTERM → flush savefile → SIGKILL).
+if kill -0 "$pid" 2>/dev/null; then
+  kill -TERM -- "-$pgid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+  for _ in $(seq 1 "$GRACE_S"); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+  kill -KILL -- "-$pgid" 2>/dev/null || true
+fi
+wait "$pid" 2>/dev/null
+rc=$?
+
+# tcpdump prints "N packets captured" to stderr at exit.
+packets=$(grep -oE '[0-9]+ packets captured' "$errfile" 2>/dev/null | grep -oE '^[0-9]+' | head -1)
+bytes=0; [ -f "$pcap" ] && bytes=$(stat -c%s "$pcap" 2>/dev/null || echo 0)
+rm -f "$errfile"
+
+# A SIGTERM kill exits non-zero but the savefile is valid; treat a clean
+# stop-condition exit as done. Only a spawn/parse failure with no bytes
+# is a real failure.
+if [ "$bytes" -gt 0 ] || [ "$rc" -eq 0 ]; then
+  log "capture $cid done: $bytes bytes, ${packets:-?} packets (reason=${stopped_reason:-eof})"
+  write_state "$cid" done "${packets:-}" "$bytes" ""
+else
+  err=$(cat "$PCAP_DIR/$cid.stderr" 2>/dev/null | tail -c 300)
+  write_state "$cid" failed "" 0 "tcpdump exited ($rc) with no capture${err:+: $err}"
+fi
+exit 0

--- a/appliance/mkosi.extra/usr/local/bin/spatium-pcap-runner
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-pcap-runner
@@ -154,8 +154,11 @@ fi
 wait "$pid" 2>/dev/null
 rc=$?
 
-# tcpdump prints "N packets captured" to stderr at exit.
+# tcpdump prints "N packets captured" to stderr at exit. Grab the tail of
+# stderr for the failure-path diagnostic BEFORE unlinking it (otherwise the
+# failed-state error would read an already-deleted file and lose the cause).
 packets=$(grep -oE '[0-9]+ packets captured' "$errfile" 2>/dev/null | grep -oE '^[0-9]+' | head -1)
+err=$(tail -c 300 "$errfile" 2>/dev/null)
 bytes=0; [ -f "$pcap" ] && bytes=$(stat -c%s "$pcap" 2>/dev/null || echo 0)
 rm -f "$errfile"
 
@@ -166,7 +169,6 @@ if [ "$bytes" -gt 0 ] || [ "$rc" -eq 0 ]; then
   log "capture $cid done: $bytes bytes, ${packets:-?} packets (reason=${stopped_reason:-eof})"
   write_state "$cid" done "${packets:-}" "$bytes" ""
 else
-  err=$(cat "$PCAP_DIR/$cid.stderr" 2>/dev/null | tail -c 300)
   write_state "$cid" failed "" 0 "tcpdump exited ($rc) with no capture${err:+: $err}"
 fi
 exit 0

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -110,9 +110,14 @@ chmod 0700 /var/lib/spatiumddi/pcaps
 # #59 Phase 2 — appliance-host capture trigger dir under release-state.
 # The supervisor (control-plane→host) drops <cid>.request here and the
 # spatiumddi-pcap.path unit watches it; the host runner writes <cid>.pcap
-# + <cid>.state back. Create it up front so the .path unit has a dir to
-# watch from first boot (the supervisor also mkdirs it on first capture).
+# + <cid>.state back. Owned by the supervisor's unprivileged uid (the
+# spatium user, 100:101 in the supervisor image) so it can write the
+# request + clean up afterwards; the host runner writes the pcap/state as
+# root into this dir (root writes anywhere) and the supervisor (dir owner,
+# no sticky bit) can still unlink them. Created up front so the .path unit
+# has a dir to watch from first boot.
 mkdir -p /var/lib/spatiumddi/release-state/pcap
+chown 100:101 /var/lib/spatiumddi/release-state/pcap
 chmod 0755 /var/lib/spatiumddi/release-state/pcap
 
 # Detect the host's root block device's rotational flag so the

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -107,6 +107,14 @@ mkdir -p /var/lib/spatiumddi/pcaps
 chown 1000:1000 /var/lib/spatiumddi/pcaps
 chmod 0700 /var/lib/spatiumddi/pcaps
 
+# #59 Phase 2 — appliance-host capture trigger dir under release-state.
+# The supervisor (control-plane→host) drops <cid>.request here and the
+# spatiumddi-pcap.path unit watches it; the host runner writes <cid>.pcap
+# + <cid>.state back. Create it up front so the .path unit has a dir to
+# watch from first boot (the supervisor also mkdirs it on first capture).
+mkdir -p /var/lib/spatiumddi/release-state/pcap
+chmod 0755 /var/lib/spatiumddi/release-state/pcap
+
 # Detect the host's root block device's rotational flag so the
 # supervisor pod (which can't see the host's /proc/mounts properly —
 # its container view shows ``overlay`` mounted at /) can surface

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -98,6 +98,15 @@ mkdir -p /var/lib/spatiumddi/slot-images
 chown 1000:1000 /var/lib/spatiumddi/slot-images
 chmod 0700 /var/lib/spatiumddi/slot-images
 
+# /var/lib/spatiumddi/pcaps — packet-capture .pcap artifacts (#59). The
+# worker writes captures here; the api reads them back on download — both
+# pods hostPath-mount this same single-node dir. Same uid-1000 + 0700
+# reasoning as slot-images (kubelet would create it root:root 0755 → the
+# worker's write fails EACCES). Idempotent on every boot.
+mkdir -p /var/lib/spatiumddi/pcaps
+chown 1000:1000 /var/lib/spatiumddi/pcaps
+chmod 0700 /var/lib/spatiumddi/pcaps
+
 # Detect the host's root block device's rotational flag so the
 # supervisor pod (which can't see the host's /proc/mounts properly —
 # its container view shows ``overlay`` mounted at /) can surface

--- a/appliance/mkosi.postinst
+++ b/appliance/mkosi.postinst
@@ -58,6 +58,7 @@ for unit in chrony.service ssh.service \
             spatiumddi-resolved-reload.path \
             spatiumddi-tz-reload.path \
             spatiumddi-verbose-boot-reload.path \
+            spatiumddi-pcap.path \
             spatium-firewall-reload.path \
             spatiumddi-firewall-revert.timer \
             spatium-install.service \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxml2 \
     libxmlsec1-openssl \
     nmap \
+    tcpdump \
     iputils-ping \
     traceroute \
     mtr-tiny \
@@ -81,6 +82,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcap2-bin \
     postgresql-client-16 \
     && setcap cap_net_raw,cap_net_bind_service+eip /usr/bin/nmap \
+    # issue #59 — grant tcpdump CAP_NET_RAW so the non-root app user can
+    # capture (server vantage). cap_net_admin is NOT granted; we run
+    # non-promiscuous by default so cap_net_raw alone suffices. Assert the
+    # cap landed so a wrong binary path fails the build instead of
+    # silently relying on a privileged container.
+    && setcap cap_net_raw+eip /usr/bin/tcpdump \
+    && getcap /usr/bin/tcpdump | grep -q cap_net_raw \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user. Pre-create + chown the on-volume paths so the
@@ -95,6 +103,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 #                                      nginx container at /etc/nginx/certs)
 #   /var/lib/spatiumddi/slot-images  — #170 follow-up (air-gap appliance
 #                                      slot-image upload storage)
+#   /var/lib/spatiumddi/pcaps        — issue #59 (packet-capture .pcap
+#                                      artifacts; shared api+worker volume)
 #
 # The user is created BEFORE the COPYs so we can use BuildKit's
 # ``--chown=app:app`` flag and avoid a trailing ``chown -R /app``
@@ -102,7 +112,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # file in a new layer (~550 MB doubled). Setting ownership at COPY
 # time keeps the source layer authoritative.
 RUN useradd --no-create-home --shell /bin/false app \
-    && mkdir -p /var/lib/spatiumddi/backups /var/lib/spatiumddi/certs /var/lib/spatiumddi/slot-images \
+    && mkdir -p /var/lib/spatiumddi/backups /var/lib/spatiumddi/certs /var/lib/spatiumddi/slot-images /var/lib/spatiumddi/pcaps \
+    && chmod 0700 /var/lib/spatiumddi/pcaps \
     && chown app:app /app \
     && chown -R app:app /var/lib/spatiumddi
 

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -186,6 +186,8 @@ backend/alembic/versions/b7e2d9a5f314_dns_import_source.py:drop_column:89
 backend/alembic/versions/b7e3a1f4c8d2_add_dns_agent_ops.py:drop_column:67
 backend/alembic/versions/b7e3a1f4c8d2_add_dns_agent_ops.py:drop_table:61
 backend/alembic/versions/b8c3f2a9e147_appliance_lldp_settings.py:drop_column:109
+backend/alembic/versions/b8e3f1c47a92_packet_capture.py:drop_column:100
+backend/alembic/versions/b8e3f1c47a92_packet_capture.py:drop_table:105
 backend/alembic/versions/b95e2d71f042_appliance_snmp_settings.py:drop_column:95
 backend/alembic/versions/b9e1c43f7d28_pairing_code_auto_approve.py:drop_column:44
 backend/alembic/versions/b9e4d2a17c83_network_neighbour.py:drop_column:112

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -186,8 +186,8 @@ backend/alembic/versions/b7e2d9a5f314_dns_import_source.py:drop_column:89
 backend/alembic/versions/b7e3a1f4c8d2_add_dns_agent_ops.py:drop_column:67
 backend/alembic/versions/b7e3a1f4c8d2_add_dns_agent_ops.py:drop_table:61
 backend/alembic/versions/b8c3f2a9e147_appliance_lldp_settings.py:drop_column:109
-backend/alembic/versions/b8e3f1c47a92_packet_capture.py:drop_column:100
-backend/alembic/versions/b8e3f1c47a92_packet_capture.py:drop_table:105
+backend/alembic/versions/b8e3f1c47a92_packet_capture.py:drop_column:110
+backend/alembic/versions/b8e3f1c47a92_packet_capture.py:drop_table:115
 backend/alembic/versions/b95e2d71f042_appliance_snmp_settings.py:drop_column:95
 backend/alembic/versions/b9e1c43f7d28_pairing_code_auto_approve.py:drop_column:44
 backend/alembic/versions/b9e4d2a17c83_network_neighbour.py:drop_column:112

--- a/backend/alembic/versions/b8e3f1c47a92_packet_capture.py
+++ b/backend/alembic/versions/b8e3f1c47a92_packet_capture.py
@@ -33,8 +33,18 @@ def upgrade() -> None:
     op.create_table(
         "packet_capture",
         sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("modified_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
         # vantage
         sa.Column("vantage_kind", sa.String(length=16), nullable=False, server_default="server"),
         sa.Column("appliance_id", postgresql.UUID(as_uuid=True), nullable=True),

--- a/backend/alembic/versions/b8e3f1c47a92_packet_capture.py
+++ b/backend/alembic/versions/b8e3f1c47a92_packet_capture.py
@@ -1,0 +1,105 @@
+"""packet_capture table + pcap_retention_days + tools.pcap feature module (#59)
+
+The persisted job model for on-demand tcpdump capture (issue #59),
+mirroring ``nmap_scan`` but with a binary ``.pcap`` artifact on disk
+(``pcap_path``) instead of inline XML/text, a vantage discriminator
+(server / appliance), and live byte/packet progress columns. Plus:
+
+* ``platform_settings.pcap_retention_days`` (default 7) — the nightly
+  prune deletes terminal rows + unlinks their .pcap files past this.
+* the ``tools.pcap`` feature-module seed (default-enabled) so the whole
+  ``/api/v1/pcap`` surface + sidebar entry gate behind one toggle
+  (non-negotiable #14).
+
+Revision ID: b8e3f1c47a92
+Revises: a3f7c1e84d59
+Create Date: 2026-06-15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "b8e3f1c47a92"
+down_revision: str | None = "a3f7c1e84d59"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "packet_capture",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("modified_at", sa.DateTime(timezone=True), nullable=False),
+        # vantage
+        sa.Column("vantage_kind", sa.String(length=16), nullable=False, server_default="server"),
+        sa.Column("appliance_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("vantage_label", sa.String(length=255), nullable=False, server_default=""),
+        # inputs
+        sa.Column("interface", sa.String(length=64), nullable=True),
+        sa.Column("bpf_filter", sa.Text(), nullable=True),
+        sa.Column("snaplen", sa.Integer(), nullable=False, server_default="256"),
+        sa.Column("promiscuous", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("max_packets", sa.Integer(), nullable=True),
+        sa.Column("max_duration_s", sa.Integer(), nullable=True),
+        sa.Column("max_bytes", sa.BigInteger(), nullable=True),
+        # run state
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="queued"),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("duration_seconds", sa.Float(), nullable=True),
+        sa.Column("exit_code", sa.Integer(), nullable=True),
+        sa.Column("command_line", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("tcpdump_pid", sa.Integer(), nullable=True),
+        # progress
+        sa.Column("packets_captured", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("bytes_captured", sa.BigInteger(), nullable=False, server_default="0"),
+        # artifact
+        sa.Column("pcap_path", sa.Text(), nullable=True),
+        sa.Column("pcap_size_bytes", sa.BigInteger(), nullable=True),
+        sa.Column("pcap_sha256", sa.String(length=64), nullable=True),
+        sa.Column(
+            "artifact_missing", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        # provenance
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.ForeignKeyConstraint(["appliance_id"], ["appliance.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_packet_capture_status", "packet_capture", ["status"])
+    op.create_index("ix_packet_capture_appliance", "packet_capture", ["appliance_id"])
+    op.create_index(
+        "ix_packet_capture_creator_created",
+        "packet_capture",
+        ["created_by_user_id", "created_at"],
+    )
+    op.create_index("ix_packet_capture_created", "packet_capture", ["created_at"])
+
+    op.add_column(
+        "platform_settings",
+        sa.Column("pcap_retention_days", sa.Integer(), nullable=False, server_default="7"),
+    )
+
+    # ── feature_module seed (non-negotiable #14) ────────────────────────
+    op.execute(sa.text("""
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('tools.pcap', TRUE)
+            ON CONFLICT (id) DO NOTHING
+            """))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'tools.pcap'"))
+    op.drop_column("platform_settings", "pcap_retention_days")
+    op.drop_index("ix_packet_capture_created", table_name="packet_capture")
+    op.drop_index("ix_packet_capture_creator_created", table_name="packet_capture")
+    op.drop_index("ix_packet_capture_appliance", table_name="packet_capture")
+    op.drop_index("ix_packet_capture_status", table_name="packet_capture")
+    op.drop_table("packet_capture")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -156,8 +156,7 @@ def _supervisor_strips_url_fragment(row: Appliance) -> bool:
     changes the URL), never the ability to upgrade (#419)."""
     ver = row.supervisor_version or row.installed_appliance_version or ""
     return (
-        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None
-        and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
+        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
     )
 
 
@@ -639,9 +638,7 @@ async def supervisor_register(
     # force a fresh registration they delete the row in the fleet UI,
     # which causes the supervisor to clear its identity + claim a new
     # pairing code on next boot.
-    existing_stmt = select(Appliance).where(
-        Appliance.public_key_fingerprint == pubkey_fingerprint
-    )
+    existing_stmt = select(Appliance).where(Appliance.public_key_fingerprint == pubkey_fingerprint)
     existing = (await db.execute(existing_stmt)).scalar_one_or_none()
     if existing is not None:
         # Idempotent re-register. Touch last_seen_at so the heartbeat
@@ -732,9 +729,7 @@ async def supervisor_register(
                 resource_type="pairing_code",
                 resource_id=str(code_row.id) if code_row is not None else "unknown",
                 resource_display=(
-                    "supervisor pairing code"
-                    if code_row is not None
-                    else "unknown pairing code"
+                    "supervisor pairing code" if code_row is not None else "unknown pairing code"
                 ),
                 result="forbidden",
                 new_value={
@@ -779,9 +774,7 @@ async def supervisor_register(
     # operator to open the role-picker.
     initial_assigned_roles: list[str] = []
     if body.appliance_variant is not None:
-        initial_assigned_roles = list(
-            _REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, [])
-        )
+        initial_assigned_roles = list(_REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, []))
     appliance_row = Appliance(
         id=appliance_id,
         hostname=body.hostname,
@@ -928,9 +921,7 @@ async def supervisor_poll(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Not found.")
 
     row = await db.get(Appliance, body.appliance_id)
-    valid = row is not None and verify_session_token(
-        body.session_token, row.session_token_hash
-    )
+    valid = row is not None and verify_session_token(body.session_token, row.session_token_hash)
     if not valid:
         await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
@@ -1271,9 +1262,7 @@ class SupervisorHeartbeatResponse(BaseModel):
     # uses this to bring up dns-bind9 / dns-powerdns / dhcp-kea
     # service containers via docker compose. Empty roles list = idle
     # (approved but no service running).
-    role_assignment: SupervisorRoleAssignment = Field(
-        default_factory=SupervisorRoleAssignment
-    )
+    role_assignment: SupervisorRoleAssignment = Field(default_factory=SupervisorRoleAssignment)
     # #272 Phase 7 — control-plane promote/demote desired state.
     # ``desired_cluster_role`` = "member" → join the seed via
     # ``desired_k3s_server_url`` + ``desired_k3s_join_token``; "none" →
@@ -1418,9 +1407,7 @@ async def _ingest_lldp_neighbours(
         .scalars()
         .all()
     )
-    by_key = {
-        (e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing
-    }
+    by_key = {(e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing}
     now = datetime.now(UTC)
 
     for key, n in desired.items():
@@ -1563,9 +1550,7 @@ async def supervisor_heartbeat(
         )
         if not valid:
             await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
-            raise HTTPException(
-                status.HTTP_403_FORBIDDEN, "Invalid appliance or session."
-            )
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
 
     assert row is not None
     # Issue #170 Wave E follow-up — reject heartbeats from soft-deleted
@@ -1803,9 +1788,7 @@ async def supervisor_heartbeat(
         for ev in evicted:
             ev.evict_requested = False
             ev.cluster_join_state = CLUSTER_JOIN_STATE_LEFT
-            logger.info(
-                "control_plane_node_evicted", hostname=ev.hostname, by=str(row.id)
-            )
+            logger.info("control_plane_node_evicted", hostname=ev.hostname, by=str(row.id))
 
     # Auto-clear the promote desired-state once the join landed: the
     # supervisor reports ``ready`` → the node IS a member now, so settle
@@ -1861,19 +1844,13 @@ async def supervisor_heartbeat(
     # the requested slot as ``current_slot`` — the operator's intent
     # was "boot into this slot next", and we got there. ``durable_
     # default`` is irrelevant here (next-boot is one-shot by design).
-    if (
-        row.desired_next_boot_slot is not None
-        and row.current_slot == row.desired_next_boot_slot
-    ):
+    if row.desired_next_boot_slot is not None and row.current_slot == row.desired_next_boot_slot:
         row.desired_next_boot_slot = None
 
     # Auto-clear desired_default_slot once the supervisor reports the
     # requested slot as ``durable_default`` — grub-set-default landed
     # and survives subsequent reboots.
-    if (
-        row.desired_default_slot is not None
-        and row.durable_default == row.desired_default_slot
-    ):
+    if row.desired_default_slot is not None and row.durable_default == row.desired_default_slot:
         row.desired_default_slot = None
 
     # Auto-clear reboot_requested 15 s after the stamp — by that
@@ -1923,17 +1900,12 @@ async def supervisor_heartbeat(
             long_poll = True
             hold_for = min(float(body.wait_seconds), _HEARTBEAT_HOLD_CAP_S)
             deadline = asyncio.get_running_loop().time() + hold_for
-            async with wake_subscription(
-                [*appliance_wake_channels(row), HOSTCONFIG_ALL]
-            ) as wake:
+            async with wake_subscription([*appliance_wake_channels(row), HOSTCONFIG_ALL]) as wake:
                 while True:
                     remaining = deadline - asyncio.get_running_loop().time()
                     if remaining <= 0:
                         break
-                    if (
-                        await wake.wait(min(WAKE_TICK_SECONDS, remaining))
-                        == WakeResult.WAKE
-                    ):
+                    if await wake.wait(min(WAKE_TICK_SECONDS, remaining)) == WakeResult.WAKE:
                         break
             # Pick up anything that committed during the hold (role /
             # firewall / desired-state edits land on other requests) before
@@ -2026,9 +1998,7 @@ async def supervisor_heartbeat(
     # Issue #165 — operator-set timezone. Empty string = no override.
     desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
     # #393 — appliance console mode (grubenv-driven, applies next reboot).
-    desired_console_mode = (
-        (cfg_row.console_mode or "dashboard") if cfg_row else "dashboard"
-    )
+    desired_console_mode = (cfg_row.console_mode or "dashboard") if cfg_row else "dashboard"
     # Issue #346 — host-config blocks for snmp / chrony / lldp. Built from the
     # same ``*_bundle`` helpers the DHCP-agent ConfigBundle uses; the
     # disabled-shape fallback keeps a stable key set when no settings row
@@ -2102,12 +2072,8 @@ async def supervisor_heartbeat(
         vip_configured=bool(metallb_vip),
         firewall_enabled=bool(cfg_row.firewall_enabled) if cfg_row else False,
         appliance_id=row.id,
-        web_ui_allowed_cidrs=(
-            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
-        ),
-        firewall_logging_enabled=(
-            bool(cfg_row.firewall_logging_enabled) if cfg_row else False
-        ),
+        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        firewall_logging_enabled=(bool(cfg_row.firewall_logging_enabled) if cfg_row else False),
     )
     # Persist the rendered hash so 2d's apply-stalled alarm + the Fleet drift
     # chip can compare it against the runner's reported applied_hash. Only
@@ -2166,9 +2132,7 @@ async def supervisor_heartbeat(
         cluster_peer_cidrs=cluster_peer_cidrs,
         firewall_pod_cidrs=firewall_pod_cidrs,
         firewall_service_cidrs=firewall_service_cidrs,
-        web_ui_allowed_cidrs=(
-            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
-        ),
+        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
         control_plane_size=control_plane_size,
         desired_metallb_enabled=metallb_enabled,
         desired_metallb_pool_addresses=metallb_pool,
@@ -2227,9 +2191,7 @@ async def firewall_render_inputs(db: DB, row: Appliance) -> dict[str, Any]:
         "cp_member_count": await _committed_cp_count(db),
         "vip_configured": bool((cfg_row.control_plane_vip or "") if cfg_row else ""),
         "firewall_enabled": bool(cfg_row.firewall_enabled) if cfg_row else False,
-        "web_ui_allowed_cidrs": (
-            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
-        ),
+        "web_ui_allowed_cidrs": (list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
     }
 
 
@@ -2243,9 +2205,7 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     from app.models.dns import DNSServerGroup
 
     assigned_roles = list(row.assigned_roles or [])
-    dns_role_assigned = (
-        "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
-    )
+    dns_role_assigned = "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
     dhcp_role_assigned = "dhcp" in assigned_roles
 
     dns_engine: str | None = None
@@ -2511,9 +2471,7 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
 async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     _require_superadmin(current_user)
     rows = (
-        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc())))
-        .scalars()
-        .all()
+        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc()))).scalars().all()
     )
     return ApplianceList(appliances=[_row_to_schema(r) for r in rows])
 
@@ -2524,9 +2482,7 @@ async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Fetch a single appliance (superadmin)",
 )
-async def get_appliance(
-    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
-) -> ApplianceRow:
+async def get_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> ApplianceRow:
     _require_superadmin(current_user)
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -2651,9 +2607,7 @@ async def approve_appliance(
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Reject a pending appliance (deletes the row, superadmin)",
 )
-async def reject_appliance(
-    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
-) -> None:
+async def reject_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> None:
     """Reject = DELETE the row. Supervisor's next poll gets 403 +
     falls back to bootstrapping. Distinct from delete (next endpoint)
     only in the audit verb — operationally identical."""
@@ -2786,9 +2740,7 @@ async def _find_appliance_dependents(
 
     return ApplianceDependents(
         dns=[
-            ApplianceDependentServer(
-                kind="dns", id=r.id, name=r.name, host=r.host, status=r.status
-            )
+            ApplianceDependentServer(kind="dns", id=r.id, name=r.name, host=r.host, status=r.status)
             for r in dns_rows
         ],
         dhcp=[
@@ -2898,12 +2850,8 @@ async def delete_appliance(
                     Appliance.id != row.id,
                     Appliance.state != APPLIANCE_STATE_REVOKED,
                     or_(
-                        Appliance.appliance_variant.in_(
-                            tuple(_SELF_BOOTSTRAP_VARIANTS)
-                        ),
-                        Appliance.cluster_role.in_(
-                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
-                        ),
+                        Appliance.appliance_variant.in_(tuple(_SELF_BOOTSTRAP_VARIANTS)),
+                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
                     ),
                 )
             )
@@ -3353,14 +3301,10 @@ async def update_appliance_roles(
             new_value={
                 "roles": list(row.assigned_roles or []),
                 "dns_group_id": (
-                    str(row.assigned_dns_group_id)
-                    if row.assigned_dns_group_id
-                    else None
+                    str(row.assigned_dns_group_id) if row.assigned_dns_group_id else None
                 ),
                 "dhcp_group_id": (
-                    str(row.assigned_dhcp_group_id)
-                    if row.assigned_dhcp_group_id
-                    else None
+                    str(row.assigned_dhcp_group_id) if row.assigned_dhcp_group_id else None
                 ),
                 "tags": dict(row.tags or {}),
             },
@@ -3412,9 +3356,7 @@ async def _effective_cp_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_(
-                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
-                        ),
+                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3502,9 +3444,7 @@ async def _firewall_peer_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_(
-                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
-                        ),
+                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3630,9 +3570,7 @@ async def promote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
-            )
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
         if row.id == primary.id:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3643,10 +3581,7 @@ async def promote_control_plane(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is in state {row.state!r}; approve it first.",
             )
-        if (
-            row.cluster_role is not None
-            or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
-        ):
+        if row.cluster_role is not None or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER:
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is already a control-plane member (or joining).",
@@ -3742,9 +3677,7 @@ async def demote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
-            )
+            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
         if row.cluster_role == CLUSTER_ROLE_PRIMARY:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3842,9 +3775,7 @@ async def replace_control_plane_member(
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found."
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found.")
     if row.cluster_role == CLUSTER_ROLE_PRIMARY:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -4073,9 +4004,7 @@ async def restore_etcd_snapshot(
             "destructive cluster-reset restore.",
         )
     known = {
-        s.get("name")
-        for s in (seed.etcd_snapshots or [])
-        if isinstance(s, dict) and s.get("name")
+        s.get("name") for s in (seed.etcd_snapshots or []) if isinstance(s, dict) and s.get("name")
     }
     if body.snapshot_name not in known:
         raise HTTPException(
@@ -4192,9 +4121,7 @@ def _metallb_pod_status() -> tuple[bool, int, int]:
 
     def _ready(pod: dict[str, Any]) -> bool:
         conds = (pod.get("status") or {}).get("conditions") or []
-        return any(
-            c.get("type") == "Ready" and c.get("status") == "True" for c in conds
-        )
+        return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conds)
 
     try:
         # #272 / #286 — MetalLB lives in its own metallb-system namespace
@@ -4280,9 +4207,7 @@ class MetalLBConfigUpdate(BaseModel):
     def _cross_field(self) -> MetalLBConfigUpdate:
         if self.enabled:
             if not self.control_plane_vip:
-                raise ValueError(
-                    "a control-plane VIP is required when MetalLB is enabled"
-                )
+                raise ValueError("a control-plane VIP is required when MetalLB is enabled")
             # #272 — auto-derive a single-address pool from the VIP when
             # no explicit pool is given. This is the common case: the
             # operator just wants one floating IP for the Web UI and
@@ -4293,11 +4218,7 @@ class MetalLBConfigUpdate(BaseModel):
             # supply one explicitly, and the VIP-in-pool check below
             # applies to it.
             if not self.pool_addresses:
-                prefix = (
-                    32
-                    if ipaddress.ip_address(self.control_plane_vip).version == 4
-                    else 128
-                )
+                prefix = 32 if ipaddress.ip_address(self.control_plane_vip).version == 4 else 128
                 self.pool_addresses = [f"{self.control_plane_vip}/{prefix}"]
         # #272 Phase 10 — data-plane VIPs require MetalLB on (no VIP path
         # exists without it) and can't reuse the control-plane VIP or each
@@ -4321,11 +4242,7 @@ class MetalLBConfigUpdate(BaseModel):
             "control-plane VIP": self.control_plane_vip,
             **dp_vips,
         }.items():
-            if (
-                vip
-                and self.pool_addresses
-                and not _vip_in_pool(vip, self.pool_addresses)
-            ):
+            if vip and self.pool_addresses and not _vip_in_pool(vip, self.pool_addresses):
                 raise ValueError(
                     f"{label} {vip} is not inside the address pool "
                     "(widen metallb_pool_addresses to include every VIP)"
@@ -4594,9 +4511,7 @@ async def schedule_appliance_upgrade(
             new_value={
                 "desired_appliance_version": body.desired_appliance_version,
                 "desired_slot_image_url": resolved_url,
-                "slot_image_id": (
-                    str(body.slot_image_id) if body.slot_image_id else None
-                ),
+                "slot_image_id": (str(body.slot_image_id) if body.slot_image_id else None),
             },
         )
     )
@@ -4913,9 +4828,7 @@ async def _require_cert_auth(request: Request, db: DB) -> Appliance:
         principal = await authenticate_cert(request, db)
     except CertAuthFailed as exc:
         logger.warning("appliance.k8s_proxy.cert_auth_failed", reason=exc.reason)
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN, "Invalid appliance client cert."
-        ) from exc
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance client cert.") from exc
     if principal is None:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
@@ -4954,9 +4867,7 @@ async def k8s_proxy_poll(request: Request, db: DB) -> K8sProxyPollResponse:
         # No request within the timeout — return an empty shape so
         # the supervisor loop just re-polls. 200 (not 204) so the
         # supervisor doesn't have to special-case "no body".
-        return K8sProxyPollResponse(
-            request_id="", method="", path="", headers={}, body_b64=""
-        )
+        return K8sProxyPollResponse(request_id="", method="", path="", headers={}, body_b64="")
     return K8sProxyPollResponse(
         request_id=queued.request_id,
         method=queued.method,
@@ -5163,17 +5074,13 @@ class PcapProgressRequest(BaseModel):
     elapsed_s: float | None = None
 
 
-async def _pcap_capture_for_appliance(
-    db: DB, capture_id: uuid.UUID, appliance: Appliance
-) -> Any:
+async def _pcap_capture_for_appliance(db: DB, capture_id: uuid.UUID, appliance: Appliance) -> Any:
     from app.models.pcap import PacketCapture  # noqa: PLC0415
 
     row = await db.get(PacketCapture, capture_id)
     if row is None or row.appliance_id != appliance.id:
         # Don't leak existence of another appliance's capture.
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, "capture not found for this appliance"
-        )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "capture not found for this appliance")
     return row
 
 
@@ -5226,9 +5133,7 @@ async def pcap_progress(
     "/supervisor/pcap/upload/{capture_id}",
     summary="Stream the finished .pcap back (or finalize as failed via ?error=)",
 )
-async def pcap_upload(
-    capture_id: uuid.UUID, request: Request, db: DB
-) -> dict[str, str]:
+async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[str, str]:
     """Cert-authed. Streams the host-captured ``.pcap`` to the shared
     PCAP_DIR (``.partial`` → atomic rename + sha256), capped at
     ``max_bytes`` + margin. ``?error=`` (empty body) finalizes a failed
@@ -5381,18 +5286,13 @@ async def k8s_rollout_restart(
     # Strategic-merge patch that bumps the pod template's
     # ``restartedAt`` annotation. Standard kubectl rollout-restart
     # shape — same JSON kubectl sends.
-    api_path = (
-        f"/apis/apps/v1/namespaces/{body.namespace}/"
-        f"{body.kind.lower()}s/{body.name}"
-    )
+    api_path = f"/apis/apps/v1/namespaces/{body.namespace}/" f"{body.kind.lower()}s/{body.name}"
     patch_body = {
         "spec": {
             "template": {
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/restartedAt": datetime.now(
-                            UTC
-                        ).isoformat()
+                        "kubectl.kubernetes.io/restartedAt": datetime.now(UTC).isoformat()
                     }
                 }
             }
@@ -5533,9 +5433,7 @@ async def reveal_appliance_kubeconfig(
         )
     # #408 — local users re-confirm with password or TOTP; external-auth
     # users with TOTP (enrol under Settings → Security if not yet enrolled).
-    outcome = reverify_operator(
-        current_user, password=body.password, totp_code=body.totp_code
-    )
+    outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
     if outcome is not ReauthOutcome.OK:
         await asyncio.sleep(0.1)
         if outcome is ReauthOutcome.MFA_REQUIRED:
@@ -5548,9 +5446,7 @@ async def reveal_appliance_kubeconfig(
             )
         _audit_denied("bad_credential")
         await db.commit()
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect."
-        )
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect.")
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -5561,9 +5457,7 @@ async def reveal_appliance_kubeconfig(
         # Clean "nothing to reveal" — supervisor hasn't shipped a
         # kubeconfig yet (legacy compose / pre-Phase-5 / k3s not
         # started). Surface as a friendly state, not an error.
-        return RevealKubeconfigResponse(
-            configured=False, kubeconfig=None, hostname=row.hostname
-        )
+        return RevealKubeconfigResponse(configured=False, kubeconfig=None, hostname=row.hostname)
 
     try:
         plaintext = decrypt_str(row.kubeconfig_encrypted)
@@ -5595,9 +5489,7 @@ async def reveal_appliance_kubeconfig(
         hostname=row.hostname,
         user=current_user.username,
     )
-    return RevealKubeconfigResponse(
-        configured=True, kubeconfig=plaintext, hostname=row.hostname
-    )
+    return RevealKubeconfigResponse(configured=True, kubeconfig=plaintext, hostname=row.hostname)
 
 
 # ── Issue #183 Phase 6 — kubeapi-expose CIDR editor ──
@@ -5776,9 +5668,7 @@ async def k8s_list_pods(
         spec = item.get("spec") or {}
         st = item.get("status") or {}
         container_statuses = st.get("containerStatuses") or []
-        ready = bool(container_statuses) and all(
-            cs.get("ready") for cs in container_statuses
-        )
+        ready = bool(container_statuses) and all(cs.get("ready") for cs in container_statuses)
         pods.append(
             K8sPodSummary(
                 name=meta.get("name") or "",
@@ -5786,9 +5676,7 @@ async def k8s_list_pods(
                 phase=st.get("phase") or "Unknown",
                 ready=ready,
                 containers=[
-                    c.get("name") or ""
-                    for c in (spec.get("containers") or [])
-                    if c.get("name")
+                    c.get("name") or "" for c in (spec.get("containers") or []) if c.get("name")
                 ],
                 labels=dict(meta.get("labels") or {}),
             )

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -156,7 +156,8 @@ def _supervisor_strips_url_fragment(row: Appliance) -> bool:
     changes the URL), never the ability to upgrade (#419)."""
     ver = row.supervisor_version or row.installed_appliance_version or ""
     return (
-        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
+        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None
+        and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
     )
 
 
@@ -638,7 +639,9 @@ async def supervisor_register(
     # force a fresh registration they delete the row in the fleet UI,
     # which causes the supervisor to clear its identity + claim a new
     # pairing code on next boot.
-    existing_stmt = select(Appliance).where(Appliance.public_key_fingerprint == pubkey_fingerprint)
+    existing_stmt = select(Appliance).where(
+        Appliance.public_key_fingerprint == pubkey_fingerprint
+    )
     existing = (await db.execute(existing_stmt)).scalar_one_or_none()
     if existing is not None:
         # Idempotent re-register. Touch last_seen_at so the heartbeat
@@ -729,7 +732,9 @@ async def supervisor_register(
                 resource_type="pairing_code",
                 resource_id=str(code_row.id) if code_row is not None else "unknown",
                 resource_display=(
-                    "supervisor pairing code" if code_row is not None else "unknown pairing code"
+                    "supervisor pairing code"
+                    if code_row is not None
+                    else "unknown pairing code"
                 ),
                 result="forbidden",
                 new_value={
@@ -774,7 +779,9 @@ async def supervisor_register(
     # operator to open the role-picker.
     initial_assigned_roles: list[str] = []
     if body.appliance_variant is not None:
-        initial_assigned_roles = list(_REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, []))
+        initial_assigned_roles = list(
+            _REGISTER_VARIANT_FIXED_ROLES.get(body.appliance_variant, [])
+        )
     appliance_row = Appliance(
         id=appliance_id,
         hostname=body.hostname,
@@ -921,7 +928,9 @@ async def supervisor_poll(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Not found.")
 
     row = await db.get(Appliance, body.appliance_id)
-    valid = row is not None and verify_session_token(body.session_token, row.session_token_hash)
+    valid = row is not None and verify_session_token(
+        body.session_token, row.session_token_hash
+    )
     if not valid:
         await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
@@ -1262,7 +1271,9 @@ class SupervisorHeartbeatResponse(BaseModel):
     # uses this to bring up dns-bind9 / dns-powerdns / dhcp-kea
     # service containers via docker compose. Empty roles list = idle
     # (approved but no service running).
-    role_assignment: SupervisorRoleAssignment = Field(default_factory=SupervisorRoleAssignment)
+    role_assignment: SupervisorRoleAssignment = Field(
+        default_factory=SupervisorRoleAssignment
+    )
     # #272 Phase 7 — control-plane promote/demote desired state.
     # ``desired_cluster_role`` = "member" → join the seed via
     # ``desired_k3s_server_url`` + ``desired_k3s_join_token``; "none" →
@@ -1407,7 +1418,9 @@ async def _ingest_lldp_neighbours(
         .scalars()
         .all()
     )
-    by_key = {(e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing}
+    by_key = {
+        (e.local_iface, e.remote_chassis_id, e.remote_port_id): e for e in existing
+    }
     now = datetime.now(UTC)
 
     for key, n in desired.items():
@@ -1550,7 +1563,9 @@ async def supervisor_heartbeat(
         )
         if not valid:
             await asyncio.sleep(_CONSUME_FAILURE_DELAY_S)
-            raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance or session.")
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN, "Invalid appliance or session."
+            )
 
     assert row is not None
     # Issue #170 Wave E follow-up — reject heartbeats from soft-deleted
@@ -1788,7 +1803,9 @@ async def supervisor_heartbeat(
         for ev in evicted:
             ev.evict_requested = False
             ev.cluster_join_state = CLUSTER_JOIN_STATE_LEFT
-            logger.info("control_plane_node_evicted", hostname=ev.hostname, by=str(row.id))
+            logger.info(
+                "control_plane_node_evicted", hostname=ev.hostname, by=str(row.id)
+            )
 
     # Auto-clear the promote desired-state once the join landed: the
     # supervisor reports ``ready`` → the node IS a member now, so settle
@@ -1844,13 +1861,19 @@ async def supervisor_heartbeat(
     # the requested slot as ``current_slot`` — the operator's intent
     # was "boot into this slot next", and we got there. ``durable_
     # default`` is irrelevant here (next-boot is one-shot by design).
-    if row.desired_next_boot_slot is not None and row.current_slot == row.desired_next_boot_slot:
+    if (
+        row.desired_next_boot_slot is not None
+        and row.current_slot == row.desired_next_boot_slot
+    ):
         row.desired_next_boot_slot = None
 
     # Auto-clear desired_default_slot once the supervisor reports the
     # requested slot as ``durable_default`` — grub-set-default landed
     # and survives subsequent reboots.
-    if row.desired_default_slot is not None and row.durable_default == row.desired_default_slot:
+    if (
+        row.desired_default_slot is not None
+        and row.durable_default == row.desired_default_slot
+    ):
         row.desired_default_slot = None
 
     # Auto-clear reboot_requested 15 s after the stamp — by that
@@ -1900,12 +1923,17 @@ async def supervisor_heartbeat(
             long_poll = True
             hold_for = min(float(body.wait_seconds), _HEARTBEAT_HOLD_CAP_S)
             deadline = asyncio.get_running_loop().time() + hold_for
-            async with wake_subscription([*appliance_wake_channels(row), HOSTCONFIG_ALL]) as wake:
+            async with wake_subscription(
+                [*appliance_wake_channels(row), HOSTCONFIG_ALL]
+            ) as wake:
                 while True:
                     remaining = deadline - asyncio.get_running_loop().time()
                     if remaining <= 0:
                         break
-                    if await wake.wait(min(WAKE_TICK_SECONDS, remaining)) == WakeResult.WAKE:
+                    if (
+                        await wake.wait(min(WAKE_TICK_SECONDS, remaining))
+                        == WakeResult.WAKE
+                    ):
                         break
             # Pick up anything that committed during the hold (role /
             # firewall / desired-state edits land on other requests) before
@@ -1998,7 +2026,9 @@ async def supervisor_heartbeat(
     # Issue #165 — operator-set timezone. Empty string = no override.
     desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
     # #393 — appliance console mode (grubenv-driven, applies next reboot).
-    desired_console_mode = (cfg_row.console_mode or "dashboard") if cfg_row else "dashboard"
+    desired_console_mode = (
+        (cfg_row.console_mode or "dashboard") if cfg_row else "dashboard"
+    )
     # Issue #346 — host-config blocks for snmp / chrony / lldp. Built from the
     # same ``*_bundle`` helpers the DHCP-agent ConfigBundle uses; the
     # disabled-shape fallback keeps a stable key set when no settings row
@@ -2072,8 +2102,12 @@ async def supervisor_heartbeat(
         vip_configured=bool(metallb_vip),
         firewall_enabled=bool(cfg_row.firewall_enabled) if cfg_row else False,
         appliance_id=row.id,
-        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
-        firewall_logging_enabled=(bool(cfg_row.firewall_logging_enabled) if cfg_row else False),
+        web_ui_allowed_cidrs=(
+            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
+        ),
+        firewall_logging_enabled=(
+            bool(cfg_row.firewall_logging_enabled) if cfg_row else False
+        ),
     )
     # Persist the rendered hash so 2d's apply-stalled alarm + the Fleet drift
     # chip can compare it against the runner's reported applied_hash. Only
@@ -2132,7 +2166,9 @@ async def supervisor_heartbeat(
         cluster_peer_cidrs=cluster_peer_cidrs,
         firewall_pod_cidrs=firewall_pod_cidrs,
         firewall_service_cidrs=firewall_service_cidrs,
-        web_ui_allowed_cidrs=(list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        web_ui_allowed_cidrs=(
+            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
+        ),
         control_plane_size=control_plane_size,
         desired_metallb_enabled=metallb_enabled,
         desired_metallb_pool_addresses=metallb_pool,
@@ -2191,7 +2227,9 @@ async def firewall_render_inputs(db: DB, row: Appliance) -> dict[str, Any]:
         "cp_member_count": await _committed_cp_count(db),
         "vip_configured": bool((cfg_row.control_plane_vip or "") if cfg_row else ""),
         "firewall_enabled": bool(cfg_row.firewall_enabled) if cfg_row else False,
-        "web_ui_allowed_cidrs": (list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []),
+        "web_ui_allowed_cidrs": (
+            list(cfg_row.web_ui_allowed_cidrs or []) if cfg_row else []
+        ),
     }
 
 
@@ -2205,7 +2243,9 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     from app.models.dns import DNSServerGroup
 
     assigned_roles = list(row.assigned_roles or [])
-    dns_role_assigned = "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
+    dns_role_assigned = (
+        "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
+    )
     dhcp_role_assigned = "dhcp" in assigned_roles
 
     dns_engine: str | None = None
@@ -2471,7 +2511,9 @@ def _row_to_schema(row: Appliance) -> ApplianceRow:
 async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     _require_superadmin(current_user)
     rows = (
-        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc()))).scalars().all()
+        (await db.execute(select(Appliance).order_by(Appliance.paired_at.desc())))
+        .scalars()
+        .all()
     )
     return ApplianceList(appliances=[_row_to_schema(r) for r in rows])
 
@@ -2482,7 +2524,9 @@ async def list_appliances(current_user: CurrentUser, db: DB) -> ApplianceList:
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Fetch a single appliance (superadmin)",
 )
-async def get_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> ApplianceRow:
+async def get_appliance(
+    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
+) -> ApplianceRow:
     _require_superadmin(current_user)
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -2607,7 +2651,9 @@ async def approve_appliance(
     dependencies=[Depends(require_permission("admin", "appliance"))],
     summary="Reject a pending appliance (deletes the row, superadmin)",
 )
-async def reject_appliance(appliance_id: uuid.UUID, current_user: CurrentUser, db: DB) -> None:
+async def reject_appliance(
+    appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
+) -> None:
     """Reject = DELETE the row. Supervisor's next poll gets 403 +
     falls back to bootstrapping. Distinct from delete (next endpoint)
     only in the audit verb — operationally identical."""
@@ -2740,7 +2786,9 @@ async def _find_appliance_dependents(
 
     return ApplianceDependents(
         dns=[
-            ApplianceDependentServer(kind="dns", id=r.id, name=r.name, host=r.host, status=r.status)
+            ApplianceDependentServer(
+                kind="dns", id=r.id, name=r.name, host=r.host, status=r.status
+            )
             for r in dns_rows
         ],
         dhcp=[
@@ -2850,8 +2898,12 @@ async def delete_appliance(
                     Appliance.id != row.id,
                     Appliance.state != APPLIANCE_STATE_REVOKED,
                     or_(
-                        Appliance.appliance_variant.in_(tuple(_SELF_BOOTSTRAP_VARIANTS)),
-                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
+                        Appliance.appliance_variant.in_(
+                            tuple(_SELF_BOOTSTRAP_VARIANTS)
+                        ),
+                        Appliance.cluster_role.in_(
+                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
+                        ),
                     ),
                 )
             )
@@ -3301,10 +3353,14 @@ async def update_appliance_roles(
             new_value={
                 "roles": list(row.assigned_roles or []),
                 "dns_group_id": (
-                    str(row.assigned_dns_group_id) if row.assigned_dns_group_id else None
+                    str(row.assigned_dns_group_id)
+                    if row.assigned_dns_group_id
+                    else None
                 ),
                 "dhcp_group_id": (
-                    str(row.assigned_dhcp_group_id) if row.assigned_dhcp_group_id else None
+                    str(row.assigned_dhcp_group_id)
+                    if row.assigned_dhcp_group_id
+                    else None
                 ),
                 "tags": dict(row.tags or {}),
             },
@@ -3356,7 +3412,9 @@ async def _effective_cp_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
+                        Appliance.cluster_role.in_(
+                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
+                        ),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3444,7 +3502,9 @@ async def _firewall_peer_members(db: DB) -> list[Appliance]:
                 select(Appliance).where(
                     Appliance.state == APPLIANCE_STATE_APPROVED,
                     or_(
-                        Appliance.cluster_role.in_((CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)),
+                        Appliance.cluster_role.in_(
+                            (CLUSTER_ROLE_PRIMARY, CLUSTER_ROLE_MEMBER)
+                        ),
                         Appliance.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER,
                     ),
                 )
@@ -3570,7 +3630,9 @@ async def promote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
+            )
         if row.id == primary.id:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3581,7 +3643,10 @@ async def promote_control_plane(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is in state {row.state!r}; approve it first.",
             )
-        if row.cluster_role is not None or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER:
+        if (
+            row.cluster_role is not None
+            or row.desired_cluster_role == DESIRED_CLUSTER_ROLE_MEMBER
+        ):
             raise HTTPException(
                 status.HTTP_409_CONFLICT,
                 f"Appliance {row.hostname!r} is already a control-plane member (or joining).",
@@ -3677,7 +3742,9 @@ async def demote_control_plane(
         seen.add(aid)
         row = await db.get(Appliance, aid)
         if row is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found.")
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, f"Appliance {aid} not found."
+            )
         if row.cluster_role == CLUSTER_ROLE_PRIMARY:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -3775,7 +3842,9 @@ async def replace_control_plane_member(
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found.")
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"Appliance {appliance_id} not found."
+        )
     if row.cluster_role == CLUSTER_ROLE_PRIMARY:
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -4004,7 +4073,9 @@ async def restore_etcd_snapshot(
             "destructive cluster-reset restore.",
         )
     known = {
-        s.get("name") for s in (seed.etcd_snapshots or []) if isinstance(s, dict) and s.get("name")
+        s.get("name")
+        for s in (seed.etcd_snapshots or [])
+        if isinstance(s, dict) and s.get("name")
     }
     if body.snapshot_name not in known:
         raise HTTPException(
@@ -4121,7 +4192,9 @@ def _metallb_pod_status() -> tuple[bool, int, int]:
 
     def _ready(pod: dict[str, Any]) -> bool:
         conds = (pod.get("status") or {}).get("conditions") or []
-        return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conds)
+        return any(
+            c.get("type") == "Ready" and c.get("status") == "True" for c in conds
+        )
 
     try:
         # #272 / #286 — MetalLB lives in its own metallb-system namespace
@@ -4207,7 +4280,9 @@ class MetalLBConfigUpdate(BaseModel):
     def _cross_field(self) -> MetalLBConfigUpdate:
         if self.enabled:
             if not self.control_plane_vip:
-                raise ValueError("a control-plane VIP is required when MetalLB is enabled")
+                raise ValueError(
+                    "a control-plane VIP is required when MetalLB is enabled"
+                )
             # #272 — auto-derive a single-address pool from the VIP when
             # no explicit pool is given. This is the common case: the
             # operator just wants one floating IP for the Web UI and
@@ -4218,7 +4293,11 @@ class MetalLBConfigUpdate(BaseModel):
             # supply one explicitly, and the VIP-in-pool check below
             # applies to it.
             if not self.pool_addresses:
-                prefix = 32 if ipaddress.ip_address(self.control_plane_vip).version == 4 else 128
+                prefix = (
+                    32
+                    if ipaddress.ip_address(self.control_plane_vip).version == 4
+                    else 128
+                )
                 self.pool_addresses = [f"{self.control_plane_vip}/{prefix}"]
         # #272 Phase 10 — data-plane VIPs require MetalLB on (no VIP path
         # exists without it) and can't reuse the control-plane VIP or each
@@ -4242,7 +4321,11 @@ class MetalLBConfigUpdate(BaseModel):
             "control-plane VIP": self.control_plane_vip,
             **dp_vips,
         }.items():
-            if vip and self.pool_addresses and not _vip_in_pool(vip, self.pool_addresses):
+            if (
+                vip
+                and self.pool_addresses
+                and not _vip_in_pool(vip, self.pool_addresses)
+            ):
                 raise ValueError(
                     f"{label} {vip} is not inside the address pool "
                     "(widen metallb_pool_addresses to include every VIP)"
@@ -4511,7 +4594,9 @@ async def schedule_appliance_upgrade(
             new_value={
                 "desired_appliance_version": body.desired_appliance_version,
                 "desired_slot_image_url": resolved_url,
-                "slot_image_id": (str(body.slot_image_id) if body.slot_image_id else None),
+                "slot_image_id": (
+                    str(body.slot_image_id) if body.slot_image_id else None
+                ),
             },
         )
     )
@@ -4828,7 +4913,9 @@ async def _require_cert_auth(request: Request, db: DB) -> Appliance:
         principal = await authenticate_cert(request, db)
     except CertAuthFailed as exc:
         logger.warning("appliance.k8s_proxy.cert_auth_failed", reason=exc.reason)
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid appliance client cert.") from exc
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "Invalid appliance client cert."
+        ) from exc
     if principal is None:
         raise HTTPException(
             status.HTTP_403_FORBIDDEN,
@@ -4867,7 +4954,9 @@ async def k8s_proxy_poll(request: Request, db: DB) -> K8sProxyPollResponse:
         # No request within the timeout — return an empty shape so
         # the supervisor loop just re-polls. 200 (not 204) so the
         # supervisor doesn't have to special-case "no body".
-        return K8sProxyPollResponse(request_id="", method="", path="", headers={}, body_b64="")
+        return K8sProxyPollResponse(
+            request_id="", method="", path="", headers={}, body_b64=""
+        )
     return K8sProxyPollResponse(
         request_id=queued.request_id,
         method=queued.method,
@@ -5082,7 +5171,9 @@ async def _pcap_capture_for_appliance(
     row = await db.get(PacketCapture, capture_id)
     if row is None or row.appliance_id != appliance.id:
         # Don't leak existence of another appliance's capture.
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "capture not found for this appliance")
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, "capture not found for this appliance"
+        )
     return row
 
 
@@ -5135,7 +5226,9 @@ async def pcap_progress(
     "/supervisor/pcap/upload/{capture_id}",
     summary="Stream the finished .pcap back (or finalize as failed via ?error=)",
 )
-async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[str, str]:
+async def pcap_upload(
+    capture_id: uuid.UUID, request: Request, db: DB
+) -> dict[str, str]:
     """Cert-authed. Streams the host-captured ``.pcap`` to the shared
     PCAP_DIR (``.partial`` → atomic rename + sha256), capped at
     ``max_bytes`` + margin. ``?error=`` (empty body) finalizes a failed
@@ -5169,8 +5262,15 @@ async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[s
     # (pcap framing), never above the hard ceiling + headroom.
     cap = min((row.max_bytes or HARD_MAX_BYTES), HARD_MAX_BYTES) + 16 * 1024 * 1024
 
-    dest = pcap_dir() / f"{capture_id}.pcap"
-    partial = dest.with_name(f"{capture_id}.pcap.partial")
+    # ``capture_id`` is a FastAPI-coerced uuid.UUID (path separators are
+    # impossible), but resolve + assert the path stays inside PCAP_DIR
+    # anyway — defence-in-depth + it clears the CodeQL path-injection taint
+    # from the HTTP path param.
+    pcap_root = pcap_dir().resolve()
+    dest = (pcap_root / f"{capture_id}.pcap").resolve()
+    if dest.parent != pcap_root:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid capture id")
+    partial = dest.with_name(f"{dest.stem}.pcap.partial")
     h = _hashlib.sha256()
     size = 0
     try:
@@ -5212,7 +5312,11 @@ async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[s
         pcap_size_bytes=size,
         pcap_sha256=h.hexdigest(),
         packet_count=packet_count,
-        metadata={"packet_count": packet_count, "byte_count": size, "stop_reason": "completed"},
+        metadata={
+            "packet_count": packet_count,
+            "byte_count": size,
+            "stop_reason": "completed",
+        },
         error=None,
     )
     if final_status == "cancelled":
@@ -5277,13 +5381,18 @@ async def k8s_rollout_restart(
     # Strategic-merge patch that bumps the pod template's
     # ``restartedAt`` annotation. Standard kubectl rollout-restart
     # shape — same JSON kubectl sends.
-    api_path = f"/apis/apps/v1/namespaces/{body.namespace}/" f"{body.kind.lower()}s/{body.name}"
+    api_path = (
+        f"/apis/apps/v1/namespaces/{body.namespace}/"
+        f"{body.kind.lower()}s/{body.name}"
+    )
     patch_body = {
         "spec": {
             "template": {
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/restartedAt": datetime.now(UTC).isoformat()
+                        "kubectl.kubernetes.io/restartedAt": datetime.now(
+                            UTC
+                        ).isoformat()
                     }
                 }
             }
@@ -5424,7 +5533,9 @@ async def reveal_appliance_kubeconfig(
         )
     # #408 — local users re-confirm with password or TOTP; external-auth
     # users with TOTP (enrol under Settings → Security if not yet enrolled).
-    outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
+    outcome = reverify_operator(
+        current_user, password=body.password, totp_code=body.totp_code
+    )
     if outcome is not ReauthOutcome.OK:
         await asyncio.sleep(0.1)
         if outcome is ReauthOutcome.MFA_REQUIRED:
@@ -5437,7 +5548,9 @@ async def reveal_appliance_kubeconfig(
             )
         _audit_denied("bad_credential")
         await db.commit()
-        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect.")
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect."
+        )
 
     row = await db.get(Appliance, appliance_id)
     if row is None:
@@ -5448,7 +5561,9 @@ async def reveal_appliance_kubeconfig(
         # Clean "nothing to reveal" — supervisor hasn't shipped a
         # kubeconfig yet (legacy compose / pre-Phase-5 / k3s not
         # started). Surface as a friendly state, not an error.
-        return RevealKubeconfigResponse(configured=False, kubeconfig=None, hostname=row.hostname)
+        return RevealKubeconfigResponse(
+            configured=False, kubeconfig=None, hostname=row.hostname
+        )
 
     try:
         plaintext = decrypt_str(row.kubeconfig_encrypted)
@@ -5480,7 +5595,9 @@ async def reveal_appliance_kubeconfig(
         hostname=row.hostname,
         user=current_user.username,
     )
-    return RevealKubeconfigResponse(configured=True, kubeconfig=plaintext, hostname=row.hostname)
+    return RevealKubeconfigResponse(
+        configured=True, kubeconfig=plaintext, hostname=row.hostname
+    )
 
 
 # ── Issue #183 Phase 6 — kubeapi-expose CIDR editor ──
@@ -5659,7 +5776,9 @@ async def k8s_list_pods(
         spec = item.get("spec") or {}
         st = item.get("status") or {}
         container_statuses = st.get("containerStatuses") or []
-        ready = bool(container_statuses) and all(cs.get("ready") for cs in container_statuses)
+        ready = bool(container_statuses) and all(
+            cs.get("ready") for cs in container_statuses
+        )
         pods.append(
             K8sPodSummary(
                 name=meta.get("name") or "",
@@ -5667,7 +5786,9 @@ async def k8s_list_pods(
                 phase=st.get("phase") or "Unknown",
                 ready=ready,
                 containers=[
-                    c.get("name") or "" for c in (spec.get("containers") or []) if c.get("name")
+                    c.get("name") or ""
+                    for c in (spec.get("containers") or [])
+                    if c.get("name")
                 ],
                 labels=dict(meta.get("labels") or {}),
             )

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -5046,6 +5046,188 @@ async def nettool_reply(
     return {"delivered": "true" if delivered else "stale"}
 
 
+# ── Packet capture (appliance-host vantage, #59 Phase 2) ─────────────────
+#
+# The supervisor's pcap_proxy thread drives these. Unlike the nettool /
+# k8s-proxy in-memory queues, the authority is the packet_capture DB row
+# (claimed via a guarded UPDATE), so any api replica can serve the poll.
+
+
+class PcapPollResponse(BaseModel):
+    """A claimed appliance-vantage capture command, or empty (capture_id
+    == "") when nothing is queued. Structured fields only — the
+    supervisor + host runner rebuild the tcpdump argv from these."""
+
+    capture_id: str = ""
+    interface: str | None = None
+    bpf_filter: str | None = None
+    snaplen: int = 256
+    promiscuous: bool = False
+    max_packets: int | None = None
+    max_duration_s: int | None = None
+    max_bytes: int | None = None
+
+
+class PcapProgressRequest(BaseModel):
+    packets: int | None = None
+    bytes_captured: int | None = None
+    elapsed_s: float | None = None
+
+
+async def _pcap_capture_for_appliance(
+    db: DB, capture_id: uuid.UUID, appliance: Appliance
+) -> Any:
+    from app.models.pcap import PacketCapture  # noqa: PLC0415
+
+    row = await db.get(PacketCapture, capture_id)
+    if row is None or row.appliance_id != appliance.id:
+        # Don't leak existence of another appliance's capture.
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "capture not found for this appliance")
+    return row
+
+
+@router.post(
+    "/supervisor/pcap/poll",
+    response_model=PcapPollResponse,
+    summary="Long-poll for the next queued appliance-host packet capture",
+)
+async def pcap_poll(request: Request, db: DB) -> PcapPollResponse:
+    """Cert-authed. Claims (guarded UPDATE → running) the oldest queued
+    appliance-vantage capture for the caller's appliance, or returns an
+    empty shape after ~30 s so the supervisor re-polls."""
+    import asyncio as _asyncio  # noqa: PLC0415
+
+    from app.services.appliance import pcap_capture as _pc  # noqa: PLC0415
+
+    appliance = await _require_cert_auth(request, db)
+    deadline = _asyncio.get_running_loop().time() + 30.0
+    while True:
+        cmd = await _pc.claim_next(db, appliance.id)
+        if cmd is not None:
+            return PcapPollResponse(**cmd)
+        if _asyncio.get_running_loop().time() >= deadline:
+            return PcapPollResponse()
+        await _asyncio.sleep(2.0)
+
+
+@router.post(
+    "/supervisor/pcap/progress/{capture_id}",
+    summary="Report live capture progress; returns the operator cancel flag",
+)
+async def pcap_progress(
+    capture_id: uuid.UUID, body: PcapProgressRequest, request: Request, db: DB
+) -> dict[str, bool]:
+    from app.services.appliance import pcap_capture as _pc  # noqa: PLC0415
+
+    appliance = await _require_cert_auth(request, db)
+    await _pcap_capture_for_appliance(db, capture_id, appliance)
+    cancel = await _pc.record_progress(
+        db,
+        capture_id,
+        packets=body.packets,
+        bytes_captured=body.bytes_captured,
+        elapsed_s=body.elapsed_s,
+    )
+    return {"cancel": cancel}
+
+
+@router.post(
+    "/supervisor/pcap/upload/{capture_id}",
+    summary="Stream the finished .pcap back (or finalize as failed via ?error=)",
+)
+async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[str, str]:
+    """Cert-authed. Streams the host-captured ``.pcap`` to the shared
+    PCAP_DIR (``.partial`` → atomic rename + sha256), capped at
+    ``max_bytes`` + margin. ``?error=`` (empty body) finalizes a failed
+    capture. Cancel is terminal — a cancelled row discards the bytes."""
+    import hashlib as _hashlib  # noqa: PLC0415
+    import os as _os  # noqa: PLC0415
+
+    from app.services.appliance import pcap_capture as _pc  # noqa: PLC0415
+    from app.services.pcap.runner import HARD_MAX_BYTES, pcap_dir  # noqa: PLC0415
+
+    appliance = await _require_cert_auth(request, db)
+    row = await _pcap_capture_for_appliance(db, capture_id, appliance)
+
+    error = request.query_params.get("error")
+    if error:
+        await _pc.finalize_capture(
+            db,
+            capture_id,
+            pcap_path=None,
+            pcap_size_bytes=None,
+            pcap_sha256=None,
+            packet_count=None,
+            metadata={"stop_reason": "error"},
+            error=error,
+        )
+        return {"status": "failed"}
+
+    packets_q = request.query_params.get("packets")
+    packet_count = int(packets_q) if packets_q and packets_q.isdigit() else None
+    # Generous transfer ceiling: the configured byte cap + 16 MiB headroom
+    # (pcap framing), never above the hard ceiling + headroom.
+    cap = min((row.max_bytes or HARD_MAX_BYTES), HARD_MAX_BYTES) + 16 * 1024 * 1024
+
+    dest = pcap_dir() / f"{capture_id}.pcap"
+    partial = dest.with_name(f"{capture_id}.pcap.partial")
+    h = _hashlib.sha256()
+    size = 0
+    try:
+        with open(partial, "wb") as fh:
+            async for chunk in request.stream():
+                if not chunk:
+                    continue
+                size += len(chunk)
+                if size > cap:
+                    fh.close()
+                    partial.unlink(missing_ok=True)
+                    raise HTTPException(
+                        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        "uploaded pcap exceeds the capture's byte cap",
+                    )
+                fh.write(chunk)
+                h.update(chunk)
+        _os.replace(partial, dest)
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        partial.unlink(missing_ok=True)
+        await _pc.finalize_capture(
+            db,
+            capture_id,
+            pcap_path=None,
+            pcap_size_bytes=None,
+            pcap_sha256=None,
+            packet_count=None,
+            metadata={"stop_reason": "upload_error"},
+            error=f"upload failed: {exc}",
+        )
+        return {"status": "failed"}
+
+    final_status = await _pc.finalize_capture(
+        db,
+        capture_id,
+        pcap_path=str(dest),
+        pcap_size_bytes=size,
+        pcap_sha256=h.hexdigest(),
+        packet_count=packet_count,
+        metadata={"packet_count": packet_count, "byte_count": size, "stop_reason": "completed"},
+        error=None,
+    )
+    if final_status == "cancelled":
+        # Cancel won the race — discard the bytes we just stored.
+        dest.unlink(missing_ok=True)
+    logger.info(
+        "appliance.pcap.upload",
+        appliance_id=str(appliance.id),
+        capture_id=str(capture_id),
+        bytes=size,
+        status=final_status,
+    )
+    return {"status": final_status}
+
+
 class ApplianceRestartDeploymentRequest(BaseModel):
     """Operator-driven Deployment / DaemonSet rollout-restart.
 

--- a/backend/app/api/v1/pcap/__init__.py
+++ b/backend/app/api/v1/pcap/__init__.py
@@ -1,0 +1,7 @@
+"""Packet capture API package (issue #59)."""
+
+from __future__ import annotations
+
+from app.api.v1.pcap.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/pcap/router.py
+++ b/backend/app/api/v1/pcap/router.py
@@ -1,0 +1,433 @@
+"""Packet capture (tcpdump) on-demand API — issue #59.
+
+Mounted at ``/api/v1/pcap`` (module-gated by ``tools.pcap``). Mirrors the
+nmap surface but the deliverable is a binary ``.pcap`` download, not a
+searchable text/XML blob, so there is **no SSE stream** — the UI polls
+``GET /captures/{id}`` for live ``bytes_captured`` + status, and the
+finished capture is fetched via ``GET /captures/{id}/download``.
+
+Endpoints (all gate on the ``manage_packet_capture`` permission):
+
+* ``POST /captures`` — start a capture (server vantage in Phase 1),
+  202 + queued row + Celery dispatch.
+* ``GET /captures`` — paginated list, filter by status / vantage /
+  appliance.
+* ``GET /captures/{id}`` — full record (incl. live progress while
+  running).
+* ``DELETE /captures/{id}`` — cancel a running capture or hard-delete a
+  terminal one (unlinks the ``.pcap``).
+* ``POST /captures/bulk-delete`` — cancel + delete up to 500.
+* ``GET /interfaces`` — capturable interfaces for a vantage (+ an honest
+  note about what it can see).
+* ``GET /captures/{id}/download`` — stream the ``.pcap`` (Bearer auth,
+  audited; 404 — never 500 — when the artifact is gone).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import FileResponse
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import DB, CurrentUser
+from app.core.permissions import require_permission
+from app.models.appliance import Appliance
+from app.models.audit import AuditLog
+from app.models.pcap import PacketCapture
+from app.services.pcap import (
+    PcapArgError,
+    build_pcap_argv,
+    clamp_caps,
+    enumerate_interfaces,
+    validate_bpf_filter,
+    validate_interface,
+)
+
+from .schemas import (
+    PcapBulkDeleteRequest,
+    PcapCaptureCreate,
+    PcapCaptureListResponse,
+    PcapCaptureRead,
+    PcapInterfacesResponse,
+)
+
+logger = structlog.get_logger(__name__)
+
+PERMISSION = "manage_packet_capture"
+
+router = APIRouter(tags=["pcap"])
+
+_TERMINAL = ("completed", "failed", "cancelled")
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _to_read(row: PacketCapture) -> PcapCaptureRead:
+    return PcapCaptureRead(
+        id=row.id,
+        vantage_kind=row.vantage_kind,
+        appliance_id=row.appliance_id,
+        vantage_label=row.vantage_label,
+        interface=row.interface,
+        bpf_filter=row.bpf_filter,
+        snaplen=row.snaplen,
+        promiscuous=row.promiscuous,
+        max_packets=row.max_packets,
+        max_duration_s=row.max_duration_s,
+        max_bytes=row.max_bytes,
+        status=row.status,
+        started_at=row.started_at,
+        finished_at=row.finished_at,
+        duration_seconds=row.duration_seconds,
+        exit_code=row.exit_code,
+        command_line=row.command_line,
+        error_message=row.error_message,
+        packets_captured=row.packets_captured,
+        bytes_captured=row.bytes_captured,
+        pcap_size_bytes=row.pcap_size_bytes,
+        pcap_sha256=row.pcap_sha256,
+        has_artifact=bool(
+            row.status == "completed"
+            and row.pcap_path
+            and not row.artifact_missing
+            and (row.pcap_size_bytes or 0) > 0
+        ),
+        metadata_json=row.metadata_json,
+        created_by_user_id=row.created_by_user_id,
+        created_at=row.created_at,
+        modified_at=row.modified_at,
+    )
+
+
+async def _audit(
+    db: AsyncSession,
+    *,
+    user: Any,
+    action: str,
+    capture_id: uuid.UUID,
+    label: str,
+    new_value: dict | None = None,
+) -> None:
+    db.add(
+        AuditLog(
+            user_id=user.id if user else None,
+            user_display_name=user.display_name if user else "system",
+            auth_source=getattr(user, "auth_source", "local") or "local",
+            action=action,
+            resource_type="packet_capture",
+            resource_id=str(capture_id),
+            resource_display=f"pcap:{label}",
+            new_value=new_value,
+        )
+    )
+
+
+# ── Interfaces ───────────────────────────────────────────────────────
+
+
+@router.get(
+    "/interfaces",
+    response_model=PcapInterfacesResponse,
+    dependencies=[Depends(require_permission("read", PERMISSION))],
+)
+async def list_interfaces(
+    db: DB,
+    current_user: CurrentUser,  # noqa: ARG001 — gate handled by dep
+    vantage: str = Query("server"),
+    appliance_id: uuid.UUID | None = Query(None),  # noqa: ARG001 — Phase 2
+) -> PcapInterfacesResponse:
+    if vantage == "server":
+        return PcapInterfacesResponse(
+            interfaces=enumerate_interfaces(),
+            note=(
+                "Control-plane container network (inter-pod / bridge traffic "
+                "only — NOT the host's physical NICs)."
+            ),
+        )
+    if vantage == "appliance":
+        # Phase 2 dispatches a list-interfaces request to the supervisor,
+        # which answers from the host net namespace. Not yet available.
+        return PcapInterfacesResponse(
+            interfaces=[],
+            note="Appliance-host capture ships in a follow-up phase.",
+        )
+    raise HTTPException(status_code=422, detail=f"unknown vantage: {vantage!r}")
+
+
+# ── CRUD ─────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/captures",
+    response_model=PcapCaptureRead,
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(require_permission("write", PERMISSION))],
+)
+async def create_capture(
+    body: PcapCaptureCreate, db: DB, current_user: CurrentUser
+) -> PcapCaptureRead:
+    if body.vantage_kind == "appliance":
+        # Phase 2 — the host-runner transport isn't wired yet.
+        raise HTTPException(
+            status_code=422,
+            detail="appliance-host capture is not available yet (ships in a follow-up phase)",
+        )
+    if body.vantage_kind != "server":
+        raise HTTPException(status_code=422, detail=f"unknown vantage: {body.vantage_kind!r}")
+
+    appliance_label = "control plane"
+    appliance_id = body.appliance_id
+    if appliance_id is not None:
+        appliance = await db.get(Appliance, appliance_id)
+        if appliance is None:
+            raise HTTPException(status_code=422, detail="appliance_id not found")
+        appliance_label = appliance.hostname or str(appliance_id)
+
+    # Pre-validate (surfaces PcapArgError before persisting a doomed row).
+    try:
+        interface = validate_interface(body.interface)
+        bpf = validate_bpf_filter(body.bpf_filter)
+        mp, md, mb, sl = clamp_caps(
+            max_packets=body.max_packets,
+            max_duration_s=body.max_duration_s,
+            max_bytes=body.max_bytes,
+            snaplen=body.snaplen,
+        )
+        # Build once to surface any argv error now.
+        build_pcap_argv(
+            interface=interface,
+            bpf_filter=bpf,
+            snaplen=sl,
+            promiscuous=body.promiscuous,
+            max_packets=mp,
+            output_path="/dev/null",
+        )
+    except PcapArgError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    cap = PacketCapture(
+        vantage_kind="server",
+        appliance_id=appliance_id,
+        vantage_label=appliance_label,
+        interface=interface,
+        bpf_filter=bpf,
+        snaplen=sl,
+        promiscuous=body.promiscuous,
+        max_packets=mp,
+        max_duration_s=md,
+        max_bytes=mb,
+        status="queued",
+        created_by_user_id=current_user.id,
+    )
+    db.add(cap)
+    await db.flush()
+    await _audit(
+        db,
+        user=current_user,
+        action="create",
+        capture_id=cap.id,
+        label=f"{interface}",
+        new_value={
+            "vantage_kind": "server",
+            "interface": interface,
+            "bpf_filter": bpf,
+            "snaplen": sl,
+            "max_packets": mp,
+            "max_duration_s": md,
+            "max_bytes": mb,
+        },
+    )
+    await db.commit()
+    await db.refresh(cap)
+
+    # Dispatch — broker outage shouldn't 500; leave queued for re-trigger.
+    try:
+        from app.tasks.pcap import run_capture_task  # noqa: PLC0415
+
+        run_capture_task.delay(str(cap.id))
+    except Exception as exc:  # noqa: BLE001 — broker down
+        logger.warning("pcap_dispatch_failed", capture_id=str(cap.id), error=str(exc))
+
+    return _to_read(cap)
+
+
+@router.get(
+    "/captures",
+    response_model=PcapCaptureListResponse,
+    dependencies=[Depends(require_permission("read", PERMISSION))],
+)
+async def list_captures(
+    db: DB,
+    current_user: CurrentUser,  # noqa: ARG001
+    status_filter: str | None = Query(None, alias="status"),
+    vantage: str | None = Query(None),
+    appliance_id: uuid.UUID | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=500),
+) -> PcapCaptureListResponse:
+    base = select(PacketCapture)
+    if status_filter:
+        base = base.where(PacketCapture.status == status_filter)
+    if vantage:
+        base = base.where(PacketCapture.vantage_kind == vantage)
+    if appliance_id is not None:
+        base = base.where(PacketCapture.appliance_id == appliance_id)
+
+    total = int((await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one())
+    stmt = (
+        base.order_by(PacketCapture.created_at.desc())
+        .limit(page_size)
+        .offset((page - 1) * page_size)
+    )
+    rows = list((await db.execute(stmt)).scalars().all())
+    return PcapCaptureListResponse(
+        items=[_to_read(r) for r in rows], total=total, page=page, page_size=page_size
+    )
+
+
+@router.get(
+    "/captures/{capture_id}",
+    response_model=PcapCaptureRead,
+    dependencies=[Depends(require_permission("read", PERMISSION))],
+)
+async def get_capture(
+    capture_id: uuid.UUID, db: DB, current_user: CurrentUser  # noqa: ARG001
+) -> PcapCaptureRead:
+    row = await db.get(PacketCapture, capture_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Capture not found")
+    return _to_read(row)
+
+
+@router.delete(
+    "/captures/{capture_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_permission("delete", PERMISSION))],
+)
+async def cancel_or_delete_capture(
+    capture_id: uuid.UUID, db: DB, current_user: CurrentUser
+) -> None:
+    """Cancel an in-flight capture or hard-delete a terminal one.
+
+    queued/running → ``cancelled`` (the runner self-terminates on its
+    next ~1 s poll). Terminal → row removed + ``.pcap`` unlinked.
+    """
+    row = await db.get(PacketCapture, capture_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Capture not found")
+    label = row.vantage_label or row.vantage_kind
+
+    if row.status in ("queued", "running"):
+        row.status = "cancelled"
+        if row.finished_at is None:
+            row.finished_at = datetime.now(UTC)
+        await _audit(db, user=current_user, action="cancel", capture_id=row.id, label=label)
+        await db.commit()
+        return
+
+    if row.pcap_path:
+        from contextlib import suppress
+
+        with suppress(OSError):
+            Path(row.pcap_path).unlink()
+    await _audit(db, user=current_user, action="delete", capture_id=row.id, label=label)
+    await db.delete(row)
+    await db.commit()
+
+
+@router.post(
+    "/captures/bulk-delete",
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(require_permission("delete", PERMISSION))],
+)
+async def bulk_delete_captures(
+    body: PcapBulkDeleteRequest, db: DB, current_user: CurrentUser
+) -> dict[str, int]:
+    """Bulk-cancel + delete up to 500 captures (same per-row policy)."""
+    from contextlib import suppress
+
+    cancelled = 0
+    deleted = 0
+    now = datetime.now(UTC)
+    for cid in body.capture_ids:
+        row = await db.get(PacketCapture, cid)
+        if row is None:
+            continue
+        label = row.vantage_label or row.vantage_kind
+        if row.status in ("queued", "running"):
+            row.status = "cancelled"
+            if row.finished_at is None:
+                row.finished_at = now
+            await _audit(db, user=current_user, action="cancel", capture_id=row.id, label=label)
+            cancelled += 1
+        else:
+            if row.pcap_path:
+                with suppress(OSError):
+                    Path(row.pcap_path).unlink()
+            await _audit(db, user=current_user, action="delete", capture_id=row.id, label=label)
+            await db.delete(row)
+            deleted += 1
+    await db.commit()
+    return {"deleted": deleted, "cancelled": cancelled}
+
+
+# ── Download ─────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/captures/{capture_id}/download",
+    dependencies=[Depends(require_permission("read", PERMISSION))],
+)
+async def download_capture(
+    capture_id: uuid.UUID, db: DB, current_user: CurrentUser
+) -> FileResponse:
+    """Stream the finished ``.pcap``.
+
+    Auth is the standard ``Authorization: Bearer`` (the frontend fetches a
+    blob — no ``?token=`` fallback, unlike the nmap SSE stream). The
+    download is audited (the moment sensitive bytes leave the system).
+    Guards return 404 — never 500 — when the artifact is gone (pruned /
+    restore drift), with a structured detail.
+    """
+    row = await db.get(PacketCapture, capture_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Capture not found")
+    if row.status != "completed":
+        raise HTTPException(status_code=404, detail="Capture has no downloadable artifact yet")
+    if not row.pcap_path or not Path(row.pcap_path).exists():
+        raise HTTPException(
+            status_code=404,
+            detail="capture artifact no longer on disk (pruned or volume drift)",
+        )
+
+    ts = (row.finished_at or row.created_at).strftime("%Y%m%d-%H%M%S")
+    iface = (row.interface or "any").replace("/", "_")
+    filename = f"capture-{row.vantage_kind}-{iface}-{ts}.pcap"
+
+    await _audit(
+        db,
+        user=current_user,
+        action="download",
+        capture_id=row.id,
+        label=row.vantage_label or row.vantage_kind,
+        new_value={"filename": filename, "bytes": row.pcap_size_bytes},
+    )
+    await db.commit()
+
+    return FileResponse(
+        row.pcap_path,
+        media_type="application/vnd.tcpdump.pcap",
+        filename=filename,
+        headers={"Referrer-Policy": "no-referrer"},
+    )
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/pcap/router.py
+++ b/backend/app/api/v1/pcap/router.py
@@ -64,8 +64,6 @@ PERMISSION = "manage_packet_capture"
 
 router = APIRouter(tags=["pcap"])
 
-_TERMINAL = ("completed", "failed", "cancelled")
-
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -175,7 +173,9 @@ async def create_capture(
     body: PcapCaptureCreate, db: DB, current_user: CurrentUser
 ) -> PcapCaptureRead:
     if body.vantage_kind not in ("server", "appliance"):
-        raise HTTPException(status_code=422, detail=f"unknown vantage: {body.vantage_kind!r}")
+        raise HTTPException(
+            status_code=422, detail=f"unknown vantage: {body.vantage_kind!r}"
+        )
 
     appliance_label = "control plane"
     appliance_id = body.appliance_id
@@ -185,7 +185,8 @@ async def create_capture(
     if body.vantage_kind == "appliance":
         if appliance_id is None:
             raise HTTPException(
-                status_code=422, detail="appliance_id is required for appliance-host capture"
+                status_code=422,
+                detail="appliance_id is required for appliance-host capture",
             )
         appliance = await db.get(Appliance, appliance_id)
         if appliance is None:
@@ -268,7 +269,9 @@ async def create_capture(
 
             run_capture_task.delay(str(cap.id))
         except Exception as exc:  # noqa: BLE001 — broker down
-            logger.warning("pcap_dispatch_failed", capture_id=str(cap.id), error=str(exc))
+            logger.warning(
+                "pcap_dispatch_failed", capture_id=str(cap.id), error=str(exc)
+            )
 
     return _to_read(cap)
 
@@ -295,7 +298,11 @@ async def list_captures(
     if appliance_id is not None:
         base = base.where(PacketCapture.appliance_id == appliance_id)
 
-    total = int((await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one())
+    total = int(
+        (
+            await db.execute(select(func.count()).select_from(base.subquery()))
+        ).scalar_one()
+    )
     stmt = (
         base.order_by(PacketCapture.created_at.desc())
         .limit(page_size)
@@ -343,7 +350,9 @@ async def cancel_or_delete_capture(
         row.status = "cancelled"
         if row.finished_at is None:
             row.finished_at = datetime.now(UTC)
-        await _audit(db, user=current_user, action="cancel", capture_id=row.id, label=label)
+        await _audit(
+            db, user=current_user, action="cancel", capture_id=row.id, label=label
+        )
         await db.commit()
         return
 
@@ -380,13 +389,17 @@ async def bulk_delete_captures(
             row.status = "cancelled"
             if row.finished_at is None:
                 row.finished_at = now
-            await _audit(db, user=current_user, action="cancel", capture_id=row.id, label=label)
+            await _audit(
+                db, user=current_user, action="cancel", capture_id=row.id, label=label
+            )
             cancelled += 1
         else:
             if row.pcap_path:
                 with suppress(OSError):
                     Path(row.pcap_path).unlink()
-            await _audit(db, user=current_user, action="delete", capture_id=row.id, label=label)
+            await _audit(
+                db, user=current_user, action="delete", capture_id=row.id, label=label
+            )
             await db.delete(row)
             deleted += 1
     await db.commit()
@@ -415,7 +428,9 @@ async def download_capture(
     if row is None:
         raise HTTPException(status_code=404, detail="Capture not found")
     if row.status != "completed":
-        raise HTTPException(status_code=404, detail="Capture has no downloadable artifact yet")
+        raise HTTPException(
+            status_code=404, detail="Capture has no downloadable artifact yet"
+        )
     if not row.pcap_path or not Path(row.pcap_path).exists():
         raise HTTPException(
             status_code=404,

--- a/backend/app/api/v1/pcap/router.py
+++ b/backend/app/api/v1/pcap/router.py
@@ -173,9 +173,7 @@ async def create_capture(
     body: PcapCaptureCreate, db: DB, current_user: CurrentUser
 ) -> PcapCaptureRead:
     if body.vantage_kind not in ("server", "appliance"):
-        raise HTTPException(
-            status_code=422, detail=f"unknown vantage: {body.vantage_kind!r}"
-        )
+        raise HTTPException(status_code=422, detail=f"unknown vantage: {body.vantage_kind!r}")
 
     appliance_label = "control plane"
     appliance_id = body.appliance_id
@@ -269,9 +267,7 @@ async def create_capture(
 
             run_capture_task.delay(str(cap.id))
         except Exception as exc:  # noqa: BLE001 — broker down
-            logger.warning(
-                "pcap_dispatch_failed", capture_id=str(cap.id), error=str(exc)
-            )
+            logger.warning("pcap_dispatch_failed", capture_id=str(cap.id), error=str(exc))
 
     return _to_read(cap)
 
@@ -298,11 +294,7 @@ async def list_captures(
     if appliance_id is not None:
         base = base.where(PacketCapture.appliance_id == appliance_id)
 
-    total = int(
-        (
-            await db.execute(select(func.count()).select_from(base.subquery()))
-        ).scalar_one()
-    )
+    total = int((await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one())
     stmt = (
         base.order_by(PacketCapture.created_at.desc())
         .limit(page_size)
@@ -350,9 +342,7 @@ async def cancel_or_delete_capture(
         row.status = "cancelled"
         if row.finished_at is None:
             row.finished_at = datetime.now(UTC)
-        await _audit(
-            db, user=current_user, action="cancel", capture_id=row.id, label=label
-        )
+        await _audit(db, user=current_user, action="cancel", capture_id=row.id, label=label)
         await db.commit()
         return
 
@@ -389,17 +379,13 @@ async def bulk_delete_captures(
             row.status = "cancelled"
             if row.finished_at is None:
                 row.finished_at = now
-            await _audit(
-                db, user=current_user, action="cancel", capture_id=row.id, label=label
-            )
+            await _audit(db, user=current_user, action="cancel", capture_id=row.id, label=label)
             cancelled += 1
         else:
             if row.pcap_path:
                 with suppress(OSError):
                     Path(row.pcap_path).unlink()
-            await _audit(
-                db, user=current_user, action="delete", capture_id=row.id, label=label
-            )
+            await _audit(db, user=current_user, action="delete", capture_id=row.id, label=label)
             await db.delete(row)
             deleted += 1
     await db.commit()
@@ -428,9 +414,7 @@ async def download_capture(
     if row is None:
         raise HTTPException(status_code=404, detail="Capture not found")
     if row.status != "completed":
-        raise HTTPException(
-            status_code=404, detail="Capture has no downloadable artifact yet"
-        )
+        raise HTTPException(status_code=404, detail="Capture has no downloadable artifact yet")
     if not row.pcap_path or not Path(row.pcap_path).exists():
         raise HTTPException(
             status_code=404,

--- a/backend/app/api/v1/pcap/router.py
+++ b/backend/app/api/v1/pcap/router.py
@@ -38,7 +38,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import require_permission
-from app.models.appliance import Appliance
+from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
 from app.models.audit import AuditLog
 from app.models.pcap import PacketCapture
 from app.services.pcap import (
@@ -174,26 +174,36 @@ async def list_interfaces(
 async def create_capture(
     body: PcapCaptureCreate, db: DB, current_user: CurrentUser
 ) -> PcapCaptureRead:
-    if body.vantage_kind == "appliance":
-        # Phase 2 — the host-runner transport isn't wired yet.
-        raise HTTPException(
-            status_code=422,
-            detail="appliance-host capture is not available yet (ships in a follow-up phase)",
-        )
-    if body.vantage_kind != "server":
+    if body.vantage_kind not in ("server", "appliance"):
         raise HTTPException(status_code=422, detail=f"unknown vantage: {body.vantage_kind!r}")
 
     appliance_label = "control plane"
     appliance_id = body.appliance_id
-    if appliance_id is not None:
+    # Server vantage enumerates the worker's own NICs; appliance vantage
+    # can't (different host), so the host runner does the membership check.
+    require_avail = True
+    if body.vantage_kind == "appliance":
+        if appliance_id is None:
+            raise HTTPException(
+                status_code=422, detail="appliance_id is required for appliance-host capture"
+            )
         appliance = await db.get(Appliance, appliance_id)
         if appliance is None:
             raise HTTPException(status_code=422, detail="appliance_id not found")
+        if appliance.state != APPLIANCE_STATE_APPROVED:
+            raise HTTPException(
+                status_code=422,
+                detail=f"appliance is {appliance.state!r}, not approved — can't dispatch a capture",
+            )
         appliance_label = appliance.hostname or str(appliance_id)
+        require_avail = False
+    else:
+        # server vantage carries no appliance binding.
+        appliance_id = None
 
     # Pre-validate (surfaces PcapArgError before persisting a doomed row).
     try:
-        interface = validate_interface(body.interface)
+        interface = validate_interface(body.interface, require_available=require_avail)
         bpf = validate_bpf_filter(body.bpf_filter)
         mp, md, mb, sl = clamp_caps(
             max_packets=body.max_packets,
@@ -214,7 +224,7 @@ async def create_capture(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     cap = PacketCapture(
-        vantage_kind="server",
+        vantage_kind=body.vantage_kind,
         appliance_id=appliance_id,
         vantage_label=appliance_label,
         interface=interface,
@@ -234,9 +244,10 @@ async def create_capture(
         user=current_user,
         action="create",
         capture_id=cap.id,
-        label=f"{interface}",
+        label=f"{appliance_label}:{interface}",
         new_value={
-            "vantage_kind": "server",
+            "vantage_kind": body.vantage_kind,
+            "appliance_id": str(appliance_id) if appliance_id else None,
             "interface": interface,
             "bpf_filter": bpf,
             "snaplen": sl,
@@ -248,13 +259,16 @@ async def create_capture(
     await db.commit()
     await db.refresh(cap)
 
-    # Dispatch — broker outage shouldn't 500; leave queued for re-trigger.
-    try:
-        from app.tasks.pcap import run_capture_task  # noqa: PLC0415
+    # Server vantage runs in the worker via Celery. Appliance vantage is
+    # NOT dispatched here — the supervisor's pcap_proxy long-polls
+    # /supervisor/pcap/poll and claims the queued row itself.
+    if body.vantage_kind == "server":
+        try:
+            from app.tasks.pcap import run_capture_task  # noqa: PLC0415
 
-        run_capture_task.delay(str(cap.id))
-    except Exception as exc:  # noqa: BLE001 — broker down
-        logger.warning("pcap_dispatch_failed", capture_id=str(cap.id), error=str(exc))
+            run_capture_task.delay(str(cap.id))
+        except Exception as exc:  # noqa: BLE001 — broker down
+            logger.warning("pcap_dispatch_failed", capture_id=str(cap.id), error=str(exc))
 
     return _to_read(cap)
 

--- a/backend/app/api/v1/pcap/schemas.py
+++ b/backend/app/api/v1/pcap/schemas.py
@@ -1,0 +1,97 @@
+"""Pydantic schemas for the packet-capture API (issue #59)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from app.services.pcap.runner import (
+    HARD_MAX_BYTES,
+    HARD_MAX_DURATION_S,
+    HARD_MAX_PACKETS,
+    MAX_SNAPLEN,
+)
+
+PcapVantageKind = Literal["server", "appliance"]
+PcapStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
+
+
+class PcapCaptureCreate(BaseModel):
+    """Operator request to start a capture.
+
+    At least one stop condition (``max_packets`` / ``max_duration_s`` /
+    ``max_bytes``) is required — enforced server-side in the runner's
+    ``clamp_caps``. ``bpf_filter`` is passed to tcpdump as a single
+    trailing argv element (never shell-interpolated)."""
+
+    vantage_kind: PcapVantageKind = "server"
+    appliance_id: uuid.UUID | None = None
+    interface: str | None = None
+    bpf_filter: str | None = Field(default=None, max_length=1024)
+    snaplen: int = Field(default=256, ge=0, le=MAX_SNAPLEN)
+    promiscuous: bool = False
+    max_packets: int | None = Field(default=10_000, ge=1, le=HARD_MAX_PACKETS)
+    max_duration_s: int | None = Field(default=60, ge=1, le=HARD_MAX_DURATION_S)
+    max_bytes: int | None = Field(default=50 * 1024 * 1024, ge=1, le=HARD_MAX_BYTES)
+
+
+class PcapCaptureRead(BaseModel):
+    id: uuid.UUID
+    vantage_kind: str
+    appliance_id: uuid.UUID | None
+    vantage_label: str
+    interface: str | None
+    bpf_filter: str | None
+    snaplen: int
+    promiscuous: bool
+    max_packets: int | None
+    max_duration_s: int | None
+    max_bytes: int | None
+    status: str
+    started_at: datetime | None
+    finished_at: datetime | None
+    duration_seconds: float | None
+    exit_code: int | None
+    command_line: str | None
+    error_message: str | None
+    packets_captured: int
+    bytes_captured: int
+    pcap_size_bytes: int | None
+    pcap_sha256: str | None
+    # True when the row has captured bytes available to download.
+    has_artifact: bool = False
+    metadata_json: dict | None = None
+    created_by_user_id: uuid.UUID | None
+    created_at: datetime
+    modified_at: datetime
+
+
+class PcapCaptureListResponse(BaseModel):
+    items: list[PcapCaptureRead]
+    total: int
+    page: int
+    page_size: int
+
+
+class PcapInterfacesResponse(BaseModel):
+    interfaces: list[str]
+    # Honest UI label about what this vantage can actually see.
+    note: str
+
+
+class PcapBulkDeleteRequest(BaseModel):
+    capture_ids: list[uuid.UUID] = Field(min_length=1, max_length=500)
+
+
+__all__ = [
+    "PcapVantageKind",
+    "PcapStatus",
+    "PcapCaptureCreate",
+    "PcapCaptureRead",
+    "PcapCaptureListResponse",
+    "PcapInterfacesResponse",
+    "PcapBulkDeleteRequest",
+]

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -52,6 +52,7 @@ from app.api.v1.ownership import (
     providers_router,
     sites_router,
 )
+from app.api.v1.pcap import router as pcap_router
 from app.api.v1.proxmox import router as proxmox_router
 from app.api.v1.reports import router as reports_router
 from app.api.v1.roles.router import router as roles_router
@@ -240,6 +241,12 @@ api_v1_router.include_router(
     prefix="/nmap",
     tags=["nmap"],
     dependencies=[Depends(require_module("tools.nmap"))],
+)
+api_v1_router.include_router(
+    pcap_router,
+    prefix="/pcap",
+    tags=["pcap"],
+    dependencies=[Depends(require_module("tools.pcap"))],
 )
 api_v1_router.include_router(
     opnsense_router,

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -43,6 +43,7 @@ celery_app = Celery(
         "app.tasks.cloud_sync",
         "app.tasks.snmp_poll",
         "app.tasks.nmap",
+        "app.tasks.pcap",
         "app.tasks.dns_pool_healthcheck",
         "app.tasks.dhcp_fingerprint",
         "app.tasks.event_outbox",
@@ -99,6 +100,7 @@ celery_app.conf.update(
         "app.tasks.cloud_sync.*": {"queue": "default"},
         "app.tasks.snmp_poll.*": {"queue": "default"},
         "app.tasks.nmap.*": {"queue": "default"},
+        "app.tasks.pcap.*": {"queue": "default"},
         "app.tasks.dns_pool_healthcheck.*": {"queue": "dns"},
         "app.tasks.dhcp_fingerprint.*": {"queue": "dhcp"},
         "app.tasks.event_outbox.*": {"queue": "default"},
@@ -251,6 +253,14 @@ celery_app.conf.update(
         "log-entries-prune": {
             "task": "app.tasks.prune_logs.prune_log_entries",
             "schedule": schedule(run_every=24 * 3600.0),
+        },
+        # Daily at 03:45 UTC (offset from the other prunes), delete
+        # terminal packet-capture rows past the retention window
+        # (default 7 d) + unlink their .pcap files, and reap captures
+        # stuck non-terminal past their deadline. Issue #59.
+        "pcap-captures-prune": {
+            "task": "app.tasks.pcap.prune_captures",
+            "schedule": crontab(hour=3, minute=45),
         },
         # Every 5 min, reap IGMP-snooping membership rows whose
         # ``last_seen_at`` is older than 30 min — see issue #126

--- a/backend/app/core/demo_mode.py
+++ b/backend/app/core/demo_mode.py
@@ -44,6 +44,7 @@ from app.config import settings
 DEMO_RESTRICTED_MODULES: Final[frozenset[str]] = frozenset(
     {
         "tools.nmap",
+        "tools.pcap",
         "ai.copilot",
         "integrations.kubernetes",
         "integrations.docker",

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -516,6 +516,7 @@ KNOWN_MANAGE_PERMISSIONS: frozenset[str] = frozenset(
         "manage_domains",
         "manage_network_devices",
         "manage_nmap_scans",
+        "manage_packet_capture",
     }
 )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -209,6 +209,7 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
         [
             {"action": "admin", "resource_type": "manage_network_devices"},
             {"action": "admin", "resource_type": "manage_nmap_scans"},
+            {"action": "admin", "resource_type": "manage_packet_capture"},
             {"action": "admin", "resource_type": "use_network_tools"},
             {"action": "admin", "resource_type": "manage_asns"},
             {"action": "admin", "resource_type": "vrf"},

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -101,6 +101,7 @@ from app.models.overlay import (
     RoutingPolicy,
 )
 from app.models.ownership import Customer, Provider, Site
+from app.models.pcap import PacketCapture
 from app.models.proxmox import ProxmoxNode
 from app.models.settings import PlatformSettings
 from app.models.system_upgrade import SystemUpgradeRun
@@ -204,6 +205,7 @@ __all__ = [
     "MulticastGroupPort",
     "MulticastMembership",
     "NmapScan",
+    "PacketCapture",
     "EventSubscription",
     "EventOutbox",
     "Customer",

--- a/backend/app/models/pcap.py
+++ b/backend/app/models/pcap.py
@@ -1,0 +1,131 @@
+"""Packet-capture (tcpdump) job history — issue #59.
+
+One row is one operator-triggered packet capture. It mirrors
+:class:`app.models.nmap.NmapScan`'s lifecycle (a persisted long-running
+job with a 5-state machine, isolated worker execution, retention) but
+diverges in three structural ways:
+
+1. The deliverable is a **binary ``.pcap`` artifact on disk** —
+   ``pcap_path`` points at a file under ``SPATIUM_PCAP_DIR``; the
+   download endpoint streams it. The bytes are *never* embedded in a DB
+   column or JSON (they're large + sensitive).
+2. The meaningful vantage is *where tcpdump runs* — the control-plane
+   container (``vantage_kind="server"``, Phase 1) or an appliance host
+   (``vantage_kind="appliance"``, Phase 2). ``vantage_label`` is the
+   denormalised hostname so the row survives a target delete.
+3. PCAP **auto-prunes** (``app.tasks.pcap.prune_captures``) — pcaps are
+   large and sensitive (plaintext creds/PII), so terminal rows + their
+   files expire after ``PlatformSettings.pcap_retention_days`` (7 by
+   default), unlike nmap's operator-curated-forever history.
+
+Live progress is **polled** (no SSE): while ``running`` the UI reads
+``bytes_captured`` (honest, from an fstat of the growing file) +
+``status``. ``packets_captured`` + ``metadata_json`` are authoritative
+only at completion (tcpdump emits its count at exit).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class PacketCapture(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """One tcpdump invocation initiated from the SpatiumDDI UI."""
+
+    __tablename__ = "packet_capture"
+    __table_args__ = (
+        Index("ix_packet_capture_status", "status"),
+        Index("ix_packet_capture_appliance", "appliance_id"),
+        Index("ix_packet_capture_creator_created", "created_by_user_id", "created_at"),
+        Index("ix_packet_capture_created", "created_at"),
+    )
+
+    # ── Vantage (where tcpdump runs) ────────────────────────────────────
+    # "server" = control-plane worker container (Phase 1).
+    # "appliance" = an approved Fleet appliance host (Phase 2).
+    vantage_kind: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="server", server_default="server"
+    )
+    appliance_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("appliance.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Denormalised hostname / "control plane" so the row stays meaningful
+    # after the appliance row is deleted (cf. NmapScan.target_ip).
+    vantage_label: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+
+    # ── Inputs (server-validated before persist; re-validated at runner) ─
+    interface: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # BPF expression — passed as tcpdump's single trailing argv element,
+    # NEVER shell-interpolated / shlex.split. Charset-validated.
+    bpf_filter: Mapped[str | None] = mapped_column(Text, nullable=True)
+    snaplen: Mapped[int] = mapped_column(Integer, nullable=False, default=256, server_default="256")
+    promiscuous: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    # Stop conditions — at least one is required at the API layer.
+    max_packets: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    max_duration_s: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    max_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    # ── Run state (5 states, identical semantics to NmapScan) ───────────
+    # status: queued | running | completed | failed | cancelled
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="queued", server_default="queued"
+    )
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    duration_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
+    exit_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    command_line: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # tcpdump PID for orphan reaping on the running vantage.
+    tcpdump_pid: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # ── Live progress (polled; not a stream) ────────────────────────────
+    packets_captured: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, server_default="0"
+    )
+    bytes_captured: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, server_default="0"
+    )
+
+    # ── Artifact (binary on disk) ───────────────────────────────────────
+    pcap_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    pcap_size_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    pcap_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Set when the row outlives its file (restore drift / pruned) so the
+    # UI hides the Download button instead of offering a 404.
+    artifact_missing: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    # {first_ts,last_ts,packet_count,byte_count,link_type,truncated}
+    metadata_json: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # ── Provenance ──────────────────────────────────────────────────────
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+
+__all__ = ["PacketCapture"]

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -288,6 +288,13 @@ class PlatformSettings(Base):
         Integer, nullable=False, default=90, server_default=sa_text("90")
     )
 
+    # How many days to retain terminal packet-capture rows (+ their .pcap
+    # files) before the nightly prune deletes them. pcaps are large +
+    # sensitive (plaintext creds/PII) so the default is short (issue #59).
+    pcap_retention_days: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=7, server_default=sa_text("7")
+    )
+
     # Fingerbank API key for passive DHCP device fingerprinting (Phase 2 of
     # the device profiling feature). Fernet-encrypted at rest; null when the
     # operator hasn't configured a key. When unset, the agent still ships

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -38,6 +38,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.auth import User
 from app.models.ipam import IPAddress, IPBlock, Subnet
 from app.services.nmap import NmapArgError, build_argv
+from app.services.pcap import (
+    PcapArgError,
+    build_pcap_argv,
+    clamp_caps,
+    validate_bpf_filter,
+    validate_interface,
+)
 
 # Per-proposal TTL. 30 minutes is a generous window for a thoughtful
 # review without keeping yesterday's proposals lying around — the
@@ -491,6 +498,165 @@ register(
         apply=_apply_run_nmap_scan,
         category="network",
         required_permission=("write", "manage_nmap_scans"),
+    )
+)
+
+
+# ── run_packet_capture operation (issue #59) ───────────────────────────
+
+
+class RunPacketCaptureArgs(BaseModel):
+    """Args for ``run_packet_capture`` — server vantage only (Phase 1)."""
+
+    interface: str | None = Field(
+        default=None,
+        description=(
+            "Interface to capture on (control-plane container network). "
+            "Omit for 'any'. Must be a real interface on the vantage."
+        ),
+    )
+    bpf_filter: str | None = Field(
+        default=None,
+        description=(
+            "Optional tcpdump BPF expression (e.g. 'port 53', "
+            "'host 10.0.0.1 and tcp'). Passed to tcpdump as a single "
+            "argv element; shell metacharacters are rejected."
+        ),
+    )
+    max_duration_s: int | None = Field(
+        default=60,
+        description="Stop after N seconds (≤1800). At least one stop condition required.",
+    )
+    max_packets: int | None = Field(default=None, description="Stop after N packets (≤1,000,000).")
+    max_bytes: int | None = Field(default=None, description="Stop near N bytes (≤100 MiB).")
+    snaplen: int | None = Field(default=256, description="Bytes captured per packet (default 256).")
+
+
+async def _preview_run_packet_capture(
+    db: AsyncSession, user: User, args: RunPacketCaptureArgs
+) -> PreviewResult:
+    try:
+        interface = validate_interface(args.interface)
+        bpf = validate_bpf_filter(args.bpf_filter)
+        mp, md, mb, sl = clamp_caps(
+            max_packets=args.max_packets,
+            max_duration_s=args.max_duration_s,
+            max_bytes=args.max_bytes,
+            snaplen=args.snaplen,
+        )
+        argv = build_pcap_argv(
+            interface=interface,
+            bpf_filter=bpf,
+            snaplen=sl,
+            promiscuous=False,
+            max_packets=mp,
+            output_path="<file>",
+        )
+    except PcapArgError as exc:
+        return PreviewResult(ok=False, detail=f"capture arg validation failed: {exc}")
+
+    parts = [
+        f"Run a packet capture on `{interface}` (control-plane vantage)",
+        f"filter: `{bpf}`" if bpf else "filter: (none — all traffic)",
+        f"stop: {md or '—'}s / {mp or '—'} pkts / {mb or '—'} bytes, snaplen {sl}",
+        f"argv: `{' '.join(argv)}`",
+        "This captures raw traffic (may include credentials/PII). Apply "
+        "only if you're authorised; the .pcap is downloadable + audited.",
+    ]
+    return PreviewResult(ok=True, detail="ready", preview_text="\n".join(parts))
+
+
+async def _apply_run_packet_capture(
+    db: AsyncSession, user: User, args: RunPacketCaptureArgs
+) -> dict[str, Any]:
+    from app.models.audit import AuditLog  # local import to avoid cycle
+    from app.models.pcap import PacketCapture  # local import to avoid cycle
+
+    # RBAC backstop — matches the REST route's
+    # require_permission("write", "manage_packet_capture").
+    enforce_operation_permission(user, _OPERATIONS["run_packet_capture"])
+
+    try:
+        interface = validate_interface(args.interface)
+        bpf = validate_bpf_filter(args.bpf_filter)
+        mp, md, mb, sl = clamp_caps(
+            max_packets=args.max_packets,
+            max_duration_s=args.max_duration_s,
+            max_bytes=args.max_bytes,
+            snaplen=args.snaplen,
+        )
+    except PcapArgError as exc:
+        raise ValueError(f"capture arg validation failed: {exc}") from exc
+
+    cap = PacketCapture(
+        vantage_kind="server",
+        vantage_label="control plane",
+        interface=interface,
+        bpf_filter=bpf,
+        snaplen=sl,
+        promiscuous=False,
+        max_packets=mp,
+        max_duration_s=md,
+        max_bytes=mb,
+        status="queued",
+        created_by_user_id=user.id,
+    )
+    db.add(cap)
+    await db.flush()
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=getattr(user, "auth_source", "local") or "local",
+            action="create",
+            resource_type="packet_capture",
+            resource_id=str(cap.id),
+            resource_display=f"pcap:{interface}",
+            new_value={
+                "vantage_kind": "server",
+                "interface": interface,
+                "bpf_filter": bpf,
+                "via": "ai_proposal",
+            },
+        )
+    )
+    await db.commit()
+    await db.refresh(cap)
+
+    try:
+        from app.tasks.pcap import run_capture_task  # noqa: PLC0415
+
+        run_capture_task.delay(str(cap.id))
+    except Exception:  # noqa: BLE001 — broker down
+        pass
+
+    return {
+        "id": str(cap.id),
+        "vantage_kind": "server",
+        "interface": interface,
+        "status": "queued",
+        "hint": (
+            "Capture dispatched. Poll get_packet_capture until status == "
+            "'completed', then download the .pcap from the UI."
+        ),
+    }
+
+
+register(
+    Operation(
+        name="run_packet_capture",
+        description=(
+            "Start an on-demand packet capture (tcpdump) on the "
+            "control-plane vantage. Always go through "
+            "propose_run_packet_capture — never call this directly. "
+            "Capturing raw traffic is sensitive, so operator approval is "
+            "required before each apply."
+        ),
+        args_model=RunPacketCaptureArgs,
+        preview=_preview_run_packet_capture,
+        apply=_apply_run_packet_capture,
+        category="network",
+        required_permission=("write", "manage_packet_capture"),
     )
 )
 

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -35,6 +35,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     ops,
     ownership,
     pairing,
+    pcap,
     proposals,
     redis,
     reports,

--- a/backend/app/services/ai/tools/pcap.py
+++ b/backend/app/services/ai/tools/pcap.py
@@ -1,0 +1,180 @@
+"""Operator Copilot tools for the packet-capture surface (issue #59).
+
+Read-only, ``module="tools.pcap"`` so disabling the feature module hides
+them. They return capture **metadata only** — never the captured bytes
+(those are sensitive + binary; the operator downloads the ``.pcap`` from
+the UI under the audited download endpoint).
+
+* ``find_packet_captures``  — paginated history, filter by status /
+                              vantage / appliance / since.
+* ``count_packet_captures`` — count by the same filters.
+* ``get_packet_capture``    — one capture's full metadata (incl. live
+                              byte progress + the parsed summary).
+
+The matching write — ``propose_run_packet_capture`` — is a gated
+propose→apply Operation registered in
+:mod:`app.services.ai.operations` (model proposes, operator clicks
+Apply; capturing traffic is never silent).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.pcap import PacketCapture
+from app.services.ai.tools.base import register_tool
+
+_MODULE = "tools.pcap"
+_PcapStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
+
+
+def _row_summary(r: PacketCapture) -> dict[str, Any]:
+    return {
+        "id": str(r.id),
+        "vantage_kind": r.vantage_kind,
+        "vantage_label": r.vantage_label,
+        "interface": r.interface,
+        "bpf_filter": r.bpf_filter,
+        "status": r.status,
+        "packets_captured": r.packets_captured,
+        "bytes_captured": r.bytes_captured,
+        "pcap_size_bytes": r.pcap_size_bytes,
+        "started_at": r.started_at.isoformat() if r.started_at else None,
+        "finished_at": r.finished_at.isoformat() if r.finished_at else None,
+        "duration_seconds": r.duration_seconds,
+        "error_message": r.error_message,
+        "has_artifact": bool(
+            r.status == "completed" and r.pcap_path and (r.pcap_size_bytes or 0) > 0
+        ),
+    }
+
+
+# ── find_packet_captures ───────────────────────────────────────────────
+
+
+class FindPacketCapturesArgs(BaseModel):
+    status: _PcapStatus | None = Field(default=None, description="Filter by run state.")
+    vantage_kind: Literal["server", "appliance"] | None = Field(
+        default=None, description="Filter by capture vantage."
+    )
+    appliance_id: str | None = Field(default=None, description="Filter by appliance UUID.")
+    since: datetime | None = Field(
+        default=None, description="Captures created at/after this UTC timestamp (ISO 8601)."
+    )
+    limit: int = Field(default=20, ge=1, le=100)
+
+
+@register_tool(
+    name="find_packet_captures",
+    module=_MODULE,
+    description=(
+        "List packet captures (tcpdump) from the on-demand capture "
+        "history. Filter by status, vantage (server / appliance), "
+        "appliance UUID, or a since-timestamp. Returns metadata only "
+        "(interface, BPF filter, status, packet/byte counts, whether a "
+        "downloadable .pcap exists) — never the captured bytes."
+    ),
+    args_model=FindPacketCapturesArgs,
+    category="network",
+)
+async def find_packet_captures(
+    db: AsyncSession, user: User, args: FindPacketCapturesArgs
+) -> list[dict[str, Any]] | dict[str, Any]:
+    stmt = select(PacketCapture)
+    if args.status:
+        stmt = stmt.where(PacketCapture.status == args.status)
+    if args.vantage_kind:
+        stmt = stmt.where(PacketCapture.vantage_kind == args.vantage_kind)
+    if args.appliance_id:
+        try:
+            stmt = stmt.where(PacketCapture.appliance_id == uuid.UUID(args.appliance_id))
+        except ValueError:
+            return {"error": f"appliance_id must be a UUID, got {args.appliance_id!r}."}
+    if args.since:
+        stmt = stmt.where(PacketCapture.created_at >= args.since)
+    stmt = stmt.order_by(desc(PacketCapture.created_at)).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_row_summary(r) for r in rows]
+
+
+# ── count_packet_captures ──────────────────────────────────────────────
+
+
+class CountPacketCapturesArgs(BaseModel):
+    status: _PcapStatus | None = Field(default=None, description="Filter by run state.")
+    vantage_kind: Literal["server", "appliance"] | None = Field(default=None)
+
+
+@register_tool(
+    name="count_packet_captures",
+    module=_MODULE,
+    description="Count packet captures, optionally filtered by status and/or vantage.",
+    args_model=CountPacketCapturesArgs,
+    category="network",
+)
+async def count_packet_captures(
+    db: AsyncSession, user: User, args: CountPacketCapturesArgs
+) -> dict[str, Any]:
+    stmt = select(func.count()).select_from(PacketCapture)
+    if args.status:
+        stmt = stmt.where(PacketCapture.status == args.status)
+    if args.vantage_kind:
+        stmt = stmt.where(PacketCapture.vantage_kind == args.vantage_kind)
+    total = int((await db.execute(stmt)).scalar_one())
+    return {"count": total}
+
+
+# ── get_packet_capture ─────────────────────────────────────────────────
+
+
+class GetPacketCaptureArgs(BaseModel):
+    capture_id: str = Field(description="The capture UUID from find_packet_captures.")
+
+
+@register_tool(
+    name="get_packet_capture",
+    module=_MODULE,
+    description=(
+        "Return full metadata for one packet capture: vantage, "
+        "interface, BPF filter, caps, live byte/packet progress, the "
+        "stop-reason summary, and whether a downloadable .pcap exists. "
+        "Never returns the captured bytes — direct the operator to the "
+        "UI download for the actual .pcap."
+    ),
+    args_model=GetPacketCaptureArgs,
+    category="network",
+)
+async def get_packet_capture(
+    db: AsyncSession, user: User, args: GetPacketCaptureArgs
+) -> dict[str, Any]:
+    try:
+        cap_uuid = uuid.UUID(args.capture_id)
+    except ValueError:
+        return {"error": f"capture_id must be a UUID, got {args.capture_id!r}."}
+    row = await db.get(PacketCapture, cap_uuid)
+    if row is None:
+        return {"error": f"No packet capture with id {args.capture_id}."}
+    out = _row_summary(row)
+    out.update(
+        {
+            "snaplen": row.snaplen,
+            "promiscuous": row.promiscuous,
+            "max_packets": row.max_packets,
+            "max_duration_s": row.max_duration_s,
+            "max_bytes": row.max_bytes,
+            "command_line": row.command_line,
+            "pcap_sha256": row.pcap_sha256,
+            "metadata": row.metadata_json,
+        }
+    )
+    return out
+
+
+__all__ = ["find_packet_captures", "count_packet_captures", "get_packet_capture"]

--- a/backend/app/services/appliance/pcap_capture.py
+++ b/backend/app/services/appliance/pcap_capture.py
@@ -30,16 +30,15 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-import structlog
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.pcap import PacketCapture
 
-logger = structlog.get_logger(__name__)
 
-
-async def claim_next(db: AsyncSession, appliance_id: uuid.UUID) -> dict[str, Any] | None:
+async def claim_next(
+    db: AsyncSession, appliance_id: uuid.UUID
+) -> dict[str, Any] | None:
     """Atomically claim the oldest queued appliance-vantage capture.
 
     Returns a structured command dict (NEVER a shell string / pre-joined

--- a/backend/app/services/appliance/pcap_capture.py
+++ b/backend/app/services/appliance/pcap_capture.py
@@ -36,9 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.pcap import PacketCapture
 
 
-async def claim_next(
-    db: AsyncSession, appliance_id: uuid.UUID
-) -> dict[str, Any] | None:
+async def claim_next(db: AsyncSession, appliance_id: uuid.UUID) -> dict[str, Any] | None:
     """Atomically claim the oldest queued appliance-vantage capture.
 
     Returns a structured command dict (NEVER a shell string / pre-joined

--- a/backend/app/services/appliance/pcap_capture.py
+++ b/backend/app/services/appliance/pcap_capture.py
@@ -1,0 +1,157 @@
+"""Appliance-host packet-capture dispatch (#59 Phase 2).
+
+The appliance vantage runs tcpdump on the appliance **host** (real NICs),
+not in a container — so the capture rides the supervisor channel. Unlike
+:mod:`app.services.appliance.agent_cmd` (an in-memory per-replica queue
+for short request/response nettools), the authority here is the
+``packet_capture`` **DB row**: a minutes-long job that outlives any single
+poll and is replica-agnostic — *any* api replica can serve the
+supervisor's poll because the claim is a guarded UPDATE against the shared
+Postgres, not an in-memory queue (which would strand a capture enqueued on
+a different replica — the #430-class delivery gap we explicitly avoid).
+
+Flow:
+  * supervisor long-polls ``/supervisor/pcap/poll`` → :func:`claim_next`
+    atomically claims the oldest ``queued`` appliance-vantage row for the
+    caller's appliance and returns a structured command (never a shell
+    string);
+  * supervisor POSTs progress → :func:`record_progress` (returns the
+    cancel flag so the host runner can stop);
+  * supervisor streams the finished ``.pcap`` to ``/supervisor/pcap/upload``
+    → :func:`finalize_capture` stamps the terminal state.
+
+A backstop reaper (``app.tasks.pcap.prune_captures``) fails any row stuck
+non-terminal past its deadline, so a lost supervisor never freezes a row.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pcap import PacketCapture
+
+logger = structlog.get_logger(__name__)
+
+
+async def claim_next(db: AsyncSession, appliance_id: uuid.UUID) -> dict[str, Any] | None:
+    """Atomically claim the oldest queued appliance-vantage capture.
+
+    Returns a structured command dict (NEVER a shell string / pre-joined
+    argv — the supervisor + host runner rebuild the argv from these
+    validated fields) or ``None`` when nothing is queued. The guarded
+    UPDATE (``WHERE status='queued'``) makes the claim safe across
+    replicas: a second claimant's rowcount is 0 and it returns None.
+    """
+    row = (
+        await db.execute(
+            select(PacketCapture)
+            .where(
+                PacketCapture.status == "queued",
+                PacketCapture.vantage_kind == "appliance",
+                PacketCapture.appliance_id == appliance_id,
+            )
+            .order_by(PacketCapture.created_at)
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+
+    res = await db.execute(
+        update(PacketCapture)
+        .where(PacketCapture.id == row.id, PacketCapture.status == "queued")
+        .values(status="running", started_at=datetime.now(UTC))
+    )
+    if (res.rowcount or 0) == 0:
+        # Lost the race to another replica's poll — leave it for them.
+        await db.rollback()
+        return None
+    await db.commit()
+    return {
+        "capture_id": str(row.id),
+        "interface": row.interface,
+        "bpf_filter": row.bpf_filter,
+        "snaplen": row.snaplen,
+        "promiscuous": row.promiscuous,
+        "max_packets": row.max_packets,
+        "max_duration_s": row.max_duration_s,
+        "max_bytes": row.max_bytes,
+    }
+
+
+async def record_progress(
+    db: AsyncSession,
+    capture_id: uuid.UUID,
+    *,
+    packets: int | None,
+    bytes_captured: int | None,
+    elapsed_s: float | None,
+) -> bool:
+    """Update live progress; return True when the operator has cancelled.
+
+    The cancel flag rides the progress response so the host runner stops
+    on its next tick (backstopped by its own hard wall-clock kill)."""
+    row = await db.get(PacketCapture, capture_id)
+    if row is None:
+        return True  # gone → tell the runner to stop
+    if row.status == "cancelled":
+        return True
+    if bytes_captured is not None:
+        row.bytes_captured = bytes_captured
+    if packets is not None:
+        row.packets_captured = packets
+    if elapsed_s is not None:
+        row.duration_seconds = elapsed_s
+    await db.commit()
+    return False
+
+
+async def finalize_capture(
+    db: AsyncSession,
+    capture_id: uuid.UUID,
+    *,
+    pcap_path: str | None,
+    pcap_size_bytes: int | None,
+    pcap_sha256: str | None,
+    packet_count: int | None,
+    metadata: dict[str, Any] | None,
+    error: str | None,
+) -> str:
+    """Stamp the terminal state after the supervisor finishes.
+
+    Returns the final status. Cancel is terminal + idempotent: if the row
+    was cancelled while the capture was finishing, the uploaded bytes are
+    discarded by the caller and the row stays ``cancelled`` (a
+    late-completing capture never overwrites a cancel)."""
+    row = await db.get(PacketCapture, capture_id)
+    if row is None:
+        return "missing"
+    row.finished_at = datetime.now(UTC)
+    if row.status == "cancelled":
+        # Caller unlinks the bytes; cancel wins.
+        return "cancelled"
+    if error:
+        row.status = "failed"
+        row.error_message = error[:500]
+        await db.commit()
+        return "failed"
+    row.status = "completed"
+    row.pcap_path = pcap_path
+    row.pcap_size_bytes = pcap_size_bytes
+    row.pcap_sha256 = pcap_sha256
+    if packet_count is not None:
+        row.packets_captured = packet_count
+    if pcap_size_bytes is not None:
+        row.bytes_captured = pcap_size_bytes
+    row.metadata_json = metadata
+    await db.commit()
+    return "completed"
+
+
+__all__ = ["claim_next", "record_progress", "finalize_capture"]

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -162,6 +162,17 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
             "Permission-gated + rate-limited."
         ),
     ),
+    ModuleSpec(
+        id="tools.pcap",
+        label="Packet capture",
+        group="Tools",
+        description=(
+            "On-demand tcpdump capture from the control-plane (or appliance "
+            "host) vantage — BPF filter + presets, live progress, downloadable "
+            ".pcap, history with auto-retention. Captures raw traffic; high "
+            "sensitivity (gated by the manage_packet_capture permission)."
+        ),
+    ),
     # DNS — togglable extras under the Settings → Import surface and
     # the DNS sidebar group. The importer is one-shot (issue #128) —
     # operators upload BIND9 configs / live-pull from Windows DNS or

--- a/backend/app/services/pcap/__init__.py
+++ b/backend/app/services/pcap/__init__.py
@@ -1,0 +1,45 @@
+"""Packet-capture service package (issue #59).
+
+Re-exports the runner's validators + builder + driver so callers import
+from ``app.services.pcap`` directly (mirrors ``app.services.nmap``).
+"""
+
+from __future__ import annotations
+
+from app.services.pcap.runner import (
+    DEFAULT_BYTES,
+    DEFAULT_DURATION_S,
+    DEFAULT_PACKETS,
+    DEFAULT_SNAPLEN,
+    HARD_MAX_BYTES,
+    HARD_MAX_DURATION_S,
+    HARD_MAX_PACKETS,
+    MAX_SNAPLEN,
+    PcapArgError,
+    build_pcap_argv,
+    clamp_caps,
+    enumerate_interfaces,
+    pcap_dir,
+    run_pcap,
+    validate_bpf_filter,
+    validate_interface,
+)
+
+__all__ = [
+    "DEFAULT_BYTES",
+    "DEFAULT_DURATION_S",
+    "DEFAULT_PACKETS",
+    "DEFAULT_SNAPLEN",
+    "HARD_MAX_BYTES",
+    "HARD_MAX_DURATION_S",
+    "HARD_MAX_PACKETS",
+    "MAX_SNAPLEN",
+    "PcapArgError",
+    "build_pcap_argv",
+    "clamp_caps",
+    "enumerate_interfaces",
+    "pcap_dir",
+    "run_pcap",
+    "validate_bpf_filter",
+    "validate_interface",
+]

--- a/backend/app/services/pcap/runner.py
+++ b/backend/app/services/pcap/runner.py
@@ -185,10 +185,17 @@ def clamp_caps(
     """
     if max_packets is None and max_duration_s is None and max_bytes is None:
         raise PcapArgError(
-            "at least one stop condition is required " "(max_packets, max_duration_s, or max_bytes)"
+            "at least one stop condition is required "
+            "(max_packets, max_duration_s, or max_bytes)"
         )
-    mp = None if max_packets is None else max(1, min(int(max_packets), HARD_MAX_PACKETS))
-    md = None if max_duration_s is None else max(1, min(int(max_duration_s), HARD_MAX_DURATION_S))
+    mp = (
+        None if max_packets is None else max(1, min(int(max_packets), HARD_MAX_PACKETS))
+    )
+    md = (
+        None
+        if max_duration_s is None
+        else max(1, min(int(max_duration_s), HARD_MAX_DURATION_S))
+    )
     mb = None if max_bytes is None else max(1, min(int(max_bytes), HARD_MAX_BYTES))
     sl = DEFAULT_SNAPLEN if snaplen is None else max(0, min(int(snaplen), MAX_SNAPLEN))
     return mp, md, mb, sl
@@ -301,7 +308,9 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
                 cap.error_message = str(exc)
                 cap.finished_at = datetime.now(UTC)
                 await db.commit()
-                logger.warning("pcap_argv_invalid", capture_id=str(capture_id), error=str(exc))
+                logger.warning(
+                    "pcap_argv_invalid", capture_id=str(capture_id), error=str(exc)
+                )
                 return
 
             cap.status = "running"
@@ -318,7 +327,9 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
                 )
             except FileNotFoundError:
                 cap.status = "failed"
-                cap.error_message = "tcpdump binary not found. Install tcpdump in the worker image."
+                cap.error_message = (
+                    "tcpdump binary not found. Install tcpdump in the worker image."
+                )
                 cap.finished_at = datetime.now(UTC)
                 await db.commit()
                 logger.error("pcap_binary_missing", capture_id=str(capture_id))
@@ -345,6 +356,9 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
                         await asyncio.wait_for(proc.wait(), timeout=_POLL_INTERVAL_S)
                         break  # tcpdump exited on its own (count cap / error)
                     except TimeoutError:
+                        # Expected: the poll tick elapsed and tcpdump is
+                        # still running — fall through to the progress /
+                        # cancel / cap checks below, then loop.
                         pass
 
                     # Progress: honest byte count from the growing file.
@@ -385,7 +399,9 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
             stderr_text = ""
             if proc.stderr is not None:
                 with contextlib.suppress(Exception):
-                    stderr_text = (await proc.stderr.read()).decode("utf-8", errors="replace")
+                    stderr_text = (await proc.stderr.read()).decode(
+                        "utf-8", errors="replace"
+                    )
 
             cap_row = await db.get(PacketCapture, capture_id)
             if cap_row is None:
@@ -401,7 +417,9 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
             if packet_count is not None:
                 cap_row.packets_captured = packet_count
 
-            truncated = bool(hit_byte_cap or timed_out or (mp is not None and packet_count == mp))
+            truncated = bool(
+                hit_byte_cap or timed_out or (mp is not None and packet_count == mp)
+            )
 
             if file_size > 0:
                 cap_row.pcap_path = str(out_path)
@@ -440,7 +458,8 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
             else:
                 cap_row.status = "failed"
                 cap_row.error_message = (
-                    stderr_text.strip()[-500:] or f"tcpdump exited with code {proc.returncode}"
+                    stderr_text.strip()[-500:]
+                    or f"tcpdump exited with code {proc.returncode}"
                 )
 
             await db.commit()

--- a/backend/app/services/pcap/runner.py
+++ b/backend/app/services/pcap/runner.py
@@ -1,0 +1,462 @@
+"""Async packet-capture (tcpdump) runner — issue #59.
+
+Owns the tcpdump subprocess lifecycle for the **server vantage** (the
+control-plane worker container). Mirrors :mod:`app.services.nmap.runner`:
+it does not own the Celery wrapper (:mod:`app.tasks.pcap`) nor the HTTP
+surface (:mod:`app.api.v1.pcap`).
+
+Security model (the headline control is the BPF filter):
+
+* The argv is built as a Python list and spawned with
+  ``create_subprocess_exec`` — **never** a shell, **never**
+  ``shlex.split`` on operator input. The BPF expression is appended as a
+  single trailing argv element; tcpdump parses it internally as BPF with
+  zero shell involvement. A charset allowlist is a secondary sanity bound
+  (the single-argv-element passing is the primary defense). The exact
+  same ``validate_bpf_filter`` / ``validate_interface`` run again on the
+  Phase-2 host runner (defence-in-depth — never trust the control plane
+  as the sole validator).
+* tcpdump runs non-root with ``cap_net_raw`` granted via ``setcap`` on
+  the binary in the image. Non-promiscuous by default so ``cap_net_raw``
+  alone suffices (no ``cap_net_admin``).
+* Hard caps (duration / packets / bytes) are clamped here AND re-enforced
+  at the runner, so a tampered row can't run unbounded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import os
+import re
+import signal
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.config import settings
+from app.models.pcap import PacketCapture
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Hard limits + defaults ──────────────────────────────────────────────
+# Hard maxima are constants (never operator-raisable beyond these); the
+# per-deployment defaults live in PlatformSettings and the API clamps a
+# request to min(requested, hard-max).
+HARD_MAX_DURATION_S = 1800  # 30 min
+HARD_MAX_PACKETS = 1_000_000
+HARD_MAX_BYTES = 100 * 1024 * 1024  # 100 MiB
+
+DEFAULT_DURATION_S = 60
+DEFAULT_PACKETS = 10_000
+DEFAULT_BYTES = 50 * 1024 * 1024  # 50 MiB
+DEFAULT_SNAPLEN = 256  # headers-only; full payload is an explicit opt-in
+MAX_SNAPLEN = 65535
+
+# Canonical BPF charset — shared byte-identically with the Phase-2 host
+# runner. Admits real BPF (byte-offset + bitmask idioms like
+# ``tcp[tcpflags] & tcp-syn != 0``, ``ip[6:2] & 0x1fff != 0``,
+# ``vlan 100 and host 10.0.0.1``) while excluding shell metacharacters
+# (`; $ \` newline { } ' "`). The parens/brackets it admits are safe
+# because the filter is a single non-shell argv element.
+_BPF_RE = re.compile(r"^[A-Za-z0-9_ .:\[\]()/&|!=<>+*x-]{0,1024}$")
+
+# Interface name: Linux IFNAMSIZ is 16, but VLAN/bridge names + the
+# special "any" go a little longer; bound generously, charset-tight.
+_IFACE_RE = re.compile(r"^[A-Za-z0-9_.:@-]{1,64}$")
+
+# pcap progress / cancel poll cadence.
+_POLL_INTERVAL_S = 1.0
+# Grace between SIGTERM (lets tcpdump flush the savefile) and SIGKILL.
+_TERM_GRACE_S = 3.0
+
+
+class PcapArgError(ValueError):
+    """Raised when capture parameters fail validation."""
+
+
+def pcap_dir() -> Path:
+    """The on-disk home for ``.pcap`` artifacts (mode 0700, auto-created)."""
+    d = Path(os.environ.get("SPATIUM_PCAP_DIR", "/var/lib/spatiumddi/pcaps"))
+    d.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        d.chmod(0o700)
+    return d
+
+
+# ── Validation ──────────────────────────────────────────────────────────
+
+
+def enumerate_interfaces() -> list[str]:
+    """List capturable interfaces visible to THIS process (server vantage).
+
+    Read from ``/proc/net/dev`` — the names the worker container can
+    actually bind tcpdump to. NOTE for the UI: in a container this is the
+    pod/bridge network, NOT the host's physical NICs. ``any`` is always
+    offered as the first option (tcpdump's all-interfaces pseudo-device).
+    """
+    names: list[str] = ["any"]
+    try:
+        content = Path("/proc/net/dev").read_text()
+    except OSError:
+        return names
+    for line in content.splitlines()[2:]:  # skip the two header rows
+        head, _, _ = line.partition(":")
+        name = head.strip()
+        if name and name != "lo":
+            names.append(name)
+    return names
+
+
+def validate_interface(iface: str | None, *, available: list[str] | None = None) -> str:
+    """Validate the requested interface against the vantage's real NICs.
+
+    Charset-tight + membership-checked (422 on an unknown name) so the
+    operator can't smuggle an argv token through the interface field and
+    can't capture on a non-existent device. Defaults to ``any`` when
+    unset, but the API encourages a specific NIC.
+    """
+    if iface is None or not iface.strip():
+        return "any"
+    iface = iface.strip()
+    if not _IFACE_RE.match(iface):
+        raise PcapArgError(f"interface name has invalid characters: {iface!r}")
+    avail = available if available is not None else enumerate_interfaces()
+    if iface not in avail:
+        raise PcapArgError(
+            f"interface {iface!r} is not one of the available interfaces on this vantage"
+        )
+    return iface
+
+
+def validate_bpf_filter(bpf: str | None) -> str | None:
+    """Validate a BPF expression. Returns the trimmed filter or None.
+
+    This is an *argv-injection* sanity bound, not a target-authorization
+    control — it deliberately admits ``host 10.0.0.1`` / ``port 53``. The
+    real safety is that the result is passed as tcpdump's single trailing
+    argv element, never through a shell.
+    """
+    if bpf is None:
+        return None
+    bpf = bpf.strip()
+    if not bpf:
+        return None
+    if not _BPF_RE.match(bpf):
+        raise PcapArgError(
+            "BPF filter contains characters that aren't valid in a capture "
+            "expression (shell metacharacters are rejected)"
+        )
+    return bpf
+
+
+def clamp_caps(
+    *,
+    max_packets: int | None,
+    max_duration_s: int | None,
+    max_bytes: int | None,
+    snaplen: int | None,
+) -> tuple[int | None, int | None, int | None, int]:
+    """Clamp stop-conditions to the hard maxima; require at least one.
+
+    Returns ``(max_packets, max_duration_s, max_bytes, snaplen)``. An
+    unbounded capture (no packet / duration / byte ceiling) is rejected —
+    it's a resource leak.
+    """
+    if max_packets is None and max_duration_s is None and max_bytes is None:
+        raise PcapArgError(
+            "at least one stop condition is required " "(max_packets, max_duration_s, or max_bytes)"
+        )
+    mp = None if max_packets is None else max(1, min(int(max_packets), HARD_MAX_PACKETS))
+    md = None if max_duration_s is None else max(1, min(int(max_duration_s), HARD_MAX_DURATION_S))
+    mb = None if max_bytes is None else max(1, min(int(max_bytes), HARD_MAX_BYTES))
+    sl = DEFAULT_SNAPLEN if snaplen is None else max(0, min(int(snaplen), MAX_SNAPLEN))
+    return mp, md, mb, sl
+
+
+def build_pcap_argv(
+    *,
+    interface: str,
+    bpf_filter: str | None,
+    snaplen: int,
+    promiscuous: bool,
+    max_packets: int | None,
+    output_path: str,
+) -> list[str]:
+    """Assemble the tcpdump argv for a write-to-file capture.
+
+    ``-U`` (packet-buffered) so the savefile grows promptly for the
+    fstat-based progress poll. ``-p`` disables promiscuous mode (tcpdump's
+    default is promiscuous; we opt OUT unless requested). The validated
+    BPF filter, if any, is the single trailing element.
+    """
+    argv = [
+        "tcpdump",
+        "-n",  # no name resolution (no side DNS, faster)
+        "-U",  # packet-buffered writes → live byte progress
+        "-i",
+        interface,
+        "-s",
+        str(snaplen),
+        "-w",
+        output_path,
+    ]
+    if not promiscuous:
+        argv.append("-p")
+    if max_packets is not None:
+        argv.extend(["-c", str(max_packets)])
+    if bpf_filter:
+        # SINGLE trailing argv element — tcpdump parses it as BPF. Never
+        # shlex.split, never shell.
+        argv.append(bpf_filter)
+    return argv
+
+
+# ── Runner ───────────────────────────────────────────────────────────────
+
+
+def _new_engine_factory() -> tuple[Any, async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(settings.database_url, future=True)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    return engine, factory
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+_PKT_RE = re.compile(r"(\d+)\s+packets?\s+captured", re.IGNORECASE)
+
+
+def _parse_packet_count(stderr_text: str) -> int | None:
+    """tcpdump prints ``N packets captured`` to stderr at exit."""
+    m = _PKT_RE.search(stderr_text or "")
+    return int(m.group(1)) if m else None
+
+
+async def run_pcap(capture_id: uuid.UUID) -> None:
+    """Drive one server-vantage capture to completion.
+
+    Marks the row ``running``, spawns tcpdump writing to a ``.pcap`` under
+    ``pcap_dir()``, polls the growing file for ``bytes_captured`` + the
+    operator-cancel flag every ~1 s, enforces the duration + byte ceilings
+    with a wall-clock kill, then on exit stamps size + sha256 + packet
+    count + terminal status. Owns its own engine/session (Celery body via
+    ``asyncio.run``).
+    """
+    engine, factory = _new_engine_factory()
+    out_path = pcap_dir() / f"{capture_id}.pcap"
+    try:
+        async with factory() as db:
+            cap = await db.get(PacketCapture, capture_id)
+            if cap is None:
+                logger.warning("pcap_run_missing", capture_id=str(capture_id))
+                return
+            if cap.status == "cancelled":
+                return
+
+            try:
+                interface = validate_interface(cap.interface)
+                bpf = validate_bpf_filter(cap.bpf_filter)
+                mp, md, mb, sl = clamp_caps(
+                    max_packets=cap.max_packets,
+                    max_duration_s=cap.max_duration_s,
+                    max_bytes=cap.max_bytes,
+                    snaplen=cap.snaplen,
+                )
+                argv = build_pcap_argv(
+                    interface=interface,
+                    bpf_filter=bpf,
+                    snaplen=sl,
+                    promiscuous=cap.promiscuous,
+                    max_packets=mp,
+                    output_path=str(out_path),
+                )
+            except PcapArgError as exc:
+                cap.status = "failed"
+                cap.error_message = str(exc)
+                cap.finished_at = datetime.now(UTC)
+                await db.commit()
+                logger.warning("pcap_argv_invalid", capture_id=str(capture_id), error=str(exc))
+                return
+
+            cap.status = "running"
+            cap.started_at = datetime.now(UTC)
+            cap.command_line = " ".join(argv)
+            await db.commit()
+            logger.info("pcap_starting", capture_id=str(capture_id), argv=argv)
+
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            except FileNotFoundError:
+                cap.status = "failed"
+                cap.error_message = "tcpdump binary not found. Install tcpdump in the worker image."
+                cap.finished_at = datetime.now(UTC)
+                await db.commit()
+                logger.error("pcap_binary_missing", capture_id=str(capture_id))
+                return
+            except Exception as exc:  # noqa: BLE001 — surface to operator
+                cap.status = "failed"
+                cap.error_message = f"failed to spawn tcpdump: {exc}"
+                cap.finished_at = datetime.now(UTC)
+                await db.commit()
+                logger.exception("pcap_spawn_failed", capture_id=str(capture_id))
+                return
+
+            cap.tcpdump_pid = proc.pid
+            await db.commit()
+
+            started = time.monotonic()
+            cancelled = False
+            hit_byte_cap = False
+            timed_out = False
+
+            try:
+                while True:
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=_POLL_INTERVAL_S)
+                        break  # tcpdump exited on its own (count cap / error)
+                    except TimeoutError:
+                        pass
+
+                    # Progress: honest byte count from the growing file.
+                    size = out_path.stat().st_size if out_path.exists() else 0
+                    elapsed = time.monotonic() - started
+
+                    refreshed = await db.get(PacketCapture, capture_id)
+                    if refreshed is None:
+                        with contextlib.suppress(ProcessLookupError):
+                            proc.terminate()
+                        return
+                    refreshed.bytes_captured = size
+                    refreshed.duration_seconds = elapsed
+                    await db.commit()
+
+                    if refreshed.status == "cancelled":
+                        cancelled = True
+                        break
+                    if mb is not None and size >= mb:
+                        hit_byte_cap = True
+                        break
+                    if md is not None and elapsed >= md:
+                        timed_out = True
+                        break
+            finally:
+                if proc.returncode is None:
+                    # SIGTERM lets tcpdump flush + close the savefile; then
+                    # SIGKILL as a backstop.
+                    with contextlib.suppress(ProcessLookupError):
+                        proc.send_signal(signal.SIGTERM)
+                    with contextlib.suppress(TimeoutError, asyncio.TimeoutError):
+                        await asyncio.wait_for(proc.wait(), timeout=_TERM_GRACE_S)
+                    if proc.returncode is None:
+                        with contextlib.suppress(ProcessLookupError):
+                            proc.kill()
+                        await proc.wait()
+
+            stderr_text = ""
+            if proc.stderr is not None:
+                with contextlib.suppress(Exception):
+                    stderr_text = (await proc.stderr.read()).decode("utf-8", errors="replace")
+
+            cap_row = await db.get(PacketCapture, capture_id)
+            if cap_row is None:
+                return
+            cap_row.tcpdump_pid = None
+            cap_row.exit_code = proc.returncode
+            cap_row.finished_at = datetime.now(UTC)
+            cap_row.duration_seconds = time.monotonic() - started
+
+            file_size = out_path.stat().st_size if out_path.exists() else 0
+            cap_row.bytes_captured = file_size
+            packet_count = _parse_packet_count(stderr_text)
+            if packet_count is not None:
+                cap_row.packets_captured = packet_count
+
+            truncated = bool(hit_byte_cap or timed_out or (mp is not None and packet_count == mp))
+
+            if file_size > 0:
+                cap_row.pcap_path = str(out_path)
+                cap_row.pcap_size_bytes = file_size
+                with contextlib.suppress(OSError):
+                    cap_row.pcap_sha256 = _sha256_file(out_path)
+            cap_row.metadata_json = {
+                "packet_count": packet_count,
+                "byte_count": file_size,
+                "truncated": truncated,
+                "stop_reason": (
+                    "cancelled"
+                    if cancelled
+                    else (
+                        "max_bytes"
+                        if hit_byte_cap
+                        else (
+                            "max_duration"
+                            if timed_out
+                            else (
+                                "max_packets"
+                                if (mp is not None and packet_count == mp)
+                                else "completed"
+                            )
+                        )
+                    )
+                ),
+            }
+
+            if cancelled:
+                cap_row.status = "cancelled"
+            elif proc.returncode in (0, None) or hit_byte_cap or timed_out:
+                # A SIGTERM kill returns non-zero but the savefile is valid;
+                # treat a clean stop-condition exit as completed.
+                cap_row.status = "completed"
+            else:
+                cap_row.status = "failed"
+                cap_row.error_message = (
+                    stderr_text.strip()[-500:] or f"tcpdump exited with code {proc.returncode}"
+                )
+
+            await db.commit()
+            logger.info(
+                "pcap_finished",
+                capture_id=str(capture_id),
+                status=cap_row.status,
+                bytes=file_size,
+                packets=packet_count,
+            )
+    finally:
+        await engine.dispose()
+
+
+__all__ = [
+    "DEFAULT_BYTES",
+    "DEFAULT_DURATION_S",
+    "DEFAULT_PACKETS",
+    "DEFAULT_SNAPLEN",
+    "HARD_MAX_BYTES",
+    "HARD_MAX_DURATION_S",
+    "HARD_MAX_PACKETS",
+    "MAX_SNAPLEN",
+    "PcapArgError",
+    "build_pcap_argv",
+    "clamp_caps",
+    "enumerate_interfaces",
+    "pcap_dir",
+    "run_pcap",
+    "validate_bpf_filter",
+    "validate_interface",
+]

--- a/backend/app/services/pcap/runner.py
+++ b/backend/app/services/pcap/runner.py
@@ -115,19 +115,32 @@ def enumerate_interfaces() -> list[str]:
     return names
 
 
-def validate_interface(iface: str | None, *, available: list[str] | None = None) -> str:
+def validate_interface(
+    iface: str | None,
+    *,
+    available: list[str] | None = None,
+    require_available: bool = True,
+) -> str:
     """Validate the requested interface against the vantage's real NICs.
 
     Charset-tight + membership-checked (422 on an unknown name) so the
     operator can't smuggle an argv token through the interface field and
     can't capture on a non-existent device. Defaults to ``any`` when
     unset, but the API encourages a specific NIC.
+
+    ``require_available=False`` skips the membership check (charset only) —
+    used for the appliance-host vantage, where the control plane can't
+    enumerate the host's NICs; the host runner does the real membership
+    check in the host net namespace and fails the capture cleanly on an
+    unknown interface.
     """
     if iface is None or not iface.strip():
         return "any"
     iface = iface.strip()
     if not _IFACE_RE.match(iface):
         raise PcapArgError(f"interface name has invalid characters: {iface!r}")
+    if not require_available:
+        return iface
     avail = available if available is not None else enumerate_interfaces()
     if iface not in avail:
         raise PcapArgError(

--- a/backend/app/services/pcap/runner.py
+++ b/backend/app/services/pcap/runner.py
@@ -185,17 +185,10 @@ def clamp_caps(
     """
     if max_packets is None and max_duration_s is None and max_bytes is None:
         raise PcapArgError(
-            "at least one stop condition is required "
-            "(max_packets, max_duration_s, or max_bytes)"
+            "at least one stop condition is required " "(max_packets, max_duration_s, or max_bytes)"
         )
-    mp = (
-        None if max_packets is None else max(1, min(int(max_packets), HARD_MAX_PACKETS))
-    )
-    md = (
-        None
-        if max_duration_s is None
-        else max(1, min(int(max_duration_s), HARD_MAX_DURATION_S))
-    )
+    mp = None if max_packets is None else max(1, min(int(max_packets), HARD_MAX_PACKETS))
+    md = None if max_duration_s is None else max(1, min(int(max_duration_s), HARD_MAX_DURATION_S))
     mb = None if max_bytes is None else max(1, min(int(max_bytes), HARD_MAX_BYTES))
     sl = DEFAULT_SNAPLEN if snaplen is None else max(0, min(int(snaplen), MAX_SNAPLEN))
     return mp, md, mb, sl
@@ -308,9 +301,7 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
                 cap.error_message = str(exc)
                 cap.finished_at = datetime.now(UTC)
                 await db.commit()
-                logger.warning(
-                    "pcap_argv_invalid", capture_id=str(capture_id), error=str(exc)
-                )
+                logger.warning("pcap_argv_invalid", capture_id=str(capture_id), error=str(exc))
                 return
 
             cap.status = "running"
@@ -327,9 +318,7 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
                 )
             except FileNotFoundError:
                 cap.status = "failed"
-                cap.error_message = (
-                    "tcpdump binary not found. Install tcpdump in the worker image."
-                )
+                cap.error_message = "tcpdump binary not found. Install tcpdump in the worker image."
                 cap.finished_at = datetime.now(UTC)
                 await db.commit()
                 logger.error("pcap_binary_missing", capture_id=str(capture_id))
@@ -399,9 +388,7 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
             stderr_text = ""
             if proc.stderr is not None:
                 with contextlib.suppress(Exception):
-                    stderr_text = (await proc.stderr.read()).decode(
-                        "utf-8", errors="replace"
-                    )
+                    stderr_text = (await proc.stderr.read()).decode("utf-8", errors="replace")
 
             cap_row = await db.get(PacketCapture, capture_id)
             if cap_row is None:
@@ -417,9 +404,7 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
             if packet_count is not None:
                 cap_row.packets_captured = packet_count
 
-            truncated = bool(
-                hit_byte_cap or timed_out or (mp is not None and packet_count == mp)
-            )
+            truncated = bool(hit_byte_cap or timed_out or (mp is not None and packet_count == mp))
 
             if file_size > 0:
                 cap_row.pcap_path = str(out_path)
@@ -458,8 +443,7 @@ async def run_pcap(capture_id: uuid.UUID) -> None:
             else:
                 cap_row.status = "failed"
                 cap_row.error_message = (
-                    stderr_text.strip()[-500:]
-                    or f"tcpdump exited with code {proc.returncode}"
+                    stderr_text.strip()[-500:] or f"tcpdump exited with code {proc.returncode}"
                 )
 
             await db.commit()

--- a/backend/app/tasks/pcap.py
+++ b/backend/app/tasks/pcap.py
@@ -1,0 +1,140 @@
+"""Celery wrappers for packet capture (issue #59).
+
+Two tasks:
+
+* ``run_capture_task`` — drives one server-vantage capture via the
+  runner. Explicitly NOT retried (``max_retries=0``): the operator
+  triggers a capture, and silently replaying it on a worker crash would
+  re-tap traffic without consent (mirrors nmap).
+* ``prune_captures`` — nightly retention sweep. pcaps are large +
+  sensitive (plaintext creds/PII), so terminal rows older than
+  ``PlatformSettings.pcap_retention_days`` are hard-deleted AND their
+  ``.pcap`` files unlinked. Also reaps rows stuck in a non-terminal
+  state past their deadline (worker crash / lost dispatch) so the
+  operator never stares at a frozen row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.celery_app import celery_app
+from app.db import task_session
+from app.models.pcap import PacketCapture
+from app.models.settings import PlatformSettings
+from app.services.pcap.runner import HARD_MAX_DURATION_S, run_pcap
+
+logger = structlog.get_logger(__name__)
+
+# Default retention if PlatformSettings has no value. pcaps are triage,
+# not analytics — short window, same argument as the 24 h query-log window.
+DEFAULT_RETENTION_DAYS = 7
+# A non-terminal row older than (its deadline + this margin) with no
+# progress is presumed dead (worker crash / lost dispatch) and reaped.
+_STUCK_MARGIN_S = 120
+
+
+@celery_app.task(name="app.tasks.pcap.run_capture", bind=True, max_retries=0)
+def run_capture_task(self: Any, capture_id_str: str) -> dict[str, str]:  # noqa: ARG001
+    """Drive one server-vantage packet capture from start to finish."""
+    capture_id = uuid.UUID(capture_id_str)
+    logger.info("pcap_run_task_started", capture_id=capture_id_str)
+    asyncio.run(run_pcap(capture_id))
+    return {"capture_id": capture_id_str}
+
+
+async def _prune_with_session(db: AsyncSession) -> dict[str, int]:
+    settings_row = (await db.execute(select(PlatformSettings).limit(1))).scalar_one_or_none()
+    retention_days = DEFAULT_RETENTION_DAYS
+    if settings_row is not None:
+        retention_days = int(
+            getattr(settings_row, "pcap_retention_days", DEFAULT_RETENTION_DAYS)
+            or DEFAULT_RETENTION_DAYS
+        )
+
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(days=retention_days)
+    removed = 0
+    files_unlinked = 0
+    reaped = 0
+
+    # 1) Retention: hard-delete terminal rows past the cutoff + unlink files.
+    terminal = ("completed", "failed", "cancelled")
+    old_rows = list(
+        (
+            await db.execute(
+                select(PacketCapture).where(
+                    PacketCapture.status.in_(terminal),
+                    PacketCapture.created_at < cutoff,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in old_rows:
+        if row.pcap_path:
+            with contextlib.suppress(OSError):
+                Path(row.pcap_path).unlink()
+                files_unlinked += 1
+        await db.delete(row)
+        removed += 1
+
+    # 2) Reap rows stuck in queued/running past their deadline.
+    stuck_rows = list(
+        (
+            await db.execute(
+                select(PacketCapture).where(PacketCapture.status.in_(("queued", "running")))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in stuck_rows:
+        deadline_s = (row.max_duration_s or HARD_MAX_DURATION_S) + _STUCK_MARGIN_S
+        anchor = row.started_at or row.created_at
+        if anchor is None:
+            continue
+        if anchor.tzinfo is None:
+            anchor = anchor.replace(tzinfo=UTC)
+        if (now - anchor).total_seconds() > deadline_s:
+            row.status = "failed"
+            row.error_message = row.error_message or "capture reaped — no progress past deadline"
+            if row.finished_at is None:
+                row.finished_at = now
+            reaped += 1
+
+    await db.commit()
+    return {
+        "removed": removed,
+        "files_unlinked": files_unlinked,
+        "reaped": reaped,
+        "retention_days": retention_days,
+    }
+
+
+async def _prune() -> dict[str, int]:
+    async with task_session() as db:
+        return await _prune_with_session(db)
+
+
+@celery_app.task(
+    name="app.tasks.pcap.prune_captures",
+    bind=True,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_kwargs={"max_retries": 3},
+)
+def prune_captures(self: Any) -> dict[str, int]:  # noqa: ARG001
+    result = asyncio.run(_prune())
+    logger.info("pcap_captures_pruned", **result)
+    return result

--- a/backend/tests/test_pcap_api.py
+++ b/backend/tests/test_pcap_api.py
@@ -305,3 +305,12 @@ async def test_permission_granted_with_perm(client: AsyncClient, db_session: Asy
     await db_session.commit()
     r = await client.get("/api/v1/pcap/captures", headers=_hdr(token))
     assert r.status_code == 200
+
+
+def test_tools_pcap_in_demo_restricted_modules() -> None:
+    # DEMO_MODE forces tools.pcap off at startup; the runtime 404 path is
+    # covered by test_module_disabled_404. This pins the membership so the
+    # demo can't become a free packet-capture launchpad.
+    from app.core.demo_mode import DEMO_RESTRICTED_MODULES
+
+    assert "tools.pcap" in DEMO_RESTRICTED_MODULES

--- a/backend/tests/test_pcap_api.py
+++ b/backend/tests/test_pcap_api.py
@@ -1,0 +1,307 @@
+"""#59 — packet-capture HTTP API tests (server vantage, Phase 1).
+
+No tcpdump is spawned — the Celery dispatch is patched, so we verify the
+router contract: create persists a queued row + audits, the appliance
+vantage is rejected (Phase 2), list/get/cancel/bulk-delete work, the
+download endpoint guards return 404 (never 500) when the artifact is
+absent, the module gate 404s when disabled, and the permission gate 403s.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import Group, Role, User
+from app.models.feature_module import FeatureModule
+from app.models.pcap import PacketCapture
+from app.services import feature_modules
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_cache() -> None:
+    feature_modules.invalidate_cache()
+    yield
+    feature_modules.invalidate_cache()
+
+
+async def _superadmin(db: AsyncSession) -> tuple[User, str]:
+    u = User(
+        username=f"admin-{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(u)
+    await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+async def _user_with_perm(db: AsyncSession, perm: dict | None) -> tuple[User, str]:
+    u = User(
+        username=f"user-{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="User",
+        hashed_password=hash_password("x"),
+        is_superadmin=False,
+    )
+    db.add(u)
+    await db.flush()
+    if perm is not None:
+        role = Role(name=f"r-{uuid.uuid4().hex[:6]}", description="", permissions=[perm])
+        db.add(role)
+        await db.flush()
+        group = Group(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+        group.roles = [role]
+        group.users = [u]
+        db.add(group)
+        await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+def _hdr(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _make_capture(
+    db: AsyncSession, *, status: str = "completed", **kw: object
+) -> PacketCapture:
+    cap = PacketCapture(
+        vantage_kind="server",
+        vantage_label="control plane",
+        interface="any",
+        status=status,
+        **kw,  # type: ignore[arg-type]
+    )
+    db.add(cap)
+    await db.flush()
+    return cap
+
+
+# ── create ───────────────────────────────────────────────────────────
+
+
+async def test_create_server_capture_queues_and_audits(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _superadmin(db_session)
+    with patch("app.tasks.pcap.run_capture_task.delay") as delay:
+        r = await client.post(
+            "/api/v1/pcap/captures",
+            json={"interface": "any", "bpf_filter": "port 53", "max_duration_s": 30},
+            headers=_hdr(token),
+        )
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["status"] == "queued"
+    assert body["vantage_kind"] == "server"
+    assert body["bpf_filter"] == "port 53"
+    delay.assert_called_once()
+
+    # audit row written
+    rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(AuditLog.resource_type == "packet_capture")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert any(a.action == "create" for a in rows)
+
+
+async def test_create_appliance_vantage_rejected_phase1(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _superadmin(db_session)
+    r = await client.post(
+        "/api/v1/pcap/captures",
+        json={"vantage_kind": "appliance", "max_duration_s": 30},
+        headers=_hdr(token),
+    )
+    assert r.status_code == 422
+    assert "appliance" in r.json()["detail"].lower()
+
+
+async def test_create_rejects_no_stop_condition(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _superadmin(db_session)
+    r = await client.post(
+        "/api/v1/pcap/captures",
+        json={
+            "interface": "any",
+            "max_duration_s": None,
+            "max_packets": None,
+            "max_bytes": None,
+        },
+        headers=_hdr(token),
+    )
+    assert r.status_code == 422
+
+
+async def test_create_rejects_bad_bpf(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _superadmin(db_session)
+    r = await client.post(
+        "/api/v1/pcap/captures",
+        json={"bpf_filter": "port 80; rm -rf /", "max_duration_s": 10},
+        headers=_hdr(token),
+    )
+    assert r.status_code == 422
+
+
+# ── list / get / cancel / bulk-delete ────────────────────────────────
+
+
+async def test_list_and_get(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _superadmin(db_session)
+    cap = await _make_capture(db_session, status="running")
+    await db_session.commit()
+
+    r = await client.get("/api/v1/pcap/captures", headers=_hdr(token))
+    assert r.status_code == 200
+    assert any(i["id"] == str(cap.id) for i in r.json()["items"])
+
+    r = await client.get(f"/api/v1/pcap/captures/{cap.id}", headers=_hdr(token))
+    assert r.status_code == 200
+    assert r.json()["status"] == "running"
+
+
+async def test_cancel_running_capture(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _superadmin(db_session)
+    cap = await _make_capture(db_session, status="running")
+    await db_session.commit()
+
+    r = await client.delete(f"/api/v1/pcap/captures/{cap.id}", headers=_hdr(token))
+    assert r.status_code == 204
+    await db_session.refresh(cap)
+    assert cap.status == "cancelled"
+
+
+async def test_bulk_delete(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _superadmin(db_session)
+    c1 = await _make_capture(db_session, status="completed")
+    c2 = await _make_capture(db_session, status="running")
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/pcap/captures/bulk-delete",
+        json={"capture_ids": [str(c1.id), str(c2.id)]},
+        headers=_hdr(token),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["deleted"] == 1
+    assert body["cancelled"] == 1
+
+
+# ── download guards ──────────────────────────────────────────────────
+
+
+async def test_download_404_before_completion(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _superadmin(db_session)
+    cap = await _make_capture(db_session, status="running")
+    await db_session.commit()
+    r = await client.get(f"/api/v1/pcap/captures/{cap.id}/download", headers=_hdr(token))
+    assert r.status_code == 404
+
+
+async def test_download_404_structured_when_artifact_missing(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _superadmin(db_session)
+    cap = await _make_capture(
+        db_session, status="completed", pcap_path="/nonexistent/x.pcap", pcap_size_bytes=10
+    )
+    await db_session.commit()
+    r = await client.get(f"/api/v1/pcap/captures/{cap.id}/download", headers=_hdr(token))
+    assert r.status_code == 404
+    assert "no longer on disk" in r.json()["detail"]
+
+
+async def test_download_streams_pcap_and_audits(
+    client: AsyncClient, db_session: AsyncSession, tmp_path: Path
+) -> None:
+    _, token = await _superadmin(db_session)
+    f = tmp_path / "cap.pcap"
+    f.write_bytes(b"\xd4\xc3\xb2\xa1pcapbytes")
+    cap = await _make_capture(
+        db_session,
+        status="completed",
+        pcap_path=str(f),
+        pcap_size_bytes=f.stat().st_size,
+        finished_at=datetime.now(UTC),
+    )
+    await db_session.commit()
+
+    r = await client.get(f"/api/v1/pcap/captures/{cap.id}/download", headers=_hdr(token))
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"] == "application/vnd.tcpdump.pcap"
+    assert ".pcap" in r.headers.get("content-disposition", "")
+    assert r.content == b"\xd4\xc3\xb2\xa1pcapbytes"
+
+    rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(AuditLog.resource_type == "packet_capture")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert any(a.action == "download" for a in rows)
+
+
+# ── interfaces ───────────────────────────────────────────────────────
+
+
+async def test_interfaces_server(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _superadmin(db_session)
+    r = await client.get("/api/v1/pcap/interfaces?vantage=server", headers=_hdr(token))
+    assert r.status_code == 200
+    body = r.json()
+    assert "any" in body["interfaces"]
+    assert body["note"]
+
+
+# ── gating: module + permission ──────────────────────────────────────
+
+
+async def test_module_disabled_404(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _superadmin(db_session)
+    db_session.add(FeatureModule(id="tools.pcap", enabled=False))
+    await db_session.commit()
+    feature_modules.invalidate_cache()
+    r = await client.get("/api/v1/pcap/captures", headers=_hdr(token))
+    assert r.status_code == 404
+
+
+async def test_permission_denied_without_perm(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _user_with_perm(db_session, None)
+    await db_session.commit()
+    r = await client.get("/api/v1/pcap/captures", headers=_hdr(token))
+    assert r.status_code == 403
+
+
+async def test_permission_granted_with_perm(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _user_with_perm(
+        db_session, {"action": "read", "resource_type": "manage_packet_capture"}
+    )
+    await db_session.commit()
+    r = await client.get("/api/v1/pcap/captures", headers=_hdr(token))
+    assert r.status_code == 200

--- a/backend/tests/test_pcap_appliance.py
+++ b/backend/tests/test_pcap_appliance.py
@@ -1,0 +1,267 @@
+"""#59 Phase 2 — appliance-host vantage dispatch + create branch.
+
+Covers the DB-poll dispatch service (claim / progress / finalize) and the
+create-capture appliance branch (approved-gate, queued, NOT Celery-
+dispatched — the supervisor polls). The cert-authed supervisor endpoints
+are thin wrappers over these + the already-tested cert auth; we assert the
+poll endpoint rejects a non-cert caller.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.appliance import (
+    APPLIANCE_STATE_APPROVED,
+    APPLIANCE_STATE_PENDING_APPROVAL,
+    Appliance,
+)
+from app.models.auth import User
+from app.models.pcap import PacketCapture
+from app.services import feature_modules
+from app.services.appliance import pcap_capture
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_cache() -> None:
+    feature_modules.invalidate_cache()
+    yield
+    feature_modules.invalidate_cache()
+
+
+async def _superadmin(db: AsyncSession) -> tuple[User, str]:
+    u = User(
+        username=f"admin-{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(u)
+    await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+async def _appliance(db: AsyncSession, *, state: str = APPLIANCE_STATE_APPROVED) -> Appliance:
+    a = Appliance(
+        hostname=f"appl-{uuid.uuid4().hex[:6]}",
+        public_key_der=b"\x00" * 44,
+        public_key_fingerprint=uuid.uuid4().hex + uuid.uuid4().hex,
+        state=state,
+    )
+    db.add(a)
+    await db.flush()
+    return a
+
+
+async def _queued_appliance_capture(db: AsyncSession, appliance_id: uuid.UUID) -> PacketCapture:
+    cap = PacketCapture(
+        vantage_kind="appliance",
+        appliance_id=appliance_id,
+        vantage_label="appl",
+        interface="eth0",
+        bpf_filter="port 53",
+        snaplen=256,
+        max_duration_s=30,
+        status="queued",
+    )
+    db.add(cap)
+    await db.flush()
+    return cap
+
+
+# ── dispatch service ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_claim_next_claims_and_marks_running(db_session: AsyncSession) -> None:
+    appl = await _appliance(db_session)
+    cap = await _queued_appliance_capture(db_session, appl.id)
+    await db_session.commit()
+
+    cmd = await pcap_capture.claim_next(db_session, appl.id)
+    assert cmd is not None
+    assert cmd["capture_id"] == str(cap.id)
+    assert cmd["interface"] == "eth0"
+    assert cmd["bpf_filter"] == "port 53"
+    await db_session.refresh(cap)
+    assert cap.status == "running"
+    assert cap.started_at is not None
+
+    # Second claim finds nothing (already running, not queued).
+    assert await pcap_capture.claim_next(db_session, appl.id) is None
+
+
+@pytest.mark.asyncio
+async def test_claim_next_scoped_to_appliance(db_session: AsyncSession) -> None:
+    a1 = await _appliance(db_session)
+    a2 = await _appliance(db_session)
+    await _queued_appliance_capture(db_session, a1.id)
+    await db_session.commit()
+    # a2 has no queued captures.
+    assert await pcap_capture.claim_next(db_session, a2.id) is None
+
+
+@pytest.mark.asyncio
+async def test_record_progress_and_cancel(db_session: AsyncSession) -> None:
+    appl = await _appliance(db_session)
+    cap = await _queued_appliance_capture(db_session, appl.id)
+    cap.status = "running"
+    await db_session.commit()
+
+    cancel = await pcap_capture.record_progress(
+        db_session, cap.id, packets=10, bytes_captured=2048, elapsed_s=3.0
+    )
+    assert cancel is False
+    await db_session.refresh(cap)
+    assert cap.bytes_captured == 2048
+    assert cap.packets_captured == 10
+
+    # Operator cancels → progress returns True.
+    cap.status = "cancelled"
+    await db_session.commit()
+    assert (
+        await pcap_capture.record_progress(
+            db_session, cap.id, packets=None, bytes_captured=4096, elapsed_s=5.0
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalize_completed_and_cancel_wins(db_session: AsyncSession) -> None:
+    appl = await _appliance(db_session)
+    cap = await _queued_appliance_capture(db_session, appl.id)
+    cap.status = "running"
+    await db_session.commit()
+
+    status = await pcap_capture.finalize_capture(
+        db_session,
+        cap.id,
+        pcap_path="/var/lib/spatiumddi/pcaps/x.pcap",
+        pcap_size_bytes=4096,
+        pcap_sha256="abc",
+        packet_count=42,
+        metadata={"stop_reason": "completed"},
+        error=None,
+    )
+    assert status == "completed"
+    await db_session.refresh(cap)
+    assert cap.status == "completed"
+    assert cap.packets_captured == 42
+    assert cap.pcap_path.endswith("x.pcap")
+
+    # A cancelled row stays cancelled even if a late upload finalizes.
+    cap2 = await _queued_appliance_capture(db_session, appl.id)
+    cap2.status = "cancelled"
+    await db_session.commit()
+    status2 = await pcap_capture.finalize_capture(
+        db_session,
+        cap2.id,
+        pcap_path="/x.pcap",
+        pcap_size_bytes=1,
+        pcap_sha256="z",
+        packet_count=1,
+        metadata={},
+        error=None,
+    )
+    assert status2 == "cancelled"
+    await db_session.refresh(cap2)
+    assert cap2.status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_finalize_failed(db_session: AsyncSession) -> None:
+    appl = await _appliance(db_session)
+    cap = await _queued_appliance_capture(db_session, appl.id)
+    cap.status = "running"
+    await db_session.commit()
+    status = await pcap_capture.finalize_capture(
+        db_session,
+        cap.id,
+        pcap_path=None,
+        pcap_size_bytes=None,
+        pcap_sha256=None,
+        packet_count=None,
+        metadata={"stop_reason": "error"},
+        error="host capture failed",
+    )
+    assert status == "failed"
+    await db_session.refresh(cap)
+    assert cap.status == "failed"
+    assert "failed" in (cap.error_message or "")
+
+
+# ── create-capture appliance branch ──────────────────────────────────
+
+
+def _hdr(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_create_appliance_requires_appliance_id(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _superadmin(db_session)
+    r = await client.post(
+        "/api/v1/pcap/captures",
+        json={"vantage_kind": "appliance", "max_duration_s": 30},
+        headers=_hdr(token),
+    )
+    assert r.status_code == 422
+    assert "appliance_id is required" in r.json()["detail"]
+
+
+async def test_create_appliance_rejects_unapproved(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _superadmin(db_session)
+    appl = await _appliance(db_session, state=APPLIANCE_STATE_PENDING_APPROVAL)
+    await db_session.commit()
+    r = await client.post(
+        "/api/v1/pcap/captures",
+        json={"vantage_kind": "appliance", "appliance_id": str(appl.id), "max_duration_s": 30},
+        headers=_hdr(token),
+    )
+    assert r.status_code == 422
+    assert "not approved" in r.json()["detail"]
+
+
+async def test_create_appliance_queues_without_dispatch(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _superadmin(db_session)
+    appl = await _appliance(db_session)
+    await db_session.commit()
+    with patch("app.tasks.pcap.run_capture_task.delay") as delay:
+        r = await client.post(
+            "/api/v1/pcap/captures",
+            json={
+                "vantage_kind": "appliance",
+                "appliance_id": str(appl.id),
+                "interface": "eth0",
+                "bpf_filter": "port 67 or port 68",
+                "max_duration_s": 30,
+            },
+            headers=_hdr(token),
+        )
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["vantage_kind"] == "appliance"
+    assert body["status"] == "queued"
+    # Appliance vantage is NOT Celery-dispatched — the supervisor polls.
+    delay.assert_not_called()
+
+
+async def test_supervisor_pcap_poll_requires_cert(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # No cert headers → 403 (the supervisor channel is cert-only).
+    r = await client.post("/api/v1/appliance/supervisor/pcap/poll")
+    assert r.status_code == 403

--- a/backend/tests/test_pcap_validators.py
+++ b/backend/tests/test_pcap_validators.py
@@ -1,0 +1,157 @@
+"""#59 — packet-capture validator + argv-builder unit tests.
+
+Pure functions, no DB / no tcpdump. The headline control is the BPF
+filter: it must admit real BPF (byte-offset + bitmask idioms) while
+rejecting shell metacharacters, and the built argv must carry the filter
+as a single trailing element (never shell-interpolated).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.pcap.runner import (
+    HARD_MAX_BYTES,
+    HARD_MAX_DURATION_S,
+    HARD_MAX_PACKETS,
+    PcapArgError,
+    build_pcap_argv,
+    clamp_caps,
+    validate_bpf_filter,
+    validate_interface,
+)
+
+# ── BPF filter ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "good",
+    [
+        "",
+        "port 53",
+        "host 10.0.0.1 and tcp",
+        "port 67 or port 68",
+        "tcp[tcpflags] & tcp-syn != 0",
+        "ip[6:2] & 0x1fff != 0",
+        "ether[0] & 1 = 1",
+        "vlan 100 and host 10.0.0.1",
+        "not port 22",
+        "proto 112",
+    ],
+)
+def test_validate_bpf_accepts_legal_expressions(good: str) -> None:
+    # Empty → None; otherwise round-trips trimmed.
+    out = validate_bpf_filter(good)
+    assert out == (good or None)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "port 80; rm -rf /",
+        "host $(whoami)",
+        "host `id`",
+        'host "x"',
+        "host 'x'",
+        "a\nb",
+        "host {1}",
+        "port 80 # comment",
+        "port 80 \\ esc",
+    ],
+)
+def test_validate_bpf_rejects_shell_metacharacters(bad: str) -> None:
+    # `;` `$` backtick quotes newline `{}` `#` `\` are rejected. Note `&`
+    # and `|` are NOT rejected — they're legal BPF bitwise operators and
+    # harmless because the filter is a single non-shell argv element (a
+    # bogus `&& reboot` just fails tcpdump's BPF parser, never a shell).
+    with pytest.raises(PcapArgError):
+        validate_bpf_filter(bad)
+
+
+def test_validate_bpf_rejects_overlong() -> None:
+    with pytest.raises(PcapArgError):
+        validate_bpf_filter("a" * 1025)
+
+
+# ── interface ───────────────────────────────────────────────────────
+
+
+def test_validate_interface_defaults_to_any() -> None:
+    assert validate_interface(None, available=["any", "eth0"]) == "any"
+    assert validate_interface("  ", available=["any", "eth0"]) == "any"
+
+
+def test_validate_interface_accepts_enumerated() -> None:
+    assert validate_interface("eth0", available=["any", "eth0"]) == "eth0"
+
+
+def test_validate_interface_rejects_unknown() -> None:
+    with pytest.raises(PcapArgError):
+        validate_interface("eth9", available=["any", "eth0"])
+
+
+def test_validate_interface_rejects_bad_charset() -> None:
+    with pytest.raises(PcapArgError):
+        validate_interface("eth0; rm", available=["any", "eth0", "eth0; rm"])
+
+
+# ── caps ────────────────────────────────────────────────────────────
+
+
+def test_clamp_caps_requires_a_stop_condition() -> None:
+    with pytest.raises(PcapArgError):
+        clamp_caps(max_packets=None, max_duration_s=None, max_bytes=None, snaplen=256)
+
+
+def test_clamp_caps_clamps_to_hard_maxima() -> None:
+    mp, md, mb, sl = clamp_caps(
+        max_packets=99_999_999,
+        max_duration_s=99_999,
+        max_bytes=10 * HARD_MAX_BYTES,
+        snaplen=999_999,
+    )
+    assert mp == HARD_MAX_PACKETS
+    assert md == HARD_MAX_DURATION_S
+    assert mb == HARD_MAX_BYTES
+    assert sl == 65535
+
+
+def test_clamp_caps_passes_through_reasonable_values() -> None:
+    mp, md, mb, sl = clamp_caps(max_packets=100, max_duration_s=30, max_bytes=1024, snaplen=256)
+    assert (mp, md, mb, sl) == (100, 30, 1024, 256)
+
+
+# ── argv ────────────────────────────────────────────────────────────
+
+
+def test_build_argv_filter_is_single_trailing_element() -> None:
+    argv = build_pcap_argv(
+        interface="eth0",
+        bpf_filter="port 53 or port 67",
+        snaplen=256,
+        promiscuous=False,
+        max_packets=100,
+        output_path="/tmp/x.pcap",
+    )
+    # The whole filter is ONE element (not split on spaces) and it's last.
+    assert argv[-1] == "port 53 or port 67"
+    assert argv[0] == "tcpdump"
+    assert "-w" in argv and "/tmp/x.pcap" in argv
+    assert "-p" in argv  # non-promiscuous opt-out
+    assert argv[argv.index("-c") + 1] == "100"
+
+
+def test_build_argv_omits_filter_when_empty() -> None:
+    argv = build_pcap_argv(
+        interface="any",
+        bpf_filter=None,
+        snaplen=0,
+        promiscuous=True,
+        max_packets=None,
+        output_path="/tmp/x.pcap",
+    )
+    assert "-p" not in argv  # promiscuous requested → no opt-out flag
+    assert "-c" not in argv
+    # Last element is the output path (no trailing filter).
+    assert argv[-2] == "-w"
+    assert argv[-1] == "/tmp/x.pcap"

--- a/charts/spatiumddi/templates/api.yaml
+++ b/charts/spatiumddi/templates/api.yaml
@@ -138,6 +138,11 @@ spec:
             - name: slot-images
               mountPath: /var/lib/spatiumddi/slot-images
             {{- end }}
+            # #59 — packet-capture .pcap store. api READS here on download;
+            # the worker writes. Single-node shared hostPath (firstboot
+            # chowns it 1000:1000). Always mounted (not mirror-gated).
+            - name: pcaps
+              mountPath: /var/lib/spatiumddi/pcaps
           {{- end }}
       {{- if .Values.api.applianceHostMounts.enabled }}
       volumes:
@@ -161,6 +166,11 @@ spec:
             path: {{ .Values.api.applianceHostMounts.slotImagesDir }}
             type: DirectoryOrCreate
         {{- end }}
+        # #59 — packet-capture .pcap store (shared with the worker).
+        - name: pcaps
+          hostPath:
+            path: {{ .Values.api.applianceHostMounts.pcapsDir }}
+            type: DirectoryOrCreate
       {{- end }}
       {{- include "spatiumddi.controlPlaneNodeSelector" (merge (dict "componentNodeSelector" .Values.api.nodeSelector) .) | nindent 6 }}
       {{- with .Values.api.tolerations }}

--- a/charts/spatiumddi/templates/worker.yaml
+++ b/charts/spatiumddi/templates/worker.yaml
@@ -68,6 +68,21 @@ spec:
             failureThreshold: 3
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
+          {{- if .Values.api.applianceHostMounts.enabled }}
+          volumeMounts:
+            # #59 — packet-capture .pcap store. The worker WRITES captures
+            # here; the api reads them back on download. Same single-node
+            # shared hostPath (firstboot chowns it 1000:1000).
+            - name: pcaps
+              mountPath: /var/lib/spatiumddi/pcaps
+          {{- end }}
+      {{- if .Values.api.applianceHostMounts.enabled }}
+      volumes:
+        - name: pcaps
+          hostPath:
+            path: {{ .Values.api.applianceHostMounts.pcapsDir }}
+            type: DirectoryOrCreate
+      {{- end }}
       {{- include "spatiumddi.controlPlaneNodeSelector" (merge (dict "componentNodeSelector" .Values.worker.nodeSelector) .) | nindent 6 }}
       {{- with .Values.worker.tolerations }}
       tolerations:

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -121,6 +121,12 @@ api:
     # they don't 404 with "bytes missing on disk" on the next upgrade.
     # Only mounted when the multi-node slot-image mirror is off.
     slotImagesDir: /var/lib/spatiumddi/slot-images
+    # #59 — host dir backing packet-capture .pcap artifacts
+    # (SPATIUM_PCAP_DIR). Shared by api (reads on download) + worker
+    # (writes the capture) on a single node. Multi-node server-vantage
+    # capture needs the mirror-proxy (a tracked follow-up); appliance is
+    # single-node so the shared hostPath is correct.
+    pcapsDir: /var/lib/spatiumddi/pcaps
 
 # ── Slot-image mirror (#296 Phase B) ────────────────────────────────────────
 # A single-replica Deployment + node-pinned local-path PVC + ClusterIP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,10 @@ services:
       # authenticated under /api/v1/appliance/slot-images/{id}/raw.xz
       # for the supervisor to download.
       - spatium_slot_images:/var/lib/spatiumddi/slot-images
+      # Packet-capture .pcap artifacts (issue #59). The worker writes
+      # captures here; the api streams them back on download. Shared so
+      # the server-vantage capture works end-to-end on compose.
+      - spatium_pcaps:/var/lib/spatiumddi/pcaps
     depends_on:
       postgres:
         condition: service_healthy
@@ -117,8 +121,13 @@ services:
     #
     # Backup local-volume target (issue #117) — the worker runs the
     # scheduled backup sweep, so it must mount the same volume the
-    # api lists archives from. Uncomment alongside the api service.
-    # volumes:
+    # api lists archives from. Uncomment the spatium_backups line below
+    # alongside the api service.
+    volumes:
+      # Packet-capture .pcap artifacts (issue #59) — the worker runs the
+      # capture, so it writes here; the api reads the same volume on
+      # download. MUST stay in sync with the api mount above.
+      - spatium_pcaps:/var/lib/spatiumddi/pcaps
     #   - /var/run/docker.sock:/var/run/docker.sock:ro
     #   - spatium_backups:/var/lib/spatiumddi/backups
     # group_add:
@@ -390,3 +399,7 @@ volumes:
   # to download. Capacity: each image is ~800 MiB-1.2 GiB; the
   # backend caps a single upload at 4 GiB.
   spatium_slot_images:
+  # Packet-capture .pcap artifacts (issue #59). Shared by api + worker
+  # so the server-vantage capture works end-to-end. Auto-pruned after
+  # PlatformSettings.pcap_retention_days (default 7).
+  spatium_pcaps:

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -73,6 +73,7 @@ Each entry in `Role.permissions` (JSONB) is an object with this shape:
 | `routing_policy`  | Per-overlay declarative routing policies (#95)        |
 | `application_category` | SaaS application catalog used by `match_kind=application` (#95) |
 | `conformity`      | Conformity policies + results + auditor PDF export (#106) |
+| `manage_packet_capture` | On-demand packet capture (tcpdump) — start / read / download / delete captures (#59). High-sensitivity (captured bytes can contain plaintext creds/PII); granted to `Network Editor`, not `Viewer`. Download is audited. |
 | `*`               | Wildcard — match any resource type                    |
 
 ## Evaluation rules
@@ -133,7 +134,7 @@ on inactive.
 | `IPAM Editor`  | `admin` on `ip_space`, `ip_block`, `subnet`, `ip_address`, `vlan`, `nat_mapping`, `custom_field`, `manage_ipam_templates`, `customer`, `site`, `provider`, `network_service` |
 | `DNS Editor`   | `admin` on `dns_zone`, `dns_record`, `dns_group`, `dns_blocklist`, `manage_dns_pools` |
 | `DHCP Editor`  | `admin` on `dhcp_server`, `dhcp_scope`, `dhcp_pool`, `dhcp_static`, `dhcp_client_class`, `dhcp_option_template`, `dhcp_mac_block` |
-| `Network Editor` | `admin` on `manage_network_devices`, `manage_nmap_scans`, `manage_asns`, `vrf`, `circuit`, `network_service`, `overlay_network`, `routing_policy`, `application_category`, `customer`, `site`, `provider` |
+| `Network Editor` | `admin` on `manage_network_devices`, `manage_nmap_scans`, `manage_packet_capture`, `manage_asns`, `vrf`, `circuit`, `network_service`, `overlay_network`, `routing_policy`, `application_category`, `customer`, `site`, `provider` |
 | `Auditor`        | `read` on `conformity`, `audit`, `subnet`, `ip_address`, `dns_zone`, `dhcp_scope` — external auditor account, can view conformity dashboard + pull the auditor PDF + verify supporting evidence without making changes |
 | `Compliance Editor` | `admin` on `conformity`, `read` on `audit`, `subnet`, `ip_address`, `dns_zone`, `dhcp_scope` — for the team that authors / tunes conformity policies without touching operational config |
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import { ProvidersPage } from "@/pages/network/ProvidersPage";
 import { ServicesPage } from "@/pages/network/ServicesPage";
 import { SitesPage } from "@/pages/network/SitesPage";
 import { NmapToolsPage } from "@/pages/nmap/NmapToolsPage";
+import { PacketCapturePage } from "@/pages/pcap/PacketCapturePage";
 import { NetworkToolsPage } from "@/pages/tools/NetworkToolsPage";
 import { CidrCalculatorPage } from "@/pages/tools/CidrCalculatorPage";
 import { SubnetPlannerListPage } from "@/pages/ipam/SubnetPlannerListPage";
@@ -142,6 +143,7 @@ export default function App() {
             redirecting to /network/devices/:id. */}
         <Route path="network/:id" element={<DeviceDetailView />} />
         <Route path="tools/nmap" element={<NmapToolsPage />} />
+        <Route path="tools/pcap" element={<PacketCapturePage />} />
         <Route path="tools/network" element={<NetworkToolsPage />} />
         <Route path="tools/cidr" element={<CidrCalculatorPage />} />
         <Route path="dhcp" element={<DHCPPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
+  Activity,
   Network,
   Globe,
   LayoutDashboard,
@@ -201,6 +202,12 @@ const toolsNav = [
     icon: Wrench,
     to: "/tools/network",
     module: "tools.network",
+  },
+  {
+    label: "Packet Capture",
+    icon: Activity,
+    to: "/tools/pcap",
+    module: "tools.pcap",
   },
 ];
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -11209,6 +11209,131 @@ export async function* streamNmapScan(
   }
 }
 
+// ── Packet capture (tcpdump) — issue #59 ────────────────────────────
+//
+// Persisted long-running capture jobs (mirrors the nmap scanner) whose
+// deliverable is a binary `.pcap` download. NO SSE — the UI polls
+// `getCapture` for live `bytes_captured` + status while running.
+
+export type PcapVantageKind = "server" | "appliance";
+export type PcapStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface PcapCaptureRead {
+  id: string;
+  vantage_kind: PcapVantageKind;
+  appliance_id: string | null;
+  vantage_label: string;
+  interface: string | null;
+  bpf_filter: string | null;
+  snaplen: number;
+  promiscuous: boolean;
+  max_packets: number | null;
+  max_duration_s: number | null;
+  max_bytes: number | null;
+  status: PcapStatus;
+  started_at: string | null;
+  finished_at: string | null;
+  duration_seconds: number | null;
+  exit_code: number | null;
+  command_line: string | null;
+  error_message: string | null;
+  packets_captured: number;
+  bytes_captured: number;
+  pcap_size_bytes: number | null;
+  pcap_sha256: string | null;
+  has_artifact: boolean;
+  metadata_json: Record<string, unknown> | null;
+  created_by_user_id: string | null;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface PcapCaptureCreate {
+  vantage_kind?: PcapVantageKind;
+  appliance_id?: string | null;
+  interface?: string | null;
+  bpf_filter?: string | null;
+  snaplen?: number;
+  promiscuous?: boolean;
+  max_packets?: number | null;
+  max_duration_s?: number | null;
+  max_bytes?: number | null;
+}
+
+export interface PcapCaptureListResponse {
+  items: PcapCaptureRead[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface PcapCaptureListQuery {
+  status?: PcapStatus;
+  vantage?: PcapVantageKind;
+  appliance_id?: string;
+  page?: number;
+  page_size?: number;
+}
+
+export interface PcapInterfacesResponse {
+  interfaces: string[];
+  note: string;
+}
+
+export const pcapApi = {
+  listCaptures: (params?: PcapCaptureListQuery) =>
+    api
+      .get<PcapCaptureListResponse>("/pcap/captures", { params })
+      .then((r) => r.data),
+  getCapture: (id: string) =>
+    api.get<PcapCaptureRead>(`/pcap/captures/${id}`).then((r) => r.data),
+  createCapture: (body: PcapCaptureCreate) =>
+    api.post<PcapCaptureRead>("/pcap/captures", body).then((r) => r.data),
+  cancelCapture: (id: string) => api.delete(`/pcap/captures/${id}`),
+  /** Cancel + delete up to 500 captures; returns `{deleted, cancelled}`. */
+  bulkDeleteCaptures: (captureIds: string[]) =>
+    api
+      .post<{ deleted: number; cancelled: number }>("/pcap/captures/bulk-delete", {
+        capture_ids: captureIds,
+      })
+      .then((r) => r.data),
+  listInterfaces: (vantage: PcapVantageKind = "server", applianceId?: string) =>
+    api
+      .get<PcapInterfacesResponse>("/pcap/interfaces", {
+        params: { vantage, appliance_id: applianceId },
+      })
+      .then((r) => r.data),
+  /** Download the finished `.pcap` as an authed blob → trigger a save.
+   *  Uses the axios instance so the Bearer token rides the
+   *  Authorization header (no `?token=` in the URL). */
+  downloadCapture: async (id: string): Promise<void> => {
+    const res = await api.get<Blob>(`/pcap/captures/${id}/download`, {
+      responseType: "blob",
+    });
+    const disposition = (res.headers as Record<string, string>)[
+      "content-disposition"
+    ];
+    const match = disposition?.match(/filename="?([^"]+)"?/);
+    const filename = match ? match[1] : `capture-${id}.pcap`;
+    const blob = new Blob([res.data as BlobPart], {
+      type: "application/vnd.tcpdump.pcap",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  },
+};
+
 // ── Built-in network tools (issue #58) ──────────────────────────────
 //
 // Stateless, synchronous server-perspective utilities. Each call POSTs

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -11298,9 +11298,12 @@ export const pcapApi = {
   /** Cancel + delete up to 500 captures; returns `{deleted, cancelled}`. */
   bulkDeleteCaptures: (captureIds: string[]) =>
     api
-      .post<{ deleted: number; cancelled: number }>("/pcap/captures/bulk-delete", {
-        capture_ids: captureIds,
-      })
+      .post<{ deleted: number; cancelled: number }>(
+        "/pcap/captures/bulk-delete",
+        {
+          capture_ids: captureIds,
+        },
+      )
       .then((r) => r.data),
   listInterfaces: (vantage: PcapVantageKind = "server", applianceId?: string) =>
     api

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  Activity,
   AlertCircle,
   Ban,
   CheckCircle2,
@@ -2276,6 +2278,17 @@ function ApplianceDrilldownModal({
                 ? ` · ${caps.baked_images_version}`
                 : ""}
             </span>
+          )}
+          {row.state === "approved" && (
+            // #59 — capture on this appliance's real NICs. Lands on the
+            // Packet Capture tool prefilled with this appliance as vantage.
+            // (404s gracefully if the tools.pcap module is off.)
+            <Link
+              to={`/tools/pcap?vantage=appliance&appliance=${row.id}`}
+              className="ml-auto inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs hover:bg-accent"
+            >
+              <Activity className="h-3 w-3" /> Packet capture
+            </Link>
           )}
         </div>
 

--- a/frontend/src/pages/pcap/PacketCapturePage.tsx
+++ b/frontend/src/pages/pcap/PacketCapturePage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Activity, Download, Loader2, Trash2 } from "lucide-react";
 import {
+  applianceApprovalApi,
   type PcapCaptureCreate,
   type PcapCaptureRead,
   pcapApi,
@@ -50,6 +52,14 @@ export function PacketCapturePage() {
   const [displayId, setDisplayId] = useState<string | null>(null);
   const [tab, setTab] = useState<RightTab>("history");
 
+  // Deep-link from the Fleet drilldown: /tools/pcap?vantage=appliance&appliance=<id>
+  // prefills the form to capture on that appliance host.
+  const [params] = useSearchParams();
+  const initialVantage =
+    params.get("vantage") === "appliance" && params.get("appliance")
+      ? (params.get("appliance") as string)
+      : "server";
+
   const onStarted = (c: PcapCaptureRead) => {
     setActiveId(c.id);
     setTab("live");
@@ -73,7 +83,7 @@ export function PacketCapturePage() {
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <div className="rounded-lg border bg-card p-4">
             <h2 className="mb-3 text-sm font-medium">New capture</h2>
-            <CaptureForm onStarted={onStarted} />
+            <CaptureForm onStarted={onStarted} initialVantage={initialVantage} />
           </div>
 
           <div className="flex flex-col rounded-lg border bg-card">
@@ -158,7 +168,15 @@ function TabButton({
   );
 }
 
-function CaptureForm({ onStarted }: { onStarted: (c: PcapCaptureRead) => void }) {
+function CaptureForm({
+  onStarted,
+  initialVantage = "server",
+}: {
+  onStarted: (c: PcapCaptureRead) => void;
+  initialVantage?: string;
+}) {
+  // vantage select value: "server" or an appliance UUID.
+  const [vantage, setVantage] = useState<string>(initialVantage);
   const [iface, setIface] = useState<string>("any");
   const [filter, setFilter] = useState("");
   const [durationS, setDurationS] = useState<number | "">(60);
@@ -167,7 +185,18 @@ function CaptureForm({ onStarted }: { onStarted: (c: PcapCaptureRead) => void })
   const [snaplen, setSnaplen] = useState<number | "">(256);
   const [promiscuous, setPromiscuous] = useState(false);
 
+  const isAppliance = vantage !== "server";
+
+  const { data: appliances } = useQuery({
+    queryKey: ["pcap-appliances"],
+    queryFn: () => applianceApprovalApi.list(),
+  });
+  const approved = (appliances ?? []).filter((a) => a.state === "approved");
+
+  // Server vantage enumerates the worker's NICs; appliance vantage can't
+  // (the control plane can't see the host's NICs) so the operator types it.
   const { data: ifaces } = useQuery({
+    enabled: !isAppliance,
     queryKey: ["pcap-interfaces", "server"],
     queryFn: () => pcapApi.listInterfaces("server"),
   });
@@ -195,7 +224,8 @@ function CaptureForm({ onStarted }: { onStarted: (c: PcapCaptureRead) => void })
         e.preventDefault();
         if (!hasStop) return;
         start.mutate({
-          vantage_kind: "server",
+          vantage_kind: isAppliance ? "appliance" : "server",
+          appliance_id: isAppliance ? vantage : null,
           interface: iface,
           bpf_filter: filter.trim() || null,
           snaplen: snaplen === "" ? 256 : Number(snaplen),
@@ -207,20 +237,57 @@ function CaptureForm({ onStarted }: { onStarted: (c: PcapCaptureRead) => void })
       }}
     >
       <div>
-        <label className="mb-1 block text-xs font-medium">Interface</label>
+        <label className="mb-1 block text-xs font-medium">Vantage</label>
         <select
-          value={iface}
-          onChange={(e) => setIface(e.target.value)}
+          value={vantage}
+          onChange={(e) => {
+            setVantage(e.target.value);
+            setIface("any"); // reset — server enumerates, appliance is free-text
+          }}
           className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
         >
-          {(ifaces?.interfaces ?? ["any"]).map((n) => (
-            <option key={n} value={n}>
-              {n}
+          <option value="server">Control plane (container network)</option>
+          {approved.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.hostname} (appliance host)
             </option>
           ))}
         </select>
-        {ifaces?.note && (
-          <p className="mt-1 text-[11px] text-muted-foreground">{ifaces.note}</p>
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs font-medium">Interface</label>
+        {isAppliance ? (
+          <>
+            <input
+              type="text"
+              value={iface}
+              onChange={(e) => setIface(e.target.value)}
+              placeholder="e.g. eth0, bond0, any"
+              className="w-full rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
+            />
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              The appliance host's real NIC — validated against the host when the
+              capture runs. "any" includes all host traffic.
+            </p>
+          </>
+        ) : (
+          <>
+            <select
+              value={iface}
+              onChange={(e) => setIface(e.target.value)}
+              className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+            >
+              {(ifaces?.interfaces ?? ["any"]).map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+            {ifaces?.note && (
+              <p className="mt-1 text-[11px] text-muted-foreground">{ifaces.note}</p>
+            )}
+          </>
         )}
       </div>
 

--- a/frontend/src/pages/pcap/PacketCapturePage.tsx
+++ b/frontend/src/pages/pcap/PacketCapturePage.tsx
@@ -73,9 +73,9 @@ export function PacketCapturePage() {
           <h1 className="text-lg font-semibold">Packet capture</h1>
         </div>
         <p className="mt-1 max-w-3xl text-xs text-muted-foreground">
-          Run tcpdump from the control-plane vantage, watch live progress, and
-          download the .pcap for Wireshark. Captures raw traffic (may include
-          sensitive payloads) — every start and download is audited.
+          Run tcpdump on the control plane or an appliance host, watch live
+          progress, and download the .pcap for Wireshark. Captures raw traffic
+          (may include sensitive payloads) — every start and download is audited.
         </p>
       </div>
 

--- a/frontend/src/pages/pcap/PacketCapturePage.tsx
+++ b/frontend/src/pages/pcap/PacketCapturePage.tsx
@@ -1,0 +1,742 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Activity, Download, Loader2, Trash2 } from "lucide-react";
+import {
+  type PcapCaptureCreate,
+  type PcapCaptureRead,
+  pcapApi,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { humanTime } from "@/pages/network/_shared";
+
+type RightTab = "live" | "history" | "result";
+
+// Curated BPF presets — DDI-relevant first. Clicking one fills the
+// advanced filter field. (A larger library can follow; these cover the
+// overwhelming majority of appliance troubleshooting.)
+const BPF_PRESETS: { label: string; filter: string }[] = [
+  { label: "DNS (53)", filter: "port 53" },
+  { label: "DHCP (67/68)", filter: "port 67 or port 68" },
+  { label: "DNS + DHCP", filter: "port 53 or port 67 or port 68" },
+  { label: "ARP", filter: "arp" },
+  { label: "ICMP", filter: "icmp or icmp6" },
+  { label: "HTTP/HTTPS", filter: "port 80 or port 443" },
+  { label: "TCP SYN only", filter: "tcp[tcpflags] & tcp-syn != 0" },
+  { label: "NTP (123)", filter: "udp port 123" },
+  { label: "VRRP", filter: "proto 112" },
+  { label: "Exclude SSH", filter: "not port 22" },
+];
+
+function fmtBytes(n: number | null | undefined): string {
+  if (!n) return "0 B";
+  const u = ["B", "KiB", "MiB", "GiB"];
+  let v = n;
+  let i = 0;
+  while (v >= 1024 && i < u.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(i === 0 ? 0 : 1)} ${u[i]}`;
+}
+
+function isTerminal(s: PcapCaptureRead): boolean {
+  return (
+    s.status === "completed" || s.status === "failed" || s.status === "cancelled"
+  );
+}
+
+export function PacketCapturePage() {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [displayId, setDisplayId] = useState<string | null>(null);
+  const [tab, setTab] = useState<RightTab>("history");
+
+  const onStarted = (c: PcapCaptureRead) => {
+    setActiveId(c.id);
+    setTab("live");
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="border-b bg-card px-6 py-4">
+        <div className="flex items-center gap-2">
+          <Activity className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-lg font-semibold">Packet capture</h1>
+        </div>
+        <p className="mt-1 max-w-3xl text-xs text-muted-foreground">
+          Run tcpdump from the control-plane vantage, watch live progress, and
+          download the .pcap for Wireshark. Captures raw traffic (may include
+          sensitive payloads) — every start and download is audited.
+        </p>
+      </div>
+
+      <div className="flex-1 overflow-auto p-6">
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="rounded-lg border bg-card p-4">
+            <h2 className="mb-3 text-sm font-medium">New capture</h2>
+            <CaptureForm onStarted={onStarted} />
+          </div>
+
+          <div className="flex flex-col rounded-lg border bg-card">
+            <div className="flex items-center gap-1 border-b px-2">
+              <TabButton
+                active={tab === "live"}
+                onClick={() => setTab("live")}
+                live={!!activeId}
+              >
+                Live
+              </TabButton>
+              <TabButton active={tab === "history"} onClick={() => setTab("history")}>
+                History
+              </TabButton>
+              <TabButton
+                active={tab === "result"}
+                onClick={() => setTab("result")}
+                disabled={!displayId}
+              >
+                Last result
+              </TabButton>
+            </div>
+            <div className="p-4">
+              {tab === "live" && (
+                <LiveTab
+                  captureId={activeId}
+                  onComplete={(id) => {
+                    setDisplayId(id);
+                    setActiveId(null);
+                    setTab("result");
+                  }}
+                />
+              )}
+              {tab === "history" && (
+                <HistoryTab
+                  onSelect={(c) => {
+                    setDisplayId(c.id);
+                    setTab("result");
+                  }}
+                />
+              )}
+              {tab === "result" && <ResultTab captureId={displayId} />}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  disabled,
+  live,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  live?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "border-b-2 px-3 py-2 text-xs font-medium transition-colors",
+        active
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground",
+        disabled && "cursor-not-allowed opacity-40 hover:text-muted-foreground",
+      )}
+    >
+      {children}
+      {live && (
+        <span className="ml-1 inline-flex h-1.5 w-1.5 rounded-full bg-blue-500 align-middle" />
+      )}
+    </button>
+  );
+}
+
+function CaptureForm({ onStarted }: { onStarted: (c: PcapCaptureRead) => void }) {
+  const [iface, setIface] = useState<string>("any");
+  const [filter, setFilter] = useState("");
+  const [durationS, setDurationS] = useState<number | "">(60);
+  const [maxPackets, setMaxPackets] = useState<number | "">(10000);
+  const [maxMiB, setMaxMiB] = useState<number | "">(50);
+  const [snaplen, setSnaplen] = useState<number | "">(256);
+  const [promiscuous, setPromiscuous] = useState(false);
+
+  const { data: ifaces } = useQuery({
+    queryKey: ["pcap-interfaces", "server"],
+    queryFn: () => pcapApi.listInterfaces("server"),
+  });
+
+  const start = useMutation({
+    mutationFn: (body: PcapCaptureCreate) => pcapApi.createCapture(body),
+    onSuccess: onStarted,
+  });
+
+  const hasStop = durationS !== "" || maxPackets !== "" || maxMiB !== "";
+
+  const commandPreview = useMemo(() => {
+    const parts = ["tcpdump", "-n", "-U", "-i", iface, "-s", String(snaplen || 0)];
+    if (!promiscuous) parts.push("-p");
+    if (maxPackets !== "") parts.push("-c", String(maxPackets));
+    parts.push("-w", "<file>");
+    if (filter.trim()) parts.push(filter.trim());
+    return parts.join(" ");
+  }, [iface, snaplen, promiscuous, maxPackets, filter]);
+
+  return (
+    <form
+      className="space-y-3"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!hasStop) return;
+        start.mutate({
+          vantage_kind: "server",
+          interface: iface,
+          bpf_filter: filter.trim() || null,
+          snaplen: snaplen === "" ? 256 : Number(snaplen),
+          promiscuous,
+          max_duration_s: durationS === "" ? null : Number(durationS),
+          max_packets: maxPackets === "" ? null : Number(maxPackets),
+          max_bytes: maxMiB === "" ? null : Number(maxMiB) * 1024 * 1024,
+        });
+      }}
+    >
+      <div>
+        <label className="mb-1 block text-xs font-medium">Interface</label>
+        <select
+          value={iface}
+          onChange={(e) => setIface(e.target.value)}
+          className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+        >
+          {(ifaces?.interfaces ?? ["any"]).map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
+          ))}
+        </select>
+        {ifaces?.note && (
+          <p className="mt-1 text-[11px] text-muted-foreground">{ifaces.note}</p>
+        )}
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs font-medium">BPF filter</label>
+        <input
+          type="text"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="e.g. port 53 or host 10.0.0.1 (empty = all traffic)"
+          className="w-full rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
+        />
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {BPF_PRESETS.map((p) => (
+            <button
+              key={p.label}
+              type="button"
+              onClick={() => setFilter(p.filter)}
+              className="rounded border px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
+              title={p.filter}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <NumField
+          label="Max seconds"
+          value={durationS}
+          onChange={setDurationS}
+          max={1800}
+        />
+        <NumField
+          label="Max packets"
+          value={maxPackets}
+          onChange={setMaxPackets}
+          max={1000000}
+        />
+        <NumField label="Max MiB" value={maxMiB} onChange={setMaxMiB} max={100} />
+      </div>
+
+      <div className="grid grid-cols-2 items-end gap-2">
+        <NumField
+          label="Snaplen (bytes/pkt)"
+          value={snaplen}
+          onChange={setSnaplen}
+          max={65535}
+        />
+        <label className="flex items-center gap-2 pb-1.5 text-xs">
+          <input
+            type="checkbox"
+            checked={promiscuous}
+            onChange={(e) => setPromiscuous(e.target.checked)}
+          />
+          Promiscuous mode
+        </label>
+      </div>
+
+      <div className="rounded-md border bg-muted/30 px-2 py-1.5">
+        <p className="break-all font-mono text-[11px] text-muted-foreground">
+          {commandPreview}
+        </p>
+      </div>
+
+      {!hasStop && (
+        <p className="text-[11px] text-amber-600">
+          Set at least one stop condition (seconds, packets, or MiB).
+        </p>
+      )}
+      {start.isError && (
+        <p className="text-[11px] text-destructive">
+          {(start.error as { response?: { data?: { detail?: string } } })
+            ?.response?.data?.detail ?? "Failed to start capture."}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={!hasStop || start.isPending}
+        className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+      >
+        {start.isPending ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Activity className="h-3.5 w-3.5" />
+        )}
+        Start capture
+      </button>
+    </form>
+  );
+}
+
+function NumField({
+  label,
+  value,
+  onChange,
+  max,
+}: {
+  label: string;
+  value: number | "";
+  onChange: (v: number | "") => void;
+  max: number;
+}) {
+  return (
+    <div>
+      <label className="mb-1 block text-xs font-medium">{label}</label>
+      <input
+        type="number"
+        min={1}
+        max={max}
+        value={value}
+        onChange={(e) =>
+          onChange(e.target.value === "" ? "" : Number(e.target.value))
+        }
+        className="w-full rounded-md border bg-background px-2 py-1.5 text-sm tabular-nums"
+      />
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: PcapCaptureRead["status"] }) {
+  const map: Record<string, string> = {
+    queued: "bg-zinc-500/15 text-zinc-600",
+    running: "bg-blue-500/15 text-blue-600",
+    completed: "bg-emerald-500/15 text-emerald-600",
+    failed: "bg-rose-500/15 text-rose-600",
+    cancelled: "bg-amber-500/15 text-amber-600",
+  };
+  return (
+    <span className={cn("rounded px-1.5 py-0.5 text-[11px] font-medium", map[status])}>
+      {status}
+    </span>
+  );
+}
+
+function LiveTab({
+  captureId,
+  onComplete,
+}: {
+  captureId: string | null;
+  onComplete: (id: string) => void;
+}) {
+  const qc = useQueryClient();
+  const { data } = useQuery({
+    enabled: !!captureId,
+    queryKey: ["pcap-capture", captureId],
+    queryFn: () => pcapApi.getCapture(captureId!),
+    refetchInterval: (q) =>
+      q.state.data && isTerminal(q.state.data) ? false : 1500,
+  });
+
+  useEffect(() => {
+    if (data && isTerminal(data)) {
+      qc.invalidateQueries({ queryKey: ["pcap-captures"] });
+      onComplete(data.id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data?.status]);
+
+  const cancel = useMutation({
+    mutationFn: (id: string) => pcapApi.cancelCapture(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["pcap-capture", captureId] }),
+  });
+
+  if (!captureId || !data) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No capture running — start one on the left. Live progress shows here.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-xs">{data.interface}</span>
+        <StatusPill status={data.status} />
+      </div>
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <Stat label="Captured" value={fmtBytes(data.bytes_captured)} />
+        <Stat
+          label="Elapsed"
+          value={`${Math.round(data.duration_seconds ?? 0)}s`}
+        />
+      </div>
+      {data.bpf_filter && (
+        <p className="font-mono text-[11px] text-muted-foreground">
+          filter: {data.bpf_filter}
+        </p>
+      )}
+      {data.status === "running" && (
+        <button
+          type="button"
+          onClick={() => cancel.mutate(data.id)}
+          disabled={cancel.isPending}
+          className="inline-flex items-center gap-1 rounded border border-destructive/40 px-2 py-1 text-xs text-destructive hover:bg-destructive/10 disabled:opacity-50"
+        >
+          <Trash2 className="h-3 w-3" /> Stop capture
+        </button>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-muted/20 px-2 py-1.5">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="font-mono text-sm tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function ResultTab({ captureId }: { captureId: string | null }) {
+  const { data } = useQuery({
+    enabled: !!captureId,
+    queryKey: ["pcap-capture", captureId],
+    queryFn: () => pcapApi.getCapture(captureId!),
+  });
+  const download = useMutation({
+    mutationFn: (id: string) => pcapApi.downloadCapture(id),
+  });
+
+  if (!data) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Nothing to show yet. Click a row in History or run a capture.
+      </p>
+    );
+  }
+  const meta = data.metadata_json as { stop_reason?: string } | null;
+  return (
+    <div className="space-y-2 text-xs">
+      <div className="flex items-center justify-between">
+        <span className="text-muted-foreground">
+          {humanTime(data.created_at)} ·{" "}
+          <span className="font-mono">{data.interface}</span>
+        </span>
+        <StatusPill status={data.status} />
+      </div>
+      {data.bpf_filter && (
+        <p className="font-mono text-[11px] text-muted-foreground">
+          filter: {data.bpf_filter}
+        </p>
+      )}
+      {data.error_message && (
+        <p className="rounded-md border border-destructive/40 bg-destructive/5 p-2 text-destructive">
+          {data.error_message}
+        </p>
+      )}
+      <div className="grid grid-cols-2 gap-2">
+        <Stat label="Packets" value={String(data.packets_captured)} />
+        <Stat label="Size" value={fmtBytes(data.pcap_size_bytes)} />
+      </div>
+      {meta?.stop_reason && (
+        <p className="text-[11px] text-muted-foreground">
+          stopped: {meta.stop_reason}
+        </p>
+      )}
+      {data.has_artifact ? (
+        <button
+          type="button"
+          onClick={() => download.mutate(data.id)}
+          disabled={download.isPending}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {download.isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Download className="h-3.5 w-3.5" />
+          )}
+          Download .pcap
+        </button>
+      ) : (
+        <p className="text-[11px] italic text-muted-foreground">
+          No downloadable artifact (capture produced no bytes, was cancelled, or
+          was pruned).
+        </p>
+      )}
+    </div>
+  );
+}
+
+function HistoryTab({ onSelect }: { onSelect: (c: PcapCaptureRead) => void }) {
+  const qc = useQueryClient();
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [pendingBulk, setPendingBulk] = useState<PcapCaptureRead[] | null>(null);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["pcap-captures", "recent"],
+    queryFn: () => pcapApi.listCaptures({ page_size: 50 }),
+    refetchInterval: 5000,
+  });
+  const items = data?.items ?? [];
+
+  useEffect(() => {
+    if (selected.size === 0) return;
+    const ids = new Set(items.map((s) => s.id));
+    const next = new Set<string>();
+    let changed = false;
+    for (const id of selected) {
+      if (ids.has(id)) next.add(id);
+      else changed = true;
+    }
+    if (changed) setSelected(next);
+  }, [items, selected]);
+
+  const download = useMutation({
+    mutationFn: (id: string) => pcapApi.downloadCapture(id),
+  });
+  const bulkDelete = useMutation({
+    mutationFn: (ids: string[]) => pcapApi.bulkDeleteCaptures(ids),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["pcap-captures"] });
+      setSelected(new Set());
+      setPendingBulk(null);
+    },
+  });
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  const allChecked = items.length > 0 && selected.size === items.length;
+  const someChecked = selected.size > 0 && !allChecked;
+
+  if (isLoading) {
+    return (
+      <p className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" /> Loading captures…
+      </p>
+    );
+  }
+  if (isError) {
+    return <p className="text-xs text-destructive">Failed to load captures.</p>;
+  }
+  if (items.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No captures yet — start one on the left.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {selected.size > 0 && (
+        <div className="flex items-center justify-between rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs">
+          <span>{selected.size} selected</span>
+          <button
+            type="button"
+            onClick={() => setPendingBulk(items.filter((s) => selected.has(s.id)))}
+            disabled={bulkDelete.isPending}
+            className="inline-flex items-center gap-1 rounded border border-destructive/40 px-2 py-0.5 text-[11px] text-destructive hover:bg-destructive/10 disabled:opacity-60"
+          >
+            <Trash2 className="h-3 w-3" /> Delete {selected.size}
+          </button>
+        </div>
+      )}
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full min-w-[560px] text-xs">
+          <thead>
+            <tr className="border-b bg-muted/30">
+              <th className="w-8 px-2 py-1.5 text-left">
+                <input
+                  type="checkbox"
+                  aria-label="Select all"
+                  checked={allChecked}
+                  ref={(el) => {
+                    if (el) el.indeterminate = someChecked;
+                  }}
+                  onChange={() =>
+                    setSelected(
+                      allChecked ? new Set() : new Set(items.map((s) => s.id)),
+                    )
+                  }
+                />
+              </th>
+              <th className="px-2 py-1.5 text-left">When</th>
+              <th className="px-2 py-1.5 text-left">Interface</th>
+              <th className="px-2 py-1.5 text-left">Filter</th>
+              <th className="px-2 py-1.5 text-left">Status</th>
+              <th className="px-2 py-1.5 text-left">Size</th>
+              <th className="px-2 py-1.5"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((s) => (
+              <tr
+                key={s.id}
+                onClick={() => onSelect(s)}
+                className={cn(
+                  "cursor-pointer border-b last:border-0 hover:bg-muted/20",
+                  selected.has(s.id) && "bg-amber-500/5",
+                )}
+              >
+                <td className="px-2 py-1" onClick={(e) => e.stopPropagation()}>
+                  <input
+                    type="checkbox"
+                    aria-label={`Select capture ${s.id}`}
+                    checked={selected.has(s.id)}
+                    onChange={() => toggle(s.id)}
+                  />
+                </td>
+                <td className="px-2 py-1 text-muted-foreground">
+                  {humanTime(s.created_at)}
+                </td>
+                <td className="px-2 py-1 font-mono">{s.interface}</td>
+                <td className="max-w-[160px] truncate px-2 py-1 font-mono text-muted-foreground">
+                  {s.bpf_filter || "—"}
+                </td>
+                <td className="px-2 py-1">
+                  <StatusPill status={s.status} />
+                </td>
+                <td className="px-2 py-1 tabular-nums">
+                  {fmtBytes(s.pcap_size_bytes)}
+                </td>
+                <td
+                  className="px-2 py-1 text-right"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {s.has_artifact && (
+                    <button
+                      type="button"
+                      title="Download .pcap"
+                      onClick={() => download.mutate(s.id)}
+                      className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+                    >
+                      <Download className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {pendingBulk && (
+        <ConfirmBulkDeleteModal
+          captures={pendingBulk}
+          pending={bulkDelete.isPending}
+          onConfirm={() => bulkDelete.mutate(pendingBulk.map((s) => s.id))}
+          onClose={() => setPendingBulk(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ConfirmBulkDeleteModal({
+  captures,
+  pending,
+  onConfirm,
+  onClose,
+}: {
+  captures: PcapCaptureRead[];
+  pending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  const inFlight = captures.filter(
+    (s) => s.status === "queued" || s.status === "running",
+  ).length;
+  const terminal = captures.length - inFlight;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
+      <div className="w-full max-w-md rounded-lg border bg-card p-5 shadow-xl">
+        <h3 className="text-base font-semibold">
+          Delete {captures.length} capture{captures.length === 1 ? "" : "s"}?
+        </h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {terminal > 0 && (
+            <>
+              {terminal} finished capture
+              {terminal === 1 ? " (and its .pcap) will be" : "s (and their .pcaps) will be"}{" "}
+              permanently removed.
+            </>
+          )}
+          {terminal > 0 && inFlight > 0 && " "}
+          {inFlight > 0 && (
+            <>
+              {inFlight} running capture{inFlight === 1 ? "" : "s"} will be
+              cancelled.
+            </>
+          )}
+        </p>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={pending}
+            className="inline-flex items-center gap-1.5 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-1.5 text-sm text-destructive hover:bg-destructive/20 disabled:opacity-50"
+          >
+            {pending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Trash2 className="h-3.5 w-3.5" />
+            )}
+            Delete {captures.length}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/pcap/PacketCapturePage.tsx
+++ b/frontend/src/pages/pcap/PacketCapturePage.tsx
@@ -43,7 +43,9 @@ function fmtBytes(n: number | null | undefined): string {
 
 function isTerminal(s: PcapCaptureRead): boolean {
   return (
-    s.status === "completed" || s.status === "failed" || s.status === "cancelled"
+    s.status === "completed" ||
+    s.status === "failed" ||
+    s.status === "cancelled"
   );
 }
 
@@ -75,7 +77,8 @@ export function PacketCapturePage() {
         <p className="mt-1 max-w-3xl text-xs text-muted-foreground">
           Run tcpdump on the control plane or an appliance host, watch live
           progress, and download the .pcap for Wireshark. Captures raw traffic
-          (may include sensitive payloads) — every start and download is audited.
+          (may include sensitive payloads) — every start and download is
+          audited.
         </p>
       </div>
 
@@ -83,7 +86,10 @@ export function PacketCapturePage() {
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <div className="rounded-lg border bg-card p-4">
             <h2 className="mb-3 text-sm font-medium">New capture</h2>
-            <CaptureForm onStarted={onStarted} initialVantage={initialVantage} />
+            <CaptureForm
+              onStarted={onStarted}
+              initialVantage={initialVantage}
+            />
           </div>
 
           <div className="flex flex-col rounded-lg border bg-card">
@@ -95,7 +101,10 @@ export function PacketCapturePage() {
               >
                 Live
               </TabButton>
-              <TabButton active={tab === "history"} onClick={() => setTab("history")}>
+              <TabButton
+                active={tab === "history"}
+                onClick={() => setTab("history")}
+              >
                 History
               </TabButton>
               <TabButton
@@ -209,7 +218,15 @@ function CaptureForm({
   const hasStop = durationS !== "" || maxPackets !== "" || maxMiB !== "";
 
   const commandPreview = useMemo(() => {
-    const parts = ["tcpdump", "-n", "-U", "-i", iface, "-s", String(snaplen || 0)];
+    const parts = [
+      "tcpdump",
+      "-n",
+      "-U",
+      "-i",
+      iface,
+      "-s",
+      String(snaplen || 0),
+    ];
     if (!promiscuous) parts.push("-p");
     if (maxPackets !== "") parts.push("-c", String(maxPackets));
     parts.push("-w", "<file>");
@@ -267,8 +284,8 @@ function CaptureForm({
               className="w-full rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
             />
             <p className="mt-1 text-[11px] text-muted-foreground">
-              The appliance host's real NIC — validated against the host when the
-              capture runs. "any" includes all host traffic.
+              The appliance host's real NIC — validated against the host when
+              the capture runs. "any" includes all host traffic.
             </p>
           </>
         ) : (
@@ -285,7 +302,9 @@ function CaptureForm({
               ))}
             </select>
             {ifaces?.note && (
-              <p className="mt-1 text-[11px] text-muted-foreground">{ifaces.note}</p>
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                {ifaces.note}
+              </p>
             )}
           </>
         )}
@@ -328,7 +347,12 @@ function CaptureForm({
           onChange={setMaxPackets}
           max={1000000}
         />
-        <NumField label="Max MiB" value={maxMiB} onChange={setMaxMiB} max={100} />
+        <NumField
+          label="Max MiB"
+          value={maxMiB}
+          onChange={setMaxMiB}
+          max={100}
+        />
       </div>
 
       <div className="grid grid-cols-2 items-end gap-2">
@@ -419,7 +443,12 @@ function StatusPill({ status }: { status: PcapCaptureRead["status"] }) {
     cancelled: "bg-amber-500/15 text-amber-600",
   };
   return (
-    <span className={cn("rounded px-1.5 py-0.5 text-[11px] font-medium", map[status])}>
+    <span
+      className={cn(
+        "rounded px-1.5 py-0.5 text-[11px] font-medium",
+        map[status],
+      )}
+    >
       {status}
     </span>
   );
@@ -451,7 +480,8 @@ function LiveTab({
 
   const cancel = useMutation({
     mutationFn: (id: string) => pcapApi.cancelCapture(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["pcap-capture", captureId] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["pcap-capture", captureId] }),
   });
 
   if (!captureId || !data) {
@@ -577,7 +607,9 @@ function ResultTab({ captureId }: { captureId: string | null }) {
 function HistoryTab({ onSelect }: { onSelect: (c: PcapCaptureRead) => void }) {
   const qc = useQueryClient();
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [pendingBulk, setPendingBulk] = useState<PcapCaptureRead[] | null>(null);
+  const [pendingBulk, setPendingBulk] = useState<PcapCaptureRead[] | null>(
+    null,
+  );
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["pcap-captures", "recent"],
@@ -645,7 +677,9 @@ function HistoryTab({ onSelect }: { onSelect: (c: PcapCaptureRead) => void }) {
           <span>{selected.size} selected</span>
           <button
             type="button"
-            onClick={() => setPendingBulk(items.filter((s) => selected.has(s.id)))}
+            onClick={() =>
+              setPendingBulk(items.filter((s) => selected.has(s.id)))
+            }
             disabled={bulkDelete.isPending}
             className="inline-flex items-center gap-1 rounded border border-destructive/40 px-2 py-0.5 text-[11px] text-destructive hover:bg-destructive/10 disabled:opacity-60"
           >
@@ -769,7 +803,9 @@ function ConfirmBulkDeleteModal({
           {terminal > 0 && (
             <>
               {terminal} finished capture
-              {terminal === 1 ? " (and its .pcap) will be" : "s (and their .pcaps) will be"}{" "}
+              {terminal === 1
+                ? " (and its .pcap) will be"
+                : "s (and their .pcaps) will be"}{" "}
               permanently removed.
             </>
           )}


### PR DESCRIPTION
Closes #59

On-demand packet capture as a first-class, RBAC-gated, audited platform tool — for troubleshooting an appliance/container where there's no easy shell. Ships both vantages from the expanded design on #59.

## What it does
A new **Tools → Packet Capture** page: pick a vantage, build a BPF filter (with DDI presets), set stop conditions (packets / duration / bytes) + snaplen, watch live byte/packet progress, and download the `.pcap` for Wireshark. Mirrors the nmap scanner (persisted job rows, 5-state lifecycle, history + bulk-delete, `tools.pcap` feature module, DEMO_MODE lockdown, `setcap cap_net_raw`) — but the deliverable is a binary `.pcap` on disk: download-only, auto-pruned after `pcap_retention_days` (default 7).

## Phase 1 — server vantage
tcpdump runs in the worker container (control-plane network). New dedicated `manage_packet_capture` permission (seeded to **Network Editor**, *not* Viewer — captured bytes are a privileged read); every start / download / cancel / delete is audited. The BPF filter is passed as tcpdump's single trailing argv element (never shell-interpolated) + charset-validated. Download is guarded 404-never-500 when the artifact is gone. Operator Copilot gets `find`/`count`/`get_packet_captures` reads (metadata only, never bytes) + a gated `propose_run_packet_capture` write. On single-node k8s the api + worker share the pcap dir via a hostPath.

## Phase 2 — appliance-host vantage (real NICs)
Captures on an appliance's *real* host NICs — what operators actually need. The supervisor pod isn't `hostNetwork` (and making it so was rejected: it would put a privileged sniffer on every HA node's host netns + break the supervisor's own in-cluster DNS), so capture runs **on the host** via the trigger-file → systemd `.path` pattern (same as snmp/chrony reload):
- `pcap_capture.py` DB-poll dispatch — the `packet_capture` row is the authority (guarded-UPDATE claim), so any api replica can serve the supervisor poll (no in-memory queue to strand the job).
- cert-authed `/supervisor/pcap/{poll,progress,upload}` — upload streams the `.pcap` to the shared dir (`.partial` → atomic rename + sha256, byte-capped); cancel is terminal (a late upload never overwrites it).
- supervisor `pcap_proxy` daemon: poll → re-validate → write request trigger → relay progress (+ cancel) → stream the finished `.pcap` back → clean up.
- host `spatium-pcap-runner` (dependency-free bash) + `spatiumddi-pcap.{path,service}` units: tcpdump in the host netns, own process group, free-space pre-check, wall-clock + byte caps, SIGTERM-then-KILL, validates the interface against `/sys/class/net`.
- frontend: vantage picker (control plane + each approved appliance) + a "Packet capture" deep-link in the Fleet drilldown.

## Verification
Both vantages verified **live on a single-node appliance**: server vantage (200 pkts → valid `.pcap`) and appliance-host vantage (300 pkts, captured on the host NIC via the full poll→trigger→tcpdump→upload chain → valid `.pcap` downloaded). 56 backend tests pass; full mypy/ruff/black + migration-shape linter clean; frontend lint+build green. A pre-PR adversarial review (6 dimensions, verified) returned **ship** with no blockers/majors; the surfaced minor polish (runner stderr diagnostic, header copy, a demo-membership test) is folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)