### PR TITLE
New-device detection (arpwatch-style) — alert on unknown MACs (#459)

### DIFF
--- a/agent/dhcp/spatium_dhcp_agent/mac_sighting.py
+++ b/agent/dhcp/spatium_dhcp_agent/mac_sighting.py
@@ -1,0 +1,386 @@
+"""Arpwatch-style L2 sniffer — Phase 3 of new-device detection (#459).
+
+Sniffs ARP frames + IPv6 Neighbor Discovery packets via scapy's
+``AsyncSniffer``, pulls the source MAC + source IP off each, and ships
+first-sightings to the control plane in batches. Unlike the DHCP
+fingerprint sniffer (which only ever sees devices that do DHCP), this
+observes *any* device that puts an ARP reply / request or an ICMPv6
+NS/NA on the wire — including statically-addressed and link-local-only
+hosts that never touch the DHCP server.
+
+Disabled by default — operators opt in by setting
+``DHCP_MAC_SIGHTING_ENABLED=1`` because:
+
+  1. The container needs ``CAP_NET_RAW`` to bind the BPF socket (the
+     same cap the passive fingerprint + rogue-probe sniffers need).
+  2. Observing every host on the segment is privacy-sensitive in BYOD
+     / guest-Wi-Fi shops, and we want operators to take an explicit
+     action before turning that surface on.
+
+The control-plane endpoint (``POST /api/v1/dhcp/agents/mac-sightings``)
+is a no-op when the new-device-watch feature module is off, so shipping
+costs nothing until the operator arms it server-side — the agent ships
+unconditionally once enabled locally.
+
+Mirrors :class:`spatium_dhcp_agent.dhcp_fingerprint.DhcpFingerprintShipper`
+for batch sizing / dedupe-ledger pruning (#257) / retry /
+re-bootstrap-on-401 semantics. See that module's docstring for the
+resilience design.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import structlog
+
+from .config import AgentConfig
+
+log = structlog.get_logger(__name__)
+
+# Tunables — keep these in sync with the fingerprint shipper values
+# where they share semantics.
+MAX_BATCH = 200
+BATCH_INTERVAL = 5.0
+MAX_BUFFER_SIZE = 5_000
+
+# Issue #257 — retention window on ``_ShipperState.last_seen``. The
+# dedupe window in ``_on_packet`` is 60 s; anything older than 5× that
+# is dead weight that can be safely evicted on each flush.
+_LAST_SEEN_RETENTION = 300.0
+
+# Server max per POST is 500; our MAX_BATCH (200) sits comfortably under.
+
+
+@dataclass
+class MacSighting:
+    """One observed ``(MAC, IP)`` pairing pulled off an ARP / ND frame."""
+
+    mac_address: str
+    ip_address: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "mac_address": self.mac_address,
+            "ip_address": self.ip_address,
+        }
+
+
+def _normalize_mac(mac: Any) -> str | None:
+    """Lower-case a ``aa:bb:cc:dd:ee:ff`` MAC and reject the ones we
+    never want to record.
+
+    Drops broadcast (``ff:ff:ff:ff:ff:ff``), the all-zero MAC (seen on
+    ARP probes / gratuitous frames before an address is claimed), and
+    any group/multicast MAC (low bit of the first octet set — IPv6
+    solicited-node multicast, etc.). Those are never a real device's
+    primary interface address.
+    """
+    if not mac:
+        return None
+    s = str(mac).strip().lower()
+    parts = s.split(":")
+    if len(parts) != 6:
+        return None
+    try:
+        octets = [int(p, 16) for p in parts]
+    except ValueError:
+        return None
+    if all(o == 0 for o in octets):
+        return None
+    if all(o == 0xFF for o in octets):
+        return None
+    # Group/multicast bit (least-significant bit of the first octet).
+    if octets[0] & 0x01:
+        return None
+    return ":".join(f"{o:02x}" for o in octets)
+
+
+def _normalize_ip(ip: Any) -> str | None:
+    """Reject the unspecified / link-scope addresses that carry no
+    identifying value.
+
+    ARP probes use ``0.0.0.0`` as the sender protocol address; IPv6
+    ND from a still-configuring host can use ``::``. We also drop the
+    IPv6 unspecified and obvious garbage. Anything else (RFC1918,
+    link-local fe80::, GUA) is recorded — link-local is exactly the
+    case this sniffer exists to catch.
+    """
+    if not ip:
+        return None
+    s = str(ip).strip().lower()
+    if not s:
+        return None
+    if s in ("0.0.0.0", "::"):
+        return None
+    return s
+
+
+def parse_sighting_packet(packet: Any) -> MacSighting | None:
+    """Pull a ``(MAC, IP)`` pairing off a scapy ARP / IPv6-ND packet.
+
+    Returns ``None`` for traffic we can't extract both a usable MAC and
+    a usable IP from. Two shapes are handled:
+
+      * **ARP** — ``Ether.src`` is the sender's hardware address and
+        ``ARP.psrc`` is the sender's protocol (IPv4) address. Works for
+        both requests and replies; both carry the sender's pairing.
+      * **IPv6 Neighbor Discovery** (ICMPv6 NS / NA) — the source MAC is
+        ``Ether.src`` and the source IP is ``IPv6.src``. We prefer the
+        explicit source/target link-layer-address option when present
+        (it's the authoritative L2 address) but fall back to
+        ``Ether.src``.
+    """
+    # Lazy import — scapy is a runtime dep, gated on the
+    # DHCP_MAC_SIGHTING_ENABLED toggle. We don't want to pay the import
+    # cost on every agent boot.
+    try:
+        from scapy.layers.inet6 import (  # type: ignore[import-not-found]
+            ICMPv6ND_NA,
+            ICMPv6ND_NS,
+            ICMPv6NDOptDstLLAddr,
+            ICMPv6NDOptSrcLLAddr,
+            IPv6,
+        )
+        from scapy.layers.l2 import ARP, Ether  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+
+    ether_mac = _normalize_mac(getattr(packet[Ether], "src", None)) if packet.haslayer(Ether) else None
+
+    # --- ARP ---
+    if packet.haslayer(ARP):
+        arp = packet[ARP]
+        # Prefer the ARP sender hardware address; fall back to Ether.src.
+        mac = _normalize_mac(getattr(arp, "hwsrc", None)) or ether_mac
+        ip = _normalize_ip(getattr(arp, "psrc", None))
+        if mac and ip:
+            return MacSighting(mac_address=mac, ip_address=ip)
+        return None
+
+    # --- IPv6 Neighbor Discovery (ICMPv6 NS / NA) ---
+    if packet.haslayer(IPv6) and (packet.haslayer(ICMPv6ND_NS) or packet.haslayer(ICMPv6ND_NA)):
+        # The link-layer-address option is the authoritative L2 address
+        # when present (NS carries src-LLA, NA carries tgt-LLA).
+        opt_mac: str | None = None
+        if packet.haslayer(ICMPv6NDOptSrcLLAddr):
+            opt_mac = _normalize_mac(getattr(packet[ICMPv6NDOptSrcLLAddr], "lladdr", None))
+        if opt_mac is None and packet.haslayer(ICMPv6NDOptDstLLAddr):
+            opt_mac = _normalize_mac(getattr(packet[ICMPv6NDOptDstLLAddr], "lladdr", None))
+        mac = opt_mac or ether_mac
+        ip = _normalize_ip(getattr(packet[IPv6], "src", None))
+        if mac and ip:
+            return MacSighting(mac_address=mac, ip_address=ip)
+        return None
+
+    return None
+
+
+@dataclass
+class _ShipperState:
+    buffer: list[MacSighting] = field(default_factory=list)
+    last_seen: dict[tuple[str, str], float] = field(default_factory=dict)
+
+
+class MacSightingShipper:
+    """Sniffer thread + batching POST loop.
+
+    The sniffer pushes sightings into an in-memory buffer; the main loop
+    drains the buffer every ``BATCH_INTERVAL`` seconds (or sooner once
+    the buffer hits ``MAX_BATCH``). On 401 / 404 we drop the batch and
+    log — the heartbeat thread is the canonical re-bootstrap trigger for
+    the agent (it clears the on-disk token and exits so the container
+    restarts), so duplicating that here would race the heartbeat.
+    """
+
+    def __init__(
+        self,
+        cfg: AgentConfig,
+        token_ref: list[str],
+        iface: str | None = None,
+    ) -> None:
+        self.cfg = cfg
+        self.token_ref = token_ref
+        # Default interface "any" matches scapy's wildcard binding —
+        # works for host-networked containers. Operators on bridge
+        # networks should set DHCP_MAC_SIGHTING_IFACE explicitly.
+        self.iface = iface or os.environ.get("DHCP_MAC_SIGHTING_IFACE") or "any"
+        self._stop = threading.Event()
+        self._state = _ShipperState()
+        self._sniffer: Any = None
+        self._lock = threading.Lock()
+        self._last_flush = time.monotonic()
+
+    def stop(self) -> None:
+        # ``run()`` owns the sniffer lifecycle and stops the scapy
+        # AsyncSniffer in its shutdown block. Calling ``_sniffer.stop()``
+        # from here too is harmless (idempotent) but dead — issue #261.
+        self._stop.set()
+
+    def _on_packet(self, packet: Any) -> None:
+        try:
+            obs = parse_sighting_packet(packet)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("mac_sighting_parse_error", error=str(exc))
+            return
+        if obs is None:
+            return
+        # Deduplicate aggressively at the agent layer — a busy segment
+        # sees the same (mac, ip) repeated continuously (ARP refresh,
+        # ND reachability). We send at most one sighting per (mac, ip)
+        # per minute; the control plane is idempotent on its end too but
+        # this keeps the wire traffic small.
+        key = (obs.mac_address, obs.ip_address)
+        now = time.monotonic()
+        with self._lock:
+            last = self._state.last_seen.get(key)
+            if last is not None and now - last < 60.0:
+                return
+            self._state.last_seen[key] = now
+            if len(self._state.buffer) >= MAX_BUFFER_SIZE:
+                drop = MAX_BUFFER_SIZE // 2
+                self._state.buffer = self._state.buffer[drop:]
+                log.warning("mac_sighting_buffer_trimmed", dropped=drop)
+            self._state.buffer.append(obs)
+
+    def _start_sniffer(self) -> bool:
+        try:
+            from scapy.sendrecv import AsyncSniffer  # type: ignore[import-not-found]
+        except ImportError as exc:
+            log.warning("mac_sighting_scapy_missing", error=str(exc))
+            return False
+        try:
+            self._sniffer = AsyncSniffer(
+                iface=None if self.iface == "any" else self.iface,
+                # ARP frames carry the sender MAC+IP; ICMPv6 (which
+                # includes ND NS/NA) carries the IPv6 pairing.
+                filter="arp or icmp6",
+                prn=self._on_packet,
+                store=False,
+            )
+            self._sniffer.start()
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "mac_sighting_sniffer_start_failed",
+                iface=self.iface,
+                error=str(exc),
+            )
+            self._sniffer = None
+            return False
+        log.info("mac_sighting_sniffer_started", iface=self.iface)
+        return True
+
+    def _cp_client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=15.0,
+        )
+
+    def _drain(self) -> list[MacSighting]:
+        with self._lock:
+            batch = self._state.buffer[:MAX_BATCH]
+            self._state.buffer = self._state.buffer[MAX_BATCH:]
+        return batch
+
+    def _prune_last_seen(self, now: float) -> None:
+        """Drop entries from ``last_seen`` whose age exceeds
+        ``_LAST_SEEN_RETENTION``.
+
+        Issue #257 — ``last_seen`` is a dedupe ledger keyed on
+        ``(mac, ip)`` with a 60 s dedupe window (see ``_on_packet``).
+        Without pruning the dict accumulates one entry per unique pair
+        for the lifetime of the agent; on a busy segment with thousands
+        of hosts this is a steady memory leak. We retain 5× the dedupe
+        window's worth of entries so a host re-ARPing every 60 s still
+        gets deduped, but anything idle for >5 min is dead weight.
+        """
+        cutoff = now - _LAST_SEEN_RETENTION
+        with self._lock:
+            stale = [key for key, ts in self._state.last_seen.items() if ts < cutoff]
+            for key in stale:
+                del self._state.last_seen[key]
+        if stale:
+            log.debug("mac_sighting_pruned_last_seen", count=len(stale))
+
+    def _should_flush(self) -> bool:
+        with self._lock:
+            buf_len = len(self._state.buffer)
+        if buf_len == 0:
+            return False
+        if buf_len >= MAX_BATCH:
+            return True
+        return (time.monotonic() - self._last_flush) >= BATCH_INTERVAL
+
+    def _flush(self) -> None:
+        # Piggyback the dedupe-ledger prune on every flush — same cadence
+        # as the wire-side batching.
+        self._prune_last_seen(time.monotonic())
+        batch = self._drain()
+        if not batch:
+            return
+        payload = {"sightings": [obs.to_payload() for obs in batch]}
+        try:
+            with self._cp_client() as c:
+                resp = c.post(
+                    "/api/v1/dhcp/agents/mac-sightings",
+                    json=payload,
+                    headers={"Authorization": f"Bearer {self.token_ref[0]}"},
+                )
+        except httpx.HTTPError as exc:
+            log.warning(
+                "mac_sighting_ship_http_error",
+                error=str(exc),
+                batch_size=len(batch),
+            )
+            self._last_flush = time.monotonic()
+            return
+        if resp.status_code in (401, 404):
+            log.warning(
+                "mac_sighting_unauthorized",
+                status=resp.status_code,
+                hint="heartbeat thread will trigger rebootstrap",
+            )
+        elif resp.status_code not in (200, 204):
+            log.warning(
+                "mac_sighting_ship_failed",
+                status=resp.status_code,
+                batch_size=len(batch),
+            )
+        self._last_flush = time.monotonic()
+
+    def run(self) -> None:
+        log.info("mac_sighting_shipper_starting", iface=self.iface)
+        started = self._start_sniffer()
+        if not started:
+            log.warning("mac_sighting_disabled_no_sniffer")
+            # Spin in idle loop so the supervisor's thread-alive check
+            # doesn't restart the container — operator can fix the
+            # cap_add / iface issue at their leisure.
+            while not self._stop.is_set():
+                self._stop.wait(timeout=30.0)
+            return
+        while not self._stop.is_set():
+            if self._should_flush():
+                self._flush()
+            self._stop.wait(timeout=1.0)
+        if self._sniffer is not None:
+            try:
+                self._sniffer.stop()
+            except Exception:  # noqa: BLE001
+                pass
+        # Final flush on shutdown so we don't drop the last bucket.
+        self._flush()
+        log.info("mac_sighting_shipper_stopped")
+
+
+__all__ = [
+    "MacSightingShipper",
+    "MacSighting",
+    "parse_sighting_packet",
+]

--- a/agent/dhcp/spatium_dhcp_agent/supervisor.py
+++ b/agent/dhcp/spatium_dhcp_agent/supervisor.py
@@ -24,6 +24,7 @@ from .ha_status import HAStatusPoller
 from .heartbeat import HeartbeatClient
 from .leases import LeaseWatcher
 from .log_shipper import LogShipper
+from .mac_sighting import MacSightingShipper
 from .metrics import MetricsPoller
 from .peer_resolve import PeerResolveWatcher
 from .sync import SyncLoop
@@ -78,6 +79,16 @@ def run(cfg: AgentConfig) -> int:
         rogue_probe = RogueProbeShipper(cfg, token_ref)
         log.info("dhcp_rogue_probe_enabled")
 
+    # Arpwatch-style L2 sighting sniffer (issue #459, Phase 3) — opt-in for the
+    # same CAP_NET_RAW + scapy reasons as fingerprinting. Observes source MACs
+    # on the wire (ARP + IPv6 ND) even for devices that never do DHCP, and ships
+    # first-sightings so the control plane can flag them as new devices.
+    mac_sighting_enabled = os.environ.get("DHCP_MAC_SIGHTING_ENABLED", "0") == "1"
+    mac_sighting_shipper: MacSightingShipper | None = None
+    if mac_sighting_enabled:
+        mac_sighting_shipper = MacSightingShipper(cfg, token_ref)
+        log.info("dhcp_mac_sighting_enabled")
+
     threads = [
         threading.Thread(target=syncer.run, name="sync", daemon=True),
         threading.Thread(target=heartbeat.run, name="heartbeat", daemon=True),
@@ -99,6 +110,14 @@ def run(cfg: AgentConfig) -> int:
         threads.append(
             threading.Thread(target=rogue_probe.run, name="rogue-probe", daemon=True)
         )
+    if mac_sighting_shipper is not None:
+        threads.append(
+            threading.Thread(
+                target=mac_sighting_shipper.run,
+                name="mac-sighting",
+                daemon=True,
+            )
+        )
     for t in threads:
         t.start()
 
@@ -118,6 +137,8 @@ def run(cfg: AgentConfig) -> int:
             fingerprint_shipper.stop()
         if rogue_probe is not None:
             rogue_probe.stop()
+        if mac_sighting_shipper is not None:
+            mac_sighting_shipper.stop()
 
     signal.signal(signal.SIGTERM, _sig)
     signal.signal(signal.SIGINT, _sig)

--- a/agent/dhcp/tests/test_mac_sighting.py
+++ b/agent/dhcp/tests/test_mac_sighting.py
@@ -1,0 +1,115 @@
+"""Tests for the arpwatch-style L2 sniffer's packet parser (#459 Phase 3).
+
+We don't run AsyncSniffer in the test env (no CAP_NET_RAW, no traffic).
+Instead we build ARP + IPv6-ND packets in-memory via scapy's layers and
+assert the parser extracts the ``(MAC, IP)`` pairings we expect.
+
+If scapy isn't installed (running unit tests without the agent's
+optional dep), the entire module is skipped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+scapy = pytest.importorskip("scapy")
+
+from scapy.layers.inet6 import (  # noqa: E402
+    ICMPv6ND_NA,
+    ICMPv6ND_NS,
+    ICMPv6NDOptSrcLLAddr,
+    IPv6,
+)
+from scapy.layers.l2 import ARP, Ether  # noqa: E402
+
+from spatium_dhcp_agent.mac_sighting import (  # noqa: E402
+    MacSighting,
+    _normalize_ip,
+    _normalize_mac,
+    parse_sighting_packet,
+)
+
+
+def test_parse_arp_reply() -> None:
+    pkt = Ether(src="aa:bb:cc:dd:ee:ff") / ARP(
+        op=2, hwsrc="aa:bb:cc:dd:ee:ff", psrc="10.0.0.5"
+    )
+    obs = parse_sighting_packet(pkt)
+    assert obs is not None
+    assert obs.mac_address == "aa:bb:cc:dd:ee:ff"
+    assert obs.ip_address == "10.0.0.5"
+
+
+def test_parse_arp_request_carries_sender_pairing() -> None:
+    # Even a request (op=1) carries the sender's MAC + IP.
+    pkt = Ether(src="52:54:00:ab:cd:ef") / ARP(
+        op=1, hwsrc="52:54:00:ab:cd:ef", psrc="192.168.1.20", pdst="192.168.1.1"
+    )
+    obs = parse_sighting_packet(pkt)
+    assert obs is not None
+    assert obs.mac_address == "52:54:00:ab:cd:ef"
+    assert obs.ip_address == "192.168.1.20"
+
+
+def test_parse_arp_probe_zero_sender_ip_dropped() -> None:
+    # ARP probes use 0.0.0.0 as the sender protocol address.
+    pkt = Ether(src="52:54:00:ab:cd:ef") / ARP(
+        op=1, hwsrc="52:54:00:ab:cd:ef", psrc="0.0.0.0", pdst="192.168.1.50"
+    )
+    assert parse_sighting_packet(pkt) is None
+
+
+def test_parse_ipv6_nd_neighbor_solicitation() -> None:
+    pkt = (
+        Ether(src="aa:bb:cc:11:22:33")
+        / IPv6(src="fe80::1")
+        / ICMPv6ND_NS(tgt="fe80::2")
+        / ICMPv6NDOptSrcLLAddr(lladdr="aa:bb:cc:11:22:33")
+    )
+    obs = parse_sighting_packet(pkt)
+    assert obs is not None
+    assert obs.mac_address == "aa:bb:cc:11:22:33"
+    assert obs.ip_address == "fe80::1"
+
+
+def test_parse_ipv6_nd_advertisement_falls_back_to_ether_src() -> None:
+    # An NA without a tgt-LLA option still yields a pairing from Ether.src.
+    pkt = (
+        Ether(src="aa:bb:cc:44:55:66")
+        / IPv6(src="2001:db8::10")
+        / ICMPv6ND_NA(tgt="2001:db8::10")
+    )
+    obs = parse_sighting_packet(pkt)
+    assert obs is not None
+    assert obs.mac_address == "aa:bb:cc:44:55:66"
+    assert obs.ip_address == "2001:db8::10"
+
+
+def test_parse_non_arp_non_nd_returns_none() -> None:
+    pkt = Ether(src="aa:bb:cc:dd:ee:ff")
+    assert parse_sighting_packet(pkt) is None
+
+
+def test_normalize_mac_rejects_broadcast_zero_multicast() -> None:
+    assert _normalize_mac("ff:ff:ff:ff:ff:ff") is None
+    assert _normalize_mac("00:00:00:00:00:00") is None
+    # Multicast/group bit set (low bit of first octet).
+    assert _normalize_mac("01:00:5e:00:00:01") is None
+    assert _normalize_mac("33:33:00:00:00:01") is None
+    # A normal unicast MAC normalises to lower-case.
+    assert _normalize_mac("AA:BB:CC:DD:EE:FF") == "aa:bb:cc:dd:ee:ff"
+    assert _normalize_mac("not-a-mac") is None
+
+
+def test_normalize_ip_rejects_unspecified() -> None:
+    assert _normalize_ip("0.0.0.0") is None
+    assert _normalize_ip("::") is None
+    assert _normalize_ip("") is None
+    assert _normalize_ip("fe80::1") == "fe80::1"
+    assert _normalize_ip("10.0.0.5") == "10.0.0.5"
+
+
+def test_sighting_payload_round_trips() -> None:
+    obs = MacSighting(mac_address="aa:bb:cc:dd:ee:ff", ip_address="10.0.0.5")
+    payload = obs.to_payload()
+    assert payload == {"mac_address": "aa:bb:cc:dd:ee:ff", "ip_address": "10.0.0.5"}

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -101,6 +101,13 @@ backend/alembic/versions/a3c8e5d61b94_subnet_classification_tags.py:drop_column:
 backend/alembic/versions/a3c8e5d61b94_subnet_classification_tags.py:drop_column:85
 backend/alembic/versions/a3e7c9d12f80_appliance_resolver_settings.py:drop_column:106
 backend/alembic/versions/a3e7c9d12f80_appliance_resolver_settings.py:drop_column:108
+backend/alembic/versions/a3f1d6c92b58_new_device_watch.py:drop_column:141
+backend/alembic/versions/a3f1d6c92b58_new_device_watch.py:drop_column:142
+backend/alembic/versions/a3f1d6c92b58_new_device_watch.py:drop_column:143
+backend/alembic/versions/a3f1d6c92b58_new_device_watch.py:drop_column:144
+backend/alembic/versions/a3f1d6c92b58_new_device_watch.py:drop_column:145
+backend/alembic/versions/a3f1d6c92b58_new_device_watch.py:drop_constraint_fk:138
+backend/alembic/versions/a3f1d6c92b58_new_device_watch.py:drop_table:136
 backend/alembic/versions/a3f1d9e07c52_firewall_apply_state.py:drop_column:66
 backend/alembic/versions/a3f1d9e07c52_firewall_apply_state.py:drop_table:67
 backend/alembic/versions/a3f1e9c47b20_platform_settings_verbose_boot.py:drop_column:37

--- a/backend/alembic/versions/a3f1d6c92b58_new_device_watch.py
+++ b/backend/alembic/versions/a3f1d6c92b58_new_device_watch.py
@@ -113,7 +113,13 @@ def upgrade() -> None:
         ),
     )
     op.create_index("ix_mac_allowlist_mac", "mac_allowlist", ["mac_address"])
