### PR TITLE
feat(pcap): #59 follow-ups — appliance NIC picker, keep partial on Stop, inline download

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -58,6 +58,53 @@ _UDEV_DATA = Path("/run/udev/data")
 
 _UUID_RE = re.compile(r"root=UUID=([0-9a-fA-F-]+)")
 
+# #59 — ephemeral / uninteresting net devices the operator would never
+# pick as a capture interface (pod veths, docker/cni internal, tunnels).
+_IFACE_SKIP_RE = re.compile(r"^(lo$|veth|vnet|docker|kube-|cali|tunl|nodelocaldns)")
+
+
+def host_network_interfaces() -> list[str]:
+    """Host NICs (e.g. ``ens18``, ``cni0``) for the appliance-vantage
+    packet-capture interface picker (#59).
+
+    The supervisor pod isn't ``hostNetwork``, so its own
+    ``/sys/class/net`` shows pod veths — NOT the host's real NICs. But
+    udev writes every host net device into ``/run/udev/data/n<ifindex>``
+    with an ``E:ID_NET_NAME=<name>`` line (``ID_NET_NAME_PATH`` as a
+    fallback), and ``/run/udev`` is already bind-mounted into the
+    supervisor — the same source the slot detector uses for block
+    devices. Ephemeral pod veths + loopback are filtered. Returns a
+    sorted, de-duplicated list; empty on non-appliance hosts or before
+    udev populates net entries (the caller only ships a non-empty list,
+    so a transient empty read never wipes the control plane's set).
+    """
+    names: set[str] = set()
+    try:
+        entries = list(_UDEV_DATA.iterdir())
+    except OSError:
+        return []
+    for entry in entries:
+        # ``n<ifindex>`` files are network devices (``b…`` block, ``c…``
+        # char, ``+…`` subsystem tags are irrelevant here).
+        if not (entry.name.startswith("n") and entry.name[1:].isdigit()):
+            continue
+        try:
+            text = entry.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        name_exact: str | None = None
+        name_path: str | None = None
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("E:ID_NET_NAME="):
+                name_exact = line.split("=", 1)[1].strip()
+            elif line.startswith("E:ID_NET_NAME_PATH="):
+                name_path = line.split("=", 1)[1].strip()
+        name = name_exact or name_path
+        if name and not _IFACE_SKIP_RE.match(name):
+            names.add(name)
+    return sorted(names)
+
 
 def detect_runtime() -> str:
     """Issue #183 Phase 7 — the appliance is k3s-only.

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -486,6 +486,16 @@ def heartbeat_once(
         if _cached_role_health:
             body["role_health"] = _cached_role_health
 
+        # #59 — host NICs (ens18, cni0, …) for the appliance-vantage
+        # packet-capture interface picker. Only shipped when non-empty so
+        # a transient empty /run/udev read never wipes the learned set.
+        try:
+            ifaces = appliance_state.host_network_interfaces()
+            if ifaces:
+                body["host_interfaces"] = ifaces
+        except Exception as exc:  # noqa: BLE001 — never break the heartbeat
+            log.warning("supervisor.host_interfaces.failed", error=str(exc))
+
         # #272 Phase 9b — report the seed's etcd snapshot inventory (read
         # from the k3s ETCDSnapshotFile CRs over the kubeapi, no host k3s
         # binary needed) so Fleet can show recoverable snapshots without an

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -214,6 +214,7 @@ backend/alembic/versions/c2a7e4f81b69_logical_ownership_entities.py:drop_table:2
 backend/alembic/versions/c2a7e4f81b69_logical_ownership_entities.py:drop_table:285
 backend/alembic/versions/c2a7e4f81b69_logical_ownership_entities.py:drop_table:290
 backend/alembic/versions/c2e6a89d4b15_platform_settings_timezone.py:drop_column:40
+backend/alembic/versions/c3a1f9d24b80_appliance_host_interfaces.py:drop_column:35
 backend/alembic/versions/c3a81f9d6b42_oui_vendor_lookup.py:drop_column:72
 backend/alembic/versions/c3a81f9d6b42_oui_vendor_lookup.py:drop_column:73
 backend/alembic/versions/c3a81f9d6b42_oui_vendor_lookup.py:drop_column:74

--- a/backend/alembic/versions/c3a1f9d24b80_appliance_host_interfaces.py
+++ b/backend/alembic/versions/c3a1f9d24b80_appliance_host_interfaces.py
@@ -1,0 +1,35 @@
+"""appliance.host_interfaces — host NICs for the appliance-vantage pcap picker (#59)
+
+The supervisor enumerates the appliance host's real NICs (from
+/run/udev/data) and reports them on every heartbeat; the packet-capture
+appliance vantage surfaces them as an interface dropdown so operators
+pick a NIC (e.g. ens18) instead of guessing or being told it's a
+"follow-up phase".
+
+Revision ID: c3a1f9d24b80
+Revises: b8e3f1c47a92
+Create Date: 2026-06-15
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "c3a1f9d24b80"
+down_revision = "b8e3f1c47a92"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "appliance",
+        sa.Column("host_interfaces", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("appliance", "host_interfaces")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -5137,7 +5137,9 @@ async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[s
     """Cert-authed. Streams the host-captured ``.pcap`` to the shared
     PCAP_DIR (``.partial`` → atomic rename + sha256), capped at
     ``max_bytes`` + margin. ``?error=`` (empty body) finalizes a failed
-    capture. Cancel is terminal — a cancelled row discards the bytes."""
+    capture. A cancelled row keeps its uploaded bytes (valid partial
+    ``.pcap`` up to the last flushed packet) so Stop-early stays
+    downloadable; it just stays terminal-cancelled (#59 follow-up)."""
     import hashlib as _hashlib  # noqa: PLC0415
     import os as _os  # noqa: PLC0415
 
@@ -5224,9 +5226,9 @@ async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[s
         },
         error=None,
     )
-    if final_status == "cancelled":
-        # Cancel won the race — discard the bytes we just stored.
-        dest.unlink(missing_ok=True)
+    # NOTE: a cancelled capture KEEPS its uploaded bytes (#59 follow-up) —
+    # the savefile is a valid partial .pcap up to the last flushed packet,
+    # so the operator can still download what was captured before Stop.
     logger.info(
         "appliance.pcap.upload",
         appliance_id=str(appliance.id),

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -5192,6 +5192,7 @@ async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[s
     partial = dest.with_name(f"{dest.stem}.pcap.partial")
     h = _hashlib.sha256()
     size = 0
+    over_cap = False
     try:
         with open(partial, "wb") as fh:
             async for chunk in request.stream():
@@ -5199,18 +5200,31 @@ async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[s
                     continue
                 size += len(chunk)
                 if size > cap:
-                    fh.close()
-                    partial.unlink(missing_ok=True)
-                    raise HTTPException(
-                        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                        "uploaded pcap exceeds the capture's byte cap",
-                    )
+                    over_cap = True
+                    break
                 fh.write(chunk)
                 h.update(chunk)
-        _os.replace(partial, dest)
-    except HTTPException:
-        raise
     except Exception as exc:  # noqa: BLE001
+        partial.unlink(missing_ok=True)
+        return {
+            "status": await _pc.finalize_capture(
+                db,
+                capture_id,
+                pcap_path=None,
+                pcap_size_bytes=None,
+                pcap_sha256=None,
+                packet_count=None,
+                metadata={"stop_reason": "upload_error"},
+                error=f"upload failed: {exc}",
+            )
+        }
+
+    if over_cap:
+        # The savefile exceeds the capture's own byte cap + margin — the host
+        # runner caps tcpdump at max_bytes, so this shouldn't happen. Finalize
+        # as failed (don't leave the row dangling for the reaper) and drop the
+        # oversized partial. A prior cancel still wins. Over-cap is the one
+        # case we can't honour the keep-partial promise for.
         partial.unlink(missing_ok=True)
         await _pc.finalize_capture(
             db,
@@ -5218,12 +5232,40 @@ async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[s
             pcap_path=None,
             pcap_size_bytes=None,
             pcap_sha256=None,
-            packet_count=None,
-            metadata={"stop_reason": "upload_error"},
-            error=f"upload failed: {exc}",
+            packet_count=packet_count,
+            metadata={"stop_reason": "over_cap"},
+            error="uploaded pcap exceeds the capture's byte cap",
         )
-        return {"status": "failed"}
+        raise HTTPException(
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            "uploaded pcap exceeds the capture's byte cap",
+        )
 
+    if size == 0:
+        # Stopped before the first packet flushed. Never leave a 0-byte file
+        # orphaned in PCAP_DIR (no row would reference it, so prune/delete —
+        # which key on pcap_path — could never reclaim it).
+        partial.unlink(missing_ok=True)
+        final_status = await _pc.finalize_capture(
+            db,
+            capture_id,
+            pcap_path=None,
+            pcap_size_bytes=0,
+            pcap_sha256=None,
+            packet_count=packet_count,
+            metadata={"packet_count": packet_count, "byte_count": 0, "stop_reason": "empty"},
+            error=None,
+        )
+        logger.info(
+            "appliance.pcap.upload",
+            appliance_id=str(appliance.id),
+            capture_id=str(capture_id),
+            bytes=0,
+            status=final_status,
+        )
+        return {"status": final_status}
+
+    _os.replace(partial, dest)
     final_status = await _pc.finalize_capture(
         db,
         capture_id,

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1083,6 +1083,12 @@ class SupervisorHeartbeatRequest(BaseModel):
     # Empty dict on legacy compose appliances; None / omitted = the
     # supervisor didn't run the probe this tick (pre-#183 supervisors).
     cluster_health: dict[str, Any] | None = None
+    # #59 — host NICs the supervisor read from /run/udev/data (real
+    # NICs like ens18 + cni0; ephemeral veth* filtered). Surfaced as the
+    # appliance-vantage packet-capture interface picker. None / omitted =
+    # the supervisor didn't enumerate this tick (non-appliance or
+    # pre-#59 supervisor); empty list = enumerated but found nothing.
+    host_interfaces: list[str] | None = None
     # Issue #183 Phase 5 — operator-facing k3s metadata.
     # ``k3s_version`` is the upstream release tag the slot was baked
     # against (e.g. ``v1.35.5+k3s1``). ``kubeconfig`` is the raw
@@ -1665,6 +1671,12 @@ async def supervisor_heartbeat(
         # Same overwrite-verbatim shape as role_health. Empty dict
         # is a meaningful signal (legacy compose; clear stale state).
         row.cluster_health = dict(body.cluster_health)
+    if body.host_interfaces is not None:
+        # #59 — host NICs for the appliance-vantage capture picker.
+        # Overwrite verbatim (the supervisor sends the current host set
+        # each tick); only update when reported so non-appliance /
+        # pre-#59 supervisors don't wipe a previously-learned list.
+        row.host_interfaces = list(body.host_interfaces)
 
     # Issue #183 Phase 5 — k3s version + kubeconfig persist. Both
     # follow "only update when not None" so legacy compose / pre-

--- a/backend/app/api/v1/pcap/router.py
+++ b/backend/app/api/v1/pcap/router.py
@@ -151,7 +151,7 @@ async def list_interfaces(
     db: DB,
     current_user: CurrentUser,  # noqa: ARG001 — gate handled by dep
     vantage: str = Query("server"),
-    appliance_id: uuid.UUID | None = Query(None),  # noqa: ARG001 — Phase 2
+    appliance_id: uuid.UUID | None = Query(None),
 ) -> PcapInterfacesResponse:
     if vantage == "server":
         return PcapInterfacesResponse(
@@ -162,12 +162,33 @@ async def list_interfaces(
             ),
         )
     if vantage == "appliance":
-        # Phase 2 dispatches a list-interfaces request to the supervisor,
-        # which answers from the host net namespace. Not yet available.
-        return PcapInterfacesResponse(
-            interfaces=[],
-            note="Appliance-host capture ships in a follow-up phase.",
-        )
+        # The supervisor enumerates the host's real NICs from
+        # /run/udev/data and reports them on every heartbeat; we surface
+        # that list so the operator picks (not guesses) the capture NIC.
+        if appliance_id is None:
+            return PcapInterfacesResponse(
+                interfaces=[],
+                note="Select an appliance to list its host network interfaces.",
+            )
+        appliance = await db.get(Appliance, appliance_id)
+        if appliance is None:
+            raise HTTPException(status_code=422, detail="appliance_id not found")
+        ifaces = [i for i in (appliance.host_interfaces or []) if i]
+        if ifaces:
+            if "any" not in ifaces:
+                ifaces = ["any", *ifaces]
+            note = (
+                "The appliance host's real NICs (reported by the supervisor). "
+                'Pick the LAN NIC to capture subnet traffic; "any" spans all '
+                "host interfaces."
+            )
+        else:
+            note = (
+                "No interfaces reported yet — the supervisor enumerates them on "
+                'its heartbeat (~30 s). Type a NIC name (e.g. eth0) or "any" '
+                "meanwhile."
+            )
+        return PcapInterfacesResponse(interfaces=ifaces, note=note)
     raise HTTPException(status_code=422, detail=f"unknown vantage: {vantage!r}")
 
 

--- a/backend/app/api/v1/pcap/router.py
+++ b/backend/app/api/v1/pcap/router.py
@@ -67,6 +67,22 @@ router = APIRouter(tags=["pcap"])
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
+# A capture is downloadable once it has a real on-disk artifact — true for
+# a normally-completed capture AND for one the operator Stopped early
+# (#59 follow-up): tcpdump flushes the savefile on SIGTERM, so the packets
+# captured before Stop are a valid, downloadable ``.pcap``. A failed
+# capture never exposes a partial (its bytes are unreliable).
+_DOWNLOADABLE_STATUSES = ("completed", "cancelled")
+
+
+def _has_artifact(row: PacketCapture) -> bool:
+    return bool(
+        row.status in _DOWNLOADABLE_STATUSES
+        and row.pcap_path
+        and not row.artifact_missing
+        and (row.pcap_size_bytes or 0) > 0
+    )
+
 
 def _to_read(row: PacketCapture) -> PcapCaptureRead:
     return PcapCaptureRead(
@@ -92,12 +108,7 @@ def _to_read(row: PacketCapture) -> PcapCaptureRead:
         bytes_captured=row.bytes_captured,
         pcap_size_bytes=row.pcap_size_bytes,
         pcap_sha256=row.pcap_sha256,
-        has_artifact=bool(
-            row.status == "completed"
-            and row.pcap_path
-            and not row.artifact_missing
-            and (row.pcap_size_bytes or 0) > 0
-        ),
+        has_artifact=_has_artifact(row),
         metadata_json=row.metadata_json,
         created_by_user_id=row.created_by_user_id,
         created_at=row.created_at,
@@ -413,7 +424,7 @@ async def download_capture(
     row = await db.get(PacketCapture, capture_id)
     if row is None:
         raise HTTPException(status_code=404, detail="Capture not found")
-    if row.status != "completed":
+    if not _has_artifact(row):
         raise HTTPException(status_code=404, detail="Capture has no downloadable artifact yet")
     if not row.pcap_path or not Path(row.pcap_path).exists():
         raise HTTPException(

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -668,6 +668,13 @@ class Appliance(Base):
         server_default="{}",
     )
 
+    # #59 — host NICs the supervisor enumerated from /run/udev/data
+    # (e.g. ens18, cni0; ephemeral veth* filtered out). Surfaced as the
+    # appliance-vantage interface picker for packet capture so operators
+    # don't have to guess the host NIC name. Reported on every
+    # appliance-mode heartbeat; None until the first one lands.
+    host_interfaces: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
+
     # #387 — per-plane host-config apply health from the supervisor's
     # bounded-retry fire-guard. ``{<plane>: {state, attempts, at}}`` for
     # the hash-keyed host-config runners (snmp / ntp / lldp / syslog /

--- a/backend/app/services/appliance/pcap_capture.py
+++ b/backend/app/services/appliance/pcap_capture.py
@@ -122,31 +122,48 @@ async def finalize_capture(
 ) -> str:
     """Stamp the terminal state after the supervisor finishes.
 
-    Returns the final status. Cancel is terminal + idempotent: if the row
-    was cancelled while the capture was finishing, the uploaded bytes are
-    discarded by the caller and the row stays ``cancelled`` (a
-    late-completing capture never overwrites a cancel)."""
+    Returns the final status. Cancel is terminal — a late-completing
+    capture never flips a cancelled row back to ``completed``. But the
+    bytes captured *before* the operator pressed Stop are kept: tcpdump
+    flushes the savefile on SIGTERM, so a partial ``.pcap`` is valid and
+    stays downloadable (#59 follow-up). Only a failed/empty upload leaves
+    the row without an artifact."""
     row = await db.get(PacketCapture, capture_id)
     if row is None:
         return "missing"
     row.finished_at = datetime.now(UTC)
-    if row.status == "cancelled":
-        # Caller unlinks the bytes; cancel wins.
-        return "cancelled"
+    was_cancelled = row.status == "cancelled"
+
     if error:
+        # Failure finalize (no usable bytes). A prior cancel still wins —
+        # don't relabel a Stopped capture as failed.
+        if was_cancelled:
+            await db.commit()
+            return "cancelled"
         row.status = "failed"
         row.error_message = error[:500]
         await db.commit()
         return "failed"
-    row.status = "completed"
-    row.pcap_path = pcap_path
-    row.pcap_size_bytes = pcap_size_bytes
-    row.pcap_sha256 = pcap_sha256
-    if packet_count is not None:
-        row.packets_captured = packet_count
-    if pcap_size_bytes is not None:
+
+    # Success finalize — a (possibly partial, if Stopped early) savefile
+    # was uploaded. Record the artifact even when cancelled so the packets
+    # captured before Stop remain downloadable.
+    if pcap_path is not None and (pcap_size_bytes or 0) > 0:
+        row.pcap_path = pcap_path
+        row.pcap_size_bytes = pcap_size_bytes
+        row.pcap_sha256 = pcap_sha256
+        if packet_count is not None:
+            row.packets_captured = packet_count
         row.bytes_captured = pcap_size_bytes
-    row.metadata_json = metadata
+    row.metadata_json = {
+        **(metadata or {}),
+        "stop_reason": "cancelled" if was_cancelled else "completed",
+    }
+    if was_cancelled:
+        # Keep the partial; the row stays terminal-cancelled.
+        await db.commit()
+        return "cancelled"
+    row.status = "completed"
     await db.commit()
     return "completed"
 

--- a/backend/app/services/appliance/pcap_capture.py
+++ b/backend/app/services/appliance/pcap_capture.py
@@ -131,12 +131,22 @@ async def finalize_capture(
     row = await db.get(PacketCapture, capture_id)
     if row is None:
         return "missing"
-    row.finished_at = datetime.now(UTC)
+    # Preserve an existing finished_at — the cancel endpoint stamps it at
+    # Stop time, which is the true "when it stopped". The upload (and this
+    # finalize) can land seconds later via the supervisor relay; re-stamping
+    # to upload-time would push the UI's cancel→artifact grace window out.
+    if row.finished_at is None:
+        row.finished_at = datetime.now(UTC)
     was_cancelled = row.status == "cancelled"
 
     if error:
-        # Failure finalize (no usable bytes). A prior cancel still wins —
-        # don't relabel a Stopped capture as failed.
+        # Failure finalize (no usable bytes). Record the metadata either way
+        # so a failed/empty row still carries its stop_reason for diagnostics.
+        row.metadata_json = {
+            **(metadata or {}),
+            "stop_reason": (metadata or {}).get("stop_reason", "error"),
+        }
+        # A prior cancel still wins — don't relabel a Stopped capture as failed.
         if was_cancelled:
             await db.commit()
             return "cancelled"

--- a/backend/tests/test_pcap_api.py
+++ b/backend/tests/test_pcap_api.py
@@ -265,6 +265,48 @@ async def test_download_streams_pcap_and_audits(
     assert any(a.action == "download" for a in rows)
 
 
+async def test_stopped_capture_keeps_partial_download(
+    client: AsyncClient, db_session: AsyncSession, tmp_path: Path
+) -> None:
+    """A capture the operator Stopped early still serves the bytes captured
+    before Stop (#59 follow-up): tcpdump flushes the savefile on SIGTERM, so
+    a cancelled row with a non-empty .pcap is a valid, downloadable artifact."""
+    _, token = await _superadmin(db_session)
+    f = tmp_path / "partial.pcap"
+    f.write_bytes(b"\xd4\xc3\xb2\xa1partialbytes")
+    cap = await _make_capture(
+        db_session,
+        status="cancelled",
+        pcap_path=str(f),
+        pcap_size_bytes=f.stat().st_size,
+        finished_at=datetime.now(UTC),
+    )
+    await db_session.commit()
+
+    # has_artifact is exposed on the read model so the UI shows Download.
+    detail = await client.get(f"/api/v1/pcap/captures/{cap.id}", headers=_hdr(token))
+    assert detail.status_code == 200
+    assert detail.json()["has_artifact"] is True
+
+    # And the bytes actually stream.
+    r = await client.get(f"/api/v1/pcap/captures/{cap.id}/download", headers=_hdr(token))
+    assert r.status_code == 200, r.text
+    assert r.content == b"\xd4\xc3\xb2\xa1partialbytes"
+
+
+async def test_cancelled_with_no_bytes_has_no_artifact(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A cancelled capture that never wrote bytes stays artifact-less."""
+    _, token = await _superadmin(db_session)
+    cap = await _make_capture(db_session, status="cancelled", pcap_size_bytes=0)
+    await db_session.commit()
+    detail = await client.get(f"/api/v1/pcap/captures/{cap.id}", headers=_hdr(token))
+    assert detail.json()["has_artifact"] is False
+    r = await client.get(f"/api/v1/pcap/captures/{cap.id}/download", headers=_hdr(token))
+    assert r.status_code == 404
+
+
 # ── interfaces ───────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_pcap_appliance.py
+++ b/backend/tests/test_pcap_appliance.py
@@ -272,3 +272,43 @@ async def test_supervisor_pcap_poll_requires_cert(
     # No cert headers → 403 (the supervisor channel is cert-only).
     r = await client.post("/api/v1/appliance/supervisor/pcap/poll")
     assert r.status_code == 403
+
+
+async def test_appliance_interfaces_lists_reported_host_nics(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#59 — the appliance vantage surfaces the host NICs the supervisor
+    reported (heartbeat), with "any" prepended and the misleading
+    "follow-up phase" note gone."""
+    _, token = await _superadmin(db_session)
+    appl = await _appliance(db_session)
+    appl.host_interfaces = ["ens18", "cni0"]
+    await db_session.commit()
+    r = await client.get(
+        f"/api/v1/pcap/interfaces?vantage=appliance&appliance_id={appl.id}",
+        headers=_hdr(token),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["interfaces"][0] == "any"  # always offered first
+    assert "ens18" in body["interfaces"]
+    assert "cni0" in body["interfaces"]
+    assert "follow-up phase" not in (body["note"] or "")
+
+
+async def test_appliance_interfaces_empty_before_first_report(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Before the supervisor's first NIC report, the list is empty and the
+    note tells the operator to wait / type one."""
+    _, token = await _superadmin(db_session)
+    appl = await _appliance(db_session)  # host_interfaces stays NULL
+    await db_session.commit()
+    r = await client.get(
+        f"/api/v1/pcap/interfaces?vantage=appliance&appliance_id={appl.id}",
+        headers=_hdr(token),
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["interfaces"] == []
+    assert "reported yet" in body["note"]

--- a/backend/tests/test_pcap_appliance.py
+++ b/backend/tests/test_pcap_appliance.py
@@ -10,6 +10,7 @@ poll endpoint rejects a non-cert caller.
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -203,6 +204,60 @@ async def test_finalize_failed(db_session: AsyncSession) -> None:
     await db_session.refresh(cap)
     assert cap.status == "failed"
     assert "failed" in (cap.error_message or "")
+    # #59 review: the error path now records metadata so a failed row still
+    # carries its stop_reason for diagnostics.
+    assert (cap.metadata_json or {}).get("stop_reason") == "error"
+
+
+@pytest.mark.asyncio
+async def test_finalize_empty_keeps_no_artifact(db_session: AsyncSession) -> None:
+    """An upload that streamed 0 bytes (Stopped before the first packet) is
+    completed but artifact-less — no pcap_path recorded, so nothing orphans."""
+    appl = await _appliance(db_session)
+    cap = await _queued_appliance_capture(db_session, appl.id)
+    cap.status = "running"
+    await db_session.commit()
+    status = await pcap_capture.finalize_capture(
+        db_session,
+        cap.id,
+        pcap_path=None,
+        pcap_size_bytes=0,
+        pcap_sha256=None,
+        packet_count=0,
+        metadata={"stop_reason": "empty"},
+        error=None,
+    )
+    assert status == "completed"
+    await db_session.refresh(cap)
+    assert cap.pcap_path is None
+    assert cap.pcap_size_bytes is None or cap.pcap_size_bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_finalize_preserves_cancel_time_finished_at(db_session: AsyncSession) -> None:
+    """A cancelled row's finished_at (stamped at Stop time) is preserved, not
+    re-stamped to the later upload/finalize time (#59 review — keeps the UI's
+    cancel→artifact grace window anchored on the real stop time)."""
+    from datetime import timedelta
+
+    appl = await _appliance(db_session)
+    cap = await _queued_appliance_capture(db_session, appl.id)
+    cap.status = "cancelled"
+    t0 = datetime.now(UTC) - timedelta(seconds=30)
+    cap.finished_at = t0
+    await db_session.commit()
+    await pcap_capture.finalize_capture(
+        db_session,
+        cap.id,
+        pcap_path="/var/lib/spatiumddi/pcaps/p.pcap",
+        pcap_size_bytes=42,
+        pcap_sha256="a",
+        packet_count=1,
+        metadata={},
+        error=None,
+    )
+    await db_session.refresh(cap)
+    assert abs((cap.finished_at - t0).total_seconds()) < 1.0  # not re-stamped to now
 
 
 # ── create-capture appliance branch ──────────────────────────────────

--- a/backend/tests/test_pcap_appliance.py
+++ b/backend/tests/test_pcap_appliance.py
@@ -157,23 +157,30 @@ async def test_finalize_completed_and_cancel_wins(db_session: AsyncSession) -> N
     assert cap.packets_captured == 42
     assert cap.pcap_path.endswith("x.pcap")
 
-    # A cancelled row stays cancelled even if a late upload finalizes.
+    # A cancelled row stays cancelled even if a late upload finalizes — but
+    # it now KEEPS the partial bytes captured before Stop (#59 follow-up),
+    # so the operator can still download what was captured.
     cap2 = await _queued_appliance_capture(db_session, appl.id)
     cap2.status = "cancelled"
     await db_session.commit()
     status2 = await pcap_capture.finalize_capture(
         db_session,
         cap2.id,
-        pcap_path="/x.pcap",
-        pcap_size_bytes=1,
+        pcap_path="/var/lib/spatiumddi/pcaps/partial.pcap",
+        pcap_size_bytes=1234,
         pcap_sha256="z",
-        packet_count=1,
+        packet_count=7,
         metadata={},
         error=None,
     )
     assert status2 == "cancelled"
     await db_session.refresh(cap2)
     assert cap2.status == "cancelled"
+    # Partial artifact retained — not discarded.
+    assert cap2.pcap_path.endswith("partial.pcap")
+    assert cap2.pcap_size_bytes == 1234
+    assert cap2.packets_captured == 7
+    assert (cap2.metadata_json or {}).get("stop_reason") == "cancelled"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/pages/pcap/PacketCapturePage.tsx
+++ b/frontend/src/pages/pcap/PacketCapturePage.tsx
@@ -58,13 +58,15 @@ function isTerminal(s: PcapCaptureRead): boolean {
 const CANCEL_ARTIFACT_GRACE_MS = 20000;
 
 function isSettled(s: PcapCaptureRead): boolean {
-  if (s.status === "completed" || s.status === "failed") return true;
-  if (s.status === "cancelled") {
-    if (s.has_artifact) return true;
+  if (!isTerminal(s)) return false; // queued / running
+  // Terminal: a Stopped capture with no artifact yet is still finalizing —
+  // wait out the grace window for the partial to land. Everything else
+  // (completed, failed, cancelled-with-artifact) is fully settled.
+  if (s.status === "cancelled" && !s.has_artifact) {
     const fin = s.finished_at ? Date.parse(s.finished_at) : 0;
     return fin > 0 && Date.now() - fin > CANCEL_ARTIFACT_GRACE_MS;
   }
-  return false;
+  return true;
 }
 
 export function PacketCapturePage() {
@@ -205,6 +207,10 @@ function CaptureForm({
   // vantage select value: "server" or an appliance UUID.
   const [vantage, setVantage] = useState<string>(initialVantage);
   const [iface, setIface] = useState<string>("any");
+  // When the operator picks "Other…" in the interface dropdown, fall back to
+  // a free-text field — udev doesn't name every host NIC (bridges, overlay /
+  // VPN interfaces), and the host runner validates whatever name is typed.
+  const [customIface, setCustomIface] = useState(false);
   const [filter, setFilter] = useState("");
   const [durationS, setDurationS] = useState<number | "">(60);
   const [maxPackets, setMaxPackets] = useState<number | "">(10000);
@@ -286,7 +292,8 @@ function CaptureForm({
           value={vantage}
           onChange={(e) => {
             setVantage(e.target.value);
-            setIface("any"); // reset — server enumerates, appliance is free-text
+            setIface("any"); // reset — interface list is per-vantage
+            setCustomIface(false);
           }}
           className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
         >
@@ -301,13 +308,20 @@ function CaptureForm({
 
       <div>
         <label className="mb-1 block text-xs font-medium">Interface</label>
-        {ifaceList.length > 0 ? (
+        {ifaceList.length > 0 && (
           <select
-            value={iface}
-            onChange={(e) => setIface(e.target.value)}
+            value={customIface ? "__other__" : iface}
+            onChange={(e) => {
+              if (e.target.value === "__other__") {
+                setCustomIface(true);
+              } else {
+                setCustomIface(false);
+                setIface(e.target.value);
+              }
+            }}
             className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
           >
-            {(ifaceList.includes(iface)
+            {(customIface || ifaceList.includes(iface)
               ? ifaceList
               : [iface, ...ifaceList]
             ).map((n) => (
@@ -315,16 +329,23 @@ function CaptureForm({
                 {n}
               </option>
             ))}
+            <option value="__other__">Other — type a NIC name…</option>
           </select>
-        ) : (
-          // Appliance vantage before the supervisor's first NIC report —
-          // free-text fallback so the operator isn't blocked.
+        )}
+        {(customIface || ifaceList.length === 0) && (
+          // "Other…" picked, or the appliance hasn't reported NICs yet — let
+          // the operator type any NIC (bridges / overlay / VPN that udev
+          // didn't name). The host runner validates it against /sys/class/net.
           <input
             type="text"
             value={iface}
             onChange={(e) => setIface(e.target.value)}
-            placeholder="e.g. eth0, bond0, any"
-            className="w-full rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
+            placeholder="e.g. br0, vmbr0, tailscale0, any"
+            className={cn(
+              "w-full rounded-md border bg-background px-2 py-1.5 font-mono text-sm",
+              ifaceList.length > 0 && "mt-1",
+            )}
+            autoFocus={customIface}
           />
         )}
         {ifaces?.note && (
@@ -511,9 +532,6 @@ function LiveTab({
     onSuccess: () =>
       qc.invalidateQueries({ queryKey: ["pcap-capture", captureId] }),
   });
-  const download = useMutation({
-    mutationFn: (id: string) => pcapApi.downloadCapture(id),
-  });
 
   if (!captureId || !data) {
     return (
@@ -550,24 +568,10 @@ function LiveTab({
           <Trash2 className="h-3 w-3" /> Stop capture
         </button>
       )}
-      {/* After Stop (or natural finish): offer the download right here so
-          the operator never has to dig through History. The partial .pcap
-          lands a beat after a cancel — until then show a spinner. */}
-      {isTerminal(data) && data.has_artifact && (
-        <button
-          type="button"
-          onClick={() => download.mutate(data.id)}
-          disabled={download.isPending}
-          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-        >
-          {download.isPending ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <Download className="h-3.5 w-3.5" />
-          )}
-          Download .pcap ({fmtBytes(data.pcap_size_bytes)})
-        </button>
-      )}
+      {/* After Stop, the partial .pcap lands a beat later (server finalizes
+          post-SIGTERM; appliance relays via the supervisor). Show a spinner
+          until it settles, then onComplete hands off to the Result tab which
+          owns the Download button + the no-artifact message. */}
       {data.status === "cancelled" &&
         !data.has_artifact &&
         !isSettled(data) && (
@@ -576,12 +580,6 @@ function LiveTab({
             Finalizing the captured packets…
           </p>
         )}
-      {isTerminal(data) && !data.has_artifact && isSettled(data) && (
-        <p className="text-[11px] italic text-muted-foreground">
-          No downloadable artifact — the capture produced no packets before it
-          stopped.
-        </p>
-      )}
     </div>
   );
 }

--- a/frontend/src/pages/pcap/PacketCapturePage.tsx
+++ b/frontend/src/pages/pcap/PacketCapturePage.tsx
@@ -49,6 +49,24 @@ function isTerminal(s: PcapCaptureRead): boolean {
   );
 }
 
+// "Settled" = terminal AND the artifact question is resolved. A Stop
+// flips status to `cancelled` immediately, but the partial .pcap lands a
+// moment later (the server vantage finalizes after SIGTERM; the appliance
+// vantage relays the upload through the supervisor). So for a cancel we
+// keep waiting until has_artifact is true OR a grace window passes — that
+// way the Download button appears right at Stop instead of looking absent.
+const CANCEL_ARTIFACT_GRACE_MS = 20000;
+
+function isSettled(s: PcapCaptureRead): boolean {
+  if (s.status === "completed" || s.status === "failed") return true;
+  if (s.status === "cancelled") {
+    if (s.has_artifact) return true;
+    const fin = s.finished_at ? Date.parse(s.finished_at) : 0;
+    return fin > 0 && Date.now() - fin > CANCEL_ARTIFACT_GRACE_MS;
+  }
+  return false;
+}
+
 export function PacketCapturePage() {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [displayId, setDisplayId] = useState<string | null>(null);
@@ -202,13 +220,22 @@ function CaptureForm({
   });
   const approved = (appliances ?? []).filter((a) => a.state === "approved");
 
-  // Server vantage enumerates the worker's NICs; appliance vantage can't
-  // (the control plane can't see the host's NICs) so the operator types it.
+  // Both vantages enumerate NICs now: server lists the worker's own
+  // container NICs; appliance lists the host's real NICs (ens18, …) that
+  // the supervisor reported via heartbeat. Re-runs when the picked
+  // appliance changes so the dropdown matches that host.
   const { data: ifaces } = useQuery({
-    enabled: !isAppliance,
-    queryKey: ["pcap-interfaces", "server"],
-    queryFn: () => pcapApi.listInterfaces("server"),
+    queryKey: [
+      "pcap-interfaces",
+      isAppliance ? `appliance:${vantage}` : "server",
+    ],
+    queryFn: () =>
+      pcapApi.listInterfaces(
+        isAppliance ? "appliance" : "server",
+        isAppliance ? vantage : undefined,
+      ),
   });
+  const ifaceList = ifaces?.interfaces ?? [];
 
   const start = useMutation({
     mutationFn: (body: PcapCaptureCreate) => pcapApi.createCapture(body),
@@ -274,39 +301,36 @@ function CaptureForm({
 
       <div>
         <label className="mb-1 block text-xs font-medium">Interface</label>
-        {isAppliance ? (
-          <>
-            <input
-              type="text"
-              value={iface}
-              onChange={(e) => setIface(e.target.value)}
-              placeholder="e.g. eth0, bond0, any"
-              className="w-full rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
-            />
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              The appliance host's real NIC — validated against the host when
-              the capture runs. "any" includes all host traffic.
-            </p>
-          </>
+        {ifaceList.length > 0 ? (
+          <select
+            value={iface}
+            onChange={(e) => setIface(e.target.value)}
+            className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+          >
+            {(ifaceList.includes(iface)
+              ? ifaceList
+              : [iface, ...ifaceList]
+            ).map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
         ) : (
-          <>
-            <select
-              value={iface}
-              onChange={(e) => setIface(e.target.value)}
-              className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
-            >
-              {(ifaces?.interfaces ?? ["any"]).map((n) => (
-                <option key={n} value={n}>
-                  {n}
-                </option>
-              ))}
-            </select>
-            {ifaces?.note && (
-              <p className="mt-1 text-[11px] text-muted-foreground">
-                {ifaces.note}
-              </p>
-            )}
-          </>
+          // Appliance vantage before the supervisor's first NIC report —
+          // free-text fallback so the operator isn't blocked.
+          <input
+            type="text"
+            value={iface}
+            onChange={(e) => setIface(e.target.value)}
+            placeholder="e.g. eth0, bond0, any"
+            className="w-full rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
+          />
+        )}
+        {ifaces?.note && (
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            {ifaces.note}
+          </p>
         )}
       </div>
 
@@ -466,22 +490,29 @@ function LiveTab({
     enabled: !!captureId,
     queryKey: ["pcap-capture", captureId],
     queryFn: () => pcapApi.getCapture(captureId!),
+    // Keep polling until the artifact question is settled — not just
+    // until terminal — so a Stopped capture's partial .pcap shows up.
     refetchInterval: (q) =>
-      q.state.data && isTerminal(q.state.data) ? false : 1500,
+      q.state.data && isSettled(q.state.data) ? false : 1500,
   });
 
   useEffect(() => {
-    if (data && isTerminal(data)) {
+    // Only hand off to the Result tab once settled, so we never switch to
+    // a "no artifact" view a beat before the partial .pcap lands.
+    if (data && isSettled(data)) {
       qc.invalidateQueries({ queryKey: ["pcap-captures"] });
       onComplete(data.id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data?.status]);
+  }, [data?.status, data?.has_artifact]);
 
   const cancel = useMutation({
     mutationFn: (id: string) => pcapApi.cancelCapture(id),
     onSuccess: () =>
       qc.invalidateQueries({ queryKey: ["pcap-capture", captureId] }),
+  });
+  const download = useMutation({
+    mutationFn: (id: string) => pcapApi.downloadCapture(id),
   });
 
   if (!captureId || !data) {
@@ -519,6 +550,38 @@ function LiveTab({
           <Trash2 className="h-3 w-3" /> Stop capture
         </button>
       )}
+      {/* After Stop (or natural finish): offer the download right here so
+          the operator never has to dig through History. The partial .pcap
+          lands a beat after a cancel — until then show a spinner. */}
+      {isTerminal(data) && data.has_artifact && (
+        <button
+          type="button"
+          onClick={() => download.mutate(data.id)}
+          disabled={download.isPending}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {download.isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Download className="h-3.5 w-3.5" />
+          )}
+          Download .pcap ({fmtBytes(data.pcap_size_bytes)})
+        </button>
+      )}
+      {data.status === "cancelled" &&
+        !data.has_artifact &&
+        !isSettled(data) && (
+          <p className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Finalizing the captured packets…
+          </p>
+        )}
+      {isTerminal(data) && !data.has_artifact && isSettled(data) && (
+        <p className="text-[11px] italic text-muted-foreground">
+          No downloadable artifact — the capture produced no packets before it
+          stopped.
+        </p>
+      )}
     </div>
   );
 }
@@ -539,6 +602,10 @@ function ResultTab({ captureId }: { captureId: string | null }) {
     enabled: !!captureId,
     queryKey: ["pcap-capture", captureId],
     queryFn: () => pcapApi.getCapture(captureId!),
+    // Keep refreshing until the artifact settles so a just-stopped
+    // capture's Download button appears without a manual refresh.
+    refetchInterval: (q) =>
+      q.state.data && isSettled(q.state.data) ? false : 2000,
   });
   const download = useMutation({
     mutationFn: (id: string) => pcapApi.downloadCapture(id),

--- a/frontend/src/pages/pcap/PacketCapturePage.tsx
+++ b/frontend/src/pages/pcap/PacketCapturePage.tsx
@@ -596,8 +596,9 @@ function ResultTab({ captureId }: { captureId: string | null }) {
         </button>
       ) : (
         <p className="text-[11px] italic text-muted-foreground">
-          No downloadable artifact (capture produced no bytes, was cancelled, or
-          was pruned).
+          No downloadable artifact (capture produced no bytes, failed, or was
+          pruned). A stopped capture still downloads whatever was captured
+          before Stop.
         </p>
       )}
     </div>


### PR DESCRIPTION
Field-testing the #59 packet-capture feature (PR #433) on a k3s appliance surfaced three operator-facing gaps; this branch closes them and folds in the self-review fixes.

## What & why

**1. Appliance vantage couldn't capture LAN traffic — wrong vantage got used.**
The appliance interface field was empty and said *"ships in a follow-up phase"*, so operators fell back to the Server vantage, which only sees the k3s pod network (10.42.x.x) — never the LAN. The capture worked; the picker didn't. Now:
- supervisor enumerates the host's real NICs from `/run/udev/data/n*` (`ID_NET_NAME`, veth*/lo filtered) — the pod isn't `hostNetwork` so its own `/sys/class/net` shows pod veths, but `/run/udev` is already bind-mounted (same source the slot detector uses);
- reported on the heartbeat → persisted to `appliance.host_interfaces` (migration `c3a1f9d24b80`) → surfaced as a real dropdown via `GET /pcap/interfaces?vantage=appliance` with an honest note;
- the dropdown keeps an **"Other — type a NIC name…"** escape hatch for bridges / overlay / VPN NICs udev doesn't name (the host runner validates the typed name).

**2. Keep + serve the partial capture on Stop.**
A Stopped capture used to discard the packets captured before Stop. tcpdump flushes the savefile on SIGTERM, so the bytes are valid — now `_has_artifact` accepts `completed`+`cancelled`, `finalize_capture` keeps the partial (cancel still wins over a late completion), and the download endpoint serves it.

**3. Download offered without a History trip.**
After Stop the UI auto-settles to the Result tab (not History) once the partial lands; polling waits out the cancel→artifact lag.

## Self-review fixes (in this branch)
0-byte uploads no longer orphan a file in PCAP_DIR; over-cap (413) finalizes the row instead of dangling; `finalize_capture` preserves the cancel-time `finished_at` and records metadata on the error path; `isSettled` builds on `isTerminal` (no duplicated status list); dead inline LiveTab download button removed.

## Scope
Backend (API image) + frontend + one additive migration + supervisor NIC enumeration. No supervisor-protocol change.

## Verification
Verified live on a k3s appliance: appliance vantage on `ens18` captured 192.168.0.0/24 (11 distinct hosts); Stop-mid-capture kept + downloaded the partial (79 pkts, all 192.168.x). 59 pcap tests pass; ruff/black/mypy/build clean; migration applies cleanly.

Follow-up to #59 / #433 (already merged — not re-closing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)