### PR TITLE
fix(dhcp): Sync→DHCP 400 on Kea (#453) + feat: paginate DNS records & DHCP leases (#455)

### DIFF
--- a/backend/app/api/pagination.py
+++ b/backend/app/api/pagination.py
@@ -1,0 +1,52 @@
+"""Shared pagination envelope for list endpoints (#455).
+
+A generic ``{items, total, page, page_size}`` response so list endpoints that
+can grow unbounded (DNS zone records, DHCP leases, …) paginate server-side
+instead of returning the whole table in one query + payload. New list
+endpoints should adopt ``Page[T]`` for a consistent shape — the same shape the
+nmap / network-device list endpoints already use ad-hoc.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Select
+
+# Default page size for paginated list endpoints. 100 keeps a 20k-record zone
+# (the #455 trigger) to a 200-row poll instead of pulling the whole table.
+DEFAULT_PAGE_SIZE = 100
+# Upper bound a client may request. Bounded so "fetch all" can't sneak back in
+# through an enormous page_size — bulk export has its own dedicated endpoint.
+MAX_PAGE_SIZE = 1000
+
+
+class Page[T](BaseModel):
+    """A single page of ``items`` plus the counters the UI needs to render
+    page controls (``total`` across all pages, current ``page``, ``page_size``).
+    """
+
+    items: list[T]
+    total: int
+    page: int
+    page_size: int
+
+
+async def paginate(
+    db: AsyncSession, base: Select[Any], *, page: int, page_size: int
+) -> tuple[list[Any], int]:
+    """Return ``(page_rows, total)`` for ``base``, a ``select`` of ORM entities.
+
+    ``base`` should already carry its ``WHERE`` + ``ORDER BY``. ``total`` is
+    counted with the ordering stripped (it's irrelevant to a count and lets
+    Postgres skip the sort); the returned slice keeps the order and applies
+    ``LIMIT``/``OFFSET``. Callers map the scalar rows to their response model.
+    """
+    total = (
+        await db.execute(select(func.count()).select_from(base.order_by(None).subquery()))
+    ).scalar_one()
+    rows = (await db.execute(base.limit(page_size).offset((page - 1) * page_size))).scalars().all()
+    return list(rows), total

--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -12,7 +12,13 @@ from sqlalchemy import func, or_, select
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.api.v1.dhcp._audit import write_audit
-from app.core.agent_wake import collect_wake, dhcp_group_channel, dhcp_server_channel
+from app.core.agent_wake import (
+    collect_wake,
+    dhcp_group_channel,
+    dhcp_server_channel,
+    dhcp_wake_channels,
+    publish_wake,
+)
 from app.core.crypto import encrypt_dict
 from app.core.permissions import require_resource_permission
 from app.drivers.dhcp import is_agentless, is_read_only
@@ -284,6 +290,10 @@ class SyncLeasesResponse(BaseModel):
     mac_blocks_added: int = 0
     mac_blocks_removed: int = 0
     errors: list[str]
+    # Set on the agent-based no-op path (Kea): a human-readable explanation
+    # that there was nothing to pull and the agent was nudged to re-poll its
+    # config. ``None`` for the normal agentless lease-pull path.
+    note: str | None = None
 
 
 @router.get("", response_model=list[ServerResponse])
@@ -583,9 +593,29 @@ async def sync_leases_now(server_id: uuid.UUID, db: DB, user: SuperAdmin) -> Syn
     if s is None:
         raise HTTPException(status_code=404, detail="Server not found")
     if not is_agentless(s.driver):
-        raise HTTPException(
-            status_code=400,
-            detail=f"driver {s.driver!r} is agent-based; leases arrive via the agent",
+        # Agent-based drivers (Kea) stream lease events continuously and pick
+        # up scope/config changes through the ConfigBundle long-poll, so there
+        # is nothing to *pull*. Returning 400 here made the IPAM "Sync → DHCP"
+        # action look broken for operators whose subnet is backed by a Kea
+        # appliance (#453) — the modal fans this endpoint out to every server
+        # behind the subnet, agent-based ones included. Instead, nudge the
+        # agent to re-poll its config now so the subnet/scope definition
+        # converges immediately, and return a no-op result with an explanatory
+        # note rather than an error.
+        await publish_wake(*dhcp_wake_channels(s))
+        return SyncLeasesResponse(
+            server_leases=0,
+            imported=0,
+            refreshed=0,
+            ipam_created=0,
+            ipam_refreshed=0,
+            out_of_scope=0,
+            errors=[],
+            note=(
+                f"{s.driver} is agent-based: leases stream live from the agent and the "
+                "scope/subnet definition converges automatically via the agent's config "
+                "poll. Nudged the agent to re-poll now."
+            ),
         )
     result = await pull_leases_from_server(db, s, apply=True)
 

--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -6,11 +6,12 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, field_validator
-from sqlalchemy import func, or_, select
+from sqlalchemy import String, cast, func, or_, select
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
+from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page, paginate
 from app.api.v1.dhcp._audit import write_audit
 from app.core.agent_wake import (
     collect_wake,
@@ -1026,31 +1027,48 @@ async def get_server_rendered_config(
     )
 
 
-@router.get("/{server_id}/leases", response_model=list[LeaseResponse])
+@router.get("/{server_id}/leases", response_model=Page[LeaseResponse])
 async def list_leases(
     server_id: uuid.UUID,
     db: DB,
     _: CurrentUser,
-    limit: int = 500,
+    search: str | None = Query(None, description="substring over ip / mac / hostname"),
+    state: str | None = Query(None, description="exact lease state filter"),
     device_class: str | None = None,
-) -> list[DHCPLease]:
-    """List leases, enriched with OUI vendor + fingerbank device class (#373).
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+) -> Page[LeaseResponse]:
+    """Leases for a server, server-side paginated (#455), enriched with OUI
+    vendor + fingerbank device class (#373).
 
-    ``device_class`` filters server-side to leases whose joined fingerbank
-    classification matches (so the ``limit`` applies to matching rows). When
-    fingerprinting is off / unconfigured the device fields are simply blank.
+    A busy server's older leases used to be unreachable past the most-recent N.
+    ``search`` matches ip / mac / hostname; ``state`` and ``device_class`` are
+    exact filters (the latter joins the fingerprint table so the page lands on
+    matching rows). When fingerprinting is off the device fields are blank.
     """
     s = await db.get(DHCPServer, server_id)
     if s is None:
         raise HTTPException(status_code=404, detail="Server not found")
     q = select(DHCPLease).where(DHCPLease.server_id == server_id)
     if device_class:
-        # Inner-join the fingerprint table so the limit lands on matching rows.
+        # Inner-join the fingerprint table so the page lands on matching rows.
         q = q.join(DHCPFingerprint, DHCPFingerprint.mac_address == DHCPLease.mac_address).where(
             DHCPFingerprint.fingerbank_device_class == device_class
         )
-    q = q.order_by(DHCPLease.last_seen_at.desc()).limit(min(limit, 5000))
-    rows = list((await db.execute(q)).scalars().all())
+    if state:
+        q = q.where(DHCPLease.state == state)
+    if search and search.strip():
+        like = f"%{search.strip()}%"
+        # ip_address / mac_address are INET / MACADDR — cast to text for ilike.
+        q = q.where(
+            or_(
+                cast(DHCPLease.ip_address, String).ilike(like),
+                cast(DHCPLease.mac_address, String).ilike(like),
+                DHCPLease.hostname.ilike(like),
+            )
+        )
+    q = q.order_by(DHCPLease.last_seen_at.desc())
+    rows, total = await paginate(db, q, page=page, page_size=page_size)
 
     vendors = await bulk_lookup_vendors(
         db, [str(lease.mac_address) if lease.mac_address else None for lease in rows]
@@ -1078,7 +1096,12 @@ async def list_leases(
             fp.fingerbank_manufacturer if fp else None
         )
         lease.fingerbank_score = fp.fingerbank_score if fp else None  # type: ignore[attr-defined]
-    return rows
+    return Page[LeaseResponse](
+        items=[LeaseResponse.model_validate(lease) for lease in rows],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
 
 
 # --- Per-server stats (#195) ------------------------------------------------

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -14,10 +14,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import delete as sa_delete
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
+from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page, paginate
 from app.core.agent_wake import collect_wake, dns_group_channel, dns_server_channel
 from app.core.crypto import decrypt_dict, encrypt_dict, encrypt_str
 from app.core.permissions import (
@@ -4191,19 +4192,31 @@ class GroupRecordResponse(BaseModel):
 
 @router.get(
     "/groups/{group_id}/records",
-    response_model=list[GroupRecordResponse],
+    response_model=Page[GroupRecordResponse],
 )
 async def list_group_records(
-    group_id: uuid.UUID, db: DB, _: CurrentUser
-) -> list[GroupRecordResponse]:
-    """Every record across every zone in the group, with zone + view context."""
+    group_id: uuid.UUID,
+    db: DB,
+    _: CurrentUser,
+    search: str | None = Query(
+        None, description="substring over name / fqdn / value / type / zone"
+    ),
+    record_type: str | None = Query(None, description="exact record type filter (A, MX, …)"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+) -> Page[GroupRecordResponse]:
+    """Every record across every zone in the group, with zone + view context,
+    server-side paginated (#455). ``search`` matches name / fqdn / value / type
+    / zone name; ``record_type`` is an exact filter for the type dropdown.
+    """
     await _require_group(group_id, db)
 
     zones = list(
         (await db.execute(select(DNSZone).where(DNSZone.group_id == group_id))).scalars().all()
     )
+    empty: Page[GroupRecordResponse] = Page(items=[], total=0, page=page, page_size=page_size)
     if not zones:
-        return []
+        return empty
     zone_by_id = {z.id: z for z in zones}
 
     views = list(
@@ -4211,17 +4224,27 @@ async def list_group_records(
     )
     view_name_by_id = {v.id: v.name for v in views}
 
-    records = list(
-        (
-            await db.execute(
-                select(DNSRecord)
-                .where(DNSRecord.zone_id.in_(list(zone_by_id.keys())))
-                .order_by(DNSRecord.fqdn, DNSRecord.record_type)
-            )
-        )
-        .scalars()
-        .all()
-    )
+    stmt = select(DNSRecord).where(DNSRecord.zone_id.in_(list(zone_by_id.keys())))
+    if record_type:
+        stmt = stmt.where(func.upper(DNSRecord.record_type) == record_type.upper())
+    if search and search.strip():
+        term = search.strip()
+        like = f"%{term}%"
+        # Zone names live on the (few) DNSZone rows already in memory — resolve
+        # the matching zone ids here so the record query stays a single filter.
+        zone_hits = [zid for zid, z in zone_by_id.items() if term.lower() in z.name.lower()]
+        conds = [
+            DNSRecord.name.ilike(like),
+            DNSRecord.fqdn.ilike(like),
+            DNSRecord.value.ilike(like),
+            DNSRecord.record_type.ilike(like),
+        ]
+        if zone_hits:
+            conds.append(DNSRecord.zone_id.in_(zone_hits))
+        stmt = stmt.where(or_(*conds))
+    stmt = stmt.order_by(DNSRecord.fqdn, DNSRecord.record_type)
+    records, total = await paginate(db, stmt, page=page, page_size=page_size)
+
     out: list[GroupRecordResponse] = []
     for rec in records:
         zone = zone_by_id.get(rec.zone_id)
@@ -4249,27 +4272,55 @@ async def list_group_records(
                 modified_at=rec.modified_at,
             )
         )
-    return out
+    return Page[GroupRecordResponse](items=out, total=total, page=page, page_size=page_size)
 
 
-@router.get("/groups/{group_id}/zones/{zone_id}/records", response_model=list[RecordResponse])
+@router.get(
+    "/groups/{group_id}/zones/{zone_id}/records",
+    response_model=Page[RecordResponse],
+)
 async def list_records(
     group_id: uuid.UUID,
     zone_id: uuid.UUID,
     db: DB,
     _: CurrentUser,
     tag: list[str] = Query(default_factory=list),
-) -> list[DNSRecord]:
+    search: str | None = Query(None, description="substring over name / fqdn / value / type"),
+    record_type: str | None = Query(None, description="exact record type filter (A, MX, …)"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+) -> Page[RecordResponse]:
+    """Records in a zone, server-side paginated (#455).
+
+    A large zone (the perf seed reaches 20k+ records) used to return its whole
+    record set on every poll. ``search`` matches name / fqdn / value / type so
+    a row is findable without paging; ``record_type`` is an exact filter for
+    the type dropdown.
+    """
     await _require_zone(group_id, zone_id, db)
     _enforce_zone_token_scope(_, zone_id)
-    stmt = (
-        select(DNSRecord)
-        .where(DNSRecord.zone_id == zone_id)
-        .order_by(DNSRecord.name, DNSRecord.record_type)
-    )
+    stmt = select(DNSRecord).where(DNSRecord.zone_id == zone_id)
+    if record_type:
+        stmt = stmt.where(func.upper(DNSRecord.record_type) == record_type.upper())
+    if search and search.strip():
+        like = f"%{search.strip()}%"
+        stmt = stmt.where(
+            or_(
+                DNSRecord.name.ilike(like),
+                DNSRecord.fqdn.ilike(like),
+                DNSRecord.value.ilike(like),
+                DNSRecord.record_type.ilike(like),
+            )
+        )
     stmt = apply_tag_filter(stmt, DNSRecord.tags, tag)
-    result = await db.execute(stmt)
-    return list(result.scalars().all())
+    stmt = stmt.order_by(DNSRecord.name, DNSRecord.record_type)
+    rows, total = await paginate(db, stmt, page=page, page_size=page_size)
+    return Page[RecordResponse](
+        items=[RecordResponse.model_validate(r) for r in rows],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
 
 
 @router.post(

--- a/backend/tests/test_dhcp_sync_leases_agent_based.py
+++ b/backend/tests/test_dhcp_sync_leases_agent_based.py
@@ -1,0 +1,109 @@
+"""Regression test for #453 — IPAM "Sync → DHCP" against an agent-based Kea
+server returned 400 Bad Request.
+
+The IPAM subnet sync modal fans ``POST /dhcp/servers/{id}/sync-leases`` out to
+every server backing the subnet, agent-based ones included. ``sync-leases`` is
+an agentless-only (Windows DHCP) operation, so it used to hard-reject Kea with
+a 400 — which read as a broken sync to the operator. The endpoint now returns a
+no-op result with an explanatory ``note`` (and nudges the agent to re-poll)
+instead of erroring.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPServer, DHCPServerGroup
+
+
+async def _superadmin(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _kea_server(db: AsyncSession, *, grouped: bool = True) -> DHCPServer:
+    group_id = None
+    if grouped:
+        grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+        db.add(grp)
+        await db.flush()
+        group_id = grp.id
+    srv = DHCPServer(
+        name=f"s-{uuid.uuid4().hex[:6]}",
+        driver="kea",  # agent-based
+        host="127.0.0.1",
+        port=67,
+        server_group_id=group_id,
+    )
+    db.add(srv)
+    await db.flush()
+    return srv
+
+
+@pytest.mark.asyncio
+async def test_sync_leases_on_kea_returns_note_not_400(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin(db_session)
+    srv = await _kea_server(db_session)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dhcp/servers/{srv.id}/sync-leases",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # No-op shape: nothing pulled, no errors, and a human-readable note.
+    assert body["note"]
+    assert "agent-based" in body["note"]
+    assert body["server_leases"] == 0
+    assert body["imported"] == 0
+    assert body["errors"] == []
+
+
+@pytest.mark.asyncio
+async def test_sync_leases_on_ungrouped_kea_still_ok(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # ``server_group_id`` is nullable; the wake-channel build must not assume a
+    # group. A standalone Kea server should still return the no-op note.
+    token = await _superadmin(db_session)
+    srv = await _kea_server(db_session, grouped=False)
+    await db_session.commit()
+
+    r = await client.post(
+        f"/api/v1/dhcp/servers/{srv.id}/sync-leases",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert r.status_code == 200, r.text
+    assert r.json()["note"]
+
+
+@pytest.mark.asyncio
+async def test_sync_leases_missing_server_404(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin(db_session)
+    await db_session.commit()
+    r = await client.post(
+        f"/api/v1/dhcp/servers/{uuid.uuid4()}/sync-leases",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 404

--- a/backend/tests/test_pagination_records_leases.py
+++ b/backend/tests/test_pagination_records_leases.py
@@ -1,0 +1,242 @@
+"""Server-side pagination for DNS records + DHCP leases (#455).
+
+Covers the paginated envelope ``{items, total, page, page_size}``, the
+``search`` filter, and the exact-match ``record_type`` / ``state`` filters on
+the three converted endpoints:
+
+* ``GET /dns/groups/{gid}/zones/{zid}/records``  (zone records)
+* ``GET /dns/groups/{gid}/records``               (group-wide records)
+* ``GET /dhcp/servers/{id}/leases``               (leases)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPLease, DHCPServer
+from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
+
+
+async def _admin_headers(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _zone(db: AsyncSession, grp: DNSServerGroup, name: str) -> DNSZone:
+    zone = DNSZone(
+        group_id=grp.id,
+        name=name,
+        zone_type="primary",
+        kind="forward",
+        primary_ns=f"ns1.{name}",
+        admin_email=f"admin.{name}",
+    )
+    db.add(zone)
+    await db.flush()
+    return zone
+
+
+def _rec(zone: DNSZone, name: str, rtype: str, value: str) -> DNSRecord:
+    return DNSRecord(
+        zone_id=zone.id,
+        name=name,
+        fqdn=f"{name}.{zone.name}",
+        record_type=rtype,
+        value=value,
+    )
+
+
+# ── DNS zone records ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_zone_records_paginate_and_filter(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+    zone = await _zone(db_session, grp, "campus.example.edu.")
+    # 25 A records + 5 MX records.
+    for i in range(25):
+        db_session.add(_rec(zone, f"host{i:03d}", "A", f"10.0.0.{i + 1}"))
+    for i in range(5):
+        db_session.add(_rec(zone, f"mail{i}", "MX", f"mx{i}.example.edu."))
+    await db_session.commit()
+
+    base = f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records"
+
+    # Default envelope shape + total across the whole set.
+    r = await client.get(base, headers=h, params={"page_size": 10})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert set(body) == {"items", "total", "page", "page_size"}
+    assert body["total"] == 30
+    assert body["page"] == 1
+    assert body["page_size"] == 10
+    assert len(body["items"]) == 10
+
+    # Page 3 holds the remaining 10.
+    r3 = await client.get(base, headers=h, params={"page_size": 10, "page": 3})
+    assert r3.json()["total"] == 30
+    assert len(r3.json()["items"]) == 10
+
+    # No page bleed: pages 1+2 are disjoint.
+    p1 = {i["id"] for i in r.json()["items"]}
+    p2 = {
+        i["id"]
+        for i in (
+            await client.get(base, headers=h, params={"page_size": 10, "page": 2})
+        ).json()["items"]
+    }
+    assert p1.isdisjoint(p2)
+
+    # record_type exact filter.
+    rmx = await client.get(base, headers=h, params={"record_type": "MX"})
+    assert rmx.json()["total"] == 5
+    assert all(i["record_type"] == "MX" for i in rmx.json()["items"])
+
+    # search over name.
+    rs = await client.get(base, headers=h, params={"search": "host01"})
+    # host010..host019 + host01 -> host010-019 is 10, plus none named exactly host01
+    assert rs.json()["total"] >= 1
+    assert all("host01" in i["name"] for i in rs.json()["items"])
+
+    # search over value.
+    rv = await client.get(base, headers=h, params={"search": "10.0.0.1"})
+    assert rv.json()["total"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_zone_records_page_size_bounds(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+    zone = await _zone(db_session, grp, "z.example.edu.")
+    await db_session.commit()
+    base = f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/records"
+    # page_size over the cap (1000) is rejected by the Query bound.
+    assert (await client.get(base, headers=h, params={"page_size": 5000})).status_code == 422
+    assert (await client.get(base, headers=h, params={"page": 0})).status_code == 422
+
+
+# ── DNS group-wide records ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_group_records_paginate_and_zone_search(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+    z1 = await _zone(db_session, grp, "alpha.example.edu.")
+    z2 = await _zone(db_session, grp, "beta.example.edu.")
+    for i in range(6):
+        db_session.add(_rec(z1, f"a{i}", "A", f"10.1.0.{i + 1}"))
+    for i in range(4):
+        db_session.add(_rec(z2, f"b{i}", "A", f"10.2.0.{i + 1}"))
+    await db_session.commit()
+
+    base = f"/api/v1/dns/groups/{grp.id}/records"
+    r = await client.get(base, headers=h, params={"page_size": 4})
+    body = r.json()
+    assert body["total"] == 10
+    assert len(body["items"]) == 4
+    # items carry zone context.
+    assert all("zone_name" in i for i in body["items"])
+
+    # search by zone name narrows to that zone's records.
+    rz = await client.get(base, headers=h, params={"search": "beta"})
+    assert rz.json()["total"] == 4
+    assert all(i["zone_name"] == "beta.example.edu" for i in rz.json()["items"])
+
+
+# ── DHCP leases ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_leases_paginate_search_and_state(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    srv = DHCPServer(
+        name=f"s-{uuid.uuid4().hex[:6]}",
+        driver="kea",
+        host="127.0.0.1",
+        port=67,
+    )
+    db_session.add(srv)
+    await db_session.flush()
+    now = datetime.now(UTC)
+    for i in range(12):
+        db_session.add(
+            DHCPLease(
+                server_id=srv.id,
+                ip_address=f"10.0.5.{i + 1}",
+                mac_address=f"aa:bb:cc:00:00:{i:02x}",
+                hostname=f"dev-{i:02d}",
+                state="active" if i % 2 == 0 else "expired",
+                last_seen_at=now - timedelta(minutes=i),
+            )
+        )
+    await db_session.commit()
+
+    base = f"/api/v1/dhcp/servers/{srv.id}/leases"
+
+    r = await client.get(base, headers=h, params={"page_size": 5})
+    body = r.json()
+    assert set(body) == {"items", "total", "page", "page_size"}
+    assert body["total"] == 12
+    assert len(body["items"]) == 5
+    # Ordered newest-first (i=0 has the most recent last_seen_at).
+    assert body["items"][0]["hostname"] == "dev-00"
+
+    # state filter.
+    ra = await client.get(base, headers=h, params={"state": "active"})
+    assert ra.json()["total"] == 6
+    assert all(i["state"] == "active" for i in ra.json()["items"])
+
+    # search by hostname.
+    rh = await client.get(base, headers=h, params={"search": "dev-07"})
+    assert rh.json()["total"] == 1
+    assert rh.json()["items"][0]["hostname"] == "dev-07"
+
+    # search by ip (INET cast to text).
+    rip = await client.get(base, headers=h, params={"search": "10.0.5.3"})
+    assert rip.json()["total"] >= 1
+    assert any(i["ip_address"] == "10.0.5.3" for i in rip.json()["items"])
+
+    # search by mac (MACADDR cast to text).
+    rmac = await client.get(base, headers=h, params={"search": "aa:bb:cc:00:00:05"})
+    assert rmac.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_leases_missing_server_404(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = await _admin_headers(db_session)
+    await db_session.commit()
+    r = await client.get(f"/api/v1/dhcp/servers/{uuid.uuid4()}/leases", headers=h)
+    assert r.status_code == 404

--- a/backend/tests/test_pagination_records_leases.py
+++ b/backend/tests/test_pagination_records_leases.py
@@ -101,9 +101,9 @@ async def test_zone_records_paginate_and_filter(
     p1 = {i["id"] for i in r.json()["items"]}
     p2 = {
         i["id"]
-        for i in (
-            await client.get(base, headers=h, params={"page_size": 10, "page": 2})
-        ).json()["items"]
+        for i in (await client.get(base, headers=h, params={"page_size": 10, "page": 2})).json()[
+            "items"
+        ]
     }
     assert p1.isdisjoint(p2)
 
@@ -124,9 +124,7 @@ async def test_zone_records_paginate_and_filter(
 
 
 @pytest.mark.asyncio
-async def test_zone_records_page_size_bounds(
-    client: AsyncClient, db_session: AsyncSession
-) -> None:
+async def test_zone_records_page_size_bounds(client: AsyncClient, db_session: AsyncSession) -> None:
     h = await _admin_headers(db_session)
     grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
     db_session.add(grp)
@@ -233,9 +231,7 @@ async def test_leases_paginate_search_and_state(
 
 
 @pytest.mark.asyncio
-async def test_leases_missing_server_404(
-    client: AsyncClient, db_session: AsyncSession
-) -> None:
+async def test_leases_missing_server_404(client: AsyncClient, db_session: AsyncSession) -> None:
     h = await _admin_headers(db_session)
     await db_session.commit()
     r = await client.get(f"/api/v1/dhcp/servers/{uuid.uuid4()}/leases", headers=h)

--- a/frontend/src/components/ui/pager.tsx
+++ b/frontend/src/components/ui/pager.tsx
@@ -1,10 +1,30 @@
 // Shared page-navigation control for server-side paginated tables (#455).
-// Mirrors the local Pager the network device-detail tabs use; lifted into a
-// shared primitive so the DNS records + DHCP lease tables (and future
-// paginated lists) render identical Prev / "Page X of Y" / Next controls.
+// Renders Prev / numbered page "breadcrumbs" (with … ellipsis for large page
+// counts) / Next, so operators can jump straight to a page instead of clicking
+// Next repeatedly. Used at both the top and bottom of paginated tables.
 //
 // Renders nothing when there's only a single page so it stays out of the way
 // on small result sets.
+
+import { cn } from "@/lib/utils";
+
+// Windowed list of page numbers around the current page: always the first and
+// last page, plus current ±1, with "ellipsis" markers collapsing the gaps.
+// e.g. page 5 of 47 → [1, "ellipsis", 4, 5, 6, "ellipsis", 47].
+function pageWindow(
+  current: number,
+  totalPages: number,
+): (number | "ellipsis")[] {
+  const out: (number | "ellipsis")[] = [];
+  for (let p = 1; p <= totalPages; p++) {
+    if (p === 1 || p === totalPages || Math.abs(p - current) <= 1) {
+      out.push(p);
+    } else if (out[out.length - 1] !== "ellipsis") {
+      out.push("ellipsis");
+    }
+  }
+  return out;
+}
 
 export function Pager({
   page,
@@ -19,24 +39,45 @@ export function Pager({
 }) {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
   if (totalPages <= 1) return null;
+  const btn =
+    "rounded-md border px-2 py-1 hover:bg-muted disabled:opacity-40 disabled:hover:bg-transparent";
   return (
-    <div className="flex items-center justify-end gap-2 text-xs">
+    <div className="flex items-center gap-1 text-xs">
       <button
         type="button"
         onClick={() => onChange(Math.max(1, page - 1))}
         disabled={page <= 1}
-        className="rounded-md border px-2 py-1 hover:bg-muted disabled:opacity-40"
+        className={btn}
       >
         Prev
       </button>
-      <span className="text-muted-foreground">
-        Page {page} of {totalPages}
-      </span>
+      {pageWindow(page, totalPages).map((p, i) =>
+        p === "ellipsis" ? (
+          <span key={`e${i}`} className="px-1 text-muted-foreground">
+            …
+          </span>
+        ) : (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onChange(p)}
+            aria-current={p === page ? "page" : undefined}
+            className={cn(
+              btn,
+              "min-w-[2rem] tabular-nums",
+              p === page &&
+                "border-primary bg-primary font-semibold text-primary-foreground hover:bg-primary",
+            )}
+          >
+            {p}
+          </button>
+        ),
+      )}
       <button
         type="button"
         onClick={() => onChange(Math.min(totalPages, page + 1))}
         disabled={page >= totalPages}
-        className="rounded-md border px-2 py-1 hover:bg-muted disabled:opacity-40"
+        className={btn}
       >
         Next
       </button>

--- a/frontend/src/components/ui/pager.tsx
+++ b/frontend/src/components/ui/pager.tsx
@@ -1,0 +1,45 @@
+// Shared page-navigation control for server-side paginated tables (#455).
+// Mirrors the local Pager the network device-detail tabs use; lifted into a
+// shared primitive so the DNS records + DHCP lease tables (and future
+// paginated lists) render identical Prev / "Page X of Y" / Next controls.
+//
+// Renders nothing when there's only a single page so it stays out of the way
+// on small result sets.
+
+export function Pager({
+  page,
+  total,
+  pageSize,
+  onChange,
+}: {
+  page: number;
+  total: number;
+  pageSize: number;
+  onChange: (p: number) => void;
+}) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  if (totalPages <= 1) return null;
+  return (
+    <div className="flex items-center justify-end gap-2 text-xs">
+      <button
+        type="button"
+        onClick={() => onChange(Math.max(1, page - 1))}
+        disabled={page <= 1}
+        className="rounded-md border px-2 py-1 hover:bg-muted disabled:opacity-40"
+      >
+        Prev
+      </button>
+      <span className="text-muted-foreground">
+        Page {page} of {totalPages}
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(Math.min(totalPages, page + 1))}
+        disabled={page >= totalPages}
+        className="rounded-md border px-2 py-1 hover:bg-muted disabled:opacity-40"
+      >
+        Next
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6174,6 +6174,9 @@ export interface DHCPLeaseSyncResult {
   mac_blocks_added?: number;
   mac_blocks_removed?: number;
   errors: string[];
+  // Present on the agent-based (Kea) no-op path: explains that leases stream
+  // live and config converges via the agent, so there was nothing to pull.
+  note?: string | null;
 }
 
 export interface DHCPOption {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4784,6 +4784,17 @@ export interface TSIGKeyUpdate {
   notes?: string;
 }
 
+// Generic server-side pagination envelope (#455). Matches the backend
+// `app.api.pagination.Page[T]` shape; adopted by list endpoints that can grow
+// unbounded (DNS records, DHCP leases, …) so the UI pages instead of pulling
+// the whole table.
+export interface Page<T> {
+  items: T[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
 export interface DNSRecord {
   id: string;
   zone_id: string;
@@ -5213,14 +5224,32 @@ export const dnsApi = {
       })
       .then((r) => r.data),
 
-  // Records
-  listGroupRecords: (groupId: string) =>
+  // Records — server-side paginated (#455)
+  listGroupRecords: (
+    groupId: string,
+    params?: {
+      search?: string;
+      record_type?: string;
+      page?: number;
+      page_size?: number;
+    },
+  ) =>
     api
-      .get<DNSGroupRecord[]>(`/dns/groups/${groupId}/records`)
+      .get<Page<DNSGroupRecord>>(`/dns/groups/${groupId}/records`, { params })
       .then((r) => r.data),
-  listRecords: (groupId: string, zoneId: string, params?: { tag?: string[] }) =>
+  listRecords: (
+    groupId: string,
+    zoneId: string,
+    params?: {
+      tag?: string[];
+      search?: string;
+      record_type?: string;
+      page?: number;
+      page_size?: number;
+    },
+  ) =>
     api
-      .get<DNSRecord[]>(`/dns/groups/${groupId}/zones/${zoneId}/records`, {
+      .get<Page<DNSRecord>>(`/dns/groups/${groupId}/zones/${zoneId}/records`, {
         params,
       })
       .then((r) => r.data),
@@ -6488,9 +6517,18 @@ export const dhcpApi = {
       .then((r) => r.data),
   resumeServer: (id: string) =>
     api.post<DHCPServer>(`/dhcp/servers/${id}/resume`).then((r) => r.data),
-  getLeases: (id: string, params?: { limit?: number }) =>
+  getLeases: (
+    id: string,
+    params?: {
+      search?: string;
+      state?: string;
+      device_class?: string;
+      page?: number;
+      page_size?: number;
+    },
+  ) =>
     api
-      .get<DHCPLease[]>(`/dhcp/servers/${id}/leases`, { params })
+      .get<Page<DHCPLease>>(`/dhcp/servers/${id}/leases`, { params })
       .then((r) => r.data),
 
   // Per-server detail (powers the DHCP ServerDetailModal — issue #181)

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -47,6 +47,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { HeaderButton } from "@/components/ui/header-button";
+import { Pager } from "@/components/ui/pager";
 import { TagFilterChips } from "@/components/TagFilterChips";
 import { AskAIButton } from "@/components/copilot/AskAIButton";
 import { ServicesUsingButton } from "@/components/ServicesUsingButton";
@@ -1717,28 +1718,46 @@ function LeasesTab({ server }: { server: DHCPServer }) {
   const [state, setState] = useState<string>("");
   const [subnetId, setSubnetId] = useState<string>("");
   const [deviceClass, setDeviceClass] = useState<string>("");
-  const limit = 500;
+  const [search, setSearch] = useState<string>("");
+  const [page, setPage] = useState(1);
+  const pageSize = 100;
 
   const { data: subnets = [] } = useQuery({
     queryKey: ["subnets"],
     queryFn: () => ipamApi.listSubnets(),
   });
 
+  // Server-side pagination + search (#455). `search` (ip / mac / hostname) and
+  // `state` filter on the server so a busy server's older leases are reachable
+  // past page 1; subnet + device-class stay client-side refinements over the
+  // current page.
+  const params = useMemo(() => {
+    const p: {
+      page: number;
+      page_size: number;
+      search?: string;
+      state?: string;
+    } = { page, page_size: pageSize };
+    if (search.trim()) p.search = search.trim();
+    if (state) p.state = state;
+    return p;
+  }, [page, search, state]);
+
   const { data, isFetching, refetch } = useQuery({
-    queryKey: ["dhcp-leases", server.id, limit],
-    queryFn: () => dhcpApi.getLeases(server.id, { limit }),
+    queryKey: ["dhcp-leases", server.id, params],
+    queryFn: () => dhcpApi.getLeases(server.id, params),
   });
 
-  const allLeases = data ?? [];
-  // Distinct fingerbank device classes present in the current result set —
-  // drives the device-class filter (#373), same client-side style as state/subnet.
+  const allLeases = data?.items ?? [];
+  const total = data?.total ?? 0;
+  // Distinct fingerbank device classes on the current page — drives the
+  // device-class refinement (#373), client-side over the visible page.
   const deviceClasses = Array.from(
     new Set(
       allLeases.map((l) => l.device_class).filter((c): c is string => !!c),
     ),
   ).sort();
   const leases = allLeases.filter((l) => {
-    if (state && l.state !== state) return false;
     if (subnetId && l.scope_id !== subnetId) return false;
     if (deviceClass && l.device_class !== deviceClass) return false;
     return true;
@@ -1747,10 +1766,22 @@ function LeasesTab({ server }: { server: DHCPServer }) {
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-3">
+        <input
+          className="rounded-md border bg-background px-2 py-1 text-xs"
+          placeholder="Search ip / mac / hostname…"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+        />
         <select
           className="rounded-md border bg-background px-2 py-1 text-xs"
           value={state}
-          onChange={(e) => setState(e.target.value)}
+          onChange={(e) => {
+            setState(e.target.value);
+            setPage(1);
+          }}
         >
           <option value="">All states</option>
           <option value="active">Active</option>
@@ -1923,11 +1954,19 @@ function LeasesTab({ server }: { server: DHCPServer }) {
           </tbody>
         </table>
       </div>
-      {allLeases.length >= limit && (
-        <p className="text-xs text-muted-foreground">
-          Showing first {limit} leases — narrow filters to refine.
-        </p>
-      )}
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>
+          {total.toLocaleString()} lease{total === 1 ? "" : "s"}
+          {(subnetId || deviceClass) && " (page filtered)"}
+          {isFetching && " · loading…"}
+        </span>
+        <Pager
+          page={page}
+          total={total}
+          pageSize={pageSize}
+          onChange={setPage}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -1816,14 +1816,24 @@ function LeasesTab({ server }: { server: DHCPServer }) {
             ))}
           </select>
         )}
-        <button
-          onClick={() => refetch()}
-          className="ml-auto flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-accent"
-          disabled={isFetching}
-        >
-          <RefreshCw className={cn("h-3 w-3", isFetching && "animate-spin")} />
-          Refresh
-        </button>
+        <div className="ml-auto flex items-center gap-3">
+          <Pager
+            page={page}
+            total={total}
+            pageSize={pageSize}
+            onChange={setPage}
+          />
+          <button
+            onClick={() => refetch()}
+            className="flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-accent"
+            disabled={isFetching}
+          >
+            <RefreshCw
+              className={cn("h-3 w-3", isFetching && "animate-spin")}
+            />
+            Refresh
+          </button>
+        </div>
       </div>
       <div className="rounded-lg border overflow-auto">
         <table className="w-full text-sm">

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -2168,6 +2168,12 @@ function ServerDetailView({
       // views refresh once scopes / pools / statics get imported.
       qc.invalidateQueries({ queryKey: ["dhcp-scopes"] });
       const parts: string[] = [];
+      // Agent-based no-op note (Kea) takes the whole banner — there are no
+      // lease counters to report on that path.
+      if (result.note) {
+        setSyncBanner(result.note);
+        return;
+      }
       // Topology line first — only shown when the driver imports scopes.
       if (
         result.scopes_imported ||

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { useLocation, useSearchParams } from "react-router-dom";
 import { useStickyLocation } from "@/lib/stickyLocation";
 import { useSessionState } from "@/lib/useSessionState";
@@ -56,6 +56,7 @@ import {
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { Modal } from "@/components/ui/modal";
 import { HeaderButton } from "@/components/ui/header-button";
+import { Pager } from "@/components/ui/pager";
 import { AskAIButton } from "@/components/copilot/AskAIButton";
 import { ServicesUsingButton } from "@/components/ServicesUsingButton";
 import {
@@ -2774,6 +2775,13 @@ function ZoneDetailView({
   const [showImport, setShowImport] = useState(false);
   const [showRecFilters, setShowRecFilters] = useState(false);
   const [recFilter, setRecFilter] = useState({ name: "", type: "", value: "" });
+  // Server-side pagination + search (#455): a large zone (20k+ records) no
+  // longer ships its whole record set per poll. `recordSearch` matches
+  // name / fqdn / value / type on the server; the per-column recFilter below
+  // stays a client-side refinement over the current page.
+  const [recordSearch, setRecordSearch] = useState("");
+  const [recordPage, setRecordPage] = useState(1);
+  const recordPageSize = 100;
   // Search-landing highlight — ``highlightRecordId`` is passed down
   // by DNSPage, which captured it from ``location.state`` before
   // ``setSelection`` fired its ``setSearchParams(..., { replace: true })``
@@ -2835,10 +2843,20 @@ function ZoneDetailView({
     queryKey: ["dns-views", group.id],
     queryFn: () => dnsApi.listViews(group.id),
   });
-  const { data: records = [], isFetching } = useQuery({
-    queryKey: ["dns-records", zone.id],
-    queryFn: () => dnsApi.listRecords(group.id, zone.id),
+  const recordParams = useMemo(() => {
+    const p: { page: number; page_size: number; search?: string } = {
+      page: recordPage,
+      page_size: recordPageSize,
+    };
+    if (recordSearch.trim()) p.search = recordSearch.trim();
+    return p;
+  }, [recordPage, recordSearch]);
+  const { data: recordsPage, isFetching } = useQuery({
+    queryKey: ["dns-records", zone.id, recordParams],
+    queryFn: () => dnsApi.listRecords(group.id, zone.id, recordParams),
   });
+  const records = recordsPage?.items ?? [];
+  const recordsTotal = recordsPage?.total ?? 0;
 
   // TLS cert targets linked to this zone (#118). Powers the Certs
   // sub-tab + the per-record state pill on A/AAAA rows. Gated on the
@@ -3218,7 +3236,7 @@ function ZoneDetailView({
                 : "border-transparent text-muted-foreground hover:text-foreground")
             }
           >
-            Records ({records.length})
+            Records ({recordsTotal.toLocaleString()})
           </button>
           <button
             type="button"
@@ -3313,6 +3331,23 @@ function ZoneDetailView({
       {/* Records table */}
       {!isForward && zoneView === "records" && (
         <div className="flex-1 overflow-auto">
+          <div className="flex items-center gap-2 px-5 py-2">
+            <input
+              className="w-72 rounded-md border bg-background px-2 py-1 text-xs"
+              placeholder="Search name / value / type…"
+              value={recordSearch}
+              onChange={(e) => {
+                setRecordSearch(e.target.value);
+                setRecordPage(1);
+              }}
+            />
+            <span className="text-xs text-muted-foreground">
+              {recordsTotal.toLocaleString()}{" "}
+              {recordsTotal === 1 ? "record" : "records"}
+              {hasRecFilter && " · page filtered"}
+              {isFetching && " · loading…"}
+            </span>
+          </div>
           {isFetching && records.length === 0 && (
             <p className="px-5 py-4 text-sm text-muted-foreground">Loading…</p>
           )}
@@ -3662,6 +3697,14 @@ function ZoneDetailView({
               </table>
             </div>
           )}
+          <div className="px-5 py-2">
+            <Pager
+              page={recordPage}
+              total={recordsTotal}
+              pageSize={recordPageSize}
+              onChange={setRecordPage}
+            />
+          </div>
         </div>
       )}
 
@@ -5734,10 +5777,26 @@ function RecordsTab({
   onSelectZone: (z: DNSZone) => void;
 }) {
   const qc = useQueryClient();
-  const { data: records = [], isLoading } = useQuery({
-    queryKey: ["dns-group-records", group.id],
-    queryFn: () => dnsApi.listGroupRecords(group.id),
+  // Server-side pagination + search (#455). `groupRecordSearch` matches
+  // name / fqdn / value / type / zone on the server; the per-column filters
+  // below stay client-side refinements over the current page.
+  const [groupRecordSearch, setGroupRecordSearch] = useState("");
+  const [groupRecordPage, setGroupRecordPage] = useState(1);
+  const groupRecordPageSize = 100;
+  const groupRecordParams = useMemo(() => {
+    const p: { page: number; page_size: number; search?: string } = {
+      page: groupRecordPage,
+      page_size: groupRecordPageSize,
+    };
+    if (groupRecordSearch.trim()) p.search = groupRecordSearch.trim();
+    return p;
+  }, [groupRecordPage, groupRecordSearch]);
+  const { data: groupRecordsPage, isLoading } = useQuery({
+    queryKey: ["dns-group-records", group.id, groupRecordParams],
+    queryFn: () => dnsApi.listGroupRecords(group.id, groupRecordParams),
   });
+  const records = groupRecordsPage?.items ?? [];
+  const recordsTotal = groupRecordsPage?.total ?? 0;
   const { data: zones = [] } = useQuery({
     queryKey: ["dns-zones", group.id],
     queryFn: () => dnsApi.listZones(group.id),
@@ -5977,12 +6036,23 @@ function RecordsTab({
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <p className="text-xs text-muted-foreground">
-          {filtered.length.toLocaleString()} of{" "}
-          {records.length.toLocaleString()}{" "}
-          {records.length === 1 ? "record" : "records"}
-        </p>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <input
+            className="w-72 rounded-md border bg-background px-2 py-1 text-xs"
+            placeholder="Search name / value / type / zone…"
+            value={groupRecordSearch}
+            onChange={(e) => {
+              setGroupRecordSearch(e.target.value);
+              setGroupRecordPage(1);
+            }}
+          />
+          <p className="text-xs text-muted-foreground">
+            {filtered.length.toLocaleString()} of{" "}
+            {recordsTotal.toLocaleString()}{" "}
+            {recordsTotal === 1 ? "record" : "records"}
+          </p>
+        </div>
         {hasActiveFilter && (
           <button
             onClick={clearFilters}
@@ -6052,7 +6122,7 @@ function RecordsTab({
                   colSpan={8}
                   className="px-4 py-8 text-center text-sm text-muted-foreground"
                 >
-                  {records.length === 0
+                  {recordsTotal === 0
                     ? "No records in this group yet."
                     : "No records match the active filters."}
                 </td>
@@ -6146,6 +6216,12 @@ function RecordsTab({
           </tbody>
         </table>
       </div>
+      <Pager
+        page={groupRecordPage}
+        total={recordsTotal}
+        pageSize={groupRecordPageSize}
+        onChange={setGroupRecordPage}
+      />
 
       {editing && (
         <RecordModal

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -3347,6 +3347,14 @@ function ZoneDetailView({
               {hasRecFilter && " · page filtered"}
               {isFetching && " · loading…"}
             </span>
+            <div className="ml-auto">
+              <Pager
+                page={recordPage}
+                total={recordsTotal}
+                pageSize={recordPageSize}
+                onChange={setRecordPage}
+              />
+            </div>
           </div>
           {isFetching && records.length === 0 && (
             <p className="px-5 py-4 text-sm text-muted-foreground">Loading…</p>
@@ -6053,15 +6061,23 @@ function RecordsTab({
             {recordsTotal === 1 ? "record" : "records"}
           </p>
         </div>
-        {hasActiveFilter && (
-          <button
-            onClick={clearFilters}
-            className="flex items-center gap-1 rounded-md border px-2 py-1 text-xs text-muted-foreground hover:bg-accent"
-          >
-            <X className="h-3 w-3" />
-            Clear filters
-          </button>
-        )}
+        <div className="flex items-center gap-2">
+          <Pager
+            page={groupRecordPage}
+            total={recordsTotal}
+            pageSize={groupRecordPageSize}
+            onChange={setGroupRecordPage}
+          />
+          {hasActiveFilter && (
+            <button
+              onClick={clearFilters}
+              className="flex items-center gap-1 rounded-md border px-2 py-1 text-xs text-muted-foreground hover:bg-accent"
+            >
+              <X className="h-3 w-3" />
+              Clear filters
+            </button>
+          )}
+        </div>
       </div>
 
       <div className="overflow-hidden rounded-lg border">

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -7128,7 +7128,12 @@ function DhcpSyncSummaryBody({
                 <span className="text-xs text-destructive">Failed</span>
               )}
             </div>
-            {s.status === "done" && (
+            {s.status === "done" && s.result.note && (
+              <p className="mt-2 rounded border border-sky-500/40 bg-sky-500/10 p-2 text-[11px] text-sky-700 dark:text-sky-300">
+                {s.result.note}
+              </p>
+            )}
+            {s.status === "done" && !s.result.note && (
               <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
                 <CounterRow
                   label="Active leases"


### PR DESCRIPTION
## Summary

Two issues from the perf-testing follow-up, bundled on one branch:

- **#453 (bug)** — IPAM "Sync → DHCP" returned **400 Bad Request** against an agent-based Kea appliance.
- **#455 (feature)** — server-side pagination for the unbounded DNS-records + DHCP-leases list endpoints.

## #453 — Sync → DHCP no longer 400s on Kea

The IPAM subnet sync modal fans `POST /dhcp/servers/{id}/sync-leases` out to every server backing the subnet. `sync-leases` is an **agentless-only** (Windows DHCP) operation, so it hard-rejected agent-based Kea with a 400 — which read as a broken sync to operators on the OS appliance.

Agent-based drivers stream lease events continuously and converge scope/config via the ConfigBundle long-poll, so there's nothing to *pull*. The endpoint now returns a no-op `SyncLeasesResponse` with an explanatory `note` (and nudges the agent to re-poll its config so the subnet/scope definition converges immediately) instead of erroring. The note renders as an info line in both the IPAM sync modal and the DHCP server-detail banner.

## #455 — server-side pagination (default 100/page)

A 20k-record zone (the #452/#454 perf seed) used to ship all 20k rows on every poll, and a busy server's older leases were unreachable past the most-recent N.

**Backend** — new shared `Page[T]` envelope (`{items, total, page, page_size}`) + `paginate()` helper. These three endpoints now return `Page[...]` with `page`/`page_size` (default 100, max 1000) + a server-side `search` filter and exact `record_type`/`state` filters:
- `GET /dns/groups/{gid}/zones/{zid}/records` — search over name/fqdn/value/type
- `GET /dns/groups/{gid}/records` — + zone name
- `GET /dhcp/servers/{id}/leases` — search over ip/mac/hostname (INET/MACADDR cast to text); the old `limit` becomes real pagination, so the per-page OUI/fingerbank enrichment now runs on the page, not 500 rows

**Frontend** — `Page<T>` type + a shared `<Pager>` primitive. The DNS zone-records, DNS group-records, and DHCP leases tables get a server-side search box + Pager + total. Per the agreed **low-risk** approach, the existing secondary filters (per-column record filters, subnet, device-class) and column sort stay as client-side refinements over the current page (labelled "page filtered"); the search box is the cross-set finder.

⚠️ **Breaking response shape** (bare array → envelope). All consumers updated: the 3 frontend tables. MCP tools query the DB directly (unaffected); the perf harness only times the records endpoint, it doesn't parse the body; no backend tests asserted the bare-list shape.

## Test plan

- Backend: `make test` — new `test_pagination_records_leases.py` (5 cases: envelope shape, page disjointness, `page_size` bounds → 422, search by name/value/ip/mac/hostname, `record_type`/`state` filters, zone-name search) + `test_dhcp_sync_leases_agent_based.py` (3 cases: grouped/ungrouped Kea → 200 + note, missing-server 404). 40-test targeted sweep over affected DNS/DHCP areas passes.
- Frontend: `npm run typecheck` / `lint` / `format:check` / `build` all green.
- Verified live on the dev stack (api boots clean with the new pagination module).

Closes #453
Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)
