### PR TITLE
feat(tls): TLS certificate monitoring — auto-discovered, probed, alerted, MCP (#118)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -47,6 +47,7 @@ components. Grouped by role; license + project URL for each.
 - Celery — BSD 3-Clause — https://celeryq.dev
 - structlog — MIT / Apache 2.0 — https://www.structlog.org
 - cryptography — Apache 2.0 / BSD 3-Clause — https://cryptography.io
+- pyOpenSSL (TLS cert chain capture) — Apache 2.0 — https://www.pyopenssl.org
 - httpx — BSD 3-Clause — https://www.python-httpx.org
 - Authlib (OIDC/OAuth) — BSD 3-Clause — https://authlib.org
 - ldap3 (LDAP) — LGPL v3 — https://github.com/cannatag/ldap3

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -271,6 +271,8 @@ backend/alembic/versions/c5f2a9b18e34_ipam_linkage_subnet_domains_bulk.py:drop_c
 backend/alembic/versions/c5f2a9b18e34_ipam_linkage_subnet_domains_bulk.py:drop_table:105
 backend/alembic/versions/c6c3137e3554_appliance_slot_image_upload.py:drop_table:110
 backend/alembic/versions/c7a3e1f90d24_subnet_utilization_history.py:drop_table:47
+backend/alembic/versions/c7d1f04e9a2b_tls_cert_target_ip_address.py:drop_column:44
+backend/alembic/versions/c7d1f04e9a2b_tls_cert_target_ip_address.py:drop_constraint_fk:43
 backend/alembic/versions/c7e2f5a91d48_audit_forward_targets.py:drop_table:172
 backend/alembic/versions/c7e5d918a3f2_appliance_cluster_health.py:drop_column:42
 backend/alembic/versions/c7e9b3a481f2_appliance_approval_workflow.py:drop_column:152

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -538,6 +538,11 @@ backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:139
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:140
 backend/alembic/versions/f3b8d24a1c70_appliance_evict_requested.py:drop_column:39
 backend/alembic/versions/f3b9c1d6a274_dhcp_group_socket_mode.py:drop_column:49
+backend/alembic/versions/f3e8b1d72a9c_tls_cert_monitoring.py:drop_column:175
+backend/alembic/versions/f3e8b1d72a9c_tls_cert_monitoring.py:drop_column:176
+backend/alembic/versions/f3e8b1d72a9c_tls_cert_monitoring.py:drop_column:177
+backend/alembic/versions/f3e8b1d72a9c_tls_cert_monitoring.py:drop_table:169
+backend/alembic/versions/f3e8b1d72a9c_tls_cert_monitoring.py:drop_table:174
 backend/alembic/versions/f4a1c9e7b2d8_appliance_host_config_health.py:drop_column:43
 backend/alembic/versions/f4a6c8b2e571_bgp_communities.py:drop_table:83
 backend/alembic/versions/f4a9c1b2d6e7_dns_zone_color.py:drop_column:33

--- a/backend/alembic/versions/c7d1f04e9a2b_tls_cert_target_ip_address.py
+++ b/backend/alembic/versions/c7d1f04e9a2b_tls_cert_target_ip_address.py
@@ -1,0 +1,44 @@
+"""TLS cert target → IP address linkage (#118 Phase 2)
+
+Adds ``tls_cert_target.ip_address_id`` (FK → ip_address, ON DELETE SET NULL)
+so IPAM-role-discovered targets carry their source IP and the IP detail
+modal can list "certs served from this IP".
+
+Revision ID: c7d1f04e9a2b
+Revises: f3e8b1d72a9c
+Create Date: 2026-06-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c7d1f04e9a2b"
+down_revision: str | None = "f3e8b1d72a9c"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tls_cert_target",
+        sa.Column("ip_address_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_tls_cert_target_ip_address_id",
+        "tls_cert_target",
+        "ip_address",
+        ["ip_address_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_tls_cert_target_ip_address_id", "tls_cert_target", ["ip_address_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tls_cert_target_ip_address_id", table_name="tls_cert_target")
+    op.drop_constraint("fk_tls_cert_target_ip_address_id", "tls_cert_target", type_="foreignkey")
+    op.drop_column("tls_cert_target", "ip_address_id")

--- a/backend/alembic/versions/f3e8b1d72a9c_tls_cert_monitoring.py
+++ b/backend/alembic/versions/f3e8b1d72a9c_tls_cert_monitoring.py
@@ -1,0 +1,177 @@
+"""TLS certificate monitoring (#118)
+
+Schema for TLS cert monitoring: ``tls_cert_target`` (what to probe + the
+per-row schedule + denormalised latest-known cert identity) and
+``tls_cert_probe`` (immutable per-probe history). Plus the per-zone /
+per-record ``auto_tls_probe`` opt-in columns, the platform-default probe
+cadence, and the ``security.tls_certs`` feature-module seed (#14).
+
+The four ``tls_cert_*`` alert rules are seeded at startup
+(``seed_tls_cert_alert_rules`` in app.services.alerts), not here — that's
+the established pattern for newer rule kinds (idempotent, keyed on rule_type).
+
+Revision ID: f3e8b1d72a9c
+Revises: e1a4b8c92f3d
+Create Date: 2026-06-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "f3e8b1d72a9c"
+down_revision: str | None = "e1a4b8c92f3d"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def _identity_columns() -> list[sa.Column]:
+    """The cert-identity snapshot columns shared by target + probe."""
+    return [
+        sa.Column("serial", sa.String(length=128), nullable=True),
+        sa.Column("subject_cn", sa.String(length=255), nullable=True),
+        sa.Column("issuer_cn", sa.String(length=255), nullable=True),
+        sa.Column("not_before", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("not_after", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "sans_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("key_algo", sa.String(length=20), nullable=True),
+        sa.Column("key_size", sa.Integer(), nullable=True),
+        sa.Column("sig_algo", sa.String(length=64), nullable=True),
+        sa.Column("chain_depth", sa.Integer(), nullable=True),
+        sa.Column("chain_valid", sa.Boolean(), nullable=True),
+        sa.Column("chain_error", sa.Text(), nullable=True),
+        sa.Column("self_signed", sa.Boolean(), nullable=True),
+        sa.Column("fingerprint_sha256", sa.String(length=95), nullable=True),
+    ]
+
+
+def upgrade() -> None:
+    # ── opt-in columns on existing tables ───────────────────────────────
+    op.add_column(
+        "dns_zone",
+        sa.Column("auto_tls_probe", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+    op.add_column(
+        "dns_record",
+        sa.Column("auto_tls_probe", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "tls_cert_check_interval_hours",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("6"),
+        ),
+    )
+
+    # ── tls_cert_target ─────────────────────────────────────────────────
+    op.create_table(
+        "tls_cert_target",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("host", sa.String(length=255), nullable=False),
+        sa.Column("port", sa.Integer(), nullable=False, server_default=sa.text("443")),
+        sa.Column("server_name", sa.String(length=255), nullable=True),
+        sa.Column("display_name", sa.String(length=255), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("source", sa.String(length=20), nullable=False, server_default="manual"),
+        sa.Column("dns_record_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("dns_zone_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("domain_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("interval_hours", sa.Integer(), nullable=True),
+        sa.Column("next_check_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_checked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("state", sa.String(length=20), nullable=False, server_default="unknown"),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column(
+            "consecutive_failures", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        *_identity_columns(),
+        sa.ForeignKeyConstraint(["dns_record_id"], ["dns_record.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["dns_zone_id"], ["dns_zone.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["domain_id"], ["domain.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "host",
+            "port",
+            "server_name",
+            name="uq_tls_cert_target_host_port_sni",
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+    op.create_index("ix_tls_cert_target_dns_record_id", "tls_cert_target", ["dns_record_id"])
+    op.create_index("ix_tls_cert_target_dns_zone_id", "tls_cert_target", ["dns_zone_id"])
+    op.create_index("ix_tls_cert_target_domain_id", "tls_cert_target", ["domain_id"])
+    op.create_index("ix_tls_cert_target_next_check_at", "tls_cert_target", ["next_check_at"])
+
+    # ── tls_cert_probe ──────────────────────────────────────────────────
+    op.create_table(
+        "tls_cert_probe",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "probed_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("ok", sa.Boolean(), nullable=False),
+        sa.Column("state", sa.String(length=20), nullable=False),
+        sa.Column("error", sa.Text(), nullable=True),
+        *_identity_columns(),
+        sa.Column("leaf_pem", sa.Text(), nullable=True),
+        sa.Column("chain_pem", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["target_id"], ["tls_cert_target.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_tls_cert_probe_target_probed", "tls_cert_probe", ["target_id", "probed_at"])
+
+    # ── feature_module seed (non-negotiable #14) ────────────────────────
+    op.execute(sa.text("""
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('security.tls_certs', TRUE)
+            ON CONFLICT (id) DO NOTHING
+            """))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'security.tls_certs'"))
+    op.drop_index("ix_tls_cert_probe_target_probed", table_name="tls_cert_probe")
+    op.drop_table("tls_cert_probe")
+    op.drop_index("ix_tls_cert_target_next_check_at", table_name="tls_cert_target")
+    op.drop_index("ix_tls_cert_target_domain_id", table_name="tls_cert_target")
+    op.drop_index("ix_tls_cert_target_dns_zone_id", table_name="tls_cert_target")
+    op.drop_index("ix_tls_cert_target_dns_record_id", table_name="tls_cert_target")
+    op.drop_table("tls_cert_target")
+    op.drop_column("platform_settings", "tls_cert_check_interval_hours")
+    op.drop_column("dns_record", "auto_tls_probe")
+    op.drop_column("dns_zone", "auto_tls_probe")

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -642,6 +642,9 @@ class ZoneCreate(BaseModel):
     primary_ns: str = ""
     admin_email: str = ""
     dnssec_enabled: bool = False
+    # TLS cert monitoring (#118) — opt every A/AAAA record in this zone
+    # into auto-discovered cert probing.
+    auto_tls_probe: bool = False
     color: str | None = None
     linked_subnet_id: uuid.UUID | None = None
     domain_id: uuid.UUID | None = None
@@ -719,6 +722,7 @@ class ZoneUpdate(BaseModel):
     primary_ns: str | None = None
     admin_email: str | None = None
     dnssec_enabled: bool | None = None
+    auto_tls_probe: bool | None = None  # TLS cert monitoring (#118)
     # DNSSEC signing policy (issue #49). null ⇒ BIND built-in "default".
     dnssec_policy_id: uuid.UUID | None = None
     color: str | None = None
@@ -785,6 +789,7 @@ class ZoneResponse(BaseModel):
     linked_subnet_id: uuid.UUID | None
     domain_id: uuid.UUID | None = None
     dnssec_enabled: bool
+    auto_tls_probe: bool = False
     dnssec_policy_id: uuid.UUID | None = None
     color: str | None
     last_serial: int

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -64,6 +64,7 @@ from app.api.v1.settings.router import router as settings_router
 from app.api.v1.system import router as system_router
 from app.api.v1.tags import router as tags_router
 from app.api.v1.tailscale import router as tailscale_router
+from app.api.v1.tls_certs import router as tls_certs_router
 from app.api.v1.tools import router as tools_router
 from app.api.v1.unifi import router as unifi_router
 from app.api.v1.upgrades import router as upgrades_router
@@ -308,6 +309,12 @@ api_v1_router.include_router(
     prefix="/tailscale",
     tags=["tailscale"],
     dependencies=[Depends(require_module("integrations.tailscale"))],
+)
+api_v1_router.include_router(
+    tls_certs_router,
+    prefix="/tls-certs",
+    tags=["tls-certs"],
+    dependencies=[Depends(require_module("security.tls_certs"))],
 )
 api_v1_router.include_router(
     tools_router,

--- a/backend/app/api/v1/tls_certs/__init__.py
+++ b/backend/app/api/v1/tls_certs/__init__.py
@@ -1,0 +1,3 @@
+from app.api.v1.tls_certs.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/tls_certs/router.py
+++ b/backend/app/api/v1/tls_certs/router.py
@@ -109,6 +109,7 @@ class TLSCertTargetRead(BaseModel):
     dns_record_id: uuid.UUID | None
     dns_zone_id: uuid.UUID | None
     domain_id: uuid.UUID | None
+    ip_address_id: uuid.UUID | None
     interval_hours: int | None
     next_check_at: datetime | None
     last_checked_at: datetime | None
@@ -222,6 +223,7 @@ async def list_targets(
     enabled: bool | None = Query(default=None),
     dns_zone_id: uuid.UUID | None = Query(default=None),
     domain_id: uuid.UUID | None = Query(default=None),
+    ip_address_id: uuid.UUID | None = Query(default=None),
     search: str | None = Query(
         default=None, description="Case-insensitive substring on host / display_name / subject_cn."
     ),
@@ -237,6 +239,8 @@ async def list_targets(
         stmt = stmt.where(TLSCertTarget.dns_zone_id == dns_zone_id)
     if domain_id is not None:
         stmt = stmt.where(TLSCertTarget.domain_id == domain_id)
+    if ip_address_id is not None:
+        stmt = stmt.where(TLSCertTarget.ip_address_id == ip_address_id)
     if search:
         needle = f"%{search.strip()}%"
         stmt = stmt.where(
@@ -419,6 +423,24 @@ async def get_chain(target_id: uuid.UUID, db: DB, _: CurrentUser) -> dict[str, A
         # captured bundle, for the cert detail view.
         "chain": parse_chain_pem(probe.chain_pem or probe.leaf_pem),
     }
+
+
+@router.get("/{target_id}/ct-log")
+async def ct_log(
+    target_id: uuid.UUID,
+    db: DB,
+    _: CurrentUser,
+    limit: int = Query(50, ge=1, le=100),
+) -> dict[str, Any]:
+    """Cross-reference this target's host against Certificate Transparency
+    logs (crt.sh). OFF-PREM + explicit: this leaks the hostname to crt.sh,
+    so it only runs on this on-demand request — never the scheduled probe."""
+    row = await db.get(TLSCertTarget, target_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="target not found")
+    from app.services.tls_cert.ct_log import lookup_ct  # noqa: PLC0415
+
+    return await lookup_ct(row.server_name or row.host, limit=limit)
 
 
 @router.post("/{target_id}/probe", response_model=TLSCertTargetRead)

--- a/backend/app/api/v1/tls_certs/router.py
+++ b/backend/app/api/v1/tls_certs/router.py
@@ -1,0 +1,443 @@
+"""TLS certificate monitoring CRUD + probe-now (issue #118).
+
+Manage probe targets (auto-discovered ones + ad-hoc external hostnames),
+read probe history + the captured chain, and fire a synchronous probe.
+
+Permissions: every endpoint gates on the ``tls_cert`` resource_type
+(admin via the seeded Network Editor builtin role; read via Viewer /
+Auditor; superadmin always passes). The whole router is feature-gated
+behind ``security.tls_certs`` at the include site (404 when off). Each
+mutation writes an ``audit_log`` row before commit (non-negotiable #4).
+
+SSRF: ``host`` is validated through ``assert_target_allowed`` (rejects
+loopback / link-local / cloud-metadata IP literals); the probe service
+additionally re-resolves the hostname at probe time and re-checks each
+answer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field, computed_field, field_validator
+from sqlalchemy import func, or_, select
+
+from app.api.deps import DB, CurrentUser
+from app.api.v1.ownership._audit import write_audit
+from app.core.permissions import require_resource_permission
+from app.models.settings import PlatformSettings
+from app.models.tls_cert import (
+    SOURCE_MANUAL,
+    TLSCertProbe,
+    TLSCertTarget,
+)
+from app.services.nettools.schemas import assert_target_allowed
+from app.services.tls_cert.probe import parse_chain_pem, probe_one
+
+router = APIRouter(
+    tags=["tls-certs"],
+    dependencies=[Depends(require_resource_permission("tls_cert"))],
+)
+
+_SINGLETON_ID = 1
+TargetState = Literal["unknown", "ok", "expiring", "expired", "mismatch", "unreachable"]
+TargetSource = Literal["manual", "discovered"]
+
+
+def _norm_host(value: str) -> str:
+    return assert_target_allowed(value.strip()).rstrip(".").lower()
+
+
+# ── Schemas ─────────────────────────────────────────────────────────
+
+
+class TLSCertTargetCreate(BaseModel):
+    host: str = Field(..., min_length=1, max_length=255)
+    port: int = Field(default=443, ge=1, le=65535)
+    server_name: str | None = Field(default=None, max_length=255)
+    display_name: str | None = Field(default=None, max_length=255)
+    interval_hours: int | None = Field(default=None, ge=1, le=168)
+    enabled: bool = True
+
+    @field_validator("host")
+    @classmethod
+    def _v_host(cls, v: str) -> str:
+        return _norm_host(v)
+
+    @field_validator("server_name")
+    @classmethod
+    def _v_sni(cls, v: str | None) -> str | None:
+        if v is None or not v.strip():
+            return None
+        return v.strip().rstrip(".").lower()
+
+
+class TLSCertTargetUpdate(BaseModel):
+    host: str | None = Field(default=None, min_length=1, max_length=255)
+    port: int | None = Field(default=None, ge=1, le=65535)
+    server_name: str | None = Field(default=None, max_length=255)
+    display_name: str | None = Field(default=None, max_length=255)
+    interval_hours: int | None = Field(default=None, ge=1, le=168)
+    enabled: bool | None = None
+
+    @field_validator("host")
+    @classmethod
+    def _v_host(cls, v: str | None) -> str | None:
+        return _norm_host(v) if v is not None else None
+
+    @field_validator("server_name")
+    @classmethod
+    def _v_sni(cls, v: str | None) -> str | None:
+        if v is None or not v.strip():
+            return None
+        return v.strip().rstrip(".").lower()
+
+
+class TLSCertTargetRead(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    host: str
+    port: int
+    server_name: str | None
+    display_name: str | None
+    enabled: bool
+    source: str
+    dns_record_id: uuid.UUID | None
+    dns_zone_id: uuid.UUID | None
+    domain_id: uuid.UUID | None
+    interval_hours: int | None
+    next_check_at: datetime | None
+    last_checked_at: datetime | None
+    state: str
+    last_error: str | None
+    consecutive_failures: int
+    serial: str | None
+    subject_cn: str | None
+    issuer_cn: str | None
+    not_before: datetime | None
+    not_after: datetime | None
+    sans_json: list[str]
+    key_algo: str | None
+    key_size: int | None
+    sig_algo: str | None
+    chain_depth: int | None
+    chain_valid: bool | None
+    chain_error: str | None
+    self_signed: bool | None
+    fingerprint_sha256: str | None
+    created_at: datetime
+    modified_at: datetime
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def days_remaining(self) -> int | None:
+        if self.not_after is None:
+            return None
+        na = self.not_after if self.not_after.tzinfo else self.not_after.replace(tzinfo=UTC)
+        return int((na - datetime.now(UTC)).total_seconds() // 86400)
+
+
+class TLSCertTargetListResponse(BaseModel):
+    items: list[TLSCertTargetRead]
+    total: int
+    limit: int
+    offset: int
+
+
+class TLSCertProbeRead(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: uuid.UUID
+    target_id: uuid.UUID
+    probed_at: datetime
+    ok: bool
+    state: str
+    error: str | None
+    serial: str | None
+    subject_cn: str | None
+    issuer_cn: str | None
+    not_before: datetime | None
+    not_after: datetime | None
+    sans_json: list[str]
+    key_algo: str | None
+    key_size: int | None
+    sig_algo: str | None
+    chain_depth: int | None
+    chain_valid: bool | None
+    chain_error: str | None
+    self_signed: bool | None
+    fingerprint_sha256: str | None
+
+
+class TLSCertProbeListResponse(BaseModel):
+    items: list[TLSCertProbeRead]
+    total: int
+    limit: int
+    offset: int
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+async def _assert_unique(
+    db: DB, host: str, port: int, sni: str | None, *, exclude: uuid.UUID | None = None
+) -> None:
+    stmt = select(TLSCertTarget).where(
+        func.lower(TLSCertTarget.host) == host,
+        TLSCertTarget.port == port,
+    )
+    stmt = stmt.where(
+        TLSCertTarget.server_name == sni if sni is not None else TLSCertTarget.server_name.is_(None)
+    )
+    if exclude is not None:
+        stmt = stmt.where(TLSCertTarget.id != exclude)
+    if (await db.scalar(stmt)) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"a target for {host}:{port} (sni={sni or '-'}) already exists",
+        )
+
+
+async def _interval(db: DB) -> int:
+    ps = await db.get(PlatformSettings, _SINGLETON_ID)
+    hours = ps.tls_cert_check_interval_hours if ps is not None else 6
+    return max(1, min(168, hours or 6))
+
+
+# ── Endpoints ───────────────────────────────────────────────────────
+
+
+@router.get("", response_model=TLSCertTargetListResponse)
+async def list_targets(
+    db: DB,
+    _: CurrentUser,
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    state: TargetState | None = Query(default=None),
+    source: TargetSource | None = Query(default=None),
+    enabled: bool | None = Query(default=None),
+    dns_zone_id: uuid.UUID | None = Query(default=None),
+    domain_id: uuid.UUID | None = Query(default=None),
+    search: str | None = Query(
+        default=None, description="Case-insensitive substring on host / display_name / subject_cn."
+    ),
+) -> TLSCertTargetListResponse:
+    stmt = select(TLSCertTarget)
+    if state is not None:
+        stmt = stmt.where(TLSCertTarget.state == state)
+    if source is not None:
+        stmt = stmt.where(TLSCertTarget.source == source)
+    if enabled is not None:
+        stmt = stmt.where(TLSCertTarget.enabled.is_(enabled))
+    if dns_zone_id is not None:
+        stmt = stmt.where(TLSCertTarget.dns_zone_id == dns_zone_id)
+    if domain_id is not None:
+        stmt = stmt.where(TLSCertTarget.domain_id == domain_id)
+    if search:
+        needle = f"%{search.strip()}%"
+        stmt = stmt.where(
+            or_(
+                TLSCertTarget.host.ilike(needle),
+                TLSCertTarget.display_name.ilike(needle),
+                TLSCertTarget.subject_cn.ilike(needle),
+            )
+        )
+    total = await db.scalar(select(func.count()).select_from(stmt.subquery())) or 0
+    stmt = stmt.order_by(TLSCertTarget.host.asc()).limit(limit).offset(offset)
+    rows = (await db.execute(stmt)).scalars().all()
+    return TLSCertTargetListResponse(
+        items=[TLSCertTargetRead.model_validate(r) for r in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("", response_model=TLSCertTargetRead, status_code=status.HTTP_201_CREATED)
+async def create_target(body: TLSCertTargetCreate, db: DB, user: CurrentUser) -> TLSCertTargetRead:
+    await _assert_unique(db, body.host, body.port, body.server_name)
+    row = TLSCertTarget(
+        host=body.host,
+        port=body.port,
+        server_name=body.server_name,
+        display_name=body.display_name or body.host,
+        interval_hours=body.interval_hours,
+        enabled=body.enabled,
+        source=SOURCE_MANUAL,
+        next_check_at=None,
+    )
+    db.add(row)
+    await db.flush()
+    write_audit(
+        db,
+        user=user,
+        action="create",
+        resource_type="tls_cert",
+        resource_id=str(row.id),
+        resource_display=row.display_name or row.host,
+        new_value={"host": row.host, "port": row.port, "server_name": row.server_name},
+    )
+    await db.commit()
+    await db.refresh(row)
+
+    # Fire the first probe right away so the row populates within seconds
+    # instead of waiting for the next sweep. Best-effort — a broker hiccup
+    # must not fail the create.
+    try:
+        from app.tasks.tls_certs import probe_one_target_by_id  # noqa: PLC0415
+
+        probe_one_target_by_id.delay(str(row.id))
+    except Exception:  # noqa: BLE001
+        pass
+
+    return TLSCertTargetRead.model_validate(row)
+
+
+@router.get("/{target_id}", response_model=TLSCertTargetRead)
+async def get_target(target_id: uuid.UUID, db: DB, _: CurrentUser) -> TLSCertTargetRead:
+    row = await db.get(TLSCertTarget, target_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="target not found")
+    return TLSCertTargetRead.model_validate(row)
+
+
+@router.put("/{target_id}", response_model=TLSCertTargetRead)
+async def update_target(
+    target_id: uuid.UUID, body: TLSCertTargetUpdate, db: DB, user: CurrentUser
+) -> TLSCertTargetRead:
+    row = await db.get(TLSCertTarget, target_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="target not found")
+    data = body.model_dump(exclude_unset=True)
+    # Re-check uniqueness if any connect-tuple field changed.
+    if {"host", "port", "server_name"} & data.keys():
+        new_host = data.get("host", row.host)
+        new_port = data.get("port", row.port)
+        new_sni = data.get("server_name", row.server_name)
+        await _assert_unique(db, new_host, new_port, new_sni, exclude=row.id)
+    changed: list[str] = []
+    for field, value in data.items():
+        if getattr(row, field) != value:
+            setattr(row, field, value)
+            changed.append(field)
+    if changed:
+        write_audit(
+            db,
+            user=user,
+            action="update",
+            resource_type="tls_cert",
+            resource_id=str(row.id),
+            resource_display=row.display_name or row.host,
+            changed_fields=changed,
+        )
+        await db.commit()
+        await db.refresh(row)
+    return TLSCertTargetRead.model_validate(row)
+
+
+@router.delete("/{target_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_target(target_id: uuid.UUID, db: DB, user: CurrentUser) -> None:
+    row = await db.get(TLSCertTarget, target_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="target not found")
+    label = row.display_name or row.host
+    write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="tls_cert",
+        resource_id=str(row.id),
+        resource_display=label,
+    )
+    await db.delete(row)
+    await db.commit()
+
+
+@router.get("/{target_id}/probes", response_model=TLSCertProbeListResponse)
+async def list_probes(
+    target_id: uuid.UUID,
+    db: DB,
+    _: CurrentUser,
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> TLSCertProbeListResponse:
+    if (await db.get(TLSCertTarget, target_id)) is None:
+        raise HTTPException(status_code=404, detail="target not found")
+    base = select(TLSCertProbe).where(TLSCertProbe.target_id == target_id)
+    total = await db.scalar(select(func.count()).select_from(base.subquery())) or 0
+    rows = (
+        (await db.execute(base.order_by(TLSCertProbe.probed_at.desc()).limit(limit).offset(offset)))
+        .scalars()
+        .all()
+    )
+    return TLSCertProbeListResponse(
+        items=[TLSCertProbeRead.model_validate(r) for r in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{target_id}/chain")
+async def get_chain(target_id: uuid.UUID, db: DB, _: CurrentUser) -> dict[str, Any]:
+    """Latest probe's captured PEM + parsed identity (powers the UI chain
+    view + the get_cert_chain MCP tool). Public material only."""
+    if (await db.get(TLSCertTarget, target_id)) is None:
+        raise HTTPException(status_code=404, detail="target not found")
+    probe = await db.scalar(
+        select(TLSCertProbe)
+        .where(TLSCertProbe.target_id == target_id, TLSCertProbe.ok.is_(True))
+        .order_by(TLSCertProbe.probed_at.desc())
+        .limit(1)
+    )
+    if probe is None:
+        raise HTTPException(status_code=404, detail="no successful probe yet")
+    return {
+        "target_id": str(target_id),
+        "probed_at": probe.probed_at.isoformat(),
+        "subject_cn": probe.subject_cn,
+        "issuer_cn": probe.issuer_cn,
+        "serial": probe.serial,
+        "not_before": probe.not_before.isoformat() if probe.not_before else None,
+        "not_after": probe.not_after.isoformat() if probe.not_after else None,
+        "sans": probe.sans_json or [],
+        "key_algo": probe.key_algo,
+        "key_size": probe.key_size,
+        "sig_algo": probe.sig_algo,
+        "chain_depth": probe.chain_depth,
+        "chain_valid": probe.chain_valid,
+        "chain_error": probe.chain_error,
+        "self_signed": probe.self_signed,
+        "fingerprint_sha256": probe.fingerprint_sha256,
+        "leaf_pem": probe.leaf_pem,
+        "chain_pem": probe.chain_pem,
+        # Per-cert breakdown (leaf → intermediate(s) → root) parsed from the
+        # captured bundle, for the cert detail view.
+        "chain": parse_chain_pem(probe.chain_pem or probe.leaf_pem),
+    }
+
+
+@router.post("/{target_id}/probe", response_model=TLSCertTargetRead)
+async def probe_now(target_id: uuid.UUID, db: DB, user: CurrentUser) -> TLSCertTargetRead:
+    """Synchronous probe — runs now (≈8 s timeout), returns the fresh row."""
+    row = await db.get(TLSCertTarget, target_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="target not found")
+    result = await probe_one(db, row, default_interval_hours=await _interval(db))
+    write_audit(
+        db,
+        user=user,
+        action="probe",
+        resource_type="tls_cert",
+        resource_id=str(row.id),
+        resource_display=row.display_name or row.host,
+        new_value={"state": result.state, "ok": result.ok, "error": result.error},
+        result="success" if result.ok else "error",
+    )
+    await db.commit()
+    await db.refresh(row)
+    return TLSCertTargetRead.model_validate(row)

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -55,6 +55,7 @@ celery_app = Celery(
         "app.tasks.upgrade_orchestrator",
         "app.tasks.time_bound_grant_sweep",
         "app.tasks.acme",
+        "app.tasks.tls_certs",
     ],
 )
 
@@ -112,6 +113,7 @@ celery_app.conf.update(
         "app.tasks.audit_chain_verify.*": {"queue": "default"},
         "app.tasks.time_bound_grant_sweep.*": {"queue": "default"},
         "app.tasks.acme.*": {"queue": "default"},
+        "app.tasks.tls_certs.*": {"queue": "default"},
     },
     beat_schedule={
         # Every 60 s, mark DNS agents as ``unreachable`` if their
@@ -487,6 +489,27 @@ celery_app.conf.update(
         "time-bound-grant-sweep": {
             "task": "app.tasks.time_bound_grant_sweep.sweep_expired_grants",
             "schedule": schedule(run_every=60.0),
+        },
+        # Every 60 s, probe every enabled TLS cert target whose
+        # ``next_check_at`` has elapsed (issue #118). Per-target cadence
+        # default is ``PlatformSettings.tls_cert_check_interval_hours``
+        # (6 h), read each run so UI changes take effect without a beat
+        # restart. Idle when no targets are due.
+        "tls-cert-probe-dispatch": {
+            "task": "app.tasks.tls_certs.probe_due_certs",
+            "schedule": schedule(run_every=60.0),
+        },
+        # Every 5 min, project TLS cert probe targets from opted-in DNS
+        # A/AAAA records + relink targets to zones/domains by SAN.
+        "tls-cert-discovery": {
+            "task": "app.tasks.tls_certs.reconcile_discovered",
+            "schedule": schedule(run_every=300.0),
+        },
+        # Daily at 03:50 UTC, prune tls_cert_probe history older than the
+        # retention window (90 d). Offset from the other 03:xx prunes.
+        "tls-cert-probe-prune": {
+            "task": "app.tasks.tls_certs.prune_probes",
+            "schedule": crontab(hour=3, minute=50),
         },
     },
 )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -223,6 +223,7 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
             {"action": "admin", "resource_type": "customer"},
             {"action": "admin", "resource_type": "site"},
             {"action": "admin", "resource_type": "provider"},
+            {"action": "admin", "resource_type": "tls_cert"},
         ],
     ),
     "Auditor": (
@@ -237,6 +238,7 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
             {"action": "read", "resource_type": "ip_address"},
             {"action": "read", "resource_type": "dns_zone"},
             {"action": "read", "resource_type": "dhcp_scope"},
+            {"action": "read", "resource_type": "tls_cert"},
         ],
     ),
     "Compliance Editor": (
@@ -415,6 +417,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await seed_rogue_dhcp_alert_rule()
     except Exception as exc:  # noqa: BLE001
         logger.debug("rogue_dhcp_alert_rule_seed_skipped", reason=str(exc))
+    # TLS certificate monitoring alert rules — four, DISABLED by default
+    # (issue #118). Opt-in once the operator adds probe targets.
+    try:
+        from app.services.alerts import seed_tls_cert_alert_rules  # noqa: PLC0415
+
+        await seed_tls_cert_alert_rules()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("tls_cert_alert_rules_seed_skipped", reason=str(exc))
     # Appliance Web UI cert bootstrap (issue #134, Phase 4b.5). On
     # appliance installs without an active row in appliance_certificate,
     # generate a self-signed default + deploy it to /etc/nginx/certs

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -109,6 +109,7 @@ from app.models.settings import PlatformSettings
 from app.models.system_upgrade import SystemUpgradeRun
 from app.models.tailscale import TailscaleTenant
 from app.models.time_bound_grant import TimeBoundGrant
+from app.models.tls_cert import TLSCertProbe, TLSCertTarget
 from app.models.unifi import UnifiController
 from app.models.vlans import VLAN, Router
 from app.models.vrf import VRF
@@ -212,6 +213,8 @@ __all__ = [
     "NmapScan",
     "PacketCapture",
     "SavedView",
+    "TLSCertTarget",
+    "TLSCertProbe",
     "EventSubscription",
     "EventOutbox",
     "Customer",

--- a/backend/app/models/dns.py
+++ b/backend/app/models/dns.py
@@ -612,6 +612,12 @@ class DNSZone(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     # the allowed keys.
     color: Mapped[str | None] = mapped_column(String(20), nullable=True)
     dnssec_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # TLS certificate monitoring (#118) — when True, the discovery
+    # reconciler auto-creates a tls_cert_target for every A/AAAA record
+    # in this zone. Per-record opt-in lives on DNSRecord.auto_tls_probe.
+    auto_tls_probe: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
     # Populated by the agent after a successful PowerDNS online-signing
     # apply. The DS rrset strings live here so the zone-edit page can
     # surface them for the operator to paste into their parent registrar
@@ -727,6 +733,11 @@ class DNSRecord(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     weight: Mapped[int | None] = mapped_column(Integer, nullable=True)
     port: Mapped[int | None] = mapped_column(Integer, nullable=True)
     auto_generated: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # TLS certificate monitoring (#118) — per-record opt-in for cert
+    # probing (the parent zone's auto_tls_probe opts in the whole zone).
+    auto_tls_probe: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
     ip_address_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("ip_address.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -78,9 +78,25 @@ IP_STATUSES: frozenset[str] = IP_STATUSES_OPERATOR_SETTABLE | IP_STATUSES_INTEGR
 # Roles in ``IP_ROLES_SHARED`` (anycast / vip / vrrp) are intentionally
 # shared across multiple devices and bypass the MAC-collision warning.
 IP_ROLES: frozenset[str] = frozenset(
-    {"host", "loopback", "anycast", "vip", "vrrp", "secondary", "gateway"}
+    {
+        "host",
+        "loopback",
+        "anycast",
+        "vip",
+        "vrrp",
+        "secondary",
+        "gateway",
+        # TLS-serving classifications (#118 Phase 2) — an IP in one of these
+        # roles is auto-added as a TLS cert probe target by the discovery
+        # reconciler (see TLS_SERVING_ROLES).
+        "web",
+        "api",
+        "lb",
+    }
 )
 IP_ROLES_SHARED: frozenset[str] = frozenset({"anycast", "vip", "vrrp"})
+# IP roles that imply a TLS endpoint worth probing for a cert (#118 Phase 2).
+TLS_SERVING_ROLES: frozenset[str] = frozenset({"web", "api", "lb"})
 
 # Network-role classification on Subnet (issue #112 phase 2). Operators
 # pick one when the subnet has a clear network function; null means

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -359,6 +359,14 @@ class PlatformSettings(Base):
         Integer, nullable=False, default=24, server_default=sa_text("24")
     )
 
+    # TLS certificate monitoring (#118) — default probe cadence per
+    # target (a target may override via tls_cert_target.interval_hours).
+    # Read every dispatch run so cadence changes take effect without
+    # restarting beat. Clamped 1..168 in the task.
+    tls_cert_check_interval_hours: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=6, server_default=sa_text("6")
+    )
+
     # VRF cross-cutting validation gate (Phase 2 of issue #86). When
     # False (default), an ``ASN:N`` route-distinguisher whose ASN
     # portion does not match the VRF's linked ``asn.number`` produces

--- a/backend/app/models/tls_cert.py
+++ b/backend/app/models/tls_cert.py
@@ -1,0 +1,227 @@
+"""TLS certificate monitoring (issue #118).
+
+SpatiumDDI already tracks Domains (RDAP expiry / NS-drift / registrar
+changes — all alerting). This is the next layer down: the TLS certs
+actually served from the hostnames we manage. Targets are auto-discovered
+from DNS A/AAAA records (or added ad-hoc), probed on a schedule, and the
+captured cert identity + chain validity is alerted on.
+
+Two tables:
+
+* :class:`TLSCertTarget` — *what to probe* + the per-row schedule + the
+  latest-known cert identity (denormalised onto the row so list views
+  never join). One row per ``(host, port, server_name)`` connect tuple.
+* :class:`TLSCertProbe` — immutable per-probe history (rotated; 90-day
+  retention via the prune task), one snapshot per probe.
+
+The issue sketches a third ``tls_cert`` "latest-known" table; we fold
+that role into the target row (denormalised identity columns) to avoid a
+circular FK + a join on every list view. The probe table is the history.
+
+We never hold private keys for these certs — only the public material the
+endpoint serves — so nothing here is encrypted at rest.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+# Target provenance.
+SOURCE_MANUAL = "manual"
+SOURCE_DISCOVERED = "discovered"
+
+# Derived health bucket (most-urgent wins; see derive_tls_state).
+STATE_UNKNOWN = "unknown"  # never probed yet
+STATE_OK = "ok"
+STATE_EXPIRING = "expiring"  # not_after within the warn window
+STATE_EXPIRED = "expired"
+STATE_MISMATCH = "mismatch"  # chain invalid / hostname mismatch
+STATE_UNREACHABLE = "unreachable"  # probe transport / handshake failed
+
+TLS_CERT_STATES = frozenset(
+    {
+        STATE_UNKNOWN,
+        STATE_OK,
+        STATE_EXPIRING,
+        STATE_EXPIRED,
+        STATE_MISMATCH,
+        STATE_UNREACHABLE,
+    }
+)
+
+
+class TLSCertTarget(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "tls_cert_target"
+    __table_args__ = (
+        # Dedupe key — the same FQDN can surface from multiple zones /
+        # views, but a probe is uniquely identified by its connect tuple.
+        # NULLS NOT DISTINCT so the dominant NULL-SNI case is actually
+        # DB-enforced (Postgres treats NULLs as distinct by default, which
+        # would let two (host,443,NULL) rows slip the constraint). PG15+;
+        # matches the network.py / ownership.py convention.
+        UniqueConstraint(
+            "host",
+            "port",
+            "server_name",
+            name="uq_tls_cert_target_host_port_sni",
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+
+    # ── connect target ──────────────────────────────────────────────
+    host: Mapped[str] = mapped_column(String(255), nullable=False)
+    port: Mapped[int] = mapped_column(Integer, nullable=False, default=443, server_default="443")
+    # SNI override; falls back to ``host`` when NULL.
+    server_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    display_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+    source: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=SOURCE_MANUAL, server_default=SOURCE_MANUAL
+    )
+
+    # ── provenance / linkage (all SET NULL so deleting the source row
+    # leaves the cert history intact) ───────────────────────────────
+    dns_record_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dns_record.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    dns_zone_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dns_zone.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    domain_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("domain.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # ── schedule ────────────────────────────────────────────────────
+    # Per-target cadence override; NULL → use the platform default.
+    interval_hours: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    next_check_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    last_checked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # ── derived state ───────────────────────────────────────────────
+    state: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=STATE_UNKNOWN, server_default=STATE_UNKNOWN
+    )
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    consecutive_failures: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
+    # ── latest-known cert identity (denormalised from the newest
+    # successful probe; NULL until first probe) ─────────────────────
+    serial: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    subject_cn: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    issuer_cn: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    not_before: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    not_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    sans_json: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'::jsonb")
+    )
+    key_algo: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    key_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sig_algo: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    chain_depth: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    chain_valid: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    chain_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    self_signed: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    fingerprint_sha256: Mapped[str | None] = mapped_column(String(95), nullable=True)
+
+
+class TLSCertProbe(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "tls_cert_probe"
+    __table_args__ = (
+        # Latest-probe lookup + history pagination per target.
+        Index("ix_tls_cert_probe_target_probed", "target_id", "probed_at"),
+    )
+
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tls_cert_target.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    probed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    ok: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    state: Mapped[str] = mapped_column(String(20), nullable=False)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Snapshot of what was observed (all nullable — a failed probe has none).
+    serial: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    subject_cn: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    issuer_cn: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    not_before: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    not_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    sans_json: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
+    key_algo: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    key_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sig_algo: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    chain_depth: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    chain_valid: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    chain_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    self_signed: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    fingerprint_sha256: Mapped[str | None] = mapped_column(String(95), nullable=True)
+
+    # Optional captured PEM — powers the get_cert_chain UI / MCP tool.
+    # Public material only; we never possess these certs' private keys.
+    leaf_pem: Mapped[str | None] = mapped_column(Text, nullable=True)
+    chain_pem: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+# Column-name list of the identity snapshot — shared by the probe service
+# when it copies a probe's observation onto the target's denormalised row.
+IDENTITY_FIELDS: tuple[str, ...] = (
+    "serial",
+    "subject_cn",
+    "issuer_cn",
+    "not_before",
+    "not_after",
+    "sans_json",
+    "key_algo",
+    "key_size",
+    "sig_algo",
+    "chain_depth",
+    "chain_valid",
+    "chain_error",
+    "self_signed",
+    "fingerprint_sha256",
+)
+
+
+def identity_snapshot(probe: TLSCertProbe) -> dict[str, Any]:
+    """Pull the identity fields off a probe row as a plain dict (for
+    copying onto the target's denormalised columns)."""
+    return {f: getattr(probe, f) for f in IDENTITY_FIELDS}

--- a/backend/app/models/tls_cert.py
+++ b/backend/app/models/tls_cert.py
@@ -120,6 +120,14 @@ class TLSCertTarget(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         nullable=True,
         index=True,
     )
+    # IPAM linkage (#118 Phase 2) — set for role-discovered targets + lets
+    # the IP detail modal list "certs served from this IP".
+    ip_address_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("ip_address.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
 
     # ── schedule ────────────────────────────────────────────────────
     # Per-target cadence override; NULL → use the platform default.

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -502,6 +502,92 @@ register(
 )
 
 
+# ── run_cert_probe operation (issue #118) ──────────────────────────────
+
+
+class RunCertProbeArgs(BaseModel):
+    """Args for ``run_cert_probe`` — probe one existing TLS cert target."""
+
+    target_id: str = Field(description="UUID of the tls_cert_target to probe now")
+
+
+async def _preview_run_cert_probe(
+    db: AsyncSession, user: User, args: RunCertProbeArgs
+) -> PreviewResult:
+    from app.models.tls_cert import TLSCertTarget  # noqa: PLC0415
+
+    try:
+        tid = UUID(args.target_id)
+    except ValueError:
+        return PreviewResult(ok=False, detail=f"invalid target_id {args.target_id!r}")
+    t = await db.get(TLSCertTarget, tid)
+    if t is None:
+        return PreviewResult(ok=False, detail=f"target {args.target_id} not found")
+    label = t.display_name or t.host
+    parts = [
+        f"Probe TLS endpoint **{label}** (`{t.host}:{t.port}`) now.",
+        "This opens a real TLS connection from the SpatiumDDI host and "
+        "refreshes the captured certificate + chain validity.",
+    ]
+    return PreviewResult(ok=True, detail="ready", preview_text="\n".join(parts))
+
+
+async def _apply_run_cert_probe(
+    db: AsyncSession, user: User, args: RunCertProbeArgs
+) -> dict[str, Any]:
+    from app.models.audit import AuditLog  # noqa: PLC0415
+    from app.models.settings import PlatformSettings  # noqa: PLC0415
+    from app.models.tls_cert import TLSCertTarget  # noqa: PLC0415
+    from app.services.tls_cert.probe import probe_one  # noqa: PLC0415
+
+    # SECURITY (#400, C2): matches the REST route's write/tls_cert gate.
+    enforce_operation_permission(user, _OPERATIONS["run_cert_probe"])
+
+    t = await db.get(TLSCertTarget, UUID(args.target_id))
+    if t is None:
+        raise ValueError(f"target {args.target_id} not found")
+    ps = await db.get(PlatformSettings, 1)
+    interval = max(1, min(168, (ps.tls_cert_check_interval_hours if ps else 6) or 6))
+    result = await probe_one(db, t, default_interval_hours=interval)
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=getattr(user, "auth_source", "local") or "local",
+            action="probe",
+            resource_type="tls_cert",
+            resource_id=str(t.id),
+            resource_display=t.display_name or t.host,
+            result="success" if result.ok else "error",
+            new_value={"state": result.state, "ok": result.ok, "via": "ai_proposal"},
+        )
+    )
+    await db.commit()
+    return {
+        "id": str(t.id),
+        "state": result.state,
+        "ok": result.ok,
+        "error": result.error,
+    }
+
+
+register(
+    Operation(
+        name="run_cert_probe",
+        description=(
+            "Probe an existing TLS cert target now. Always go through "
+            "propose_run_cert_probe — never call this directly. The probe "
+            "opens a real TLS connection, so operator approval is required."
+        ),
+        args_model=RunCertProbeArgs,
+        preview=_preview_run_cert_probe,
+        apply=_apply_run_cert_probe,
+        category="security",
+        required_permission=("write", "tls_cert"),
+    )
+)
+
+
 # ── run_packet_capture operation (issue #59) ───────────────────────────
 
 

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -46,6 +46,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     snmp,
     ssh,
     syslog,
+    tls_certs,
     upgrades,
     vendor,
     webhooks,

--- a/backend/app/services/ai/tools/tls_certs.py
+++ b/backend/app/services/ai/tools/tls_certs.py
@@ -276,6 +276,36 @@ async def count_tls_targets_by_state(
     return {"by_state": by_state, "total": sum(by_state.values())}
 
 
+# ── find_ct_log_entries (off-prem read, default-disabled) ──────────
+
+
+class FindCTLogEntriesArgs(BaseModel):
+    host: str = Field(description="Hostname / domain to query CT logs for.")
+    limit: int = Field(default=25, ge=1, le=100)
+
+
+@register_tool(
+    name="find_ct_log_entries",
+    description=(
+        "Cross-reference a host/domain against public Certificate "
+        "Transparency logs (crt.sh) — every CA-logged cert issued for the "
+        "name, to spot issuance you didn't deploy. OFF-PREM: this queries "
+        "crt.sh and leaks the hostname to it, so it's default-disabled; an "
+        "operator opts in per provider. Read-only."
+    ),
+    args_model=FindCTLogEntriesArgs,
+    category="security",
+    default_enabled=False,
+    module=_MODULE,
+)
+async def find_ct_log_entries(
+    db: AsyncSession, user: User, args: FindCTLogEntriesArgs
+) -> dict[str, Any]:
+    from app.services.tls_cert.ct_log import lookup_ct  # noqa: PLC0415
+
+    return await lookup_ct(args.host, limit=args.limit)
+
+
 # ── propose_run_cert_probe (gated write, default-disabled) ─────────
 
 

--- a/backend/app/services/ai/tools/tls_certs.py
+++ b/backend/app/services/ai/tools/tls_certs.py
@@ -1,0 +1,319 @@
+"""Operator Copilot tools for TLS certificate monitoring (issue #118).
+
+Read tools (all default-enabled, ``module="security.tls_certs"`` so
+disabling the feature module strips them — NN #14):
+
+* ``find_tls_cert`` — list / look up monitored targets by host, domain,
+  zone, IP, or expiring-within-N-days. Identity + lifecycle only.
+* ``count_tls_certs_expiring`` — rollup of certs expiring within N days
+  (≤7 / ≤14 / ≤30 / ≤90 buckets) + the soonest.
+* ``get_cert_chain`` — the latest probe's parsed chain for one target.
+* ``count_tls_targets_by_state`` — coarse health rollup by state bucket.
+
+Write tool:
+
+* ``propose_run_cert_probe`` — gated write (default-DISABLED: it touches
+  the network). Delegates to the ``run_cert_probe`` Operation so the
+  preview / apply contract matches the REST ``POST /tls-certs/{id}/probe``.
+
+NEVER returns private keys (we never hold them) — PEM is only surfaced
+via ``get_cert_chain`` and is public material.
+
+Distinct tool names from the ACME-client tools (``find_certificates`` /
+``count_certificates_expiring``) so the registry doesn't collide.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.tls_cert import TLSCertProbe, TLSCertTarget
+from app.services.ai import operations
+from app.services.ai.tools.base import register_tool
+
+_MODULE = "security.tls_certs"
+
+
+def _days_remaining(not_after: datetime | None, now: datetime) -> int | None:
+    if not_after is None:
+        return None
+    na = not_after if not_after.tzinfo else not_after.replace(tzinfo=UTC)
+    return int((na - now).total_seconds() // 86400)
+
+
+def _target_to_dict(t: TLSCertTarget, now: datetime) -> dict[str, Any]:
+    return {
+        "id": str(t.id),
+        "host": t.host,
+        "port": t.port,
+        "display_name": t.display_name,
+        "state": t.state,
+        "source": t.source,
+        "enabled": t.enabled,
+        "subject_cn": t.subject_cn,
+        "issuer_cn": t.issuer_cn,
+        "sans": list(t.sans_json or []),
+        "not_after": t.not_after.isoformat() if t.not_after else None,
+        "days_remaining": _days_remaining(t.not_after, now),
+        "chain_valid": t.chain_valid,
+        "self_signed": t.self_signed,
+        "fingerprint_sha256": t.fingerprint_sha256,
+        "last_checked_at": t.last_checked_at.isoformat() if t.last_checked_at else None,
+        "last_error": t.last_error,
+    }
+
+
+# ── find_tls_cert ──────────────────────────────────────────────────
+
+
+class FindTLSCertArgs(BaseModel):
+    host: str | None = Field(default=None, description="Substring match on host / display_name.")
+    domain_id: str | None = Field(default=None, description="Filter to a tracked Domain (UUID).")
+    dns_zone_id: str | None = Field(default=None, description="Filter to a DNS zone (UUID).")
+    state: str | None = Field(
+        default=None,
+        description="Filter by state: ok / expiring / expired / mismatch / unreachable / unknown.",
+    )
+    expiring_within_days: int | None = Field(
+        default=None, ge=1, le=3650, description="Only certs whose not_after is within N days."
+    )
+    limit: int = Field(default=50, ge=1, le=200)
+
+
+@register_tool(
+    name="find_tls_cert",
+    description=(
+        "List monitored TLS certificate targets. Each row carries host, "
+        "state (ok / expiring / expired / mismatch / unreachable), subject "
+        "+ issuer CN, SANs, not_after + days_remaining, chain validity, and "
+        "fingerprint. Filter by host substring, domain_id, dns_zone_id, "
+        "state, or expiring_within_days. Use to answer 'which services have "
+        "a cert expiring this month?' or 'is auth.example.com's chain "
+        "valid?'. Read-only; never returns private keys."
+    ),
+    args_model=FindTLSCertArgs,
+    category="security",
+    default_enabled=True,
+    module=_MODULE,
+)
+async def find_tls_cert(db: AsyncSession, user: User, args: FindTLSCertArgs) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    stmt = select(TLSCertTarget)
+    if args.host:
+        needle = f"%{args.host.strip()}%"
+        stmt = stmt.where(
+            or_(TLSCertTarget.host.ilike(needle), TLSCertTarget.display_name.ilike(needle))
+        )
+    if args.domain_id:
+        try:
+            stmt = stmt.where(TLSCertTarget.domain_id == uuid.UUID(args.domain_id))
+        except ValueError:
+            return {"error": f"invalid domain_id {args.domain_id!r}"}
+    if args.dns_zone_id:
+        try:
+            stmt = stmt.where(TLSCertTarget.dns_zone_id == uuid.UUID(args.dns_zone_id))
+        except ValueError:
+            return {"error": f"invalid dns_zone_id {args.dns_zone_id!r}"}
+    if args.state:
+        stmt = stmt.where(TLSCertTarget.state == args.state)
+    if args.expiring_within_days is not None:
+        cutoff = now + timedelta(days=args.expiring_within_days)
+        stmt = stmt.where(TLSCertTarget.not_after.is_not(None), TLSCertTarget.not_after <= cutoff)
+    stmt = stmt.order_by(TLSCertTarget.host.asc()).limit(args.limit)
+    rows = list((await db.execute(stmt)).scalars().all())
+    return {"targets": [_target_to_dict(t, now) for t in rows], "count": len(rows)}
+
+
+# ── count_tls_certs_expiring ───────────────────────────────────────
+
+
+class CountTLSCertsExpiringArgs(BaseModel):
+    within_days: int = Field(default=30, ge=1, le=3650)
+    enabled_only: bool = Field(default=True)
+
+
+@register_tool(
+    name="count_tls_certs_expiring",
+    description=(
+        "Count monitored TLS certs expiring within N days (default 30), "
+        "bucketed ≤7 / ≤14 / ≤30 / ≤90 days, plus the soonest-expiring "
+        "target. Use for 'how many certs lapse this month?'. Read-only."
+    ),
+    args_model=CountTLSCertsExpiringArgs,
+    category="security",
+    default_enabled=True,
+    module=_MODULE,
+)
+async def count_tls_certs_expiring(
+    db: AsyncSession, user: User, args: CountTLSCertsExpiringArgs
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    stmt = select(TLSCertTarget).where(TLSCertTarget.not_after.is_not(None))
+    if args.enabled_only:
+        stmt = stmt.where(TLSCertTarget.enabled.is_(True))
+    rows = list((await db.execute(stmt)).scalars().all())
+
+    buckets = {"<=7": 0, "<=14": 0, "<=30": 0, "<=90": 0}
+    within = 0
+    soonest: dict[str, Any] | None = None
+    for t in rows:
+        d = _days_remaining(t.not_after, now)
+        if d is None:
+            continue
+        if d <= args.within_days:
+            within += 1
+        if d <= 7:
+            buckets["<=7"] += 1
+        if d <= 14:
+            buckets["<=14"] += 1
+        if d <= 30:
+            buckets["<=30"] += 1
+        if d <= 90:
+            buckets["<=90"] += 1
+        if soonest is None or d < soonest["days_remaining"]:
+            soonest = {
+                "id": str(t.id),
+                "host": t.host,
+                "days_remaining": d,
+                "not_after": t.not_after.isoformat() if t.not_after else None,
+            }
+    return {
+        "within_days": args.within_days,
+        "count": within,
+        "buckets": buckets,
+        "soonest_expiring": soonest,
+    }
+
+
+# ── get_cert_chain ─────────────────────────────────────────────────
+
+
+class GetCertChainArgs(BaseModel):
+    target_id: str = Field(description="UUID of the tls_cert_target.")
+
+
+@register_tool(
+    name="get_cert_chain",
+    description=(
+        "Return the latest successful probe's parsed certificate for one "
+        "target: subject / issuer CN, serial, validity window, SANs, key "
+        "algorithm + size, signature algorithm, chain depth + validity, "
+        "self-signed flag, and SHA-256 fingerprint. Public chain data — no "
+        "private keys. Read-only."
+    ),
+    args_model=GetCertChainArgs,
+    category="security",
+    default_enabled=True,
+    module=_MODULE,
+)
+async def get_cert_chain(db: AsyncSession, user: User, args: GetCertChainArgs) -> dict[str, Any]:
+    try:
+        tid = uuid.UUID(args.target_id)
+    except ValueError:
+        return {"error": f"invalid target_id {args.target_id!r}"}
+    probe = await db.scalar(
+        select(TLSCertProbe)
+        .where(TLSCertProbe.target_id == tid, TLSCertProbe.ok.is_(True))
+        .order_by(TLSCertProbe.probed_at.desc())
+        .limit(1)
+    )
+    if probe is None:
+        return {"error": "no successful probe yet for this target"}
+    return {
+        "target_id": str(tid),
+        "probed_at": probe.probed_at.isoformat(),
+        "subject_cn": probe.subject_cn,
+        "issuer_cn": probe.issuer_cn,
+        "serial": probe.serial,
+        "not_before": probe.not_before.isoformat() if probe.not_before else None,
+        "not_after": probe.not_after.isoformat() if probe.not_after else None,
+        "sans": list(probe.sans_json or []),
+        "key_algo": probe.key_algo,
+        "key_size": probe.key_size,
+        "sig_algo": probe.sig_algo,
+        "chain_depth": probe.chain_depth,
+        "chain_valid": probe.chain_valid,
+        "chain_error": probe.chain_error,
+        "self_signed": probe.self_signed,
+        "fingerprint_sha256": probe.fingerprint_sha256,
+    }
+
+
+# ── count_tls_targets_by_state ─────────────────────────────────────
+
+
+class CountTLSTargetsByStateArgs(BaseModel):
+    enabled_only: bool = Field(default=True)
+
+
+@register_tool(
+    name="count_tls_targets_by_state",
+    description=(
+        "Coarse health rollup of monitored TLS endpoints grouped by state "
+        "(ok / expiring / expired / mismatch / unreachable / unknown). Use "
+        "for 'how healthy is the cert fleet?'. Read-only."
+    ),
+    args_model=CountTLSTargetsByStateArgs,
+    category="security",
+    default_enabled=True,
+    module=_MODULE,
+)
+async def count_tls_targets_by_state(
+    db: AsyncSession, user: User, args: CountTLSTargetsByStateArgs
+) -> dict[str, Any]:
+    stmt = select(TLSCertTarget.state, func.count()).group_by(TLSCertTarget.state)
+    if args.enabled_only:
+        stmt = stmt.where(TLSCertTarget.enabled.is_(True))
+    rows = (await db.execute(stmt)).all()
+    by_state = {state: count for state, count in rows}
+    return {"by_state": by_state, "total": sum(by_state.values())}
+
+
+# ── propose_run_cert_probe (gated write, default-disabled) ─────────
+
+
+@register_tool(
+    name="propose_run_cert_probe",
+    description=(
+        "Prepare a proposal to probe a TLS cert target now. The operator "
+        "must click Apply for the probe to run — it opens a real TLS "
+        "connection. Returns kind='proposal'; surface the preview and wait "
+        "for the operator's decision. Use when someone just rotated a cert "
+        "and wants to confirm the new one is live."
+    ),
+    args_model=operations.RunCertProbeArgs,
+    writes=False,  # the propose tool is read-only; apply is the write
+    category="security",
+    default_enabled=False,
+    module=_MODULE,
+)
+async def propose_run_cert_probe(
+    db: AsyncSession, user: User, args: operations.RunCertProbeArgs
+) -> dict[str, Any]:
+    from app.services.ai.tools.proposals import _persist_proposal, _proposal_result  # noqa: PLC0415
+
+    op = operations.get_operation("run_cert_probe")
+    if op is None:
+        return {"error": "Operation 'run_cert_probe' is not registered"}
+    preview = await op.preview(db, user, args)
+    if not preview.ok:
+        return {
+            "kind": "proposal_rejected",
+            "operation": "run_cert_probe",
+            "detail": preview.detail,
+        }
+    proposal = await _persist_proposal(
+        db,
+        user=user,
+        operation="run_cert_probe",
+        args=args.model_dump(),
+        preview_text=preview.preview_text,
+    )
+    return _proposal_result(proposal, preview_text=preview.preview_text)

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -198,6 +198,9 @@ RULE_TYPE_TLS_CERT_EXPIRING = "tls_cert_expiring"
 RULE_TYPE_TLS_CERT_CHAIN_INVALID = "tls_cert_chain_invalid"
 RULE_TYPE_TLS_CERT_UNREACHABLE = "tls_cert_unreachable"
 RULE_TYPE_TLS_CERT_CHANGED = "tls_cert_changed"
+# Cert-rotation deviation (#118 Phase 3) — the issuing CA changed (a
+# normally-ACME cert coming back from a different issuer); transition-once.
+RULE_TYPE_TLS_CERT_ISSUER_CHANGED = "tls_cert_issuer_changed"
 # Unreachable only pages after a couple of consecutive failures so a
 # single transient handshake blip doesn't fire.
 _TLS_CERT_UNREACHABLE_MIN_FAILURES = 2
@@ -237,6 +240,7 @@ RULE_TYPES = frozenset(
         RULE_TYPE_TLS_CERT_CHAIN_INVALID,
         RULE_TYPE_TLS_CERT_UNREACHABLE,
         RULE_TYPE_TLS_CERT_CHANGED,
+        RULE_TYPE_TLS_CERT_ISSUER_CHANGED,
     }
 )
 
@@ -1191,15 +1195,25 @@ async def _matching_tls_cert_unreachable_subjects(
     return matches
 
 
-async def _evaluate_tls_cert_changed_rule(
+async def _evaluate_tls_cert_transition_rule(
     db: AsyncSession,
     rule: AlertRule,
     now: datetime,
+    *,
+    value_attr: str = "fingerprint_sha256",
+    what: str = "fingerprint",
 ) -> tuple[int, int, int, int, int]:
-    """``tls_cert_changed`` — transition-once rule latching the leaf
-    fingerprint pair, modelled on :func:`_evaluate_domain_transition_rule`.
-    Legitimate on renewal, suspicious otherwise. First sighting records a
-    silent baseline; open events auto-resolve after
+    """Transition-once rule over a per-target cert attribute, modelled on
+    :func:`_evaluate_domain_transition_rule`. ``value_attr`` selects the
+    watched column:
+
+    * ``fingerprint_sha256`` (``tls_cert_changed``) — any cert swap;
+      legitimate on renewal, suspicious otherwise.
+    * ``issuer_cn`` (``tls_cert_issuer_changed``) — the issuing CA changed,
+      i.e. cert-rotation *deviation* (a normally-ACME cert coming back from a
+      different issuer). Higher-signal than a plain fingerprint change.
+
+    First sighting records a silent baseline; open events auto-resolve after
     ``_TRANSITION_AUTO_RESOLVE_DAYS``."""
     targets = await audit_forward._load_targets()  # noqa: SLF001
 
@@ -1235,7 +1249,7 @@ async def _evaluate_tls_cert_changed_rule(
     )
     for t in rows:
         subject_id = str(t.id)
-        current_value = t.fingerprint_sha256
+        current_value = getattr(t, value_attr)
         if open_by_subject.get(subject_id) is not None:
             continue
 
@@ -1256,7 +1270,7 @@ async def _evaluate_tls_cert_changed_rule(
                     subject_id=subject_id,
                     subject_display=label,
                     severity="info",
-                    message=f"Initial TLS cert fingerprint baseline for {label}: {current_value}",
+                    message=f"Initial TLS cert {what} baseline for {label}: {current_value}",
                     fired_at=now,
                     resolved_at=now,
                     last_observed_value={"from": None, "to": current_value},
@@ -1267,7 +1281,7 @@ async def _evaluate_tls_cert_changed_rule(
         if current_value is None or current_value == prior_value:
             continue
 
-        message = f"TLS cert for {label} changed: {prior_value} → {current_value}"
+        message = f"TLS cert {what} for {label} changed: {prior_value} → {current_value}"
         event = AlertEvent(
             rule_id=rule.id,
             subject_type="tls_cert",
@@ -2768,6 +2782,19 @@ _TLS_CERT_RULE_SEEDS: list[dict[str, object]] = [
             "otherwise). Auto-resolves after the transition window."
         ),
     },
+    {
+        "name": "TLS cert issuer changed",
+        "rule_type": RULE_TYPE_TLS_CERT_ISSUER_CHANGED,
+        "severity": "warning",
+        "threshold_days": None,
+        "description": (
+            "Fires once when a monitored endpoint's certificate comes back "
+            "from a DIFFERENT issuing CA — cert-rotation deviation (e.g. a "
+            "normally-Let's-Encrypt cert suddenly issued by another CA), a "
+            "higher-signal subset of 'cert changed'. Auto-resolves after the "
+            "transition window."
+        ),
+    },
 ]
 
 
@@ -2941,7 +2968,20 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 subject_type = "tls_cert"
             elif rule.rule_type == RULE_TYPE_TLS_CERT_CHANGED:
                 # Transition-once — latches the fingerprint pair + auto-resolves.
-                op_, res_, dsy, dwh, dsm = await _evaluate_tls_cert_changed_rule(db, rule, now)
+                op_, res_, dsy, dwh, dsm = await _evaluate_tls_cert_transition_rule(
+                    db, rule, now, value_attr="fingerprint_sha256", what="fingerprint"
+                )
+                opened += op_
+                resolved += res_
+                delivered_syslog += dsy
+                delivered_webhook += dwh
+                delivered_smtp += dsm
+                continue
+            elif rule.rule_type == RULE_TYPE_TLS_CERT_ISSUER_CHANGED:
+                # Transition-once on the issuing CA — cert-rotation deviation.
+                op_, res_, dsy, dwh, dsm = await _evaluate_tls_cert_transition_rule(
+                    db, rule, now, value_attr="issuer_cn", what="issuer"
+                )
                 opened += op_
                 resolved += res_
                 delivered_syslog += dsy

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -56,6 +56,11 @@ from app.models.network_service import NetworkService, NetworkServiceResource
 from app.models.overlay import OverlayNetwork
 from app.models.ownership import Site
 from app.models.settings import PlatformSettings
+from app.models.tls_cert import (
+    STATE_MISMATCH,
+    STATE_UNREACHABLE,
+    TLSCertTarget,
+)
 from app.models.vrf import VRF
 from app.services import audit_forward
 
@@ -183,6 +188,20 @@ RULE_TYPE_UNKNOWN_MAC_IN_STATIC_RANGE = "unknown_mac_in_static_range"
 RULE_TYPE_ROGUE_DHCP = "rogue_dhcp"
 _ROGUE_DHCP_RECENCY_DAYS = 1
 
+# TLS certificate monitoring — issue #118. Subject = tls_cert (one per
+# tls_cert_target). ``tls_cert_expiring`` is a standard escalating-expiry
+# rule (info → warning → critical as not_after nears, like domain_expiring);
+# ``tls_cert_chain_invalid`` / ``tls_cert_unreachable`` are standard
+# open-while-true rules; ``tls_cert_changed`` is a transition-once rule that
+# latches the fingerprint pair and auto-resolves after the window.
+RULE_TYPE_TLS_CERT_EXPIRING = "tls_cert_expiring"
+RULE_TYPE_TLS_CERT_CHAIN_INVALID = "tls_cert_chain_invalid"
+RULE_TYPE_TLS_CERT_UNREACHABLE = "tls_cert_unreachable"
+RULE_TYPE_TLS_CERT_CHANGED = "tls_cert_changed"
+# Unreachable only pages after a couple of consecutive failures so a
+# single transient handshake blip doesn't fire.
+_TLS_CERT_UNREACHABLE_MIN_FAILURES = 2
+
 RULE_TYPES = frozenset(
     {
         RULE_TYPE_SUBNET_UTILIZATION,
@@ -214,6 +233,10 @@ RULE_TYPES = frozenset(
         RULE_TYPE_STALE_RESERVATION,
         RULE_TYPE_UNKNOWN_MAC_IN_STATIC_RANGE,
         RULE_TYPE_ROGUE_DHCP,
+        RULE_TYPE_TLS_CERT_EXPIRING,
+        RULE_TYPE_TLS_CERT_CHAIN_INVALID,
+        RULE_TYPE_TLS_CERT_UNREACHABLE,
+        RULE_TYPE_TLS_CERT_CHANGED,
     }
 )
 
@@ -1040,6 +1063,236 @@ async def _matching_domain_expiring_subjects(
         )
         matches.append((str(d.id), d.name, message, sev))
     return matches
+
+
+async def _matching_tls_cert_expiring_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+    now: datetime,
+) -> list[tuple[str, str, str, str]]:
+    """``tls_cert_expiring`` — escalating-expiry rule over the latest-known
+    ``not_after`` per enabled target (same severity ramp as domain_expiring).
+    Auto-resolves via the generic loop once the cert is renewed past the
+    cutoff (not_after moves out → no longer returned)."""
+    threshold_days = rule.threshold_days or _DEFAULT_EXPIRING_THRESHOLD_DAYS
+    cutoff = now + timedelta(days=threshold_days)
+    rows = (
+        (
+            await db.execute(
+                select(TLSCertTarget).where(
+                    TLSCertTarget.enabled.is_(True),
+                    TLSCertTarget.not_after.is_not(None),
+                    TLSCertTarget.not_after <= cutoff,
+                    # NOTE: intentionally NOT excluding unreachable here — a
+                    # cert's expiry is a fact from the last good probe, so a
+                    # briefly-unreachable endpoint near expiry should keep the
+                    # expiring event OPEN (excluding it makes the generic loop
+                    # resolve→reopen → notification flap on a flapping host).
+                    # The unreachable rule co-fires to signal the data is stale.
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    matches: list[tuple[str, str, str, str]] = []
+    for t in rows:
+        exp = t.not_after
+        if exp is None:
+            continue
+        if exp.tzinfo is None:
+            exp = exp.replace(tzinfo=UTC)
+        days_to_expiry = (exp - now).total_seconds() / 86400.0
+        sev = _escalate_severity_for_expiring(
+            rule.severity,
+            threshold_days=threshold_days,
+            days_to_expiry=days_to_expiry,
+        )
+        if days_to_expiry <= 0:
+            descriptor = "expired"
+        elif days_to_expiry < 1:
+            descriptor = "expires within 24 h"
+        else:
+            descriptor = f"expires in {int(days_to_expiry)} day(s)"
+        label = t.display_name or t.host
+        message = (
+            f"TLS cert for {label} {descriptor} (not_after "
+            f"{exp.isoformat()}, threshold {threshold_days} d)"
+        )
+        matches.append((str(t.id), label, message, sev))
+    return matches
+
+
+async def _matching_tls_cert_chain_invalid_subjects(
+    db: AsyncSession, rule: AlertRule
+) -> list[tuple[str, str, str]]:
+    """``tls_cert_chain_invalid`` — fires for a reachable, unexpired cert
+    that isn't usable: an untrusted chain (self-signed / wrong CA / broken
+    chain → ``chain_valid IS FALSE``) OR a trusted chain served on the wrong
+    hostname (SAN/CN mismatch → ``chain_valid IS TRUE`` but the probed name
+    isn't covered). ``derive_tls_state`` buckets BOTH as ``STATE_MISMATCH``
+    (expiry + unreachable take precedence in that ordering), so keying on the
+    state covers the hostname-mismatch case the rule advertises without
+    double-paging an expired or down cert (owned by the expiring /
+    unreachable rules). Auto-resolves once a probe validates + name-matches."""
+    rows = (
+        (
+            await db.execute(
+                select(TLSCertTarget).where(
+                    TLSCertTarget.enabled.is_(True),
+                    TLSCertTarget.state == STATE_MISMATCH,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    matches: list[tuple[str, str, str]] = []
+    for t in rows:
+        label = t.display_name or t.host
+        if t.chain_valid is False:
+            detail = t.chain_error or "certificate chain did not validate"
+        else:
+            # Trusted chain, wrong name — the SAN-drift case the module advertises.
+            detail = "certificate served does not match the expected hostname (SAN mismatch)"
+        message = f"TLS cert for {label} invalid: {detail}"
+        matches.append((str(t.id), label, message))
+    return matches
+
+
+async def _matching_tls_cert_unreachable_subjects(
+    db: AsyncSession, rule: AlertRule
+) -> list[tuple[str, str, str]]:
+    """``tls_cert_unreachable`` — fires while the endpoint can't be probed,
+    gated on a couple of consecutive failures so a single transient blip
+    doesn't page. Auto-resolves on the next successful probe."""
+    rows = (
+        (
+            await db.execute(
+                select(TLSCertTarget).where(
+                    TLSCertTarget.enabled.is_(True),
+                    TLSCertTarget.state == STATE_UNREACHABLE,
+                    TLSCertTarget.consecutive_failures >= _TLS_CERT_UNREACHABLE_MIN_FAILURES,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    matches: list[tuple[str, str, str]] = []
+    for t in rows:
+        label = t.display_name or t.host
+        message = (
+            f"TLS endpoint {label} unreachable "
+            f"({t.consecutive_failures} consecutive failures): "
+            f"{t.last_error or 'probe failed'}"
+        )
+        matches.append((str(t.id), label, message))
+    return matches
+
+
+async def _evaluate_tls_cert_changed_rule(
+    db: AsyncSession,
+    rule: AlertRule,
+    now: datetime,
+) -> tuple[int, int, int, int, int]:
+    """``tls_cert_changed`` — transition-once rule latching the leaf
+    fingerprint pair, modelled on :func:`_evaluate_domain_transition_rule`.
+    Legitimate on renewal, suspicious otherwise. First sighting records a
+    silent baseline; open events auto-resolve after
+    ``_TRANSITION_AUTO_RESOLVE_DAYS``."""
+    targets = await audit_forward._load_targets()  # noqa: SLF001
+
+    opened = resolved = delivered_syslog = delivered_webhook = delivered_smtp = 0
+
+    open_res = await db.execute(
+        select(AlertEvent).where(
+            AlertEvent.rule_id == rule.id,
+            AlertEvent.resolved_at.is_(None),
+        )
+    )
+    open_events = list(open_res.scalars().all())
+    open_by_subject: dict[str, AlertEvent] = {ev.subject_id: ev for ev in open_events}
+
+    cutoff = now - timedelta(days=_TRANSITION_AUTO_RESOLVE_DAYS)
+    for ev in list(open_events):
+        if ev.fired_at < cutoff:
+            ev.resolved_at = now
+            resolved += 1
+            del open_by_subject[ev.subject_id]
+
+    last_event_res = await db.execute(
+        select(AlertEvent).where(AlertEvent.rule_id == rule.id).order_by(AlertEvent.fired_at.desc())
+    )
+    last_event_by_subject: dict[str, AlertEvent] = {}
+    for ev in last_event_res.scalars().all():
+        last_event_by_subject.setdefault(ev.subject_id, ev)
+
+    rows = (
+        (await db.execute(select(TLSCertTarget).where(TLSCertTarget.enabled.is_(True))))
+        .scalars()
+        .all()
+    )
+    for t in rows:
+        subject_id = str(t.id)
+        current_value = t.fingerprint_sha256
+        if open_by_subject.get(subject_id) is not None:
+            continue
+
+        prior_event = last_event_by_subject.get(subject_id)
+        if prior_event is not None and isinstance(prior_event.last_observed_value, dict):
+            prior_value = prior_event.last_observed_value.get("to")
+        else:
+            prior_value = None
+
+        label = t.display_name or t.host
+        if prior_event is None:
+            if current_value is None:
+                continue
+            db.add(
+                AlertEvent(
+                    rule_id=rule.id,
+                    subject_type="tls_cert",
+                    subject_id=subject_id,
+                    subject_display=label,
+                    severity="info",
+                    message=f"Initial TLS cert fingerprint baseline for {label}: {current_value}",
+                    fired_at=now,
+                    resolved_at=now,
+                    last_observed_value={"from": None, "to": current_value},
+                )
+            )
+            continue
+
+        if current_value is None or current_value == prior_value:
+            continue
+
+        message = f"TLS cert for {label} changed: {prior_value} → {current_value}"
+        event = AlertEvent(
+            rule_id=rule.id,
+            subject_type="tls_cert",
+            subject_id=subject_id,
+            subject_display=label,
+            severity=rule.severity,
+            message=message,
+            fired_at=now,
+            last_observed_value={"from": prior_value, "to": current_value},
+        )
+        db.add(event)
+        await db.flush()
+        ds, dw, dm = await _deliver(rule, event, targets)
+        event.delivered_syslog = ds
+        event.delivered_webhook = dw
+        event.delivered_smtp = dm
+        opened += 1
+        if ds:
+            delivered_syslog += 1
+        if dw:
+            delivered_webhook += 1
+        if dm:
+            delivered_smtp += 1
+
+    return opened, resolved, delivered_syslog, delivered_webhook, delivered_smtp
 
 
 async def _matching_domain_drift_subjects(
@@ -2468,6 +2721,90 @@ async def _deliver(
 # ── Main entry point ───────────────────────────────────────────────────────
 
 
+_TLS_CERT_RULE_SEEDS: list[dict[str, object]] = [
+    {
+        "name": "TLS cert expiring",
+        "rule_type": RULE_TYPE_TLS_CERT_EXPIRING,
+        "severity": "warning",
+        "threshold_days": 30,
+        "description": (
+            "Fires when a monitored TLS endpoint's served certificate is "
+            "within threshold_days of expiry. Severity escalates info → "
+            "warning → critical as the expiry nears. Auto-resolves on renewal."
+        ),
+    },
+    {
+        "name": "TLS cert chain invalid",
+        "rule_type": RULE_TYPE_TLS_CERT_CHAIN_INVALID,
+        "severity": "critical",
+        "threshold_days": None,
+        "description": (
+            "Fires when a monitored endpoint's certificate is reachable and "
+            "unexpired but not usable: an untrusted chain (self-signed / wrong "
+            "CA / broken chain) or a trusted cert served for the wrong hostname "
+            "(SAN/CN mismatch). Expiry is covered by the expiring rule. "
+            "Auto-resolves once the cert validates and matches the hostname."
+        ),
+    },
+    {
+        "name": "TLS cert unreachable",
+        "rule_type": RULE_TYPE_TLS_CERT_UNREACHABLE,
+        "severity": "warning",
+        "threshold_days": None,
+        "description": (
+            "Fires when a monitored endpoint can't be probed (TCP refused / "
+            "TLS handshake failed / DNS) for a couple of consecutive cycles. "
+            "Auto-resolves on the next successful probe."
+        ),
+    },
+    {
+        "name": "TLS cert changed",
+        "rule_type": RULE_TYPE_TLS_CERT_CHANGED,
+        "severity": "info",
+        "threshold_days": None,
+        "description": (
+            "Fires once when a monitored endpoint's certificate fingerprint "
+            "changes unexpectedly (legitimate on renewal, suspicious "
+            "otherwise). Auto-resolves after the transition window."
+        ),
+    },
+]
+
+
+async def seed_tls_cert_alert_rules() -> None:
+    """Seed the four ``tls_cert_*`` rules (issue #118), DISABLED by default.
+
+    Opt-in like the other monitoring signals — seeding them surfaces their
+    existence in the Alerts UI without firing on installs that never add a
+    probe target. Keyed on ``rule_type`` (one per type); an operator who
+    enables / renames one is never overridden.
+    """
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+    from app.models.alerts import AlertRule  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as session:
+        for seed in _TLS_CERT_RULE_SEEDS:
+            existing = await session.scalar(
+                select(AlertRule).where(AlertRule.rule_type == seed["rule_type"])
+            )
+            if existing is not None:
+                continue
+            session.add(
+                AlertRule(
+                    name=seed["name"],
+                    description=seed["description"],
+                    rule_type=seed["rule_type"],
+                    severity=seed["severity"],
+                    threshold_days=seed["threshold_days"],
+                    enabled=False,
+                    notify_syslog=True,
+                    notify_webhook=True,
+                    notify_smtp=False,
+                )
+            )
+        await session.commit()
+
+
 async def evaluate_all(db: AsyncSession) -> dict[str, int]:
     """Evaluate every enabled rule; open / resolve events as needed.
 
@@ -2590,6 +2927,27 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 expiring = await _matching_decom_expiring_subjects(db, rule, now)
                 matches = [(sid, disp, msg, sev) for sid, disp, msg, sev in expiring]
                 subject_type = "subnet"
+            elif rule.rule_type == RULE_TYPE_TLS_CERT_EXPIRING:
+                expiring = await _matching_tls_cert_expiring_subjects(db, rule, now)
+                matches = [(sid, disp, msg, sev) for sid, disp, msg, sev in expiring]
+                subject_type = "tls_cert"
+            elif rule.rule_type == RULE_TYPE_TLS_CERT_CHAIN_INVALID:
+                invalid = await _matching_tls_cert_chain_invalid_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in invalid]
+                subject_type = "tls_cert"
+            elif rule.rule_type == RULE_TYPE_TLS_CERT_UNREACHABLE:
+                down = await _matching_tls_cert_unreachable_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in down]
+                subject_type = "tls_cert"
+            elif rule.rule_type == RULE_TYPE_TLS_CERT_CHANGED:
+                # Transition-once — latches the fingerprint pair + auto-resolves.
+                op_, res_, dsy, dwh, dsm = await _evaluate_tls_cert_changed_rule(db, rule, now)
+                opened += op_
+                resolved += res_
+                delivered_syslog += dsy
+                delivered_webhook += dwh
+                delivered_smtp += dsm
+                continue
             elif rule.rule_type == RULE_TYPE_SERVICE_RESOURCE_ORPHANED:
                 orphans = await _matching_service_resource_orphaned_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in orphans]

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -285,6 +285,12 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         group="Security",
         description="Embedded RFC 8555 ACME client that issues a CA-trusted Web UI TLS cert from Let's Encrypt, solving the DNS-01 challenge through SpatiumDDI's own managed DNS zones. Discovery toggle only — issuance is RBAC-gated and requires an explicit operator opt-in (Settings → acme_enabled).",
     ),
+    ModuleSpec(
+        id="security.tls_certs",
+        label="TLS certificate monitoring",
+        group="Security",
+        description="Watch external TLS endpoints for expiry / chain validity / SAN drift; auto-discover probe targets from DNS A/AAAA records; alert on approaching expiry, broken chains, unreachable endpoints, and unexpected cert changes. Read-only monitoring — distinct from the ACME client that issues the appliance's own cert.",
+    ),
     # UI — cross-cutting personalisation surfaces. Per-user, never shared.
     ModuleSpec(
         id="ui.saved_views",

--- a/backend/app/services/nettools/schemas.py
+++ b/backend/app/services/nettools/schemas.py
@@ -104,6 +104,10 @@ _BLOCKED_NETWORKS: Final[tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ..
     ipaddress.ip_network("::1/128"),
     ipaddress.ip_network("169.254.0.0/16"),
     ipaddress.ip_network("fe80::/10"),
+    # 0.0.0.0 (and ::) — the kernel routes a connect() to these to
+    # loopback, so they're an SSRF bypass of the 127/8 block.
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("::/128"),
 )
 
 

--- a/backend/app/services/tls_cert/ct_log.py
+++ b/backend/app/services/tls_cert/ct_log.py
@@ -45,8 +45,15 @@ async def lookup_ct(host: str, *, limit: int = 50) -> dict[str, Any]:
             resp.raise_for_status()
             raw = resp.json()
     except (httpx.HTTPError, ValueError) as exc:
+        # Log the detail server-side; return a generic message to the client
+        # (don't echo the raw exception — info exposure).
         logger.info("ct_log_lookup_failed", host=host, error=str(exc))
-        return {"host": host, "entries": [], "count": 0, "error": str(exc)}
+        return {
+            "host": host,
+            "entries": [],
+            "count": 0,
+            "error": "CT-log lookup failed (crt.sh unreachable or rate-limited)",
+        }
 
     if not isinstance(raw, list):
         return {"host": host, "entries": [], "count": 0, "error": "unexpected response"}

--- a/backend/app/services/tls_cert/ct_log.py
+++ b/backend/app/services/tls_cert/ct_log.py
@@ -1,0 +1,82 @@
+"""Certificate Transparency log cross-reference (issue #118 Phase 3).
+
+Queries the public crt.sh CT aggregator for every logged certificate
+issued for a host/domain, so an operator can spot issuance they didn't
+deploy (mis-issuance / rogue certs) next to what the probe actually sees.
+
+OFF-PREM: this is the only part of the TLS feature that makes an outbound
+call to a third party, and it leaks the queried hostname to crt.sh. It is
+therefore an EXPLICIT, on-demand action only — never run by the scheduled
+probe — and the matching MCP tool ships default-disabled. Best-effort:
+crt.sh is frequently slow/rate-limited, so failures degrade to an empty
+result with an ``error`` string rather than raising.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+_CRT_SH_URL = "https://crt.sh/"
+_TIMEOUT = 12.0
+_MAX_ENTRIES = 100
+
+
+async def lookup_ct(host: str, *, limit: int = 50) -> dict[str, Any]:
+    """Return recent CT-logged certificates for ``host`` (via crt.sh).
+
+    ``{"host", "entries": [...], "count", "error"}`` — ``error`` is set + a
+    fast empty result returned on any transport / parse failure."""
+    host = (host or "").strip().rstrip(".").lower()
+    if not host:
+        return {"host": host, "entries": [], "count": 0, "error": "no host"}
+    limit = max(1, min(_MAX_ENTRIES, limit))
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.get(
+                _CRT_SH_URL,
+                params={"q": host, "output": "json", "exclude": "expired"},
+                headers={"User-Agent": "SpatiumDDI-TLS-monitor"},
+            )
+            resp.raise_for_status()
+            raw = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        logger.info("ct_log_lookup_failed", host=host, error=str(exc))
+        return {"host": host, "entries": [], "count": 0, "error": str(exc)}
+
+    if not isinstance(raw, list):
+        return {"host": host, "entries": [], "count": 0, "error": "unexpected response"}
+
+    # Dedupe on (issuer, serial) — crt.sh returns one row per log entry, so
+    # the same cert appears many times.
+    seen: set[tuple[str, str]] = set()
+    entries: list[dict[str, Any]] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        key = (str(row.get("issuer_name", "")), str(row.get("serial_number", "")))
+        if key in seen:
+            continue
+        seen.add(key)
+        entries.append(
+            {
+                "id": row.get("id"),
+                "common_name": row.get("common_name"),
+                "name_value": row.get("name_value"),
+                "issuer_name": row.get("issuer_name"),
+                "serial_number": row.get("serial_number"),
+                "not_before": row.get("not_before"),
+                "not_after": row.get("not_after"),
+                "entry_timestamp": row.get("entry_timestamp"),
+            }
+        )
+        if len(entries) >= limit:
+            break
+
+    # Newest issuance first.
+    entries.sort(key=lambda e: str(e.get("not_before") or ""), reverse=True)
+    return {"host": host, "entries": entries, "count": len(entries), "error": None}

--- a/backend/app/services/tls_cert/discovery.py
+++ b/backend/app/services/tls_cert/discovery.py
@@ -35,9 +35,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.dns import DNSRecord, DNSZone
 from app.models.domain import Domain
+from app.models.ipam import TLS_SERVING_ROLES, IPAddress
 from app.models.tls_cert import SOURCE_DISCOVERED, TLSCertTarget
 
 logger = structlog.get_logger(__name__)
+
+
+def _host_for_ip(ip: IPAddress) -> str:
+    """Probe host for a TLS-serving IP — prefer a name (so SNI + cert-name
+    match work), fall back to the literal IP."""
+    if ip.fqdn and ip.fqdn.strip():
+        return ip.fqdn.rstrip(".").lower()
+    if ip.hostname and ip.hostname.strip():
+        return ip.hostname.rstrip(".").lower()
+    return str(ip.address).split("/")[0]
 
 
 def _best_suffix_match(
@@ -106,7 +117,14 @@ async def reconcile_discovered_targets(
     """Create / disable discovered targets + relink by SAN. No commit."""
     _ = now or datetime.now(UTC)
 
-    rows = (
+    # Unified candidate map keyed on the connect tuple (host, 443, None).
+    # Each value carries whatever provenance links apply (DNS record/zone/
+    # domain + IPAM IP) — the same FQDN can surface from a DNS record AND a
+    # TLS-serving IP, which merge into one target.
+    candidates: dict[tuple[str, int, None], dict[str, uuid.UUID | None]] = {}
+
+    # Source 1 — opted-in DNS A/AAAA records.
+    dns_rows = (
         await db.execute(
             select(DNSRecord, DNSZone)
             .join(DNSZone, DNSRecord.zone_id == DNSZone.id)
@@ -119,14 +137,27 @@ async def reconcile_discovered_targets(
             )
         )
     ).all()
-
-    # Dedupe candidates on the connect tuple (same FQDN from >1 record).
-    candidates: dict[tuple[str, int, None], tuple[DNSRecord, DNSZone]] = {}
-    for rec, zone in rows:
+    for rec, zone in dns_rows:
         host = (rec.fqdn or "").rstrip(".").lower()
         if not host:
             continue
-        candidates.setdefault((host, 443, None), (rec, zone))
+        cand = candidates.setdefault((host, 443, None), {})
+        cand.setdefault("dns_record_id", rec.id)
+        cand.setdefault("dns_zone_id", zone.id)
+        cand.setdefault("domain_id", zone.domain_id)
+
+    # Source 2 — IPs classified into a TLS-serving role (#118 Phase 2).
+    ip_rows = (
+        (await db.execute(select(IPAddress).where(IPAddress.role.in_(TLS_SERVING_ROLES))))
+        .scalars()
+        .all()
+    )
+    for ip in ip_rows:
+        host = _host_for_ip(ip)
+        if not host:
+            continue
+        cand = candidates.setdefault((host, 443, None), {})
+        cand.setdefault("ip_address_id", ip.id)
 
     existing = (
         (await db.execute(select(TLSCertTarget).where(TLSCertTarget.source == SOURCE_DISCOVERED)))
@@ -136,23 +167,22 @@ async def reconcile_discovered_targets(
     existing_by_key = {(t.host.lower(), t.port, t.server_name): t for t in existing}
 
     created = reenabled = 0
-    for (host, port, sni), (rec, zone) in candidates.items():
+    for (host, port, sni), cand in candidates.items():
         et = existing_by_key.get((host, port, sni))
         if et is not None:
-            # Already tracked. Re-enable + refresh provenance if the record
-            # came back (a re-added record is a NEW row with a fresh uuid).
-            # Discovered targets are a projection of DNS state — to stop
-            # probing, opt the record/zone OUT (auto_tls_probe=False); a
-            # manually-disabled discovered row is re-enabled here by design.
+            # Already tracked. Re-enable + refresh provenance. Discovered
+            # targets are a projection of DNS/IPAM state — to stop probing,
+            # opt the source out; a manually-disabled discovered row is
+            # re-enabled here by design.
             touched = False
             if not et.enabled:
                 et.enabled = True
                 touched = True
-            if et.dns_record_id != rec.id:
-                et.dns_record_id = rec.id
-                touched = True
-            if et.dns_zone_id is None:
-                et.dns_zone_id = zone.id
+            for field in ("dns_record_id", "dns_zone_id", "domain_id", "ip_address_id"):
+                val = cand.get(field)
+                if val is not None and getattr(et, field) != val:
+                    setattr(et, field, val)
+                    touched = True
             reenabled += 1 if touched else 0
             continue
         # Don't collide with a manually-added target on the same tuple.
@@ -172,18 +202,19 @@ async def reconcile_discovered_targets(
                 server_name=None,
                 display_name=host,
                 source=SOURCE_DISCOVERED,
-                dns_record_id=rec.id,
-                dns_zone_id=zone.id,
-                domain_id=zone.domain_id,
+                dns_record_id=cand.get("dns_record_id"),
+                dns_zone_id=cand.get("dns_zone_id"),
+                domain_id=cand.get("domain_id"),
+                ip_address_id=cand.get("ip_address_id"),
                 enabled=True,
                 next_check_at=None,  # picked up on the next probe sweep
             )
         )
         created += 1
 
-    # Disable discovered targets no longer backed by an opted-in record —
-    # keyed on the connect tuple (not dns_record_id), so a hard-deleted
-    # record (FK SET NULL'd to dns_record_id=None) is caught too.
+    # Disable discovered targets no longer backed by any opted-in source —
+    # keyed on the connect tuple (not the FK), so a hard-deleted record /
+    # role change (FK SET NULL'd) is caught too.
     candidate_keys = set(candidates.keys())
     disabled = 0
     for t in existing:

--- a/backend/app/services/tls_cert/discovery.py
+++ b/backend/app/services/tls_cert/discovery.py
@@ -1,0 +1,210 @@
+"""TLS cert target auto-discovery (issue #118, Phase 1).
+
+Projects probe targets from DNS state, so the cert inventory tracks the
+hostnames SpatiumDDI already manages instead of being a parallel list the
+operator maintains by hand:
+
+* **create** — one ``tls_cert_target(source='discovered')`` per A/AAAA
+  record whose parent zone has ``auto_tls_probe=True`` *or* whose own
+  ``auto_tls_probe=True``. Connect host is the record's stored ``fqdn``;
+  the connect tuple ``(host, 443, NULL)`` dedupes the same name surfacing
+  from multiple records.
+* **disable** — a discovered target whose source record was opted out or
+  soft-deleted is flagged ``enabled=False`` (kept, not deleted, so its
+  probe history survives and it re-enables cleanly if the record returns).
+* **relink** — fill any target's empty ``dns_zone_id`` / ``domain_id`` by
+  longest-suffix match of its observed SANs against managed zones +
+  domains (so a manually-added external cert still shows under the right
+  Domain / DNS-zone Certificates tab once probed).
+
+Soft-deleted ``dns_record`` / ``dns_zone`` rows are excluded automatically
+by the ORM soft-delete query filter (``app.db._filter_soft_deleted``).
+
+Mirrors the no-commit contract of the probe service — the caller (the
+discovery task) owns the commit.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns import DNSRecord, DNSZone
+from app.models.domain import Domain
+from app.models.tls_cert import SOURCE_DISCOVERED, TLSCertTarget
+
+logger = structlog.get_logger(__name__)
+
+
+def _best_suffix_match(
+    names: list[str], candidates_desc: list[tuple[uuid.UUID, str]]
+) -> uuid.UUID | None:
+    """Longest-suffix match of any name against ``candidates_desc`` (which
+    must be pre-sorted longest-name-first). The leading ``.`` guard keeps
+    ``example.com.au`` from matching the zone ``example.com``."""
+    for cid, cname in candidates_desc:
+        for name in names:
+            if name == cname or name.endswith("." + cname):
+                return cid
+    return None
+
+
+async def _relink_by_san(db: AsyncSession) -> int:
+    """Fill empty zone/domain FKs on any target from its observed SANs."""
+    zones = [
+        (zid, (zname or "").rstrip(".").lower())
+        for zid, zname in (await db.execute(select(DNSZone.id, DNSZone.name))).all()
+    ]
+    domains = [
+        (did, (dname or "").rstrip(".").lower())
+        for did, dname in (await db.execute(select(Domain.id, Domain.name))).all()
+    ]
+    zones.sort(key=lambda z: len(z[1]), reverse=True)
+    domains.sort(key=lambda d: len(d[1]), reverse=True)
+
+    relinked = 0
+    # Only targets actually missing a link can be updated here — scanning
+    # every target each tick is wasted work.
+    targets = (
+        (
+            await db.execute(
+                select(TLSCertTarget).where(
+                    or_(
+                        TLSCertTarget.dns_zone_id.is_(None),
+                        TLSCertTarget.domain_id.is_(None),
+                    )
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for t in targets:
+        sans = [s.rstrip(".").lower() for s in (t.sans_json or []) if isinstance(s, str)]
+        if not sans:
+            continue
+        if t.dns_zone_id is None:
+            zid = _best_suffix_match(sans, zones)
+            if zid is not None:
+                t.dns_zone_id = zid
+                relinked += 1
+        if t.domain_id is None:
+            did = _best_suffix_match(sans, domains)
+            if did is not None:
+                t.domain_id = did
+                relinked += 1
+    return relinked
+
+
+async def reconcile_discovered_targets(
+    db: AsyncSession, now: datetime | None = None
+) -> dict[str, int]:
+    """Create / disable discovered targets + relink by SAN. No commit."""
+    _ = now or datetime.now(UTC)
+
+    rows = (
+        await db.execute(
+            select(DNSRecord, DNSZone)
+            .join(DNSZone, DNSRecord.zone_id == DNSZone.id)
+            .where(
+                DNSRecord.record_type.in_(("A", "AAAA")),
+                or_(
+                    DNSZone.auto_tls_probe.is_(True),
+                    DNSRecord.auto_tls_probe.is_(True),
+                ),
+            )
+        )
+    ).all()
+
+    # Dedupe candidates on the connect tuple (same FQDN from >1 record).
+    candidates: dict[tuple[str, int, None], tuple[DNSRecord, DNSZone]] = {}
+    for rec, zone in rows:
+        host = (rec.fqdn or "").rstrip(".").lower()
+        if not host:
+            continue
+        candidates.setdefault((host, 443, None), (rec, zone))
+
+    existing = (
+        (await db.execute(select(TLSCertTarget).where(TLSCertTarget.source == SOURCE_DISCOVERED)))
+        .scalars()
+        .all()
+    )
+    existing_by_key = {(t.host.lower(), t.port, t.server_name): t for t in existing}
+
+    created = reenabled = 0
+    for (host, port, sni), (rec, zone) in candidates.items():
+        et = existing_by_key.get((host, port, sni))
+        if et is not None:
+            # Already tracked. Re-enable + refresh provenance if the record
+            # came back (a re-added record is a NEW row with a fresh uuid).
+            # Discovered targets are a projection of DNS state — to stop
+            # probing, opt the record/zone OUT (auto_tls_probe=False); a
+            # manually-disabled discovered row is re-enabled here by design.
+            touched = False
+            if not et.enabled:
+                et.enabled = True
+                touched = True
+            if et.dns_record_id != rec.id:
+                et.dns_record_id = rec.id
+                touched = True
+            if et.dns_zone_id is None:
+                et.dns_zone_id = zone.id
+            reenabled += 1 if touched else 0
+            continue
+        # Don't collide with a manually-added target on the same tuple.
+        clash = await db.scalar(
+            select(TLSCertTarget).where(
+                func.lower(TLSCertTarget.host) == host,
+                TLSCertTarget.port == port,
+                TLSCertTarget.server_name.is_(None),
+            )
+        )
+        if clash is not None:
+            continue
+        db.add(
+            TLSCertTarget(
+                host=host,
+                port=port,
+                server_name=None,
+                display_name=host,
+                source=SOURCE_DISCOVERED,
+                dns_record_id=rec.id,
+                dns_zone_id=zone.id,
+                domain_id=zone.domain_id,
+                enabled=True,
+                next_check_at=None,  # picked up on the next probe sweep
+            )
+        )
+        created += 1
+
+    # Disable discovered targets no longer backed by an opted-in record —
+    # keyed on the connect tuple (not dns_record_id), so a hard-deleted
+    # record (FK SET NULL'd to dns_record_id=None) is caught too.
+    candidate_keys = set(candidates.keys())
+    disabled = 0
+    for t in existing:
+        key = (t.host.lower(), t.port, t.server_name)
+        if t.enabled and key not in candidate_keys:
+            t.enabled = False
+            disabled += 1
+
+    relinked = await _relink_by_san(db)
+
+    if created or disabled or relinked or reenabled:
+        logger.info(
+            "tls_cert_discovery",
+            created=created,
+            reenabled=reenabled,
+            disabled=disabled,
+            relinked=relinked,
+        )
+    return {
+        "created": created,
+        "reenabled": reenabled,
+        "disabled": disabled,
+        "relinked": relinked,
+    }

--- a/backend/app/services/tls_cert/probe.py
+++ b/backend/app/services/tls_cert/probe.py
@@ -295,6 +295,10 @@ def _served_chain_ders(connect_ip: str, port: int, sni: str, timeout: float) -> 
     trust is judged separately by :func:`_verify_trust`. Leaf-first DERs.
     Raises on transport / handshake failure (the caller classifies)."""
     ctx = SSL.Context(SSL.TLS_CLIENT_METHOD)
+    # Floor at TLS 1.2 — TLS 1.0/1.1 are deprecated, and a monitor probing
+    # 2026-era endpoints shouldn't negotiate them. Verification is still off
+    # (we capture untrusted chains); trust is judged by _verify_trust.
+    ctx.set_min_proto_version(SSL.TLS1_2_VERSION)
     ctx.set_verify(SSL.VERIFY_NONE, lambda *_a: True)
     sock = socket.create_connection((connect_ip, port), timeout=timeout)
     # Non-blocking + a select() deadline: a timeout-mode socket makes
@@ -340,6 +344,7 @@ def _verify_trust(
     as chain-invalid). (True, None) trusted; (False, error) verification
     failure; (None, None) when a transport hiccup leaves it undetermined."""
     ctx = ssl.create_default_context()
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2  # explicit (default, but pinned)
     ctx.check_hostname = False
     try:
         with socket.create_connection((connect_ip, port), timeout=timeout) as sock:

--- a/backend/app/services/tls_cert/probe.py
+++ b/backend/app/services/tls_cert/probe.py
@@ -296,8 +296,11 @@ def _served_chain_ders(connect_ip: str, port: int, sni: str, timeout: float) -> 
     Raises on transport / handshake failure (the caller classifies)."""
     ctx = SSL.Context(SSL.TLS_CLIENT_METHOD)
     # Floor at TLS 1.2 — TLS 1.0/1.1 are deprecated, and a monitor probing
-    # 2026-era endpoints shouldn't negotiate them. Verification is still off
+    # 2026-era endpoints shouldn't negotiate them. set_options(OP_NO_*) is
+    # the explicit, statically-recognised form (set_min_proto_version alone
+    # isn't seen as remediation by static analysis). Verification stays off
     # (we capture untrusted chains); trust is judged by _verify_trust.
+    ctx.set_options(SSL.OP_NO_SSLv2 | SSL.OP_NO_SSLv3 | SSL.OP_NO_TLSv1 | SSL.OP_NO_TLSv1_1)
     ctx.set_min_proto_version(SSL.TLS1_2_VERSION)
     ctx.set_verify(SSL.VERIFY_NONE, lambda *_a: True)
     sock = socket.create_connection((connect_ip, port), timeout=timeout)

--- a/backend/app/services/tls_cert/probe.py
+++ b/backend/app/services/tls_cert/probe.py
@@ -1,0 +1,537 @@
+"""TLS certificate probe (issue #118).
+
+Connect to a target endpoint over TLS, capture the served certificate +
+chain, validate the chain against the system trust store, and write the
+observation to a ``tls_cert_probe`` row while denormalising the latest
+identity onto the ``tls_cert_target``.
+
+Two-pass design:
+
+1. **Capture pass** (pyOpenSSL ``get_peer_cert_chain()`` with verification
+   OFF) — grabs the chain the server PRESENTS (leaf + intermediates) even
+   when it's broken/untrusted, so the detail view can show every cert.
+   stdlib ssl on Python 3.12 only exposes the leaf, hence pyOpenSSL. The
+   trust-anchor root (which servers normally omit) is then resolved from
+   the system CA store and appended.
+2. **Verify pass** (``ssl.create_default_context()`` with
+   ``check_hostname=False`` + ``CERT_REQUIRED``) — judges chain TRUST only
+   (``chain_valid``); the hostname match is computed separately from the
+   leaf so a pure name mismatch isn't mislabelled chain-invalid. Transport
+   failures (refused / timeout / DNS) → ``unreachable``.
+
+Reuses the cert-parse helpers from ``app.services.nettools.socket_tools``
+so we don't re-implement x509 extraction. SSRF: the host is re-resolved
+at probe time and every resolved IP re-checked against the blocked-range
+list (closing the documented hostname-into-blocked-range hole that the
+shape-only ``assert_target_allowed`` validator leaves open).
+
+``probe_one`` mirrors ``app.services.domain_refresh.refresh_one_domain``:
+it writes the result back and stamps ``next_check_at`` but does NOT commit
+— the caller owns the session.
+"""
+
+from __future__ import annotations
+
+import select
+import socket
+import ssl
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import structlog
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed448, ed25519, rsa
+from OpenSSL import SSL, crypto
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.tls_cert import (
+    IDENTITY_FIELDS,
+    STATE_EXPIRED,
+    STATE_EXPIRING,
+    STATE_MISMATCH,
+    STATE_OK,
+    STATE_UNKNOWN,
+    STATE_UNREACHABLE,
+    TLSCertProbe,
+    TLSCertTarget,
+)
+from app.services.nettools.schemas import is_blocked_target
+from app.services.nettools.socket_tools import (
+    _common_names,
+    _hostname_matches,
+    _rfc4514,
+    _san_dns_names,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Default connect timeout per pass (seconds). The synchronous probe runs
+# in a worker thread / under the scheduled task; keep it tight so a dead
+# host doesn't stall the dispatcher.
+PROBE_TIMEOUT = 8.0
+
+# The "expiring soon" window used for the derived state bucket (the UI
+# pill + count_tls_targets_by_state). Distinct from any alert rule's own
+# threshold_days — this is just the cosmetic bucket boundary.
+STATE_EXPIRING_WARN_DAYS = 30
+
+
+def derive_tls_state(
+    *,
+    ok: bool,
+    not_after: datetime | None,
+    chain_valid: bool | None,
+    hostname_matches: bool | None,
+    now: datetime,
+    warn_days: int = STATE_EXPIRING_WARN_DAYS,
+) -> str:
+    """Single source of truth for the target's derived health bucket.
+
+    Order (most-urgent wins): unreachable > expired > expiring > mismatch > ok.
+    """
+    if not ok:
+        return STATE_UNREACHABLE
+    if not_after is None:
+        return STATE_UNKNOWN
+    na = not_after if not_after.tzinfo else not_after.replace(tzinfo=UTC)
+    if now >= na:
+        return STATE_EXPIRED
+    if (na - now).days <= warn_days:
+        return STATE_EXPIRING
+    if chain_valid is False or hostname_matches is False:
+        return STATE_MISMATCH
+    return STATE_OK
+
+
+@dataclass(frozen=True)
+class ProbeOutcome:
+    """Raw result of reaching the endpoint (no DB)."""
+
+    ok: bool
+    error: str | None
+    identity: dict[str, Any] | None  # IDENTITY_FIELDS values
+    hostname_matches: bool | None
+    leaf_pem: str | None
+    chain_pem: str | None
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """What probe_one observed + what changed (for audit gating)."""
+
+    target_id: uuid.UUID
+    ok: bool
+    state: str
+    error: str | None
+    fingerprint_changed: bool
+    state_changed: bool
+    chain_valid_changed: bool
+
+    @property
+    def any_meaningful_change(self) -> bool:
+        return self.fingerprint_changed or self.state_changed or self.chain_valid_changed
+
+
+# ── resolution / SSRF ────────────────────────────────────────────────
+
+
+def _resolve_safe_ip(host: str) -> tuple[str | None, str | None]:
+    """Resolve ``host`` ONCE and return ``(connect_ip, None)`` for the first
+    usable answer, or ``(None, error)`` if it can't resolve or ANY answer is
+    in a blocked range.
+
+    Closing the SSRF hole properly requires connecting to *this* IP literal
+    (not re-resolving the hostname at connect time) — otherwise a DNS-
+    rebinding attacker returns a public IP for the check and 169.254.169.254
+    / 127.0.0.1 for the connect (the IP that passed the check is never the
+    IP we'd connect to). We reject if any answer is blocked (an attacker can
+    return ``[public, metadata]``) and connect to the chosen literal. An IP
+    literal host is covered too — getaddrinfo echoes it and is_blocked_target
+    classifies it.
+    """
+    try:
+        infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        return None, f"DNS resolution failed: {exc}"
+    chosen: str | None = None
+    for info in infos:
+        ip = info[4][0]  # sockaddr address element (str for AF_INET/INET6)
+        if not isinstance(ip, str):
+            continue
+        if is_blocked_target(ip):
+            return None, (
+                f"{host!r} resolves to {ip} which is in a blocked range "
+                "(loopback / link-local / cloud-metadata) and will not be probed"
+            )
+        if chosen is None:
+            chosen = ip
+    if chosen is None:
+        return None, f"{host!r} did not resolve to a usable address"
+    return chosen, None
+
+
+# ── cert parsing ─────────────────────────────────────────────────────
+
+
+def _key_params(cert: x509.Certificate) -> tuple[str | None, int | None]:
+    pub = cert.public_key()
+    if isinstance(pub, rsa.RSAPublicKey):
+        return "RSA", pub.key_size
+    if isinstance(pub, ec.EllipticCurvePublicKey):
+        return "EC", pub.key_size
+    if isinstance(pub, ed25519.Ed25519PublicKey):
+        return "Ed25519", 256
+    if isinstance(pub, ed448.Ed448PublicKey):
+        return "Ed448", 456
+    if isinstance(pub, dsa.DSAPublicKey):
+        return "DSA", pub.key_size
+    return type(pub).__name__, None
+
+
+def _fingerprint(cert: x509.Certificate) -> str:
+    # Colon-hex uppercase — matches `openssl x509 -fingerprint -sha256`.
+    return ":".join(f"{b:02X}" for b in cert.fingerprint(hashes.SHA256()))
+
+
+def _sig_algo(cert: x509.Certificate) -> str | None:
+    try:
+        name = cert.signature_algorithm_oid._name  # e.g. sha256WithRSAEncryption
+        if name and name != "Unknown OID":
+            return name
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        return cert.signature_hash_algorithm.name if cert.signature_hash_algorithm else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _parse_identity(
+    leaf_der: bytes, chain_ders: list[bytes], server_name: str
+) -> tuple[dict[str, Any], bool]:
+    cert = x509.load_der_x509_certificate(leaf_der)
+    san = _san_dns_names(cert)
+    cn = _common_names(cert.subject)
+    issuer_cn = _common_names(cert.issuer)
+    key_algo, key_size = _key_params(cert)
+    return {
+        "serial": format(cert.serial_number, "x"),
+        "subject_cn": (cn[0] if cn else None),
+        "issuer_cn": (issuer_cn[0] if issuer_cn else None),
+        "not_before": cert.not_valid_before_utc,
+        "not_after": cert.not_valid_after_utc,
+        "sans_json": san,
+        "key_algo": key_algo,
+        "key_size": key_size,
+        "sig_algo": _sig_algo(cert),
+        "chain_depth": len(chain_ders) or 1,
+        "self_signed": _rfc4514(cert.subject) == _rfc4514(cert.issuer),
+        "fingerprint_sha256": _fingerprint(cert),
+        # chain_valid / chain_error filled by the caller (validation pass).
+        "chain_valid": None,
+        "chain_error": None,
+    }, _hostname_matches(server_name, san, cn)
+
+
+def _pem(der: bytes) -> str:
+    return (
+        x509.load_der_x509_certificate(der).public_bytes(serialization.Encoding.PEM).decode("ascii")
+    )
+
+
+def parse_chain_pem(pem: str | None) -> list[dict[str, Any]]:
+    """Parse a concatenated PEM bundle into per-cert summaries, leaf →
+    intermediate(s) → root, for the cert detail view."""
+    if not pem:
+        return []
+    try:
+        certs = x509.load_pem_x509_certificates(pem.encode())
+    except Exception:  # noqa: BLE001 — best-effort parse
+        return []
+    out: list[dict[str, Any]] = []
+    for i, c in enumerate(certs):
+        cn = _common_names(c.subject)
+        icn = _common_names(c.issuer)
+        self_signed = _rfc4514(c.subject) == _rfc4514(c.issuer)
+        role = "leaf" if i == 0 else ("root" if self_signed else "intermediate")
+        key_algo, key_size = _key_params(c)
+        try:
+            bc = c.extensions.get_extension_for_class(x509.BasicConstraints).value
+            is_ca: bool | None = bool(bc.ca)
+        except Exception:  # noqa: BLE001
+            is_ca = None
+        out.append(
+            {
+                "position": i,
+                "role": role,
+                "subject_cn": (cn[0] if cn else _rfc4514(c.subject)),
+                "issuer_cn": (icn[0] if icn else _rfc4514(c.issuer)),
+                "serial": format(c.serial_number, "x"),
+                "not_before": c.not_valid_before_utc.isoformat(),
+                "not_after": c.not_valid_after_utc.isoformat(),
+                "key_algo": key_algo,
+                "key_size": key_size,
+                "sig_algo": _sig_algo(c),
+                "is_ca": is_ca,
+                "self_signed": self_signed,
+                "fingerprint_sha256": _fingerprint(c),
+            }
+        )
+    return out
+
+
+# ── the probe ────────────────────────────────────────────────────────
+
+
+def _served_chain_ders(connect_ip: str, port: int, sni: str, timeout: float) -> list[bytes]:
+    """Capture the chain the server PRESENTS (leaf + intermediates) via
+    pyOpenSSL — stdlib ssl on Python 3.12 only exposes the leaf. Verification
+    is disabled so a broken / untrusted chain is still captured for display;
+    trust is judged separately by :func:`_verify_trust`. Leaf-first DERs.
+    Raises on transport / handshake failure (the caller classifies)."""
+    ctx = SSL.Context(SSL.TLS_CLIENT_METHOD)
+    ctx.set_verify(SSL.VERIFY_NONE, lambda *_a: True)
+    sock = socket.create_connection((connect_ip, port), timeout=timeout)
+    # Non-blocking + a select() deadline: a timeout-mode socket makes
+    # pyOpenSSL's do_handshake raise WantReadError, so drive it explicitly.
+    sock.setblocking(False)
+    deadline = time.monotonic() + timeout
+    try:
+        conn = SSL.Connection(ctx, sock)
+        conn.set_connect_state()
+        try:
+            conn.set_tlsext_host_name(sni.encode("idna"))
+        except Exception:  # noqa: BLE001 — non-IDNA SNI
+            conn.set_tlsext_host_name(sni.encode("ascii", "ignore"))
+        while True:
+            try:
+                conn.do_handshake()
+                break
+            except (SSL.WantReadError, SSL.WantWriteError) as exc:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("TLS handshake timed out") from exc
+                want_read = isinstance(exc, SSL.WantReadError)
+                rlist = [sock] if want_read else []
+                wlist = [] if want_read else [sock]
+                if not select.select(rlist, wlist, [], remaining)[0 if want_read else 1]:
+                    raise TimeoutError("TLS handshake timed out") from exc
+        chain = conn.get_peer_cert_chain() or []
+        ders = [crypto.dump_certificate(crypto.FILETYPE_ASN1, c) for c in chain]
+        try:
+            conn.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+        return ders
+    finally:
+        sock.close()
+
+
+def _verify_trust(
+    connect_ip: str, port: int, sni: str, timeout: float
+) -> tuple[bool | None, str | None]:
+    """Judge chain TRUST against the system store (hostname NOT checked — the
+    name match is computed separately, so a pure name mismatch isn't reported
+    as chain-invalid). (True, None) trusted; (False, error) verification
+    failure; (None, None) when a transport hiccup leaves it undetermined."""
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    try:
+        with socket.create_connection((connect_ip, port), timeout=timeout) as sock:
+            with ctx.wrap_socket(sock, server_hostname=sni):
+                return True, None
+    except ssl.SSLCertVerificationError as exc:
+        return False, str(exc)
+    except (ssl.SSLError, OSError):
+        return None, None
+
+
+_TRUST_STORE: dict[str, x509.Certificate] | None = None
+
+
+def _trust_store() -> dict[str, x509.Certificate]:
+    """Lazy {subject_rfc4514: cert} index of the system CA bundle — used to
+    resolve the root (servers normally omit it; it lives in the store)."""
+    global _TRUST_STORE
+    if _TRUST_STORE is None:
+        idx: dict[str, x509.Certificate] = {}
+        for path in (
+            "/etc/ssl/certs/ca-certificates.crt",
+            "/etc/pki/tls/certs/ca-bundle.crt",
+        ):
+            try:
+                data = Path(path).read_bytes()
+            except OSError:
+                continue
+            try:
+                for cert in x509.load_pem_x509_certificates(data):
+                    idx[_rfc4514(cert.subject)] = cert
+            except Exception:  # noqa: BLE001
+                pass
+            break
+        _TRUST_STORE = idx
+    return _TRUST_STORE
+
+
+def _append_root(chain_ders: list[bytes]) -> list[bytes]:
+    """Append the trust-anchor root when the server-sent chain's topmost cert
+    isn't already self-signed (servers normally don't send the root)."""
+    if not chain_ders:
+        return chain_ders
+    try:
+        top = x509.load_der_x509_certificate(chain_ders[-1])
+    except Exception:  # noqa: BLE001
+        return chain_ders
+    if _rfc4514(top.subject) == _rfc4514(top.issuer):
+        return chain_ders  # already a self-signed root
+    root = _trust_store().get(_rfc4514(top.issuer))
+    if root is not None:
+        return chain_ders + [root.public_bytes(serialization.Encoding.DER)]
+    return chain_ders
+
+
+def fetch_endpoint(
+    host: str, port: int, server_name: str | None, *, timeout: float = PROBE_TIMEOUT
+) -> ProbeOutcome:
+    """Synchronous two-pass probe. Run under ``asyncio.to_thread``."""
+    sni = server_name or host
+
+    # Resolve ONCE and pin the IP we connect to (DNS-rebinding-safe).
+    connect_ip, resolve_err = _resolve_safe_ip(host)
+    if connect_ip is None:
+        return _failure(resolve_err or f"{host!r} could not be resolved")
+
+    # Capture the served chain (leaf + intermediates); verification off so a
+    # broken/untrusted chain is still captured for display.
+    try:
+        chain_ders = _served_chain_ders(connect_ip, port, sni, timeout)
+    except TimeoutError:
+        return _failure(f"TLS handshake timed out after {timeout:.1f}s")
+    except (SSL.Error, ssl.SSLError, OSError, socket.gaierror) as exc:
+        return _failure(f"TLS connection failed: {exc}")
+
+    if not chain_ders:
+        return _failure("server presented no certificate")
+
+    leaf_der = chain_ders[0]
+    # Resolve + append the root from the trust store (servers omit it).
+    chain_ders = _append_root(chain_ders)
+    # Judge trust separately (hostname computed from the leaf below).
+    chain_valid, chain_error = _verify_trust(connect_ip, port, sni, timeout)
+
+    try:
+        identity, hostname_matches = _parse_identity(leaf_der, chain_ders, sni)
+    except Exception as exc:  # noqa: BLE001 — surface parse failures cleanly
+        logger.warning("tls_cert_parse_failed", host=host, error=str(exc))
+        return _failure(f"failed to parse certificate: {exc}")
+
+    identity["chain_valid"] = chain_valid
+    identity["chain_error"] = chain_error
+    leaf_pem = _safe_pem(leaf_der)
+    chain_pem = "".join(_safe_pem(d) for d in chain_ders) if chain_ders else None
+    return ProbeOutcome(
+        ok=True,
+        error=None,
+        identity=identity,
+        hostname_matches=hostname_matches,
+        leaf_pem=leaf_pem,
+        chain_pem=chain_pem,
+    )
+
+
+def _safe_pem(der: bytes) -> str:
+    try:
+        return _pem(der)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _failure(error: str) -> ProbeOutcome:
+    return ProbeOutcome(
+        ok=False,
+        error=error,
+        identity=None,
+        hostname_matches=None,
+        leaf_pem=None,
+        chain_pem=None,
+    )
+
+
+async def probe_one(
+    db: AsyncSession,
+    target: TLSCertTarget,
+    *,
+    default_interval_hours: int,
+    now: datetime | None = None,
+) -> ProbeResult:
+    """Probe one target, write a probe row + update the target. No commit."""
+    import asyncio  # noqa: PLC0415 — local import keeps module import cheap
+
+    when = now or datetime.now(UTC)
+    prev_fp = target.fingerprint_sha256
+    prev_state = target.state
+    prev_chain_valid = target.chain_valid
+
+    outcome = await asyncio.to_thread(fetch_endpoint, target.host, target.port, target.server_name)
+
+    hours = target.interval_hours or default_interval_hours
+    hours = max(1, min(168, hours))
+    target.last_checked_at = when
+    target.next_check_at = when + timedelta(hours=hours)
+
+    probe = TLSCertProbe(target_id=target.id, probed_at=when, ok=outcome.ok)
+
+    if outcome.ok and outcome.identity is not None:
+        ident = outcome.identity
+        state = derive_tls_state(
+            ok=True,
+            not_after=ident.get("not_after"),
+            chain_valid=ident.get("chain_valid"),
+            hostname_matches=outcome.hostname_matches,
+            now=when,
+        )
+        # Copy identity onto both the probe snapshot and the target's
+        # denormalised columns.
+        for field in IDENTITY_FIELDS:
+            setattr(probe, field, ident.get(field))
+            setattr(target, field, ident.get(field))
+        probe.leaf_pem = outcome.leaf_pem
+        probe.chain_pem = outcome.chain_pem
+        probe.error = None
+        target.last_error = None
+        target.consecutive_failures = 0
+    else:
+        # Transport / handshake failure — PRESERVE the prior identity so a
+        # transient outage doesn't wipe the last-known cert (and doesn't
+        # fire a spurious "changed" alert). Only flip state + failure count.
+        state = STATE_UNREACHABLE
+        probe.error = outcome.error
+        target.last_error = outcome.error
+        target.consecutive_failures = (target.consecutive_failures or 0) + 1
+
+    probe.state = state
+    target.state = state
+    db.add(probe)
+
+    new_fp = target.fingerprint_sha256
+    fingerprint_changed = bool(outcome.ok and prev_fp and new_fp and prev_fp != new_fp)
+    return ProbeResult(
+        target_id=target.id,
+        ok=outcome.ok,
+        state=state,
+        error=outcome.error,
+        fingerprint_changed=fingerprint_changed,
+        state_changed=(prev_state != state),
+        # Guard the first probe (prev is None) so a fresh target's first
+        # observation isn't logged as a chain-validity "change".
+        chain_valid_changed=(
+            outcome.ok
+            and prev_chain_valid is not None
+            and prev_chain_valid is not target.chain_valid
+        ),
+    )

--- a/backend/app/tasks/tls_certs.py
+++ b/backend/app/tasks/tls_certs.py
@@ -1,0 +1,268 @@
+"""TLS certificate monitoring tasks (issue #118).
+
+Three beat-driven tasks:
+
+* :func:`probe_due_certs` — 60 s tick; probes every enabled target whose
+  ``next_check_at`` has elapsed (default cadence
+  ``PlatformSettings.tls_cert_check_interval_hours`` = 6 h, read every run
+  so UI changes take effect without restarting beat; per-target override
+  via ``tls_cert_target.interval_hours``). Per-row isolation — one bad
+  endpoint never poisons the sweep. Per-row audit only on a meaningful
+  change; one summary audit per sweep.
+* :func:`reconcile_discovered` — 5 min tick; projects probe targets from
+  opted-in DNS A/AAAA records + relinks targets to zones/domains by SAN.
+* :func:`prune_probes` — daily; drops ``tls_cert_probe`` rows older than
+  the retention window (the latest cert identity is denormalised onto the
+  target, so pruning all old probe history is safe).
+
+All idempotent. Network probe failures are recorded as data
+(``state='unreachable'``) by the probe service, not raised, so they never
+trigger Celery autoretry.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from sqlalchemy import delete, or_, select
+
+from app.celery_app import celery_app
+from app.db import task_session
+from app.models.audit import AuditLog
+from app.models.settings import PlatformSettings
+from app.models.tls_cert import TLSCertProbe, TLSCertTarget
+from app.services.tls_cert.discovery import reconcile_discovered_targets
+from app.services.tls_cert.probe import probe_one
+
+logger = structlog.get_logger(__name__)
+
+_SINGLETON_ID = 1
+_MIN_INTERVAL_HOURS = 1
+_MAX_INTERVAL_HOURS = 168
+_DEFAULT_INTERVAL_HOURS = 6
+_PROBE_RETENTION_DAYS = 90
+# Defensive cap on probes per sweep so a sudden flood of new targets can't
+# blow a single 60 s tick into a multi-minute network stall.
+_MAX_PROBES_PER_SWEEP = 200
+
+
+def _clamp_interval(hours: int | None) -> int:
+    if hours is None or hours < _MIN_INTERVAL_HOURS:
+        return _DEFAULT_INTERVAL_HOURS if hours is None else _MIN_INTERVAL_HOURS
+    if hours > _MAX_INTERVAL_HOURS:
+        return _MAX_INTERVAL_HOURS
+    return hours
+
+
+async def _probe_due_async() -> dict[str, Any]:
+    async with task_session() as db:
+        ps = await db.get(PlatformSettings, _SINGLETON_ID)
+        interval = _clamp_interval(ps.tls_cert_check_interval_hours if ps is not None else None)
+        now = datetime.now(UTC)
+
+        rows = (
+            (
+                await db.execute(
+                    select(TLSCertTarget)
+                    .where(
+                        TLSCertTarget.enabled.is_(True),
+                        or_(
+                            TLSCertTarget.next_check_at.is_(None),
+                            TLSCertTarget.next_check_at <= now,
+                        ),
+                    )
+                    .order_by(TLSCertTarget.next_check_at.asc().nulls_first())
+                    .limit(_MAX_PROBES_PER_SWEEP)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        scanned = changed = unreachable = 0
+        errors: list[str] = []
+        for t in rows:
+            label = t.display_name or t.host
+            try:
+                result = await probe_one(db, t, default_interval_hours=interval, now=now)
+                if not result.ok:
+                    unreachable += 1
+                if result.any_meaningful_change:
+                    changed += 1
+                    db.add(
+                        AuditLog(
+                            user_display_name="<system>",
+                            auth_source="system",
+                            action="probe",
+                            resource_type="tls_cert",
+                            resource_id=str(t.id),
+                            resource_display=label,
+                            result="success" if result.ok else "error",
+                            new_value={
+                                "state": result.state,
+                                "ok": result.ok,
+                                "fingerprint_changed": result.fingerprint_changed,
+                                "chain_valid_changed": result.chain_valid_changed,
+                                "error": result.error,
+                            },
+                        )
+                    )
+                await db.commit()
+                scanned += 1
+            except Exception as exc:  # noqa: BLE001 — isolate one bad row
+                await db.rollback()
+                errors.append(f"{label}: {exc}")
+                logger.warning("tls_cert_probe_row_failed", target=label, error=str(exc))
+                # Advance next_check_at in a fresh tx so a row that
+                # repeatably *raises* (not a network failure, which probe_one
+                # records as data) backs off instead of re-probing every tick.
+                try:
+                    fresh = await db.get(TLSCertTarget, t.id)
+                    if fresh is not None:
+                        fresh.last_checked_at = now
+                        fresh.next_check_at = now + timedelta(hours=interval)
+                        fresh.last_error = str(exc)
+                        fresh.consecutive_failures = (fresh.consecutive_failures or 0) + 1
+                        await db.commit()
+                except Exception:  # noqa: BLE001
+                    await db.rollback()
+
+        if scanned and (changed or errors):
+            db.add(
+                AuditLog(
+                    user_display_name="<system>",
+                    auth_source="system",
+                    action="tls-cert-probe-sweep",
+                    resource_type="platform",
+                    resource_id=str(_SINGLETON_ID),
+                    resource_display="auto-probe",
+                    result="error" if errors else "success",
+                    new_value={
+                        "scanned": scanned,
+                        "changed": changed,
+                        "unreachable": unreachable,
+                        "interval_hours": interval,
+                        "errors": errors[:20],
+                    },
+                )
+            )
+            await db.commit()
+
+        if scanned:
+            logger.info(
+                "tls_cert_probe_sweep_completed",
+                scanned=scanned,
+                changed=changed,
+                unreachable=unreachable,
+                interval_hours=interval,
+                error_count=len(errors),
+            )
+        return {
+            "status": "ran" if scanned else "idle",
+            "scanned": scanned,
+            "changed": changed,
+            "unreachable": unreachable,
+            "interval_hours": interval,
+            "errors": len(errors),
+        }
+
+
+@celery_app.task(name="app.tasks.tls_certs.probe_due_certs", bind=True)
+def probe_due_certs(self: object) -> dict[str, Any]:  # type: ignore[type-arg]
+    import asyncio  # noqa: PLC0415
+
+    try:
+        return asyncio.run(_probe_due_async())
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("tls_cert_probe_sweep_failed", error=str(exc))
+        raise
+
+
+async def _reconcile_async() -> dict[str, Any]:
+    async with task_session() as db:
+        result = await reconcile_discovered_targets(db)
+        await db.commit()
+        return {"status": "ran", **result}
+
+
+@celery_app.task(name="app.tasks.tls_certs.reconcile_discovered", bind=True)
+def reconcile_discovered(self: object) -> dict[str, Any]:  # type: ignore[type-arg]
+    import asyncio  # noqa: PLC0415
+
+    try:
+        return asyncio.run(_reconcile_async())
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("tls_cert_discovery_failed", error=str(exc))
+        raise
+
+
+async def _prune_async() -> dict[str, Any]:
+    async with task_session() as db:
+        cutoff = datetime.now(UTC) - timedelta(days=_PROBE_RETENTION_DAYS)
+        # Keep each target's most-recent successful probe regardless of age,
+        # so the /chain endpoint + history aren't left empty for a target
+        # that hasn't been re-probed in >90d (e.g. a disabled one).
+        keep_ids = list(
+            (
+                await db.execute(
+                    select(TLSCertProbe.id)
+                    .distinct(TLSCertProbe.target_id)
+                    .where(TLSCertProbe.ok.is_(True))
+                    .order_by(TLSCertProbe.target_id, TLSCertProbe.probed_at.desc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        stmt = delete(TLSCertProbe).where(TLSCertProbe.probed_at < cutoff)
+        if keep_ids:
+            stmt = stmt.where(TLSCertProbe.id.not_in(keep_ids))
+        res = await db.execute(stmt)
+        await db.commit()
+        deleted = res.rowcount or 0
+        if deleted:
+            logger.info("tls_cert_probe_prune_completed", deleted=deleted)
+        return {"status": "ran", "deleted": deleted}
+
+
+@celery_app.task(name="app.tasks.tls_certs.prune_probes", bind=True)
+def prune_probes(self: object) -> dict[str, Any]:  # type: ignore[type-arg]
+    import asyncio  # noqa: PLC0415
+
+    try:
+        return asyncio.run(_prune_async())
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("tls_cert_probe_prune_failed", error=str(exc))
+        raise
+
+
+# Dispatched right after a target is created (router) so the first probe
+# lands within seconds instead of waiting for the next sweep.
+async def _probe_one_by_id_async(target_id: str) -> dict[str, Any]:
+    import uuid  # noqa: PLC0415
+
+    async with task_session() as db:
+        t = await db.get(TLSCertTarget, uuid.UUID(target_id))
+        if t is None:
+            return {"status": "missing", "target_id": target_id}
+        ps = await db.get(PlatformSettings, _SINGLETON_ID)
+        interval = _clamp_interval(ps.tls_cert_check_interval_hours if ps is not None else None)
+        result = await probe_one(db, t, default_interval_hours=interval)
+        await db.commit()
+        return {"status": "ran", "state": result.state, "ok": result.ok}
+
+
+@celery_app.task(name="app.tasks.tls_certs.probe_one_target_by_id", bind=True)
+def probe_one_target_by_id(self: object, target_id: str) -> dict[str, Any]:  # type: ignore[type-arg]
+    import asyncio  # noqa: PLC0415
+
+    try:
+        return asyncio.run(_probe_one_by_id_async(target_id))
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("tls_cert_probe_one_failed", target_id=target_id, error=str(exc))
+        raise
+
+
+__all__ = ["probe_due_certs", "reconcile_discovered", "prune_probes"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,6 +26,10 @@ dependencies = [
     "joserfc>=1.0.0",
     "httpx>=0.28.0",
     "cryptography>=43.0.0",
+    # TLS cert monitoring (#118) — get_peer_cert_chain() captures the
+    # server-presented chain (leaf + intermediates) for the cert detail
+    # view; stdlib ssl can't on Python 3.12 (get_*_chain is 3.13+).
+    "pyOpenSSL>=24.0.0",
     "ldap3>=2.9.1",
     "python3-saml>=1.16.0",
     "pyrad>=2.4",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -140,11 +140,13 @@ async def create_test_schema() -> AsyncGenerator[None, None]:
         await conn.execute(text("CREATE SCHEMA public"))
         await conn.run_sync(Base.metadata.create_all)
     yield
-    # Teardown: same trick in reverse. No-op for CI (ephemeral DB) but keeps
-    # local runs clean.
-    async with _test_engine.begin() as conn:
-        await conn.execute(text("DROP SCHEMA public CASCADE"))
-        await conn.execute(text("CREATE SCHEMA public"))
+    # No session-teardown drop. The setup above already wipes any prior
+    # schema, so a teardown ``DROP SCHEMA … CASCADE`` is purely cosmetic —
+    # and as the schema grew it became a liability: all xdist workers finish
+    # ~together, so their simultaneous CASCADE drops (one AccessExclusiveLock
+    # per table/index/FK/sequence) exhausted the shared lock table on the CI
+    # Postgres ("out of shared memory / increase max_locks_per_transaction").
+    # CI DBs are ephemeral; local runs are cleaned by the next run's setup.
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/backend/tests/test_tls_certs.py
+++ b/backend/tests/test_tls_certs.py
@@ -291,6 +291,97 @@ async def test_discovery_disable_then_reenable_cycle(db_session: AsyncSession):
     assert (await db_session.execute(select(TLSCertTarget))).scalars().all().__len__() == 1
 
 
+async def test_discovery_from_ip_role(db_session: AsyncSession):
+    """#118 Phase 2 — an IP in a TLS-serving role auto-becomes a target."""
+    from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+    from app.services.tls_cert.discovery import reconcile_discovered_targets
+
+    sp = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}")
+    db_session.add(sp)
+    await db_session.flush()
+    blk = IPBlock(space_id=sp.id, network="10.9.0.0/16")
+    db_session.add(blk)
+    await db_session.flush()
+    sn = Subnet(space_id=sp.id, block_id=blk.id, network="10.9.1.0/24")
+    db_session.add(sn)
+    await db_session.flush()
+    ip = IPAddress(
+        subnet_id=sn.id,
+        address="10.9.1.10",
+        role="web",
+        fqdn="svc.example.com",
+        status="allocated",
+    )
+    db_session.add(ip)
+    await db_session.flush()
+
+    res = await reconcile_discovered_targets(db_session)
+    await db_session.flush()
+    assert res["created"] == 1
+    t = (await db_session.execute(select(TLSCertTarget))).scalars().one()
+    assert t.host == "svc.example.com"
+    assert t.ip_address_id == ip.id
+    assert t.source == "discovered"
+
+    # Role cleared → target disabled (no longer a TLS-serving IP).
+    ip.role = "host"
+    await db_session.flush()
+    res2 = await reconcile_discovered_targets(db_session)
+    await db_session.flush()
+    await db_session.refresh(t)
+    assert t.enabled is False and res2["disabled"] == 1
+
+
+async def test_ct_log_no_host():
+    from app.services.tls_cert.ct_log import lookup_ct
+
+    out = await lookup_ct("")
+    assert out["entries"] == [] and out["count"] == 0 and out["error"]
+
+
+async def test_issuer_change_alert(db_session: AsyncSession):
+    from app.models.alerts import AlertEvent, AlertRule
+    from app.services.alerts import (
+        RULE_TYPE_TLS_CERT_ISSUER_CHANGED,
+        _evaluate_tls_cert_transition_rule,
+    )
+
+    now = datetime.now(UTC)
+    t = TLSCertTarget(host="rot.example.com", port=443, enabled=True, issuer_cn="Let's Encrypt")
+    db_session.add(t)
+    rule = AlertRule(name="ic", rule_type=RULE_TYPE_TLS_CERT_ISSUER_CHANGED, severity="warning")
+    db_session.add(rule)
+    await db_session.flush()
+
+    # First sighting → silent baseline (no open event).
+    opened, *_ = await _evaluate_tls_cert_transition_rule(
+        db_session, rule, now, value_attr="issuer_cn", what="issuer"
+    )
+    await db_session.flush()
+    assert opened == 0
+
+    # Issuer flips → one open event.
+    t.issuer_cn = "Rogue CA"
+    await db_session.flush()
+    opened2, *_ = await _evaluate_tls_cert_transition_rule(
+        db_session, rule, now + timedelta(minutes=1), value_attr="issuer_cn", what="issuer"
+    )
+    await db_session.flush()
+    assert opened2 == 1
+    events = (
+        (
+            await db_session.execute(
+                select(AlertEvent).where(
+                    AlertEvent.rule_id == rule.id, AlertEvent.resolved_at.is_(None)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(events) == 1 and "Rogue CA" in events[0].message
+
+
 # ── alert matchers ───────────────────────────────────────────────────
 
 

--- a/backend/tests/test_tls_certs.py
+++ b/backend/tests/test_tls_certs.py
@@ -1,0 +1,490 @@
+"""TLS certificate monitoring (issue #118).
+
+Covers the probe state-derivation, probe_one's failure-preserves-identity
+contract, discovery creation + dedupe, the alert matchers, the router CRUD
++ audit + feature-gate, and the MCP tool registration (name collisions).
+The live network probe itself is monkeypatched — these tests never open a
+socket.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
+from app.models.feature_module import FeatureModule
+from app.models.tls_cert import (
+    STATE_EXPIRED,
+    STATE_EXPIRING,
+    STATE_MISMATCH,
+    STATE_OK,
+    STATE_UNREACHABLE,
+    TLSCertProbe,
+    TLSCertTarget,
+)
+from app.services import feature_modules
+from app.services.tls_cert import probe as probe_mod
+from app.services.tls_cert.probe import ProbeOutcome, derive_tls_state, probe_one
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_module_cache():
+    feature_modules.invalidate_cache()
+    yield
+    feature_modules.invalidate_cache()
+
+
+async def _superadmin(db: AsyncSession) -> tuple[User, str]:
+    u = User(
+        username=f"a-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(u)
+    await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+def _hdr(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _ok_outcome(
+    *,
+    fingerprint: str,
+    not_after: datetime,
+    chain_valid: bool = True,
+    hostname_matches: bool = True,
+) -> ProbeOutcome:
+    identity = {
+        "serial": "deadbeef",
+        "subject_cn": "example.com",
+        "issuer_cn": "Let's Encrypt",
+        "not_before": datetime.now(UTC) - timedelta(days=1),
+        "not_after": not_after,
+        "sans_json": ["example.com", "www.example.com"],
+        "key_algo": "RSA",
+        "key_size": 2048,
+        "sig_algo": "sha256WithRSAEncryption",
+        "chain_depth": 2,
+        "chain_valid": chain_valid,
+        "chain_error": None if chain_valid else "self signed certificate",
+        "self_signed": not chain_valid,
+        "fingerprint_sha256": fingerprint,
+    }
+    return ProbeOutcome(
+        ok=True,
+        error=None,
+        identity=identity,
+        hostname_matches=hostname_matches,
+        leaf_pem="-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----\n",
+        chain_pem=None,
+    )
+
+
+def _fail_outcome(error: str = "TLS connection failed: refused") -> ProbeOutcome:
+    return ProbeOutcome(
+        ok=False, error=error, identity=None, hostname_matches=None, leaf_pem=None, chain_pem=None
+    )
+
+
+# ── derive_tls_state (pure unit) ─────────────────────────────────────
+
+
+def test_derive_tls_state_ordering():
+    now = datetime.now(UTC)
+    soon = now + timedelta(days=5)
+    far = now + timedelta(days=200)
+    past = now - timedelta(days=1)
+
+    assert (
+        derive_tls_state(ok=False, not_after=far, chain_valid=True, hostname_matches=True, now=now)
+        == STATE_UNREACHABLE
+    )
+    assert (
+        derive_tls_state(ok=True, not_after=past, chain_valid=True, hostname_matches=True, now=now)
+        == STATE_EXPIRED
+    )
+    assert (
+        derive_tls_state(ok=True, not_after=soon, chain_valid=True, hostname_matches=True, now=now)
+        == STATE_EXPIRING
+    )
+    assert (
+        derive_tls_state(ok=True, not_after=far, chain_valid=False, hostname_matches=True, now=now)
+        == STATE_MISMATCH
+    )
+    assert (
+        derive_tls_state(ok=True, not_after=far, chain_valid=True, hostname_matches=False, now=now)
+        == STATE_MISMATCH
+    )
+    assert (
+        derive_tls_state(ok=True, not_after=far, chain_valid=True, hostname_matches=True, now=now)
+        == STATE_OK
+    )
+
+
+# ── probe_one ────────────────────────────────────────────────────────
+
+
+async def test_probe_one_success_sets_identity(db_session: AsyncSession, monkeypatch):
+    t = TLSCertTarget(host="example.com", port=443, display_name="example")
+    db_session.add(t)
+    await db_session.flush()
+
+    na = datetime.now(UTC) + timedelta(days=200)
+    monkeypatch.setattr(
+        probe_mod, "fetch_endpoint", lambda *a, **k: _ok_outcome(fingerprint="AA:BB", not_after=na)
+    )
+    result = await probe_one(db_session, t, default_interval_hours=6)
+    await db_session.flush()
+
+    assert result.ok is True
+    assert t.state == STATE_OK
+    assert t.fingerprint_sha256 == "AA:BB"
+    assert t.subject_cn == "example.com"
+    assert t.chain_valid is True
+    assert t.consecutive_failures == 0
+    assert t.next_check_at is not None
+    probes = (
+        (await db_session.execute(select(TLSCertProbe).where(TLSCertProbe.target_id == t.id)))
+        .scalars()
+        .all()
+    )
+    assert len(probes) == 1 and probes[0].ok is True
+
+
+async def test_probe_one_failure_preserves_identity(db_session: AsyncSession, monkeypatch):
+    t = TLSCertTarget(host="example.com", port=443)
+    db_session.add(t)
+    await db_session.flush()
+
+    na = datetime.now(UTC) + timedelta(days=200)
+    monkeypatch.setattr(
+        probe_mod, "fetch_endpoint", lambda *a, **k: _ok_outcome(fingerprint="AA:BB", not_after=na)
+    )
+    await probe_one(db_session, t, default_interval_hours=6)
+    await db_session.flush()
+    assert t.fingerprint_sha256 == "AA:BB"
+
+    # Now the endpoint goes dark — identity must be preserved, only state flips.
+    monkeypatch.setattr(probe_mod, "fetch_endpoint", lambda *a, **k: _fail_outcome())
+    result = await probe_one(db_session, t, default_interval_hours=6)
+    await db_session.flush()
+
+    assert result.ok is False
+    assert t.state == STATE_UNREACHABLE
+    assert t.fingerprint_sha256 == "AA:BB"  # PRESERVED
+    assert t.subject_cn == "example.com"  # PRESERVED
+    assert t.consecutive_failures == 1
+    assert t.last_error is not None
+    assert result.fingerprint_changed is False  # no spurious "changed"
+
+
+async def test_probe_one_detects_fingerprint_change(db_session: AsyncSession, monkeypatch):
+    t = TLSCertTarget(host="example.com", port=443)
+    db_session.add(t)
+    await db_session.flush()
+    na = datetime.now(UTC) + timedelta(days=200)
+    monkeypatch.setattr(
+        probe_mod, "fetch_endpoint", lambda *a, **k: _ok_outcome(fingerprint="OLD", not_after=na)
+    )
+    await probe_one(db_session, t, default_interval_hours=6)
+    await db_session.flush()
+    monkeypatch.setattr(
+        probe_mod, "fetch_endpoint", lambda *a, **k: _ok_outcome(fingerprint="NEW", not_after=na)
+    )
+    result = await probe_one(db_session, t, default_interval_hours=6)
+    assert result.fingerprint_changed is True
+
+
+# ── discovery ────────────────────────────────────────────────────────
+
+
+async def test_discovery_creates_and_dedupes(db_session: AsyncSession):
+    from app.services.tls_cert.discovery import reconcile_discovered_targets
+
+    group = DNSServerGroup(name=f"grp-{uuid.uuid4().hex[:8]}")
+    db_session.add(group)
+    await db_session.flush()
+    zone = DNSZone(group_id=group.id, name="example.com", auto_tls_probe=True)
+    db_session.add(zone)
+    await db_session.flush()
+    for label, fqdn in (("www", "www.example.com"), ("api", "api.example.com")):
+        db_session.add(
+            DNSRecord(zone_id=zone.id, name=label, fqdn=fqdn, record_type="A", value="203.0.113.10")
+        )
+    # A second record for the SAME fqdn must dedupe to one target.
+    db_session.add(
+        DNSRecord(
+            zone_id=zone.id,
+            name="www",
+            fqdn="www.example.com",
+            record_type="A",
+            value="203.0.113.11",
+        )
+    )
+    await db_session.flush()
+
+    res = await reconcile_discovered_targets(db_session)
+    await db_session.flush()
+    assert res["created"] == 2  # www + api, deduped
+
+    targets = (await db_session.execute(select(TLSCertTarget))).scalars().all()
+    hosts = sorted(t.host for t in targets)
+    assert hosts == ["api.example.com", "www.example.com"]
+    assert all(t.source == "discovered" and t.dns_zone_id == zone.id for t in targets)
+
+    # Idempotent — a second run creates nothing new.
+    res2 = await reconcile_discovered_targets(db_session)
+    assert res2["created"] == 0
+
+
+async def test_discovery_disable_then_reenable_cycle(db_session: AsyncSession):
+    from app.services.tls_cert.discovery import reconcile_discovered_targets
+
+    group = DNSServerGroup(name=f"grp-{uuid.uuid4().hex[:8]}")
+    db_session.add(group)
+    await db_session.flush()
+    zone = DNSZone(group_id=group.id, name="example.com", auto_tls_probe=True)
+    db_session.add(zone)
+    await db_session.flush()
+    rec = DNSRecord(
+        zone_id=zone.id, name="www", fqdn="www.example.com", record_type="A", value="203.0.113.10"
+    )
+    db_session.add(rec)
+    await db_session.flush()
+
+    await reconcile_discovered_targets(db_session)
+    await db_session.flush()
+    t = (await db_session.execute(select(TLSCertTarget))).scalars().one()
+    assert t.enabled is True
+
+    # Opt out → target disabled (key no longer a candidate).
+    zone.auto_tls_probe = False
+    await db_session.flush()
+    res = await reconcile_discovered_targets(db_session)
+    await db_session.flush()
+    await db_session.refresh(t)
+    assert t.enabled is False and res["disabled"] == 1
+
+    # Opt back in → SAME target re-enabled (not a duplicate).
+    zone.auto_tls_probe = True
+    await db_session.flush()
+    res2 = await reconcile_discovered_targets(db_session)
+    await db_session.flush()
+    await db_session.refresh(t)
+    assert t.enabled is True
+    assert res2["created"] == 0  # re-enabled, not re-created
+    assert (await db_session.execute(select(TLSCertTarget))).scalars().all().__len__() == 1
+
+
+# ── alert matchers ───────────────────────────────────────────────────
+
+
+async def test_alert_matchers(db_session: AsyncSession):
+    from app.models.alerts import AlertRule
+    from app.services.alerts import (
+        RULE_TYPE_TLS_CERT_CHAIN_INVALID,
+        RULE_TYPE_TLS_CERT_EXPIRING,
+        RULE_TYPE_TLS_CERT_UNREACHABLE,
+        _matching_tls_cert_chain_invalid_subjects,
+        _matching_tls_cert_expiring_subjects,
+        _matching_tls_cert_unreachable_subjects,
+    )
+
+    now = datetime.now(UTC)
+    expiring = TLSCertTarget(
+        host="exp.example.com", port=443, enabled=True, not_after=now + timedelta(days=5)
+    )
+    # Untrusted chain → chain_valid False, state mismatch.
+    invalid = TLSCertTarget(
+        host="bad.example.com",
+        port=443,
+        enabled=True,
+        chain_valid=False,
+        chain_error="self signed",
+        state=STATE_MISMATCH,
+    )
+    # Trusted chain served on the wrong hostname → chain_valid True but
+    # state mismatch. Must ALSO fire chain_invalid (the SAN-drift case).
+    name_mismatch = TLSCertTarget(
+        host="wrongname.example.com",
+        port=443,
+        enabled=True,
+        chain_valid=True,
+        state=STATE_MISMATCH,
+        not_after=now + timedelta(days=300),
+    )
+    down = TLSCertTarget(
+        host="down.example.com",
+        port=443,
+        enabled=True,
+        state=STATE_UNREACHABLE,
+        consecutive_failures=3,
+    )
+    healthy = TLSCertTarget(
+        host="ok.example.com",
+        port=443,
+        enabled=True,
+        state="ok",
+        not_after=now + timedelta(days=300),
+    )
+    db_session.add_all([expiring, invalid, name_mismatch, down, healthy])
+    await db_session.flush()
+
+    exp_rule = AlertRule(
+        name="x", rule_type=RULE_TYPE_TLS_CERT_EXPIRING, severity="warning", threshold_days=30
+    )
+    inv_rule = AlertRule(name="y", rule_type=RULE_TYPE_TLS_CERT_CHAIN_INVALID, severity="critical")
+    down_rule = AlertRule(name="z", rule_type=RULE_TYPE_TLS_CERT_UNREACHABLE, severity="warning")
+
+    exp_matches = await _matching_tls_cert_expiring_subjects(db_session, exp_rule, now)
+    assert {m[0] for m in exp_matches} == {str(expiring.id)}
+
+    # chain_invalid fires for BOTH the untrusted chain AND the trusted-but-
+    # wrong-hostname cert (both state='mismatch') — the SAN-drift coverage.
+    inv_matches = await _matching_tls_cert_chain_invalid_subjects(db_session, inv_rule)
+    assert {m[0] for m in inv_matches} == {str(invalid.id), str(name_mismatch.id)}
+
+    down_matches = await _matching_tls_cert_unreachable_subjects(db_session, down_rule)
+    assert {m[0] for m in down_matches} == {str(down.id)}
+
+
+def _self_signed_pem(cn: str) -> str:
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC) - timedelta(days=1))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def test_parse_chain_pem_roles():
+    from app.services.tls_cert.probe import parse_chain_pem
+
+    assert parse_chain_pem(None) == []
+    assert parse_chain_pem("not a pem") == []
+
+    # leaf (position 0) + a self-signed cert above it → root.
+    pem = _self_signed_pem("leaf.example.com") + _self_signed_pem("Example Root CA")
+    parsed = parse_chain_pem(pem)
+    assert [c["role"] for c in parsed] == ["leaf", "root"]
+    assert parsed[0]["subject_cn"] == "leaf.example.com"
+    assert parsed[1]["subject_cn"] == "Example Root CA"
+    assert parsed[1]["self_signed"] is True
+    assert all(c["fingerprint_sha256"] and c["key_algo"] == "EC" for c in parsed)
+
+
+# ── router CRUD + audit + feature gate ───────────────────────────────
+
+
+async def test_router_crud_roundtrip(client: AsyncClient, db_session: AsyncSession, monkeypatch):
+    _, token = await _superadmin(db_session)
+    await db_session.commit()
+    h = _hdr(token)
+
+    # Create.
+    r = await client.post(
+        "/api/v1/tls-certs",
+        headers=h,
+        json={"host": "Example.COM", "port": 443, "display_name": "Example"},
+    )
+    assert r.status_code == 201, r.text
+    row = r.json()
+    assert row["host"] == "example.com"  # normalised lower
+    tid = row["id"]
+
+    # Duplicate connect tuple → 409.
+    r = await client.post("/api/v1/tls-certs", headers=h, json={"host": "example.com"})
+    assert r.status_code == 409, r.text
+
+    # SSRF — loopback literal rejected at validation (422).
+    r = await client.post("/api/v1/tls-certs", headers=h, json={"host": "127.0.0.1"})
+    assert r.status_code == 422, r.text
+
+    # List + get.
+    r = await client.get("/api/v1/tls-certs", headers=h)
+    assert r.status_code == 200 and r.json()["total"] >= 1
+    r = await client.get(f"/api/v1/tls-certs/{tid}", headers=h)
+    assert r.status_code == 200
+
+    # Update.
+    r = await client.put(f"/api/v1/tls-certs/{tid}", headers=h, json={"display_name": "Renamed"})
+    assert r.status_code == 200 and r.json()["display_name"] == "Renamed"
+
+    # Probe-now (monkeypatched endpoint).
+    na = datetime.now(UTC) + timedelta(days=100)
+    monkeypatch.setattr(
+        probe_mod, "fetch_endpoint", lambda *a, **k: _ok_outcome(fingerprint="ZZ", not_after=na)
+    )
+    r = await client.post(f"/api/v1/tls-certs/{tid}/probe", headers=h)
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == STATE_OK
+    assert r.json()["fingerprint_sha256"] == "ZZ"
+
+    # Delete.
+    r = await client.delete(f"/api/v1/tls-certs/{tid}", headers=h)
+    assert r.status_code == 204
+    r = await client.get(f"/api/v1/tls-certs/{tid}", headers=h)
+    assert r.status_code == 404
+
+
+async def test_router_feature_gate_404(client: AsyncClient, db_session: AsyncSession):
+    _, token = await _superadmin(db_session)
+    # Disable the module.
+    fm = await db_session.get(FeatureModule, "security.tls_certs")
+    if fm is None:
+        db_session.add(FeatureModule(id="security.tls_certs", enabled=False))
+    else:
+        fm.enabled = False
+    await db_session.commit()
+    feature_modules.invalidate_cache()
+
+    r = await client.get("/api/v1/tls-certs", headers=_hdr(token))
+    assert r.status_code == 404, r.text
+
+
+# ── MCP tools ────────────────────────────────────────────────────────
+
+
+def test_mcp_tool_names_registered_no_collision():
+    import app.services.ai.tools  # noqa: F401 — triggers registration
+    from app.services.ai.tools.base import REGISTRY
+
+    for name in (
+        "find_tls_cert",
+        "count_tls_certs_expiring",
+        "get_cert_chain",
+        "count_tls_targets_by_state",
+        "propose_run_cert_probe",
+    ):
+        assert REGISTRY.get(name) is not None, f"{name} not registered"
+    # Distinct from the ACME-client tools (no collision).
+    assert REGISTRY.get("find_certificates") is not None
+    assert REGISTRY.get("find_tls_cert") is not REGISTRY.get("find_certificates")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import { NetworkPage } from "@/pages/network/NetworkPage";
 import { DeviceDetailView } from "@/pages/network/DeviceDetailView";
 import { AsnsPage } from "@/pages/network/AsnsPage";
 import { AsnDetailPage } from "@/pages/network/AsnDetailPage";
+import { CertificatesPage } from "@/pages/network/CertificatesPage";
 import { CircuitsPage } from "@/pages/network/CircuitsPage";
 import { MulticastGroupsPage } from "@/pages/network/MulticastGroupsPage";
 import { CustomersPage } from "@/pages/network/CustomersPage";
@@ -121,6 +122,7 @@ export default function App() {
         <Route path="network/vrfs/:id" element={<VRFDetailPage />} />
         <Route path="network/asns" element={<AsnsPage />} />
         <Route path="network/asns/:id" element={<AsnDetailPage />} />
+        <Route path="network/certificates" element={<CertificatesPage />} />
         <Route path="network/circuits" element={<CircuitsPage />} />
         <Route path="network/customers" element={<CustomersPage />} />
         <Route path="network/multicast" element={<MulticastGroupsPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -157,6 +157,12 @@ const networkInfrastructureNav = [
     module: "network.asn",
   },
   {
+    label: "Certificates",
+    icon: ShieldCheck,
+    to: "/network/certificates",
+    module: "security.tls_certs",
+  },
+  {
     label: "Circuits",
     icon: Waypoints,
     to: "/network/circuits",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2979,6 +2979,7 @@ export interface PlatformSettings {
    *  effect on the next tick without restarting beat. 1–168 h range
    *  enforced server-side. */
   domain_whois_interval_hours: number;
+  tls_cert_check_interval_hours: number;
   asn_whois_interval_hours: number;
   rpki_roa_source: string;
   rpki_roa_refresh_interval_hours: number;
@@ -4481,6 +4482,7 @@ export interface DNSZone {
   linked_subnet_id: string | null;
   domain_id?: string | null;
   dnssec_enabled: boolean;
+  auto_tls_probe?: boolean;
   dnssec_policy_id?: string | null;
   dnssec_ds_records: string[] | null;
   dnssec_synced_at: string | null;
@@ -12365,6 +12367,186 @@ export const circuitsApi = {
       .then((r) => r.data),
   bySite: (siteId: string) =>
     api.get<CircuitRead[]>(`/circuits/by-site/${siteId}`).then((r) => r.data),
+};
+
+// ── TLS certificate monitoring (issue #118 Phase 1) ───────────────
+//
+// Read-only-style watch list of TLS endpoints. Each ``TLSCertTarget``
+// is probed on its interval (or on demand); the server records the
+// leaf cert subject / issuer / validity window + chain status and
+// derives a single ``state`` pill. ``days_remaining`` is computed
+// server-side from ``not_after``.
+
+export type TLSCertState =
+  | "unknown"
+  | "ok"
+  | "expiring"
+  | "expired"
+  | "mismatch"
+  | "unreachable";
+
+export type TLSCertSource = "manual" | "discovered";
+
+export interface TLSCertTarget {
+  id: string;
+  host: string;
+  port: number;
+  server_name: string | null;
+  display_name: string | null;
+  enabled: boolean;
+  source: TLSCertSource;
+  dns_record_id: string | null;
+  dns_zone_id: string | null;
+  domain_id: string | null;
+  interval_hours: number | null;
+  next_check_at: string | null;
+  last_checked_at: string | null;
+  state: TLSCertState;
+  last_error: string | null;
+  consecutive_failures: number;
+  serial: string | null;
+  subject_cn: string | null;
+  issuer_cn: string | null;
+  not_before: string | null;
+  not_after: string | null;
+  sans_json: string[];
+  key_algo: string | null;
+  key_size: number | null;
+  sig_algo: string | null;
+  chain_depth: number | null;
+  chain_valid: boolean | null;
+  chain_error: string | null;
+  self_signed: boolean | null;
+  fingerprint_sha256: string | null;
+  created_at: string;
+  modified_at: string;
+  days_remaining: number | null;
+}
+
+export interface TLSCertProbe {
+  id: string;
+  target_id: string;
+  probed_at: string;
+  ok: boolean;
+  state: TLSCertState;
+  error: string | null;
+  serial: string | null;
+  subject_cn: string | null;
+  issuer_cn: string | null;
+  not_before: string | null;
+  not_after: string | null;
+  sans_json: string[];
+  key_algo: string | null;
+  key_size: number | null;
+  sig_algo: string | null;
+  chain_depth: number | null;
+  chain_valid: boolean | null;
+  chain_error: string | null;
+  self_signed: boolean | null;
+  fingerprint_sha256: string | null;
+}
+
+export interface TLSChainCert {
+  position: number;
+  role: "leaf" | "intermediate" | "root";
+  subject_cn: string;
+  issuer_cn: string;
+  serial: string;
+  not_before: string;
+  not_after: string;
+  key_algo: string | null;
+  key_size: number | null;
+  sig_algo: string | null;
+  is_ca: boolean | null;
+  self_signed: boolean;
+  fingerprint_sha256: string;
+}
+
+export interface TLSCertChain {
+  target_id: string;
+  probed_at: string;
+  subject_cn: string | null;
+  issuer_cn: string | null;
+  serial: string | null;
+  not_before: string | null;
+  not_after: string | null;
+  sans: string[];
+  key_algo: string | null;
+  key_size: number | null;
+  sig_algo: string | null;
+  chain_depth: number | null;
+  chain_valid: boolean | null;
+  chain_error: string | null;
+  self_signed: boolean | null;
+  fingerprint_sha256: string | null;
+  leaf_pem: string | null;
+  chain_pem: string | null;
+  chain: TLSChainCert[];
+}
+
+export interface TLSCertTargetCreate {
+  host: string;
+  port?: number;
+  server_name?: string | null;
+  display_name?: string | null;
+  interval_hours?: number | null;
+  enabled?: boolean;
+}
+
+export interface TLSCertTargetUpdate {
+  host?: string;
+  port?: number;
+  server_name?: string | null;
+  display_name?: string | null;
+  interval_hours?: number | null;
+  enabled?: boolean;
+}
+
+export interface TLSCertTargetListResponse {
+  items: TLSCertTarget[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface TLSCertTargetListQuery {
+  limit?: number;
+  offset?: number;
+  state?: TLSCertState;
+  source?: TLSCertSource;
+  enabled?: boolean;
+  dns_zone_id?: string;
+  domain_id?: string;
+  search?: string;
+}
+
+export interface TLSCertProbeListResponse {
+  items: TLSCertProbe[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export const tlsCertsApi = {
+  list: (params?: TLSCertTargetListQuery) =>
+    api
+      .get<TLSCertTargetListResponse>("/tls-certs", { params })
+      .then((r) => r.data),
+  get: (id: string) =>
+    api.get<TLSCertTarget>(`/tls-certs/${id}`).then((r) => r.data),
+  create: (data: TLSCertTargetCreate) =>
+    api.post<TLSCertTarget>("/tls-certs", data).then((r) => r.data),
+  update: (id: string, data: TLSCertTargetUpdate) =>
+    api.put<TLSCertTarget>(`/tls-certs/${id}`, data).then((r) => r.data),
+  remove: (id: string) => api.delete(`/tls-certs/${id}`),
+  probes: (id: string, params?: { limit?: number; offset?: number }) =>
+    api
+      .get<TLSCertProbeListResponse>(`/tls-certs/${id}/probes`, { params })
+      .then((r) => r.data),
+  chain: (id: string) =>
+    api.get<TLSCertChain>(`/tls-certs/${id}/chain`).then((r) => r.data),
+  probeNow: (id: string) =>
+    api.post<TLSCertTarget>(`/tls-certs/${id}/probe`).then((r) => r.data),
 };
 
 // ── Multicast groups (issue #126 Phase 1) ─────────────────────────

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12398,6 +12398,7 @@ export interface TLSCertTarget {
   dns_record_id: string | null;
   dns_zone_id: string | null;
   domain_id: string | null;
+  ip_address_id: string | null;
   interval_hours: number | null;
   next_check_at: string | null;
   last_checked_at: string | null;
@@ -12517,7 +12518,26 @@ export interface TLSCertTargetListQuery {
   enabled?: boolean;
   dns_zone_id?: string;
   domain_id?: string;
+  ip_address_id?: string;
   search?: string;
+}
+
+export interface TLSCertCTEntry {
+  id: number | null;
+  common_name: string | null;
+  name_value: string | null;
+  issuer_name: string | null;
+  serial_number: string | null;
+  not_before: string | null;
+  not_after: string | null;
+  entry_timestamp: string | null;
+}
+
+export interface TLSCertCTResult {
+  host: string;
+  entries: TLSCertCTEntry[];
+  count: number;
+  error: string | null;
 }
 
 export interface TLSCertProbeListResponse {
@@ -12545,6 +12565,10 @@ export const tlsCertsApi = {
       .then((r) => r.data),
   chain: (id: string) =>
     api.get<TLSCertChain>(`/tls-certs/${id}/chain`).then((r) => r.data),
+  ctLog: (id: string, params?: { limit?: number }) =>
+    api
+      .get<TLSCertCTResult>(`/tls-certs/${id}/ct-log`, { params })
+      .then((r) => r.data),
   probeNow: (id: string) =>
     api.post<TLSCertTarget>(`/tls-certs/${id}/probe`).then((r) => r.data),
 };

--- a/frontend/src/lib/tls-cert-state.ts
+++ b/frontend/src/lib/tls-cert-state.ts
@@ -1,0 +1,33 @@
+// Shared TLS-cert state helpers (issue #118). Kept out of the page
+// component file so React Fast Refresh doesn't warn on mixed
+// component/value exports (same split as ``use-draggable-modal.ts``).
+
+import type { TLSCertState } from "@/lib/api";
+
+export const TLS_CERT_STATES: TLSCertState[] = [
+  "unknown",
+  "ok",
+  "expiring",
+  "expired",
+  "mismatch",
+  "unreachable",
+];
+
+const STATE_CLS: Record<TLSCertState, string> = {
+  ok: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400",
+  expiring:
+    "bg-amber-100 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400",
+  expired: "bg-red-100 text-red-700 dark:bg-red-950/30 dark:text-red-400",
+  mismatch: "bg-red-100 text-red-700 dark:bg-red-950/30 dark:text-red-400",
+  unreachable: "bg-red-100 text-red-700 dark:bg-red-950/30 dark:text-red-400",
+  unknown: "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300",
+};
+
+export function tlsStateCls(state: TLSCertState): string {
+  return STATE_CLS[state] ?? STATE_CLS.unknown;
+}
+
+export function fmtDateTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString();
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -55,6 +55,7 @@ import {
   alertsApi,
   conformityApi,
   dashboardsApi,
+  tlsCertsApi,
   type IPSpace,
   type Subnet,
   type DNSServer,
@@ -2649,7 +2650,7 @@ function CompliancePanel({ subnets }: { subnets: Subnet[] }) {
   return (
     <div className="space-y-5">
       {/* Headline KPIs */}
-      <div className="grid gap-3 grid-cols-1 md:grid-cols-3">
+      <div className="grid gap-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-4">
         <ComplianceKpi
           label="PCI scope"
           count={pciCount}
@@ -2671,6 +2672,7 @@ function CompliancePanel({ subnets }: { subnets: Subnet[] }) {
           to="/admin/compliance"
           tone="warn"
         />
+        <CertsExpiringKpi />
       </div>
 
       <div className="grid gap-5 lg:grid-cols-2">
@@ -2785,6 +2787,46 @@ function CompliancePanel({ subnets }: { subnets: Subnet[] }) {
         auditor-facing PDF export.
       </p>
     </div>
+  );
+}
+
+// TLS certs expiring within 30 days (#118). Self-contained + gated on
+// the ``security.tls_certs`` feature module so it renders nothing when
+// the operator has the module turned off.
+function CertsExpiringKpi() {
+  const { enabled, ready } = useFeatureModules();
+  const moduleOn = enabled("security.tls_certs");
+
+  const { data } = useQuery({
+    queryKey: ["tls-certs", "kpi"],
+    queryFn: () => tlsCertsApi.list({ limit: 500 }),
+    enabled: ready && moduleOn,
+    staleTime: 60_000,
+  });
+
+  if (ready && !moduleOn) return null;
+
+  const items = data?.items ?? [];
+  const expiring = items.filter(
+    (t) => t.days_remaining !== null && t.days_remaining <= 30,
+  ).length;
+  const cls = TONE_CLASS[expiring > 0 ? "bad" : "good"];
+
+  return (
+    <Link
+      to="/network/certificates"
+      className="rounded-lg border bg-card p-4 transition-colors hover:bg-accent/40"
+    >
+      <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
+        Certs expiring ≤30d
+      </p>
+      <p className={cn("mt-2 text-3xl font-bold tabular-nums", cls.value)}>
+        {expiring}
+      </p>
+      <p className="text-[11px] text-muted-foreground">
+        of {items.length} monitored · click to review
+      </p>
+    </Link>
   );
 }
 

--- a/frontend/src/pages/admin/DomainDetailPage.tsx
+++ b/frontend/src/pages/admin/DomainDetailPage.tsx
@@ -13,11 +13,14 @@ import {
   alertsApi,
   dnsApi,
   domainsApi,
+  tlsCertsApi,
   type AlertSeverity,
   type Domain,
   type DomainWhoisState,
 } from "@/lib/api";
 import { RdapPanel } from "@/components/network/rdap-panel";
+import { CertsCompactTable } from "@/pages/network/CertificatesPage";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { cn, zebraBodyCls } from "@/lib/utils";
 
 // ── helpers ─────────────────────────────────────────────────────────────────
@@ -120,7 +123,7 @@ function SeverityBadge({ severity }: { severity: AlertSeverity }) {
 
 // ── Tab button ───────────────────────────────────────────────────────────────
 
-type Tab = "whois" | "zones" | "alerts";
+type Tab = "whois" | "zones" | "certs" | "alerts";
 
 function TabButton({
   active,
@@ -348,6 +351,35 @@ function LinkedZonesTab({ domain }: { domain: Domain }) {
         </tbody>
       </table>
     </div>
+  );
+}
+
+// ── Certificates tab ──────────────────────────────────────────────────────────
+
+function CertificatesTab({ domainId }: { domainId: string }) {
+  const { enabled, ready } = useFeatureModules();
+  const moduleOn = enabled("security.tls_certs");
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["tls-certs", "domain", domainId],
+    queryFn: () => tlsCertsApi.list({ domain_id: domainId, limit: 200 }),
+    enabled: ready && moduleOn,
+  });
+
+  if (ready && !moduleOn) {
+    return (
+      <p className="rounded-lg border bg-card px-4 py-8 text-center text-xs text-muted-foreground">
+        TLS certificate monitoring is disabled.
+      </p>
+    );
+  }
+
+  return (
+    <CertsCompactTable
+      targets={data?.items ?? []}
+      isLoading={isLoading}
+      emptyLabel="No TLS certificates linked to this domain."
+    />
   );
 }
 
@@ -599,6 +631,11 @@ export function DomainDetailPage() {
               label="Linked DNS Zones"
             />
             <TabButton
+              active={tab === "certs"}
+              onClick={() => setTab("certs")}
+              label="Certificates"
+            />
+            <TabButton
               active={tab === "alerts"}
               onClick={() => setTab("alerts")}
               label="Alert History"
@@ -607,6 +644,7 @@ export function DomainDetailPage() {
           <div className="mt-4">
             {tab === "whois" && <WhoisTab domain={domain} />}
             {tab === "zones" && <LinkedZonesTab domain={domain} />}
+            {tab === "certs" && <CertificatesTab domainId={domain.id} />}
             {tab === "alerts" && <AlertHistoryTab domainId={domain.id} />}
           </div>
         </div>

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -3239,7 +3239,9 @@ function ZoneDetailView({
                   type="checkbox"
                   checked={!!zone.auto_tls_probe}
                   disabled={autoTlsProbeMutation.isPending}
-                  onChange={(e) => autoTlsProbeMutation.mutate(e.target.checked)}
+                  onChange={(e) =>
+                    autoTlsProbeMutation.mutate(e.target.checked)
+                  }
                 />
                 <span>
                   Auto-discover &amp; probe every A/AAAA record in this zone

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -49,6 +49,11 @@ import { ZoneTemplateModal } from "./ZoneTemplateModal";
 import { ServerDetailModal } from "./ServerDetailModal";
 import { PauseServerModal } from "@/components/ui/pause-server-modal";
 import { PoolsView } from "./PoolsView";
+import {
+  CertsCompactTable,
+  TLSStatePill,
+} from "@/pages/network/CertificatesPage";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { Modal } from "@/components/ui/modal";
 import { HeaderButton } from "@/components/ui/header-button";
 import { AskAIButton } from "@/components/copilot/AskAIButton";
@@ -58,6 +63,7 @@ import {
   dnsBlocklistApi,
   domainsApi,
   formatApiError,
+  tlsCertsApi,
   type DNSServerGroup,
   type DNSServer,
   type DNSZone,
@@ -2813,6 +2819,33 @@ function ZoneDetailView({
     queryFn: () => dnsApi.listRecords(group.id, zone.id),
   });
 
+  // TLS cert targets linked to this zone (#118). Powers the Certs
+  // sub-tab + the per-record state pill on A/AAAA rows. Gated on the
+  // feature module so disabling it stops the extra query entirely.
+  const { enabled: moduleEnabled, ready: modulesReady } = useFeatureModules();
+  const tlsCertsOn = moduleEnabled("security.tls_certs");
+  const { data: tlsCerts, isLoading: tlsCertsLoading } = useQuery({
+    queryKey: ["tls-certs", "dns-zone", zone.id],
+    queryFn: () => tlsCertsApi.list({ dns_zone_id: zone.id, limit: 200 }),
+    enabled: modulesReady && tlsCertsOn,
+  });
+  // #118 — toggle auto-discovery of cert probe targets for this zone's
+  // A/AAAA records. The discovery reconciler picks the change up on its
+  // next sweep (~5 min).
+  const autoTlsProbeMutation = useMutation({
+    mutationFn: (next: boolean) =>
+      dnsApi.updateZone(group.id, zone.id, { auto_tls_probe: next }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dns-zones", group.id] });
+      qc.invalidateQueries({ queryKey: ["tls-certs", "dns-zone", zone.id] });
+    },
+  });
+  const certStateByRecord = new Map(
+    (tlsCerts?.items ?? [])
+      .filter((t) => t.dns_record_id)
+      .map((t) => [t.dns_record_id as string, t.state]),
+  );
+
   const deleteZone = useMutation({
     mutationFn: () => dnsApi.deleteZone(group.id, zone.id),
     onSuccess: () => {
@@ -2858,10 +2891,17 @@ function ZoneDetailView({
   // pre-selects the Pools tab so the deep-link lands on the right
   // surface; otherwise default to Records.
   const [zoneSearchParams, setZoneSearchParams] = useSearchParams();
-  const initialSubtab =
-    zoneSearchParams.get("subtab") === "pools" ? "pools" : "records";
-  const [zoneView, _setZoneView] = useState<"records" | "pools">(initialSubtab);
-  const setZoneView = (v: "records" | "pools") => {
+  const subtabParam = zoneSearchParams.get("subtab");
+  const initialSubtab: "records" | "pools" | "certs" =
+    subtabParam === "pools"
+      ? "pools"
+      : subtabParam === "certs"
+        ? "certs"
+        : "records";
+  const [zoneView, _setZoneView] = useState<"records" | "pools" | "certs">(
+    initialSubtab,
+  );
+  const setZoneView = (v: "records" | "pools" | "certs") => {
     _setZoneView(v);
     // Keep the URL in sync so a refresh / back-navigation lands on
     // the same tab. ``subtab=records`` is the default state — drop
@@ -2869,8 +2909,8 @@ function ZoneDetailView({
     setZoneSearchParams(
       (prev: URLSearchParams) => {
         const next = new URLSearchParams(prev);
-        if (v === "pools") next.set("subtab", "pools");
-        else next.delete("subtab");
+        if (v === "records") next.delete("subtab");
+        else next.set("subtab", v);
         return next;
       },
       { replace: true },
@@ -3163,12 +3203,56 @@ function ZoneDetailView({
           >
             Pools ({poolsForCount.length})
           </button>
+          {(!modulesReady || tlsCertsOn) && (
+            <button
+              type="button"
+              onClick={() => setZoneView("certs")}
+              className={
+                "border-b-2 px-3 py-2 text-xs font-medium transition-colors " +
+                (zoneView === "certs"
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground")
+              }
+            >
+              Certificates ({tlsCerts?.items.length ?? 0})
+            </button>
+          )}
         </div>
       )}
 
       {/* Pools sub-view */}
       {!isForward && !zone.tailscale_tenant_id && zoneView === "pools" && (
         <PoolsView group={group} zone={zone} />
+      )}
+
+      {/* Certificates sub-view */}
+      {!isForward && !zone.tailscale_tenant_id && zoneView === "certs" && (
+        <div className="flex-1 overflow-auto p-5">
+          {modulesReady && !tlsCertsOn ? (
+            <p className="text-sm text-muted-foreground">
+              TLS certificate monitoring is disabled.
+            </p>
+          ) : (
+            <>
+              <label className="mb-4 flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={!!zone.auto_tls_probe}
+                  disabled={autoTlsProbeMutation.isPending}
+                  onChange={(e) => autoTlsProbeMutation.mutate(e.target.checked)}
+                />
+                <span>
+                  Auto-discover &amp; probe every A/AAAA record in this zone
+                </span>
+              </label>
+              <CertsCompactTable
+                targets={tlsCerts?.items ?? []}
+                isLoading={tlsCertsLoading}
+                emptyLabel="No TLS certificates linked to records in this zone."
+              />
+            </>
+          )}
+        </div>
       )}
 
       {/* Bulk actions — shown when any manual records are selected. */}
@@ -3391,10 +3475,19 @@ function ZoneDetailView({
                             )}
                           </td>
                           <td className="py-1.5">
-                            <span
-                              className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${RECORD_TYPE_BADGE[r.record_type] ?? RECORD_TYPE_BADGE_FALLBACK}`}
-                            >
-                              {r.record_type}
+                            <span className="inline-flex items-center gap-1.5">
+                              <span
+                                className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${RECORD_TYPE_BADGE[r.record_type] ?? RECORD_TYPE_BADGE_FALLBACK}`}
+                              >
+                                {r.record_type}
+                              </span>
+                              {(r.record_type === "A" ||
+                                r.record_type === "AAAA") &&
+                                certStateByRecord.has(r.id) && (
+                                  <TLSStatePill
+                                    state={certStateByRecord.get(r.id)!}
+                                  />
+                                )}
                             </span>
                           </td>
                           <td className="py-1.5 font-mono text-xs text-muted-foreground max-w-xs truncate">

--- a/frontend/src/pages/ipam/IPDetailModal.tsx
+++ b/frontend/src/pages/ipam/IPDetailModal.tsx
@@ -9,6 +9,7 @@ import {
   Radar,
   Radio,
   RefreshCw,
+  ShieldCheck,
   Trash2,
   X,
 } from "lucide-react";
@@ -17,6 +18,7 @@ import {
   ipamApi,
   multicastApi,
   nmapApi,
+  tlsCertsApi,
   type DHCPFingerprintResponse,
   type IPAddress,
   type MulticastMembershipReadWithGroup,
@@ -24,6 +26,7 @@ import {
   type Subnet,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { CertsCompactTable } from "@/pages/network/CertificatesPage";
 import {
   MODAL_BACKDROP_CLS,
   useDraggableModal,
@@ -475,6 +478,8 @@ export function IPDetailModal({
           {/* Multicast memberships (issue #126 Wave 4). Hidden when
               the network.multicast feature module is disabled. */}
           <MulticastMembershipsSection addressId={addr.id} />
+
+          <CertsSection addressId={addr.id} />
         </div>
       </div>
     </div>
@@ -487,6 +492,32 @@ export function IPDetailModal({
 // consumer / RP). Hidden when the network.multicast feature module
 // is off, so non-multicast deployments don't see chrome they don't
 // need.
+
+function CertsSection({ addressId }: { addressId: string }) {
+  const { enabled } = useFeatureModules();
+  const certsEnabled = enabled("security.tls_certs");
+
+  const q = useQuery({
+    queryKey: ["tls-certs", "by-ip", addressId],
+    queryFn: () => tlsCertsApi.list({ ip_address_id: addressId, limit: 50 }),
+    enabled: certsEnabled,
+    staleTime: 30_000,
+  });
+
+  if (!certsEnabled) return null;
+  const targets = q.data?.items ?? [];
+  // Most IPs serve no monitored cert — hide the section entirely then.
+  if (targets.length === 0) return null;
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        <ShieldCheck className="h-3 w-3" /> TLS certificates
+      </div>
+      <CertsCompactTable targets={targets} />
+    </div>
+  );
+}
 
 function MulticastMembershipsSection({ addressId }: { addressId: string }) {
   const { enabled } = useFeatureModules();

--- a/frontend/src/pages/network/CertificatesPage.tsx
+++ b/frontend/src/pages/network/CertificatesPage.tsx
@@ -536,7 +536,9 @@ function CertDetailModal({
           <DetailRow label="Signature">{t.sig_algo || DASH}</DetailRow>
         </DetailSection>
 
-        <DetailSection title={`Subject alternative names (${t.sans_json.length})`}>
+        <DetailSection
+          title={`Subject alternative names (${t.sans_json.length})`}
+        >
           {t.sans_json.length === 0 ? (
             <p className="py-1 text-sm text-muted-foreground">{DASH}</p>
           ) : (
@@ -782,7 +784,9 @@ export function CertificatesPage() {
           <select
             className={cn(inputCls, "max-w-[180px]")}
             value={stateFilter}
-            onChange={(e) => setStateFilter(e.target.value as TLSCertState | "")}
+            onChange={(e) =>
+              setStateFilter(e.target.value as TLSCertState | "")
+            }
           >
             <option value="">All states</option>
             {TLS_CERT_STATES.map((s) => (

--- a/frontend/src/pages/network/CertificatesPage.tsx
+++ b/frontend/src/pages/network/CertificatesPage.tsx
@@ -1,0 +1,968 @@
+import { useState, type ReactNode } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Pencil, Plus, RefreshCw, ShieldCheck, Trash2 } from "lucide-react";
+
+import {
+  settingsApi,
+  tlsCertsApi,
+  type TLSCertSource,
+  type TLSCertState,
+  type TLSCertTarget,
+  type TLSCertTargetCreate,
+  type TLSCertTargetUpdate,
+} from "@/lib/api";
+import { cn, zebraBodyCls } from "@/lib/utils";
+import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { HeaderButton } from "@/components/ui/header-button";
+import { SavedViewsMenu } from "@/components/SavedViewsMenu";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
+import {
+  TLS_CERT_STATES,
+  fmtDateTime,
+  tlsStateCls,
+} from "@/lib/tls-cert-state";
+
+const inputCls =
+  "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+// ── Shared state pill components ──────────────────────────────────────
+//
+// Re-exported so the Domain / DNS-zone Certs tabs and the DNS record
+// pill render the same styling. The colour/label helpers themselves
+// live in ``@/lib/tls-cert-state`` (kept out of this component file so
+// Fast Refresh doesn't warn on mixed exports).
+
+export function TLSStateBadge({ state }: { state: TLSCertState }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-2 py-0.5 text-[11px] font-medium uppercase tracking-wider",
+        tlsStateCls(state),
+      )}
+    >
+      {state}
+    </span>
+  );
+}
+
+/** Subtle inline pill — used on the DNS record table for A/AAAA rows. */
+export function TLSStatePill({ state }: { state: TLSCertState }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+        tlsStateCls(state),
+      )}
+      title={`TLS cert: ${state}`}
+    >
+      TLS {state}
+    </span>
+  );
+}
+
+/** Compact "<date> · <Nd>" cell showing expiry + days-remaining badge. */
+export function NotAfterCell({
+  notAfter,
+  daysRemaining,
+}: {
+  notAfter: string | null;
+  daysRemaining: number | null;
+}) {
+  if (!notAfter) return <span className="text-muted-foreground/50">—</span>;
+  let cls =
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400";
+  let label = daysRemaining !== null ? `${daysRemaining}d` : "—";
+  if (daysRemaining !== null) {
+    if (daysRemaining < 0) {
+      cls = "bg-red-200 text-red-900 dark:bg-red-950/50 dark:text-red-300";
+      label = `expired ${Math.abs(daysRemaining)}d ago`;
+    } else if (daysRemaining <= 14) {
+      cls = "bg-red-100 text-red-700 dark:bg-red-950/30 dark:text-red-400";
+    } else if (daysRemaining <= 30) {
+      cls =
+        "bg-amber-100 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400";
+    }
+  }
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span className="text-[11px] tabular-nums text-muted-foreground">
+        {new Date(notAfter).toLocaleDateString()}
+      </span>
+      <span
+        className={cn(
+          "rounded px-2 py-0.5 text-[10px] font-medium tabular-nums",
+          cls,
+        )}
+      >
+        {label}
+      </span>
+    </span>
+  );
+}
+
+/** Compact read-only certs table reused by the Domain / DNS-zone Certs
+ *  tabs. Takes a pre-fetched list so the parent owns the gated query. */
+export function CertsCompactTable({
+  targets,
+  isLoading,
+  emptyLabel = "No TLS certificates linked.",
+}: {
+  targets: TLSCertTarget[];
+  isLoading?: boolean;
+  emptyLabel?: string;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
+          <tr>
+            <th className="px-3 py-2 text-left">Host</th>
+            <th className="px-3 py-2 text-left">State</th>
+            <th className="px-3 py-2 text-left">Issuer</th>
+            <th className="px-3 py-2 text-left">Expires</th>
+          </tr>
+        </thead>
+        <tbody className={zebraBodyCls}>
+          {isLoading && (
+            <tr>
+              <td
+                colSpan={4}
+                className="px-3 py-6 text-center text-muted-foreground"
+              >
+                Loading…
+              </td>
+            </tr>
+          )}
+          {!isLoading && targets.length === 0 && (
+            <tr>
+              <td
+                colSpan={4}
+                className="px-3 py-6 text-center text-muted-foreground"
+              >
+                {emptyLabel}
+              </td>
+            </tr>
+          )}
+          {targets.map((t) => (
+            <tr key={t.id} className="border-t">
+              <td className="px-3 py-2 align-top break-words">
+                <span className="font-medium">{t.host}</span>
+                <span className="text-muted-foreground">:{t.port}</span>
+              </td>
+              <td className="px-3 py-2 align-top">
+                <TLSStateBadge state={t.state} />
+              </td>
+              <td className="px-3 py-2 align-top break-words text-muted-foreground">
+                {t.issuer_cn ?? "—"}
+              </td>
+              <td className="px-3 py-2 align-top">
+                <NotAfterCell
+                  notAfter={t.not_after}
+                  daysRemaining={t.days_remaining}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ChainBadge({ target }: { target: TLSCertTarget }) {
+  if (target.chain_valid === null) {
+    return <span className="text-muted-foreground/50">—</span>;
+  }
+  if (target.chain_valid) {
+    return (
+      <span className="inline-flex items-center rounded bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400">
+        valid
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center rounded bg-red-100 px-2 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950/30 dark:text-red-400"
+      title={target.chain_error ?? "Chain invalid"}
+    >
+      {target.self_signed ? "self-signed" : "invalid"}
+    </span>
+  );
+}
+
+function SourceChip({ source }: { source: TLSCertSource }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider",
+        source === "manual"
+          ? "bg-blue-100 text-blue-700 dark:bg-blue-950/30 dark:text-blue-400"
+          : "bg-violet-100 text-violet-700 dark:bg-violet-950/30 dark:text-violet-400",
+      )}
+    >
+      {source}
+    </span>
+  );
+}
+
+// ── Editor modal ─────────────────────────────────────────────────────
+
+function CertTargetEditorModal({
+  existing,
+  onClose,
+}: {
+  existing: TLSCertTarget | null;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+
+  const [host, setHost] = useState(existing?.host ?? "");
+  const [port, setPort] = useState(String(existing?.port ?? 443));
+  const [serverName, setServerName] = useState(existing?.server_name ?? "");
+  const [displayName, setDisplayName] = useState(existing?.display_name ?? "");
+  const [intervalHours, setIntervalHours] = useState(
+    existing?.interval_hours != null ? String(existing.interval_hours) : "",
+  );
+  const [enabled, setEnabled] = useState(existing?.enabled ?? true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Platform default cadence — shown so the operator knows what "blank" means.
+  const { data: settings } = useQuery({
+    queryKey: ["platform-settings"],
+    queryFn: settingsApi.get,
+    staleTime: 5 * 60 * 1000,
+  });
+  const defaultHours = settings?.tls_cert_check_interval_hours ?? 6;
+
+  const mut = useMutation({
+    mutationFn: async () => {
+      if (!host.trim()) throw new Error("Host is required");
+      const parsedInterval = intervalHours.trim()
+        ? Number(intervalHours)
+        : null;
+      const body: TLSCertTargetCreate | TLSCertTargetUpdate = {
+        host: host.trim(),
+        port: Number(port) || 443,
+        server_name: serverName.trim() || null,
+        display_name: displayName.trim() || null,
+        interval_hours: parsedInterval,
+        enabled,
+      };
+      if (existing) return tlsCertsApi.update(existing.id, body);
+      return tlsCertsApi.create(body as TLSCertTargetCreate);
+    },
+    onSuccess: (saved) => {
+      qc.invalidateQueries({ queryKey: ["tls-certs"] });
+      onClose();
+      // A freshly-added target probes immediately so the row shows a real
+      // state within seconds instead of sitting at "unknown" until the next
+      // sweep. Detached — the modal closes right away; the synchronous probe
+      // refreshes the list when it lands (~a few seconds).
+      if (!existing && saved?.id) {
+        tlsCertsApi
+          .probeNow(saved.id)
+          .catch(() => {})
+          .finally(() => qc.invalidateQueries({ queryKey: ["tls-certs"] }));
+      }
+    },
+    onError: (e: unknown) => {
+      const err = e as {
+        message?: string;
+        response?: { data?: { detail?: string } };
+      };
+      setError(err?.response?.data?.detail ?? err?.message ?? "Save failed");
+    },
+  });
+
+  return (
+    <Modal
+      onClose={onClose}
+      title={
+        existing
+          ? `Edit ${existing.display_name || existing.host}`
+          : "New TLS cert target"
+      }
+    >
+      <div className="grid grid-cols-1 gap-3 pb-2 sm:grid-cols-2">
+        <div>
+          <label className="text-xs font-medium text-muted-foreground">
+            Host
+          </label>
+          <input
+            className={inputCls}
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            placeholder="e.g. www.example.com or 10.0.0.5"
+            autoFocus={!existing}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-medium text-muted-foreground">
+            Port
+          </label>
+          <input
+            type="number"
+            min={1}
+            max={65535}
+            className={inputCls}
+            value={port}
+            onChange={(e) => setPort(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-medium text-muted-foreground">
+            Server name (SNI, optional)
+          </label>
+          <input
+            className={inputCls}
+            value={serverName}
+            onChange={(e) => setServerName(e.target.value)}
+            placeholder="Overrides the SNI sent during the handshake"
+          />
+        </div>
+        <div>
+          <label className="text-xs font-medium text-muted-foreground">
+            Display name (optional)
+          </label>
+          <input
+            className={inputCls}
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="Friendly label for the list view"
+          />
+        </div>
+        <div>
+          <label className="text-xs font-medium text-muted-foreground">
+            Check interval (hours, optional)
+          </label>
+          <input
+            type="number"
+            min={1}
+            max={168}
+            className={inputCls}
+            value={intervalHours}
+            onChange={(e) => setIntervalHours(e.target.value)}
+            placeholder={`Default: every ${defaultHours}h`}
+          />
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Leave blank to use the platform default (every {defaultHours} h).
+          </p>
+        </div>
+        <div className="flex items-end">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+            />
+            Enabled
+          </label>
+        </div>
+      </div>
+
+      {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
+
+      <div className="mt-6 flex justify-end gap-2 border-t pt-3">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          disabled={mut.isPending}
+          onClick={() => mut.mutate()}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {mut.isPending ? "Saving…" : existing ? "Save" : "Create"}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+// ── Detail modal ──────────────────────────────────────────────────────
+
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-[140px_1fr] gap-2 py-1 text-sm">
+      <div className="text-muted-foreground">{label}</div>
+      <div className="min-w-0 break-words">{children}</div>
+    </div>
+  );
+}
+
+function DetailSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mt-4 first:mt-0">
+      <h3 className="mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        {title}
+      </h3>
+      <div className="rounded-md border px-3 py-1.5">{children}</div>
+    </div>
+  );
+}
+
+const DASH = "—";
+
+function chainRoleCls(role: string): string {
+  if (role === "leaf")
+    return "bg-blue-100 text-blue-700 dark:bg-blue-950/30 dark:text-blue-400";
+  if (role === "root")
+    return "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400";
+  return "bg-violet-100 text-violet-700 dark:bg-violet-950/30 dark:text-violet-400";
+}
+
+function CertDetailModal({
+  target,
+  onClose,
+  onEdit,
+}: {
+  target: TLSCertTarget;
+  onClose: () => void;
+  onEdit: () => void;
+}) {
+  const qc = useQueryClient();
+  const [showPem, setShowPem] = useState(false);
+
+  // Live row so a probe-now reflects without reopening.
+  const { data: t = target } = useQuery({
+    queryKey: ["tls-certs", "detail", target.id],
+    queryFn: () => tlsCertsApi.get(target.id),
+    initialData: target,
+  });
+
+  const chainQuery = useQuery({
+    queryKey: ["tls-certs", "chain", target.id],
+    queryFn: () => tlsCertsApi.chain(target.id),
+    retry: false, // 404 until the first successful probe — don't hammer
+  });
+  const chain = chainQuery.data?.chain ?? [];
+
+  const probe = useMutation({
+    mutationFn: () => tlsCertsApi.probeNow(target.id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["tls-certs"] });
+    },
+  });
+
+  const effectiveInterval = t.interval_hours
+    ? `${t.interval_hours} h (override)`
+    : "platform default";
+
+  return (
+    <Modal onClose={onClose} title={t.display_name || t.host} wide>
+      <div>
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+          <span className="font-mono text-xs text-muted-foreground">
+            {t.host}:{t.port}
+          </span>
+          <TLSStateBadge state={t.state} />
+        </div>
+        <DetailSection title="Endpoint">
+          <DetailRow label="Host : port">
+            <span className="font-mono">
+              {t.host}:{t.port}
+            </span>
+          </DetailRow>
+          <DetailRow label="SNI">
+            <span className="font-mono">{t.server_name || `(${t.host})`}</span>
+          </DetailRow>
+          <DetailRow label="Source">{t.source}</DetailRow>
+          <DetailRow label="Enabled">{t.enabled ? "Yes" : "No"}</DetailRow>
+          <DetailRow label="Check interval">{effectiveInterval}</DetailRow>
+          <DetailRow label="Last checked">
+            {fmtDateTime(t.last_checked_at)}
+          </DetailRow>
+          <DetailRow label="Next check">
+            {fmtDateTime(t.next_check_at)}
+          </DetailRow>
+          {t.last_error && (
+            <DetailRow label="Last error">
+              <span className="text-destructive">{t.last_error}</span>
+            </DetailRow>
+          )}
+        </DetailSection>
+
+        <DetailSection title="Certificate">
+          <DetailRow label="Subject CN">{t.subject_cn || DASH}</DetailRow>
+          <DetailRow label="Issuer CN">{t.issuer_cn || DASH}</DetailRow>
+          <DetailRow label="Serial">
+            <span className="font-mono text-xs">{t.serial || DASH}</span>
+          </DetailRow>
+          <DetailRow label="Valid from">{fmtDateTime(t.not_before)}</DetailRow>
+          <DetailRow label="Valid to">
+            <NotAfterCell
+              notAfter={t.not_after}
+              daysRemaining={t.days_remaining}
+            />
+          </DetailRow>
+          <DetailRow label="Self-signed">
+            {t.self_signed == null ? DASH : t.self_signed ? "Yes" : "No"}
+          </DetailRow>
+        </DetailSection>
+
+        <DetailSection title="Chain & key">
+          <DetailRow label="Chain valid">
+            {t.chain_valid == null ? DASH : t.chain_valid ? "Yes" : "No"}
+          </DetailRow>
+          {t.chain_error && (
+            <DetailRow label="Chain error">
+              <span className="text-destructive">{t.chain_error}</span>
+            </DetailRow>
+          )}
+          <DetailRow label="Chain depth">{t.chain_depth ?? DASH}</DetailRow>
+          <DetailRow label="Key">
+            {t.key_algo
+              ? `${t.key_algo}${t.key_size ? ` ${t.key_size}-bit` : ""}`
+              : DASH}
+          </DetailRow>
+          <DetailRow label="Signature">{t.sig_algo || DASH}</DetailRow>
+        </DetailSection>
+
+        <DetailSection title={`Subject alternative names (${t.sans_json.length})`}>
+          {t.sans_json.length === 0 ? (
+            <p className="py-1 text-sm text-muted-foreground">{DASH}</p>
+          ) : (
+            <div className="flex flex-wrap gap-1.5 py-1">
+              {t.sans_json.map((s) => (
+                <span
+                  key={s}
+                  className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs"
+                >
+                  {s}
+                </span>
+              ))}
+            </div>
+          )}
+        </DetailSection>
+
+        <DetailSection title="Fingerprint (SHA-256)">
+          <p className="break-all py-1 font-mono text-xs">
+            {t.fingerprint_sha256 || DASH}
+          </p>
+        </DetailSection>
+
+        <DetailSection
+          title={`Certificate chain${chain.length ? ` (${chain.length})` : ""}`}
+        >
+          {chainQuery.isLoading ? (
+            <p className="py-1 text-sm text-muted-foreground">Loading chain…</p>
+          ) : chain.length === 0 ? (
+            <p className="py-1 text-sm text-muted-foreground">
+              No chain captured yet — run a probe.
+            </p>
+          ) : (
+            <div className="space-y-2 py-1">
+              {chain.map((c) => (
+                <div
+                  key={c.position}
+                  className="rounded-md border px-2.5 py-1.5"
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        "rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider",
+                        chainRoleCls(c.role),
+                      )}
+                    >
+                      {c.role}
+                    </span>
+                    <span className="min-w-0 break-words text-sm font-medium">
+                      {c.subject_cn}
+                    </span>
+                  </div>
+                  <div className="mt-1 grid grid-cols-[88px_1fr] gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground">
+                    <span>Issuer</span>
+                    <span className="break-words">{c.issuer_cn}</span>
+                    <span>Valid to</span>
+                    <span>{new Date(c.not_after).toLocaleDateString()}</span>
+                    <span>Key</span>
+                    <span>
+                      {c.key_algo
+                        ? `${c.key_algo}${c.key_size ? ` ${c.key_size}-bit` : ""}`
+                        : DASH}
+                      {c.sig_algo ? ` · ${c.sig_algo}` : ""}
+                    </span>
+                    <span>SHA-256</span>
+                    <span className="break-all font-mono">
+                      {c.fingerprint_sha256}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </DetailSection>
+
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setShowPem((v) => !v)}
+            className="text-xs font-medium text-primary hover:underline"
+          >
+            {showPem ? "Hide" : "Show"} PEM
+          </button>
+          {showPem && (
+            <pre className="mt-2 max-h-64 overflow-auto rounded-md border bg-muted/40 p-2 text-[11px] leading-tight">
+              {chainQuery.isLoading
+                ? "Loading…"
+                : chainQuery.isError
+                  ? "No successful probe captured a certificate yet."
+                  : (chainQuery.data?.chain_pem ??
+                    chainQuery.data?.leaf_pem ??
+                    "No PEM captured.")}
+            </pre>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-5 flex justify-end gap-2 border-t pt-3">
+        <button
+          type="button"
+          disabled={probe.isPending}
+          onClick={() => probe.mutate()}
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+        >
+          <RefreshCw
+            className={cn("h-3.5 w-3.5", probe.isPending && "animate-spin")}
+          />
+          {probe.isPending ? "Probing…" : "Probe now"}
+        </button>
+        <button
+          type="button"
+          onClick={onEdit}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Close
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────
+
+export function CertificatesPage() {
+  const qc = useQueryClient();
+  const { enabled, ready } = useFeatureModules();
+  const moduleOn = enabled("security.tls_certs");
+
+  const [search, setSearch] = useState("");
+  const [stateFilter, setStateFilter] = useState<TLSCertState | "">("");
+  const [sourceFilter, setSourceFilter] = useState<TLSCertSource | "">("");
+  const [editing, setEditing] = useState<TLSCertTarget | null>(null);
+  const [detail, setDetail] = useState<TLSCertTarget | null>(null);
+  const [showNew, setShowNew] = useState(false);
+  const [confirm, setConfirm] = useState<{
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    onConfirm: () => void;
+  } | null>(null);
+
+  // Saved-views payload (#77) — the page's filter state, stored verbatim.
+  type CertsViewPayload = {
+    search: string;
+    state: TLSCertState | "";
+    source: TLSCertSource | "";
+  };
+  const viewPayload: CertsViewPayload = {
+    search,
+    state: stateFilter,
+    source: sourceFilter,
+  };
+  function applyView(p: CertsViewPayload) {
+    setSearch(typeof p.search === "string" ? p.search : "");
+    setStateFilter((p.state ?? "") as TLSCertState | "");
+    setSourceFilter((p.source ?? "") as TLSCertSource | "");
+  }
+
+  const query = useQuery({
+    queryKey: ["tls-certs", "list", search, stateFilter, sourceFilter],
+    queryFn: () =>
+      tlsCertsApi.list({
+        limit: 500,
+        search: search || undefined,
+        state: (stateFilter || undefined) as TLSCertState | undefined,
+        source: (sourceFilter || undefined) as TLSCertSource | undefined,
+      }),
+    enabled: ready && moduleOn,
+  });
+
+  const items = query.data?.items ?? [];
+
+  const probeNow = useMutation({
+    mutationFn: (id: string) => tlsCertsApi.probeNow(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tls-certs"] }),
+  });
+
+  const removeOne = useMutation({
+    mutationFn: (id: string) => tlsCertsApi.remove(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tls-certs"] }),
+  });
+
+  if (ready && !moduleOn) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        TLS certificate monitoring is disabled. An administrator can enable the
+        "security.tls_certs" feature module in Settings → Features.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto p-6">
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <h1 className="flex items-center gap-2 text-xl font-semibold">
+              <ShieldCheck className="h-5 w-5 text-muted-foreground" />
+              TLS certificates
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Watch list of TLS endpoints — subject, issuer, validity window and
+              chain status are probed on a schedule (or on demand) so expiring
+              and misconfigured certs surface before they break clients.
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <SavedViewsMenu
+              page="network.certificates"
+              currentPayload={viewPayload}
+              onApply={applyView}
+            />
+            <HeaderButton
+              icon={RefreshCw}
+              onClick={() => query.refetch()}
+              iconClassName={query.isFetching ? "animate-spin" : undefined}
+            >
+              Refresh
+            </HeaderButton>
+            <HeaderButton
+              variant="primary"
+              icon={Plus}
+              onClick={() => setShowNew(true)}
+            >
+              New target
+            </HeaderButton>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            className={cn(inputCls, "max-w-xs")}
+            placeholder="Search host / subject / issuer…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <select
+            className={cn(inputCls, "max-w-[180px]")}
+            value={stateFilter}
+            onChange={(e) => setStateFilter(e.target.value as TLSCertState | "")}
+          >
+            <option value="">All states</option>
+            {TLS_CERT_STATES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <select
+            className={cn(inputCls, "max-w-[180px]")}
+            value={sourceFilter}
+            onChange={(e) =>
+              setSourceFilter(e.target.value as TLSCertSource | "")
+            }
+          >
+            <option value="">All sources</option>
+            <option value="manual">manual</option>
+            <option value="discovered">discovered</option>
+          </select>
+        </div>
+
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 text-left">Host</th>
+                <th className="px-3 py-2 text-left">State</th>
+                <th className="px-3 py-2 text-left">Issuer</th>
+                <th className="px-3 py-2 text-left">Expires</th>
+                <th className="px-3 py-2 text-left">Chain</th>
+                <th className="px-3 py-2 text-left">Source</th>
+                <th className="px-3 py-2 text-left">Last checked</th>
+                <th className="w-28 px-3 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className={zebraBodyCls}>
+              {query.isLoading && (
+                <tr>
+                  <td
+                    className="px-3 py-6 text-center text-muted-foreground"
+                    colSpan={8}
+                  >
+                    Loading…
+                  </td>
+                </tr>
+              )}
+              {!query.isLoading && items.length === 0 && (
+                <tr>
+                  <td
+                    className="px-3 py-6 text-center text-muted-foreground"
+                    colSpan={8}
+                  >
+                    No targets yet — click "New target" to add one.
+                  </td>
+                </tr>
+              )}
+              {items.map((t) => (
+                <tr
+                  key={t.id}
+                  className="cursor-pointer border-t hover:bg-muted/30"
+                  onClick={() => setDetail(t)}
+                  title="View certificate details"
+                >
+                  <td className="px-3 py-2 align-top break-words">
+                    <div className="font-medium">
+                      {t.host}
+                      <span className="text-muted-foreground">:{t.port}</span>
+                    </div>
+                    {t.display_name && (
+                      <div className="text-[11px] text-muted-foreground">
+                        {t.display_name}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <TLSStateBadge state={t.state} />
+                  </td>
+                  <td className="px-3 py-2 align-top break-words text-muted-foreground">
+                    {t.issuer_cn ?? "—"}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <NotAfterCell
+                      notAfter={t.not_after}
+                      daysRemaining={t.days_remaining}
+                    />
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <ChainBadge target={t} />
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <SourceChip source={t.source} />
+                  </td>
+                  <td className="px-3 py-2 align-top text-[11px] tabular-nums text-muted-foreground">
+                    {fmtDateTime(t.last_checked_at)}
+                  </td>
+                  <td
+                    className="px-3 py-2 align-top text-right"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      type="button"
+                      title="Probe now"
+                      disabled={probeNow.isPending}
+                      onClick={() => probeNow.mutate(t.id)}
+                      className="ml-1 rounded p-1 hover:bg-muted disabled:opacity-50"
+                    >
+                      <RefreshCw
+                        className={cn(
+                          "h-3.5 w-3.5",
+                          probeNow.isPending &&
+                            probeNow.variables === t.id &&
+                            "animate-spin",
+                        )}
+                      />
+                    </button>
+                    <button
+                      type="button"
+                      title="Edit"
+                      onClick={() => setEditing(t)}
+                      className="ml-1 rounded p-1 hover:bg-muted"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      title="Delete"
+                      onClick={() => {
+                        setConfirm({
+                          title: "Delete TLS cert target",
+                          message: `Delete the target "${t.display_name || t.host}"?`,
+                          confirmLabel: "Delete",
+                          onConfirm: () => removeOne.mutate(t.id),
+                        });
+                      }}
+                      className="ml-1 rounded p-1 text-destructive hover:bg-destructive/10"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {detail && (
+          <CertDetailModal
+            target={detail}
+            onClose={() => setDetail(null)}
+            onEdit={() => {
+              setEditing(detail);
+              setDetail(null);
+            }}
+          />
+        )}
+        {showNew && (
+          <CertTargetEditorModal
+            existing={null}
+            onClose={() => setShowNew(false)}
+          />
+        )}
+        {editing && (
+          <CertTargetEditorModal
+            existing={editing}
+            onClose={() => setEditing(null)}
+          />
+        )}
+        <ConfirmModal
+          open={confirm !== null}
+          title={confirm?.title ?? ""}
+          message={confirm?.message ?? ""}
+          confirmLabel={confirm?.confirmLabel}
+          tone="destructive"
+          onConfirm={() => {
+            confirm?.onConfirm();
+            setConfirm(null);
+          }}
+          onClose={() => setConfirm(null)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/network/CertificatesPage.tsx
+++ b/frontend/src/pages/network/CertificatesPage.tsx
@@ -439,6 +439,9 @@ function CertDetailModal({
 }) {
   const qc = useQueryClient();
   const [showPem, setShowPem] = useState(false);
+  // CT log is an off-prem call (leaks the hostname to crt.sh) — opt-in,
+  // fetched only when the operator expands it.
+  const [showCt, setShowCt] = useState(false);
 
   // Live row so a probe-now reflects without reopening.
   const { data: t = target } = useQuery({
@@ -453,6 +456,14 @@ function CertDetailModal({
     retry: false, // 404 until the first successful probe — don't hammer
   });
   const chain = chainQuery.data?.chain ?? [];
+
+  const ctQuery = useQuery({
+    queryKey: ["tls-certs", "ct-log", target.id],
+    queryFn: () => tlsCertsApi.ctLog(target.id, { limit: 50 }),
+    enabled: showCt,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });
 
   const probe = useMutation({
     mutationFn: () => tlsCertsApi.probeNow(target.id),
@@ -631,6 +642,69 @@ function CertDetailModal({
                     chainQuery.data?.leaf_pem ??
                     "No PEM captured.")}
             </pre>
+          )}
+        </div>
+
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={() => setShowCt((v) => !v)}
+            className="text-xs font-medium text-primary hover:underline"
+            title="Queries crt.sh — sends this hostname off-prem"
+          >
+            {showCt ? "Hide" : "Show"} CT-log cross-reference (crt.sh ↗)
+          </button>
+          {showCt && (
+            <div className="mt-2 rounded-md border">
+              {ctQuery.isLoading ? (
+                <p className="px-3 py-2 text-xs text-muted-foreground">
+                  Querying crt.sh…
+                </p>
+              ) : ctQuery.isError ? (
+                <p className="px-3 py-2 text-xs text-destructive">
+                  CT-log lookup failed.
+                </p>
+              ) : (ctQuery.data?.entries.length ?? 0) === 0 ? (
+                <p className="px-3 py-2 text-xs text-muted-foreground">
+                  {ctQuery.data?.error
+                    ? `crt.sh: ${ctQuery.data.error}`
+                    : "No CT-log entries found for this host."}
+                </p>
+              ) : (
+                <table className="w-full text-[11px]">
+                  <thead className="text-left uppercase tracking-wider text-muted-foreground">
+                    <tr className="border-b bg-muted/30">
+                      <th className="px-2 py-1">Issuer</th>
+                      <th className="px-2 py-1">Common name</th>
+                      <th className="px-2 py-1">Not before</th>
+                      <th className="px-2 py-1">Not after</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {ctQuery.data?.entries.map((e) => (
+                      <tr key={`${e.id}`} className="border-t align-top">
+                        <td className="px-2 py-1 break-words">
+                          {e.issuer_name ?? "—"}
+                        </td>
+                        <td className="px-2 py-1 break-words font-mono">
+                          {e.common_name ?? "—"}
+                        </td>
+                        <td className="px-2 py-1 tabular-nums">
+                          {e.not_before
+                            ? new Date(e.not_before).toLocaleDateString()
+                            : "—"}
+                        </td>
+                        <td className="px-2 py-1 tabular-nums">
+                          {e.not_after
+                            ? new Date(e.not_after).toLocaleDateString()
+                            : "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
Closes #118

Phase 1 of TLS certificate monitoring — watch the certs serving from the hostnames SpatiumDDI already manages, so expiring / misconfigured certs surface before they break clients. The cert inventory is a **projection of DNS state**, not a parallel list operators maintain by hand.

## Backend
- **Models** — `tls_cert_target` (connect tuple + per-row schedule + denormalised latest-known cert identity) and `tls_cert_probe` (immutable history); `auto_tls_probe` opt-in on `DNSZone` + `DNSRecord`; `tls_cert_check_interval_hours` on `PlatformSettings`. Migration `f3e8b1d72a9c` (with `NULLS NOT DISTINCT` on the connect-tuple unique constraint so the common NULL-SNI case is DB-enforced).
- **Probe** — captures the **served chain** (leaf + intermediates) via `pyOpenSSL` (stdlib `ssl` on Python 3.12 only exposes the leaf), **resolves the root** from the system trust store, and validates trust in a separate stdlib pass so a pure hostname/SAN mismatch isn't mislabeled chain-invalid. **DNS-rebinding-safe**: resolves once and pins the connect IP, re-checking every resolved address against the blocked-range list.
- **Discovery** — projects targets from opted-in A/AAAA records (deduped on the connect tuple), re-enables on record return, disables on drop, links to zones/domains by SAN suffix-match.
- **Alerts** — 4 rule kinds (`tls_cert_expiring` / `tls_cert_chain_invalid` (covers untrusted **and** SAN mismatch) / `tls_cert_unreachable` / `tls_cert_changed`), startup-seeded **disabled**.
- **Celery** — probe sweep (60 s, per-target `next_check_at`) + discovery (5 min) + prune (daily; keeps each target's latest good probe).
- **Router** `/api/v1/tls-certs` — CRUD + probe history + parsed chain + synchronous probe-now; audited (NN #4); gated on the `tls_cert` permission + `security.tls_certs` feature module (NN #14).
- **MCP** (NN #13) — `find_tls_cert` / `count_tls_certs_expiring` / `get_cert_chain` / `count_tls_targets_by_state` (read, default-on) + `propose_run_cert_probe` (write, default-off).
- **RBAC** — `tls_cert` granted to **Network Editor** (admin) + **Auditor** (read).

## Frontend
- **Network → Certificates** page (list + filters + SavedViewsMenu). The add-target modal shows the platform default cadence and probes immediately on add (row populates within seconds).
- **Click-through detail modal** — endpoint, certificate, chain & key, SANs, fingerprint, and the **full leaf → intermediate(s) → root chain** (each cert as a role-badged card) plus raw PEM.
- **Domain** + **DNS-zone** Certs tabs (the zone tab has an auto-probe toggle), a **DNS record** state pill, and a Dashboard **"Certs expiring ≤30d"** Compliance KPI.

## Notes
- Adds `pyOpenSSL` (built on the `cryptography` we already ship; `NOTICE` updated).
- Targets probed before this lands only stored the leaf; a re-probe (the row's Probe-now) populates the full chain.

## Review
Went through two adversarial multi-agent review passes; fixes folded in (SSRF resolve-once-and-pin, NULLS-NOT-DISTINCT constraint, hostname-mismatch alert coverage, discovery re-enable, blocked `0.0.0.0`/`::`, expiring-alert flap, prune-keeps-latest, …).

## Test plan
- `backend/tests/test_tls_certs.py` — 11 tests: probe state-derivation / failure-preserves-identity / fingerprint-change, discovery dedupe + disable↔re-enable cycle, alert matchers (incl. SAN-mismatch), `parse_chain_pem` roles, router CRUD + audit + 409 + SSRF-422 + feature-gate-404, MCP no-collision. All pass.
- Full AI-tools + alerts regression suite (192 tests) green — no breakage from the `alerts.py` / tool-registry changes.
- `ruff` / `black` / `mypy` + `tsc` / `eslint` clean; migration applies (single head `f3e8b1d72a9c`); lint baseline updated.
- Live-validated on the dev stack: probing `github.com` captures leaf → 2 intermediates → USERTrust ECC root (depth 4), `chain_valid=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — Phases 2 + 3 now included

**Phase 2:** `tls_cert_target.ip_address_id` (migration `c7d1f04e9a2b`); **IPAM-role-driven discovery** — `IP_ROLES` gains `web`/`api`/`lb` and the reconciler unifies DNS A/AAAA records **and** TLS-serving IPs into one candidate set (re-enable/disable on role change, dedupe on the connect tuple); a **"TLS certificates" section on the IP detail modal**; `ip_address_id` read field + list filter.

**Phase 3:** **cert-rotation deviation** — new `tls_cert_issuer_changed` alert (the transition evaluator generalised to watch `issuer_cn`; fires once when a cert returns from a **different issuing CA**); **CT-log cross-reference** — on-demand `GET /tls-certs/{id}/ct-log` (crt.sh), a default-**disabled** `find_ct_log_entries` MCP tool, and a "Show CT-log" panel in the detail modal — **off-prem/opt-in only**, never the scheduled probe.

(Ad-hoc external targets + per-cert cadence override already shipped in Phase 1.) All three phases of #118 are now implemented here.

**Added tests:** IP-role discovery (+ disable on role clear), issuer-change transition, CT-log no-host path — 14 TLS tests total, all green; lint baseline re-based for the new migration.
