### PR TITLE
feat(rbac): approval workflows for risky ops + self-governance lock (#62)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -22,6 +22,8 @@ backend/alembic/versions/1a48e694db0b_initial_schema.py:drop_table:308
 backend/alembic/versions/1a48e694db0b_initial_schema.py:drop_table:310
 backend/alembic/versions/1a48e694db0b_initial_schema.py:drop_table:312
 backend/alembic/versions/1a48e694db0b_initial_schema.py:drop_table:317
+backend/alembic/versions/2c24fe41a7ed_change_requests.py:drop_table:152
+backend/alembic/versions/2c24fe41a7ed_change_requests.py:drop_table:156
 backend/alembic/versions/2c4e9d1a7f63_vrf_first_class.py:drop_column:264
 backend/alembic/versions/2c4e9d1a7f63_vrf_first_class.py:drop_column:268
 backend/alembic/versions/2c4e9d1a7f63_vrf_first_class.py:drop_constraint_fk:263
@@ -439,7 +441,7 @@ backend/alembic/versions/e1f2a3b4c5d6_subnet_ddns_fields.py:drop_column:64
 backend/alembic/versions/e1f2a3b4c5d6_subnet_ddns_fields.py:drop_column:65
 backend/alembic/versions/e1f2a3b4c5d6_subnet_ddns_fields.py:drop_column:66
 backend/alembic/versions/e2a6f3b8c1d4_add_auto_from_lease_to_ipaddress.py:drop_column:33
-backend/alembic/versions/e2b9c4f1a7d6_address_sets.py:drop_table:104
+backend/alembic/versions/e2b9c4f1a7d6_address_sets.py:drop_table:102
 backend/alembic/versions/e2c91d5f7a48_appliance_pairing_codes.py:drop_table:126
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:59
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:60

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -22,8 +22,8 @@ backend/alembic/versions/1a48e694db0b_initial_schema.py:drop_table:308
 backend/alembic/versions/1a48e694db0b_initial_schema.py:drop_table:310
 backend/alembic/versions/1a48e694db0b_initial_schema.py:drop_table:312
 backend/alembic/versions/1a48e694db0b_initial_schema.py:drop_table:317
-backend/alembic/versions/2c24fe41a7ed_change_requests.py:drop_table:152
-backend/alembic/versions/2c24fe41a7ed_change_requests.py:drop_table:156
+backend/alembic/versions/2c24fe41a7ed_change_requests.py:drop_table:151
+backend/alembic/versions/2c24fe41a7ed_change_requests.py:drop_table:155
 backend/alembic/versions/2c4e9d1a7f63_vrf_first_class.py:drop_column:264
 backend/alembic/versions/2c4e9d1a7f63_vrf_first_class.py:drop_column:268
 backend/alembic/versions/2c4e9d1a7f63_vrf_first_class.py:drop_constraint_fk:263
@@ -59,6 +59,7 @@ backend/alembic/versions/4c9e1f82a3b7_add_dns_schema.py:drop_table:195
 backend/alembic/versions/4c9e1f82a3b7_add_dns_schema.py:drop_table:196
 backend/alembic/versions/4c9e1f82a3b7_add_dns_schema.py:drop_table:197
 backend/alembic/versions/4c9e1f82a3b7_add_dns_schema.py:drop_table:198
+backend/alembic/versions/5443d2756647_approvals_protect_controls.py:drop_column:40
 backend/alembic/versions/5d2a8f91c4e6_add_dns_settings_and_fix_session_timeout.py:drop_column:39
 backend/alembic/versions/5d2a8f91c4e6_add_dns_settings_and_fix_session_timeout.py:drop_column:40
 backend/alembic/versions/5d2a8f91c4e6_add_dns_settings_and_fix_session_timeout.py:drop_column:41

--- a/backend/alembic/versions/2c24fe41a7ed_change_requests.py
+++ b/backend/alembic/versions/2c24fe41a7ed_change_requests.py
@@ -116,6 +116,15 @@ def upgrade() -> None:
 
     # ── built-in approval policies — all enabled=FALSE so existing ───────
     # installs see zero behaviour change until an operator opts in.
+    #
+    # P1 HONESTY (#2/#4): seed ONLY the six delete:<resource> policies —
+    # the only actions actually wired to a registered risky Operation +
+    # gate threading today. The bulk_delete / bulk_edit / bulk_allocate /
+    # factory_reset / import_commit policies are deliberately NOT seeded:
+    # nothing gates those actions in P1, so an operator who flips one to
+    # enabled=TRUE would get an enabled-but-inert rule that silently never
+    # fires (a fail-open trap). They land in P2 alongside their gate
+    # threading. The policy CRUD likewise rejects creating them (422).
     op.execute(sa.text("""
             INSERT INTO approval_policy
                 (id, name, resource_type, action, min_count,
@@ -132,17 +141,7 @@ def upgrade() -> None:
                 (gen_random_uuid(), 'Delete DHCP scope', 'dhcp_scope', 'delete',
                  NULL, FALSE, TRUE, 168, TRUE),
                 (gen_random_uuid(), 'Delete DHCP server group',
-                 'dhcp_server_group', 'delete', NULL, FALSE, TRUE, 168, TRUE),
-                (gen_random_uuid(), 'Bulk delete (>= 25)', '*', 'bulk_delete',
-                 25, FALSE, TRUE, 168, TRUE),
-                (gen_random_uuid(), 'Bulk edit (>= 50)', '*', 'bulk_edit',
-                 50, FALSE, TRUE, 168, TRUE),
-                (gen_random_uuid(), 'Bulk allocate (>= 256)', '*',
-                 'bulk_allocate', 256, FALSE, TRUE, 168, TRUE),
-                (gen_random_uuid(), 'Factory reset', 'platform',
-                 'factory_reset', NULL, FALSE, TRUE, 168, TRUE),
-                (gen_random_uuid(), 'Import commit (>= 100)', '*',
-                 'import_commit', 100, FALSE, TRUE, 168, TRUE)
+                 'dhcp_server_group', 'delete', NULL, FALSE, TRUE, 168, TRUE)
             """))
 
 

--- a/backend/alembic/versions/2c24fe41a7ed_change_requests.py
+++ b/backend/alembic/versions/2c24fe41a7ed_change_requests.py
@@ -1,0 +1,156 @@
+"""change_request + approval_policy tables + governance.approvals module (#62)
+
+Two-person approval workflow substrate: ``change_request`` holds a risky
+operation queued for second-person approval, ``approval_policy`` holds the
+operator-tunable rules deciding when the gate fires. Built-in policy rows
+seed ``enabled=False`` so existing installs see zero behaviour change until
+an operator opts in. The ``governance.approvals`` feature_module row seeds
+``FALSE`` (default-off, non-negotiable #14). The "Change Approver" builtin
+role is seeded in main.py startup, not here.
+
+Revision ID: 2c24fe41a7ed
+Revises: e2b9c4f1a7d6
+Create Date: 2026-06-22
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "2c24fe41a7ed"
+down_revision: str | None = "e2b9c4f1a7d6"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "change_request",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("operation", sa.String(length=64), nullable=False),
+        sa.Column("resource_type", sa.String(length=100), nullable=False),
+        sa.Column("resource_id", sa.String(length=255), nullable=True),
+        sa.Column("resource_display", sa.String(length=500), nullable=False),
+        sa.Column("args", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("preview_text", sa.Text(), nullable=False),
+        sa.Column("risk_reason", sa.String(length=255), nullable=False),
+        sa.Column(
+            "state",
+            sa.String(length=16),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("requested_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("requested_by_display", sa.String(length=255), nullable=False),
+        sa.Column("decided_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("decided_by_display", sa.String(length=255), nullable=True),
+        sa.Column("decision_note", sa.Text(), nullable=True),
+        sa.Column("result", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("executed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["requested_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["decided_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_change_request_state_expires", "change_request", ["state", "expires_at"])
+    op.create_index("ix_change_request_requested_by", "change_request", ["requested_by_user_id"])
+    op.create_index(
+        "ix_change_request_resource", "change_request", ["resource_type", "resource_id"]
+    )
+
+    op.create_table(
+        "approval_policy",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("resource_type", sa.String(length=100), nullable=False),
+        sa.Column("action", sa.String(length=50), nullable=False),
+        sa.Column("min_count", sa.Integer(), nullable=True),
+        sa.Column("enabled", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column(
+            "applies_to_superadmin",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+        sa.Column("ttl_hours", sa.Integer(), server_default=sa.text("168"), nullable=False),
+        sa.Column("is_builtin", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_approval_policy_match", "approval_policy", ["resource_type", "action"])
+
+    # ── feature_module seed (non-negotiable #14) — default-off ───────────
+    op.execute(sa.text("""
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('governance.approvals', FALSE)
+            ON CONFLICT (id) DO NOTHING
+            """))
+
+    # ── built-in approval policies — all enabled=FALSE so existing ───────
+    # installs see zero behaviour change until an operator opts in.
+    op.execute(sa.text("""
+            INSERT INTO approval_policy
+                (id, name, resource_type, action, min_count,
+                 enabled, applies_to_superadmin, ttl_hours, is_builtin)
+            VALUES
+                (gen_random_uuid(), 'Delete subnet', 'subnet', 'delete',
+                 NULL, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Delete IP block', 'ip_block', 'delete',
+                 NULL, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Delete IP space', 'ip_space', 'delete',
+                 NULL, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Delete DNS zone', 'dns_zone', 'delete',
+                 NULL, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Delete DHCP scope', 'dhcp_scope', 'delete',
+                 NULL, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Delete DHCP server group',
+                 'dhcp_server_group', 'delete', NULL, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Bulk delete (>= 25)', '*', 'bulk_delete',
+                 25, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Bulk edit (>= 50)', '*', 'bulk_edit',
+                 50, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Bulk allocate (>= 256)', '*',
+                 'bulk_allocate', 256, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Factory reset', 'platform',
+                 'factory_reset', NULL, FALSE, TRUE, 168, TRUE),
+                (gen_random_uuid(), 'Import commit (>= 100)', '*',
+                 'import_commit', 100, FALSE, TRUE, 168, TRUE)
+            """))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'governance.approvals'"))
+    op.drop_index("ix_approval_policy_match", table_name="approval_policy")
+    op.drop_table("approval_policy")
+    op.drop_index("ix_change_request_resource", table_name="change_request")
+    op.drop_index("ix_change_request_requested_by", table_name="change_request")
+    op.drop_index("ix_change_request_state_expires", table_name="change_request")
+    op.drop_table("change_request")

--- a/backend/alembic/versions/5443d2756647_approvals_protect_controls.py
+++ b/backend/alembic/versions/5443d2756647_approvals_protect_controls.py
@@ -1,0 +1,40 @@
+"""approvals self-protection lock flag (#62)
+
+Adds ``platform_settings.approvals_protect_controls`` — the opt-in
+self-governance lock for the two-person approval workflow. When True,
+weakening the approval control plane (disabling the module, disabling /
+deleting a policy, lowering a policy's superadmin gate, or turning this
+lock off) requires a second superadmin's approval. Additive boolean with
+``server_default false`` so every existing install stays exactly as it is.
+
+Revision ID: 5443d2756647
+Revises: 2c24fe41a7ed
+Create Date: 2026-06-22
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "5443d2756647"
+down_revision: str | None = "2c24fe41a7ed"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "approvals_protect_controls",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_settings", "approvals_protect_controls")

--- a/backend/app/api/v1/admin/feature_modules.py
+++ b/backend/app/api/v1/admin/feature_modules.py
@@ -18,20 +18,39 @@ catalog metadata (label / group / description) for the Settings page.
 
 from __future__ import annotations
 
+import asyncio
+from uuid import UUID
+
 import structlog
-from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.demo_mode import DEMO_RESTRICTED_MODULES, is_demo_mode
+from app.core.permissions import is_effective_superadmin
 from app.models.audit import AuditLog
 from app.models.feature_module import FeatureModule
 from app.models.settings import PlatformSettings
 from app.services import feature_modules as fm_svc
+from app.services.ai.operations import get_operation
+from app.services.ai.operations_control import (
+    MODULE_ID as APPROVALS_MODULE_ID,
+)
+from app.services.ai.operations_control import (
+    ControlKind,
+    ModifyApprovalControlArgs,
+    is_controls_protected,
+    maybe_gate_control,
+)
+from app.services.reauth import ReauthOutcome, reverify_operator
 
 logger = structlog.get_logger(__name__)
 router = APIRouter()
+
+# Typed confirmation phrase the break-glass caller must echo exactly — mirrors
+# factory-reset's exact-match phrase guard. Wrong phrase → 422.
+BREAK_GLASS_PHRASE = "BREAK GLASS"
 
 
 class FeatureModuleEntry(BaseModel):
@@ -50,6 +69,11 @@ class FeatureModuleEntry(BaseModel):
 
 class FeatureModuleToggleBody(BaseModel):
     enabled: bool
+    # #62: when enabling ``governance.approvals``, the operator may also turn
+    # on the self-governance lock in the same call. Only honoured for that
+    # module on the enable path; ignored everywhere else (enabling never
+    # CLEARS the lock — that's a gated weakening move).
+    protect_controls: bool | None = None
 
 
 @router.get("/feature-modules", response_model=list[FeatureModuleEntry])
@@ -70,13 +94,14 @@ async def list_feature_modules(db: DB, current_user: CurrentUser) -> list[Featur
     ]
 
 
-@router.patch("/feature-modules/{module_id}", response_model=FeatureModuleEntry)
+@router.patch("/feature-modules/{module_id}")
 async def toggle_feature_module(
     module_id: str,
     body: FeatureModuleToggleBody,
     db: DB,
     current_user: SuperAdmin,
-) -> FeatureModuleEntry:
+    request: Request,
+):  # noqa: ANN201 — returns FeatureModuleEntry OR a 202 JSONResponse (gated)
     if not fm_svc.is_known(module_id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -96,6 +121,31 @@ async def toggle_feature_module(
         )
 
     spec = fm_svc.MODULES_BY_ID[module_id]
+
+    # #62 self-governance lock: disabling ``governance.approvals`` is a
+    # WEAKENING change. When the lock is on (and the caller isn't going
+    # through break-glass), this returns a 202 + a pending change_request a
+    # SECOND superadmin must approve, INSTEAD of disabling inline. When the
+    # lock is off ``maybe_gate_control`` returns None immediately (before any
+    # extra query) so the inline path below is byte-identical to today.
+    if module_id == APPROVALS_MODULE_ID and body.enabled is False:
+        from fastapi.responses import JSONResponse  # noqa: PLC0415
+
+        pending = await maybe_gate_control(
+            db,
+            current_user,
+            request,
+            kind="disable_module",
+            resource_type="feature_module",
+            resource_id=module_id,
+            resource_display="Approval workflows",
+        )
+        if pending is not None:
+            return JSONResponse(
+                status_code=status.HTTP_202_ACCEPTED,
+                content=pending.as_dict(),
+            )
+
     row = await fm_svc.set_module_enabled(db, module_id, body.enabled, user_id=current_user.id)
     # Mirror the toggle into the matching ``PlatformSettings`` column
     # for integrations. The Celery beat reconcilers gate on those
@@ -120,6 +170,30 @@ async def toggle_feature_module(
             new_value={"enabled": body.enabled},
         )
     )
+
+    # #62 set-at-enable-time: turning ON ``governance.approvals`` with
+    # ``protect_controls=true`` also flips the self-protection lock on. This
+    # is a STRENGTHENING move → stays single-person inline + audited.
+    # ``protect_controls`` is never honoured to CLEAR the lock here (that's a
+    # gated weakening move via break-glass / approval).
+    if module_id == APPROVALS_MODULE_ID and body.enabled and body.protect_controls:
+        ps = await db.get(PlatformSettings, 1)
+        if ps is not None and not ps.approvals_protect_controls:
+            ps.approvals_protect_controls = True
+            db.add(
+                AuditLog(
+                    user_id=current_user.id,
+                    user_display_name=current_user.display_name,
+                    auth_source=current_user.auth_source,
+                    action="update",
+                    resource_type="platform_settings",
+                    resource_id="approvals_protect_controls",
+                    resource_display="Approval self-protection lock",
+                    result="success",
+                    new_value={"approvals_protect_controls": True},
+                )
+            )
+
     await db.commit()
     fm_svc.invalidate_cache()
 
@@ -131,3 +205,227 @@ async def toggle_feature_module(
         default_enabled=spec.default_enabled,
         enabled=row.enabled,
     )
+
+
+# ── Self-protection lock toggle (#62) ───────────────────────────────────
+
+
+class ApprovalsLockBody(BaseModel):
+    enabled: bool
+
+
+@router.get("/feature-modules/approvals-lock")
+async def get_approvals_lock(db: DB, current_user: SuperAdmin) -> dict:
+    """Current self-governance lock state (superadmin)."""
+    return {"approvals_protect_controls": await is_controls_protected(db)}
+
+
+@router.post("/feature-modules/approvals-lock")
+async def set_approvals_lock(
+    body: ApprovalsLockBody,
+    db: DB,
+    current_user: SuperAdmin,
+    request: Request,
+):  # noqa: ANN201 — {state} OR a 202 JSONResponse (gated when turning OFF)
+    """Turn the self-governance lock on / off (superadmin, #62).
+
+    Turning it ON is a STRENGTHENING move → inline + audited, single-person.
+    Turning it OFF is a WEAKENING move → when the lock is currently on it
+    routes through ``maybe_gate_control`` (a second superadmin must approve)
+    so you can't quietly self-unlock; the break-glass endpoint is the
+    immediate escape hatch.
+    """
+    currently = await is_controls_protected(db)
+
+    if body.enabled:
+        # Strengthen — inline.
+        if not currently:
+            ps = await db.get(PlatformSettings, 1)
+            if ps is not None:
+                ps.approvals_protect_controls = True
+            db.add(
+                AuditLog(
+                    user_id=current_user.id,
+                    user_display_name=current_user.display_name,
+                    auth_source=current_user.auth_source,
+                    action="update",
+                    resource_type="platform_settings",
+                    resource_id="approvals_protect_controls",
+                    resource_display="Approval self-protection lock",
+                    result="success",
+                    new_value={"approvals_protect_controls": True},
+                )
+            )
+            await db.commit()
+        return {"approvals_protect_controls": True}
+
+    # Weaken (turn off) — gate when currently on.
+    pending = await maybe_gate_control(
+        db,
+        current_user,
+        request,
+        kind="unlock",
+        resource_type="platform_settings",
+        resource_id="approvals_protect_controls",
+        resource_display="Approval self-protection lock",
+    )
+    if pending is not None:
+        from fastapi.responses import JSONResponse  # noqa: PLC0415
+
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+
+    # Lock already off (maybe_gate_control short-circuited) → idempotent no-op.
+    return {"approvals_protect_controls": False}
+
+
+# ── Break-glass: force a protected control change immediately (#62) ──────
+
+
+class BreakGlassBody(BaseModel):
+    """Force a weakening control change immediately, bypassing the
+    two-person gate. The mandatory anti-lockout escape hatch."""
+
+    kind: ControlKind
+    policy_id: UUID | None = None
+    # Re-confirmation — local users supply ``password``; external-auth
+    # users (no local password) supply ``totp_code`` (see services/reauth.py).
+    password: str | None = None
+    totp_code: str | None = None
+    # Typed confirmation phrase — must equal BREAK_GLASS_PHRASE exactly.
+    confirm_phrase: str = Field(min_length=1)
+
+
+def _break_glass_audit(
+    db: DB,
+    *,
+    user,  # type: ignore[no-untyped-def]
+    kind: str,
+    result: str,
+    new_value: dict | None = None,
+) -> None:
+    """HIGH-severity break-glass audit row.
+
+    There is no ``severity`` column (NN #4 trail is the signal); the distinct
+    ``action="approvals.break_glass"`` + the ``governance.break_glass`` typed
+    event (event_publisher special map) convey the high-severity intent so
+    operators can wire a dedicated alert / SIEM rule on it.
+    """
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=getattr(user, "auth_source", "local") or "local",
+            action="approvals.break_glass",
+            resource_type="approval_control",
+            resource_id=kind,
+            resource_display=f"Break-glass: {kind}",
+            result=result,
+            new_value=new_value,
+        )
+    )
+
+
+@router.post("/feature-modules/break-glass", status_code=status.HTTP_200_OK)
+async def break_glass(
+    body: BreakGlassBody,
+    db: DB,
+    current_user: SuperAdmin,
+    request: Request,
+) -> dict:
+    """Force a protected control change IMMEDIATELY (anti-lockout, #62).
+
+    Superadmin-only. Requires BOTH a typed confirmation phrase AND password /
+    TOTP re-confirmation, then executes the weakening control change under the
+    calling superadmin — bypassing the two-person gate. This must never be
+    gateable itself, or a fully-locked platform with no second superadmin could
+    be permanently wedged. Writes a HIGH-severity audit row + fires the
+    ``governance.break_glass`` event.
+    """
+    # 1. Superadmin gate (SuperAdmin dep already enforces, but audit the shape).
+    if not is_effective_superadmin(current_user):  # pragma: no cover — dep enforces
+        _break_glass_audit(
+            db,
+            user=current_user,
+            kind=body.kind,
+            result="forbidden",
+            new_value={"reason": "non_superadmin"},
+        )
+        await db.commit()
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Only superadmins can break the glass")
+
+    # 2. Typed confirmation phrase — exact match (mirrors factory-reset).
+    if body.confirm_phrase != BREAK_GLASS_PHRASE:
+        _break_glass_audit(
+            db,
+            user=current_user,
+            kind=body.kind,
+            result="forbidden",
+            new_value={"reason": "bad_phrase"},
+        )
+        await db.commit()
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            f"Confirmation phrase must be exactly {BREAK_GLASS_PHRASE!r}",
+        )
+
+    # 3. Password / TOTP re-confirmation (#408 pattern).
+    outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
+    if outcome is not ReauthOutcome.OK:
+        reason = "mfa_required" if outcome is ReauthOutcome.MFA_REQUIRED else "bad_credential"
+        _break_glass_audit(
+            db,
+            user=current_user,
+            kind=body.kind,
+            result="forbidden",
+            new_value={"reason": reason},
+        )
+        await db.commit()
+        # Friction-sleep so a bad-credential attempt doesn't leak via timing.
+        await asyncio.sleep(0.5)
+        if outcome is ReauthOutcome.MFA_REQUIRED:
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                "Re-confirmation requires MFA. Your account has no local "
+                "password — enrol TOTP under Settings → Security, then retry.",
+            )
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect")
+
+    # 4. Execute the control change IMMEDIATELY under the caller, bypassing the
+    #    gate (apply() never re-enters maybe_gate_control). Write the
+    #    HIGH-severity audit row in the same transaction BEFORE apply commits
+    #    it, so the break-glass is recorded even if apply's own audit + commit
+    #    is the thing that lands. apply() commits; we add our row first.
+    op = get_operation("modify_approval_control")
+    assert op is not None  # registered at import
+    args = ModifyApprovalControlArgs(kind=body.kind, policy_id=body.policy_id)
+
+    # Stale-state guard — refuse a moot change with a clear reason.
+    preview = await op.preview(db, current_user, args)
+    if not preview.ok:
+        _break_glass_audit(
+            db,
+            user=current_user,
+            kind=body.kind,
+            result="error",
+            new_value={"reason": "stale", "detail": preview.detail},
+        )
+        await db.commit()
+        raise HTTPException(status.HTTP_409_CONFLICT, preview.detail)
+
+    _break_glass_audit(
+        db,
+        user=current_user,
+        kind=body.kind,
+        result="success",
+        new_value={"kind": body.kind, "policy_id": str(body.policy_id) if body.policy_id else None},
+    )
+    logger.warning(
+        "approvals.break_glass",
+        user=current_user.username,
+        kind=body.kind,
+        policy_id=str(body.policy_id) if body.policy_id else None,
+    )
+    # apply() runs the mutation + its own audit row + commit (our break-glass
+    # row is flushed in the same session and lands on that commit).
+    result = await op.apply(db, current_user, args)
+    return {"forced": True, "kind": body.kind, "result": result}

--- a/backend/app/api/v1/admin/feature_modules.py
+++ b/backend/app/api/v1/admin/feature_modules.py
@@ -27,12 +27,15 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
+from app.core.auth_throttle import login_rate_limited
 from app.core.demo_mode import DEMO_RESTRICTED_MODULES, is_demo_mode
 from app.core.permissions import is_effective_superadmin
+from app.core.request_meta import client_ip
 from app.models.audit import AuditLog
 from app.models.feature_module import FeatureModule
 from app.models.settings import PlatformSettings
 from app.services import feature_modules as fm_svc
+from app.services.account_lockout import LockoutPolicy, is_locked, register_failure
 from app.services.ai.operations import get_operation
 from app.services.ai.operations_control import (
     MODULE_ID as APPROVALS_MODULE_ID,
@@ -51,6 +54,16 @@ router = APIRouter()
 # Typed confirmation phrase the break-glass caller must echo exactly — mirrors
 # factory-reset's exact-match phrase guard. Wrong phrase → 422.
 BREAK_GLASS_PHRASE = "BREAK GLASS"
+
+# Audit action strings. The SUCCESS path keeps the HIGH-severity
+# ``approvals.break_glass`` action so SIEM rules keying on it stay clean — a
+# real break-glass is rare and alarming. Post-auth VALIDATION failures (wrong
+# phrase / bad password / stale change) use a distinct lower-severity action so
+# they don't pollute the high-sev success signal with noise an attacker could
+# generate at will. (NN #4 — every attempt that passes the superadmin gate is
+# still durably audited, just under the right action.)
+_BREAK_GLASS_ACTION_SUCCESS = "approvals.break_glass"
+_BREAK_GLASS_ACTION_DENIED = "approvals.break_glass_denied"
 
 
 class FeatureModuleEntry(BaseModel):
@@ -177,8 +190,17 @@ async def toggle_feature_module(
     # ``protect_controls`` is never honoured to CLEAR the lock here (that's a
     # gated weakening move via break-glass / approval).
     if module_id == APPROVALS_MODULE_ID and body.enabled and body.protect_controls:
+        # Get-or-create the settings row before mutating — on a fresh install
+        # there is no ``PlatformSettings(1)`` yet, and skipping the write while
+        # still reporting the lock ON would leave the lock reading OFF (so every
+        # weakening op runs ungated). Mirrors the firewall.py pattern. Only the
+        # audit row lands AFTER the flag is actually staged.
         ps = await db.get(PlatformSettings, 1)
-        if ps is not None and not ps.approvals_protect_controls:
+        if ps is None:
+            ps = PlatformSettings(id=1)
+            db.add(ps)
+            await db.flush()
+        if not ps.approvals_protect_controls:
             ps.approvals_protect_controls = True
             db.add(
                 AuditLog(
@@ -240,9 +262,17 @@ async def set_approvals_lock(
     if body.enabled:
         # Strengthen — inline.
         if not currently:
+            # Get-or-create the settings row before mutating. On a fresh
+            # install no ``PlatformSettings(1)`` exists yet; skipping the write
+            # while reporting the lock ON would leave it reading OFF and every
+            # weakening op ungated. Mirrors firewall.py; audit lands only AFTER
+            # the flag is actually staged.
             ps = await db.get(PlatformSettings, 1)
-            if ps is not None:
-                ps.approvals_protect_controls = True
+            if ps is None:
+                ps = PlatformSettings(id=1)
+                db.add(ps)
+                await db.flush()
+            ps.approvals_protect_controls = True
             db.add(
                 AuditLog(
                     user_id=current_user.id,
@@ -302,20 +332,23 @@ def _break_glass_audit(
     kind: str,
     result: str,
     new_value: dict | None = None,
+    action: str = _BREAK_GLASS_ACTION_SUCCESS,
 ) -> None:
-    """HIGH-severity break-glass audit row.
+    """Break-glass audit row.
 
     There is no ``severity`` column (NN #4 trail is the signal); the distinct
     ``action="approvals.break_glass"`` + the ``governance.break_glass`` typed
     event (event_publisher special map) convey the high-severity intent so
-    operators can wire a dedicated alert / SIEM rule on it.
+    operators can wire a dedicated alert / SIEM rule on it. Post-auth validation
+    failures pass ``action=_BREAK_GLASS_ACTION_DENIED`` so they stay
+    distinguishable from genuine successes for SIEM rules.
     """
     db.add(
         AuditLog(
             user_id=user.id,
             user_display_name=user.display_name,
             auth_source=getattr(user, "auth_source", "local") or "local",
-            action="approvals.break_glass",
+            action=action,
             resource_type="approval_control",
             resource_id=kind,
             resource_display=f"Break-glass: {kind}",
@@ -340,7 +373,24 @@ async def break_glass(
     gateable itself, or a fully-locked platform with no second superadmin could
     be permanently wedged. Writes a HIGH-severity audit row + fires the
     ``governance.break_glass`` event.
+
+    The reauth surface is rate-limited (#4): per-IP via the shared login budget
+    AND per-account via the lockout machinery, so a captured-session attacker
+    can't brute-force the TOTP (relevant for external-auth superadmins with no
+    local password) or spam the high-sev audit log. The HIGH-severity SUCCESS
+    audit is committed in ITS OWN transaction BEFORE apply() runs (#3), so a
+    break-glass that passed phrase+reauth is durably recorded even if apply()
+    raises (e.g. policy deleted concurrently) and rolls the session back.
     """
+    # 0. Per-IP rate limit (#4) — same Redis budget /auth/login uses, fails open.
+    #    Bounds TOTP-spray + high-sev audit noise from one source even before
+    #    we touch the per-account counter.
+    if await login_rate_limited(client_ip(request)):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many break-glass attempts. Try again shortly.",
+        )
+
     # 1. Superadmin gate (SuperAdmin dep already enforces, but audit the shape).
     if not is_effective_superadmin(current_user):  # pragma: no cover — dep enforces
         _break_glass_audit(
@@ -349,9 +399,28 @@ async def break_glass(
             kind=body.kind,
             result="forbidden",
             new_value={"reason": "non_superadmin"},
+            action=_BREAK_GLASS_ACTION_DENIED,
         )
         await db.commit()
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Only superadmins can break the glass")
+
+    # 1b. Per-account lockout short-circuit (#4) — runs BEFORE the credential
+    #     check so a locked account can't keep guessing. Same machinery as
+    #     /auth/login's per-account lockout (#71).
+    if is_locked(current_user):
+        _break_glass_audit(
+            db,
+            user=current_user,
+            kind=body.kind,
+            result="forbidden",
+            new_value={"reason": "account_locked"},
+            action=_BREAK_GLASS_ACTION_DENIED,
+        )
+        await db.commit()
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "Account is temporarily locked due to repeated failed re-confirmation attempts.",
+        )
 
     # 2. Typed confirmation phrase — exact match (mirrors factory-reset).
     if body.confirm_phrase != BREAK_GLASS_PHRASE:
@@ -361,6 +430,7 @@ async def break_glass(
             kind=body.kind,
             result="forbidden",
             new_value={"reason": "bad_phrase"},
+            action=_BREAK_GLASS_ACTION_DENIED,
         )
         await db.commit()
         raise HTTPException(
@@ -372,12 +442,19 @@ async def break_glass(
     outcome = reverify_operator(current_user, password=body.password, totp_code=body.totp_code)
     if outcome is not ReauthOutcome.OK:
         reason = "mfa_required" if outcome is ReauthOutcome.MFA_REQUIRED else "bad_credential"
+        # #4: bump the per-account lockout counter on a genuine BAD CREDENTIAL
+        # (not on MFA_REQUIRED, which is a "you haven't enrolled" config issue,
+        # not a guess). Mirrors /auth/login's register_failure on bad_password.
+        if outcome is ReauthOutcome.BAD_CREDENTIAL:
+            settings_row = await db.get(PlatformSettings, 1)
+            register_failure(current_user, LockoutPolicy.from_row(settings_row))
         _break_glass_audit(
             db,
             user=current_user,
             kind=body.kind,
             result="forbidden",
             new_value={"reason": reason},
+            action=_BREAK_GLASS_ACTION_DENIED,
         )
         await db.commit()
         # Friction-sleep so a bad-credential attempt doesn't leak via timing.
@@ -391,15 +468,14 @@ async def break_glass(
         raise HTTPException(status.HTTP_403_FORBIDDEN, "Password or TOTP code is incorrect")
 
     # 4. Execute the control change IMMEDIATELY under the caller, bypassing the
-    #    gate (apply() never re-enters maybe_gate_control). Write the
-    #    HIGH-severity audit row in the same transaction BEFORE apply commits
-    #    it, so the break-glass is recorded even if apply's own audit + commit
-    #    is the thing that lands. apply() commits; we add our row first.
+    #    gate (apply() never re-enters maybe_gate_control).
     op = get_operation("modify_approval_control")
     assert op is not None  # registered at import
     args = ModifyApprovalControlArgs(kind=body.kind, policy_id=body.policy_id)
 
-    # Stale-state guard — refuse a moot change with a clear reason.
+    # Stale-state guard — refuse a moot change with a clear reason. Runs BEFORE
+    # the success audit so a preview-moot break-glass records the lower-severity
+    # ``denied`` row, not a success.
     preview = await op.preview(db, current_user, args)
     if not preview.ok:
         _break_glass_audit(
@@ -408,10 +484,43 @@ async def break_glass(
             kind=body.kind,
             result="error",
             new_value={"reason": "stale", "detail": preview.detail},
+            action=_BREAK_GLASS_ACTION_DENIED,
         )
         await db.commit()
         raise HTTPException(status.HTTP_409_CONFLICT, preview.detail)
 
+    # Idempotent — the desired end-state is already reached (#5). The
+    # break-glass was authenticated, so record a SUCCESS row (the operator
+    # forced the change; it just turned out to be a no-op) and return cleanly
+    # without re-running apply().
+    if preview.idempotent:
+        _break_glass_audit(
+            db,
+            user=current_user,
+            kind=body.kind,
+            result="success",
+            new_value={
+                "kind": body.kind,
+                "policy_id": str(body.policy_id) if body.policy_id else None,
+                "idempotent": True,
+                "detail": preview.detail,
+            },
+        )
+        await db.commit()
+        logger.warning(
+            "approvals.break_glass",
+            user=current_user.username,
+            kind=body.kind,
+            policy_id=str(body.policy_id) if body.policy_id else None,
+            idempotent=True,
+        )
+        return {"forced": True, "kind": body.kind, "result": {"idempotent": True}}
+
+    # #3: durably record the authenticated break-glass in ITS OWN transaction
+    # BEFORE apply() runs. apply() commits its own mutation; if it raises (e.g.
+    # the policy was deleted concurrently → ValueError) the session rolls back
+    # — committing the success audit FIRST guarantees a row exists for every
+    # break-glass that passed phrase + reauth, closing the non-repudiation gap.
     _break_glass_audit(
         db,
         user=current_user,
@@ -419,13 +528,14 @@ async def break_glass(
         result="success",
         new_value={"kind": body.kind, "policy_id": str(body.policy_id) if body.policy_id else None},
     )
+    await db.commit()
     logger.warning(
         "approvals.break_glass",
         user=current_user.username,
         kind=body.kind,
         policy_id=str(body.policy_id) if body.policy_id else None,
     )
-    # apply() runs the mutation + its own audit row + commit (our break-glass
-    # row is flushed in the same session and lands on that commit).
+    # apply() runs the mutation + its own audit row + commit. The success audit
+    # above is already durable, so an apply() failure can't erase it.
     result = await op.apply(db, current_user, args)
     return {"forced": True, "kind": body.kind, "result": result}

--- a/backend/app/api/v1/change_requests/__init__.py
+++ b/backend/app/api/v1/change_requests/__init__.py
@@ -1,0 +1,5 @@
+"""Two-person approval workflow — change-request lifecycle API (#62)."""
+
+from app.api.v1.change_requests.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/change_requests/router.py
+++ b/backend/app/api/v1/change_requests/router.py
@@ -30,7 +30,7 @@ other sees 409).
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 
 import structlog
@@ -48,16 +48,15 @@ from app.core.request_meta import clean_user_agent, client_ip
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.change_request import ApprovalPolicy, ChangeRequest
-from app.services.ai import operations
+from app.services.approvals.policy import GATEABLE_ACTIONS, GATEABLE_RESOURCE_TYPES
 from app.services.approvals.service import (
     ChangeRequestStateError,
+    DecisionError,
+    approve_change_request,
     get_change_request,
     list_change_requests,
-    mark_approved,
     mark_cancelled,
-    mark_executed,
-    mark_failed,
-    mark_rejected,
+    reject_change_request,
 )
 
 logger = structlog.get_logger(__name__)
@@ -201,6 +200,31 @@ def _audit_policy(
     )
 
 
+def _validate_gateable(action: str | None, resource_type: str | None) -> None:
+    """Reject a policy whose (action, resource_type) isn't currently wired to
+    a registered risky operation (#4 — no enabled-but-inert policies).
+
+    Only validates the fields that are present (so a PUT touching just
+    ``enabled`` doesn't re-validate the unchanged action). ``"*"`` wildcard
+    resource_types are P2-only (bulk ops) and rejected in P1.
+    """
+    if action is not None and action not in GATEABLE_ACTIONS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"action {action!r} is not gateable yet — supported: " f"{sorted(GATEABLE_ACTIONS)}"
+            ),
+        )
+    if resource_type is not None and resource_type not in GATEABLE_RESOURCE_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"resource_type {resource_type!r} is not gateable yet — supported: "
+                f"{sorted(GATEABLE_RESOURCE_TYPES)}"
+            ),
+        )
+
+
 def _require_read(user: CurrentUser) -> None:
     """Reads on the queue need ``read,change_request`` (or superadmin)."""
     if is_effective_superadmin(user):
@@ -264,6 +288,7 @@ async def create_policy(
     db: DB,
     request: Request,
 ) -> ApprovalPolicyResponse:
+    _validate_gateable(body.action, body.resource_type)
     policy = ApprovalPolicy(
         name=body.name,
         resource_type=body.resource_type,
@@ -307,6 +332,12 @@ async def update_policy(
     if policy is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     changes = body.model_dump(exclude_unset=True)
+    # Validate the post-update (action, resource_type) — an operator can't
+    # repoint a policy at an action/type that isn't wired yet (#4).
+    _validate_gateable(
+        changes.get("action", policy.action),
+        changes.get("resource_type", policy.resource_type),
+    )
     for field, value in changes.items():
         setattr(policy, field, value)
     _audit_policy(
@@ -373,11 +404,16 @@ async def approve_request(
 ) -> ChangeRequestResponse:
     """Approve and execute a pending change request — the two-person spine.
 
-    Server-side invariants (every one enforced here, never trusting the UI):
+    Thin wrapper over ``services.approvals.service.approve_change_request``,
+    which owns every server-side invariant (never trusting the UI) so this
+    HTTP path and the AI propose→apply path enforce them identically:
 
     1. The row is loaded ``FOR UPDATE`` and must still be ``pending`` (a
-       racing approver loses with 409); an expired row flips to ``expired``.
-    2. **Self-approval blocked** — ``approver.id != requested_by_user_id``.
+       racing approver loses with 409); an expired row routes through the
+       audited ``mark_expired`` then 409s.
+    2. **Self-approval blocked** — ``approver.id != requested_by_user_id``;
+       a request whose requester was deleted (``requested_by_user_id`` NULL)
+       is refused (409) rather than failing open.
     3. Approver holds ``{approve, change_request}``.
     4. Approver holds the underlying operation's ``required_permission`` —
        they can't rubber-stamp a delete they couldn't perform themselves.
@@ -386,122 +422,24 @@ async def approve_request(
        (409, left ``pending`` so the requester can cancel).
     6. ``apply()`` dispatches under the **approver's** identity; the audit
        ``executed`` row carries the approver as actor and the requester id
-       in ``old_value.requested_by``.
+       in ``old_value.requested_by``. A client 4xx raised by ``apply()``
+       leaves the row ``pending`` and surfaces the status; a server fault
+       marks it ``failed``.
     """
     note = body.decision_note if body is not None else None
 
-    # 1. Row lock + state guard — race-safe against a second approver.
-    cr = await get_change_request(db, cr_id, for_update=True)
-    if cr is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-    if cr.state != "pending":
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"Change request is not pending (state={cr.state!r})",
-        )
-    if cr.expires_at < datetime.now(UTC):
-        cr.state = "expired"
-        cr.decided_at = datetime.now(UTC)
-        await db.commit()
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Change request has expired",
-        )
-
-    # 2. Self-approval is forbidden — the whole point of two-person.
-    if cr.requested_by_user_id is not None and current_user.id == cr.requested_by_user_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You cannot approve your own change request",
-        )
-
-    op = operations.get_operation(cr.operation)
-    if op is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Operation {cr.operation!r} is not registered",
-        )
-
-    # 3. Approver holds the approve capability.
-    if not user_has_permission(current_user, "approve", RESOURCE_TYPE_CHANGE_REQUEST):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Permission denied: need 'approve' on '{RESOURCE_TYPE_CHANGE_REQUEST}'",
-        )
-
-    # 4. Approver holds the underlying operation's own permission.
+    # Delegate to the single two-person spine (services/approvals/service.py)
+    # so this HTTP path and the AI propose→apply path enforce the IDENTICAL
+    # invariants (#5 fail-closed on a deleted requester, #11 client-4xx from
+    # apply leaves the row pending, #13 expiry routes through the audited
+    # mark_expired, #14 mark_failed carries the requester id, #15 guarded
+    # rollback). DecisionError subclasses carry the right HTTP status.
     try:
-        operations.enforce_operation_permission(current_user, op)
-    except operations.OperationPermissionError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
-
-    # Re-validate the frozen args through the op's pydantic model — guards
-    # the rare redeploy-mid-flight schema-change case.
-    try:
-        args = op.args_model.model_validate(cr.args or {})
-    except Exception as exc:  # noqa: BLE001
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Stored args no longer validate: {exc}",
-        ) from exc
-
-    # 5. Stale-state re-check. Leave the row pending (requester may cancel)
-    #    but surface the diagnostic — do NOT execute a doomed op.
-    preview = await op.preview(db, current_user, args)
-    if not preview.ok:
-        logger.info(
-            "change_request.stale",
-            change_request_id=str(cr.id),
-            operation=cr.operation,
-            detail=preview.detail,
-            approver=str(current_user.id),
+        cr = await approve_change_request(
+            db, cr_id, approver=current_user, request=request, note=note
         )
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=preview.detail)
-
-    requester_id = cr.requested_by_user_id
-
-    # Record the approval transition (pending → approved, audited).
-    await mark_approved(db, cr, approver=current_user, request=request, note=note)
-
-    # 6. Dispatch apply() under the approver's identity. ``apply`` runs its
-    #    own mutation + writes its own audit row(s); on success mark_executed
-    #    writes the change_request.executed audit row carrying both ids.
-    try:
-        result = await op.apply(db, current_user, args)
-    except operations.OperationPermissionError as exc:
-        await db.rollback()
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
-    except Exception as exc:  # noqa: BLE001
-        # apply() rolled back its own transaction; reload + lock the row to
-        # stamp the failure (the approval transition was rolled back too).
-        await db.rollback()
-        cr = await get_change_request(db, cr_id, for_update=True)
-        if cr is None or cr.state != "pending":
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Change request vanished or changed state mid-apply — investigate",
-            ) from exc
-        await mark_approved(db, cr, approver=current_user, request=request, note=note)
-        await mark_failed(db, cr, approver=current_user, request=request, error=str(exc))
-        await db.commit()
-        logger.warning(
-            "change_request.apply_failed",
-            change_request_id=str(cr.id),
-            operation=cr.operation,
-            error=str(exc),
-        )
-        return _cr_to_response(cr)
-
-    await mark_executed(
-        db,
-        cr,
-        approver=current_user,
-        requester_id=requester_id,
-        request=request,
-        result=result,
-    )
-    await db.commit()
-    await db.refresh(cr)
+    except DecisionError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
     return _cr_to_response(cr)
 
 
@@ -516,26 +454,13 @@ async def reject_request(
     """Decline a pending request. Needs ``approve,change_request``; like
     approve, the rejecter may not be the requester (a self-reject is just a
     cancel — use that)."""
-    if not user_has_permission(current_user, "approve", RESOURCE_TYPE_CHANGE_REQUEST):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Permission denied: need 'approve' on '{RESOURCE_TYPE_CHANGE_REQUEST}'",
-        )
-    cr = await get_change_request(db, cr_id, for_update=True)
-    if cr is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-    if cr.requested_by_user_id is not None and current_user.id == cr.requested_by_user_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You cannot reject your own request — cancel it instead",
-        )
     note = body.decision_note if body is not None else None
     try:
-        await mark_rejected(db, cr, approver=current_user, request=request, note=note)
-    except ChangeRequestStateError as exc:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
-    await db.commit()
-    await db.refresh(cr)
+        cr = await reject_change_request(
+            db, cr_id, approver=current_user, request=request, note=note
+        )
+    except DecisionError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
     return _cr_to_response(cr)
 
 

--- a/backend/app/api/v1/change_requests/router.py
+++ b/backend/app/api/v1/change_requests/router.py
@@ -33,7 +33,6 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-import structlog
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
@@ -64,7 +63,6 @@ from app.services.approvals.service import (
     reject_change_request,
 )
 
-logger = structlog.get_logger(__name__)
 router = APIRouter()
 
 

--- a/backend/app/api/v1/change_requests/router.py
+++ b/backend/app/api/v1/change_requests/router.py
@@ -236,6 +236,27 @@ def _require_read(user: CurrentUser) -> None:
         )
 
 
+def _can_see_all_change_requests(user: User) -> bool:
+    """READ RULE (#1): who may see EVERY change request (not just their own).
+
+    A change request row leaks the frozen args / preview_text / target /
+    requester / approver. Only callers who can act on the governance surface
+    should see the whole queue:
+
+    * an **effective superadmin** (governance admin); or
+    * a holder of ``{approve, change_request}`` (an eligible approver who
+      needs the queue to do their job).
+
+    Everyone else — including a plain ``{read, change_request}`` holder — sees
+    only the rows they themselves requested (``requested_by_user_id ==
+    caller.id``). The list endpoint forces that scope; get/{id} 404s on a row
+    the caller may not see (404, not 403, so existence isn't confirmed).
+    """
+    return is_effective_superadmin(user) or user_has_permission(
+        user, "approve", RESOURCE_TYPE_CHANGE_REQUEST
+    )
+
+
 # ── Change-request queue ───────────────────────────────────────────────────
 
 
@@ -250,13 +271,23 @@ async def list_requests(
     offset: int = 0,
 ) -> list[ChangeRequestResponse]:
     """List change requests newest-first. ``mine=true`` scopes to the
-    caller's own requests; ``state`` / ``resource_type`` filter."""
+    caller's own requests; ``state`` / ``resource_type`` filter.
+
+    READ RULE (#1): a caller who isn't a superadmin / approve-holder is
+    ALWAYS scoped to their own requests regardless of the ``mine`` flag — a
+    plain ``{read, change_request}`` holder can never enumerate the platform
+    queue (which leaks args / preview / target / requester / approver)."""
     _require_read(current_user)
+    if _can_see_all_change_requests(current_user):
+        scope_user_id = current_user.id if mine else None
+    else:
+        # Force own-scope — ignore the requested ``mine`` value.
+        scope_user_id = current_user.id
     rows = await list_change_requests(
         db,
         state=state,
         resource_type=resource_type,
-        requested_by_user_id=current_user.id if mine else None,
+        requested_by_user_id=scope_user_id,
         limit=max(1, min(limit, 500)),
         offset=max(0, offset),
     )
@@ -267,8 +298,12 @@ async def list_requests(
 
 
 @router.get("/policies", response_model=list[ApprovalPolicyResponse])
-async def list_policies(current_user: CurrentUser, db: DB) -> list[ApprovalPolicyResponse]:
-    _require_read(current_user)
+async def list_policies(_admin: SuperAdmin, db: DB) -> list[ApprovalPolicyResponse]:
+    # #2: the policy list exposes which (resource, threshold) pairs are
+    # un-gated, plus the ``applies_to_superadmin`` flag — an attacker could use
+    # it to learn what to delete to dodge approval. Gate on SuperAdmin, matching
+    # the create/update/delete handlers (the frontend already hides the tab from
+    # non-superadmins).
     rows = (
         (await db.execute(select(ApprovalPolicy).order_by(ApprovalPolicy.name.asc())))
         .scalars()
@@ -389,7 +424,13 @@ async def delete_policy(
 async def get_request(cr_id: uuid.UUID, current_user: CurrentUser, db: DB) -> ChangeRequestResponse:
     _require_read(current_user)
     cr = await get_change_request(db, cr_id)
-    if cr is None:
+    # READ RULE (#1): 404 (not 403) unless the caller is the requester, holds
+    # approve, or is a superadmin — so a non-eligible caller can't even confirm
+    # a given change-request id EXISTS, let alone read its contents.
+    if cr is None or (
+        not _can_see_all_change_requests(current_user)
+        and cr.requested_by_user_id != current_user.id
+    ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return _cr_to_response(cr)
 
@@ -485,13 +526,14 @@ async def cancel_request(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only the requester or a superadmin can cancel this request",
         )
+    # #5: pass the optional note INTO mark_cancelled so it lands on both the row
+    # and the change_request.cancelled audit row (was set after the audit wrote,
+    # so it never reached audit_log).
+    note = body.decision_note if body is not None else None
     try:
-        await mark_cancelled(db, cr, user=current_user, request=request)
+        await mark_cancelled(db, cr, user=current_user, request=request, note=note)
     except ChangeRequestStateError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
-    # Carry the optional note even though cancel doesn't require one.
-    if body is not None and body.decision_note is not None:
-        cr.decision_note = body.decision_note
     await db.commit()
     await db.refresh(cr)
     return _cr_to_response(cr)

--- a/backend/app/api/v1/change_requests/router.py
+++ b/backend/app/api/v1/change_requests/router.py
@@ -1,0 +1,575 @@
+"""Change-request lifecycle API — the two-person approval spine (#62).
+
+This router is the operator-facing surface for the approval queue created
+by ``services/approvals/gate.py``. A covered risky handler (delete_subnet,
+delete_zone, …) returns ``202`` with a ``change_request`` id; the queue
+sits here. A *different* eligible approver drives it to a terminal state:
+
+* ``POST /{id}/approve`` — the two-person spine. Enforced server-side:
+  approver != requester, approver holds ``{approve, change_request}``
+  **and** the underlying operation's ``required_permission``. On approve
+  the operation's ``preview()`` re-runs (stale-state guard); if still
+  valid, ``apply()`` dispatches under the **approver's** identity and the
+  audit ``executed`` row carries both user ids.
+* ``POST /{id}/reject`` — an approver declines.
+* ``POST /{id}/cancel`` — the requester (or a superadmin) withdraws.
+* ``GET`` list / get — the queue + history.
+* ``/policies`` CRUD — operator-tunable :class:`ApprovalPolicy` rows
+  (superadmin only for writes).
+
+The whole router is gated behind the ``governance.approvals`` feature
+module (NN #14) via the ``require_module`` dependency on the include in
+``api/v1/router.py``. Every state transition writes an ``audit_log`` row
+before responding (NN #4) — owned by the service layer's ``mark_*``
+helpers, committed here. Concurrency is handled with a row-level
+``SELECT ... FOR UPDATE`` on the change_request plus the ``pending`` state
+guard, so two racing approvers can't both execute (NN: only one wins, the
+other sees 409).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser, SuperAdmin
+from app.core.permissions import (
+    RESOURCE_TYPE_CHANGE_REQUEST,
+    is_effective_superadmin,
+    user_has_permission,
+)
+from app.core.request_meta import clean_user_agent, client_ip
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.change_request import ApprovalPolicy, ChangeRequest
+from app.services.ai import operations
+from app.services.approvals.service import (
+    ChangeRequestStateError,
+    get_change_request,
+    list_change_requests,
+    mark_approved,
+    mark_cancelled,
+    mark_executed,
+    mark_failed,
+    mark_rejected,
+)
+
+logger = structlog.get_logger(__name__)
+router = APIRouter()
+
+
+# ── Schemas ────────────────────────────────────────────────────────────────
+
+
+class ChangeRequestResponse(BaseModel):
+    id: uuid.UUID
+    operation: str
+    resource_type: str
+    resource_id: str | None
+    resource_display: str
+    args: dict[str, Any]
+    preview_text: str
+    risk_reason: str
+    state: str
+    requested_by_user_id: uuid.UUID | None
+    requested_by_display: str
+    decided_by_user_id: uuid.UUID | None
+    decided_by_display: str | None
+    decision_note: str | None
+    result: dict[str, Any] | None
+    error: str | None
+    expires_at: datetime
+    decided_at: datetime | None
+    executed_at: datetime | None
+    created_at: datetime
+    modified_at: datetime
+
+
+class DecisionBody(BaseModel):
+    decision_note: str | None = Field(default=None, max_length=2000)
+
+
+class ApprovalPolicyResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    resource_type: str
+    action: str
+    min_count: int | None
+    enabled: bool
+    applies_to_superadmin: bool
+    ttl_hours: int
+    is_builtin: bool
+    created_at: datetime
+    modified_at: datetime
+
+
+class ApprovalPolicyCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    resource_type: str = Field(min_length=1, max_length=100)
+    action: str = Field(min_length=1, max_length=50)
+    min_count: int | None = Field(default=None, ge=1)
+    enabled: bool = False
+    applies_to_superadmin: bool = True
+    ttl_hours: int = Field(default=168, ge=1, le=8760)
+
+
+class ApprovalPolicyUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    resource_type: str | None = Field(default=None, min_length=1, max_length=100)
+    action: str | None = Field(default=None, min_length=1, max_length=50)
+    min_count: int | None = Field(default=None, ge=1)
+    enabled: bool | None = None
+    applies_to_superadmin: bool | None = None
+    ttl_hours: int | None = Field(default=None, ge=1, le=8760)
+
+
+# ── Serialisers ──────────────────────────────────────────────────────────────
+
+
+def _cr_to_response(cr: ChangeRequest) -> ChangeRequestResponse:
+    return ChangeRequestResponse(
+        id=cr.id,
+        operation=cr.operation,
+        resource_type=cr.resource_type,
+        resource_id=cr.resource_id,
+        resource_display=cr.resource_display,
+        args=cr.args or {},
+        preview_text=cr.preview_text,
+        risk_reason=cr.risk_reason,
+        state=cr.state,
+        requested_by_user_id=cr.requested_by_user_id,
+        requested_by_display=cr.requested_by_display,
+        decided_by_user_id=cr.decided_by_user_id,
+        decided_by_display=cr.decided_by_display,
+        decision_note=cr.decision_note,
+        result=cr.result,
+        error=cr.error,
+        expires_at=cr.expires_at,
+        decided_at=cr.decided_at,
+        executed_at=cr.executed_at,
+        created_at=cr.created_at,
+        modified_at=cr.modified_at,
+    )
+
+
+def _policy_to_response(p: ApprovalPolicy) -> ApprovalPolicyResponse:
+    return ApprovalPolicyResponse(
+        id=p.id,
+        name=p.name,
+        resource_type=p.resource_type,
+        action=p.action,
+        min_count=p.min_count,
+        enabled=p.enabled,
+        applies_to_superadmin=p.applies_to_superadmin,
+        ttl_hours=p.ttl_hours,
+        is_builtin=p.is_builtin,
+        created_at=p.created_at,
+        modified_at=p.modified_at,
+    )
+
+
+def _audit_policy(
+    db: DB,
+    *,
+    user: User,
+    request: Request,
+    action: str,
+    policy_id: str,
+    name: str,
+    new_value: dict[str, Any] | None = None,
+) -> None:
+    """Append an ``audit_log`` row for an ``approval_policy`` mutation (NN #4)."""
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=user.auth_source,
+            source_ip=client_ip(request),
+            user_agent=clean_user_agent(request.headers.get("user-agent")),
+            action=action,
+            resource_type="approval_policy",
+            resource_id=policy_id,
+            resource_display=name,
+            new_value=new_value,
+        )
+    )
+
+
+def _require_read(user: CurrentUser) -> None:
+    """Reads on the queue need ``read,change_request`` (or superadmin)."""
+    if is_effective_superadmin(user):
+        return
+    if not user_has_permission(user, "read", RESOURCE_TYPE_CHANGE_REQUEST):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Permission denied: need 'read' on '{RESOURCE_TYPE_CHANGE_REQUEST}'",
+        )
+
+
+# ── Change-request queue ───────────────────────────────────────────────────
+
+
+@router.get("", response_model=list[ChangeRequestResponse])
+async def list_requests(
+    current_user: CurrentUser,
+    db: DB,
+    state: str | None = None,
+    resource_type: str | None = None,
+    mine: bool = False,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[ChangeRequestResponse]:
+    """List change requests newest-first. ``mine=true`` scopes to the
+    caller's own requests; ``state`` / ``resource_type`` filter."""
+    _require_read(current_user)
+    rows = await list_change_requests(
+        db,
+        state=state,
+        resource_type=resource_type,
+        requested_by_user_id=current_user.id if mine else None,
+        limit=max(1, min(limit, 500)),
+        offset=max(0, offset),
+    )
+    return [_cr_to_response(r) for r in rows]
+
+
+# ── Approval policies (operator-tunable rules) ─────────────────────────────
+
+
+@router.get("/policies", response_model=list[ApprovalPolicyResponse])
+async def list_policies(current_user: CurrentUser, db: DB) -> list[ApprovalPolicyResponse]:
+    _require_read(current_user)
+    rows = (
+        (await db.execute(select(ApprovalPolicy).order_by(ApprovalPolicy.name.asc())))
+        .scalars()
+        .all()
+    )
+    return [_policy_to_response(p) for p in rows]
+
+
+@router.post(
+    "/policies",
+    response_model=ApprovalPolicyResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_policy(
+    body: ApprovalPolicyCreate,
+    _admin: SuperAdmin,
+    db: DB,
+    request: Request,
+) -> ApprovalPolicyResponse:
+    policy = ApprovalPolicy(
+        name=body.name,
+        resource_type=body.resource_type,
+        action=body.action,
+        min_count=body.min_count,
+        enabled=body.enabled,
+        applies_to_superadmin=body.applies_to_superadmin,
+        ttl_hours=body.ttl_hours,
+        is_builtin=False,
+    )
+    db.add(policy)
+    await db.flush()
+    _audit_policy(
+        db,
+        user=_admin,
+        request=request,
+        action="write",
+        policy_id=str(policy.id),
+        name=policy.name,
+        new_value={
+            "resource_type": policy.resource_type,
+            "action": policy.action,
+            "min_count": policy.min_count,
+            "enabled": policy.enabled,
+        },
+    )
+    await db.commit()
+    await db.refresh(policy)
+    return _policy_to_response(policy)
+
+
+@router.put("/policies/{policy_id}", response_model=ApprovalPolicyResponse)
+async def update_policy(
+    policy_id: uuid.UUID,
+    body: ApprovalPolicyUpdate,
+    _admin: SuperAdmin,
+    db: DB,
+    request: Request,
+) -> ApprovalPolicyResponse:
+    policy = await db.get(ApprovalPolicy, policy_id)
+    if policy is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    changes = body.model_dump(exclude_unset=True)
+    for field, value in changes.items():
+        setattr(policy, field, value)
+    _audit_policy(
+        db,
+        user=_admin,
+        request=request,
+        action="write",
+        policy_id=str(policy.id),
+        name=policy.name,
+        new_value=changes,
+    )
+    await db.commit()
+    await db.refresh(policy)
+    return _policy_to_response(policy)
+
+
+@router.delete("/policies/{policy_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_policy(
+    policy_id: uuid.UUID,
+    _admin: SuperAdmin,
+    db: DB,
+    request: Request,
+) -> None:
+    policy = await db.get(ApprovalPolicy, policy_id)
+    if policy is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    if policy.is_builtin:
+        # Built-in policies are kept for the registry-completeness check;
+        # toggle ``enabled`` off instead of deleting them.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Built-in policies cannot be deleted — disable them instead",
+        )
+    name = policy.name
+    await db.delete(policy)
+    _audit_policy(
+        db,
+        user=_admin,
+        request=request,
+        action="delete",
+        policy_id=str(policy_id),
+        name=name,
+    )
+    await db.commit()
+    return None
+
+
+@router.get("/{cr_id}", response_model=ChangeRequestResponse)
+async def get_request(cr_id: uuid.UUID, current_user: CurrentUser, db: DB) -> ChangeRequestResponse:
+    _require_read(current_user)
+    cr = await get_change_request(db, cr_id)
+    if cr is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return _cr_to_response(cr)
+
+
+@router.post("/{cr_id}/approve", response_model=ChangeRequestResponse)
+async def approve_request(
+    cr_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: DB,
+    request: Request,
+    body: DecisionBody | None = None,
+) -> ChangeRequestResponse:
+    """Approve and execute a pending change request — the two-person spine.
+
+    Server-side invariants (every one enforced here, never trusting the UI):
+
+    1. The row is loaded ``FOR UPDATE`` and must still be ``pending`` (a
+       racing approver loses with 409); an expired row flips to ``expired``.
+    2. **Self-approval blocked** — ``approver.id != requested_by_user_id``.
+    3. Approver holds ``{approve, change_request}``.
+    4. Approver holds the underlying operation's ``required_permission`` —
+       they can't rubber-stamp a delete they couldn't perform themselves.
+    5. The operation's ``preview()`` re-runs under the approver; a stale
+       request (target gone / now non-empty / synthesised) does NOT execute
+       (409, left ``pending`` so the requester can cancel).
+    6. ``apply()`` dispatches under the **approver's** identity; the audit
+       ``executed`` row carries the approver as actor and the requester id
+       in ``old_value.requested_by``.
+    """
+    note = body.decision_note if body is not None else None
+
+    # 1. Row lock + state guard — race-safe against a second approver.
+    cr = await get_change_request(db, cr_id, for_update=True)
+    if cr is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    if cr.state != "pending":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Change request is not pending (state={cr.state!r})",
+        )
+    if cr.expires_at < datetime.now(UTC):
+        cr.state = "expired"
+        cr.decided_at = datetime.now(UTC)
+        await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Change request has expired",
+        )
+
+    # 2. Self-approval is forbidden — the whole point of two-person.
+    if cr.requested_by_user_id is not None and current_user.id == cr.requested_by_user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot approve your own change request",
+        )
+
+    op = operations.get_operation(cr.operation)
+    if op is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Operation {cr.operation!r} is not registered",
+        )
+
+    # 3. Approver holds the approve capability.
+    if not user_has_permission(current_user, "approve", RESOURCE_TYPE_CHANGE_REQUEST):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Permission denied: need 'approve' on '{RESOURCE_TYPE_CHANGE_REQUEST}'",
+        )
+
+    # 4. Approver holds the underlying operation's own permission.
+    try:
+        operations.enforce_operation_permission(current_user, op)
+    except operations.OperationPermissionError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+
+    # Re-validate the frozen args through the op's pydantic model — guards
+    # the rare redeploy-mid-flight schema-change case.
+    try:
+        args = op.args_model.model_validate(cr.args or {})
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Stored args no longer validate: {exc}",
+        ) from exc
+
+    # 5. Stale-state re-check. Leave the row pending (requester may cancel)
+    #    but surface the diagnostic — do NOT execute a doomed op.
+    preview = await op.preview(db, current_user, args)
+    if not preview.ok:
+        logger.info(
+            "change_request.stale",
+            change_request_id=str(cr.id),
+            operation=cr.operation,
+            detail=preview.detail,
+            approver=str(current_user.id),
+        )
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=preview.detail)
+
+    requester_id = cr.requested_by_user_id
+
+    # Record the approval transition (pending → approved, audited).
+    await mark_approved(db, cr, approver=current_user, request=request, note=note)
+
+    # 6. Dispatch apply() under the approver's identity. ``apply`` runs its
+    #    own mutation + writes its own audit row(s); on success mark_executed
+    #    writes the change_request.executed audit row carrying both ids.
+    try:
+        result = await op.apply(db, current_user, args)
+    except operations.OperationPermissionError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        # apply() rolled back its own transaction; reload + lock the row to
+        # stamp the failure (the approval transition was rolled back too).
+        await db.rollback()
+        cr = await get_change_request(db, cr_id, for_update=True)
+        if cr is None or cr.state != "pending":
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Change request vanished or changed state mid-apply — investigate",
+            ) from exc
+        await mark_approved(db, cr, approver=current_user, request=request, note=note)
+        await mark_failed(db, cr, approver=current_user, request=request, error=str(exc))
+        await db.commit()
+        logger.warning(
+            "change_request.apply_failed",
+            change_request_id=str(cr.id),
+            operation=cr.operation,
+            error=str(exc),
+        )
+        return _cr_to_response(cr)
+
+    await mark_executed(
+        db,
+        cr,
+        approver=current_user,
+        requester_id=requester_id,
+        request=request,
+        result=result,
+    )
+    await db.commit()
+    await db.refresh(cr)
+    return _cr_to_response(cr)
+
+
+@router.post("/{cr_id}/reject", response_model=ChangeRequestResponse)
+async def reject_request(
+    cr_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: DB,
+    request: Request,
+    body: DecisionBody | None = None,
+) -> ChangeRequestResponse:
+    """Decline a pending request. Needs ``approve,change_request``; like
+    approve, the rejecter may not be the requester (a self-reject is just a
+    cancel — use that)."""
+    if not user_has_permission(current_user, "approve", RESOURCE_TYPE_CHANGE_REQUEST):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Permission denied: need 'approve' on '{RESOURCE_TYPE_CHANGE_REQUEST}'",
+        )
+    cr = await get_change_request(db, cr_id, for_update=True)
+    if cr is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    if cr.requested_by_user_id is not None and current_user.id == cr.requested_by_user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot reject your own request — cancel it instead",
+        )
+    note = body.decision_note if body is not None else None
+    try:
+        await mark_rejected(db, cr, approver=current_user, request=request, note=note)
+    except ChangeRequestStateError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    await db.commit()
+    await db.refresh(cr)
+    return _cr_to_response(cr)
+
+
+@router.post("/{cr_id}/cancel", response_model=ChangeRequestResponse)
+async def cancel_request(
+    cr_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: DB,
+    request: Request,
+    body: DecisionBody | None = None,
+) -> ChangeRequestResponse:
+    """Withdraw a pending request. Only the original requester or a
+    superadmin may cancel."""
+    cr = await get_change_request(db, cr_id, for_update=True)
+    if cr is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    is_requester = (
+        cr.requested_by_user_id is not None and current_user.id == cr.requested_by_user_id
+    )
+    if not is_requester and not is_effective_superadmin(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the requester or a superadmin can cancel this request",
+        )
+    try:
+        await mark_cancelled(db, cr, user=current_user, request=request)
+    except ChangeRequestStateError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    # Carry the optional note even though cancel doesn't require one.
+    if body is not None and body.decision_note is not None:
+        cr.decision_note = body.decision_note
+    await db.commit()
+    await db.refresh(cr)
+    return _cr_to_response(cr)
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/change_requests/router.py
+++ b/backend/app/api/v1/change_requests/router.py
@@ -48,7 +48,11 @@ from app.core.request_meta import clean_user_agent, client_ip
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.change_request import ApprovalPolicy, ChangeRequest
-from app.services.ai.operations_control import is_controls_protected, maybe_gate_control
+from app.services.ai.operations_control import (
+    coverage_reducing_diffs,
+    is_controls_protected,
+    maybe_gate_control,
+)
 from app.services.approvals.policy import GATEABLE_ACTIONS, GATEABLE_RESOURCE_TYPES
 from app.services.approvals.service import (
     ChangeRequestStateError,
@@ -109,11 +113,19 @@ class ApprovalPolicyResponse(BaseModel):
     modified_at: datetime
 
 
+# Upper bound on ``min_count`` (#2). ``ge=1`` alone let a superadmin inflate
+# the threshold to an astronomical value so an enabled-looking policy gates
+# nothing — bound it so an inflated threshold is rejected at the schema layer
+# (422) before it can be used as a side-door. Generous: a real op never touches
+# this many rows.
+_MIN_COUNT_MAX = 1_000_000
+
+
 class ApprovalPolicyCreate(BaseModel):
     name: str = Field(min_length=1, max_length=255)
     resource_type: str = Field(min_length=1, max_length=100)
     action: str = Field(min_length=1, max_length=50)
-    min_count: int | None = Field(default=None, ge=1)
+    min_count: int | None = Field(default=None, ge=1, le=_MIN_COUNT_MAX)
     enabled: bool = False
     applies_to_superadmin: bool = True
     ttl_hours: int = Field(default=168, ge=1, le=8760)
@@ -123,7 +135,7 @@ class ApprovalPolicyUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
     resource_type: str | None = Field(default=None, min_length=1, max_length=100)
     action: str | None = Field(default=None, min_length=1, max_length=50)
-    min_count: int | None = Field(default=None, ge=1)
+    min_count: int | None = Field(default=None, ge=1, le=_MIN_COUNT_MAX)
     enabled: bool | None = None
     applies_to_superadmin: bool | None = None
     ttl_hours: int | None = Field(default=None, ge=1, le=8760)
@@ -375,33 +387,36 @@ async def update_policy(
         changes.get("resource_type", policy.resource_type),
     )
 
-    # #62 self-governance lock: detect WEAKENING transitions on this PUT and
-    # gate them behind a second superadmin when the lock is on. Only the
-    # weakening half is gated — ``enabled`` false→true, ``applies_to_superadmin``
-    # false→true, and name/ttl/min_count edits all stay inline. ``maybe_gate_control``
-    # short-circuits to None the instant the lock is off, so the inline path
-    # below is byte-identical to today. A single PUT that weakens BOTH knobs is
-    # gated on the first weakening it sees (disable wins); the requester
-    # re-submits post-approval for any remaining change.
-    if await is_controls_protected(db):
-        disabling = changes.get("enabled") is False and policy.enabled
-        lowering = changes.get("applies_to_superadmin") is False and policy.applies_to_superadmin
-        kind = "disable_policy" if disabling else ("lower_superadmin_gate" if lowering else None)
-        if kind is not None:
-            pending = await maybe_gate_control(
-                db,
-                _admin,
-                request,
-                kind=kind,  # type: ignore[arg-type]
-                policy_id=policy_id,
-                resource_type="approval_policy",
-                resource_id=str(policy_id),
-                resource_display=policy.name,
-            )
-            if pending is not None:
-                from fastapi.responses import JSONResponse  # noqa: PLC0415
+    # #62 self-governance lock: detect every COVERAGE-REDUCING transition on
+    # this PUT and gate the whole edit behind a second superadmin when the lock
+    # is on. Coverage-reducing = enabled true→false, applies_to_superadmin
+    # true→false, resource_type changed, action changed, min_count raised, or
+    # min_count set NULL→value (NULL is always-gate = strongest). A superadmin
+    # used to be able to neuter a policy INLINE by repointing resource_type /
+    # action to a non-matching pair or inflating min_count while keeping
+    # enabled=true so it LOOKED live but matched nothing — #2's side-door.
+    # Strengthening / neutral edits (name, ttl, enabling, raising the superadmin
+    # gate, lowering min_count, min_count→NULL) stay inline.
+    # ``maybe_gate_control`` short-circuits to None the instant the lock is off,
+    # so the inline path below is byte-identical to today. The WHOLE proposed
+    # ``changes`` payload rides into the gate so the approved op replays the
+    # exact edit (not just the weakening half) under the approver.
+    if await is_controls_protected(db) and coverage_reducing_diffs(policy, changes):
+        pending = await maybe_gate_control(
+            db,
+            _admin,
+            request,
+            kind="update_policy",
+            policy_id=policy_id,
+            update_payload=changes,
+            resource_type="approval_policy",
+            resource_id=str(policy_id),
+            resource_display=policy.name,
+        )
+        if pending is not None:
+            from fastapi.responses import JSONResponse  # noqa: PLC0415
 
-                return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
 
     for field, value in changes.items():
         setattr(policy, field, value)

--- a/backend/app/api/v1/change_requests/router.py
+++ b/backend/app/api/v1/change_requests/router.py
@@ -48,6 +48,7 @@ from app.core.request_meta import clean_user_agent, client_ip
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.change_request import ApprovalPolicy, ChangeRequest
+from app.services.ai.operations_control import is_controls_protected, maybe_gate_control
 from app.services.approvals.policy import GATEABLE_ACTIONS, GATEABLE_RESOURCE_TYPES
 from app.services.approvals.service import (
     ChangeRequestStateError,
@@ -355,14 +356,14 @@ async def create_policy(
     return _policy_to_response(policy)
 
 
-@router.put("/policies/{policy_id}", response_model=ApprovalPolicyResponse)
+@router.put("/policies/{policy_id}")
 async def update_policy(
     policy_id: uuid.UUID,
     body: ApprovalPolicyUpdate,
     _admin: SuperAdmin,
     db: DB,
     request: Request,
-) -> ApprovalPolicyResponse:
+):  # noqa: ANN201 — ApprovalPolicyResponse OR a 202 JSONResponse (gated)
     policy = await db.get(ApprovalPolicy, policy_id)
     if policy is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
@@ -373,6 +374,35 @@ async def update_policy(
         changes.get("action", policy.action),
         changes.get("resource_type", policy.resource_type),
     )
+
+    # #62 self-governance lock: detect WEAKENING transitions on this PUT and
+    # gate them behind a second superadmin when the lock is on. Only the
+    # weakening half is gated — ``enabled`` false→true, ``applies_to_superadmin``
+    # false→true, and name/ttl/min_count edits all stay inline. ``maybe_gate_control``
+    # short-circuits to None the instant the lock is off, so the inline path
+    # below is byte-identical to today. A single PUT that weakens BOTH knobs is
+    # gated on the first weakening it sees (disable wins); the requester
+    # re-submits post-approval for any remaining change.
+    if await is_controls_protected(db):
+        disabling = changes.get("enabled") is False and policy.enabled
+        lowering = changes.get("applies_to_superadmin") is False and policy.applies_to_superadmin
+        kind = "disable_policy" if disabling else ("lower_superadmin_gate" if lowering else None)
+        if kind is not None:
+            pending = await maybe_gate_control(
+                db,
+                _admin,
+                request,
+                kind=kind,  # type: ignore[arg-type]
+                policy_id=policy_id,
+                resource_type="approval_policy",
+                resource_id=str(policy_id),
+                resource_display=policy.name,
+            )
+            if pending is not None:
+                from fastapi.responses import JSONResponse  # noqa: PLC0415
+
+                return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+
     for field, value in changes.items():
         setattr(policy, field, value)
     _audit_policy(
@@ -389,13 +419,13 @@ async def update_policy(
     return _policy_to_response(policy)
 
 
-@router.delete("/policies/{policy_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/policies/{policy_id}")
 async def delete_policy(
     policy_id: uuid.UUID,
     _admin: SuperAdmin,
     db: DB,
     request: Request,
-) -> None:
+):  # noqa: ANN201 — 204 (deleted) OR a 202 JSONResponse (gated)
     policy = await db.get(ApprovalPolicy, policy_id)
     if policy is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
@@ -406,6 +436,25 @@ async def delete_policy(
             status_code=status.HTTP_409_CONFLICT,
             detail="Built-in policies cannot be deleted — disable them instead",
         )
+
+    # #62 self-governance lock: deleting a policy is a WEAKENING change →
+    # gate behind a second superadmin when the lock is on. Off → inline 204.
+    if await is_controls_protected(db):
+        pending = await maybe_gate_control(
+            db,
+            _admin,
+            request,
+            kind="delete_policy",
+            policy_id=policy_id,
+            resource_type="approval_policy",
+            resource_id=str(policy_id),
+            resource_display=policy.name,
+        )
+        if pending is not None:
+            from fastapi.responses import JSONResponse  # noqa: PLC0415
+
+            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+
     name = policy.name
     await db.delete(policy)
     _audit_policy(
@@ -417,7 +466,9 @@ async def delete_policy(
         name=name,
     )
     await db.commit()
-    return None
+    from fastapi import Response  # noqa: PLC0415
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get("/{cr_id}", response_model=ChangeRequestResponse)

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -10,7 +10,8 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
 
@@ -20,13 +21,11 @@ from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.permissions import require_resource_permission
 from app.models.dhcp import DHCPScope, DHCPServerGroup
 from app.models.ipam import Subnet
+from app.services.ai.operations import get_operation
+from app.services.ai.operations_risky import DeleteScopeArgs
+from app.services.approvals.gate import gate_or_execute
 from app.services.dhcp.windows_writethrough import (
-    push_scope_delete,
     push_scope_upsert,
-)
-from app.services.soft_delete import (
-    apply_soft_delete,
-    collect_soft_delete_batch,
 )
 from app.services.tags import apply_tag_filter
 
@@ -460,13 +459,14 @@ async def update_scope(
     return _scope_to_response(scope)
 
 
-@router.delete("/scopes/{scope_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/scopes/{scope_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def delete_scope(
     scope_id: uuid.UUID,
     db: DB,
     user: SuperAdmin,
+    request: Request,
     permanent: bool = False,
-) -> None:
+) -> Any:
     """Delete a DHCP scope.
 
     Default soft-delete stamps the scope with a fresh batch UUID so it
@@ -474,36 +474,17 @@ async def delete_scope(
     fired on the permanent path; soft-delete leaves the scope in the
     rendered config until restoration deadline expires (the purge sweep
     triggers the actual config refresh by hard-deleting then).
+
+    Two-person approval (#62): when the ``governance.approvals`` module is on
+    and a ``delete:dhcp_scope`` policy matches, returns ``202`` with a pending
+    change-request; otherwise executes inline via ``operation.apply`` exactly
+    as before (route stays SuperAdmin-gated).
     """
-    scope = await db.get(DHCPScope, scope_id)
-    if scope is None:
-        raise HTTPException(status_code=404, detail="Scope not found")
-    collect_wake(dhcp_group_channel(scope.group_id))
-
-    if not permanent:
-        batch = await collect_soft_delete_batch(db, scope)
-        apply_soft_delete(batch, user.id)
-        for row in batch.rows:
-            write_audit(
-                db,
-                user=user,
-                action="soft_delete",
-                resource_type=row.resource_type,
-                resource_id=str(row.obj.id),
-                resource_display=row.display,
-                old_value={"deletion_batch_id": str(batch.batch_id)},
-            )
-        await db.commit()
-        return
-
-    await push_scope_delete(db, scope)
-    write_audit(
-        db,
-        user=user,
-        action="delete",
-        resource_type="dhcp_scope",
-        resource_id=str(scope.id),
-        resource_display=str(scope.id),
-    )
-    await db.delete(scope)
-    await db.commit()
+    op = get_operation("delete_scope")
+    assert op is not None  # registered at import
+    args = DeleteScopeArgs(scope_id=scope_id, permanent=permanent)
+    pending = await gate_or_execute(db, user, request, operation=op, args=args)
+    if pending is not None:
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+    await op.apply(db, user, args)
+    return None

--- a/backend/app/api/v1/dhcp/server_groups.py
+++ b/backend/app/api/v1/dhcp/server_groups.py
@@ -12,15 +12,19 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
-from sqlalchemy import func, select
+from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.api.v1.dhcp._audit import write_audit
 from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.permissions import require_resource_permission
-from app.models.dhcp import DHCPServer, DHCPServerGroup
+from app.models.dhcp import DHCPServerGroup
+from app.services.ai.operations import get_operation
+from app.services.ai.operations_risky import DeleteGroupArgs
+from app.services.approvals.gate import gate_or_execute
 
 router = APIRouter(
     prefix="/server-groups",
@@ -218,39 +222,22 @@ async def update_group(
     return _group_to_response(g)
 
 
-@router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_group(group_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
-    g = await db.get(DHCPServerGroup, group_id)
-    if g is None:
-        raise HTTPException(status_code=404, detail="Server group not found")
+@router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
+async def delete_group(
+    group_id: uuid.UUID, db: DB, user: SuperAdmin, request: Request
+) -> JSONResponse | None:
+    """Delete a DHCP server group (refused if it still holds servers).
 
-    # ORM ``cascade="all, delete-orphan"`` on ``servers``/``scopes`` will silently
-    # nuke every child row. Pre-check and return 409 so the user can't wipe a
-    # populated group by mistake.
-    server_count = (
-        await db.execute(
-            select(func.count())
-            .select_from(DHCPServer)
-            .where(DHCPServer.server_group_id == group_id)
-        )
-    ).scalar_one()
-    if server_count:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                f"DHCP server group {g.name!r} still contains "
-                f"{server_count} server(s). Move them to another group "
-                "(or standalone) before deleting the group."
-            ),
-        )
-
-    write_audit(
-        db,
-        user=user,
-        action="delete",
-        resource_type="dhcp_server_group",
-        resource_id=str(g.id),
-        resource_display=g.name,
-    )
-    await db.delete(g)
-    await db.commit()
+    Two-person approval (#62): when the ``governance.approvals`` module is on
+    and a ``delete:dhcp_server_group`` policy matches, returns ``202`` with a
+    pending change-request; otherwise executes inline via ``operation.apply``
+    exactly as before (route stays SuperAdmin-gated).
+    """
+    op = get_operation("delete_group")
+    assert op is not None  # registered at import
+    args = DeleteGroupArgs(group_id=group_id)
+    pending = await gate_or_execute(db, user, request, operation=op, args=args)
+    if pending is not None:
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+    await op.apply(db, user, args)
+    return None

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -10,8 +10,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import Response, StreamingResponse
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import func, select
@@ -45,6 +45,9 @@ from app.models.dns import (
     DNSView,
     DNSZone,
 )
+from app.services.ai.operations import get_operation
+from app.services.ai.operations_risky import DeleteZoneArgs
+from app.services.approvals.gate import gate_or_execute
 from app.services.dns.delegation import (
     compute_delegation,
     find_parent_zone,
@@ -3793,14 +3796,15 @@ async def rollover_zone_dnssec_key(
     return {"status": "queued", "zone_id": str(zone.id), "key_tag": body.key_tag}
 
 
-@router.delete("/groups/{group_id}/zones/{zone_id}", status_code=204)
+@router.delete("/groups/{group_id}/zones/{zone_id}", status_code=204, response_model=None)
 async def delete_zone(
     group_id: uuid.UUID,
     zone_id: uuid.UUID,
     db: DB,
     current_user: SuperAdmin,
+    request: Request,
     permanent: bool = False,
-) -> None:
+) -> Any:
     """Delete a DNS zone.
 
     Default behavior is soft-delete: the zone + every record in it gets
@@ -3813,51 +3817,20 @@ async def delete_zone(
     the write-through first.
 
     ``?permanent=true`` runs the legacy hard-delete path (super-admin only).
+
+    Two-person approval (#62): when the ``governance.approvals`` module is on
+    and a ``delete:dns_zone`` policy matches, returns ``202`` with a pending
+    change-request; otherwise executes inline via ``operation.apply`` exactly
+    as before (route stays SuperAdmin-gated).
     """
-    zone = await _require_zone(group_id, zone_id, db)
-    _reject_if_synthesised_zone(zone, "delete")
-
-    if not permanent:
-        batch = await collect_soft_delete_batch(db, zone)
-        apply_soft_delete(batch, current_user.id)
-        for row in batch.rows:
-            db.add(
-                AuditLog(
-                    user_id=current_user.id,
-                    user_display_name=current_user.display_name,
-                    auth_source=current_user.auth_source,
-                    action="soft_delete",
-                    resource_type=row.resource_type,
-                    resource_id=str(row.obj.id),
-                    resource_display=row.display,
-                    old_value={"deletion_batch_id": str(batch.batch_id)},
-                    result="success",
-                )
-            )
-        # Soft-delete stamps deleted_at; the global filter then drops the
-        # zone from the served bundle, so the agents must re-poll.
-        collect_wake(dns_group_channel(group_id))
-        await db.commit()
-        return
-
-    # Same write-through contract as create: push the delete first, only
-    # drop the DB row if the Windows side agreed.
-    await _push_zone_to_agentless_servers(db, zone, "delete")
-    db.add(
-        AuditLog(
-            user_id=current_user.id,
-            user_display_name=current_user.display_name,
-            auth_source=current_user.auth_source,
-            action="delete",
-            resource_type="dns_zone",
-            resource_id=str(zone.id),
-            resource_display=zone.name,
-            result="success",
-        )
-    )
-    collect_wake(dns_group_channel(group_id))
-    await db.delete(zone)
-    await db.commit()
+    op = get_operation("delete_zone")
+    assert op is not None  # registered at import
+    args = DeleteZoneArgs(group_id=group_id, zone_id=zone_id, permanent=permanent)
+    pending = await gate_or_execute(db, current_user, request, operation=op, args=args)
+    if pending is not None:
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+    await op.apply(db, current_user, args)
+    return None
 
 
 # ── Zone template wizard ────────────────────────────────────────────────────

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -11,9 +11,10 @@ from datetime import UTC, date, datetime, timedelta
 from typing import Any, cast
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
-from sqlalchemy import delete, func, select, text
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -24,9 +25,8 @@ from app.core.permissions import (
     token_scope_allows,
     user_has_permission,
 )
-from app.drivers.dhcp import is_agentless
 from app.models.audit import AuditLog
-from app.models.dhcp import DHCPConfigOp, DHCPPool, DHCPScope, DHCPServer, DHCPStaticAssignment
+from app.models.dhcp import DHCPPool, DHCPScope, DHCPStaticAssignment
 from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
 from app.models.ipam import (
     IP_ROLES,
@@ -44,9 +44,14 @@ from app.models.ipam import (
 )
 from app.models.settings import PlatformSettings
 from app.models.vlans import VLAN
-from app.services.dhcp.config_bundle import build_config_bundle
+from app.services.ai.operations import get_operation
+from app.services.ai.operations_risky import (
+    DeleteBlockArgs,
+    DeleteSpaceArgs,
+    DeleteSubnetArgs,
+)
+from app.services.approvals.gate import gate_or_execute
 from app.services.dhcp.windows_writethrough import (
-    push_scope_delete,
     push_statics_bulk_delete,
 )
 from app.services.ipam.address_set_gate import (
@@ -57,10 +62,6 @@ from app.services.ipam.address_set_gate import (
     user_can_write_ip as _user_can_write_ip,
 )
 from app.services.oui import bulk_lookup_vendors, is_voip_phone_vendor, normalize_mac_key
-from app.services.soft_delete import (
-    apply_soft_delete,
-    collect_soft_delete_batch,
-)
 from app.services.tags import apply_tag_filter
 
 logger = structlog.get_logger(__name__)
@@ -2525,13 +2526,14 @@ async def get_effective_space_dhcp(
     )
 
 
-@router.delete("/spaces/{space_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/spaces/{space_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def delete_space(
     space_id: uuid.UUID,
     current_user: CurrentUser,
     db: DB,
+    request: Request,
     permanent: bool = False,
-) -> None:
+) -> Any:
     """Delete an IP space.
 
     Default behavior is soft-delete: the space, every block under it, every
@@ -2541,72 +2543,20 @@ async def delete_space(
     hidden from every default SELECT by the global query filter.
 
     ``?permanent=true`` runs the legacy hard-delete path (super-admin only).
+
+    Two-person approval (#62): when the ``governance.approvals`` module is on
+    and a ``delete:ip_space`` policy matches, this returns ``202 Accepted``
+    with a pending change-request instead of executing. Module-off / no
+    policy → executes inline via ``operation.apply`` exactly as before.
     """
-    space = await db.get(IPSpace, space_id)
-    if space is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP space not found")
-
-    if permanent:
-        # Permanent deletion is destructive — gate on superadmin.
-        from app.api.deps import require_superadmin  # local import for circularity safety
-
-        require_superadmin(current_user)
-        # Subnet.space_id is ondelete=RESTRICT so a naive delete bubbles as 500
-        # when anything is still anchored here. Pre-check blocks and subnets so
-        # the UI gets a clear 409 with a count instead of an opaque server error.
-        subnet_count = (
-            await db.execute(
-                select(func.count()).select_from(Subnet).where(Subnet.space_id == space_id)
-            )
-        ).scalar_one()
-        block_count = (
-            await db.execute(
-                select(func.count()).select_from(IPBlock).where(IPBlock.space_id == space_id)
-            )
-        ).scalar_one()
-        if subnet_count or block_count:
-            parts = []
-            if block_count:
-                parts.append(f"{block_count} block(s)")
-            if subnet_count:
-                parts.append(f"{subnet_count} subnet(s)")
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    f"IP space {space.name!r} still contains {' and '.join(parts)}. "
-                    "Delete or move them before deleting the space."
-                ),
-            )
-
-        db.add(
-            _audit(
-                current_user,
-                "delete",
-                "ip_space",
-                str(space.id),
-                space.name,
-                old_value={"name": space.name},
-            )
-        )
-        await db.delete(space)
-        await db.commit()
-        return
-
-    # Soft-delete: cascade-stamp the whole subtree under one batch UUID.
-    batch = await collect_soft_delete_batch(db, space)
-    apply_soft_delete(batch, current_user.id)
-    for row in batch.rows:
-        db.add(
-            _audit(
-                current_user,
-                "soft_delete",
-                row.resource_type,
-                str(row.obj.id),
-                row.display,
-                old_value={"deletion_batch_id": str(batch.batch_id)},
-            )
-        )
-    await db.commit()
+    op = get_operation("delete_space")
+    assert op is not None  # registered at import
+    args = DeleteSpaceArgs(space_id=space_id, permanent=permanent)
+    pending = await gate_or_execute(db, current_user, request, operation=op, args=args)
+    if pending is not None:
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+    await op.apply(db, current_user, args)
+    return None
 
 
 # ── IP Blocks ──────────────────────────────────────────────────────────────────
@@ -2996,85 +2946,32 @@ async def update_block(
     return _block_to_response(block, warn)
 
 
-@router.delete("/blocks/{block_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/blocks/{block_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def delete_block(
     block_id: uuid.UUID,
     current_user: CurrentUser,
     db: DB,
+    request: Request,
     permanent: bool = False,
-) -> None:
+) -> Any:
     """Delete an IP block.
 
     Default soft-delete cascades to child blocks + every subnet (and their
     DHCP scopes) anchored under this block. ``?permanent=true`` is the
     legacy hard-delete path (superadmin only).
+
+    Two-person approval (#62): when the ``governance.approvals`` module is on
+    and a ``delete:ip_block`` policy matches, returns ``202`` with a pending
+    change-request; otherwise executes inline via ``operation.apply``.
     """
-    block = await db.get(IPBlock, block_id)
-    if block is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP block not found")
-
-    if permanent:
-        from app.api.deps import require_superadmin  # local import for circularity safety
-
-        require_superadmin(current_user)
-        # Refuse if anything is anchored below this block. Child blocks cascade,
-        # which would silently nuke a chunk of the tree. Subnet.block_id is
-        # RESTRICT at the DB level so a subnet-having block would bubble a 500
-        # anyway — but the DB column is also historically nullable (schema
-        # drift), so a naive delete can end up orphaning subnets with
-        # ``block_id=NULL``. Check explicitly and return a useful 409.
-        subnet_count = (
-            await db.execute(
-                select(func.count()).select_from(Subnet).where(Subnet.block_id == block_id)
-            )
-        ).scalar_one()
-        child_block_count = (
-            await db.execute(
-                select(func.count()).select_from(IPBlock).where(IPBlock.parent_block_id == block_id)
-            )
-        ).scalar_one()
-        if subnet_count or child_block_count:
-            parts = []
-            if child_block_count:
-                parts.append(f"{child_block_count} child block(s)")
-            if subnet_count:
-                parts.append(f"{subnet_count} subnet(s)")
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    f"Block {block.network} still contains {' and '.join(parts)}. "
-                    "Delete or move them before deleting the block."
-                ),
-            )
-
-        db.add(
-            _audit(
-                current_user,
-                "delete",
-                "ip_block",
-                str(block.id),
-                f"{block.network} ({block.name})",
-                old_value={"network": str(block.network)},
-            )
-        )
-        await db.delete(block)
-        await db.commit()
-        return
-
-    batch = await collect_soft_delete_batch(db, block)
-    apply_soft_delete(batch, current_user.id)
-    for row in batch.rows:
-        db.add(
-            _audit(
-                current_user,
-                "soft_delete",
-                row.resource_type,
-                str(row.obj.id),
-                row.display,
-                old_value={"deletion_batch_id": str(batch.batch_id)},
-            )
-        )
-    await db.commit()
+    op = get_operation("delete_block")
+    assert op is not None  # registered at import
+    args = DeleteBlockArgs(block_id=block_id, permanent=permanent)
+    pending = await gate_or_execute(db, current_user, request, operation=op, args=args)
+    if pending is not None:
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+    await op.apply(db, current_user, args)
+    return None
 
 
 @router.get("/blocks/{block_id}/available-subnets", response_model=list[str])
@@ -4591,14 +4488,15 @@ async def _revoke_subnet_lease_mirrors(db: DB, subnet: Subnet) -> int:
     return revoked
 
 
-@router.delete("/subnets/{subnet_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/subnets/{subnet_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
 async def delete_subnet(
     subnet_id: uuid.UUID,
     current_user: CurrentUser,
     db: DB,
+    request: Request,
     force: bool = False,
     permanent: bool = False,
-) -> None:
+) -> Any:
     """Delete a subnet.
 
     Default soft-delete stamps the subnet (and its DHCP scopes) under one
@@ -4607,186 +4505,21 @@ async def delete_subnet(
     ``permanent=true`` runs the legacy hard-delete path; soft-delete is
     additive — non-emptiness doesn't block it because the operator can
     always restore on second thought.
+
+    Two-person approval (#62): when the ``governance.approvals`` module is on
+    and a ``delete:subnet`` policy matches, returns ``202`` with a pending
+    change-request (the ``force`` / ``permanent`` flags are frozen so the
+    approved replay takes the identical branch). Otherwise executes inline via
+    ``operation.apply`` — same logic, side effects, audit, and 204 as before.
     """
-    from app.models.dns import DNSRecord, DNSZone
-
-    subnet = await db.get(Subnet, subnet_id)
-    if subnet is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
-    _enforce_subnet_token_scope(current_user, subnet_id)
-
-    if not permanent:
-        # #428 — a DHCP-lease-mirrored IPAM row's DDNS A/PTR record must not
-        # outlive the subnet. The soft-delete batch only stamps the subnet +
-        # its scopes (not IPAddress/DNSRecord), so without this the lease
-        # mirrors + their published DNS records would be orphaned: still on
-        # the DNS server, pointing at a now-deleted subnet, invisible to the
-        # sweeps (the subnet is hidden). Revoke the DNS records and drop the
-        # transient mirror rows; if the subnet is restored with live leases,
-        # the lease pipeline re-mirrors + re-publishes them.
-        await _revoke_subnet_lease_mirrors(db, subnet)
-
-        # Soft-delete: cascade-stamp the subnet + its scopes. Non-emptiness
-        # is allowed since the operator can restore via /admin/trash.
-        batch = await collect_soft_delete_batch(db, subnet)
-        apply_soft_delete(batch, current_user.id)
-        for row in batch.rows:
-            db.add(
-                _audit(
-                    current_user,
-                    "soft_delete",
-                    row.resource_type,
-                    str(row.obj.id),
-                    row.display,
-                    old_value={"deletion_batch_id": str(batch.batch_id)},
-                )
-            )
-        await db.commit()
-        return
-
-    from app.api.deps import require_superadmin  # noqa: PLC0415
-
-    require_superadmin(current_user)
-
-    # Refuse to delete a non-empty subnet unless the caller explicitly opts in
-    # via ?force=true. A subnet is considered "non-empty" if it has any user-
-    # owned IP records (anything other than the auto-generated network /
-    # broadcast placeholders, orphan rows, or DHCP-lease-mirrored rows) or a
-    # DHCP scope attached. Forcing still runs the cascade path below, so API
-    # consumers who really need it can still drop the whole subtree.
-    if not force:
-        user_ip_count = (
-            await db.execute(
-                select(func.count(IPAddress.id)).where(
-                    IPAddress.subnet_id == subnet_id,
-                    IPAddress.status.notin_(["network", "broadcast", "orphan"]),
-                    IPAddress.auto_from_lease.is_(False),
-                )
-            )
-        ).scalar_one()
-        scope_count = (
-            await db.execute(
-                select(func.count(DHCPScope.id)).where(DHCPScope.subnet_id == subnet_id)
-            )
-        ).scalar_one()
-        if user_ip_count or scope_count:
-            parts = []
-            if user_ip_count:
-                parts.append(
-                    f"{user_ip_count} allocated IP address" + ("es" if user_ip_count != 1 else "")
-                )
-            if scope_count:
-                parts.append(f"{scope_count} DHCP scope" + ("s" if scope_count != 1 else ""))
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    f"Subnet is not empty: {', '.join(parts)}. "
-                    "Delete the contents first, or retry with force=true to cascade."
-                ),
-            )
-
-    block_id = subnet.block_id
-
-    # Clean up DHCP artifacts first so downstream servers don't keep
-    # serving leases for a range that no longer exists in IPAM.
-    #
-    #   * windows_dhcp (agentless) → push a remove-scope via WinRM before
-    #     the DB row disappears; failure bubbles as 502 and rolls back.
-    #   * kea (agent-based) → we can't actually reconfigure from the
-    #     DB delete alone. Mark its config_etag dirty and enqueue an
-    #     ``apply_config`` op so the next agent poll rebuilds the
-    #     bundle without the removed scope.
-    #
-    # DHCPScope.subnet_id is ``ondelete=CASCADE`` so the rows themselves
-    # (+ pools / statics via ORM cascade) will be cleaned automatically
-    # when the subnet is deleted.
-    # Under the group-centric model, a scope belongs to a group which
-    # may contain N servers (mixed drivers allowed). Fan out:
-    #   * push_scope_delete walks the group's Windows members and pushes
-    #     the Remove-DhcpServerv4Scope cmdlet to each of them.
-    #   * Every Kea member needs a bundle refresh so the next long-poll
-    #     drops the subnet from its rendered config.
-    scope_rows = (
-        (await db.execute(select(DHCPScope).where(DHCPScope.subnet_id == subnet_id)))
-        .scalars()
-        .all()
-    )
-    agent_servers_to_refresh: dict[uuid.UUID, DHCPServer] = {}
-    for scope in scope_rows:
-        await push_scope_delete(db, scope)  # fans out over Windows members of the group
-        group_servers = (
-            (
-                await db.execute(
-                    select(DHCPServer).where(DHCPServer.server_group_id == scope.group_id)
-                )
-            )
-            .scalars()
-            .all()
-        )
-        for srv in group_servers:
-            if not is_agentless(srv.driver):
-                agent_servers_to_refresh[srv.id] = srv
-
-    # Clean up DNS artifacts so we don't leave orphaned records/zones behind.
-    # IPAddress rows cascade-delete with the subnet, but DNSRecord.ip_address_id
-    # is ON DELETE SET NULL, and auto-generated reverse zones keep linked_subnet_id
-    # nulled instead of being removed.
-    addr_result = await db.execute(
-        select(IPAddress.dns_record_id).where(
-            IPAddress.subnet_id == subnet_id,
-            IPAddress.dns_record_id.isnot(None),
-        )
-    )
-    record_ids = [rid for rid in addr_result.scalars().all() if rid is not None]
-    if record_ids:
-        await db.execute(delete(DNSRecord).where(DNSRecord.id.in_(record_ids)))
-
-    await db.execute(
-        delete(DNSZone).where(
-            DNSZone.linked_subnet_id == subnet_id,
-            DNSZone.is_auto_generated.is_(True),
-        )
-    )
-
-    db.add(
-        _audit(
-            current_user,
-            "delete",
-            "subnet",
-            str(subnet.id),
-            f"{subnet.network} ({subnet.name})",
-            old_value={"network": str(subnet.network), "name": subnet.name},
-        )
-    )
-    await db.delete(subnet)
-    await db.flush()
-    await _update_block_utilization(db, block_id)
-
-    # Rebuild bundles for any agent-based servers that lost a scope. Done
-    # after the delete so the fresh bundle reflects the post-delete state.
-    for server in agent_servers_to_refresh.values():
-        bundle = await build_config_bundle(db, server)
-        server.config_etag = bundle.etag
-        existing = (
-            await db.execute(
-                select(DHCPConfigOp).where(
-                    DHCPConfigOp.server_id == server.id,
-                    DHCPConfigOp.op_type == "apply_config",
-                    DHCPConfigOp.status == "pending",
-                )
-            )
-        ).scalar_one_or_none()
-        if existing is None:
-            db.add(
-                DHCPConfigOp(
-                    server_id=server.id,
-                    op_type="apply_config",
-                    payload={"etag": bundle.etag},
-                    status="pending",
-                )
-            )
-
-    await db.commit()
+    op = get_operation("delete_subnet")
+    assert op is not None  # registered at import
+    args = DeleteSubnetArgs(subnet_id=subnet_id, force=force, permanent=permanent)
+    pending = await gate_or_execute(db, current_user, request, operation=op, args=args)
+    if pending is not None:
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+    await op.apply(db, current_user, args)
+    return None
 
 
 # ── Subnet + Block Resize (grow-only) ─────────────────────────────────────────

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -21,6 +21,7 @@ from app.api.v1.auth.router import router as auth_router
 from app.api.v1.auth_providers.router import router as auth_providers_router
 from app.api.v1.backup import router as backup_router
 from app.api.v1.bgp import router as bgp_router
+from app.api.v1.change_requests import router as change_requests_router
 from app.api.v1.circuits import router as circuits_router
 from app.api.v1.cloud import router as cloud_router
 from app.api.v1.conformity import router as conformity_router
@@ -131,6 +132,12 @@ api_v1_router.include_router(
 )
 api_v1_router.include_router(backup_router, prefix="/backup", tags=["backup"])
 api_v1_router.include_router(bgp_router, prefix="/bgp", tags=["bgp"])
+api_v1_router.include_router(
+    change_requests_router,
+    prefix="/change-requests",
+    tags=["change-requests"],
+    dependencies=[Depends(require_module("governance.approvals"))],
+)
 api_v1_router.include_router(
     circuits_router,
     prefix="/circuits",

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -54,6 +54,7 @@ celery_app = Celery(
         "app.tasks.audit_chain_verify",
         "app.tasks.upgrade_orchestrator",
         "app.tasks.time_bound_grant_sweep",
+        "app.tasks.change_request_expiry",
         "app.tasks.acme",
         "app.tasks.tls_certs",
     ],
@@ -112,6 +113,7 @@ celery_app.conf.update(
         "app.tasks.ai_digest.*": {"queue": "default"},
         "app.tasks.audit_chain_verify.*": {"queue": "default"},
         "app.tasks.time_bound_grant_sweep.*": {"queue": "default"},
+        "app.tasks.change_request_expiry.*": {"queue": "default"},
         "app.tasks.acme.*": {"queue": "default"},
         "app.tasks.tls_certs.*": {"queue": "default"},
     },
@@ -488,6 +490,15 @@ celery_app.conf.update(
         # row per expired grant).
         "time-bound-grant-sweep": {
             "task": "app.tasks.time_bound_grant_sweep.sweep_expired_grants",
+            "schedule": schedule(run_every=60.0),
+        },
+        # Every 60 s, flip pending change requests (#62) whose TTL has
+        # elapsed to ``expired`` (terminal) + write the system-actor audit
+        # row. Idempotent — only pending+past-expiry rows match. The approve
+        # endpoint also lazily expires a stale row on read, so a request
+        # never executes past its TTL regardless of this sweep's cadence.
+        "change-request-expiry-sweep": {
+            "task": "app.tasks.change_request_expiry.sweep_expired_change_requests",
             "schedule": schedule(run_every=60.0),
         },
         # Every 60 s, probe every enabled TLS cert target whose

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -63,6 +63,21 @@ RESOURCE_TYPE_VRF = "vrf"
 # return empty data because the underlying OS surfaces aren't there.
 RESOURCE_TYPE_APPLIANCE = "appliance"
 
+# Two-person approval workflow surface (issue #62). The
+# /api/v1/change-requests/* router gates on ``read`` (queue + history)
+# and the new ``approve`` action (decide a request) against this
+# resource_type. The "Change Approver" builtin role grants both.
+#
+# ``approve`` is a NEW action string deliberately NOT covered by the
+# ``admin`` implication (``_ADMIN_IMPLIES`` lists only read/write/delete/
+# admin): a wildcard/admin grant on ``change_request`` does NOT confer
+# approve. Approve must be granted explicitly — a two-person rule whose
+# approve capability rides along with generic admin isn't a two-person
+# rule. The approve endpoint additionally enforces, server-side, that the
+# approver holds the *underlying operation's* required_permission and is
+# not the requester.
+RESOURCE_TYPE_CHANGE_REQUEST = "change_request"
+
 
 def _action_matches(granted: str, requested: str) -> bool:
     """Return True if a granted `action` string covers the requested action."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -190,6 +190,19 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
             {"action": "admin", "resource_type": "address_set"},
         ],
     ),
+    "Change Approver": (
+        "Approve or reject queued change requests in the two-person approval "
+        "workflow (#62). Grants ``approve`` + ``read`` on the synthetic "
+        "``change_request`` resource_type. Note: this role only confers the "
+        "second-person decision capability — to approve a specific request the "
+        "operator must ALSO hold the underlying operation's permission (e.g. "
+        "``delete,subnet`` to approve a subnet delete), enforced server-side at "
+        "the approve endpoint, and may never approve their own request.",
+        [
+            {"action": "approve", "resource_type": "change_request"},
+            {"action": "read", "resource_type": "change_request"},
+        ],
+    ),
     "DNS Editor": (
         "Full CRUD on DNS zones, records, server groups, blocklists, and pools.",
         [

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -21,6 +21,7 @@ from app.models.auth import APIToken, Group, Role, User, UserSession, user_group
 from app.models.auth_provider import AuthGroupMapping, AuthProvider
 from app.models.backup import BackupTarget
 from app.models.base import Base
+from app.models.change_request import ApprovalPolicy, ChangeRequest
 from app.models.circuit import Circuit
 from app.models.cloud import CloudEndpoint
 from app.models.conformity import ConformityPolicy, ConformityResult
@@ -240,4 +241,6 @@ __all__ = [
     "InternalError",
     "BackupTarget",
     "TimeBoundGrant",
+    "ApprovalPolicy",
+    "ChangeRequest",
 ]

--- a/backend/app/models/change_request.py
+++ b/backend/app/models/change_request.py
@@ -1,0 +1,161 @@
+"""Two-person approval workflow — change requests + approval policies (#62).
+
+A ``ChangeRequest`` is a high-blast-radius operation (a delete, a bulk
+op, a factory reset, a large import) that a policy decided needs a
+*second* eligible operator to approve before it runs. The requester
+submits; the row sits in ``state="pending"``; a different approver who
+holds both ``{approve, change_request}`` and the operation's own
+``required_permission`` approves; the operation then executes under the
+**approver's** identity after re-running its preview (stale-state guard).
+The audit trail carries both user IDs — requester on the ``requested``
+row, approver on the ``executed`` row with ``old_value.requested_by``.
+
+An ``ApprovalPolicy`` is the operator-tunable rule that decides whether
+a given ``(resource_type, action[, count])`` triggers the gate. Built-in
+rows seed ``enabled=False`` so existing installs see zero behaviour
+change until an operator opts in. The whole surface is gated behind the
+``governance.approvals`` feature module (default-off, non-negotiable #14).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+# Legal lifecycle states for a change request.
+#
+# ``pending``   — awaiting a second-person decision.
+# ``approved``  — an approver accepted; transient until ``executed``/``failed``.
+# ``rejected``  — an approver declined; terminal.
+# ``executed``  — the operation ran successfully under the approver; terminal.
+# ``failed``    — apply() (or its re-preview) failed at execution; terminal.
+# ``expired``   — TTL elapsed before a decision; terminal.
+# ``cancelled`` — the requester (or a superadmin) withdrew it; terminal.
+CHANGE_REQUEST_STATES: frozenset[str] = frozenset(
+    {"pending", "approved", "rejected", "executed", "failed", "expired", "cancelled"}
+)
+
+# Actions an approval policy can gate. Coarse on purpose (resource_type +
+# action [+ count threshold]); per-resource_id scoping is a later
+# enhancement that rides #64.
+APPROVAL_POLICY_ACTIONS: frozenset[str] = frozenset(
+    {"delete", "bulk_delete", "bulk_edit", "bulk_allocate", "factory_reset", "import_commit"}
+)
+
+
+class ChangeRequest(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A risky operation queued for second-person approval."""
+
+    __tablename__ = "change_request"
+    __table_args__ = (
+        # Pending-queue read + the Celery expiry sweep both scan by
+        # (state, expires_at).
+        Index("ix_change_request_state_expires", "state", "expires_at"),
+        # "my requests" filter.
+        Index("ix_change_request_requested_by", "requested_by_user_id"),
+        # "what's queued against this resource" lookup.
+        Index("ix_change_request_resource", "resource_type", "resource_id"),
+    )
+
+    # Operation registry key to replay (e.g. ``delete_subnet``).
+    operation: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    # Frozen identity of the target, for filtering + audit. ``resource_id``
+    # is NULL for ops with no single target (e.g. factory_reset).
+    resource_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    resource_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    resource_display: Mapped[str] = mapped_column(String(500), nullable=False)
+
+    # The operation args to replay on approve, and the preview text + the
+    # policy reason both frozen at request time.
+    args: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    preview_text: Mapped[str] = mapped_column(Text, nullable=False)
+    risk_reason: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    state: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="pending", server_default="pending"
+    )
+
+    # Requester — FK SET NULL so deleting the user keeps the audit trail;
+    # ``requested_by_display`` survives the deletion.
+    requested_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    requested_by_display: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # Approver/rejecter — populated on the deciding transition.
+    decided_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    decided_by_display: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    decision_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # apply() outcome.
+    result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    executed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class ApprovalPolicy(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A rule deciding whether an operation needs second-person approval."""
+
+    __tablename__ = "approval_policy"
+    __table_args__ = (
+        # The match query filters on (resource_type, action).
+        Index("ix_approval_policy_match", "resource_type", "action"),
+    )
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # ``resource_type`` may be the wildcard ``"*"`` to match any type.
+    resource_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    action: Mapped[str] = mapped_column(String(50), nullable=False)
+
+    # Threshold: only require approval when the op touches >= N rows.
+    # NULL = always require approval regardless of count.
+    min_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    # A two-person rule that superadmin bypasses isn't a two-person rule —
+    # default True so superadmin also needs a second superadmin.
+    applies_to_superadmin: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
+    # Request expiry window (default 7 days).
+    ttl_hours: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=168, server_default=text("168")
+    )
+    is_builtin: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+
+
+__all__ = [
+    "APPROVAL_POLICY_ACTIONS",
+    "CHANGE_REQUEST_STATES",
+    "ApprovalPolicy",
+    "ChangeRequest",
+]

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -882,3 +882,19 @@ class PlatformSettings(Base):
     acme_domains: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
     )
+
+    # ── Governance self-protection lock (#62) ────────────────────────────
+    # OPT-IN at enable time. When True, WEAKENING the approval control plane
+    # (disabling the ``governance.approvals`` module, disabling / deleting a
+    # policy, lowering a policy's ``applies_to_superadmin``, or turning this
+    # very lock back off) requires a SECOND superadmin's approval via the
+    # change-request flow — so a single compromised / rogue superadmin can't
+    # quietly defang the workflow. STRENGTHENING moves (enabling the module,
+    # enabling a policy, raising ``applies_to_superadmin``, turning this lock
+    # on) stay single-person inline. A superadmin break-glass (password
+    # re-confirm + typed phrase) can force any weakening change immediately so
+    # the platform can never be permanently locked out. The lock is ON iff
+    # this flag is True.
+    approvals_protect_controls: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -99,11 +99,23 @@ class PreviewResult:
     subnet doesn't exist, address out of range) — surface ``detail``
     to the operator and don't even create a proposal row. ``ok=True``
     proceeds to persist the proposal with ``preview_text``.
+
+    ``idempotent=True`` (only meaningful when ``ok=True``) signals the
+    target is ALREADY in the desired end-state at approve time — the
+    effect this change requested was achieved by some other path (e.g. a
+    concurrent break-glass) between request and approval. The approve spine
+    resolves such a request as IDEMPOTENT SUCCESS (``executed`` with an
+    "already in desired state" note) WITHOUT re-running ``apply()`` and
+    WITHOUT the scope-drift guard 409'ing — so a change_request whose effect
+    already landed resolves cleanly instead of stranding ``pending`` / failing
+    (#62 concurrent break-glass). Defaults False so no existing op changes
+    behaviour.
     """
 
     ok: bool
     detail: str
     preview_text: str = ""
+    idempotent: bool = False
 
 
 _OPERATIONS: dict[str, Operation] = {}

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -2982,3 +2982,237 @@ register(
         category="admin",
     )
 )
+
+
+# ── approve / reject change request (#62 two-person spine) ─────────────
+#
+# The change-request approval flow is itself an Operation so the Copilot
+# can surface "approve change request X" as a propose→Apply card. The
+# propose tool only persists a proposal (read-only); the human operator
+# who clicks Apply in the chat drawer becomes the *approver*, and the
+# server-side two-person invariants in apply() still fire — the model can
+# never self-approve. The whole spine (self-approval block, approver !=
+# requester, approver holds {approve, change_request} AND the underlying
+# op's required_permission, stale-state re-preview, execute-under-approver)
+# lives in services/approvals/service.py and is shared verbatim with the
+# REST router so there is exactly one implementation of the invariants.
+#
+# required_permission=("approve", "change_request") is the apply endpoint's
+# authoritative RBAC backstop (#400, C2); the deeper checks (self-approval,
+# underlying-op permission, stale state) run inside the shared orchestrator.
+
+
+class ApproveChangeRequestArgs(BaseModel):
+    """Args for the ``approve_change_request`` operation."""
+
+    change_request_id: str = Field(description="UUID of the pending change request to approve.")
+    note: str | None = Field(
+        default=None,
+        description="Optional decision note recorded on the change request.",
+    )
+
+
+class RejectChangeRequestArgs(BaseModel):
+    """Args for the ``reject_change_request`` operation."""
+
+    change_request_id: str = Field(description="UUID of the pending change request to reject.")
+    note: str | None = Field(
+        default=None,
+        description="Optional decision note recorded on the change request.",
+    )
+
+
+def _parse_cr_id(raw: str) -> UUID | None:
+    try:
+        return UUID(str(raw))
+    except (ValueError, AttributeError):
+        return None
+
+
+async def _preview_approve_change_request(
+    db: AsyncSession, user: User, args: ApproveChangeRequestArgs
+) -> PreviewResult:
+    """Surface every two-person failure mode as ``ok=False`` so the propose
+    tool returns ``proposal_rejected`` rather than queuing a doomed proposal.
+    Read-only — mirrors the early checks the shared orchestrator re-runs."""
+    from app.core.permissions import (  # noqa: PLC0415
+        RESOURCE_TYPE_CHANGE_REQUEST,
+        user_has_permission,
+    )
+    from app.services.approvals.service import get_change_request  # noqa: PLC0415
+
+    cr_id = _parse_cr_id(args.change_request_id)
+    if cr_id is None:
+        return PreviewResult(
+            ok=False, detail=f"Invalid change request id: {args.change_request_id!r}"
+        )
+    cr = await get_change_request(db, cr_id)
+    if cr is None:
+        return PreviewResult(ok=False, detail=f"Change request {args.change_request_id} not found.")
+    if cr.state != "pending":
+        return PreviewResult(
+            ok=False, detail=f"Change request is not pending (state={cr.state!r})."
+        )
+    if cr.expires_at < datetime.now(UTC):
+        return PreviewResult(ok=False, detail="Change request has expired.")
+    if cr.requested_by_user_id is not None and user.id == cr.requested_by_user_id:
+        return PreviewResult(ok=False, detail="You cannot approve your own change request.")
+    if not user_has_permission(user, "approve", RESOURCE_TYPE_CHANGE_REQUEST):
+        return PreviewResult(
+            ok=False, detail="Permission denied: need 'approve' on 'change_request'."
+        )
+    op = get_operation(cr.operation)
+    if op is None:
+        return PreviewResult(ok=False, detail=f"Operation {cr.operation!r} is not registered.")
+    try:
+        enforce_operation_permission(user, op)
+    except OperationPermissionError as exc:
+        return PreviewResult(ok=False, detail=str(exc))
+    # Re-run the underlying op's preview as the stale-state guard.
+    try:
+        inner_args = op.args_model.model_validate(cr.args or {})
+    except Exception as exc:  # noqa: BLE001
+        return PreviewResult(ok=False, detail=f"Stored args no longer validate: {exc}")
+    inner = await op.preview(db, user, inner_args)
+    if not inner.ok:
+        return PreviewResult(ok=False, detail=f"Stale change request: {inner.detail}")
+    preview_text = (
+        f"Approve + execute change request `{cr.id}` "
+        f"({cr.operation} on {cr.resource_display}), requested by "
+        f"{cr.requested_by_display}. On Apply it runs under YOUR identity "
+        f"after re-validating state. Underlying preview:\n{inner.preview_text}"
+    )
+    return PreviewResult(ok=True, detail="ready", preview_text=preview_text)
+
+
+async def _apply_approve_change_request(
+    db: AsyncSession, user: User, args: ApproveChangeRequestArgs
+) -> dict[str, Any]:
+    """Approve + execute under the approver's identity. Delegates to the
+    shared orchestrator so the two-person invariants are enforced once,
+    server-side, identically to the REST router."""
+    from app.services.approvals.service import (  # noqa: PLC0415
+        DecisionError,
+        DecisionForbidden,
+        approve_change_request,
+    )
+
+    enforce_operation_permission(user, _OPERATIONS["approve_change_request"])
+
+    cr_id = _parse_cr_id(args.change_request_id)
+    if cr_id is None:
+        raise ValueError(f"Invalid change request id: {args.change_request_id!r}")
+    try:
+        cr = await approve_change_request(db, cr_id, approver=user, request=None, note=args.note)
+    except DecisionForbidden as exc:
+        # Map the self-approval / missing-permission case to the op's RBAC
+        # error so the apply endpoint returns a clean 403.
+        raise OperationPermissionError("approve", "change_request") from exc
+    except DecisionError as exc:
+        raise ValueError(str(exc)) from exc
+    return {
+        "id": str(cr.id),
+        "operation": cr.operation,
+        "state": cr.state,
+        "result": cr.result,
+        "error": cr.error,
+    }
+
+
+async def _preview_reject_change_request(
+    db: AsyncSession, user: User, args: RejectChangeRequestArgs
+) -> PreviewResult:
+    from app.core.permissions import (  # noqa: PLC0415
+        RESOURCE_TYPE_CHANGE_REQUEST,
+        user_has_permission,
+    )
+    from app.services.approvals.service import get_change_request  # noqa: PLC0415
+
+    cr_id = _parse_cr_id(args.change_request_id)
+    if cr_id is None:
+        return PreviewResult(
+            ok=False, detail=f"Invalid change request id: {args.change_request_id!r}"
+        )
+    cr = await get_change_request(db, cr_id)
+    if cr is None:
+        return PreviewResult(ok=False, detail=f"Change request {args.change_request_id} not found.")
+    if cr.state != "pending":
+        return PreviewResult(
+            ok=False, detail=f"Change request is not pending (state={cr.state!r})."
+        )
+    if cr.requested_by_user_id is not None and user.id == cr.requested_by_user_id:
+        return PreviewResult(
+            ok=False, detail="You cannot reject your own request — cancel it instead."
+        )
+    if not user_has_permission(user, "approve", RESOURCE_TYPE_CHANGE_REQUEST):
+        return PreviewResult(
+            ok=False, detail="Permission denied: need 'approve' on 'change_request'."
+        )
+    preview_text = (
+        f"Reject change request `{cr.id}` "
+        f"({cr.operation} on {cr.resource_display}), requested by "
+        f"{cr.requested_by_display}. The operation will NOT run."
+    )
+    return PreviewResult(ok=True, detail="ready", preview_text=preview_text)
+
+
+async def _apply_reject_change_request(
+    db: AsyncSession, user: User, args: RejectChangeRequestArgs
+) -> dict[str, Any]:
+    from app.services.approvals.service import (  # noqa: PLC0415
+        DecisionError,
+        DecisionForbidden,
+        reject_change_request,
+    )
+
+    enforce_operation_permission(user, _OPERATIONS["reject_change_request"])
+
+    cr_id = _parse_cr_id(args.change_request_id)
+    if cr_id is None:
+        raise ValueError(f"Invalid change request id: {args.change_request_id!r}")
+    try:
+        cr = await reject_change_request(db, cr_id, approver=user, request=None, note=args.note)
+    except DecisionForbidden as exc:
+        raise OperationPermissionError("approve", "change_request") from exc
+    except DecisionError as exc:
+        raise ValueError(str(exc)) from exc
+    return {"id": str(cr.id), "operation": cr.operation, "state": cr.state}
+
+
+register(
+    Operation(
+        name="approve_change_request",
+        description=(
+            "Approve a pending two-person change request (#62). Re-runs the "
+            "underlying operation's preview as a stale-state guard, then "
+            "executes it under the approver's identity. Always route via "
+            "propose_approve_change_request — the human operator clicks Apply "
+            "and becomes the approver; the model can never self-approve. "
+            "Server enforces approver != requester + the underlying op's "
+            "permission."
+        ),
+        args_model=ApproveChangeRequestArgs,
+        preview=_preview_approve_change_request,
+        apply=_apply_approve_change_request,
+        category="ops",
+        required_permission=("approve", "change_request"),
+    )
+)
+
+
+register(
+    Operation(
+        name="reject_change_request",
+        description=(
+            "Reject a pending two-person change request (#62). The underlying "
+            "operation does NOT run. Always route via "
+            "propose_reject_change_request. Server enforces rejecter != "
+            "requester + {approve, change_request}."
+        ),
+        args_model=RejectChangeRequestArgs,
+        preview=_preview_reject_change_request,
+        apply=_apply_reject_change_request,
+        category="ops",
+        required_permission=("approve", "change_request"),
+    )
+)

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -3055,7 +3055,14 @@ async def _preview_approve_change_request(
         )
     if cr.expires_at < datetime.now(UTC):
         return PreviewResult(ok=False, detail="Change request has expired.")
-    if cr.requested_by_user_id is not None and user.id == cr.requested_by_user_id:
+    # #5 fail CLOSED: a deleted requester (requested_by_user_id NULL) is
+    # refused, not silently approvable — mirrors approve_change_request.
+    if cr.requested_by_user_id is None:
+        return PreviewResult(
+            ok=False,
+            detail="Requester no longer exists; cancel and recreate this change request.",
+        )
+    if user.id == cr.requested_by_user_id:
         return PreviewResult(ok=False, detail="You cannot approve your own change request.")
     if not user_has_permission(user, "approve", RESOURCE_TYPE_CHANGE_REQUEST):
         return PreviewResult(

--- a/backend/app/services/ai/operations_control.py
+++ b/backend/app/services/ai/operations_control.py
@@ -77,17 +77,6 @@ MODULE_ID = "governance.approvals"
 # assertion must never see them (they're absent from RISKY_OPERATION_NAMES).
 _CONTROL_PERMISSION: tuple[str, str] = ("admin", "approval_control")
 
-# Human kind → preview verb. Single source of truth for both preview() and
-# the break-glass audit ``resource_display``.
-_KIND_LABELS: dict[str, str] = {
-    "disable_module": "Disable approval workflows entirely",
-    "disable_policy": "Disable approval policy",
-    "delete_policy": "Delete approval policy",
-    "lower_superadmin_gate": "Stop a policy applying to superadmins",
-    "unlock": "Remove the require-approval-to-disable lock",
-    "update_policy": "Weaken approval policy (coverage-reducing edit)",
-}
-
 ControlKind = Literal[
     "disable_module",
     "disable_policy",

--- a/backend/app/services/ai/operations_control.py
+++ b/backend/app/services/ai/operations_control.py
@@ -17,6 +17,8 @@ gated behind a SECOND superadmin's approval, reusing the same
   * deleting a policy                                    (kind=delete_policy)
   * lowering a policy's superadmin gate (true → false)   (kind=lower_superadmin_gate)
   * turning the lock itself off (true → false)           (kind=unlock)
+  * any coverage-REDUCING policy edit (repoint resource_type/action, raise
+    min_count, set min_count NULL→value)                 (kind=update_policy)
 
 STRENGTHENING moves (enabling the module, enabling a policy, raising the
 superadmin gate, turning the lock on) stay single-person inline — making
@@ -52,6 +54,7 @@ from uuid import UUID
 import structlog
 from fastapi import Request
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.auth import User
@@ -82,6 +85,7 @@ _KIND_LABELS: dict[str, str] = {
     "delete_policy": "Delete approval policy",
     "lower_superadmin_gate": "Stop a policy applying to superadmins",
     "unlock": "Remove the require-approval-to-disable lock",
+    "update_policy": "Weaken approval policy (coverage-reducing edit)",
 }
 
 ControlKind = Literal[
@@ -90,19 +94,40 @@ ControlKind = Literal[
     "delete_policy",
     "lower_superadmin_gate",
     "unlock",
+    "update_policy",
 ]
+
+# Fields a ``update_policy`` weakening edit may carry in ``update_payload``.
+# Mirrors ApprovalPolicyUpdate; the apply() replays these verbatim under the
+# approver. Unknown keys are ignored (defensive).
+_POLICY_UPDATE_FIELDS: frozenset[str] = frozenset(
+    {
+        "name",
+        "resource_type",
+        "action",
+        "min_count",
+        "enabled",
+        "applies_to_superadmin",
+        "ttl_hours",
+    }
+)
 
 
 class ModifyApprovalControlArgs(BaseModel):
     """Args for the ``modify_approval_control`` operation.
 
-    ``kind`` discriminates the five weakening changes. ``policy_id`` is
-    required for the three policy-scoped kinds; ignored for
-    ``disable_module`` / ``unlock``.
+    ``kind`` discriminates the weakening changes. ``policy_id`` is required for
+    the policy-scoped kinds; ignored for ``disable_module`` / ``unlock``.
+    ``update_payload`` carries the full proposed policy edit for the
+    ``update_policy`` kind (a coverage-reducing PUT routed through the gate) —
+    it is the exact ``model_dump(exclude_unset=True)`` of the operator's
+    ``ApprovalPolicyUpdate`` so apply() can REPLAY the identical edit under the
+    approver. Ignored for every other kind.
     """
 
     kind: ControlKind
     policy_id: UUID | None = None
+    update_payload: dict[str, Any] | None = None
 
 
 async def is_controls_protected(db: AsyncSession) -> bool:
@@ -115,7 +140,73 @@ async def is_controls_protected(db: AsyncSession) -> bool:
     return bool(ps is not None and ps.approvals_protect_controls)
 
 
+async def _get_policy_for_update(db: AsyncSession, policy_id: UUID) -> ApprovalPolicy | None:
+    """Load an ``ApprovalPolicy`` row with ``FOR UPDATE`` (#5).
+
+    Locking the row in both preview and apply closes the TOCTOU window where a
+    concurrent break-glass deletes / flips the policy between the spine's
+    preview and its apply — the second caller blocks until the first commits,
+    then sees the settled state (gone / changed) and resolves idempotently."""
+    stmt = select(ApprovalPolicy).where(ApprovalPolicy.id == policy_id).with_for_update()
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def _settings_for_update(db: AsyncSession) -> PlatformSettings | None:
+    """Load ``PlatformSettings(1)`` with ``FOR UPDATE`` (#6) where the lock flag
+    is mutated, so a flag flip can't race the gate-decision read."""
+    stmt = select(PlatformSettings).where(PlatformSettings.id == 1).with_for_update()
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
 # ── modify_approval_control operation ───────────────────────────────────
+
+
+def _coverage_reducing_diffs(policy: ApprovalPolicy, payload: dict[str, Any]) -> list[str]:
+    """Return human diffs for every COVERAGE-REDUCING field in ``payload``.
+
+    A coverage-reducing edit makes a live policy match FEWER operations while
+    still looking enabled — the side-door #2 closes. Compared against the live
+    ``policy`` row so the same rule decides the gate (in the router, pre-edit)
+    AND re-asserts it at approve/replay time (in preview, against whatever the
+    row is then). Empty list ⇒ the edit doesn't weaken coverage (inline-safe).
+
+    Weakening transitions (each gated):
+      * ``enabled`` true → false           — policy goes dark.
+      * ``applies_to_superadmin`` true→false — superadmins escape the gate.
+      * ``resource_type`` changed          — repoints at a different surface.
+      * ``action`` changed                 — repoints at a different verb.
+      * ``min_count`` raised               — gates fewer (larger) ops.
+      * ``min_count`` NULL → a value       — NULL = always-gate (strongest);
+        any concrete threshold lets small ops slip through ungated.
+
+    Strengthening / neutral edits (NOT gated — return no diff for them):
+      name, description, ttl_hours, enabling, raising applies_to_superadmin,
+      lowering min_count, min_count → NULL.
+    """
+    diffs: list[str] = []
+
+    if payload.get("enabled") is False and policy.enabled:
+        diffs.append("disabled (enabled true→false)")
+
+    if payload.get("applies_to_superadmin") is False and policy.applies_to_superadmin:
+        diffs.append("no longer applies to superadmins")
+
+    if "resource_type" in payload and payload["resource_type"] != policy.resource_type:
+        diffs.append(f"resource_type {policy.resource_type!r}→{payload['resource_type']!r}")
+
+    if "action" in payload and payload["action"] != policy.action:
+        diffs.append(f"action {policy.action!r}→{payload['action']!r}")
+
+    if "min_count" in payload:
+        new_mc = payload["min_count"]
+        old_mc = policy.min_count
+        if old_mc is None and new_mc is not None:
+            # NULL (always-gate) → a concrete threshold = weaker.
+            diffs.append(f"min_count NULL→{new_mc} (was always-gate)")
+        elif old_mc is not None and new_mc is not None and new_mc > old_mc:
+            diffs.append(f"min_count {old_mc}→{new_mc} (gates fewer ops)")
+
+    return diffs
 
 
 async def _preview_modify_approval_control(
@@ -123,10 +214,21 @@ async def _preview_modify_approval_control(
 ) -> PreviewResult:
     """Re-validate the weakening change + render a clear human description.
 
-    ``ok=False`` (with a reason) when the change is already moot — the
-    module is already off, the policy vanished or is already disabled, the
-    lock is already off — so the approve spine refuses to execute a no-op /
-    doomed control change exactly like a stale risky delete.
+    Three outcomes (#5 / #6):
+
+    * ``ok=False`` — the change is structurally invalid (missing policy_id,
+      built-in delete, unknown kind). The approve spine 409s like a stale delete.
+    * ``ok=True, idempotent=True`` — the desired end-state is ALREADY reached
+      (module already off, lock already off, policy already gone / already
+      disabled, edit already applied) OR the gate PREMISE is gone (the lock was
+      turned off out of band, e.g. by a concurrent break-glass ``unlock``). The
+      approve spine resolves the request as EXECUTED-idempotent WITHOUT
+      re-running apply(), so a CR whose effect already landed (or whose
+      protection premise vanished) resolves cleanly instead of stranding.
+    * ``ok=True`` (not idempotent) — proceed; apply() performs the change.
+
+    Rows are read FOR UPDATE so a concurrent break-glass can't delete / flip
+    the target between this preview and apply() in the same spine call.
     """
     from app.services.feature_modules import is_module_enabled  # noqa: PLC0415
 
@@ -134,7 +236,12 @@ async def _preview_modify_approval_control(
 
     if kind == "disable_module":
         if not await is_module_enabled(db, MODULE_ID):
-            return PreviewResult(ok=False, detail="Approval workflows are already disabled.")
+            return PreviewResult(
+                ok=True,
+                idempotent=True,
+                detail="Approval workflows are already disabled.",
+                preview_text="Disable approval workflows entirely",
+            )
         return PreviewResult(
             ok=True, detail="ready", preview_text="Disable approval workflows entirely"
         )
@@ -142,7 +249,10 @@ async def _preview_modify_approval_control(
     if kind == "unlock":
         if not await is_controls_protected(db):
             return PreviewResult(
-                ok=False, detail="The require-approval-to-disable lock is already off."
+                ok=True,
+                idempotent=True,
+                detail="The require-approval-to-disable lock is already off.",
+                preview_text="Remove the require-approval-to-disable lock",
             )
         return PreviewResult(
             ok=True,
@@ -150,16 +260,30 @@ async def _preview_modify_approval_control(
             preview_text="Remove the require-approval-to-disable lock",
         )
 
-    # Policy-scoped kinds need the row.
+    # Policy-scoped kinds need the row — locked FOR UPDATE (#5) so a concurrent
+    # break-glass delete can't slip in between preview and apply.
     if args.policy_id is None:
         return PreviewResult(ok=False, detail=f"{kind} requires a policy_id.")
-    policy = await db.get(ApprovalPolicy, args.policy_id)
+    policy = await _get_policy_for_update(db, args.policy_id)
     if policy is None:
+        # For delete_policy a vanished row IS the desired end-state (#5).
+        if kind == "delete_policy":
+            return PreviewResult(
+                ok=True,
+                idempotent=True,
+                detail=f"Approval policy {args.policy_id} is already gone.",
+                preview_text="Delete approval policy",
+            )
         return PreviewResult(ok=False, detail=f"Approval policy {args.policy_id} not found.")
 
     if kind == "disable_policy":
         if not policy.enabled:
-            return PreviewResult(ok=False, detail=f"Policy {policy.name!r} is already disabled.")
+            return PreviewResult(
+                ok=True,
+                idempotent=True,
+                detail=f"Policy {policy.name!r} is already disabled.",
+                preview_text=f"Disable approval policy `{policy.name}`",
+            )
         return PreviewResult(
             ok=True, detail="ready", preview_text=f"Disable approval policy `{policy.name}`"
         )
@@ -175,13 +299,40 @@ async def _preview_modify_approval_control(
     if kind == "lower_superadmin_gate":
         if not policy.applies_to_superadmin:
             return PreviewResult(
-                ok=False,
+                ok=True,
+                idempotent=True,
                 detail=f"Policy {policy.name!r} already does not apply to superadmins.",
+                preview_text=f"Stop policy `{policy.name}` applying to superadmins",
             )
         return PreviewResult(
             ok=True,
             detail="ready",
             preview_text=f"Stop policy `{policy.name}` applying to superadmins",
+        )
+
+    if kind == "update_policy":
+        payload = args.update_payload or {}
+        diffs = _coverage_reducing_diffs(policy, payload)
+        if not diffs:
+            # The proposed edit no longer reduces coverage vs the live row —
+            # already applied, or the row drifted. The requested weakening is a
+            # no-op now → idempotent success (#5) rather than a 409 dead-end.
+            return PreviewResult(
+                ok=True,
+                idempotent=True,
+                detail=(
+                    f"Policy {policy.name!r} edit no longer reduces coverage "
+                    "(already applied or the policy changed)."
+                ),
+                preview_text=f"Weaken approval policy `{policy.name}`",
+            )
+        return PreviewResult(
+            ok=True,
+            detail="ready",
+            preview_text=(
+                f"Weaken approval policy `{policy.name}` — coverage-reducing edit: "
+                + "; ".join(diffs)
+            ),
         )
 
     return PreviewResult(ok=False, detail=f"Unknown control kind {kind!r}.")  # pragma: no cover
@@ -253,9 +404,13 @@ async def _apply_modify_approval_control(
         return {"kind": kind, "module": MODULE_ID, "enabled": False}
 
     if kind == "unlock":
-        ps = await db.get(PlatformSettings, 1)
-        if ps is not None:
-            ps.approvals_protect_controls = False
+        # FOR UPDATE (#6) so a racing flag flip can't clobber this write.
+        ps = await _settings_for_update(db)
+        if ps is None or not ps.approvals_protect_controls:
+            # Already off (idempotent) — nothing to do, no audit noise.
+            await db.commit()
+            return {"kind": kind, "approvals_protect_controls": False, "idempotent": True}
+        ps.approvals_protect_controls = False
         _control_audit(
             db,
             user=user,
@@ -268,12 +423,17 @@ async def _apply_modify_approval_control(
         await db.commit()
         return {"kind": kind, "approvals_protect_controls": False}
 
-    # Policy-scoped kinds.
+    # Policy-scoped kinds — lock the row FOR UPDATE (#5).
     if args.policy_id is None:
         raise ValueError(f"{kind} requires a policy_id.")
-    policy = await db.get(ApprovalPolicy, args.policy_id)
+    policy = await _get_policy_for_update(db, args.policy_id)
     if policy is None:
-        raise ValueError(f"Approval policy {args.policy_id} not found.")
+        # The policy vanished (e.g. a concurrent break-glass delete won the
+        # race). For delete that IS the desired end-state → idempotent success;
+        # for the others there's nothing left to weaken → also idempotent, not
+        # a crash (the direct break-glass call path must not 500 here).
+        await db.commit()
+        return {"kind": kind, "policy_id": str(args.policy_id), "idempotent": True}
     name = policy.name
 
     if kind == "disable_policy":
@@ -283,6 +443,19 @@ async def _apply_modify_approval_control(
     elif kind == "lower_superadmin_gate":
         policy.applies_to_superadmin = False
         new_value = {"applies_to_superadmin": False, "via": "approval_control"}
+        action_audit = "write"
+    elif kind == "update_policy":
+        # REPLAY the operator's exact coverage-reducing edit under the approver.
+        # Apply only known policy fields from the frozen payload (defensive
+        # filter — never trust extra keys); the preview() re-asserted it still
+        # reduces coverage before we got here.
+        payload = args.update_payload or {}
+        applied: dict[str, Any] = {}
+        for field, value in payload.items():
+            if field in _POLICY_UPDATE_FIELDS:
+                setattr(policy, field, value)
+                applied[field] = value
+        new_value = {**applied, "via": "approval_control"}
         action_audit = "write"
     elif kind == "delete_policy":
         if policy.is_builtin:
@@ -331,6 +504,25 @@ register(_OP_MODIFY_APPROVAL_CONTROL)
 CONTROL_OPERATION_NAMES: frozenset[str] = frozenset({"modify_approval_control"})
 
 
+async def control_gate_premise_lost(db: AsyncSession, args: ModifyApprovalControlArgs) -> bool:
+    """True iff a queued control-op change_request's gate PREMISE has evaporated
+    (#6 — TOCTOU defense-in-depth).
+
+    Every control change_request was queued BECAUSE the self-protection lock was
+    ON when it was requested. If the lock is now OFF at approve time (e.g. a
+    concurrent break-glass ``unlock`` landed first), the second-superadmin
+    protection rationale no longer holds — the approve spine should resolve the
+    request as idempotent/clear rather than silently executing a weakening
+    change under approver authority whose premise is gone. ``unlock`` itself is
+    exempt: its desired end-state IS the lock being off, so the op's own
+    preview() already reports it idempotent. The flag is read FOR UPDATE so the
+    decision can't race a concurrent flip."""
+    if args.kind == "unlock":
+        return False
+    ps = await _settings_for_update(db)
+    return not bool(ps is not None and ps.approvals_protect_controls)
+
+
 def _assert_registered() -> None:  # pragma: no cover — import-time invariant
     if get_operation("modify_approval_control") is None:
         raise RuntimeError("modify_approval_control operation not registered")
@@ -349,6 +541,7 @@ async def maybe_gate_control(
     *,
     kind: ControlKind,
     policy_id: UUID | None = None,
+    update_payload: dict[str, Any] | None = None,
     resource_type: str,
     resource_id: str | None,
     resource_display: str,
@@ -376,7 +569,7 @@ async def maybe_gate_control(
 
     op = get_operation("modify_approval_control")
     assert op is not None  # registered at import
-    args = ModifyApprovalControlArgs(kind=kind, policy_id=policy_id)
+    args = ModifyApprovalControlArgs(kind=kind, policy_id=policy_id, update_payload=update_payload)
 
     # 2. Re-run preview — don't queue a doomed / no-op control change.
     from fastapi import HTTPException, status  # noqa: PLC0415
@@ -414,6 +607,12 @@ __all__ = [
     "CONTROL_OPERATION_NAMES",
     "ControlKind",
     "ModifyApprovalControlArgs",
+    "coverage_reducing_diffs",
     "is_controls_protected",
     "maybe_gate_control",
 ]
+
+
+# Public alias for the router's gate-decision call (the leading underscore
+# keeps the impl private; the router imports this name).
+coverage_reducing_diffs = _coverage_reducing_diffs

--- a/backend/app/services/ai/operations_control.py
+++ b/backend/app/services/ai/operations_control.py
@@ -1,0 +1,419 @@
+"""Self-governance control-plane operations + flag gate (#62).
+
+The approval *control plane* — the ``governance.approvals`` module toggle,
+the ``approval_policy`` rows, and the ``approvals_protect_controls`` lock —
+can itself be weakened. A single rogue / compromised superadmin could
+disable the module, delete every policy, or flip the lock off and then
+delete whatever they wanted with no second pair of eyes.
+
+The self-governance lock closes that hole. It is OPT-IN
+(``PlatformSettings.approvals_protect_controls``, set at module-enable
+time). When ON, every *weakening* change to the control plane is itself
+gated behind a SECOND superadmin's approval, reusing the same
+``change_request`` flow risky deletes use:
+
+  * disabling the ``governance.approvals`` module        (kind=disable_module)
+  * disabling a policy (enabled true → false)            (kind=disable_policy)
+  * deleting a policy                                    (kind=delete_policy)
+  * lowering a policy's superadmin gate (true → false)   (kind=lower_superadmin_gate)
+  * turning the lock itself off (true → false)           (kind=unlock)
+
+STRENGTHENING moves (enabling the module, enabling a policy, raising the
+superadmin gate, turning the lock on) stay single-person inline — making
+the control safer never needs a second person.
+
+These ops are NOT policy-row driven (unlike the risky deletes that flow
+through ``match_policy``). They are gated DIRECTLY on the flag, so they
+must NOT appear in ``RISKY_OPERATION_NAMES`` (which is asserted against the
+``GATEABLE_*`` policy-key sets at boot) and their ``required_permission``
+pair (``("admin", "approval_control")``) must NOT be added to
+``GATEABLE_ACTIONS`` / ``GATEABLE_RESOURCE_TYPES``. ``CONTROL_OPERATION_NAMES``
+below is the separate registry the approve spine consults to enforce the
+superadmin-only requirement on top of the normal checks.
+
+BREAK-GLASS — a superadmin can force any of these weakening changes
+IMMEDIATELY (bypassing the two-person gate) via the dedicated break-glass
+endpoint, which re-confirms the operator's password / TOTP AND a typed
+confirmation phrase and writes a HIGH-severity audit row + event. That is
+the mandatory anti-lockout escape hatch; it calls ``apply()`` directly and
+never re-enters the gate.
+
+CLAUDE.md non-negotiables honoured: #2 (async throughout), #3
+(server-side authorization — superadmin enforced in the approve spine + on
+the break-glass endpoint), #4 (each ``apply()`` writes its own audit row
+before commit).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+from uuid import UUID
+
+import structlog
+from fastapi import Request
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.change_request import ApprovalPolicy
+from app.models.settings import PlatformSettings
+from app.services.ai.operations import (
+    Operation,
+    PreviewResult,
+    get_operation,
+    register,
+)
+
+logger = structlog.get_logger(__name__)
+
+MODULE_ID = "governance.approvals"
+
+# The control operation's RBAC pair. Deliberately NOT in GATEABLE_ACTIONS /
+# GATEABLE_RESOURCE_TYPES — these ops are flag-gated, not policy-row gated,
+# so ``match_policy`` must never try to gate them and the gate-invariant
+# assertion must never see them (they're absent from RISKY_OPERATION_NAMES).
+_CONTROL_PERMISSION: tuple[str, str] = ("admin", "approval_control")
+
+# Human kind → preview verb. Single source of truth for both preview() and
+# the break-glass audit ``resource_display``.
+_KIND_LABELS: dict[str, str] = {
+    "disable_module": "Disable approval workflows entirely",
+    "disable_policy": "Disable approval policy",
+    "delete_policy": "Delete approval policy",
+    "lower_superadmin_gate": "Stop a policy applying to superadmins",
+    "unlock": "Remove the require-approval-to-disable lock",
+}
+
+ControlKind = Literal[
+    "disable_module",
+    "disable_policy",
+    "delete_policy",
+    "lower_superadmin_gate",
+    "unlock",
+]
+
+
+class ModifyApprovalControlArgs(BaseModel):
+    """Args for the ``modify_approval_control`` operation.
+
+    ``kind`` discriminates the five weakening changes. ``policy_id`` is
+    required for the three policy-scoped kinds; ignored for
+    ``disable_module`` / ``unlock``.
+    """
+
+    kind: ControlKind
+    policy_id: UUID | None = None
+
+
+async def is_controls_protected(db: AsyncSession) -> bool:
+    """True iff the self-governance lock is ON.
+
+    The single read all three gated surfaces share so they observe the
+    flag identically. Missing settings row → not protected (defensive: a
+    fresh install with no row behaves exactly as today)."""
+    ps = await db.get(PlatformSettings, 1)
+    return bool(ps is not None and ps.approvals_protect_controls)
+
+
+# ── modify_approval_control operation ───────────────────────────────────
+
+
+async def _preview_modify_approval_control(
+    db: AsyncSession, user: User, args: ModifyApprovalControlArgs
+) -> PreviewResult:
+    """Re-validate the weakening change + render a clear human description.
+
+    ``ok=False`` (with a reason) when the change is already moot — the
+    module is already off, the policy vanished or is already disabled, the
+    lock is already off — so the approve spine refuses to execute a no-op /
+    doomed control change exactly like a stale risky delete.
+    """
+    from app.services.feature_modules import is_module_enabled  # noqa: PLC0415
+
+    kind = args.kind
+
+    if kind == "disable_module":
+        if not await is_module_enabled(db, MODULE_ID):
+            return PreviewResult(ok=False, detail="Approval workflows are already disabled.")
+        return PreviewResult(
+            ok=True, detail="ready", preview_text="Disable approval workflows entirely"
+        )
+
+    if kind == "unlock":
+        if not await is_controls_protected(db):
+            return PreviewResult(
+                ok=False, detail="The require-approval-to-disable lock is already off."
+            )
+        return PreviewResult(
+            ok=True,
+            detail="ready",
+            preview_text="Remove the require-approval-to-disable lock",
+        )
+
+    # Policy-scoped kinds need the row.
+    if args.policy_id is None:
+        return PreviewResult(ok=False, detail=f"{kind} requires a policy_id.")
+    policy = await db.get(ApprovalPolicy, args.policy_id)
+    if policy is None:
+        return PreviewResult(ok=False, detail=f"Approval policy {args.policy_id} not found.")
+
+    if kind == "disable_policy":
+        if not policy.enabled:
+            return PreviewResult(ok=False, detail=f"Policy {policy.name!r} is already disabled.")
+        return PreviewResult(
+            ok=True, detail="ready", preview_text=f"Disable approval policy `{policy.name}`"
+        )
+    if kind == "delete_policy":
+        if policy.is_builtin:
+            return PreviewResult(
+                ok=False,
+                detail="Built-in policies cannot be deleted — disable them instead.",
+            )
+        return PreviewResult(
+            ok=True, detail="ready", preview_text=f"Delete approval policy `{policy.name}`"
+        )
+    if kind == "lower_superadmin_gate":
+        if not policy.applies_to_superadmin:
+            return PreviewResult(
+                ok=False,
+                detail=f"Policy {policy.name!r} already does not apply to superadmins.",
+            )
+        return PreviewResult(
+            ok=True,
+            detail="ready",
+            preview_text=f"Stop policy `{policy.name}` applying to superadmins",
+        )
+
+    return PreviewResult(ok=False, detail=f"Unknown control kind {kind!r}.")  # pragma: no cover
+
+
+def _control_audit(
+    db: AsyncSession,
+    *,
+    user: User,
+    action: str,
+    resource_type: str,
+    resource_id: str,
+    resource_display: str,
+    new_value: dict[str, Any] | None = None,
+) -> None:
+    """Append an audit row for a control-plane mutation (NN #4)."""
+    from app.models.audit import AuditLog  # noqa: PLC0415
+
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=getattr(user, "auth_source", "local") or "local",
+            action=action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            resource_display=resource_display,
+            result="success",
+            new_value=new_value,
+        )
+    )
+
+
+async def _apply_modify_approval_control(
+    db: AsyncSession, user: User, args: ModifyApprovalControlArgs
+) -> dict[str, Any]:
+    """Perform the weakening control change UNDER THE APPROVER + audit it.
+
+    Called by the approve spine (second superadmin) AND by the break-glass
+    endpoint (the same superadmin, after re-confirm). Each branch reads the
+    relevant state FRESH and is idempotent against a state that already
+    moved — so a break-glass ``unlock`` after a quiet flip is a no-op, not a
+    crash. Commits on success.
+    """
+    from app.services.feature_modules import (  # noqa: PLC0415
+        invalidate_cache,
+        set_module_enabled,
+    )
+
+    kind = args.kind
+
+    if kind == "disable_module":
+        # NOTE: this is the disable path itself — set_module_enabled writes
+        # the override row; we do NOT re-enter the gate (apply() never calls
+        # gate_or_execute), so the break-glass / approve disable can't
+        # self-block.
+        await set_module_enabled(db, MODULE_ID, False, user_id=user.id)
+        _control_audit(
+            db,
+            user=user,
+            action="update",
+            resource_type="feature_module",
+            resource_id=MODULE_ID,
+            resource_display="Approval workflows",
+            new_value={"enabled": False, "via": "approval_control"},
+        )
+        await db.commit()
+        invalidate_cache()
+        return {"kind": kind, "module": MODULE_ID, "enabled": False}
+
+    if kind == "unlock":
+        ps = await db.get(PlatformSettings, 1)
+        if ps is not None:
+            ps.approvals_protect_controls = False
+        _control_audit(
+            db,
+            user=user,
+            action="update",
+            resource_type="platform_settings",
+            resource_id="approvals_protect_controls",
+            resource_display="Approval self-protection lock",
+            new_value={"approvals_protect_controls": False, "via": "approval_control"},
+        )
+        await db.commit()
+        return {"kind": kind, "approvals_protect_controls": False}
+
+    # Policy-scoped kinds.
+    if args.policy_id is None:
+        raise ValueError(f"{kind} requires a policy_id.")
+    policy = await db.get(ApprovalPolicy, args.policy_id)
+    if policy is None:
+        raise ValueError(f"Approval policy {args.policy_id} not found.")
+    name = policy.name
+
+    if kind == "disable_policy":
+        policy.enabled = False
+        new_value: dict[str, Any] = {"enabled": False, "via": "approval_control"}
+        action_audit = "write"
+    elif kind == "lower_superadmin_gate":
+        policy.applies_to_superadmin = False
+        new_value = {"applies_to_superadmin": False, "via": "approval_control"}
+        action_audit = "write"
+    elif kind == "delete_policy":
+        if policy.is_builtin:
+            raise ValueError("Built-in policies cannot be deleted — disable them instead.")
+        await db.delete(policy)
+        new_value = {"deleted": True, "via": "approval_control"}
+        action_audit = "delete"
+    else:  # pragma: no cover — args model constrains kind
+        raise ValueError(f"Unknown control kind {kind!r}.")
+
+    _control_audit(
+        db,
+        user=user,
+        action=action_audit,
+        resource_type="approval_policy",
+        resource_id=str(args.policy_id),
+        resource_display=name,
+        new_value=new_value,
+    )
+    await db.commit()
+    return {"kind": kind, "policy_id": str(args.policy_id)}
+
+
+_OP_MODIFY_APPROVAL_CONTROL = Operation(
+    name="modify_approval_control",
+    description=(
+        "Weaken the approval control plane (disable the module, disable / "
+        "delete a policy, lower a policy's superadmin gate, or remove the "
+        "self-protection lock). Gated behind a second superadmin's approval "
+        "when the self-protection lock is on."
+    ),
+    args_model=ModifyApprovalControlArgs,
+    preview=_preview_modify_approval_control,
+    apply=_apply_modify_approval_control,
+    category="governance",
+    required_permission=_CONTROL_PERMISSION,
+)
+register(_OP_MODIFY_APPROVAL_CONTROL)
+
+
+# The approve spine consults this to enforce the superadmin-only requirement
+# on a control op IN ADDITION to the normal {approve, change_request} +
+# required_permission checks. Kept separate from RISKY_OPERATION_NAMES so the
+# gate-invariant assertion (which asserts those against GATEABLE_*) never sees
+# these flag-gated ops.
+CONTROL_OPERATION_NAMES: frozenset[str] = frozenset({"modify_approval_control"})
+
+
+def _assert_registered() -> None:  # pragma: no cover — import-time invariant
+    if get_operation("modify_approval_control") is None:
+        raise RuntimeError("modify_approval_control operation not registered")
+
+
+_assert_registered()
+
+
+# ── Flag-driven gate the three control surfaces call ─────────────────────
+
+
+async def maybe_gate_control(
+    db: AsyncSession,
+    user: User,
+    request: Request,
+    *,
+    kind: ControlKind,
+    policy_id: UUID | None = None,
+    resource_type: str,
+    resource_id: str | None,
+    resource_display: str,
+) -> Any:
+    """Decide whether a weakening control change must be queued for a second
+    superadmin (the flag-driven analogue of ``gate_or_execute``).
+
+    Returns ``None`` (proceed INLINE, single-person, byte-identical to
+    pre-#62) the instant the lock is OFF — before any other query — so the
+    flag-off path never even constructs a change_request. When the lock is
+    ON, re-runs the op's ``preview()`` (409 if the change is already moot)
+    and persists a pending ``change_request`` for ``modify_approval_control``,
+    returning a :class:`ChangeRequestPending`. The break-glass endpoint does
+    NOT call this — it calls ``apply()`` directly.
+    """
+    # Local imports — keep the approvals package off this module's import
+    # graph (operations_control is imported by the API layer at startup).
+    from app.services.approvals.gate import ChangeRequestPending  # noqa: PLC0415
+    from app.services.approvals.service import create_change_request  # noqa: PLC0415
+
+    # 1. Lock off → never gate, never query anything. Flag-off MUST be
+    #    byte-identical to today (#62 design footgun guard).
+    if not await is_controls_protected(db):
+        return None
+
+    op = get_operation("modify_approval_control")
+    assert op is not None  # registered at import
+    args = ModifyApprovalControlArgs(kind=kind, policy_id=policy_id)
+
+    # 2. Re-run preview — don't queue a doomed / no-op control change.
+    from fastapi import HTTPException, status  # noqa: PLC0415
+
+    preview = await op.preview(db, user, args)
+    if not preview.ok:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=preview.detail)
+
+    cr = await create_change_request(
+        db,
+        user=user,
+        request=request,
+        operation=op.name,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        resource_display=resource_display,
+        args=args.model_dump(mode="json"),
+        preview_text=preview.preview_text,
+        risk_reason="approvals self-protection lock",
+        ttl_hours=168,
+    )
+    await db.commit()
+    logger.info(
+        "approval_control.queued",
+        change_request_id=str(cr.id),
+        kind=kind,
+        requested_by=str(user.id),
+    )
+    return ChangeRequestPending(
+        change_request_id=cr.id, state="pending", preview_text=cr.preview_text
+    )
+
+
+__all__ = [
+    "CONTROL_OPERATION_NAMES",
+    "ControlKind",
+    "ModifyApprovalControlArgs",
+    "is_controls_protected",
+    "maybe_gate_control",
+]

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -70,6 +70,62 @@ from app.services.ai.operations import (
 logger = structlog.get_logger(__name__)
 
 
+# ── Blast-radius preview helper (#3a) ──────────────────────────────────────
+#
+# The approve path re-runs preview() and compares its preview_text against the
+# frozen request-time preview_text; any drift refuses execution (#3b). For
+# that drift check to actually catch a cascade that GREW between request and
+# approval, every delete op's preview_text must embed the CURRENT blast radius
+# (counts that move when the cascade changes), not just a static label.
+
+
+async def _soft_delete_cascade_summary(db: AsyncSession, root: Any) -> str:
+    """Render the soft-delete cascade blast radius for ``root`` as a stable,
+    count-bearing string (#3a).
+
+    Uses the SAME ``collect_soft_delete_batch`` walk ``apply()`` will use, so
+    the preview reflects exactly what would be soft-deleted right now. Counts
+    are grouped by resource type and rendered in a fixed order so the string is
+    deterministic for a given set of rows (the approve-time drift compare is a
+    plain string equality, so ordering must not jitter). The root row itself is
+    excluded from the cascade counts (it's the target, not collateral)."""
+    # Local import — keep the soft_delete dependency off module load.
+    from app.services.soft_delete import (  # noqa: PLC0415
+        _resource_type,
+        collect_soft_delete_batch,
+    )
+
+    batch = await collect_soft_delete_batch(db, root)
+    root_id = getattr(root, "id", None)
+    root_rt = _resource_type(root)
+    counts: dict[str, int] = {}
+    for row in batch.rows:
+        if getattr(row.obj, "id", None) == root_id and row.resource_type == root_rt:
+            continue
+        counts[row.resource_type] = counts.get(row.resource_type, 0) + 1
+    labels = {
+        "ip_block": "child block",
+        "subnet": "subnet",
+        "dhcp_scope": "DHCP scope",
+        "dns_record": "DNS record",
+    }
+    order = ["ip_block", "subnet", "dhcp_scope", "dns_record"]
+    parts = []
+    for rt in order:
+        n = counts.get(rt, 0)
+        if n:
+            noun = labels[rt]
+            parts.append(f"{n} {noun}" + ("s" if n != 1 else ""))
+    # Include the leftover types deterministically (sorted) in case the walk
+    # grows to cover a type not in ``order`` — never silently drop a count.
+    for rt in sorted(counts):
+        if rt not in order and counts[rt]:
+            parts.append(f"{counts[rt]} {rt}")
+    if not parts:
+        return "cascades nothing (empty)"
+    return "cascades " + ", ".join(parts)
+
+
 # ── delete_subnet ──────────────────────────────────────────────────────────
 
 
@@ -136,6 +192,8 @@ async def _preview_delete_subnet(
     mode = "Permanently delete" if args.permanent else "Soft-delete"
     parts = [f"{mode} subnet `{subnet.network}`" + (f" ({subnet.name})" if subnet.name else "")]
     if args.permanent:
+        # #3a: counts move as the cascade grows → the approve-time drift check
+        # catches a subnet that gained IPs/scopes since it was requested.
         scope_count = (
             await db.execute(
                 select(func.count(DHCPScope.id)).where(DHCPScope.subnet_id == args.subnet_id)
@@ -147,12 +205,15 @@ async def _preview_delete_subnet(
             )
         ).scalar_one()
         parts.append(
-            f"cascade: {scope_count} DHCP scope(s) + {ip_count} IP row(s) + auto DNS cleanup"
+            f"cascades {scope_count} DHCP scope(s) + {ip_count} IP row(s) + auto DNS cleanup"
         )
         if args.force:
             parts.append("force=true (skip non-empty check)")
     else:
-        parts.append("the subnet + its DHCP scopes are restorable from /admin/trash")
+        # #3a: the soft-delete cascade summary embeds the current blast radius
+        # (DHCP scopes the subnet holds) so a grown cascade is detectable.
+        parts.append(await _soft_delete_cascade_summary(db, subnet))
+        parts.append("restorable from /admin/trash")
     return PreviewResult(ok=True, detail="ready", preview_text="; ".join(parts))
 
 
@@ -354,12 +415,15 @@ async def _preview_delete_block(
             preview_text=f"Permanently delete empty block `{block.network}` ({block.name})",
         )
 
+    # #3a: embed the current cascade counts so the approve-time drift check
+    # catches new child blocks / subnets added since the request.
     return PreviewResult(
         ok=True,
         detail="ready",
         preview_text=(
-            f"Soft-delete block `{block.network}` ({block.name}) — cascades to child "
-            "blocks + subnets + their DHCP scopes; restorable from /admin/trash"
+            f"Soft-delete block `{block.network}` ({block.name}) — "
+            f"{await _soft_delete_cascade_summary(db, block)}; "
+            "restorable from /admin/trash"
         ),
     )
 
@@ -480,12 +544,15 @@ async def _preview_delete_space(
             preview_text=f"Permanently delete empty IP space `{space.name}`",
         )
 
+    # #3a: embed the current cascade counts so the approve-time drift check
+    # catches new blocks / subnets / scopes added since the request.
     return PreviewResult(
         ok=True,
         detail="ready",
         preview_text=(
-            f"Soft-delete IP space `{space.name}` — cascades to every block, subnet, "
-            "and DHCP scope under it; restorable from /admin/trash"
+            f"Soft-delete IP space `{space.name}` — "
+            f"{await _soft_delete_cascade_summary(db, space)}; "
+            "restorable from /admin/trash"
         ),
     )
 
@@ -571,11 +638,26 @@ async def _preview_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArg
         return PreviewResult(ok=False, detail=str(exc.detail))
 
     mode = "Permanently delete" if args.permanent else "Soft-delete"
-    suffix = (
-        " (pushes a remove-zone write-through to agentless servers first)"
-        if args.permanent
-        else " — the zone + its records are restorable from /admin/trash"
-    )
+    if args.permanent:
+        # #3a: count the records this zone holds so a permanent delete of a
+        # zone that grew records since request is caught by the drift check.
+        from app.models.dns import DNSRecord  # noqa: PLC0415
+
+        rec_count = (
+            await db.execute(
+                select(func.count(DNSRecord.id)).where(DNSRecord.zone_id == args.zone_id)
+            )
+        ).scalar_one()
+        suffix = (
+            f" — cascades {rec_count} DNS record(s)"
+            " (pushes a remove-zone write-through to agentless servers first)"
+        )
+    else:
+        # #3a: the soft-delete cascade summary embeds the current record count.
+        suffix = (
+            f" — {await _soft_delete_cascade_summary(db, zone)};"
+            " the zone + its records are restorable from /admin/trash"
+        )
     return PreviewResult(
         ok=True, detail="ready", preview_text=f"{mode} DNS zone `{zone.name}`{suffix}"
     )
@@ -670,11 +752,13 @@ async def _preview_delete_scope(
     if scope is None:
         return PreviewResult(ok=False, detail="Scope not found")
     mode = "Permanently delete" if args.permanent else "Soft-delete"
-    suffix = (
-        " (pushes a remove-scope write-through to Windows members first)"
-        if args.permanent
-        else " — restorable from /admin/trash"
-    )
+    if args.permanent:
+        # A scope is a cascade leaf (no soft-delete descendants), so there is
+        # no growing blast radius — the preview stays stable across request →
+        # approve, which is correct (#3a: a leaf has nothing to drift).
+        suffix = " (pushes a remove-scope write-through to Windows members first)"
+    else:
+        suffix = f" — {await _soft_delete_cascade_summary(db, scope)}; restorable from /admin/trash"
     return PreviewResult(
         ok=True, detail="ready", preview_text=f"{mode} DHCP scope `{scope.id}`{suffix}"
     )

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -1,0 +1,884 @@
+"""Risky-operation registry for the two-person approval workflow (#62).
+
+Each delete handler covered by the approval gate has its mutation body
+factored verbatim into an :class:`Operation` ``apply()`` here, with a
+``preview()`` that re-runs the same 404 / 409 / synthesised-zone guards
+the original handler did inline. The REST handler delegates to
+``apply()`` on the inline (no-approval) path AND the approve endpoint
+replays the same ``apply()`` under the approver's identity after a
+fresh ``preview()`` stale-state check — one mutation path, two callers.
+
+CRITICAL — byte-identical inline behaviour:
+
+* The ``apply()`` body is the original handler body, unchanged. Every
+  side effect (soft-delete batch + per-row audit, permanent cascade of
+  DHCP scopes / DNS records / zones, agent bundle rebuilds, ``collect_wake``
+  / ``publish_wake`` of the affected channel, ``_update_block_utilization``)
+  is preserved in the same order.
+* The ``permanent`` / ``force`` flags are frozen into the args model so
+  the approved replay takes the *identical* branch the requester intended.
+* The ``require_superadmin`` check that the original ``permanent`` /
+  ``force`` paths ran inline lives inside ``apply()`` (and the matching
+  ``preview()``), so both the inline path and the approver replay enforce
+  it — a non-superadmin approver can never complete a ``permanent`` op.
+* Audit ``action`` strings stay exactly as today (``soft_delete`` on the
+  default path, ``delete`` on the permanent path) — never collapsed.
+
+CLAUDE.md non-negotiables honoured: #2 (async throughout), #3 (server-side
+permission enforcement via ``enforce_operation_permission`` defense-in-depth
++ the original route gates), #4 (every mutation writes its audit row before
+the commit inside ``apply()``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from uuid import UUID
+
+import structlog
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.services.ai.operations import (
+    Operation,
+    PreviewResult,
+    enforce_operation_permission,
+    get_operation,
+    register,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# ── delete_subnet ──────────────────────────────────────────────────────────
+
+
+class DeleteSubnetArgs(BaseModel):
+    subnet_id: UUID
+    force: bool = False
+    permanent: bool = False
+
+
+async def _preview_delete_subnet(
+    db: AsyncSession, user: User, args: DeleteSubnetArgs
+) -> PreviewResult:
+    from app.api.v1.ipam.router import _enforce_subnet_token_scope
+    from app.models.dhcp import DHCPScope
+    from app.models.ipam import IPAddress, Subnet
+
+    subnet = await db.get(Subnet, args.subnet_id)
+    if subnet is None:
+        return PreviewResult(ok=False, detail="Subnet not found")
+    # Per-row API-token binding — mirrors the inline handler.
+    _enforce_subnet_token_scope(user, args.subnet_id)
+
+    if args.permanent and not args.force:
+        # Re-run the non-empty 409 the inline permanent path raises.
+        user_ip_count = (
+            await db.execute(
+                select(func.count(IPAddress.id)).where(
+                    IPAddress.subnet_id == args.subnet_id,
+                    IPAddress.status.notin_(["network", "broadcast", "orphan"]),
+                    IPAddress.auto_from_lease.is_(False),
+                )
+            )
+        ).scalar_one()
+        scope_count = (
+            await db.execute(
+                select(func.count(DHCPScope.id)).where(DHCPScope.subnet_id == args.subnet_id)
+            )
+        ).scalar_one()
+        if user_ip_count or scope_count:
+            parts = []
+            if user_ip_count:
+                parts.append(
+                    f"{user_ip_count} allocated IP address" + ("es" if user_ip_count != 1 else "")
+                )
+            if scope_count:
+                parts.append(f"{scope_count} DHCP scope" + ("s" if scope_count != 1 else ""))
+            return PreviewResult(
+                ok=False,
+                detail=(
+                    f"Subnet is not empty: {', '.join(parts)}. "
+                    "Delete the contents first, or retry with force=true to cascade."
+                ),
+            )
+
+    mode = "Permanently delete" if args.permanent else "Soft-delete"
+    parts = [f"{mode} subnet `{subnet.network}`" + (f" ({subnet.name})" if subnet.name else "")]
+    if args.permanent:
+        scope_count = (
+            await db.execute(
+                select(func.count(DHCPScope.id)).where(DHCPScope.subnet_id == args.subnet_id)
+            )
+        ).scalar_one()
+        ip_count = (
+            await db.execute(
+                select(func.count(IPAddress.id)).where(IPAddress.subnet_id == args.subnet_id)
+            )
+        ).scalar_one()
+        parts.append(
+            f"cascade: {scope_count} DHCP scope(s) + {ip_count} IP row(s) + auto DNS cleanup"
+        )
+        if args.force:
+            parts.append("force=true (skip non-empty check)")
+    else:
+        parts.append("the subnet + its DHCP scopes are restorable from /admin/trash")
+    return PreviewResult(ok=True, detail="ready", preview_text="; ".join(parts))
+
+
+async def _apply_delete_subnet(
+    db: AsyncSession, user: User, args: DeleteSubnetArgs
+) -> dict[str, Any]:
+    """Body factored verbatim from ipam/router.py:delete_subnet."""
+    from sqlalchemy import delete as sa_delete
+
+    from app.api.deps import require_superadmin
+    from app.api.v1.ipam.router import (
+        _audit,
+        _enforce_subnet_token_scope,
+        _revoke_subnet_lease_mirrors,
+        _update_block_utilization,
+    )
+    from app.drivers.dhcp import is_agentless
+    from app.models.dhcp import DHCPConfigOp, DHCPScope, DHCPServer
+    from app.models.dns import DNSRecord, DNSZone
+    from app.models.ipam import IPAddress, Subnet
+    from app.services.dhcp.config_bundle import build_config_bundle
+    from app.services.dhcp.windows_writethrough import push_scope_delete
+    from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
+
+    enforce_operation_permission(user, _OP_DELETE_SUBNET)
+
+    subnet = await db.get(Subnet, args.subnet_id)
+    if subnet is None:
+        raise ValueError("Subnet not found")
+    _enforce_subnet_token_scope(user, args.subnet_id)
+
+    if not args.permanent:
+        await _revoke_subnet_lease_mirrors(db, subnet)
+
+        batch = await collect_soft_delete_batch(db, subnet)
+        apply_soft_delete(batch, user.id)
+        for row in batch.rows:
+            db.add(
+                _audit(
+                    user,
+                    "soft_delete",
+                    row.resource_type,
+                    str(row.obj.id),
+                    row.display,
+                    old_value={"deletion_batch_id": str(batch.batch_id)},
+                )
+            )
+        await db.commit()
+        return {"subnet_id": str(args.subnet_id), "mode": "soft_delete"}
+
+    require_superadmin(user)
+
+    if not args.force:
+        user_ip_count = (
+            await db.execute(
+                select(func.count(IPAddress.id)).where(
+                    IPAddress.subnet_id == args.subnet_id,
+                    IPAddress.status.notin_(["network", "broadcast", "orphan"]),
+                    IPAddress.auto_from_lease.is_(False),
+                )
+            )
+        ).scalar_one()
+        scope_count = (
+            await db.execute(
+                select(func.count(DHCPScope.id)).where(DHCPScope.subnet_id == args.subnet_id)
+            )
+        ).scalar_one()
+        if user_ip_count or scope_count:
+            parts = []
+            if user_ip_count:
+                parts.append(
+                    f"{user_ip_count} allocated IP address" + ("es" if user_ip_count != 1 else "")
+                )
+            if scope_count:
+                parts.append(f"{scope_count} DHCP scope" + ("s" if scope_count != 1 else ""))
+            raise ValueError(
+                f"Subnet is not empty: {', '.join(parts)}. "
+                "Delete the contents first, or retry with force=true to cascade."
+            )
+
+    block_id = subnet.block_id
+
+    scope_rows = (
+        (await db.execute(select(DHCPScope).where(DHCPScope.subnet_id == args.subnet_id)))
+        .scalars()
+        .all()
+    )
+    agent_servers_to_refresh: dict[uuid.UUID, DHCPServer] = {}
+    for scope in scope_rows:
+        await push_scope_delete(db, scope)
+        group_servers = (
+            (
+                await db.execute(
+                    select(DHCPServer).where(DHCPServer.server_group_id == scope.group_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for srv in group_servers:
+            if not is_agentless(srv.driver):
+                agent_servers_to_refresh[srv.id] = srv
+
+    addr_result = await db.execute(
+        select(IPAddress.dns_record_id).where(
+            IPAddress.subnet_id == args.subnet_id,
+            IPAddress.dns_record_id.isnot(None),
+        )
+    )
+    record_ids = [rid for rid in addr_result.scalars().all() if rid is not None]
+    if record_ids:
+        await db.execute(sa_delete(DNSRecord).where(DNSRecord.id.in_(record_ids)))
+
+    await db.execute(
+        sa_delete(DNSZone).where(
+            DNSZone.linked_subnet_id == args.subnet_id,
+            DNSZone.is_auto_generated.is_(True),
+        )
+    )
+
+    db.add(
+        _audit(
+            user,
+            "delete",
+            "subnet",
+            str(subnet.id),
+            f"{subnet.network} ({subnet.name})",
+            old_value={"network": str(subnet.network), "name": subnet.name},
+        )
+    )
+    await db.delete(subnet)
+    await db.flush()
+    await _update_block_utilization(db, block_id)
+
+    for server in agent_servers_to_refresh.values():
+        bundle = await build_config_bundle(db, server)
+        server.config_etag = bundle.etag
+        existing = (
+            await db.execute(
+                select(DHCPConfigOp).where(
+                    DHCPConfigOp.server_id == server.id,
+                    DHCPConfigOp.op_type == "apply_config",
+                    DHCPConfigOp.status == "pending",
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            db.add(
+                DHCPConfigOp(
+                    server_id=server.id,
+                    op_type="apply_config",
+                    payload={"etag": bundle.etag},
+                    status="pending",
+                )
+            )
+
+    await db.commit()
+    return {"subnet_id": str(args.subnet_id), "mode": "delete"}
+
+
+_OP_DELETE_SUBNET = Operation(
+    name="delete_subnet",
+    description="Delete a subnet (soft-delete batch, or permanent cascade of DHCP scopes + auto DNS).",
+    args_model=DeleteSubnetArgs,
+    preview=_preview_delete_subnet,
+    apply=_apply_delete_subnet,
+    category="ipam",
+    required_permission=("delete", "subnet"),
+)
+register(_OP_DELETE_SUBNET)
+
+
+# ── delete_block ───────────────────────────────────────────────────────────
+
+
+class DeleteBlockArgs(BaseModel):
+    block_id: UUID
+    permanent: bool = False
+
+
+async def _preview_delete_block(
+    db: AsyncSession, user: User, args: DeleteBlockArgs
+) -> PreviewResult:
+    from app.models.ipam import IPBlock, Subnet
+
+    block = await db.get(IPBlock, args.block_id)
+    if block is None:
+        return PreviewResult(ok=False, detail="IP block not found")
+
+    if args.permanent:
+        subnet_count = (
+            await db.execute(
+                select(func.count()).select_from(Subnet).where(Subnet.block_id == args.block_id)
+            )
+        ).scalar_one()
+        child_block_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(IPBlock)
+                .where(IPBlock.parent_block_id == args.block_id)
+            )
+        ).scalar_one()
+        if subnet_count or child_block_count:
+            parts = []
+            if child_block_count:
+                parts.append(f"{child_block_count} child block(s)")
+            if subnet_count:
+                parts.append(f"{subnet_count} subnet(s)")
+            return PreviewResult(
+                ok=False,
+                detail=(
+                    f"Block {block.network} still contains {' and '.join(parts)}. "
+                    "Delete or move them before deleting the block."
+                ),
+            )
+        return PreviewResult(
+            ok=True,
+            detail="ready",
+            preview_text=f"Permanently delete empty block `{block.network}` ({block.name})",
+        )
+
+    return PreviewResult(
+        ok=True,
+        detail="ready",
+        preview_text=(
+            f"Soft-delete block `{block.network}` ({block.name}) — cascades to child "
+            "blocks + subnets + their DHCP scopes; restorable from /admin/trash"
+        ),
+    )
+
+
+async def _apply_delete_block(
+    db: AsyncSession, user: User, args: DeleteBlockArgs
+) -> dict[str, Any]:
+    """Body factored verbatim from ipam/router.py:delete_block."""
+    from app.api.deps import require_superadmin
+    from app.api.v1.ipam.router import _audit
+    from app.models.ipam import IPBlock, Subnet
+    from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
+
+    enforce_operation_permission(user, _OP_DELETE_BLOCK)
+
+    block = await db.get(IPBlock, args.block_id)
+    if block is None:
+        raise ValueError("IP block not found")
+
+    if args.permanent:
+        require_superadmin(user)
+        subnet_count = (
+            await db.execute(
+                select(func.count()).select_from(Subnet).where(Subnet.block_id == args.block_id)
+            )
+        ).scalar_one()
+        child_block_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(IPBlock)
+                .where(IPBlock.parent_block_id == args.block_id)
+            )
+        ).scalar_one()
+        if subnet_count or child_block_count:
+            parts = []
+            if child_block_count:
+                parts.append(f"{child_block_count} child block(s)")
+            if subnet_count:
+                parts.append(f"{subnet_count} subnet(s)")
+            raise ValueError(
+                f"Block {block.network} still contains {' and '.join(parts)}. "
+                "Delete or move them before deleting the block."
+            )
+
+        db.add(
+            _audit(
+                user,
+                "delete",
+                "ip_block",
+                str(block.id),
+                f"{block.network} ({block.name})",
+                old_value={"network": str(block.network)},
+            )
+        )
+        await db.delete(block)
+        await db.commit()
+        return {"block_id": str(args.block_id), "mode": "delete"}
+
+    batch = await collect_soft_delete_batch(db, block)
+    apply_soft_delete(batch, user.id)
+    for row in batch.rows:
+        db.add(
+            _audit(
+                user,
+                "soft_delete",
+                row.resource_type,
+                str(row.obj.id),
+                row.display,
+                old_value={"deletion_batch_id": str(batch.batch_id)},
+            )
+        )
+    await db.commit()
+    return {"block_id": str(args.block_id), "mode": "soft_delete"}
+
+
+_OP_DELETE_BLOCK = Operation(
+    name="delete_block",
+    description="Delete an IP block (soft-delete cascade, or permanent if empty).",
+    args_model=DeleteBlockArgs,
+    preview=_preview_delete_block,
+    apply=_apply_delete_block,
+    category="ipam",
+    required_permission=("delete", "ip_block"),
+)
+register(_OP_DELETE_BLOCK)
+
+
+# ── delete_space ───────────────────────────────────────────────────────────
+
+
+class DeleteSpaceArgs(BaseModel):
+    space_id: UUID
+    permanent: bool = False
+
+
+async def _preview_delete_space(
+    db: AsyncSession, user: User, args: DeleteSpaceArgs
+) -> PreviewResult:
+    from app.models.ipam import IPBlock, IPSpace, Subnet
+
+    space = await db.get(IPSpace, args.space_id)
+    if space is None:
+        return PreviewResult(ok=False, detail="IP space not found")
+
+    if args.permanent:
+        subnet_count = (
+            await db.execute(
+                select(func.count()).select_from(Subnet).where(Subnet.space_id == args.space_id)
+            )
+        ).scalar_one()
+        block_count = (
+            await db.execute(
+                select(func.count()).select_from(IPBlock).where(IPBlock.space_id == args.space_id)
+            )
+        ).scalar_one()
+        if subnet_count or block_count:
+            parts = []
+            if block_count:
+                parts.append(f"{block_count} block(s)")
+            if subnet_count:
+                parts.append(f"{subnet_count} subnet(s)")
+            return PreviewResult(
+                ok=False,
+                detail=(
+                    f"IP space {space.name!r} still contains {' and '.join(parts)}. "
+                    "Delete or move them before deleting the space."
+                ),
+            )
+        return PreviewResult(
+            ok=True,
+            detail="ready",
+            preview_text=f"Permanently delete empty IP space `{space.name}`",
+        )
+
+    return PreviewResult(
+        ok=True,
+        detail="ready",
+        preview_text=(
+            f"Soft-delete IP space `{space.name}` — cascades to every block, subnet, "
+            "and DHCP scope under it; restorable from /admin/trash"
+        ),
+    )
+
+
+async def _apply_delete_space(
+    db: AsyncSession, user: User, args: DeleteSpaceArgs
+) -> dict[str, Any]:
+    """Body factored verbatim from ipam/router.py:delete_space."""
+    from app.api.deps import require_superadmin
+    from app.api.v1.ipam.router import _audit
+    from app.models.ipam import IPBlock, IPSpace, Subnet
+    from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
+
+    enforce_operation_permission(user, _OP_DELETE_SPACE)
+
+    space = await db.get(IPSpace, args.space_id)
+    if space is None:
+        raise ValueError("IP space not found")
+
+    if args.permanent:
+        require_superadmin(user)
+        subnet_count = (
+            await db.execute(
+                select(func.count()).select_from(Subnet).where(Subnet.space_id == args.space_id)
+            )
+        ).scalar_one()
+        block_count = (
+            await db.execute(
+                select(func.count()).select_from(IPBlock).where(IPBlock.space_id == args.space_id)
+            )
+        ).scalar_one()
+        if subnet_count or block_count:
+            parts = []
+            if block_count:
+                parts.append(f"{block_count} block(s)")
+            if subnet_count:
+                parts.append(f"{subnet_count} subnet(s)")
+            raise ValueError(
+                f"IP space {space.name!r} still contains {' and '.join(parts)}. "
+                "Delete or move them before deleting the space."
+            )
+
+        db.add(
+            _audit(
+                user,
+                "delete",
+                "ip_space",
+                str(space.id),
+                space.name,
+                old_value={"name": space.name},
+            )
+        )
+        await db.delete(space)
+        await db.commit()
+        return {"space_id": str(args.space_id), "mode": "delete"}
+
+    batch = await collect_soft_delete_batch(db, space)
+    apply_soft_delete(batch, user.id)
+    for row in batch.rows:
+        db.add(
+            _audit(
+                user,
+                "soft_delete",
+                row.resource_type,
+                str(row.obj.id),
+                row.display,
+                old_value={"deletion_batch_id": str(batch.batch_id)},
+            )
+        )
+    await db.commit()
+    return {"space_id": str(args.space_id), "mode": "soft_delete"}
+
+
+_OP_DELETE_SPACE = Operation(
+    name="delete_space",
+    description="Delete an IP space (soft-delete subtree, or permanent if empty).",
+    args_model=DeleteSpaceArgs,
+    preview=_preview_delete_space,
+    apply=_apply_delete_space,
+    category="ipam",
+    required_permission=("delete", "ip_space"),
+)
+register(_OP_DELETE_SPACE)
+
+
+# ── delete_zone ────────────────────────────────────────────────────────────
+
+
+class DeleteZoneArgs(BaseModel):
+    group_id: UUID
+    zone_id: UUID
+    permanent: bool = False
+
+
+async def _preview_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArgs) -> PreviewResult:
+    from fastapi import HTTPException
+
+    from app.api.v1.dns.router import _reject_if_synthesised_zone, _require_zone
+
+    try:
+        zone = await _require_zone(args.group_id, args.zone_id, db)
+        _reject_if_synthesised_zone(zone, "delete")
+    except HTTPException as exc:
+        return PreviewResult(ok=False, detail=str(exc.detail))
+
+    mode = "Permanently delete" if args.permanent else "Soft-delete"
+    suffix = (
+        " (pushes a remove-zone write-through to agentless servers first)"
+        if args.permanent
+        else " — the zone + its records are restorable from /admin/trash"
+    )
+    return PreviewResult(
+        ok=True, detail="ready", preview_text=f"{mode} DNS zone `{zone.name}`{suffix}"
+    )
+
+
+async def _apply_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArgs) -> dict[str, Any]:
+    """Body factored verbatim from dns/router.py:delete_zone."""
+    from app.api.v1.dns.router import (
+        _push_zone_to_agentless_servers,
+        _reject_if_synthesised_zone,
+        _require_zone,
+    )
+    from app.core.agent_wake import collect_wake, dns_group_channel
+    from app.models.audit import AuditLog
+    from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
+
+    enforce_operation_permission(user, _OP_DELETE_ZONE)
+
+    zone = await _require_zone(args.group_id, args.zone_id, db)
+    _reject_if_synthesised_zone(zone, "delete")
+
+    if not args.permanent:
+        batch = await collect_soft_delete_batch(db, zone)
+        apply_soft_delete(batch, user.id)
+        for row in batch.rows:
+            db.add(
+                AuditLog(
+                    user_id=user.id,
+                    user_display_name=user.display_name,
+                    auth_source=user.auth_source,
+                    action="soft_delete",
+                    resource_type=row.resource_type,
+                    resource_id=str(row.obj.id),
+                    resource_display=row.display,
+                    old_value={"deletion_batch_id": str(batch.batch_id)},
+                    result="success",
+                )
+            )
+        collect_wake(dns_group_channel(args.group_id))
+        await db.commit()
+        return {"zone_id": str(args.zone_id), "mode": "soft_delete"}
+
+    await _push_zone_to_agentless_servers(db, zone, "delete")
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=user.auth_source,
+            action="delete",
+            resource_type="dns_zone",
+            resource_id=str(zone.id),
+            resource_display=zone.name,
+            result="success",
+        )
+    )
+    collect_wake(dns_group_channel(args.group_id))
+    await db.delete(zone)
+    await db.commit()
+    return {"zone_id": str(args.zone_id), "mode": "delete"}
+
+
+_OP_DELETE_ZONE = Operation(
+    name="delete_zone",
+    description="Delete a DNS zone (soft-delete batch, or permanent with agentless write-through).",
+    args_model=DeleteZoneArgs,
+    preview=_preview_delete_zone,
+    apply=_apply_delete_zone,
+    category="dns",
+    required_permission=("delete", "dns_zone"),
+)
+register(_OP_DELETE_ZONE)
+
+
+# ── delete_scope ───────────────────────────────────────────────────────────
+
+
+class DeleteScopeArgs(BaseModel):
+    scope_id: UUID
+    permanent: bool = False
+
+
+async def _preview_delete_scope(
+    db: AsyncSession, user: User, args: DeleteScopeArgs
+) -> PreviewResult:
+    from app.models.dhcp import DHCPScope
+
+    scope = await db.get(DHCPScope, args.scope_id)
+    if scope is None:
+        return PreviewResult(ok=False, detail="Scope not found")
+    mode = "Permanently delete" if args.permanent else "Soft-delete"
+    suffix = (
+        " (pushes a remove-scope write-through to Windows members first)"
+        if args.permanent
+        else " — restorable from /admin/trash"
+    )
+    return PreviewResult(
+        ok=True, detail="ready", preview_text=f"{mode} DHCP scope `{scope.id}`{suffix}"
+    )
+
+
+async def _apply_delete_scope(
+    db: AsyncSession, user: User, args: DeleteScopeArgs
+) -> dict[str, Any]:
+    """Body factored verbatim from dhcp/scopes.py:delete_scope."""
+    from app.api.v1.dhcp._audit import write_audit
+    from app.core.agent_wake import collect_wake, dhcp_group_channel
+    from app.models.dhcp import DHCPScope
+    from app.services.dhcp.windows_writethrough import push_scope_delete
+    from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
+
+    enforce_operation_permission(user, _OP_DELETE_SCOPE)
+
+    scope = await db.get(DHCPScope, args.scope_id)
+    if scope is None:
+        raise ValueError("Scope not found")
+    collect_wake(dhcp_group_channel(scope.group_id))
+
+    if not args.permanent:
+        batch = await collect_soft_delete_batch(db, scope)
+        apply_soft_delete(batch, user.id)
+        for row in batch.rows:
+            write_audit(
+                db,
+                user=user,
+                action="soft_delete",
+                resource_type=row.resource_type,
+                resource_id=str(row.obj.id),
+                resource_display=row.display,
+                old_value={"deletion_batch_id": str(batch.batch_id)},
+            )
+        await db.commit()
+        return {"scope_id": str(args.scope_id), "mode": "soft_delete"}
+
+    await push_scope_delete(db, scope)
+    write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="dhcp_scope",
+        resource_id=str(scope.id),
+        resource_display=str(scope.id),
+    )
+    await db.delete(scope)
+    await db.commit()
+    return {"scope_id": str(args.scope_id), "mode": "delete"}
+
+
+_OP_DELETE_SCOPE = Operation(
+    name="delete_scope",
+    description="Delete a DHCP scope (soft-delete, or permanent with Windows write-through).",
+    args_model=DeleteScopeArgs,
+    preview=_preview_delete_scope,
+    apply=_apply_delete_scope,
+    category="dhcp",
+    required_permission=("delete", "dhcp_scope"),
+)
+register(_OP_DELETE_SCOPE)
+
+
+# ── delete_group ───────────────────────────────────────────────────────────
+
+
+class DeleteGroupArgs(BaseModel):
+    group_id: UUID
+
+
+async def _preview_delete_group(
+    db: AsyncSession, user: User, args: DeleteGroupArgs
+) -> PreviewResult:
+    from app.models.dhcp import DHCPServer, DHCPServerGroup
+
+    g = await db.get(DHCPServerGroup, args.group_id)
+    if g is None:
+        return PreviewResult(ok=False, detail="Server group not found")
+    server_count = (
+        await db.execute(
+            select(func.count())
+            .select_from(DHCPServer)
+            .where(DHCPServer.server_group_id == args.group_id)
+        )
+    ).scalar_one()
+    if server_count:
+        return PreviewResult(
+            ok=False,
+            detail=(
+                f"DHCP server group {g.name!r} still contains "
+                f"{server_count} server(s). Move them to another group "
+                "(or standalone) before deleting the group."
+            ),
+        )
+    return PreviewResult(
+        ok=True, detail="ready", preview_text=f"Delete empty DHCP server group `{g.name}`"
+    )
+
+
+async def _apply_delete_group(
+    db: AsyncSession, user: User, args: DeleteGroupArgs
+) -> dict[str, Any]:
+    """Body factored verbatim from dhcp/server_groups.py:delete_group."""
+    from fastapi import HTTPException, status
+
+    from app.api.v1.dhcp._audit import write_audit
+    from app.models.dhcp import DHCPServer, DHCPServerGroup
+
+    enforce_operation_permission(user, _OP_DELETE_GROUP)
+
+    g = await db.get(DHCPServerGroup, args.group_id)
+    if g is None:
+        raise ValueError("Server group not found")
+
+    server_count = (
+        await db.execute(
+            select(func.count())
+            .select_from(DHCPServer)
+            .where(DHCPServer.server_group_id == args.group_id)
+        )
+    ).scalar_one()
+    if server_count:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"DHCP server group {g.name!r} still contains "
+                f"{server_count} server(s). Move them to another group "
+                "(or standalone) before deleting the group."
+            ),
+        )
+
+    write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="dhcp_server_group",
+        resource_id=str(g.id),
+        resource_display=g.name,
+    )
+    await db.delete(g)
+    await db.commit()
+    return {"group_id": str(args.group_id), "mode": "delete"}
+
+
+_OP_DELETE_GROUP = Operation(
+    name="delete_group",
+    description="Delete a DHCP server group (refused if it still holds servers).",
+    args_model=DeleteGroupArgs,
+    preview=_preview_delete_group,
+    apply=_apply_delete_group,
+    category="dhcp",
+    # The REST route is SuperAdmin-only; this declares the granular backstop
+    # the approver is checked against (a superadmin approver passes via {*,*}).
+    required_permission=("delete", "dhcp_server_group"),
+)
+register(_OP_DELETE_GROUP)
+
+
+# Registry-completeness anchor for the startup assertion (sibling slice):
+# every operation name the seeded policies reference must exist here.
+RISKY_OPERATION_NAMES: frozenset[str] = frozenset(
+    {
+        "delete_subnet",
+        "delete_block",
+        "delete_space",
+        "delete_zone",
+        "delete_scope",
+        "delete_group",
+    }
+)
+
+
+def _assert_registered() -> None:
+    """Defensive: prove all six names registered at import (catches a
+    rename that desyncs the seeded policies from the registry)."""
+    missing = [n for n in RISKY_OPERATION_NAMES if get_operation(n) is None]
+    if missing:  # pragma: no cover — import-time invariant
+        raise RuntimeError(f"risky operations not registered: {missing}")
+
+
+_assert_registered()

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -8,26 +8,43 @@ the original handler did inline. The REST handler delegates to
 replays the same ``apply()`` under the approver's identity after a
 fresh ``preview()`` stale-state check — one mutation path, two callers.
 
-CRITICAL — byte-identical inline behaviour:
+THE INLINE-FIDELITY CONTRACT — ``apply()`` must be byte-identical to the
+pre-#62 handler when the module is off:
 
 * The ``apply()`` body is the original handler body, unchanged. Every
   side effect (soft-delete batch + per-row audit, permanent cascade of
   DHCP scopes / DNS records / zones, agent bundle rebuilds, ``collect_wake``
   / ``publish_wake`` of the affected channel, ``_update_block_utilization``)
   is preserved in the same order.
+* ``apply()`` / ``preview()`` raise the original handler's HTTP statuses —
+  ``HTTPException(404)`` for not-found, ``HTTPException(409)`` for
+  not-empty / conflict, ``HTTPException(403)`` for superadmin-required —
+  CONSISTENTLY across all six ops. (A bare ``ValueError`` here would
+  surface as a 500 to the inline caller — fixed.)
+* ``apply()`` does NOT call ``enforce_operation_permission``: the inline
+  handler is already authorized by the router's permission gate, and the
+  two callers that bypass that gate — the approve endpoint + the AI
+  propose→apply path — enforce the permission themselves *before*
+  dispatching ``apply()``. Re-checking inside ``apply()`` would 403 a
+  delegate whose scoped grant the router admitted (#103 address-set
+  delegate) — fidelity break.
+* Superadmin parity with the ORIGINAL ROUTE (so the approve path, which
+  bypasses the delete route's dependencies, enforces identically):
+  subnet / block / space require superadmin only on the ``permanent``
+  branch; ``delete_zone`` / ``delete_scope`` / ``delete_group`` were
+  fully ``SuperAdmin``-gated at the route, so their ``apply()`` requires
+  superadmin ALWAYS. A failed check raises ``HTTPException(403)``.
 * The ``permanent`` / ``force`` flags are frozen into the args model so
   the approved replay takes the *identical* branch the requester intended.
-* The ``require_superadmin`` check that the original ``permanent`` /
-  ``force`` paths ran inline lives inside ``apply()`` (and the matching
-  ``preview()``), so both the inline path and the approver replay enforce
-  it — a non-superadmin approver can never complete a ``permanent`` op.
 * Audit ``action`` strings stay exactly as today (``soft_delete`` on the
   default path, ``delete`` on the permanent path) — never collapsed.
+* The not-found / not-empty validation is factored into one shared helper
+  used by both ``preview()`` and ``apply()`` so the two never drift.
 
 CLAUDE.md non-negotiables honoured: #2 (async throughout), #3 (server-side
-permission enforcement via ``enforce_operation_permission`` defense-in-depth
-+ the original route gates), #4 (every mutation writes its audit row before
-the commit inside ``apply()``).
+permission enforcement — by the router gate inline, by the approve / AI
+dispatch sites for the bypass callers), #4 (every mutation writes its audit
+row before the commit inside ``apply()``).
 """
 
 from __future__ import annotations
@@ -37,6 +54,7 @@ from typing import Any
 from uuid import UUID
 
 import structlog
+from fastapi import HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -45,7 +63,6 @@ from app.models.auth import User
 from app.services.ai.operations import (
     Operation,
     PreviewResult,
-    enforce_operation_permission,
     get_operation,
     register,
 )
@@ -60,6 +77,41 @@ class DeleteSubnetArgs(BaseModel):
     subnet_id: UUID
     force: bool = False
     permanent: bool = False
+
+
+async def _subnet_not_empty_detail(db: AsyncSession, subnet_id: UUID) -> str | None:
+    """Shared non-empty check for subnet permanent-delete (#17).
+
+    Returns the 409 detail string when the subnet still holds user IPs or
+    DHCP scopes, else ``None``. Both ``preview()`` and ``apply()`` call this
+    so the two can never drift. Mirrors the inline handler's count query.
+    """
+    from app.models.dhcp import DHCPScope
+    from app.models.ipam import IPAddress
+
+    user_ip_count = (
+        await db.execute(
+            select(func.count(IPAddress.id)).where(
+                IPAddress.subnet_id == subnet_id,
+                IPAddress.status.notin_(["network", "broadcast", "orphan"]),
+                IPAddress.auto_from_lease.is_(False),
+            )
+        )
+    ).scalar_one()
+    scope_count = (
+        await db.execute(select(func.count(DHCPScope.id)).where(DHCPScope.subnet_id == subnet_id))
+    ).scalar_one()
+    if not (user_ip_count or scope_count):
+        return None
+    parts = []
+    if user_ip_count:
+        parts.append(f"{user_ip_count} allocated IP address" + ("es" if user_ip_count != 1 else ""))
+    if scope_count:
+        parts.append(f"{scope_count} DHCP scope" + ("s" if scope_count != 1 else ""))
+    return (
+        f"Subnet is not empty: {', '.join(parts)}. "
+        "Delete the contents first, or retry with force=true to cascade."
+    )
 
 
 async def _preview_delete_subnet(
@@ -77,35 +129,9 @@ async def _preview_delete_subnet(
 
     if args.permanent and not args.force:
         # Re-run the non-empty 409 the inline permanent path raises.
-        user_ip_count = (
-            await db.execute(
-                select(func.count(IPAddress.id)).where(
-                    IPAddress.subnet_id == args.subnet_id,
-                    IPAddress.status.notin_(["network", "broadcast", "orphan"]),
-                    IPAddress.auto_from_lease.is_(False),
-                )
-            )
-        ).scalar_one()
-        scope_count = (
-            await db.execute(
-                select(func.count(DHCPScope.id)).where(DHCPScope.subnet_id == args.subnet_id)
-            )
-        ).scalar_one()
-        if user_ip_count or scope_count:
-            parts = []
-            if user_ip_count:
-                parts.append(
-                    f"{user_ip_count} allocated IP address" + ("es" if user_ip_count != 1 else "")
-                )
-            if scope_count:
-                parts.append(f"{scope_count} DHCP scope" + ("s" if scope_count != 1 else ""))
-            return PreviewResult(
-                ok=False,
-                detail=(
-                    f"Subnet is not empty: {', '.join(parts)}. "
-                    "Delete the contents first, or retry with force=true to cascade."
-                ),
-            )
+        detail = await _subnet_not_empty_detail(db, args.subnet_id)
+        if detail is not None:
+            return PreviewResult(ok=False, detail=detail)
 
     mode = "Permanently delete" if args.permanent else "Soft-delete"
     parts = [f"{mode} subnet `{subnet.network}`" + (f" ({subnet.name})" if subnet.name else "")]
@@ -151,11 +177,9 @@ async def _apply_delete_subnet(
     from app.services.dhcp.windows_writethrough import push_scope_delete
     from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
 
-    enforce_operation_permission(user, _OP_DELETE_SUBNET)
-
     subnet = await db.get(Subnet, args.subnet_id)
     if subnet is None:
-        raise ValueError("Subnet not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
     _enforce_subnet_token_scope(user, args.subnet_id)
 
     if not args.permanent:
@@ -180,32 +204,9 @@ async def _apply_delete_subnet(
     require_superadmin(user)
 
     if not args.force:
-        user_ip_count = (
-            await db.execute(
-                select(func.count(IPAddress.id)).where(
-                    IPAddress.subnet_id == args.subnet_id,
-                    IPAddress.status.notin_(["network", "broadcast", "orphan"]),
-                    IPAddress.auto_from_lease.is_(False),
-                )
-            )
-        ).scalar_one()
-        scope_count = (
-            await db.execute(
-                select(func.count(DHCPScope.id)).where(DHCPScope.subnet_id == args.subnet_id)
-            )
-        ).scalar_one()
-        if user_ip_count or scope_count:
-            parts = []
-            if user_ip_count:
-                parts.append(
-                    f"{user_ip_count} allocated IP address" + ("es" if user_ip_count != 1 else "")
-                )
-            if scope_count:
-                parts.append(f"{scope_count} DHCP scope" + ("s" if scope_count != 1 else ""))
-            raise ValueError(
-                f"Subnet is not empty: {', '.join(parts)}. "
-                "Delete the contents first, or retry with force=true to cascade."
-            )
+        detail = await _subnet_not_empty_detail(db, args.subnet_id)
+        if detail is not None:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
 
     block_id = subnet.block_id
 
@@ -307,41 +308,46 @@ class DeleteBlockArgs(BaseModel):
     permanent: bool = False
 
 
+async def _block_not_empty_detail(db: AsyncSession, block_id: UUID, network: Any) -> str | None:
+    """Shared non-empty check for block permanent-delete (#17)."""
+    from app.models.ipam import IPBlock, Subnet
+
+    subnet_count = (
+        await db.execute(
+            select(func.count()).select_from(Subnet).where(Subnet.block_id == block_id)
+        )
+    ).scalar_one()
+    child_block_count = (
+        await db.execute(
+            select(func.count()).select_from(IPBlock).where(IPBlock.parent_block_id == block_id)
+        )
+    ).scalar_one()
+    if not (subnet_count or child_block_count):
+        return None
+    parts = []
+    if child_block_count:
+        parts.append(f"{child_block_count} child block(s)")
+    if subnet_count:
+        parts.append(f"{subnet_count} subnet(s)")
+    return (
+        f"Block {network} still contains {' and '.join(parts)}. "
+        "Delete or move them before deleting the block."
+    )
+
+
 async def _preview_delete_block(
     db: AsyncSession, user: User, args: DeleteBlockArgs
 ) -> PreviewResult:
-    from app.models.ipam import IPBlock, Subnet
+    from app.models.ipam import IPBlock
 
     block = await db.get(IPBlock, args.block_id)
     if block is None:
         return PreviewResult(ok=False, detail="IP block not found")
 
     if args.permanent:
-        subnet_count = (
-            await db.execute(
-                select(func.count()).select_from(Subnet).where(Subnet.block_id == args.block_id)
-            )
-        ).scalar_one()
-        child_block_count = (
-            await db.execute(
-                select(func.count())
-                .select_from(IPBlock)
-                .where(IPBlock.parent_block_id == args.block_id)
-            )
-        ).scalar_one()
-        if subnet_count or child_block_count:
-            parts = []
-            if child_block_count:
-                parts.append(f"{child_block_count} child block(s)")
-            if subnet_count:
-                parts.append(f"{subnet_count} subnet(s)")
-            return PreviewResult(
-                ok=False,
-                detail=(
-                    f"Block {block.network} still contains {' and '.join(parts)}. "
-                    "Delete or move them before deleting the block."
-                ),
-            )
+        detail = await _block_not_empty_detail(db, args.block_id, block.network)
+        if detail is not None:
+            return PreviewResult(ok=False, detail=detail)
         return PreviewResult(
             ok=True,
             detail="ready",
@@ -364,39 +370,18 @@ async def _apply_delete_block(
     """Body factored verbatim from ipam/router.py:delete_block."""
     from app.api.deps import require_superadmin
     from app.api.v1.ipam.router import _audit
-    from app.models.ipam import IPBlock, Subnet
+    from app.models.ipam import IPBlock
     from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
-
-    enforce_operation_permission(user, _OP_DELETE_BLOCK)
 
     block = await db.get(IPBlock, args.block_id)
     if block is None:
-        raise ValueError("IP block not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP block not found")
 
     if args.permanent:
         require_superadmin(user)
-        subnet_count = (
-            await db.execute(
-                select(func.count()).select_from(Subnet).where(Subnet.block_id == args.block_id)
-            )
-        ).scalar_one()
-        child_block_count = (
-            await db.execute(
-                select(func.count())
-                .select_from(IPBlock)
-                .where(IPBlock.parent_block_id == args.block_id)
-            )
-        ).scalar_one()
-        if subnet_count or child_block_count:
-            parts = []
-            if child_block_count:
-                parts.append(f"{child_block_count} child block(s)")
-            if subnet_count:
-                parts.append(f"{subnet_count} subnet(s)")
-            raise ValueError(
-                f"Block {block.network} still contains {' and '.join(parts)}. "
-                "Delete or move them before deleting the block."
-            )
+        detail = await _block_not_empty_detail(db, args.block_id, block.network)
+        if detail is not None:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
 
         db.add(
             _audit(
@@ -449,39 +434,46 @@ class DeleteSpaceArgs(BaseModel):
     permanent: bool = False
 
 
+async def _space_not_empty_detail(db: AsyncSession, space_id: UUID, name: str) -> str | None:
+    """Shared non-empty check for space permanent-delete (#17)."""
+    from app.models.ipam import IPBlock, Subnet
+
+    subnet_count = (
+        await db.execute(
+            select(func.count()).select_from(Subnet).where(Subnet.space_id == space_id)
+        )
+    ).scalar_one()
+    block_count = (
+        await db.execute(
+            select(func.count()).select_from(IPBlock).where(IPBlock.space_id == space_id)
+        )
+    ).scalar_one()
+    if not (subnet_count or block_count):
+        return None
+    parts = []
+    if block_count:
+        parts.append(f"{block_count} block(s)")
+    if subnet_count:
+        parts.append(f"{subnet_count} subnet(s)")
+    return (
+        f"IP space {name!r} still contains {' and '.join(parts)}. "
+        "Delete or move them before deleting the space."
+    )
+
+
 async def _preview_delete_space(
     db: AsyncSession, user: User, args: DeleteSpaceArgs
 ) -> PreviewResult:
-    from app.models.ipam import IPBlock, IPSpace, Subnet
+    from app.models.ipam import IPSpace
 
     space = await db.get(IPSpace, args.space_id)
     if space is None:
         return PreviewResult(ok=False, detail="IP space not found")
 
     if args.permanent:
-        subnet_count = (
-            await db.execute(
-                select(func.count()).select_from(Subnet).where(Subnet.space_id == args.space_id)
-            )
-        ).scalar_one()
-        block_count = (
-            await db.execute(
-                select(func.count()).select_from(IPBlock).where(IPBlock.space_id == args.space_id)
-            )
-        ).scalar_one()
-        if subnet_count or block_count:
-            parts = []
-            if block_count:
-                parts.append(f"{block_count} block(s)")
-            if subnet_count:
-                parts.append(f"{subnet_count} subnet(s)")
-            return PreviewResult(
-                ok=False,
-                detail=(
-                    f"IP space {space.name!r} still contains {' and '.join(parts)}. "
-                    "Delete or move them before deleting the space."
-                ),
-            )
+        detail = await _space_not_empty_detail(db, args.space_id, space.name)
+        if detail is not None:
+            return PreviewResult(ok=False, detail=detail)
         return PreviewResult(
             ok=True,
             detail="ready",
@@ -504,37 +496,18 @@ async def _apply_delete_space(
     """Body factored verbatim from ipam/router.py:delete_space."""
     from app.api.deps import require_superadmin
     from app.api.v1.ipam.router import _audit
-    from app.models.ipam import IPBlock, IPSpace, Subnet
+    from app.models.ipam import IPSpace
     from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
-
-    enforce_operation_permission(user, _OP_DELETE_SPACE)
 
     space = await db.get(IPSpace, args.space_id)
     if space is None:
-        raise ValueError("IP space not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP space not found")
 
     if args.permanent:
         require_superadmin(user)
-        subnet_count = (
-            await db.execute(
-                select(func.count()).select_from(Subnet).where(Subnet.space_id == args.space_id)
-            )
-        ).scalar_one()
-        block_count = (
-            await db.execute(
-                select(func.count()).select_from(IPBlock).where(IPBlock.space_id == args.space_id)
-            )
-        ).scalar_one()
-        if subnet_count or block_count:
-            parts = []
-            if block_count:
-                parts.append(f"{block_count} block(s)")
-            if subnet_count:
-                parts.append(f"{subnet_count} subnet(s)")
-            raise ValueError(
-                f"IP space {space.name!r} still contains {' and '.join(parts)}. "
-                "Delete or move them before deleting the space."
-            )
+        detail = await _space_not_empty_detail(db, args.space_id, space.name)
+        if detail is not None:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
 
         db.add(
             _audit(
@@ -589,8 +562,6 @@ class DeleteZoneArgs(BaseModel):
 
 
 async def _preview_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArgs) -> PreviewResult:
-    from fastapi import HTTPException
-
     from app.api.v1.dns.router import _reject_if_synthesised_zone, _require_zone
 
     try:
@@ -612,6 +583,7 @@ async def _preview_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArg
 
 async def _apply_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArgs) -> dict[str, Any]:
     """Body factored verbatim from dns/router.py:delete_zone."""
+    from app.api.deps import require_superadmin
     from app.api.v1.dns.router import (
         _push_zone_to_agentless_servers,
         _reject_if_synthesised_zone,
@@ -621,9 +593,12 @@ async def _apply_delete_zone(db: AsyncSession, user: User, args: DeleteZoneArgs)
     from app.models.audit import AuditLog
     from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
 
-    enforce_operation_permission(user, _OP_DELETE_ZONE)
+    # The original DELETE route was fully SuperAdmin-gated — replicate here so
+    # the approve path (which bypasses the route's SuperAdmin dependency)
+    # enforces identically (#8). require_superadmin raises HTTPException(403).
+    require_superadmin(user)
 
-    zone = await _require_zone(args.group_id, args.zone_id, db)
+    zone = await _require_zone(args.group_id, args.zone_id, db)  # raises 404 if absent
     _reject_if_synthesised_zone(zone, "delete")
 
     if not args.permanent:
@@ -709,17 +684,19 @@ async def _apply_delete_scope(
     db: AsyncSession, user: User, args: DeleteScopeArgs
 ) -> dict[str, Any]:
     """Body factored verbatim from dhcp/scopes.py:delete_scope."""
+    from app.api.deps import require_superadmin
     from app.api.v1.dhcp._audit import write_audit
     from app.core.agent_wake import collect_wake, dhcp_group_channel
     from app.models.dhcp import DHCPScope
     from app.services.dhcp.windows_writethrough import push_scope_delete
     from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
 
-    enforce_operation_permission(user, _OP_DELETE_SCOPE)
+    # The original DELETE route was fully SuperAdmin-gated (#8).
+    require_superadmin(user)
 
     scope = await db.get(DHCPScope, args.scope_id)
     if scope is None:
-        raise ValueError("Scope not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Scope not found")
     collect_wake(dhcp_group_channel(scope.group_id))
 
     if not args.permanent:
@@ -804,16 +781,16 @@ async def _apply_delete_group(
     db: AsyncSession, user: User, args: DeleteGroupArgs
 ) -> dict[str, Any]:
     """Body factored verbatim from dhcp/server_groups.py:delete_group."""
-    from fastapi import HTTPException, status
-
+    from app.api.deps import require_superadmin
     from app.api.v1.dhcp._audit import write_audit
     from app.models.dhcp import DHCPServer, DHCPServerGroup
 
-    enforce_operation_permission(user, _OP_DELETE_GROUP)
+    # The original DELETE route was fully SuperAdmin-gated (#8).
+    require_superadmin(user)
 
     g = await db.get(DHCPServerGroup, args.group_id)
     if g is None:
-        raise ValueError("Server group not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Server group not found")
 
     server_count = (
         await db.execute(

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -16,6 +16,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     backup,
     bgp,
     certificates,
+    changes,
     conformity,
     copilot,
     dhcp,

--- a/backend/app/services/ai/tools/changes.py
+++ b/backend/app/services/ai/tools/changes.py
@@ -1,0 +1,260 @@
+"""Operator Copilot tools for the two-person approval queue (issue #62).
+
+Four tools, all carrying ``module="governance.approvals"`` so disabling the
+(default-off) feature module strips them from the AI surface (NN #14):
+
+Reads — answer "what's waiting on a second approver?" / "how big is the
+backlog?":
+
+* ``find_change_requests`` — list change requests with optional state /
+  resource-type / mine filters.
+* ``count_change_requests`` — counts grouped by state.
+
+Propose writes — the model surfaces an approve/reject as a propose→Apply
+card; the tool itself is read-only (it only persists an
+``AIOperationProposal``):
+
+* ``propose_approve_change_request`` — prepare an approval proposal.
+* ``propose_reject_change_request`` — prepare a rejection proposal.
+
+The model can NEVER self-approve: the actual decision runs only through
+``POST /api/v1/ai/proposals/{id}/apply`` when a *human operator* clicks
+Apply, and the backing ``approve_change_request`` / ``reject_change_request``
+Operations enforce the full two-person spine server-side (approver !=
+requester, approver holds ``{approve, change_request}`` AND the underlying
+operation's ``required_permission``, plus a stale-state re-preview). The
+human who clicks Apply becomes the approver, so the second-person
+constraint the feature exists to enforce is preserved end-to-end.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.change_request import CHANGE_REQUEST_STATES, ChangeRequest
+from app.services.ai import operations
+from app.services.ai.operations import (
+    ApproveChangeRequestArgs,
+    RejectChangeRequestArgs,
+)
+from app.services.ai.tools.base import register_tool
+
+MODULE = "governance.approvals"
+
+
+def _cr_to_dict(cr: ChangeRequest) -> dict[str, Any]:
+    return {
+        "id": str(cr.id),
+        "operation": cr.operation,
+        "resource_type": cr.resource_type,
+        "resource_id": cr.resource_id,
+        "resource_display": cr.resource_display,
+        "state": cr.state,
+        "risk_reason": cr.risk_reason,
+        "requested_by": cr.requested_by_display,
+        "decided_by": cr.decided_by_display,
+        "preview_text": cr.preview_text,
+        "expires_at": cr.expires_at.isoformat(),
+        "created_at": cr.created_at.isoformat(),
+    }
+
+
+# ── find_change_requests ─────────────────────────────────────────────
+
+
+class FindChangeRequestsArgs(BaseModel):
+    state: str | None = Field(
+        default=None,
+        description=(
+            "Filter to one lifecycle state: pending / approved / rejected / "
+            "executed / failed / expired / cancelled. Omit for all states."
+        ),
+    )
+    resource_type: str | None = Field(
+        default=None,
+        description="Filter to one resource type (subnet / dns_zone / dhcp_scope / …).",
+    )
+    mine: bool = Field(
+        default=False,
+        description="When true, only requests the current user submitted.",
+    )
+    limit: int = Field(default=50, ge=1, le=200)
+
+
+@register_tool(
+    name="find_change_requests",
+    description=(
+        "List two-person approval change requests — risky operations "
+        "(deletes, etc.) a policy queued for a second operator's approval. "
+        "Each row carries the operation, frozen target, state, who "
+        "requested it, who decided it, the rendered preview, and the TTL. "
+        "Use to answer 'what's waiting for approval?' or 'show pending "
+        "subnet deletes'. Read-only."
+    ),
+    args_model=FindChangeRequestsArgs,
+    category="read",
+    default_enabled=True,
+    module=MODULE,
+)
+async def find_change_requests(
+    db: AsyncSession, user: User, args: FindChangeRequestsArgs
+) -> dict[str, Any]:
+    stmt = select(ChangeRequest)
+    if args.state is not None:
+        stmt = stmt.where(ChangeRequest.state == args.state)
+    if args.resource_type is not None:
+        stmt = stmt.where(ChangeRequest.resource_type == args.resource_type)
+    if args.mine:
+        stmt = stmt.where(ChangeRequest.requested_by_user_id == user.id)
+    stmt = stmt.order_by(ChangeRequest.created_at.desc()).limit(args.limit)
+    rows = list((await db.execute(stmt)).scalars().all())
+    return {
+        "change_requests": [_cr_to_dict(r) for r in rows],
+        "count": len(rows),
+    }
+
+
+# ── count_change_requests ────────────────────────────────────────────
+
+
+class CountChangeRequestsArgs(BaseModel):
+    mine: bool = Field(
+        default=False,
+        description="When true, count only requests the current user submitted.",
+    )
+
+
+@register_tool(
+    name="count_change_requests",
+    description=(
+        "Count two-person approval change requests grouped by lifecycle "
+        "state (pending / executed / rejected / …). Use to size the "
+        "approval backlog. Read-only."
+    ),
+    args_model=CountChangeRequestsArgs,
+    category="read",
+    default_enabled=True,
+    module=MODULE,
+)
+async def count_change_requests(
+    db: AsyncSession, user: User, args: CountChangeRequestsArgs
+) -> dict[str, Any]:
+    stmt = select(ChangeRequest.state, func.count(ChangeRequest.id)).group_by(ChangeRequest.state)
+    if args.mine:
+        stmt = stmt.where(ChangeRequest.requested_by_user_id == user.id)
+    by_state: dict[str, int] = {s: 0 for s in sorted(CHANGE_REQUEST_STATES)}
+    total = 0
+    for state, n in (await db.execute(stmt)).all():
+        by_state[state] = int(n)
+        total += int(n)
+    return {"total": total, "by_state": by_state}
+
+
+# ── propose_approve_change_request / propose_reject_change_request ────
+#
+# Both reuse the proposals.py propose→Apply contract: build the
+# Operation, run preview(), persist an AIOperationProposal on success,
+# return the kind="proposal" card the chat drawer renders. The tool is
+# read-only (writes=False); the mutation only lands when a human clicks
+# Apply. Default-enabled (NN #13): no secrets, no off-prem call — and the
+# blast radius is *narrowed* by the two-person spine, since the apply step
+# re-enforces approver != requester + the underlying op's permission. The
+# module gate (governance.approvals, default-off) keeps them invisible
+# until an operator turns the feature on.
+
+
+async def _propose_decision(
+    db: AsyncSession,
+    *,
+    user: User,
+    operation_name: str,
+    args: ApproveChangeRequestArgs | RejectChangeRequestArgs,
+) -> dict[str, Any]:
+    """Run preview + persist a proposal (or surface the rejection). Mirrors
+    proposals.py:_propose_via — kept local so changes.py owns its own
+    propose surface without importing a sibling's private helper."""
+    from app.services.ai.tools.proposals import (  # noqa: PLC0415
+        _persist_proposal,
+        _proposal_result,
+    )
+
+    op = operations.get_operation(operation_name)
+    if op is None:
+        return {"error": f"Operation {operation_name!r} is not registered"}
+    preview = await op.preview(db, user, args)
+    if not preview.ok:
+        return {
+            "kind": "proposal_rejected",
+            "operation": operation_name,
+            "detail": preview.detail,
+        }
+    proposal = await _persist_proposal(
+        db,
+        user=user,
+        operation=operation_name,
+        args=args.model_dump(),
+        preview_text=preview.preview_text,
+    )
+    return _proposal_result(proposal, preview_text=preview.preview_text)
+
+
+@register_tool(
+    name="propose_approve_change_request",
+    description=(
+        "Prepare an approval proposal for a pending two-person change "
+        "request (#62). Pass change_request_id (UUID) and an optional note. "
+        "The proposal must be applied by a human operator clicking Apply — "
+        "that operator becomes the approver, the underlying operation's "
+        "preview re-runs as a stale-state guard, and it executes under the "
+        "approver's identity. You can never self-approve. The server "
+        "enforces approver != requester and that the approver holds both "
+        "{approve, change_request} and the underlying op's permission. "
+        "Returns a kind='proposal' card; never call twice for the same id."
+    ),
+    args_model=ApproveChangeRequestArgs,
+    writes=False,  # The propose tool itself is read-only; apply is the write.
+    category="ops",
+    default_enabled=True,
+    module=MODULE,
+)
+async def propose_approve_change_request(
+    db: AsyncSession, user: User, args: ApproveChangeRequestArgs
+) -> dict[str, Any]:
+    return await _propose_decision(
+        db, user=user, operation_name="approve_change_request", args=args
+    )
+
+
+@register_tool(
+    name="propose_reject_change_request",
+    description=(
+        "Prepare a rejection proposal for a pending two-person change "
+        "request (#62). Pass change_request_id (UUID) and an optional note. "
+        "On Apply the request is rejected and the underlying operation does "
+        "NOT run. The rejecter may not be the requester (a self-reject is a "
+        "cancel). Returns a kind='proposal' card; never call twice for the "
+        "same id."
+    ),
+    args_model=RejectChangeRequestArgs,
+    writes=False,  # The propose tool itself is read-only; apply is the write.
+    category="ops",
+    default_enabled=True,
+    module=MODULE,
+)
+async def propose_reject_change_request(
+    db: AsyncSession, user: User, args: RejectChangeRequestArgs
+) -> dict[str, Any]:
+    return await _propose_decision(db, user=user, operation_name="reject_change_request", args=args)
+
+
+__all__ = [
+    "count_change_requests",
+    "find_change_requests",
+    "propose_approve_change_request",
+    "propose_reject_change_request",
+]

--- a/backend/app/services/ai/tools/changes.py
+++ b/backend/app/services/ai/tools/changes.py
@@ -35,6 +35,11 @@ from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import (
+    RESOURCE_TYPE_CHANGE_REQUEST,
+    is_effective_superadmin,
+    user_has_permission,
+)
 from app.models.auth import User
 from app.models.change_request import CHANGE_REQUEST_STATES, ChangeRequest
 from app.services.ai import operations
@@ -45,6 +50,18 @@ from app.services.ai.operations import (
 from app.services.ai.tools.base import register_tool
 
 MODULE = "governance.approvals"
+
+
+def _can_see_all_change_requests(user: User) -> bool:
+    """READ RULE (#1), identical to the REST router: a superadmin or a holder
+    of ``{approve, change_request}`` may see EVERY change request; everyone
+    else is scoped to their own. The MCP read tools have no router gate, so the
+    scope is enforced here in-tool — without it the copilot would leak the
+    whole platform queue (args / preview / target / requester / approver) to
+    any user who can reach the (default-off) governance.approvals module."""
+    return is_effective_superadmin(user) or user_has_permission(
+        user, "approve", RESOURCE_TYPE_CHANGE_REQUEST
+    )
 
 
 def _cr_to_dict(cr: ChangeRequest) -> dict[str, Any]:
@@ -109,7 +126,9 @@ async def find_change_requests(
         stmt = stmt.where(ChangeRequest.state == args.state)
     if args.resource_type is not None:
         stmt = stmt.where(ChangeRequest.resource_type == args.resource_type)
-    if args.mine:
+    # READ RULE (#1): force own-scope for callers who aren't a superadmin /
+    # approve-holder, regardless of the ``mine`` arg.
+    if args.mine or not _can_see_all_change_requests(user):
         stmt = stmt.where(ChangeRequest.requested_by_user_id == user.id)
     stmt = stmt.order_by(ChangeRequest.created_at.desc()).limit(args.limit)
     rows = list((await db.execute(stmt)).scalars().all())
@@ -145,7 +164,10 @@ async def count_change_requests(
     db: AsyncSession, user: User, args: CountChangeRequestsArgs
 ) -> dict[str, Any]:
     stmt = select(ChangeRequest.state, func.count(ChangeRequest.id)).group_by(ChangeRequest.state)
-    if args.mine:
+    # READ RULE (#1): a non-superadmin / non-approve-holder may only count
+    # their own requests — counting the whole queue leaks backlog size + (via
+    # find) row contents. Force own-scope regardless of the ``mine`` arg.
+    if args.mine or not _can_see_all_change_requests(user):
         stmt = stmt.where(ChangeRequest.requested_by_user_id == user.id)
     by_state: dict[str, int] = {s: 0 for s in sorted(CHANGE_REQUEST_STATES)}
     total = 0

--- a/backend/app/services/approvals/__init__.py
+++ b/backend/app/services/approvals/__init__.py
@@ -1,0 +1,64 @@
+"""Two-person approval workflow (issue #62).
+
+The change-gating spine: a risky operation submitted by one operator is
+queued as a ``ChangeRequest`` and only executes after a *different*
+eligible approver accepts it. Reuses the AI Copilot's
+preview/apply ``Operation`` registry — the approve path replays the same
+``apply()`` under the approver's identity, after re-running ``preview()``
+as a stale-state guard.
+
+Public surface:
+
+* ``policy.match_policy`` — the pure async policy engine deciding
+  whether an ``(resource_type, action[, count])`` triggers the gate.
+* ``service`` — change-request data access + the guarded state machine
+  (create / get / list + the ``mark_*`` transitions), each mutation
+  audited.
+
+The gate (``gate.py``) + the API router + the per-handler call sites
+land in later slices of #62; this package ships the substrate they call.
+"""
+
+from __future__ import annotations
+
+from app.services.approvals.policy import match_policy
+from app.services.approvals.service import (
+    ChangeRequestStateError,
+    DecisionConflict,
+    DecisionError,
+    DecisionForbidden,
+    DecisionNotFound,
+    DecisionUnprocessable,
+    approve_change_request,
+    create_change_request,
+    get_change_request,
+    list_change_requests,
+    mark_approved,
+    mark_cancelled,
+    mark_executed,
+    mark_expired,
+    mark_failed,
+    mark_rejected,
+    reject_change_request,
+)
+
+__all__ = [
+    "ChangeRequestStateError",
+    "DecisionConflict",
+    "DecisionError",
+    "DecisionForbidden",
+    "DecisionNotFound",
+    "DecisionUnprocessable",
+    "approve_change_request",
+    "create_change_request",
+    "get_change_request",
+    "list_change_requests",
+    "mark_approved",
+    "mark_cancelled",
+    "mark_executed",
+    "mark_expired",
+    "mark_failed",
+    "mark_rejected",
+    "match_policy",
+    "reject_change_request",
+]

--- a/backend/app/services/approvals/gate.py
+++ b/backend/app/services/approvals/gate.py
@@ -42,13 +42,6 @@ from fastapi import HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-# Side-effect import: loading operations_control registers the flag-gated
-# ``modify_approval_control`` op into the shared registry. Done here (a module
-# every approvals path imports) so the op is available wherever the approve
-# spine / control surfaces run, without depending on import order elsewhere.
-# (The approve spine imports ``CONTROL_OPERATION_NAMES`` directly from
-# operations_control where it needs it.)
-import app.services.ai.operations_control  # noqa: F401
 from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.services.ai.operations import Operation, get_operation

--- a/backend/app/services/approvals/gate.py
+++ b/backend/app/services/approvals/gate.py
@@ -15,9 +15,12 @@ return value tells the handler what to do:
 Control flow (pinned by the #62 design):
 
 1. Module off → ``None`` (never touches the policy table).
-2. Derive ``(action, resource_type)`` for the policy lookup from the
-   operation (delete-family → ``action="delete"``; resource_type is the
-   operation's ``required_permission[1]``).
+2. Derive ``(action, resource_type)`` for the policy lookup *directly*
+   from the operation's ``required_permission`` (e.g. ``("delete",
+   "subnet")``) — no hand-maintained name→action map to drift out of
+   sync (#2/#3). An import-time assertion proves every registered risky
+   op carries a ``required_permission`` so a future op that forgets one
+   fails loudly at boot rather than silently never-gating.
 3. ``match_policy`` → no enabled match → ``None``.
 4. Superadmin caller + ``not policy.applies_to_superadmin`` → ``None``.
 5. ``operation.preview`` → if not ok, raise 409 (don't queue a doomed
@@ -41,7 +44,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
-from app.services.ai.operations import Operation
+from app.services.ai.operations import Operation, get_operation
+from app.services.ai.operations_risky import RISKY_OPERATION_NAMES
 from app.services.approvals.policy import match_policy
 from app.services.approvals.service import create_change_request
 from app.services.feature_modules import is_module_enabled
@@ -50,19 +54,28 @@ logger = structlog.get_logger(__name__)
 
 MODULE_ID = "governance.approvals"
 
-# Maps a registered risky operation name to the (action, ...) the policy
-# lookup keys on. The resource_type comes from the operation's
-# ``required_permission[1]`` so the policy ``resource_type`` matches the
-# seeded rows (``subnet`` / ``ip_block`` / ``ip_space`` / ``dns_zone`` /
-# ``dhcp_scope`` / ``dhcp_server_group``). Every covered op is a delete.
-OPERATION_ACTION: dict[str, str] = {
-    "delete_subnet": "delete",
-    "delete_block": "delete",
-    "delete_space": "delete",
-    "delete_zone": "delete",
-    "delete_scope": "delete",
-    "delete_group": "delete",
-}
+
+def _assert_risky_ops_have_permission() -> None:
+    """Fail loudly at import if any registered risky op lacks a
+    ``required_permission`` (#3).
+
+    The gate derives the policy-lookup ``(action, resource_type)`` straight
+    from ``operation.required_permission``; an op that forgets to declare one
+    would silently never gate (fail-open). Catch the drift at boot instead.
+    """
+    missing = []
+    for name in RISKY_OPERATION_NAMES:
+        op = get_operation(name)
+        if op is None or op.required_permission is None:
+            missing.append(name)
+    if missing:  # pragma: no cover — import-time invariant
+        raise RuntimeError(
+            f"risky operations missing required_permission (cannot derive "
+            f"approval policy keys): {sorted(missing)}"
+        )
+
+
+_assert_risky_ops_have_permission()
 
 
 @dataclass(frozen=True)
@@ -117,12 +130,15 @@ async def gate_or_execute(
     if not await is_module_enabled(db, MODULE_ID):
         return None
 
-    # 2. Derive the policy lookup keys from the operation.
-    action = OPERATION_ACTION.get(operation.name)
-    if action is None or operation.required_permission is None:
-        # An operation not in the action map isn't gateable — run inline.
+    # 2. Derive the policy lookup keys directly from the operation's
+    #    declared permission — no hand-maintained name→action map (#2).
+    #    ``required_permission`` is guaranteed present for every risky op by
+    #    the import-time assertion above; the guard keeps mypy + a
+    #    defensive run-inline fallthrough for any op dispatched here that
+    #    didn't declare one.
+    if operation.required_permission is None:
         return None
-    resource_type = operation.required_permission[1]
+    action, resource_type = operation.required_permission
 
     # 3. Strongest enabled matching policy, or None.
     policy = await match_policy(db, resource_type, action, count)
@@ -139,6 +155,11 @@ async def gate_or_execute(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=preview.detail)
 
     # 6. Persist the pending change request + its audit row, then commit.
+    #    #18: args are frozen as JSON via ``model_dump(mode="json")`` here and
+    #    rehydrated with ``args_model.model_validate(...)`` at approve time.
+    #    That round-trip assumes every arg type is JSON-coercible (UUID→str,
+    #    bool, int, str) — true for all six covered delete ops. A future op
+    #    carrying a non-JSON-native arg type would need a custom (de)serializer.
     cr = await create_change_request(
         db,
         user=user,
@@ -166,4 +187,4 @@ async def gate_or_execute(
     )
 
 
-__all__ = ["ChangeRequestPending", "OPERATION_ACTION", "gate_or_execute"]
+__all__ = ["ChangeRequestPending", "gate_or_execute"]

--- a/backend/app/services/approvals/gate.py
+++ b/backend/app/services/approvals/gate.py
@@ -45,6 +45,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.services.ai.operations import Operation, get_operation
+
+# Importing operations_control registers the flag-gated ``modify_approval_control``
+# op into the shared registry. Done here (a module every approvals path imports)
+# so the op + ``CONTROL_OPERATION_NAMES`` are available wherever the approve spine
+# / control surfaces run, without depending on import order elsewhere.
+from app.services.ai.operations_control import CONTROL_OPERATION_NAMES  # noqa: F401
 from app.services.ai.operations_risky import RISKY_OPERATION_NAMES
 from app.services.approvals.policy import (
     GATEABLE_ACTIONS,

--- a/backend/app/services/approvals/gate.py
+++ b/backend/app/services/approvals/gate.py
@@ -1,0 +1,169 @@
+"""Approval gate — the single interception point risky handlers call (#62).
+
+A covered delete handler calls :func:`gate_or_execute` at the top. The
+return value tells the handler what to do:
+
+* ``None``  → no approval required. The handler executes inline exactly as
+  today (delegating to ``operation.apply``). This is the *default* path:
+  the ``governance.approvals`` module is off out of the box, and even when
+  on, only enabled policies gate. Behaviour is byte-identical to pre-#62.
+* :class:`ChangeRequestPending` → a policy matched and the caller can't
+  self-approve. A ``change_request`` row is persisted (+ its ``requested``
+  audit row, committed) and the handler must return ``202 Accepted`` with
+  ``pending.as_dict()`` instead of executing.
+
+Control flow (pinned by the #62 design):
+
+1. Module off → ``None`` (never touches the policy table).
+2. Derive ``(action, resource_type)`` for the policy lookup from the
+   operation (delete-family → ``action="delete"``; resource_type is the
+   operation's ``required_permission[1]``).
+3. ``match_policy`` → no enabled match → ``None``.
+4. Superadmin caller + ``not policy.applies_to_superadmin`` → ``None``.
+5. ``operation.preview`` → if not ok, raise 409 (don't queue a doomed
+   request — matches today's inline 409).
+6. Persist the ``change_request`` (+ audit), commit, return the pending.
+
+#4 (audit-before-respond): the ``requested`` audit row is committed inside
+:func:`create_change_request` before this returns. #2 (async throughout):
+everything here is async.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from fastapi import HTTPException, Request, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permissions import is_effective_superadmin
+from app.models.auth import User
+from app.services.ai.operations import Operation
+from app.services.approvals.policy import match_policy
+from app.services.approvals.service import create_change_request
+from app.services.feature_modules import is_module_enabled
+
+logger = structlog.get_logger(__name__)
+
+MODULE_ID = "governance.approvals"
+
+# Maps a registered risky operation name to the (action, ...) the policy
+# lookup keys on. The resource_type comes from the operation's
+# ``required_permission[1]`` so the policy ``resource_type`` matches the
+# seeded rows (``subnet`` / ``ip_block`` / ``ip_space`` / ``dns_zone`` /
+# ``dhcp_scope`` / ``dhcp_server_group``). Every covered op is a delete.
+OPERATION_ACTION: dict[str, str] = {
+    "delete_subnet": "delete",
+    "delete_block": "delete",
+    "delete_space": "delete",
+    "delete_zone": "delete",
+    "delete_scope": "delete",
+    "delete_group": "delete",
+}
+
+
+@dataclass(frozen=True)
+class ChangeRequestPending:
+    """Returned when an operation was queued for approval instead of run."""
+
+    change_request_id: Any
+    state: str
+    preview_text: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "change_request_id": str(self.change_request_id),
+            "state": self.state,
+            "preview_text": self.preview_text,
+        }
+
+
+def _resource_id_from_args(args: BaseModel) -> str | None:
+    """Best-effort single-target id for the change_request row.
+
+    Covered ops carry a single ``*_id`` (subnet_id / block_id / space_id /
+    zone_id / scope_id / group_id). Pick the first such field; ops with no
+    single target leave ``resource_id`` NULL.
+    """
+    data = args.model_dump(mode="json")
+    # Prefer the operation's own target id over a secondary (e.g. delete_zone
+    # carries both group_id and zone_id — zone_id is the real target).
+    for key in ("zone_id", "scope_id", "subnet_id", "block_id", "space_id", "group_id"):
+        val = data.get(key)
+        if val is not None:
+            return str(val)
+    return None
+
+
+async def gate_or_execute(
+    db: AsyncSession,
+    user: User,
+    request: Request,
+    *,
+    operation: Operation,
+    args: BaseModel,
+    count: int | None = None,
+) -> ChangeRequestPending | None:
+    """Decide whether ``operation`` must be queued for second-person approval.
+
+    Returns ``None`` to tell the caller to execute inline (today's behaviour);
+    a :class:`ChangeRequestPending` to tell the caller to return 202.
+    """
+    # 1. Module off → never gate, never query policies. This is the path
+    #    every existing install takes (default-off) → zero behaviour change.
+    if not await is_module_enabled(db, MODULE_ID):
+        return None
+
+    # 2. Derive the policy lookup keys from the operation.
+    action = OPERATION_ACTION.get(operation.name)
+    if action is None or operation.required_permission is None:
+        # An operation not in the action map isn't gateable — run inline.
+        return None
+    resource_type = operation.required_permission[1]
+
+    # 3. Strongest enabled matching policy, or None.
+    policy = await match_policy(db, resource_type, action, count)
+    if policy is None:
+        return None
+
+    # 4. Superadmin bypass — only when the policy explicitly allows it.
+    if is_effective_superadmin(user) and not policy.applies_to_superadmin:
+        return None
+
+    # 5. Re-run preview now; don't queue a request that can't execute.
+    preview = await operation.preview(db, user, args)
+    if not preview.ok:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=preview.detail)
+
+    # 6. Persist the pending change request + its audit row, then commit.
+    cr = await create_change_request(
+        db,
+        user=user,
+        request=request,
+        operation=operation.name,
+        resource_type=resource_type,
+        resource_id=_resource_id_from_args(args),
+        resource_display=preview.preview_text[:500],
+        args=args.model_dump(mode="json"),
+        preview_text=preview.preview_text,
+        risk_reason=policy.name or f"{action}:{resource_type}",
+        ttl_hours=policy.ttl_hours,
+    )
+    await db.commit()
+    logger.info(
+        "approval_gate.queued",
+        change_request_id=str(cr.id),
+        operation=operation.name,
+        resource_type=resource_type,
+        policy_id=str(policy.id),
+        requested_by=str(user.id),
+    )
+    return ChangeRequestPending(
+        change_request_id=cr.id, state="pending", preview_text=cr.preview_text
+    )
+
+
+__all__ = ["ChangeRequestPending", "OPERATION_ACTION", "gate_or_execute"]

--- a/backend/app/services/approvals/gate.py
+++ b/backend/app/services/approvals/gate.py
@@ -42,15 +42,16 @@ from fastapi import HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# Side-effect import: loading operations_control registers the flag-gated
+# ``modify_approval_control`` op into the shared registry. Done here (a module
+# every approvals path imports) so the op is available wherever the approve
+# spine / control surfaces run, without depending on import order elsewhere.
+# (The approve spine imports ``CONTROL_OPERATION_NAMES`` directly from
+# operations_control where it needs it.)
+import app.services.ai.operations_control  # noqa: F401
 from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.services.ai.operations import Operation, get_operation
-
-# Importing operations_control registers the flag-gated ``modify_approval_control``
-# op into the shared registry. Done here (a module every approvals path imports)
-# so the op + ``CONTROL_OPERATION_NAMES`` are available wherever the approve spine
-# / control surfaces run, without depending on import order elsewhere.
-from app.services.ai.operations_control import CONTROL_OPERATION_NAMES  # noqa: F401
 from app.services.ai.operations_risky import RISKY_OPERATION_NAMES
 from app.services.approvals.policy import (
     GATEABLE_ACTIONS,

--- a/backend/app/services/approvals/gate.py
+++ b/backend/app/services/approvals/gate.py
@@ -46,7 +46,11 @@ from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.services.ai.operations import Operation, get_operation
 from app.services.ai.operations_risky import RISKY_OPERATION_NAMES
-from app.services.approvals.policy import match_policy
+from app.services.approvals.policy import (
+    GATEABLE_ACTIONS,
+    GATEABLE_RESOURCE_TYPES,
+    match_policy,
+)
 from app.services.approvals.service import create_change_request
 from app.services.feature_modules import is_module_enabled
 
@@ -56,22 +60,40 @@ MODULE_ID = "governance.approvals"
 
 
 def _assert_risky_ops_have_permission() -> None:
-    """Fail loudly at import if any registered risky op lacks a
-    ``required_permission`` (#3).
+    """Fail loudly at import if any registered risky op can't be gated (#4).
 
     The gate derives the policy-lookup ``(action, resource_type)`` straight
     from ``operation.required_permission``; an op that forgets to declare one
-    would silently never gate (fail-open). Catch the drift at boot instead.
+    would silently never gate (fail-open). Worse: an op that DOES declare a
+    permission whose ``(action, resource_type)`` is not in the gateable sets
+    passes a "permission exists" check but ``match_policy`` can never select a
+    policy for it (the policy CRUD rejects non-gateable pairs), so it would
+    still run inline with no approval — a fail-open trap. Require BOTH: the
+    permission exists AND its pair is gateable, so a future risky op forces an
+    explicit widening of ``GATEABLE_ACTIONS`` / ``GATEABLE_RESOURCE_TYPES``
+    instead of silently never gating. Catch the drift at boot.
     """
-    missing = []
+    missing: list[str] = []
+    non_gateable: list[str] = []
     for name in RISKY_OPERATION_NAMES:
         op = get_operation(name)
         if op is None or op.required_permission is None:
             missing.append(name)
+            continue
+        action, resource_type = op.required_permission
+        if action not in GATEABLE_ACTIONS or resource_type not in GATEABLE_RESOURCE_TYPES:
+            non_gateable.append(f"{name} ({action}:{resource_type})")
     if missing:  # pragma: no cover — import-time invariant
         raise RuntimeError(
             f"risky operations missing required_permission (cannot derive "
             f"approval policy keys): {sorted(missing)}"
+        )
+    if non_gateable:  # pragma: no cover — import-time invariant
+        raise RuntimeError(
+            "risky operations declare a non-gateable (action, resource_type) — "
+            "match_policy can never gate them, so they would run inline with no "
+            f"approval (fail-open). Widen GATEABLE_ACTIONS / "
+            f"GATEABLE_RESOURCE_TYPES: {sorted(non_gateable)}"
         )
 
 

--- a/backend/app/services/approvals/policy.py
+++ b/backend/app/services/approvals/policy.py
@@ -20,6 +20,21 @@ from app.models.change_request import ApprovalPolicy
 
 logger = structlog.get_logger(__name__)
 
+# ── Currently-gateable surface (#4) ────────────────────────────────────────
+#
+# A policy is only enforceable when there's a registered risky Operation
+# whose ``required_permission`` produces the policy's (action, resource_type).
+# In P1 the only gated action is ``delete`` and the only gated resource types
+# are the six delete-covered families. The policy CRUD validates against these
+# sets so an operator can't create an *enabled-but-inert* policy for an action
+# that isn't wired yet (the fail-open #2/#4 the seed used to ship). P2 widens
+# both sets as bulk_delete / bulk_edit / bulk_allocate / factory_reset /
+# import_commit ops land their gate threading.
+GATEABLE_ACTIONS: frozenset[str] = frozenset({"delete"})
+GATEABLE_RESOURCE_TYPES: frozenset[str] = frozenset(
+    {"subnet", "ip_block", "ip_space", "dns_zone", "dhcp_scope", "dhcp_server_group"}
+)
+
 
 async def match_policy(
     db: AsyncSession,
@@ -56,7 +71,12 @@ async def match_policy(
 
     best: ApprovalPolicy | None = None
     for policy in rows:
-        # Threshold gate.
+        # Threshold gate. NOTE (P1): no covered op threads a ``count`` —
+        # ``gate_or_execute`` always calls this with ``count=None`` for the
+        # six single-target deletes, so a policy carrying a numeric
+        # ``min_count`` never matches yet. The machinery stays for the P2
+        # bulk_* ops (which will pass a row count); the P1 migration seeds no
+        # min_count policies, so this branch is inert until then.
         if policy.min_count is not None and (count is None or count < policy.min_count):
             continue
         if best is None or _is_stronger(policy, best, resource_type):
@@ -94,4 +114,4 @@ def _is_stronger(candidate: ApprovalPolicy, current: ApprovalPolicy, resource_ty
     return candidate.min_count < current.min_count
 
 
-__all__ = ["match_policy"]
+__all__ = ["GATEABLE_ACTIONS", "GATEABLE_RESOURCE_TYPES", "match_policy"]

--- a/backend/app/services/approvals/policy.py
+++ b/backend/app/services/approvals/policy.py
@@ -1,0 +1,97 @@
+"""Approval policy engine (#62).
+
+Pure async decision layer: given an ``(resource_type, action[, count])``
+tuple, return the strongest *enabled* :class:`ApprovalPolicy` that
+matches, or ``None`` when no approval is required. Kept side-effect-free
+and superadmin-agnostic on purpose — the *gate* (``gate.py``, later
+slice) decides the superadmin bypass using the returned row's
+``applies_to_superadmin`` flag. Splitting the decision this way keeps the
+engine trivially testable and the gate the single place authorization is
+applied.
+"""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.change_request import ApprovalPolicy
+
+logger = structlog.get_logger(__name__)
+
+
+async def match_policy(
+    db: AsyncSession,
+    resource_type: str,
+    action: str,
+    count: int | None = None,
+) -> ApprovalPolicy | None:
+    """Strongest enabled policy matching ``(resource_type | "*") + action``.
+
+    A row matches when it is ``enabled``, its ``action`` equals ``action``,
+    and its ``resource_type`` is either ``resource_type`` or the wildcard
+    ``"*"``. A matched row's threshold is satisfied when ``min_count IS
+    NULL`` (always require approval) OR ``count`` is provided and
+    ``count >= min_count``.
+
+    An exact ``resource_type`` match wins over a ``"*"`` match. Among rows
+    of equal specificity, the one with the *lower* ``min_count`` (the
+    stricter threshold; ``NULL`` is strictest) wins — so the request is
+    gated by the tightest applicable rule.
+
+    Returns ``None`` when nothing matches → no approval required, the
+    caller proceeds inline. The superadmin bypass is decided by the CALLER
+    via the returned row's ``applies_to_superadmin`` flag, NOT here.
+    """
+    rows = (
+        await db.execute(
+            select(ApprovalPolicy).where(
+                ApprovalPolicy.enabled.is_(True),
+                ApprovalPolicy.action == action,
+                ApprovalPolicy.resource_type.in_([resource_type, "*"]),
+            )
+        )
+    ).scalars()
+
+    best: ApprovalPolicy | None = None
+    for policy in rows:
+        # Threshold gate.
+        if policy.min_count is not None and (count is None or count < policy.min_count):
+            continue
+        if best is None or _is_stronger(policy, best, resource_type):
+            best = policy
+
+    if best is not None:
+        logger.debug(
+            "approval_policy.matched",
+            resource_type=resource_type,
+            action=action,
+            count=count,
+            policy_id=str(best.id),
+            policy_name=best.name,
+        )
+    return best
+
+
+def _is_stronger(candidate: ApprovalPolicy, current: ApprovalPolicy, resource_type: str) -> bool:
+    """True if ``candidate`` should beat the currently-selected ``current``.
+
+    Exact ``resource_type`` beats wildcard ``"*"``. At equal specificity,
+    the stricter threshold wins — ``min_count IS NULL`` (always) beats any
+    numeric threshold, and a lower numeric threshold beats a higher one.
+    """
+    cand_exact = candidate.resource_type == resource_type
+    curr_exact = current.resource_type == resource_type
+    if cand_exact != curr_exact:
+        return cand_exact
+
+    # Equal specificity → compare thresholds (None == strictest).
+    if candidate.min_count is None:
+        return current.min_count is not None
+    if current.min_count is None:
+        return False
+    return candidate.min_count < current.min_count
+
+
+__all__ = ["match_policy"]

--- a/backend/app/services/approvals/service.py
+++ b/backend/app/services/approvals/service.py
@@ -623,6 +623,43 @@ async def approve_change_request(
         )
         raise DecisionUnprocessable("Stored args no longer validate for this operation") from exc
 
+    # 4c. Control-op gate-premise re-assertion (#62, #6). A queued control op
+    #     (modify_approval_control) was created BECAUSE the self-protection lock
+    #     was on; if the lock is now off (e.g. a concurrent break-glass unlock
+    #     landed first), the second-superadmin protection premise has
+    #     evaporated. Resolve the request idempotently rather than executing a
+    #     weakening change under approver authority whose rationale is gone. The
+    #     flag is read FOR UPDATE so this can't race a concurrent flip.
+    from app.services.ai.operations_control import (  # noqa: PLC0415
+        ModifyApprovalControlArgs,
+        control_gate_premise_lost,
+    )
+
+    if cr.operation in CONTROL_OPERATION_NAMES and isinstance(args, ModifyApprovalControlArgs):
+        if await control_gate_premise_lost(db, args):
+            requester_id = cr.requested_by_user_id
+            await mark_approved(db, cr, approver=approver, request=request, note=note)
+            await mark_executed(
+                db,
+                cr,
+                approver=approver,
+                requester_id=requester_id,
+                request=request,
+                result={
+                    "idempotent": True,
+                    "note": "self-protection lock already off; gated change no longer applies",
+                },
+            )
+            await db.commit()
+            await db.refresh(cr)
+            logger.info(
+                "change_request.control_premise_lost",
+                change_request_id=str(cr.id),
+                operation=cr.operation,
+                approver=str(approver.id),
+            )
+            return cr
+
     # 5. Stale-state re-check — do NOT execute a doomed op; leave it pending.
     preview = await op.preview(db, approver, args)
     if not preview.ok:
@@ -634,6 +671,42 @@ async def approve_change_request(
             approver=str(approver.id),
         )
         raise DecisionConflict(preview.detail)
+
+    # 5a. Idempotent resolution (#62 concurrent break-glass). When the op's
+    #     preview reports the target is ALREADY in the desired end-state
+    #     (``idempotent=True``) — e.g. a break-glass deleted the policy / flipped
+    #     the lock between request and approval — the effect this request asked
+    #     for already happened. Resolve the request as EXECUTED with an
+    #     "already in desired state" note WITHOUT re-running apply() (there's
+    #     nothing left to do) and WITHOUT the scope-drift guard 409'ing on the
+    #     changed preview text. This unwedges a CR whose effect was achieved out
+    #     of band, instead of leaving it stuck pending / marking it failed.
+    if preview.idempotent:
+        requester_id = cr.requested_by_user_id
+        cr.preview_text = preview.preview_text
+        await mark_approved(db, cr, approver=approver, request=request, note=note)
+        await mark_executed(
+            db,
+            cr,
+            approver=approver,
+            requester_id=requester_id,
+            request=request,
+            result={
+                "idempotent": True,
+                "note": "already in desired state",
+                "detail": preview.detail,
+            },
+        )
+        await db.commit()
+        await db.refresh(cr)
+        logger.info(
+            "change_request.idempotent",
+            change_request_id=str(cr.id),
+            operation=cr.operation,
+            approver=str(approver.id),
+            detail=preview.detail,
+        )
+        return cr
 
     # 5b. Scope-drift guard (#3b — TOCTOU). The frozen ``cr.preview_text`` is
     #     what the approver saw rendered when the request was created; each

--- a/backend/app/services/approvals/service.py
+++ b/backend/app/services/approvals/service.py
@@ -26,6 +26,7 @@ from fastapi import HTTPException, Request, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.core.request_meta import clean_user_agent, client_ip
 from app.models.audit import AuditLog
 from app.models.auth import User
@@ -589,6 +590,23 @@ async def approve_change_request(
         operations.enforce_operation_permission(approver, op)
     except OperationPermissionError as exc:
         raise DecisionForbidden(str(exc)) from exc
+
+    # 4b. Self-governance control ops (#62) are SUPERADMIN-ONLY to approve —
+    #     IN ADDITION to the {approve, change_request} + required_permission
+    #     checks above. A control op weakens the approval control plane
+    #     itself, so only a *different* superadmin may sign off (the
+    #     "different" half is the step-2b self-approval block above; this
+    #     half is the superadmin requirement). Without this, a plain
+    #     {approve, change_request} + {admin, approval_control} holder could
+    #     rubber-stamp turning the whole workflow off.
+    from app.services.ai.operations_control import (  # noqa: PLC0415
+        CONTROL_OPERATION_NAMES,
+    )
+
+    if cr.operation in CONTROL_OPERATION_NAMES and not is_effective_superadmin(approver):
+        raise DecisionForbidden(
+            "Approving a control-plane change to the approval workflow requires superadmin"
+        )
 
     # Re-validate frozen args (guards the rare redeploy-mid-flight schema change).
     # #6: never echo the Pydantic ValidationError back to the client — it

--- a/backend/app/services/approvals/service.py
+++ b/backend/app/services/approvals/service.py
@@ -22,7 +22,7 @@ from typing import Any
 from uuid import UUID
 
 import structlog
-from fastapi import Request
+from fastapi import HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -33,17 +33,19 @@ from app.models.change_request import ChangeRequest
 
 logger = structlog.get_logger(__name__)
 
-# Audit action strings — kept aligned with the ``change_request`` event
-# namespace (event_publisher.py) so typed webhook events flow
-# automatically: change_request.{requested,approved,rejected,cancelled,
-# executed,failed,expired}.
-_ACTION_REQUESTED = "change_request.requested"
-_ACTION_APPROVED = "change_request.approved"
-_ACTION_REJECTED = "change_request.rejected"
-_ACTION_CANCELLED = "change_request.cancelled"
-_ACTION_EXECUTED = "change_request.executed"
-_ACTION_FAILED = "change_request.failed"
-_ACTION_EXPIRED = "change_request.expired"
+# Audit action strings — PLAIN verbs (#10). The event publisher maps
+# resource_type ``change_request`` → namespace ``change_request`` and, for a
+# verb outside the create/update/delete trio, passes the action through as
+# the verb, yielding ``change_request.<verb>`` (e.g. ``change_request.requested``).
+# Using already-namespaced strings here would double the namespace
+# (``change_request.change_request.requested``) — so keep these bare verbs.
+_ACTION_REQUESTED = "requested"
+_ACTION_APPROVED = "approved"
+_ACTION_REJECTED = "rejected"
+_ACTION_CANCELLED = "cancelled"
+_ACTION_EXECUTED = "executed"
+_ACTION_FAILED = "failed"
+_ACTION_EXPIRED = "expired"
 
 
 class ChangeRequestStateError(Exception):
@@ -323,11 +325,14 @@ async def mark_failed(
     cr: ChangeRequest,
     *,
     approver: User,
+    requester_id: UUID | None,
     request: Request | None,
     error: str,
 ) -> ChangeRequest:
     """``approved`` → ``failed`` (terminal). ``apply()`` (or its
-    re-preview stale-state guard) failed at execution time."""
+    re-preview stale-state guard) failed at execution time. Like
+    :func:`mark_executed`, the audit row carries the requester→approver
+    correlation (#14): ``user_id=approver`` + ``old_value.requested_by``."""
     _require_state(cr, "approved")
     cr.state = "failed"
     cr.error = error
@@ -338,7 +343,10 @@ async def mark_failed(
         request=request,
         action=_ACTION_FAILED,
         cr=cr,
-        old_value={"state": "approved"},
+        old_value={
+            "state": "approved",
+            "requested_by": str(requester_id) if requester_id is not None else None,
+        },
         new_value={"state": "failed", "error": error},
     )
     logger.warning(
@@ -419,6 +427,64 @@ class DecisionUnprocessable(DecisionError):
     status_code = 422
 
 
+def _decision_for_status(status_code: int, detail: str) -> DecisionError:
+    """Map an HTTP 4xx ``apply()`` raised to the matching DecisionError so the
+    approve callers surface the precondition status (#11)."""
+    mapping: dict[int, type[DecisionError]] = {
+        403: DecisionForbidden,
+        404: DecisionNotFound,
+        409: DecisionConflict,
+        422: DecisionUnprocessable,
+    }
+    return mapping.get(status_code, DecisionConflict)(detail)
+
+
+async def _safe_rollback(db: AsyncSession) -> None:
+    """Roll back, swallowing a rollback-time failure (#15).
+
+    If ``apply()`` already rolled back (or the connection is wedged) a second
+    rollback can itself raise; letting that propagate would mask the original
+    error and could strand the row. Best-effort + log, never re-raise.
+    """
+    try:
+        await db.rollback()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("change_request.rollback_failed", error=str(exc))
+
+
+async def _stamp_apply_failed(
+    db: AsyncSession,
+    cr_id: UUID,
+    *,
+    approver: User,
+    request: Request | None,
+    note: str | None,
+    error: str,
+) -> ChangeRequest:
+    """Re-lock the (rolled-back) row and stamp ``pending → approved → failed``.
+
+    Shared by the approve spine's 5xx and generic-exception paths. The
+    approval transition was rolled back alongside ``apply()``, so replay it
+    before ``mark_failed``. Raises :class:`DecisionError` if the row vanished
+    or another actor flipped it mid-apply."""
+    cr = await get_change_request(db, cr_id, for_update=True)
+    if cr is None or cr.state != "pending":
+        raise DecisionError("Change request vanished or changed state mid-apply — investigate")
+    requester_id = cr.requested_by_user_id
+    await mark_approved(db, cr, approver=approver, request=request, note=note)
+    await mark_failed(
+        db, cr, approver=approver, requester_id=requester_id, request=request, error=error
+    )
+    await db.commit()
+    logger.warning(
+        "change_request.apply_failed",
+        change_request_id=str(cr.id),
+        operation=cr.operation,
+        error=error,
+    )
+    return cr
+
+
 async def approve_change_request(
     db: AsyncSession,
     cr_id: UUID,
@@ -449,13 +515,24 @@ async def approve_change_request(
     if cr.state != "pending":
         raise DecisionConflict(f"Change request is not pending (state={cr.state!r})")
     if cr.expires_at < datetime.now(UTC):
-        cr.state = "expired"
-        cr.decided_at = datetime.now(UTC)
+        # #13: route through the audited mark_expired transition (not a raw
+        # field poke) so the change_request.expired audit row lands.
+        await mark_expired(db, cr)
         await db.commit()
         raise DecisionConflict("Change request has expired")
 
-    # 2. Self-approval is forbidden — the whole point of two-person.
-    if cr.requested_by_user_id is not None and approver.id == cr.requested_by_user_id:
+    # 2a. Fail CLOSED when the requester row is gone (#5). ON DELETE SET NULL
+    #     nulls ``requested_by_user_id`` if the requester is deleted; the
+    #     self-approval guard below would then fail OPEN (None != approver.id
+    #     is always true), letting anyone rubber-stamp an orphaned request and
+    #     defeating two-person. Refuse instead — the requester must recreate.
+    if cr.requested_by_user_id is None:
+        raise DecisionConflict(
+            "Requester no longer exists; cancel and recreate this change request"
+        )
+
+    # 2b. Self-approval is forbidden — the whole point of two-person.
+    if approver.id == cr.requested_by_user_id:
         raise DecisionForbidden("You cannot approve your own change request")
 
     op = operations.get_operation(cr.operation)
@@ -503,27 +580,37 @@ async def approve_change_request(
     try:
         result = await op.apply(db, approver, args)
     except OperationPermissionError as exc:
-        await db.rollback()
+        await _safe_rollback(db)
         raise DecisionForbidden(str(exc)) from exc
+    except HTTPException as exc:
+        # #11: a client 4xx from apply() is NOT an execution failure — it's a
+        # raced precondition the op rejected (e.g. the subnet became
+        # non-empty, or the row vanished, between preview and apply). Surface
+        # the same status, leave the request PENDING (the requester can cancel
+        # or retry once the precondition clears). Only a 5xx (server fault)
+        # falls through to mark_failed below.
+        await _safe_rollback(db)
+        sc = exc.status_code
+        if 400 <= sc < 500:
+            detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+            logger.info(
+                "change_request.apply_precondition",
+                change_request_id=str(cr_id),
+                operation=op.name,
+                status_code=sc,
+                detail=detail,
+            )
+            raise _decision_for_status(sc, detail) from exc
+        return await _stamp_apply_failed(
+            db, cr_id, approver=approver, request=request, note=note, error=str(exc.detail)
+        )
     except Exception as exc:  # noqa: BLE001
         # apply() rolled back its own transaction; reload + lock to stamp the
         # failure (the approval transition was rolled back too).
-        await db.rollback()
-        cr = await get_change_request(db, cr_id, for_update=True)
-        if cr is None or cr.state != "pending":
-            raise DecisionError(
-                "Change request vanished or changed state mid-apply — investigate"
-            ) from exc
-        await mark_approved(db, cr, approver=approver, request=request, note=note)
-        await mark_failed(db, cr, approver=approver, request=request, error=str(exc))
-        await db.commit()
-        logger.warning(
-            "change_request.apply_failed",
-            change_request_id=str(cr.id),
-            operation=cr.operation,
-            error=str(exc),
+        await _safe_rollback(db)
+        return await _stamp_apply_failed(
+            db, cr_id, approver=approver, request=request, note=note, error=str(exc)
         )
-        return cr
 
     await mark_executed(
         db,

--- a/backend/app/services/approvals/service.py
+++ b/backend/app/services/approvals/service.py
@@ -1,0 +1,600 @@
+"""Change-request service — data access + audited state machine (#62).
+
+This module owns the ``change_request`` row lifecycle: create a pending
+request, read/list it, and the guarded ``mark_*`` transitions an approver
+/ requester / sweep drives. Every mutation writes an ``audit_log`` row
+before returning (non-negotiable #4); the caller owns the commit so the
+audit row and the state change land atomically.
+
+The gate (``gate.py``) + the approve/reject/cancel API router + the
+Celery expiry sweep all call into here. Two-person authorization (approver
+!= requester, approver holds ``{approve, change_request}`` AND the
+operation's ``required_permission``) is enforced by the API layer *before*
+calling :func:`mark_approved` / :func:`mark_executed`; this module owns
+the *state-machine* invariants (a request only ever transitions out of
+``pending``, and only once, under ``SELECT ... FOR UPDATE``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+import structlog
+from fastapi import Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.request_meta import clean_user_agent, client_ip
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.change_request import ChangeRequest
+
+logger = structlog.get_logger(__name__)
+
+# Audit action strings — kept aligned with the ``change_request`` event
+# namespace (event_publisher.py) so typed webhook events flow
+# automatically: change_request.{requested,approved,rejected,cancelled,
+# executed,failed,expired}.
+_ACTION_REQUESTED = "change_request.requested"
+_ACTION_APPROVED = "change_request.approved"
+_ACTION_REJECTED = "change_request.rejected"
+_ACTION_CANCELLED = "change_request.cancelled"
+_ACTION_EXECUTED = "change_request.executed"
+_ACTION_FAILED = "change_request.failed"
+_ACTION_EXPIRED = "change_request.expired"
+
+
+class ChangeRequestStateError(Exception):
+    """A transition was attempted from an illegal current state.
+
+    The API layer translates this into a 409 Conflict — e.g. two
+    approvers race and the second one finds the row already
+    ``approved``/``executed``.
+    """
+
+
+def _audit(
+    db: AsyncSession,
+    *,
+    user: User | None,
+    request: Request | None,
+    action: str,
+    cr: ChangeRequest,
+    old_value: dict[str, Any] | None = None,
+    new_value: dict[str, Any] | None = None,
+) -> None:
+    """Append an ``audit_log`` row for a change-request transition.
+
+    ``user`` is the actor (None only for the system-driven expiry sweep,
+    which records a synthetic ``system`` actor). ``request`` is None on
+    non-HTTP paths (the Celery sweep) — source_ip / user_agent stay NULL.
+    """
+    db.add(
+        AuditLog(
+            user_id=user.id if user is not None else None,
+            user_display_name=user.display_name if user is not None else "system",
+            auth_source=user.auth_source if user is not None else "system",
+            source_ip=client_ip(request) if request is not None else None,
+            user_agent=(
+                clean_user_agent(request.headers.get("user-agent")) if request is not None else None
+            ),
+            action=action,
+            resource_type="change_request",
+            resource_id=str(cr.id),
+            resource_display=cr.resource_display,
+            old_value=old_value,
+            new_value=new_value,
+        )
+    )
+
+
+# ── Create / read ────────────────────────────────────────────────────────
+
+
+async def create_change_request(
+    db: AsyncSession,
+    *,
+    user: User,
+    request: Request,
+    operation: str,
+    resource_type: str,
+    resource_id: str | None,
+    resource_display: str,
+    args: dict[str, Any],
+    preview_text: str,
+    risk_reason: str,
+    ttl_hours: int,
+) -> ChangeRequest:
+    """Persist a new ``pending`` change request + its ``requested`` audit row.
+
+    The caller (the gate) owns the commit. ``ttl_hours`` comes from the
+    matched policy; ``expires_at`` is stamped now + ttl.
+    """
+    now = datetime.now(UTC)
+    cr = ChangeRequest(
+        operation=operation,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        resource_display=resource_display,
+        args=args,
+        preview_text=preview_text,
+        risk_reason=risk_reason,
+        state="pending",
+        requested_by_user_id=user.id,
+        requested_by_display=user.display_name,
+        expires_at=now + timedelta(hours=ttl_hours),
+    )
+    db.add(cr)
+    # Flush so the row gets its id before the audit row references it.
+    await db.flush()
+    _audit(
+        db,
+        user=user,
+        request=request,
+        action=_ACTION_REQUESTED,
+        cr=cr,
+        new_value={
+            "operation": operation,
+            "resource_type": resource_type,
+            "resource_id": resource_id,
+            "risk_reason": risk_reason,
+            "state": "pending",
+        },
+    )
+    logger.info(
+        "change_request.created",
+        change_request_id=str(cr.id),
+        operation=operation,
+        resource_type=resource_type,
+        requested_by=str(user.id),
+    )
+    return cr
+
+
+async def get_change_request(
+    db: AsyncSession, cr_id: UUID, *, for_update: bool = False
+) -> ChangeRequest | None:
+    """Load one change request. ``for_update`` takes a row-level lock so a
+    transition is race-safe against a concurrent approver (#62 concurrency
+    edge-case)."""
+    stmt = select(ChangeRequest).where(ChangeRequest.id == cr_id)
+    if for_update:
+        stmt = stmt.with_for_update()
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_change_requests(
+    db: AsyncSession,
+    *,
+    state: str | None = None,
+    resource_type: str | None = None,
+    requested_by_user_id: UUID | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> list[ChangeRequest]:
+    """List change requests newest-first with optional filters."""
+    stmt = select(ChangeRequest)
+    if state is not None:
+        stmt = stmt.where(ChangeRequest.state == state)
+    if resource_type is not None:
+        stmt = stmt.where(ChangeRequest.resource_type == resource_type)
+    if requested_by_user_id is not None:
+        stmt = stmt.where(ChangeRequest.requested_by_user_id == requested_by_user_id)
+    stmt = stmt.order_by(ChangeRequest.created_at.desc()).limit(limit).offset(offset)
+    return list((await db.execute(stmt)).scalars().all())
+
+
+# ── State transitions (each guarded + audited) ─────────────────────────────
+
+
+def _require_state(cr: ChangeRequest, expected: str) -> None:
+    if cr.state != expected:
+        raise ChangeRequestStateError(
+            f"change request {cr.id} is {cr.state!r}, expected {expected!r}"
+        )
+
+
+async def mark_approved(
+    db: AsyncSession,
+    cr: ChangeRequest,
+    *,
+    approver: User,
+    request: Request | None,
+    note: str | None,
+) -> ChangeRequest:
+    """``pending`` → ``approved``. Caller must have already loaded ``cr``
+    with ``for_update=True`` and enforced two-person RBAC. Records the
+    approver + decision time; execution (``apply()``) is a separate
+    :func:`mark_executed` / :func:`mark_failed` call by the API layer."""
+    _require_state(cr, "pending")
+    cr.state = "approved"
+    cr.decided_by_user_id = approver.id
+    cr.decided_by_display = approver.display_name
+    cr.decision_note = note
+    cr.decided_at = datetime.now(UTC)
+    _audit(
+        db,
+        user=approver,
+        request=request,
+        action=_ACTION_APPROVED,
+        cr=cr,
+        old_value={"state": "pending"},
+        new_value={"state": "approved", "note": note},
+    )
+    return cr
+
+
+async def mark_rejected(
+    db: AsyncSession,
+    cr: ChangeRequest,
+    *,
+    approver: User,
+    request: Request | None,
+    note: str | None,
+) -> ChangeRequest:
+    """``pending`` → ``rejected`` (terminal)."""
+    _require_state(cr, "pending")
+    cr.state = "rejected"
+    cr.decided_by_user_id = approver.id
+    cr.decided_by_display = approver.display_name
+    cr.decision_note = note
+    cr.decided_at = datetime.now(UTC)
+    _audit(
+        db,
+        user=approver,
+        request=request,
+        action=_ACTION_REJECTED,
+        cr=cr,
+        old_value={"state": "pending"},
+        new_value={"state": "rejected", "note": note},
+    )
+    return cr
+
+
+async def mark_cancelled(
+    db: AsyncSession,
+    cr: ChangeRequest,
+    *,
+    user: User,
+    request: Request | None,
+) -> ChangeRequest:
+    """``pending`` → ``cancelled`` (terminal). Driven by the requester (or
+    a superadmin); the API layer enforces who may cancel."""
+    _require_state(cr, "pending")
+    cr.state = "cancelled"
+    cr.decided_by_user_id = user.id
+    cr.decided_by_display = user.display_name
+    cr.decided_at = datetime.now(UTC)
+    _audit(
+        db,
+        user=user,
+        request=request,
+        action=_ACTION_CANCELLED,
+        cr=cr,
+        old_value={"state": "pending"},
+        new_value={"state": "cancelled"},
+    )
+    return cr
+
+
+async def mark_executed(
+    db: AsyncSession,
+    cr: ChangeRequest,
+    *,
+    approver: User,
+    requester_id: UUID | None,
+    request: Request | None,
+    result: dict[str, Any],
+) -> ChangeRequest:
+    """``approved`` → ``executed`` (terminal). The operation's ``apply()``
+    ran successfully under the approver's identity. The audit row sets
+    ``user_id=approver`` and ``old_value.requested_by=<requester>`` so the
+    two-person trail is queryable (#62)."""
+    _require_state(cr, "approved")
+    cr.state = "executed"
+    cr.result = result
+    cr.executed_at = datetime.now(UTC)
+    _audit(
+        db,
+        user=approver,
+        request=request,
+        action=_ACTION_EXECUTED,
+        cr=cr,
+        old_value={
+            "state": "approved",
+            "requested_by": str(requester_id) if requester_id is not None else None,
+        },
+        new_value={"state": "executed", "result": result},
+    )
+    logger.info(
+        "change_request.executed",
+        change_request_id=str(cr.id),
+        operation=cr.operation,
+        approved_by=str(approver.id),
+        requested_by=str(requester_id) if requester_id is not None else None,
+    )
+    return cr
+
+
+async def mark_failed(
+    db: AsyncSession,
+    cr: ChangeRequest,
+    *,
+    approver: User,
+    request: Request | None,
+    error: str,
+) -> ChangeRequest:
+    """``approved`` → ``failed`` (terminal). ``apply()`` (or its
+    re-preview stale-state guard) failed at execution time."""
+    _require_state(cr, "approved")
+    cr.state = "failed"
+    cr.error = error
+    cr.executed_at = datetime.now(UTC)
+    _audit(
+        db,
+        user=approver,
+        request=request,
+        action=_ACTION_FAILED,
+        cr=cr,
+        old_value={"state": "approved"},
+        new_value={"state": "failed", "error": error},
+    )
+    logger.warning(
+        "change_request.failed",
+        change_request_id=str(cr.id),
+        operation=cr.operation,
+        error=error,
+    )
+    return cr
+
+
+async def mark_expired(db: AsyncSession, cr: ChangeRequest) -> ChangeRequest:
+    """``pending`` → ``expired`` (terminal). System-driven by the Celery
+    sweep; no HTTP request / human actor."""
+    _require_state(cr, "pending")
+    cr.state = "expired"
+    cr.decided_at = datetime.now(UTC)
+    _audit(
+        db,
+        user=None,
+        request=None,
+        action=_ACTION_EXPIRED,
+        cr=cr,
+        old_value={"state": "pending"},
+        new_value={"state": "expired"},
+    )
+    logger.info("change_request.expired", change_request_id=str(cr.id))
+    return cr
+
+
+# ── Shared approve / reject orchestration (the two-person spine) ───────────
+#
+# These functions own the full two-person decision flow so the HTTP router
+# (api/v1/change_requests/router.py) and the AI propose→apply path
+# (services/ai/operations.py: approve_change_request / reject_change_request)
+# enforce the *identical* invariants without copy-pasting them. The
+# invariants are enforced here, never trusting the caller:
+#
+#   1. Row loaded ``FOR UPDATE`` + must still be ``pending`` (racing
+#      approver loses → ``DecisionConflict``); an expired row flips to
+#      ``expired`` and raises ``DecisionConflict``.
+#   2. Self-approval blocked — approver != requester (``DecisionForbidden``).
+#   3. Approver holds ``{approve, change_request}`` (``DecisionForbidden``).
+#   4. Approver holds the underlying op's ``required_permission``
+#      (``DecisionForbidden``) — can't rubber-stamp a delete you couldn't do.
+#   5. ``preview()`` re-runs (stale-state guard); if not ok the op does NOT
+#      execute (``DecisionConflict``), the row stays ``pending``.
+#   6. ``apply()`` dispatches under the **approver's** identity; the audit
+#      ``executed`` row carries approver as actor + requester in
+#      ``old_value.requested_by``.
+#
+# The error subclasses carry an HTTP-ish ``status_code`` so the two call
+# sites translate them uniformly. ``request`` is optional — None on the
+# AI propose→apply path (no FastAPI Request there); audit source_ip /
+# user_agent stay NULL exactly like the Celery sweep.
+
+
+class DecisionError(Exception):
+    """Base for a refused approve/reject decision. ``status_code`` lets the
+    caller map it to the right HTTP response."""
+
+    status_code: int = 400
+
+
+class DecisionNotFound(DecisionError):
+    status_code = 404
+
+
+class DecisionForbidden(DecisionError):
+    status_code = 403
+
+
+class DecisionConflict(DecisionError):
+    status_code = 409
+
+
+class DecisionUnprocessable(DecisionError):
+    status_code = 422
+
+
+async def approve_change_request(
+    db: AsyncSession,
+    cr_id: UUID,
+    *,
+    approver: User,
+    request: Request | None,
+    note: str | None,
+) -> ChangeRequest:
+    """Approve + execute a pending change request — the two-person spine.
+
+    Loads the row ``FOR UPDATE``, enforces every server-side invariant
+    (steps 1–6 above), runs the underlying operation's ``apply()`` under
+    ``approver``'s identity, and **commits**. On a successful apply the row
+    is ``executed`` (with ``result``); on an apply-time failure the row is
+    ``failed`` (with ``error``) and the function returns normally (the
+    caller surfaces the terminal row). Raises a :class:`DecisionError`
+    subclass for every refused-decision case before any mutation lands.
+    """
+    # Local import — operations imports this module's siblings, so importing
+    # it at module top would risk a cycle.
+    from app.services.ai import operations  # noqa: PLC0415
+    from app.services.ai.operations import OperationPermissionError  # noqa: PLC0415
+
+    # 1. Row lock + state guard — race-safe against a second approver.
+    cr = await get_change_request(db, cr_id, for_update=True)
+    if cr is None:
+        raise DecisionNotFound(f"Change request {cr_id} not found")
+    if cr.state != "pending":
+        raise DecisionConflict(f"Change request is not pending (state={cr.state!r})")
+    if cr.expires_at < datetime.now(UTC):
+        cr.state = "expired"
+        cr.decided_at = datetime.now(UTC)
+        await db.commit()
+        raise DecisionConflict("Change request has expired")
+
+    # 2. Self-approval is forbidden — the whole point of two-person.
+    if cr.requested_by_user_id is not None and approver.id == cr.requested_by_user_id:
+        raise DecisionForbidden("You cannot approve your own change request")
+
+    op = operations.get_operation(cr.operation)
+    if op is None:
+        raise DecisionError(f"Operation {cr.operation!r} is not registered")
+
+    # 3. Approver holds the approve capability.
+    if not _can_approve(approver):
+        raise DecisionForbidden(
+            "Permission denied: need 'approve' on 'change_request'",
+        )
+
+    # 4. Approver holds the underlying operation's own permission.
+    try:
+        operations.enforce_operation_permission(approver, op)
+    except OperationPermissionError as exc:
+        raise DecisionForbidden(str(exc)) from exc
+
+    # Re-validate frozen args (guards the rare redeploy-mid-flight schema change).
+    try:
+        args = op.args_model.model_validate(cr.args or {})
+    except Exception as exc:  # noqa: BLE001
+        raise DecisionUnprocessable(f"Stored args no longer validate: {exc}") from exc
+
+    # 5. Stale-state re-check — do NOT execute a doomed op; leave it pending.
+    preview = await op.preview(db, approver, args)
+    if not preview.ok:
+        logger.info(
+            "change_request.stale",
+            change_request_id=str(cr.id),
+            operation=cr.operation,
+            detail=preview.detail,
+            approver=str(approver.id),
+        )
+        raise DecisionConflict(preview.detail)
+
+    requester_id = cr.requested_by_user_id
+
+    # Record the approval transition (pending → approved, audited).
+    await mark_approved(db, cr, approver=approver, request=request, note=note)
+
+    # 6. Dispatch apply() under the approver's identity. apply() runs its own
+    #    mutation + audit + commit; on success mark_executed writes the
+    #    change_request.executed audit row carrying both ids.
+    try:
+        result = await op.apply(db, approver, args)
+    except OperationPermissionError as exc:
+        await db.rollback()
+        raise DecisionForbidden(str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        # apply() rolled back its own transaction; reload + lock to stamp the
+        # failure (the approval transition was rolled back too).
+        await db.rollback()
+        cr = await get_change_request(db, cr_id, for_update=True)
+        if cr is None or cr.state != "pending":
+            raise DecisionError(
+                "Change request vanished or changed state mid-apply — investigate"
+            ) from exc
+        await mark_approved(db, cr, approver=approver, request=request, note=note)
+        await mark_failed(db, cr, approver=approver, request=request, error=str(exc))
+        await db.commit()
+        logger.warning(
+            "change_request.apply_failed",
+            change_request_id=str(cr.id),
+            operation=cr.operation,
+            error=str(exc),
+        )
+        return cr
+
+    await mark_executed(
+        db,
+        cr,
+        approver=approver,
+        requester_id=requester_id,
+        request=request,
+        result=result,
+    )
+    await db.commit()
+    await db.refresh(cr)
+    return cr
+
+
+async def reject_change_request(
+    db: AsyncSession,
+    cr_id: UUID,
+    *,
+    approver: User,
+    request: Request | None,
+    note: str | None,
+) -> ChangeRequest:
+    """Decline a pending change request (``pending`` → ``rejected``).
+
+    Needs ``approve,change_request``; like approve, the rejecter may not be
+    the requester (a self-reject is a cancel). Commits + returns the terminal
+    row, or raises a :class:`DecisionError` subclass for a refused decision.
+    """
+    if not _can_approve(approver):
+        raise DecisionForbidden("Permission denied: need 'approve' on 'change_request'")
+    cr = await get_change_request(db, cr_id, for_update=True)
+    if cr is None:
+        raise DecisionNotFound(f"Change request {cr_id} not found")
+    if cr.requested_by_user_id is not None and approver.id == cr.requested_by_user_id:
+        raise DecisionForbidden("You cannot reject your own request — cancel it instead")
+    try:
+        await mark_rejected(db, cr, approver=approver, request=request, note=note)
+    except ChangeRequestStateError as exc:
+        raise DecisionConflict(str(exc)) from exc
+    await db.commit()
+    await db.refresh(cr)
+    return cr
+
+
+def _can_approve(user: User) -> bool:
+    """True when ``user`` holds ``{approve, change_request}``. Local import
+    of the permission helper avoids an import cycle at module load."""
+    from app.core.permissions import (  # noqa: PLC0415
+        RESOURCE_TYPE_CHANGE_REQUEST,
+        user_has_permission,
+    )
+
+    return user_has_permission(user, "approve", RESOURCE_TYPE_CHANGE_REQUEST)
+
+
+__all__ = [
+    "ChangeRequestStateError",
+    "DecisionConflict",
+    "DecisionError",
+    "DecisionForbidden",
+    "DecisionNotFound",
+    "DecisionUnprocessable",
+    "approve_change_request",
+    "create_change_request",
+    "get_change_request",
+    "list_change_requests",
+    "mark_approved",
+    "mark_cancelled",
+    "mark_executed",
+    "mark_expired",
+    "mark_failed",
+    "mark_rejected",
+    "reject_change_request",
+]

--- a/backend/app/services/approvals/service.py
+++ b/backend/app/services/approvals/service.py
@@ -22,8 +22,8 @@ from typing import Any
 from uuid import UUID
 
 import structlog
-from fastapi import HTTPException, Request
-from sqlalchemy import select
+from fastapi import HTTPException, Request, status
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.request_meta import clean_user_agent, client_ip
@@ -46,6 +46,13 @@ _ACTION_CANCELLED = "cancelled"
 _ACTION_EXECUTED = "executed"
 _ACTION_FAILED = "failed"
 _ACTION_EXPIRED = "expired"
+
+# #8: per-user pending-request cap. Bounds change_request table + expiry-sweep
+# growth from a single noisy requester (or a script). A requester at the cap
+# must let some of their pending requests resolve (approve / reject / cancel /
+# expire) before queuing more. Sized generously — a human operator rarely has
+# this many open at once; it's a runaway guard, not a workflow throttle.
+_MAX_PENDING_PER_USER = 50
 
 
 class ChangeRequestStateError(Exception):
@@ -113,7 +120,29 @@ async def create_change_request(
 
     The caller (the gate) owns the commit. ``ttl_hours`` comes from the
     matched policy; ``expires_at`` is stamped now + ttl.
+
+    #8: refuses (429) when the requester already holds ``_MAX_PENDING_PER_USER``
+    pending requests — a per-user cap that bounds table + sweep growth.
     """
+    # #8: per-user pending quota — fail before persisting anything.
+    pending_count = (
+        await db.execute(
+            select(func.count(ChangeRequest.id)).where(
+                ChangeRequest.requested_by_user_id == user.id,
+                ChangeRequest.state == "pending",
+            )
+        )
+    ).scalar_one()
+    if pending_count >= _MAX_PENDING_PER_USER:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                f"You already have {pending_count} pending change requests "
+                f"(max {_MAX_PENDING_PER_USER}). Resolve or cancel some before "
+                "submitting more."
+            ),
+        )
+
     now = datetime.now(UTC)
     cr = ChangeRequest(
         operation=operation,
@@ -261,13 +290,20 @@ async def mark_cancelled(
     *,
     user: User,
     request: Request | None,
+    note: str | None = None,
 ) -> ChangeRequest:
     """``pending`` → ``cancelled`` (terminal). Driven by the requester (or
-    a superadmin); the API layer enforces who may cancel."""
+    a superadmin); the API layer enforces who may cancel.
+
+    #5: the optional cancellation ``note`` is stamped on the row AND carried
+    into the audit ``new_value`` here — previously the router set
+    ``cr.decision_note`` only AFTER this wrote the audit row, so the note never
+    reached ``audit_log`` (unlike approve/reject)."""
     _require_state(cr, "pending")
     cr.state = "cancelled"
     cr.decided_by_user_id = user.id
     cr.decided_by_display = user.display_name
+    cr.decision_note = note
     cr.decided_at = datetime.now(UTC)
     _audit(
         db,
@@ -276,7 +312,7 @@ async def mark_cancelled(
         action=_ACTION_CANCELLED,
         cr=cr,
         old_value={"state": "pending"},
-        new_value={"state": "cancelled"},
+        new_value={"state": "cancelled", "note": note},
     )
     return cr
 
@@ -514,7 +550,10 @@ async def approve_change_request(
         raise DecisionNotFound(f"Change request {cr_id} not found")
     if cr.state != "pending":
         raise DecisionConflict(f"Change request is not pending (state={cr.state!r})")
-    if cr.expires_at < datetime.now(UTC):
+    # #10: one expiry convention everywhere — ``expires_at <= now`` means expired
+    # (matches the sweep select + recheck), so a request can't be approved in the
+    # same instant the sweep would expire it.
+    if cr.expires_at <= datetime.now(UTC):
         # #13: route through the audited mark_expired transition (not a raw
         # field poke) so the change_request.expired audit row lands.
         await mark_expired(db, cr)
@@ -552,10 +591,19 @@ async def approve_change_request(
         raise DecisionForbidden(str(exc)) from exc
 
     # Re-validate frozen args (guards the rare redeploy-mid-flight schema change).
+    # #6: never echo the Pydantic ValidationError back to the client — it
+    # interpolates ``input_value`` (the frozen args). Log the detail
+    # server-side and surface a generic message.
     try:
         args = op.args_model.model_validate(cr.args or {})
     except Exception as exc:  # noqa: BLE001
-        raise DecisionUnprocessable(f"Stored args no longer validate: {exc}") from exc
+        logger.warning(
+            "change_request.args_revalidation_failed",
+            change_request_id=str(cr.id),
+            operation=cr.operation,
+            error=str(exc),
+        )
+        raise DecisionUnprocessable("Stored args no longer validate for this operation") from exc
 
     # 5. Stale-state re-check — do NOT execute a doomed op; leave it pending.
     preview = await op.preview(db, approver, args)
@@ -569,7 +617,36 @@ async def approve_change_request(
         )
         raise DecisionConflict(preview.detail)
 
+    # 5b. Scope-drift guard (#3b — TOCTOU). The frozen ``cr.preview_text`` is
+    #     what the approver saw rendered when the request was created; each
+    #     delete op's preview_text now embeds the CURRENT blast radius (#3a).
+    #     If the fresh preview_text differs, the blast radius CHANGED between
+    #     request and approval (e.g. the requester added 50 IPs to a subnet
+    #     queued for soft-delete) — refuse so the approver never rubber-stamps
+    #     a scope larger than the one they reviewed. Treat any drift as stale;
+    #     the requester must cancel and re-submit to capture the new scope.
+    #     This closes the TOCTOU for both soft and permanent paths via one rule.
+    if preview.preview_text != cr.preview_text:
+        logger.info(
+            "change_request.scope_drift",
+            change_request_id=str(cr.id),
+            operation=cr.operation,
+            approver=str(approver.id),
+            frozen_preview=cr.preview_text,
+            fresh_preview=preview.preview_text,
+        )
+        raise DecisionConflict(
+            "The change's scope changed since it was requested — cancel and "
+            "re-submit to capture the new scope."
+        )
+
     requester_id = cr.requested_by_user_id
+
+    # #3b transparency: surface the freshly-rendered preview on the returned
+    # row. On the success path it equals the frozen text (drift would have
+    # 409'd above), but persisting it makes the executed row reflect exactly
+    # what was re-validated at approve time.
+    cr.preview_text = preview.preview_text
 
     # Record the approval transition (pending → approved, audited).
     await mark_approved(db, cr, approver=approver, request=request, note=note)

--- a/backend/app/services/event_publisher.py
+++ b/backend/app/services/event_publisher.py
@@ -120,9 +120,13 @@ _RESOURCE_NAMESPACE: dict[str, str] = {
     "firewall_policy": "firewall.policy",
     "firewall_rule": "firewall.rule",
     "firewall_alias": "firewall.alias",
-    # Approvals (#62) — change_request.requested / .approved / .rejected /
-    # .cancelled / .executed / .failed / .expired flow as typed events.
-    "change_request": "change_request",
+    # NOTE: ``change_request`` (#62) is deliberately NOT here. Its lifecycle
+    # uses non-CRUD verbs (requested / approved / rejected / cancelled /
+    # executed / failed / expired), so a namespace entry would make the
+    # catalog advertise the never-fired change_request.created/updated/deleted
+    # trio. Instead every change_request event is an explicit
+    # _SPECIAL_EVENT_MAP row below — checked before this map at publish time
+    # AND unioned into the event-type catalog.
 }
 
 
@@ -185,6 +189,21 @@ _SPECIAL_EVENT_MAP: dict[tuple[str, str], str] = {
     ("upgrade.node_failed", "system_upgrade_run"): "system.upgrade.failed",
     ("upgrade.chart_bump_failed", "system_upgrade_run"): "system.upgrade.failed",
     ("upgrade.post_upgrade_verify_failed", "system_upgrade_run"): "system.upgrade.failed",
+    # Approval workflow lifecycle (#62). The service layer writes plain-verb
+    # audit actions (requested / approved / …); without these explicit
+    # entries the auto-derivation still yields ``change_request.<verb>`` (the
+    # action passes through as the verb), but the event-type CATALOG
+    # enumeration only knows the create/update/delete trio per namespace — so
+    # it would advertise the never-fired change_request.created/updated/deleted
+    # and miss the real lifecycle. Listing them here makes them authoritative
+    # AND surfaces them in the catalog (which unions _SPECIAL_EVENT_MAP.values).
+    ("requested", "change_request"): "change_request.requested",
+    ("approved", "change_request"): "change_request.approved",
+    ("rejected", "change_request"): "change_request.rejected",
+    ("cancelled", "change_request"): "change_request.cancelled",
+    ("executed", "change_request"): "change_request.executed",
+    ("failed", "change_request"): "change_request.failed",
+    ("expired", "change_request"): "change_request.expired",
 }
 
 

--- a/backend/app/services/event_publisher.py
+++ b/backend/app/services/event_publisher.py
@@ -120,6 +120,9 @@ _RESOURCE_NAMESPACE: dict[str, str] = {
     "firewall_policy": "firewall.policy",
     "firewall_rule": "firewall.rule",
     "firewall_alias": "firewall.alias",
+    # Approvals (#62) — change_request.requested / .approved / .rejected /
+    # .cancelled / .executed / .failed / .expired flow as typed events.
+    "change_request": "change_request",
 }
 
 

--- a/backend/app/services/event_publisher.py
+++ b/backend/app/services/event_publisher.py
@@ -204,6 +204,13 @@ _SPECIAL_EVENT_MAP: dict[tuple[str, str], str] = {
     ("executed", "change_request"): "change_request.executed",
     ("failed", "change_request"): "change_request.failed",
     ("expired", "change_request"): "change_request.expired",
+    # Self-governance break-glass (#62). A superadmin forced a protected
+    # control change (disable module / disable-delete-or-weaken a policy /
+    # unlock) past the two-person gate. HIGH-severity by intent — there is no
+    # severity column, so this distinct event name is the signal operators
+    # wire a dedicated alert / SIEM rule on. Special-map-only (like
+    # change_request): no _RESOURCE_NAMESPACE entry for ``approval_control``.
+    ("approvals.break_glass", "approval_control"): "governance.break_glass",
 }
 
 

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -297,6 +297,15 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         group="Security",
         description="Watch external TLS endpoints for expiry / chain validity / SAN drift; auto-discover probe targets from DNS A/AAAA records; alert on approaching expiry, broken chains, unreachable endpoints, and unexpected cert changes. Read-only monitoring — distinct from the ACME client that issues the appliance's own cert.",
     ),
+    # Governance — change-gating + approval workflows. Default-off so
+    # existing installs see zero behaviour change until opted in (#62).
+    ModuleSpec(
+        id="governance.approvals",
+        label="Approval workflows",
+        group="Security",
+        description="Two-person approval gating for high-blast-radius operations (deletes, bulk ops, factory reset, large imports). A risky action submitted by one operator is queued as a change request and only executes after a *different* eligible approver accepts it — the operation then runs under the approver's identity with the audit log carrying both user IDs. Default-off: when disabled (or no policy matches) every covered handler executes inline exactly as today.",
+        default_enabled=False,
+    ),
     # UI — cross-cutting personalisation surfaces. Per-user, never shared.
     ModuleSpec(
         id="ui.saved_views",

--- a/backend/app/tasks/change_request_expiry.py
+++ b/backend/app/tasks/change_request_expiry.py
@@ -42,12 +42,14 @@ async def _sweep() -> dict[str, int]:
         now = datetime.now(UTC)
         # Candidate ids only — re-load each FOR UPDATE so a mid-loop decision
         # by an approver/requester is observed under the lock (#12).
+        # #10: ``expires_at <= now`` is the single "expired" convention,
+        # matching the approve-path check + the per-row recheck below.
         candidate_ids = list(
             (
                 await db.execute(
                     select(ChangeRequest.id)
                     .where(ChangeRequest.state == "pending")
-                    .where(ChangeRequest.expires_at < now)
+                    .where(ChangeRequest.expires_at <= now)
                 )
             )
             .scalars()
@@ -62,8 +64,9 @@ async def _sweep() -> dict[str, int]:
             try:
                 cr = await get_change_request(db, cr_id, for_update=True)
                 # Re-check under the lock: an approver/requester may have
-                # flipped it out of pending (or it may have re-expired-past).
-                if cr is None or cr.state != "pending" or cr.expires_at >= datetime.now(UTC):
+                # flipped it out of pending. #10: ``expires_at > now`` (the
+                # negation of ``<= now``) means not-yet-expired → skip.
+                if cr is None or cr.state != "pending" or cr.expires_at > datetime.now(UTC):
                     skipped += 1
                     await db.commit()  # release the row lock
                     continue

--- a/backend/app/tasks/change_request_expiry.py
+++ b/backend/app/tasks/change_request_expiry.py
@@ -1,0 +1,58 @@
+"""Sweep change requests whose ``expires_at`` has passed — issue #62.
+
+Beat fires every 60 s (always-on; the per-row ``expires_at`` is the only
+knob — stamped at request time from the matched policy's ``ttl_hours``).
+Idempotent: only matches rows that are still ``pending`` AND past
+``expires_at``, so re-running on a quiet system picks up nothing new and a
+row that an approver/requester already decided is never touched.
+
+For each match the sweep flips ``pending`` → ``expired`` (terminal) and
+writes one ``change_request.expired`` audit row attributed to the
+synthetic ``system`` actor (NN #4 — every state change is audited). The
+approve endpoint also lazily expires a row it finds stale on read, so a
+request never executes past its TTL regardless of when this sweep runs;
+the sweep is the durable bookkeeping layer that clears the queue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select
+
+from app.celery_app import celery_app
+from app.db import task_session
+from app.models.change_request import ChangeRequest
+from app.services.approvals.service import mark_expired
+
+logger = structlog.get_logger(__name__)
+
+
+async def _sweep() -> dict[str, int]:
+    async with task_session() as db:
+        now = datetime.now(UTC)
+        rows = list(
+            (
+                await db.execute(
+                    select(ChangeRequest)
+                    .where(ChangeRequest.state == "pending")
+                    .where(ChangeRequest.expires_at < now)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for cr in rows:
+            await mark_expired(db, cr)
+        await db.commit()
+        return {"checked": len(rows), "expired": len(rows)}
+
+
+@celery_app.task(name="app.tasks.change_request_expiry.sweep_expired_change_requests")
+def sweep_expired_change_requests() -> dict[str, int]:
+    """Celery entry point. Idempotent — safe to retry."""
+    result = asyncio.run(_sweep())
+    logger.info("change_request_expiry_sweep_complete", **result)
+    return result

--- a/backend/app/tasks/change_request_expiry.py
+++ b/backend/app/tasks/change_request_expiry.py
@@ -12,6 +12,13 @@ synthetic ``system`` actor (NN #4 — every state change is audited). The
 approve endpoint also lazily expires a row it finds stale on read, so a
 request never executes past its TTL regardless of when this sweep runs;
 the sweep is the durable bookkeeping layer that clears the queue.
+
+Resilience (#12): the sweep processes one row at a time, each re-locked
+``FOR UPDATE`` and re-checked for ``state == "pending"`` inside its own
+transaction. A row an approver / requester flips out of ``pending`` between
+the candidate SELECT and the per-row lock is skipped (not an error), and a
+single row that raises is logged + skipped rather than aborting the whole
+batch — so one wedged row can't strand the queue.
 """
 
 from __future__ import annotations
@@ -25,7 +32,7 @@ from sqlalchemy import select
 from app.celery_app import celery_app
 from app.db import task_session
 from app.models.change_request import ChangeRequest
-from app.services.approvals.service import mark_expired
+from app.services.approvals.service import get_change_request, mark_expired
 
 logger = structlog.get_logger(__name__)
 
@@ -33,10 +40,12 @@ logger = structlog.get_logger(__name__)
 async def _sweep() -> dict[str, int]:
     async with task_session() as db:
         now = datetime.now(UTC)
-        rows = list(
+        # Candidate ids only — re-load each FOR UPDATE so a mid-loop decision
+        # by an approver/requester is observed under the lock (#12).
+        candidate_ids = list(
             (
                 await db.execute(
-                    select(ChangeRequest)
+                    select(ChangeRequest.id)
                     .where(ChangeRequest.state == "pending")
                     .where(ChangeRequest.expires_at < now)
                 )
@@ -44,10 +53,35 @@ async def _sweep() -> dict[str, int]:
             .scalars()
             .all()
         )
-        for cr in rows:
-            await mark_expired(db, cr)
-        await db.commit()
-        return {"checked": len(rows), "expired": len(rows)}
+
+        checked = 0
+        expired = 0
+        skipped = 0
+        for cr_id in candidate_ids:
+            checked += 1
+            try:
+                cr = await get_change_request(db, cr_id, for_update=True)
+                # Re-check under the lock: an approver/requester may have
+                # flipped it out of pending (or it may have re-expired-past).
+                if cr is None or cr.state != "pending" or cr.expires_at >= datetime.now(UTC):
+                    skipped += 1
+                    await db.commit()  # release the row lock
+                    continue
+                await mark_expired(db, cr)
+                await db.commit()
+                expired += 1
+            except Exception as exc:  # noqa: BLE001 — one bad row can't abort the batch
+                skipped += 1
+                logger.warning(
+                    "change_request_expiry_row_failed",
+                    change_request_id=str(cr_id),
+                    error=str(exc),
+                )
+                try:
+                    await db.rollback()
+                except Exception as rb_exc:  # noqa: BLE001
+                    logger.warning("change_request_expiry_rollback_failed", error=str(rb_exc))
+        return {"checked": checked, "expired": expired, "skipped": skipped}
 
 
 @celery_app.task(name="app.tasks.change_request_expiry.sweep_expired_change_requests")

--- a/backend/tests/test_approval_workflows.py
+++ b/backend/tests/test_approval_workflows.py
@@ -1,0 +1,557 @@
+"""Regression tests for the two-person approval workflow (#62).
+
+Covers the acceptance criteria pinned in the issue:
+
+* **Module off (default)** → a covered ``DELETE /subnets/{id}`` executes
+  inline (204) and creates NO ``change_request`` — zero behaviour change.
+* **Policy on** → the same DELETE returns ``202`` with a ``pending``
+  change_request, and the subnet still exists.
+* **Self-approval** is blocked (403).
+* **Two-person approve** — a *different* approver holding both
+  ``{approve, change_request}`` and ``{delete, subnet}`` approves; the
+  subnet is soft-deleted and the ``executed`` audit row carries the
+  requester id (in ``old_value.requested_by``) AND the approver id
+  (``user_id``).
+* **Stale request** — the subnet became non-empty between submit and
+  approve; approve re-runs preview and refuses (409); the row stays
+  pending and the subnet is untouched.
+* **Expiry sweep** flips a ``pending`` row past its TTL to ``expired``.
+* **Superadmin** still needs a *second* superadmin to approve when the
+  matched policy has ``applies_to_superadmin=True``.
+
+The ``client`` + ``db_session`` fixtures share one session (handlers
+commit on it), so a fixture write is visible to the HTTP handler and a
+post-call DB read sees the handler's committed mutation. The
+``governance.approvals`` feature-module cache is reset around every test
+by the autouse ``_reset_global_caches`` fixture; ``_enable_module``
+re-invalidates after inserting the override row so the gate observes it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import Group, Role, User
+from app.models.change_request import ApprovalPolicy, ChangeRequest
+from app.models.feature_module import FeatureModule
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services import feature_modules
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+async def _user(
+    db: AsyncSession,
+    *,
+    name: str,
+    permissions: list[dict] | None = None,
+    superadmin: bool = False,
+) -> tuple[User, str]:
+    """Create a user with exactly ``permissions`` (via a fresh Group+Role)
+    and return ``(user, bearer_token)``."""
+    user = User(
+        username=f"{name}-{uuid.uuid4().hex[:8]}",
+        email=f"{name}-{uuid.uuid4().hex[:8]}@t.io",
+        display_name=name,
+        hashed_password=hash_password("password123"),
+        is_superadmin=superadmin,
+    )
+    user.groups = []
+    if permissions:
+        role = Role(name=f"role-{uuid.uuid4().hex[:8]}", permissions=permissions)
+        group = Group(name=f"grp-{uuid.uuid4().hex[:8]}")
+        group.roles = [role]
+        user.groups = [group]
+        db.add_all([role, group])
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _subnet(db: AsyncSession, network: str = "10.0.5.0/24") -> Subnet:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/16", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=network, name="s")
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _enable_module(db: AsyncSession, *, enabled: bool = True) -> None:
+    """Upsert the ``governance.approvals`` override + bust the global cache
+    so the next ``is_module_enabled`` call observes the change."""
+    existing = await db.get(FeatureModule, "governance.approvals")
+    if existing is None:
+        db.add(FeatureModule(id="governance.approvals", enabled=enabled))
+    else:
+        existing.enabled = enabled
+    await db.flush()
+    feature_modules.invalidate_cache()
+
+
+async def _enable_delete_subnet_policy(
+    db: AsyncSession, *, applies_to_superadmin: bool = True, ttl_hours: int = 168
+) -> ApprovalPolicy:
+    """Seed an enabled ``delete:subnet`` approval policy (built-in rows are
+    normally seeded by migration; tests run on create_all so we seed our
+    own)."""
+    policy = ApprovalPolicy(
+        name="delete:subnet",
+        resource_type="subnet",
+        action="delete",
+        min_count=None,
+        enabled=True,
+        applies_to_superadmin=applies_to_superadmin,
+        ttl_hours=ttl_hours,
+        is_builtin=True,
+    )
+    db.add(policy)
+    await db.flush()
+    return policy
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _add_ip(db: AsyncSession, subnet: Subnet, address: str) -> None:
+    """Make a subnet non-empty (an allocated, non-lease IP) — what the
+    permanent-delete preview's stale check counts."""
+    db.add(IPAddress(subnet_id=subnet.id, address=address, status="allocated"))
+    await db.flush()
+
+
+# ── Module off (default) → inline, no change_request ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_module_off_deletes_inline(client: AsyncClient, db_session: AsyncSession) -> None:
+    """With the module off (default), a covered delete executes inline (204)
+    and creates no change_request — even if a policy row exists."""
+    await _enable_module(db_session, enabled=False)
+    await _enable_delete_subnet_policy(db_session)  # exists but never consulted
+    subnet = await _subnet(db_session)
+    _, token = await _user(
+        db_session,
+        name="op-a",
+        permissions=[{"action": "delete", "resource_type": "subnet"}],
+    )
+
+    r = await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(token))
+    assert r.status_code == 204, r.text
+
+    n_cr = (await db_session.execute(select(func.count(ChangeRequest.id)))).scalar_one()
+    assert n_cr == 0
+    # Soft-deleted inline.
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is not None
+
+
+# ── Policy on → 202 + pending row, subnet survives ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_policy_on_queues_request(client: AsyncClient, db_session: AsyncSession) -> None:
+    """Module on + delete:subnet policy enabled → DELETE returns 202 with a
+    pending change_request, and the subnet still exists."""
+    await _enable_module(db_session)
+    await _enable_delete_subnet_policy(db_session)
+    subnet = await _subnet(db_session)
+    requester, token = await _user(
+        db_session,
+        name="requester",
+        permissions=[{"action": "delete", "resource_type": "subnet"}],
+    )
+
+    r = await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(token))
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["state"] == "pending"
+    cr_id = body["change_request_id"]
+
+    cr = await db_session.get(ChangeRequest, uuid.UUID(cr_id))
+    assert cr is not None
+    assert cr.state == "pending"
+    assert cr.operation == "delete_subnet"
+    assert cr.resource_type == "subnet"
+    assert cr.requested_by_user_id == requester.id
+
+    # The subnet is NOT deleted — it's queued.
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is None
+
+    # The ``requested`` audit row was committed before the response (NN #4).
+    n_requested = (
+        await db_session.execute(
+            select(func.count(AuditLog.id)).where(AuditLog.action == "change_request.requested")
+        )
+    ).scalar_one()
+    assert n_requested == 1
+
+
+# ── Self-approval blocked ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_self_approval_forbidden(client: AsyncClient, db_session: AsyncSession) -> None:
+    """The requester cannot approve their own request (403) even if they
+    hold the approve capability."""
+    await _enable_module(db_session)
+    await _enable_delete_subnet_policy(db_session)
+    subnet = await _subnet(db_session)
+    # The requester holds BOTH delete:subnet AND approve:change_request — the
+    # only thing stopping them is the self-approval invariant.
+    _, token = await _user(
+        db_session,
+        name="self-approver",
+        permissions=[
+            {"action": "delete", "resource_type": "subnet"},
+            {"action": "approve", "resource_type": "change_request"},
+            {"action": "read", "resource_type": "change_request"},
+        ],
+    )
+
+    r = await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(token))
+    assert r.status_code == 202, r.text
+    cr_id = r.json()["change_request_id"]
+
+    r2 = await client.post(
+        f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(token), json={}
+    )
+    assert r2.status_code == 403, r2.text
+    assert "your own" in r2.json()["detail"].lower()
+
+    cr = await db_session.get(ChangeRequest, uuid.UUID(cr_id))
+    assert cr is not None and cr.state == "pending"
+
+
+# ── Two-person approve → subnet deleted + audit carries both ids ──────────────
+
+
+@pytest.mark.asyncio
+async def test_two_person_approve_executes(client: AsyncClient, db_session: AsyncSession) -> None:
+    """A different approver with {approve, change_request} + {delete, subnet}
+    approves → the subnet is soft-deleted and the executed audit row carries
+    requester (old_value.requested_by) and approver (user_id)."""
+    await _enable_module(db_session)
+    await _enable_delete_subnet_policy(db_session)
+    subnet = await _subnet(db_session)
+    requester, rtoken = await _user(
+        db_session,
+        name="requester",
+        permissions=[{"action": "delete", "resource_type": "subnet"}],
+    )
+    approver, atoken = await _user(
+        db_session,
+        name="approver",
+        permissions=[
+            {"action": "approve", "resource_type": "change_request"},
+            {"action": "read", "resource_type": "change_request"},
+            {"action": "delete", "resource_type": "subnet"},
+        ],
+    )
+
+    r = await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(rtoken))
+    assert r.status_code == 202, r.text
+    cr_id = r.json()["change_request_id"]
+
+    r2 = await client.post(
+        f"/api/v1/change-requests/{cr_id}/approve",
+        headers=_auth(atoken),
+        json={"decision_note": "looks fine"},
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["state"] == "executed"
+
+    # Subnet is now soft-deleted.
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is not None
+
+    cr = await db_session.get(ChangeRequest, uuid.UUID(cr_id))
+    assert cr is not None
+    assert cr.state == "executed"
+    assert cr.decided_by_user_id == approver.id
+    assert cr.decision_note == "looks fine"
+
+    # The executed audit row carries BOTH user ids.
+    row = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "change_request.executed",
+                AuditLog.resource_id == cr_id,
+            )
+        )
+    ).scalar_one()
+    assert row.user_id == approver.id
+    assert row.old_value is not None
+    assert row.old_value.get("requested_by") == str(requester.id)
+
+
+# ── Approver lacking the underlying op permission → 403 ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_approver_without_underlying_perm_denied(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An approver who holds {approve, change_request} but NOT {delete,
+    subnet} cannot rubber-stamp a delete they couldn't perform (403)."""
+    await _enable_module(db_session)
+    await _enable_delete_subnet_policy(db_session)
+    subnet = await _subnet(db_session)
+    _, rtoken = await _user(
+        db_session,
+        name="requester",
+        permissions=[{"action": "delete", "resource_type": "subnet"}],
+    )
+    _, atoken = await _user(
+        db_session,
+        name="approver-noperm",
+        permissions=[
+            {"action": "approve", "resource_type": "change_request"},
+            {"action": "read", "resource_type": "change_request"},
+        ],
+    )
+
+    cr_id = (
+        await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(rtoken))
+    ).json()["change_request_id"]
+    r = await client.post(
+        f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(atoken), json={}
+    )
+    assert r.status_code == 403, r.text
+
+
+# ── Stale request → approve refuses, subnet untouched ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stale_request_refuses(client: AsyncClient, db_session: AsyncSession) -> None:
+    """A permanent-delete request whose subnet became non-empty between
+    submit and approve re-runs preview and refuses (409); the row stays
+    pending and the subnet survives."""
+    await _enable_module(db_session)
+    # applies_to_superadmin so the superadmin requester is gated (needed
+    # because the permanent path requires superadmin).
+    await _enable_delete_subnet_policy(db_session, applies_to_superadmin=True)
+    subnet = await _subnet(db_session)
+    _, rtoken = await _user(db_session, name="sa-requester", superadmin=True)
+    _, atoken = await _user(db_session, name="sa-approver", superadmin=True)
+
+    # Submit on the permanent path while the subnet is empty → preview ok.
+    r = await client.delete(
+        f"/api/v1/ipam/subnets/{subnet.id}?permanent=true", headers=_auth(rtoken)
+    )
+    assert r.status_code == 202, r.text
+    cr_id = r.json()["change_request_id"]
+
+    # The subnet becomes non-empty after submission — the stale case.
+    await _add_ip(db_session, subnet, "10.0.5.42")
+    await db_session.commit()
+
+    r2 = await client.post(
+        f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(atoken), json={}
+    )
+    assert r2.status_code == 409, r2.text
+    assert "not empty" in r2.json()["detail"].lower()
+
+    # Left pending; subnet untouched.
+    cr = await db_session.get(ChangeRequest, uuid.UUID(cr_id))
+    assert cr is not None and cr.state == "pending"
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is None
+
+
+# ── Expiry sweep flips pending → expired ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_expiry_sweep(db_session: AsyncSession) -> None:
+    """A pending row past its TTL is flipped to ``expired`` by the sweep and
+    never executes."""
+    from app.services.approvals.service import mark_expired
+
+    subnet = await _subnet(db_session)
+    requester, _ = await _user(db_session, name="requester")
+    cr = ChangeRequest(
+        operation="delete_subnet",
+        resource_type="subnet",
+        resource_id=str(subnet.id),
+        resource_display="s",
+        args={"subnet_id": str(subnet.id), "force": False, "permanent": False},
+        preview_text="Soft-delete subnet",
+        risk_reason="delete:subnet",
+        state="pending",
+        requested_by_user_id=requester.id,
+        requested_by_display="requester",
+        expires_at=datetime.now(UTC) - timedelta(hours=1),
+    )
+    db_session.add(cr)
+    await db_session.flush()
+
+    # Drive the sweep's per-row transition directly (the Celery wrapper opens
+    # its own task_session against a different DB; the transition logic is the
+    # unit under test).
+    await mark_expired(db_session, cr)
+    await db_session.commit()
+
+    await db_session.refresh(cr)
+    assert cr.state == "expired"
+    assert cr.decided_at is not None
+
+    n_expired = (
+        await db_session.execute(
+            select(func.count(AuditLog.id)).where(AuditLog.action == "change_request.expired")
+        )
+    ).scalar_one()
+    assert n_expired == 1
+
+
+# ── Superadmin still needs a second superadmin ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_superadmin_needs_second_superadmin(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """With applies_to_superadmin=True a superadmin's covered delete is
+    queued (202), they can't self-approve (403), and a *second* superadmin
+    approves it (200 → executed)."""
+    await _enable_module(db_session)
+    await _enable_delete_subnet_policy(db_session, applies_to_superadmin=True)
+    subnet = await _subnet(db_session)
+    _, token_a = await _user(db_session, name="super-a", superadmin=True)
+    _, token_b = await _user(db_session, name="super-b", superadmin=True)
+
+    r = await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(token_a))
+    assert r.status_code == 202, r.text
+    cr_id = r.json()["change_request_id"]
+
+    # Self-approve refused.
+    r_self = await client.post(
+        f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(token_a), json={}
+    )
+    assert r_self.status_code == 403, r_self.text
+
+    # Second superadmin approves.
+    r_b = await client.post(
+        f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(token_b), json={}
+    )
+    assert r_b.status_code == 200, r_b.text
+    assert r_b.json()["state"] == "executed"
+
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is not None
+
+
+# ── Superadmin bypass when applies_to_superadmin=False ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_superadmin_bypass_when_not_applies(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """With applies_to_superadmin=False a superadmin's covered delete runs
+    inline (204) — the policy doesn't gate them."""
+    await _enable_module(db_session)
+    await _enable_delete_subnet_policy(db_session, applies_to_superadmin=False)
+    subnet = await _subnet(db_session)
+    _, token = await _user(db_session, name="super", superadmin=True)
+
+    r = await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(token))
+    assert r.status_code == 204, r.text
+    n_cr = (await db_session.execute(select(func.count(ChangeRequest.id)))).scalar_one()
+    assert n_cr == 0
+
+
+# ── Reject by a second operator ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reject_by_second_operator(client: AsyncClient, db_session: AsyncSession) -> None:
+    """An approver can reject; the subnet is never touched and the row is
+    terminal-rejected."""
+    await _enable_module(db_session)
+    await _enable_delete_subnet_policy(db_session)
+    subnet = await _subnet(db_session)
+    _, rtoken = await _user(
+        db_session,
+        name="requester",
+        permissions=[{"action": "delete", "resource_type": "subnet"}],
+    )
+    _, atoken = await _user(
+        db_session,
+        name="approver",
+        permissions=[
+            {"action": "approve", "resource_type": "change_request"},
+            {"action": "read", "resource_type": "change_request"},
+        ],
+    )
+
+    cr_id = (
+        await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(rtoken))
+    ).json()["change_request_id"]
+    r = await client.post(
+        f"/api/v1/change-requests/{cr_id}/reject",
+        headers=_auth(atoken),
+        json={"decision_note": "no"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == "rejected"
+
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is None
+
+
+# ── Cancel by the requester ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_by_requester(client: AsyncClient, db_session: AsyncSession) -> None:
+    """The original requester can withdraw their own pending request."""
+    await _enable_module(db_session)
+    await _enable_delete_subnet_policy(db_session)
+    subnet = await _subnet(db_session)
+    _, rtoken = await _user(
+        db_session,
+        name="requester",
+        permissions=[
+            {"action": "delete", "resource_type": "subnet"},
+            {"action": "read", "resource_type": "change_request"},
+        ],
+    )
+
+    cr_id = (
+        await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(rtoken))
+    ).json()["change_request_id"]
+    r = await client.post(f"/api/v1/change-requests/{cr_id}/cancel", headers=_auth(rtoken), json={})
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == "cancelled"
+
+
+# ── Router is module-gated (404 when off) ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_404_when_module_off(client: AsyncClient, db_session: AsyncSession) -> None:
+    """The whole change-requests router 404s when the module is off (NN #14)."""
+    await _enable_module(db_session, enabled=False)
+    _, token = await _user(
+        db_session,
+        name="reader",
+        permissions=[{"action": "read", "resource_type": "change_request"}],
+    )
+    r = await client.get("/api/v1/change-requests", headers=_auth(token))
+    assert r.status_code == 404, r.text

--- a/backend/tests/test_approval_workflows.py
+++ b/backend/tests/test_approval_workflows.py
@@ -195,7 +195,10 @@ async def test_policy_on_queues_request(client: AsyncClient, db_session: AsyncSe
     # The ``requested`` audit row was committed before the response (NN #4).
     n_requested = (
         await db_session.execute(
-            select(func.count(AuditLog.id)).where(AuditLog.action == "change_request.requested")
+            select(func.count(AuditLog.id)).where(
+                AuditLog.action == "requested",
+                AuditLog.resource_type == "change_request",
+            )
         )
     ).scalar_one()
     assert n_requested == 1
@@ -289,7 +292,8 @@ async def test_two_person_approve_executes(client: AsyncClient, db_session: Asyn
     row = (
         await db_session.execute(
             select(AuditLog).where(
-                AuditLog.action == "change_request.executed",
+                AuditLog.action == "executed",
+                AuditLog.resource_type == "change_request",
                 AuditLog.resource_id == cr_id,
             )
         )
@@ -413,7 +417,10 @@ async def test_expiry_sweep(db_session: AsyncSession) -> None:
 
     n_expired = (
         await db_session.execute(
-            select(func.count(AuditLog.id)).where(AuditLog.action == "change_request.expired")
+            select(func.count(AuditLog.id)).where(
+                AuditLog.action == "expired",
+                AuditLog.resource_type == "change_request",
+            )
         )
     ).scalar_one()
     assert n_expired == 1

--- a/backend/tests/test_approval_workflows_fixes.py
+++ b/backend/tests/test_approval_workflows_fixes.py
@@ -375,3 +375,271 @@ def test_change_request_event_type_single_namespaced() -> None:
     assert "change_request.requested" in catalog
     assert "change_request.created" not in catalog
     assert "change_request.deleted" not in catalog
+
+
+# ── #1: queue read scoping (REST list / get + MCP find) ────────────────────────
+
+
+async def _pending_cr(
+    db: AsyncSession, subnet: Subnet, requester: User, *, display: str = "owned"
+) -> ChangeRequest:
+    """Seed a pending delete_subnet change request owned by ``requester``."""
+    cr = ChangeRequest(
+        operation="delete_subnet",
+        resource_type="subnet",
+        resource_id=str(subnet.id),
+        resource_display=display,
+        args={"subnet_id": str(subnet.id), "force": False, "permanent": False},
+        preview_text=f"Soft-delete subnet ({display})",
+        risk_reason="delete:subnet",
+        state="pending",
+        requested_by_user_id=requester.id,
+        requested_by_display=requester.display_name,
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    db.add(cr)
+    await db.flush()
+    return cr
+
+
+@pytest.mark.asyncio
+async def test_read_only_user_sees_only_own_requests(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """READ RULE (#1): a plain {read, change_request} holder (not approve, not
+    superadmin) sees ONLY their own rows via the list endpoint — never another
+    user's — and ``mine=false`` can't widen that."""
+    await _enable_module(db_session)
+    subnet_a = await _subnet(db_session, "10.20.1.0/24")
+    subnet_b = await _subnet(db_session, "10.20.2.0/24")
+
+    reader, rtok = await _user(
+        db_session,
+        name="reader",
+        permissions=[{"action": "read", "resource_type": "change_request"}],
+    )
+    other, _ = await _user(db_session, name="other")
+
+    mine = await _pending_cr(db_session, subnet_a, reader, display="mine")
+    theirs = await _pending_cr(db_session, subnet_b, other, display="theirs")
+    await db_session.commit()
+
+    # Even with mine=false the read-only user is forced to own-scope.
+    r = await client.get("/api/v1/change-requests?mine=false", headers=_auth(rtok))
+    assert r.status_code == 200, r.text
+    ids = {row["id"] for row in r.json()}
+    assert str(mine.id) in ids
+    assert str(theirs.id) not in ids
+
+
+@pytest.mark.asyncio
+async def test_read_only_user_404_on_another_users_request(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """READ RULE (#1): get/{id} on a row the read-only caller doesn't own 404s
+    (not 403) — existence isn't confirmed."""
+    await _enable_module(db_session)
+    subnet = await _subnet(db_session, "10.21.1.0/24")
+    _, rtok = await _user(
+        db_session,
+        name="reader2",
+        permissions=[{"action": "read", "resource_type": "change_request"}],
+    )
+    owner, _ = await _user(db_session, name="owner2")
+    theirs = await _pending_cr(db_session, subnet, owner, display="theirs")
+    await db_session.commit()
+
+    r = await client.get(f"/api/v1/change-requests/{theirs.id}", headers=_auth(rtok))
+    assert r.status_code == 404, r.text
+
+
+@pytest.mark.asyncio
+async def test_approve_holder_sees_all_requests(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """READ RULE (#1): an {approve, change_request} holder sees EVERY row (an
+    eligible approver needs the whole queue) — list + get."""
+    await _enable_module(db_session)
+    subnet_a = await _subnet(db_session, "10.22.1.0/24")
+    subnet_b = await _subnet(db_session, "10.22.2.0/24")
+    approver, atok = await _user(
+        db_session,
+        name="approver-reader",
+        permissions=[
+            {"action": "read", "resource_type": "change_request"},
+            {"action": "approve", "resource_type": "change_request"},
+        ],
+    )
+    other, _ = await _user(db_session, name="other3")
+    a = await _pending_cr(db_session, subnet_a, approver, display="approvers-own")
+    b = await _pending_cr(db_session, subnet_b, other, display="someone-elses")
+    await db_session.commit()
+
+    r = await client.get("/api/v1/change-requests", headers=_auth(atok))
+    assert r.status_code == 200, r.text
+    ids = {row["id"] for row in r.json()}
+    assert str(a.id) in ids
+    assert str(b.id) in ids
+
+    # And get/{id} on someone else's row succeeds for an approve-holder.
+    r2 = await client.get(f"/api/v1/change-requests/{b.id}", headers=_auth(atok))
+    assert r2.status_code == 200, r2.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_find_change_requests_scopes_to_own(db_session: AsyncSession) -> None:
+    """READ RULE (#1) parity in the MCP surface: find_change_requests scopes a
+    plain read-only user to their own rows, and lets an approve-holder see all.
+    The MCP tools have no router gate, so the scope is enforced in-tool."""
+    from app.services.ai.tools.changes import (
+        FindChangeRequestsArgs,
+        find_change_requests,
+    )
+
+    subnet_a = await _subnet(db_session, "10.23.1.0/24")
+    subnet_b = await _subnet(db_session, "10.23.2.0/24")
+    reader, _ = await _user(
+        db_session,
+        name="mcp-reader",
+        permissions=[{"action": "read", "resource_type": "change_request"}],
+    )
+    approver, _ = await _user(
+        db_session,
+        name="mcp-approver",
+        permissions=[{"action": "approve", "resource_type": "change_request"}],
+    )
+    mine = await _pending_cr(db_session, subnet_a, reader, display="mcp-mine")
+    theirs = await _pending_cr(db_session, subnet_b, approver, display="mcp-theirs")
+    await db_session.commit()
+
+    # Read-only user: own row only, even with mine=False.
+    res = await find_change_requests(db_session, reader, FindChangeRequestsArgs(mine=False))
+    ids = {row["id"] for row in res["change_requests"]}
+    assert str(mine.id) in ids
+    assert str(theirs.id) not in ids
+
+    # Approve-holder: sees both.
+    res2 = await find_change_requests(db_session, approver, FindChangeRequestsArgs(mine=False))
+    ids2 = {row["id"] for row in res2["change_requests"]}
+    assert str(mine.id) in ids2
+    assert str(theirs.id) in ids2
+
+
+# ── #2: policies list gated on SuperAdmin ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_policies_list_forbidden_for_non_superadmin(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The policy LIST leaks un-gated (resource, threshold) pairs +
+    applies_to_superadmin → SuperAdmin-only (#2). A read-holder is 403."""
+    await _enable_module(db_session)
+    _, rtok = await _user(
+        db_session,
+        name="policy-reader",
+        permissions=[{"action": "read", "resource_type": "change_request"}],
+    )
+    r = await client.get("/api/v1/change-requests/policies", headers=_auth(rtok))
+    assert r.status_code == 403, r.text
+
+
+@pytest.mark.asyncio
+async def test_policies_list_ok_for_superadmin(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A superadmin can still read the policy list (#2)."""
+    await _enable_module(db_session)
+    _, stok = await _user(db_session, name="policy-super", superadmin=True)
+    r = await client.get("/api/v1/change-requests/policies", headers=_auth(stok))
+    assert r.status_code == 200, r.text
+
+
+# ── #3b: approve refuses with 409 when the blast radius drifted ────────────────
+
+
+@pytest.mark.asyncio
+async def test_approve_refuses_on_scope_drift(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#3: a permanent+force delete request whose subnet GREW IP rows between
+    submit and approve has a changed preview blast radius → approve refuses
+    (409 scope drift); the row stays pending and the subnet survives.
+
+    force=true keeps the op preview ``ok`` (it skips the non-empty check), so
+    the refusal is driven purely by the blast-radius drift compare, not the
+    pre-existing non-empty stale check."""
+    from app.models.change_request import ApprovalPolicy
+
+    await _enable_module(db_session)
+    db_session.add(
+        ApprovalPolicy(
+            name="delete:subnet",
+            resource_type="subnet",
+            action="delete",
+            min_count=None,
+            enabled=True,
+            applies_to_superadmin=True,
+            ttl_hours=168,
+            is_builtin=True,
+        )
+    )
+    await db_session.flush()
+
+    subnet = await _subnet(db_session, "10.24.1.0/24")
+    _, rtok = await _user(db_session, name="drift-requester", superadmin=True)
+    _, atok = await _user(db_session, name="drift-approver", superadmin=True)
+
+    # Submit a permanent+force delete while the subnet is empty.
+    r = await client.delete(
+        f"/api/v1/ipam/subnets/{subnet.id}?permanent=true&force=true", headers=_auth(rtok)
+    )
+    assert r.status_code == 202, r.text
+    cr_id = r.json()["change_request_id"]
+    frozen = (await db_session.get(ChangeRequest, uuid.UUID(cr_id))).preview_text
+
+    # Blast radius grows: add IP rows after submission.
+    for i in range(3):
+        db_session.add(
+            IPAddress(subnet_id=subnet.id, address=f"10.24.1.{10 + i}", status="allocated")
+        )
+    await db_session.flush()
+    await db_session.commit()
+
+    r2 = await client.post(f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(atok), json={})
+    assert r2.status_code == 409, r2.text
+    assert "scope changed" in r2.json()["detail"].lower()
+
+    # Left pending; subnet untouched; frozen preview unchanged.
+    cr = await db_session.get(ChangeRequest, uuid.UUID(cr_id))
+    assert cr is not None and cr.state == "pending"
+    assert cr.preview_text == frozen
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is None
+
+
+# ── #4: import-time assert rejects a non-gateable risky op ─────────────────────
+
+
+def test_gate_import_assert_rejects_non_gateable_pair() -> None:
+    """#4: the gate's import-time assert fails loudly when a registered risky
+    op declares a (action, resource_type) outside the gateable sets — such an
+    op would pass a 'permission exists' check but match_policy could never gate
+    it (fail-open). Simulate by monkeypatching the registry's view."""
+    from app.services.approvals import gate
+
+    real_get = gate.get_operation
+
+    class _FakeOp:
+        required_permission = ("delete", "totally_not_gateable")
+
+    def _fake_get(name: str):
+        return _FakeOp()
+
+    gate.get_operation = _fake_get  # type: ignore[assignment]
+    try:
+        with pytest.raises(RuntimeError) as ei:
+            gate._assert_risky_ops_have_permission()
+        assert "non-gateable" in str(ei.value).lower()
+    finally:
+        gate.get_operation = real_get  # type: ignore[assignment]

--- a/backend/tests/test_approval_workflows_fixes.py
+++ b/backend/tests/test_approval_workflows_fixes.py
@@ -1,0 +1,377 @@
+"""Regression tests for the #62 code-review fixes (inline-fidelity contract).
+
+These pin the seven findings the review surfaced on top of the original
+two-person approval workflow (covered by ``test_approval_workflows.py``):
+
+* **#7 — ValueError→500.** A module-OFF DELETE of a *missing* subnet must
+  surface the original handler's ``404`` (the factored ``apply()`` used to
+  raise a bare ``ValueError`` → 500).
+* **#7/#17 — not-empty 409.** A module-OFF permanent DELETE of a *non-empty*
+  subnet without ``force`` must surface ``409`` (not 500), exactly like the
+  pre-#62 handler.
+* **#1 — no inline permission re-check.** A delegate admitted by the IPAM
+  router's coarse gate via a scoped ``{delete, address_set, <id>}`` grant
+  (#103) must be able to soft-delete inline WITHOUT the factored ``apply()``
+  403/500-ing on a permission re-check it shouldn't run.
+* **#8 — approve-path superadmin parity.** ``delete_zone`` / ``delete_scope``
+  / ``delete_group`` were fully ``SuperAdmin``-gated at the route, so their
+  ``apply()`` must require superadmin ALWAYS — the approve path (which
+  bypasses the route's dependency) relies on this.
+* **#5 — fail-closed on a deleted requester.** When ``requested_by_user_id``
+  is NULL (requester deleted), approval is REFUSED (409), not fail-open.
+* **#4 — non-gateable policy rejected.** Creating an approval policy with an
+  action that isn't wired to a registered risky op → ``422``.
+* **#10 — single-namespaced event type.** The ``change_request.approved``
+  event type derives once (no ``change_request.change_request.*``), and the
+  webhook catalog advertises the real lifecycle events.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import Group, Role, User
+from app.models.change_request import ChangeRequest
+from app.models.feature_module import FeatureModule
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services import feature_modules
+
+# ── Fixtures (mirrors test_approval_workflows.py) ──────────────────────────────
+
+
+async def _user(
+    db: AsyncSession,
+    *,
+    name: str,
+    permissions: list[dict] | None = None,
+    superadmin: bool = False,
+) -> tuple[User, str]:
+    user = User(
+        username=f"{name}-{uuid.uuid4().hex[:8]}",
+        email=f"{name}-{uuid.uuid4().hex[:8]}@t.io",
+        display_name=name,
+        hashed_password=hash_password("password123"),
+        is_superadmin=superadmin,
+    )
+    user.groups = []
+    if permissions:
+        role = Role(name=f"role-{uuid.uuid4().hex[:8]}", permissions=permissions)
+        group = Group(name=f"grp-{uuid.uuid4().hex[:8]}")
+        group.roles = [role]
+        user.groups = [group]
+        db.add_all([role, group])
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _subnet(db: AsyncSession, network: str = "10.9.5.0/24") -> Subnet:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.9.0.0/16", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=network, name="s")
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _enable_module(db: AsyncSession, *, enabled: bool = True) -> None:
+    existing = await db.get(FeatureModule, "governance.approvals")
+    if existing is None:
+        db.add(FeatureModule(id="governance.approvals", enabled=enabled))
+    else:
+        existing.enabled = enabled
+    await db.flush()
+    feature_modules.invalidate_cache()
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── #7: missing subnet → 404 (not 500) ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_module_off_delete_missing_subnet_404(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Module-OFF DELETE of a non-existent subnet surfaces 404, not a 500 from
+    a bare ValueError in the factored apply()."""
+    await _enable_module(db_session, enabled=False)
+    _, token = await _user(
+        db_session,
+        name="op",
+        permissions=[{"action": "delete", "resource_type": "subnet"}],
+    )
+    r = await client.delete(f"/api/v1/ipam/subnets/{uuid.uuid4()}", headers=_auth(token))
+    assert r.status_code == 404, r.text
+
+
+# ── #7/#17: non-empty permanent delete without force → 409 ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_module_off_delete_nonempty_permanent_409(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Module-OFF permanent DELETE of a non-empty subnet without force surfaces
+    409 (the inline handler's not-empty conflict), not a 500."""
+    await _enable_module(db_session, enabled=False)
+    subnet = await _subnet(db_session)
+    db_session.add(IPAddress(subnet_id=subnet.id, address="10.9.5.42", status="allocated"))
+    await db_session.flush()
+    # Permanent path requires superadmin; use one so we exercise the 409 branch.
+    _, token = await _user(db_session, name="sa", superadmin=True)
+
+    r = await client.delete(
+        f"/api/v1/ipam/subnets/{subnet.id}?permanent=true", headers=_auth(token)
+    )
+    assert r.status_code == 409, r.text
+    assert "not empty" in r.json()["detail"].lower()
+    # Untouched.
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is None
+
+
+# ── #1: scoped address-set delegate deletes inline without a perm re-check ─────
+
+
+@pytest.mark.asyncio
+async def test_scoped_delegate_inline_delete_no_500(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A delegate the IPAM router gate admits via a scoped {delete,
+    address_set, <id>} grant (#103) can soft-delete inline — the factored
+    apply() must NOT run enforce_operation_permission (which would 403/500 a
+    delegate lacking the type-level {delete, subnet})."""
+    await _enable_module(db_session, enabled=False)
+    subnet = await _subnet(db_session)
+    # ONLY an instance-scoped address_set delete grant — no {delete, subnet}.
+    _, token = await _user(
+        db_session,
+        name="delegate",
+        permissions=[
+            {
+                "action": "delete",
+                "resource_type": "address_set",
+                "resource_id": str(uuid.uuid4()),
+            }
+        ],
+    )
+
+    r = await client.delete(f"/api/v1/ipam/subnets/{subnet.id}", headers=_auth(token))
+    # Must not 500 (perm re-check) and must not 403 — the coarse gate admitted
+    # the delegate and the inline soft-delete runs.
+    assert r.status_code == 204, r.text
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is not None
+
+
+# ── #8: apply() requires superadmin ALWAYS for zone / scope / group ────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_zone_apply_requires_superadmin(db_session: AsyncSession) -> None:
+    """delete_zone.apply() raises 403 for a non-superadmin — the route was
+    fully SuperAdmin-gated, so the approve path (which bypasses the route's
+    SuperAdmin dependency) must enforce it inside apply() (#8). The superadmin
+    check runs before the zone lookup, so random ids suffice."""
+    from fastapi import HTTPException
+
+    from app.services.ai.operations_risky import DeleteZoneArgs, _apply_delete_zone
+
+    nonadmin, _ = await _user(
+        db_session,
+        name="zone-editor",
+        permissions=[{"action": "delete", "resource_type": "dns_zone"}],
+    )
+    args = DeleteZoneArgs(group_id=uuid.uuid4(), zone_id=uuid.uuid4(), permanent=False)
+    with pytest.raises(HTTPException) as ei:
+        await _apply_delete_zone(db_session, nonadmin, args)
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_scope_apply_requires_superadmin(db_session: AsyncSession) -> None:
+    """delete_scope.apply() requires superadmin always (#8)."""
+    from fastapi import HTTPException
+
+    from app.services.ai.operations_risky import DeleteScopeArgs, _apply_delete_scope
+
+    nonadmin, _ = await _user(
+        db_session,
+        name="scope-editor",
+        permissions=[{"action": "delete", "resource_type": "dhcp_scope"}],
+    )
+    # Missing scope would 404 — but superadmin is checked first, so a
+    # non-superadmin gets 403 before the lookup.
+    args = DeleteScopeArgs(scope_id=uuid.uuid4(), permanent=False)
+    with pytest.raises(HTTPException) as ei:
+        await _apply_delete_scope(db_session, nonadmin, args)
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_group_apply_requires_superadmin(db_session: AsyncSession) -> None:
+    """delete_group.apply() requires superadmin always (#8)."""
+    from fastapi import HTTPException
+
+    from app.services.ai.operations_risky import DeleteGroupArgs, _apply_delete_group
+
+    nonadmin, _ = await _user(
+        db_session,
+        name="group-editor",
+        permissions=[{"action": "delete", "resource_type": "dhcp_server_group"}],
+    )
+    args = DeleteGroupArgs(group_id=uuid.uuid4())
+    with pytest.raises(HTTPException) as ei:
+        await _apply_delete_group(db_session, nonadmin, args)
+    assert ei.value.status_code == 403
+
+
+# ── #5: approval refused when the requester was deleted (requested_by NULL) ────
+
+
+@pytest.mark.asyncio
+async def test_approve_refused_when_requester_deleted(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A pending request whose requested_by_user_id is NULL (requester deleted)
+    is refused on approve (409) — fail CLOSED, not fail open."""
+    await _enable_module(db_session)
+    subnet = await _subnet(db_session)
+    cr = ChangeRequest(
+        operation="delete_subnet",
+        resource_type="subnet",
+        resource_id=str(subnet.id),
+        resource_display="s",
+        args={"subnet_id": str(subnet.id), "force": False, "permanent": False},
+        preview_text="Soft-delete subnet",
+        risk_reason="delete:subnet",
+        state="pending",
+        requested_by_user_id=None,  # requester deleted → SET NULL
+        requested_by_display="gone",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    db_session.add(cr)
+    await db_session.flush()
+    await db_session.commit()
+
+    _, atoken = await _user(
+        db_session,
+        name="approver",
+        permissions=[
+            {"action": "approve", "resource_type": "change_request"},
+            {"action": "read", "resource_type": "change_request"},
+            {"action": "delete", "resource_type": "subnet"},
+        ],
+    )
+    r = await client.post(
+        f"/api/v1/change-requests/{cr.id}/approve", headers=_auth(atoken), json={}
+    )
+    assert r.status_code == 409, r.text
+    assert "no longer exists" in r.json()["detail"].lower()
+
+    refreshed = await db_session.get(ChangeRequest, cr.id)
+    assert refreshed is not None and refreshed.state == "pending"
+    await db_session.refresh(subnet)
+    assert subnet.deleted_at is None
+
+
+# ── #4: policy create with a non-gateable action → 422 ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_policy_create_nongateable_action_422(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An approval policy for an action that isn't wired to a registered risky
+    op (e.g. bulk_delete in P1) is rejected 422 — no enabled-but-inert rules."""
+    await _enable_module(db_session)
+    _, token = await _user(db_session, name="super", superadmin=True)
+
+    r = await client.post(
+        "/api/v1/change-requests/policies",
+        headers=_auth(token),
+        json={
+            "name": "Bulk delete",
+            "resource_type": "subnet",
+            "action": "bulk_delete",
+            "enabled": True,
+        },
+    )
+    assert r.status_code == 422, r.text
+    assert "not gateable" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_policy_create_nongateable_resource_type_422(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A delete policy against a non-gateable resource_type (e.g. the '*'
+    wildcard, P2 only) is rejected 422."""
+    await _enable_module(db_session)
+    _, token = await _user(db_session, name="super2", superadmin=True)
+
+    r = await client.post(
+        "/api/v1/change-requests/policies",
+        headers=_auth(token),
+        json={"name": "Wildcard delete", "resource_type": "*", "action": "delete"},
+    )
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_policy_create_gateable_ok(client: AsyncClient, db_session: AsyncSession) -> None:
+    """A delete:subnet policy (gateable) is accepted (201) — the validator
+    rejects only the un-wired surface."""
+    await _enable_module(db_session)
+    _, token = await _user(db_session, name="super3", superadmin=True)
+
+    r = await client.post(
+        "/api/v1/change-requests/policies",
+        headers=_auth(token),
+        json={"name": "Delete subnet (custom)", "resource_type": "subnet", "action": "delete"},
+    )
+    assert r.status_code == 201, r.text
+
+
+# ── #10: event type single-namespaced + catalog advertises lifecycle ──────────
+
+
+def test_change_request_event_type_single_namespaced() -> None:
+    """change_request.approved derives once — no change_request.change_request.*
+    doubling — and the webhook catalog advertises the real lifecycle events,
+    not the never-fired created/updated/deleted trio."""
+    from app.services.event_publisher import (
+        _RESOURCE_NAMESPACE,
+        _SPECIAL_EVENT_MAP,
+        _VERB_MAP,
+        _audit_to_event_type,
+    )
+
+    for verb in ("requested", "approved", "rejected", "cancelled", "executed", "failed", "expired"):
+        assert _audit_to_event_type(verb, "change_request") == f"change_request.{verb}"
+
+    # Reproduce the catalog enumeration (webhooks router) and assert shape.
+    catalog: set[str] = set()
+    for ns in set(_RESOURCE_NAMESPACE.values()):
+        for v in _VERB_MAP.values():
+            catalog.add(f"{ns}.{v}")
+    catalog.update(_SPECIAL_EVENT_MAP.values())
+
+    assert not any("change_request.change_request" in t for t in catalog)
+    assert "change_request.approved" in catalog
+    assert "change_request.requested" in catalog
+    assert "change_request.created" not in catalog
+    assert "change_request.deleted" not in catalog

--- a/backend/tests/test_approvals_lock.py
+++ b/backend/tests/test_approvals_lock.py
@@ -1,0 +1,415 @@
+"""Self-governance lock tests (#62).
+
+The lock (``PlatformSettings.approvals_protect_controls``, opt-in at
+enable time) makes WEAKENING the approval control plane require a SECOND
+superadmin's approval, with a superadmin break-glass escape hatch so the
+platform can never be permanently locked out.
+
+Covered:
+
+* flag-on → PATCH disable ``governance.approvals`` returns 202 + a pending
+  change_request; the module stays enabled.
+* a DIFFERENT superadmin approves → module disabled.
+* a non-superadmin holding ``{approve, change_request}`` CANNOT approve a
+  control op (403).
+* flag-on → disabling a policy / deleting a policy / lowering
+  applies_to_superadmin / unlocking each returns 202 (gated).
+* break-glass (superadmin + correct password + correct phrase) force-disables
+  immediately + writes the high-severity ``approvals.break_glass`` audit row;
+  wrong phrase → 422; wrong password → 403.
+* flag-off → every control op executes inline single-person, byte-identical
+  to today (no change_request row created).
+* enabling protection at enable time (``protect_controls=true`` with
+  ``enabled=true``) is single-person/inline + audited.
+
+Mirrors ``test_approval_workflows.py``'s shared-session fixture model — the
+``client`` + ``db_session`` fixtures share one session, so a fixture write
+is visible to the handler and a post-call read sees the handler's commit.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import Group, Role, User
+from app.models.change_request import ApprovalPolicy, ChangeRequest
+from app.models.feature_module import FeatureModule
+from app.models.settings import PlatformSettings
+from app.services import feature_modules
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+async def _user(
+    db: AsyncSession,
+    *,
+    name: str,
+    permissions: list[dict] | None = None,
+    superadmin: bool = False,
+    password: str = "password123",
+) -> tuple[User, str]:
+    user = User(
+        username=f"{name}-{uuid.uuid4().hex[:8]}",
+        email=f"{name}-{uuid.uuid4().hex[:8]}@t.io",
+        display_name=name,
+        hashed_password=hash_password(password),
+        is_superadmin=superadmin,
+    )
+    user.groups = []
+    if permissions:
+        role = Role(name=f"role-{uuid.uuid4().hex[:8]}", permissions=permissions)
+        group = Group(name=f"grp-{uuid.uuid4().hex[:8]}")
+        group.roles = [role]
+        user.groups = [group]
+        db.add_all([role, group])
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _enable_module(db: AsyncSession, *, enabled: bool = True) -> None:
+    existing = await db.get(FeatureModule, "governance.approvals")
+    if existing is None:
+        db.add(FeatureModule(id="governance.approvals", enabled=enabled))
+    else:
+        existing.enabled = enabled
+    await db.flush()
+    feature_modules.invalidate_cache()
+
+
+async def _settings(db: AsyncSession) -> PlatformSettings:
+    ps = await db.get(PlatformSettings, 1)
+    if ps is None:
+        ps = PlatformSettings(id=1)
+        db.add(ps)
+        await db.flush()
+    return ps
+
+
+async def _set_lock(db: AsyncSession, *, on: bool) -> None:
+    ps = await _settings(db)
+    ps.approvals_protect_controls = on
+    await db.flush()
+
+
+async def _policy(
+    db: AsyncSession,
+    *,
+    enabled: bool = True,
+    applies_to_superadmin: bool = True,
+    is_builtin: bool = False,
+    name: str | None = None,
+) -> ApprovalPolicy:
+    p = ApprovalPolicy(
+        name=name or f"pol-{uuid.uuid4().hex[:6]}",
+        resource_type="subnet",
+        action="delete",
+        min_count=None,
+        enabled=enabled,
+        applies_to_superadmin=applies_to_superadmin,
+        ttl_hours=168,
+        is_builtin=is_builtin,
+    )
+    db.add(p)
+    await db.flush()
+    return p
+
+
+# ── flag-on: disable module → 202, second superadmin approves → disabled ─────
+
+
+@pytest.mark.asyncio
+async def test_locked_disable_module_queues_then_approved(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    _, tb = await _user(db_session, name="super-b", superadmin=True)
+    await db_session.commit()
+
+    # Disable attempt is gated → 202 + pending CR; module still enabled.
+    r = await client.patch(
+        "/api/v1/admin/feature-modules/governance.approvals",
+        headers=_auth(ta),
+        json={"enabled": False},
+    )
+    assert r.status_code == 202, r.text
+    cr_id = r.json()["change_request_id"]
+    assert r.json()["state"] == "pending"
+    assert await feature_modules.is_module_enabled(db_session, "governance.approvals")
+
+    cr = await db_session.get(ChangeRequest, uuid.UUID(cr_id))
+    assert cr is not None and cr.operation == "modify_approval_control"
+
+    # A DIFFERENT superadmin approves → module disabled.
+    r2 = await client.post(f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(tb), json={})
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["state"] == "executed"
+    feature_modules.invalidate_cache()
+    assert not await feature_modules.is_module_enabled(db_session, "governance.approvals")
+
+
+@pytest.mark.asyncio
+async def test_non_superadmin_cannot_approve_control_op(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A non-superadmin holding {approve, change_request} + {admin,
+    approval_control} still cannot approve a control op (403)."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    _, approver_t = await _user(
+        db_session,
+        name="approver",
+        permissions=[
+            {"action": "approve", "resource_type": "change_request"},
+            {"action": "read", "resource_type": "change_request"},
+            {"action": "admin", "resource_type": "approval_control"},
+        ],
+    )
+    await db_session.commit()
+
+    cr_id = (
+        await client.patch(
+            "/api/v1/admin/feature-modules/governance.approvals",
+            headers=_auth(ta),
+            json={"enabled": False},
+        )
+    ).json()["change_request_id"]
+
+    r = await client.post(
+        f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(approver_t), json={}
+    )
+    assert r.status_code == 403, r.text
+    assert "superadmin" in r.json()["detail"].lower()
+    cr = await db_session.get(ChangeRequest, uuid.UUID(cr_id))
+    assert cr is not None and cr.state == "pending"
+
+
+# ── flag-on: weaken-policy + unlock all gated (202) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_locked_disable_policy_gated(client: AsyncClient, db_session: AsyncSession) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    p = await _policy(db_session, enabled=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.put(
+        f"/api/v1/change-requests/policies/{p.id}",
+        headers=_auth(ta),
+        json={"enabled": False},
+    )
+    assert r.status_code == 202, r.text
+    assert r.json()["state"] == "pending"
+    await db_session.refresh(p)
+    assert p.enabled is True  # not weakened inline
+
+
+@pytest.mark.asyncio
+async def test_locked_delete_policy_gated(client: AsyncClient, db_session: AsyncSession) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    p = await _policy(db_session, is_builtin=False)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.delete(f"/api/v1/change-requests/policies/{p.id}", headers=_auth(ta))
+    assert r.status_code == 202, r.text
+    assert r.json()["state"] == "pending"
+    assert await db_session.get(ApprovalPolicy, p.id) is not None  # not deleted inline
+
+
+@pytest.mark.asyncio
+async def test_locked_lower_superadmin_gate_gated(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    p = await _policy(db_session, applies_to_superadmin=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.put(
+        f"/api/v1/change-requests/policies/{p.id}",
+        headers=_auth(ta),
+        json={"applies_to_superadmin": False},
+    )
+    assert r.status_code == 202, r.text
+    await db_session.refresh(p)
+    assert p.applies_to_superadmin is True
+
+
+@pytest.mark.asyncio
+async def test_locked_unlock_gated(client: AsyncClient, db_session: AsyncSession) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/admin/feature-modules/approvals-lock",
+        headers=_auth(ta),
+        json={"enabled": False},
+    )
+    assert r.status_code == 202, r.text
+    assert r.json()["state"] == "pending"
+    ps = await db_session.get(PlatformSettings, 1)
+    assert ps is not None and ps.approvals_protect_controls is True  # still locked
+
+
+# ── break-glass ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_break_glass_force_disables(client: AsyncClient, db_session: AsyncSession) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True, password="hunter2!")
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/admin/feature-modules/break-glass",
+        headers=_auth(ta),
+        json={"kind": "disable_module", "password": "hunter2!", "confirm_phrase": "BREAK GLASS"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["forced"] is True
+    feature_modules.invalidate_cache()
+    assert not await feature_modules.is_module_enabled(db_session, "governance.approvals")
+
+    # High-severity break-glass audit row landed.
+    n = (
+        await db_session.execute(
+            select(func.count(AuditLog.id)).where(
+                AuditLog.action == "approvals.break_glass",
+                AuditLog.resource_type == "approval_control",
+                AuditLog.result == "success",
+            )
+        )
+    ).scalar_one()
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_break_glass_wrong_phrase_422(client: AsyncClient, db_session: AsyncSession) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True, password="hunter2!")
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/admin/feature-modules/break-glass",
+        headers=_auth(ta),
+        json={"kind": "disable_module", "password": "hunter2!", "confirm_phrase": "nope"},
+    )
+    assert r.status_code == 422, r.text
+    assert await feature_modules.is_module_enabled(db_session, "governance.approvals")
+
+
+@pytest.mark.asyncio
+async def test_break_glass_wrong_password_403(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True, password="hunter2!")
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/admin/feature-modules/break-glass",
+        headers=_auth(ta),
+        json={"kind": "disable_module", "password": "WRONG", "confirm_phrase": "BREAK GLASS"},
+    )
+    assert r.status_code == 403, r.text
+    assert await feature_modules.is_module_enabled(db_session, "governance.approvals")
+
+
+# ── flag-off: every control op inline single-person, no CR row ───────────────
+
+
+@pytest.mark.asyncio
+async def test_flag_off_disable_module_inline(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=False)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.patch(
+        "/api/v1/admin/feature-modules/governance.approvals",
+        headers=_auth(ta),
+        json={"enabled": False},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["enabled"] is False
+    n_cr = (await db_session.execute(select(func.count(ChangeRequest.id)))).scalar_one()
+    assert n_cr == 0
+
+
+@pytest.mark.asyncio
+async def test_flag_off_delete_policy_inline(client: AsyncClient, db_session: AsyncSession) -> None:
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=False)
+    p = await _policy(db_session, is_builtin=False)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.delete(f"/api/v1/change-requests/policies/{p.id}", headers=_auth(ta))
+    assert r.status_code == 204, r.text
+    assert await db_session.get(ApprovalPolicy, p.id) is None
+    n_cr = (await db_session.execute(select(func.count(ChangeRequest.id)))).scalar_one()
+    assert n_cr == 0
+
+
+# ── set-at-enable-time is single-person inline + audited ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enable_with_protect_controls_inline(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # Start disabled + unlocked.
+    await _enable_module(db_session, enabled=False)
+    await _set_lock(db_session, on=False)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.patch(
+        "/api/v1/admin/feature-modules/governance.approvals",
+        headers=_auth(ta),
+        json={"enabled": True, "protect_controls": True},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["enabled"] is True
+
+    ps = await db_session.get(PlatformSettings, 1)
+    assert ps is not None and ps.approvals_protect_controls is True
+    # No change_request — strengthening stays single-person.
+    n_cr = (await db_session.execute(select(func.count(ChangeRequest.id)))).scalar_one()
+    assert n_cr == 0
+    # Lock-set audit row written.
+    n = (
+        await db_session.execute(
+            select(func.count(AuditLog.id)).where(
+                AuditLog.resource_type == "platform_settings",
+                AuditLog.resource_id == "approvals_protect_controls",
+            )
+        )
+    ).scalar_one()
+    assert n == 1

--- a/backend/tests/test_approvals_lock.py
+++ b/backend/tests/test_approvals_lock.py
@@ -413,3 +413,397 @@ async def test_enable_with_protect_controls_inline(
         )
     ).scalar_one()
     assert n == 1
+
+
+# ── #1: enabling the lock when NO PlatformSettings row exists persists it ─────
+
+
+@pytest.mark.asyncio
+async def test_enable_lock_with_no_settings_row_persists_then_gates(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#1 CRITICAL regression: turning the lock ON via the dedicated endpoint
+    on a DB that has NO ``PlatformSettings(1)`` row must CREATE the row and
+    persist ``approvals_protect_controls=True`` (previously the write was
+    silently skipped + the API reported the lock ON while it read OFF, so every
+    weakening op ran ungated). Then prove a weakening op is actually gated."""
+    await _enable_module(db_session)
+    # Ensure there is genuinely no settings row.
+    existing = await db_session.get(PlatformSettings, 1)
+    if existing is not None:
+        await db_session.delete(existing)
+        await db_session.flush()
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+    assert await db_session.get(PlatformSettings, 1) is None
+
+    r = await client.post(
+        "/api/v1/admin/feature-modules/approvals-lock",
+        headers=_auth(ta),
+        json={"enabled": True},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["approvals_protect_controls"] is True
+
+    # The row now exists AND the flag actually persisted.
+    ps = await db_session.get(PlatformSettings, 1)
+    assert ps is not None and ps.approvals_protect_controls is True
+
+    # And a weakening op is now genuinely gated (proves the lock READS on).
+    r2 = await client.patch(
+        "/api/v1/admin/feature-modules/governance.approvals",
+        headers=_auth(ta),
+        json={"enabled": False},
+    )
+    assert r2.status_code == 202, r2.text
+    assert await feature_modules.is_module_enabled(db_session, "governance.approvals")
+
+
+@pytest.mark.asyncio
+async def test_enable_at_enable_time_with_no_settings_row_persists(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#1 companion: the set-at-enable-time path (PATCH enabled=true +
+    protect_controls=true) must also get-or-create the settings row."""
+    await _enable_module(db_session, enabled=False)
+    existing = await db_session.get(PlatformSettings, 1)
+    if existing is not None:
+        await db_session.delete(existing)
+        await db_session.flush()
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+    assert await db_session.get(PlatformSettings, 1) is None
+
+    r = await client.patch(
+        "/api/v1/admin/feature-modules/governance.approvals",
+        headers=_auth(ta),
+        json={"enabled": True, "protect_controls": True},
+    )
+    assert r.status_code == 200, r.text
+    ps = await db_session.get(PlatformSettings, 1)
+    assert ps is not None and ps.approvals_protect_controls is True
+
+
+# ── #2: coverage-reducing policy edits are gated (side-door closed) ───────────
+
+
+@pytest.mark.asyncio
+async def test_locked_repoint_resource_type_gated(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#2 CRITICAL regression: while locked, a PUT that repoints
+    ``resource_type`` to a different (non-matching) pair while keeping
+    enabled=true is a COVERAGE-REDUCING edit and must be gated (202), not run
+    inline. Previously this was the side-door to neuter a live-looking policy."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    # Start on a gateable pair; repoint to another gateable pair so
+    # _validate_gateable passes and only the coverage-reduction gating fires.
+    p = await _policy(db_session, enabled=True)  # subnet/delete
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.put(
+        f"/api/v1/change-requests/policies/{p.id}",
+        headers=_auth(ta),
+        json={"resource_type": "dns_zone"},
+    )
+    assert r.status_code == 202, r.text
+    assert r.json()["state"] == "pending"
+    await db_session.refresh(p)
+    assert p.resource_type == "subnet"  # not repointed inline
+
+
+@pytest.mark.asyncio
+async def test_locked_inflate_min_count_gated(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#2: while locked, raising ``min_count`` (gates fewer ops) is gated."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    p = await _policy(db_session, enabled=True)
+    p.min_count = 5
+    await db_session.flush()
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.put(
+        f"/api/v1/change-requests/policies/{p.id}",
+        headers=_auth(ta),
+        json={"min_count": 500},
+    )
+    assert r.status_code == 202, r.text
+    await db_session.refresh(p)
+    assert p.min_count == 5  # not inflated inline
+
+
+@pytest.mark.asyncio
+async def test_locked_min_count_null_to_value_gated(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#2: while locked, setting ``min_count`` NULL→value (NULL = always-gate =
+    strongest) is coverage-reducing and gated."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    p = await _policy(db_session, enabled=True)  # min_count starts None
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.put(
+        f"/api/v1/change-requests/policies/{p.id}",
+        headers=_auth(ta),
+        json={"min_count": 10},
+    )
+    assert r.status_code == 202, r.text
+    await db_session.refresh(p)
+    assert p.min_count is None  # not weakened inline
+
+
+@pytest.mark.asyncio
+async def test_locked_strengthening_edit_stays_inline(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#2 negative: a STRENGTHENING / neutral edit (lower min_count, rename)
+    while locked stays inline (200) — only coverage-reducing edits gate."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    p = await _policy(db_session, enabled=True)
+    p.min_count = 100
+    await db_session.flush()
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.put(
+        f"/api/v1/change-requests/policies/{p.id}",
+        headers=_auth(ta),
+        json={"min_count": 5, "name": "tighter"},
+    )
+    assert r.status_code == 200, r.text
+    await db_session.refresh(p)
+    assert p.min_count == 5 and p.name == "tighter"
+    n_cr = (await db_session.execute(select(func.count(ChangeRequest.id)))).scalar_one()
+    assert n_cr == 0
+
+
+@pytest.mark.asyncio
+async def test_repoint_resource_type_replays_on_approve(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#2: the gated repoint edit, once approved by a SECOND superadmin, REPLAYS
+    the exact edit under the approver."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    p = await _policy(db_session, enabled=True)  # subnet/delete
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    _, tb = await _user(db_session, name="super-b", superadmin=True)
+    await db_session.commit()
+
+    cr_id = (
+        await client.put(
+            f"/api/v1/change-requests/policies/{p.id}",
+            headers=_auth(ta),
+            json={"resource_type": "dns_zone"},
+        )
+    ).json()["change_request_id"]
+
+    r = await client.post(f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(tb), json={})
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == "executed"
+    await db_session.refresh(p)
+    assert p.resource_type == "dns_zone"  # edit replayed
+
+
+@pytest.mark.asyncio
+async def test_min_count_over_bound_422(client: AsyncClient, db_session: AsyncSession) -> None:
+    """#2: ``min_count`` above the new upper bound is rejected at the schema
+    layer (422) — closes the 'inflate to astronomical so it gates nothing'
+    side-door before it can even reach the gating logic."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=False)
+    p = await _policy(db_session, enabled=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    await db_session.commit()
+
+    r = await client.put(
+        f"/api/v1/change-requests/policies/{p.id}",
+        headers=_auth(ta),
+        json={"min_count": 2_000_000},
+    )
+    assert r.status_code == 422, r.text
+    # Create path bounded too.
+    r2 = await client.post(
+        "/api/v1/change-requests/policies",
+        headers=_auth(ta),
+        json={
+            "name": "x",
+            "resource_type": "subnet",
+            "action": "delete",
+            "min_count": 2_000_000,
+        },
+    )
+    assert r2.status_code == 422, r2.text
+
+
+# ── #3: break-glass result audit survives an apply() failure ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_break_glass_audit_survives_apply_failure(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#3 HIGH regression: a break-glass whose apply() raises after the
+    re-confirm + preview must STILL leave a durable result audit row (the
+    success audit is committed in its own txn BEFORE apply runs). Forces the
+    apply path to blow up (the disable_module apply calls set_module_enabled);
+    asserts the audit row landed and the exception surfaced."""
+    from app.services import feature_modules as fm_source
+
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True, password="hunter2!")
+    await db_session.commit()
+
+    # apply() does a LOCAL ``from app.services.feature_modules import
+    # set_module_enabled`` at call time, so patching the source-module attr
+    # forces the disable_module apply branch to raise AFTER the preview + the
+    # break-glass success audit was committed in its own txn.
+    async def _boom(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("simulated apply failure")
+
+    monkeypatch.setattr(fm_source, "set_module_enabled", _boom, raising=True)
+
+    with pytest.raises(Exception):  # noqa: B017 — the apply error propagates
+        await client.post(
+            "/api/v1/admin/feature-modules/break-glass",
+            headers=_auth(ta),
+            json={
+                "kind": "disable_module",
+                "password": "hunter2!",
+                "confirm_phrase": "BREAK GLASS",
+            },
+        )
+
+    # The HIGH-severity success audit is durable despite the apply failure.
+    n = (
+        await db_session.execute(
+            select(func.count(AuditLog.id)).where(
+                AuditLog.action == "approvals.break_glass",
+                AuditLog.resource_type == "approval_control",
+                AuditLog.result == "success",
+            )
+        )
+    ).scalar_one()
+    assert n == 1
+
+
+# ── #4 / #2: denied break-glass uses the lower-severity action string ─────────
+
+
+@pytest.mark.asyncio
+async def test_break_glass_bad_password_uses_denied_action(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#4: a post-auth validation failure (bad password) records the distinct
+    lower-severity ``approvals.break_glass_denied`` action, NOT the high-sev
+    success action — so SIEM rules keyed on the success action stay clean."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True, password="hunter2!")
+    await db_session.commit()
+
+    r = await client.post(
+        "/api/v1/admin/feature-modules/break-glass",
+        headers=_auth(ta),
+        json={"kind": "disable_module", "password": "WRONG", "confirm_phrase": "BREAK GLASS"},
+    )
+    assert r.status_code == 403, r.text
+    # No high-sev success/forbidden row under the success action…
+    n_success_action = (
+        await db_session.execute(
+            select(func.count(AuditLog.id)).where(
+                AuditLog.action == "approvals.break_glass",
+            )
+        )
+    ).scalar_one()
+    assert n_success_action == 0
+    # …but a denied-action row landed.
+    n_denied = (
+        await db_session.execute(
+            select(func.count(AuditLog.id)).where(
+                AuditLog.action == "approvals.break_glass_denied",
+                AuditLog.result == "forbidden",
+            )
+        )
+    ).scalar_one()
+    assert n_denied == 1
+
+
+# ── #5 / #6: concurrent break-glass leaves the queued CR resolvable ──────────
+
+
+@pytest.mark.asyncio
+async def test_premise_lost_resolves_cr_idempotent(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#6 regression: a queued control-op change_request whose gate premise
+    evaporated (the lock got turned off out of band, simulating a concurrent
+    break-glass unlock) resolves on approve as IDEMPOTENT EXECUTED — not stuck
+    pending / failed."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    _, tb = await _user(db_session, name="super-b", superadmin=True)
+    await db_session.commit()
+
+    # Queue a disable-module CR while locked.
+    cr_id = (
+        await client.patch(
+            "/api/v1/admin/feature-modules/governance.approvals",
+            headers=_auth(ta),
+            json={"enabled": False},
+        )
+    ).json()["change_request_id"]
+
+    # The lock gets turned off out of band (simulate a concurrent break-glass
+    # unlock). The premise for the queued CR is now gone.
+    await _set_lock(db_session, on=False)
+    await db_session.commit()
+
+    # A second superadmin approves → the CR resolves as idempotent executed,
+    # and the module is NOT silently disabled under the now-orphaned premise.
+    r = await client.post(f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(tb), json={})
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == "executed"
+    assert r.json()["result"].get("idempotent") is True
+    feature_modules.invalidate_cache()
+    assert await feature_modules.is_module_enabled(db_session, "governance.approvals")
+
+
+@pytest.mark.asyncio
+async def test_delete_policy_already_gone_resolves_idempotent(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#5 regression: a queued delete_policy CR whose target was deleted out of
+    band (e.g. a concurrent break-glass delete) resolves on approve as
+    idempotent executed rather than failing."""
+    await _enable_module(db_session)
+    await _set_lock(db_session, on=True)
+    p = await _policy(db_session, is_builtin=False)
+    _, ta = await _user(db_session, name="super-a", superadmin=True)
+    _, tb = await _user(db_session, name="super-b", superadmin=True)
+    await db_session.commit()
+
+    cr_id = (
+        await client.delete(f"/api/v1/change-requests/policies/{p.id}", headers=_auth(ta))
+    ).json()["change_request_id"]
+
+    # The policy vanishes out of band before approval.
+    target = await db_session.get(ApprovalPolicy, p.id)
+    assert target is not None
+    await db_session.delete(target)
+    await db_session.commit()
+
+    r = await client.post(f"/api/v1/change-requests/{cr_id}/approve", headers=_auth(tb), json={})
+    assert r.status_code == 200, r.text
+    assert r.json()["state"] == "executed"
+    assert r.json()["result"].get("idempotent") is True

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,6 +72,7 @@ import { CompliancePage } from "@/pages/admin/CompliancePage";
 import { ConformityPage } from "@/pages/admin/ConformityPage";
 import { TrashPage } from "@/pages/admin/TrashPage";
 import { WebhooksPage } from "@/pages/admin/WebhooksPage";
+import { ChangeRequestsPage } from "@/pages/admin/ChangeRequestsPage";
 import { PlatformInsightsPage } from "@/pages/admin/PlatformInsightsPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { useAuth } from "@/hooks/useAuth";
@@ -184,6 +185,7 @@ export default function App() {
         <Route path="admin/domains" element={<DomainsPage />} />
         <Route path="admin/domains/:id" element={<DomainDetailPage />} />
         <Route path="admin/webhooks" element={<WebhooksPage />} />
+        <Route path="admin/change-requests" element={<ChangeRequestsPage />} />
         <Route path="admin/compliance" element={<CompliancePage />} />
         <Route path="admin/conformity" element={<ConformityPage />} />
         <Route path="admin/trash" element={<TrashPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -51,6 +51,7 @@ import {
   BarChart3,
   Webhook,
   Workflow,
+  GitPullRequest,
   Monitor,
   ToggleLeft,
   Upload,
@@ -60,7 +61,7 @@ import {
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { versionApi } from "@/lib/api";
+import { changeRequestsApi, versionApi } from "@/lib/api";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { useSessionState } from "@/lib/useSessionState";
 import logoIcon from "@/assets/logo-icon.svg";
@@ -293,6 +294,12 @@ const adminConfigurationNav = [
 
 const adminNotificationsNav = [
   { label: "Alerts", icon: BellRing, to: "/admin/alerts" },
+  {
+    label: "Change Requests",
+    icon: GitPullRequest,
+    to: "/admin/change-requests",
+    module: "governance.approvals",
+  },
   { label: "Webhooks", icon: Webhook, to: "/admin/webhooks" },
 ];
 
@@ -411,6 +418,7 @@ function NavItem({
   collapsed,
   onNavigate,
   end,
+  badge,
 }: {
   label: string;
   icon: React.ElementType;
@@ -419,6 +427,9 @@ function NavItem({
   collapsed: boolean;
   onNavigate?: () => void;
   end?: boolean;
+  /** Optional count pill rendered after the label (e.g. the pending
+   *  approval-queue size). Only shown expanded when ``badge > 0``. */
+  badge?: number;
 }) {
   return (
     <NavLink
@@ -440,7 +451,12 @@ function NavItem({
       }
     >
       <Icon className="h-4 w-4 flex-shrink-0" />
-      {!collapsed && label}
+      {!collapsed && <span className="flex-1">{label}</span>}
+      {!collapsed && badge != null && badge > 0 && (
+        <span className="rounded-full bg-amber-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-amber-600 dark:text-amber-400">
+          {badge}
+        </span>
+      )}
     </NavLink>
   );
 }
@@ -540,6 +556,17 @@ export function Sidebar({
   const { enabled: moduleEnabled } = useFeatureModules();
   const filterByModule = <T extends { module?: string }>(items: T[]): T[] =>
     items.filter((it) => !it.module || moduleEnabled(it.module));
+
+  // Pending approval-queue count → the Change Requests nav badge. Only
+  // polls when the (default-off) governance.approvals module is on, so a
+  // disabled module fires zero requests.
+  const approvalsOn = moduleEnabled("governance.approvals");
+  const pendingChangeCount = useQuery({
+    queryKey: ["change-requests", "pending-count"],
+    queryFn: changeRequestsApi.countPending,
+    enabled: approvalsOn,
+    refetchInterval: 30000,
+  }).data;
 
   // Integrations live in their own sidebar section, rendered between
   // the main nav and the admin nav, but only when at least one
@@ -812,10 +839,15 @@ export function Sidebar({
               />
             ))}
             <SubNavLabel label="Notifications" collapsed={effectiveCollapsed} />
-            {adminNotificationsNav.map((item) => (
+            {filterByModule(adminNotificationsNav).map((item) => (
               <NavItem
                 key={item.to}
                 {...item}
+                badge={
+                  item.to === "/admin/change-requests"
+                    ? pendingChangeCount
+                    : undefined
+                }
                 collapsed={effectiveCollapsed}
                 onNavigate={mobileOpen ? onMobileClose : undefined}
               />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7901,6 +7901,144 @@ export const webhooksApi = {
       .then((r) => r.data),
 };
 
+// ── Change requests (two-person approval workflow, #62) ─────────────────────
+//
+// Gated behind the default-OFF ``governance.approvals`` feature module — the
+// whole router 404s when the module is disabled, so every covered mutation
+// executes inline exactly as before (the Sidebar nav entry carries the same
+// module gate so the page is hidden until an operator turns the feature on).
+
+export type ChangeRequestState =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "executed"
+  | "failed"
+  | "expired"
+  | "cancelled";
+
+export interface ChangeRequest {
+  id: string;
+  operation: string;
+  resource_type: string;
+  resource_id: string | null;
+  resource_display: string;
+  args: Record<string, unknown>;
+  preview_text: string;
+  risk_reason: string;
+  state: ChangeRequestState;
+  requested_by_user_id: string | null;
+  requested_by_display: string;
+  decided_by_user_id: string | null;
+  decided_by_display: string | null;
+  decision_note: string | null;
+  result: Record<string, unknown> | null;
+  error: string | null;
+  expires_at: string;
+  decided_at: string | null;
+  executed_at: string | null;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface ChangeRequestListParams {
+  state?: ChangeRequestState;
+  resource_type?: string;
+  mine?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+// Threshold actions an approval policy can gate (mirror the backend
+// ``APPROVAL_POLICY_ACTIONS`` frozenset).
+export const APPROVAL_POLICY_ACTIONS = [
+  "delete",
+  "bulk_delete",
+  "bulk_edit",
+  "bulk_allocate",
+  "factory_reset",
+  "import_commit",
+] as const;
+export type ApprovalPolicyAction = (typeof APPROVAL_POLICY_ACTIONS)[number];
+
+export interface ApprovalPolicy {
+  id: string;
+  name: string;
+  resource_type: string;
+  action: string;
+  min_count: number | null;
+  enabled: boolean;
+  applies_to_superadmin: boolean;
+  ttl_hours: number;
+  is_builtin: boolean;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface ApprovalPolicyWrite {
+  name: string;
+  resource_type: string;
+  action: string;
+  min_count?: number | null;
+  enabled: boolean;
+  applies_to_superadmin: boolean;
+  ttl_hours: number;
+}
+
+// The 202 envelope a covered mutation returns (instead of 204) when the
+// operation was queued for approval rather than executed inline.
+export interface ChangeRequestQueued {
+  change_request_id: string;
+  state: "pending";
+  preview_text: string;
+}
+
+export const changeRequestsApi = {
+  list: (params: ChangeRequestListParams = {}) =>
+    api
+      .get<ChangeRequest[]>("/change-requests", { params })
+      .then((r) => r.data),
+  get: (id: string) =>
+    api.get<ChangeRequest>(`/change-requests/${id}`).then((r) => r.data),
+  // No dedicated pending-count endpoint server-side — derive the badge from
+  // a state=pending list (cheap; the queue is small by construction).
+  countPending: () =>
+    api
+      .get<ChangeRequest[]>("/change-requests", {
+        params: { state: "pending", limit: 500 },
+      })
+      .then((r) => r.data.length),
+  approve: (id: string, decisionNote?: string) =>
+    api
+      .post<ChangeRequest>(`/change-requests/${id}/approve`, {
+        decision_note: decisionNote ?? null,
+      })
+      .then((r) => r.data),
+  reject: (id: string, decisionNote?: string) =>
+    api
+      .post<ChangeRequest>(`/change-requests/${id}/reject`, {
+        decision_note: decisionNote ?? null,
+      })
+      .then((r) => r.data),
+  cancel: (id: string, decisionNote?: string) =>
+    api
+      .post<ChangeRequest>(`/change-requests/${id}/cancel`, {
+        decision_note: decisionNote ?? null,
+      })
+      .then((r) => r.data),
+  listPolicies: () =>
+    api.get<ApprovalPolicy[]>("/change-requests/policies").then((r) => r.data),
+  createPolicy: (body: ApprovalPolicyWrite) =>
+    api
+      .post<ApprovalPolicy>("/change-requests/policies", body)
+      .then((r) => r.data),
+  updatePolicy: (id: string, body: ApprovalPolicyWrite) =>
+    api
+      .put<ApprovalPolicy>(`/change-requests/policies/${id}`, body)
+      .then((r) => r.data),
+  deletePolicy: (id: string) => api.delete(`/change-requests/policies/${id}`),
+};
+
 export type MetricsWindow = "1h" | "6h" | "24h" | "7d";
 
 export interface DNSMetricsPoint {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2324,12 +2324,64 @@ export interface FeatureModuleEntry {
   enabled: boolean;
 }
 
+// #62 break-glass: force a weakening control change immediately (the 5 kinds
+// the backend ``ModifyApprovalControlArgs.kind`` accepts).
+export type ApprovalControlKind =
+  | "disable_module"
+  | "disable_policy"
+  | "delete_policy"
+  | "lower_superadmin_gate"
+  | "unlock";
+
+export interface BreakGlassBody {
+  kind: ApprovalControlKind;
+  policy_id?: string | null;
+  password?: string | null;
+  totp_code?: string | null;
+  confirm_phrase: string;
+}
+
 export const featureModulesApi = {
   list: () =>
     api.get<FeatureModuleEntry[]>("/admin/feature-modules").then((r) => r.data),
-  toggle: (id: string, enabled: boolean) =>
+  // Toggle a module. Returns the FULL axios response (no trailing
+  // ``.then(r => r.data)``) so the #62 self-governance lock's 202
+  // approval-queue envelope is observable: disabling ``governance.approvals``
+  // while the lock is on returns 202 + a ``ChangeRequestQueued`` body instead
+  // of the FeatureModuleEntry. Callers route the response through
+  // ``handleApprovalQueued`` (``@/lib/approvalQueue``) and read ``.data`` for
+  // the inline 200 case. ``protectControls`` is only honoured by the backend
+  // when enabling ``governance.approvals`` (strengthening → single-person).
+  toggle: (id: string, enabled: boolean, protectControls?: boolean) =>
+    api.patch<FeatureModuleEntry | ChangeRequestQueued>(
+      `/admin/feature-modules/${id}`,
+      { enabled, protect_controls: protectControls },
+    ),
+  // #62 self-governance lock state. ON ⇒ disabling/weakening the approval
+  // control requires a second superadmin (or break-glass).
+  getApprovalsLock: () =>
     api
-      .patch<FeatureModuleEntry>(`/admin/feature-modules/${id}`, { enabled })
+      .get<{
+        approvals_protect_controls: boolean;
+      }>("/admin/feature-modules/approvals-lock")
+      .then((r) => r.data),
+  // Turn the lock on (strengthen → inline 200) or off (weaken → 202 gated
+  // when currently on). Full response so the 202 envelope is observable.
+  setApprovalsLock: (enabled: boolean) =>
+    api.post<{ approvals_protect_controls: boolean } | ChangeRequestQueued>(
+      "/admin/feature-modules/approvals-lock",
+      { enabled },
+    ),
+  // #62 break-glass — force a protected control change IMMEDIATELY, bypassing
+  // the two-person gate. Superadmin-only; the backend re-confirms password /
+  // TOTP + the typed phrase, writes a HIGH-severity audit row, and fires the
+  // ``governance.break_glass`` event.
+  breakGlass: (body: BreakGlassBody) =>
+    api
+      .post<{
+        forced: boolean;
+        kind: string;
+      }>("/admin/feature-modules/break-glass", body)
       .then((r) => r.data),
 };
 
@@ -8053,11 +8105,19 @@ export const changeRequestsApi = {
     api
       .post<ApprovalPolicy>("/change-requests/policies", body)
       .then((r) => r.data),
+  // #62 self-governance lock: WEAKENING a policy (disable enabled→false, lower
+  // applies_to_superadmin true→false, or delete) returns **202** with a
+  // ``ChangeRequestQueued`` body when the lock is on instead of mutating
+  // inline. Return the FULL axios response so callers can route it through
+  // ``handleApprovalQueued``; strengthening edits + lock-off return the
+  // 200/204 inline path. (See featureModulesApi.toggle for the same shape.)
   updatePolicy: (id: string, body: ApprovalPolicyWrite) =>
-    api
-      .put<ApprovalPolicy>(`/change-requests/policies/${id}`, body)
-      .then((r) => r.data),
-  deletePolicy: (id: string) => api.delete(`/change-requests/policies/${id}`),
+    api.put<ApprovalPolicy | ChangeRequestQueued>(
+      `/change-requests/policies/${id}`,
+      body,
+    ),
+  deletePolicy: (id: string) =>
+    api.delete<ChangeRequestQueued | "">(`/change-requests/policies/${id}`),
 };
 
 export type MetricsWindow = "1h" | "6h" | "24h" | "7d";

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1254,6 +1254,13 @@ export const ipamApi = {
     api.post<IPSpace>("/ipam/spaces", data).then((r) => r.data),
   updateSpace: (id: string, data: Partial<IPSpace>) =>
     api.put<IPSpace>(`/ipam/spaces/${id}`, data).then((r) => r.data),
+  // #62 two-person approval: when the ``governance.approvals`` module is on
+  // and a policy matches, this returns **202** with a ``ChangeRequestQueued``
+  // body (queued, NOT deleted) instead of 204. Returns the FULL axios
+  // response on purpose — do NOT chain ``.then((r) => r.data)`` here or the
+  // 202 status is invisible. Callers pass the response to
+  // ``handleApprovalQueued`` (``@/lib/approvalQueue``); see deleteBlock /
+  // deleteSubnet below + dnsApi/dhcpApi delete methods.
   deleteSpace: (id: string) => api.delete(`/ipam/spaces/${id}`),
 
   listBlocks: (spaceId?: string) =>
@@ -1287,6 +1294,8 @@ export const ipamApi = {
       >
     >,
   ) => api.put<IPBlock>(`/ipam/blocks/${id}`, data).then((r) => r.data),
+  // #62: returns the full axios response (may be 202 queued-for-approval —
+  // see deleteSpace). Do NOT add ``.then((r) => r.data)``.
   deleteBlock: (id: string) => api.delete(`/ipam/blocks/${id}`),
   availableSubnets: (blockId: string, prefixLen: number) =>
     api
@@ -1451,6 +1460,8 @@ export const ipamApi = {
   // explicit ("…and all IP address records will be permanently
   // deleted") so they pass force=true; the bare-id callable shape is
   // kept for any future "soft" call site.
+  // #62: returns the full axios response (may be 202 queued-for-approval —
+  // see deleteSpace). Do NOT add ``.then((r) => r.data)``.
   deleteSubnet: (id: string, force: boolean = false) =>
     api.delete(`/ipam/subnets/${id}${force ? "?force=true" : ""}`),
 
@@ -4846,6 +4857,9 @@ export const dnsApi = {
     api.post<DNSServerGroup>("/dns/groups", data).then((r) => r.data),
   updateGroup: (id: string, data: Partial<DNSServerGroup>) =>
     api.put<DNSServerGroup>(`/dns/groups/${id}`, data).then((r) => r.data),
+  // #62: returns the full axios response (may be 202 queued-for-approval —
+  // see ipamApi.deleteSpace). Do NOT add ``.then((r) => r.data)`` or the
+  // 202 envelope is lost; callers pass it to ``handleApprovalQueued``.
   deleteGroup: (id: string) => api.delete(`/dns/groups/${id}`),
 
   // Servers
@@ -5045,6 +5059,8 @@ export const dnsApi = {
     api
       .put<DNSZone>(`/dns/groups/${groupId}/zones/${zoneId}`, data)
       .then((r) => r.data),
+  // #62: returns the full axios response (may be 202 queued-for-approval —
+  // see ipamApi.deleteSpace). Do NOT add ``.then((r) => r.data)``.
   deleteZone: (groupId: string, zoneId: string) =>
     api.delete(`/dns/groups/${groupId}/zones/${zoneId}`),
   getZoneServerState: (groupId: string, zoneId: string) =>
@@ -6362,6 +6378,9 @@ export const dhcpApi = {
     api
       .put<DHCPServerGroup>(`/dhcp/server-groups/${id}`, data)
       .then((r) => r.data),
+  // #62: returns the full axios response (may be 202 queued-for-approval —
+  // see ipamApi.deleteSpace). Do NOT add ``.then((r) => r.data)`` or the
+  // 202 envelope is lost; callers pass it to ``handleApprovalQueued``.
   deleteGroup: (id: string) => api.delete(`/dhcp/server-groups/${id}`),
 
   listServers: (groupId?: string) =>
@@ -6462,6 +6481,8 @@ export const dhcpApi = {
       .then((r) => r.data),
   updateScope: (id: string, data: Partial<DHCPScope>) =>
     api.put<DHCPScope>(`/dhcp/scopes/${id}`, data).then((r) => r.data),
+  // #62: returns the full axios response (may be 202 queued-for-approval —
+  // see ipamApi.deleteSpace). Do NOT add ``.then((r) => r.data)``.
   deleteScope: (id: string) => api.delete(`/dhcp/scopes/${id}`),
 
   listPools: (scopeId: string) =>

--- a/frontend/src/lib/approvalQueue.ts
+++ b/frontend/src/lib/approvalQueue.ts
@@ -1,0 +1,67 @@
+import type { AxiosResponse } from "axios";
+
+import type { ChangeRequestQueued } from "@/lib/api";
+
+/**
+ * Detect the two-person approval queue envelope (#62).
+ *
+ * When the ``governance.approvals`` feature module is on and a policy
+ * matches, a covered risky mutation (delete / bulk / factory-reset)
+ * returns **202 Accepted** with a ``ChangeRequestQueued`` body instead
+ * of performing the change. The operation now sits in the approval queue
+ * waiting for a *second* eligible operator to approve it.
+ *
+ * Covered mutation hooks call this in their ``onSuccess`` and branch on a
+ * non-null return: show the toast string below instead of the usual
+ * "deleted" feedback, and invalidate the change-request queries so the
+ * Sidebar pending-count badge + the Change Requests page refresh.
+ *
+ * ```ts
+ * onSuccess: (resp) => {
+ *   const queued = handleApprovalQueued(resp);
+ *   if (queued) {
+ *     toast(APPROVAL_QUEUED_MESSAGE);
+ *     queryClient.invalidateQueries({ queryKey: ["change-requests"] });
+ *     return; // skip the normal post-delete invalidations
+ *   }
+ *   // ... normal success path ...
+ * }
+ * ```
+ *
+ * IMPORTANT for callers: the api-client method for a covered route must
+ * return the **full axios response** (i.e. ``api.delete(...)`` WITHOUT a
+ * trailing ``.then((r) => r.data)``) so the 202 status is observable.
+ * ``ipamApi.deleteSubnet`` / ``deleteBlock`` / ``deleteSpace`` already do.
+ *
+ * @returns the queued payload when the response was a 202 approval-queue
+ *   envelope, else ``null`` (the mutation executed inline as before).
+ */
+export function handleApprovalQueued(
+  resp: AxiosResponse<unknown> | unknown,
+): ChangeRequestQueued | null {
+  const r = resp as AxiosResponse<ChangeRequestQueued> | null | undefined;
+  if (
+    r &&
+    typeof r === "object" &&
+    "status" in r &&
+    r.status === 202 &&
+    r.data &&
+    typeof r.data === "object" &&
+    "change_request_id" in r.data
+  ) {
+    return r.data;
+  }
+  return null;
+}
+
+/** Operator-facing feedback when a mutation was queued for approval. */
+export const APPROVAL_QUEUED_MESSAGE =
+  "Submitted for approval — awaiting a second operator.";
+
+/** React-Query keys the approval queue touches; invalidate both on any
+ *  state transition (and after a 202-queued mutation). */
+export const CHANGE_REQUEST_QUERY_KEY = ["change-requests"] as const;
+export const PENDING_CHANGE_COUNT_QUERY_KEY = [
+  "change-requests",
+  "pending-count",
+] as const;

--- a/frontend/src/pages/admin/BreakGlassModal.tsx
+++ b/frontend/src/pages/admin/BreakGlassModal.tsx
@@ -1,0 +1,207 @@
+/**
+ * BreakGlassModal — the mandatory anti-lockout escape hatch (#62).
+ *
+ * When the self-governance lock (``approvals_protect_controls``) is on, every
+ * WEAKENING control change (disable the approval module, disable / delete /
+ * lower a policy, turn the lock off) normally routes through the two-person
+ * approval queue. If no second superadmin is available you'd be permanently
+ * wedged — so a superadmin can force the change IMMEDIATELY here.
+ *
+ * This is deliberately alarmed: it requires BOTH a password (or TOTP for
+ * external-auth accounts with no local password) AND a typed confirmation
+ * phrase, and the server writes a HIGH-severity ``approvals.break_glass``
+ * audit row + fires the ``governance.break_glass`` event. We surface that
+ * loudly in the modal copy so it never feels routine.
+ *
+ * The backend phrase guard is an EXACT match on "BREAK GLASS" (422 otherwise),
+ * mirrored here so the Confirm button stays disabled until it's typed right.
+ */
+
+import { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle } from "lucide-react";
+
+import {
+  type ApprovalControlKind,
+  featureModulesApi,
+  formatApiError,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { Modal } from "@/components/ui/modal";
+import { HeaderButton } from "@/components/ui/header-button";
+
+// Must match BREAK_GLASS_PHRASE in backend feature_modules.py.
+const BREAK_GLASS_PHRASE = "BREAK GLASS";
+
+const inputCls =
+  "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+const KIND_LABELS: Record<ApprovalControlKind, string> = {
+  disable_module: "Disable approval workflows entirely",
+  disable_policy: "Disable this approval policy",
+  delete_policy: "Delete this approval policy",
+  lower_superadmin_gate: "Stop this policy applying to superadmins",
+  unlock: "Remove the require-approval-to-disable lock",
+};
+
+export function BreakGlassModal({
+  kind,
+  policyId,
+  policyName,
+  onClose,
+  onDone,
+}: {
+  kind: ApprovalControlKind;
+  policyId?: string | null;
+  /** When the kind targets a policy, render its name in the warning copy. */
+  policyName?: string | null;
+  onClose: () => void;
+  /** Fired after a successful force so the caller can refresh its own queries. */
+  onDone?: () => void;
+}) {
+  const qc = useQueryClient();
+  const [password, setPassword] = useState("");
+  const [totp, setTotp] = useState("");
+  const [phrase, setPhrase] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPassword("");
+    setTotp("");
+    setPhrase("");
+    setError(null);
+  }, [kind, policyId]);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      featureModulesApi.breakGlass({
+        kind,
+        policy_id: policyId ?? null,
+        password: password || null,
+        totp_code: totp || null,
+        confirm_phrase: phrase,
+      }),
+    onSuccess: () => {
+      // The force mutated a control surface — bust every cache it could touch.
+      qc.invalidateQueries({ queryKey: ["feature-modules"] });
+      qc.invalidateQueries({ queryKey: ["change-requests"] });
+      qc.invalidateQueries({ queryKey: ["approvals-lock"] });
+      onDone?.();
+      onClose();
+    },
+    onError: (err) =>
+      setError(formatApiError(err, "Break-glass failed. Check the audit log.")),
+  });
+
+  const phraseOk = phrase === BREAK_GLASS_PHRASE;
+  // Either a password OR a TOTP code is required (the server picks based on the
+  // account); require at least one to be present client-side.
+  const credOk = password.trim() !== "" || totp.trim() !== "";
+  const disabled = !phraseOk || !credOk || mutation.isPending;
+
+  const target =
+    policyName != null
+      ? `${KIND_LABELS[kind]} (${policyName})`
+      : KIND_LABELS[kind];
+
+  return (
+    <Modal title="Break glass — force control change" onClose={onClose} wide>
+      <div className="space-y-4">
+        <div className="flex items-start gap-2 rounded-md border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-700 dark:text-rose-300">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <div className="space-y-1">
+            <p className="font-medium">
+              This bypasses the two-person approval gate.
+            </p>
+            <p className="text-xs">
+              You're about to force: <strong>{target}</strong>. This is the
+              anti-lockout escape hatch — it executes immediately under your
+              identity, writes a high-severity audit row, and fires a{" "}
+              <span className="font-mono">governance.break_glass</span> alert.
+              Use it only when no second superadmin can approve.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-muted-foreground">
+            Confirm with your password
+          </label>
+          <input
+            type="password"
+            autoComplete="current-password"
+            className={inputCls}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Local password"
+          />
+          <p className="text-[11px] text-muted-foreground/80">
+            External-auth accounts with no local password: enter your TOTP code
+            below instead.
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-muted-foreground">
+            TOTP code (if your account uses MFA without a local password)
+          </label>
+          <input
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            className={inputCls}
+            value={totp}
+            onChange={(e) => setTotp(e.target.value)}
+            placeholder="123456"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-muted-foreground">
+            Type{" "}
+            <span className="font-mono font-semibold">
+              {BREAK_GLASS_PHRASE}
+            </span>{" "}
+            to confirm
+          </label>
+          <input
+            type="text"
+            autoCapitalize="characters"
+            className={cn(
+              inputCls,
+              phrase !== "" &&
+                !phraseOk &&
+                "border-destructive focus:ring-destructive",
+            )}
+            value={phrase}
+            onChange={(e) => setPhrase(e.target.value)}
+            placeholder={BREAK_GLASS_PHRASE}
+          />
+        </div>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <HeaderButton
+            variant="secondary"
+            onClick={onClose}
+            disabled={mutation.isPending}
+          >
+            Cancel
+          </HeaderButton>
+          <HeaderButton
+            variant="destructive"
+            icon={AlertTriangle}
+            disabled={disabled}
+            onClick={() => {
+              setError(null);
+              mutation.mutate();
+            }}
+          >
+            {mutation.isPending ? "Forcing…" : "Break glass & force"}
+          </HeaderButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/admin/ChangeRequestsPage.tsx
+++ b/frontend/src/pages/admin/ChangeRequestsPage.tsx
@@ -21,6 +21,7 @@
 
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { AxiosResponse } from "axios";
 import {
   Ban,
   Check,
@@ -38,16 +39,25 @@ import {
   type ApprovalPolicy,
   type ApprovalPolicyWrite,
   type ChangeRequest,
+  type ChangeRequestQueued,
   type ChangeRequestState,
   authApi,
   changeRequestsApi,
   formatApiError,
 } from "@/lib/api";
+import {
+  APPROVAL_QUEUED_MESSAGE,
+  CHANGE_REQUEST_QUERY_KEY,
+  handleApprovalQueued,
+} from "@/lib/approvalQueue";
+import { featureModulesApi } from "@/lib/api";
 import { usePermissions } from "@/hooks/usePermissions";
 import { cn, zebraBodyCls } from "@/lib/utils";
 import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { HeaderButton } from "@/components/ui/header-button";
+import { ShieldAlert, AlertTriangle } from "lucide-react";
+import { BreakGlassModal } from "./BreakGlassModal";
 
 const inputCls =
   "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
@@ -415,9 +425,13 @@ function RequestTable({
 function PolicyEditor({
   existing,
   onClose,
+  onQueued,
 }: {
   existing: ApprovalPolicy | null;
   onClose: () => void;
+  /** Fired when a weakening edit was queued for approval (#62) instead of
+   *  mutating inline. */
+  onQueued?: () => void;
 }) {
   const qc = useQueryClient();
   const locked = existing?.is_builtin ?? false;
@@ -438,7 +452,15 @@ function PolicyEditor({
   );
   const [error, setError] = useState<string | null>(null);
 
-  const mutation = useMutation({
+  const mutation = useMutation<
+    // createPolicy returns the unwrapped row; updatePolicy returns the full
+    // axios response so the #62 lock's 202 envelope is observable. Both shapes
+    // flow through handleApprovalQueued (unwrapped rows have no `status`, so
+    // they read as "executed inline").
+    ApprovalPolicy | AxiosResponse<ApprovalPolicy | ChangeRequestQueued>,
+    unknown,
+    void
+  >({
     mutationFn: () => {
       const body: ApprovalPolicyWrite = {
         name: name.trim(),
@@ -449,11 +471,25 @@ function PolicyEditor({
         applies_to_superadmin: appliesToSuperadmin,
         ttl_hours: Number(ttlHours) || 168,
       };
+      // createPolicy already returns the unwrapped row; updatePolicy returns
+      // the full axios response so the #62 self-governance lock's 202
+      // approval-queue envelope (weakening a policy while the lock is on) is
+      // observable.
       return existing
         ? changeRequestsApi.updatePolicy(existing.id, body)
         : changeRequestsApi.createPolicy(body);
     },
-    onSuccess: () => {
+    onSuccess: (resp) => {
+      // #62: a weakening edit (disable / lower applies_to_superadmin) returns
+      // 202 + a pending change_request when the lock is on instead of mutating
+      // inline. Surface the queued state rather than closing silently.
+      if (handleApprovalQueued(resp)) {
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+        qc.invalidateQueries({ queryKey: ["change-requests", "policies"] });
+        onQueued?.();
+        onClose();
+        return;
+      }
       qc.invalidateQueries({ queryKey: ["change-requests", "policies"] });
       onClose();
     },
@@ -592,13 +628,30 @@ function PoliciesTab() {
     queryKey: ["change-requests", "policies"],
     queryFn: changeRequestsApi.listPolicies,
   });
+  // #62 self-governance lock state — drives the banner + the queued path on
+  // policy weakening + the break-glass affordance.
+  const { data: lockState } = useQuery({
+    queryKey: ["approvals-lock"],
+    queryFn: featureModulesApi.getApprovalsLock,
+  });
+  const lockOn = lockState?.approvals_protect_controls ?? false;
+
   const [editing, setEditing] = useState<ApprovalPolicy | null>(null);
   const [creating, setCreating] = useState(false);
   const [deleting, setDeleting] = useState<ApprovalPolicy | null>(null);
+  const [queuedNotice, setQueuedNotice] = useState<string | null>(null);
+  // Break-glass for a specific policy weakening (delete it now).
+  const [breakGlass, setBreakGlass] = useState<ApprovalPolicy | null>(null);
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => changeRequestsApi.deletePolicy(id),
-    onSuccess: () => {
+    onSuccess: (resp) => {
+      // #62: deleting a policy while the lock is on returns 202 + a pending
+      // change_request instead of deleting inline.
+      if (handleApprovalQueued(resp)) {
+        setQueuedNotice(APPROVAL_QUEUED_MESSAGE);
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+      }
       qc.invalidateQueries({ queryKey: ["change-requests", "policies"] });
       setDeleting(null);
     },
@@ -606,6 +659,29 @@ function PoliciesTab() {
 
   return (
     <div className="space-y-3">
+      {lockOn && (
+        <div className="flex flex-wrap items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          <ShieldAlert className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+          <div className="min-w-0 flex-1">
+            <p className="font-medium text-amber-700 dark:text-amber-300">
+              Self-governance lock is ON
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Weakening a policy — <strong>disabling</strong> it,{" "}
+              <strong>deleting</strong> it, or turning off{" "}
+              <em>Applies to superadmin</em> — now needs a second superadmin to
+              approve via the Queue. Strengthening edits stay single-person. Use
+              break-glass (per-row) to force a weakening change immediately if
+              you're locked out.
+            </p>
+          </div>
+        </div>
+      )}
+      {queuedNotice && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-300">
+          {queuedNotice} See the Queue tab.
+        </div>
+      )}
       <div className="flex justify-end">
         <HeaderButton
           variant="primary"
@@ -679,6 +755,18 @@ function PoliciesTab() {
                           Delete
                         </HeaderButton>
                       )}
+                      {/* #62: when the lock is on, deleting/disabling routes
+                       *  through approval. Break-glass forces it now. */}
+                      {lockOn && !p.is_builtin && (
+                        <HeaderButton
+                          variant="destructive"
+                          icon={AlertTriangle}
+                          title="Force-delete this policy now (break-glass)"
+                          onClick={() => setBreakGlass(p)}
+                        >
+                          Break glass
+                        </HeaderButton>
+                      )}
                     </div>
                   </td>
                 </tr>
@@ -695,6 +783,7 @@ function PoliciesTab() {
             setCreating(false);
             setEditing(null);
           }}
+          onQueued={() => setQueuedNotice(APPROVAL_QUEUED_MESSAGE)}
         />
       )}
 
@@ -702,17 +791,35 @@ function PoliciesTab() {
         open={deleting !== null}
         title="Delete approval policy"
         tone="destructive"
-        confirmLabel="Delete"
+        confirmLabel={lockOn ? "Submit for approval" : "Delete"}
         loading={deleteMutation.isPending}
         message={
           <span>
             Delete the policy <strong>{deleting?.name}</strong>? Operations it
             covered will no longer require a second approver.
+            {lockOn && (
+              <span className="mt-2 block text-amber-600 dark:text-amber-400">
+                The self-governance lock is on — this will be queued for a
+                second superadmin to approve rather than deleted immediately.
+              </span>
+            )}
           </span>
         }
         onConfirm={() => deleting && deleteMutation.mutate(deleting.id)}
         onClose={() => setDeleting(null)}
       />
+
+      {breakGlass && (
+        <BreakGlassModal
+          kind="delete_policy"
+          policyId={breakGlass.id}
+          policyName={breakGlass.name}
+          onClose={() => setBreakGlass(null)}
+          onDone={() =>
+            qc.invalidateQueries({ queryKey: ["change-requests", "policies"] })
+          }
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/admin/ChangeRequestsPage.tsx
+++ b/frontend/src/pages/admin/ChangeRequestsPage.tsx
@@ -1,0 +1,883 @@
+/**
+ * ChangeRequestsPage — the two-person approval queue (#62).
+ *
+ * Surfaces the ``change_request`` rows queued by the approval gate. A
+ * covered risky operation (delete / bulk / factory-reset) that a policy
+ * decided needs a second operator lands here in ``pending``; a *different*
+ * eligible approver drives it to a terminal state.
+ *
+ * Three tabs:
+ *  - **Queue** — pending requests with Approve / Reject (note) / Cancel.
+ *  - **History** — terminal requests (executed / rejected / … ).
+ *  - **Policies** — operator-tunable ``approval_policy`` rules (superadmin).
+ *
+ * Gating is server-side (every endpoint re-enforces the two-person spine);
+ * this only drives affordance *visibility*: Approve/Reject need
+ * ``approve,change_request``; Cancel needs requester-or-superadmin; the
+ * Policies tab needs superadmin. The whole page is reached only when the
+ * default-off ``governance.approvals`` module is on (the Sidebar nav entry
+ * + backend ``require_module`` both gate it).
+ */
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Ban,
+  Check,
+  CheckCircle2,
+  Clock,
+  GitPullRequest,
+  Pencil,
+  Plus,
+  ThumbsDown,
+  Trash2,
+  XCircle,
+} from "lucide-react";
+import {
+  APPROVAL_POLICY_ACTIONS,
+  type ApprovalPolicy,
+  type ApprovalPolicyWrite,
+  type ChangeRequest,
+  type ChangeRequestState,
+  authApi,
+  changeRequestsApi,
+  formatApiError,
+} from "@/lib/api";
+import { usePermissions } from "@/hooks/usePermissions";
+import { cn, zebraBodyCls } from "@/lib/utils";
+import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { HeaderButton } from "@/components/ui/header-button";
+
+const inputCls =
+  "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+// Terminal lifecycle states render in History; pending lives in the Queue.
+const TERMINAL_STATES: ChangeRequestState[] = [
+  "executed",
+  "rejected",
+  "failed",
+  "expired",
+  "cancelled",
+];
+
+type StateMeta = {
+  label: string;
+  className: string;
+  Icon: typeof Check;
+};
+
+// Mirrors the FleetTab status palette: emerald=good, rose=bad, amber=in-flight.
+function stateBadge(state: ChangeRequestState): StateMeta {
+  switch (state) {
+    case "pending":
+      return {
+        label: "pending",
+        className:
+          "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/30",
+        Icon: Clock,
+      };
+    case "approved":
+      return {
+        label: "approved",
+        className:
+          "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30",
+        Icon: Check,
+      };
+    case "executed":
+      return {
+        label: "executed",
+        className:
+          "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/30",
+        Icon: CheckCircle2,
+      };
+    case "rejected":
+      return {
+        label: "rejected",
+        className:
+          "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/30",
+        Icon: ThumbsDown,
+      };
+    case "failed":
+      return {
+        label: "failed",
+        className:
+          "bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/30",
+        Icon: XCircle,
+      };
+    case "expired":
+      return {
+        label: "expired",
+        className: "bg-muted text-muted-foreground border-border",
+        Icon: Clock,
+      };
+    case "cancelled":
+      return {
+        label: "cancelled",
+        className: "bg-muted text-muted-foreground border-border",
+        Icon: Ban,
+      };
+  }
+}
+
+function StateChip({ state }: { state: ChangeRequestState }) {
+  const { label, className, Icon } = stateBadge(state);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium",
+        className,
+      )}
+    >
+      <Icon className="h-3 w-3" /> {label}
+    </span>
+  );
+}
+
+function UserChip({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-foreground">
+      {label}
+    </span>
+  );
+}
+
+function fmtTime(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString();
+}
+
+// ── Decision modal (approve / reject with an optional note) ─────────────────
+//
+// ConfirmModal carries only checkbox + password — no free-text field — so
+// the note-bearing decision uses the shared draggable Modal directly.
+
+function DecisionModal({
+  cr,
+  mode,
+  onClose,
+}: {
+  cr: ChangeRequest;
+  mode: "approve" | "reject";
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [note, setNote] = useState("");
+  const [confirmed, setConfirmed] = useState(mode === "reject");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      mode === "approve"
+        ? changeRequestsApi.approve(cr.id, note || undefined)
+        : changeRequestsApi.reject(cr.id, note || undefined),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["change-requests"] });
+      onClose();
+    },
+    onError: (err) =>
+      setError(formatApiError(err, `Failed to ${mode} the request.`)),
+  });
+
+  const title =
+    mode === "approve" ? "Approve change request" : "Reject change request";
+
+  return (
+    <Modal title={title} onClose={onClose} wide>
+      <div className="space-y-4">
+        <div className="rounded-md border bg-muted/20 p-3 text-sm">
+          <div className="mb-1 flex items-center gap-2">
+            <span className="font-mono text-xs">{cr.operation}</span>
+            <StateChip state={cr.state} />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Requested by <UserChip label={cr.requested_by_display} /> on{" "}
+            {fmtTime(cr.created_at)}
+          </p>
+          <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-background p-2 text-[11px]">
+            {cr.preview_text}
+          </pre>
+        </div>
+
+        {mode === "approve" && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            On approve this operation re-runs its preview (stale-state guard),
+            then executes under <strong>your</strong> identity. The audit log
+            records both you and the requester.
+          </p>
+        )}
+
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-muted-foreground">
+            Decision note {mode === "reject" ? "" : "(optional)"}
+          </label>
+          <textarea
+            className={cn(inputCls, "min-h-[64px] resize-y")}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder={
+              mode === "approve"
+                ? "Why this is OK to run…"
+                : "Why this is being declined…"
+            }
+          />
+        </div>
+
+        {mode === "approve" && (
+          <label className="flex items-start gap-2 text-xs">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={confirmed}
+              onChange={(e) => setConfirmed(e.target.checked)}
+            />
+            <span>
+              I understand this executes the operation immediately under my
+              identity.
+            </span>
+          </label>
+        )}
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <HeaderButton variant="secondary" onClick={onClose}>
+            Cancel
+          </HeaderButton>
+          <HeaderButton
+            variant={mode === "approve" ? "primary" : "destructive"}
+            icon={mode === "approve" ? Check : ThumbsDown}
+            disabled={!confirmed || mutation.isPending}
+            onClick={() => {
+              setError(null);
+              mutation.mutate();
+            }}
+          >
+            {mutation.isPending
+              ? "Working…"
+              : mode === "approve"
+                ? "Approve & execute"
+                : "Reject"}
+          </HeaderButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ── Change-request row ──────────────────────────────────────────────────────
+
+function RequestRow({
+  cr,
+  canApprove,
+  canCancel,
+  onDecide,
+  onCancel,
+}: {
+  cr: ChangeRequest;
+  canApprove: boolean;
+  canCancel: boolean;
+  onDecide: (cr: ChangeRequest, mode: "approve" | "reject") => void;
+  onCancel: (cr: ChangeRequest) => void;
+}) {
+  const isPending = cr.state === "pending";
+  return (
+    <tr className="border-b align-top">
+      <td className="px-3 py-2">
+        <StateChip state={cr.state} />
+      </td>
+      <td className="px-3 py-2">
+        <div className="font-mono text-xs">{cr.operation}</div>
+        <div className="text-[11px] text-muted-foreground">
+          {cr.resource_type}
+          {cr.resource_display ? ` · ${cr.resource_display}` : ""}
+        </div>
+        {cr.error && (
+          <div className="mt-1 text-[11px] text-destructive break-words">
+            {cr.error}
+          </div>
+        )}
+      </td>
+      <td className="px-3 py-2 text-xs">
+        <UserChip label={cr.requested_by_display} />
+        {cr.decided_by_display && (
+          <>
+            {" → "}
+            <UserChip label={cr.decided_by_display} />
+          </>
+        )}
+        {cr.decision_note && (
+          <div className="mt-1 italic text-muted-foreground break-words">
+            “{cr.decision_note}”
+          </div>
+        )}
+      </td>
+      <td className="px-3 py-2 text-[11px] text-muted-foreground whitespace-nowrap">
+        {fmtTime(cr.created_at)}
+        {isPending && (
+          <div className="text-amber-600 dark:text-amber-400">
+            expires {fmtTime(cr.expires_at)}
+          </div>
+        )}
+      </td>
+      <td className="px-3 py-2 text-right whitespace-nowrap">
+        {isPending && (
+          <div className="inline-flex gap-1">
+            {canApprove && (
+              <>
+                <HeaderButton
+                  variant="primary"
+                  icon={Check}
+                  onClick={() => onDecide(cr, "approve")}
+                >
+                  Approve
+                </HeaderButton>
+                <HeaderButton
+                  variant="destructive"
+                  icon={ThumbsDown}
+                  onClick={() => onDecide(cr, "reject")}
+                >
+                  Reject
+                </HeaderButton>
+              </>
+            )}
+            {canCancel && (
+              <HeaderButton
+                variant="secondary"
+                icon={Ban}
+                onClick={() => onCancel(cr)}
+              >
+                Cancel
+              </HeaderButton>
+            )}
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function RequestTable({
+  rows,
+  canApprove,
+  isRequester,
+  isSuperadmin,
+  onDecide,
+  onCancel,
+  emptyText,
+}: {
+  rows: ChangeRequest[];
+  canApprove: boolean;
+  isRequester: (cr: ChangeRequest) => boolean;
+  isSuperadmin: boolean;
+  onDecide: (cr: ChangeRequest, mode: "approve" | "reject") => void;
+  onCancel: (cr: ChangeRequest) => void;
+  emptyText: string;
+}) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+        {emptyText}
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <table className={cn("w-full min-w-[760px] text-sm", zebraBodyCls)}>
+        <thead className="border-b bg-muted/40 text-left text-xs text-muted-foreground">
+          <tr>
+            <th className="px-3 py-2 font-medium">State</th>
+            <th className="px-3 py-2 font-medium">Operation</th>
+            <th className="px-3 py-2 font-medium">Requester → Approver</th>
+            <th className="px-3 py-2 font-medium">Created</th>
+            <th className="px-3 py-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((cr) => (
+            <RequestRow
+              key={cr.id}
+              cr={cr}
+              canApprove={canApprove}
+              canCancel={isRequester(cr) || isSuperadmin}
+              onDecide={onDecide}
+              onCancel={onCancel}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Policy editor ───────────────────────────────────────────────────────────
+
+function PolicyEditor({
+  existing,
+  onClose,
+}: {
+  existing: ApprovalPolicy | null;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const locked = existing?.is_builtin ?? false;
+  const [name, setName] = useState(existing?.name ?? "");
+  const [resourceType, setResourceType] = useState(
+    existing?.resource_type ?? "",
+  );
+  const [action, setAction] = useState(existing?.action ?? "delete");
+  const [minCount, setMinCount] = useState<string>(
+    existing?.min_count != null ? String(existing.min_count) : "",
+  );
+  const [ttlHours, setTtlHours] = useState<string>(
+    String(existing?.ttl_hours ?? 168),
+  );
+  const [enabled, setEnabled] = useState(existing?.enabled ?? false);
+  const [appliesToSuperadmin, setAppliesToSuperadmin] = useState(
+    existing?.applies_to_superadmin ?? true,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const body: ApprovalPolicyWrite = {
+        name: name.trim(),
+        resource_type: resourceType.trim(),
+        action,
+        min_count: minCount.trim() === "" ? null : Number(minCount),
+        enabled,
+        applies_to_superadmin: appliesToSuperadmin,
+        ttl_hours: Number(ttlHours) || 168,
+      };
+      return existing
+        ? changeRequestsApi.updatePolicy(existing.id, body)
+        : changeRequestsApi.createPolicy(body);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["change-requests", "policies"] });
+      onClose();
+    },
+    onError: (err) => setError(formatApiError(err, "Failed to save policy.")),
+  });
+
+  return (
+    <Modal
+      title={existing ? "Edit approval policy" : "New approval policy"}
+      onClose={onClose}
+      wide
+    >
+      <div className="space-y-3">
+        {locked && (
+          <p className="text-xs text-muted-foreground">
+            Built-in policy — only the threshold, TTL, and toggles are tunable.
+          </p>
+        )}
+        <div className="space-y-1">
+          <label className="text-xs font-medium text-muted-foreground">
+            Name
+          </label>
+          <input
+            className={inputCls}
+            value={name}
+            disabled={locked}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              Resource type
+            </label>
+            <input
+              className={inputCls}
+              value={resourceType}
+              disabled={locked}
+              placeholder="subnet / dns_zone / *"
+              onChange={(e) => setResourceType(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              Action
+            </label>
+            <select
+              className={inputCls}
+              value={action}
+              disabled={locked}
+              onChange={(e) => setAction(e.target.value)}
+            >
+              {APPROVAL_POLICY_ACTIONS.map((a) => (
+                <option key={a} value={a}>
+                  {a}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              Threshold (min rows)
+            </label>
+            <input
+              className={inputCls}
+              type="number"
+              min={1}
+              value={minCount}
+              placeholder="always"
+              onChange={(e) => setMinCount(e.target.value)}
+            />
+            <p className="text-[11px] text-muted-foreground/80">
+              Blank = require approval regardless of count.
+            </p>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground">
+              TTL (hours)
+            </label>
+            <input
+              className={inputCls}
+              type="number"
+              min={1}
+              value={ttlHours}
+              onChange={(e) => setTtlHours(e.target.value)}
+            />
+          </div>
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />
+          Enabled
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={appliesToSuperadmin}
+            onChange={(e) => setAppliesToSuperadmin(e.target.checked)}
+          />
+          Applies to superadmin
+          <span className="text-[11px] text-muted-foreground">
+            (a rule superadmin bypasses isn't a two-person rule)
+          </span>
+        </label>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <HeaderButton variant="secondary" onClick={onClose}>
+            Cancel
+          </HeaderButton>
+          <HeaderButton
+            variant="primary"
+            disabled={mutation.isPending}
+            onClick={() => {
+              setError(null);
+              mutation.mutate();
+            }}
+          >
+            {mutation.isPending ? "Saving…" : "Save"}
+          </HeaderButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function PoliciesTab() {
+  const qc = useQueryClient();
+  const { data: policies = [], isLoading } = useQuery({
+    queryKey: ["change-requests", "policies"],
+    queryFn: changeRequestsApi.listPolicies,
+  });
+  const [editing, setEditing] = useState<ApprovalPolicy | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [deleting, setDeleting] = useState<ApprovalPolicy | null>(null);
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => changeRequestsApi.deletePolicy(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["change-requests", "policies"] });
+      setDeleting(null);
+    },
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <HeaderButton
+          variant="primary"
+          icon={Plus}
+          onClick={() => setCreating(true)}
+        >
+          New policy
+        </HeaderButton>
+      </div>
+      {isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading…</p>
+      ) : policies.length === 0 ? (
+        <div className="rounded-md border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+          No approval policies yet.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className={cn("w-full min-w-[760px] text-sm", zebraBodyCls)}>
+            <thead className="border-b bg-muted/40 text-left text-xs text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 font-medium">Name</th>
+                <th className="px-3 py-2 font-medium">Resource</th>
+                <th className="px-3 py-2 font-medium">Action</th>
+                <th className="px-3 py-2 font-medium">Threshold</th>
+                <th className="px-3 py-2 font-medium">TTL</th>
+                <th className="px-3 py-2 font-medium">Enabled</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {policies.map((p) => (
+                <tr key={p.id} className="border-b">
+                  <td className="px-3 py-2">
+                    {p.name}
+                    {p.is_builtin && (
+                      <span className="ml-1.5 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                        built-in
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs">
+                    {p.resource_type}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs">{p.action}</td>
+                  <td className="px-3 py-2">{p.min_count ?? "always"}</td>
+                  <td className="px-3 py-2">{p.ttl_hours}h</td>
+                  <td className="px-3 py-2">
+                    {p.enabled ? (
+                      <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+                        <Check className="h-3 w-3" /> on
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">off</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right whitespace-nowrap">
+                    <div className="inline-flex gap-1">
+                      <HeaderButton
+                        variant="secondary"
+                        icon={Pencil}
+                        onClick={() => setEditing(p)}
+                      >
+                        Edit
+                      </HeaderButton>
+                      {!p.is_builtin && (
+                        <HeaderButton
+                          variant="destructive"
+                          icon={Trash2}
+                          onClick={() => setDeleting(p)}
+                        >
+                          Delete
+                        </HeaderButton>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {(creating || editing) && (
+        <PolicyEditor
+          existing={editing}
+          onClose={() => {
+            setCreating(false);
+            setEditing(null);
+          }}
+        />
+      )}
+
+      <ConfirmModal
+        open={deleting !== null}
+        title="Delete approval policy"
+        tone="destructive"
+        confirmLabel="Delete"
+        loading={deleteMutation.isPending}
+        message={
+          <span>
+            Delete the policy <strong>{deleting?.name}</strong>? Operations it
+            covered will no longer require a second approver.
+          </span>
+        }
+        onConfirm={() => deleting && deleteMutation.mutate(deleting.id)}
+        onClose={() => setDeleting(null)}
+      />
+    </div>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export function ChangeRequestsPage() {
+  const { can, isSuperadmin } = usePermissions();
+  const canApprove = can("approve", "change_request");
+  const myUserId = useMyUserId();
+
+  const [tab, setTab] = useState<"queue" | "history" | "policies">("queue");
+  const [decision, setDecision] = useState<{
+    cr: ChangeRequest;
+    mode: "approve" | "reject";
+  } | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<ChangeRequest | null>(null);
+
+  const qc = useQueryClient();
+
+  const queueQuery = useQuery({
+    queryKey: ["change-requests", "pending"],
+    queryFn: () => changeRequestsApi.list({ state: "pending", limit: 500 }),
+    // Adaptive poll (FleetTab pattern): tighter while anything is pending.
+    refetchInterval: (q) => ((q.state.data?.length ?? 0) > 0 ? 5000 : 20000),
+  });
+
+  const historyQuery = useQuery({
+    queryKey: ["change-requests", "history"],
+    queryFn: () => changeRequestsApi.list({ limit: 200 }),
+    enabled: tab === "history",
+  });
+
+  const historyRows = useMemo(
+    () =>
+      (historyQuery.data ?? []).filter((r) =>
+        TERMINAL_STATES.includes(r.state),
+      ),
+    [historyQuery.data],
+  );
+
+  const cancelMutation = useMutation({
+    mutationFn: (id: string) => changeRequestsApi.cancel(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["change-requests"] });
+      setCancelTarget(null);
+    },
+  });
+
+  const isRequester = (cr: ChangeRequest) =>
+    cr.requested_by_user_id != null && cr.requested_by_user_id === myUserId;
+
+  return (
+    <div className="h-full overflow-auto p-6">
+      <div className="mx-auto max-w-6xl space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <h1 className="flex items-center gap-2 text-xl font-semibold">
+              <GitPullRequest className="h-5 w-5" /> Change Requests
+            </h1>
+            <p className="max-w-2xl text-xs text-muted-foreground">
+              Risky operations (deletes, bulk changes, factory reset) that a
+              policy queued for a second eligible operator. A requester can't
+              approve their own request — a different operator holding{" "}
+              <span className="font-mono">approve,change_request</span> plus the
+              operation's own permission approves, and it executes under the
+              approver's identity after a stale-state re-check.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex gap-1 border-b">
+          {(["queue", "history", isSuperadmin ? "policies" : null] as const)
+            .filter((t): t is "queue" | "history" | "policies" => t !== null)
+            .map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setTab(t)}
+                className={cn(
+                  "border-b-2 px-3 py-1.5 text-sm capitalize",
+                  tab === t
+                    ? "border-primary font-medium text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {t}
+                {t === "queue" && (queueQuery.data?.length ?? 0) > 0 && (
+                  <span className="ml-1.5 rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
+                    {queueQuery.data?.length}
+                  </span>
+                )}
+              </button>
+            ))}
+        </div>
+
+        {tab === "queue" &&
+          (queueQuery.isLoading ? (
+            <p className="text-xs text-muted-foreground">Loading…</p>
+          ) : (
+            <RequestTable
+              rows={queueQuery.data ?? []}
+              canApprove={canApprove}
+              isRequester={isRequester}
+              isSuperadmin={isSuperadmin}
+              onDecide={(cr, mode) => setDecision({ cr, mode })}
+              onCancel={setCancelTarget}
+              emptyText="Nothing waiting for approval."
+            />
+          ))}
+
+        {tab === "history" &&
+          (historyQuery.isLoading ? (
+            <p className="text-xs text-muted-foreground">Loading…</p>
+          ) : (
+            <RequestTable
+              rows={historyRows}
+              canApprove={false}
+              isRequester={isRequester}
+              isSuperadmin={isSuperadmin}
+              onDecide={(cr, mode) => setDecision({ cr, mode })}
+              onCancel={setCancelTarget}
+              emptyText="No decided requests yet."
+            />
+          ))}
+
+        {tab === "policies" && isSuperadmin && <PoliciesTab />}
+      </div>
+
+      {decision && (
+        <DecisionModal
+          cr={decision.cr}
+          mode={decision.mode}
+          onClose={() => setDecision(null)}
+        />
+      )}
+
+      <ConfirmModal
+        open={cancelTarget !== null}
+        title="Cancel change request"
+        confirmLabel="Withdraw request"
+        loading={cancelMutation.isPending}
+        message={
+          <span>
+            Withdraw this pending request for{" "}
+            <span className="font-mono">{cancelTarget?.operation}</span>? The
+            operation will not run.
+          </span>
+        }
+        onConfirm={() => cancelTarget && cancelMutation.mutate(cancelTarget.id)}
+        onClose={() => setCancelTarget(null)}
+      />
+    </div>
+  );
+}
+
+// The "is this my request?" check (Cancel affordance) needs the caller's
+// own user id — ``GET /auth/me`` returns it.
+function useMyUserId(): string | null {
+  const query = useQuery({
+    queryKey: ["auth-me"],
+    queryFn: authApi.me,
+    staleTime: 5 * 60 * 1000,
+  });
+  return query.data?.id ?? null;
+}
+
+export default ChangeRequestsPage;

--- a/frontend/src/pages/admin/FeaturesPage.tsx
+++ b/frontend/src/pages/admin/FeaturesPage.tsx
@@ -1,10 +1,29 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { RefreshCcw, ToggleLeft } from "lucide-react";
+import {
+  AlertTriangle,
+  RefreshCcw,
+  ShieldAlert,
+  ToggleLeft,
+} from "lucide-react";
 import { featureModulesApi, type FeatureModuleEntry } from "@/lib/api";
+import {
+  APPROVAL_QUEUED_MESSAGE,
+  CHANGE_REQUEST_QUERY_KEY,
+  handleApprovalQueued,
+} from "@/lib/approvalQueue";
+import { usePermissions } from "@/hooks/usePermissions";
 import { useSessionState } from "@/lib/useSessionState";
 import { cn } from "@/lib/utils";
+import { Modal } from "@/components/ui/modal";
+import { HeaderButton } from "@/components/ui/header-button";
 import { Toggle } from "@/components/ui/toggle";
+import { BreakGlassModal } from "./BreakGlassModal";
+
+// The module whose disable is gated by the #62 self-governance lock. Enabling
+// it can opt into the lock; disabling it (when the lock is on) routes through
+// the two-person approval queue.
+const APPROVALS_MODULE_ID = "governance.approvals";
 
 const headerCls =
   "flex shrink-0 items-center gap-1.5 rounded-md border bg-background px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50";
@@ -19,7 +38,7 @@ const TABS: { id: TabId; label: string; groups: string[] }[] = [
   {
     id: "features",
     label: "Features",
-    groups: ["Network", "AI", "Compliance", "Tools"],
+    groups: ["Network", "AI", "Compliance", "Security", "Tools"],
   },
   {
     id: "integrations",
@@ -48,6 +67,7 @@ const TABS: { id: TabId; label: string; groups: string[] }[] = [
  */
 export function FeaturesPage() {
   const qc = useQueryClient();
+  const { isSuperadmin } = usePermissions();
   const [activeTab, setActiveTab] = useSessionState<TabId>(
     "features-page-tab",
     "features",
@@ -57,11 +77,49 @@ export function FeaturesPage() {
     queryFn: featureModulesApi.list,
   });
 
+  // #62 self-governance lock state — drives the lock banner + the
+  // "submitted for approval" path when disabling governance.approvals while
+  // the lock is on. Only superadmins can read it; viewers skip the query.
+  const { data: lockState } = useQuery({
+    queryKey: ["approvals-lock"],
+    queryFn: featureModulesApi.getApprovalsLock,
+    enabled: isSuperadmin,
+  });
+  const lockOn = lockState?.approvals_protect_controls ?? false;
+
+  // Transient feedback: when a control-disable is queued for approval rather
+  // than executed inline (#62), show the queued message instead of toggling.
+  const [queuedNotice, setQueuedNotice] = useState<string | null>(null);
+  // Enable-time opt-in modal for governance.approvals (protect_controls).
+  const [enableApprovalsModal, setEnableApprovalsModal] = useState(false);
+  // Break-glass force-disable affordance (superadmin escape hatch).
+  const [breakGlass, setBreakGlass] = useState(false);
+
   const toggleMutation = useMutation({
-    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
-      featureModulesApi.toggle(id, enabled),
-    onSuccess: () => {
+    mutationFn: ({
+      id,
+      enabled,
+      protectControls,
+    }: {
+      id: string;
+      enabled: boolean;
+      protectControls?: boolean;
+    }) => featureModulesApi.toggle(id, enabled, protectControls),
+    onSuccess: (resp) => {
+      // #62: disabling governance.approvals while the lock is on returns 202
+      // with a ChangeRequestQueued envelope instead of disabling inline.
+      if (handleApprovalQueued(resp)) {
+        setQueuedNotice(APPROVAL_QUEUED_MESSAGE);
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+        // The module is unchanged (still enabled) — re-sync so the toggle
+        // snaps back to its real server state.
+        qc.invalidateQueries({ queryKey: ["feature-modules"] });
+        return;
+      }
+      setQueuedNotice(null);
       qc.invalidateQueries({ queryKey: ["feature-modules"] });
+      // The lock can flip on at enable-time (protect_controls) — re-read it.
+      qc.invalidateQueries({ queryKey: ["approvals-lock"] });
       // Settings page also reads PlatformSettings.integration_*_enabled
       // (the toggle endpoint mirrors the value). Bust that cache too
       // so any open Settings tab catches the change without a manual
@@ -69,6 +127,18 @@ export function FeaturesPage() {
       qc.invalidateQueries({ queryKey: ["settings"] });
     },
   });
+
+  // Route a module toggle. governance.approvals gets special handling:
+  //  - enabling → open the protect_controls opt-in modal first;
+  //  - disabling → fire the toggle (the 202 path handles the locked case).
+  const handleToggle = (m: FeatureModuleEntry, next: boolean) => {
+    setQueuedNotice(null);
+    if (m.id === APPROVALS_MODULE_ID && next) {
+      setEnableApprovalsModal(true);
+      return;
+    }
+    toggleMutation.mutate({ id: m.id, enabled: next });
+  };
 
   const activeTabDef = TABS.find((t) => t.id === activeTab) ?? TABS[0];
   const grouped = useMemo(() => {
@@ -138,6 +208,44 @@ export function FeaturesPage() {
           </button>
         ))}
       </div>
+
+      {/* #62 self-governance lock banner — visible only on the Features tab to
+       *  superadmins when the lock is on. Explains why disabling Approval
+       *  workflows now needs a second operator + offers the break-glass
+       *  escape hatch. */}
+      {activeTab === "features" && isSuperadmin && lockOn && (
+        <div className="mx-4 mt-3 flex flex-wrap items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          <ShieldAlert className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+          <div className="min-w-0 flex-1">
+            <p className="font-medium text-amber-700 dark:text-amber-300">
+              Self-governance lock is ON
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Disabling <strong>Approval workflows</strong> (or weakening a
+              policy, or turning this lock off) now requires a{" "}
+              <em>second superadmin</em> to approve via the Change Requests
+              queue. Strengthening moves stay single-person. If you're locked
+              out with no second superadmin, use break-glass to force the change
+              immediately — it's audited and alarmed.
+            </p>
+          </div>
+          <HeaderButton
+            variant="destructive"
+            icon={AlertTriangle}
+            onClick={() => setBreakGlass(true)}
+            className="shrink-0"
+          >
+            Break glass…
+          </HeaderButton>
+        </div>
+      )}
+
+      {/* Queued-for-approval feedback (#62 control-disable). */}
+      {queuedNotice && (
+        <div className="mx-4 mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-300">
+          {queuedNotice} See the <strong>Change Requests</strong> queue.
+        </div>
+      )}
 
       {isLoading && (
         <div className="p-4 text-sm text-muted-foreground">Loading…</div>
@@ -252,9 +360,7 @@ export function FeaturesPage() {
                             label={`${m.enabled ? "Disable" : "Enable"} ${m.label}`}
                             checked={m.enabled}
                             disabled={toggleMutation.isPending}
-                            onChange={(v) =>
-                              toggleMutation.mutate({ id: m.id, enabled: v })
-                            }
+                            onChange={(v) => handleToggle(m, v)}
                           />
                         </div>
                       </div>
@@ -294,6 +400,100 @@ export function FeaturesPage() {
           </div>
         )}
       </div>
+
+      {/* #62 enable-time opt-in: when turning ON Approval workflows, offer to
+       *  also turn on the self-governance lock in the same call. */}
+      {enableApprovalsModal && (
+        <EnableApprovalsModal
+          onClose={() => setEnableApprovalsModal(false)}
+          onConfirm={(protectControls) => {
+            setEnableApprovalsModal(false);
+            toggleMutation.mutate({
+              id: APPROVALS_MODULE_ID,
+              enabled: true,
+              protectControls,
+            });
+          }}
+          pending={toggleMutation.isPending}
+        />
+      )}
+
+      {/* #62 break-glass escape hatch — force-disable Approval workflows. */}
+      {breakGlass && (
+        <BreakGlassModal
+          kind="disable_module"
+          onClose={() => setBreakGlass(false)}
+          onDone={() => {
+            setQueuedNotice(null);
+            qc.invalidateQueries({ queryKey: ["approvals-lock"] });
+          }}
+        />
+      )}
     </div>
+  );
+}
+
+// ── Enable-time opt-in for the self-governance lock (#62) ───────────────────
+//
+// Surfaced when a superadmin turns ON Approval workflows. The checkbox feeds
+// ``protect_controls`` into the toggle call — enabling the lock in the same
+// request (strengthening → single-person, no approval needed). Leaving it
+// unchecked enables the module without the lock; it can be turned on later.
+
+function EnableApprovalsModal({
+  onClose,
+  onConfirm,
+  pending,
+}: {
+  onClose: () => void;
+  onConfirm: (protectControls: boolean) => void;
+  pending: boolean;
+}) {
+  const [protectControls, setProtectControls] = useState(false);
+  return (
+    <Modal title="Enable Approval workflows" onClose={onClose} wide>
+      <div className="space-y-4 text-sm">
+        <p className="text-muted-foreground">
+          Risky operations (deletes, bulk changes, factory reset) that a policy
+          covers will require a second eligible operator to approve before they
+          run.
+        </p>
+        <label className="flex items-start gap-2">
+          <input
+            type="checkbox"
+            className="mt-0.5 cursor-pointer"
+            checked={protectControls}
+            onChange={(e) => setProtectControls(e.target.checked)}
+          />
+          <span>
+            <span className="font-medium">
+              Require two-person approval to disable this
+            </span>
+            <span className="mt-0.5 block text-xs text-muted-foreground">
+              Turns on the self-governance lock: from now on, disabling Approval
+              workflows (or weakening a policy, or turning the lock back off)
+              also needs a second superadmin to approve. A superadmin can always
+              force the change in an emergency via break-glass (audited).
+            </span>
+          </span>
+        </label>
+        <div className="flex justify-end gap-2">
+          <HeaderButton
+            variant="secondary"
+            onClick={onClose}
+            disabled={pending}
+          >
+            Cancel
+          </HeaderButton>
+          <HeaderButton
+            variant="primary"
+            onClick={() => onConfirm(protectControls)}
+            disabled={pending}
+          >
+            {pending ? "Enabling…" : "Enable"}
+          </HeaderButton>
+        </div>
+      </div>
+    </Modal>
   );
 }

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -60,6 +60,11 @@ import { CreateOptionTemplateModal } from "./CreateOptionTemplateModal";
 import { MacBlocksTab } from "./MacBlocksTab";
 import { PhoneProfilesTab } from "./PhoneProfilesTab";
 import { DeleteConfirmModal, StatusDot } from "./_shared";
+import {
+  APPROVAL_QUEUED_MESSAGE,
+  CHANGE_REQUEST_QUERY_KEY,
+  handleApprovalQueued,
+} from "@/lib/approvalQueue";
 
 type Selection =
   | { type: "group"; group: DHCPServerGroup }
@@ -929,12 +934,15 @@ function ScopeDeleteModal({
   onConfirm,
   onClose,
   isPending,
+  notice,
 }: {
   scope: DHCPScope;
   groupId: string;
   onConfirm: () => void;
   onClose: () => void;
   isPending: boolean;
+  // #62 two-person approval queue "Submitted for approval" message.
+  notice?: string | null;
 }) {
   const { data: pools = [] } = useQuery({
     queryKey: ["dhcp-pools", scope.id],
@@ -977,6 +985,7 @@ function ScopeDeleteModal({
       onConfirm={onConfirm}
       onClose={onClose}
       isPending={isPending}
+      notice={notice}
     />
   );
 }
@@ -1013,10 +1022,19 @@ function ServerScopesTab({ groupId }: { groupId: string }) {
   const [createForSubnet, setCreateForSubnet] = useState<string | null>(null);
   const [editScope, setEditScope] = useState<DHCPScope | null>(null);
   const [delScope, setDelScope] = useState<DHCPScope | null>(null);
+  const [delScopeNotice, setDelScopeNotice] = useState<string | null>(null);
 
   const delMut = useMutation({
     mutationFn: (id: string) => dhcpApi.deleteScope(id),
-    onSuccess: () => {
+    onSuccess: (resp) => {
+      // Two-person approval (#62): a covered delete returns 202 with a
+      // queued change-request instead of deleting. Surface the message,
+      // refresh the approval queue, and leave the scope in place.
+      if (handleApprovalQueued(resp)) {
+        setDelScopeNotice(APPROVAL_QUEUED_MESSAGE);
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+        return;
+      }
       qc.invalidateQueries({ queryKey: ["dhcp-scopes-subnet"] });
       qc.invalidateQueries({ queryKey: ["dhcp-scopes-group"] });
       qc.invalidateQueries({ queryKey: ["dhcp-pools"] });
@@ -1191,8 +1209,13 @@ function ServerScopesTab({ groupId }: { groupId: string }) {
           scope={delScope}
           groupId={groupId}
           onConfirm={() => delMut.mutate(delScope.id)}
-          onClose={() => setDelScope(null)}
+          onClose={() => {
+            setDelScope(null);
+            setDelScopeNotice(null);
+            delMut.reset();
+          }}
           isPending={delMut.isPending}
+          notice={delScopeNotice}
         />
       )}
     </div>
@@ -2439,6 +2462,7 @@ export function DHCPPage() {
   const [showCreateGroup, setShowCreateGroup] = useState(false);
   const [editGroup, setEditGroup] = useState<DHCPServerGroup | null>(null);
   const [delGroup, setDelGroup] = useState<DHCPServerGroup | null>(null);
+  const [delGroupNotice, setDelGroupNotice] = useState<string | null>(null);
   const [addServerFor, setAddServerFor] = useState<string | null>(null);
   const [editServer, setEditServer] = useState<DHCPServer | null>(null);
   const [delServer, setDelServer] = useState<DHCPServer | null>(null);
@@ -2519,7 +2543,15 @@ export function DHCPPage() {
 
   const deleteGroupMut = useMutation({
     mutationFn: (id: string) => dhcpApi.deleteGroup(id),
-    onSuccess: (_, id) => {
+    onSuccess: (resp, id) => {
+      // Two-person approval (#62): a covered delete returns 202 with a
+      // queued change-request instead of deleting. Surface the message,
+      // refresh the approval queue, and leave the group in place.
+      if (handleApprovalQueued(resp)) {
+        setDelGroupNotice(APPROVAL_QUEUED_MESSAGE);
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+        return;
+      }
       qc.invalidateQueries({ queryKey: ["dhcp-groups"] });
       if (selection && "group" in selection && selection.group?.id === id)
         setSelection(null);
@@ -2616,10 +2648,12 @@ export function DHCPPage() {
           onConfirm={() => deleteGroupMut.mutate(delGroup.id)}
           onClose={() => {
             setDelGroup(null);
+            setDelGroupNotice(null);
             deleteGroupMut.reset();
           }}
           isPending={deleteGroupMut.isPending}
           error={deleteGroupError || null}
+          notice={delGroupNotice}
         />
       )}
       {addServerFor && (

--- a/frontend/src/pages/dhcp/DHCPSubnetPanel.tsx
+++ b/frontend/src/pages/dhcp/DHCPSubnetPanel.tsx
@@ -10,6 +10,11 @@ import {
 } from "lucide-react";
 import { dhcpApi, type DHCPPool, type DHCPScope } from "@/lib/api";
 import { zebraBodyCls } from "@/lib/utils";
+import {
+  APPROVAL_QUEUED_MESSAGE,
+  CHANGE_REQUEST_QUERY_KEY,
+  handleApprovalQueued,
+} from "@/lib/approvalQueue";
 import { CreateScopeModal } from "./CreateScopeModal";
 import { CreatePoolModal } from "./CreatePoolModal";
 import { DeleteConfirmModal } from "./_shared";
@@ -75,6 +80,7 @@ function ScopeCard({ scope }: { scope: DHCPScope }) {
   const [showAddPool, setShowAddPool] = useState(false);
   const [editScope, setEditScope] = useState(false);
   const [deleteScope, setDeleteScope] = useState(false);
+  const [deleteNotice, setDeleteNotice] = useState<string | null>(null);
 
   const { data: pools = [] } = useQuery({
     queryKey: ["dhcp-pools", scope.id],
@@ -93,7 +99,15 @@ function ScopeCard({ scope }: { scope: DHCPScope }) {
 
   const delMut = useMutation({
     mutationFn: () => dhcpApi.deleteScope(scope.id),
-    onSuccess: () => {
+    onSuccess: (resp) => {
+      // Two-person approval (#62): a covered delete returns 202 with a
+      // queued change-request instead of deleting. Surface the message,
+      // refresh the approval queue, and leave the scope in place.
+      if (handleApprovalQueued(resp)) {
+        setDeleteNotice(APPROVAL_QUEUED_MESSAGE);
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+        return;
+      }
       qc.invalidateQueries({
         queryKey: ["dhcp-scopes-subnet", scope.subnet_id],
       });
@@ -197,8 +211,13 @@ function ScopeCard({ scope }: { scope: DHCPScope }) {
           description={`Delete scope "${scope.name}" and all its pools?`}
           references={[`${pools.length} pool${pools.length !== 1 ? "s" : ""}`]}
           onConfirm={() => delMut.mutate()}
-          onClose={() => setDeleteScope(false)}
+          onClose={() => {
+            setDeleteScope(false);
+            setDeleteNotice(null);
+            delMut.reset();
+          }}
           isPending={delMut.isPending}
+          notice={deleteNotice}
         />
       )}
     </div>

--- a/frontend/src/pages/dhcp/_shared.tsx
+++ b/frontend/src/pages/dhcp/_shared.tsx
@@ -87,6 +87,7 @@ export function DeleteConfirmModal({
   onClose,
   isPending,
   error,
+  notice,
 }: {
   title: string;
   description: string;
@@ -96,6 +97,10 @@ export function DeleteConfirmModal({
   onClose: () => void;
   isPending?: boolean;
   error?: string | null;
+  // Non-error feedback shown in a neutral box — used for the #62
+  // two-person approval queue "Submitted for approval" message, where
+  // the delete returned 202 instead of executing.
+  notice?: string | null;
 }) {
   const [checked, setChecked] = useState(false);
   return (
@@ -126,6 +131,11 @@ export function DeleteConfirmModal({
         {error && (
           <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
             {error}
+          </div>
+        )}
+        {notice && (
+          <div className="rounded-md border border-blue-500/40 bg-blue-500/5 px-3 py-2 text-xs text-blue-600 dark:text-blue-400">
+            {notice}
           </div>
         )}
         <div className="flex justify-end gap-2">

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -103,6 +103,11 @@ import {
   RECORD_TYPE_BADGE,
   RECORD_TYPE_BADGE_FALLBACK,
 } from "./recordTypeBadge";
+import {
+  APPROVAL_QUEUED_MESSAGE,
+  CHANGE_REQUEST_QUERY_KEY,
+  handleApprovalQueued,
+} from "@/lib/approvalQueue";
 
 const inputCls =
   "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
@@ -485,6 +490,7 @@ function ConfirmDestroyModal({
   onClose,
   isPending,
   error,
+  notice,
 }: {
   title: string;
   description: React.ReactNode;
@@ -493,6 +499,10 @@ function ConfirmDestroyModal({
   onClose: () => void;
   isPending?: boolean;
   error?: string | null;
+  // Non-error feedback shown in a neutral box — used for the #62
+  // two-person approval queue "Submitted for approval" message, where
+  // the delete returned 202 instead of executing.
+  notice?: string | null;
 }) {
   const [step, setStep] = useState<1 | 2>(1);
   const [checked, setChecked] = useState(false);
@@ -505,6 +515,11 @@ function ConfirmDestroyModal({
           {error && (
             <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
               {error}
+            </div>
+          )}
+          {notice && (
+            <div className="rounded-md border border-blue-500/40 bg-blue-500/5 px-3 py-2 text-xs text-blue-600 dark:text-blue-400">
+              {notice}
             </div>
           )}
           <div className="flex justify-end gap-2">
@@ -545,6 +560,11 @@ function ConfirmDestroyModal({
         {error && (
           <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
             {error}
+          </div>
+        )}
+        {notice && (
+          <div className="rounded-md border border-blue-500/40 bg-blue-500/5 px-3 py-2 text-xs text-blue-600 dark:text-blue-400">
+            {notice}
           </div>
         )}
         <div className="flex justify-end gap-2">
@@ -2750,6 +2770,7 @@ function ZoneDetailView({
   const [showAddSubzone, setShowAddSubzone] = useState(false);
   const [showDelegate, setShowDelegate] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleteNotice, setDeleteNotice] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
   const [showRecFilters, setShowRecFilters] = useState(false);
   const [recFilter, setRecFilter] = useState({ name: "", type: "", value: "" });
@@ -2848,7 +2869,15 @@ function ZoneDetailView({
 
   const deleteZone = useMutation({
     mutationFn: () => dnsApi.deleteZone(group.id, zone.id),
-    onSuccess: () => {
+    onSuccess: (resp) => {
+      // Two-person approval (#62): a covered delete returns 202 with a
+      // queued change-request instead of deleting. Surface the message,
+      // refresh the approval queue, and leave the zone in place.
+      if (handleApprovalQueued(resp)) {
+        setDeleteNotice(APPROVAL_QUEUED_MESSAGE);
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+        return;
+      }
       qc.invalidateQueries({ queryKey: ["dns-zones", group.id] });
       onDeleted();
     },
@@ -3738,8 +3767,13 @@ function ZoneDetailView({
           description={`Permanently delete zone "${zone.name}" and all its records from SpatiumDDI?`}
           checkLabel={`I understand all records in "${zone.name}" will be permanently deleted.`}
           onConfirm={() => deleteZone.mutate()}
-          onClose={() => setConfirmDelete(false)}
+          onClose={() => {
+            setConfirmDelete(false);
+            setDeleteNotice(null);
+            deleteZone.reset();
+          }}
           isPending={deleteZone.isPending}
+          notice={deleteNotice}
         />
       )}
       {syncResult && (
@@ -8422,6 +8456,9 @@ export function DNSPage() {
   const [editGroup, setEditGroup] = useState<DNSServerGroup | null>(null);
   const [confirmDeleteGroup, setConfirmDeleteGroup] =
     useState<DNSServerGroup | null>(null);
+  const [deleteGroupNotice, setDeleteGroupNotice] = useState<string | null>(
+    null,
+  );
   const [expandedGroups, setExpandedGroups] = useSessionState<Set<string>>(
     "spatium.dns.expandedGroups",
     new Set(),
@@ -8546,7 +8583,15 @@ export function DNSPage() {
 
   const deleteGroup = useMutation({
     mutationFn: (id: string) => dnsApi.deleteGroup(id),
-    onSuccess: (_, id) => {
+    onSuccess: (resp, id) => {
+      // Two-person approval (#62): a covered delete returns 202 with a
+      // queued change-request instead of deleting. Surface the message,
+      // refresh the approval queue, and leave the group in place.
+      if (handleApprovalQueued(resp)) {
+        setDeleteGroupNotice(APPROVAL_QUEUED_MESSAGE);
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+        return;
+      }
       qc.invalidateQueries({ queryKey: ["dns-groups"] });
       if (selection && "group" in selection && selection.group.id === id)
         setSelection(null);
@@ -8750,10 +8795,12 @@ export function DNSPage() {
           onConfirm={() => deleteGroup.mutate(confirmDeleteGroup.id)}
           onClose={() => {
             setConfirmDeleteGroup(null);
+            setDeleteGroupNotice(null);
             deleteGroup.reset();
           }}
           isPending={deleteGroup.isPending}
           error={deleteGroupError || null}
+          notice={deleteGroupNotice}
         />
       )}
     </div>

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -83,6 +83,10 @@ import {
   formatApiError,
 } from "@/lib/api";
 import { usePermissions } from "@/hooks/usePermissions";
+import {
+  APPROVAL_QUEUED_MESSAGE,
+  handleApprovalQueued,
+} from "@/lib/approvalQueue";
 import { copyToClipboard } from "@/lib/clipboard";
 import { cn, swatchTintCls, zebraBodyCls } from "@/lib/utils";
 import { SwatchPicker } from "@/components/ui/swatch-picker";
@@ -6604,7 +6608,15 @@ function EditSubnetModal({
     // operator to tick "…and all its contents will be permanently
     // deleted" — cascade is the right semantics. force=true.
     mutationFn: () => ipamApi.deleteSubnet(subnet.id, true),
-    onSuccess: () => {
+    onSuccess: (resp) => {
+      // Two-person approval (#62): a covered delete returns 202 with a
+      // queued change-request instead of deleting. Surface the message,
+      // refresh the approval queue, and leave the subnet in place.
+      if (handleApprovalQueued(resp)) {
+        setDeleteError(APPROVAL_QUEUED_MESSAGE);
+        qc.invalidateQueries({ queryKey: ["change-requests"] });
+        return;
+      }
       qc.invalidateQueries({ queryKey: ["subnets", subnet.space_id] });
       qc.invalidateQueries({ queryKey: ["blocks", subnet.space_id] });
       onDeleted?.();

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -85,6 +85,7 @@ import {
 import { usePermissions } from "@/hooks/usePermissions";
 import {
   APPROVAL_QUEUED_MESSAGE,
+  CHANGE_REQUEST_QUERY_KEY,
   handleApprovalQueued,
 } from "@/lib/approvalQueue";
 import { copyToClipboard } from "@/lib/clipboard";
@@ -9412,6 +9413,7 @@ function ConfirmDestroyModal({
   onClose,
   isPending,
   error,
+  notice,
 }: {
   title: string;
   description: string;
@@ -9420,6 +9422,10 @@ function ConfirmDestroyModal({
   onClose: () => void;
   isPending?: boolean;
   error?: string | null;
+  // Non-error feedback shown in a neutral box — used for the #62
+  // two-person approval queue "Submitted for approval" message, where
+  // the delete returned 202 instead of executing.
+  notice?: string | null;
 }) {
   const [step, setStep] = useState<1 | 2>(1);
   const [checked, setChecked] = useState(false);
@@ -9432,6 +9438,11 @@ function ConfirmDestroyModal({
           {error && (
             <div className="max-h-48 overflow-auto whitespace-pre-line rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
               {error}
+            </div>
+          )}
+          {notice && (
+            <div className="max-h-48 overflow-auto whitespace-pre-line rounded-md border border-blue-500/40 bg-blue-500/5 px-3 py-2 text-xs text-blue-600 dark:text-blue-400">
+              {notice}
             </div>
           )}
           <div className="flex justify-end gap-2">
@@ -9472,6 +9483,11 @@ function ConfirmDestroyModal({
         {error && (
           <div className="max-h-48 overflow-auto whitespace-pre-line rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
             {error}
+          </div>
+        )}
+        {notice && (
+          <div className="max-h-48 overflow-auto whitespace-pre-line rounded-md border border-blue-500/40 bg-blue-500/5 px-3 py-2 text-xs text-blue-600 dark:text-blue-400">
+            {notice}
           </div>
         )}
         <div className="flex justify-end gap-2">
@@ -10896,6 +10912,9 @@ function BlockDetailView({
   const [blockBulkDeleteError, setBlockBulkDeleteError] = useState<
     string | null
   >(null);
+  const [blockBulkDeleteNotice, setBlockBulkDeleteNotice] = useState<
+    string | null
+  >(null);
   const blockBulkDeleteMut = useMutation({
     // allSettled on both phases so a single 409 (non-empty subnet/block)
     // doesn't hide the rest. Subnets first — a subnet hanging off a leaf
@@ -10917,6 +10936,11 @@ function BlockDetailView({
       );
       type Fail = { id: string; kind: "subnet" | "block"; message: string };
       const failures: Fail[] = [];
+      // #62: a covered delete returns 202 (a *fulfilled* response, not a
+      // rejection) with a queued change-request instead of executing. The
+      // old logic counted every non-rejected promise as deleted, silently
+      // swallowing the queue. Inspect each fulfilled response's status.
+      let queued = 0;
       const collect = (
         ids: string[],
         results: PromiseSettledResult<unknown>[],
@@ -10939,20 +10963,34 @@ function BlockDetailView({
                     ? JSON.stringify(detail)
                     : "Unknown error",
             });
+          } else if (handleApprovalQueued(r.value)) {
+            queued += 1;
           }
         });
       };
       collect(subnetIds, subnetResults, "subnet");
       collect(blockIds, blockResults, "block");
-      return { failures, total: subnetIds.length + blockIds.length };
+      return { failures, queued, total: subnetIds.length + blockIds.length };
     },
-    onSuccess: ({ failures, total }) => {
+    onSuccess: ({ failures, queued, total }) => {
       qc.invalidateQueries({ queryKey: ["subnets", block.space_id] });
       qc.invalidateQueries({ queryKey: ["blocks", block.space_id] });
+      if (queued > 0)
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+      const queuedNote =
+        queued > 0 ? `${queued} of ${total} submitted for approval.` : null;
       if (failures.length === 0) {
+        setBlockBulkDeleteError(null);
+        if (queued > 0) {
+          // Some/all were queued — keep the modal open to show the
+          // approval notice instead of reporting them deleted.
+          setBlockBulkDeleteNotice(queuedNote);
+          setSelected(new Set());
+          return;
+        }
         setSelected(new Set());
         setShowBulkDelete(false);
-        setBlockBulkDeleteError(null);
+        setBlockBulkDeleteNotice(null);
         return;
       }
       const subnetLookup = new Map(allSubnets.map((s) => [s.id, s.network]));
@@ -10963,6 +11001,7 @@ function BlockDetailView({
           return `• ${f.kind} ${lookup.get(f.id) ?? f.id}: ${f.message}`;
         })
         .join("\n");
+      setBlockBulkDeleteNotice(queuedNote);
       setBlockBulkDeleteError(
         `${failures.length} of ${total} items could not be deleted:\n${detail}`,
       );
@@ -11312,12 +11351,16 @@ function BlockDetailView({
               checkLabel={`I understand ${noun} will be deleted.`}
               isPending={blockBulkDeleteMut.isPending}
               error={blockBulkDeleteError}
+              notice={blockBulkDeleteNotice}
               onClose={() => {
                 setShowBulkDelete(false);
                 setBlockBulkDeleteError(null);
+                setBlockBulkDeleteNotice(null);
+                blockBulkDeleteMut.reset();
               }}
               onConfirm={() => {
                 setBlockBulkDeleteError(null);
+                setBlockBulkDeleteNotice(null);
                 blockBulkDeleteMut.mutate();
               }}
             />
@@ -12172,6 +12215,9 @@ function SpaceTableView({
   const [spaceBulkDeleteError, setSpaceBulkDeleteError] = useState<
     string | null
   >(null);
+  const [spaceBulkDeleteNotice, setSpaceBulkDeleteNotice] = useState<
+    string | null
+  >(null);
   const bulkDeleteMut = useMutation({
     // allSettled on both phases so a single 409 (non-empty subnet/block)
     // doesn't hide the rest. Subnets first — a subnet hanging off a leaf
@@ -12196,6 +12242,11 @@ function SpaceTableView({
       );
       type Fail = { id: string; kind: "subnet" | "block"; message: string };
       const failures: Fail[] = [];
+      // #62: a covered delete returns 202 (a *fulfilled* response, not a
+      // rejection) with a queued change-request instead of executing. The
+      // old logic counted every non-rejected promise as deleted, silently
+      // swallowing the queue. Inspect each fulfilled response's status.
+      let queued = 0;
       const collect = (
         ids: string[],
         results: PromiseSettledResult<unknown>[],
@@ -12218,20 +12269,34 @@ function SpaceTableView({
                     ? JSON.stringify(detail)
                     : "Unknown error",
             });
+          } else if (handleApprovalQueued(r.value)) {
+            queued += 1;
           }
         });
       };
       collect(subnetIds, subnetResults, "subnet");
       collect(blockIds, blockResults, "block");
-      return { failures, total: subnetIds.length + blockIds.length };
+      return { failures, queued, total: subnetIds.length + blockIds.length };
     },
-    onSuccess: ({ failures, total }) => {
+    onSuccess: ({ failures, queued, total }) => {
       qc.invalidateQueries({ queryKey: ["subnets", space.id] });
       qc.invalidateQueries({ queryKey: ["blocks", space.id] });
+      if (queued > 0)
+        qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY });
+      const queuedNote =
+        queued > 0 ? `${queued} of ${total} submitted for approval.` : null;
       if (failures.length === 0) {
+        setSpaceBulkDeleteError(null);
+        if (queued > 0) {
+          // Some/all were queued — keep the modal open to show the
+          // approval notice instead of reporting them deleted.
+          setSpaceBulkDeleteNotice(queuedNote);
+          setSelected(new Set());
+          return;
+        }
         setSelected(new Set());
         setShowBulkDelete(false);
-        setSpaceBulkDeleteError(null);
+        setSpaceBulkDeleteNotice(null);
         return;
       }
       const lookup = new Map<string, string>();
@@ -12240,6 +12305,7 @@ function SpaceTableView({
       const detail = failures
         .map((f) => `• ${f.kind} ${lookup.get(f.id) ?? f.id}: ${f.message}`)
         .join("\n");
+      setSpaceBulkDeleteNotice(queuedNote);
       setSpaceBulkDeleteError(
         `${failures.length} of ${total} items could not be deleted:\n${detail}`,
       );
@@ -12895,12 +12961,16 @@ function SpaceTableView({
               checkLabel={`I understand ${summary} will be moved to Trash.`}
               isPending={bulkDeleteMut.isPending}
               error={spaceBulkDeleteError}
+              notice={spaceBulkDeleteNotice}
               onClose={() => {
                 setShowBulkDelete(false);
                 setSpaceBulkDeleteError(null);
+                setSpaceBulkDeleteNotice(null);
+                bulkDeleteMut.reset();
               }}
               onConfirm={() => {
                 setSpaceBulkDeleteError(null);
+                setSpaceBulkDeleteNotice(null);
                 bulkDeleteMut.mutate();
               }}
             />


### PR DESCRIPTION
Closes #62.

Two-person approval for high-blast-radius operations — the next item in the RBAC/governance cluster, built on the `Operation` registry + per-resource gating patterns from #103/#449. **Default-off**; when off (or no policy matches) every covered handler executes inline exactly as today.

## What it does
- **Gate:** a covered delete handler calls `gate_or_execute`. If an enabled `approval_policy` matches and the caller can't self-approve, it persists a **change request** (frozen operation + args + preview) and returns **202** instead of executing.
- **Approve:** a *different* eligible operator approves → the op re-runs `preview()` (stale guard) then `apply()` **under the approver**; the audit log carries **both** user IDs. Self-approval is blocked; approving requires `{approve, change_request}` + the underlying op's permission; transitions are `FOR UPDATE` + state-guarded.
- **Coverage (P1):** the 6 risky deletes — subnet / IP block / IP space / DNS zone / DHCP scope / DHCP server-group. Each handler's body is factored into a registered `Operation` so the inline path and the approver-replay path are one code path.
- **Surfaces:** `governance.approvals` feature module (default-off), "Change Approver" builtin role, lifecycle API `/api/v1/change-requests` (approve/reject/cancel + policies CRUD), Celery expiry sweep, 4 MCP tools, and a **Change Requests** admin page (queue + approve/reject + policies tab, `usePermissions`-gated) with 202 handling across the delete surfaces.

## Self-governance lock (the "who guards the guard" answer)
An **opt-in chosen at enable time** (`PlatformSettings.approvals_protect_controls`) so the control itself can't be quietly switched off:
- When on, **disabling** the control needs a **second superadmin** — across all three side-doors: disabling the module, disabling/deleting/weakening a policy (incl. repointing `resource_type`/`action` or inflating `min_count`), and turning the lock off. Strengthening stays single-person.
- **Break-glass:** superadmin force-disable requiring the exact `BREAK GLASS` phrase + password/TOTP reverify, rate-limited, with a high-severity audit + `governance.break_glass` event — so you're never permanently locked out.

## Review trail (all fixed, all on this branch)
- **Code review** — 18 findings incl. **8 blockers** (the factored-handler inline-fidelity regression — 500s instead of 404/409 + an inline permission check; three fail-open gate paths; self-approval-when-requester-deleted; missing frontend 202 handling).
- **Security review (workflows)** — confirmed the two-person spine has **no approval bypass**; fixed its findings (queue read-scoping incl. MCP, policies-list superadmin gate, the stale-preview/soft-delete TOCTOU guard).
- **Lock security review** — caught that the lock initially *didn't hold* (silent no-op on fresh install; policy side-door) → both criticals + the break-glass non-repudiation/rate-limit highs fixed.

## Out of scope (documented follow-up)
P2: bulk_delete / bulk_edit / bulk_allocate (threshold-gated) + factory_reset + import_commit coverage, and notification/digest wiring.

## Verification
`make ci` green; `test_approval_workflows.py` 12/12 · `test_approval_workflows_fixes.py` 19/19 · `test_approvals_lock.py` 24/24 — all run against a freshly-rebuilt container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)