### PR TITLE
fix(dns,perf): bulk record-create + recursion gate + perf-suite follow-ups (#454)

### DIFF
--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -53,7 +53,11 @@ from app.services.dns.delegation import (
     find_parent_zone,
     preview_to_dict,
 )
-from app.services.dns.record_ops import enqueue_record_op, enqueue_record_ops_batch
+from app.services.dns.record_ops import (
+    enqueue_record_op,
+    enqueue_record_ops_batch,
+    enqueue_record_ops_bulk,
+)
 from app.services.dns.serial import bump_zone_serial
 from app.services.dns.zone_templates import (
     get_template,
@@ -4601,6 +4605,152 @@ async def bulk_delete_records(
 
     await db.commit()
     return BulkDeleteRecordsResponse(deleted=deleted, skipped=skipped)
+
+
+# Cap on records per bulk-create call. Keeps the single transaction (and the
+# fan-out of one DNSRecordOp row per record per agent-based server) bounded;
+# callers seeding more loop in chunks of this size.
+BULK_CREATE_RECORDS_MAX = 2000
+
+
+class BulkCreateRecordsRequest(BaseModel):
+    """Create many records in one zone in a single transaction.
+
+    The fast-path counterpart to N singular ``POST .../records`` calls. Each
+    singular create runs its own transaction — commit + zone-SOA-serial bump +
+    audit-chain hash — and every create UPDATEs the one zone row, so concurrent
+    singular creates serialize on that row lock (~6 records/s observed while
+    seeding, perf #454). This bumps the serial once, enqueues all record ops in
+    one batch, writes one audit row, and commits once.
+
+    Exact ``(name, record_type, value)`` duplicates *within the submitted
+    batch* are de-duplicated and reported in ``skipped``; pre-existing records
+    in the zone are NOT checked (the caller owns idempotency — the perf seeder,
+    for example, skips re-seeding a zone it already populated).
+    """
+
+    records: list[RecordCreate]
+
+    @field_validator("records")
+    @classmethod
+    def _validate_records(cls, v: list[RecordCreate]) -> list[RecordCreate]:
+        if not v:
+            raise ValueError("records must be a non-empty list")
+        if len(v) > BULK_CREATE_RECORDS_MAX:
+            raise ValueError(f"at most {BULK_CREATE_RECORDS_MAX} records per bulk-create call")
+        return v
+
+
+class BulkCreateRecordsResponse(BaseModel):
+    created: int
+    skipped: list[dict[str, str]]  # each: {name, record_type, value, reason}
+    target_serial: int | None
+
+
+@router.post(
+    "/groups/{group_id}/zones/{zone_id}/records/bulk-create",
+    response_model=BulkCreateRecordsResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def bulk_create_records(
+    group_id: uuid.UUID,
+    zone_id: uuid.UUID,
+    body: BulkCreateRecordsRequest,
+    db: DB,
+    current_user: CurrentUser,
+) -> BulkCreateRecordsResponse:
+    """Bulk-create records in one zone — one serial bump, one commit, one dispatch."""
+    zone = await _require_zone(group_id, zone_id, db)
+    _enforce_zone_token_scope(current_user, zone_id)
+    _reject_if_synthesised_zone(zone, "add records to")
+
+    # Driver gating is per record-type — check each distinct type once.
+    for rtype in {r.record_type for r in body.records}:
+        await _check_driver_gated_record_type(rtype, group_id, db)
+
+    # De-dupe exact (name, type, value) collisions within the batch so a sloppy
+    # payload doesn't insert pointless duplicate rows.
+    seen: set[tuple[str, str, str]] = set()
+    skipped: list[dict[str, str]] = []
+    accepted: list[RecordCreate] = []
+    for r in body.records:
+        key = (r.name, r.record_type, r.value)
+        if key in seen:
+            skipped.append(
+                {
+                    "name": r.name,
+                    "record_type": r.record_type,
+                    "value": r.value,
+                    "reason": "duplicate within batch",
+                }
+            )
+            continue
+        seen.add(key)
+        accepted.append(r)
+
+    if not accepted:
+        return BulkCreateRecordsResponse(created=0, skipped=skipped, target_serial=None)
+
+    records: list[DNSRecord] = []
+    for r in accepted:
+        r.priority, r.weight, r.port = _normalize_record_struct_fields(
+            r.record_type, r.priority, r.weight, r.port
+        )
+        fqdn = f"{r.name}.{zone.name}" if r.name != "@" else zone.name
+        records.append(
+            DNSRecord(
+                zone_id=zone_id,
+                fqdn=fqdn,
+                created_by_user_id=current_user.id,
+                **r.model_dump(),
+            )
+        )
+    db.add_all(records)
+    target_serial = bump_zone_serial(zone)
+    await db.flush()
+
+    ops = [
+        {
+            "op": "create",
+            "record": {
+                "name": rec.name,
+                "type": rec.record_type,
+                "value": rec.value,
+                "ttl": rec.ttl,
+                "priority": rec.priority,
+                "weight": rec.weight,
+                "port": rec.port,
+            },
+            "target_serial": target_serial,
+        }
+        for rec in records
+    ]
+    await enqueue_record_ops_bulk(db, zone, ops)
+
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="bulk_create",
+            resource_type="dns_record",
+            # One summary row keyed on the zone (the bulk op's target) — a
+            # per-record audit row would reintroduce the audit-chain hash cost
+            # this fast-path exists to avoid. resource_id is NOT NULL.
+            resource_id=str(zone_id),
+            resource_display=f"{len(records)} records in {zone.name}",
+            new_value={
+                "created": len(records),
+                "zone": zone.name,
+                "target_serial": target_serial,
+            },
+            result="success",
+        )
+    )
+    await db.commit()
+    return BulkCreateRecordsResponse(
+        created=len(records), skipped=skipped, target_serial=target_serial
+    )
 
 
 # ── Bulk zone import / export ───────────────────────────────────────────────

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -317,10 +317,18 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             continue
         tsig_keys.append({"name": k.name, "secret": secret, "algorithm": k.algorithm})
 
+    # The DNS group's ``is_recursive=False`` is the high-level authoritative-only
+    # intent (§4.9 DNS safety); it MUST force ``recursion no;`` regardless of the
+    # per-group server options. Previously only ``DNSServerOptions.recursion_enabled``
+    # (default True) drove the render, so a group created with ``is_recursive=False``
+    # silently stayed an open recursive resolver (perf #454). AND the two so the
+    # group flag can only ever tighten, never loosen, recursion.
+    group_is_recursive = bool(getattr(grp, "is_recursive", True)) if grp else True
+    opts_recursion_enabled = getattr(opts, "recursion_enabled", True) if opts else True
     options_block = {
         "forwarders": getattr(opts, "forwarders", []) if opts else [],
         "forward_policy": getattr(opts, "forward_policy", "first") if opts else "first",
-        "recursion_enabled": getattr(opts, "recursion_enabled", True) if opts else True,
+        "recursion_enabled": opts_recursion_enabled and group_is_recursive,
         "dnssec_validation": (getattr(opts, "dnssec_validation", "auto") if opts else "auto"),
         "allow_query": getattr(opts, "allow_query", ["any"]) if opts else ["any"],
         "allow_transfer": (getattr(opts, "allow_transfer", ["none"]) if opts else ["none"]),

--- a/backend/app/services/dns/record_ops.py
+++ b/backend/app/services/dns/record_ops.py
@@ -279,6 +279,80 @@ async def enqueue_record_ops_batch(
     return await _apply_agentless_batch(db, primary, zone, ops)
 
 
+async def enqueue_record_ops_bulk(
+    db: AsyncSession,
+    zone: DNSZone,
+    ops: list[dict[str, Any]],
+) -> int:
+    """Enqueue many ops for a SINGLE zone with one server-set resolution.
+
+    The seeding / bulk-import fast-path. :func:`enqueue_record_ops_batch`
+    re-resolves the agent server list once *per op* (it loops the singular
+    path), which is fine for a handful of records but quadratic-feeling at
+    seed scale. This resolves the enabled agent-based servers once and inserts
+    all ``DNSRecordOp`` rows in a single ``add_all`` + flush; agentless
+    primaries delegate to the existing batched driver call.
+
+    Returns the number of ops dispatched (0 if no enabled primary).
+    """
+    if not ops:
+        return 0
+
+    primary = await resolve_primary_server(db, zone)
+    if primary is None or not primary.is_enabled:
+        logger.warning(
+            "record_op_bulk_dropped",
+            zone=zone.name,
+            group_id=str(zone.group_id),
+            count=len(ops),
+            reason="no enabled primary configured for zone",
+        )
+        return 0
+
+    if is_agentless(primary.driver):
+        rows = await _apply_agentless_batch(db, primary, zone, ops)
+        return sum(1 for r in rows if r is not None)
+
+    # Agent-based: every enabled agent-based server in the group renders an
+    # independent authoritative copy, so each needs its own op rows. Resolve
+    # the set ONCE (mirrors enqueue_record_op's fan-out query).
+    agent_rows = (
+        (
+            await db.execute(
+                select(DNSServer).where(
+                    DNSServer.group_id == zone.group_id,
+                    DNSServer.is_enabled.is_(True),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    agent_servers = [s for s in agent_rows if not is_agentless(s.driver)]
+    if not agent_servers:
+        return 0
+    for srv in agent_servers:
+        db.add_all(
+            [
+                DNSRecordOp(
+                    server_id=srv.id,
+                    zone_name=zone.name,
+                    op=o["op"],
+                    record=o["record"],
+                    target_serial=o.get("target_serial"),
+                    state="pending",
+                )
+                for o in ops
+            ]
+        )
+    await db.flush()
+    # #358 — wake every agent in the group so they drain the queued ops on the
+    # next poll instead of the belt-and-braces tick. Flushed after the outer
+    # commit by the request's ``wake_publishing`` dependency.
+    collect_wake(dns_group_channel(zone.group_id))
+    return len(ops)
+
+
 async def _apply_agentless_batch(
     db: AsyncSession,
     server: DNSServer,

--- a/backend/tests/test_dns_bulk_create_and_recursion.py
+++ b/backend/tests/test_dns_bulk_create_and_recursion.py
@@ -1,0 +1,242 @@
+"""perf #454 — DNS bulk record-create fast-path + `is_recursive` recursion gate.
+
+Two independent fixes surfaced running the perf suite (#452) against a real
+appliance:
+
+* **Bulk create** (`POST .../records/bulk-create`): the seeder did one POST per
+  record; each singular create commits + bumps the zone SOA serial (one row, so
+  concurrent creates serialize on it) + hashes the audit chain → ~6 records/s.
+  The bulk path bumps the serial once, enqueues all ops in one batch, and commits
+  once. Validates: records land, the serial bumps exactly once, one op row per
+  record per enabled agent-based server, within-batch de-dupe, the size cap.
+
+* **Recursion gate**: the bind9 renderer keyed `recursion yes|no;` off
+  ``DNSServerOptions.recursion_enabled`` (default True), ignoring the DNS group's
+  ``is_recursive``. So a group created ``is_recursive=False`` (the §4.9
+  authoritative-only intent) silently stayed an open recursive resolver. The
+  group flag must now force recursion off.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import (
+    DNSRecord,
+    DNSRecordOp,
+    DNSServer,
+    DNSServerGroup,
+    DNSServerOptions,
+    DNSZone,
+)
+from app.services.dns.agent_config import build_config_bundle
+
+
+async def _admin_headers(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _bind9_group(
+    db: AsyncSession, *, is_recursive: bool = True, recursion_enabled: bool = True
+) -> tuple[DNSServerGroup, DNSZone, DNSServer]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", is_recursive=is_recursive)
+    db.add(grp)
+    await db.flush()
+    server = DNSServer(
+        group_id=grp.id,
+        driver="bind9",
+        host="bind9.example.com",
+        name=f"srv-{uuid.uuid4().hex[:6]}",
+        is_primary=True,
+        is_enabled=True,
+    )
+    db.add(server)
+    db.add(DNSServerOptions(group_id=grp.id, recursion_enabled=recursion_enabled))
+    zone = DNSZone(
+        group_id=grp.id,
+        name="campus.example.edu.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.campus.example.edu.",
+        admin_email="admin.campus.example.edu.",
+    )
+    db.add(zone)
+    await db.flush()
+    return grp, zone, server
+
+
+# ── Bulk create ──────────────────────────────────────────────────────────
+
+
+async def test_bulk_create_inserts_all_with_single_serial_bump(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone, server = await _bind9_group(db_session)
+    serial_before = zone.last_serial
+    await db_session.commit()
+
+    records = [
+        {"name": f"dev-{i:05d}", "record_type": "A", "value": f"10.0.0.{i % 250 + 1}"}
+        for i in range(50)
+    ]
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records/bulk-create",
+        headers=h,
+        json={"records": records},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["created"] == 50
+    assert body["skipped"] == []
+    assert body["target_serial"] is not None
+
+    # All 50 records present in the zone.
+    rows = (
+        (await db_session.execute(select(DNSRecord).where(DNSRecord.zone_id == zone.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 50
+
+    # Serial bumped exactly once (not 50 times).
+    await db_session.refresh(zone)
+    assert zone.last_serial == body["target_serial"]
+    assert zone.last_serial > serial_before
+
+    # One pending op row per record for the single enabled agent-based server.
+    ops = (
+        (await db_session.execute(select(DNSRecordOp).where(DNSRecordOp.server_id == server.id)))
+        .scalars()
+        .all()
+    )
+    assert len(ops) == 50
+    assert all(o.op == "create" and o.state == "pending" for o in ops)
+    assert all(o.target_serial == body["target_serial"] for o in ops)
+
+
+async def test_bulk_create_dedupes_within_batch(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone, _ = await _bind9_group(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records/bulk-create",
+        headers=h,
+        json={
+            "records": [
+                {"name": "dup", "record_type": "A", "value": "10.0.0.1"},
+                {"name": "dup", "record_type": "A", "value": "10.0.0.1"},  # exact dup
+                {"name": "dup", "record_type": "A", "value": "10.0.0.2"},  # diff value: kept
+            ]
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["created"] == 2
+    assert len(body["skipped"]) == 1
+    assert body["skipped"][0]["reason"] == "duplicate within batch"
+
+
+async def test_bulk_create_rejects_empty_and_oversize(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone, _ = await _bind9_group(db_session)
+    await db_session.commit()
+
+    base = f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records/bulk-create"
+    empty = await client.post(base, headers=h, json={"records": []})
+    assert empty.status_code == 422, empty.text
+
+    over = await client.post(
+        base,
+        headers=h,
+        json={
+            "records": [
+                {"name": f"d{i}", "record_type": "A", "value": "10.0.0.1"} for i in range(2001)
+            ]
+        },
+    )
+    assert over.status_code == 422, over.text
+
+
+async def test_bulk_create_srv_normalizes_struct_fields(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp, zone, _ = await _bind9_group(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records/bulk-create",
+        headers=h,
+        json={
+            "records": [
+                {
+                    "name": "_sip._tcp",
+                    "record_type": "SRV",
+                    "value": "sip.campus.example.edu.",
+                    "priority": 10,
+                    "weight": 20,
+                    "port": 5060,
+                },
+            ]
+        },
+    )
+    assert r.status_code == 201, r.text
+    rec = (
+        (await db_session.execute(select(DNSRecord).where(DNSRecord.zone_id == zone.id)))
+        .scalars()
+        .one()
+    )
+    assert (rec.priority, rec.weight, rec.port) == (10, 20, 5060)
+
+
+# ── Recursion gate (perf #454) ───────────────────────────────────────────
+
+
+async def test_group_is_recursive_false_forces_recursion_off(
+    db_session: AsyncSession,
+) -> None:
+    # Options say recursion is ON, but the group is authoritative-only — the
+    # group flag must win so the rendered config gets ``recursion no;``.
+    _grp, _zone, server = await _bind9_group(db_session, is_recursive=False, recursion_enabled=True)
+    await db_session.commit()
+
+    bundle = await build_config_bundle(db_session, server)
+    assert bundle["options"]["recursion_enabled"] is False
+
+
+async def test_group_is_recursive_true_respects_options(
+    db_session: AsyncSession,
+) -> None:
+    _grp, _zone, server = await _bind9_group(db_session, is_recursive=True, recursion_enabled=True)
+    await db_session.commit()
+    bundle = await build_config_bundle(db_session, server)
+    assert bundle["options"]["recursion_enabled"] is True
+
+    # And options can still turn it off on a recursive group.
+    _grp2, _zone2, server2 = await _bind9_group(
+        db_session, is_recursive=True, recursion_enabled=False
+    )
+    await db_session.commit()
+    bundle2 = await build_config_bundle(db_session, server2)
+    assert bundle2["options"]["recursion_enabled"] is False

--- a/docs/PERF_APPLIANCE_SETUP.md
+++ b/docs/PERF_APPLIANCE_SETUP.md
@@ -63,15 +63,30 @@ The supervisor brings up bind9 + kea on its next heartbeat (~30–60 s). Verify:
 K get pods -n spatium -o wide | grep -E 'bind9|kea'         # both Running, IP = node IP (hostNetwork)
 $SSH 'echo <ssh-pass> | sudo -S ss -lntu' | grep -E ':53 |:67 '   # node IP listening on :53/:67
 dig +short @$APP version.bind CH TXT                        # bind answers
-dig +short @$APP google.com A                               # → SERVFAIL/empty (recursion OFF; NOT a real answer = no leak)
+dig +short @$APP google.com A                               # → SERVFAIL/REFUSED/empty (recursion OFF; a real IP = LEAK)
 K exec -n spatium ds/dns-bind9 -- grep -iE 'recursion|allow-recursion' /etc/bind/named.conf.options
-#   → "recursion no;" + "allow-recursion { none; };"   (the §4.9 safety property)
+#   → "recursion no;"   (the §4.9 safety property)
 ```
 The appliance capabilities must advertise `can_run_dns_bind9` / `can_run_dhcp` (they
 do on a full appliance); the role PUT 422s otherwise.
 
-> **Recursion note:** this bind returns **SERVFAIL** (not REFUSED) for out-of-zone
-> names. Both mean "did not resolve" — the §4.9 recursion-leak pre-flight should treat
+> **⚠️ Recursion (perf #454).** The rendered `recursion no;` is driven by the bind9
+> server **options** (`DNSServerOptions.recursion_enabled`), and historically the
+> group's `is_recursive=false` did NOT propagate to it — so a group created per §1
+> above could still render `recursion yes;` and resolve the public internet (a §4.9
+> leak). Fixed so `is_recursive=false` now forces recursion off. **Always verify with
+> the `dig google.com` above** — a real A record back means recursion is still on.
+> Belt-and-braces (and the fix for appliances on a pre-#454 backend), force it off via
+> the options endpoint:
+>
+> ```bash
+> curl -sk -X PUT https://$APP/api/v1/dns/groups/$DNS_GID/options \
+>   -H "Authorization: Bearer $(tok)" -H 'Content-Type: application/json' \
+>   -d '{"recursion_enabled": false, "allow_recursion": []}'
+> ```
+>
+> This bind returns **REFUSED/SERVFAIL** (not a real answer) for out-of-zone names
+> once recursion is off — both mean "did not resolve". The §4.9 pre-flight treats
 > *only* a real external answer (NOERROR + an A record) as a leak.
 
 ## 3. Expose Postgres + Redis off-box (NodePorts)

--- a/perf/generators/orchestrator/device_fleet.py
+++ b/perf/generators/orchestrator/device_fleet.py
@@ -141,6 +141,7 @@ class SubnetInfo:
 class Counters:
     dora_sent: int = 0
     dora_ack: int = 0
+    foreign_ack: int = 0   # ACKs whose IP is outside every seeded subnet (perf #454 — wrong DHCP server answered)
     nak: int = 0
     timeout: int = 0
     decline: int = 0
@@ -288,6 +289,13 @@ class Orchestrator:
 
         self.subnets = _derive_subnets(self.m, self.rp, self.log)
         self.n_subnets = len(self.subnets)
+        # perf #454 — foreign-responder guard. On a shared LAN the site's
+        # production DHCP server can win the broadcast race and ACK from a
+        # different subnet; a lease outside every seeded subnet means we're
+        # measuring the wrong server. Precompute the seeded networks once.
+        import ipaddress as _ipa  # noqa: PLC0415
+        self._seeded_nets = [_ipa.ip_network(s.cidr, strict=False) for s in self.subnets]
+        self._foreign_warned = False
 
         # Disjoint device index range for this shard (sharded over unique_devices).
         self.indices = list(fleet.shard_indices(self.m.scale.unique_devices, self.shard, self.shards))
@@ -339,6 +347,21 @@ class Orchestrator:
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        # Multi-homed egress (perf #454). In broadcast topology the DISCOVER goes
+        # to 255.255.255.255; on a box with several NICs (docker bridges, tailscale,
+        # …) the kernel won't necessarily send it out the one facing the appliance.
+        # Bind the socket to the configured device so it does. SO_BINDTODEVICE needs
+        # CAP_NET_RAW (the load-gen already runs as root for the :67/:68 bind).
+        iface = getattr(self.m.target.dhcp, "iface", "") or ""
+        if iface:
+            try:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, iface.encode())
+                self.log.info("dhcp socket bound to device", extra={"fields": {
+                    "event": "socket_bindtodevice", "iface": iface}})
+            except OSError as exc:
+                self.log.error("SO_BINDTODEVICE(%s) failed: %s — broadcast may not "
+                               "reach the appliance on a multi-homed box", iface, exc,
+                               extra={"fields": {"event": "bindtodevice_failed", "iface": iface}})
         # Relay topology: bind to the relay/server port (67) so Kea unicasts replies
         # to giaddr:67 back to us. Broadcast topology: bind to the client port (68).
         bind_port = 67 if self.relay else 68
@@ -472,11 +495,36 @@ class Orchestrator:
             return
         self._send_request_selecting(dev, offered, sid)
 
+    def _ip_in_seeded_subnet(self, ip: str) -> bool:
+        """True if ``ip`` falls within any seeded subnet (perf #454 foreign-responder guard)."""
+        import ipaddress as _ipa  # noqa: PLC0415
+        try:
+            addr = _ipa.ip_address(ip)
+        except ValueError:
+            return False
+        return any(addr in net for net in self._seeded_nets)
+
     def _on_ack(self, dev: Device, reply: dict, now: float) -> None:
         prev_state = dev.state
         new_ip = reply.get("yiaddr")
         latency_ms = (now - dev.tx_at) * 1000.0
         if prev_state in (DState.DISCOVERING,):
+            # perf #454 — foreign-responder guard. If the leased IP is outside
+            # every seeded subnet, a DIFFERENT DHCP server answered (e.g. the
+            # site router on a shared LAN) — we're not testing the appliance's
+            # Kea. Count it and warn loudly (once) so the run isn't silently
+            # measuring the wrong server. Use an isolated VLAN or relay topology.
+            if new_ip and self._seeded_nets and not self._ip_in_seeded_subnet(new_ip):
+                self.counters.foreign_ack += 1
+                if not self._foreign_warned:
+                    self._foreign_warned = True
+                    self.log.error(
+                        "DHCP ACK from a FOREIGN server — leased IP %s is outside "
+                        "every seeded subnet. A non-appliance DHCP server is winning "
+                        "the broadcast race; use an isolated test VLAN or relay "
+                        "topology (perf #454).", new_ip,
+                        extra={"fields": {"event": "foreign_dhcp_responder",
+                                          "leased_ip": new_ip, "server_id": reply.get("server_id")}})
             # DORA ACK — first lease (or re-lease after re-arrival).
             dev.leased_ip = new_ip
             dev.server_id = reply.get("server_id") or dev.server_id

--- a/perf/harness/spddi_perf/logging_util.py
+++ b/perf/harness/spddi_perf/logging_util.py
@@ -79,7 +79,12 @@ def get_logger(
     stream.setFormatter(fmt)
     logger.addHandler(stream)
 
-    if logfile:
+    # Workers run under the controller with their stderr already teed to this same
+    # logfile (workers.child_env sets SPDDI_PERF_LOG_VIA_STDERR). Adding a
+    # FileHandler too would write every line twice (perf #454), so the marker
+    # makes us stay stderr-only. The foreground controller (no marker) still gets
+    # both its terminal (stderr) and its own logfile.
+    if logfile and not os.environ.get("SPDDI_PERF_LOG_VIA_STDERR"):
         Path(logfile).parent.mkdir(parents=True, exist_ok=True)
         fh = logging.FileHandler(logfile)
         fh.setFormatter(fmt)

--- a/perf/harness/spddi_perf/manifest.py
+++ b/perf/harness/spddi_perf/manifest.py
@@ -31,6 +31,12 @@ class DhcpTarget:
     port: int = 67
     topology: str = "broadcast"      # "relay" | "broadcast" (Phase-0 decision, §3.1.2)
     giaddr: list[str] = field(default_factory=list)  # one per subnet when relay
+    # Egress interface for the broadcast DISCOVER (perf #454). On a multi-homed
+    # load-gen box ``255.255.255.255`` won't necessarily leave the NIC facing the
+    # appliance, so the orchestrator binds the socket to this device
+    # (SO_BINDTODEVICE). Empty = let the kernel route (single-homed boxes).
+    # ``SPDDI_PERF_DHCP_IFACE`` overrides at runtime.
+    iface: str = ""
 
 
 @dataclass
@@ -181,7 +187,8 @@ def _as_target(d: dict[str, Any]) -> Target:
         node_ip=d.get("node_ip", ""),
         api_base=d.get("api_base", ""),
         dhcp=DhcpTarget(port=dhcp.get("port", 67), topology=dhcp.get("topology", "broadcast"),
-                        giaddr=list(dhcp.get("giaddr", []) or [])),
+                        giaddr=list(dhcp.get("giaddr", []) or []),
+                        iface=os.environ.get("SPDDI_PERF_DHCP_IFACE", dhcp.get("iface", "")) or ""),
         dns=DnsTarget(port=dns.get("port", 53), driver=dns.get("driver", "bind9"),
                       recursion=bool(dns.get("recursion", False))),
         appliance=d.get("appliance", {}) or {},

--- a/perf/harness/spddi_perf/workers.py
+++ b/perf/harness/spddi_perf/workers.py
@@ -72,6 +72,12 @@ def child_env() -> dict[str, str]:
     existing = env.get("PYTHONPATH", "")
     parts = [str(HARNESS_DIR)] + ([existing] if existing else [])
     env["PYTHONPATH"] = os.pathsep.join(parts)
+    # Workers are launched with stderr→logfile (the oneshot/longrunning helpers
+    # redirect the child's stdout+stderr into the per-worker logfile). Their
+    # get_logger must therefore NOT also add its own FileHandler to that same
+    # file, or every JSON line lands twice (perf #454). This marker tells
+    # get_logger to stay stderr-only so the redirect is the sole file writer.
+    env["SPDDI_PERF_LOG_VIA_STDERR"] = "1"
     return env
 
 

--- a/perf/seeder/seed_scaffold.py
+++ b/perf/seeder/seed_scaffold.py
@@ -72,7 +72,9 @@ ENV_DNS_GROUP_ID = "SPDDI_PERF_DNS_GROUP_ID"
 ENV_DHCP_GROUP_ID = "SPDDI_PERF_DHCP_GROUP_ID"
 
 RECORD_CHUNK = 200          # records logged per progress line
-RECORD_WORKERS = 16         # concurrent POSTs for the bulk record load
+RECORD_WORKERS = 16         # concurrent POSTs for the per-record fallback load
+BULK_BATCH = 1000           # records per records/bulk-create call (endpoint cap is 2000)
+BULK_WORKERS = 6            # concurrent bulk-create batches (perf #454 fast-path)
 
 
 # ---------------------------------------------------------------------------
@@ -264,11 +266,90 @@ class _BulkLoader:
                     self.aborted = True
                     log_event(self.log, 40, "bulk_load_auth_abort", error=msg[:200])
 
+    def _bulk_post(self, zone_id: str, batch: list[dict[str, Any]]) -> int | None:
+        """POST one ``records/bulk-create`` batch. Returns the created count, or
+        ``None`` if the endpoint is absent (404 — appliance predates perf #454),
+        signalling the caller to fall back to the per-record path."""
+        # POST /v1/dns/groups/{gid}/zones/{zid}/records/bulk-create — dns/router.py
+        path = f"/v1/dns/groups/{self.group_id}/zones/{zone_id}/records/bulk-create"
+        body = {"records": [
+            {"name": r["name"], "record_type": r["record_type"], "value": r["value"]}
+            for r in batch
+        ]}
+        try:
+            resp = self.api.json("POST", path, json=body, ok=(201,))
+            return int(resp.get("created", 0))
+        except ApiError as exc:
+            if exc.status_code == 404:
+                return None  # endpoint not deployed — fall back to per-record
+            msg = str(exc)
+            with self._lock:
+                self.failed += len(batch)
+                if len(self._first_errors) < 5:
+                    self._first_errors.append(msg[:200])
+                if not self.aborted and exc.status_code in (401, 403):
+                    self.aborted = True
+                    log_event(self.log, 40, "bulk_load_auth_abort", error=msg[:200])
+            return 0
+
     def load(self, items: list[tuple[str, dict[str, Any]]]) -> None:
-        """Load ``(zone_id, record)`` pairs concurrently with progress logging."""
+        """Load ``(zone_id, record)`` pairs with progress logging.
+
+        Fast-path (perf #454): group by zone and POST in ``records/bulk-create``
+        batches — one transaction / serial-bump / commit per batch instead of
+        per record (~6 rec/s → orders of magnitude faster). Probes the endpoint
+        with the first batch; on 404 (older appliance) falls back to the legacy
+        concurrent per-record POST loop so the seeder still works either way.
+        """
         total = len(items)
         if not total:
             return
+
+        # Group by zone so each bulk batch targets a single zone.
+        by_zone: dict[str, list[dict[str, Any]]] = {}
+        for zid, rec in items:
+            by_zone.setdefault(zid, []).append(rec)
+        batches: list[tuple[str, list[dict[str, Any]]]] = []
+        for zid, recs in by_zone.items():
+            for i in range(0, len(recs), BULK_BATCH):
+                batches.append((zid, recs[i:i + BULK_BATCH]))
+
+        t0 = time.time()
+        done = 0
+
+        # Probe the endpoint synchronously with the first batch.
+        zid0, batch0 = batches[0]
+        probe = self._bulk_post(zid0, batch0)
+        if probe is None:
+            log_event(self.log, logging.INFO, "bulk_create_unavailable",
+                      note="records/bulk-create returned 404 — falling back to per-record POST")
+            self._load_per_record(items)
+            return
+        with self._lock:
+            self.created += probe
+        done += len(batch0)
+        log_event(self.log, logging.INFO, "bulk_record_progress", done=done, total=total,
+                  created=self.created, failed=self.failed,
+                  rate_per_s=round(done / max(1e-6, time.time() - t0), 1))
+
+        # Remaining batches concurrently.
+        with cf.ThreadPoolExecutor(max_workers=BULK_WORKERS) as ex:
+            futs = {ex.submit(self._bulk_post, zid, b): len(b) for zid, b in batches[1:]}
+            for fut in cf.as_completed(futs):
+                n = futs[fut]
+                created = fut.result()
+                with self._lock:
+                    if created:
+                        self.created += created
+                done += n
+                if done % max(BULK_BATCH, RECORD_CHUNK) < n or done == total:
+                    log_event(self.log, logging.INFO, "bulk_record_progress", done=done,
+                              total=total, created=self.created, failed=self.failed,
+                              rate_per_s=round(done / max(1e-6, time.time() - t0), 1))
+
+    def _load_per_record(self, items: list[tuple[str, dict[str, Any]]]) -> None:
+        """Legacy fallback: one POST per record (used when bulk-create is 404)."""
+        total = len(items)
         done = 0
         t0 = time.time()
         with cf.ThreadPoolExecutor(max_workers=RECORD_WORKERS) as ex:


### PR DESCRIPTION
Follow-up fixes from the first real-appliance run of the perf suite (#452), tracked in
#454. **Based on `issue-452`** (not `main`) because the perf suite isn't merged yet —
re-target to `main` once #452 lands.

## What's here (2 commits)

**`fix(dns)` — backend, unit-tested**
- New `POST /dns/groups/{gid}/zones/{zid}/records/bulk-create`: many records in one
  transaction — one zone-SOA-serial bump, one batched record-op dispatch
  (`enqueue_record_ops_bulk` resolves the agent server set once), one summary audit
  row, one commit. The per-record POST path serialized on the single zone row at
  ~6 rec/s, so the 24h manifest (500k records) needed ~21h just to seed.
- Recursion: `build_config_bundle` now ANDs the DNS group's `is_recursive` into the
  rendered `recursion_enabled`. Previously the bind9 render keyed only off
  `DNSServerOptions.recursion_enabled` (default on), so a group created
  `is_recursive=False` (the §4.9 authoritative-only intent) silently stayed an open
  recursive resolver. The group flag can now only tighten recursion, never loosen it.

**`fix(perf)` — harness**
- Seeder uses bulk-create (chunks of 1000) with a graceful per-record fallback when the
  appliance predates the endpoint (404).
- Orchestrator binds the broadcast socket to `target.dhcp.iface` / `SPDDI_PERF_DHCP_IFACE`
  (SO_BINDTODEVICE) — on a multi-homed load-gen box `255.255.255.255` wasn't egressing
  the appliance-facing NIC.
- Foreign-DHCP-responder guard: an ACK whose IP is outside every seeded subnet (the site
  DHCP server winning the broadcast race on a shared LAN) is counted + warned loudly.
- Worker logs no longer double-write (stderr was teed to the same logfile `get_logger`'s
  FileHandler wrote).
- `PERF_APPLIANCE_SETUP.md` §2: correct the stale "is_recursive renders recursion no;"
  claim + add the `dig` verification and options fallback.

## Validation
- `test_dns_bulk_create_and_recursion.py` (6 cases); `make perf-compile` + ruff/black/mypy
  clean; 60 existing DNS tests still pass.
- **Deployed + validated live on a test appliance** (release-schema build of the same
  fix): bulk-create did **250 records in 0.11s (~2,344 rec/s vs ~6/s)**, records served
  by BIND end-to-end, and the recursion fix held (`recursion_enabled=true` +
  `is_recursive=false` → rendered `recursion no;`, no leak).

## Scope notes
- Addresses #454. Still open there: a hard pre-flight DHCP responder-identity gate
  (#454 item 2 is a runtime warning only) and seed-progress in `state.json` (item 6).
- DNS-records / DHCP-leases **pagination** spun out as #455 (separate effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
