### PR TITLE
fix(supervisor): write secret-bearing host-config triggers owner-only at creation (CodeQL #82)

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -875,6 +875,28 @@ def _hostcfg_should_fire(
     return True, attempts + 1
 
 
+def _write_owner_only(tmp: Path, payload: str) -> None:
+    """Write ``payload`` to ``tmp`` as an owner-only (0o600) file, with the
+    restrictive mode set *at creation* rather than after the fact.
+
+    The host-config trigger files can carry decrypted secrets — the SNMP
+    community, APT private-mirror passwords + GPG armour (#155), the syslog
+    forwarding CA material (#156), the SSH config (#157), and the k3s join
+    token (#272) — and they land in the 1777-sticky ``release-state`` dir
+    that any unprivileged host user can list. A plain ``write_text`` then
+    ``chmod(0o600)`` left a window where the file existed at the umask
+    default (typically 0644, world-readable) before the chmod landed, so a
+    local user could race-open the ``.new`` temp and read the secret.
+    ``os.open`` with ``O_CREAT`` + mode ``0o600`` closes that window;
+    ``O_NOFOLLOW`` refuses a symlink an attacker could plant in the
+    world-writable dir. The root ``.path`` runner reads as root and is
+    unaffected by the tighter mode.
+    """
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(payload)
+
+
 def _fire_host_config(
     trigger_file: Path,
     applied_hash_sidecar: Path,
@@ -901,13 +923,12 @@ def _fire_host_config(
     try:
         trigger_file.parent.mkdir(parents=True, exist_ok=True)
         tmp = trigger_file.with_suffix(".new")
-        tmp.write_text(payload, encoding="utf-8")
         # The payload can carry decrypted secrets (SNMP community, APT
-        # GPG armour + private-mirror passwords #155) and lands in the
-        # 1777-sticky release-state dir; restrict to owner-only so another
-        # unprivileged host user can't read it in the window before the
-        # root .path runner consumes it. The runner reads as root regardless.
-        tmp.chmod(0o600)
+        # GPG armour + private-mirror passwords #155, syslog CA #156, the
+        # SSH config #157) and lands in the 1777-sticky release-state dir.
+        # Create it owner-only atomically — see _write_owner_only — so no
+        # window exists where another unprivileged host user could read it.
+        _write_owner_only(tmp, payload)
         tmp.replace(trigger_file)
     except OSError:
         return False
@@ -1360,9 +1381,10 @@ def maybe_fire_cluster_join(
     try:
         _CLUSTER_JOIN_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
         tmp = _CLUSTER_JOIN_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(
-            f"{_CLUSTER_JOIN_CONFIRM}\n{server_url}\n{join_token}\n", encoding="utf-8"
-        )
+        # The join token is a control-plane-admin-equivalent secret; write
+        # it owner-only atomically (see _write_owner_only) so it can't be
+        # read by another unprivileged user out of the 1777-sticky dir.
+        _write_owner_only(tmp, f"{_CLUSTER_JOIN_CONFIRM}\n{server_url}\n{join_token}\n")
         tmp.replace(_CLUSTER_JOIN_TRIGGER_FILE)
         return True
     except OSError:

--- a/agent/supervisor/tests/test_cluster_join_triggers.py
+++ b/agent/supervisor/tests/test_cluster_join_triggers.py
@@ -8,6 +8,7 @@ sidecar readers. The actual k3s reconfigure is the host-side runner
 
 from __future__ import annotations
 
+import stat
 from pathlib import Path
 
 import pytest
@@ -41,6 +42,16 @@ def test_join_writes_trigger_with_payload(appliance_paths: Path) -> None:
     assert body == (
         f"{appliance_state._CLUSTER_JOIN_CONFIRM}\nhttps://10.0.0.1:6443\nK10::tok\n"
     )
+
+
+def test_join_trigger_is_owner_only(appliance_paths: Path) -> None:
+    # The payload carries the k3s join token (a control-plane-admin-
+    # equivalent secret) into the 1777-sticky release-state dir — the
+    # trigger file must be 0o600 so no other unprivileged host user can
+    # read it before the root runner consumes it (sec scanning #82).
+    assert appliance_state.maybe_fire_cluster_join("member", "https://s:6443", "tok") is True
+    mode = stat.S_IMODE((appliance_paths / "cluster-join-pending").stat().st_mode)
+    assert mode == 0o600
 
 
 def test_join_idempotent_until_consumed(appliance_paths: Path) -> None:

--- a/agent/supervisor/tests/test_ssh_triggers.py
+++ b/agent/supervisor/tests/test_ssh_triggers.py
@@ -9,6 +9,7 @@ reload is the host-side runner (spatiumddi-ssh-reload).
 from __future__ import annotations
 
 import json
+import stat
 from pathlib import Path
 
 import pytest
@@ -59,6 +60,16 @@ def test_enabled_writes_payload(ssh_paths: Path) -> None:
     rest = body.split("\n", 6)[6]
     assert rest.encode("utf-8")[:ak_len].decode("utf-8") == _AUTH_KEYS
     assert rest.encode("utf-8")[ak_len:].decode("utf-8") == _SSHD_CONF
+
+
+def test_trigger_is_owner_only(ssh_paths: Path) -> None:
+    # _fire_host_config writes secret-bearing payloads (here the sshd
+    # config; for the APT/SNMP planes, mirror passwords + the SNMP
+    # community) into the 1777-sticky release-state dir, so the trigger
+    # file must land 0o600 with no world-readable window (sec scanning #82).
+    assert appliance_state.maybe_fire_ssh_reload(_BLOCK) is True
+    mode = stat.S_IMODE((ssh_paths / "ssh-config-pending").stat().st_mode)
+    assert mode == 0o600
 
 
 def test_idempotent_until_consumed(ssh_paths: Path) -> None:


### PR DESCRIPTION
## What

Fixes **CodeQL alert [#82](https://github.com/spatiumddi/spatiumddi/security/code-scanning/82)** — `py/clear-text-storage-sensitive-data` (high), flagged at `appliance_state.py:904` in the supervisor's shared host-config trigger writer.

The supervisor writes decrypted secrets — the SNMP community, **APT private-mirror passwords + GPG armour** (#155), syslog forwarding CA (#156), the SSH config (#157), and the **k3s join token** (#272) — into `/var/lib/spatiumddi-host/release-state/`, which is a **`1777`-sticky world-writable** dir on the appliance.

## The concrete bug

Two flavours of the same local information-disclosure flaw:

1. **`_fire_host_config`** (the flagged line) — `write_text()` creates the `.new` temp at the umask default (`0644`, world-readable), and only the *following* `chmod(0o600)` restricts it. That's a genuine **TOCTOU window** where another unprivileged local user can race-open the temp and read the secret before the chmod lands.
2. **`maybe_fire_cluster_join`** (found while scoping the fix) — wrote the **k3s join token** (control-plane-admin-equivalent) with a bare `write_text` and **no chmod at all** → `0644` for the file's entire lifetime, not just a race window.

The reboot / verbose-boot / cluster-leave / cluster-restore / fire-state writers carry only markers/timestamps — not secrets — so they're left as-is.

## The fix

A shared `_write_owner_only` helper creates the temp **owner-only atomically**:

```python
fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
```

- Mode is set **at creation** → no world-readable window.
- `O_NOFOLLOW` refuses a symlink an attacker could plant in the world-writable dir.
- Matches the repo's existing secure-write pattern (#249 / #253).

Both secret-bearing writers (`_fire_host_config` and `maybe_fire_cluster_join`) now route through it. The root `.path` runner still reads as root and is unaffected by the tighter mode.

## Tests

- New `test_trigger_is_owner_only` (SSH plane, covers `_fire_host_config`) and `test_join_trigger_is_owner_only` (k3s join token) assert the trigger files land `0o600`.
- All 53 trigger-writer tests pass; ruff + black clean on the changed lines.
- The 4 pre-existing `test_register` / `test_smoke` failures are host-env-dependent and reproduce on clean `main` — unrelated to this change.

CodeQL re-scans on this PR and will auto-close #82 once the fix reaches a scanned ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)