-    op.create_index("ix_mac_allowlist_oui_prefix", "mac_allowlist", ["oui_prefix"])
+    op.create_index(
+        "uq_mac_allowlist_oui_prefix",
+        "mac_allowlist",
+        ["oui_prefix"],
+        unique=True,
+        postgresql_where=sa.text("oui_prefix IS NOT NULL"),
+    )
 
     # ── 3. feature_module seed (non-negotiable #14), default-OFF ─────────
     op.execute(sa.text("""
@@ -125,7 +131,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute(sa.text("DELETE FROM feature_module WHERE id = 'security.new_device_watch'"))
-    op.drop_index("ix_mac_allowlist_oui_prefix", table_name="mac_allowlist")
+    op.drop_index("uq_mac_allowlist_oui_prefix", table_name="mac_allowlist")
     op.drop_index("ix_mac_allowlist_mac", table_name="mac_allowlist")
     op.drop_table("mac_allowlist")
     op.drop_index("ix_ip_mac_history_classification", table_name="ip_mac_history")

--- a/backend/alembic/versions/a3f1d6c92b58_new_device_watch.py
+++ b/backend/alembic/versions/a3f1d6c92b58_new_device_watch.py
@@ -1,0 +1,137 @@
+"""new-device watch: extend ip_mac_history + mac_allowlist (#459)
+
+arpwatch-style new-device detection (issue #459). Rather than a parallel
+sighting table, the existing ``ip_mac_history`` observation log (issue #369)
+gains a classification layer:
+
+* ``classification`` — new | acknowledged | known
+* ``source`` — sweep | snmp | dhcp_lease | l2_sniff (which path observed it)
+* ``is_randomized`` — locally-administered (privacy) MAC, skipped by the
+  default alert so reconnecting phones don't storm
+* ``acknowledged_at`` / ``acknowledged_by_user_id`` — operator dismissal trail
+
+Plus a ``mac_allowlist`` table (MAC or OUI prefix) of trusted devices that
+never alert — keyed on the MAC so it survives the cascade-delete of any IP it
+was first seen on — and the default-off ``security.new_device_watch`` feature
+module (non-negotiable #14).
+
+All additive: every new column carries a ``server_default`` so existing rows
+backfill in place and fresh-install + rolling-upgrade stay safe.
+
+Revision ID: a3f1d6c92b58
+Revises: 5443d2756647
+Create Date: 2026-06-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a3f1d6c92b58"
+down_revision: str | None = "5443d2756647"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # ── 1. Extend ip_mac_history with the classification layer ───────────
+    op.add_column(
+        "ip_mac_history",
+        sa.Column(
+            "classification",
+            sa.String(length=16),
+            server_default=sa.text("'new'"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "ip_mac_history",
+        sa.Column(
+            "source",
+            sa.String(length=16),
+            server_default=sa.text("'sweep'"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "ip_mac_history",
+        sa.Column(
+            "is_randomized",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "ip_mac_history",
+        sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "ip_mac_history",
+        sa.Column("acknowledged_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_ip_mac_history_ack_user",
+        "ip_mac_history",
+        "user",
+        ["acknowledged_by_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_ip_mac_history_classification", "ip_mac_history", ["classification"])
+
+    # ── 2. mac_allowlist — trusted MACs / OUI prefixes ───────────────────
+    op.create_table(
+        "mac_allowlist",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("mac_address", postgresql.MACADDR(), nullable=True),
+        sa.Column("oui_prefix", sa.String(length=6), nullable=True),
+        sa.Column("note", sa.Text(), server_default="", nullable=False),
+        sa.Column("is_builtin", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("mac_address", name="uq_mac_allowlist_mac"),
+        sa.CheckConstraint(
+            "mac_address IS NOT NULL OR oui_prefix IS NOT NULL",
+            name="ck_mac_allowlist_one_key",
+        ),
+    )
+    op.create_index("ix_mac_allowlist_mac", "mac_allowlist", ["mac_address"])
+    op.create_index("ix_mac_allowlist_oui_prefix", "mac_allowlist", ["oui_prefix"])
+
+    # ── 3. feature_module seed (non-negotiable #14), default-OFF ─────────
+    op.execute(sa.text("""
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('security.new_device_watch', FALSE)
+            ON CONFLICT (id) DO NOTHING
+            """))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'security.new_device_watch'"))
+    op.drop_index("ix_mac_allowlist_oui_prefix", table_name="mac_allowlist")
+    op.drop_index("ix_mac_allowlist_mac", table_name="mac_allowlist")
+    op.drop_table("mac_allowlist")
+    op.drop_index("ix_ip_mac_history_classification", table_name="ip_mac_history")
+    op.drop_constraint("fk_ip_mac_history_ack_user", "ip_mac_history", type_="foreignkey")
+    op.drop_column("ip_mac_history", "acknowledged_by_user_id")
+    op.drop_column("ip_mac_history", "acknowledged_at")
+    op.drop_column("ip_mac_history", "is_randomized")
+    op.drop_column("ip_mac_history", "source")
+    op.drop_column("ip_mac_history", "classification")

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -762,12 +762,20 @@ async def agent_lease_events(
         _find_containing_subnet,
         _load_subnet_cache,
     )
+    from app.services.feature_modules import is_module_enabled
 
     server, _ = auth
     now = datetime.now(UTC)
     events = body.leases
     if not events:
         return {"upserted": 0}
+
+    # New-device watch (issue #459) — only log MAC sightings to ip_mac_history
+    # when the operator has opted in; keeps this hot ingestion path (up to 100
+    # events/POST) at its current cost when the feature is off.
+    watch_enabled = await is_module_enabled(db, "security.new_device_watch")
+    # (ipam_row, mac) pairs to classify after the mirror pass flushes ids.
+    to_observe: list[tuple[IPAddress, str]] = []
 
     # ── Bulk preload (avoid the per-event N+1: this is the hottest DHCP
     # ingestion path, up to 100 events/POST). Three queries total instead
@@ -871,6 +879,13 @@ async def agent_lease_events(
                 ipam_row.dhcp_lease_id = str(lease.id) if lease.id else None
             # else: manual/static — leave it alone
 
+            # New-device watch: record the MAC sighting for this lease,
+            # regardless of whether the IPAM row is auto/manual (a new MAC
+            # squatting a static IP is exactly worth flagging). Deferred until
+            # after the flush below so new rows have ids.
+            if watch_enabled and ipam_row is not None and ev.mac_address:
+                to_observe.append((ipam_row, ev.mac_address))
+
             # DDNS — mirrors services/dhcp/pull_leases.py. Only fires on
             # auto-from-lease rows inside DDNS-enabled subnets; errors are
             # logged but never break the lease upsert pass (DNS will
@@ -931,8 +946,162 @@ async def agent_lease_events(
                 await db.delete(ipam_row)
                 ipam_by_key.pop((subnet.id, ev.ip_address), None)
 
+    # ── New-device watch: classify the collected MAC sightings (issue #459) ──
+    # Flush first so freshly-created mirror rows have ids for the FK. Each
+    # genuinely-new device writes a device.first_seen audit row, which the
+    # after-commit publisher turns into a typed event (≤10 s) — the real-time
+    # "something new joined" signal, independent of the 60 s alert tick.
+    if to_observe:
+        from app.api.v1.dhcp._audit import write_audit
+        from app.services.ipam.discovery import record_mac_observation
+
+        await db.flush()
+        for ipam_row, mac in to_observe:
+            if ipam_row.id is None:
+                continue
+            try:
+                result = await record_mac_observation(db, ipam_row.id, mac, source="dhcp_lease")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "dhcp_agent_lease_mac_observation_failed",
+                    server=str(server.id),
+                    ip=str(ipam_row.address),
+                    error=str(exc),
+                )
+                continue
+            if result is not None and result.is_first_seen_new:
+                write_audit(
+                    db,
+                    user=None,
+                    action="first_seen",
+                    resource_type="ip_mac_observation",
+                    resource_id=f"{ipam_row.id}:{result.mac_address}",
+                    resource_display=f"{ipam_row.address} ({result.mac_address})",
+                    new_value={
+                        "mac_address": result.mac_address,
+                        "ip_address": str(ipam_row.address),
+                        "source": "dhcp_lease",
+                        "is_randomized": result.is_randomized,
+                    },
+                )
+
     await db.commit()
     return {"upserted": upserted}
+
+
+class MacSightingEntry(BaseModel):
+    """One first-sighting from the agent's L2 (ARP / ND) sniffer (issue #459).
+
+    ``ip_address`` is the sender protocol address from the ARP / ND frame —
+    required, since the sighting is logged against an IPAM row.
+    """
+
+    mac_address: str
+    ip_address: str
+
+
+class MacSightingBatch(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    sightings: list[MacSightingEntry] = Field(default_factory=list, max_length=500)
+
+
+@router.post("/mac-sightings")
+async def agent_mac_sightings(
+    body: MacSightingBatch,
+    db: DB,
+    auth: tuple[DHCPServer, dict[str, Any]] = Depends(_auth_agent),
+) -> dict[str, int]:
+    """Ingest first-sighting (mac, ip) pairs from the agent's opt-in L2 sniffer.
+
+    arpwatch-style: a MAC seen on the wire even if it never does DHCP (static
+    IP, link-local, rogue). Resolves each IP to a subnet, creates a
+    ``discovered`` IPAM row if there's none yet (like the SNMP ARP path), and
+    records the MAC sighting with ``source='l2_sniff'``. Genuinely-new devices
+    write a ``device.first_seen`` audit row → typed event. No-op (zero writes)
+    when new-device watch is off, so an agent left sniffing costs nothing
+    server-side until the operator arms the feature.
+    """
+    from app.models.ipam import IPAddress
+    from app.services.dhcp.pull_leases import _find_containing_subnet, _load_subnet_cache
+    from app.services.feature_modules import is_module_enabled
+
+    server, _ = auth
+    if not body.sightings:
+        return {"recorded": 0, "new": 0}
+    if not await is_module_enabled(db, "security.new_device_watch"):
+        return {"recorded": 0, "new": 0}
+
+    from app.api.v1.dhcp._audit import write_audit
+    from app.services.ipam.discovery import record_mac_observation
+
+    now = datetime.now(UTC)
+    subnets = await _load_subnet_cache(db)
+    ips = list({s.ip_address for s in body.sightings})
+    existing = (
+        (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips)))).scalars().all()
+    )
+    by_key: dict[tuple[Any, str], IPAddress] = {(r.subnet_id, r.address): r for r in existing}
+
+    # (ipam_row, mac) pairs to classify after the flush assigns new-row ids.
+    to_observe: list[tuple[IPAddress, str]] = []
+    for s in body.sightings:
+        subnet = _find_containing_subnet(s.ip_address, subnets)
+        if subnet is None:
+            continue
+        row = by_key.get((subnet.id, s.ip_address))
+        if row is None:
+            row = IPAddress(
+                subnet_id=subnet.id,
+                address=s.ip_address,
+                status="discovered",
+                mac_address=s.mac_address,
+                last_seen_at=now,
+                last_seen_method="l2_sniff",
+            )
+            db.add(row)
+            by_key[(subnet.id, s.ip_address)] = row
+        else:
+            row.last_seen_at = now
+            row.last_seen_method = "l2_sniff"
+        to_observe.append((row, s.mac_address))
+
+    recorded = 0
+    new_count = 0
+    if to_observe:
+        await db.flush()
+        for row, mac in to_observe:
+            if row.id is None:
+                continue
+            try:
+                result = await record_mac_observation(db, row.id, mac, source="l2_sniff")
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "dhcp_agent_mac_sighting_failed",
+                    server=str(server.id),
+                    ip=str(row.address),
+                    error=str(exc),
+                )
+                continue
+            recorded += 1
+            if result is not None and result.is_first_seen_new:
+                new_count += 1
+                write_audit(
+                    db,
+                    user=None,
+                    action="first_seen",
+                    resource_type="ip_mac_observation",
+                    resource_id=f"{row.id}:{result.mac_address}",
+                    resource_display=f"{row.address} ({result.mac_address})",
+                    new_value={
+                        "mac_address": result.mac_address,
+                        "ip_address": str(row.address),
+                        "source": "l2_sniff",
+                        "is_randomized": result.is_randomized,
+                    },
+                )
+    await db.commit()
+    return {"recorded": recorded, "new": new_count}
 
 
 @router.post("/ha-status")

--- a/backend/app/api/v1/new_devices/__init__.py
+++ b/backend/app/api/v1/new_devices/__init__.py
@@ -1,0 +1,5 @@
+"""New-device (arpwatch) detection API — issue #459."""
+
+from app.api.v1.new_devices.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/new_devices/router.py
+++ b/backend/app/api/v1/new_devices/router.py
@@ -1,0 +1,490 @@
+"""New-device (arpwatch) detection — operator REST surface (issue #459).
+
+Review queue + allowlist + baseline import + one-click acknowledge / block over
+the ``ip_mac_history`` classification layer. Gated behind the
+``security.new_device_watch`` feature module (applied at the router include in
+``app.api.v1.router``). Reads need ``read,ip_address``; mutations need
+``write,ip_address``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, model_validator
+from sqlalchemy import String, and_, cast, func, or_, select
+
+from app.api.deps import DB
+from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page
+from app.api.v1.dhcp._audit import write_audit
+from app.core.agent_wake import collect_wake, dhcp_group_channel
+from app.core.permissions import require_permission
+from app.models.auth import User
+from app.models.dhcp import DHCPMACBlock, DHCPServerGroup
+from app.models.ipam import IPAddress, IpMacHistory, MACAllowlist, Subnet
+from app.services.ipam.new_device import (
+    BUILTIN_VIRT_OUIS,
+    acknowledge_sighting,
+    add_allowlist_entry,
+    baseline_import,
+    normalize_oui_prefix,
+    remove_allowlist_entry,
+)
+from app.services.oui import bulk_lookup_vendors, normalize_mac_key
+
+router = APIRouter(prefix="/new-devices", tags=["new-devices"])
+
+ReadUser = Annotated[User, Depends(require_permission("read", "ip_address"))]
+WriteUser = Annotated[User, Depends(require_permission("write", "ip_address"))]
+
+
+# ── Schemas ─────────────────────────────────────────────────────────────────
+
+
+class SightingOut(BaseModel):
+    id: uuid.UUID
+    ip_address_id: uuid.UUID
+    ip_address: str
+    subnet_id: uuid.UUID | None
+    subnet_name: str | None
+    mac_address: str
+    oui_vendor: str | None
+    classification: str
+    source: str
+    is_randomized: bool
+    first_seen: datetime
+    last_seen: datetime
+    acknowledged_at: datetime | None
+
+
+class SummaryOut(BaseModel):
+    new_count: int
+    new_randomized_count: int
+    new_last_24h: int
+    acknowledged_count: int
+    known_count: int
+    allowlist_count: int
+
+
+class AcknowledgeBody(BaseModel):
+    note: str = ""
+
+
+class BlockBody(BaseModel):
+    mac_address: str
+    group_id: uuid.UUID | None = None  # None → block in every DHCP server group
+    reason: str = "other"
+    description: str = ""
+
+
+class BlockResult(BaseModel):
+    mac_address: str
+    blocked_group_ids: list[uuid.UUID]
+    already_blocked_group_ids: list[uuid.UUID]
+
+
+class AllowlistOut(BaseModel):
+    id: uuid.UUID
+    mac_address: str | None
+    oui_prefix: str | None
+    note: str
+    is_builtin: bool
+    created_at: datetime
+
+
+class AllowlistCreate(BaseModel):
+    mac_address: str | None = None
+    oui_prefix: str | None = None
+    note: str = ""
+
+    @model_validator(mode="after")
+    def _one_key(self) -> AllowlistCreate:
+        if not self.mac_address and not self.oui_prefix:
+            raise ValueError("provide a mac_address or an oui_prefix")
+        return self
+
+
+class AllowlistCreateResult(BaseModel):
+    entry: AllowlistOut
+    reclassified_count: int
+
+
+class BaselineResult(BaseModel):
+    reclassified_count: int
+
+
+class VirtDefaultsResult(BaseModel):
+    added: int
+    skipped: int
+
+
+# ── Reads ───────────────────────────────────────────────────────────────────
+
+
+@router.get("/summary", response_model=SummaryOut)
+async def get_summary(db: DB, _: ReadUser) -> SummaryOut:
+    """Counts for the dashboard KPI + review-queue tabs."""
+    day_ago = datetime.now(UTC) - timedelta(hours=24)
+
+    def _count(*conds: Any) -> Any:
+        return select(func.count()).select_from(IpMacHistory).where(*conds)
+
+    new_count = (
+        await db.execute(
+            _count(IpMacHistory.classification == "new", IpMacHistory.is_randomized.is_(False))
+        )
+    ).scalar_one()
+    new_randomized = (
+        await db.execute(
+            _count(IpMacHistory.classification == "new", IpMacHistory.is_randomized.is_(True))
+        )
+    ).scalar_one()
+    new_24h = (
+        await db.execute(
+            _count(
+                IpMacHistory.classification == "new",
+                IpMacHistory.is_randomized.is_(False),
+                IpMacHistory.first_seen >= day_ago,
+            )
+        )
+    ).scalar_one()
+    ack = (await db.execute(_count(IpMacHistory.classification == "acknowledged"))).scalar_one()
+    known = (await db.execute(_count(IpMacHistory.classification == "known"))).scalar_one()
+    allowlist = (await db.execute(select(func.count()).select_from(MACAllowlist))).scalar_one()
+    return SummaryOut(
+        new_count=new_count,
+        new_randomized_count=new_randomized,
+        new_last_24h=new_24h,
+        acknowledged_count=ack,
+        known_count=known,
+        allowlist_count=allowlist,
+    )
+
+
+@router.get("/sightings", response_model=Page[SightingOut])
+async def list_sightings(
+    db: DB,
+    _: ReadUser,
+    classification: str | None = Query("new"),
+    subnet_id: uuid.UUID | None = None,
+    since_hours: int | None = Query(None, ge=1, le=24 * 365),
+    include_randomized: bool = False,
+    search: str | None = None,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
+) -> Page[SightingOut]:
+    """Paginated review queue. Defaults to unacknowledged new devices."""
+    conds: list[Any] = []
+    if classification:
+        if classification not in ("new", "acknowledged", "known"):
+            raise HTTPException(status_code=422, detail="invalid classification")
+        conds.append(IpMacHistory.classification == classification)
+    if subnet_id is not None:
+        conds.append(IPAddress.subnet_id == subnet_id)
+    if since_hours is not None:
+        conds.append(IpMacHistory.first_seen >= datetime.now(UTC) - timedelta(hours=since_hours))
+    if not include_randomized:
+        conds.append(IpMacHistory.is_randomized.is_(False))
+    if search:
+        like = f"%{search.strip()}%"
+        conds.append(
+            or_(
+                cast(IpMacHistory.mac_address, String).ilike(like),
+                cast(IPAddress.address, String).ilike(like),
+                IPAddress.hostname.ilike(like),
+            )
+        )
+
+    base = (
+        select(IpMacHistory, IPAddress, Subnet)
+        .join(IPAddress, IPAddress.id == IpMacHistory.ip_address_id)
+        .outerjoin(Subnet, Subnet.id == IPAddress.subnet_id)
+        .where(and_(*conds))
+    )
+    total = (
+        await db.execute(select(func.count()).select_from(base.order_by(None).subquery()))
+    ).scalar_one()
+    rows = (
+        await db.execute(
+            base.order_by(IpMacHistory.first_seen.desc())
+            .limit(page_size)
+            .offset((page - 1) * page_size)
+        )
+    ).all()
+
+    macs: list[str | None] = [str(h.mac_address) for h, _ip, _s in rows]
+    vendors = await bulk_lookup_vendors(db, macs)
+    items = [
+        SightingOut(
+            id=h.id,
+            ip_address_id=h.ip_address_id,
+            ip_address=str(ip.address),
+            subnet_id=subnet.id if subnet else None,
+            subnet_name=subnet.name if subnet else None,
+            mac_address=str(h.mac_address),
+            oui_vendor=vendors.get(normalize_mac_key(str(h.mac_address)) or ""),
+            classification=h.classification,
+            source=h.source,
+            is_randomized=h.is_randomized,
+            first_seen=h.first_seen,
+            last_seen=h.last_seen,
+            acknowledged_at=h.acknowledged_at,
+        )
+        for h, ip, subnet in rows
+    ]
+    return Page[SightingOut](items=items, total=total, page=page, page_size=page_size)
+
+
+@router.get("/allowlist", response_model=list[AllowlistOut])
+async def list_allowlist(db: DB, _: ReadUser) -> list[AllowlistOut]:
+    rows = (
+        (await db.execute(select(MACAllowlist).order_by(MACAllowlist.created_at.desc())))
+        .scalars()
+        .all()
+    )
+    return [
+        AllowlistOut(
+            id=r.id,
+            mac_address=str(r.mac_address) if r.mac_address else None,
+            oui_prefix=r.oui_prefix,
+            note=r.note,
+            is_builtin=r.is_builtin,
+            created_at=r.created_at,
+        )
+        for r in rows
+    ]
+
+
+# ── Mutations ───────────────────────────────────────────────────────────────
+
+
+async def _load_sighting_out(db: DB, sighting_id: uuid.UUID) -> SightingOut:
+    row = (
+        await db.execute(
+            select(IpMacHistory, IPAddress, Subnet)
+            .join(IPAddress, IPAddress.id == IpMacHistory.ip_address_id)
+            .outerjoin(Subnet, Subnet.id == IPAddress.subnet_id)
+            .where(IpMacHistory.id == sighting_id)
+        )
+    ).first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="sighting not found")
+    h, ip, subnet = row
+    one_mac: list[str | None] = [str(h.mac_address)]
+    vendors = await bulk_lookup_vendors(db, one_mac)
+    return SightingOut(
+        id=h.id,
+        ip_address_id=h.ip_address_id,
+        ip_address=str(ip.address),
+        subnet_id=subnet.id if subnet else None,
+        subnet_name=subnet.name if subnet else None,
+        mac_address=str(h.mac_address),
+        oui_vendor=vendors.get(normalize_mac_key(str(h.mac_address)) or ""),
+        classification=h.classification,
+        source=h.source,
+        is_randomized=h.is_randomized,
+        first_seen=h.first_seen,
+        last_seen=h.last_seen,
+        acknowledged_at=h.acknowledged_at,
+    )
+
+
+@router.post("/sightings/{sighting_id}/acknowledge", response_model=SightingOut)
+async def acknowledge(
+    sighting_id: uuid.UUID, body: AcknowledgeBody, db: DB, user: WriteUser
+) -> SightingOut:
+    """Dismiss a new-device sighting → ``acknowledged`` (fires device.acknowledged)."""
+    row = await acknowledge_sighting(db, sighting_id, user)
+    if row is None:
+        raise HTTPException(status_code=404, detail="sighting not found")
+    write_audit(
+        db,
+        user=user,
+        action="acknowledged",
+        resource_type="ip_mac_observation",
+        resource_id=f"{row.ip_address_id}:{row.mac_address}",
+        resource_display=str(row.mac_address),
+        new_value={"mac_address": str(row.mac_address), "note": body.note},
+    )
+    await db.commit()
+    return await _load_sighting_out(db, sighting_id)
+
+
+@router.post("/baseline", response_model=BaselineResult)
+async def run_baseline(db: DB, user: WriteUser) -> BaselineResult:
+    """Mark every currently-observed MAC as ``known`` (learning-mode baseline)."""
+    count = await baseline_import(db)
+    write_audit(
+        db,
+        user=user,
+        action="baseline_import",
+        resource_type="ip_mac_observation",
+        resource_id="*",
+        resource_display="new-device baseline import",
+        new_value={"reclassified_count": count},
+    )
+    await db.commit()
+    return BaselineResult(reclassified_count=count)
+
+
+@router.post(
+    "/allowlist", response_model=AllowlistCreateResult, status_code=status.HTTP_201_CREATED
+)
+async def create_allowlist(body: AllowlistCreate, db: DB, user: WriteUser) -> AllowlistCreateResult:
+    try:
+        row, reclassified = await add_allowlist_entry(
+            db,
+            mac_address=body.mac_address,
+            oui_prefix=body.oui_prefix,
+            note=body.note,
+            user=user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    await db.flush()
+    write_audit(
+        db,
+        user=user,
+        action="create",
+        resource_type="mac_allowlist",
+        resource_id=str(row.id),
+        resource_display=str(row.mac_address or row.oui_prefix),
+        new_value={
+            "mac_address": str(row.mac_address) if row.mac_address else None,
+            "oui_prefix": row.oui_prefix,
+            "reclassified_count": reclassified,
+        },
+    )
+    await db.commit()
+    await db.refresh(row)
+    return AllowlistCreateResult(
+        entry=AllowlistOut(
+            id=row.id,
+            mac_address=str(row.mac_address) if row.mac_address else None,
+            oui_prefix=row.oui_prefix,
+            note=row.note,
+            is_builtin=row.is_builtin,
+            created_at=row.created_at,
+        ),
+        reclassified_count=reclassified,
+    )
+
+
+@router.post("/allowlist/virt-defaults", response_model=VirtDefaultsResult)
+async def add_virt_defaults(db: DB, user: WriteUser) -> VirtDefaultsResult:
+    """Add the well-known virtualisation / container OUIs to the allowlist so VM
+    and container MACs stop reading as rogue devices. Skips any already present."""
+    existing = {
+        r[0]
+        for r in (
+            await db.execute(
+                select(MACAllowlist.oui_prefix).where(MACAllowlist.oui_prefix.is_not(None))
+            )
+        ).all()
+    }
+    added = 0
+    for prefix, vendor in BUILTIN_VIRT_OUIS:
+        if prefix in existing:
+            continue
+        await add_allowlist_entry(
+            db, oui_prefix=prefix, note=f"{vendor} (built-in)", user=user, is_builtin=True
+        )
+        added += 1
+    if added:
+        write_audit(
+            db,
+            user=user,
+            action="create",
+            resource_type="mac_allowlist",
+            resource_id="*",
+            resource_display="virtualization OUI defaults",
+            new_value={"added": added},
+        )
+    await db.commit()
+    return VirtDefaultsResult(added=added, skipped=len(BUILTIN_VIRT_OUIS) - added)
+
+
+@router.delete("/allowlist/{allowlist_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_allowlist(allowlist_id: uuid.UUID, db: DB, user: WriteUser) -> None:
+    existing = await db.get(MACAllowlist, allowlist_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="allowlist entry not found")
+    display = str(existing.mac_address or existing.oui_prefix)
+    await remove_allowlist_entry(db, allowlist_id)
+    write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="mac_allowlist",
+        resource_id=str(allowlist_id),
+        resource_display=display,
+    )
+    await db.commit()
+
+
+@router.post("/block", response_model=BlockResult)
+async def block_mac(body: BlockBody, db: DB, user: WriteUser) -> BlockResult:
+    """Block a MAC in one DHCP server group (or all groups when ``group_id`` is
+    omitted) — arpwatch with teeth. Creates ``dhcp_mac_block`` rows + wakes the
+    affected agents."""
+    if body.group_id is not None:
+        group_ids = [body.group_id]
+        if await db.get(DHCPServerGroup, body.group_id) is None:
+            raise HTTPException(status_code=404, detail="DHCP server group not found")
+    else:
+        group_ids = list((await db.execute(select(DHCPServerGroup.id))).scalars().all())
+        if not group_ids:
+            raise HTTPException(status_code=409, detail="no DHCP server groups to block in")
+
+    already = {
+        r[0]
+        for r in (
+            await db.execute(
+                select(DHCPMACBlock.group_id).where(
+                    DHCPMACBlock.mac_address == body.mac_address,
+                    DHCPMACBlock.group_id.in_(group_ids),
+                )
+            )
+        ).all()
+    }
+    blocked: list[uuid.UUID] = []
+    for gid in group_ids:
+        if gid in already:
+            continue
+        db.add(
+            DHCPMACBlock(
+                group_id=gid,
+                mac_address=body.mac_address,
+                reason=body.reason,
+                description=body.description or "Blocked from new-device review (#459)",
+                enabled=True,
+                created_by_user_id=user.id,
+                updated_by_user_id=user.id,
+            )
+        )
+        collect_wake(dhcp_group_channel(gid))
+        blocked.append(gid)
+
+    if blocked:
+        write_audit(
+            db,
+            user=user,
+            action="create",
+            resource_type="dhcp_mac_block",
+            resource_id=body.mac_address,
+            resource_display=body.mac_address,
+            new_value={"mac_address": body.mac_address, "blocked_groups": len(blocked)},
+        )
+    await db.commit()
+    return BlockResult(
+        mac_address=body.mac_address,
+        blocked_group_ids=blocked,
+        already_blocked_group_ids=list(already),
+    )
+
+
+# Keep ``normalize_oui_prefix`` reachable for tests that exercise the parser.
+__all__ = ["router", "normalize_oui_prefix"]

--- a/backend/app/api/v1/new_devices/router.py
+++ b/backend/app/api/v1/new_devices/router.py
@@ -16,6 +16,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, model_validator
 from sqlalchemy import String, and_, cast, func, or_, select
+from sqlalchemy.exc import IntegrityError
 
 from app.api.deps import DB
 from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page
@@ -30,6 +31,7 @@ from app.services.ipam.new_device import (
     acknowledge_sighting,
     add_allowlist_entry,
     baseline_import,
+    new_device_counts,
     normalize_oui_prefix,
     remove_allowlist_entry,
 )
@@ -121,46 +123,45 @@ class VirtDefaultsResult(BaseModel):
     skipped: int
 
 
+def _sighting_out(
+    h: IpMacHistory, ip: IPAddress, subnet: Subnet | None, vendors: dict[str, str]
+) -> SightingOut:
+    """Project a ``(IpMacHistory, IPAddress, Subnet)`` row tuple → ``SightingOut``.
+
+    Single source of truth for the wire shape so the list + single-row endpoints
+    can't drift (vendors is the bulk_lookup_vendors result for the page).
+    """
+    return SightingOut(
+        id=h.id,
+        ip_address_id=h.ip_address_id,
+        ip_address=str(ip.address),
+        subnet_id=subnet.id if subnet else None,
+        subnet_name=subnet.name if subnet else None,
+        mac_address=str(h.mac_address),
+        oui_vendor=vendors.get(normalize_mac_key(str(h.mac_address)) or ""),
+        classification=h.classification,
+        source=h.source,
+        is_randomized=h.is_randomized,
+        first_seen=h.first_seen,
+        last_seen=h.last_seen,
+        acknowledged_at=h.acknowledged_at,
+    )
+
+
 # ── Reads ───────────────────────────────────────────────────────────────────
 
 
 @router.get("/summary", response_model=SummaryOut)
 async def get_summary(db: DB, _: ReadUser) -> SummaryOut:
     """Counts for the dashboard KPI + review-queue tabs."""
-    day_ago = datetime.now(UTC) - timedelta(hours=24)
-
-    def _count(*conds: Any) -> Any:
-        return select(func.count()).select_from(IpMacHistory).where(*conds)
-
-    new_count = (
-        await db.execute(
-            _count(IpMacHistory.classification == "new", IpMacHistory.is_randomized.is_(False))
-        )
-    ).scalar_one()
-    new_randomized = (
-        await db.execute(
-            _count(IpMacHistory.classification == "new", IpMacHistory.is_randomized.is_(True))
-        )
-    ).scalar_one()
-    new_24h = (
-        await db.execute(
-            _count(
-                IpMacHistory.classification == "new",
-                IpMacHistory.is_randomized.is_(False),
-                IpMacHistory.first_seen >= day_ago,
-            )
-        )
-    ).scalar_one()
-    ack = (await db.execute(_count(IpMacHistory.classification == "acknowledged"))).scalar_one()
-    known = (await db.execute(_count(IpMacHistory.classification == "known"))).scalar_one()
-    allowlist = (await db.execute(select(func.count()).select_from(MACAllowlist))).scalar_one()
+    c = await new_device_counts(db)
     return SummaryOut(
-        new_count=new_count,
-        new_randomized_count=new_randomized,
-        new_last_24h=new_24h,
-        acknowledged_count=ack,
-        known_count=known,
-        allowlist_count=allowlist,
+        new_count=c["new"],
+        new_randomized_count=c["new_randomized"],
+        new_last_24h=c["new_last_24h"],
+        acknowledged_count=c["acknowledged"],
+        known_count=c["known"],
+        allowlist_count=c["allowlist"],
     )
 
 
@@ -217,24 +218,7 @@ async def list_sightings(
 
     macs: list[str | None] = [str(h.mac_address) for h, _ip, _s in rows]
     vendors = await bulk_lookup_vendors(db, macs)
-    items = [
-        SightingOut(
-            id=h.id,
-            ip_address_id=h.ip_address_id,
-            ip_address=str(ip.address),
-            subnet_id=subnet.id if subnet else None,
-            subnet_name=subnet.name if subnet else None,
-            mac_address=str(h.mac_address),
-            oui_vendor=vendors.get(normalize_mac_key(str(h.mac_address)) or ""),
-            classification=h.classification,
-            source=h.source,
-            is_randomized=h.is_randomized,
-            first_seen=h.first_seen,
-            last_seen=h.last_seen,
-            acknowledged_at=h.acknowledged_at,
-        )
-        for h, ip, subnet in rows
-    ]
+    items = [_sighting_out(h, ip, subnet, vendors) for h, ip, subnet in rows]
     return Page[SightingOut](items=items, total=total, page=page, page_size=page_size)
 
 
@@ -275,21 +259,7 @@ async def _load_sighting_out(db: DB, sighting_id: uuid.UUID) -> SightingOut:
     h, ip, subnet = row
     one_mac: list[str | None] = [str(h.mac_address)]
     vendors = await bulk_lookup_vendors(db, one_mac)
-    return SightingOut(
-        id=h.id,
-        ip_address_id=h.ip_address_id,
-        ip_address=str(ip.address),
-        subnet_id=subnet.id if subnet else None,
-        subnet_name=subnet.name if subnet else None,
-        mac_address=str(h.mac_address),
-        oui_vendor=vendors.get(normalize_mac_key(str(h.mac_address)) or ""),
-        classification=h.classification,
-        source=h.source,
-        is_randomized=h.is_randomized,
-        first_seen=h.first_seen,
-        last_seen=h.last_seen,
-        acknowledged_at=h.acknowledged_at,
-    )
+    return _sighting_out(h, ip, subnet, vendors)
 
 
 @router.post("/sightings/{sighting_id}/acknowledge", response_model=SightingOut)
@@ -342,9 +312,15 @@ async def create_allowlist(body: AllowlistCreate, db: DB, user: WriteUser) -> Al
             note=body.note,
             user=user,
         )
+        await db.flush()
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    await db.flush()
+    except IntegrityError as exc:
+        # Already allowlisted (uq_mac_allowlist_mac / uq_mac_allowlist_oui_prefix).
+        await db.rollback()
+        raise HTTPException(
+            status_code=409, detail="That MAC or OUI prefix is already allowlisted"
+        ) from exc
     write_audit(
         db,
         user=user,

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -46,6 +46,7 @@ from app.api.v1.logs import logs_router
 from app.api.v1.metrics import router as metrics_router
 from app.api.v1.multicast import router as multicast_router
 from app.api.v1.network import router as network_router
+from app.api.v1.new_devices import router as new_devices_router
 from app.api.v1.nmap import router as nmap_router
 from app.api.v1.opnsense import router as opnsense_router
 from app.api.v1.overlays import router as overlays_router
@@ -251,6 +252,10 @@ api_v1_router.include_router(
     network_router,
     tags=["network"],
     dependencies=[Depends(require_module("network.device"))],
+)
+api_v1_router.include_router(
+    new_devices_router,
+    dependencies=[Depends(require_module("security.new_device_watch"))],
 )
 api_v1_router.include_router(
     nmap_router,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -443,6 +443,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await seed_rogue_dhcp_alert_rule()
     except Exception as exc:  # noqa: BLE001
         logger.debug("rogue_dhcp_alert_rule_seed_skipped", reason=str(exc))
+    # New-device (arpwatch) alert rule — singleton, DISABLED by default (issue
+    # #459). Fires on never-before-seen MACs once new-device watch is on.
+    try:
+        from app.services.alerts import seed_new_mac_seen_alert_rule  # noqa: PLC0415
+
+        await seed_new_mac_seen_alert_rule()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("new_mac_seen_alert_rule_seed_skipped", reason=str(exc))
     # TLS certificate monitoring alert rules — four, DISABLED by default
     # (issue #118). Opt-in once the operator adds probe targets.
     try:

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -1089,7 +1089,15 @@ class MACAllowlist(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             name="ck_mac_allowlist_one_key",
         ),
         Index("ix_mac_allowlist_mac", "mac_address"),
-        Index("ix_mac_allowlist_oui_prefix", "oui_prefix"),
+        # Partial-unique so an OUI prefix can't be allowlisted twice (the DB is
+        # the source of truth, not a racy check-then-insert). NULLs are exempt
+        # (rows keyed on mac_address only).
+        Index(
+            "uq_mac_allowlist_oui_prefix",
+            "oui_prefix",
+            unique=True,
+            postgresql_where=sa_text("oui_prefix IS NOT NULL"),
+        ),
     )
 
     mac_address: Mapped[str | None] = mapped_column(MACADDR, nullable=True)

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from sqlalchemy import (
     BigInteger,
     Boolean,
+    CheckConstraint,
     Date,
     DateTime,
     ForeignKey,
@@ -1021,6 +1022,14 @@ class IpMacHistory(UUIDPrimaryKeyMixin, Base):
 
     Keyed on (ip_address_id, mac_address); last_seen bumped each touch.
     Cascades on IP delete.
+
+    Doubles as the new-device-watch sighting store (issue #459): each row's
+    ``classification`` distinguishes a never-before-seen MAC (``new``) from one
+    the operator has acknowledged (``acknowledged``) or that is part of the
+    known fleet / allowlist (``known``). ``source`` records which ingestion path
+    first/last touched it; ``is_randomized`` flags a locally-administered
+    (privacy-randomised) MAC so the ``new_mac_seen`` alert can skip it by
+    default and avoid a reconnection storm.
     """
 
     __tablename__ = "ip_mac_history"
@@ -1028,6 +1037,7 @@ class IpMacHistory(UUIDPrimaryKeyMixin, Base):
         UniqueConstraint("ip_address_id", "mac_address", name="uq_ip_mac_history_ip_mac"),
         Index("ix_ip_mac_history_ip_address_id", "ip_address_id"),
         Index("ix_ip_mac_history_last_seen", "last_seen"),
+        Index("ix_ip_mac_history_classification", "classification"),
     )
 
     ip_address_id: Mapped[uuid.UUID] = mapped_column(
@@ -1041,6 +1051,59 @@ class IpMacHistory(UUIDPrimaryKeyMixin, Base):
     )
     last_seen: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=sa_text("now()")
+    )
+    # new | acknowledged | known  (issue #459)
+    classification: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=sa_text("'new'")
+    )
+    # sweep | snmp | dhcp_lease | l2_sniff  — which path first/last observed it
+    source: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=sa_text("'sweep'")
+    )
+    # Locally-administered (privacy-randomised) MAC — second-least-significant
+    # bit of the first octet is set. Flagged, not alerted, by default.
+    is_randomized: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=sa_text("false")
+    )
+    acknowledged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    acknowledged_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+
+
+class MACAllowlist(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """Operator-curated set of trusted MACs that never raise a new-device alert.
+
+    Keyed on the MAC itself (or an OUI prefix for vendor/virtualisation
+    allowlisting, e.g. ``005056`` for VMware), so a trusted device stays quiet
+    wherever it shows up — independent of the ``ip_mac_history`` rows it
+    generates, which cascade-delete with their IP. At least one of
+    ``mac_address`` / ``oui_prefix`` must be set (issue #459).
+    """
+
+    __tablename__ = "mac_allowlist"
+    __table_args__ = (
+        UniqueConstraint("mac_address", name="uq_mac_allowlist_mac"),
+        CheckConstraint(
+            "mac_address IS NOT NULL OR oui_prefix IS NOT NULL",
+            name="ck_mac_allowlist_one_key",
+        ),
+        Index("ix_mac_allowlist_mac", "mac_address"),
+        Index("ix_mac_allowlist_oui_prefix", "oui_prefix"),
+    )
+
+    mac_address: Mapped[str | None] = mapped_column(MACADDR, nullable=True)
+    # 6 hex chars, lower-case, no separators (e.g. "005056"); matches any MAC
+    # whose first three octets equal this prefix.
+    oui_prefix: Mapped[str | None] = mapped_column(String(6), nullable=True)
+    note: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    # True for the seeded virtualisation-vendor rows; lets the UI distinguish
+    # platform defaults from operator entries (cloned but not deleted).
+    is_builtin: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=sa_text("false")
+    )
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
     )
 
 

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -32,7 +32,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.address_set import AddressSet, validate_address_set_shape
@@ -3233,5 +3233,265 @@ register(
         apply=_apply_reject_change_request,
         category="ops",
         required_permission=("approve", "change_request"),
+    )
+)
+
+
+# ── New-device watch operations (issue #459) ─────────────────────────────────
+
+
+class AcknowledgeDeviceArgs(BaseModel):
+    """Args for the ``acknowledge_device`` operation."""
+
+    sighting_id: UUID = Field(description="UUID of the ip_mac_history sighting to acknowledge")
+
+
+async def _preview_acknowledge_device(
+    db: AsyncSession, user: User, args: AcknowledgeDeviceArgs
+) -> PreviewResult:
+    from app.models.ipam import IpMacHistory  # noqa: PLC0415
+
+    row = await db.get(IpMacHistory, args.sighting_id)
+    if row is None:
+        return PreviewResult(ok=False, detail=f"Sighting {args.sighting_id} not found")
+    ip = await db.get(IPAddress, row.ip_address_id)
+    where = str(ip.address) if ip else "an IP"
+    return PreviewResult(
+        ok=True,
+        detail="ready",
+        preview_text=f"Acknowledge new device {row.mac_address} on {where} "
+        f"(currently '{row.classification}') — it stops raising the new-device alert.",
+    )
+
+
+async def _apply_acknowledge_device(
+    db: AsyncSession, user: User, args: AcknowledgeDeviceArgs
+) -> dict[str, Any]:
+    from app.api.v1.dhcp._audit import write_audit  # noqa: PLC0415
+    from app.services.ipam.new_device import acknowledge_sighting  # noqa: PLC0415
+
+    enforce_operation_permission(user, _OPERATIONS["acknowledge_device"])
+    row = await acknowledge_sighting(db, args.sighting_id, user)
+    if row is None:
+        raise ValueError(f"Sighting {args.sighting_id} not found")
+    write_audit(
+        db,
+        user=user,
+        action="acknowledged",
+        resource_type="ip_mac_observation",
+        resource_id=f"{row.ip_address_id}:{row.mac_address}",
+        resource_display=str(row.mac_address),
+        new_value={"mac_address": str(row.mac_address), "via": "ai_proposal"},
+    )
+    await db.commit()
+    return {"sighting_id": str(row.id), "classification": row.classification}
+
+
+register(
+    Operation(
+        name="acknowledge_device",
+        description=(
+            "Acknowledge (dismiss) a new-device sighting so it stops raising the "
+            "new_mac_seen alert. Always route via propose_acknowledge_device."
+        ),
+        args_model=AcknowledgeDeviceArgs,
+        preview=_preview_acknowledge_device,
+        apply=_apply_acknowledge_device,
+        category="ipam",
+        required_permission=("write", "ip_address"),
+    )
+)
+
+
+class AllowlistMacArgs(BaseModel):
+    """Args for the ``allowlist_mac`` operation."""
+
+    mac_address: str | None = Field(default=None, description="Exact MAC to trust")
+    oui_prefix: str | None = Field(
+        default=None, description="OUI prefix (e.g. '00:50:56' or '005056') to trust a whole vendor"
+    )
+    note: str = Field(default="", description="Why this MAC/vendor is trusted")
+
+
+async def _preview_allowlist_mac(
+    db: AsyncSession, user: User, args: AllowlistMacArgs
+) -> PreviewResult:
+    from app.services.ipam.new_device import normalize_oui_prefix  # noqa: PLC0415
+
+    prefix = normalize_oui_prefix(args.oui_prefix)
+    if not args.mac_address and not prefix:
+        return PreviewResult(ok=False, detail="Provide a mac_address or an oui_prefix")
+    target = args.mac_address or f"OUI {prefix}"
+    return PreviewResult(
+        ok=True,
+        detail="ready",
+        preview_text=f"Trust {target} — it (and matching sightings) become 'known' "
+        f"and never raise a new-device alert.",
+    )
+
+
+async def _apply_allowlist_mac(
+    db: AsyncSession, user: User, args: AllowlistMacArgs
+) -> dict[str, Any]:
+    from app.api.v1.dhcp._audit import write_audit  # noqa: PLC0415
+    from app.services.ipam.new_device import add_allowlist_entry  # noqa: PLC0415
+
+    enforce_operation_permission(user, _OPERATIONS["allowlist_mac"])
+    try:
+        row, reclassified = await add_allowlist_entry(
+            db,
+            mac_address=args.mac_address,
+            oui_prefix=args.oui_prefix,
+            note=args.note,
+            user=user,
+        )
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+    await db.flush()
+    write_audit(
+        db,
+        user=user,
+        action="create",
+        resource_type="mac_allowlist",
+        resource_id=str(row.id),
+        resource_display=str(row.mac_address or row.oui_prefix),
+        new_value={
+            "mac_address": str(row.mac_address) if row.mac_address else None,
+            "oui_prefix": row.oui_prefix,
+            "reclassified_count": reclassified,
+            "via": "ai_proposal",
+        },
+    )
+    await db.commit()
+    return {"id": str(row.id), "reclassified_count": reclassified}
+
+
+register(
+    Operation(
+        name="allowlist_mac",
+        description=(
+            "Add a MAC (or OUI prefix) to the trusted allowlist so it never "
+            "raises a new-device alert and matching sightings become 'known'. "
+            "Always route via propose_allowlist_mac."
+        ),
+        args_model=AllowlistMacArgs,
+        preview=_preview_allowlist_mac,
+        apply=_apply_allowlist_mac,
+        category="ipam",
+        required_permission=("write", "ip_address"),
+    )
+)
+
+
+class BlockMacArgs(BaseModel):
+    """Args for the ``block_mac`` operation."""
+
+    mac_address: str = Field(description="MAC to block from getting a DHCP lease")
+    group_id: UUID | None = Field(
+        default=None, description="DHCP server group to block in (default: every group)"
+    )
+    reason: str = Field(default="other", description="Block reason code")
+    description: str = Field(default="", description="Free-form note")
+
+
+async def _block_target_groups(db: AsyncSession, args: BlockMacArgs) -> list[UUID]:
+    from app.models.dhcp import DHCPServerGroup  # noqa: PLC0415
+
+    if args.group_id is not None:
+        return [args.group_id]
+    return list((await db.execute(select(DHCPServerGroup.id))).scalars().all())
+
+
+async def _preview_block_mac(db: AsyncSession, user: User, args: BlockMacArgs) -> PreviewResult:
+    from app.models.dhcp import DHCPLease, DHCPServerGroup  # noqa: PLC0415
+
+    if args.group_id is not None and await db.get(DHCPServerGroup, args.group_id) is None:
+        return PreviewResult(ok=False, detail=f"DHCP server group {args.group_id} not found")
+    groups = await _block_target_groups(db, args)
+    if not groups:
+        return PreviewResult(ok=False, detail="No DHCP server groups to block in")
+    active = (
+        await db.execute(
+            select(func.count())
+            .select_from(DHCPLease)
+            .where(DHCPLease.mac_address == args.mac_address, DHCPLease.state == "active")
+        )
+    ).scalar_one()
+    warn = f" Note: {active} active lease(s) currently held by this MAC." if active else ""
+    return PreviewResult(
+        ok=True,
+        detail="ready",
+        preview_text=f"Block {args.mac_address} from DHCP in {len(groups)} group(s)." + warn,
+    )
+
+
+async def _apply_block_mac(db: AsyncSession, user: User, args: BlockMacArgs) -> dict[str, Any]:
+    from app.api.v1.dhcp._audit import write_audit  # noqa: PLC0415
+    from app.core.agent_wake import collect_wake, dhcp_group_channel  # noqa: PLC0415
+    from app.models.dhcp import DHCPMACBlock  # noqa: PLC0415
+
+    enforce_operation_permission(user, _OPERATIONS["block_mac"])
+    groups = await _block_target_groups(db, args)
+    if not groups:
+        raise ValueError("No DHCP server groups to block in")
+    already = {
+        r[0]
+        for r in (
+            await db.execute(
+                select(DHCPMACBlock.group_id).where(
+                    DHCPMACBlock.mac_address == args.mac_address,
+                    DHCPMACBlock.group_id.in_(groups),
+                )
+            )
+        ).all()
+    }
+    blocked: list[str] = []
+    for gid in groups:
+        if gid in already:
+            continue
+        db.add(
+            DHCPMACBlock(
+                group_id=gid,
+                mac_address=args.mac_address,
+                reason=args.reason,
+                description=args.description or "Blocked from new-device review (#459)",
+                enabled=True,
+                created_by_user_id=user.id,
+                updated_by_user_id=user.id,
+            )
+        )
+        collect_wake(dhcp_group_channel(gid))
+        blocked.append(str(gid))
+    if blocked:
+        write_audit(
+            db,
+            user=user,
+            action="create",
+            resource_type="dhcp_mac_block",
+            resource_id=args.mac_address,
+            resource_display=args.mac_address,
+            new_value={
+                "mac_address": args.mac_address,
+                "blocked_groups": len(blocked),
+                "via": "ai_proposal",
+            },
+        )
+    await db.commit()
+    return {"mac_address": args.mac_address, "blocked_group_ids": blocked}
+
+
+register(
+    Operation(
+        name="block_mac",
+        description=(
+            "Block a MAC from getting a DHCP lease (creates a dhcp_mac_block in "
+            "one or every server group) — arpwatch with teeth. Always route via "
+            "propose_block_mac."
+        ),
+        args_model=BlockMacArgs,
+        preview=_preview_block_mac,
+        apply=_apply_block_mac,
+        category="dhcp",
+        required_permission=("write", "dhcp_mac_block"),
     )
 )

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -32,6 +32,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     nettools,
     network,
     network_modeling,
+    new_devices,
     nmap,
     ntp,
     observability,

--- a/backend/app/services/ai/tools/new_devices.py
+++ b/backend/app/services/ai/tools/new_devices.py
@@ -12,12 +12,13 @@ from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.auth import User
 from app.models.ipam import IPAddress, IpMacHistory, MACAllowlist, Subnet
 from app.services.ai.tools.base import register_tool
+from app.services.ipam.new_device import new_device_counts
 from app.services.oui import bulk_lookup_vendors, normalize_mac_key
 
 _MODULE = "security.new_device_watch"
@@ -114,32 +115,16 @@ class CountNewDevicesArgs(BaseModel):
 async def count_new_devices(
     db: AsyncSession, user: User, args: CountNewDevicesArgs
 ) -> dict[str, Any]:
-    day_ago = datetime.now(UTC) - timedelta(hours=24)
-
-    async def _c(*conds: Any) -> int:
-        return int(
-            (
-                await db.execute(select(func.count()).select_from(IpMacHistory).where(*conds))
-            ).scalar_one()
-        )
-
+    # Single source of truth shared with the dashboard summary endpoint so the
+    # two can't drift (one aggregate query under the hood).
+    c = await new_device_counts(db)
     return {
-        "new": await _c(
-            IpMacHistory.classification == "new", IpMacHistory.is_randomized.is_(False)
-        ),
-        "new_randomized": await _c(
-            IpMacHistory.classification == "new", IpMacHistory.is_randomized.is_(True)
-        ),
-        "new_last_24h": await _c(
-            IpMacHistory.classification == "new",
-            IpMacHistory.is_randomized.is_(False),
-            IpMacHistory.first_seen >= day_ago,
-        ),
-        "acknowledged": await _c(IpMacHistory.classification == "acknowledged"),
-        "known": await _c(IpMacHistory.classification == "known"),
-        "allowlist_entries": int(
-            (await db.execute(select(func.count()).select_from(MACAllowlist))).scalar_one()
-        ),
+        "new": c["new"],
+        "new_randomized": c["new_randomized"],
+        "new_last_24h": c["new_last_24h"],
+        "acknowledged": c["acknowledged"],
+        "known": c["known"],
+        "allowlist_entries": c["allowlist"],
     }
 
 

--- a/backend/app/services/ai/tools/new_devices.py
+++ b/backend/app/services/ai/tools/new_devices.py
@@ -1,0 +1,183 @@
+"""Operator-Copilot read tools for new-device (arpwatch) detection — #459.
+
+All three reads are gated on the ``security.new_device_watch`` feature module so
+they disappear from the registry in lock-step with the sidebar surface when the
+feature is off. MACs are OUI-vendor-enriched inline (the established pattern).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.ipam import IPAddress, IpMacHistory, MACAllowlist, Subnet
+from app.services.ai.tools.base import register_tool
+from app.services.oui import bulk_lookup_vendors, normalize_mac_key
+
+_MODULE = "security.new_device_watch"
+
+
+class FindNewDevicesArgs(BaseModel):
+    since_hours: int = Field(
+        default=168,
+        ge=1,
+        le=24 * 365,
+        description="Only sightings first seen within this many hours (default 7 days).",
+    )
+    classification: str = Field(
+        default="new",
+        description="'new' (default, the review queue), 'acknowledged', or 'known'.",
+    )
+    subnet_id: UUID | None = Field(default=None, description="Restrict to one subnet.")
+    include_randomized: bool = Field(
+        default=False,
+        description="Include locally-administered (privacy-randomised) MACs.",
+    )
+    limit: int = Field(default=50, ge=1, le=500)
+
+
+@register_tool(
+    name="find_new_devices",
+    description=(
+        "List recently first-seen MAC addresses (new-device / arpwatch review "
+        "queue). Each row has the IP, subnet, MAC, OUI vendor, source (dhcp_lease "
+        "/ snmp / sweep / l2_sniff), classification, randomised flag, and "
+        "first/last-seen times. Defaults to unacknowledged new devices in the "
+        "last 7 days. Use this to answer 'what new devices showed up?'."
+    ),
+    args_model=FindNewDevicesArgs,
+    category="ipam",
+    module=_MODULE,
+)
+async def find_new_devices(
+    db: AsyncSession, user: User, args: FindNewDevicesArgs
+) -> list[dict[str, Any]]:
+    cutoff = datetime.now(UTC) - timedelta(hours=args.since_hours)
+    stmt = (
+        select(IpMacHistory, IPAddress, Subnet)
+        .join(IPAddress, IPAddress.id == IpMacHistory.ip_address_id)
+        .outerjoin(Subnet, Subnet.id == IPAddress.subnet_id)
+        .where(
+            IpMacHistory.classification == args.classification,
+            IpMacHistory.first_seen >= cutoff,
+        )
+        .order_by(IpMacHistory.first_seen.desc())
+        .limit(args.limit)
+    )
+    if args.subnet_id is not None:
+        stmt = stmt.where(IPAddress.subnet_id == args.subnet_id)
+    if not args.include_randomized:
+        stmt = stmt.where(IpMacHistory.is_randomized.is_(False))
+    rows = (await db.execute(stmt)).all()
+    macs: list[str | None] = [str(h.mac_address) for h, _ip, _s in rows]
+    vendors = await bulk_lookup_vendors(db, macs)
+    return [
+        {
+            "sighting_id": str(h.id),
+            "ip_address_id": str(h.ip_address_id),
+            "ip_address": str(ip.address),
+            "subnet_id": str(s.id) if s else None,
+            "subnet": str(s.network) if s else None,
+            "mac_address": str(h.mac_address),
+            "oui_vendor": vendors.get(normalize_mac_key(str(h.mac_address)) or ""),
+            "source": h.source,
+            "classification": h.classification,
+            "is_randomized": h.is_randomized,
+            "first_seen": h.first_seen.isoformat(),
+            "last_seen": h.last_seen.isoformat(),
+        }
+        for h, ip, s in rows
+    ]
+
+
+class CountNewDevicesArgs(BaseModel):
+    pass
+
+
+@register_tool(
+    name="count_new_devices",
+    description=(
+        "Count new-device sightings by classification (new / acknowledged / "
+        "known), plus how many new ones appeared in the last 24h and the "
+        "allowlist size. Use for 'how many new devices are waiting for review?'."
+    ),
+    args_model=CountNewDevicesArgs,
+    category="ipam",
+    module=_MODULE,
+)
+async def count_new_devices(
+    db: AsyncSession, user: User, args: CountNewDevicesArgs
+) -> dict[str, Any]:
+    day_ago = datetime.now(UTC) - timedelta(hours=24)
+
+    async def _c(*conds: Any) -> int:
+        return int(
+            (
+                await db.execute(select(func.count()).select_from(IpMacHistory).where(*conds))
+            ).scalar_one()
+        )
+
+    return {
+        "new": await _c(
+            IpMacHistory.classification == "new", IpMacHistory.is_randomized.is_(False)
+        ),
+        "new_randomized": await _c(
+            IpMacHistory.classification == "new", IpMacHistory.is_randomized.is_(True)
+        ),
+        "new_last_24h": await _c(
+            IpMacHistory.classification == "new",
+            IpMacHistory.is_randomized.is_(False),
+            IpMacHistory.first_seen >= day_ago,
+        ),
+        "acknowledged": await _c(IpMacHistory.classification == "acknowledged"),
+        "known": await _c(IpMacHistory.classification == "known"),
+        "allowlist_entries": int(
+            (await db.execute(select(func.count()).select_from(MACAllowlist))).scalar_one()
+        ),
+    }
+
+
+class FindMacAllowlistArgs(BaseModel):
+    limit: int = Field(default=100, ge=1, le=1000)
+
+
+@register_tool(
+    name="find_mac_allowlist",
+    description=(
+        "List the trusted-MAC allowlist entries (exact MAC or OUI prefix) that "
+        "suppress new-device alerts. Use to check whether a MAC/vendor is already "
+        "trusted before alerting on it."
+    ),
+    args_model=FindMacAllowlistArgs,
+    category="ipam",
+    module=_MODULE,
+)
+async def find_mac_allowlist(
+    db: AsyncSession, user: User, args: FindMacAllowlistArgs
+) -> list[dict[str, Any]]:
+    rows = (
+        (
+            await db.execute(
+                select(MACAllowlist).order_by(MACAllowlist.created_at.desc()).limit(args.limit)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [
+        {
+            "id": str(r.id),
+            "mac_address": str(r.mac_address) if r.mac_address else None,
+            "oui_prefix": r.oui_prefix,
+            "note": r.note,
+            "is_builtin": r.is_builtin,
+            "created_at": r.created_at.isoformat(),
+        }
+        for r in rows
+    ]

--- a/backend/app/services/ai/tools/proposals.py
+++ b/backend/app/services/ai/tools/proposals.py
@@ -23,9 +23,12 @@ from app.models.ai import AIOperationProposal
 from app.models.auth import User
 from app.services.ai import operations
 from app.services.ai.operations import (
+    AcknowledgeDeviceArgs,
     AllocateMulticastGroupsArgs,
     AllocateSubnetArgs,
+    AllowlistMacArgs,
     ArchiveSessionArgs,
+    BlockMacArgs,
     CreateAddressSetArgs,
     CreateAlertRuleArgs,
     CreateDHCPStaticArgs,
@@ -845,3 +848,64 @@ async def propose_commit_dhcp_import(
     db: AsyncSession, user: User, args: CommitDHCPImportArgs
 ) -> dict[str, Any]:
     return await _propose_via(db=db, user=user, operation_name="commit_dhcp_import", args=args)
+
+
+# ── New-device watch proposals (issue #459) ──────────────────────────────────
+
+
+@register_tool(
+    name="propose_acknowledge_device",
+    description=(
+        "Prepare a proposal to acknowledge (dismiss) a new-device sighting so it "
+        "stops raising the new_mac_seen alert. Pass the sighting_id from "
+        "find_new_devices. Operator must click Approve. Returns a kind='proposal' "
+        "card; never call twice for the same change."
+    ),
+    args_model=AcknowledgeDeviceArgs,
+    writes=False,
+    category="ipam",
+    default_enabled=True,
+    module="security.new_device_watch",
+)
+async def propose_acknowledge_device(
+    db: AsyncSession, user: User, args: AcknowledgeDeviceArgs
+) -> dict[str, Any]:
+    return await _propose_via(db=db, user=user, operation_name="acknowledge_device", args=args)
+
+
+@register_tool(
+    name="propose_allowlist_mac",
+    description=(
+        "Prepare a proposal to add a MAC (or OUI prefix like '00:50:56' for a "
+        "whole vendor) to the trusted allowlist so it never raises a new-device "
+        "alert and matching sightings become 'known'. Operator must click "
+        "Approve. Returns a kind='proposal' card; never call twice."
+    ),
+    args_model=AllowlistMacArgs,
+    writes=False,
+    category="ipam",
+    default_enabled=True,
+    module="security.new_device_watch",
+)
+async def propose_allowlist_mac(
+    db: AsyncSession, user: User, args: AllowlistMacArgs
+) -> dict[str, Any]:
+    return await _propose_via(db=db, user=user, operation_name="allowlist_mac", args=args)
+
+
+@register_tool(
+    name="propose_block_mac",
+    description=(
+        "Prepare a proposal to block a MAC from getting a DHCP lease (creates a "
+        "dhcp_mac_block in one or every server group) — arpwatch with teeth. Pass "
+        "mac_address and optionally group_id. Operator must click Approve. "
+        "Returns a kind='proposal' card; never call twice."
+    ),
+    args_model=BlockMacArgs,
+    writes=False,
+    category="dhcp",
+    default_enabled=True,
+    module="security.new_device_watch",
+)
+async def propose_block_mac(db: AsyncSession, user: User, args: BlockMacArgs) -> dict[str, Any]:
+    return await _propose_via(db=db, user=user, operation_name="block_mac", args=args)

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -192,6 +192,16 @@ RULE_TYPE_UNKNOWN_MAC_IN_STATIC_RANGE = "unknown_mac_in_static_range"
 RULE_TYPE_ROGUE_DHCP = "rogue_dhcp"
 _ROGUE_DHCP_RECENCY_DAYS = 1
 
+# New-device (arpwatch) detection — issue #459. Subject = ip_mac_observation
+# (composite ``ip_id:mac``). Fires on ip_mac_history rows classified ``new``
+# (a MAC never seen before, not allowlisted, not on the known fleet) observed
+# within ``threshold_days`` (default 7). Locally-administered (randomised) MACs
+# are excluded by default to avoid a reconnection storm — set the rule's
+# ``classification`` to ``"all"`` to include them. Auto-resolves once the MAC is
+# acknowledged / allowlisted (reclassified) or ages out of the window.
+RULE_TYPE_NEW_MAC_SEEN = "new_mac_seen"
+_NEW_MAC_SEEN_RECENCY_DAYS = 7
+
 # TLS certificate monitoring — issue #118. Subject = tls_cert (one per
 # tls_cert_target). ``tls_cert_expiring`` is a standard escalating-expiry
 # rule (info → warning → critical as not_after nears, like domain_expiring);
@@ -241,6 +251,7 @@ RULE_TYPES = frozenset(
         RULE_TYPE_STALE_RESERVATION,
         RULE_TYPE_UNKNOWN_MAC_IN_STATIC_RANGE,
         RULE_TYPE_ROGUE_DHCP,
+        RULE_TYPE_NEW_MAC_SEEN,
         RULE_TYPE_TLS_CERT_EXPIRING,
         RULE_TYPE_TLS_CERT_CHAIN_INVALID,
         RULE_TYPE_TLS_CERT_UNREACHABLE,
@@ -716,6 +727,54 @@ async def _matching_rogue_dhcp_subjects(
             f"misconfigured DHCP server, or acknowledge it if expected."
         )
         matches.append((str(r.id), display, message))
+    return matches
+
+
+async def _matching_new_mac_seen_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+) -> list[tuple[str, str, str]]:
+    """ip_mac_history rows classified ``new`` + first seen within the recency
+    window (issue #459) — a MAC never seen before, not allowlisted, not on the
+    known fleet. One event per ``(ip, mac)`` pair so two MACs on one IP both
+    surface. Auto-resolves once acknowledged / allowlisted (reclassified) or the
+    sighting ages out of the window.
+
+    Locally-administered (randomised) MACs are excluded unless the rule's
+    ``classification`` is ``"all"`` — modern phones rotate them per network and
+    would otherwise storm the operator on every reconnect.
+    """
+    days = rule.threshold_days if rule.threshold_days is not None else _NEW_MAC_SEEN_RECENCY_DAYS
+    cutoff = datetime.now(UTC) - timedelta(days=max(1, days))
+    include_randomized = (rule.classification or "").lower() == "all"
+    conds = [
+        IpMacHistory.classification == "new",
+        IpMacHistory.first_seen >= cutoff,
+    ]
+    if not include_randomized:
+        conds.append(IpMacHistory.is_randomized.is_(False))
+    rows = (
+        await db.execute(
+            select(
+                IPAddress, IpMacHistory.mac_address, IpMacHistory.first_seen, IpMacHistory.source
+            )
+            .join(IpMacHistory, IpMacHistory.ip_address_id == IPAddress.id)
+            .where(*conds)
+            .order_by(IpMacHistory.first_seen.desc())
+            .limit(_IP_HYGIENE_MAX_EVENTS)
+        )
+    ).all()
+    matches: list[tuple[str, str, str]] = []
+    for ip_row, obs_mac, first_at, source in rows:
+        subject_id = f"{ip_row.id}:{obs_mac}"
+        display = f"{ip_row.address} ({obs_mac})"
+        message = (
+            f"New device: MAC {obs_mac} first seen on {ip_row.address} at "
+            f"{first_at.isoformat()} (source: {source}). Not previously known, "
+            f"allowlisted, or part of the allocated fleet — acknowledge, add to "
+            f"the allowlist, or block it."
+        )
+        matches.append((subject_id, display, message))
     return matches
 
 
@@ -2687,6 +2746,50 @@ async def seed_rogue_dhcp_alert_rule() -> None:
         await session.commit()
 
 
+async def seed_new_mac_seen_alert_rule() -> None:
+    """Seed the singleton ``new_mac_seen`` rule (issue #459), DISABLED by default.
+
+    The companion to the ``security.new_device_watch`` feature module: noisy
+    until the operator runs a baseline import to mark the existing fleet as
+    ``known``, so it seeds off and discoverable in the Alerts UI. Keyed on
+    ``rule_type`` — an operator who enables / renames it is never overridden.
+    Excludes locally-administered (randomised) MACs by default (``classification``
+    left NULL; set to ``"all"`` to include them).
+    """
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+    from app.models.alerts import AlertRule  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as session:
+        existing = await session.scalar(
+            select(AlertRule).where(AlertRule.rule_type == RULE_TYPE_NEW_MAC_SEEN)
+        )
+        if existing is not None:
+            return
+        session.add(
+            AlertRule(
+                name="New device on the network",
+                description=(
+                    "Fires when a MAC address never seen before appears on the "
+                    "network (via a DHCP lease, SNMP ARP/FDB, the ping/ARP sweep, "
+                    "or the opt-in L2 sniffer) and is not allowlisted or part of "
+                    "the allocated fleet. Auto-resolves when the MAC is "
+                    "acknowledged, allowlisted, or ages out of the window. "
+                    "Enable once new-device watch (security.new_device_watch) is "
+                    "on and you've run a baseline import. Randomised (privacy) "
+                    "MACs are skipped by default."
+                ),
+                rule_type=RULE_TYPE_NEW_MAC_SEEN,
+                threshold_days=_NEW_MAC_SEEN_RECENCY_DAYS,
+                severity="info",
+                enabled=False,
+                notify_syslog=True,
+                notify_webhook=True,
+                notify_smtp=False,
+            )
+        )
+        await session.commit()
+
+
 async def seed_builtin_compliance_alert_rules() -> None:
     """Insert the three disabled compliance-change rules on first
     boot. Idempotent — only inserts a row when no rule with the same
@@ -2976,6 +3079,10 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 base = await _matching_rogue_dhcp_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]
                 subject_type = "dhcp_responder"
+            elif rule.rule_type == RULE_TYPE_NEW_MAC_SEEN:
+                base = await _matching_new_mac_seen_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "ip_mac_observation"
             elif rule.rule_type == RULE_TYPE_SERVER_UNREACHABLE:
                 base = await _matching_server_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]

--- a/backend/app/services/event_publisher.py
+++ b/backend/app/services/event_publisher.py
@@ -211,6 +211,14 @@ _SPECIAL_EVENT_MAP: dict[tuple[str, str], str] = {
     # wire a dedicated alert / SIEM rule on. Special-map-only (like
     # change_request): no _RESOURCE_NAMESPACE entry for ``approval_control``.
     ("approvals.break_glass", "approval_control"): "governance.break_glass",
+    # New-device watch (issue #459). A never-before-seen MAC was observed
+    # (``device.first_seen``) or an operator dismissed one (``device.acknowledged``).
+    # Special-map-only (like change_request): ``ip_mac_observation`` has no
+    # _RESOURCE_NAMESPACE entry, so these names are authoritative here AND
+    # unioned into the event-type catalog. first_seen is the real-time
+    # "something new joined" signal external automation/SIEM subscribes to.
+    ("first_seen", "ip_mac_observation"): "device.first_seen",
+    ("acknowledged", "ip_mac_observation"): "device.acknowledged",
 }
 
 

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -313,6 +313,15 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         group="UI",
         description='Per-user named filter/sort/column presets on list pages — "All subnets in DC1 over 80% utilization, sorted by name" becomes a one-click view. Personal-only; no cross-user visibility.',
     ),
+    # Security — arpwatch-style new-device detection. Default-off: watching is
+    # noisy and needs a baseline import before it is useful (#459).
+    ModuleSpec(
+        id="security.new_device_watch",
+        label="New device watch",
+        group="Security",
+        description="Alert the moment a previously-unseen MAC address appears on the network (arpwatch-style), across DHCP leases, SNMP ARP/FDB, and an opt-in L2 sniffer. Maintain an allowlist of trusted MACs (or OUI prefixes for VMs/containers), acknowledge or block from a review queue, and fire a real-time device.first_seen event. Default-off: enable, run a baseline import to mark the existing fleet as known, then arm.",
+        default_enabled=False,
+    ),
 )
 
 # Map a feature_module id to the ``PlatformSettings`` column whose

--- a/backend/app/services/ipam/discovery.py
+++ b/backend/app/services/ipam/discovery.py
@@ -46,6 +46,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.dhcp import DHCPPool, DHCPScope
 from app.models.ipam import IPAddress, Subnet
+from app.services.ipam.new_device import (
+    MacObservationResult,
+    classify_mac,
+    is_locally_administered,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -397,28 +402,63 @@ async def reconcile_subnet(db: AsyncSession, subnet: Subnet, sweep: SweepResult)
 
 
 async def record_mac_observation(
-    db: AsyncSession, ip_id: uuid.UUID, mac_address: str | None
-) -> None:
+    db: AsyncSession,
+    ip_id: uuid.UUID,
+    mac_address: str | None,
+    *,
+    source: str = "sweep",
+) -> MacObservationResult | None:
     """Upsert an observed ``(ip_id, mac)`` into ``ip_mac_history`` (issue #369).
 
-    Called from the ping/ARP sweep + SNMP ARP cross-reference for EVERY MAC
-    observed on the wire — not just when the IPAddress row's canonical
-    ``mac_address`` is empty. That's what lets the ``unknown_mac_in_static_range``
-    hygiene alert compare the operator-recorded MAC against what's actually
-    answering: a differing recent history row is a squat. Mirrors the router's
-    ``_record_mac_history`` upsert (kept separate to avoid a router→service
-    import cycle). No-op on a missing MAC.
+    Called from the ping/ARP sweep + SNMP ARP cross-reference + DHCP lease
+    events + L2 sniff for EVERY MAC observed on the wire — not just when the
+    IPAddress row's canonical ``mac_address`` is empty. That's what lets the
+    ``unknown_mac_in_static_range`` hygiene alert compare the operator-recorded
+    MAC against what's actually answering: a differing recent history row is a
+    squat.
+
+    New-device watch (issue #459): on the *first-ever* sighting of a ``(ip, mac)``
+    pair the row is stamped with a :func:`~app.services.ipam.new_device.classify_mac`
+    classification (``new`` / ``known``), the ``source`` path, and an
+    ``is_randomized`` flag. Subsequent sightings only bump ``last_seen`` + the
+    ``source`` and never downgrade an operator-set ``acknowledged`` / ``known``
+    classification. Returns a :class:`MacObservationResult` describing the
+    outcome (so the caller can fire a ``device.first_seen`` event), or ``None``
+    on a missing MAC.
+
+    ``source`` is one of ``sweep`` / ``snmp`` / ``dhcp_lease`` / ``l2_sniff``.
     """
     if not mac_address:
-        return
-    await db.execute(
-        text("""
-            INSERT INTO ip_mac_history (id, ip_address_id, mac_address, first_seen, last_seen)
-            VALUES (gen_random_uuid(), :ip_id, CAST(:mac AS macaddr), now(), now())
-            ON CONFLICT (ip_address_id, mac_address)
-            DO UPDATE SET last_seen = now()
-            """),
-        {"ip_id": str(ip_id), "mac": mac_address},
+        return None
+
+    classification = await classify_mac(db, mac_address)
+    is_randomized = is_locally_administered(mac_address)
+    row = (
+        await db.execute(
+            text("""
+                INSERT INTO ip_mac_history
+                    (id, ip_address_id, mac_address, first_seen, last_seen,
+                     classification, source, is_randomized)
+                VALUES (gen_random_uuid(), :ip_id, CAST(:mac AS macaddr), now(), now(),
+                        :classification, :source, :is_randomized)
+                ON CONFLICT (ip_address_id, mac_address)
+                DO UPDATE SET last_seen = now(), source = :source
+                RETURNING (xmax = 0) AS inserted, classification
+                """),
+            {
+                "ip_id": str(ip_id),
+                "mac": mac_address,
+                "classification": classification,
+                "source": source,
+                "is_randomized": is_randomized,
+            },
+        )
+    ).one()
+    return MacObservationResult(
+        mac_address=mac_address,
+        classification=row.classification,
+        is_new_row=bool(row.inserted),
+        is_randomized=is_randomized,
     )
 
 

--- a/backend/app/services/ipam/discovery.py
+++ b/backend/app/services/ipam/discovery.py
@@ -350,6 +350,10 @@ async def reconcile_subnet(db: AsyncSession, subnet: Subnet, sweep: SweepResult)
     )
     by_ip: dict[str, IPAddress] = {str(r.address): r for r in existing_rows}
 
+    # New-device watch (issue #459): sightings for rows created in this pass,
+    # recorded after the loop once the rows have ids (mirrors the SNMP path).
+    newly_discovered: list[tuple[IPAddress, str]] = []
+
     for ip in sweep.alive:
         try:
             ip_int = int(ipaddress.ip_address(ip))
@@ -383,17 +387,27 @@ async def reconcile_subnet(db: AsyncSession, subnet: Subnet, sweep: SweepResult)
             counts["skipped_pool"] += 1
             continue
 
-        db.add(
-            IPAddress(
-                subnet_id=subnet.id,
-                address=ip,
-                status="discovered",
-                mac_address=sweep.arp.get(ip),
-                last_seen_at=now,
-                last_seen_method=method,
-            )
+        new_row = IPAddress(
+            subnet_id=subnet.id,
+            address=ip,
+            status="discovered",
+            mac_address=sweep.arp.get(ip),
+            last_seen_at=now,
+            last_seen_method=method,
         )
+        db.add(new_row)
         counts["created"] += 1
+        if ip in sweep.arp:
+            newly_discovered.append((new_row, sweep.arp[ip]))
+
+    # Log a MAC sighting for each newly-created discovered row too (#459), so a
+    # never-before-tracked host found by the sweep classifies + surfaces in the
+    # new-device review queue / new_mac_seen alert — not just existing rows.
+    if newly_discovered:
+        await db.flush()
+        for new_row, mac in newly_discovered:
+            if new_row.id is not None:
+                await record_mac_observation(db, new_row.id, mac)
 
     return counts
 

--- a/backend/app/services/ipam/new_device.py
+++ b/backend/app/services/ipam/new_device.py
@@ -29,10 +29,10 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import structlog
-from sqlalchemy import delete, or_, select, text, update
+from sqlalchemy import and_, delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.auth import User
@@ -146,6 +146,50 @@ async def classify_mac(db: AsyncSession, mac_address: str | None) -> str:
         return CLASSIFICATION_KNOWN
 
     return CLASSIFICATION_NEW
+
+
+# ── Counts (shared by the REST summary endpoint + the MCP count tool) ───────
+
+
+async def new_device_counts(db: AsyncSession) -> dict[str, int]:
+    """Return new-device counts by bucket in a single pass.
+
+    Canonical keys: ``new`` (non-randomised) / ``new_randomized`` /
+    ``new_last_24h`` / ``acknowledged`` / ``known`` / ``allowlist``. One
+    aggregate query over ``ip_mac_history`` (FILTER) + one over the allowlist,
+    so the dashboard summary and the Copilot count tool can't drift.
+    """
+    day_ago = datetime.now(UTC) - timedelta(hours=24)
+    not_random = IpMacHistory.is_randomized.is_(False)
+    is_new = IpMacHistory.classification == CLASSIFICATION_NEW
+    row = (
+        await db.execute(
+            select(
+                func.count().filter(and_(is_new, not_random)).label("new"),
+                func.count()
+                .filter(and_(is_new, IpMacHistory.is_randomized.is_(True)))
+                .label("new_randomized"),
+                func.count()
+                .filter(and_(is_new, not_random, IpMacHistory.first_seen >= day_ago))
+                .label("new_last_24h"),
+                func.count()
+                .filter(IpMacHistory.classification == CLASSIFICATION_ACKNOWLEDGED)
+                .label("acknowledged"),
+                func.count()
+                .filter(IpMacHistory.classification == CLASSIFICATION_KNOWN)
+                .label("known"),
+            )
+        )
+    ).one()
+    allowlist = (await db.execute(select(func.count()).select_from(MACAllowlist))).scalar_one()
+    return {
+        "new": int(row.new),
+        "new_randomized": int(row.new_randomized),
+        "new_last_24h": int(row.new_last_24h),
+        "acknowledged": int(row.acknowledged),
+        "known": int(row.known),
+        "allowlist": int(allowlist),
+    }
 
 
 # ── Operator actions (shared by the REST router + MCP propose_* tools) ──────

--- a/backend/app/services/ipam/new_device.py
+++ b/backend/app/services/ipam/new_device.py
@@ -1,0 +1,264 @@
+"""New-device (arpwatch-style) detection — classification + ingest helpers.
+
+Issue #459. The platform already logs every observed ``(ip, mac)`` pair into
+``ip_mac_history`` (issue #369). This module adds the *classification* layer on
+top of that store: deciding whether a freshly-observed MAC is something the
+operator already trusts (``known``), has dismissed (``acknowledged``), or has
+never seen before (``new``) — the last being what raises a ``new_mac_seen``
+alert and a ``device.first_seen`` event.
+
+Design notes:
+
+* **One store, not two.** We extend ``ip_mac_history`` rather than build a
+  parallel sighting table — see ``docs/features/IPAM.md`` §8.x. Every ingestion
+  path (DHCP lease, SNMP ARP, ping/ARP sweep, L2 sniff) routes through
+  :func:`app.services.ipam.discovery.record_mac_observation`, which calls
+  :func:`classify_mac` on first sight.
+* **Allowlist is MAC-keyed, sightings are (ip, mac)-keyed.** The allowlist
+  (``mac_allowlist``) survives the cascade-delete of the IP a MAC was first
+  seen on, and silences a trusted MAC wherever it appears. Acknowledgement, by
+  contrast, dismisses one specific ``(ip, mac)`` sighting.
+* **Randomised MACs are flagged, not hidden.** Modern phones rotate
+  locally-administered MACs per network; :func:`is_locally_administered`
+  stamps ``ip_mac_history.is_randomized`` so the default alert rule can skip
+  them and avoid a reconnection storm, while they stay visible in the review
+  queue.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import delete, or_, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.ipam import IPAddress, IpMacHistory, MACAllowlist
+from app.services.oui import _prefix_from_mac, normalize_mac_key
+
+logger = structlog.get_logger(__name__)
+
+# IPAddress.status values that mean "an operator deliberately associated this
+# MAC with this IP" — i.e. part of the known fleet, never a surprise.
+_KNOWN_FLEET_STATUSES: frozenset[str] = frozenset({"allocated", "reserved", "static_dhcp"})
+
+# Classification values stored on ip_mac_history.classification.
+CLASSIFICATION_NEW = "new"
+CLASSIFICATION_ACKNOWLEDGED = "acknowledged"
+CLASSIFICATION_KNOWN = "known"
+
+# Well-known virtualisation / container OUIs seeded (disabled by default, the
+# operator enables what applies) so a hypervisor or Docker host spinning up VMs
+# doesn't read as a fleet of rogue devices. Lower-case, no separators.
+BUILTIN_VIRT_OUIS: tuple[tuple[str, str], ...] = (
+    ("005056", "VMware"),
+    ("000c29", "VMware"),
+    ("000569", "VMware"),
+    ("001c14", "VMware"),
+    ("00155d", "Microsoft Hyper-V"),
+    ("00163e", "Xen"),
+    ("0a0027", "VirtualBox"),
+    ("080027", "VirtualBox"),
+    ("525400", "QEMU/KVM"),
+    ("0242ac", "Docker"),
+)
+
+
+@dataclass(slots=True)
+class MacObservationResult:
+    """Outcome of recording one MAC sighting."""
+
+    mac_address: str
+    classification: str
+    is_new_row: bool  # True only on the first-ever sighting of this (ip, mac)
+    is_randomized: bool
+
+    @property
+    def is_first_seen_new(self) -> bool:
+        """A genuinely new device worth a ``device.first_seen`` event/alert."""
+        return self.is_new_row and self.classification == CLASSIFICATION_NEW
+
+
+def is_locally_administered(mac: str | None) -> bool:
+    """True if the MAC's locally-administered (privacy-randomised) bit is set.
+
+    The second-least-significant bit of the first octet (``0x02``) marks a
+    locally-administered address — iOS / Android per-network randomised MACs,
+    and most software-assigned virtual NIC MACs. Returns False for an
+    unparseable MAC (treated as a real, globally-unique address).
+    """
+    key = normalize_mac_key(mac)
+    if key is None:
+        return False
+    try:
+        first_octet = int(key[:2], 16)
+    except ValueError:
+        return False
+    return bool(first_octet & 0x02)
+
+
+def oui_prefix_of(mac: str | None) -> str | None:
+    """Return the 6-char lowercase OUI prefix of a MAC (or None)."""
+    return _prefix_from_mac(mac)
+
+
+async def classify_mac(db: AsyncSession, mac_address: str | None) -> str:
+    """Classify a MAC as ``known`` or ``new`` at observation time.
+
+    ``acknowledged`` is never returned here — it is only ever set by an explicit
+    operator dismissal of a specific ``(ip, mac)`` sighting. The two ``known``
+    paths are:
+
+    * the MAC (or its OUI prefix) is in ``mac_allowlist`` — operator trusts it
+      everywhere;
+    * the MAC already sits on an operator-allocated IP (``allocated`` /
+      ``reserved`` / ``static_dhcp``) — it is part of the known fleet.
+
+    Everything else is ``new``.
+    """
+    if not mac_address:
+        return CLASSIFICATION_NEW
+
+    prefix = oui_prefix_of(mac_address)
+    allow_conds = [MACAllowlist.mac_address == mac_address]
+    if prefix is not None:
+        allow_conds.append(MACAllowlist.oui_prefix == prefix)
+    allow_hit = (
+        await db.execute(select(MACAllowlist.id).where(or_(*allow_conds)).limit(1))
+    ).first()
+    if allow_hit is not None:
+        return CLASSIFICATION_KNOWN
+
+    fleet_hit = (
+        await db.execute(
+            select(IPAddress.id)
+            .where(
+                IPAddress.mac_address == mac_address,
+                IPAddress.status.in_(_KNOWN_FLEET_STATUSES),
+            )
+            .limit(1)
+        )
+    ).first()
+    if fleet_hit is not None:
+        return CLASSIFICATION_KNOWN
+
+    return CLASSIFICATION_NEW
+
+
+# ── Operator actions (shared by the REST router + MCP propose_* tools) ──────
+
+
+async def baseline_import(db: AsyncSession) -> int:
+    """Mark every currently-observed MAC as ``known`` (learning-mode baseline).
+
+    Run once when arming the feature so day-one isn't a wall of alerts for the
+    fleet that was already on the network. Flips every ``ip_mac_history`` row not
+    already ``known`` → ``known``. Returns the number of rows reclassified. Does
+    NOT commit — the caller owns the transaction (so it can audit in the same
+    unit of work).
+    """
+    result = await db.execute(
+        update(IpMacHistory)
+        .where(IpMacHistory.classification != CLASSIFICATION_KNOWN)
+        .values(classification=CLASSIFICATION_KNOWN)
+    )
+    return int(result.rowcount or 0)
+
+
+async def acknowledge_sighting(
+    db: AsyncSession, sighting_id: uuid.UUID, user: User | None
+) -> IpMacHistory | None:
+    """Dismiss one ``(ip, mac)`` sighting → ``acknowledged``. Returns the row, or
+    None if it doesn't exist. Idempotent. Does NOT commit."""
+    row = await db.get(IpMacHistory, sighting_id)
+    if row is None:
+        return None
+    row.classification = CLASSIFICATION_ACKNOWLEDGED
+    row.acknowledged_at = datetime.now(UTC)
+    row.acknowledged_by_user_id = user.id if user else None
+    return row
+
+
+def normalize_oui_prefix(raw: str | None) -> str | None:
+    """Return a 6-char lowercase hex OUI prefix from a partial MAC / prefix.
+
+    Accepts ``00:50:56``, ``005056``, ``00-50-56``, ``0050.56xx`` → ``005056``.
+    Returns None when fewer than 6 hex chars are present.
+    """
+    if not raw:
+        return None
+    cleaned = "".join(c for c in raw.lower() if c in "0123456789abcdef")
+    return cleaned[:6] if len(cleaned) >= 6 else None
+
+
+async def _reclassify_for_allowlist(
+    db: AsyncSession, *, mac_address: str | None, oui_prefix: str | None
+) -> int:
+    """Reclassify existing non-``known`` sightings that the new allowlist entry
+    now covers → ``known`` (so the review queue clears + open alerts resolve).
+    Matches by exact MAC and/or OUI prefix. Returns the count touched.
+
+    The OUI match formats the MACADDR column to its canonical lowercase text
+    (``08:00:2b:…``), strips the colons, and compares the first 6 chars to the
+    stored prefix — robust across however the MAC was originally written.
+    """
+    if not mac_address and not oui_prefix:
+        return 0
+    clauses = []
+    params: dict[str, str] = {}
+    if mac_address:
+        clauses.append("mac_address = CAST(:mac AS macaddr)")
+        params["mac"] = mac_address
+    if oui_prefix:
+        clauses.append("left(replace(mac_address::text, ':', ''), 6) = :prefix")
+        params["prefix"] = oui_prefix
+    result = await db.execute(
+        text(
+            "UPDATE ip_mac_history SET classification = 'known' "
+            "WHERE classification <> 'known' AND (" + " OR ".join(clauses) + ")"
+        ),
+        params,
+    )
+    return int(result.rowcount or 0)
+
+
+async def add_allowlist_entry(
+    db: AsyncSession,
+    *,
+    mac_address: str | None = None,
+    oui_prefix: str | None = None,
+    note: str = "",
+    user: User | None = None,
+    is_builtin: bool = False,
+) -> tuple[MACAllowlist, int]:
+    """Create a ``mac_allowlist`` row and reclassify the sightings it now
+    covers → ``known``. Returns ``(row, reclassified_count)``. Does NOT commit.
+
+    Normalises ``oui_prefix`` to 6 lowercase hex chars. Raises ``ValueError`` if
+    neither key is usable (mirrors the table's CHECK constraint)."""
+    norm_prefix = normalize_oui_prefix(oui_prefix)
+    if not mac_address and not norm_prefix:
+        raise ValueError("an allowlist entry needs a MAC address or an OUI prefix")
+    row = MACAllowlist(
+        mac_address=mac_address,
+        oui_prefix=norm_prefix,
+        note=note,
+        is_builtin=is_builtin,
+        created_by_user_id=user.id if user else None,
+    )
+    db.add(row)
+    reclassified = await _reclassify_for_allowlist(
+        db, mac_address=mac_address, oui_prefix=norm_prefix
+    )
+    return row, reclassified
+
+
+async def remove_allowlist_entry(db: AsyncSession, allowlist_id: uuid.UUID) -> bool:
+    """Delete a ``mac_allowlist`` row. Returns False if it didn't exist. Does NOT
+    commit. Existing ``known`` sightings keep their classification — removing
+    trust doesn't retroactively re-flag; the next fresh sighting re-evaluates."""
+    result = await db.execute(delete(MACAllowlist).where(MACAllowlist.id == allowlist_id))
+    return bool(result.rowcount)

--- a/backend/app/services/snmp/cross_reference.py
+++ b/backend/app/services/snmp/cross_reference.py
@@ -91,6 +91,10 @@ async def cross_reference_arp(
 
     by_ip: dict[str, IPAddress] = {str(r.address): r for r in existing_rows}
 
+    # New-device-watch sightings for rows created in this pass (issue #459);
+    # recorded after the loop once the rows have ids.
+    newly_discovered: list[tuple[IPAddress, str]] = []
+
     for arp in arp_list:
         ip_str = arp.ip_address
         existing = by_ip.get(ip_str)
@@ -108,7 +112,7 @@ async def cross_reference_arp(
                     record_mac_observation,
                 )
 
-                await record_mac_observation(db, existing.id, arp.mac_address)
+                await record_mac_observation(db, existing.id, arp.mac_address, source="snmp")
             counts["updated"] += 1
             continue
 
@@ -146,6 +150,22 @@ async def cross_reference_arp(
         )
         db.add(new_row)
         counts["created"] += 1
+        if arp.mac_address:
+            newly_discovered.append((new_row, arp.mac_address))
+
+    # New-device watch (issue #459): log a MAC sighting for each newly-created
+    # discovered row too, so a host seen only via SNMP ARP on a never-tracked IP
+    # still classifies + surfaces in the review queue / new_mac_seen alert.
+    # Flush first so the rows have ids for the FK.
+    if newly_discovered:
+        from app.services.ipam.discovery import (  # noqa: PLC0415
+            record_mac_observation,
+        )
+
+        await db.flush()
+        for new_row, mac in newly_discovered:
+            if new_row.id is not None:
+                await record_mac_observation(db, new_row.id, mac, source="snmp")
 
     return counts
 

--- a/backend/tests/test_new_device_watch.py
+++ b/backend/tests/test_new_device_watch.py
@@ -1,0 +1,506 @@
+"""New-device (arpwatch) detection — issue #459.
+
+Covers the classification core (``classify_mac`` / ``is_locally_administered`` /
+``record_mac_observation``), the operator service actions (baseline / allowlist /
+acknowledge), the ``new_mac_seen`` alert matcher, and the end-to-end DHCP
+lease-events → new-sighting + ``device.first_seen`` audit path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dhcp.agents import _auth_agent
+from app.core.security import create_access_token, hash_password
+from app.main import app
+from app.models.alerts import AlertRule
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.dhcp import DHCPMACBlock, DHCPServer, DHCPServerGroup
+from app.models.feature_module import FeatureModule
+from app.models.ipam import IPAddress, IPBlock, IpMacHistory, IPSpace, MACAllowlist, Subnet
+from app.services import feature_modules
+from app.services.alerts import RULE_TYPE_NEW_MAC_SEEN, _matching_new_mac_seen_subjects
+from app.services.ipam.discovery import record_mac_observation
+from app.services.ipam.new_device import (
+    CLASSIFICATION_ACKNOWLEDGED,
+    CLASSIFICATION_KNOWN,
+    CLASSIFICATION_NEW,
+    acknowledge_sighting,
+    add_allowlist_entry,
+    baseline_import,
+    classify_mac,
+    is_locally_administered,
+    normalize_oui_prefix,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_module_cache():
+    feature_modules.invalidate_cache()
+    yield
+    feature_modules.invalidate_cache()
+
+
+async def _enable_watch(db: AsyncSession) -> None:
+    db.add(FeatureModule(id="security.new_device_watch", enabled=True))
+    await db.flush()
+    feature_modules.invalidate_cache()
+
+
+async def _make_subnet(db: AsyncSession) -> Subnet:
+    space = IPSpace(name=f"nd-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.40.0.0/16", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network="10.40.1.0/24",
+        name="sn",
+        total_ips=254,
+    )
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _ip(
+    db: AsyncSession, subnet: Subnet, addr: str, *, status: str, mac: str | None = None
+) -> IPAddress:
+    row = IPAddress(subnet_id=subnet.id, address=addr, status=status, mac_address=mac)
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def _superadmin(db: AsyncSession) -> tuple[User, str]:
+    u = User(
+        username=f"a-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(u)
+    await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+def _hdr(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── MAC helpers ──────────────────────────────────────────────────────────
+
+
+async def test_is_locally_administered() -> None:
+    # 0x02 bit set in the first octet → randomised (0x02, 0x0a, 0xaa, 0xde).
+    assert is_locally_administered("02:11:22:33:44:55") is True
+    assert is_locally_administered("0a:11:22:33:44:55") is True
+    assert is_locally_administered("aa:bb:cc:dd:ee:ff") is True  # 0xAA & 0x02 == 2
+    assert is_locally_administered("DE:AD:BE:EF:00:01") is True  # 0xDE & 0x02 == 2
+    # Globally-unique (vendor) MACs (bit clear) → not randomised.
+    assert is_locally_administered("00:50:56:11:22:33") is False  # 0x00
+    assert is_locally_administered("3c:5a:b4:11:22:33") is False  # 0x3c
+    assert is_locally_administered("08:00:27:11:22:33") is False  # 0x08
+    assert is_locally_administered(None) is False
+    assert is_locally_administered("not-a-mac") is False
+
+
+async def test_normalize_oui_prefix() -> None:
+    assert normalize_oui_prefix("00:50:56") == "005056"
+    assert normalize_oui_prefix("005056") == "005056"
+    assert normalize_oui_prefix("00-50-56-ab-cd-ef") == "005056"
+    assert normalize_oui_prefix("0050.56ab.cdef") == "005056"
+    assert normalize_oui_prefix("0050") is None
+    assert normalize_oui_prefix(None) is None
+
+
+# ── classify_mac ─────────────────────────────────────────────────────────
+
+
+async def test_classify_unknown_is_new(db_session: AsyncSession) -> None:
+    assert await classify_mac(db_session, "aa:bb:cc:00:00:01") == CLASSIFICATION_NEW
+
+
+async def test_classify_known_fleet(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    await _ip(db_session, subnet, "10.40.1.10", status="allocated", mac="aa:bb:cc:00:00:02")
+    await db_session.flush()
+    assert await classify_mac(db_session, "aa:bb:cc:00:00:02") == CLASSIFICATION_KNOWN
+    # A MAC only on a 'dhcp' (integration-owned) row is NOT the known fleet.
+    subnet2 = await _make_subnet(db_session)
+    await _ip(db_session, subnet2, "10.40.1.11", status="dhcp", mac="aa:bb:cc:00:00:03")
+    await db_session.flush()
+    assert await classify_mac(db_session, "aa:bb:cc:00:00:03") == CLASSIFICATION_NEW
+
+
+async def test_classify_allowlisted(db_session: AsyncSession) -> None:
+    db_session.add(MACAllowlist(mac_address="aa:bb:cc:00:00:04"))
+    await db_session.flush()
+    assert await classify_mac(db_session, "aa:bb:cc:00:00:04") == CLASSIFICATION_KNOWN
+
+
+async def test_classify_oui_allowlisted(db_session: AsyncSession) -> None:
+    db_session.add(MACAllowlist(oui_prefix="005056"))
+    await db_session.flush()
+    assert await classify_mac(db_session, "00:50:56:ab:cd:ef") == CLASSIFICATION_KNOWN
+    assert await classify_mac(db_session, "00:50:57:ab:cd:ef") == CLASSIFICATION_NEW
+
+
+# ── record_mac_observation ───────────────────────────────────────────────
+
+
+async def test_record_observation_first_then_repeat(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    ip = await _ip(db_session, subnet, "10.40.1.20", status="dhcp")
+    await db_session.flush()
+
+    first = await record_mac_observation(
+        db_session, ip.id, "aa:bb:cc:00:00:10", source="dhcp_lease"
+    )
+    assert first is not None
+    assert first.is_new_row is True
+    assert first.is_first_seen_new is True
+    assert first.classification == CLASSIFICATION_NEW
+
+    # A second sighting of the same (ip, mac) is not a new row.
+    second = await record_mac_observation(db_session, ip.id, "aa:bb:cc:00:00:10", source="snmp")
+    assert second is not None
+    assert second.is_new_row is False
+    assert second.is_first_seen_new is False
+
+    # Acknowledging then re-observing must NOT downgrade back to 'new'.
+    row = (
+        await db_session.execute(select(IpMacHistory).where(IpMacHistory.ip_address_id == ip.id))
+    ).scalar_one()
+    row.classification = CLASSIFICATION_ACKNOWLEDGED
+    await db_session.flush()
+    third = await record_mac_observation(db_session, ip.id, "aa:bb:cc:00:00:10", source="sweep")
+    assert third is not None
+    assert third.classification == CLASSIFICATION_ACKNOWLEDGED
+
+
+async def test_record_observation_randomized_flag(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    ip = await _ip(db_session, subnet, "10.40.1.21", status="dhcp")
+    await db_session.flush()
+    res = await record_mac_observation(db_session, ip.id, "02:aa:bb:cc:dd:ee", source="dhcp_lease")
+    assert res is not None and res.is_randomized is True
+    stored = (
+        await db_session.execute(select(IpMacHistory).where(IpMacHistory.ip_address_id == ip.id))
+    ).scalar_one()
+    assert stored.is_randomized is True
+    assert stored.source == "dhcp_lease"
+
+
+# ── baseline / allowlist / acknowledge ───────────────────────────────────
+
+
+async def test_baseline_import(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    for i in range(3):
+        ip = await _ip(db_session, subnet, f"10.40.1.{30 + i}", status="dhcp")
+        await db_session.flush()
+        await record_mac_observation(
+            db_session, ip.id, f"aa:bb:cc:00:01:{i:02d}", source="dhcp_lease"
+        )
+    await db_session.flush()
+    count = await baseline_import(db_session)
+    assert count == 3
+    remaining_new = (
+        (
+            await db_session.execute(
+                select(IpMacHistory).where(IpMacHistory.classification == CLASSIFICATION_NEW)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining_new == []
+
+
+async def test_add_allowlist_reclassifies(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    ip = await _ip(db_session, subnet, "10.40.1.40", status="dhcp")
+    await db_session.flush()
+    await record_mac_observation(db_session, ip.id, "00:50:56:aa:bb:cc", source="dhcp_lease")
+    await db_session.flush()
+
+    row, reclassified = await add_allowlist_entry(db_session, oui_prefix="00:50:56", note="vmware")
+    await db_session.flush()
+    assert row.oui_prefix == "005056"
+    assert reclassified == 1
+    stored = (
+        await db_session.execute(select(IpMacHistory).where(IpMacHistory.ip_address_id == ip.id))
+    ).scalar_one()
+    assert stored.classification == CLASSIFICATION_KNOWN
+
+
+async def test_add_allowlist_requires_a_key(db_session: AsyncSession) -> None:
+    with pytest.raises(ValueError):
+        await add_allowlist_entry(db_session, note="nothing")
+
+
+async def test_acknowledge_sighting(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    ip = await _ip(db_session, subnet, "10.40.1.50", status="dhcp")
+    await db_session.flush()
+    await record_mac_observation(db_session, ip.id, "aa:bb:cc:00:02:00", source="dhcp_lease")
+    await db_session.flush()
+    sighting = (
+        await db_session.execute(select(IpMacHistory).where(IpMacHistory.ip_address_id == ip.id))
+    ).scalar_one()
+    u, _ = await _superadmin(db_session)
+    out = await acknowledge_sighting(db_session, sighting.id, u)
+    assert out is not None
+    assert out.classification == CLASSIFICATION_ACKNOWLEDGED
+    assert out.acknowledged_by_user_id == u.id
+    assert out.acknowledged_at is not None
+    assert await acknowledge_sighting(db_session, uuid.uuid4(), u) is None
+
+
+# ── new_mac_seen alert matcher ───────────────────────────────────────────
+
+
+async def test_new_mac_seen_matcher(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+
+    async def _sighting(addr: str, mac: str, classification: str, *, randomized: bool) -> IPAddress:
+        ip = await _ip(db_session, subnet, addr, status="dhcp")
+        await db_session.flush()
+        await record_mac_observation(db_session, ip.id, mac, source="dhcp_lease")
+        row = (
+            await db_session.execute(
+                select(IpMacHistory).where(IpMacHistory.ip_address_id == ip.id)
+            )
+        ).scalar_one()
+        row.classification = classification
+        row.is_randomized = randomized
+        await db_session.flush()
+        return ip
+
+    new_ip = await _sighting("10.40.1.60", "aa:bb:cc:00:03:00", "new", randomized=False)
+    rand_ip = await _sighting("10.40.1.61", "02:bb:cc:00:03:01", "new", randomized=True)
+    ack_ip = await _sighting("10.40.1.62", "aa:bb:cc:00:03:02", "acknowledged", randomized=False)
+    await db_session.commit()
+
+    rule = AlertRule(name="t", rule_type=RULE_TYPE_NEW_MAC_SEEN, severity="info", threshold_days=7)
+    subjects = await _matching_new_mac_seen_subjects(db_session, rule)
+    ids = {sid for sid, _d, _m in subjects}
+    assert f"{new_ip.id}:aa:bb:cc:00:03:00" in ids  # composite subject id
+    assert not any(str(rand_ip.id) in sid for sid in ids)  # randomised excluded by default
+    assert not any(str(ack_ip.id) in sid for sid in ids)  # acknowledged excluded
+
+    # classification='all' opts randomised back in.
+    rule_all = AlertRule(
+        name="t",
+        rule_type=RULE_TYPE_NEW_MAC_SEEN,
+        severity="info",
+        threshold_days=7,
+        classification="all",
+    )
+    ids_all = {sid for sid, _d, _m in await _matching_new_mac_seen_subjects(db_session, rule_all)}
+    assert any(str(rand_ip.id) in sid for sid in ids_all)
+
+
+# ── HTTP: lease-events → new sighting + device.first_seen ────────────────
+
+
+async def _seed_dhcp(db: AsyncSession) -> tuple[DHCPServer, Subnet]:
+    space = IPSpace(name=f"le-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.41.0.0/16", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.41.1.0/24", name="sn")
+    db.add(subnet)
+    server = DHCPServer(
+        name=f"kea-{uuid.uuid4().hex[:6]}", driver="kea", host="127.0.0.1", port=67, status="active"
+    )
+    db.add(server)
+    await db.flush()
+    return server, subnet
+
+
+def _lease_payload(ip: str, mac: str) -> dict:
+    end = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    return {
+        "leases": [
+            {
+                "ip_address": ip,
+                "mac_address": mac,
+                "hostname": "host1",
+                "state": "active",
+                "starts_at": datetime.now(UTC).isoformat(),
+                "ends_at": end,
+                "expires_at": end,
+            }
+        ]
+    }
+
+
+async def test_lease_event_creates_new_sighting(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    server, _subnet = await _seed_dhcp(db_session)
+    await _enable_watch(db_session)
+    await db_session.commit()
+
+    app.dependency_overrides[_auth_agent] = lambda: (server, {})
+    try:
+        resp = await client.post(
+            "/api/v1/dhcp/agents/lease-events",
+            json=_lease_payload("10.41.1.50", "aa:bb:cc:de:ad:01"),
+        )
+    finally:
+        app.dependency_overrides.pop(_auth_agent, None)
+    assert resp.status_code == 200, resp.text
+
+    sighting = (
+        await db_session.execute(
+            select(IpMacHistory).where(IpMacHistory.mac_address == "aa:bb:cc:de:ad:01")
+        )
+    ).scalar_one()
+    assert sighting.classification == "new"
+    assert sighting.source == "dhcp_lease"
+
+    # device.first_seen audit row was written (the after-commit publisher turns
+    # it into the typed event).
+    audit = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(
+                    AuditLog.action == "first_seen",
+                    AuditLog.resource_type == "ip_mac_observation",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert any("aa:bb:cc:de:ad:01" in str(a.resource_id) for a in audit)
+
+
+async def test_lease_event_no_sighting_when_module_off(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    server, _subnet = await _seed_dhcp(db_session)
+    await db_session.commit()  # module NOT enabled
+
+    app.dependency_overrides[_auth_agent] = lambda: (server, {})
+    try:
+        resp = await client.post(
+            "/api/v1/dhcp/agents/lease-events",
+            json=_lease_payload("10.41.1.51", "aa:bb:cc:de:ad:02"),
+        )
+    finally:
+        app.dependency_overrides.pop(_auth_agent, None)
+    assert resp.status_code == 200, resp.text
+    sighting = (
+        await db_session.execute(
+            select(IpMacHistory).where(IpMacHistory.mac_address == "aa:bb:cc:de:ad:02")
+        )
+    ).scalar_one_or_none()
+    assert sighting is None  # zero-overhead when the feature is off
+
+
+# ── HTTP: review queue + block ───────────────────────────────────────────
+
+
+async def test_sightings_and_block_endpoints(client: AsyncClient, db_session: AsyncSession) -> None:
+    await _enable_watch(db_session)
+    subnet = await _make_subnet(db_session)
+    ip = await _ip(db_session, subnet, "10.40.1.70", status="dhcp")
+    await db_session.flush()
+    await record_mac_observation(db_session, ip.id, "3c:5a:b4:de:ad:10", source="dhcp_lease")
+    group = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(group)
+    _u, token = await _superadmin(db_session)
+    await db_session.commit()
+
+    # list sightings
+    resp = await client.get("/api/v1/new-devices/sightings", headers=_hdr(token))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] >= 1
+    assert any(r["mac_address"] == "3c:5a:b4:de:ad:10" for r in body["items"])
+
+    # block the MAC in all groups
+    resp = await client.post(
+        "/api/v1/new-devices/block",
+        headers=_hdr(token),
+        json={"mac_address": "3c:5a:b4:de:ad:10", "reason": "other"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()["blocked_group_ids"]) == 1
+    block = (
+        await db_session.execute(
+            select(DHCPMACBlock).where(DHCPMACBlock.mac_address == "3c:5a:b4:de:ad:10")
+        )
+    ).scalar_one()
+    assert block.group_id == group.id
+
+
+async def test_mac_sightings_endpoint(client: AsyncClient, db_session: AsyncSession) -> None:
+    """The L2-sniffer ingest endpoint creates a discovered IPAM row + new sighting."""
+    server, _subnet = await _seed_dhcp(db_session)
+    await _enable_watch(db_session)
+    await db_session.commit()
+
+    app.dependency_overrides[_auth_agent] = lambda: (server, {})
+    try:
+        resp = await client.post(
+            "/api/v1/dhcp/agents/mac-sightings",
+            json={"sightings": [{"mac_address": "3c:5a:b4:5e:e0:01", "ip_address": "10.41.1.80"}]},
+        )
+    finally:
+        app.dependency_overrides.pop(_auth_agent, None)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"recorded": 1, "new": 1}
+
+    # A 'discovered' IPAM row was auto-created and a 'new' sighting logged.
+    ip = (
+        await db_session.execute(select(IPAddress).where(IPAddress.address == "10.41.1.80"))
+    ).scalar_one()
+    assert ip.status == "discovered"
+    sighting = (
+        await db_session.execute(
+            select(IpMacHistory).where(IpMacHistory.mac_address == "3c:5a:b4:5e:e0:01")
+        )
+    ).scalar_one()
+    assert sighting.source == "l2_sniff"
+    assert sighting.classification == "new"
+
+
+async def test_mac_sightings_noop_when_module_off(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    server, _subnet = await _seed_dhcp(db_session)
+    await db_session.commit()  # module NOT enabled
+    app.dependency_overrides[_auth_agent] = lambda: (server, {})
+    try:
+        resp = await client.post(
+            "/api/v1/dhcp/agents/mac-sightings",
+            json={"sightings": [{"mac_address": "3c:5a:b4:5e:e0:02", "ip_address": "10.41.1.81"}]},
+        )
+    finally:
+        app.dependency_overrides.pop(_auth_agent, None)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"recorded": 0, "new": 0}
+    assert (
+        await db_session.execute(select(IPAddress).where(IPAddress.address == "10.41.1.81"))
+    ).scalar_one_or_none() is None

--- a/backend/tests/test_new_device_watch.py
+++ b/backend/tests/test_new_device_watch.py
@@ -504,3 +504,54 @@ async def test_mac_sightings_noop_when_module_off(
     assert (
         await db_session.execute(select(IPAddress).where(IPAddress.address == "10.41.1.81"))
     ).scalar_one_or_none() is None
+
+
+async def test_sweep_discovered_new_row_records_sighting(db_session: AsyncSession) -> None:
+    """A never-tracked host found by the ping/ARP sweep gets a sighting too — not
+    just existing rows (regression guard for the new-row branch in #459)."""
+    from app.services.ipam.discovery import SweepResult, reconcile_subnet
+
+    subnet = await _make_subnet(db_session)
+    await db_session.flush()
+    sweep = SweepResult(
+        ping_alive={"10.40.1.200"},
+        arp={"10.40.1.200": "3c:5a:b4:0d:15:c0"},
+    )
+    counts = await reconcile_subnet(db_session, subnet, sweep)
+    await db_session.flush()
+    assert counts["created"] == 1
+
+    new_row = (
+        await db_session.execute(select(IPAddress).where(IPAddress.address == "10.40.1.200"))
+    ).scalar_one()
+    assert new_row.status == "discovered"
+    sighting = (
+        await db_session.execute(
+            select(IpMacHistory).where(IpMacHistory.ip_address_id == new_row.id)
+        )
+    ).scalar_one()
+    assert sighting.mac_address == "3c:5a:b4:0d:15:c0"
+    assert sighting.source == "sweep"
+    assert sighting.classification == "new"
+
+
+async def test_duplicate_allowlist_returns_409(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Allowlisting an already-allowlisted MAC is a clean 409, not a 500."""
+    await _enable_watch(db_session)
+    _u, token = await _superadmin(db_session)
+    await db_session.commit()
+
+    first = await client.post(
+        "/api/v1/new-devices/allowlist",
+        headers=_hdr(token),
+        json={"mac_address": "3c:5a:b4:ab:cd:ef", "note": "trusted"},
+    )
+    assert first.status_code == 201, first.text
+    dup = await client.post(
+        "/api/v1/new-devices/allowlist",
+        headers=_hdr(token),
+        json={"mac_address": "3c:5a:b4:ab:cd:ef", "note": "again"},
+    )
+    assert dup.status_code == 409, dup.text

--- a/docs/deployment/DOCKER.md
+++ b/docs/deployment/DOCKER.md
@@ -326,6 +326,38 @@ control plane to enable enrichment; without a key the agent still
 ships raw signatures, fingerbank lookups just don't run. See
 `docs/features/DHCP.md §15` for the full design and privacy notes.
 
+#### Optional: arpwatch-style new-device detection
+
+To enable Phase 3 new-device detection (issue #459), the agent runs
+an additional opt-in L2 sniffer that observes source MACs on the wire
+via **ARP + IPv6 Neighbor Discovery** — so it catches statically
+addressed and link-local-only hosts that never touch the DHCP server,
+not just DHCP clients. First-sightings ship to the control plane,
+which classifies them and surfaces unknowns in the new-device-watch
+review queue.
+
+It shares the same `NET_RAW` capability as passive fingerprinting (no
+new capability is required) and is gated on its own env toggle:
+
+```yaml
+services:
+  dhcp-kea:
+    cap_add:
+      - NET_RAW
+    environment:
+      DHCP_MAC_SIGHTING_ENABLED: "1"
+      # Optional — interface name for the sniffer. Default "any"
+      # works for host-networked containers; bridge-networked
+      # containers should set this explicitly.
+      DHCP_MAC_SIGHTING_IFACE: "any"
+```
+
+Like fingerprinting, this is **default-off** — flip the toggle (and
+grant `NET_RAW` if you haven't already) to arm it. The control-plane
+endpoint is a no-op until the new-device-watch feature module is
+enabled server-side, so a locally-armed agent that hasn't been wired
+up on the control plane just ships into a black hole at no cost.
+
 ### DNS-only VM
 
 Pick the compose file that matches the driver on the control plane's

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -317,6 +317,63 @@ sweep only refreshes their `last_seen_at`. Subnets larger than a /20
 `stale_minutes` (default 24 h) is the window after which a row's
 `last_seen_at` counts as stale.
 
+### New-device detection — arpwatch-style (issue #459)
+
+Behind the default-**off** `security.new_device_watch` feature module
+(group **Security**), SpatiumDDI alerts the moment a **never-before-seen
+MAC** appears on the network — the classic arpwatch "new station"
+behaviour, for operators who want a real-time heads-up on anything that
+joins.
+
+**One store, not two.** Rather than a parallel sighting table, the
+feature extends the existing `ip_mac_history` observation log (the same
+store that feeds the `unknown_mac_in_static_range` alert above) with a
+classification layer:
+
+| Column | Meaning |
+|---|---|
+| `classification` | `new` (never seen — raises the alert) · `acknowledged` (operator dismissed this `(ip, mac)`) · `known` (allowlisted, or on an allocated/reserved/static IP) |
+| `source` | which path first/last saw it — `sweep` · `snmp` · `dhcp_lease` · `l2_sniff` |
+| `is_randomized` | the MAC's locally-administered (privacy-randomised) bit is set — flagged, and skipped by the default alert so reconnecting phones don't storm |
+
+**Detection sources** (all route through
+`record_mac_observation`, which classifies on first sight):
+
+1. **DHCP leases** — the agent's lease-event stream (zero-effort, the
+   lowest-friction source).
+2. **SNMP ARP/FDB** — the existing device-poll cross-reference
+   (agentless).
+3. **L2 sniff** — an opt-in arpwatch-style ARP/ND sniffer on the DHCP
+   agent (`DHCP_MAC_SIGHTING_ENABLED=1`, needs `cap_add: NET_RAW`),
+   catching devices that never DHCP (static IP, link-local). Ships to
+   `POST /api/v1/dhcp/agents/mac-sightings`.
+
+**Allowlist.** A `mac_allowlist` table of trusted MACs (or **OUI
+prefixes** for VMs/containers — `POST /new-devices/allowlist/virt-defaults`
+seeds the well-known virtualisation OUIs) that never alert and reclassify
+matching sightings to `known`. Keyed on the MAC, so it survives the
+cascade-delete of any IP it was first seen on.
+
+**Alert + events.** The `new_mac_seen` alert rule (seeded disabled) opens
+one `AlertEvent` per `(ip, mac)` sighting classified `new`, auto-resolving
+once acknowledged / allowlisted or aged out (set its `classification` to
+`"all"` to include randomised MACs). Genuinely-new devices also fire a
+real-time `device.first_seen` typed webhook event (and
+`device.acknowledged` on dismissal) on **ingest** — sub-minute, ahead of
+the 60 s alert tick.
+
+**Operator surface.** `GET /new-devices/{summary,sightings,allowlist}` +
+acknowledge / baseline-import / allowlist / block actions
+(`/api/v1/new-devices`, gated on `read`/`write` `ip_address`). The
+**Tools → New Devices** review queue lists sightings with one-click
+**Acknowledge / Add to allowlist / Block** (block creates a
+`DHCPMACBlock` — arpwatch with teeth). Run a **baseline import** when
+arming the feature to mark the existing fleet as `known` so day-one isn't
+a wall of alerts. Operator-Copilot tools: `find_new_devices` /
+`count_new_devices` / `find_mac_allowlist` (read) +
+`propose_acknowledge_device` / `propose_allowlist_mac` /
+`propose_block_mac` (Apply-gated writes).
+
 ### Stale-IP Report (issue #45)
 
 A cross-subnet "address-space hygiene" view that reads the discovery

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,7 @@ import { NmapToolsPage } from "@/pages/nmap/NmapToolsPage";
 import { PacketCapturePage } from "@/pages/pcap/PacketCapturePage";
 import { NetworkToolsPage } from "@/pages/tools/NetworkToolsPage";
 import { CidrCalculatorPage } from "@/pages/tools/CidrCalculatorPage";
+import { NewDevicesPage } from "@/pages/security/NewDevicesPage";
 import { SubnetPlannerListPage } from "@/pages/ipam/SubnetPlannerListPage";
 import { SubnetPlannerEditorPage } from "@/pages/ipam/SubnetPlannerEditorPage";
 import { LogsPage } from "@/pages/LogsPage";
@@ -149,6 +150,7 @@ export default function App() {
         <Route path="tools/pcap" element={<PacketCapturePage />} />
         <Route path="tools/network" element={<NetworkToolsPage />} />
         <Route path="tools/cidr" element={<CidrCalculatorPage />} />
+        <Route path="security/new-devices" element={<NewDevicesPage />} />
         <Route path="dhcp" element={<DHCPPage />} />
         <Route path="dhcp/groups/:groupId/pxe" element={<PXEProfilesPage />} />
         <Route path="logs" element={<LogsPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -30,6 +30,7 @@ import {
   Settings,
   Tags,
   ShieldCheck,
+  ShieldQuestion,
   ScrollText,
   BellRing,
   Sparkles,
@@ -203,6 +204,12 @@ const networkInfrastructureNav = [
 
 const toolsNav = [
   { label: "CIDR Calculator", icon: Calculator, to: "/tools/cidr" },
+  {
+    label: "New Devices",
+    icon: ShieldQuestion,
+    to: "/security/new-devices",
+    module: "security.new_device_watch",
+  },
   { label: "Nmap", icon: Search, to: "/tools/nmap", module: "tools.nmap" },
   {
     label: "Network Tools",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6756,6 +6756,126 @@ export const dhcpApi = {
     api.delete(`/dhcp/mac-blocks/${blockId}`),
 };
 
+// ── New-device watch (issue #459) ──────────────────────────────────────
+// arpwatch-style first-seen MAC tracking. The whole surface is gated by
+// the (default-off) ``security.new_device_watch`` feature module — every
+// endpoint 404s when the module is off, so callers must gate their
+// queries on ``useFeatureModules().enabled("security.new_device_watch")``.
+
+export type NewDeviceClassification = "new" | "acknowledged" | "known";
+export type NewDeviceSource = "dhcp_lease" | "snmp" | "sweep" | "l2_sniff";
+
+export interface NewDeviceSummary {
+  new_count: number;
+  new_randomized_count: number;
+  new_last_24h: number;
+  acknowledged_count: number;
+  known_count: number;
+  allowlist_count: number;
+}
+
+export interface NewDeviceSighting {
+  id: string;
+  ip_address_id: string;
+  ip_address: string;
+  subnet_id: string | null;
+  subnet_name: string | null;
+  mac_address: string;
+  oui_vendor: string | null;
+  classification: NewDeviceClassification;
+  source: NewDeviceSource;
+  is_randomized: boolean;
+  first_seen: string;
+  last_seen: string;
+  acknowledged_at: string | null;
+}
+
+export interface NewDeviceAllowlistEntry {
+  id: string;
+  mac_address: string | null;
+  oui_prefix: string | null;
+  note: string;
+  is_builtin: boolean;
+  created_at: string;
+}
+
+export interface NewDeviceAllowlistResult {
+  entry: NewDeviceAllowlistEntry;
+  reclassified_count: number;
+}
+
+export interface NewDeviceBlockResult {
+  mac_address: string;
+  blocked_group_ids: string[];
+  already_blocked_group_ids: string[];
+}
+
+export const newDeviceApi = {
+  summary: () =>
+    api
+      .get<NewDeviceSummary>("/new-devices/summary")
+      .then((r) => r.data),
+
+  listSightings: (params?: {
+    classification?: NewDeviceClassification;
+    subnet_id?: string;
+    since_hours?: number;
+    include_randomized?: boolean;
+    search?: string;
+    page?: number;
+    page_size?: number;
+  }) =>
+    api
+      .get<Page<NewDeviceSighting>>("/new-devices/sightings", { params })
+      .then((r) => r.data),
+
+  acknowledge: (sightingId: string, note?: string) =>
+    api
+      .post<NewDeviceSighting>(`/new-devices/sightings/${sightingId}/acknowledge`, {
+        note,
+      })
+      .then((r) => r.data),
+
+  baseline: () =>
+    api
+      .post<{ reclassified_count: number }>("/new-devices/baseline")
+      .then((r) => r.data),
+
+  listAllowlist: () =>
+    api
+      .get<NewDeviceAllowlistEntry[]>("/new-devices/allowlist")
+      .then((r) => r.data),
+
+  addAllowlist: (data: {
+    mac_address?: string;
+    oui_prefix?: string;
+    note?: string;
+  }) =>
+    api
+      .post<NewDeviceAllowlistResult>("/new-devices/allowlist", data)
+      .then((r) => r.data),
+
+  addVirtDefaults: () =>
+    api
+      .post<{ added: number; skipped: number }>(
+        "/new-devices/allowlist/virt-defaults",
+      )
+      .then((r) => r.data),
+
+  deleteAllowlist: (id: string) =>
+    api.delete(`/new-devices/allowlist/${id}`),
+
+  block: (data: {
+    mac_address: string;
+    group_id?: string;
+    reason?: string;
+    description?: string;
+  }) =>
+    api
+      .post<NewDeviceBlockResult>("/new-devices/block", data)
+      .then((r) => r.data),
+};
+
 export interface DHCPPool {
   id: string;
   scope_id: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6812,9 +6812,7 @@ export interface NewDeviceBlockResult {
 
 export const newDeviceApi = {
   summary: () =>
-    api
-      .get<NewDeviceSummary>("/new-devices/summary")
-      .then((r) => r.data),
+    api.get<NewDeviceSummary>("/new-devices/summary").then((r) => r.data),
 
   listSightings: (params?: {
     classification?: NewDeviceClassification;
@@ -6831,9 +6829,12 @@ export const newDeviceApi = {
 
   acknowledge: (sightingId: string, note?: string) =>
     api
-      .post<NewDeviceSighting>(`/new-devices/sightings/${sightingId}/acknowledge`, {
-        note,
-      })
+      .post<NewDeviceSighting>(
+        `/new-devices/sightings/${sightingId}/acknowledge`,
+        {
+          note,
+        },
+      )
       .then((r) => r.data),
 
   baseline: () =>
@@ -6857,13 +6858,13 @@ export const newDeviceApi = {
 
   addVirtDefaults: () =>
     api
-      .post<{ added: number; skipped: number }>(
-        "/new-devices/allowlist/virt-defaults",
-      )
+      .post<{
+        added: number;
+        skipped: number;
+      }>("/new-devices/allowlist/virt-defaults")
       .then((r) => r.data),
 
-  deleteAllowlist: (id: string) =>
-    api.delete(`/new-devices/allowlist/${id}`),
+  deleteAllowlist: (id: string) => api.delete(`/new-devices/allowlist/${id}`),
 
   block: (data: {
     mac_address: string;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -56,6 +56,7 @@ import {
   conformityApi,
   dashboardsApi,
   tlsCertsApi,
+  newDeviceApi,
   type IPSpace,
   type Subnet,
   type DNSServer,
@@ -1473,6 +1474,10 @@ export function DashboardPage() {
                 overallUtil >= 95 ? "bad" : overallUtil >= 80 ? "warn" : "good"
               }
             />
+
+            {/* New-device watch (#459) — renders nothing when the
+                security.new_device_watch module is off. */}
+            <NewDevicesKpi />
           </div>
         )}
 
@@ -2825,6 +2830,43 @@ function CertsExpiringKpi() {
       </p>
       <p className="text-[11px] text-muted-foreground">
         of {items.length} monitored · click to review
+      </p>
+    </Link>
+  );
+}
+
+// New devices seen in the last 24h (#459). Self-contained + gated on the
+// (default-off) ``security.new_device_watch`` feature module so it renders
+// nothing — and fires no query — when the module is turned off.
+function NewDevicesKpi() {
+  const { enabled, ready } = useFeatureModules();
+  const moduleOn = enabled("security.new_device_watch");
+
+  const { data } = useQuery({
+    queryKey: ["new-devices", "summary", "kpi"],
+    queryFn: () => newDeviceApi.summary(),
+    enabled: ready && moduleOn,
+    staleTime: 30_000,
+  });
+
+  if (ready && !moduleOn) return null;
+
+  const last24h = data?.new_last_24h ?? 0;
+  const cls = TONE_CLASS[last24h > 0 ? "bad" : "good"];
+
+  return (
+    <Link
+      to="/security/new-devices"
+      className="rounded-lg border bg-card p-4 transition-colors hover:bg-accent/40"
+    >
+      <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
+        New devices (24h)
+      </p>
+      <p className={cn("mt-2 text-3xl font-bold tabular-nums", cls.value)}>
+        {last24h}
+      </p>
+      <p className="text-[11px] text-muted-foreground">
+        {data?.new_count ?? 0} awaiting review · click to triage
       </p>
     </Link>
   );

--- a/frontend/src/pages/security/NewDevicesPage.tsx
+++ b/frontend/src/pages/security/NewDevicesPage.tsx
@@ -1,0 +1,903 @@
+import { useMemo, useState } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  RefreshCw,
+  ShieldCheck,
+  ShieldQuestion,
+  Ban,
+  ListChecks,
+  Trash2,
+  Plus,
+  History,
+} from "lucide-react";
+
+import {
+  newDeviceApi,
+  ipamApi,
+  type NewDeviceSighting,
+  type NewDeviceClassification,
+  type NewDeviceSource,
+  type NewDeviceAllowlistEntry,
+} from "@/lib/api";
+import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { HeaderButton } from "@/components/ui/header-button";
+import { Pager } from "@/components/ui/pager";
+import { errMsg, inputCls } from "@/pages/dhcp/_shared";
+
+const PAGE_SIZE = 100;
+
+const CLASSIFICATIONS: {
+  value: NewDeviceClassification;
+  label: string;
+}[] = [
+  { value: "new", label: "New" },
+  { value: "acknowledged", label: "Acknowledged" },
+  { value: "known", label: "Known" },
+];
+
+const SOURCE_LABELS: Record<NewDeviceSource, string> = {
+  dhcp_lease: "DHCP lease",
+  snmp: "SNMP",
+  sweep: "Sweep",
+  l2_sniff: "L2 sniff",
+};
+
+const SOURCE_COLORS: Record<NewDeviceSource, string> = {
+  dhcp_lease: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
+  snmp: "bg-violet-500/10 text-violet-700 dark:text-violet-400",
+  sweep: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+  l2_sniff: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+};
+
+function SourcePill({ source }: { source: NewDeviceSource }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium ${SOURCE_COLORS[source]}`}
+    >
+      {SOURCE_LABELS[source] ?? source}
+    </span>
+  );
+}
+
+// Relative "time ago" for the Seen column. Cheap, no dependency.
+function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  return `${days}d ago`;
+}
+
+export function NewDevicesPage() {
+  const qc = useQueryClient();
+
+  const [classification, setClassification] =
+    useState<NewDeviceClassification>("new");
+  const [subnetId, setSubnetId] = useState("");
+  const [includeRandomized, setIncludeRandomized] = useState(false);
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const [showAllowlist, setShowAllowlist] = useState(false);
+  const [showBaseline, setShowBaseline] = useState(false);
+  const [showAddAllowlist, setShowAddAllowlist] = useState(false);
+  const [showBlock, setShowBlock] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const summaryQ = useQuery({
+    queryKey: ["new-devices", "summary"],
+    queryFn: newDeviceApi.summary,
+    refetchInterval: 30_000,
+  });
+
+  // Subnets power the filter dropdown. Best-effort — if it fails the
+  // filter just stays empty.
+  const subnetsQ = useQuery({
+    queryKey: ["new-devices", "subnets"],
+    queryFn: () => ipamApi.listSubnets(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const sightingsQ = useQuery({
+    queryKey: [
+      "new-devices",
+      "sightings",
+      classification,
+      subnetId,
+      includeRandomized,
+      search,
+      page,
+    ],
+    queryFn: () =>
+      newDeviceApi.listSightings({
+        classification,
+        subnet_id: subnetId || undefined,
+        include_randomized: includeRandomized,
+        search: search.trim() || undefined,
+        page,
+        page_size: PAGE_SIZE,
+      }),
+    placeholderData: (prev) => prev,
+  });
+
+  const rows = sightingsQ.data?.items ?? [];
+  const total = sightingsQ.data?.total ?? 0;
+
+  function invalidateAll() {
+    qc.invalidateQueries({ queryKey: ["new-devices"] });
+  }
+
+  function resetToFirstPage() {
+    setPage(1);
+    setSelected(new Set());
+  }
+
+  const allSelected = rows.length > 0 && rows.every((r) => selected.has(r.id));
+  const someSelected = selected.size > 0;
+
+  function toggleRow(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  function toggleAll() {
+    setSelected((prev) => {
+      if (rows.every((r) => prev.has(r.id))) {
+        const next = new Set(prev);
+        rows.forEach((r) => next.delete(r.id));
+        return next;
+      }
+      const next = new Set(prev);
+      rows.forEach((r) => next.add(r.id));
+      return next;
+    });
+  }
+
+  const selectedRows = useMemo(
+    () => rows.filter((r) => selected.has(r.id)),
+    [rows, selected],
+  );
+
+  // Bulk acknowledge — fan out per selected row.
+  const ackMut = useMutation({
+    mutationFn: async () => {
+      setActionError(null);
+      const results = await Promise.allSettled(
+        selectedRows.map((r) => newDeviceApi.acknowledge(r.id)),
+      );
+      const failed = results.filter((r) => r.status === "rejected").length;
+      if (failed > 0)
+        throw new Error(`${failed} of ${selectedRows.length} failed to acknowledge`);
+    },
+    onSuccess: () => {
+      invalidateAll();
+      setSelected(new Set());
+    },
+    onError: (e) => setActionError(errMsg(e, "Acknowledge failed")),
+  });
+
+  const baselineMut = useMutation({
+    mutationFn: newDeviceApi.baseline,
+    onSuccess: () => {
+      invalidateAll();
+      setShowBaseline(false);
+    },
+    onError: (e) => setActionError(errMsg(e, "Baseline import failed")),
+  });
+
+  const moduleSummary = summaryQ.data;
+
+  return (
+    <div className="space-y-4 p-4 md:p-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <h1 className="flex items-center gap-2 text-lg font-semibold">
+            <ShieldQuestion className="h-5 w-5 flex-shrink-0" />
+            New device watch
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            arpwatch-style first-seen MAC tracking — triage previously-unseen
+            devices across DHCP, SNMP, sweep and L2 sources.
+          </p>
+        </div>
+        <HeaderButton
+          icon={RefreshCw}
+          iconClassName={sightingsQ.isFetching ? "animate-spin" : undefined}
+          onClick={() => invalidateAll()}
+          disabled={sightingsQ.isFetching}
+        >
+          Refresh
+        </HeaderButton>
+        <HeaderButton icon={ListChecks} onClick={() => setShowAllowlist(true)}>
+          Allowlist
+        </HeaderButton>
+        <HeaderButton icon={History} onClick={() => setShowBaseline(true)}>
+          Run baseline import
+        </HeaderButton>
+      </div>
+
+      {/* Summary counts */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <SummaryCard
+          label="New"
+          value={moduleSummary?.new_count}
+          sub={
+            moduleSummary != null
+              ? `${moduleSummary.new_last_24h} in 24h`
+              : undefined
+          }
+          tone="bad"
+        />
+        <SummaryCard
+          label="New (randomized)"
+          value={moduleSummary?.new_randomized_count}
+          sub="hidden by default"
+        />
+        <SummaryCard
+          label="Acknowledged"
+          value={moduleSummary?.acknowledged_count}
+        />
+        <SummaryCard label="Known" value={moduleSummary?.known_count} />
+        <SummaryCard
+          label="Allowlist"
+          value={moduleSummary?.allowlist_count}
+        />
+        <SummaryCard
+          label="New (24h)"
+          value={moduleSummary?.new_last_24h}
+          tone="bad"
+        />
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex overflow-hidden rounded-md border">
+          {CLASSIFICATIONS.map((c) => (
+            <button
+              key={c.value}
+              type="button"
+              onClick={() => {
+                setClassification(c.value);
+                resetToFirstPage();
+              }}
+              className={`px-3 py-1.5 text-sm ${
+                classification === c.value
+                  ? "bg-primary text-primary-foreground"
+                  : "hover:bg-muted"
+              }`}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+
+        <select
+          value={subnetId}
+          onChange={(e) => {
+            setSubnetId(e.target.value);
+            resetToFirstPage();
+          }}
+          className="rounded-md border bg-background px-2 py-1.5 text-sm"
+        >
+          <option value="">All subnets</option>
+          {(subnetsQ.data ?? []).map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.network}
+              {s.name ? ` · ${s.name}` : ""}
+            </option>
+          ))}
+        </select>
+
+        <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={includeRandomized}
+            onChange={(e) => {
+              setIncludeRandomized(e.target.checked);
+              resetToFirstPage();
+            }}
+          />
+          <span>Include randomized MACs</span>
+        </label>
+
+        <input
+          placeholder="Search IP, MAC, vendor…"
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+          className="w-64 rounded-md border bg-background px-2 py-1.5 text-sm"
+        />
+
+        <span className="ml-auto text-xs text-muted-foreground">
+          {total} sighting{total === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      {actionError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {actionError}
+        </div>
+      )}
+
+      {/* Bulk toolbar — slides in when rows are selected. */}
+      {someSelected && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/40 px-3 py-2">
+          <span className="text-sm font-medium">
+            {selected.size} selected
+          </span>
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <HeaderButton
+              icon={ShieldCheck}
+              onClick={() => ackMut.mutate()}
+              disabled={ackMut.isPending}
+            >
+              Acknowledge
+            </HeaderButton>
+            <HeaderButton
+              icon={Plus}
+              onClick={() => {
+                setActionError(null);
+                setShowAddAllowlist(true);
+              }}
+            >
+              Add to allowlist
+            </HeaderButton>
+            <HeaderButton
+              icon={Ban}
+              variant="destructive"
+              onClick={() => {
+                setActionError(null);
+                setShowBlock(true);
+              }}
+            >
+              Block
+            </HeaderButton>
+          </div>
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="rounded-lg border">
+        {rows.length === 0 ? (
+          <p className="p-8 text-center text-sm text-muted-foreground">
+            {sightingsQ.isLoading
+              ? "Loading…"
+              : "No sightings match these filters."}
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[960px] text-xs">
+              <thead>
+                <tr className="border-b bg-muted/30">
+                  <th className="w-8 px-3 py-2">
+                    <input
+                      type="checkbox"
+                      checked={allSelected}
+                      onChange={toggleAll}
+                      aria-label="Select all"
+                    />
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                    IP
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                    MAC
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                    Vendor
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                    Subnet
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                    Source
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                    First seen
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                    Seen
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr
+                    key={r.id}
+                    className={`border-b last:border-0 ${
+                      selected.has(r.id) ? "bg-primary/5" : ""
+                    }`}
+                  >
+                    <td className="px-3 py-2">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(r.id)}
+                        onChange={() => toggleRow(r.id)}
+                        aria-label={`Select ${r.mac_address}`}
+                      />
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 font-mono">
+                      {r.ip_address}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2">
+                      <span className="break-all font-mono">
+                        {r.mac_address}
+                      </span>
+                      {r.is_randomized && (
+                        <span className="ml-1.5 rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
+                          random
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {r.oui_vendor ?? "—"}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                      {r.subnet_name ?? "—"}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2">
+                      <SourcePill source={r.source} />
+                    </td>
+                    <td
+                      className="whitespace-nowrap px-3 py-2 text-muted-foreground"
+                      title={new Date(r.first_seen).toLocaleString()}
+                    >
+                      {timeAgo(r.first_seen)}
+                    </td>
+                    <td
+                      className="whitespace-nowrap px-3 py-2 text-muted-foreground"
+                      title={new Date(r.last_seen).toLocaleString()}
+                    >
+                      {timeAgo(r.last_seen)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end">
+        <Pager
+          page={page}
+          total={total}
+          pageSize={PAGE_SIZE}
+          onChange={(p) => {
+            setPage(p);
+            setSelected(new Set());
+          }}
+        />
+      </div>
+
+      {/* Modals */}
+      {showAllowlist && (
+        <AllowlistModal onClose={() => setShowAllowlist(false)} />
+      )}
+      {showAddAllowlist && (
+        <AddSelectedToAllowlistModal
+          sightings={selectedRows}
+          onClose={() => setShowAddAllowlist(false)}
+          onDone={() => {
+            invalidateAll();
+            setSelected(new Set());
+            setShowAddAllowlist(false);
+          }}
+          onError={(m) => setActionError(m)}
+        />
+      )}
+      {showBlock && (
+        <BlockSelectedModal
+          sightings={selectedRows}
+          onClose={() => setShowBlock(false)}
+          onDone={() => {
+            invalidateAll();
+            setSelected(new Set());
+            setShowBlock(false);
+          }}
+          onError={(m) => setActionError(m)}
+        />
+      )}
+      <ConfirmModal
+        open={showBaseline}
+        title="Run baseline import"
+        message={
+          <>
+            This marks every currently-observed MAC on the network as{" "}
+            <strong>known</strong>, so the review queue starts clean. Run this
+            once after enabling the module, then arm — anything seen afterwards
+            shows up as a new device. Existing acknowledgements are preserved.
+          </>
+        }
+        confirmLabel="Mark fleet as known"
+        loading={baselineMut.isPending}
+        onConfirm={() => baselineMut.mutate()}
+        onClose={() => setShowBaseline(false)}
+      />
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  sub,
+  tone = "default",
+}: {
+  label: string;
+  value: number | undefined;
+  sub?: string;
+  tone?: "default" | "bad";
+}) {
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
+      <p
+        className={`mt-1 text-2xl font-bold tabular-nums ${
+          tone === "bad" && (value ?? 0) > 0
+            ? "text-red-600 dark:text-red-400"
+            : ""
+        }`}
+      >
+        {value ?? "—"}
+      </p>
+      {sub && <p className="text-[11px] text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}
+
+// ── Allowlist management modal ────────────────────────────────────────
+function AllowlistModal({ onClose }: { onClose: () => void }) {
+  const qc = useQueryClient();
+  const [mac, setMac] = useState("");
+  const [oui, setOui] = useState("");
+  const [note, setNote] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [del, setDel] = useState<NewDeviceAllowlistEntry | null>(null);
+
+  const listQ = useQuery({
+    queryKey: ["new-devices", "allowlist"],
+    queryFn: newDeviceApi.listAllowlist,
+  });
+
+  function invalidate() {
+    qc.invalidateQueries({ queryKey: ["new-devices"] });
+  }
+
+  const addMut = useMutation({
+    mutationFn: () =>
+      newDeviceApi.addAllowlist({
+        mac_address: mac.trim() || undefined,
+        oui_prefix: oui.trim() || undefined,
+        note: note.trim() || undefined,
+      }),
+    onSuccess: () => {
+      invalidate();
+      setMac("");
+      setOui("");
+      setNote("");
+      setError(null);
+    },
+    onError: (e) => setError(errMsg(e, "Failed to add allowlist entry")),
+  });
+
+  const virtMut = useMutation({
+    mutationFn: newDeviceApi.addVirtDefaults,
+    onSuccess: () => {
+      invalidate();
+      setError(null);
+    },
+    onError: (e) => setError(errMsg(e, "Failed to add virtualization OUIs")),
+  });
+
+  const delMut = useMutation({
+    mutationFn: (id: string) => newDeviceApi.deleteAllowlist(id),
+    onSuccess: () => {
+      invalidate();
+      setDel(null);
+    },
+  });
+
+  const entries = listQ.data ?? [];
+
+  return (
+    <Modal title="Allowlist" onClose={onClose} wide>
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Trusted MACs (or OUI prefixes for VMs/containers) are reclassified as
+          known and never page you. Provide a full MAC or an OUI prefix.
+        </p>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            addMut.mutate();
+          }}
+          className="grid grid-cols-1 gap-2 sm:grid-cols-4"
+        >
+          <input
+            className={`${inputCls} font-mono sm:col-span-1`}
+            placeholder="MAC (aa:bb:cc:…)"
+            value={mac}
+            onChange={(e) => setMac(e.target.value)}
+          />
+          <input
+            className={`${inputCls} font-mono sm:col-span-1`}
+            placeholder="OUI (aa:bb:cc)"
+            value={oui}
+            onChange={(e) => setOui(e.target.value)}
+          />
+          <input
+            className={`${inputCls} sm:col-span-1`}
+            placeholder="Note (optional)"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+          />
+          <button
+            type="submit"
+            disabled={addMut.isPending || (!mac.trim() && !oui.trim())}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50 sm:col-span-1"
+          >
+            Add
+          </button>
+        </form>
+
+        <div className="flex items-center justify-between">
+          <HeaderButton
+            icon={Plus}
+            onClick={() => virtMut.mutate()}
+            disabled={virtMut.isPending}
+          >
+            Add common virtualization OUIs
+          </HeaderButton>
+          <span className="text-xs text-muted-foreground">
+            {entries.length} entr{entries.length === 1 ? "y" : "ies"}
+          </span>
+        </div>
+
+        {error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="max-h-72 overflow-auto rounded-md border">
+          {entries.length === 0 ? (
+            <p className="p-6 text-center text-sm text-muted-foreground">
+              No allowlist entries yet.
+            </p>
+          ) : (
+            <table className="w-full min-w-[520px] text-xs">
+              <thead>
+                <tr className="border-b bg-muted/30">
+                  <th className="px-3 py-2 text-left font-medium">MAC</th>
+                  <th className="px-3 py-2 text-left font-medium">OUI</th>
+                  <th className="px-3 py-2 text-left font-medium">Note</th>
+                  <th className="px-3 py-2"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((en) => (
+                  <tr key={en.id} className="border-b last:border-0">
+                    <td className="break-all px-3 py-2 font-mono">
+                      {en.mac_address ?? "—"}
+                    </td>
+                    <td className="break-all px-3 py-2 font-mono">
+                      {en.oui_prefix ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {en.note || "—"}
+                      {en.is_builtin && (
+                        <span className="ml-1.5 rounded bg-muted px-1 py-0.5 text-[10px]">
+                          built-in
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <button
+                        onClick={() => setDel(en)}
+                        className="rounded p-1 text-muted-foreground hover:text-destructive"
+                        title="Remove"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      <ConfirmModal
+        open={!!del}
+        title="Remove allowlist entry"
+        message={
+          <>
+            Remove{" "}
+            <span className="font-mono">
+              {del?.mac_address ?? del?.oui_prefix}
+            </span>{" "}
+            from the allowlist? Matching devices will be re-evaluated and may
+            re-appear in the new-device queue.
+          </>
+        }
+        tone="destructive"
+        confirmLabel="Remove"
+        loading={delMut.isPending}
+        onConfirm={() => del && delMut.mutate(del.id)}
+        onClose={() => setDel(null)}
+      />
+    </Modal>
+  );
+}
+
+// ── Add selected sightings to allowlist (by MAC) ──────────────────────
+function AddSelectedToAllowlistModal({
+  sightings,
+  onClose,
+  onDone,
+  onError,
+}: {
+  sightings: NewDeviceSighting[];
+  onClose: () => void;
+  onDone: () => void;
+  onError: (msg: string) => void;
+}) {
+  const [note, setNote] = useState("");
+  const mut = useMutation({
+    mutationFn: async () => {
+      const results = await Promise.allSettled(
+        sightings.map((s) =>
+          newDeviceApi.addAllowlist({
+            mac_address: s.mac_address,
+            note: note.trim() || undefined,
+          }),
+        ),
+      );
+      const failed = results.filter((r) => r.status === "rejected").length;
+      if (failed > 0)
+        throw new Error(`${failed} of ${sightings.length} failed`);
+    },
+    onSuccess: onDone,
+    onError: (e) => onError(errMsg(e, "Failed to add to allowlist")),
+  });
+
+  return (
+    <Modal title="Add to allowlist" onClose={onClose}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mut.mutate();
+        }}
+        className="space-y-3"
+      >
+        <p className="text-sm text-muted-foreground">
+          Allowlist {sightings.length} MAC
+          {sightings.length === 1 ? "" : "s"} — they'll be marked known and
+          won't page you again.
+        </p>
+        <input
+          className={inputCls}
+          placeholder="Note (optional)"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mut.isPending}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {mut.isPending ? "Adding…" : "Add to allowlist"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+// ── Block selected MACs across DHCP server groups ─────────────────────
+function BlockSelectedModal({
+  sightings,
+  onClose,
+  onDone,
+  onError,
+}: {
+  sightings: NewDeviceSighting[];
+  onClose: () => void;
+  onDone: () => void;
+  onError: (msg: string) => void;
+}) {
+  const [reason, setReason] = useState("");
+  const mut = useMutation({
+    mutationFn: async () => {
+      const results = await Promise.allSettled(
+        sightings.map((s) =>
+          newDeviceApi.block({
+            mac_address: s.mac_address,
+            reason: reason.trim() || undefined,
+          }),
+        ),
+      );
+      const failed = results.filter((r) => r.status === "rejected").length;
+      if (failed > 0)
+        throw new Error(`${failed} of ${sightings.length} failed to block`);
+    },
+    onSuccess: onDone,
+    onError: (e) => onError(errMsg(e, "Failed to block")),
+  });
+
+  return (
+    <Modal title="Block MACs" onClose={onClose}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mut.mutate();
+        }}
+        className="space-y-3"
+      >
+        <p className="text-sm text-muted-foreground">
+          Block {sightings.length} MAC
+          {sightings.length === 1 ? "" : "s"} in <strong>every</strong> DHCP
+          server group. Blocked devices can't obtain a lease.
+        </p>
+        <div className="max-h-32 overflow-auto rounded-md border bg-muted/30 p-2">
+          {sightings.map((s) => (
+            <div key={s.id} className="break-all font-mono text-xs">
+              {s.mac_address}
+            </div>
+          ))}
+        </div>
+        <input
+          className={inputCls}
+          placeholder="Reason (optional)"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mut.isPending}
+            className="rounded-md bg-destructive px-3 py-1.5 text-sm text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+          >
+            {mut.isPending ? "Blocking…" : "Block"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/security/NewDevicesPage.tsx
+++ b/frontend/src/pages/security/NewDevicesPage.tsx
@@ -1,9 +1,5 @@
 import { useMemo, useState } from "react";
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   RefreshCw,
   ShieldCheck,
@@ -180,7 +176,9 @@ export function NewDevicesPage() {
       );
       const failed = results.filter((r) => r.status === "rejected").length;
       if (failed > 0)
-        throw new Error(`${failed} of ${selectedRows.length} failed to acknowledge`);
+        throw new Error(
+          `${failed} of ${selectedRows.length} failed to acknowledge`,
+        );
     },
     onSuccess: () => {
       invalidateAll();
@@ -252,10 +250,7 @@ export function NewDevicesPage() {
           value={moduleSummary?.acknowledged_count}
         />
         <SummaryCard label="Known" value={moduleSummary?.known_count} />
-        <SummaryCard
-          label="Allowlist"
-          value={moduleSummary?.allowlist_count}
-        />
+        <SummaryCard label="Allowlist" value={moduleSummary?.allowlist_count} />
         <SummaryCard
           label="New (24h)"
           value={moduleSummary?.new_last_24h}
@@ -338,9 +333,7 @@ export function NewDevicesPage() {
       {/* Bulk toolbar — slides in when rows are selected. */}
       {someSelected && (
         <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/40 px-3 py-2">
-          <span className="text-sm font-medium">
-            {selected.size} selected
-          </span>
+          <span className="text-sm font-medium">{selected.size} selected</span>
           <div className="ml-auto flex flex-wrap items-center gap-2">
             <HeaderButton
               icon={ShieldCheck}


### PR DESCRIPTION
Closes #459.

Arpwatch-style **new-device detection**: alert the moment a never-before-seen MAC appears on the network, with a trusted-MAC allowlist and one-click block. Behind the default-**off** `security.new_device_watch` feature module. Mirrors the rogue-DHCP detection pipeline — **observe → classify → upsert → alert**.

### Architecture decision
Rather than the standalone sighting table the issue sketched, this **extends the existing `ip_mac_history` observation store** (shipped by #369, already fed by discovery + SNMP) with a classification layer — one write path, reuses the already-wired feeds, no two-table sync problem. Migration `a3f1d6c92b58` is additive (every column `server_default`'d; downgrade baselined for the shape linter).

### Detection sources (all via `record_mac_observation`, classify on first sight)
- **DHCP lease-events** — the lowest-effort cut; gated on the module so the hot path (≤100 events/POST) is unchanged when off.
- **SNMP ARP/FDB** — the existing device-poll cross-reference (`source=snmp`), incl. newly-discovered rows.
- **Ping/ARP sweep** — discovery reconciler records sightings for existing **and** newly-`discovered` rows.
- **Opt-in L2 sniffer** — an ARP/ND scapy sniffer on the DHCP agent (`DHCP_MAC_SIGHTING_ENABLED=1`, needs `cap_add: NET_RAW`) → `POST /api/v1/dhcp/agents/mac-sightings`. Catches static-IP / link-local devices that never DHCP.

### Classification + allowlist
`new` (raises the alert) / `acknowledged` (operator dismissed a specific `(ip, mac)`) / `known` (allowlisted, or on an allocated/reserved/static IP). A `mac_allowlist` table of trusted MACs (or **OUI prefixes** for VMs/containers — `virt-defaults` seeds the well-known ones) reclassifies matching sightings to `known`. Locally-administered (privacy-randomised) MACs are flagged and **excluded from the default alert** so reconnecting phones don't storm.

### Alerting + events
- `new_mac_seen` alert rule (seeded disabled): one `AlertEvent` per `(ip, mac)` classified `new`, auto-resolving on acknowledge/allowlist/age-out (set `classification="all"` to include randomised MACs).
- `device.first_seen` / `device.acknowledged` typed webhook events fire on **ingest** (≤10s), ahead of the 60s alert tick.

### Surfaces
- **REST:** `/api/v1/new-devices` (summary / sightings / acknowledge / baseline-import / allowlist CRUD + virt-defaults / block), gated on `read`/`write` `ip_address`. Block creates a `DHCPMACBlock` — arpwatch with teeth.
- **Operator Copilot (+6 tools):** `find_new_devices` / `count_new_devices` / `find_mac_allowlist` + `propose_acknowledge_device` / `propose_allowlist_mac` / `propose_block_mac` (Apply-gated, module-tagged).
- **Frontend:** a **Tools → New Devices** review queue (bulk acknowledge / allowlist / block, search, pager, allowlist manager, baseline import), a "new devices 24h" dashboard KPI, and a module-gated nav entry.

### Non-negotiables
API-first, audit-on-mutation, server-side authz, structured logs, MCP coverage with explicit default-enabled decisions, and full feature-module gating (`ModuleSpec` + migration seed + `require_module` on the router + `module=` on every MCP tool + `module` on the NavItem).

### Tests / quality
22 backend tests (classify / observe / baseline / allowlist / acknowledge, `new_mac_seen` matcher, lease + mac-sightings + sweep HTTP paths, module-off no-op, dup-allowlist 409) + an agent parser test. `make ci` green: `ruff` + `mypy` (621 files) + `black` + frontend `eslint`/`build` + migration shape linter; 51 pass incl. lease / hygiene / mac-block / discovery regression suites. Docs: `IPAM.md` §8 + `DOCKER.md`.

The L2 sniffer's live ARP/ND path can't be exercised in CI (no NIC/`CAP_NET_RAW`) — covered by an import-skipped parser test.

### Code review
A second commit addresses an xhigh multi-angle review: a HIGH sweep-observation gap (new-`discovered` rows now record sightings), allowlist 500→409 + a partial unique index on `oui_prefix`, and dedup of the sighting serialization + the count buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
