### PR TITLE
feat(rbac): permission introspection (#449) + address sets (#103)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -439,6 +439,7 @@ backend/alembic/versions/e1f2a3b4c5d6_subnet_ddns_fields.py:drop_column:64
 backend/alembic/versions/e1f2a3b4c5d6_subnet_ddns_fields.py:drop_column:65
 backend/alembic/versions/e1f2a3b4c5d6_subnet_ddns_fields.py:drop_column:66
 backend/alembic/versions/e2a6f3b8c1d4_add_auto_from_lease_to_ipaddress.py:drop_column:33
+backend/alembic/versions/e2b9c4f1a7d6_address_sets.py:drop_table:104
 backend/alembic/versions/e2c91d5f7a48_appliance_pairing_codes.py:drop_table:126
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:59
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:60

--- a/backend/alembic/versions/e2b9c4f1a7d6_address_sets.py
+++ b/backend/alembic/versions/e2b9c4f1a7d6_address_sets.py
@@ -1,0 +1,102 @@
+"""address_set table + ipam.address_sets feature module (#103)
+
+Named, RBAC-scoped slices of a subnet's address space (issue #103). A
+row carries its own ``resource_type="address_set"`` identity so edit of
+a slice (e.g. ``.50``–``.99``) can be delegated without subnet-wide
+write. Plus the ``ipam.address_sets`` feature-module seed
+(default-enabled) so the ``/api/v1/address-sets`` surface gates behind
+one toggle (non-negotiable #14).
+
+Revision ID: e2b9c4f1a7d6
+Revises: d8f3a1c6e09b
+Create Date: 2026-06-20
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e2b9c4f1a7d6"
+down_revision: str | None = "d8f3a1c6e09b"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "address_set",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), server_default="", nullable=False),
+        sa.Column("subnet_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("customer_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("site_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "range_kind",
+            sa.String(length=16),
+            server_default="contiguous",
+            nullable=False,
+        ),
+        sa.Column("start_address", postgresql.INET(), nullable=True),
+        sa.Column("end_address", postgresql.INET(), nullable=True),
+        sa.Column(
+            "explicit_addresses",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "tags",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "custom_fields",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["subnet_id"], ["subnet.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["customer_id"], ["customer.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["site_id"], ["site.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("subnet_id", "name", name="uq_address_set_subnet_name"),
+        sa.CheckConstraint(
+            "end_address IS NULL OR start_address <= end_address",
+            name="ck_address_set_range_order",
+        ),
+    )
+    op.create_index("ix_address_set_subnet_id", "address_set", ["subnet_id"])
+    op.create_index("ix_address_set_customer_id", "address_set", ["customer_id"])
+    op.create_index("ix_address_set_site_id", "address_set", ["site_id"])
+
+    # ── feature_module seed (non-negotiable #14) ────────────────────────
+    op.execute(sa.text("""
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('ipam.address_sets', TRUE)
+            ON CONFLICT (id) DO NOTHING
+            """))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'ipam.address_sets'"))
+    op.drop_index("ix_address_set_site_id", table_name="address_set")
+    op.drop_index("ix_address_set_customer_id", table_name="address_set")
+    op.drop_index("ix_address_set_subnet_id", table_name="address_set")
+    op.drop_table("address_set")

--- a/backend/app/api/v1/address_sets/__init__.py
+++ b/backend/app/api/v1/address_sets/__init__.py
@@ -1,0 +1,3 @@
+from app.api.v1.address_sets.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/address_sets/router.py
+++ b/backend/app/api/v1/address_sets/router.py
@@ -28,7 +28,11 @@ from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import require_any_resource_permission, user_has_permission
-from app.models.address_set import AddressSet, validate_address_set_shape
+from app.models.address_set import (
+    EXPLICIT_ADDRESSES_MAX,
+    AddressSet,
+    validate_address_set_shape,
+)
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.ipam import Subnet
@@ -67,7 +71,7 @@ class AddressSetCreate(BaseModel):
     range_kind: str = "contiguous"
     start_address: str | None = None
     end_address: str | None = None
-    explicit_addresses: list[str] = Field(default_factory=list)
+    explicit_addresses: list[str] = Field(default_factory=list, max_length=EXPLICIT_ADDRESSES_MAX)
     tags: dict[str, Any] = Field(default_factory=dict)
     custom_fields: dict[str, Any] = Field(default_factory=dict)
 
@@ -87,12 +91,20 @@ class AddressSetUpdate(BaseModel):
     range_kind: str | None = None
     start_address: str | None = None
     end_address: str | None = None
-    explicit_addresses: list[str] | None = None
+    explicit_addresses: list[str] | None = Field(default=None, max_length=EXPLICIT_ADDRESSES_MAX)
     tags: dict[str, Any] | None = None
     custom_fields: dict[str, Any] | None = None
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _can_read_set(user: User, row: AddressSet) -> bool:
+    """Read-model (#103 security): a set is visible only to a caller who can
+    READ its parent subnet. The coarse router-level gate only proves the caller
+    holds *some* address_set permission; this scopes each row to the subnet it
+    carves from so a delegate can't enumerate the whole fleet."""
+    return user_has_permission(user, "read", "subnet", row.subnet_id)
 
 
 def _validate_range_shape(
@@ -222,7 +234,10 @@ async def list_address_sets(
         stmt = stmt.where(AddressSet.name.ilike(f"%{search}%"))
     stmt = stmt.order_by(AddressSet.name).limit(limit)
     rows = (await db.execute(stmt)).scalars().all()
-    return [_to_response(r) for r in rows]
+    # Read-model (#103 security): a caller may see a set only if they can read
+    # its parent subnet. Superadmin / IPAM-reader pass for all; a zero-subnet
+    # caller gets nothing even though the coarse address_set gate let them in.
+    return [_to_response(r) for r in rows if _can_read_set(current_user, r)]
 
 
 @router.get("/{set_id}", response_model=AddressSetResponse)
@@ -233,6 +248,10 @@ async def get_address_set(
 ) -> AddressSetResponse:
     row = await db.get(AddressSet, set_id)
     if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Address set not found.")
+    # Read-model (#103 security): scope to the parent subnet. 404 (not 403) so
+    # we don't confirm the set exists to a caller who can't read its subnet.
+    if not _can_read_set(current_user, row):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Address set not found.")
     return _to_response(row)
 
@@ -248,6 +267,11 @@ async def create_address_set(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Permission denied: need 'admin' on address_set to create.",
         )
+    # ``_validate_within_subnet`` loads + range-checks the subnet (404 if it's
+    # gone). Carving a delegation slice is a subnet-owner operation, so it ALSO
+    # requires write/admin on the PARENT SUBNET — otherwise an Address Set
+    # Editor (type-wide admin:address_set) could self-delegate write on any
+    # subnet (#103 self-escalation, finding #1).
     await _validate_within_subnet(
         db,
         body.subnet_id,
@@ -256,6 +280,11 @@ async def create_address_set(
         end_address=body.end_address,
         explicit_addresses=body.explicit_addresses,
     )
+    if not user_has_permission(current_user, "write", "subnet", body.subnet_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You need write on the parent subnet to create an address set in it.",
+        )
     # Friendly 409 rather than leaking the unique-constraint error.
     existing = (
         await db.execute(
@@ -338,6 +367,29 @@ async def update_address_set(
         k in data for k in ("range_kind", "start_address", "end_address", "explicit_addresses")
     )
     if range_touched:
+        # A change to any RANGE field is a subnet-owner operation (resize of the
+        # delegated slice), so it requires write/admin on the PARENT SUBNET — a
+        # delegate holding only scoped admin:address_set must not widen their own
+        # slice (#103, finding #2). Non-range edits (name / description / tags /
+        # custom_fields / customer_id / site_id) stay allowed for a set-scoped
+        # admin. Compare resolved-new against the stored row so a no-op resend of
+        # the same range doesn't demand subnet write.
+        cur_start = str(row.start_address) if row.start_address is not None else None
+        cur_end = str(row.end_address) if row.end_address is not None else None
+        cur_explicit = list(row.explicit_addresses or [])
+        range_changed = (
+            new_range_kind != row.range_kind
+            or new_start != cur_start
+            or new_end != cur_end
+            or new_explicit != cur_explicit
+        )
+        if range_changed and not user_has_permission(
+            current_user, "write", "subnet", row.subnet_id
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You need write on the parent subnet to resize an address set.",
+            )
         _validate_range_shape(new_range_kind, new_start, new_end, new_explicit)
         await _validate_within_subnet(
             db,

--- a/backend/app/api/v1/address_sets/router.py
+++ b/backend/app/api/v1/address_sets/router.py
@@ -28,7 +28,7 @@ from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import require_any_resource_permission, user_has_permission
-from app.models.address_set import ADDRESS_SET_RANGE_KINDS, AddressSet
+from app.models.address_set import AddressSet, validate_address_set_shape
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.ipam import Subnet
@@ -101,50 +101,16 @@ def _validate_range_shape(
     end_address: str | None,
     explicit_addresses: list[str],
 ) -> None:
-    """Validate the contiguous/explicit shape (parse-only — no subnet check)."""
-    if range_kind not in ADDRESS_SET_RANGE_KINDS:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"range_kind must be one of {sorted(ADDRESS_SET_RANGE_KINDS)}",
-        )
-    if range_kind == "contiguous":
-        if not start_address or not end_address:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="contiguous range requires start_address and end_address",
-            )
-        try:
-            s = ipaddress.ip_address(start_address)
-            e = ipaddress.ip_address(end_address)
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"invalid start/end address: {exc}",
-            ) from exc
-        if s.version != e.version:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="start_address and end_address must be the same IP family",
-            )
-        if int(s) > int(e):
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="start_address must be <= end_address",
-            )
-    else:  # explicit
-        if not explicit_addresses:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="explicit range requires a non-empty explicit_addresses list",
-            )
-        for raw in explicit_addresses:
-            try:
-                ipaddress.ip_address(raw)
-            except ValueError as exc:
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail=f"invalid address in explicit_addresses: {raw}",
-                ) from exc
+    """422-adapter over the shared ``validate_address_set_shape`` validator.
+
+    The contiguous/explicit + IPv4/IPv6 rules live once in
+    ``app.models.address_set`` so the REST surface and the AI operation
+    can't diverge; here we just turn the returned error string into an
+    HTTP 422.
+    """
+    err = validate_address_set_shape(range_kind, start_address, end_address, explicit_addresses)
+    if err is not None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=err)
 
 
 async def _validate_within_subnet(
@@ -196,19 +162,16 @@ def _to_response(row: AddressSet) -> AddressSetResponse:
 
 
 def _snapshot(row: AddressSet) -> dict[str, Any]:
-    return {
-        "name": row.name,
-        "description": row.description,
-        "subnet_id": str(row.subnet_id),
-        "customer_id": str(row.customer_id) if row.customer_id else None,
-        "site_id": str(row.site_id) if row.site_id else None,
-        "range_kind": row.range_kind,
-        "start_address": str(row.start_address) if row.start_address is not None else None,
-        "end_address": str(row.end_address) if row.end_address is not None else None,
-        "explicit_addresses": list(row.explicit_addresses or []),
-        "tags": dict(row.tags or {}),
-        "custom_fields": dict(row.custom_fields or {}),
-    }
+    """Audit snapshot — delegates to ``_to_response`` so the stored
+    old/new_value shape matches what the API returns (same INET / uuid /
+    JSONB / ``description or ""`` coercion rules), then drops the
+    server-managed identity + timestamp fields the snapshot doesn't need.
+    JSON-mode dump stringifies the uuid fields for audit storage.
+    """
+    data = _to_response(row).model_dump(mode="json")
+    for key in ("id", "created_at", "modified_at"):
+        data.pop(key, None)
+    return data
 
 
 def _audit(

--- a/backend/app/api/v1/address_sets/router.py
+++ b/backend/app/api/v1/address_sets/router.py
@@ -1,0 +1,457 @@
+"""Address sets CRUD (issue #103).
+
+A named, RBAC-scoped slice of a subnet's address space. Granting
+``write``/``admin`` on a single ``address_set`` id lets a department
+admin edit just their range of a subnet without holding subnet-wide
+write — the gate that consults these rows lives in the IPAM address
+handlers (``app.api.v1.ipam.router``).
+
+This surface CRUD-manages the set rows themselves. Read is subnet-wide
+(any ``read`` on ``address_set``); writes require ``admin`` on the
+``address_set`` type (create) or on the specific row id (update/delete).
+Every mutation writes an ``AuditLog`` row before commit (non-negotiable
+#4). The whole router gates behind the ``ipam.address_sets`` feature
+module at the v1 include (non-negotiable #14).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from datetime import datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field, model_validator
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser
+from app.core.permissions import require_any_resource_permission, user_has_permission
+from app.models.address_set import ADDRESS_SET_RANGE_KINDS, AddressSet
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.ipam import Subnet
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(dependencies=[Depends(require_any_resource_permission("address_set"))])
+
+
+# ── Schemas ──────────────────────────────────────────────────────────────
+
+
+class AddressSetResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str
+    subnet_id: uuid.UUID
+    customer_id: uuid.UUID | None
+    site_id: uuid.UUID | None
+    range_kind: str
+    start_address: str | None
+    end_address: str | None
+    explicit_addresses: list[str]
+    tags: dict[str, Any]
+    custom_fields: dict[str, Any]
+    created_at: datetime
+    modified_at: datetime
+
+
+class AddressSetCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    description: str = ""
+    subnet_id: uuid.UUID
+    customer_id: uuid.UUID | None = None
+    site_id: uuid.UUID | None = None
+    range_kind: str = "contiguous"
+    start_address: str | None = None
+    end_address: str | None = None
+    explicit_addresses: list[str] = Field(default_factory=list)
+    tags: dict[str, Any] = Field(default_factory=dict)
+    custom_fields: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _check_shape(self) -> AddressSetCreate:
+        _validate_range_shape(
+            self.range_kind, self.start_address, self.end_address, self.explicit_addresses
+        )
+        return self
+
+
+class AddressSetUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    customer_id: uuid.UUID | None = None
+    site_id: uuid.UUID | None = None
+    range_kind: str | None = None
+    start_address: str | None = None
+    end_address: str | None = None
+    explicit_addresses: list[str] | None = None
+    tags: dict[str, Any] | None = None
+    custom_fields: dict[str, Any] | None = None
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _validate_range_shape(
+    range_kind: str,
+    start_address: str | None,
+    end_address: str | None,
+    explicit_addresses: list[str],
+) -> None:
+    """Validate the contiguous/explicit shape (parse-only — no subnet check)."""
+    if range_kind not in ADDRESS_SET_RANGE_KINDS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"range_kind must be one of {sorted(ADDRESS_SET_RANGE_KINDS)}",
+        )
+    if range_kind == "contiguous":
+        if not start_address or not end_address:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="contiguous range requires start_address and end_address",
+            )
+        try:
+            s = ipaddress.ip_address(start_address)
+            e = ipaddress.ip_address(end_address)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"invalid start/end address: {exc}",
+            ) from exc
+        if s.version != e.version:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="start_address and end_address must be the same IP family",
+            )
+        if int(s) > int(e):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="start_address must be <= end_address",
+            )
+    else:  # explicit
+        if not explicit_addresses:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="explicit range requires a non-empty explicit_addresses list",
+            )
+        for raw in explicit_addresses:
+            try:
+                ipaddress.ip_address(raw)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"invalid address in explicit_addresses: {raw}",
+                ) from exc
+
+
+async def _validate_within_subnet(
+    db: DB,
+    subnet_id: uuid.UUID,
+    *,
+    range_kind: str,
+    start_address: str | None,
+    end_address: str | None,
+    explicit_addresses: list[str],
+) -> Subnet:
+    """Confirm the subnet exists and the range falls within its CIDR."""
+    subnet = await db.get(Subnet, subnet_id)
+    if subnet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found.")
+    net = ipaddress.ip_network(str(subnet.network), strict=False)
+    if range_kind == "contiguous":
+        addrs = [start_address, end_address]
+    else:
+        addrs = list(explicit_addresses)
+    for raw in addrs:
+        if raw is None:
+            continue
+        if ipaddress.ip_address(raw) not in net:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"address {raw} is outside subnet {subnet.network}",
+            )
+    return subnet
+
+
+def _to_response(row: AddressSet) -> AddressSetResponse:
+    return AddressSetResponse(
+        id=row.id,
+        name=row.name,
+        description=row.description or "",
+        subnet_id=row.subnet_id,
+        customer_id=row.customer_id,
+        site_id=row.site_id,
+        range_kind=row.range_kind,
+        start_address=str(row.start_address) if row.start_address is not None else None,
+        end_address=str(row.end_address) if row.end_address is not None else None,
+        explicit_addresses=list(row.explicit_addresses or []),
+        tags=dict(row.tags or {}),
+        custom_fields=dict(row.custom_fields or {}),
+        created_at=row.created_at,
+        modified_at=row.modified_at,
+    )
+
+
+def _snapshot(row: AddressSet) -> dict[str, Any]:
+    return {
+        "name": row.name,
+        "description": row.description,
+        "subnet_id": str(row.subnet_id),
+        "customer_id": str(row.customer_id) if row.customer_id else None,
+        "site_id": str(row.site_id) if row.site_id else None,
+        "range_kind": row.range_kind,
+        "start_address": str(row.start_address) if row.start_address is not None else None,
+        "end_address": str(row.end_address) if row.end_address is not None else None,
+        "explicit_addresses": list(row.explicit_addresses or []),
+        "tags": dict(row.tags or {}),
+        "custom_fields": dict(row.custom_fields or {}),
+    }
+
+
+def _audit(
+    db: DB,
+    *,
+    user: User,
+    action: str,
+    row: AddressSet,
+    old_value: dict[str, Any] | None = None,
+    new_value: dict[str, Any] | None = None,
+) -> None:
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=user.auth_source,
+            action=action,
+            resource_type="address_set",
+            resource_id=str(row.id),
+            resource_display=row.name,
+            old_value=old_value,
+            new_value=new_value,
+        )
+    )
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────────
+
+
+@router.get("", response_model=list[AddressSetResponse])
+async def list_address_sets(
+    current_user: CurrentUser,
+    db: DB,
+    subnet_id: uuid.UUID | None = None,
+    customer_id: uuid.UUID | None = None,
+    site_id: uuid.UUID | None = None,
+    search: str | None = None,
+    limit: int = Query(200, ge=1, le=1000),
+) -> list[AddressSetResponse]:
+    stmt = select(AddressSet)
+    if subnet_id is not None:
+        stmt = stmt.where(AddressSet.subnet_id == subnet_id)
+    if customer_id is not None:
+        stmt = stmt.where(AddressSet.customer_id == customer_id)
+    if site_id is not None:
+        stmt = stmt.where(AddressSet.site_id == site_id)
+    if search:
+        stmt = stmt.where(AddressSet.name.ilike(f"%{search}%"))
+    stmt = stmt.order_by(AddressSet.name).limit(limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_to_response(r) for r in rows]
+
+
+@router.get("/{set_id}", response_model=AddressSetResponse)
+async def get_address_set(
+    set_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: DB,
+) -> AddressSetResponse:
+    row = await db.get(AddressSet, set_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Address set not found.")
+    return _to_response(row)
+
+
+@router.post("", response_model=AddressSetResponse, status_code=status.HTTP_201_CREATED)
+async def create_address_set(
+    body: AddressSetCreate,
+    current_user: CurrentUser,
+    db: DB,
+) -> AddressSetResponse:
+    if not user_has_permission(current_user, "admin", "address_set"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied: need 'admin' on address_set to create.",
+        )
+    await _validate_within_subnet(
+        db,
+        body.subnet_id,
+        range_kind=body.range_kind,
+        start_address=body.start_address,
+        end_address=body.end_address,
+        explicit_addresses=body.explicit_addresses,
+    )
+    # Friendly 409 rather than leaking the unique-constraint error.
+    existing = (
+        await db.execute(
+            select(AddressSet.id).where(
+                AddressSet.subnet_id == body.subnet_id,
+                AddressSet.name == body.name,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f'An address set named "{body.name}" already exists on this subnet.',
+        )
+
+    row = AddressSet(
+        name=body.name,
+        description=body.description or "",
+        subnet_id=body.subnet_id,
+        customer_id=body.customer_id,
+        site_id=body.site_id,
+        range_kind=body.range_kind,
+        start_address=body.start_address,
+        end_address=body.end_address,
+        explicit_addresses=list(body.explicit_addresses),
+        tags=dict(body.tags),
+        custom_fields=dict(body.custom_fields),
+    )
+    db.add(row)
+    await db.flush()
+    _audit(db, user=current_user, action="create", row=row, new_value=_snapshot(row))
+    await db.commit()
+    await db.refresh(row)
+    logger.info(
+        "address_set.created",
+        address_set_id=str(row.id),
+        subnet_id=str(row.subnet_id),
+        range_kind=row.range_kind,
+    )
+    return _to_response(row)
+
+
+@router.put("/{set_id}", response_model=AddressSetResponse)
+async def update_address_set(
+    set_id: uuid.UUID,
+    body: AddressSetUpdate,
+    current_user: CurrentUser,
+    db: DB,
+) -> AddressSetResponse:
+    row = await db.get(AddressSet, set_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Address set not found.")
+    if not user_has_permission(current_user, "admin", "address_set", row.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied: need 'admin' on this address set.",
+        )
+
+    old_value = _snapshot(row)
+    data = body.model_dump(exclude_unset=True)
+
+    # Resolve the post-update range shape so it can be validated as a whole.
+    new_range_kind = data.get("range_kind", row.range_kind)
+    new_start = (
+        data["start_address"]
+        if "start_address" in data
+        else (str(row.start_address) if row.start_address is not None else None)
+    )
+    new_end = (
+        data["end_address"]
+        if "end_address" in data
+        else (str(row.end_address) if row.end_address is not None else None)
+    )
+    new_explicit = (
+        data["explicit_addresses"]
+        if "explicit_addresses" in data
+        else list(row.explicit_addresses or [])
+    )
+    range_touched = any(
+        k in data for k in ("range_kind", "start_address", "end_address", "explicit_addresses")
+    )
+    if range_touched:
+        _validate_range_shape(new_range_kind, new_start, new_end, new_explicit)
+        await _validate_within_subnet(
+            db,
+            row.subnet_id,
+            range_kind=new_range_kind,
+            start_address=new_start,
+            end_address=new_end,
+            explicit_addresses=new_explicit,
+        )
+
+    if "name" in data and data["name"] != row.name:
+        clash = (
+            await db.execute(
+                select(AddressSet.id).where(
+                    AddressSet.subnet_id == row.subnet_id,
+                    AddressSet.name == data["name"],
+                    AddressSet.id != row.id,
+                )
+            )
+        ).scalar_one_or_none()
+        if clash is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f'An address set named "{data["name"]}" already exists on this subnet.',
+            )
+
+    for field in (
+        "name",
+        "description",
+        "customer_id",
+        "site_id",
+        "range_kind",
+        "start_address",
+        "end_address",
+        "explicit_addresses",
+        "tags",
+        "custom_fields",
+    ):
+        if field in data:
+            setattr(row, field, data[field])
+    # Contiguous sets never carry an explicit list, and vice-versa — keep
+    # the inactive shape's columns clean so reads don't surface stale data.
+    if row.range_kind == "explicit":
+        row.start_address = None
+        row.end_address = None
+    elif row.range_kind == "contiguous":
+        row.explicit_addresses = []
+
+    _audit(
+        db,
+        user=current_user,
+        action="update",
+        row=row,
+        old_value=old_value,
+        new_value=_snapshot(row),
+    )
+    await db.commit()
+    await db.refresh(row)
+    logger.info("address_set.updated", address_set_id=str(row.id))
+    return _to_response(row)
+
+
+@router.delete("/{set_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_address_set(
+    set_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: DB,
+) -> None:
+    row = await db.get(AddressSet, set_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Address set not found.")
+    if not user_has_permission(current_user, "admin", "address_set", row.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied: need 'admin' on this address set.",
+        )
+    _audit(db, user=current_user, action="delete", row=row, old_value=_snapshot(row))
+    await db.delete(row)
+    await db.commit()
+    logger.info("address_set.deleted", address_set_id=str(set_id))

--- a/backend/app/api/v1/auth/router.py
+++ b/backend/app/api/v1/auth/router.py
@@ -42,7 +42,7 @@ from app.core.auth.user_sync import (
 )
 from app.core.auth_throttle import login_rate_limited, mfa_challenge_consume
 from app.core.demo_mode import forbid_in_demo_mode
-from app.core.permissions import is_effective_superadmin
+from app.core.permissions import effective_grants, is_effective_superadmin
 from app.core.request_meta import clean_user_agent
 from app.core.security import (
     create_access_token,
@@ -141,6 +141,17 @@ class UserResponse(BaseModel):
     auth_source: str
 
     model_config = {"from_attributes": True}
+
+
+class PermissionGrant(BaseModel):
+    action: str
+    resource_type: str
+    resource_id: str | None = None
+
+
+class MyPermissionsResponse(BaseModel):
+    is_superadmin: bool
+    grants: list[PermissionGrant]
 
 
 class ChangePasswordRequest(BaseModel):
@@ -859,6 +870,41 @@ async def get_me(current_user: CurrentUser) -> UserResponse:
         is_superadmin=is_effective_superadmin(current_user),
         force_password_change=current_user.force_password_change,
         auth_source=current_user.auth_source,
+    )
+
+
+@router.get("/me/permissions", response_model=MyPermissionsResponse)
+async def get_my_permissions(current_user: CurrentUser) -> MyPermissionsResponse:
+    """Return the calling credential's effective permission grants (issue #449).
+
+    Self-only introspection: reads only ``current_user`` (no user-id param, no
+    DB query by id), so a caller can never enumerate another user's grants. The
+    payload is the *effective* set — static role permissions ∪ live time-bound
+    grants (issue #65), then narrowed by the active credential's API-token
+    resource grants (issue #374) — assembled by ``effective_grants`` along the
+    exact resolution path ``user_has_permission`` enforces. ``is_superadmin``
+    reports the *effective* status (legacy column OR RBAC ``{*, *}`` wildcard),
+    matching ``/auth/me``; the client short-circuits on it and treats the user
+    as omnipotent without inspecting ``grants``.
+
+    Read-only introspection → **no audit row** (consistent with ``/auth/me`` and
+    ``/auth/mfa/status``). The grant triples are already stashed on
+    ``current_user`` by the auth dependency, so the body performs no DB or
+    network IO.
+
+    Explicit non-coverage decisions:
+
+    * **MCP (#13):** no MCP tool is warranted. This is caller-credential-scoped
+      self-data with no resource ``find_*`` / ``count_*`` semantics; the MCP
+      transport exposes the read-only tool registry, not per-credential
+      introspection.
+    * **Feature module (#14):** not a new top-level resource family — it is an
+      introspection read on the existing ``/auth`` router, so no ``ModuleSpec``
+      gating applies.
+    """
+    return MyPermissionsResponse(
+        is_superadmin=is_effective_superadmin(current_user),
+        grants=[PermissionGrant(**g) for g in effective_grants(current_user)],
     )
 
 

--- a/backend/app/api/v1/ipam/io_router.py
+++ b/backend/app/api/v1/ipam/io_router.py
@@ -182,12 +182,38 @@ async def import_addresses_commit(
     """
     data = await _read_upload(file)
     payload = parse_payload(data, file.filename or "", file.content_type)
+
+    # Address-set write delegation (#103): resolve the caller's writable
+    # ranges once and refuse the whole import if they hold neither subnet-wide
+    # write nor any address set on this subnet. Otherwise pass a per-IP gate
+    # closure so rows outside the writable ranges are skipped + reported.
+    import ipaddress
+
+    from app.api.v1.ipam.router import _load_writable_set_ranges, _user_can_write_ip
+    from app.core.permissions import user_has_permission
+
+    subnet_writable = user_has_permission(current_user, "write", "subnet", subnet_id)
+    set_ranges = await _load_writable_set_ranges(db, current_user, subnet_id)
+    if not subnet_writable and not set_ranges:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No write permission on subnet or any address set on it.",
+        )
+
+    def _can_write(addr: str) -> bool:
+        try:
+            ip_int = int(ipaddress.ip_address(addr))
+        except ValueError:
+            return False
+        return _user_can_write_ip(current_user, ip_int, subnet_writable, set_ranges)
+
     result = await commit_address_import(
         db,
         payload,
         current_user=current_user,
         subnet_id=subnet_id,
         strategy=strategy,
+        can_write_ip=None if subnet_writable else _can_write,
     )
     await db.commit()
     return result.as_dict()

--- a/backend/app/api/v1/ipam/io_router.py
+++ b/backend/app/api/v1/ipam/io_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import uuid
 from typing import Literal
 
@@ -10,6 +11,11 @@ from fastapi import APIRouter, Body, File, Form, HTTPException, Query, UploadFil
 from fastapi.responses import Response
 
 from app.api.deps import DB, CurrentUser
+from app.core.permissions import user_has_permission
+from app.services.ipam.address_set_gate import (
+    load_writable_set_ranges,
+    user_can_write_ip,
+)
 from app.services.ipam_io import (
     commit_address_import,
     commit_import,
@@ -186,14 +192,10 @@ async def import_addresses_commit(
     # Address-set write delegation (#103): resolve the caller's writable
     # ranges once and refuse the whole import if they hold neither subnet-wide
     # write nor any address set on this subnet. Otherwise pass a per-IP gate
-    # closure so rows outside the writable ranges are skipped + reported.
-    import ipaddress
-
-    from app.api.v1.ipam.router import _load_writable_set_ranges, _user_can_write_ip
-    from app.core.permissions import user_has_permission
-
+    # closure so rows outside the writable ranges are skipped + reported. The
+    # gate helpers are imported at module level from the shared module (#12).
     subnet_writable = user_has_permission(current_user, "write", "subnet", subnet_id)
-    set_ranges = await _load_writable_set_ranges(db, current_user, subnet_id)
+    set_ranges = await load_writable_set_ranges(db, current_user, subnet_id)
     if not subnet_writable and not set_ranges:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -205,7 +207,7 @@ async def import_addresses_commit(
             ip_int = int(ipaddress.ip_address(addr))
         except ValueError:
             return False
-        return _user_can_write_ip(current_user, ip_int, subnet_writable, set_ranges)
+        return user_can_write_ip(current_user, ip_int, subnet_writable, set_ranges)
 
     result = await commit_address_import(
         db,

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -25,7 +25,6 @@ from app.core.permissions import (
     user_has_permission,
 )
 from app.drivers.dhcp import is_agentless
-from app.models.address_set import AddressSet
 from app.models.audit import AuditLog
 from app.models.dhcp import DHCPConfigOp, DHCPPool, DHCPScope, DHCPServer, DHCPStaticAssignment
 from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
@@ -50,6 +49,13 @@ from app.services.dhcp.windows_writethrough import (
     push_scope_delete,
     push_statics_bulk_delete,
 )
+from app.services.ipam.address_set_gate import (
+    WritableSetRanges,
+    load_writable_set_ranges,
+)
+from app.services.ipam.address_set_gate import (
+    user_can_write_ip as _user_can_write_ip,
+)
 from app.services.oui import bulk_lookup_vendors, is_voip_phone_vendor, normalize_mac_key
 from app.services.soft_delete import (
     apply_soft_delete,
@@ -61,10 +67,13 @@ logger = structlog.get_logger(__name__)
 
 # Router-level permission gate: GET → `read`, POST/PUT/PATCH → `write`,
 # DELETE → `delete`. Endpoints under /ipam manipulate IPAM resources, so we
-# accept any of the four IPAM resource types (an "IPAM Editor" role grants all
+# accept any of the IPAM resource types (an "IPAM Editor" role grants all
 # four; a scoped Subnet-writer role would be matched here for subnet routes
-# and fail for space routes — which is intended). Per-row scoping happens
-# inline in the handlers via `user_has_permission`.
+# and fail for space routes — which is intended). ``address_set`` is included
+# so the "Address Set Editor" role (admin on address_set only, #103) clears
+# this coarse gate and reaches the per-IP delegation gate
+# (``_user_can_write_ip``), which enforces the real per-row boundary. Per-row
+# scoping happens inline in the handlers via `user_has_permission`.
 router = APIRouter(
     dependencies=[
         Depends(
@@ -73,6 +82,7 @@ router = APIRouter(
                 "ip_block",
                 "subnet",
                 "ip_address",
+                "address_set",
                 "custom_field",
                 "nat_mapping",
                 "manage_ipam_templates",
@@ -613,64 +623,18 @@ def _ip_int_in_dynamic_pool(ip_int: int, ranges: list[tuple[int, int]]) -> bool:
 # ── Address-set write delegation (#103) ───────────────────────────────────
 #
 # A caller without subnet-wide ``write`` may still mutate an IP if it falls
-# inside an AddressSet they hold ``write``/``admin`` on. Resolve the writable
-# ranges once per request and check each IP against the packed int tuples.
+# inside an AddressSet they hold ``write``/``admin`` on. The gate helpers live
+# in ``app.services.ipam.address_set_gate`` (shared with the import path, #12);
+# ``_load_writable_set_ranges`` is a thin local alias preserving the original
+# call-site name.
 
 
 async def _load_writable_set_ranges(
     db: AsyncSession, user: Any, subnet_id: uuid.UUID
-) -> list[tuple[int, int]]:
-    """Return packed ``[(start_int, end_int)]`` for every AddressSet on this
-    subnet the user can WRITE (``write`` OR ``admin`` on that address_set id).
-
-    Resolved once per request; contiguous sets expand to one tuple, explicit
-    sets to one tuple per host (``(ip, ip)``). Empty when none — the caller
-    still must hold subnet write for any IP outside these ranges.
-    """
-    rows = await db.execute(
-        select(
-            AddressSet.id,
-            AddressSet.range_kind,
-            AddressSet.start_address,
-            AddressSet.end_address,
-            AddressSet.explicit_addresses,
-        ).where(AddressSet.subnet_id == subnet_id)
-    )
-    out: list[tuple[int, int]] = []
-    for set_id, range_kind, start_addr, end_addr, explicit in rows.all():
-        if not (
-            user_has_permission(user, "write", "address_set", set_id)
-            or user_has_permission(user, "admin", "address_set", set_id)
-        ):
-            continue
-        if range_kind == "contiguous" and start_addr is not None and end_addr is not None:
-            try:
-                s = int(ipaddress.ip_address(str(start_addr)))
-                e = int(ipaddress.ip_address(str(end_addr)))
-            except (ValueError, TypeError):
-                continue
-            if s > e:
-                s, e = e, s
-            out.append((s, e))
-        else:
-            for raw in explicit or []:
-                try:
-                    v = int(ipaddress.ip_address(str(raw)))
-                except (ValueError, TypeError):
-                    continue
-                out.append((v, v))
-    return out
-
-
-def _user_can_write_ip(
-    user: Any,
-    ip_int: int,
-    subnet_writable: bool,
-    set_ranges: list[tuple[int, int]],
-) -> bool:
-    """True if the caller may mutate this IP — either subnet-wide write, or
-    the IP falls inside an address set they hold write/admin on."""
-    return subnet_writable or any(s <= ip_int <= e for s, e in set_ranges)
+) -> WritableSetRanges:
+    """Resolve the caller's address-set-delegated writable ranges on this subnet
+    (alias for :func:`app.services.ipam.address_set_gate.load_writable_set_ranges`)."""
+    return await load_writable_set_ranges(db, user, subnet_id)
 
 
 def _eui64_from_mac(net: ipaddress.IPv6Network, mac: str) -> ipaddress.IPv6Address | None:
@@ -703,11 +667,20 @@ async def _pick_next_available_ip(
     *,
     strategy: str = "sequential",
     mac_address: str | None = None,
+    allowed_ranges: WritableSetRanges | None = None,
 ) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
     """Return the first free host in ``subnet`` that isn't in a dynamic pool.
 
     Shared by ``allocate_next_ip`` (which commits) and the read-only
     preview endpoint.
+
+    ``allowed_ranges`` (#8): when set, candidate IPs are constrained to the
+    caller's address-set-delegated writable space (intersected with the
+    subnet). A caller who lacks subnet-wide write but holds writable sets must
+    pass their resolved ranges here so the picker never hands out an address
+    the per-IP gate would then 403 (and reports "no available IP" only when no
+    free host inside *their* ranges exists). ``None`` = unconstrained (the
+    subnet-write-holder path).
 
     For IPv6 the ``strategy`` argument is honoured but also falls back
     to ``Subnet.ipv6_allocation_policy`` when the caller doesn't know
@@ -730,6 +703,11 @@ async def _pick_next_available_ip(
 
     dynamic_ranges = await _load_dynamic_pool_ranges(db, subnet.id)
 
+    def _allowed(ip_int: int) -> bool:
+        """#8: when the caller is address-set-delegated, the candidate must
+        fall inside their writable ranges. ``None`` = unconstrained."""
+        return allowed_ranges is None or allowed_ranges.contains(ip_int)
+
     # ── IPv6 ──────────────────────────────────────────────────────────
     if isinstance(net, ipaddress.IPv6Network):
         effective = strategy
@@ -744,7 +722,7 @@ async def _pick_next_available_ip(
 
         if effective == "eui64":
             candidate = _eui64_from_mac(net, mac_address or "")
-            if candidate is not None and str(candidate) not in used:
+            if candidate is not None and str(candidate) not in used and _allowed(int(candidate)):
                 return candidate
             # Fall through to random if EUI-64 can't be honoured (bad
             # MAC, non-/64, or collision with an existing row).
@@ -759,6 +737,8 @@ async def _pick_next_available_ip(
                 if str(host) in used:
                     continue
                 if dynamic_ranges and _ip_int_in_dynamic_pool(int(host), dynamic_ranges):
+                    continue
+                if not _allowed(int(host)):
                     continue
                 return host
             return None
@@ -786,6 +766,8 @@ async def _pick_next_available_ip(
                 continue
             if dynamic_ranges and _ip_int_in_dynamic_pool(candidate_int, dynamic_ranges):
                 continue
+            if not _allowed(candidate_int):
+                continue
             return candidate
         return None
 
@@ -803,6 +785,8 @@ async def _pick_next_available_ip(
         if str(host) in used:
             continue
         if dynamic_ranges and _ip_int_in_dynamic_pool(int(host), dynamic_ranges):
+            continue
+        if not _allowed(int(host)):
             continue
         return host
     return None
@@ -7675,6 +7659,19 @@ async def allocate_next_ip(
     # so a caller scoped to one set can't allocate outside it.
     subnet_writable = user_has_permission(current_user, "write", "subnet", subnet_id)
     set_ranges = await _load_writable_set_ranges(db, current_user, subnet_id)
+    # #8: a caller with neither subnet-wide write nor any writable address set
+    # on this subnet can't allocate anywhere — 403 early with a clear message
+    # rather than scanning the subnet and 403'ing per-candidate. When the
+    # caller IS address-set-delegated (no subnet write), constrain the
+    # candidate space to their writable ranges so the picker never hands out
+    # an address outside them (which would then 403, or report "none available"
+    # while free IPs exist outside their reach).
+    if not subnet_writable and not set_ranges:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No write permission on this subnet or any address set on it.",
+        )
+    allowed_ranges = None if subnet_writable else set_ranges
     if subnet.kind == "multicast":
         raise HTTPException(
             status_code=422,
@@ -7707,15 +7704,23 @@ async def allocate_next_ip(
         subnet,
         strategy=body.strategy,
         mac_address=body.mac_address,
+        allowed_ranges=allowed_ranges,
     )
     if chosen is None:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
+        # Tailor the message: a delegated caller's "none" means none free
+        # inside THEIR ranges, not the whole subnet.
+        if allowed_ranges is not None:
+            detail = (
+                "No available IP addresses inside the address set(s) you can "
+                "write on this subnet (every host is allocated or in a dynamic "
+                "DHCP pool)."
+            )
+        else:
+            detail = (
                 "No available IP addresses in this subnet (every free host "
                 "is reserved or falls in a dynamic DHCP pool)."
-            ),
-        )
+            )
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
 
     if not _user_can_write_ip(current_user, int(chosen), subnet_writable, set_ranges):
         raise HTTPException(
@@ -8293,9 +8298,9 @@ async def bulk_delete_addresses(
     subnets_touched: set[uuid.UUID] = set()
     # Address-set write delegation (#103): resolve writable ranges once per
     # distinct subnet so a per-IP check is cheap.
-    set_gate_cache: dict[uuid.UUID, tuple[bool, list[tuple[int, int]]]] = {}
+    set_gate_cache: dict[uuid.UUID, tuple[bool, WritableSetRanges]] = {}
 
-    async def _gate_for(sid: uuid.UUID) -> tuple[bool, list[tuple[int, int]]]:
+    async def _gate_for(sid: uuid.UUID) -> tuple[bool, WritableSetRanges]:
         if sid not in set_gate_cache:
             set_gate_cache[sid] = (
                 user_has_permission(current_user, "write", "subnet", sid),
@@ -8498,9 +8503,9 @@ async def bulk_edit_addresses(
     subnet_cache: dict[uuid.UUID, Subnet] = {}
     # Address-set write delegation (#103): resolve writable ranges once per
     # distinct subnet (not per IP).
-    set_gate_cache: dict[uuid.UUID, tuple[bool, list[tuple[int, int]]]] = {}
+    set_gate_cache: dict[uuid.UUID, tuple[bool, WritableSetRanges]] = {}
 
-    async def _gate_for(sid: uuid.UUID) -> tuple[bool, list[tuple[int, int]]]:
+    async def _gate_for(sid: uuid.UUID) -> tuple[bool, WritableSetRanges]:
         if sid not in set_gate_cache:
             set_gate_cache[sid] = (
                 user_has_permission(current_user, "write", "subnet", sid),

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -19,8 +19,13 @@ from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser
 from app.api.v1.ipam.io_router import router as io_router
-from app.core.permissions import require_any_resource_permission, token_scope_allows
+from app.core.permissions import (
+    require_any_resource_permission,
+    token_scope_allows,
+    user_has_permission,
+)
 from app.drivers.dhcp import is_agentless
+from app.models.address_set import AddressSet
 from app.models.audit import AuditLog
 from app.models.dhcp import DHCPConfigOp, DHCPPool, DHCPScope, DHCPServer, DHCPStaticAssignment
 from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
@@ -603,6 +608,69 @@ async def _load_dynamic_pool_ranges(
 
 def _ip_int_in_dynamic_pool(ip_int: int, ranges: list[tuple[int, int]]) -> bool:
     return any(s <= ip_int <= e for s, e in ranges)
+
+
+# ── Address-set write delegation (#103) ───────────────────────────────────
+#
+# A caller without subnet-wide ``write`` may still mutate an IP if it falls
+# inside an AddressSet they hold ``write``/``admin`` on. Resolve the writable
+# ranges once per request and check each IP against the packed int tuples.
+
+
+async def _load_writable_set_ranges(
+    db: AsyncSession, user: Any, subnet_id: uuid.UUID
+) -> list[tuple[int, int]]:
+    """Return packed ``[(start_int, end_int)]`` for every AddressSet on this
+    subnet the user can WRITE (``write`` OR ``admin`` on that address_set id).
+
+    Resolved once per request; contiguous sets expand to one tuple, explicit
+    sets to one tuple per host (``(ip, ip)``). Empty when none — the caller
+    still must hold subnet write for any IP outside these ranges.
+    """
+    rows = await db.execute(
+        select(
+            AddressSet.id,
+            AddressSet.range_kind,
+            AddressSet.start_address,
+            AddressSet.end_address,
+            AddressSet.explicit_addresses,
+        ).where(AddressSet.subnet_id == subnet_id)
+    )
+    out: list[tuple[int, int]] = []
+    for set_id, range_kind, start_addr, end_addr, explicit in rows.all():
+        if not (
+            user_has_permission(user, "write", "address_set", set_id)
+            or user_has_permission(user, "admin", "address_set", set_id)
+        ):
+            continue
+        if range_kind == "contiguous" and start_addr is not None and end_addr is not None:
+            try:
+                s = int(ipaddress.ip_address(str(start_addr)))
+                e = int(ipaddress.ip_address(str(end_addr)))
+            except (ValueError, TypeError):
+                continue
+            if s > e:
+                s, e = e, s
+            out.append((s, e))
+        else:
+            for raw in explicit or []:
+                try:
+                    v = int(ipaddress.ip_address(str(raw)))
+                except (ValueError, TypeError):
+                    continue
+                out.append((v, v))
+    return out
+
+
+def _user_can_write_ip(
+    user: Any,
+    ip_int: int,
+    subnet_writable: bool,
+    set_ranges: list[tuple[int, int]],
+) -> bool:
+    """True if the caller may mutate this IP — either subnet-wide write, or
+    the IP falls inside an address set they hold write/admin on."""
+    return subnet_writable or any(s <= ip_int <= e for s, e in set_ranges)
 
 
 def _eui64_from_mac(net: ipaddress.IPv6Network, mac: str) -> ipaddress.IPv6Address | None:
@@ -6234,6 +6302,16 @@ async def create_address(
             detail=f"Address {body.address} is not within subnet {subnet.network}",
         )
 
+    # Address-set write delegation (#103): permit if the caller holds subnet
+    # write OR write/admin on an address set covering this IP.
+    subnet_writable = user_has_permission(current_user, "write", "subnet", subnet_id)
+    set_ranges = await _load_writable_set_ranges(db, current_user, subnet_id)
+    if not _user_can_write_ip(current_user, int(addr), subnet_writable, set_ranges):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(f"No write permission on subnet or any address set covering {body.address}"),
+        )
+
     # Refuse allocation inside a dynamic DHCP pool — the DHCP server owns
     # that range and will hand it out on first ``DISCOVER``. Other pool
     # types (excluded / reserved) don't conflict with manual allocation.
@@ -6437,6 +6515,16 @@ async def update_address(
                 "DHCP server. Edit the lease or convert it to a reservation "
                 "at the source."
             ),
+        )
+
+    # Address-set write delegation (#103).
+    subnet_writable = user_has_permission(current_user, "write", "subnet", ip.subnet_id)
+    set_ranges = await _load_writable_set_ranges(db, current_user, ip.subnet_id)
+    ip_int = int(ipaddress.ip_address(str(ip.address)))
+    if not _user_can_write_ip(current_user, ip_int, subnet_writable, set_ranges):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(f"No write permission on subnet or any address set covering {ip.address}"),
         )
 
     # MAC required if transitioning to static_dhcp
@@ -6881,6 +6969,17 @@ async def delete_address(
             ),
         )
 
+    # Address-set write delegation (#103).
+    subnet_writable = user_has_permission(current_user, "write", "subnet", ip.subnet_id)
+    set_ranges = await _load_writable_set_ranges(db, current_user, ip.subnet_id)
+    if not _user_can_write_ip(
+        current_user, int(ipaddress.ip_address(str(ip.address))), subnet_writable, set_ranges
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(f"No write permission on subnet or any address set covering {ip.address}"),
+        )
+
     subnet = await db.get(Subnet, ip.subnet_id)
 
     # Clean up any DHCP static reservations tied to this IP. The FK is
@@ -7157,6 +7256,9 @@ class BulkAllocateCommitResponse(BaseModel):
     skipped_in_use: int
     skipped_in_pool: int
     skipped_fqdn_collision: int
+    # IPs the caller has no write permission on (subnet-wide nor any address
+    # set covering them) — #103 delegation.
+    skipped_no_perm: int = 0
     sample_created: list[str]
     summary: list[str]
 
@@ -7341,6 +7443,9 @@ async def bulk_allocate_commit(
     subnet = result.unique().scalar_one_or_none()
     if subnet is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
+    # Token-scope parity with the other address handlers (this one historically
+    # lacked the check).
+    _enforce_subnet_token_scope(current_user, subnet_id)
     if subnet.kind == "multicast":
         raise HTTPException(
             status_code=422,
@@ -7350,6 +7455,18 @@ async def bulk_allocate_commit(
             ),
         )
 
+    # Address-set write delegation (#103), resolved once for the whole batch.
+    subnet_writable = user_has_permission(current_user, "write", "subnet", subnet_id)
+    set_ranges = await _load_writable_set_ranges(db, current_user, subnet_id)
+
+    def _no_perm(addr: str) -> bool:
+        try:
+            return not _user_can_write_ip(
+                current_user, int(ipaddress.ip_address(addr)), subnet_writable, set_ranges
+            )
+        except ValueError:
+            return True
+
     items, _warnings, _ = await _build_bulk_allocate_candidates(db, subnet, body)
 
     skipped_in_use = sum(1 for i in items if i.in_use)
@@ -7357,7 +7474,14 @@ async def bulk_allocate_commit(
     skipped_fqdn = sum(
         1 for i in items if not i.in_use and not i.in_dynamic_pool and i.fqdn_collision
     )
-    total_conflicts = skipped_in_use + skipped_in_pool + skipped_fqdn
+    # Only IPs that survive the other conflict buckets can be perm-blocked —
+    # count them on the would-be-created set so the buckets don't double-count.
+    skipped_no_perm = sum(
+        1
+        for i in items
+        if not i.in_use and not i.in_dynamic_pool and not i.fqdn_collision and _no_perm(i.address)
+    )
+    total_conflicts = skipped_in_use + skipped_in_pool + skipped_fqdn + skipped_no_perm
 
     if body.on_collision == "abort" and total_conflicts > 0:
         raise HTTPException(
@@ -7370,6 +7494,7 @@ async def bulk_allocate_commit(
                 "conflicts_in_use": skipped_in_use,
                 "conflicts_in_pool": skipped_in_pool,
                 "conflicts_fqdn": skipped_fqdn,
+                "conflicts_no_perm": skipped_no_perm,
             },
         )
 
@@ -7381,6 +7506,8 @@ async def bulk_allocate_commit(
     async with _batched_dns_ops(db):
         for item in items:
             if item.in_use or item.in_dynamic_pool or item.fqdn_collision:
+                continue
+            if _no_perm(item.address):
                 continue
             ip = IPAddress(
                 subnet_id=subnet_id,
@@ -7431,6 +7558,7 @@ async def bulk_allocate_commit(
                 "skipped_in_use": skipped_in_use,
                 "skipped_in_pool": skipped_in_pool,
                 "skipped_fqdn": skipped_fqdn,
+                "skipped_no_perm": skipped_no_perm,
             },
         )
     )
@@ -7444,6 +7572,7 @@ async def bulk_allocate_commit(
         skipped_in_use=skipped_in_use,
         skipped_in_pool=skipped_in_pool,
         skipped_fqdn=skipped_fqdn,
+        skipped_no_perm=skipped_no_perm,
     )
 
     sample_created = (
@@ -7456,12 +7585,15 @@ async def bulk_allocate_commit(
         summary.append(f"Skipped {skipped_in_pool} IP(s) inside dynamic DHCP pools.")
     if skipped_fqdn:
         summary.append(f"Skipped {skipped_fqdn} IP(s) due to FQDN collisions.")
+    if skipped_no_perm:
+        summary.append(f"Skipped {skipped_no_perm} IP(s) outside your write permission.")
 
     return BulkAllocateCommitResponse(
         created=len(created_addrs),
         skipped_in_use=skipped_in_use,
         skipped_in_pool=skipped_in_pool,
         skipped_fqdn_collision=skipped_fqdn,
+        skipped_no_perm=skipped_no_perm,
         sample_created=sample_created,
         summary=summary,
     )
@@ -7539,6 +7671,10 @@ async def allocate_next_ip(
     if subnet is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
     _enforce_subnet_token_scope(current_user, subnet_id)
+    # Resolve address-set write delegation (#103) once, before the pick loop
+    # so a caller scoped to one set can't allocate outside it.
+    subnet_writable = user_has_permission(current_user, "write", "subnet", subnet_id)
+    set_ranges = await _load_writable_set_ranges(db, current_user, subnet_id)
     if subnet.kind == "multicast":
         raise HTTPException(
             status_code=422,
@@ -7579,6 +7715,12 @@ async def allocate_next_ip(
                 "No available IP addresses in this subnet (every free host "
                 "is reserved or falls in a dynamic DHCP pool)."
             ),
+        )
+
+    if not _user_can_write_ip(current_user, int(chosen), subnet_writable, set_ranges):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(f"No write permission on subnet or any address set covering {chosen}"),
         )
 
     ip = IPAddress(
@@ -8149,6 +8291,17 @@ async def bulk_delete_addresses(
     deleted = 0
     skipped: list[uuid.UUID] = []
     subnets_touched: set[uuid.UUID] = set()
+    # Address-set write delegation (#103): resolve writable ranges once per
+    # distinct subnet so a per-IP check is cheap.
+    set_gate_cache: dict[uuid.UUID, tuple[bool, list[tuple[int, int]]]] = {}
+
+    async def _gate_for(sid: uuid.UUID) -> tuple[bool, list[tuple[int, int]]]:
+        if sid not in set_gate_cache:
+            set_gate_cache[sid] = (
+                user_has_permission(current_user, "write", "subnet", sid),
+                await _load_writable_set_ranges(db, current_user, sid),
+            )
+        return set_gate_cache[sid]
 
     for ip in rows:
         if ip.status in ("network", "broadcast"):
@@ -8160,6 +8313,14 @@ async def bulk_delete_addresses(
         # Resource-scoped token (#374): skip IPs outside the token's bound
         # subnet so a subnet-scoped token can't bulk-delete across subnets.
         if not token_scope_allows(current_user, "subnet", ip.subnet_id):
+            skipped.append(ip.id)
+            continue
+        # Address-set write delegation (#103): skip IPs the caller has no
+        # write permission on (subnet-wide nor any covering address set).
+        subnet_writable, set_ranges = await _gate_for(ip.subnet_id)
+        if not _user_can_write_ip(
+            current_user, int(ipaddress.ip_address(str(ip.address))), subnet_writable, set_ranges
+        ):
             skipped.append(ip.id)
             continue
         subnet = await db.get(Subnet, ip.subnet_id)
@@ -8335,6 +8496,17 @@ async def bulk_edit_addresses(
 
     # Cache the subnet rows so per-IP DNS sync doesn't re-query for every row.
     subnet_cache: dict[uuid.UUID, Subnet] = {}
+    # Address-set write delegation (#103): resolve writable ranges once per
+    # distinct subnet (not per IP).
+    set_gate_cache: dict[uuid.UUID, tuple[bool, list[tuple[int, int]]]] = {}
+
+    async def _gate_for(sid: uuid.UUID) -> tuple[bool, list[tuple[int, int]]]:
+        if sid not in set_gate_cache:
+            set_gate_cache[sid] = (
+                user_has_permission(current_user, "write", "subnet", sid),
+                await _load_writable_set_ranges(db, current_user, sid),
+            )
+        return set_gate_cache[sid]
 
     # A zone re-assignment edit fans the same op out to one new zone across
     # every selected IP — batch per zone so an agentless Windows-DNS primary
@@ -8353,6 +8525,17 @@ async def bulk_edit_addresses(
             # Resource-scoped token (#374): a subnet-scoped token can't bulk-edit
             # IPs outside its bound subnet.
             if not token_scope_allows(current_user, "subnet", ip.subnet_id):
+                skipped.append(ip.id)
+                continue
+            # Address-set write delegation (#103): skip IPs the caller has no
+            # write permission on (subnet-wide nor any covering address set).
+            subnet_writable, set_ranges = await _gate_for(ip.subnet_id)
+            if not _user_can_write_ip(
+                current_user,
+                int(ipaddress.ip_address(str(ip.address))),
+                subnet_writable,
+                set_ranges,
+            ):
                 skipped.append(ip.id)
                 continue
 

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import selectinload
 from app.api.deps import DB, CurrentUser
 from app.api.v1.ipam.io_router import router as io_router
 from app.core.permissions import (
-    require_any_resource_permission,
+    require_any_resource_or_scoped,
     token_scope_allows,
     user_has_permission,
 )
@@ -77,15 +77,25 @@ logger = structlog.get_logger(__name__)
 router = APIRouter(
     dependencies=[
         Depends(
-            require_any_resource_permission(
-                "ip_space",
-                "ip_block",
-                "subnet",
-                "ip_address",
-                "address_set",
-                "custom_field",
-                "nat_mapping",
-                "manage_ipam_templates",
+            require_any_resource_or_scoped(
+                # Unscoped types: a normal (type-level / wildcard) grant on any
+                # of these admits the request.
+                (
+                    "ip_space",
+                    "ip_block",
+                    "subnet",
+                    "ip_address",
+                    "custom_field",
+                    "nat_mapping",
+                    "manage_ipam_templates",
+                ),
+                # Scoped-admit types (write/delete only): a delegate holding only
+                # an instance-scoped ``{write, address_set, <id>}`` grant clears
+                # this coarse gate and reaches the per-IP gate
+                # (``_user_can_write_ip``), which enforces the real range boundary
+                # (#103). require_any_resource_permission's unscoped check would
+                # 403 such a delegate before delegation ever runs.
+                ("address_set",),
             )
         )
     ]

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 
 from app.api.v1.acme import router as acme_router
+from app.api.v1.address_sets import router as address_sets_router
 from app.api.v1.admin.agent_keys import router as agent_keys_router
 from app.api.v1.admin.containers import router as containers_router
 from app.api.v1.admin.feature_modules import router as feature_modules_router
@@ -81,6 +82,12 @@ api_v1_router = APIRouter()
 # Tags are alphabetised so the ReDoc / Swagger surface lists sections
 # A → Z. New entries should be inserted in sort order.
 api_v1_router.include_router(acme_router, prefix="/acme", tags=["acme"])
+api_v1_router.include_router(
+    address_sets_router,
+    prefix="/address-sets",
+    dependencies=[Depends(require_module("ipam.address_sets"))],
+    tags=["address-sets"],
+)
 api_v1_router.include_router(
     ai_router,
     prefix="/ai",

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -261,6 +261,68 @@ def _user_rbac_allows(user: User, action: str, resource_type: str, req_rid: str 
     return False
 
 
+def effective_grants(user: User) -> list[dict]:
+    """Assemble the deduped, effective permission triples ``user`` resolves to.
+
+    Mirrors the resolution path of :func:`user_has_permission` exactly so the
+    list answers "which (action, resource_type, resource_id) does this caller
+    actually get?" for self-introspection (``GET /auth/me/permissions``):
+
+    * static role permissions (``group → role → permissions``)
+    * ∪ live time-bound grants (issue #65, stashed on
+      ``_active_time_bound_grants`` by the auth dep)
+    * **then narrowed** by the active credential's API-token resource grants
+      (issue #374) — a resource-scoped token only ever shrinks the owner's set,
+      so the returned list is the intersection that ``user_has_permission``
+      enforces.
+
+    Resource ids are normalised through :func:`_perm_triple` so ``""`` / ``"*"``
+    collapse to ``None`` (any-instance). A legacy-column superadmin with no RBAC
+    wildcard gets a synthetic ``{*, *}`` entry appended so the list is non-empty
+    and backs the client-side ``is_superadmin`` short-circuit. Returns ``[]`` for
+    an inactive user (mirrors ``user_has_permission`` failing closed).
+
+    Pure / synchronous — reads only attributes already stashed on ``user`` by
+    the auth dependency; performs no DB or network IO.
+    """
+    if not user.is_active:
+        return []
+
+    triples: set[tuple[str, str, str | None]] = set()
+
+    # Legacy-column superadmin without an RBAC wildcard role: surface the
+    # wildcard explicitly so the introspection payload is non-empty.
+    if user.is_superadmin:
+        triples.add(("*", "*", None))
+
+    # Static role permissions.
+    for group in user.groups:
+        for role in group.roles:
+            for perm in role.permissions or []:
+                triple = _perm_triple(perm)
+                if triple is not None:
+                    triples.add(triple)
+
+    # Additive union over any live time-bound grants (issue #65).
+    for grant in getattr(user, "_active_time_bound_grants", None) or []:
+        triple = _perm_triple(grant)
+        if triple is not None:
+            triples.add(triple)
+
+    # Token narrowing (issue #374): when the active credential is a
+    # resource-scoped token, keep only triples the token also permits — the
+    # exact intersection ``user_has_permission`` applies.
+    token_grants = _token_grants_for(user)
+    if token_grants:
+        triples = {t for t in triples if _token_grants_allow(token_grants, t[0], t[1], t[2])}
+
+    ordered = sorted(triples, key=lambda t: (t[1], t[0], t[2] or ""))
+    return [
+        {"action": action, "resource_type": resource_type, "resource_id": rid}
+        for action, resource_type, rid in ordered
+    ]
+
+
 # ── Privilege ceiling for delegated role / group editing ──────────────────────
 #
 # SECURITY (#400, finding C4): a non-superadmin holding a delegated
@@ -524,6 +586,7 @@ KNOWN_MANAGE_PERMISSIONS: frozenset[str] = frozenset(
 __all__ = [
     "KNOWN_MANAGE_PERMISSIONS",
     "caller_can_grant",
+    "effective_grants",
     "is_effective_superadmin",
     "require_any_permission",
     "require_any_resource_permission",

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -277,10 +277,12 @@ def effective_grants(user: User) -> list[dict]:
       enforces.
 
     Resource ids are normalised through :func:`_perm_triple` so ``""`` / ``"*"``
-    collapse to ``None`` (any-instance). A legacy-column superadmin with no RBAC
-    wildcard gets a synthetic ``{*, *}`` entry appended so the list is non-empty
-    and backs the client-side ``is_superadmin`` short-circuit. Returns ``[]`` for
-    an inactive user (mirrors ``user_has_permission`` failing closed).
+    collapse to ``None`` (any-instance). A legacy-column superadmin
+    (``user.is_superadmin``) always gets a synthetic ``{*, *}`` entry added
+    before role processing so the list is non-empty and backs the client-side
+    ``is_superadmin`` short-circuit; if a role already carries the RBAC wildcard
+    the set-dedup makes the synthetic add a harmless no-op. Returns ``[]`` for an
+    inactive user (mirrors ``user_has_permission`` failing closed).
 
     Pure / synchronous — reads only attributes already stashed on ``user`` by
     the auth dependency; performs no DB or network IO.
@@ -290,8 +292,10 @@ def effective_grants(user: User) -> list[dict]:
 
     triples: set[tuple[str, str, str | None]] = set()
 
-    # Legacy-column superadmin without an RBAC wildcard role: surface the
-    # wildcard explicitly so the introspection payload is non-empty.
+    # Legacy-column superadmin: surface the wildcard explicitly so the
+    # introspection payload is non-empty. Added unconditionally before role
+    # processing — if a role already carries ``{*, *}`` the set-dedup makes
+    # this a harmless no-op.
     if user.is_superadmin:
         triples.add(("*", "*", None))
 
@@ -310,11 +314,50 @@ def effective_grants(user: User) -> list[dict]:
             triples.add(triple)
 
     # Token narrowing (issue #374): when the active credential is a
-    # resource-scoped token, keep only triples the token also permits — the
-    # exact intersection ``user_has_permission`` applies.
+    # resource-scoped token, intersect the RBAC set with the token's grants so
+    # ``permissionMatch`` over the returned list equals ``user_has_permission``
+    # for EVERY (action, resource_type, resource_id).
+    #
+    # The scoped path (``rid is not None``) reuses ``_token_grants_allow``'s
+    # exact check verbatim. The any-instance path (``rid is None``) must NOT be
+    # kept verbatim — ``_token_grants_allow`` returns True for a None req_rid as
+    # a COARSE router gate (so the request reaches the handler), but enforcement
+    # via per-row ``token_scope_allows`` is narrower. Keeping the broad
+    # ``(a, ty, None)`` triple here over-reports: it would claim any-instance
+    # access the token doesn't actually grant. So for a None-rid RBAC triple we
+    # substitute the token's own narrower scoped ids: if a covering grant is
+    # itself any-instance (None/``""``/``*``) we keep ``(a, ty, None)``; for each
+    # scoped covering grant we emit ``(a, ty, <grant.resource_id>)`` instead. A
+    # grant "covers" the action under the same rule ``_token_grants_allow`` uses
+    # (``_action_matches`` OR the read-implies-write/delete relaxation).
     token_grants = _token_grants_for(user)
     if token_grants:
-        triples = {t for t in triples if _token_grants_allow(token_grants, t[0], t[1], t[2])}
+        narrowed: set[tuple[str, str, str | None]] = set()
+        for action, resource_type, rid in triples:
+            if rid is not None:
+                # Scoped RBAC triple — keep iff the token also permits that
+                # exact instance (unchanged exact-scope intersection).
+                if _token_grants_allow(token_grants, action, resource_type, rid):
+                    narrowed.add((action, resource_type, rid))
+                continue
+            # Any-instance RBAC triple — narrow by each covering token grant.
+            for g in token_grants:
+                g_action = g.get("action", "")
+                action_ok = _action_matches(g_action, action) or (
+                    action == "read" and g_action in ("write", "delete")
+                )
+                if not action_ok:
+                    continue
+                if not _resource_type_matches(g.get("resource_type", ""), resource_type):
+                    continue
+                g_rid = g.get("resource_id")
+                if g_rid is None or g_rid == "" or g_rid == "*":
+                    # Token grant is itself any-instance — the broad triple holds.
+                    narrowed.add((action, resource_type, None))
+                else:
+                    # Substitute the token's narrower scoped id.
+                    narrowed.add((action, resource_type, str(g_rid)))
+        triples = narrowed
 
     ordered = sorted(triples, key=lambda t: (t[1], t[0], t[2] or ""))
     return [

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -608,6 +608,83 @@ def require_any_resource_permission(
     return _dep
 
 
+def has_any_grant_for(user: User, action: str, resource_type: str) -> bool:
+    """True if the user holds ANY grant matching ``(action, resource_type)``,
+    SCOPED OR UNSCOPED — ``resource_id`` is ignored.
+
+    For COARSE router gates that must admit an instance-scoped delegate so a
+    downstream per-row gate can enforce the real boundary. The ordinary
+    ``require_*_resource_permission`` dependencies do an *unscoped* check
+    (``resource_id=None``) which a purely instance-scoped grant fails:
+    ``_resource_id_matches`` returns ``False`` when the request is unscoped but
+    the grant is scoped. Address-set delegation (issue #103) hands out scoped
+    ``{write, address_set, <id>}`` grants, so the IPAM router gate uses this to
+    let those callers *reach* the per-IP gate
+    (``app.services.ipam.address_set_gate``), which is the authoritative check.
+    """
+    if not user.is_active:
+        return False
+    if is_effective_superadmin(user):
+        return True
+    perms: list[object] = []
+    for group in user.groups:
+        for role in group.roles:
+            perms.extend(role.permissions or [])
+    perms.extend(getattr(user, "_active_time_bound_grants", None) or [])
+    for perm in perms:
+        triple = _perm_triple(perm)
+        if triple is None:
+            continue
+        g_action, g_type, _rid = triple
+        if _action_matches(g_action, action) and _resource_type_matches(g_type, resource_type):
+            return True
+    return False
+
+
+def require_any_resource_or_scoped(
+    unscoped_types: tuple[str, ...],
+    scoped_types: tuple[str, ...],
+) -> Callable[..., Awaitable[User]]:
+    """Coarse router gate that also admits instance-scoped delegates.
+
+    Passes if the user has the method-derived action (unscoped) on ANY
+    ``unscoped_types`` — the normal :func:`require_any_resource_permission`
+    behaviour — OR, for **mutating** methods only (write / delete, never read),
+    holds ANY grant (scoped or unscoped) on ANY ``scoped_types`` via
+    :func:`has_any_grant_for`.
+
+    The scoped admit exists for delegation types (``address_set``, #103) whose
+    real boundary is enforced by a downstream per-row gate, so a delegate with
+    only ``{write, address_set, <id>}`` clears the coarse gate and reaches that
+    gate. It is restricted to write/delete so a scoped *read* grant can never
+    widen read access to the aggregate router's data; read still requires a
+    normal (typically type-level) read grant.
+    """
+
+    async def _dep(
+        request: Request,
+        current_user: CurrentUser,
+        db: Annotated[AsyncSession, Depends(get_db)],
+    ) -> User:
+        action = _METHOD_TO_ACTION.get(request.method.upper(), "write")
+        for rt in unscoped_types:
+            if user_has_permission(current_user, action, rt):
+                return current_user
+        if action != "read":
+            for rt in scoped_types:
+                if has_any_grant_for(current_user, action, rt):
+                    return current_user
+        all_types = list(unscoped_types) + list(scoped_types)
+        first = all_types[0] if all_types else "*"
+        await _record_denial(db, current_user, request, action, first, None)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Permission denied: need '{action}' on one of {all_types}",
+        )
+
+    return _dep
+
+
 # ── Known synthetic permission resource_types ─────────────────────────────────
 #
 # Most resource_types map 1:1 to a real DB row (``ip_space``, ``dns_zone`` …),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -181,7 +181,11 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
     "Address Set Editor": (
         "Admin on address sets — delegated edit of a named IP slice within a "
         "subnet (its own range) without subnet-wide write. Grant on a specific "
-        "address-set id to scope a department admin to just their slice.",
+        "address-set id to scope a department admin to just their slice. Note: "
+        "creating a set or resizing its range additionally requires write on the "
+        "parent subnet (carving/widening a delegation slice is a subnet-owner "
+        "operation); set-scoped admins may still edit name / description / tags / "
+        "ownership without subnet write.",
         [
             {"action": "admin", "resource_type": "address_set"},
         ],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -167,6 +167,7 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
             {"action": "admin", "resource_type": "ip_block"},
             {"action": "admin", "resource_type": "subnet"},
             {"action": "admin", "resource_type": "ip_address"},
+            {"action": "admin", "resource_type": "address_set"},
             {"action": "admin", "resource_type": "vlan"},
             {"action": "admin", "resource_type": "nat_mapping"},
             {"action": "admin", "resource_type": "custom_field"},
@@ -175,6 +176,14 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
             {"action": "admin", "resource_type": "site"},
             {"action": "admin", "resource_type": "provider"},
             {"action": "admin", "resource_type": "network_service"},
+        ],
+    ),
+    "Address Set Editor": (
+        "Admin on address sets — delegated edit of a named IP slice within a "
+        "subnet (its own range) without subnet-wide write. Grant on a specific "
+        "address-set id to scope a department admin to just their slice.",
+        [
+            {"action": "admin", "resource_type": "address_set"},
         ],
     ),
     "DNS Editor": (

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.acme import ACMEAccount
 from app.models.acme_client import ACMEClientAccount, ACMEHTTPChallenge, ACMEOrder
+from app.models.address_set import ADDRESS_SET_RANGE_KINDS, AddressSet
 from app.models.ai import AIChatMessage, AIChatSession, AIProvider
 from app.models.alerts import AlertEvent, AlertRule
 from app.models.appliance import (
@@ -119,6 +120,8 @@ __all__ = [
     "ACMEClientAccount",
     "ACMEHTTPChallenge",
     "ACMEOrder",
+    "ADDRESS_SET_RANGE_KINDS",
+    "AddressSet",
     "AIChatMessage",
     "AIChatSession",
     "AIProvider",

--- a/backend/app/models/address_set.py
+++ b/backend/app/models/address_set.py
@@ -22,6 +22,7 @@ once its subnet is gone.
 
 from __future__ import annotations
 
+import ipaddress
 import uuid
 
 from sqlalchemy import (
@@ -41,6 +42,46 @@ from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
 # ``contiguous`` — a ``start_address``..``end_address`` span.
 # ``explicit``   — an arbitrary list of host addresses in ``explicit_addresses``.
 ADDRESS_SET_RANGE_KINDS: frozenset[str] = frozenset({"contiguous", "explicit"})
+
+
+def validate_address_set_shape(
+    range_kind: str,
+    start_address: str | None,
+    end_address: str | None,
+    explicit_addresses: list[str],
+) -> str | None:
+    """Validate the contiguous/explicit shape (parse-only — no subnet check).
+
+    Single source of truth for the contiguous/explicit + IPv4/IPv6 rules,
+    shared by the REST router (``api.v1.address_sets.router``) and the AI
+    operation (``services.ai.operations``) so the two surfaces can't
+    diverge. Returns ``None`` when the shape is valid, otherwise an
+    operator-readable error string. Each call site adapts the string into
+    its own error surface (HTTP 422 vs ``PreviewResult.detail``).
+    """
+    if range_kind not in ADDRESS_SET_RANGE_KINDS:
+        return f"range_kind must be one of {sorted(ADDRESS_SET_RANGE_KINDS)}"
+    if range_kind == "contiguous":
+        if not start_address or not end_address:
+            return "contiguous range requires start_address and end_address"
+        try:
+            s = ipaddress.ip_address(start_address)
+            e = ipaddress.ip_address(end_address)
+        except ValueError as exc:
+            return f"invalid start/end address: {exc}"
+        if s.version != e.version:
+            return "start_address and end_address must be the same IP family"
+        if int(s) > int(e):
+            return "start_address must be <= end_address"
+    else:  # explicit
+        if not explicit_addresses:
+            return "explicit range requires a non-empty explicit_addresses list"
+        for raw in explicit_addresses:
+            try:
+                ipaddress.ip_address(raw)
+            except ValueError:
+                return f"invalid address in explicit_addresses: {raw}"
+    return None
 
 
 class AddressSet(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -110,4 +151,5 @@ class AddressSet(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 __all__ = [
     "ADDRESS_SET_RANGE_KINDS",
     "AddressSet",
+    "validate_address_set_shape",
 ]

--- a/backend/app/models/address_set.py
+++ b/backend/app/models/address_set.py
@@ -1,0 +1,113 @@
+"""Address sets — named IP ranges within a subnet with their own RBAC scope (#103).
+
+An ``AddressSet`` is a named slice of a subnet (a contiguous range such
+as ``.50``–``.99``, or an explicit list of host addresses) that carries
+its own ``resource_type="address_set"`` identity in the RBAC permission
+grammar. The point is *delegation*: granting ``write``/``admin`` on a
+single address-set id lets a department admin edit just their slice of
+a subnet's address space without holding subnet-wide write.
+
+The gate lives in the IPAM address handlers (``app.api.v1.ipam.router``):
+a mutation against an IP is permitted when the caller holds subnet
+``write`` **or** holds ``write``/``admin`` on some address set whose
+range covers that IP. The set rows themselves are CRUD-managed through
+``/api/v1/address-sets`` and gated behind the ``ipam.address_sets``
+feature module (non-negotiable #14).
+
+``customer_id`` / ``site_id`` are the logical-ownership cross-references
+(#91), ``ON DELETE SET NULL`` so deleting an owner re-tags rather than
+cascades. ``subnet_id`` is ``ON DELETE CASCADE`` — a set has no meaning
+once its subnet is gone.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import (
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import INET, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+# ``contiguous`` — a ``start_address``..``end_address`` span.
+# ``explicit``   — an arbitrary list of host addresses in ``explicit_addresses``.
+ADDRESS_SET_RANGE_KINDS: frozenset[str] = frozenset({"contiguous", "explicit"})
+
+
+class AddressSet(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A named, RBAC-scoped slice of a subnet's address space."""
+
+    __tablename__ = "address_set"
+    __table_args__ = (
+        UniqueConstraint("subnet_id", "name", name="uq_address_set_subnet_name"),
+        # ``start_address <= end_address`` whenever both are set. NULL-safe
+        # so explicit-kind sets (no contiguous bounds) pass.
+        CheckConstraint(
+            "end_address IS NULL OR start_address <= end_address",
+            name="ck_address_set_range_order",
+        ),
+        Index("ix_address_set_subnet_id", "subnet_id"),
+        Index("ix_address_set_customer_id", "customer_id"),
+        Index("ix_address_set_site_id", "site_id"),
+    )
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="", server_default="")
+
+    # Indexes are declared once in ``__table_args__`` (matching the
+    # migration's index set), so the columns themselves don't carry
+    # ``index=True`` — that would emit a second redundant index.
+    subnet_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("subnet.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Logical-ownership cross-references (#91). SET NULL so deleting an
+    # owner re-tags the set rather than cascading the set delete.
+    customer_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("customer.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    site_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("site.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # ``contiguous`` | ``explicit``
+    range_kind: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="contiguous", server_default="contiguous"
+    )
+    # Inclusive bounds for ``contiguous`` sets; NULL for ``explicit``.
+    start_address: Mapped[str | None] = mapped_column(INET, nullable=True)
+    end_address: Mapped[str | None] = mapped_column(INET, nullable=True)
+    # Host addresses for ``explicit`` sets (list of string IPs).
+    explicit_addresses: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'::jsonb")
+    )
+
+    tags: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+    custom_fields: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+
+    subnet = relationship("Subnet")
+
+
+__all__ = [
+    "ADDRESS_SET_RANGE_KINDS",
+    "AddressSet",
+]

--- a/backend/app/models/address_set.py
+++ b/backend/app/models/address_set.py
@@ -43,6 +43,14 @@ from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
 # ``explicit``   — an arbitrary list of host addresses in ``explicit_addresses``.
 ADDRESS_SET_RANGE_KINDS: frozenset[str] = frozenset({"contiguous", "explicit"})
 
+# Upper bound on the number of host addresses an ``explicit`` set may carry.
+# The write-delegation gate (``services.ipam.address_set_gate``) re-parses every
+# explicit host on EVERY IPAM mutation to build its membership set, so an
+# unbounded list is a per-request DoS vector (#103, finding #6). Enforced in
+# BOTH the Pydantic schemas (REST) and here (the shared validator the AI path +
+# any direct caller also run through), so no surface can exceed it.
+EXPLICIT_ADDRESSES_MAX: int = 1024
+
 
 def validate_address_set_shape(
     range_kind: str,
@@ -76,6 +84,11 @@ def validate_address_set_shape(
     else:  # explicit
         if not explicit_addresses:
             return "explicit range requires a non-empty explicit_addresses list"
+        if len(explicit_addresses) > EXPLICIT_ADDRESSES_MAX:
+            return (
+                f"explicit_addresses may not exceed {EXPLICIT_ADDRESSES_MAX} entries "
+                f"(got {len(explicit_addresses)})"
+            )
         for raw in explicit_addresses:
             try:
                 ipaddress.ip_address(raw)
@@ -150,6 +163,7 @@ class AddressSet(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
 __all__ = [
     "ADDRESS_SET_RANGE_KINDS",
+    "EXPLICIT_ADDRESSES_MAX",
     "AddressSet",
     "validate_address_set_shape",
 ]

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -965,9 +965,20 @@ def _address_set_targets(args: CreateAddressSetArgs) -> list[str]:
 async def _preview_create_address_set(
     db: AsyncSession, user: User, args: CreateAddressSetArgs
 ) -> PreviewResult:
+    from app.core.permissions import user_has_permission  # noqa: PLC0415 — avoid cycle
+
     subnet = await db.get(Subnet, args.subnet_id)
     if subnet is None:
         return PreviewResult(ok=False, detail=f"Subnet {args.subnet_id} not found")
+
+    # Carving a delegation slice is a subnet-owner operation — require write/admin
+    # on the PARENT SUBNET so the operator isn't shown a false "ready" preview
+    # they can't actually apply (#103, finding #3; mirrors the REST create gate).
+    if not user_has_permission(user, "write", "subnet", args.subnet_id):
+        return PreviewResult(
+            ok=False,
+            detail="You need write on the parent subnet to create an address set in it.",
+        )
 
     shape_err = _validate_address_set_shape(args)
     if shape_err is not None:
@@ -1000,12 +1011,20 @@ async def _apply_create_address_set(
     db: AsyncSession, user: User, args: CreateAddressSetArgs
 ) -> dict[str, Any]:
     from app.api.v1.dhcp._audit import write_audit  # local import to avoid cycle
+    from app.core.permissions import user_has_permission  # noqa: PLC0415 — avoid cycle
 
     enforce_operation_permission(user, _OPERATIONS["create_address_set"])
 
     subnet = await db.get(Subnet, args.subnet_id)
     if subnet is None:
         raise ValueError(f"Subnet {args.subnet_id} not found")
+
+    # Subnet-owner gate — same wording as the REST create path (#103, finding #3).
+    # ``enforce_operation_permission`` already proved type-wide admin:address_set;
+    # this additionally requires write/admin on the PARENT SUBNET so a delegate
+    # can't self-escalate by carving a slice out of a subnet they don't control.
+    if not user_has_permission(user, "write", "subnet", args.subnet_id):
+        raise ValueError("You need write on the parent subnet to create an address set in it.")
 
     shape_err = _validate_address_set_shape(args)
     if shape_err is not None:

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -35,7 +35,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.address_set import ADDRESS_SET_RANGE_KINDS, AddressSet
+from app.models.address_set import AddressSet, validate_address_set_shape
 from app.models.auth import User
 from app.models.ipam import IPAddress, IPBlock, Subnet
 from app.services.nmap import NmapArgError, build_argv
@@ -942,30 +942,18 @@ class CreateAddressSetArgs(BaseModel):
 
 
 def _validate_address_set_shape(args: CreateAddressSetArgs) -> str | None:
-    """Return an error string if the contiguous/explicit shape is invalid."""
-    if args.range_kind not in ADDRESS_SET_RANGE_KINDS:
-        return f"range_kind must be one of {sorted(ADDRESS_SET_RANGE_KINDS)}"
-    if args.range_kind == "contiguous":
-        if not args.start_address or not args.end_address:
-            return "contiguous range requires start_address and end_address"
-        try:
-            s = ipaddress.ip_address(args.start_address)
-            e = ipaddress.ip_address(args.end_address)
-        except ValueError as exc:
-            return f"invalid start/end address: {exc}"
-        if s.version != e.version:
-            return "start_address and end_address must be the same IP family"
-        if int(s) > int(e):
-            return "start_address must be <= end_address"
-    else:
-        if not args.explicit_addresses:
-            return "explicit range requires a non-empty explicit_addresses list"
-        for raw in args.explicit_addresses:
-            try:
-                ipaddress.ip_address(raw)
-            except ValueError:
-                return f"invalid address in explicit_addresses: {raw}"
-    return None
+    """Return an error string if the contiguous/explicit shape is invalid.
+
+    Thin adapter over the shared ``validate_address_set_shape`` validator
+    in ``app.models.address_set`` — the rules live there once so the AI
+    operation and the REST router can't diverge.
+    """
+    return validate_address_set_shape(
+        args.range_kind,
+        args.start_address,
+        args.end_address,
+        list(args.explicit_addresses),
+    )
 
 
 def _address_set_targets(args: CreateAddressSetArgs) -> list[str]:
@@ -1055,7 +1043,10 @@ async def _apply_create_address_set(
         db,
         user=user,
         action="create",
-        resource_type="ipam.address_set",
+        # Bare RBAC type — the audit→event mapping in event_publisher keys
+        # on "address_set" (→ "ipam.address_set"); using the namespaced
+        # string here would silence the webhook event for AI-created sets.
+        resource_type="address_set",
         resource_id=str(row.id),
         resource_display=args.name,
         new_value={

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.address_set import ADDRESS_SET_RANGE_KINDS, AddressSet
 from app.models.auth import User
 from app.models.ipam import IPAddress, IPBlock, Subnet
 from app.services.nmap import NmapArgError, build_argv
@@ -914,6 +915,183 @@ register(
         apply=_apply_create_ip_address,
         category="ipam",
         required_permission=("write", "ip_address"),
+    )
+)
+
+
+# ── create_address_set operation (issue #103) ───────────────────────────────
+
+
+class CreateAddressSetArgs(BaseModel):
+    """Args for the ``create_address_set`` operation."""
+
+    name: str = Field(description="Name of the address set (unique within the subnet)")
+    subnet_id: UUID = Field(description="UUID of the subnet to create the set in")
+    description: str = Field(default="", description="Free-form description")
+    range_kind: str = Field(
+        default="contiguous",
+        description="'contiguous' (start..end span) or 'explicit' (list of host IPs)",
+    )
+    start_address: str | None = Field(
+        default=None, description="First address of a contiguous range"
+    )
+    end_address: str | None = Field(default=None, description="Last address of a contiguous range")
+    explicit_addresses: list[str] = Field(
+        default_factory=list, description="Host addresses for an explicit set"
+    )
+
+
+def _validate_address_set_shape(args: CreateAddressSetArgs) -> str | None:
+    """Return an error string if the contiguous/explicit shape is invalid."""
+    if args.range_kind not in ADDRESS_SET_RANGE_KINDS:
+        return f"range_kind must be one of {sorted(ADDRESS_SET_RANGE_KINDS)}"
+    if args.range_kind == "contiguous":
+        if not args.start_address or not args.end_address:
+            return "contiguous range requires start_address and end_address"
+        try:
+            s = ipaddress.ip_address(args.start_address)
+            e = ipaddress.ip_address(args.end_address)
+        except ValueError as exc:
+            return f"invalid start/end address: {exc}"
+        if s.version != e.version:
+            return "start_address and end_address must be the same IP family"
+        if int(s) > int(e):
+            return "start_address must be <= end_address"
+    else:
+        if not args.explicit_addresses:
+            return "explicit range requires a non-empty explicit_addresses list"
+        for raw in args.explicit_addresses:
+            try:
+                ipaddress.ip_address(raw)
+            except ValueError:
+                return f"invalid address in explicit_addresses: {raw}"
+    return None
+
+
+def _address_set_targets(args: CreateAddressSetArgs) -> list[str]:
+    if args.range_kind == "contiguous":
+        return [a for a in (args.start_address, args.end_address) if a]
+    return list(args.explicit_addresses)
+
+
+async def _preview_create_address_set(
+    db: AsyncSession, user: User, args: CreateAddressSetArgs
+) -> PreviewResult:
+    subnet = await db.get(Subnet, args.subnet_id)
+    if subnet is None:
+        return PreviewResult(ok=False, detail=f"Subnet {args.subnet_id} not found")
+
+    shape_err = _validate_address_set_shape(args)
+    if shape_err is not None:
+        return PreviewResult(ok=False, detail=shape_err)
+
+    try:
+        net = ipaddress.ip_network(str(subnet.network), strict=False)
+    except ValueError:
+        return PreviewResult(ok=False, detail=f"Subnet network {subnet.network!r} is unparseable")
+    for raw in _address_set_targets(args):
+        if ipaddress.ip_address(raw) not in net:
+            return PreviewResult(
+                ok=False, detail=f"address {raw} is outside subnet {subnet.network}"
+            )
+
+    if args.range_kind == "contiguous":
+        scope = f"{args.start_address}–{args.end_address}"
+    else:
+        scope = f"{len(args.explicit_addresses)} explicit address(es)"
+    parts = [
+        f"Create address set {args.name!r}",
+        f"in subnet {subnet.network}{f' ({subnet.name})' if subnet.name else ''}",
+        f"kind={args.range_kind}",
+        scope,
+    ]
+    return PreviewResult(ok=True, detail="ready", preview_text=", ".join(parts))
+
+
+async def _apply_create_address_set(
+    db: AsyncSession, user: User, args: CreateAddressSetArgs
+) -> dict[str, Any]:
+    from app.api.v1.dhcp._audit import write_audit  # local import to avoid cycle
+
+    enforce_operation_permission(user, _OPERATIONS["create_address_set"])
+
+    subnet = await db.get(Subnet, args.subnet_id)
+    if subnet is None:
+        raise ValueError(f"Subnet {args.subnet_id} not found")
+
+    shape_err = _validate_address_set_shape(args)
+    if shape_err is not None:
+        raise ValueError(shape_err)
+
+    net = ipaddress.ip_network(str(subnet.network), strict=False)
+    for raw in _address_set_targets(args):
+        if ipaddress.ip_address(raw) not in net:
+            raise ValueError(f"address {raw} is outside subnet {subnet.network}")
+
+    existing = (
+        await db.execute(
+            select(AddressSet.id).where(
+                AddressSet.subnet_id == subnet.id,
+                AddressSet.name == args.name,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise ValueError(f"An address set named {args.name!r} already exists on this subnet")
+
+    row = AddressSet(
+        name=args.name,
+        description=args.description or "",
+        subnet_id=subnet.id,
+        range_kind=args.range_kind,
+        start_address=args.start_address if args.range_kind == "contiguous" else None,
+        end_address=args.end_address if args.range_kind == "contiguous" else None,
+        explicit_addresses=(list(args.explicit_addresses) if args.range_kind == "explicit" else []),
+    )
+    db.add(row)
+    await db.flush()
+
+    write_audit(
+        db,
+        user=user,
+        action="create",
+        resource_type="ipam.address_set",
+        resource_id=str(row.id),
+        resource_display=args.name,
+        new_value={
+            "subnet_id": str(subnet.id),
+            "subnet": str(subnet.network),
+            "name": args.name,
+            "range_kind": args.range_kind,
+            "via": "ai_proposal",
+        },
+    )
+    await db.commit()
+    await db.refresh(row)
+    return {
+        "id": str(row.id),
+        "name": row.name,
+        "subnet_id": str(subnet.id),
+        "range_kind": row.range_kind,
+    }
+
+
+register(
+    Operation(
+        name="create_address_set",
+        description=(
+            "Create a named, RBAC-scoped address set (a slice of a subnet's "
+            "address space) so edit of that slice can be delegated without "
+            "subnet-wide write. Pass name, subnet_id, range_kind "
+            "('contiguous' with start/end, or 'explicit' with a host list). "
+            "Always go through propose_create_address_set — never call this "
+            "directly without an explicit operator approval step."
+        ),
+        args_model=CreateAddressSetArgs,
+        preview=_preview_create_address_set,
+        apply=_apply_create_address_set,
+        category="ipam",
+        required_permission=("admin", "address_set"),
     )
 )
 

--- a/backend/app/services/ai/tools/ipam.py
+++ b/backend/app/services/ai/tools/ipam.py
@@ -21,6 +21,7 @@ from sqlalchemy import cast, func, literal, or_, select
 from sqlalchemy.dialects.postgresql import INET
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.address_set import AddressSet
 from app.models.asn import ASN
 from app.models.auth import User
 from app.models.circuit import Circuit
@@ -913,6 +914,87 @@ async def count_ipam_resources(
         "subnets": int(subnet_count or 0),
         "ip_addresses": int(ip_count or 0),
         "ip_addresses_by_status": {row[0]: int(row[1]) for row in by_status_rows},
+    }
+
+
+# ── address sets (#103) ───────────────────────────────────────────────
+
+
+class FindAddressSetsArgs(BaseModel):
+    subnet_id: str | None = Field(
+        default=None,
+        description="Filter by subnet UUID — omit to search across all subnets.",
+    )
+    search: str | None = Field(default=None, description="Substring match on the address-set name.")
+    limit: int = Field(default=200, ge=1, le=1000)
+
+
+@register_tool(
+    name="find_address_sets",
+    description=(
+        "List address sets — named, RBAC-scoped slices of a subnet's "
+        "address space (a contiguous range like .50–.99 or an explicit "
+        "list of hosts) used to delegate edit of just that slice without "
+        "subnet-wide write. Filterable by subnet and name substring."
+    ),
+    args_model=FindAddressSetsArgs,
+    category="ipam",
+)
+async def find_address_sets(
+    db: AsyncSession, user: User, args: FindAddressSetsArgs
+) -> list[dict[str, Any]] | dict[str, Any]:
+    stmt = select(AddressSet)
+    if args.subnet_id:
+        try:
+            stmt = stmt.where(AddressSet.subnet_id == uuid.UUID(args.subnet_id))
+        except ValueError:
+            return {"error": f"subnet_id {args.subnet_id!r} is not a valid UUID."}
+    if args.search:
+        stmt = stmt.where(AddressSet.name.ilike(f"%{args.search}%"))
+    stmt = stmt.order_by(AddressSet.name).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": str(s.id),
+            "name": s.name,
+            "subnet_id": str(s.subnet_id),
+            "range_kind": s.range_kind,
+            "start_address": str(s.start_address) if s.start_address is not None else None,
+            "end_address": str(s.end_address) if s.end_address is not None else None,
+            "explicit_addresses": list(s.explicit_addresses or []),
+            "customer_id": str(s.customer_id) if s.customer_id else None,
+            "site_id": str(s.site_id) if s.site_id else None,
+        }
+        for s in rows
+    ]
+
+
+class CountAddressSetsArgs(BaseModel):
+    pass
+
+
+@register_tool(
+    name="count_address_sets",
+    description=(
+        "Total count of address sets plus a breakdown by range kind "
+        "(contiguous vs explicit). Use to answer 'how many address sets "
+        "do I have?'."
+    ),
+    args_model=CountAddressSetsArgs,
+    category="ipam",
+)
+async def count_address_sets(
+    db: AsyncSession, user: User, args: CountAddressSetsArgs
+) -> dict[str, Any]:
+    total = await db.scalar(select(func.count(AddressSet.id)))
+    by_kind_rows = (
+        await db.execute(
+            select(AddressSet.range_kind, func.count(AddressSet.id)).group_by(AddressSet.range_kind)
+        )
+    ).all()
+    return {
+        "address_sets": int(total or 0),
+        "by_range_kind": {row[0]: int(row[1]) for row in by_kind_rows},
     }
 
 

--- a/backend/app/services/ai/tools/ipam.py
+++ b/backend/app/services/ai/tools/ipam.py
@@ -944,6 +944,8 @@ class FindAddressSetsArgs(BaseModel):
 async def find_address_sets(
     db: AsyncSession, user: User, args: FindAddressSetsArgs
 ) -> list[dict[str, Any]] | dict[str, Any]:
+    from app.core.permissions import user_has_permission  # noqa: PLC0415 — avoid cycle
+
     stmt = select(AddressSet)
     if args.subnet_id:
         try:
@@ -954,6 +956,10 @@ async def find_address_sets(
         stmt = stmt.where(AddressSet.name.ilike(f"%{args.search}%"))
     stmt = stmt.order_by(AddressSet.name).limit(args.limit)
     rows = (await db.execute(stmt)).scalars().all()
+    # Read-model (#103, finding #4): an MCP caller may see a set only if they can
+    # READ its parent subnet — otherwise any authenticated copilot user could
+    # enumerate the whole fleet's delegation slices. Superadmin / IPAM-reader
+    # pass for all; a zero-subnet-read caller gets nothing.
     return [
         {
             "id": str(s.id),
@@ -967,6 +973,7 @@ async def find_address_sets(
             "site_id": str(s.site_id) if s.site_id else None,
         }
         for s in rows
+        if user_has_permission(user, "read", "subnet", s.subnet_id)
     ]
 
 
@@ -988,15 +995,22 @@ class CountAddressSetsArgs(BaseModel):
 async def count_address_sets(
     db: AsyncSession, user: User, args: CountAddressSetsArgs
 ) -> dict[str, Any]:
-    total = await db.scalar(select(func.count(AddressSet.id)))
-    by_kind_rows = (
-        await db.execute(
-            select(AddressSet.range_kind, func.count(AddressSet.id)).group_by(AddressSet.range_kind)
-        )
-    ).all()
+    from app.core.permissions import user_has_permission  # noqa: PLC0415 — avoid cycle
+
+    # Count only sets whose parent subnet the caller can READ (#103, finding #4).
+    # The per-row subnet check is synchronous Python, so the SQL can't group it
+    # in-DB; pull just (subnet_id, range_kind) and aggregate the visible rows.
+    rows = (await db.execute(select(AddressSet.subnet_id, AddressSet.range_kind))).all()
+    total = 0
+    by_kind: dict[str, int] = {}
+    for subnet_id, range_kind in rows:
+        if not user_has_permission(user, "read", "subnet", subnet_id):
+            continue
+        total += 1
+        by_kind[range_kind] = by_kind.get(range_kind, 0) + 1
     return {
-        "address_sets": int(total or 0),
-        "by_range_kind": {row[0]: int(row[1]) for row in by_kind_rows},
+        "address_sets": total,
+        "by_range_kind": by_kind,
     }
 
 

--- a/backend/app/services/ai/tools/ipam.py
+++ b/backend/app/services/ai/tools/ipam.py
@@ -939,6 +939,7 @@ class FindAddressSetsArgs(BaseModel):
     ),
     args_model=FindAddressSetsArgs,
     category="ipam",
+    module="ipam.address_sets",
 )
 async def find_address_sets(
     db: AsyncSession, user: User, args: FindAddressSetsArgs
@@ -982,6 +983,7 @@ class CountAddressSetsArgs(BaseModel):
     ),
     args_model=CountAddressSetsArgs,
     category="ipam",
+    module="ipam.address_sets",
 )
 async def count_address_sets(
     db: AsyncSession, user: User, args: CountAddressSetsArgs

--- a/backend/app/services/ai/tools/proposals.py
+++ b/backend/app/services/ai/tools/proposals.py
@@ -26,6 +26,7 @@ from app.services.ai.operations import (
     AllocateMulticastGroupsArgs,
     AllocateSubnetArgs,
     ArchiveSessionArgs,
+    CreateAddressSetArgs,
     CreateAlertRuleArgs,
     CreateDHCPStaticArgs,
     CreateDNSRecordArgs,
@@ -258,6 +259,32 @@ async def _propose_via(
         preview_text=preview.preview_text,
     )
     return _proposal_result(proposal, preview_text=preview.preview_text)
+
+
+# ── propose_create_address_set (issue #103) ───────────────────────────
+
+
+@register_tool(
+    name="propose_create_address_set",
+    description=(
+        "Prepare an address-set creation proposal. Operator must click "
+        "Approve in the chat drawer to apply. An address set is a named, "
+        "RBAC-scoped slice of a subnet (a contiguous range or an explicit "
+        "host list) used to delegate edit of just that slice without "
+        "subnet-wide write. Pass name, subnet_id, range_kind "
+        "('contiguous' with start_address/end_address, or 'explicit' with "
+        "explicit_addresses). Returns a kind='proposal' card; never call "
+        "twice for the same change."
+    ),
+    args_model=CreateAddressSetArgs,
+    writes=False,
+    category="ipam",
+    default_enabled=False,
+)
+async def propose_create_address_set(
+    db: AsyncSession, user: User, args: CreateAddressSetArgs
+) -> dict[str, Any]:
+    return await _propose_via(db=db, user=user, operation_name="create_address_set", args=args)
 
 
 # ── propose_create_dns_record ─────────────────────────────────────────

--- a/backend/app/services/ai/tools/proposals.py
+++ b/backend/app/services/ai/tools/proposals.py
@@ -279,7 +279,11 @@ async def _propose_via(
     args_model=CreateAddressSetArgs,
     writes=False,
     category="ipam",
-    default_enabled=False,
+    # Default-on (NN #13): no secrets, no broad blast radius, no off-prem
+    # call — matches sibling propose_create_ip_address / propose_allocate
+    # _subnet. The op still requires admin on address_set + explicit Apply.
+    default_enabled=True,
+    module="ipam.address_sets",
 )
 async def propose_create_address_set(
     db: AsyncSession, user: User, args: CreateAddressSetArgs

--- a/backend/app/services/event_publisher.py
+++ b/backend/app/services/event_publisher.py
@@ -79,6 +79,7 @@ _RESOURCE_NAMESPACE: dict[str, str] = {
     "ip_address": "ip",
     "nat_mapping": "ipam.nat",
     "subnet_plan": "ipam.plan",
+    "address_set": "ipam.address_set",
     # DNS
     "dns_zone": "dns.zone",
     "dns_record": "dns.record",

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -125,6 +125,12 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         group="Network",
         description="Multicast group registry — addresses + producer/consumer memberships for SMPTE 2110 / Dante / NDI / market-data deployments. Niche but high-value when operators need it.",
     ),
+    ModuleSpec(
+        id="ipam.address_sets",
+        label="Address sets",
+        group="Network",
+        description="Named IP ranges within a subnet carrying their own RBAC scope, so edit of a slice (e.g. .50–.99) can be delegated without subnet-wide write.",
+    ),
     # AI — operator copilot, gated as a whole.
     ModuleSpec(
         id="ai.copilot",

--- a/backend/app/services/ipam/address_set_gate.py
+++ b/backend/app/services/ipam/address_set_gate.py
@@ -1,0 +1,129 @@
+"""Address-set write-delegation gate (issue #103).
+
+A caller without subnet-wide ``write`` may still mutate an IP if it falls
+inside an :class:`~app.models.address_set.AddressSet` they hold
+``write``/``admin`` on. The control plane resolves the caller's writable
+ranges on a subnet ONCE per request (:func:`load_writable_set_ranges`) and
+then checks each candidate IP against them (:func:`user_can_write_ip`).
+
+Both the interactive IPAM router and the import path consume these helpers;
+they live here (not inside ``ipam.router``) so neither side reaches across
+modules via a function-local import that would break only at runtime if a
+helper were renamed (#12).
+
+Representation (#10): contiguous sets become ``(start_int, end_int)`` interval
+tuples (O(interval-count) membership), and explicit sets become a hash SET of
+packed host ints (O(1) membership) so a large explicit set doesn't degrade to
+an O(n) linear scan per candidate IP.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permissions import user_has_permission
+from app.models.address_set import AddressSet
+
+logger = structlog.get_logger(__name__)
+
+
+def _pack_ip(value: object) -> int | None:
+    """Pack an IP (string / INET) into its integer form, or ``None`` if it
+    can't be parsed. Shared by every IP→int conversion in this module so the
+    packing rule lives in exactly one place (#12)."""
+    try:
+        return int(ipaddress.ip_address(str(value)))
+    except (ValueError, TypeError):
+        return None
+
+
+@dataclass
+class WritableSetRanges:
+    """The caller's address-set-delegated writable space on one subnet.
+
+    * ``intervals`` — contiguous ``(start_int, end_int)`` spans (inclusive).
+    * ``hosts`` — packed ints for explicit-set members; O(1) membership.
+
+    ``bool(ranges)`` is True iff the caller can write at least one address via
+    delegation, so call sites can keep the prior ``if not set_ranges`` idiom.
+    """
+
+    intervals: list[tuple[int, int]] = field(default_factory=list)
+    hosts: set[int] = field(default_factory=set)
+
+    def __bool__(self) -> bool:
+        return bool(self.intervals) or bool(self.hosts)
+
+    def contains(self, ip_int: int) -> bool:
+        if ip_int in self.hosts:
+            return True
+        return any(s <= ip_int <= e for s, e in self.intervals)
+
+
+async def load_writable_set_ranges(
+    db: AsyncSession, user: Any, subnet_id: uuid.UUID
+) -> WritableSetRanges:
+    """Return the :class:`WritableSetRanges` the ``user`` can WRITE on this subnet.
+
+    A set counts when the user holds ``write`` on its address_set id — ``admin``
+    implies ``write`` via the permission matcher, so a SINGLE ``write`` check per
+    set is sufficient (#9; the old code resolved ``write`` then ``admin``,
+    doubling the role-tree walk). Empty when none — the caller still must hold
+    subnet write for any IP outside these ranges.
+    """
+    rows = await db.execute(
+        select(
+            AddressSet.id,
+            AddressSet.range_kind,
+            AddressSet.start_address,
+            AddressSet.end_address,
+            AddressSet.explicit_addresses,
+        ).where(AddressSet.subnet_id == subnet_id)
+    )
+    ranges = WritableSetRanges()
+    for set_id, range_kind, start_addr, end_addr, explicit in rows.all():
+        # ``admin`` implies ``write`` through ``_action_matches`` — one check.
+        if not user_has_permission(user, "write", "address_set", set_id):
+            continue
+        if range_kind == "contiguous" and start_addr is not None and end_addr is not None:
+            s = _pack_ip(start_addr)
+            e = _pack_ip(end_addr)
+            if s is None or e is None:
+                continue
+            if s > e:
+                # Guarded by a CHECK constraint + API validation, so this
+                # should never fire; keep the defensive swap but flag it as a
+                # data-integrity signal if it ever does (#13).
+                logger.warning(
+                    "address_set_inverted_bounds",
+                    address_set_id=str(set_id),
+                    subnet_id=str(subnet_id),
+                    start_address=str(start_addr),
+                    end_address=str(end_addr),
+                )
+                s, e = e, s
+            ranges.intervals.append((s, e))
+        else:
+            for raw in explicit or []:
+                v = _pack_ip(raw)
+                if v is not None:
+                    ranges.hosts.add(v)
+    return ranges
+
+
+def user_can_write_ip(
+    user: Any,
+    ip_int: int,
+    subnet_writable: bool,
+    set_ranges: WritableSetRanges,
+) -> bool:
+    """True if the caller may mutate this IP — either subnet-wide write, or the
+    IP falls inside an address set they hold write/admin on (#103)."""
+    return subnet_writable or set_ranges.contains(ip_int)

--- a/backend/app/services/ipam/address_set_gate.py
+++ b/backend/app/services/ipam/address_set_gate.py
@@ -19,6 +19,7 @@ an O(n) linear scan per candidate IP.
 
 from __future__ import annotations
 
+import bisect
 import ipaddress
 import uuid
 from dataclasses import dataclass, field
@@ -32,6 +33,16 @@ from app.core.permissions import user_has_permission
 from app.models.address_set import AddressSet
 
 logger = structlog.get_logger(__name__)
+
+# Availability bound (#103, finding #7): cap the number of address-set rows we
+# consider per subnet, and the total host ints an explicit-set load may
+# accumulate, so a pathological subnet (thousands of delegated sets) can't turn
+# the per-request gate build into an unbounded scan/allocation. Beyond the caps
+# we stop loading and log a structured warning; correctness is unchanged for the
+# normal (tens-of-sets) case. The interval list is additionally sorted + merged
+# so membership is a binary search, not a linear scan over every interval.
+_MAX_SETS_PER_SUBNET: int = 4096
+_MAX_EXPLICIT_HOSTS: int = 1_000_000
 
 
 def _pack_ip(value: object) -> int | None:
@@ -48,23 +59,66 @@ def _pack_ip(value: object) -> int | None:
 class WritableSetRanges:
     """The caller's address-set-delegated writable space on one subnet.
 
-    * ``intervals`` — contiguous ``(start_int, end_int)`` spans (inclusive).
-    * ``hosts`` — packed ints for explicit-set members; O(1) membership.
+    * ``intervals`` — contiguous ``(start_int, end_int)`` spans (inclusive),
+      kept SORTED + non-overlapping after :meth:`finalize` so membership is an
+      ``O(log n)`` binary search rather than an ``O(n)`` linear scan (#7).
+    * ``hosts`` — packed ints for explicit-set members; ``O(1)`` membership.
 
     ``bool(ranges)`` is True iff the caller can write at least one address via
     delegation, so call sites can keep the prior ``if not set_ranges`` idiom.
+
+    Build by appending raw intervals/hosts, then call :meth:`finalize` once;
+    :func:`load_writable_set_ranges` does this before returning.
     """
 
     intervals: list[tuple[int, int]] = field(default_factory=list)
     hosts: set[int] = field(default_factory=set)
+    # Lower bounds of the merged intervals, kept parallel to ``intervals`` so a
+    # single ``bisect`` locates the only interval that could contain a query.
+    _starts: list[int] = field(default_factory=list, repr=False)
 
     def __bool__(self) -> bool:
         return bool(self.intervals) or bool(self.hosts)
 
+    def finalize(self) -> WritableSetRanges:
+        """Sort + merge overlapping/adjacent intervals and cache their lower
+        bounds for binary-search membership. Idempotent; returns ``self`` so it
+        can be used inline."""
+        if not self.intervals:
+            self._starts = []
+            return self
+        ordered = sorted(self.intervals)
+        merged: list[tuple[int, int]] = [ordered[0]]
+        for s, e in ordered[1:]:
+            ls, le = merged[-1]
+            # Merge when the next span overlaps or is immediately adjacent
+            # (``s <= le + 1``) — contiguous coverage collapses to one interval.
+            if s <= le + 1:
+                if e > le:
+                    merged[-1] = (ls, e)
+            else:
+                merged.append((s, e))
+        self.intervals = merged
+        self._starts = [s for s, _ in merged]
+        return self
+
     def contains(self, ip_int: int) -> bool:
         if ip_int in self.hosts:
             return True
-        return any(s <= ip_int <= e for s, e in self.intervals)
+        if not self.intervals:
+            return False
+        # Defensive: if intervals were appended without a ``finalize`` (e.g. a
+        # direct construction outside ``load_writable_set_ranges``), the cached
+        # ``_starts`` is stale — finalize once so the binary search is correct.
+        if len(self._starts) != len(self.intervals):
+            self.finalize()
+        # Intervals are sorted + non-overlapping after ``finalize``: the only
+        # candidate is the last interval whose start <= ip_int.
+        idx = bisect.bisect_right(self._starts, ip_int) - 1
+        if idx < 0:
+            return False
+        s, e = self.intervals[idx]
+        return s <= ip_int <= e
 
 
 async def load_writable_set_ranges(
@@ -78,6 +132,9 @@ async def load_writable_set_ranges(
     doubling the role-tree walk). Empty when none — the caller still must hold
     subnet write for any IP outside these ranges.
     """
+    # Bound the rows we pull per subnet (#7) — a pathological subnet with an
+    # absurd number of delegated sets must not turn this per-request build into
+    # an unbounded scan. ``+1`` so we can detect (and warn on) the overflow.
     rows = await db.execute(
         select(
             AddressSet.id,
@@ -85,10 +142,23 @@ async def load_writable_set_ranges(
             AddressSet.start_address,
             AddressSet.end_address,
             AddressSet.explicit_addresses,
-        ).where(AddressSet.subnet_id == subnet_id)
+        )
+        .where(AddressSet.subnet_id == subnet_id)
+        .limit(_MAX_SETS_PER_SUBNET + 1)
     )
+    fetched = rows.all()
+    if len(fetched) > _MAX_SETS_PER_SUBNET:
+        logger.warning(
+            "address_set_gate_truncated",
+            subnet_id=str(subnet_id),
+            cap=_MAX_SETS_PER_SUBNET,
+            reason="too_many_sets",
+        )
+        fetched = fetched[:_MAX_SETS_PER_SUBNET]
+
     ranges = WritableSetRanges()
-    for set_id, range_kind, start_addr, end_addr, explicit in rows.all():
+    explicit_overflowed = False
+    for set_id, range_kind, start_addr, end_addr, explicit in fetched:
         # ``admin`` implies ``write`` through ``_action_matches`` — one check.
         if not user_has_permission(user, "write", "address_set", set_id):
             continue
@@ -112,10 +182,26 @@ async def load_writable_set_ranges(
             ranges.intervals.append((s, e))
         else:
             for raw in explicit or []:
+                # Bound the total explicit-host set so a heap of large explicit
+                # sets can't balloon memory (#7). Correctness for normal sizes is
+                # unchanged; over the cap we stop adding and warn once.
+                if len(ranges.hosts) >= _MAX_EXPLICIT_HOSTS:
+                    explicit_overflowed = True
+                    break
                 v = _pack_ip(raw)
                 if v is not None:
                     ranges.hosts.add(v)
-    return ranges
+            if explicit_overflowed:
+                break
+    if explicit_overflowed:
+        logger.warning(
+            "address_set_gate_truncated",
+            subnet_id=str(subnet_id),
+            cap=_MAX_EXPLICIT_HOSTS,
+            reason="too_many_explicit_hosts",
+        )
+    # Sort + merge the contiguous intervals once so membership is a binary search.
+    return ranges.finalize()
 
 
 def user_can_write_ip(

--- a/backend/app/services/ipam_io/importer.py
+++ b/backend/app/services/ipam_io/importer.py
@@ -753,7 +753,12 @@ async def commit_address_import(
     subnet_net = ipaddress.ip_network(str(subnet.network), strict=False)
     existing = await _load_existing_addresses(db, subnet.id)
 
-    # Pre-flight: fail-strategy bails out before mutating anything.
+    # Pre-flight: fail-strategy bails out before mutating anything. A
+    # permission-blocked row (#103 delegation gate) is skipped from the
+    # duplicate check — we don't 409 a caller on a row they can't write
+    # anyway — but it is NOT silent: it's counted below so a fully
+    # permission-blocked import can't masquerade as a generic 0-created
+    # success (#7).
     if strategy == "fail":
         for row in payload.addresses:
             canonical, _, err = _row_address_fields(row)
@@ -892,6 +897,18 @@ async def commit_address_import(
                 result_obj.errors.append(f"{canonical}: DNS sync failed: {exc}")
         result_obj.created += 1
 
+    # #7: surface a permission-blocked batch distinctly. ``skipped_no_perm``
+    # already carries the per-row count, but a fully RBAC-blocked import would
+    # otherwise return created=0 / updated=0 with no ``errors`` entry — which
+    # reads as a benign no-op rather than the authorization failure it is. When
+    # nothing landed AND at least one row was permission-blocked, add a clear
+    # error so the caller can tell "blocked" apart from "already exists" / empty.
+    if result_obj.skipped_no_perm and not result_obj.created and not result_obj.updated:
+        result_obj.errors.append(
+            f"Permission denied: {result_obj.skipped_no_perm} row(s) fall outside "
+            "the subnet or any address set you can write — nothing was imported."
+        )
+
     # Keep the subnet's utilization counters roughly honest. The periodic
     # allocation-recount task corrects drift, but users expect the UI to
     # reflect the new row count immediately.
@@ -906,6 +923,7 @@ async def commit_address_import(
         created=result_obj.created,
         updated=result_obj.updated,
         skipped=result_obj.skipped,
+        skipped_no_perm=result_obj.skipped_no_perm,
         dns_synced=result_obj.dns_synced,
         errors=len(result_obj.errors),
     )

--- a/backend/app/services/ipam_io/importer.py
+++ b/backend/app/services/ipam_io/importer.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import ipaddress
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -525,6 +526,9 @@ class AddressImportResult:
     created: int = 0
     updated: int = 0
     skipped: int = 0
+    # Rows skipped because the caller has no write permission on the IP
+    # (subnet-wide nor any covering address set) — #103 delegation.
+    skipped_no_perm: int = 0
     dns_synced: int = 0
     errors: list[str] = field(default_factory=list)
 
@@ -725,6 +729,7 @@ async def commit_address_import(
     current_user: Any,
     subnet_id: uuid.UUID,
     strategy: Strategy = "fail",
+    can_write_ip: Callable[[str], bool] | None = None,
 ) -> AddressImportResult:
     """Apply the address import in the caller's transaction.
 
@@ -734,6 +739,12 @@ async def commit_address_import(
     that the interactive UI uses. The import is equivalent to N calls to
     ``POST /ipam/addresses`` / ``PUT /ipam/addresses/{id}`` — same audit
     log, same DNS side-effects.
+
+    ``can_write_ip`` is the optional #103 address-set write-delegation gate
+    (a closure over the caller's writable ranges). Rows the caller can't
+    write are skipped and counted in ``skipped_no_perm`` rather than
+    mutated. ``None`` means "no per-IP gate" (caller already proved
+    subnet-wide write).
     """
     from app.api.v1.ipam.router import _sync_dns_record
 
@@ -747,6 +758,8 @@ async def commit_address_import(
         for row in payload.addresses:
             canonical, _, err = _row_address_fields(row)
             if err or canonical is None:
+                continue
+            if can_write_ip is not None and not can_write_ip(canonical):
                 continue
             if canonical in existing:
                 raise HTTPException(
@@ -769,6 +782,12 @@ async def commit_address_import(
                 continue
         except ValueError:
             result_obj.errors.append(f"{canonical}: invalid IP")
+            continue
+
+        # Address-set write delegation (#103): skip rows outside the caller's
+        # writable ranges.
+        if can_write_ip is not None and not can_write_ip(canonical):
+            result_obj.skipped_no_perm += 1
             continue
 
         existing_ip = existing.get(canonical)

--- a/backend/tests/test_address_set_security.py
+++ b/backend/tests/test_address_set_security.py
@@ -1,0 +1,429 @@
+"""Security regression tests for the address-set delegation feature (#103).
+
+These cover the seven security-review findings closed on ``issue-449-103``.
+The read-model the fixes enforce:
+
+* **CREATE / RANGE-RESIZE** of an address set is a *subnet-owner* operation →
+  requires ``write`` (or ``admin``, which implies write) on the PARENT SUBNET.
+* **READ** (get / list / MCP find / count) is scoped to the parent subnet →
+  a caller may see a set only if they can read its parent subnet.
+* **WRITE/ADMIN on a specific set** (the delegated grant) is unchanged — the
+  per-IP gate handles "edit IPs in my set's range".
+
+So a type-wide ``admin:address_set`` (the "Address Set Editor" role) can no
+longer self-delegate write on an arbitrary subnet by carving a slice out of it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.address_set import EXPLICIT_ADDRESSES_MAX, AddressSet
+from app.models.auth import Group, Role, User
+from app.models.ipam import IPBlock, IPSpace, Subnet
+from app.services.ai.tools import REGISTRY
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+async def _user(
+    db: AsyncSession,
+    *,
+    name: str,
+    permissions: list[dict] | None = None,
+    superadmin: bool = False,
+) -> tuple[User, str]:
+    """Create a user with exactly ``permissions`` (attached via a fresh
+    Group+Role) and return ``(user, bearer_token)``."""
+    user = User(
+        username=f"{name}-{uuid.uuid4().hex[:8]}",
+        email=f"{name}-{uuid.uuid4().hex[:8]}@t.io",
+        display_name=name,
+        hashed_password=hash_password("password123"),
+        is_superadmin=superadmin,
+    )
+    user.groups = []
+    if permissions:
+        role = Role(name=f"role-{uuid.uuid4().hex[:8]}", permissions=permissions)
+        group = Group(name=f"grp-{uuid.uuid4().hex[:8]}")
+        group.roles = [role]
+        user.groups = [group]
+        db.add_all([role, group])
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _subnet(db: AsyncSession, network: str = "10.0.5.0/24") -> Subnet:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/16", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=network, name="s")
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _set(
+    db: AsyncSession,
+    subnet: Subnet,
+    *,
+    name: str = "delegated",
+    start: str = "10.0.5.50",
+    end: str = "10.0.5.99",
+) -> AddressSet:
+    row = AddressSet(
+        name=name,
+        subnet_id=subnet.id,
+        range_kind="contiguous",
+        start_address=start,
+        end_address=end,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Finding #1: CREATE requires write on the parent subnet ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_denied_without_subnet_write(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A user with type-wide ``admin:address_set`` but NO subnet write gets 403
+    on POST /address-sets for a subnet they can't write (self-escalation)."""
+    subnet = await _subnet(db_session)
+    _, token = await _user(
+        db_session,
+        name="addrset-editor",
+        permissions=[{"action": "admin", "resource_type": "address_set"}],
+    )
+    r = await client.post(
+        "/api/v1/address-sets",
+        headers=_auth(token),
+        json={
+            "name": "mine",
+            "subnet_id": str(subnet.id),
+            "range_kind": "contiguous",
+            "start_address": "10.0.5.50",
+            "end_address": "10.0.5.99",
+        },
+    )
+    assert r.status_code == 403, r.text
+    assert "parent subnet" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_allowed_with_subnet_write(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The same user who ALSO holds write on the subnet succeeds."""
+    subnet = await _subnet(db_session)
+    _, token = await _user(
+        db_session,
+        name="addrset-owner",
+        permissions=[
+            {"action": "admin", "resource_type": "address_set"},
+            {"action": "write", "resource_type": "subnet"},
+        ],
+    )
+    r = await client.post(
+        "/api/v1/address-sets",
+        headers=_auth(token),
+        json={
+            "name": "mine",
+            "subnet_id": str(subnet.id),
+            "range_kind": "contiguous",
+            "start_address": "10.0.5.50",
+            "end_address": "10.0.5.99",
+        },
+    )
+    assert r.status_code == 201, r.text
+
+
+# ── Finding #2: RANGE-resize requires subnet write; non-range edits don't ─────
+
+
+@pytest.mark.asyncio
+async def test_update_range_widen_denied_without_subnet_write(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An Address Set Editor (type-wide ``admin:address_set``, no subnet write)
+    gets 403 when the PUT widens the range, but succeeds when only editing
+    name/description. Type-wide admin is what actually reaches the PUT handler —
+    the coarse router gate maps PUT → write on ``address_set``, which a purely
+    set-scoped grant can't satisfy, so the realistic finding-#2 threat is the
+    type-wide editor widening a slice they don't own the subnet of."""
+    subnet = await _subnet(db_session)
+    row = await _set(db_session, subnet)
+    await db_session.flush()
+    _, token = await _user(
+        db_session,
+        name="set-delegate",
+        permissions=[
+            # Address Set Editor role shape: type-wide admin on address sets,
+            # plus subnet READ so the read-model lets them see the row.
+            {"action": "admin", "resource_type": "address_set"},
+            {"action": "read", "resource_type": "subnet"},
+        ],
+    )
+
+    # Widening the range is a subnet-owner op → 403.
+    r = await client.put(
+        f"/api/v1/address-sets/{row.id}",
+        headers=_auth(token),
+        json={"end_address": "10.0.5.200"},
+    )
+    assert r.status_code == 403, r.text
+    assert "parent subnet" in r.json()["detail"]
+
+    # Name / description edit (no range change) → allowed for the address-set admin.
+    r = await client.put(
+        f"/api/v1/address-sets/{row.id}",
+        headers=_auth(token),
+        json={"name": "renamed", "description": "ok"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["name"] == "renamed"
+    # Range is untouched.
+    assert r.json()["end_address"] == "10.0.5.99"
+
+
+@pytest.mark.asyncio
+async def test_update_range_noop_resend_allowed(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Resending the SAME range values is not a resize — no subnet write needed."""
+    subnet = await _subnet(db_session)
+    row = await _set(db_session, subnet)
+    await db_session.flush()
+    _, token = await _user(
+        db_session,
+        name="set-delegate2",
+        permissions=[
+            {"action": "admin", "resource_type": "address_set"},
+            {"action": "read", "resource_type": "subnet"},
+        ],
+    )
+    r = await client.put(
+        f"/api/v1/address-sets/{row.id}",
+        headers=_auth(token),
+        json={"start_address": "10.0.5.50", "end_address": "10.0.5.99", "description": "same"},
+    )
+    assert r.status_code == 200, r.text
+
+
+# ── Finding #4: MCP find/count scoped to readable parent subnets ──────────────
+
+
+@pytest.mark.asyncio
+async def test_find_address_sets_scoped_to_subnet_read(db_session: AsyncSession) -> None:
+    """find_address_sets returns nothing for a user with no subnet read, and the
+    set for a user who can read the subnet."""
+    subnet = await _subnet(db_session)
+    await _set(db_session, subnet, name="visible-only-to-readers")
+    await db_session.flush()
+
+    no_read, _ = await _user(
+        db_session,
+        name="no-read",
+        permissions=[{"action": "admin", "resource_type": "address_set"}],
+    )
+    can_read, _ = await _user(
+        db_session,
+        name="can-read",
+        permissions=[{"action": "read", "resource_type": "subnet"}],
+    )
+
+    out_none = await REGISTRY.call("find_address_sets", {}, db=db_session, user=no_read)
+    assert out_none == []
+
+    out_some = await REGISTRY.call("find_address_sets", {}, db=db_session, user=can_read)
+    assert isinstance(out_some, list)
+    names = {s["name"] for s in out_some}
+    assert "visible-only-to-readers" in names
+
+
+@pytest.mark.asyncio
+async def test_count_address_sets_scoped_to_subnet_read(db_session: AsyncSession) -> None:
+    subnet = await _subnet(db_session)
+    await _set(db_session, subnet, name="counted")
+    await db_session.flush()
+
+    no_read, _ = await _user(
+        db_session,
+        name="no-read-c",
+        permissions=[{"action": "admin", "resource_type": "address_set"}],
+    )
+    can_read, _ = await _user(
+        db_session,
+        name="can-read-c",
+        permissions=[{"action": "read", "resource_type": "subnet"}],
+    )
+
+    out_none = await REGISTRY.call("count_address_sets", {}, db=db_session, user=no_read)
+    assert out_none["address_sets"] == 0
+
+    out_some = await REGISTRY.call("count_address_sets", {}, db=db_session, user=can_read)
+    assert out_some["address_sets"] >= 1
+
+
+# ── Finding #5: REST get/list read-model (404 / filtered) ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_address_set_404_without_subnet_read(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    subnet = await _subnet(db_session)
+    row = await _set(db_session, subnet)
+    await db_session.flush()
+    # Type-wide address_set read, but NO subnet read → must not confirm existence.
+    _, token = await _user(
+        db_session,
+        name="addrset-reader",
+        permissions=[{"action": "read", "resource_type": "address_set"}],
+    )
+    r = await client.get(f"/api/v1/address-sets/{row.id}", headers=_auth(token))
+    assert r.status_code == 404, r.text
+
+    # The list is filtered to nothing for the same caller.
+    r = await client.get("/api/v1/address-sets", headers=_auth(token))
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+# ── Finding #6: explicit_addresses is capped ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_explicit_addresses_over_cap_rejected(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An explicit_addresses list over the cap is rejected (422) — the gate
+    re-parses these on every IPAM mutation, so an unbounded list is a DoS."""
+    subnet = await _subnet(db_session, network="10.9.0.0/16")
+    _, token = await _user(
+        db_session,
+        name="addrset-dos",
+        permissions=[
+            {"action": "admin", "resource_type": "address_set"},
+            {"action": "write", "resource_type": "subnet"},
+        ],
+    )
+    # One more than the cap → rejected by the Pydantic schema before the handler.
+    too_many = [f"10.9.{i // 254}.{(i % 254) + 1}" for i in range(EXPLICIT_ADDRESSES_MAX + 1)]
+    r = await client.post(
+        "/api/v1/address-sets",
+        headers=_auth(token),
+        json={
+            "name": "huge",
+            "subnet_id": str(subnet.id),
+            "range_kind": "explicit",
+            "explicit_addresses": too_many,
+        },
+    )
+    assert r.status_code == 422, r.text
+
+
+def test_validate_shape_rejects_over_cap() -> None:
+    """The shared validator (AI path + any direct caller) also enforces the
+    cap, so no surface can exceed it."""
+    from app.models.address_set import validate_address_set_shape
+
+    over = [f"10.9.0.{i}" for i in range(EXPLICIT_ADDRESSES_MAX + 1)]
+    err = validate_address_set_shape("explicit", None, None, over)
+    assert err is not None
+    assert str(EXPLICIT_ADDRESSES_MAX) in err
+    # At-cap is fine (shape-wise).
+    at_cap = [f"10.9.0.{i % 256}" for i in range(EXPLICIT_ADDRESSES_MAX)]
+    assert validate_address_set_shape("explicit", None, None, at_cap) is None
+
+
+# ── The core delegation case: a SCOPED grant clears the coarse IPAM gate ──────
+# Both the code review and the security review tested only the type-wide
+# "Address Set Editor" role (unscoped admin:address_set, which passes the
+# coarse gate's unscoped check). The ACTUAL #103 delegation hands out a scoped
+# ``{write, address_set, <id>}`` grant — which the unscoped coarse check would
+# 403 before the per-IP gate ever runs. These two tests prove the scoped
+# delegate works end to end (admit at the coarse gate via require_any_resource_
+# or_scoped, real boundary enforced by the per-IP gate).
+
+
+@pytest.mark.asyncio
+async def test_scoped_delegate_can_write_ip_inside_set(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A delegate holding ONLY ``{write, address_set, <set_id>}`` (no subnet
+    write) can allocate an IP that falls inside that set's range."""
+    subnet = await _subnet(db_session)
+    row = await _set(db_session, subnet, start="10.0.5.50", end="10.0.5.59")
+    await db_session.flush()
+    _, token = await _user(
+        db_session,
+        name="printers-admin",
+        permissions=[
+            {"action": "write", "resource_type": "address_set", "resource_id": str(row.id)}
+        ],
+    )
+    r = await client.post(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses",
+        headers=_auth(token),
+        json={"address": "10.0.5.55", "hostname": "printer-1"},
+    )
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_scoped_delegate_denied_ip_outside_set(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The same scoped delegate is 403'd for an IP outside their set's range —
+    the per-IP gate, not the coarse gate, draws the boundary."""
+    subnet = await _subnet(db_session)
+    row = await _set(db_session, subnet, start="10.0.5.50", end="10.0.5.59")
+    await db_session.flush()
+    _, token = await _user(
+        db_session,
+        name="printers-admin",
+        permissions=[
+            {"action": "write", "resource_type": "address_set", "resource_id": str(row.id)}
+        ],
+    )
+    r = await client.post(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses",
+        headers=_auth(token),
+        json={"address": "10.0.5.10", "hostname": "not-mine"},
+    )
+    assert r.status_code == 403, r.text
+
+
+# ── Finding #7: gate merges intervals + bounds work ───────────────────────────
+
+
+def test_writable_ranges_merge_and_membership() -> None:
+    """Merged/sorted intervals give correct membership via binary search."""
+    from app.services.ipam.address_set_gate import WritableSetRanges
+
+    r = WritableSetRanges()
+    # Deliberately unsorted + overlapping + adjacent.
+    r.intervals = [(20, 30), (1, 10), (11, 15), (25, 40)]
+    r.finalize()
+    # (1,10)+(11,15) merge (adjacent), (20,30)+(25,40) merge (overlap).
+    assert r.intervals == [(1, 15), (20, 40)]
+    assert r.contains(1) and r.contains(15) and r.contains(40)
+    assert not r.contains(0) and not r.contains(16) and not r.contains(41)
+    assert r.contains(25)

--- a/frontend/src/components/ownership/ResourceIdPicker.tsx
+++ b/frontend/src/components/ownership/ResourceIdPicker.tsx
@@ -1,0 +1,143 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { customersApi, ipamApi, providersApi, sitesApi } from "@/lib/api";
+
+interface ResourceIdPickerProps {
+  /** The permission's `resource_type`. Drives which list (if any) is
+   *  offered as a dropdown. Unmapped types fall back to a raw text input. */
+  resourceType: string;
+  value: string | null;
+  onChange: (id: string | null) => void;
+  className?: string;
+  disabled?: boolean;
+}
+
+/** An option rendered in the scoped-instance dropdown. */
+interface PickerOption {
+  id: string;
+  label: string;
+}
+
+/** Per-resource_type list config. Each entry knows how to fetch a flat
+ *  list of selectable instances and how to label each row. Only resource
+ *  types that list flatly (no required parent id) are mapped — VLANs and
+ *  DNS zones need a router/group id this picker doesn't have, so they fall
+ *  through to the raw text input below.
+ *
+ *  The query keys are shared with the ownership pickers in `pickers.tsx`
+ *  (`customers-picker` / `sites-picker` / `providers-picker`) so caches are
+ *  reused rather than duplicated. */
+const RESOURCE_TYPE_LIST_QUERY: Record<
+  string,
+  { queryKey: unknown[]; queryFn: () => Promise<PickerOption[]> }
+> = {
+  ip_space: {
+    queryKey: ["resource-id-picker", "ip_space"],
+    queryFn: () =>
+      ipamApi
+        .listSpaces()
+        .then((rows) => rows.map((s) => ({ id: s.id, label: s.name }))),
+  },
+  ip_block: {
+    queryKey: ["resource-id-picker", "ip_block"],
+    queryFn: () =>
+      ipamApi.listBlocks().then((rows) =>
+        rows.map((b) => ({
+          id: b.id,
+          label: b.name ? `${b.name} (${b.network})` : b.network,
+        })),
+      ),
+  },
+  subnet: {
+    queryKey: ["resource-id-picker", "subnet"],
+    queryFn: () =>
+      ipamApi.listSubnets().then((rows) =>
+        rows.map((s) => ({
+          id: s.id,
+          label: s.name ? `${s.name} (${s.network})` : s.network,
+        })),
+      ),
+  },
+  customer: {
+    queryKey: ["customers-picker"],
+    queryFn: () =>
+      customersApi
+        .list({ limit: 500 })
+        .then((r) => r.items.map((c) => ({ id: c.id, label: c.name }))),
+  },
+  site: {
+    queryKey: ["sites-picker"],
+    queryFn: () =>
+      sitesApi.list({ limit: 500 }).then((r) =>
+        r.items.map((s) => ({
+          id: s.id,
+          label: s.code ? `${s.name} (${s.code})` : s.name,
+        })),
+      ),
+  },
+  provider: {
+    queryKey: ["providers-picker"],
+    queryFn: () =>
+      providersApi
+        .list({ limit: 500 })
+        .then((r) => r.items.map((p) => ({ id: p.id, label: p.name }))),
+  },
+};
+
+/** Resource-id input for a permission row. When `resourceType` maps to a
+ *  flat-listable resource (IP space / block / subnet, customer / site /
+ *  provider), renders a `<select>` of named instances so operators don't
+ *  paste raw UUIDs. For every other type (`*`, `settings`, `manage_*`,
+ *  `audit_log`, …) it falls back to the original free-text input so no
+ *  capability is lost. Empty selection / blank text ⇒ `null` (whole type). */
+export function ResourceIdPicker({
+  resourceType,
+  value,
+  onChange,
+  className,
+  disabled,
+}: ResourceIdPickerProps) {
+  const config = RESOURCE_TYPE_LIST_QUERY[resourceType];
+
+  const { data } = useQuery({
+    queryKey: config?.queryKey ?? ["resource-id-picker", "noop"],
+    queryFn: config!.queryFn,
+    staleTime: 60_000,
+    enabled: !!config && !disabled,
+  });
+
+  if (!config) {
+    return (
+      <input
+        className={className}
+        placeholder="resource_id (optional)"
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value || null)}
+        disabled={disabled}
+      />
+    );
+  }
+
+  const options = data ?? [];
+  // If the current value isn't in the loaded list (stale id, or list not
+  // yet fetched) keep it selectable so we don't silently drop it.
+  const hasValue = value != null && value !== "";
+  const valueMissing = hasValue && !options.some((o) => o.id === value);
+
+  return (
+    <select
+      className={className}
+      value={value ?? ""}
+      onChange={(e) => onChange(e.target.value || null)}
+      disabled={disabled}
+    >
+      <option value="">— Whole resource type —</option>
+      {valueMissing && <option value={value!}>{value}</option>}
+      {options.map((o) => (
+        <option key={o.id} value={o.id}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/components/ownership/ResourceIdPicker.tsx
+++ b/frontend/src/components/ownership/ResourceIdPicker.tsx
@@ -101,7 +101,11 @@ export function ResourceIdPicker({
 
   const { data } = useQuery({
     queryKey: config?.queryKey ?? ["resource-id-picker", "noop"],
-    queryFn: config!.queryFn,
+    // ``config`` may be undefined for unmapped resource types; the query is
+    // gated off via ``enabled`` below so this never actually runs, but supply
+    // a safe no-op fn instead of a non-null assertion that would crash if the
+    // ``enabled`` gate ever changed.
+    queryFn: config ? config.queryFn : async () => [] as PickerOption[],
     staleTime: 60_000,
     enabled: !!config && !disabled,
   });

--- a/frontend/src/hooks/usePermissions.ts
+++ b/frontend/src/hooks/usePermissions.ts
@@ -1,0 +1,88 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { authApi, type PermissionGrant } from "@/lib/api";
+
+// Actions a granted `admin` implies. Mirrors the backend
+// `_ADMIN_IMPLIES` frozenset in `app/core/permissions.py`.
+const ADMIN_IMPLIES = new Set(["read", "write", "delete", "admin"]);
+
+/** Pure matching predicate — a line-for-line mirror of the backend
+ *  `_action_matches` / `_resource_type_matches` / `_resource_id_matches`
+ *  helpers in `app/core/permissions.py`. Keep the two paired: any change to
+ *  the server semantics must be reflected here (and vice versa) or client
+ *  graying-out drifts from what the API actually enforces.
+ *
+ *  - action: granted `*` matches anything; granted `admin` ⇒
+ *    read|write|delete|admin; else exact.
+ *  - resource_type: granted `*` matches anything; else exact.
+ *  - resource_id: granted `null`/`""`/`"*"` ⇒ any instance; else, when a
+ *    requested id is supplied, exact string match; an unscoped request
+ *    (`undefined`/`null`) against a scoped grant ⇒ no match.
+ */
+export function permissionMatch(
+  grant: PermissionGrant,
+  action: string,
+  resourceType: string,
+  resourceId?: string | null,
+): boolean {
+  // _action_matches
+  const grantedAction = grant.action;
+  const actionOk =
+    grantedAction === "*" ||
+    grantedAction === action ||
+    (grantedAction === "admin" && ADMIN_IMPLIES.has(action));
+  if (!actionOk) return false;
+
+  // _resource_type_matches
+  const grantedType = grant.resource_type;
+  if (grantedType !== "*" && grantedType !== resourceType) return false;
+
+  // _resource_id_matches
+  const grantedId = grant.resource_id;
+  if (grantedId === null || grantedId === "" || grantedId === "*") return true;
+  if (resourceId === undefined || resourceId === null) return false;
+  return String(grantedId) === String(resourceId);
+}
+
+/** Self-introspection of the calling credential's effective permissions.
+ *
+ * Single React Query subscription (cached 5 min, mirroring
+ * `useFeatureModules`). `can()` answers "may I do this?" by matching the
+ * server-returned grant list with the same semantics the API enforces.
+ *
+ * Fail-closed: while the permission set is still loading (or errored),
+ * `can()` returns `false`. This is the safe default for graying-out UI —
+ * we never optimistically enable an action the user might not hold. The
+ * server is always the real gate; this only drives affordance visibility.
+ */
+export function usePermissions(): {
+  can: (
+    action: string,
+    resourceType: string,
+    resourceId?: string | null,
+  ) => boolean;
+  isSuperadmin: boolean;
+  isLoading: boolean;
+} {
+  const query = useQuery({
+    queryKey: ["my-permissions"],
+    queryFn: authApi.myPermissions,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const isSuperadmin = query.data?.is_superadmin ?? false;
+
+  function can(
+    action: string,
+    resourceType: string,
+    resourceId?: string | null,
+  ): boolean {
+    if (isSuperadmin) return true;
+    if (!query.data) return false; // fail-closed while loading / errored
+    return query.data.grants.some((g) =>
+      permissionMatch(g, action, resourceType, resourceId),
+    );
+  }
+
+  return { can, isSuperadmin, isLoading: query.isLoading };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1843,6 +1843,83 @@ export const ipamApi = {
       .then((r) => r.data),
 };
 
+// ── Address sets (#103) ────────────────────────────────────────────────────────
+//
+// A named, RBAC-scoped slice of a subnet's address space. Granting
+// ``admin`` on a single ``address_set`` id (via a role permission entry
+// ``{action:"admin", resource_type:"address_set", resource_id:<id>}``)
+// lets a delegated admin edit just their range of a subnet without
+// holding subnet-wide write. The CRUD surface lives at the top-level
+// ``/address-sets`` endpoint (list is filterable by ``subnet_id``).
+
+export type AddressSetRangeKind = "contiguous" | "explicit";
+
+export interface AddressSet {
+  id: string;
+  name: string;
+  description: string;
+  subnet_id: string;
+  customer_id: string | null;
+  site_id: string | null;
+  range_kind: AddressSetRangeKind;
+  // Contiguous span — both set when ``range_kind === "contiguous"``.
+  start_address: string | null;
+  end_address: string | null;
+  // Arbitrary host list — non-empty when ``range_kind === "explicit"``.
+  explicit_addresses: string[];
+  tags: Record<string, unknown>;
+  custom_fields: Record<string, unknown>;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface AddressSetCreate {
+  name: string;
+  description?: string;
+  subnet_id: string;
+  customer_id?: string | null;
+  site_id?: string | null;
+  range_kind?: AddressSetRangeKind;
+  start_address?: string | null;
+  end_address?: string | null;
+  explicit_addresses?: string[];
+  tags?: Record<string, unknown>;
+  custom_fields?: Record<string, unknown>;
+}
+
+export interface AddressSetUpdate {
+  name?: string;
+  description?: string;
+  customer_id?: string | null;
+  site_id?: string | null;
+  range_kind?: AddressSetRangeKind;
+  start_address?: string | null;
+  end_address?: string | null;
+  explicit_addresses?: string[];
+  tags?: Record<string, unknown>;
+  custom_fields?: Record<string, unknown>;
+}
+
+export const addressSetsApi = {
+  // ``list`` returns a bare array (ordered by name), matching the
+  // sibling subnet sub-resources (aliases) rather than the paginated
+  // ``{items,total,...}`` envelope customers/sites use.
+  list: (params?: {
+    subnet_id?: string;
+    customer_id?: string;
+    site_id?: string;
+    search?: string;
+    limit?: number;
+  }) => api.get<AddressSet[]>("/address-sets", { params }).then((r) => r.data),
+  get: (id: string) =>
+    api.get<AddressSet>(`/address-sets/${id}`).then((r) => r.data),
+  create: (data: AddressSetCreate) =>
+    api.post<AddressSet>("/address-sets", data).then((r) => r.data),
+  update: (id: string, data: AddressSetUpdate) =>
+    api.put<AddressSet>(`/address-sets/${id}`, data).then((r) => r.data),
+  remove: (id: string) => api.delete(`/address-sets/${id}`),
+};
+
 // ── IPAM Import / Export ───────────────────────────────────────────────────────
 
 export interface ImportDiffRow {
@@ -6738,6 +6815,22 @@ export interface PublicAuthProvider {
   type: AuthProviderType;
 }
 
+/** One effective permission triple the calling credential resolves to.
+ *  `resource_id === null` means "any instance" of `resource_type`. */
+export interface PermissionGrant {
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+}
+
+/** Self-introspection of the calling credential's effective permissions
+ *  (`GET /auth/me/permissions`). When `is_superadmin` is true, callers
+ *  short-circuit and never inspect `grants`. */
+export interface MyPermissions {
+  is_superadmin: boolean;
+  grants: PermissionGrant[];
+}
+
 export const authApi = {
   login: (username: string, password: string) =>
     api
@@ -6781,6 +6874,12 @@ export const authApi = {
         auth_source: string;
       }>("/auth/me")
       .then((r) => r.data),
+
+  /** Effective permissions of the calling credential (self-only; reflects
+   *  RBAC ∪ live time-bound grants, narrowed by any API-token resource
+   *  binding). Drives client-side gating via the `usePermissions` hook. */
+  myPermissions: () =>
+    api.get<MyPermissions>("/auth/me/permissions").then((r) => r.data),
 
   // ── MFA (issue #69) ─────────────────────────────────────────────────
   mfaStatus: () =>

--- a/frontend/src/pages/admin/CreateTimeBoundGrantModal.tsx
+++ b/frontend/src/pages/admin/CreateTimeBoundGrantModal.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { timeBoundGrantsApi, type TimeBoundGrantCreate } from "@/lib/api";
 import { Modal } from "@/components/ui/modal";
+import { ResourceIdPicker } from "@/components/ownership/ResourceIdPicker";
 
 const inputCls =
   "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
@@ -20,6 +21,7 @@ const RESOURCE_TYPES: string[] = [
   "ip_block",
   "subnet",
   "ip_address",
+  "address_set",
   "vlan",
   "vrf",
   "asn",
@@ -168,11 +170,11 @@ export function CreateTimeBoundGrantModal({
         </div>
 
         <Field label="Resource ID (optional — scope to one instance)">
-          <input
+          <ResourceIdPicker
             className={inputCls}
-            value={resourceId}
-            onChange={(e) => setResourceId(e.target.value)}
-            placeholder="Leave blank for the whole resource type"
+            resourceType={resourceType}
+            value={resourceId || null}
+            onChange={(id) => setResourceId(id ?? "")}
           />
         </Field>
 

--- a/frontend/src/pages/admin/RolesPage.tsx
+++ b/frontend/src/pages/admin/RolesPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/api";
 import { zebraBodyCls } from "@/lib/utils";
 import { Modal } from "@/components/ui/modal";
+import { ResourceIdPicker } from "@/components/ownership/ResourceIdPicker";
 
 // Mirror of docs/PERMISSIONS.md — keep these in sync.
 const ACTIONS = ["read", "write", "delete", "admin", "*"] as const;
@@ -19,6 +20,7 @@ const RESOURCE_TYPES = [
   "ip_block",
   "subnet",
   "ip_address",
+  "address_set",
   "vlan",
   "dns_group",
   "dns_zone",
@@ -121,13 +123,11 @@ function PermissionEditor({
               <option key={t}>{t}</option>
             ))}
           </select>
-          <input
+          <ResourceIdPicker
             className={inputCls}
-            placeholder="resource_id (optional)"
-            value={p.resource_id ?? ""}
-            onChange={(e) =>
-              update(idx, { resource_id: e.target.value || null })
-            }
+            resourceType={p.resource_type}
+            value={p.resource_id ?? null}
+            onChange={(id) => update(idx, { resource_id: id })}
           />
           <button
             onClick={() => remove(idx)}

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { DHCPSubnetPanel } from "@/pages/dhcp/DHCPSubnetPanel";
 import {
   useQuery,
@@ -3670,6 +3670,85 @@ function ipStringToInt(ip: string): number {
   return ((p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3]) >>> 0;
 }
 
+// Parse a dotted IPv4 quad to its 32-bit BigInt value, or null if malformed.
+function ipv4ToBigInt(ip: string): bigint | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let acc = 0n;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null;
+    const n = Number(part);
+    if (n < 0 || n > 255) return null;
+    acc = (acc << 8n) | BigInt(n);
+  }
+  return acc;
+}
+
+// Parse any IPv4 or IPv6 literal to its integer value as a BigInt, mirroring
+// Python's ``int(ipaddress.ip_address(...))`` so the client-side address-set
+// membership test matches the backend gate (``_user_can_write_ip``) exactly.
+// Handles ``::`` zero-run expansion and embedded IPv4-mapped suffixes
+// (e.g. ``::ffff:192.0.2.10``). Returns null on truly-unparseable input so
+// callers can fail closed.
+function ipToBigInt(ip: string): bigint | null {
+  const raw = ip.trim();
+  if (raw === "") return null;
+  // Strip a zone id (``fe80::1%eth0``) — not significant for containment.
+  const addr = raw.includes("%") ? raw.slice(0, raw.indexOf("%")) : raw;
+
+  if (!addr.includes(":")) {
+    return ipv4ToBigInt(addr);
+  }
+
+  // IPv6. Split off an optional trailing embedded IPv4 quad and fold it into
+  // two 16-bit groups.
+  let head = addr;
+  const tailGroups: string[] = [];
+  const lastColon = addr.lastIndexOf(":");
+  const tail = addr.slice(lastColon + 1);
+  if (tail.includes(".")) {
+    const v4 = ipv4ToBigInt(tail);
+    if (v4 === null) return null;
+    tailGroups.push(((v4 >> 16n) & 0xffffn).toString(16));
+    tailGroups.push((v4 & 0xffffn).toString(16));
+    head = addr.slice(0, lastColon + 1); // keep trailing ':' for split
+  }
+
+  // Expand the ``::`` zero run (at most one allowed).
+  const doubleColonCount = (head.match(/::/g) ?? []).length;
+  if (doubleColonCount > 1) return null;
+
+  let groups: string[];
+  if (doubleColonCount === 1) {
+    const [left, right] = head.split("::");
+    const leftGroups = left === "" ? [] : left.split(":");
+    const rightGroups =
+      right === "" ? [] : right.split(":").filter((g) => g !== "");
+    const known = leftGroups.length + rightGroups.length + tailGroups.length;
+    const missing = 8 - known;
+    if (missing < 0) return null;
+    groups = [
+      ...leftGroups,
+      ...Array(missing).fill("0"),
+      ...rightGroups,
+      ...tailGroups,
+    ];
+  } else {
+    // No ``::`` — head may carry a trailing ':' from the embedded-v4 split.
+    const trimmed = head.endsWith(":") ? head.slice(0, -1) : head;
+    const headGroups = trimmed === "" ? [] : trimmed.split(":");
+    groups = [...headGroups, ...tailGroups];
+  }
+
+  if (groups.length !== 8) return null;
+  let acc = 0n;
+  for (const g of groups) {
+    if (g === "" || !/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+    acc = (acc << 16n) | BigInt(parseInt(g, 16));
+  }
+  return acc;
+}
+
 function intToIpv4(n: number): string {
   return [
     (n >>> 24) & 0xff,
@@ -3792,28 +3871,58 @@ function SubnetDetail({
   const writableSets = addressSets.filter((s) =>
     perms.can("write", "address_set", s.id),
   );
+  // Stable cache key for the memo below: the ``perms.can`` closure is a fresh
+  // identity every render, so we can't depend on ``writableSets`` directly
+  // (it re-allocates each render and would defeat the memo). Hash the writable
+  // sets' ids + bounds into a string instead so re-parsing only happens when
+  // the writable set membership or its ranges actually change.
+  const writableSetsKey = writableSets
+    .map(
+      (s) =>
+        `${s.id}|${s.range_kind}|${s.start_address ?? ""}|${s.end_address ?? ""}|${s.explicit_addresses.join(",")}`,
+    )
+    .join(";");
 
-  // True when the operator may edit the given IP: subnet-write, OR the IP
-  // falls inside a writable address set's range. Contiguous ranges are
-  // compared numerically (IPv4 via ``ipStringToInt``; IPv6 falls through
-  // to string-equality on the bounds), explicit sets by string match.
-  const ipInWritableSet = (address: string): boolean => {
+  // Pre-parse every writable address set's bounds once (BigInt, IPv4+IPv6),
+  // so per-row ``ipInWritableSet`` checks don't re-parse the same strings on
+  // every render (was O(IPs × sets × parse) per render). Mirrors the backend
+  // gate (``_user_can_write_ip``): contiguous = ``lo <= ip <= hi`` on the
+  // integer value, explicit = exact integer membership — both computed via
+  // ``ipToBigInt`` so the client and server agree for IPv4 and IPv6 alike.
+  const writableRanges = useMemo(() => {
+    const contiguous: Array<{ lo: bigint; hi: bigint }> = [];
+    const explicit = new Set<bigint>();
     for (const s of writableSets) {
       if (s.range_kind === "explicit") {
-        if (s.explicit_addresses.includes(address)) return true;
+        for (const raw of s.explicit_addresses) {
+          const v = ipToBigInt(raw);
+          if (v !== null) explicit.add(v);
+        }
         continue;
       }
       if (!s.start_address || !s.end_address) continue;
-      // IPv4 numeric containment.
-      if (address.includes(".") && s.start_address.includes(".")) {
-        const ipInt = ipStringToInt(address);
-        const lo = ipStringToInt(s.start_address);
-        const hi = ipStringToInt(s.end_address);
-        if (ipInt >= lo && ipInt <= hi) return true;
-      } else if (address === s.start_address || address === s.end_address) {
-        // IPv6 / non-dotted — conservative: only the exact bounds count.
-        return true;
-      }
+      let lo = ipToBigInt(s.start_address);
+      let hi = ipToBigInt(s.end_address);
+      if (lo === null || hi === null) continue;
+      if (lo > hi) [lo, hi] = [hi, lo];
+      contiguous.push({ lo, hi });
+    }
+    return { contiguous, explicit };
+    // ``writableSets`` is intentionally read inside but keyed via the stable
+    // ``writableSetsKey`` string so the memo only re-runs on real changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [writableSetsKey]);
+
+  // True when the operator may edit the given IP: subnet-write, OR the IP
+  // falls inside a writable address set's range. Unparseable input fails
+  // closed (no set match) as a last resort, consistent with the backend
+  // skipping unparseable bounds.
+  const ipInWritableSet = (address: string): boolean => {
+    const ip = ipToBigInt(address);
+    if (ip === null) return false;
+    if (writableRanges.explicit.has(ip)) return true;
+    for (const { lo, hi } of writableRanges.contiguous) {
+      if (ip >= lo && ip <= hi) return true;
     }
     return false;
   };

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -34,6 +34,7 @@ import {
   Maximize2,
   ShieldCheck,
   Radio,
+  Boxes,
 } from "lucide-react";
 import {
   DndContext,
@@ -55,6 +56,7 @@ import {
   asnsApi,
   vrfsApi,
   multicastApi,
+  addressSetsApi,
   IP_ROLE_OPTIONS,
   SUBNET_ROLES,
   SUBNET_ROLE_LABELS,
@@ -75,8 +77,12 @@ import {
   type MacHistoryEntry,
   type NATMapping,
   type NetworkContextEntry,
+  type AddressSet,
+  type AddressSetCreate,
+  type AddressSetUpdate,
   formatApiError,
 } from "@/lib/api";
+import { usePermissions } from "@/hooks/usePermissions";
 import { copyToClipboard } from "@/lib/clipboard";
 import { cn, swatchTintCls, zebraBodyCls } from "@/lib/utils";
 import { SwatchPicker } from "@/components/ui/swatch-picker";
@@ -97,6 +103,7 @@ import {
   useDraggableModal,
 } from "@/components/ui/use-draggable-modal";
 import { HeaderButton } from "@/components/ui/header-button";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { TagFilterChips } from "@/components/TagFilterChips";
 import { matchesAllTagChips } from "@/components/tag-filter-utils";
 import { AskAIButton } from "@/components/copilot/AskAIButton";
@@ -3763,12 +3770,64 @@ function SubnetDetail({
     queryFn: () => ipamApi.dnsSyncSummary(subnet.id),
     refetchOnMount: "always",
   });
+  // Effective-permission self-introspection (#449). Drives gray-out of
+  // edit affordances on addresses the operator can't write — the server
+  // is always the real gate (403 on the mutation), this only hides the
+  // affordance. Fail-closed: ``can`` returns false while loading.
+  const perms = usePermissions();
+
+  // Address sets on this subnet (#103). Fetched here (not just inside the
+  // Address Sets panel) because the IP table's per-row gray-out derives
+  // editability from "does the operator hold write/admin on a set whose
+  // range contains this IP?" — computed client-side from these rows.
+  const { data: addressSets = [] } = useQuery({
+    queryKey: ["address-sets", subnet.id],
+    queryFn: () => addressSetsApi.list({ subnet_id: subnet.id }),
+  });
+
+  // Subnet-wide write gate (one lookup, reused for every row).
+  const subnetWritable = perms.can("write", "subnet", subnet.id);
+  // Address sets the operator may write (holds write/admin on the row id).
+  // Empty until ``perms`` resolves — fail-closed, like ``subnetWritable``.
+  const writableSets = addressSets.filter((s) =>
+    perms.can("write", "address_set", s.id),
+  );
+
+  // True when the operator may edit the given IP: subnet-write, OR the IP
+  // falls inside a writable address set's range. Contiguous ranges are
+  // compared numerically (IPv4 via ``ipStringToInt``; IPv6 falls through
+  // to string-equality on the bounds), explicit sets by string match.
+  const ipInWritableSet = (address: string): boolean => {
+    for (const s of writableSets) {
+      if (s.range_kind === "explicit") {
+        if (s.explicit_addresses.includes(address)) return true;
+        continue;
+      }
+      if (!s.start_address || !s.end_address) continue;
+      // IPv4 numeric containment.
+      if (address.includes(".") && s.start_address.includes(".")) {
+        const ipInt = ipStringToInt(address);
+        const lo = ipStringToInt(s.start_address);
+        const hi = ipStringToInt(s.end_address);
+        if (ipInt >= lo && ipInt <= hi) return true;
+      } else if (address === s.start_address || address === s.end_address) {
+        // IPv6 / non-dotted — conservative: only the exact bounds count.
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // The full per-IP write decision used by gray-out + checkbox + menu.
+  const permitsWriteIp = (address: string): boolean =>
+    subnetWritable || ipInWritableSet(address);
+
   const [editingAddress, setEditingAddress] = useState<IPAddress | null>(null);
   const [viewingAddress, setViewingAddress] = useState<IPAddress | null>(null);
   const [scanFromDetail, setScanFromDetail] = useState<IPAddress | null>(null);
   const [showFilters, setShowFilters] = useState(false);
   const [activeSubnetTab, setActiveSubnetTab] = useState<
-    "addresses" | "dhcp" | "aliases" | "nat" | "trend"
+    "addresses" | "dhcp" | "aliases" | "nat" | "trend" | "address-sets"
   >("addresses");
   const [natModalIp, setNatModalIp] = useState<IPAddress | null>(null);
   const [selectedIpIds, setSelectedIpIds] = useState<Set<string>>(new Set());
@@ -4415,6 +4474,18 @@ function SubnetDetail({
             Aliases
           </button>
           <button
+            onClick={() => setActiveSubnetTab("address-sets")}
+            className={cn(
+              "px-3 py-2 text-xs font-medium border-b-2 -mb-px transition-colors",
+              activeSubnetTab === "address-sets"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+            title="Named, RBAC-scoped slices of this subnet's address space"
+          >
+            Address Sets
+          </button>
+          <button
             onClick={() => setActiveSubnetTab("nat")}
             className={cn(
               "px-3 py-2 text-xs font-medium border-b-2 -mb-px transition-colors",
@@ -4491,6 +4562,12 @@ function SubnetDetail({
       {activeSubnetTab === "trend" && (
         <div className="flex-1 overflow-auto p-4">
           <SubnetUtilizationHistory subnetId={subnet.id} />
+        </div>
+      )}
+
+      {activeSubnetTab === "address-sets" && (
+        <div className="flex-1 overflow-auto">
+          <AddressSetsSubnetPanel subnet={subnet} />
         </div>
       )}
 
@@ -4883,10 +4960,15 @@ function SubnetDetail({
                       addr.status === "broadcast" ||
                       !!addr.auto_from_lease;
                     const rowSelected = selectedIpIds.has(addr.id);
+                    // RBAC gate (#103/#449): subnet-write OR the IP falls
+                    // inside an address set the operator can write. The
+                    // server is the real gate — this only hides affordances.
+                    const permitsWrite = permitsWriteIp(addr.address);
                     const canEdit =
                       !systemRow &&
                       addr.status !== "orphan" &&
-                      !isReadOnly(addr.status);
+                      !isReadOnly(addr.status) &&
+                      permitsWrite;
                     return (
                       <ContextMenu key={addr.id}>
                         <ContextMenuTrigger asChild>
@@ -4899,6 +4981,13 @@ function SubnetDetail({
                                 addr.status === "broadcast") &&
                                 "opacity-50",
                               addr.status === "orphan" && "opacity-40",
+                              // Gray out rows the operator can't write
+                              // (no subnet-write + not in a writable set).
+                              // Read stays active (row click → detail).
+                              !systemRow &&
+                                addr.status !== "orphan" &&
+                                !permitsWrite &&
+                                "opacity-50",
                               rowSelected && "bg-primary/5",
                               isHighlightedRow(addr.id) &&
                                 "spatium-row-highlight",
@@ -4908,7 +4997,7 @@ function SubnetDetail({
                               className="w-8 px-2 py-2"
                               onClick={(e) => e.stopPropagation()}
                             >
-                              {!systemRow && (
+                              {!systemRow && permitsWrite && (
                                 <input
                                   type="checkbox"
                                   checked={rowSelected}
@@ -5431,7 +5520,7 @@ function SubnetDetail({
               !!viewingAddress.auto_from_lease ||
               viewingAddress.status === "orphan" ||
               isReadOnly(viewingAddress.status)
-            )
+            ) && permitsWriteIp(viewingAddress.address)
           }
           onClose={() => setViewingAddress(null)}
           onEdit={() => {
@@ -7932,6 +8021,389 @@ function AliasesSubnetPanel({ subnetId }: { subnetId: string }) {
         />
       )}
     </div>
+  );
+}
+
+// ── Address Sets panel (#103) ──────────────────────────────────────────────
+//
+// Named, RBAC-scoped slices of a subnet. List / create / edit / delete.
+// Management (create + per-row edit/delete) is gated on subnet-write OR
+// ``admin`` on the specific set row; the server is the real gate (403 +
+// audit on every mutation) — this only drives affordance visibility.
+
+function addressSetRangeLabel(s: AddressSet): string {
+  if (s.range_kind === "explicit") {
+    const n = s.explicit_addresses.length;
+    return `${n} address${n === 1 ? "" : "es"}`;
+  }
+  if (s.start_address && s.end_address) {
+    return s.start_address === s.end_address
+      ? s.start_address
+      : `${s.start_address} – ${s.end_address}`;
+  }
+  return "—";
+}
+
+function AddressSetsSubnetPanel({ subnet }: { subnet: Subnet }) {
+  const qc = useQueryClient();
+  const perms = usePermissions();
+  const { data: sets = [], isLoading } = useQuery({
+    queryKey: ["address-sets", subnet.id],
+    queryFn: () => addressSetsApi.list({ subnet_id: subnet.id }),
+  });
+  // Resolve customer / site names for the Owner chips.
+  const subnetWritable = perms.can("write", "subnet", subnet.id);
+  // ``admin`` on the ``address_set`` type lets you create new sets.
+  const canCreate = perms.can("admin", "address_set");
+  const canManageSet = (id: string) =>
+    subnetWritable || perms.can("admin", "address_set", id);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [editingSet, setEditingSet] = useState<AddressSet | null>(null);
+  const [confirmDel, setConfirmDel] = useState<AddressSet | null>(null);
+
+  const delSet = useMutation({
+    mutationFn: (id: string) => addressSetsApi.remove(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["address-sets", subnet.id] });
+      qc.invalidateQueries({ queryKey: ["addresses", subnet.id] });
+      setConfirmDel(null);
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <p className="p-6 text-sm text-muted-foreground">Loading address sets…</p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between gap-2 border-b bg-card px-4 py-2">
+        <p className="text-xs text-muted-foreground">
+          Named, RBAC-scoped slices of this subnet. Grant a role{" "}
+          <span className="font-mono">admin</span> on a set to delegate edit
+          rights for just its range.
+        </p>
+        {canCreate && (
+          <HeaderButton
+            icon={Plus}
+            variant="primary"
+            onClick={() => setShowCreate(true)}
+          >
+            New address set
+          </HeaderButton>
+        )}
+      </div>
+
+      {sets.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <Boxes className="mb-3 h-10 w-10 text-muted-foreground/30" />
+          <p className="text-sm text-muted-foreground">
+            No address sets in this subnet.
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground/70">
+            Create one to delegate edit rights over a range of addresses.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[720px] text-sm">
+            <thead>
+              <tr className="border-b bg-muted/40 text-xs">
+                <th className="px-4 py-2 text-left font-medium">Name</th>
+                <th className="px-4 py-2 text-left font-medium">Range</th>
+                <th className="px-4 py-2 text-left font-medium">Kind</th>
+                <th className="px-4 py-2 text-left font-medium">Owner</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody className={zebraBodyCls}>
+              {sets.map((s) => {
+                const manageable = canManageSet(s.id);
+                return (
+                  <tr
+                    key={s.id}
+                    className="border-b last:border-0 hover:bg-muted/20"
+                  >
+                    <td className="px-4 py-2">
+                      <div className="font-medium">{s.name}</div>
+                      {s.description && (
+                        <div className="text-xs text-muted-foreground">
+                          {s.description}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 font-mono text-xs">
+                      {addressSetRangeLabel(s)}
+                    </td>
+                    <td className="px-4 py-2">
+                      <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
+                        {s.range_kind}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2">
+                      <div className="flex flex-wrap items-center gap-1">
+                        <CustomerChip customerId={s.customer_id} />
+                        <SiteChip siteId={s.site_id} />
+                        {!s.customer_id && !s.site_id && (
+                          <span className="text-muted-foreground/40">—</span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      {manageable && (
+                        <div className="flex justify-end gap-1">
+                          <button
+                            onClick={() => setEditingSet(s)}
+                            className="rounded p-1 text-muted-foreground hover:text-foreground"
+                            title="Edit address set"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            onClick={() => setConfirmDel(s)}
+                            className="rounded p-1 text-muted-foreground hover:text-destructive"
+                            title="Delete address set"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {showCreate && (
+        <AddressSetModal
+          subnet={subnet}
+          onClose={() => setShowCreate(false)}
+          onSaved={() => {
+            qc.invalidateQueries({ queryKey: ["address-sets", subnet.id] });
+            qc.invalidateQueries({ queryKey: ["addresses", subnet.id] });
+            setShowCreate(false);
+          }}
+        />
+      )}
+      {editingSet && (
+        <AddressSetModal
+          subnet={subnet}
+          existing={editingSet}
+          onClose={() => setEditingSet(null)}
+          onSaved={() => {
+            qc.invalidateQueries({ queryKey: ["address-sets", subnet.id] });
+            qc.invalidateQueries({ queryKey: ["addresses", subnet.id] });
+            setEditingSet(null);
+          }}
+        />
+      )}
+      <ConfirmModal
+        open={confirmDel !== null}
+        title="Delete address set"
+        tone="destructive"
+        confirmLabel="Delete"
+        loading={delSet.isPending}
+        message={
+          confirmDel
+            ? `Delete address set "${confirmDel.name}"? Any permissions ` +
+              `granted on this set will no longer match. The IP addresses ` +
+              `themselves are not removed.`
+            : ""
+        }
+        onConfirm={() => confirmDel && delSet.mutate(confirmDel.id)}
+        onClose={() => setConfirmDel(null)}
+      />
+    </div>
+  );
+}
+
+function AddressSetModal({
+  subnet,
+  existing,
+  onClose,
+  onSaved,
+}: {
+  subnet: Subnet;
+  existing?: AddressSet;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const isEdit = !!existing;
+  const [name, setName] = useState(existing?.name ?? "");
+  const [description, setDescription] = useState(existing?.description ?? "");
+  const [rangeKind, setRangeKind] = useState<AddressSet["range_kind"]>(
+    existing?.range_kind ?? "contiguous",
+  );
+  const [startAddress, setStartAddress] = useState(
+    existing?.start_address ?? "",
+  );
+  const [endAddress, setEndAddress] = useState(existing?.end_address ?? "");
+  // Explicit addresses edited as a newline/comma-separated textarea.
+  const [explicitText, setExplicitText] = useState(
+    (existing?.explicit_addresses ?? []).join("\n"),
+  );
+  const [customerId, setCustomerId] = useState<string | null>(
+    existing?.customer_id ?? null,
+  );
+  const [siteId, setSiteId] = useState<string | null>(
+    existing?.site_id ?? null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const parseExplicit = (): string[] =>
+    explicitText
+      .split(/[\s,]+/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+  const save = useMutation({
+    mutationFn: () => {
+      const explicit = parseExplicit();
+      if (isEdit && existing) {
+        const body: AddressSetUpdate = {
+          name,
+          description,
+          customer_id: customerId,
+          site_id: siteId,
+          range_kind: rangeKind,
+          start_address: rangeKind === "contiguous" ? startAddress : null,
+          end_address: rangeKind === "contiguous" ? endAddress : null,
+          explicit_addresses: rangeKind === "explicit" ? explicit : [],
+        };
+        return addressSetsApi.update(existing.id, body);
+      }
+      const body: AddressSetCreate = {
+        name,
+        description,
+        subnet_id: subnet.id,
+        customer_id: customerId,
+        site_id: siteId,
+        range_kind: rangeKind,
+        start_address: rangeKind === "contiguous" ? startAddress : null,
+        end_address: rangeKind === "contiguous" ? endAddress : null,
+        explicit_addresses: rangeKind === "explicit" ? explicit : [],
+      };
+      return addressSetsApi.create(body);
+    },
+    onSuccess: () => onSaved(),
+    onError: (e) => setError(formatApiError(e)),
+  });
+
+  const canSubmit =
+    name.trim() !== "" &&
+    (rangeKind === "contiguous"
+      ? startAddress.trim() !== "" && endAddress.trim() !== ""
+      : parseExplicit().length > 0);
+
+  return (
+    <Modal
+      title={isEdit ? `Edit ${existing!.name}` : "New address set"}
+      onClose={onClose}
+      wide
+    >
+      <div className="space-y-3">
+        <Field label="Name">
+          <input
+            className={inputCls}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Servers, Printers"
+            autoFocus
+          />
+        </Field>
+        <Field label="Description">
+          <input
+            className={inputCls}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional"
+          />
+        </Field>
+        <Field label="Range kind">
+          <select
+            className={inputCls}
+            value={rangeKind}
+            onChange={(e) =>
+              setRangeKind(e.target.value as AddressSet["range_kind"])
+            }
+          >
+            <option value="contiguous">Contiguous (start – end)</option>
+            <option value="explicit">Explicit (list of addresses)</option>
+          </select>
+        </Field>
+        {rangeKind === "contiguous" ? (
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Start address">
+              <input
+                className={inputCls}
+                value={startAddress}
+                onChange={(e) => setStartAddress(e.target.value)}
+                placeholder={`First IP in ${subnet.network}`}
+              />
+            </Field>
+            <Field label="End address">
+              <input
+                className={inputCls}
+                value={endAddress}
+                onChange={(e) => setEndAddress(e.target.value)}
+                placeholder={`Last IP in ${subnet.network}`}
+              />
+            </Field>
+          </div>
+        ) : (
+          <Field
+            label="Addresses"
+            hint="One per line (or comma / space separated). Each must fall within the subnet."
+          >
+            <textarea
+              className={cn(inputCls, "min-h-[96px] font-mono text-xs")}
+              value={explicitText}
+              onChange={(e) => setExplicitText(e.target.value)}
+              placeholder={"10.0.0.10\n10.0.0.20"}
+            />
+          </Field>
+        )}
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Customer">
+            <CustomerPicker value={customerId} onChange={setCustomerId} />
+          </Field>
+          <Field label="Site">
+            <SitePicker value={siteId} onChange={setSiteId} />
+          </Field>
+        </div>
+        {error && (
+          <p className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            {error}
+          </p>
+        )}
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={save.isPending}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canSubmit || save.isPending}
+            onClick={() => {
+              setError(null);
+              save.mutate();
+            }}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {save.isPending ? "Saving…" : isEdit ? "Save" : "Create"}
+          </button>
+        </div>
+      </div>
+    </Modal>
   );
 }
 


### PR DESCRIPTION
Closes #449. Closes #103.

Two RBAC/governance features that ship together — #449 is the introspection prerequisite #103's UI consumes. Built dependency-ordered on one branch.

## #449 — Permission introspection
- `GET /api/v1/auth/me/permissions` returns the **caller's own** effective grants (role ∪ live time-bound #65 ∪ resource-scoped-token narrowing #374), self-only, via `permissions.effective_grants()`.
- `usePermissions()` hook + pure `permissionMatch()` util (backend-identical semantics, fail-closed while loading).
- Reusable `<ResourceIdPicker>`; RolesPage + time-bound-grant modal swap the raw UUID input for it.

## #103 — Address sets (delegate an IP range without subnet-wide write)
- `AddressSet` model + migration `e2b9c4f1a7d6` + feature module `ipam.address_sets` + `address_set` resource type + builtin "Address Set Editor" role + typed events.
- CRUD at `/api/v1/address-sets` (audited, module-gated).
- **Per-IP write gate** (`app/services/ipam/address_set_gate.py`, reuses the DHCP-pool int-range pattern) wired into all 8 IPAM mutation chokepoints: subnet write **OR** write/admin on a containing set. Out-of-set single edits 403; bulk loops skip + report.
- MCP `find_address_sets` / `count_address_sets` / `propose_create_address_set`.
- Frontend: Address Sets subnet tab + IPAM gray-out (BigInt IPv4/IPv6 membership matching the backend gate).

## Review trail (all fixed, all on this branch)
**Recall code review** — 18 findings incl. 2 blockers (router gate omitted `address_set`; `effective_grants` over-reported under a scoped token).

**Adversarial security review** — 7 findings, must-fix:
- 🔴 **CRITICAL self-delegation** — `create_address_set` now requires write on the **parent subnet** (was only `admin:address_set`, letting the Address Set Editor role carve a set over any subnet and self-grant IP-write).
- range-widen escape (REST + AI) now needs subnet write; read endpoints + MCP scoped to readable subnets (was an enumeration leak of the delegation map); `explicit_addresses` capped at 1024 (DoS); gate interval-merge + bounds.

**Gap both reviews missed (caught on manual re-check):** the IPAM coarse gate did an *unscoped* permission check that 403'd a **scoped** `{write, address_set, <id>}` delegate — #103's actual acceptance case — before the per-IP gate ran. Added `require_any_resource_or_scoped` + `has_any_grant_for` (write/delete only; per-IP gate still draws the boundary). Regression tests prove a scoped delegate writes inside their set (201) and is 403'd outside it.

## Verification
`make ci` green (ruff/black/mypy, eslint/prettier/tsc, vite build); migration linter clean; `tests/test_address_set_security.py` 12/12 (incl. the self-delegation, range-widen, MCP-scope, DoS-cap, and scoped-delegate end-to-end cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)