### PR TITLE
IPAM UX review — bug fixes, quick wins, inline editing, NetBox-chip dismiss (#465)

### DIFF
--- a/backend/app/api/v1/netbox_import/router.py
+++ b/backend/app/api/v1/netbox_import/router.py
@@ -231,7 +231,7 @@ class CommitIn(BaseModel):
     conflict_actions: dict[str, ConflictDecision] = Field(default_factory=dict)
     space_strategy: Literal["per_vrf", "single"] = "per_vrf"
     target_space_id: uuid.UUID | None = None
-    default_router_name: str = "NetBox import"
+    default_router_name: str = "Imported VLANs (NetBox)"
 
 
 class NetboxTestOut(BaseModel):

--- a/backend/app/services/netbox_import/commit.py
+++ b/backend/app/services/netbox_import/commit.py
@@ -989,13 +989,31 @@ async def _commit_vlan(
     )
 
 
+# Default name(s) the synthetic VLAN router shipped under before
+# ``default_router_name`` was renamed. A re-import must reuse an existing
+# router created under any of these rather than spawn a duplicate.
+_LEGACY_ROUTER_NAMES: tuple[str, ...] = ("NetBox import",)
+
+
 async def _ensure_router(db: AsyncSession, name: str) -> Router:
-    """Find-or-create the synthetic router VLANs hang off (UNIQUE name)."""
-    existing = (
-        (await db.execute(select(Router).where(Router.name == name).limit(1))).scalars().first()
-    )
-    if existing is not None:
-        return existing
+    """Find-or-create the synthetic router VLANs hang off (UNIQUE name).
+
+    Matches the requested ``name`` first, then any legacy alias, so renaming
+    the default no longer orphans a router an earlier import already created
+    (and leaves the imported VLANs hanging off a duplicate).
+    """
+    seen: set[str] = set()
+    for candidate in (name, *_LEGACY_ROUTER_NAMES):
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        existing = (
+            (await db.execute(select(Router).where(Router.name == candidate).limit(1)))
+            .scalars()
+            .first()
+        )
+        if existing is not None:
+            return existing
     row = Router(name=name, description="Synthetic router for NetBox-imported VLANs")
     db.add(row)
     await db.flush()

--- a/backend/app/services/netbox_import/commit.py
+++ b/backend/app/services/netbox_import/commit.py
@@ -1435,7 +1435,7 @@ async def commit_import(
     conflict_actions: dict[str, ConflictAction],
     space_strategy: str = "per_vrf",
     target_space_id: uuid.UUID | None = None,
-    default_router_name: str = "NetBox import",
+    default_router_name: str = "Imported VLANs (NetBox)",
     actor: User,
 ) -> CommitResult:
     """Apply ``preview`` to the DB, one entity per savepoint.

--- a/backend/tests/test_netbox_import.py
+++ b/backend/tests/test_netbox_import.py
@@ -517,7 +517,7 @@ async def test_commit_prefix_vlan_link(
 
     # The synthetic router exists and holds the deduped VLANs.
     router = (
-        await db_session.execute(select(Router).where(Router.name == "NetBox import"))
+        await db_session.execute(select(Router).where(Router.name == "Imported VLANs (NetBox)"))
     ).scalar_one()
     vlan_100 = (
         await db_session.execute(
@@ -551,7 +551,7 @@ async def test_commit_vlan_clash_skipped_not_500(
     assert result.total_failed == 0, [e.error for e in result.entities if e.error]
 
     router = (
-        await db_session.execute(select(Router).where(Router.name == "NetBox import"))
+        await db_session.execute(select(Router).where(Router.name == "Imported VLANs (NetBox)"))
     ).scalar_one()
     vlans = (
         (await db_session.execute(select(VLAN).where(VLAN.router_id == router.id))).scalars().all()

--- a/docs/reviews/ipam/00-SYNTHESIS.md
+++ b/docs/reviews/ipam/00-SYNTHESIS.md
@@ -1,0 +1,127 @@
+# SpatiumDDI IPAM — Consolidated UX Review
+
+**Synthesized from 10 persona reviews:** expert network engineer, first-time
+user, LAN administrator, novice NOC tech, accessibility specialist, visual/UX
+designer, NetBox migrant, mobile/responsive on-call user, information
+architect, enterprise-scale admin.
+
+Signal strength = how many personas independently raised a theme. Where
+personas genuinely disagree, the disagreement is preserved rather than
+averaged.
+
+---
+
+## Prioritized theme table (highest impact first)
+
+| # | Theme | Severity | Raised by (n) | Recommendation |
+|---|---|---|---|---|
+| 1 | **Bare "0" in IP detail modal** (REVERSE DNS ZONE / DNS-DHCP LINKAGE / counters) — looks broken, erodes trust | blocker | 9 | Fix the falsy-render bug; render zone NAME or em-dash; never surface a raw id/count. **(BUG)** |
+| 2 | **IPv6 /64 capacity math** — "0 / 9,223,372,036,854,776,000" (2^63 signed overflow, not 2^64) + meaningless 0% bar | blocker | 9 | For prefixes > ~/100 suppress denominator + % bar; show "/64 · N allocated"; fix the overflow. **(BUG + UX)** |
+| 3 | **No global / tree search** — can't jump to a CIDR, hostname, MAC, or IP; tree is the only way in | blocker (at scale) / high | 5 | Add a tree quick-filter now; ship a global Cmd-K search across all spaces deep-linking to subnet/IP. |
+| 4 | **Raw NetBox provenance leaking** — `netbox_id`, `netbox_is_pool false` chips on block header | high | 8 | Collapse to one "Imported from NetBox" chip; hide negative booleans; move raw fields behind a Provenance disclosure. |
+| 5 | **"NetBox import" string in the Router column** — provenance masquerading as a typed device value | high | 7 | Stop writing import source into Router; render unmapped values as "—" or "unmapped (imported)". **(BUG-adjacent)** |
+| 6 | **Unexplained green status dot in the tree** — no legend, no tooltip, conflated with the 4-state Seen dot | medium | 9 | Add tooltip/legend; if it is Seen-recency reuse that 4-state key; make the two dot systems visually distinct. |
+| 7 | **Status conveyed by color alone** (Seen dots, DNS "• in sync") — fails WCAG 1.4.1, invisible on touch (no hover) | blocker (a11y/mobile) / high | 4 | Shared `<StatusTag>` icon+text+color primitive; render the word in-cell, never a tooltip-only dot. |
+| 8 | **Mixed block+subnet table** — shared columns blank for ~half the rows; reads as missing data, not "N/A for blocks" | high | 6 | Add a Type column / row-type badge, or split into stacked "Child blocks" / "Subnets" tables; show block-level utilization. |
+| 9 | **VRF/BGP header treatment** — "not configured" nags newcomers, hides VRF from experts; lost-on-import for migrants | high | 6 | Collapse to a quiet chip when unset; promote VRF to a column/chip when set; map NetBox VRFs on import. |
+| 10 | **Wide tables break on mobile** (10–12 cols) — on-call essentials (Status/Seen) scroll off-screen right | blocker (mobile) | 2 | Stacked card layout < ~640px showing Address · Hostname · Status · Seen-as-text; collapse the rest behind tap. |
+| 11 | **No inline editing / multi-step allocate** — every hostname/tag/status fix is a modal round-trip | high | 2 | Double-click-to-edit cells; put Hostname + MAC in the Allocate modal so a new host is one form, one save. |
+| 12 | **No estate-wide filtering** — can't answer "subnets > 90% util" across spaces; no pagination/virtualization cue | high (at scale) | 1 | Estate-wide Subnets query page with column filters + saved views (model on the existing Stale-IP report). |
+| 13 | **Icon-only controls without names** — sidebar refresh/upload/+, per-row pencil/trash, copy icon | high (a11y) / low | 5 | Add accessible names incl. row identity ("Edit 10.1.0.5"); tooltips on sidebar icons; clarify what "upload" imports. |
+| 14 | **`auto:` prefix in tree labels** — machine token glued to CIDR; reads as debug/junk | medium | 7 | Render `auto:` as a muted badge + tooltip, not part of the name. |
+| 15 | **Inconsistent toolbar grammar across levels** — flat buttons → dropdown/Tools-overflow on drill-down | high (design) | 2 | One level-invariant toolbar grammar applied identically at Space/Block/Subnet. |
+| 16 | **Destructive vs read-only actions look identical** — Sync DNS / Merge / Resize undistinguished from Export | high (novice) | 2 | Visually separate mutating vs read-only; danger-style + blast-radius confirm on destructive items. |
+| 17 | **Jargon without inline help** — "aggregation suggestion / supernet", "Address Sets / RBAC-scoped slices", "Find Free", Role taxonomy | medium | 5 | Plain-language tooltips that don't explain jargon with more jargon; one-line definitions where the term appears. |
+| 18 | **Tree / modal / tab ARIA + focus** — likely div-based tree, draggable-modal focus loops, placeholder-as-label | high (a11y) | 1 | Audit shared tree + Modal once; real `role="tree"`, dialog focus trap/return, real labels not placeholders. |
+| 19 | **Flat IP-detail field grid** — 10 fields spanning 4 concepts with no subheads | low | 1 | Group into Identity / DNS & DHCP / Lifecycle subheads. |
+| 20 | **Role concept is half-wired** — filter chips at block level, per-IP "— None —" dropdown, "Legacy tag" tooltip | medium | 5 | Unify/clarify Role scope (IP vs subnet vs block); resolve legacy-vs-current ambiguity; map on import not into tags. |
+
+---
+
+## Likely bugs (defects, not preferences)
+
+1. **Bare "0" in IP detail modal.** Confirmed in two reviews against
+   `IPDetailModal.tsx:373`: `{(addr.alias_count || addr.nat_mapping_count) && (…)}`
+   — when both are 0, `0 || 0 → 0` and React renders the literal `0`. Fix:
+   `((alias_count ?? 0) > 0 || (nat_mapping_count ?? 0) > 0)`.
+2. **REVERSE DNS ZONE / DNS-DHCP LINKAGE render a raw FK id (often `0`)** when
+   the zone-name lookup misses. After a NetBox import (no reverse zones yet),
+   every IP shows `0`. Fix: treat falsy/zero ids as empty → em-dash; render the
+   zone NAME, never the id.
+3. **IPv6 /64 capacity overflow.** Shows `9,223,372,036,854,776,000` = 2^63
+   (signed-int / JS MAX_SAFE_INTEGER artifact), not the correct 2^64 ≈ 1.8e19.
+   The number is *wrong*, plus a 0% utilization bar against it is meaningless.
+4. **"NetBox import" written into the Router column** — the importer stamped a
+   provenance string into a typed operational field. Category error that will
+   break gateway reconciliation; affects thousands of rows at scale.
+5. *(Suspected)* **NetBox VRF/tenant not mapped on import** — every imported
+   space reads "VRF — not configured" and there is no Tenant/Customer column,
+   despite the importer claiming tenant→Customer. Reads as data loss to migrants.
+
+---
+
+## Quick wins (low effort, high value)
+
+- Fix the counters falsy-render `0` bug (one-line guard).
+- Em-dash fallback for empty zone/linkage fields; never print a raw id.
+- Suppress IPv6 host count + % bar for very large prefixes; show "/64 · N allocated".
+- Stop writing "NetBox import" into Router; render "—".
+- Collapse `netbox_id` / `netbox_is_pool false` into one "Imported from NetBox" chip.
+- Render `auto:` as a muted badge instead of a label prefix.
+- Add tooltip/legend to the tree green dot (or reuse the Seen 4-state key).
+- Tooltips + accessible names on sidebar refresh/upload/+ and per-row pencil/trash.
+- Real `aria-label`s on alias/filter inputs (placeholder is not a label).
+- Plain-English rewrites: "aggregation suggestion", "Address Sets", "Find free space…".
+- Collapse the VRF/BGP "not configured" nag to a quiet chip when unset.
+- Render in-cell text for Seen + DNS-sync states (don't rely on tooltip-only dot).
+
+## Big bets (structural / redesign)
+
+- **Global Cmd-K search + estate-wide Subnets query page** with column filters
+  and saved views — make search the primary nav, not the tree (scale story).
+- **Tree-at-scale**: virtualization / lazy-load on expand + an inline quick-filter.
+- **Mobile "on-call mode"**: stacked card IP list < 640px + full-screen
+  (non-draggable) detail sheet + persistent IP/hostname search.
+- **Inline cell editing** on the IP table (double-click Hostname/Tags/Status/Desc).
+- **One-form allocate** (Hostname + MAC in the Allocate modal).
+- **Shared `<StatusTag>` primitive** (icon+text+color) adopted everywhere to kill
+  color-alone — fixes WCAG 1.4.1 + touch + scannability in one move.
+- **Level-invariant toolbar grammar** across Space/Block/Subnet.
+- **Split the block+subnet table** into two nouns (or a first-class Type column).
+- **Invisible-import**: full field mapping at import time (VRF→Space, tenant→
+  Customer column, gateway→Router, role→Role, pool flag→reservation behavior).
+- **Accessibility pass** on shared tree + Modal (ARIA tree, focus trap/return).
+
+---
+
+## Genuine disagreements (do NOT average away)
+
+- **Density vs guidance.** The expert network engineer and enterprise admin
+  want *more* density, inline editing, no hand-holding, and explicitly do **not**
+  want the "Ask AI" button taking primary real estate. The first-time user and
+  novice NOC tech want *less* density, first-run empty-state guidance, jargon
+  defined inline, and clear safe-vs-dangerous styling. → Resolve with
+  progressive disclosure (dense default + opt-in guidance/help layer), not a
+  single compromise altitude.
+- **VRF prominence.** Expert/migrant want VRF promoted to a column/chip and
+  visible at a glance; first-timer/novice/on-call want it *hidden* because it
+  reads as intimidating or irrelevant. → Show prominently only when configured;
+  collapse to nothing/quiet chip when unset.
+- **Reserved (.0/.255/gateway) rows.** Novice and first-timer love them as a
+  protective teaching affordance; LAN admin wants a "hide reserved rows" toggle
+  to cut scroll on a /24. → Keep by default, add a sticky per-user hide toggle.
+- **"Ask AI" button.** Experts want it demoted out of the primary action row;
+  no persona defended its current prominence. → Demote into a Tools/overflow.
+
+---
+
+## What consistently works well (preserve)
+
+- **Dashed-emerald GAP row** ("245 free · click to allocate") — cited by every
+  persona as the best single affordance; turns a hole into a call-to-action.
+- **Greyed network/broadcast/gateway rows** — protective + teaches protocol reality.
+- **Subnet summary stat row** (Gateway · VLAN · Total · Allocated · Util%) — right density, right order.
+- **Allocation Map (Band/Treemap) + Find Free / Resize / Move / Aggregation suggestion** — real capacity tools.
+- **Seen 4-state dot** as an axis orthogonal to lifecycle status (modeling is right; presentation needs text).
+- **Self-explaining empty states** (Network Discovery / Device Profile) — name the cause AND the fix; the template the rest of IPAM should adopt.
+- **Status as text pills** (not color-only) where used — the correct pattern to extend.

--- a/docs/reviews/ipam/README.md
+++ b/docs/reviews/ipam/README.md
@@ -1,0 +1,33 @@
+# IPAM UX Review — 2026-06-28
+
+A point-in-time, multi-persona UX/presentation review of the SpatiumDDI **IPAM**
+pages (IP Spaces tree, Space / Block / Subnet detail, IP detail + edit modals).
+
+It is **review material**, not a spec — the actionable, deduplicated outcome is
+tracked in a GitHub issue. These files are kept for provenance and context.
+
+## How it was produced
+
+Ten independent reviewer personas each walked the IPAM UI from their own
+perspective and wrote a findings file; a synthesis pass then deduplicated the
+findings into cross-persona themes (signal = how many personas raised a theme),
+quick wins, big bets, likely-bugs, and genuine disagreements.
+
+The review was grounded in screenshots of the live UI plus the actual frontend
+component source. Several "likely bugs" were subsequently confirmed against the
+code before being filed.
+
+## Contents
+
+- [`00-SYNTHESIS.md`](00-SYNTHESIS.md) — **start here**: consolidated, prioritized findings
+- Per-persona reports:
+  - [`expert-network-engineer.md`](expert-network-engineer.md)
+  - [`first-time-user.md`](first-time-user.md)
+  - [`lan-administrator.md`](lan-administrator.md)
+  - [`novice-noc-tech.md`](novice-noc-tech.md)
+  - [`accessibility-specialist.md`](accessibility-specialist.md)
+  - [`visual-ux-designer.md`](visual-ux-designer.md)
+  - [`netbox-migrant.md`](netbox-migrant.md)
+  - [`mobile-responsive-user.md`](mobile-responsive-user.md)
+  - [`information-architect.md`](information-architect.md)
+  - [`enterprise-scale-admin.md`](enterprise-scale-admin.md)

--- a/docs/reviews/ipam/accessibility-specialist.md
+++ b/docs/reviews/ipam/accessibility-specialist.md
@@ -1,0 +1,171 @@
+# IPAM Accessibility (WCAG 2.1 AA) Review — SpatiumDDI
+
+## Who I am & what I want
+
+I'm an accessibility specialist. I audit against WCAG 2.1 AA, and I test
+every screen three ways: (1) keyboard only, no mouse — Tab/Shift-Tab,
+Enter/Space, arrow keys, Esc; (2) with a screen reader (NVDA/VoiceOver),
+listening to what each control announces; (3) for color independence —
+I desaturate the screen and check whether anything that mattered just
+vanished. My non-negotiables here: status that doesn't rely on color
+alone (WCAG 1.4.1), 4.5:1 text contrast / 3:1 non-text contrast (1.4.3,
+1.4.11), a visible focus indicator on everything operable (2.4.7),
+logical focus order with no traps (2.4.3 / 2.1.2), name/role/value on
+every custom control (4.1.2), and accessible names on icon-only buttons
+(2.5.3 / 4.1.2). A dense network tool like IPAM is exactly where these
+break, because the whole UI is built out of tiny colored dots, pills,
+icon buttons, and a deep tree — none of which are accessible by default.
+
+What I want: to navigate the Space → Block → Subnet tree, read an IP
+table, and operate the IP detail / edit modals entirely from the
+keyboard and with a screen reader, and to never need to perceive color
+to understand "is this IP alive?" or "is DNS in sync?".
+
+## Page-by-page walkthrough
+
+**IP Spaces tree (left sidebar).** This is the spine of IPAM and my
+first worry. A tree of Space → Block → Subnet with expand/collapse is a
+classic ARIA `tree` widget, and they almost never get implemented as
+one. The little green dot next to each subnet has "unexplained meaning"
+even to sighted users — so it certainly has no text equivalent for a
+screen reader, and it fails color-alone. The refresh / upload / + icons
+in the sidebar header are icon-only; I need to confirm they have
+accessible names. The auto-block label "auto:10.50.0.0/24" reads fine.
+My core question: can I expand a Space with the Right-arrow / collapse
+with Left-arrow and move with Up/Down, and does the SR announce
+"Acme-Prod, tree item, collapsed, level 1, 3 of 5"? If this is a pile
+of nested `<div onClick>`s, the tree is unusable by keyboard.
+
+**Space detail (level 1).** Header line "VRF / BGP — not configured
+(Edit Space to add)" is good plain-language. The action buttons have
+text labels — good. The combined block+subnet table has 10 columns
+(checkbox, Network, Name, Router, VLAN, Used IPs, Utilization, Size,
+Status, Environment). Two issues jump out: (1) "Utilization" is shown
+as a percentage AND likely a colored mini-bar — if the bar carries
+meaning beyond the number that's a color-redundancy check; the number
+saves it, good. (2) Sortable "Network" column — does the header expose
+`aria-sort` and is it a real `<button>` inside `<th>`? Sort state is
+typically conveyed by a caret glyph only, which is color/shape with no
+programmatic state. The "Status" column ("active") is text — good,
+that's the right pattern, color can decorate it.
+
+**Block detail (level 2).** Breadcrumb "pills" — are these a real
+`<nav aria-label="Breadcrumb">` with an ordered list, and is the
+current page marked `aria-current="page"`? The raw metadata chips
+"netbox_id 1   netbox_is_pool false" are visual noise but readable.
+The yellow "1 aggregation suggestion" badge — yellow on white is my
+contrast red flag; amber/yellow text or badges routinely fail 4.5:1.
+The **ALLOCATION MAP** is my biggest concern on this page: a striped
+horizontal band with legend "Child blocks / Subnets / Free (saturated
+portion = % allocated)". This is a graphical data viz encoding
+allocation by color + stripe pattern. For a screen reader this band is
+almost certainly an empty/meaningless `<div>` — there's no text
+alternative for "X% allocated, child blocks occupy this range." It
+needs an accessible summary (1.1.1). The [Band]/[Treemap] toggle — is
+it a proper toggle/tablist with pressed state? The ROLE filter chips
+[Data][Voice][Management][Guest] are toggle buttons; they must expose
+`aria-pressed` and not signal "selected" by background color alone.
+
+**Subnet detail (level 3).** The richest and most dangerous screen.
+- The title row "10.1.0.0/24  active  Office-LAN" — status as a pill
+  with text "active": good, color-independent.
+- The **tabs** [IP Addresses][DHCP Pools][Aliases][Address Sets][NAT]
+  [Trend] must be a real `role="tablist"` with arrow-key navigation,
+  `aria-selected`, and `tabpanel` association. shadcn Tabs usually get
+  this right — I'd verify, but it's the one widget likely to pass.
+- The **IP table** has 12+ columns plus per-row pencil/trash. Two hard
+  fails I can predict: (a) **Seen column** = colored dots only; (b)
+  **DNS column** = "• in sync" where the bullet is a colored dot and
+  "in sync"/"Missing in DNS"/"Mismatched" status leans on color. The
+  per-row **pencil/trash** icon buttons need accessible names that
+  include the row identity ("Edit 10.1.0.5", not just "Edit").
+- The **greyed network/broadcast/reserved rows** (.0, .255, gateway)
+  are dimmed muted text — this is my #1 contrast bet: greyed-out rows
+  on a dark/light surface almost always drop under 4.5:1. WCAG has no
+  exemption for "disabled-looking" informational rows; these aren't
+  disabled controls, they're data, so 1.4.3 applies.
+- The dashed-emerald **GAP row** "10.1.0.10 – 10.1.0.254 · 245 free ·
+  click to allocate" is clever visually but: it's encoded by a dashed
+  EMERALD border (color + style), the text says "click to allocate"
+  (mouse-only verb — fails 2.1.1 if it's not keyboard-focusable and
+  Enter-activatable), and a screen reader needs to know this is an
+  actionable region, not a data row. Is it a `<button>`/`<a>` or a
+  `<tr onClick>`? If the latter, it's invisible to keyboard + SR.
+
+**IP detail modal.** Read-only panel. Modal accessibility checklist:
+does focus move into the dialog on open, is it `role="dialog"`
+`aria-modal="true"` with an `aria-labelledby` pointing at the IP
+header, is focus trapped, does Esc close, and does focus return to the
+triggering row on close? The header IP + **copy icon** is icon-only —
+needs "Copy IP address". The status pill + dot is fine (text present).
+The 2-col field grid is readable, BUT the observed quirk where
+**REVERSE DNS ZONE shows a bare "0"** and **DNS/DHCP LINKAGE shows
+"0"** is an accessibility problem too, not just UX: a screen reader
+announces "Reverse DNS zone, 0" which is meaningless — that's a
+name/value mismatch (4.1.2) and an info clarity failure. The empty
+states ("No network discovery data…", "No active profile yet…") are
+excellent plain-language and they reference paths/toggles clearly.
+
+**Edit IP modal.** Tabs [Details][Network][Scan with Nmap]. Form
+fields mostly have visible labels (Hostname, Description (Optional),
+MAC Address, Status, Role) — good, as long as the label is
+programmatically associated (`<label for>` / `aria-labelledby`), not
+just visually adjacent. The **DNS Aliases** row "[CNAME v] dropdown +
+'alias name (e.g. www, mail)' + [+ Add]" — the text input relies on
+placeholder text as its only label; placeholder is NOT an accessible
+name and disappears on input (fails 1.3.1/3.3.2 / "Label in Name").
+The "(empty clears field)" / "Auto-assigned if blank" helper texts are
+good but must be wired via `aria-describedby` to actually be announced.
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| blocker | Subnet detail / Seen column (SeenDot.tsx) | Status is a bare `<span>` colored dot (emerald/amber/rose/grey) with state conveyed by **color only**. The meaning lives only in `title`/`aria-label` — invisible to keyboard-only and color-blind sighted users. Fails WCAG 1.4.1 Use of Color. The span isn't focusable, so `title` never appears for keyboard users either. | Add a non-color cue: a short text token next to/under the dot ("alive"/"stale"/"cold"/"never") or distinct icon shapes (●/◐/○). Keep `aria-label`. Make the cell text-readable so desaturation doesn't destroy it. |
+| blocker | Subnet detail / DNS column | "• in sync" / "Missing in DNS" / "Mismatched" encode sync state with a colored bullet. The tooltip strings ("DNS records match IPAM"/"Missing in DNS"/"Mismatched") confirm the states exist but the in-table glyph leans on color. Fails 1.4.1. | Always render the word ("In sync"/"Missing"/"Mismatched") in the cell, not just a colored dot; use an icon with distinct shape (✓ / ! / ≠) in addition to color. |
+| blocker | Subnet detail / GAP "click to allocate" row | Dashed-emerald row says "click to allocate" — a mouse-only affordance. If it's a `<tr onClick>` it's not keyboard-focusable/activatable (2.1.1 Keyboard) and a screen reader can't tell it's actionable (4.1.2). The dashed-emerald styling is the only signal it differs from data rows (1.4.1). | Make it a real `<button>` (or row with `role="button"`, `tabindex=0`, Enter/Space handler). Accessible name: "Allocate an IP in 10.1.0.10–10.1.0.254 (245 free)". Add a non-color cue (icon/label), not just dashed emerald. |
+| high | IP Spaces sidebar / tree | Space→Block→Subnet tree likely built from nested clickable divs, not an ARIA `tree`. Without `role="tree"/"treeitem"`, `aria-expanded`, `aria-level`, and arrow-key navigation it is not keyboard-operable and SR-announceable. Fails 2.1.1 / 4.1.2 / 2.4.3. | Implement as a real tree: `role="tree"` container, `treeitem` rows with `aria-expanded`, `aria-level`, `aria-selected`; Up/Down move, Right/Left expand/collapse, Enter activates. The unexplained green subnet dot also needs a text/aria meaning. |
+| high | Greyed .0/.255/gateway rows | Network/broadcast/reserved rows render as dimmed muted text. Greyed informational text almost always falls below 4.5:1 (1.4.3). These are data, not disabled controls, so no exemption applies. | Raise muted-text color to meet 4.5:1 in both themes; convey "Network/Broadcast/Reserved" via the existing text label + a non-color marker, not just dimming. Verify with a contrast checker in dark AND light. |
+| high | Per-row + modal icon buttons | Pencil/trash per IP row and the copy icon in the IP detail header are icon-only. If their accessible name is generic ("Edit"/"Delete") or absent, SR users get "button" with no context. Fails 2.5.3 / 4.1.2. | Give each a name that includes the target: "Edit 10.1.0.5", "Delete 10.1.0.5", "Copy IP address 10.1.0.5". Use `aria-label`; ensure a visible focus ring (2.4.7). |
+| high | Edit IP modal / DNS Aliases + filters | The alias-name input and the tag-filter inputs ("Filter addresses by tag…") rely on placeholder text as their only label. Placeholder is not an accessible name and vanishes on typing (1.3.1 / 3.3.2). | Add a real `<label>` (visually-hidden if needed) or `aria-label` to every text input. Wire helper text ("Auto-assigned if blank", "(empty clears field)") via `aria-describedby`. |
+| high | Block detail / ALLOCATION MAP band + treemap | The striped allocation band and treemap encode allocation by color + stripe pattern with no text alternative (1.1.1) and likely fail 1.4.11 non-text contrast between the Child-blocks/Subnets/Free segments. SR users get nothing. | Add an accessible summary ("64% allocated: 12 subnets, 3 child blocks, 245 addresses free") as visually-hidden text or a caption; ensure ≥3:1 contrast between adjacent segments; don't rely on stripe-vs-solid alone. |
+| medium | All modals (IP detail, Edit, Create/Edit Space/Block/Subnet, Confirm-Destroy, etc.) | Need to verify dialog semantics across the ~25 modals: `role="dialog"` + `aria-modal`, `aria-labelledby` to the title, focus moved in on open, focus trap, Esc to close, focus returned to trigger on close (2.4.3 / 2.1.2 / 4.1.2). Draggable modals especially risk a broken focus loop. | Audit the shared `Modal`/`useDraggableModal` once — fixing it there fixes all IPAM modals. Confirm the drag handle is not the only way to operate and doesn't steal focus order. |
+| medium | IP detail modal / "0" values | REVERSE DNS ZONE and DNS/DHCP LINKAGE render a bare "0" with no units/label context. SR announces "Reverse DNS zone, 0" — meaningless; an info-clarity + name/value failure (4.1.2). | Render an explicit empty/none state ("Not configured" / "—") or the real value with units; never surface a raw numeric id as a field value. |
+| medium | Block detail / yellow badge + sort carets | The yellow "1 aggregation suggestion" badge risks failing 4.5:1; sortable column carets convey sort by glyph/color with no `aria-sort` state. (1.4.3 / 4.1.2) | Darken the amber badge to pass contrast; add `aria-sort="ascending|descending|none"` on sortable `<th>` and make the header a real button. |
+| medium | ROLE filter chips + [Band]/[Treemap] toggle | Toggle chips ([Data][Voice][Management][Guest]) and the Band/Treemap switch convey selected state by background color. Without `aria-pressed`/`aria-selected` the state is invisible to SR and to color-blind users (1.4.1 / 4.1.2). | Use `aria-pressed` (toggle buttons) or a `role="tablist"` for Band/Treemap; add a non-color selected cue (underline/checkmark/border). |
+| low | Wide IP table (12+ columns) | Many-column table on narrow viewports forces horizontal scroll; need `<th scope="col">`, a `<caption>` or `aria-label` on the table, and the scroll container must be keyboard-scrollable + focusable (1.3.1 / 2.1.1). | Ensure proper `scope` attributes and a table caption; verify the horizontal-scroll wrapper is reachable by keyboard (tabindex=0 + role/region+label). |
+| low | IPv6 huge-number cells | "/64 … 9,223,372,036,854,776,000" reads as a 19-digit string to a screen reader — exhausting and unhelpful. | For huge counts, show "~9.2 quintillion (/64)" with the precise value in `title`/`aria-describedby`, or label as "effectively unlimited". |
+
+## What works well
+
+- **Status as text, not just color, in the right places.** Subnet
+  "active" status pill and the table "Status" column use the word — that's
+  the correct color-independent pattern, and it shows the team knows how
+  to do it. The fix for Seen/DNS is to extend this same habit.
+- **Excellent plain-language empty states.** "No network discovery data —
+  add the upstream switch in /network and wait a polling cycle." and
+  "No active profile yet. Auto-profiling triggers on a fresh DHCP lease…"
+  are clear, actionable, and read perfectly on a screen reader.
+- **Visible field labels on most form fields** (Hostname, MAC Address,
+  Status, Role) rather than placeholder-only — the alias/filter inputs are
+  the exception, not the rule.
+- **Helpful descriptive tooltips/helper text** ("Find unused CIDRs in this
+  block", "(empty clears field)", "Auto-assigned if blank") — good raw
+  material; they just need `aria-describedby` wiring to be announced.
+- **Tabs** likely inherit shadcn's accessible `role="tablist"` behavior —
+  one of the few complex widgets I expect to pass out of the box.
+
+## My one big idea
+
+**Kill "color-alone" across IPAM with one shared `<StatusTag>` primitive
+— icon + text + color, never color alone — and adopt it for Seen, DNS
+sync, status pills, role chips, and the allocation legend.** Right now
+the most information-dense parts of IPAM (the Seen dots and DNS "in sync"
+bullets in every IP row) are pure-color spans whose meaning lives only in
+a `title` attribute that keyboard and color-blind users never receive.
+A single primitive that always renders a distinct-shape icon + a short
+text label, with color as decoration on top, fixes WCAG 1.4.1 everywhere
+at once, makes the tables scannable when desaturated, and gives screen
+readers a real name to announce. Pair it with one audit of the shared
+`Modal`/tree components (focus management + ARIA roles) and IPAM goes
+from "fails the first three things I test" to genuinely AA-conformant.

--- a/docs/reviews/ipam/enterprise-scale-admin.md
+++ b/docs/reviews/ipam/enterprise-scale-admin.md
@@ -1,0 +1,138 @@
+# IPAM Review — Enterprise Admin at Scale (10k+ subnets)
+
+## Who I am & what I want
+
+I run IPAM for a large org: tens of IP spaces, thousands of blocks, 10k+ subnets,
+hundreds of thousands of allocated addresses across IPv4 and IPv6. My day is not
+"create one subnet." My day is:
+
+- Jump to a *specific* subnet or IP in under 5 seconds without remembering which
+  space/block it lives under.
+- Answer questions that span the whole estate: "show me every subnet over 90%
+  utilization," "where does 10.84.17.5 live," "which subnets haven't been touched
+  in a year."
+- Trust that the tree, the tables, and the maps don't fall over (or scroll
+  forever) when the dataset is large.
+- Do bulk things safely — allocate ranges, deprecate stale IPs, reconcile drift —
+  with guardrails and a clear blast radius.
+
+My core test of this product: **does it stay usable as a navigation and search
+problem at 10k subnets, or is it a tool designed for 10 subnets with a tree bolted
+on?** I navigate by search and by saved filters, almost never by clicking down a
+tree.
+
+## Page-by-page walkthrough
+
+### IP Spaces tree (left sidebar)
+First thing I look for: a **global search box at the top of the sidebar**. I don't
+see one described — just refresh / upload / + icons. That's an immediate red flag.
+At 10k subnets a Space → Block → Subnet tree is an *infinite scroll*. Acme-Prod
+alone could be hundreds of blocks each with dozens of subnets. Expanding to find
+`10.84.17.0/24` by eye is a non-starter. I need to type "10.84.17" or "Office-LAN"
+and teleport.
+
+The little green dot on subnets with "unexplained meaning" bugs me — at scale,
+every pixel of signal needs a legend or a tooltip, otherwise it's noise I learn to
+ignore. The `auto:10.50.0.0/24` auto-block labels are honest provenance, but in a
+tree of thousands they add visual clutter; I'd want to collapse/hide auto-created
+scaffolding.
+
+No mention of tree **virtualization** or lazy-loading. If the sidebar renders
+every space/block/subnet node into the DOM, the browser will choke. I'd want to
+confirm nodes are loaded on expand and the list is windowed.
+
+### Space detail (level 1)
+The combined block+subnet table with sortable Network, plus Utilization / Used IPs
+/ Status / Environment columns is genuinely useful — this is the altitude I work
+at. Sortable Network is good. But:
+- **No visible pagination/virtualization cue.** A flat space can hold thousands of
+  rows. Is this windowed? Is there a row count? "Showing 1–200 of 4,312"? Without
+  that I don't trust it's showing me everything.
+- **No column filter for Utilization.** My #1 recurring query is "subnets > 90%."
+  I can sort by Utilization, but sort ≠ filter, and sort only helps within one
+  space. I have dozens of spaces.
+- The "VRF / BGP — not configured (Edit Space to add)" line is fine for one space
+  but it's prime real estate repeated on every space header.
+
+### Block detail (level 2)
+The ALLOCATION MAP (Band/Treemap toggle, "Plan allocation…", role filter chips
+[Data][Voice][Management][Guest], "Find Free…") is the strongest part of the IPAM
+UX for *planning within a block*. I like Find-Free, Resize, Move, and the
+aggregation-suggestion badge — those are real enterprise capacity-management
+features, not toy features.
+
+The wart: raw provenance chips on the header — `netbox_id 1`,
+`netbox_is_pool false`. That's a database column leaking into operator chrome. At
+scale I imported from NetBox; I do NOT want `netbox_id`/`netbox_is_pool` shouting
+at me on every block I open. Hide it behind a "Provenance" disclosure or a metadata
+tab.
+
+### Subnet detail (level 3)
+This page is well-built for a single subnet: summary stats (Gateway/VLAN/Total/
+Allocated/Utilization), tabs (IP Addresses / DHCP Pools / Aliases / Address Sets /
+NAT / Trend), the GAP row ("10.1.0.10 – 10.1.0.254 · 245 free · click to
+allocate") is a lovely touch, and the Seen-dot column is exactly the staleness
+signal I need. Bulk Allocate and the Tools menu are good.
+
+But this is *per subnet*. Everything good here is locked to one /24. None of it
+answers a cross-estate question.
+
+The IPv6 quirk is the clearest "designed for /24s" tell: a /64 showing **Used IPs
+0 / 9,223,372,036,854,776,000** and Size 9.2 quintillion. Utilization % is
+meaningless for a /64; "Allocated 11 / 254" is the right mental model for v4 and
+absurd for v6. For v6 I want "N addresses allocated" and "no utilization bar," not
+a fake denominator.
+
+### IP detail modal
+Decent read-only panel. Two concrete data bugs visible: **REVERSE DNS ZONE shows a
+bare "0"** and **DNS / DHCP LINKAGE shows "0"** — numeric values with no label or
+units. At scale these unlabeled zeros will generate support tickets ("why does my
+reverse zone say 0?"). The NETWORK DISCOVERY and DEVICE PROFILE empty states are
+well-worded and tell me exactly what to do.
+
+### Edit IP modal
+Clean. DNS Aliases, Role dropdown, MAC history, Owner custom field — all sensible.
+The "Legacy tag — assign a Router/VLAN from the Edit modal" tooltip and the literal
+`NetBox import` text in a Router column tell me migration leftovers are surfacing in
+operator-facing fields. At my scale that's thousands of rows carrying "NetBox
+import" as a router name.
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| blocker | Spaces tree / global nav | No global search to jump to a subnet/IP/hostname across all spaces. A Space→Block→Subnet tree is unusable as the primary nav at 10k subnets. | Add a prominent global search/command-palette (Cmd-K) that searches CIDR, name, hostname, MAC, tag across all spaces and deep-links to the subnet/IP. This is the single most important scale feature. |
+| high | Space/Block tables | No visible pagination/virtualization or total-count cue ("Showing 1–200 of N"). At scale I can't tell if the table is complete or truncated. | Show row counts + page controls; confirm tables are virtualized/server-paginated. Persist sort/filter in the URL. |
+| high | Cross-estate filtering | No way to answer "all subnets with utilization > 90%" across spaces. Sort is per-space and not a filter. | Add an estate-wide subnet search page with column filters (utilization range, status, role, VLAN, tag, environment) — the Stale-IP report proves the pattern exists; replicate it for utilization/capacity. |
+| high | IPv6 modeling | /64 shows Used 0 / 9.2 quintillion and a meaningless Utilization %. The whole "X / total + %" model assumes small v4 subnets. | For prefixes larger than ~/100, drop the denominator + % bar; show "N addresses allocated" and a capacity descriptor instead. |
+| medium | IP detail modal | REVERSE DNS ZONE and DNS/DHCP LINKAGE render a bare "0" — unlabeled numeric with no units. Will generate confusion/tickets at volume. | Show the actual zone name (or "— none —") and a human linkage label; never render a raw count/ID with no label. |
+| medium | Block detail header | Raw `netbox_id`/`netbox_is_pool` provenance chips clutter every imported block. | Move import provenance behind a "Provenance"/"Metadata" disclosure or tab; don't show raw DB column names in chrome. |
+| medium | Migration leftovers | Literal "NetBox import" text shows in the Router column; "Legacy tag" tooltips. Thousands of rows carry import artifacts as real values. | Post-import cleanup pass / a filter to surface and bulk-fix import-stub values; don't let provenance masquerade as operator data. |
+| medium | Sidebar tree | Unexplained green subnet dot + `auto:` block clutter add noise at scale; no way to collapse auto-created scaffolding. | Add a legend/tooltip for the dot; add a toggle to hide auto-generated blocks; ensure tree is lazy-loaded + virtualized. |
+| low | Bulk-allocate cap | Bulk allocate is capped (1024) and Stale-deprecate at 5000 — fine, but a 10k-subnet operator hits caps constantly and must re-run manually. | Surface "capped — N remaining, run again" clearly (Stale report does this) and consider a queued/async bulk job for very large ranges. |
+| low | Space header | "VRF / BGP — not configured" repeated per space consumes header space when most spaces won't use it. | Collapse to a single quiet chip; only expand when configured. |
+| nit | Subnet utilization | "0 / 256" and "0%" are clear, but no quick "near-full" visual at the list level beyond the bar. | Add an at-a-glance capacity badge (e.g. red ≥90%) and make it filterable. |
+
+## What works well
+
+- **Find-Free, Resize, Move, Aggregation suggestions, Plan Allocation, Allocation
+  Map (Band/Treemap)** — these are genuine capacity-management tools, not toys.
+  This is the part that signals the team understands enterprise IPAM.
+- **Stale-IP Report** is exactly the cross-subnet hygiene view I need, *and* it has
+  the right scale ergonomics: space filter, server pagination (200/page), a
+  bulk-deprecate cap with a "capped — run again" signal, and reversible action.
+  This is the template the rest of IPAM should follow.
+- **Seen-dot staleness signal + GAP rows** ("245 free · click to allocate") are
+  excellent operator affordances.
+- Empty states (NETWORK DISCOVERY, DEVICE PROFILE) are specific and actionable —
+  they tell me the exact next step.
+
+## My one big idea
+
+**Make estate-wide search + saved filtered views the primary navigation model, not
+the tree.** Ship a global Cmd-K search (CIDR / name / hostname / MAC / tag across
+all spaces, deep-linking straight to the subnet or IP) AND a top-level "Subnets"
+query page with column filters and saved views — modeled directly on the Stale-IP
+Report you already built. Then the tree becomes a nice-to-have browse affordance
+instead of the only way in. At 10k subnets, whoever owns search owns the product;
+right now the tree is the front door and it doesn't scale.

--- a/docs/reviews/ipam/expert-network-engineer.md
+++ b/docs/reviews/ipam/expert-network-engineer.md
@@ -1,0 +1,207 @@
+# SpatiumDDI IPAM — Review through a Senior Network Engineer's eyes
+
+## Who I am & what I want
+
+I've run IPAM for a large multi-VRF network for years — Infoblox at the
+old shop, phpIPAM and NetBox more recently. On a heavy day I'm touching
+50–100 subnets: carving new blocks, reclaiming stale space, fixing VLAN
+tags, reconciling DNS, exporting for an audit. What I care about:
+
+- **Speed and keyboard efficiency.** Every modal-with-three-clicks where a
+  Tab + inline edit would do is friction multiplied by 100.
+- **Dense, correct information.** I want to see utilization, VLAN, VRF,
+  role, status at a glance. I don't want columns that hide the thing I'm
+  actually managing.
+- **Correct CIDR / capacity math.** I will notice immediately when a /64
+  utilization number is nonsense.
+- **VRF / VLAN / ASN as first-class citizens**, not afterthoughts.
+- **Respect for my expertise** — no hand-holding wizards for things I do
+  in my sleep, no wasted confirmation steps, but DO protect me from the
+  genuinely irreversible.
+
+I do NOT need an "Ask AI" button on every screen. I need bulk ops that
+work and a table I can scan.
+
+## Page-by-page walkthrough
+
+### Spaces tree (left sidebar)
+
+First impression is good — Space → Block → Subnet is the right mental
+model and matches how I think (VRF-ish container → aggregate → leaf).
+But:
+
+- The **green dot next to every subnet has no legend.** In the tree it
+  means... what? Status? Reachability? Sync state? I'm guessing, and I
+  hate guessing in an IPAM tool. The subnet-detail "Seen" dots have a
+  documented 4-state meaning (alive<24h / stale / cold / never) — if the
+  tree dot is the same thing, tell me; if it's something else, definitely
+  tell me.
+- **`auto:10.50.0.0/24` blocks** are leaking an internal naming
+  convention into my navigation. I know what an auto-created container
+  block is, but a fresh operator will think someone fat-fingered a name.
+  At minimum render the `auto:` as a muted badge, not part of the label.
+- Sidebar header icons (refresh / upload / +) are **icon-only with no
+  labels.** Upload = import what, exactly? Spaces? A CSV? I'd hover, but
+  on a 100-subnet day I shouldn't have to.
+- No **search/filter box in the tree.** With dozens of spaces and
+  hundreds of blocks this tree becomes a scroll-hunt. NetBox's prefix
+  search is the thing I reach for constantly; its absence here is the
+  single biggest day-to-day speed gap.
+
+### Space detail (level 1)
+
+The combined **blocks-AND-subnets-in-one-table** is a defensible choice
+and the columns (Network / Name / Router / VLAN / Used IPs / Utilization
+/ Size / Status / Environment) are the right ones. Sortable Network is
+exactly what I want.
+
+Problems:
+
+- **`VRF / BGP — not configured (Edit Space to add)`** as a header line
+  is honest but reads like a nag. For someone who runs VRFs, burying VRF
+  behind "Edit Space" (a modal) means I can't see at a glance which space
+  maps to which VRF/RD across my estate. VRF should be a column or a
+  prominent chip, not a parenthetical.
+- Blocks show **only Network + Size**, blank everywhere else. Half my
+  table is empty cells. A block has a meaningful utilization (allocated
+  child space / total) — Infoblox and NetBox both show it. Showing blanks
+  makes the aggregate level feel like dead weight.
+- **`Router` column** showing the literal string `"NetBox import"` (from
+  the migration) is provenance pollution in an operational column. And
+  the tooltip elsewhere even says Router is a "Legacy tag — assign a
+  Router/VLAN from the Edit modal." If it's legacy, why is it a
+  first-class column competing for width with VLAN?
+
+### Block detail (level 2)
+
+The **ALLOCATION MAP with Band/Treemap toggle** is genuinely nice — this
+is the phpIPAM "visual subnet map" done better, and the saturated-portion
+= % allocated encoding reads fast once you know it. "Plan allocation…"
+and "Find Free…" are the right verbs. Aggregation-suggestion badge is a
+power feature I'd actually use.
+
+But:
+
+- **`netbox_id 1   netbox_is_pool false`** raw provenance chips on the
+  detail header are developer debris. I do not care that this came from
+  NetBox row 1, and `netbox_is_pool false` is double-negative noise.
+  Collapse all import provenance into one "Imported from NetBox" chip
+  with details on hover.
+- The **ROLE filter chips [Data][Voice][Management][Guest]** are great,
+  but role is filterable here yet (per the Edit-IP modal) set per-IP as a
+  "— None —" dropdown. Where do block/subnet roles get set? The model
+  feels half-wired.
+- The legend "Child blocks / Subnets / Free (saturated portion = %
+  allocated)" is doing a lot of work in small text. Fine for me after one
+  read; worth a hover-explainer.
+
+### Subnet detail (level 3)
+
+This is where I live, and it's mostly strong. The summary row (Gateway ·
+VLAN · Total IPs · Allocated 11/254 · Utilization 4%) is exactly the
+density I want. The IP table columns are well chosen, the greyed
+network/broadcast/gateway rows are correct and respectful of how the
+address space actually works, and the **dashed-emerald GAP row
+("10.1.0.10 – 10.1.0.254 · 245 free · click to allocate")** is a
+genuinely excellent touch — that's the kind of "see the hole, fill the
+hole" affordance Infoblox never gave me. Delight.
+
+`DNS · in sync` per row and the **Seen** dots are good operational signal.
+
+Friction:
+
+- **No inline editing.** To fix a hostname or a tag I open a modal. For
+  one IP, fine. For the 30 IPs I'm cleaning up after a migration, that's
+  30 modal round-trips. Double-click-to-edit-cell would change my day.
+- **The /64 IPv6 subnet shows "Used IPs 0 / 9223372036854776000" and
+  Size "9,223,372,036,854,776,000".** This is wrong on two counts: (1) a
+  /64 has 2^64 ≈ 1.8e19 addresses, and that number is 2^63 — it's
+  overflowing into a signed 64-bit and showing half the real value; (2)
+  showing a raw 19-digit integer and a 0% utilization bar for an IPv6
+  /64 is meaningless. Every serious IPAM shows IPv6 as "/64" with
+  allocated-count, never a denominator. This will make an IPv6 operator
+  distrust the whole tool's math.
+- **Tabs [IP Addresses][DHCP Pools][Aliases][Address Sets][NAT][Trend]**
+  — six tabs is a lot, and Aliases/Address Sets/NAT are niche enough that
+  they push the thing I use 95% of the time (IP Addresses) into
+  competing for attention. Fine, but consider a "more" overflow.
+- **"Ask AI"** sitting in the primary button row next to [Edit] and
+  [+ Allocate IP] is button-bar real estate I'd rather give to a power
+  action. I'm never going to ask an LLM about a /24 I can read myself.
+
+### IP detail modal (read-only)
+
+Clean 2-col grid, copy icon on the IP, status pill — good. But:
+
+- **`REVERSE DNS ZONE` shows a bare "0"** and **`DNS / DHCP LINKAGE`
+  shows "0".** I checked: the linkage row is a falsy-render bug — when
+  alias_count and nat_mapping_count are both 0, the `{(a || b) && …}`
+  guard renders the literal `0`. And the zone fields render the raw
+  `reverse_zone_id` (a UUID/number) instead of the zone name when the
+  name lookup misses. Either way, an unlabeled numeric "0" in a DDI tool
+  is exactly the kind of thing that makes me file a bug and lose trust in
+  the rest of the panel. **Show the zone NAME or an em-dash; never a bare
+  id, never a stray 0.**
+- The empty states for NETWORK DISCOVERY and DEVICE PROFILE are
+  well-written and actually tell me how to populate them (add the switch
+  in /network, enable subnet device-profiling). That's the right tone.
+
+### Edit IP modal
+
+- Tabs [Details][Network][Scan with Nmap] — sensible. DNS Aliases inline
+  with a CNAME dropdown + "+ Add" is good; the helper text ("removed
+  automatically when the IP is purged") is exactly the kind of
+  consequence-disclosure I want.
+- **Role is a "— None —" dropdown here** but a filter-chip set at the
+  block level — confirm these are the same taxonomy. If block roles and
+  IP roles are different concepts sharing the word "Role," that's a trap.
+- Custom Fields showing "Owner" with good helper text — fine.
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| Blocker | Subnet detail / IPv6 capacity | /64 shows "0 / 9223372036854776000" — that's 2^63 (signed-int overflow), not 2^64; raw 19-digit denominator + 0% bar is meaningless for IPv6 | For prefixes ≤ /64 (or below some host threshold) drop the denominator and % bar entirely; show "/64 · N allocated". Fix the integer math so it never overflows. |
+| High | IP detail modal / DNS-DHCP fields | REVERSE DNS ZONE renders a bare "0" and DNS/DHCP LINKAGE renders "0" — falsy-render bug + raw id leaking instead of zone name | Render the zone NAME (fall back to em-dash, never the id); fix the linkage guard so 0+0 shows an em-dash, not literal 0 |
+| High | Spaces tree | No search/filter box — finding a prefix in a large estate is a scroll-hunt | Add a prefix/name search at the tree top (NetBox-style); ideally jump-to-CIDR |
+| High | Subnet detail / IP table | No inline cell editing — every hostname/tag/status fix is a modal round-trip; brutal at scale | Double-click-to-edit on Hostname/Description/Tags/Status; keep modal for full edit |
+| Medium | Space + Block detail / provenance | Raw `netbox_id`, `netbox_is_pool false`, and `Router = "NetBox import"` leak import internals into operational columns/headers | Collapse to one "Imported from NetBox" chip with details on hover; keep provenance out of the Router column |
+| Medium | Space detail / VRF | VRF/BGP is a parenthetical header nag behind "Edit Space"; VRF operators can't see RD/VRF at a glance across spaces | Promote VRF to a column or prominent chip on the space list; surface RD |
+| Medium | Spaces tree / status dot | Green dot per subnet has no legend; meaning unknown | Add a tooltip/legend; if it's the Seen state, reuse the documented 4-state key |
+| Medium | Space detail / block rows | Blocks render blank Used IPs/Utilization — half the table is empty | Compute and show block-level utilization (child-allocated / total) |
+| Low | Sidebar header / icons | refresh/upload/+ are icon-only; "upload" target ambiguous | Add tooltips/labels; clarify what upload imports |
+| Low | Subnet detail / button bar | "Ask AI" occupies primary-action real estate next to Edit / Allocate IP | Demote Ask AI into a "Tools ▾" or overflow; give the slot to a power action |
+| Low | Block detail / Role model | Role filterable at block level but set as per-IP "— None —" dropdown — unclear if same taxonomy / where block roles are set | Document/unify the Role concept; clarify scope (IP vs subnet vs block) |
+| Nit | Spaces tree / auto blocks | `auto:10.50.0.0/24` leaks naming convention into nav labels | Render `auto:` as a muted badge, not part of the name |
+
+## What works well
+
+- **The dashed-emerald GAP row** ("X – Y · N free · click to allocate")
+  is the best single idea on the subnet page — instant "see the hole,
+  fill the hole." More IPAM tools should steal this.
+- **Greyed network/broadcast/gateway rows** with correct statuses —
+  respects how the address space actually works instead of pretending
+  every offset is allocatable.
+- **Allocation Map (Band/Treemap) + Aggregation suggestions + Find Free**
+  — real power features I'd use weekly, presented compactly.
+- **Subnet summary row** density (Gateway · VLAN · Total · Allocated ·
+  Util%) is exactly right.
+- **Empty states that tell me the fix** (device-profile / network-
+  discovery) — well-written, no fluff.
+- **Per-row DNS sync indicator + Seen dots** — good operational signal
+  without a separate dashboard trip.
+
+## My one big idea
+
+**Make the IP table editable in place, and make capacity math
+trustworthy for IPv6.** Those are the two things that decide whether a
+power user adopts or abandons an IPAM tool. Inline cell editing on the
+subnet IP table (double-click Hostname/Tags/Status/Description, Tab to
+next, Enter to commit) turns my 30-modal migration cleanup into a 2-minute
+spreadsheet pass — that's the difference between "tolerable" and "I'll
+move my whole org to this." And a /64 that proudly displays a
+signed-int-overflowed denominator with a 0% bar is the kind of math error
+that makes an experienced operator quietly distrust every other number on
+the screen. Fix IPv6 to show "/64 · N allocated" with no fake
+denominator, and you keep the trust the GAP row and allocation map
+earned.

--- a/docs/reviews/ipam/first-time-user.md
+++ b/docs/reviews/ipam/first-time-user.md
@@ -1,0 +1,163 @@
+# IPAM Review — First-Time User
+
+## Who I am & what I want
+
+I just got handed a login for SpatiumDDI. I've used a spreadsheet to track IPs
+before, and maybe poked at phpIPAM once. I know what an IP address and a subnet
+are. I do **not** know what *this product* means by a "Space," a "Block," or an
+"Address Set," and I've never heard "Find Free," "Reconciliation," or
+"Aggregation suggestion" in this context. My goal right now is dead simple:
+**I want to record a network and start assigning IP addresses.** I'm judging one
+thing — *can I figure out what to do first without reading a manual?*
+
+---
+
+## Page-by-page walkthrough
+
+### Sidebar "IP Spaces" tree
+First thing I see is a left tree labeled **"IP Spaces"** with entries like
+"Acme-Prod" and "Corporate." I don't know what an "IP Space" is — is it a tenant?
+a region? a VRF? Nothing tells me. I expand one and get **Blocks** (a
+stacked-squares icon) and under those, **Subnets** (a tree icon). So the hierarchy
+is Space → Block → Subnet, but I had to reverse-engineer that by clicking. There's
+no one-line "A Space contains Blocks, which contain Subnets" anywhere.
+
+Each subnet has a little **green dot** next to it. I have no idea what it means.
+(I later learn the *table's* "Seen" dots mean wire-recency — but this sidebar dot
+is unexplained, and my brain assumes "green = good / healthy," which may be wrong.)
+
+I see auto-created entries like **"auto:10.50.0.0/24"**. The `auto:` prefix looks
+like debug output leaking into my UI. Did I create that? Should I delete it?
+
+The sidebar header has three bare icons (refresh / upload / +). On hover I'd hope
+for tooltips; as a newcomer I'm guessing "+" makes... a Space? A Block? Unclear.
+
+**Biggest gap: what do I click first?** If my org is brand new, presumably the tree
+is empty. There's no described empty state ("No IP spaces yet — create your first
+one") with a primary button and a sentence explaining what a Space is. That's the
+single most important screen for me and it's the one with the least guidance.
+
+### Space detail (level 1)
+Header shows the space name and a line: **"VRF / BGP — not configured (Edit Space
+to add)."** As a first-timer this is intimidating — VRF and BGP are advanced
+networking concepts and they're the *first* thing the page tells me about my space.
+It reads like the page is mostly for network engineers, not me.
+
+The table lists **Blocks AND Subnets together** with columns Network / Name /
+Router / VLAN / Used IPs / Utilization / Size / Status / Environment. Blocks only
+fill in Network + Size; subnets fill the rest. So half the cells are blank
+depending on row type, and nothing labels which rows are blocks vs subnets except
+that I have to notice the empty cells. I can't tell the two apart at a glance.
+
+Buttons: **[Sync DNS] [Export] [Find Free…] [Edit Space] [Add Block] [+ Add
+Subnet]**. Two creation buttons (Add Block / Add Subnet) and I don't know which I
+need. "Find Free…" — find free *what*? I'd guess free IPs, but I haven't allocated
+anything yet, so why would I look for free space first?
+
+### Block detail (level 2)
+Title is a raw CIDR. Below it: **"netbox_id 1   netbox_is_pool false"** chips.
+This is internal provenance metadata from some NetBox import — it means nothing to
+me and looks like a database dump bled into the header. A "1 aggregation
+suggestion" yellow badge appears; I don't know what aggregation is or whether I'm
+supposed to act on the suggestion.
+
+The **ALLOCATION MAP** with [Band]/[Treemap] toggle is actually kind of cool — a
+visual of what's used. But the legend "Free (saturated portion = % allocated)" is
+a confusing sentence; I read it three times. The **ROLE filter chips
+[Data][Voice][Management][Guest]** appear with no context — are these filters? tags
+I should assign? Clicking them filters, I assume, but a brand-new block has nothing
+to filter.
+
+So many buttons now: Sync DNS, Export, Find Free…, Edit, Resize…, Move…, Add
+Block, + New Subnet. The density is high and I don't know which 1–2 matter for my
+"just add a subnet" goal.
+
+### Subnet detail (level 3) — finally something I understand
+This is the **best page for me.** The summary row is human:
+**Gateway · VLAN · Total IPs 254 · Allocated 11/254 · Utilization 4%.** That's
+exactly the mental model I have. The IP table is clear: Address, Hostname, MAC,
+Status, etc.
+
+The **greyed ".0 Network address" / ".255 Broadcast address" / gateway
+"reserved"** rows are a genuinely nice touch — they teach me the protocol reality
+without me having to know it. And the **dashed-emerald GAP row**
+"10.1.0.10 – 10.1.0.254 · 245 free · click to allocate" is *fantastic* — it tells
+me exactly what to do next. This is the only place in IPAM where the UI clearly
+guides a first action. If the rest of the product onboarded me this well I'd be
+happy.
+
+Tabs [IP Addresses][DHCP Pools][Aliases][Address Sets][NAT][Trend] — "Address
+Sets" and "Aliases" mean nothing to me yet, but at least they're tabs I can ignore.
+
+### IP detail modal
+Clicking an IP gives a clean read-only panel. Mostly fine. But two fields show a
+bare **"0"** with no label/units: **REVERSE DNS ZONE** shows "0" and **DNS / DHCP
+LINKAGE** shows "0". I cannot tell if that's a count, an ID, an error, or
+"nothing." That looks broken.
+
+The empty states here are actually *good*: NETWORK DISCOVERY says "add the upstream
+switch in /network and wait a polling cycle," and DEVICE PROFILE explains when
+auto-profiling triggers. Those teach me something. (Ironically the deep,
+advanced features have better onboarding copy than the top-level Space concept.)
+
+### Edit IP modal
+Tabbed [Details][Network][Scan with Nmap]. Reasonable. **DNS Aliases** helper text
+("Extra records pointing to this IP… removed automatically when the IP is purged")
+is clear and friendly — good example of the tone the rest of IPAM should use.
+The **Role "— None —"** dropdown and the "Legacy tag — assign a Router/VLAN from
+the Edit modal" tooltip elsewhere hint there are two ways to do the same thing
+(legacy vs new), which is confusing for someone with no history here.
+
+### Real data quirks I tripped on
+- A /64 IPv6 subnet shows **"Used IPs 0 / 9,223,372,036,854,776,000."** That giant
+  number is comical and useless to me; a /64 should just say "huge / not
+  enumerable." It made me distrust the numbers on the page.
+- Router column literally shows the text **"NetBox import"** — that's a data source,
+  not a router. Looks like a bug.
+
+---
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| blocker | Sidebar / initial state | No guidance on what to do first; "IP Space / Block / Subnet" never defined; likely-empty tree has no guiding empty state | Add a first-run empty state in the tree + Space detail: one sentence defining Space→Block→Subnet and a primary "Create your first IP Space" button with inline help |
+| high | Space detail header | First thing shown is "VRF / BGP — not configured" — advanced jargon greets every newcomer and signals "this is for network engineers only" | Hide VRF/BGP behind an "Advanced" disclosure; lead the header with something a newcomer needs (e.g. "0 subnets · add your first") |
+| high | Block detail header | Raw "netbox_id 1 / netbox_is_pool false" provenance chips look like leaked DB internals | Move import provenance to a collapsed "Source" detail or a small info tooltip; never show raw column names like `netbox_is_pool` in the header |
+| high | Space/Block table | Blocks and Subnets share one table with half-empty rows and no visible type label; can't tell them apart | Add a "Type" badge column (Block / Subnet) or visually group/section them; or use the row icon inline |
+| high | IP detail modal | REVERSE DNS ZONE and DNS/DHCP LINKAGE render a bare "0" — reads as broken/missing | Show a real label/value ("Not linked", a zone name, or hide the field when empty); never render a context-free "0" |
+| medium | Sidebar | "auto:10.50.0.0/24" prefix looks like debug output; unclear if user-deletable | Render auto-created blocks with a subtle "auto" badge + tooltip "Created automatically by import/discovery" instead of an `auto:` text prefix |
+| medium | Sidebar | Green dot on each subnet is unexplained (and green reads as "healthy", not its real meaning) | Add a tooltip/legend; if it's the same "Seen" recency state, label it the same way as the table's Seen column |
+| medium | Space detail buttons | "Find Free…" is the wrong first action for an empty space and the label doesn't say "free what" | Rename to "Find free space…" with a tooltip; de-emphasize until the space actually has allocations |
+| medium | IPv6 subnet | "/64 → Used 0 / 9,223,372,036,854,776,000" is meaningless and erodes trust in the numbers | For very large subnets show "Enumerable space too large" or a relative %, not the literal count |
+| medium | Block detail | "1 aggregation suggestion" badge + "ALLOCATION MAP" + role chips appear with zero explanation of what aggregation/roles are | Add hover help defining "aggregation" in one line; gate the suggestion badge to a clickable explainer |
+| low | Router column | Shows literal "NetBox import" text where a router is expected | Don't put the import source in the Router cell; leave blank or show "—" |
+| low | Allocation Map legend | "Free (saturated portion = % allocated)" is hard to parse | Reword: "Shaded = allocated, light = free" |
+| low | Edit IP modal | "Legacy tag" vs new Router/VLAN field implies two ways to do one thing — confusing with no history | Add a one-line note explaining the migration, or hide legacy affordances for fresh installs |
+
+## What works well
+
+- **Subnet detail summary row** (Gateway · VLAN · Total · Allocated · Utilization)
+  matches a newcomer's mental model perfectly — clearest screen in IPAM.
+- **The dashed-emerald GAP row** ("245 free · click to allocate") is the single
+  best onboarding affordance in the product — it literally tells me my next step.
+- **Greyed Network/Broadcast/reserved rows** teach protocol reality without
+  requiring me to already know it. Lovely touch.
+- **Empty-state copy on NETWORK DISCOVERY and DEVICE PROFILE** in the IP modal is
+  genuinely instructive — it explains *why* it's empty and *how* to populate it.
+- **Friendly helper text on DNS Aliases** in the Edit modal sets a good tone.
+- **Allocation Map (Band/Treemap)** is a nice at-a-glance visual, once you decode
+  the legend.
+
+## My one big idea
+
+Bring the quality of the *deep* empty states (the IP modal's "add the upstream
+switch and wait a polling cycle" copy) **up to the top level.** Right now the
+hardest, most advanced screens onboard me better than the very first one. Add a
+**first-run guided empty state** to the IP Spaces tree and Space detail that (1)
+defines Space → Block → Subnet in one plain sentence with the same icons used in
+the tree, and (2) offers a single primary "Create your first network" path that
+walks Space → Block → Subnet → first IP. Pair that with hiding the VRF/BGP and
+NetBox-provenance noise behind an "Advanced/Source" disclosure so a newcomer isn't
+greeted by jargon they can't act on. Make the rest of IPAM as self-explanatory as
+that one beautiful gap row already is.

--- a/docs/reviews/ipam/information-architect.md
+++ b/docs/reviews/ipam/information-architect.md
@@ -1,0 +1,178 @@
+# SpatiumDDI IPAM — Information Architecture Review
+
+## Who I am & what I want
+
+I'm an information architect / data-density analyst. I don't care whether the
+buttons are rounded — I care whether the *model* is right and whether the
+screen *teaches* the model to someone seeing it cold. My questions for any IPAM:
+
+1. Is **Space → Block → Subnet** the correct containment model, and does every
+   screen reinforce that hierarchy rather than blur it?
+2. When two entity types share one table (blocks AND subnets), can I tell them
+   apart at a glance, and do the columns mean the same thing for both rows?
+3. Are the **columns** carrying their weight — Router, VLAN, Environment, Seen,
+   DHCP Pool — or are they decoration?
+4. Are the **tabs** (6 on the subnet) the right set, and in defensible order?
+5. Does the **IP-detail field grid** group fields by concept (identity / DNS /
+   DHCP / lifecycle), or is it a flat dump?
+6. Do quantities **degrade gracefully** at IPv6 scale, or do I get
+   `9,223,372,036,854,776,000`?
+
+## Page-by-page walkthrough
+
+### Spaces tree (left rail)
+The Space → Block → Subnet tree is exactly the right spine, and putting it in a
+persistent left rail is the correct call — it's the one place the full
+containment model is visible at once. Two things immediately undercut it:
+
+- The green dot on subnets has **no legend anywhere in the tree**. As an IA I
+  read a colored dot as "carries state," but I can't decode it without hovering
+  elsewhere. A status affordance with no key is noise, not signal.
+- Auto-created blocks render their *internal identity* as the label:
+  `auto:10.50.0.0/24`. That's a provenance fact leaking into the name slot. The
+  tree is the navigation index; it should show a human label, with "auto" as a
+  badge or muted tag, not as a prefix glued to the CIDR.
+
+### Space detail (level 1)
+The header line "VRF / BGP — not configured (Edit Space to add)" is good IA — it
+names an empty concept *and* tells me how to fill it. More empty states should
+do this.
+
+My core structural complaint lives here: **one table holds both blocks and
+subnets**, and the columns don't mean the same thing across row types. A block
+populates only Network + Size; a subnet populates Used IPs / Utilization /
+Status / Environment. So six of ten columns are systematically blank for half
+the rows. That reads as "missing data" when it's actually "not-applicable." The
+two row types are *different nouns* — a block is a container, a subnet is a leaf
+address range. Mixing them in one flat grid with shared columns forces the
+reader to first classify each row, then re-interpret each column. Either split
+into two stacked tables ("Child blocks" / "Subnets," which the Block-detail
+allocation legend already names) or add an explicit Type column as the first
+data column so the eye sorts rows before reading values.
+
+### Block detail (level 2)
+The ALLOCATION MAP with Band/Treemap toggle is the strongest IA artifact in the
+whole section — it answers "how full is this container and what's inside it" in
+one glance, and the legend ("Child blocks / Subnets / Free") finally names the
+two child types the level-1 table refused to distinguish. The ROLE filter chips
+(Data/Voice/Management/Guest) are a real taxonomy and a good one.
+
+But the header dumps raw provenance as first-class chips:
+`netbox_id 1   netbox_is_pool false`. That's a foreign system's primary key and
+a boolean flag sitting at the same visual altitude as the CIDR title. As an IA
+this is a layer violation — import bookkeeping is metadata-about-the-record, not
+an attribute of the network. It belongs in a collapsed "Provenance / Import"
+disclosure, not the masthead. And `netbox_is_pool false` shows a *negative*
+boolean, which carries no information at all — only show it when true.
+
+### Subnet detail (level 3)
+The summary stats row (Gateway · VLAN · Total · Allocated 11/254 · Util 4%) is
+well-chosen and correctly ordered: location → identity → capacity. Good.
+
+The six tabs — **IP Addresses / DHCP Pools / Aliases / Address Sets / NAT /
+Trend** — are a defensible set but the ordering mixes axes. IP Addresses, DHCP
+Pools, and Address Sets are all "ways of carving this subnet's address space";
+Aliases and NAT are "mappings that reference addresses"; Trend is analytics. I'd
+group: *space carving* (IP Addresses, DHCP Pools, Address Sets) → *mappings*
+(Aliases, NAT) → *analytics* (Trend). As shipped, Address Sets is stranded
+between DHCP Pools and Aliases, splitting the two pool-ish concepts.
+
+The IP table is genuinely good IA: synthetic rows (network/broadcast/reserved)
+are greyed and labeled by *role* not just status, and the dashed-emerald GAP row
+("…245 free · click to allocate") turns absence-of-data into an actionable
+object. That's exactly how to represent free space — as a first-class row, not a
+hole. The Seen column's 4-state dot (alive/stale/cold/never, <24h / 24h–7d / >7d
+/ never per `SeenDot.tsx`) is a clean orthogonal axis to lifecycle status, and
+keeping it *separate* from the Status column is the right modeling decision.
+
+### IP detail modal
+The 2-col field grid is laid out as one flat list: HOSTNAME, FQDN, MAC, SUBNET,
+DESCRIPTION, RESERVED UNTIL, LAST SEEN, FORWARD DNS ZONE, REVERSE DNS ZONE, DNS/
+DHCP LINKAGE. These fields belong to **four distinct concepts** — identity
+(hostname/FQDN/MAC), location (subnet), lifecycle (description/reserved until/
+last seen), and DNS+DHCP bindings (the three zone/linkage fields). A flat grid
+makes me re-derive that grouping every time. Add three subheads (Identity / DNS
+& DHCP / Lifecycle) and the modal becomes self-documenting.
+
+The **bare "0"** the screenshots show under REVERSE DNS ZONE and DNS/DHCP
+LINKAGE is a real bug, and an instructive one. The code intends a dash fallback
+(`reverse_zone_id ? … : dash(null)`), but `0` is falsy in JS the same as `null`
+— except where an upstream value of literal `0` (a zone id of 0, or a count
+field rendered raw) slips through it prints "0" instead of "—". Either way the
+reader sees a naked number with no unit and no meaning. For an IA this is the
+worst kind of cell: it *looks* like data, so I trust it, and it's noise. Every
+empty field must render the same em-dash, and no numeric id should ever surface
+in a value slot.
+
+The NETWORK DISCOVERY and DEVICE PROFILE empty states are excellent — both name
+the missing concept *and* the exact action/precondition to populate it ("add the
+upstream switch in /network and wait a polling cycle"). This is the template the
+green-dot and bare-0 cases should follow.
+
+### The IPv6 scale problem
+A /64 showing **Used IPs 0 / 9,223,372,036,854,776,000** and Size
+`9,223,372,036,854,776,000` is an IA failure, not just an aesthetic one. That
+number (a) is wrong — a /64 is 2^64 ≈ 1.8e19, this is 2^63 capped at JS
+`Number.MAX_SAFE_INTEGER`-ish precision, so it's *lying* — and (b) is
+uncountable by a human, so a denominator and a "0%" utilization against it
+convey nothing. IPv6 capacity should be expressed in **prefix terms** ("/64 —
+host enumeration N/A") or as an order-of-magnitude ("~1.8×10¹⁹"), never as a
+literal integer. Utilization-% against a /64 is meaningless and should be
+suppressed for prefixes larger than, say, /100.
+
+### Cross-cutting: NetBox import as literal column data
+A Router column reading the literal string **"NetBox import"** is a category
+error — Router is a typed reference to a device, and the cell is showing where
+the row *came from*. Same family as the provenance chips on the block header.
+Imported-but-unmapped values should render as a muted "unmapped (imported)"
+placeholder, not masquerade as real attribute data. VLAN "200 (voice)" by
+contrast is exactly right — value plus human role inline.
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| high | IP detail modal / field grid | REVERSE DNS ZONE and DNS/DHCP LINKAGE render a bare "0" — a numeric id/count leaking into a value slot, indistinguishable from real data | Normalize every empty field to the same em-dash; never render a zone id or count integer in a value cell; guard against literal-`0` falling through the dash fallback |
+| high | IPv6 subnet capacity | /64 shows "Used 0 / 9,223,372,036,854,776,000" and Size as a literal 19-digit integer — uncountable and numerically wrong (capped, not 2^64) | Express large prefixes in prefix terms ("/64 — host count N/A") or order-of-magnitude; suppress Used/Size integers and the 0% utilization bar for prefixes wider than ~/100 |
+| high | Space/Block detail table | Blocks and subnets share one table with shared columns; 6 of 10 columns are systematically blank for block rows, reading as missing data | Split into two stacked tables (Child blocks / Subnets) OR add a Type column as the first data column so row class is read before values |
+| medium | Block detail header | Raw import provenance (`netbox_id 1`, `netbox_is_pool false`) shown as first-class chips at title altitude; negative boolean carries no info | Move provenance into a collapsed "Import / Provenance" disclosure; suppress false booleans; never put a foreign PK at masthead level |
+| medium | Spaces tree | Subnet green dot has no legend anywhere in the tree — a state affordance with no key | Add a hover/legend mapping the dot to its meaning (status? sync? seen?); if it duplicates the Status column, consider dropping it |
+| medium | Subnet detail tabs | Tab order mixes axes — Address Sets is stranded between DHCP Pools and Aliases, splitting the two pool-like concepts from the mapping concepts | Reorder by concept: space-carving (IP Addresses, DHCP Pools, Address Sets) → mappings (Aliases, NAT) → analytics (Trend) |
+| medium | Router column / NetBox import | Router cell shows literal "NetBox import" — provenance masquerading as a typed device reference | Render unmapped imported values as muted "unmapped (imported)"; keep typed columns typed |
+| low | Spaces tree | Auto-blocks labeled `auto:10.50.0.0/24` — provenance prefix glued into the name slot | Show the CIDR/name clean; render "auto" as a muted badge, not a label prefix |
+| low | IP detail modal grouping | 10-field grid is flat; spans four concepts (identity / location / DNS+DHCP / lifecycle) with no subheads | Add 3 subheadings (Identity · DNS & DHCP · Lifecycle) so the modal self-documents |
+| low | Block detail | "1 aggregation suggestion" yellow badge is good, but its relationship to the ALLOCATION MAP isn't spatially clear | Anchor the badge to the allocation map header so the suggestion reads as "about this map" |
+
+## What works well
+
+- **Space → Block → Subnet is the correct containment model**, and the
+  persistent left tree is the right place to make the full hierarchy legible.
+- The **ALLOCATION MAP (Band/Treemap)** with its "Child blocks / Subnets / Free"
+  legend is the best single IA artifact here — it answers occupancy and
+  composition in one glance and finally names the two child types.
+- **Free space as a first-class object**: the dashed-emerald GAP row
+  ("…245 free · click to allocate") models absence as an actionable entity
+  instead of a silent hole. Exactly right.
+- **Seen as an orthogonal axis** (4-state dot, lifecycle status kept separate) is
+  a clean modeling decision — reachability and administrative status are
+  genuinely different dimensions and shouldn't be conflated.
+- **Self-explaining empty states** on Network Discovery and Device Profile —
+  they name the concept and the exact precondition to populate it. This is the
+  pattern the rest of the section should adopt.
+- The **subnet summary stats row** is correctly ordered: location → identity →
+  capacity.
+
+## My one big idea
+
+**Stop overloading one grid with two nouns, and make capacity scale-aware.**
+The single highest-leverage IA change is to stop forcing blocks and subnets
+through one table with one column set — split them (the allocation legend already
+proves the system knows they're different) — and to teach every quantity column
+to *degrade gracefully* at IPv6 scale (prefix-terms, not literal 19-digit
+integers, with utilization suppressed where it's meaningless). Those two moves
+fix the same root disease in two places: the UI currently renders the *storage
+shape* of the data (every column for every row, every integer in full) instead
+of the *conceptual shape* (this is a container vs a leaf; this prefix is too
+large to enumerate). Get the conceptual shape on screen and the bare-0s, the
+blank columns, and the uncountable denominators all resolve as symptoms of the
+same fix.

--- a/docs/reviews/ipam/lan-administrator.md
+++ b/docs/reviews/ipam/lan-administrator.md
@@ -1,0 +1,141 @@
+# IPAM Review — LAN Administrator (daily repetitive ops)
+
+## Who I am & what I want
+
+I run a campus/office LAN. I'm in this tool dozens of times a day doing the
+same five things:
+
+1. Allocate the next free IP for a new host and stamp its hostname + MAC.
+2. Reserve a gateway / fixed-function address.
+3. Find a free /24 (or smaller) when someone asks for a new segment.
+4. Check that DNS and DHCP are actually in sync after I change something.
+5. Glance at whether an IP is actually live on the wire before I reuse it.
+
+I don't care about VRF/BGP, NetBox provenance, or treemaps. I care about
+**clicks-per-task** and **not having to re-type things I just typed**. If a
+flow takes 6 clicks when it could take 2, that's hundreds of wasted clicks a
+week for me. Speed and muscle memory are everything.
+
+## Page-by-page walkthrough
+
+### Spaces tree (left sidebar)
+First thing I see: a tree of Space > Block > Subnet. Fine. But every subnet has
+a little **green dot of unexplained meaning**. I stare at it. Is that
+utilization? Health? DNS-sync? Live-on-wire? No tooltip I can find at the tree
+level. For something I see on every row all day, "mystery green dot" is exactly
+the kind of small friction that adds up. And the auto-blocks named
+`auto:10.50.0.0/24` are noise to me — I didn't make those, they clutter my tree.
+
+To get to my daily workspace (a specific /24) I have to expand Space, expand
+Block, then click the subnet. Three drill-downs every single time. There's a
+refresh / upload / + in the sidebar header but **no search box** to jump
+straight to "10.1.0.0/24" or "Office-LAN". I know exactly where I'm going and
+the tree makes me click my way there.
+
+### Space detail (level 1)
+Header wastes its most valuable line on `VRF / BGP — not configured (Edit Space
+to add)`. I will never configure that. That nag sits at the top of a page I open
+constantly. The table mixing blocks AND subnets in one list is OK but the
+columns I actually want (Used IPs / Utilization) are blank for blocks, so half
+the rows have holes. `[Find Free…]` up here is genuinely useful for my
+"find a free /24" task — good.
+
+### Block detail (level 2)
+This is where it gets busy for a daily user. The title is a CIDR, and right
+under it are raw provenance chips: `netbox_id 1   netbox_is_pool false`. That's
+database internals leaking onto my screen. Means nothing to me, takes up the
+prime real estate under the title. The ALLOCATION MAP with Band/Treemap toggle
+and "Plan allocation…" is nice-to-have but it's the first thing I see, above the
+table I actually use. `[Find Free…]` is here too (good — "Find unused CIDRs in
+this block" tooltip is clear).
+
+### Subnet detail (level 3) — my home base
+This is the screen I live on. Good stuff: the summary row (Gateway · VLAN ·
+Total · Allocated 11/254 · Utilization 4%) is exactly the at-a-glance I want.
+The **dashed-emerald GAP row** "10.1.0.10 – 10.1.0.254 · 245 free · click to
+allocate" is genuinely delightful — clicking the gap to allocate is the single
+best thing in here for my workflow. The Seen column dots have real tooltips
+("Alive — last seen 3m ago via dhcp") — confirmed in code, that's perfect for
+my "is this IP actually live before I reuse it" check. The DNS column "• in
+sync" is the at-a-glance I need for task #4.
+
+Friction: the header has **7 controls** — [Refresh] [Sync v] [Import/Export v]
+[Tools v] [Ask AI] [Edit] [+ Allocate IP]. My #1 action, "+ Allocate IP", is
+buried at the far right next to Edit. "Allocate next free IP + set
+hostname/MAC" is my most-repeated task and it's not the most prominent thing.
+Also network/broadcast/gateway rows are always shown greyed — fine, but they
+add scroll on a /24 when I just want the live hosts.
+
+### Add/Allocate IP modal
+Placeholder "Auto-assigned if blank" for the address is good — that's my
+next-free flow. But after I allocate, to set hostname + MAC I'm in the
+**Details** tab of the Edit modal (Hostname, Description, MAC, Status, Role,
+DNS Aliases, Custom Fields). For a brand-new host I want IP + hostname + MAC in
+**one** form, one save. If allocate and edit are two separate modals/saves,
+that's double the round-trips on my single most frequent task.
+
+### IP detail modal (read-only)
+Click a row, get a read-only panel. The header buttons [Ask AI][Scan with
+Nmap][Edit][Delete] are reasonable. BUT — confirmed in code
+(`IPDetailModal.tsx:373`) — the counters row does
+`{(addr.alias_count || addr.nat_mapping_count) && (…)}`, so when both are 0 it
+**renders a literal `0`** on screen with no label. That's the mystery "0" in
+the screenshots. Looks broken. "Reverse DNS zone" and "DNS/DHCP linkage" render
+fine when populated (a dash when empty), so the stray "0" is specifically the
+counters bug, not those fields. Either way, a bare unlabelled number erodes my
+trust in the panel.
+
+The NETWORK DISCOVERY and DEVICE PROFILE empty states are wordy
+("Auto-profiling triggers on a fresh DHCP lease when the subnet Device
+profiling toggle is enabled…"). I read that once; after that it's just vertical
+noise I scroll past every time I open the modal to copy a MAC.
+
+### Edit IP modal
+Tabs [Details][Network][Scan with Nmap]. For my daily "set hostname + MAC"
+this is the right place, but it's tab #1 of 3 and has DNS Aliases + Custom
+Fields below the fold. The MAC field has no "looks like a MAC?" validation hint
+visible, and there's no quick "copy MAC from last lease" — I often re-type a MAC
+I can see in the leases. The "Role (— None —)" dropdown and the tooltip
+"Legacy tag — assign a Router/VLAN from the Edit modal" are confusing: is Role
+legacy or current? For a daily user that ambiguity is a paper-cut every time.
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| high | IP detail modal | Bare unlabelled `0` renders when alias_count & nat_mapping_count are both 0 (`IPDetailModal.tsx:373` uses `count && (…)`, so `0 &&` leaks a literal 0). Looks like broken data. | Guard with `(alias_count ?? 0) > 0 \|\| (nat_mapping_count ?? 0) > 0` so the whole counters row is hidden when empty. |
+| high | Subnet detail / allocate flow | Allocating a new host = Allocate IP (modal 1) then Edit (modal 2, Details tab) to set hostname + MAC. Two modals/saves for my single most frequent task. | Put Hostname + MAC fields directly in the Allocate IP modal so a new host is one form, one save. |
+| high | Spaces tree | No search/jump box. Reaching a known subnet always takes 3 drill-down clicks (Space>Block>Subnet). | Add a filter/quick-jump field in the sidebar header that matches on CIDR or subnet name and deep-links. |
+| medium | Subnet detail header | 7 controls; my #1 action "+ Allocate IP" is far-right next to Edit. | Make "+ Allocate IP" the primary, left-most or visually dominant button; collapse Refresh into Sync/Tools. |
+| medium | Spaces tree | Green dot on every subnet has no explained meaning and no tooltip. | Add a tooltip (and ideally make color = utilization or DNS-sync, the two things I check). |
+| medium | Space detail header | Top line nags `VRF / BGP — not configured (Edit Space to add)` on a page I open all day. | Hide the VRF/BGP nag unless the space actually uses VRF, or move it into Edit Space only. |
+| medium | Block detail header | Raw `netbox_id` / `netbox_is_pool` provenance chips sit under the title. | Move provenance into a collapsed "Source" detail or a tooltip; don't show DB internals by default. |
+| medium | Edit IP modal | "Role (— None —)" plus tooltip "Legacy tag — assign Router/VLAN from the Edit modal" is self-contradictory/ambiguous. | Clarify whether Role is deprecated; if legacy, hide it or label it "(legacy)" explicitly. |
+| low | IP detail modal | NETWORK DISCOVERY / DEVICE PROFILE long empty-state paragraphs add scroll every open. | Collapse empty sections to a one-line "No discovery data" with a (?) for the full explanation. |
+| low | Subnet detail IP table | Network/broadcast/gateway placeholder rows always shown; add scroll on /24 when I want live hosts. | Add a "hide reserved/placeholder rows" toggle that sticks per-user. |
+| low | Edit IP modal | MAC field has no inline format hint/validation; no "copy MAC from lease". | Add MAC format hint + a one-click "use last-seen MAC" when a lease exists. |
+| nit | IPv6 subnet | Used IPs shows "0 / 9223372036854776000"; Size "9,223,372,036,854,776,000". | For /64+ show "—" or "/64 (SLAAC)" instead of an unusable host count. |
+
+## What works well
+
+- **Click-the-gap-to-allocate** dashed-emerald GAP row ("245 free · click to
+  allocate") — best feature in here for my workflow.
+- **Seen dots with real tooltips** ("Alive — last seen 3m ago via dhcp") — exactly
+  the live-on-wire check I need before reusing an IP.
+- **DNS "• in sync" column** + the **Sync v** dropdown — my sync-check task is
+  visible right where I work.
+- **Subnet summary row** (Gateway · VLAN · Allocated 11/254 · Utilization) — great
+  at-a-glance.
+- **`[Find Free…]`** on both Space and Block detail with clear tooltips — covers my
+  "find a free /24" task well.
+
+## My one big idea
+
+**Make "allocate a new host" a single, one-form, one-save action.** Today the
+high-frequency flow is: drill three levels into the subnet → click the
+far-right "+ Allocate IP" → save → re-open the row → Edit → Details tab → type
+hostname + MAC → save. That's the thing I do all day and it's the slowest. Put
+Hostname + MAC right in the Allocate modal (address defaults to "next free"),
+make that button the dominant action on the subnet header, and let me hit it
+straight from a sidebar quick-jump. That single change would cut my most-common
+task from ~6 clicks and two saves down to two clicks and one save.

--- a/docs/reviews/ipam/mobile-responsive-user.md
+++ b/docs/reviews/ipam/mobile-responsive-user.md
@@ -1,0 +1,134 @@
+# IPAM Review — On-call admin, 2am, on a phone
+
+## Who I am & what I want
+
+I'm the on-call admin. It's 2:14am, a phone woke me, I'm in bed with a 6"
+screen and one thumb. PagerDuty says "DHCP exhaustion on Office-LAN" or
+"host 10.1.0.45 went rogue." I do NOT want to plan subnets, edit VRFs, or
+admire a treemap. I want exactly three things, fast:
+
+1. **Find one IP / one subnet** and see: is it allocated, to whom (hostname),
+   what MAC, and is it alive on the wire right now.
+2. **See utilization** of a named subnet so I know if "exhaustion" is real.
+3. **Make one tiny change** — flip a status to `quarantine`, free an IP,
+   maybe fix a hostname — and get back to sleep.
+
+Everything else is daytime-at-a-desk work. My lens for this whole product
+tonight: can I do those three things one-handed without pinch-zooming and
+horizontal-scrolling a 12-column table? Mostly: no.
+
+## Page-by-page walkthrough
+
+**IP Spaces tree (left sidebar).** On desktop this is the nav spine. On my
+phone, per the responsive pattern this app uses, the sidebar collapses into a
+hamburger drawer — fine. But the tree itself is Space → Block → Subnet, three
+levels deep, with tiny disclosure carets and tiny icons (stacked-squares vs
+tree). Tapping the right caret vs the row label with a thumb is a coin-flip.
+And the green dot next to subnets has *no explanation anywhere I can tap* —
+at 2am an unexplained green dot is noise. Auto-created entries like
+`auto:10.50.0.0/24` read like garbage rows to a half-asleep brain. The drawer
+also eats the whole screen, so I lose the detail I was looking at.
+
+**Space detail (level 1).** Header line "VRF / BGP — not configured (Edit
+Space to add)" is desktop chrome I don't care about tonight; it's burning a
+whole row of my tiny viewport. Then a row of SIX buttons: Sync DNS, Export,
+Find Free…, Edit Space, Add Block, +Add Subnet. On a phone those either wrap
+into a 2-3 row pile or run off-screen. None of them is the thing I want
+(search/jump to an IP). The combined block+subnet table has **10 columns**
+(checkbox, Network, Name, Router, VLAN, Used IPs, Utilization, Size, Status,
+Environment). On a 360px screen that's a horizontal-scroll nightmare — I can
+see Network and maybe Name, and everything that actually tells me "is this
+full?" (Used IPs / Utilization / Status) is two swipes to the right, off
+where I can't see the row I'm scrolling. Classic wide-table-on-mobile death.
+
+**Block detail (level 2).** Breadcrumb pills (Space > block) are actually
+*good* on mobile — compact, tappable, tell me where I am. But the title is a
+raw CIDR and right under it are provenance chips "netbox_id 1 netbox_is_pool
+false" — meaningless to me on call, taking vertical space I'd rather spend on
+data. The ALLOCATION MAP with Band/Treemap toggle + "Plan allocation…" is
+pure daytime planning; the striped band is hard to read small and impossible
+to interpret quickly. Seven buttons here (Sync DNS/Export/Find Free/Edit/
+Resize/Move/Add Block/+New Subnet). Then the same overloaded table again.
+
+**Subnet detail (level 3).** This is where I actually live on call, and it's
+the most painful. The summary stats row — "Gateway · VLAN · Total IPs ·
+Allocated 11/254 · Utilization 4%" — is *exactly* what I need, but on a phone
+those 5 stats either wrap weirdly or scroll. SIX tabs (IP Addresses, DHCP
+Pools, Aliases, Address Sets, NAT, Trend) won't fit; they'll scroll
+horizontally and I'll fat-finger "Aliases" trying to hit "IP Addresses."
+Then **6+ action buttons** (Refresh, Sync▾, Import/Export▾, Tools▾, Ask AI,
+Edit, +Allocate IP). The IP table is the worst offender: **11 columns**
+(checkbox, Address, Hostname, MAC, Description, Tags, Status, DHCP Pool, DNS,
+Seen, Network) plus per-row pencil/trash. To answer "who has .45 and is it
+alive" I have to scroll right past Hostname/MAC/Description/Tags to reach
+Status and the Seen dot — and the Seen dot's meaning is **tooltip-only**
+(confirmed: `title=`/`aria-label=` in SeenDot.tsx). There's no hover on a
+phone. So the single most on-call-relevant signal — "is this host alive,
+stale, or cold" — is *invisible* to me unless I long-press and hope a tooltip
+fires. The dashed-emerald GAP row "10.1.0.10 – .254 · 245 free · click to
+allocate" is genuinely nice and survives mobile well.
+
+**IP detail modal (tap a row).** It opens as a *draggable* modal (confirmed
+`useDraggableModal`). On touch, "draggable by the title bar" means every time
+I try to scroll the modal content with my thumb starting near the top, I drag
+the whole window instead. The 2-column field grid (HOSTNAME, FQDN, MAC,
+SUBNET, … REVERSE DNS ZONE, DNS/DHCP LINKAGE) collapses badly at 360px — two
+columns of long values like FQDNs and MACs means each cell is ~150px and
+wraps mid-value. And the bugs bite hardest here on a small screen where I
+can't cross-check: REVERSE DNS ZONE shows a bare **"0"** and DNS/DHCP LINKAGE
+shows **"0"** — at 2am I genuinely cannot tell if that means "zone id 0,"
+"zero records," or "broken." Four header buttons (Ask AI, Scan with Nmap,
+Edit, Delete, x) crammed next to a copy icon and status pill — Delete and x
+sitting together is a misclick waiting to happen on a thumb.
+
+**Edit IP modal.** Three tabs (Details/Network/Scan with Nmap) again risk
+horizontal scroll. The actual fields I'd want at 2am — Status dropdown, maybe
+Hostname — are fine, but they're buried under DNS Aliases and Custom Fields
+sections I have to scroll past. The footer [Cancel][Save] is correct and
+sticky-ish, good.
+
+**The IPv6 quirk.** A /64 showing "Used IPs 0 / 9223372036854776000" and Size
+"9,223,372,036,854,776,000" — that 19-digit number alone is wider than my
+phone screen and forces horizontal scroll on a row that should just say
+"/64 — effectively unlimited." On mobile this single cell breaks the table.
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| blocker | Subnet detail / IP table | 11-column table forces horizontal scroll; Status + Seen (the on-call essentials) are off-screen right while you scroll a row you can't see | Add a mobile card/stacked layout under ~640px: each IP = one card showing Address, Hostname, Status pill, Seen state as text+color. Hide MAC/Tags/Description/DHCP Pool/Network behind a tap-to-expand |
+| blocker | Subnet detail / Seen column | "Seen" alive/stale/cold/never is a color dot with a *tooltip-only* label — no hover exists on touch, so the most on-call-relevant signal is unreadable on a phone | Render a text chip next to the dot ("alive 3m", "cold 9d") or make the dot tappable to reveal the label; never rely on `title=` for primary meaning |
+| high | IP detail modal | Modal is draggable by its title bar — on touch, scrolling from the top drags the whole window instead of scrolling content | Disable drag below a breakpoint (or require a dedicated drag handle); make the modal a full-screen sheet on mobile |
+| high | IP detail modal | REVERSE DNS ZONE and DNS/DHCP LINKAGE render a bare "0" with no label/units — undebuggable at 2am on a phone | Show a name or "none"/"not linked"; never surface a raw numeric id as a field value |
+| high | Space/Block/Subnet headers | 6-8 action buttons per header pile up / overflow on a narrow screen; the action I want (find an IP) isn't among them | Collapse secondary actions into one "⋯ Actions" menu; keep only +Allocate (or a search field) visible; promote a global IP search |
+| high | All IPAM levels | No fast "jump to IP / search address" entry point — I must drill Space→Block→Subnet then horizontally scroll to find one host | Add a persistent search box ("find 10.1.0.45 or hostname") that deep-links straight to the IP detail modal |
+| medium | IPv6 subnets | "/64 → 9,223,372,036,854,776,000" in Total/Size/Used columns is wider than the screen and breaks the row | Render huge address spaces as "/64 (~unlimited)" or abbreviate; don't print the full 19-digit integer |
+| medium | Subnet detail / tabs | 6 tabs and 6 action buttons each scroll horizontally and invite fat-finger taps | Make tabs a dropdown or 2-row wrap on mobile; default to IP Addresses; demote Trend/Aliases/Address Sets |
+| medium | Block detail header | Provenance chips ("netbox_id 1 netbox_is_pool false") and the ALLOCATION MAP eat vertical space above the data I need | Hide provenance + allocation map behind a collapsed "Details" disclosure on mobile |
+| medium | IP detail modal header | Delete and the close "x" sit adjacent — easy thumb misfire that destroys a record | Separate destructive actions; put Delete behind the ⋯ menu, keep x in a clear corner |
+| low | IP Spaces tree | Green subnet dot is unexplained; tiny carets/icons are hard to tap; auto:CIDR rows look like junk | Add a one-line legend; enlarge tap targets to ~44px; style auto-created rows distinctly with a tooltip-free label |
+| low | Space detail | "VRF / BGP — not configured (Edit Space to add)" burns a header row that's irrelevant on call | Hide config-prompt rows on mobile or move below the data |
+
+## What works well
+
+- **Breadcrumb pills** (Space > block > subnet) are compact, tappable, and
+  orient me instantly — keep these exactly as-is on mobile.
+- **The subnet summary stats** (Allocated 11/254 · Utilization 4%) are
+  precisely the at-a-glance answer I need for "is exhaustion real" — just make
+  them survive a narrow viewport.
+- **The dashed-emerald GAP row** "10.1.0.10 – .254 · 245 free · click to
+  allocate" is genuinely delightful and reads fine small.
+- **Status pills** are colored and labeled (not color-only), so unlike the
+  Seen dot they actually work on a phone.
+- **Sticky footer [Cancel][Save]** in modals — correct, thumb-reachable.
+
+## My one big idea
+
+Ship a **mobile "on-call mode" for the IP table**: below ~640px, replace the
+11-column grid with a stacked card list where each IP shows only the four
+things that matter at 2am — Address, Hostname, Status pill, and Seen state as
+a *text+color chip* (not a tooltip dot) — plus a single tap to open a
+full-screen (non-draggable) detail sheet. Pair it with a persistent
+"find an IP or hostname" search at the top of IPAM that deep-links straight to
+that sheet. That one change turns the entire IPAM section from "pinch, zoom,
+and swipe sideways forever" into something I can actually triage from bed.

--- a/docs/reviews/ipam/netbox-migrant.md
+++ b/docs/reviews/ipam/netbox-migrant.md
@@ -1,0 +1,135 @@
+# IPAM Review — NetBox Migrant
+
+## Who I am & what I want
+
+I run NetBox today. My world is organized around **prefixes** (with a
+**role**, a **status**, a **VRF**, a **tenant**, a **site**, and a **VLAN**),
+**IP addresses** (with DNS name, status, role, NAT inside/outside), and a
+clean **aggregate → prefix → IP** containment hierarchy. I just ran the
+SpatiumDDI NetBox importer and clicked into IPAM to answer one question:
+**did my data come across intact, and can I still find things the way I think
+about them?**
+
+What I care about, in order:
+1. My prefixes/IPs landed in the right place and nothing silently dropped.
+2. My **roles** (Data / Voice / Management / Guest) are still first-class and
+   filterable — that's how I segment everything.
+3. My **VRFs and tenants** map to *something* I can navigate by.
+4. The import is invisible once it's done — I should see *my* data, not the
+   importer's bookkeeping.
+
+## Page-by-page walkthrough
+
+### Spaces tree (left sidebar)
+First reaction: "IP Spaces" is a new word. I quickly map **Space ≈ VRF/tenant
+container, Block ≈ aggregate, Subnet ≈ prefix** — that's mostly fine and the
+3-level tree matches my aggregate→prefix instinct. But I immediately see
+`auto:10.50.0.0/24` blocks the importer invented. In NetBox I had a clean
+aggregate list; here there are synthetic parent blocks with an `auto:` prefix
+bleeding into the tree label. That's the importer talking to me, and I didn't
+ask it to. The green dot on subnets has no legend in the tree — I don't know if
+it's status, sync, or utilization.
+
+### Space detail (level 1)
+The header line "VRF / BGP — not configured (Edit Space to add)" is the first
+real disappointment. **My NetBox VRFs should have populated this.** I had RDs
+and route-targets on those VRFs. If the importer mapped tenants→Customers (per
+the docs) and VRFs→Spaces, why does every space say VRF "not configured"? Either
+the VRF didn't come across or it's stored somewhere this header doesn't read.
+Coming from NetBox this reads as **data loss** until proven otherwise.
+
+The combined block+subnet table is reasonable. "Environment" as the last column
+is unfamiliar — in NetBox that'd be a custom field or a role. I don't see a
+**Tenant** or **Customer** column anywhere, which is odd given the importer
+claims to create Customers from tenants.
+
+### Block detail (level 2)
+This is where the import leak is loudest. Under the CIDR title sit raw chips:
+**`netbox_id 1   netbox_is_pool false`**. This is pure NetBox internals — a
+primary key and a NetBox-specific boolean — surfaced as if they were real
+attributes of *my* network. `netbox_is_pool` in NetBox means "treat this prefix
+as a pool (no network/broadcast reservation)"; dumping it as a dead chip
+labeled `netbox_is_pool false` is meaningless to anyone who didn't write the
+importer. It should either drive behavior (skip .0/.255 reservation) or not be
+shown.
+
+On the upside: the **role filter chips [Data][Voice][Management][Guest]** here
+are exactly the NetBox role concept and I'm glad they exist. The ALLOCATION MAP
+with Band/Treemap is nicer than anything NetBox gives me. The "1 aggregation
+suggestion" badge is a genuinely good idea.
+
+### Subnet detail (level 3)
+Best page. CIDR + status pill + name reads like a NetBox prefix detail. Gateway/
+VLAN/Total/Allocated/Utilization summary is clean. The dashed-emerald GAP row
+("245 free · click to allocate") is better than NetBox's "Available" rows.
+
+Two NetBox-migrant snags: (1) **Router column shows the literal text "NetBox
+import"** on imported subnets — that's the importer's provenance string sitting
+in a real operational field that should hold an actual device/gateway. I'll
+trip over this when I try to reconcile gateways. (2) The **IPv6 /64** shows
+"Used IPs 0 / 9,223,372,036,854,776,000" and Size "9.2 quintillion". NetBox
+just says "/64" and doesn't pretend to count host addresses. The giant number
+is noise (and it's even rounded wrong — 2^63, not 2^64).
+
+VLAN "200 (voice)" is nicely done — that's the role hint inline, good.
+
+### IP detail modal
+Mostly familiar. But **"Reverse DNS zone" shows a bare `0`** and **"DNS / DHCP
+linkage" shows `0`** — I confirmed in the component these fields render a raw FK
+id when the zone-name lookup misses, so a stale/zero id from import leaks
+through as a naked number with no label or units. After a NetBox import where
+reverse zones may not exist yet, every IP shows `0` here, which looks broken.
+
+NETWORK DISCOVERY and DEVICE PROFILE empty states are clear and even tell me
+*how* to populate them — better onboarding than NetBox. No complaint there.
+
+### Edit IP modal
+Relief: **Role** is a real dropdown here (— None —), and there's a "MAC
+history" button NetBox doesn't have. But I notice a tooltip elsewhere:
+"Legacy tag — assign a Router/VLAN from the Edit modal." Combined with the
+"NetBox import" string in the Router column, it looks like the importer dumped
+some of my data into **tags** rather than structured fields, and now I'm being
+told to manually re-key it. That's migration friction NetBox users will feel
+immediately.
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| high | Block detail header | Raw `netbox_id 1` / `netbox_is_pool false` provenance chips shown as if they were real network attributes | Hide import internals from the detail header. Surface provenance once, subtly (e.g. a single "Imported from NetBox #1" badge with a tooltip), and make `netbox_is_pool` actually drive .0/.255 reservation rather than render a dead boolean. |
+| high | Subnet table / Router column | Imported subnets show literal text "NetBox import" in the Router field — a provenance string polluting an operational column | Don't write the import source into Router. Leave Router empty and store source in a dedicated read-only "Imported from" field; show a small NetBox chip instead. |
+| high | Space detail header | "VRF / BGP — not configured" on every space after import — NetBox VRFs/RDs/RTs appear lost or unmapped | Map NetBox VRFs into the Space's VRF binding during import and populate this header; if intentionally separate, say "VRF: <name> (imported)" so it doesn't read as data loss. |
+| high | IP detail modal | "Reverse DNS zone" and "DNS / DHCP linkage" render a bare `0` (raw FK id leaking when zone-name lookup misses) | Treat falsy/zero ids as empty and render the dash; never print a raw id as a value. |
+| medium | Spaces tree | Synthetic `auto:10.50.0.0/24` blocks with importer prefix clutter the tree | Drop the `auto:` label prefix; mark synthetic parents with an icon/tooltip ("auto-created to hold imported prefixes") instead of leaking it into the name. |
+| medium | Edit modal / tags | Imported attributes landed in tags ("Legacy tag — assign Router/VLAN from Edit modal") forcing manual re-keying | Map NetBox structured fields (role, VLAN, gateway) to structured fields on import, not tags; offer a bulk "promote legacy tags" action. |
+| medium | Subnet detail | IPv6 /64 shows "Used 0 / 9,223,372,036,854,776,000" and a quintillion-size column | For prefixes larger than /64-ish, suppress host counts and show "/64 — host counting disabled" like NetBox; also the value is 2^63, not 2^64. |
+| medium | Space detail table | No Tenant/Customer column despite importer creating Customers from tenants | Add an optional Customer/Tenant column so NetBox tenant structure is visible after import. |
+| low | Spaces tree | Green status dot on subnets has no legend in the tree | Add a hover tooltip or a small legend; reuse the Seen/Status color key already defined elsewhere. |
+| low | Vocabulary | "Space / Block / Subnet / Environment" vs NetBox "VRF / Aggregate / Prefix / Role" | Add a one-line "Coming from NetBox?" mapping note on the import result screen and/or tooltips on the column headers. |
+| low | Post-import UX | No visible import summary ("X prefixes, Y IPs, Z skipped") once I'm in IPAM | Persist a dismissible import-report banner/link on first IPAM visit after a commit. |
+
+## What works well
+
+- **Role chips [Data][Voice][Management][Guest]** on the block detail and a real
+  **Role** dropdown in Edit IP — the NetBox role concept survived and is
+  filterable. This is the single most important thing for a NetBox user and it's
+  here.
+- **VLAN "200 (voice)"** inline rendering — role context right where I need it.
+- The **dashed-emerald GAP / "click to allocate"** rows beat NetBox's available-
+  prefix UX.
+- **ALLOCATION MAP (Band/Treemap)** and the **aggregation suggestion** badge are
+  genuinely better than anything in NetBox.
+- **Empty states with instructions** (Network Discovery, Device Profile) tell me
+  exactly how to populate them — friendlier onboarding than NetBox.
+
+## My one big idea
+
+**Make the import invisible once it's done.** Right now the importer's
+bookkeeping (`netbox_id`, `netbox_is_pool`, the "NetBox import" Router string,
+`auto:` block names, tags-instead-of-fields) leaks into real operational fields,
+so my clean NetBox dataset looks polluted the moment it lands. Do a proper
+**field mapping at import time** — VRF→Space VRF binding, tenant→Customer column,
+role→Role, gateway→Router, pool flag→reservation behavior — and collapse all
+provenance into a single, quiet, read-only "Imported from NetBox #N" badge with
+a tooltip. The payoff: a NetBox migrant opens IPAM and sees *their* network in
+SpatiumDDI's nicer UI, not the importer's scratch notes.

--- a/docs/reviews/ipam/novice-noc-tech.md
+++ b/docs/reviews/ipam/novice-noc-tech.md
@@ -1,0 +1,179 @@
+# IPAM Review — Junior NOC Technician
+
+## Who I am & what I want
+
+I'm a junior NOC tech. I know what a subnet, a gateway, a VLAN, and a CIDR
+are. I can ping things and read an ARP table. But I'm brand new to IPAM
+tooling, and honestly I'm a little scared of this app. My #1 fear is that I
+click the wrong thing on a production subnet and take something down, and
+then I'm the person who broke prod on week three. What I want from this UI:
+
+- Tell me plainly which buttons are safe (read-only) and which are dangerous.
+- Explain the words I don't know — "aggregation suggestion", "orphan",
+  "reconciliation", "supernet", "VRF/BGP", "address set" — right where they
+  appear, not in docs I have to go hunt for.
+- When I'm about to do something destructive, make me stop and confirm with
+  language a beginner understands.
+- Don't show me cryptic numbers with no label that make me wonder if I broke
+  something.
+
+## Page-by-page walkthrough
+
+### IP Spaces tree (left sidebar)
+First thing I see is a tree: Space → Block → Subnet. Okay, that hierarchy
+makes sense to me even as a newbie — it reads like a filing cabinet. But each
+subnet has a little **green dot** with no explanation. Is that "healthy"?
+"online"? "selected"? I have no idea, and there's no legend in the sidebar.
+I also see blocks named **"auto:10.50.0.0/24"**. What does "auto:" mean? Did
+the system create that? Can I delete it? Am I allowed to touch it? Nervous.
+
+The sidebar header has three bare icons — refresh, an upload-looking arrow,
+and a "+". No labels, no tooltips that I can tell. The upload one worries me
+the most: upload *what*? Could I overwrite the whole tree by clicking it?
+
+### Space detail (level 1)
+Header says **"VRF / BGP — not configured (Edit Space to add)"**. I have a
+vague idea VRF is a routing thing and BGP is a routing protocol, but I have
+zero idea what configuring them *here* does or whether I'm supposed to. The
+fact that it's front-and-center makes me feel like I'm missing a required
+step. A one-liner like "Optional — only needed if you run multiple isolated
+routing tables" would calm me right down.
+
+The button row — **[Sync DNS] [Export] [Find Free…] [Edit Space] [Add Block]
+[+ Add Subnet]** — mixes safe and scary with no visual difference.
+"Export" I'd guess is safe. "Find Free…" sounds safe (finding, not changing).
+But "Sync DNS" — does that *push* changes to real DNS servers? On prod? That
+feels like it could have real-world consequences and it's styled identically
+to Export. I'd want the read-only ones to look obviously different from the
+ones that change live infrastructure.
+
+The combined block+subnet table is actually nice — one place to see Network,
+Used IPs, Utilization, Status, Environment. Sortable Network column is great.
+
+### Block detail (level 2)
+Breadcrumb pills are good — I always know where I am. But right under the CIDR
+title I see raw chips: **"netbox_id 1   netbox_is_pool false"**. That's
+database/import gunk leaking onto my screen. I don't know what NetBox is and
+I definitely don't know what "is_pool false" should mean to me. It reads like
+a debug field someone forgot to hide.
+
+A yellow badge says **"1 aggregation suggestion"**. I click it (curiosity).
+The tooltip says *"Sibling subnets that would pack into a clean supernet."*
+I don't know what a "supernet" is, and "pack into" doesn't tell me what
+happens if I act on it. Will it **merge/delete** my subnets? That word
+"suggestion" plus an action button is exactly the kind of thing I'd be afraid
+to touch because I can't tell if accepting it is destructive.
+
+The **ALLOCATION MAP** with [Band]/[Treemap] is genuinely cool and the legend
+("Child blocks / Subnets / Free") helps. The **ROLE filter chips**
+[Data][Voice][Management][Guest] are friendly and self-explanatory — love
+those.
+
+### Subnet detail (level 3)
+This is the page I'd live in, and mostly it's good. The summary row —
+**Gateway · VLAN · Total IPs · Allocated 11/254 · Utilization 4%** — is
+exactly what I want at a glance. The IP table is readable.
+
+Special rows are handled really well: the **.0 "Network address"** and
+**.255 "Broadcast address"** are greyed out and labelled, so I won't try to
+assign them — that actively protects a beginner like me. The dashed-emerald
+**GAP row** ("10.1.0.10 – 10.1.0.254 · 245 free · click to allocate") is
+lovely; it tells me where the free space is AND what clicking does. Best
+single piece of UX on the page.
+
+The **Seen** column dots — when I hover, the tooltip says "Alive — last seen
+2h ago via dhcp" / "Stale" / "Cold" / "Never seen on the wire". That's
+**great** — clear, plain English, tells me the source. (The sidebar green dot
+should steal this tooltip treatment.)
+
+The **DNS column "• in sync"** is reassuring, and hovering gives
+"DNS records match IPAM" — good.
+
+But the tabs across the top — **[IP Addresses] [DHCP Pools] [Aliases]
+[Address Sets] [NAT] [Trend]** — "Address Sets" means nothing to me. The
+tooltip ("Named, RBAC-scoped slices of this subnet address space") uses
+*more* jargon ("RBAC-scoped slices") to explain jargon. As a junior I'd just
+avoid that tab entirely.
+
+The **[Sync v] [Tools v]** dropdowns hide actions I can't preview. "Tools"
+could contain Merge/Split/Resize (per the tooltips: "Merge contiguous sibling
+subnets") — those are destructive and they're buried in an innocuous-looking
+"Tools" menu. I'd want destructive items in there clearly flagged (red text /
+warning icon).
+
+### IP detail modal (read-only)
+Mostly fine and I appreciate it's read-only by default — header buttons
+[Ask AI][Scan with Nmap][Edit][Delete][x]. But the field grid shows
+**REVERSE DNS ZONE = "0"** and **DNS / DHCP LINKAGE = "0"** — bare numbers
+with no label or unit. As a nervous newbie, a lone "0" makes me think
+something is broken or unset and I'd go ask a senior "is this IP okay?" when
+probably nothing is wrong. Either show a real value, a name, or "None".
+
+The **NETWORK DISCOVERY** and **DEVICE PROFILE** empty states are actually
+*excellent* for me — they tell me exactly why there's no data and what to do
+("add the upstream switch in /network and wait a polling cycle"). That's the
+tone the whole app should use with beginners.
+
+**[Scan with Nmap]** sitting right there worries me a little — scanning is
+something I've been told to be careful about on prod networks. No warning or
+"this is safe / read-only" note. I'd hesitate.
+
+### Edit IP modal
+Clean. Tabs [Details][Network][Scan with Nmap]. The DNS Aliases helper —
+"Extra records pointing to this IP. Added records are removed automatically
+when the IP is purged." — is a nice plain-English explanation. The Custom
+Fields "Owner" helper ("Operator team or person responsible for this IP") is
+friendly. The **Role "— None —"** dropdown is unexplained though — role for
+what? The tooltip elsewhere calls it "Legacy tag" which is even more
+confusing for a newcomer.
+
+### Data quirks that scared/confused me
+- A /64 IPv6 subnet shows **Used IPs 0 / 9223372036854776000** and Size
+  "9,223,372,036,854,776,000". That giant number looks like a bug/overflow.
+  A beginner can't tell if that's correct or broken. Show "/64 (vast)" or
+  similar.
+- Router column literally shows the text **"NetBox import"** — that's not a
+  router, that's a provenance note in the wrong column. Confusing.
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| high | Space detail / button row | Read-only actions (Export, Find Free) look identical to live-infra actions (Sync DNS). A nervous junior can't tell what's safe. "Sync DNS" especially sounds like it pushes to production. | Visually separate read-only vs mutating buttons (e.g. neutral vs amber/primary), and give Sync DNS a tooltip stating exactly what it changes and that it's previewed first. |
+| high | Block detail / aggregation suggestion | "aggregation suggestion" + "pack into a clean supernet" is pure jargon; I can't tell if accepting it merges/deletes my subnets. | Reword to plain English: "These small subnets sit next to each other and could be combined into one larger subnet." Spell out that accepting only proposes a change and shows a confirm. |
+| high | IP detail modal | REVERSE DNS ZONE shows bare "0" and DNS/DHCP LINKAGE shows "0" — looks like something is broken/unset. | Render a real zone name or "None / not linked"; never show a context-free numeric "0". |
+| medium | Sidebar tree | Subnet green dot has no legend or tooltip; meaning is a mystery (health? selected?). | Add a tooltip/legend; reuse the clear "Seen" dot wording if it's a recency dot. |
+| medium | Subnet detail / Tools menu | Destructive ops (Merge, Resize, Split) are hidden inside an innocuous "Tools v" dropdown with no danger styling. | Flag destructive menu items with red text + warning icon; keep purely-read tools visually distinct. |
+| medium | Subnet detail / tabs | "Address Sets" tab is meaningless to a beginner; tooltip "RBAC-scoped slices" explains jargon with more jargon. | Plain tooltip: "Optional named groups of IPs within this subnet you can give specific people access to." |
+| medium | Block detail header | Raw "netbox_id 1 / netbox_is_pool false" provenance chips leak DB/import internals onto the main screen. | Move provenance behind an info/ⓘ popover or a "Details" expander; don't surface raw field names by default. |
+| medium | IPv6 subnet display | "0 / 9223372036854776000" and a 19-digit Size look like an overflow bug to a novice. | For huge IPv6 ranges show "/64 — practically unlimited" instead of the raw count. |
+| low | Sidebar header icons | Three unlabeled icons (refresh/upload/+); "upload" is scary with no tooltip. | Add tooltips; clarify what "upload" imports and that it won't overwrite the tree. |
+| low | Space detail / VRF-BGP banner | "VRF / BGP — not configured" reads like a required missing step. | Add "(optional — only for multi-routing-table setups)" so beginners don't feel they skipped something. |
+| low | Router column | Literal text "NetBox import" appears under "Router". | Don't place provenance text in the Router column; show actual router or blank. |
+| nit | Edit IP modal / Role | "Role (— None —)" unexplained; elsewhere called "Legacy tag". | Add a one-line helper describing what Role does, or hide if truly legacy. |
+
+## What works well
+
+- **.0/.255 greyed "Network address" / "Broadcast address" rows** — actively
+  stops a beginner from assigning unusable IPs. Excellent guardrail.
+- **The dashed-emerald GAP row** ("X – Y · 245 free · click to allocate") —
+  tells me where free space is and exactly what clicking does. Best UX here.
+- **Seen-column dot tooltips** — "Alive — last seen 2h ago via dhcp" is plain,
+  honest, and tells me the source. This is the tone the whole app needs.
+- **Empty states in the IP detail modal** (Network Discovery / Device Profile)
+  — they explain *why* there's no data and what to do next. Beginner-perfect.
+- **Breadcrumb pills + the combined block/subnet table + Allocation Map legend**
+  — I always know where I am and what I'm looking at.
+- **Role filter chips [Data][Voice][Management][Guest]** — self-explanatory.
+
+## My one big idea
+
+Add a simple, consistent **"safe vs changes-things" visual language across all
+of IPAM**, plus plain-English microcopy on the jargon. Concretely: style
+read-only actions (Export, Find Free, Scan, view tabs) one neutral way, and
+anything that mutates real config or infrastructure (Sync DNS/DHCP, Merge,
+Resize, Delete, accept-aggregation) another way with a warning icon — and
+gate every destructive one behind a confirm modal that describes the blast
+radius in beginner terms ("This will combine 2 subnets into one and cannot be
+undone"). That single change would turn this from an app I'm scared to click
+in into one I can learn on without breaking prod.

--- a/docs/reviews/ipam/visual-ux-designer.md
+++ b/docs/reviews/ipam/visual-ux-designer.md
@@ -1,0 +1,86 @@
+# IPAM Visual / Interaction Design Review — SpatiumDDI
+
+## Who I am & what I want
+
+I'm a visual / interaction designer. When I land on a screen, the first thing my eye does is look for *rhythm*: do the header buttons line up and read the same way across sibling pages? Are stat numbers aligned to a grid? Does spacing breathe consistently, or does every card invent its own padding? I care about visual hierarchy (what should I see first?), consistency (does "the same thing" look the same everywhere?), and information density (is this scannable or is it a wall of mono-spaced strings?).
+
+My north star for an IPAM tool: the three drill-down levels (Space → Block → Subnet) should feel like *one product zooming in*, not three pages a different person built. The user should never have to re-learn the header, the table, or the vocabulary as they descend the tree.
+
+## Page-by-page walkthrough
+
+### Spaces tree (left sidebar)
+First impression: dense and legible, good. The Space → Block → Subnet nesting with distinct icons (stacked-squares for blocks, tree for subnets) is a clean way to signal level. But two things snag me immediately:
+
+- The little **green dot** next to subnets has no legend, no tooltip, no key. As a designer I assume color *means* something (health? sync? utilization?). An unexplained colored dot is a visual promise the UI doesn't keep. I'd either explain it or remove it.
+- Auto-created blocks labelled **`auto:10.50.0.0/24`** leak an implementation prefix into a human-facing tree. The `auto:` token is a machine concept; it reads like a debug string sitting next to nicely-named spaces like "Acme-Prod."
+
+The header icons (refresh / upload / +) are icon-only with presumably tooltips — fine for a dense rail, consistent with the rest.
+
+### Space detail (level 1)
+Header reads: space name + a subdued line **"VRF / BGP — not configured (Edit Space to add)"**. The empty-state-as-subtitle pattern is actually nice — it tells me what's missing and how to fix it inline. I like it.
+
+Button row: `[Sync DNS] [Export] [Find Free…] [Edit Space] [Add Block] [+ Add Subnet]`. Reads left-to-right reasonably (reads → edits → adds), and the `+` primary is last. Good baseline. **But hold this in your head**, because the Subnet level breaks it.
+
+The combined **blocks + subnets in one table** is a defensible density choice, but visually it's ragged: blocks fill only Network + Size, subnets fill Used IPs / Utilization / Status / Environment. So I'm staring at a table with lots of half-empty rows. The eye reads "missing data" not "different row type." There's no visual differentiator (no row tint, no type badge, no icon in the Network cell) telling me "this row is a *block*, that's why it has no utilization." That's a hierarchy failure inside the table.
+
+### Block detail (level 2)
+Breadcrumb pills (Space > block) — good, consistent affordance. Title = CIDR.
+
+Then the thing that makes me wince as a designer: **raw provenance chips on the detail header** — `netbox_id 1   netbox_is_pool false`. This is a backend field name and a boolean dumped onto a human header. `netbox_is_pool false` is exactly the kind of string that should *never* reach a polished header — snake_case key + literal `false`. If provenance matters, it belongs as a single tasteful "Imported from NetBox" chip (with detail on hover or in an Info/Provenance section), not two raw key/value pairs competing with the CIDR title for attention.
+
+The **ALLOCATION MAP** with `[Band]/[Treemap]` toggle and the legend "Child blocks / Subnets / Free (saturated portion = % allocated)" is genuinely the best-designed element on these pages — it's a real visualization with a real legend, and the toggle is a clean interaction. Delight point.
+
+The yellow **"1 aggregation suggestion"** badge is good information scent. Role filter chips `[Data][Voice][Management][Guest]` are clean.
+
+Button row here: `[Sync DNS] [Export] [Find Free…] [Edit] [Resize…] [Move…] [Add Block] [+ New Subnet]`. Note it's already drifting from Space level — "Edit Space" became "Edit," and we've gained Resize/Move. Acceptable drift (those ops only exist at block level), but watch the count: 8 buttons is getting crowded.
+
+### Subnet detail (level 3) — the consistency break
+This is where the product stops feeling like one zooming view. The button row is now: `[Refresh] [Sync v] [Import / Export v] [Tools v] [Ask AI] [Edit] [+ Allocate IP]`.
+
+Compare across levels:
+- **Sync**: Space/Block show a flat **`[Sync DNS]`** button. Subnet shows a **`[Sync v]`** *dropdown menu*. Same conceptual action, two different control types, two different labels.
+- **Find Free**: Space/Block show a flat **`[Find Free…]`** button. At Subnet it's presumably *inside* **`[Tools v]`**. So the same family of operations is sometimes a top-level button and sometimes buried in an overflow menu — and the user has to re-scan to find it at each level.
+- **Export**: flat `[Export]` at Space/Block, folded into `[Import / Export v]` at Subnet.
+
+The *logic* (more actions exist deeper, so they get collapsed into menus) is understandable, but the *visual experience* is that the toolbar reshuffles under you on every drill-down. I can't build muscle memory. As a designer I'd want a consistent toolbar grammar: pick "always menus" or "always flat buttons with overflow," and apply one rule at all three levels.
+
+The **summary stat row** ("Gateway 10.1.0.1 · VLAN 10 · Total IPs 254 · Allocated 11/254 · Utilization 4%") with middot separators is tidy and scannable — I like this more than a card grid would be here.
+
+The **IP table** is the strongest table in the section: status pills, the dashed-emerald **GAP row** ("10.1.0.10 – 10.1.0.254 · 245 free · click to allocate") is a lovely, inviting affordance — it turns empty space into a call-to-action. The greyed `.0`/`.255`/gateway rows are well-handled visually (muted = not actionable). The **Seen** dots are good *if* the tooltip is discoverable; the dot has a real `title` (confirmed: "Alive — last seen … via dhcp") but there's still no on-screen legend, same unexplained-color problem as the sidebar dot, and the two dot systems (sidebar green dot vs Seen-column 4-color dots) are unrelated yet visually identical — a viewer will assume they mean the same thing.
+
+### IP detail modal
+Clean 2-col field grid, good label/value rhythm. Two real defects:
+
+1. **The bare "0".** The persona saw numeric "0" values with no label. Confirmed in the markup: the counters row is guarded by `{(addr.alias_count || addr.nat_mapping_count) && (…)}`. When both are `0`, JS evaluates `0 || 0 → 0`, and React *renders that literal `0`* on the page. So a clean IP with no aliases/NAT shows a stray "0" floating under the field grid. This is a classic React falsy-render bug surfacing as a visual artifact. (The "Reverse DNS zone: 0" the persona noted is likely the same family — a numeric id leaking where a name/dash should be, though that field is dash-guarded in code; the counters "0" is the clear culprit.)
+2. **Empty states are wordy but good.** "No network discovery data — add the upstream switch in /network and wait a polling cycle." and the Device Profile empty state are *genuinely helpful* — they tell me the cause and the fix. I'd only tighten the typography (they're long sentences in a tight panel).
+
+### Edit IP modal
+Tabbed `[Details][Network][Scan with Nmap]` — consistent with the rest of the app's modal-tabs pattern, good. The "DNS Aliases" helper text and "No aliases." empty state are clear. "CUSTOM FIELDS" → Owner with helper text is fine. No major visual issues here; this modal is the most consistent surface in the section.
+
+## Findings
+
+| Severity | Area | Issue | Suggestion |
+|---|---|---|---|
+| high | Subnet detail / toolbar | Header button grammar is inconsistent across levels: flat `[Sync DNS]`/`[Find Free…]`/`[Export]` at Space/Block become `[Sync v]` menu, `[Tools v]` overflow, `[Import / Export v]` menu at Subnet. Same actions, different control types — breaks muscle memory on every drill-down. | Pick ONE toolbar grammar for all three levels. E.g. always show a small set of flat primaries (Refresh, Sync, Add) + one consistent `[Tools v]` overflow that contains the same families everywhere. Keep label + control type identical level-to-level. |
+| high | Block detail / header | Raw provenance chips `netbox_id 1   netbox_is_pool false` — snake_case backend keys + literal `false` rendered on a human-facing detail header, competing with the CIDR title. | Replace with one tasteful "Imported from NetBox" chip; move raw id/is_pool into an Info/Provenance section or hover. Never render a literal boolean as header text. |
+| high | IP detail modal | A stray literal **`0`** renders under the field grid for IPs with no aliases/NAT — caused by `{(alias_count || nat_mapping_count) && …}` where `0 || 0 → 0` and React prints the 0. | Coerce to boolean: `{((alias_count ?? 0) > 0 || (nat_mapping_count ?? 0) > 0) && …}`. Verify the "Reverse DNS zone: 0" sighting isn't a sibling id-leak. |
+| medium | Spaces tree + Subnet table | Two unrelated colored-dot systems (sidebar single green dot vs Seen-column 4-color dots) look identical but mean different things, and the sidebar dot has no legend at all. | Give the sidebar dot a tooltip/legend or remove it. Make the two dot vocabularies visually distinct (shape/size) if they must coexist, and add a small "Seen" legend near the IP table. |
+| medium | Space/Block table | Mixed block+subnet table has many half-empty rows (blocks fill only Network+Size); reads as missing data, not as a different row type. | Add a clear row-type signal: a Block/Subnet badge or icon in the Network cell, and/or a subtle row tint for block rows, so empty cells read as "N/A for blocks." |
+| medium | Spaces tree | Auto-created blocks show machine prefix `auto:10.50.0.0/24` in a human tree. | Drop the `auto:` prefix from the display label; convey "auto-created" with a small muted icon/badge + tooltip instead. |
+| low | IPv6 subnet | A /64 shows "Used IPs 0 / 9,223,372,036,854,776,000" and Size "9.2e18" — a wall of digits that destroys the stat row's scannability and is also a rounded/wrong value. | For huge address families, render "/64 (2^64 addresses)" or "≈1.8×10^19" instead of a 19-digit integer; show utilization as "—" or "negligible" rather than 0%. |
+| low | Block detail | 8 header buttons (`Sync DNS, Export, Find Free…, Edit, Resize…, Move…, Add Block, +New Subnet`) is crowded and increases per-level toolbar drift. | Collapse secondary block ops (Resize/Move/Find Free) into a `[Tools v]` overflow — which also helps unify the grammar with the Subnet level. |
+| low | Subnet detail / Router col | Router column shows literal text "NetBox import" and tag system has a "Legacy tag" tooltip — provenance/legacy strings appearing as data values. | Don't put import-source strings in the Router column; show real router or a dash. Visually distinguish legacy tags (muted/strikethrough or a "legacy" pill). |
+| nit | IP detail modal | Helpful but long empty-state sentences ("…add the upstream switch in /network and wait a polling cycle.") sit in a tight panel. | Keep the helpfulness; tighten to two lines with the action ("Add upstream switch") as a subtle link, body text smaller/muted. |
+| nit | Subnet stats | Middot-separated stat row is good, but "Allocated 11/254" and "Utilization 4%" duplicate the same fact in two forms. | Consider merging into one ("11 / 254 · 4%") to free horizontal space and reduce redundancy. |
+
+## What works well
+
+- **Allocation Map (Band/Treemap toggle + legend)** at the block level is the standout — a real visualization with a real legend and a clean toggle. This is the visual quality bar the rest of the section should rise to.
+- **The dashed-emerald GAP row** in the IP table ("245 free · click to allocate") is a delightful, inviting affordance that turns dead space into an action. Best micro-interaction in the section.
+- **Empty-state-as-subtitle** ("VRF / BGP — not configured (Edit Space to add)") and the modal empty states are genuinely helpful — they name the cause and the fix instead of just saying "no data."
+- **Breadcrumb pills + the middot summary stat row** give a consistent, scannable sense of place and at-a-glance status at the subnet level.
+- **Greyed network/broadcast/gateway rows** correctly signal "not actionable" through muting — good use of de-emphasis.
+
+## My one big idea
+
+**Adopt a single, level-invariant toolbar grammar across Space / Block / Subnet.** Right now the same operations (Sync, Export, Find Free) shape-shift between flat buttons, dropdown menus, and overflow `Tools` at different levels, so the toolbar visually reshuffles on every drill-down and I can't build muscle memory. Define one rule — e.g. a fixed left cluster `[Refresh] [Sync v] [+ Add …]` plus one consistent `[Tools v]` overflow whose contents are the union of level-relevant ops — and apply it identically at all three levels. The label, the control type, and the position of each action stay constant as you zoom in. That one change makes the three pages finally read as *one product zooming in* rather than three pages with three toolbars, and it's the highest-leverage consistency fix available here.

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -214,6 +214,33 @@ function RoleBadge({ role }: { role: string }) {
   );
 }
 
+// Import-provenance custom-field keys (stamped by the NetBox / cloud importers).
+// Collapse these into a single "Imported from …" chip instead of leaking raw
+// key/value pairs (netbox_id, netbox_is_pool, import_source, …) into the UI.
+function isProvenanceKey(k: string): boolean {
+  return /^(netbox|import_)/.test(k) || k === "imported_at";
+}
+
+function ImportedChip({ fields }: { fields: Record<string, unknown> }) {
+  const fromNetbox =
+    Object.keys(fields).some((k) => k.startsWith("netbox")) ||
+    String(fields["import_source"] ?? "")
+      .toLowerCase()
+      .includes("netbox");
+  const label = fromNetbox ? "Imported from NetBox" : "Imported";
+  const detail = Object.entries(fields)
+    .map(([k, v]) => `${k}: ${String(v)}`)
+    .join(" · ");
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded bg-sky-100 px-1.5 py-0.5 text-[11px] font-medium text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
+      title={detail}
+    >
+      {label}
+    </span>
+  );
+}
+
 const COUNTABLE_MAX = Number.MAX_SAFE_INTEGER;
 
 // IPv6 subnets (a /64 is 2^64 addresses) overflow the BIGINT total_ips column,
@@ -1697,6 +1724,7 @@ function AdditionalZonesPicker({
           value={filter}
           onChange={(e) => onFilter(e.target.value)}
           placeholder="Filter…"
+          aria-label="Filter"
           disabled={disabled}
           className="w-full rounded-t-md border border-b-0 bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
         />
@@ -4574,12 +4602,29 @@ function SubnetDetail({
               uncountable={isUncountable(subnet.total_ips)}
             />
           </div>
-          {Object.entries(subnet.custom_fields ?? {}).map(([k, v]) => (
-            <div key={k} className="flex items-center gap-1.5">
-              <span className="text-xs text-muted-foreground">{k}</span>
-              <span className="text-xs font-medium">{String(v)}</span>
-            </div>
-          ))}
+          {(() => {
+            const all = (subnet.custom_fields ?? {}) as Record<string, unknown>;
+            const prov = Object.fromEntries(
+              Object.entries(all).filter(([k]) => isProvenanceKey(k)),
+            );
+            const rest = Object.entries(all).filter(([k]) => !isProvenanceKey(k));
+            return (
+              <>
+                {Object.keys(prov).length > 0 && (
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-xs text-muted-foreground">Source</span>
+                    <ImportedChip fields={prov} />
+                  </div>
+                )}
+                {rest.map(([k, v]) => (
+                  <div key={k} className="flex items-center gap-1.5">
+                    <span className="text-xs text-muted-foreground">{k}</span>
+                    <span className="text-xs font-medium">{String(v)}</span>
+                  </div>
+                ))}
+              </>
+            );
+          })()}
         </div>
 
         {/* DNS drift banner — only shows when records exist out-of-sync
@@ -4775,6 +4820,7 @@ function SubnetDetail({
                   value={addressTagFilters}
                   onChange={setAddressTagFilters}
                   placeholder="Filter addresses by tag — try env or env:prod…"
+                  aria-label="Filter addresses by tag"
                 />
               </div>
               {/* No nested overflow wrapper — Chrome/WebKit treat
@@ -4973,6 +5019,7 @@ function SubnetDetail({
                                   }))
                                 }
                                 placeholder="Filter…"
+          aria-label="Filter"
                                 className="w-full min-w-0 rounded-l border border-r-0 bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
                               />
                               <div className="relative">
@@ -5421,10 +5468,11 @@ function SubnetDetail({
                                   an ``allocated`` row can still be cold,
                                   a ``discovered`` row can be alive right
                                   now. Tooltip carries exact age + method. */}
-                            <td className="px-4 py-2 text-center">
+                            <td className="px-4 py-2">
                               <SeenDot
                                 lastSeenAt={addr.last_seen_at}
                                 lastSeenMethod={addr.last_seen_method}
+                                withLabel
                               />
                             </td>
                             {/* Network discovery — switch / port / VLAN
@@ -11253,17 +11301,26 @@ function BlockDetailView({
             </span>
           )}
         </div>
-        {/* Custom field values */}
-        {Object.keys(block.custom_fields ?? {}).length > 0 && (
-          <div className="flex flex-wrap gap-x-6 gap-y-1 border-t bg-muted/20 px-6 py-2">
-            {Object.entries(block.custom_fields).map(([k, v]) => (
-              <div key={k} className="flex items-center gap-1.5">
-                <span className="text-xs text-muted-foreground">{k}</span>
-                <span className="text-xs font-medium">{String(v)}</span>
+        {/* Custom field values — import provenance collapsed into one chip */}
+        {Object.keys(block.custom_fields ?? {}).length > 0 &&
+          (() => {
+            const all = block.custom_fields as Record<string, unknown>;
+            const prov = Object.fromEntries(
+              Object.entries(all).filter(([k]) => isProvenanceKey(k)),
+            );
+            const rest = Object.entries(all).filter(([k]) => !isProvenanceKey(k));
+            return (
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-1 border-t bg-muted/20 px-6 py-2">
+                {Object.keys(prov).length > 0 && <ImportedChip fields={prov} />}
+                {rest.map(([k, v]) => (
+                  <div key={k} className="flex items-center gap-1.5">
+                    <span className="text-xs text-muted-foreground">{k}</span>
+                    <span className="text-xs font-medium">{String(v)}</span>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        )}
+            );
+          })()}
         {/* Allocation map */}
         <div className="border-t px-6 py-2">
           <div className="mb-1 flex items-center justify-between">
@@ -11489,6 +11546,7 @@ function BlockDetailView({
             value={tagFilters}
             onChange={setTagFilters}
             placeholder="Filter subnets + child blocks by tag — try env or env:prod…"
+            aria-label="Filter subnets and child blocks by tag"
           />
           <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
             role:
@@ -11840,6 +11898,7 @@ function BlockDetailView({
                                 }))
                               }
                               placeholder="Filter…"
+          aria-label="Filter"
                               className="w-full rounded border bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
                             />
                           </td>
@@ -12737,6 +12796,7 @@ function SpaceTableView({
                               }))
                             }
                             placeholder="Filter…"
+          aria-label="Filter"
                             className="w-full rounded border border-border bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
                           />
                         </td>

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -2658,6 +2658,68 @@ const IP_STATUS_OPTIONS = [
   "deprecated",
 ] as const;
 
+// Double-click-to-change status badge on the IP table (sibling of
+// InlineEditableText). Swallows single clicks so it doesn't open the row
+// detail; commit on select, Escape/blur cancels. Disabled on read-only rows.
+function InlineStatusSelect({
+  status,
+  disabled = false,
+  onSave,
+}: {
+  status: string;
+  disabled?: boolean;
+  onSave: (next: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  if (disabled) return <StatusBadge status={status} />;
+  if (editing) {
+    const known = (IP_STATUS_OPTIONS as readonly string[]).includes(status);
+    const opts = known
+      ? (IP_STATUS_OPTIONS as readonly string[])
+      : [status, ...IP_STATUS_OPTIONS];
+    return (
+      <select
+        autoFocus
+        value={status}
+        aria-label="Status"
+        onClick={(e) => e.stopPropagation()}
+        onChange={(e) => {
+          const v = e.target.value;
+          setEditing(false);
+          if (v && v !== status) onSave(v);
+        }}
+        onBlur={() => setEditing(false)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            setEditing(false);
+          }
+        }}
+        className="rounded border bg-background px-1 py-0.5 text-xs"
+      >
+        {opts.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+    );
+  }
+  return (
+    <span
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        setEditing(true);
+      }}
+      title="Double-click to change status"
+      className="cursor-pointer"
+    >
+      <StatusBadge status={status} />
+    </span>
+  );
+}
+
 // IP allocate/edit/delete cascades into DNS via ``_sync_dns_record``
 // (auto A + PTR) and can land a DHCP static when ``status='static_dhcp'``.
 // Every mutation that invalidates ``["addresses", ...]`` below also
@@ -5560,7 +5622,16 @@ function SubnetDetail({
                             </td>
                             <td className="px-4 py-2">
                               <span className="inline-flex items-center">
-                                <StatusBadge status={addr.status} />
+                                <InlineStatusSelect
+                                  status={addr.status}
+                                  disabled={isReadOnly(addr.status)}
+                                  onSave={(v) =>
+                                    inlineEditMut.mutate({
+                                      id: addr.id,
+                                      data: { status: v },
+                                    })
+                                  }
+                                />
                                 {addr.role ? (
                                   <RoleBadge role={addr.role} />
                                 ) : null}

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -221,7 +221,25 @@ function isProvenanceKey(k: string): boolean {
   return /^(netbox|import_)/.test(k) || k === "imported_at";
 }
 
-function ImportedChip({ fields }: { fields: Record<string, unknown> }) {
+// Collapsed import-provenance chip with a dismiss (×) that clears the
+// netbox_*/import_* keys from the resource's custom_fields. `fields` is the
+// provenance subset (for the label/tooltip); `keep` is the custom_fields dict
+// WITHOUT the provenance keys (what we PUT back when the operator removes it).
+function ImportedChip({
+  fields,
+  kind,
+  id,
+  keep,
+  onUpdated,
+}: {
+  fields: Record<string, unknown>;
+  kind: "block" | "subnet";
+  id: string;
+  keep: Record<string, unknown>;
+  onUpdated: (updated: IPBlock | Subnet) => void;
+}) {
+  const qc = useQueryClient();
+  const [confirming, setConfirming] = useState(false);
   const fromNetbox =
     Object.keys(fields).some((k) => k.startsWith("netbox")) ||
     String(fields["import_source"] ?? "")
@@ -231,13 +249,53 @@ function ImportedChip({ fields }: { fields: Record<string, unknown> }) {
   const detail = Object.entries(fields)
     .map(([k, v]) => `${k}: ${String(v)}`)
     .join(" · ");
+  const clearMut = useMutation<IPBlock | Subnet, Error, void>({
+    mutationFn: () =>
+      kind === "block"
+        ? ipamApi.updateBlock(id, { custom_fields: keep })
+        : ipamApi.updateSubnet(id, { custom_fields: keep }),
+    onSuccess: (updated) => {
+      // Update the displayed detail object immediately. The chip renders
+      // from the detail view's local copy of the block/subnet, which query
+      // invalidation alone does not refresh — without this the chip only
+      // disappeared after a full page reload.
+      onUpdated(updated);
+      qc.invalidateQueries({ queryKey: ["blocks"] });
+      qc.invalidateQueries({ queryKey: ["subnets"] });
+      setConfirming(false);
+    },
+  });
   return (
-    <span
-      className="inline-flex items-center gap-1 rounded bg-sky-100 px-1.5 py-0.5 text-[11px] font-medium text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
-      title={detail}
-    >
-      {label}
-    </span>
+    <>
+      <span
+        className="inline-flex items-center gap-1 rounded bg-sky-100 px-1.5 py-0.5 text-[11px] font-medium text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
+        title={detail}
+      >
+        {label}
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          aria-label={`Remove import metadata from this ${kind}`}
+          title="Remove import metadata"
+          className="ml-0.5 rounded px-0.5 leading-none text-sky-700/60 hover:bg-sky-200 hover:text-sky-900 dark:text-sky-400/60 dark:hover:bg-sky-800/60"
+        >
+          ×
+        </button>
+      </span>
+      <ConfirmModal
+        open={confirming}
+        title="Remove import metadata?"
+        confirmLabel="Remove"
+        loading={clearMut.isPending}
+        message={`This clears the import-provenance fields (${Object.keys(
+          fields,
+        ).join(
+          ", ",
+        )}) from this ${kind}, so the "${label}" chip disappears. The ${kind} itself and its other fields are unchanged.`}
+        onConfirm={() => clearMut.mutate()}
+        onClose={() => setConfirming(false)}
+      />
+    </>
   );
 }
 
@@ -4786,7 +4844,13 @@ function SubnetDetail({
                 {Object.keys(prov).length > 0 && (
                   <div className="flex items-center gap-1.5">
                     <span className="text-xs text-muted-foreground">Source</span>
-                    <ImportedChip fields={prov} />
+                    <ImportedChip
+                      fields={prov}
+                      kind="subnet"
+                      id={subnet.id}
+                      keep={Object.fromEntries(rest)}
+                      onUpdated={(u) => onSubnetEdited(u as Subnet)}
+                    />
                   </div>
                 )}
                 {rest.map(([k, v]) => (
@@ -11534,7 +11598,15 @@ function BlockDetailView({
             const rest = Object.entries(all).filter(([k]) => !isProvenanceKey(k));
             return (
               <div className="flex flex-wrap items-center gap-x-6 gap-y-1 border-t bg-muted/20 px-6 py-2">
-                {Object.keys(prov).length > 0 && <ImportedChip fields={prov} />}
+                {Object.keys(prov).length > 0 && (
+                  <ImportedChip
+                    fields={prov}
+                    kind="block"
+                    id={block.id}
+                    keep={Object.fromEntries(rest)}
+                    onUpdated={(u) => setBlock(u as IPBlock)}
+                  />
+                )}
                 {rest.map(([k, v]) => (
                   <div key={k} className="flex items-center gap-1.5">
                     <span className="text-xs text-muted-foreground">{k}</span>

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -365,6 +365,69 @@ function BlockNameTag({
   return <span className={className}>{name}</span>;
 }
 
+// Double-click-to-edit cell for the IP table. Swallows single clicks so it
+// doesn't trigger the row's open-detail handler; Enter/blur commit, Escape
+// cancels. `display` is what shows when not editing; `value` seeds the input.
+function InlineEditableText({
+  value,
+  placeholder,
+  display,
+  onSave,
+  disabled = false,
+}: {
+  value: string;
+  placeholder: string;
+  display: React.ReactNode;
+  onSave: (next: string) => void;
+  disabled?: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  if (disabled) return <>{display}</>;
+  if (editing) {
+    const commit = () => {
+      setEditing(false);
+      if (draft.trim() !== value.trim()) onSave(draft);
+    };
+    return (
+      <input
+        autoFocus
+        value={draft}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        onChange={(e) => setDraft(e.target.value)}
+        onClick={(e) => e.stopPropagation()}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            setDraft(value);
+            setEditing(false);
+          }
+        }}
+        className="w-full min-w-[6rem] rounded border bg-background px-1 py-0.5 text-xs"
+      />
+    );
+  }
+  return (
+    <span
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        setDraft(value);
+        setEditing(true);
+      }}
+      title="Double-click to edit"
+      className="cursor-text"
+    >
+      {display}
+    </span>
+  );
+}
+
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   function handleCopy(e: React.MouseEvent) {
@@ -4062,6 +4125,12 @@ function SubnetDetail({
     "ipam-hide-reserved",
     false,
   );
+  // Inline (double-click) edits of hostname / description on the IP table.
+  const inlineEditMut = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: Partial<IPAddress> }) =>
+      ipamApi.updateAddress(id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["addresses"] }),
+  });
   const [activeSubnetTab, setActiveSubnetTab] = useState<
     "addresses" | "dhcp" | "aliases" | "nat" | "trend" | "address-sets"
   >("addresses");
@@ -5343,19 +5412,32 @@ function SubnetDetail({
                             </td>
                             <td className="px-4 py-2">
                               <span className="inline-flex items-center gap-1.5">
-                                {addr.fqdn ? (
-                                  <span className="font-mono text-xs">
-                                    {addr.fqdn}
-                                  </span>
-                                ) : addr.hostname ? (
-                                  <span className="text-muted-foreground">
-                                    {addr.hostname}
-                                  </span>
-                                ) : (
-                                  <span className="text-muted-foreground/40">
-                                    —
-                                  </span>
-                                )}
+                                <InlineEditableText
+                                  value={addr.hostname ?? ""}
+                                  placeholder="hostname"
+                                  disabled={isReadOnly(addr.status)}
+                                  onSave={(v) =>
+                                    inlineEditMut.mutate({
+                                      id: addr.id,
+                                      data: { hostname: v.trim() },
+                                    })
+                                  }
+                                  display={
+                                    addr.fqdn ? (
+                                      <span className="font-mono text-xs">
+                                        {addr.fqdn}
+                                      </span>
+                                    ) : addr.hostname ? (
+                                      <span className="text-muted-foreground">
+                                        {addr.hostname}
+                                      </span>
+                                    ) : (
+                                      <span className="text-muted-foreground/40">
+                                        —
+                                      </span>
+                                    )
+                                  }
+                                />
                                 {(addr.alias_count ?? 0) > 0 && (
                                   <span
                                     className="inline-flex items-center rounded bg-indigo-100 px-1.5 py-0.5 text-[10px] font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400"
@@ -5414,11 +5496,26 @@ function SubnetDetail({
                               )}
                             </td>
                             <td className="px-4 py-2 text-muted-foreground">
-                              {addr.description ?? (
-                                <span className="text-muted-foreground/40">
-                                  —
-                                </span>
-                              )}
+                              <InlineEditableText
+                                value={addr.description ?? ""}
+                                placeholder="description"
+                                disabled={isReadOnly(addr.status)}
+                                onSave={(v) =>
+                                  inlineEditMut.mutate({
+                                    id: addr.id,
+                                    data: { description: v.trim() },
+                                  })
+                                }
+                                display={
+                                  addr.description ? (
+                                    <>{addr.description}</>
+                                  ) : (
+                                    <span className="text-muted-foreground/40">
+                                      —
+                                    </span>
+                                  )
+                                }
+                              />
                             </td>
                             <td className="px-4 py-2">
                               {(() => {

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -327,12 +327,42 @@ function UtilizationDot({ percent }: { percent: number }) {
       : percent >= 80
         ? "bg-amber-400"
         : "bg-green-500";
+  const tip = `${percent.toFixed(0)}% utilized`;
   return (
     <span
-      title={`${percent.toFixed(0)}% utilized`}
+      title={tip}
+      aria-label={tip}
       className={cn("inline-block h-2 w-2 flex-shrink-0 rounded-full", color)}
     />
   );
+}
+
+// Synthesized wrapper blocks are named "auto:<cidr>" by the importers, which
+// just duplicates the Network column. Render a compact "auto" badge instead of
+// the redundant string; realBlockName() strips it for plain-text label sites.
+function realBlockName(name?: string | null): string {
+  return name && !name.startsWith("auto:") ? name : "";
+}
+
+function BlockNameTag({
+  name,
+  className,
+}: {
+  name?: string | null;
+  className?: string;
+}) {
+  if (!name) return null;
+  if (name.startsWith("auto:")) {
+    return (
+      <span
+        title="Auto-created wrapper block (name derived from its CIDR)"
+        className="inline-flex items-center rounded bg-muted px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground/70"
+      >
+        auto
+      </span>
+    );
+  }
+  return <span className={className}>{name}</span>;
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -10113,7 +10143,7 @@ function flattenBlocks(
   return nodes.flatMap(({ block, children }) => [
     {
       id: block.id,
-      label: `${"  ".repeat(depth)}${block.network}${block.name ? ` — ${block.name}` : ""}`,
+      label: `${"  ".repeat(depth)}${block.network}${realBlockName(block.name) ? ` — ${realBlockName(block.name)}` : ""}`,
     },
     ...flattenBlocks(children, depth + 1),
   ]);
@@ -10881,11 +10911,10 @@ function BlockTreeRow({
               <span className="font-mono font-medium flex-1 truncate">
                 {node.block.network}
               </span>
-              {node.block.name && (
-                <span className="truncate text-[10px] opacity-60 mr-1">
-                  {node.block.name}
-                </span>
-              )}
+              <BlockNameTag
+                name={node.block.name}
+                className="truncate text-[10px] opacity-60 mr-1"
+              />
               <CustomerChip customerId={node.block.customer_id} />
               <SiteChip siteId={node.block.site_id} />
             </button>
@@ -11182,7 +11211,7 @@ function BlockDetailView({
       }),
     ),
     {
-      label: block.network + (block.name ? ` (${block.name})` : ""),
+      label: block.network + (realBlockName(block.name) ? ` (${realBlockName(block.name)})` : ""),
       variant: "block",
     },
   ];
@@ -11292,9 +11321,10 @@ function BlockDetailView({
           <span className="font-mono text-xl font-bold tracking-tight">
             {block.network}
           </span>
-          {block.name && (
-            <span className="text-sm text-muted-foreground">{block.name}</span>
-          )}
+          <BlockNameTag
+            name={block.name}
+            className="text-sm text-muted-foreground"
+          />
           {block.description && (
             <span className="text-xs text-muted-foreground/70">
               · {block.description}
@@ -11446,7 +11476,7 @@ function BlockDetailView({
           scope={{
             kind: "block",
             id: block.id,
-            label: block.network + (block.name ? ` (${block.name})` : ""),
+            label: block.network + (realBlockName(block.name) ? ` (${realBlockName(block.name)})` : ""),
           }}
           onClose={() => setShowDnsSync(false)}
         />

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -214,11 +214,46 @@ function RoleBadge({ role }: { role: string }) {
   );
 }
 
-// Import-provenance custom-field keys (stamped by the NetBox / cloud importers).
-// Collapse these into a single "Imported from …" chip instead of leaking raw
-// key/value pairs (netbox_id, netbox_is_pool, import_source, …) into the UI.
+// Import-provenance custom-field keys (stamped by the NetBox / cloud importers
+// — the canonical list is backend/app/services/netbox_import/mapping.py). We
+// collapse exactly these into a single "Imported from …" chip instead of
+// leaking raw key/value pairs into the UI.
+//
+// This is a precise allowlist on purpose. A broad `^netbox`/`^import` prefix
+// would also swallow — and, on chip-dismiss, permanently delete — a
+// NetBox-origin custom field an operator deliberately named e.g. `netbox_url`
+// or `import_notes`: `_merge_custom_fields` copies NetBox's own custom fields
+// in verbatim, so they sit alongside the keys we stamp. New importers add
+// their keys here.
+const PROVENANCE_KEYS = new Set<string>([
+  "netbox_id",
+  "netbox_slug",
+  "netbox_role",
+  "netbox_rir",
+  "netbox_is_pool",
+  "netbox_vlan_id",
+  "netbox_managed_by",
+  "netbox_enforce_unique",
+  "netbox_tenant_group",
+  "import_source",
+  "imported_at",
+]);
 function isProvenanceKey(k: string): boolean {
-  return /^(netbox|import_)/.test(k) || k === "imported_at";
+  return PROVENANCE_KEYS.has(k);
+}
+
+// Split a custom_fields dict into its import-provenance subset (`prov`) and the
+// rest (`keep`). Both the subnet- and block-detail headers use this — one pass
+// instead of the two inline filters each previously ran.
+function splitProvenance(
+  customFields: Record<string, unknown> | null | undefined,
+): { prov: Record<string, unknown>; keep: Record<string, unknown> } {
+  const prov: Record<string, unknown> = {};
+  const keep: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(customFields ?? {})) {
+    (isProvenanceKey(k) ? prov : keep)[k] = v;
+  }
+  return { prov, keep };
 }
 
 // Collapsed import-provenance chip with a dismiss (×) that clears the
@@ -240,6 +275,7 @@ function ImportedChip({
 }) {
   const qc = useQueryClient();
   const [confirming, setConfirming] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
   const fromNetbox =
     Object.keys(fields).some((k) => k.startsWith("netbox")) ||
     String(fields["import_source"] ?? "")
@@ -262,8 +298,12 @@ function ImportedChip({
       onUpdated(updated);
       qc.invalidateQueries({ queryKey: ["blocks"] });
       qc.invalidateQueries({ queryKey: ["subnets"] });
+      setErr(null);
       setConfirming(false);
     },
+    // Surface a failed clear (403 RBAC / 422) in the modal instead of
+    // silently leaving the Remove button re-enabled with no feedback.
+    onError: (e) => setErr(formatApiError(e)),
   });
   return (
     <>
@@ -274,7 +314,10 @@ function ImportedChip({
         {label}
         <button
           type="button"
-          onClick={() => setConfirming(true)}
+          onClick={() => {
+            setErr(null);
+            setConfirming(true);
+          }}
           aria-label={`Remove import metadata from this ${kind}`}
           title="Remove import metadata"
           className="ml-0.5 rounded px-0.5 leading-none text-sky-700/60 hover:bg-sky-200 hover:text-sky-900 dark:text-sky-400/60 dark:hover:bg-sky-800/60"
@@ -287,11 +330,14 @@ function ImportedChip({
         title="Remove import metadata?"
         confirmLabel="Remove"
         loading={clearMut.isPending}
-        message={`This clears the import-provenance fields (${Object.keys(
-          fields,
-        ).join(
-          ", ",
-        )}) from this ${kind}, so the "${label}" chip disappears. The ${kind} itself and its other fields are unchanged.`}
+        message={
+          <>
+            {`This clears the import-provenance fields (${Object.keys(fields).join(
+              ", ",
+            )}) from this ${kind}, so the "${label}" chip disappears. The ${kind} itself and its other fields are unchanged.`}
+            {err && <span className="mt-2 block text-destructive">{err}</span>}
+          </>
+        }
         onConfirm={() => clearMut.mutate()}
         onClose={() => setConfirming(false)}
       />
@@ -378,7 +424,25 @@ function UtilizationBar({
   );
 }
 
-function UtilizationDot({ percent }: { percent: number }) {
+function UtilizationDot({
+  percent,
+  uncountable = false,
+}: {
+  percent: number;
+  uncountable?: boolean;
+}) {
+  if (uncountable) {
+    // Parity with UtilizationBar — a clamped IPv6 subnet computes ≈0%, so a
+    // green dot would falsely read "empty". Render a neutral dot instead.
+    const tip = "Utilization is not meaningful for an IPv6 subnet this large";
+    return (
+      <span
+        title={tip}
+        aria-label={tip}
+        className="inline-block h-2 w-2 flex-shrink-0 rounded-full bg-muted-foreground/30"
+      />
+    );
+  }
   const color =
     percent >= 95
       ? "bg-red-500"
@@ -400,6 +464,14 @@ function UtilizationDot({ percent }: { percent: number }) {
 // the redundant string; realBlockName() strips it for plain-text label sites.
 function realBlockName(name?: string | null): string {
   return name && !name.startsWith("auto:") ? name : "";
+}
+
+// "network (name)" when the block carries a real (non-auto) name, else just the
+// network. Used by the breadcrumb + DNS-sync scope label so realBlockName isn't
+// evaluated twice per label.
+function blockLabel(network: string, name?: string | null): string {
+  const n = realBlockName(name);
+  return n ? `${network} (${n})` : network;
 }
 
 function BlockNameTag({
@@ -426,17 +498,40 @@ function BlockNameTag({
 // Double-click-to-edit cell for the IP table. Swallows single clicks so it
 // doesn't trigger the row's open-detail handler; Enter/blur commit, Escape
 // cancels. `display` is what shows when not editing; `value` seeds the input.
+// One shared timer for click-vs-double-click discrimination on inline-editable
+// cells. A single click opens the row detail (consistent with the rest of the
+// row), a double-click edits — but a double-click fires `click` twice then
+// `dblclick`, so we defer the single-click action briefly and cancel it when a
+// double-click lands. User interaction is serial, so one module-level timer is
+// safe and keeps these cells hook-free for the discrimination logic.
+let _inlineClickTimer: ReturnType<typeof setTimeout> | null = null;
+function deferRowActivate(fn: () => void) {
+  if (_inlineClickTimer) clearTimeout(_inlineClickTimer);
+  _inlineClickTimer = setTimeout(() => {
+    _inlineClickTimer = null;
+    fn();
+  }, 220);
+}
+function cancelRowActivate() {
+  if (_inlineClickTimer) {
+    clearTimeout(_inlineClickTimer);
+    _inlineClickTimer = null;
+  }
+}
+
 function InlineEditableText({
   value,
   placeholder,
   display,
   onSave,
+  onActivate,
   disabled = false,
 }: {
   value: string;
   placeholder: string;
   display: React.ReactNode;
   onSave: (next: string) => void;
+  onActivate?: () => void;
   disabled?: boolean;
 }) {
   const [editing, setEditing] = useState(false);
@@ -472,13 +567,17 @@ function InlineEditableText({
   }
   return (
     <span
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (onActivate) deferRowActivate(onActivate);
+      }}
       onDoubleClick={(e) => {
         e.stopPropagation();
+        cancelRowActivate();
         setDraft(value);
         setEditing(true);
       }}
-      title="Double-click to edit"
+      title="Click to open · double-click to edit"
       className="cursor-text"
     >
       {display}
@@ -2723,10 +2822,12 @@ function InlineStatusSelect({
   status,
   disabled = false,
   onSave,
+  onActivate,
 }: {
   status: string;
   disabled?: boolean;
   onSave: (next: string) => void;
+  onActivate?: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   if (disabled) return <StatusBadge status={status} />;
@@ -2765,12 +2866,16 @@ function InlineStatusSelect({
   }
   return (
     <span
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (onActivate) deferRowActivate(onActivate);
+      }}
       onDoubleClick={(e) => {
         e.stopPropagation();
+        cancelRowActivate();
         setEditing(true);
       }}
-      title="Double-click to change status"
+      title="Click to open · double-click to change status"
       className="cursor-pointer"
     >
       <StatusBadge status={status} />
@@ -4239,17 +4344,33 @@ function SubnetDetail({
   const [viewingAddress, setViewingAddress] = useState<IPAddress | null>(null);
   const [scanFromDetail, setScanFromDetail] = useState<IPAddress | null>(null);
   const [showFilters, setShowFilters] = useState(false);
-  // Per-user sticky toggle to hide the protocol-reserved rows
-  // (network / broadcast / gateway) that pad every subnet table.
+  // Per-user sticky toggle to hide the protocol-padding rows (network /
+  // broadcast) that auto-pad every subnet table. Operator-set "reserved"
+  // allocations stay visible — they are real entries, not padding.
   const [hideReserved, setHideReserved] = useSessionState<boolean>(
     "ipam-hide-reserved",
     false,
   );
-  // Inline (double-click) edits of hostname / description on the IP table.
+  // Rows the "Hide network/broadcast" toggle removes. Defined once so the
+  // Select-all `selectable` set can exclude exactly what the table hides —
+  // otherwise Select-all would pick hidden rows and a bulk delete/edit would
+  // hit addresses the operator can't see (#465 review).
+  const isPaddingRow = (a: { status: string }) =>
+    a.status === "network" || a.status === "broadcast";
+  // Surfaced banner for a rejected inline edit (collision 409 / static_dhcp
+  // needs-MAC 422 / DHCP-lease 409 / RBAC 403) — without it the cell silently
+  // reverts on refetch and the operator thinks the edit saved.
+  const [inlineEditError, setInlineEditError] = useState<string | null>(null);
+  // Inline (double-click) edits of hostname / description / status on the IP
+  // table.
   const inlineEditMut = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Partial<IPAddress> }) =>
       ipamApi.updateAddress(id, data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["addresses"] }),
+    onSuccess: () => {
+      setInlineEditError(null);
+      qc.invalidateQueries({ queryKey: ["addresses"] });
+    },
+    onError: (e) => setInlineEditError(formatApiError(e)),
   });
   const [activeSubnetTab, setActiveSubnetTab] = useState<
     "addresses" | "dhcp" | "aliases" | "nat" | "trend" | "address-sets"
@@ -4564,10 +4685,7 @@ function SubnetDetail({
       }
     }
     if (hideReserved)
-      return rows.filter((r) => {
-        if (r.kind !== "ip") return true;
-        return !["network", "broadcast", "reserved"].includes(r.addr.status);
-      });
+      return rows.filter((r) => r.kind !== "ip" || !isPaddingRow(r.addr));
     return rows;
   })();
 
@@ -4834,11 +4952,7 @@ function SubnetDetail({
             />
           </div>
           {(() => {
-            const all = (subnet.custom_fields ?? {}) as Record<string, unknown>;
-            const prov = Object.fromEntries(
-              Object.entries(all).filter(([k]) => isProvenanceKey(k)),
-            );
-            const rest = Object.entries(all).filter(([k]) => !isProvenanceKey(k));
+            const { prov, keep } = splitProvenance(subnet.custom_fields);
             return (
               <>
                 {Object.keys(prov).length > 0 && (
@@ -4848,12 +4962,12 @@ function SubnetDetail({
                       fields={prov}
                       kind="subnet"
                       id={subnet.id}
-                      keep={Object.fromEntries(rest)}
+                      keep={keep}
                       onUpdated={(u) => onSubnetEdited(u as Subnet)}
                     />
                   </div>
                 )}
-                {rest.map(([k, v]) => (
+                {Object.entries(keep).map(([k, v]) => (
                   <div key={k} className="flex items-center gap-1.5">
                     <span className="text-xs text-muted-foreground">{k}</span>
                     <span className="text-xs font-medium">{String(v)}</span>
@@ -5068,9 +5182,22 @@ function SubnetDetail({
                     checked={hideReserved}
                     onChange={(e) => setHideReserved(e.target.checked)}
                   />
-                  Hide reserved rows
+                  Hide network/broadcast
                 </label>
               </div>
+              {inlineEditError && (
+                <div className="mb-2 flex items-start gap-2 rounded border border-destructive/40 bg-destructive/10 px-2 py-1.5 text-xs text-destructive">
+                  <span className="flex-1">{inlineEditError}</span>
+                  <button
+                    type="button"
+                    onClick={() => setInlineEditError(null)}
+                    aria-label="Dismiss error"
+                    className="shrink-0 rounded px-1 leading-none hover:bg-destructive/20"
+                  >
+                    ×
+                  </button>
+                </div>
+              )}
               {/* No nested overflow wrapper — Chrome/WebKit treat
                   ``overflow-x: auto`` as establishing a Y-scroll
                   context too (CSS spec: paired axis can't be
@@ -5093,7 +5220,9 @@ function SubnetDetail({
                           (a: IPAddress) =>
                             a.status !== "network" &&
                             a.status !== "broadcast" &&
-                            !a.auto_from_lease,
+                            !a.auto_from_lease &&
+                            // Never select a row the table is currently hiding.
+                            !(hideReserved && isPaddingRow(a)),
                         );
                         const allSelected =
                           selectable.length > 0 &&
@@ -5541,11 +5670,12 @@ function SubnetDetail({
                                 <InlineEditableText
                                   value={addr.hostname ?? ""}
                                   placeholder="hostname"
-                                  disabled={isReadOnly(addr.status)}
+                                  disabled={!canEdit}
+                                  onActivate={() => setViewingAddress(addr)}
                                   onSave={(v) =>
                                     inlineEditMut.mutate({
                                       id: addr.id,
-                                      data: { hostname: v.trim() },
+                                      data: { hostname: v.trim() || null },
                                     })
                                   }
                                   display={
@@ -5625,7 +5755,8 @@ function SubnetDetail({
                               <InlineEditableText
                                 value={addr.description ?? ""}
                                 placeholder="description"
-                                disabled={isReadOnly(addr.status)}
+                                disabled={!canEdit}
+                                onActivate={() => setViewingAddress(addr)}
                                 onSave={(v) =>
                                   inlineEditMut.mutate({
                                     id: addr.id,
@@ -5688,7 +5819,8 @@ function SubnetDetail({
                               <span className="inline-flex items-center">
                                 <InlineStatusSelect
                                   status={addr.status}
-                                  disabled={isReadOnly(addr.status)}
+                                  disabled={!canEdit}
+                                  onActivate={() => setViewingAddress(addr)}
                                   onSave={(v) =>
                                     inlineEditMut.mutate({
                                       id: addr.id,
@@ -9658,7 +9790,10 @@ function SubnetRow({
           </div>
           <CustomerChip customerId={subnet.customer_id} />
           <SiteChip siteId={subnet.site_id} />
-          <UtilizationDot percent={subnet.utilization_percent} />
+          <UtilizationDot
+            percent={subnet.utilization_percent}
+            uncountable={isUncountable(subnet.total_ips)}
+          />
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent>
@@ -10397,13 +10532,16 @@ function flattenBlocks(
   nodes: BlockNode[],
   depth = 0,
 ): { id: string; label: string }[] {
-  return nodes.flatMap(({ block, children }) => [
-    {
-      id: block.id,
-      label: `${"  ".repeat(depth)}${block.network}${realBlockName(block.name) ? ` — ${realBlockName(block.name)}` : ""}`,
-    },
-    ...flattenBlocks(children, depth + 1),
-  ]);
+  return nodes.flatMap(({ block, children }) => {
+    const n = realBlockName(block.name);
+    return [
+      {
+        id: block.id,
+        label: `${"  ".repeat(depth)}${block.network}${n ? ` — ${n}` : ""}`,
+      },
+      ...flattenBlocks(children, depth + 1),
+    ];
+  });
 }
 
 // ─── Create Block Modal ───────────────────────────────────────────────────────
@@ -11468,7 +11606,7 @@ function BlockDetailView({
       }),
     ),
     {
-      label: block.network + (realBlockName(block.name) ? ` (${realBlockName(block.name)})` : ""),
+      label: blockLabel(block.network, block.name),
       variant: "block",
     },
   ];
@@ -11591,11 +11729,7 @@ function BlockDetailView({
         {/* Custom field values — import provenance collapsed into one chip */}
         {Object.keys(block.custom_fields ?? {}).length > 0 &&
           (() => {
-            const all = block.custom_fields as Record<string, unknown>;
-            const prov = Object.fromEntries(
-              Object.entries(all).filter(([k]) => isProvenanceKey(k)),
-            );
-            const rest = Object.entries(all).filter(([k]) => !isProvenanceKey(k));
+            const { prov, keep } = splitProvenance(block.custom_fields);
             return (
               <div className="flex flex-wrap items-center gap-x-6 gap-y-1 border-t bg-muted/20 px-6 py-2">
                 {Object.keys(prov).length > 0 && (
@@ -11603,11 +11737,11 @@ function BlockDetailView({
                     fields={prov}
                     kind="block"
                     id={block.id}
-                    keep={Object.fromEntries(rest)}
+                    keep={keep}
                     onUpdated={(u) => setBlock(u as IPBlock)}
                   />
                 )}
-                {rest.map(([k, v]) => (
+                {Object.entries(keep).map(([k, v]) => (
                   <div key={k} className="flex items-center gap-1.5">
                     <span className="text-xs text-muted-foreground">{k}</span>
                     <span className="text-xs font-medium">{String(v)}</span>
@@ -11741,7 +11875,7 @@ function BlockDetailView({
           scope={{
             kind: "block",
             id: block.id,
-            label: block.network + (realBlockName(block.name) ? ` (${realBlockName(block.name)})` : ""),
+            label: blockLabel(block.network, block.name),
           }}
           onClose={() => setShowDnsSync(false)}
         />

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -4055,6 +4055,12 @@ function SubnetDetail({
   const [viewingAddress, setViewingAddress] = useState<IPAddress | null>(null);
   const [scanFromDetail, setScanFromDetail] = useState<IPAddress | null>(null);
   const [showFilters, setShowFilters] = useState(false);
+  // Per-user sticky toggle to hide the protocol-reserved rows
+  // (network / broadcast / gateway) that pad every subnet table.
+  const [hideReserved, setHideReserved] = useSessionState<boolean>(
+    "ipam-hide-reserved",
+    false,
+  );
   const [activeSubnetTab, setActiveSubnetTab] = useState<
     "addresses" | "dhcp" | "aliases" | "nat" | "trend" | "address-sets"
   >("addresses");
@@ -4367,6 +4373,11 @@ function SubnetDetail({
         rows.push({ kind: "pool-boundary", pool: p, boundary: "end" });
       }
     }
+    if (hideReserved)
+      return rows.filter((r) => {
+        if (r.kind !== "ip") return true;
+        return !["network", "broadcast", "reserved"].includes(r.addr.status);
+      });
     return rows;
   })();
 
@@ -4845,13 +4856,24 @@ function SubnetDetail({
             </div>
           ) : (
             <>
-              <div className="mb-2 px-1">
-                <TagFilterChips
-                  value={addressTagFilters}
-                  onChange={setAddressTagFilters}
-                  placeholder="Filter addresses by tag — try env or env:prod…"
-                  aria-label="Filter addresses by tag"
-                />
+              <div className="mb-2 flex items-center gap-2 px-1">
+                <div className="min-w-0 flex-1">
+                  <TagFilterChips
+                    value={addressTagFilters}
+                    onChange={setAddressTagFilters}
+                    placeholder="Filter addresses by tag — try env or env:prod…"
+                    aria-label="Filter addresses by tag"
+                  />
+                </div>
+                <label className="flex flex-shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground hover:text-foreground">
+                  <input
+                    type="checkbox"
+                    className="h-3.5 w-3.5"
+                    checked={hideReserved}
+                    onChange={(e) => setHideReserved(e.target.checked)}
+                  />
+                  Hide reserved rows
+                </label>
               </div>
               {/* No nested overflow wrapper — Chrome/WebKit treat
                   ``overflow-x: auto`` as establishing a Y-scroll

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -214,7 +214,64 @@ function RoleBadge({ role }: { role: string }) {
   );
 }
 
-function UtilizationBar({ percent }: { percent: number }) {
+const COUNTABLE_MAX = Number.MAX_SAFE_INTEGER;
+
+// IPv6 subnets (a /64 is 2^64 addresses) overflow the BIGINT total_ips column,
+// which the API clamps to ~9.2e18. A raw "N / 9,223,372,036,854,776,000" ratio
+// and a 0% bar are meaningless, so we present such prefixes as uncountable.
+function isUncountable(total: number): boolean {
+  return total > COUNTABLE_MAX;
+}
+
+// Human size for a subnet's address count: exact for countable prefixes,
+// 2^bits power-notation for uncountable IPv6 (falls back gracefully).
+function subnetSizeLabel(total: number, network?: string): string {
+  if (!isUncountable(total)) return total.toLocaleString();
+  if (network && network.includes("/")) {
+    const prefix = Number(network.split("/")[1]);
+    if (Number.isFinite(prefix)) {
+      const bits = (network.includes(":") ? 128 : 32) - prefix;
+      if (bits >= 0) return `2^${bits}`;
+    }
+  }
+  return "huge";
+}
+
+// Allocated / total cell — suppresses the meaningless huge denominator for
+// uncountable IPv6 prefixes.
+function UsedIps({ allocated, total }: { allocated: number; total: number }) {
+  if (isUncountable(total)) {
+    return (
+      <span title="IPv6 address space too large to enumerate">
+        {allocated.toLocaleString()}{" "}
+        <span className="text-muted-foreground">/ ∞</span>
+      </span>
+    );
+  }
+  return (
+    <>
+      {allocated.toLocaleString()} / {total.toLocaleString()}
+    </>
+  );
+}
+
+function UtilizationBar({
+  percent,
+  uncountable = false,
+}: {
+  percent: number;
+  uncountable?: boolean;
+}) {
+  if (uncountable) {
+    return (
+      <span
+        className="text-xs text-muted-foreground"
+        title="Utilization is not meaningful for an IPv6 subnet this large"
+      >
+        —
+      </span>
+    );
+  }
   const color =
     percent >= 95
       ? "bg-red-500"
@@ -4500,17 +4557,22 @@ function SubnetDetail({
           )}
           <div className="flex items-center gap-1.5">
             <span className="text-xs text-muted-foreground">Total IPs</span>
-            <span className="text-xs font-medium">{subnet.total_ips}</span>
+            <span className="text-xs font-medium">
+              {subnetSizeLabel(subnet.total_ips, subnet.network)}
+            </span>
           </div>
           <div className="flex items-center gap-1.5">
             <span className="text-xs text-muted-foreground">Allocated</span>
             <span className="text-xs font-medium">
-              {subnet.allocated_ips} / {subnet.total_ips}
+              <UsedIps allocated={subnet.allocated_ips} total={subnet.total_ips} />
             </span>
           </div>
           <div className="flex items-center gap-2">
             <span className="text-xs text-muted-foreground">Utilization</span>
-            <UtilizationBar percent={subnet.utilization_percent} />
+            <UtilizationBar
+              percent={subnet.utilization_percent}
+              uncountable={isUncountable(subnet.total_ips)}
+            />
           </div>
           {Object.entries(subnet.custom_fields ?? {}).map(([k, v]) => (
             <div key={k} className="flex items-center gap-1.5">
@@ -11942,13 +12004,13 @@ function BlockDetailView({
                             )}
                           </td>
                           <td className="px-4 py-2 tabular-nums text-muted-foreground">
-                            {s.allocated_ips} / {s.total_ips}
+                            <UsedIps allocated={s.allocated_ips} total={s.total_ips} />
                           </td>
                           <td className="px-4 py-2">
-                            <UtilizationBar percent={s.utilization_percent} />
+                            <UtilizationBar percent={s.utilization_percent} uncountable={isUncountable(s.total_ips)} />
                           </td>
                           <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
-                            {s.total_ips.toLocaleString()}
+                            {subnetSizeLabel(s.total_ips, s.network)}
                           </td>
                           <td className="px-4 py-2">
                             <StatusBadge status={s.status} />
@@ -12827,13 +12889,13 @@ function SpaceTableView({
                           )}
                         </td>
                         <td className="px-4 py-2 tabular-nums text-muted-foreground">
-                          {s.allocated_ips} / {s.total_ips}
+                          <UsedIps allocated={s.allocated_ips} total={s.total_ips} />
                         </td>
                         <td className="px-4 py-2">
-                          <UtilizationBar percent={s.utilization_percent} />
+                          <UtilizationBar percent={s.utilization_percent} uncountable={isUncountable(s.total_ips)} />
                         </td>
                         <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
-                          {s.total_ips.toLocaleString()}
+                          {subnetSizeLabel(s.total_ips, s.network)}
                         </td>
                         <td className="px-4 py-2">
                           <StatusBadge status={s.status} />

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -332,7 +332,9 @@ function ImportedChip({
         loading={clearMut.isPending}
         message={
           <>
-            {`This clears the import-provenance fields (${Object.keys(fields).join(
+            {`This clears the import-provenance fields (${Object.keys(
+              fields,
+            ).join(
               ", ",
             )}) from this ${kind}, so the "${label}" chip disappears. The ${kind} itself and its other fields are unchanged.`}
             {err && <span className="mt-2 block text-destructive">{err}</span>}
@@ -4941,7 +4943,10 @@ function SubnetDetail({
           <div className="flex items-center gap-1.5">
             <span className="text-xs text-muted-foreground">Allocated</span>
             <span className="text-xs font-medium">
-              <UsedIps allocated={subnet.allocated_ips} total={subnet.total_ips} />
+              <UsedIps
+                allocated={subnet.allocated_ips}
+                total={subnet.total_ips}
+              />
             </span>
           </div>
           <div className="flex items-center gap-2">
@@ -4957,7 +4962,9 @@ function SubnetDetail({
               <>
                 {Object.keys(prov).length > 0 && (
                   <div className="flex items-center gap-1.5">
-                    <span className="text-xs text-muted-foreground">Source</span>
+                    <span className="text-xs text-muted-foreground">
+                      Source
+                    </span>
                     <ImportedChip
                       fields={prov}
                       kind="subnet"
@@ -5396,7 +5403,7 @@ function SubnetDetail({
                                   }))
                                 }
                                 placeholder="Filter…"
-          aria-label="Filter"
+                                aria-label="Filter"
                                 className="w-full min-w-0 rounded-l border border-r-0 bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
                               />
                               <div className="relative">
@@ -12327,7 +12334,7 @@ function BlockDetailView({
                                 }))
                               }
                               placeholder="Filter…"
-          aria-label="Filter"
+                              aria-label="Filter"
                               className="w-full rounded border bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
                             />
                           </td>
@@ -12492,10 +12499,16 @@ function BlockDetailView({
                             )}
                           </td>
                           <td className="px-4 py-2 tabular-nums text-muted-foreground">
-                            <UsedIps allocated={s.allocated_ips} total={s.total_ips} />
+                            <UsedIps
+                              allocated={s.allocated_ips}
+                              total={s.total_ips}
+                            />
                           </td>
                           <td className="px-4 py-2">
-                            <UtilizationBar percent={s.utilization_percent} uncountable={isUncountable(s.total_ips)} />
+                            <UtilizationBar
+                              percent={s.utilization_percent}
+                              uncountable={isUncountable(s.total_ips)}
+                            />
                           </td>
                           <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
                             {subnetSizeLabel(s.total_ips, s.network)}
@@ -13225,7 +13238,7 @@ function SpaceTableView({
                               }))
                             }
                             placeholder="Filter…"
-          aria-label="Filter"
+                            aria-label="Filter"
                             className="w-full rounded border border-border bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
                           />
                         </td>
@@ -13378,10 +13391,16 @@ function SpaceTableView({
                           )}
                         </td>
                         <td className="px-4 py-2 tabular-nums text-muted-foreground">
-                          <UsedIps allocated={s.allocated_ips} total={s.total_ips} />
+                          <UsedIps
+                            allocated={s.allocated_ips}
+                            total={s.total_ips}
+                          />
                         </td>
                         <td className="px-4 py-2">
-                          <UtilizationBar percent={s.utilization_percent} uncountable={isUncountable(s.total_ips)} />
+                          <UtilizationBar
+                            percent={s.utilization_percent}
+                            uncountable={isUncountable(s.total_ips)}
+                          />
                         </td>
                         <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
                           {subnetSizeLabel(s.total_ips, s.network)}

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -380,6 +380,7 @@ function CopyButton({ text }: { text: string }) {
     <button
       onClick={handleCopy}
       title="Copy to clipboard"
+      aria-label={`Copy ${text} to clipboard`}
       className="ml-1 rounded p-0.5 text-muted-foreground/0 hover:text-muted-foreground group-hover/addr:text-muted-foreground/60 hover:!text-foreground transition-colors"
     >
       {copied ? (
@@ -5577,14 +5578,16 @@ function SubnetDetail({
                                     <button
                                       onClick={() => setEditingAddress(addr)}
                                       className="rounded p-1 text-muted-foreground hover:text-foreground"
-                                      title="Edit"
+                                      title={`Edit ${addr.address}`}
+                                      aria-label={`Edit ${addr.address}`}
                                     >
                                       <Pencil className="h-3.5 w-3.5" />
                                     </button>
                                     <button
                                       onClick={() => setConfirmDeleteAddr(addr)}
                                       className="rounded p-1 text-muted-foreground hover:text-destructive"
-                                      title="Delete"
+                                      title={`Delete ${addr.address}`}
+                                      aria-label={`Delete ${addr.address}`}
                                     >
                                       <Trash2 className="h-3.5 w-3.5" />
                                     </button>
@@ -13895,6 +13898,7 @@ export function IPAMPage() {
               }}
               className="rounded p-1 text-muted-foreground hover:text-foreground"
               title="Refresh"
+              aria-label="Refresh IP spaces"
             >
               <RefreshCw className="h-3.5 w-3.5" />
             </button>
@@ -13903,6 +13907,7 @@ export function IPAMPage() {
               disabled={!spaces || spaces.length === 0}
               className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-40"
               title="Import subnets"
+              aria-label="Import subnets"
             >
               <Upload className="h-3.5 w-3.5" />
             </button>
@@ -13910,6 +13915,7 @@ export function IPAMPage() {
               onClick={() => setShowCreateSpace(true)}
               className="rounded p-1 text-muted-foreground hover:text-foreground"
               title="New IP Space"
+              aria-label="New IP Space"
             >
               <Plus className="h-3.5 w-3.5" />
             </button>

--- a/frontend/src/pages/ipam/IPDetailModal.tsx
+++ b/frontend/src/pages/ipam/IPDetailModal.tsx
@@ -370,7 +370,8 @@ export function IPDetailModal({
           </div>
 
           {/* Counters row */}
-          {((addr.alias_count ?? 0) > 0 || (addr.nat_mapping_count ?? 0) > 0) && (
+          {((addr.alias_count ?? 0) > 0 ||
+            (addr.nat_mapping_count ?? 0) > 0) && (
             <div className="flex flex-wrap items-center gap-2 text-[11px]">
               {(addr.alias_count ?? 0) > 0 && (
                 <span className="inline-flex items-center rounded bg-indigo-100 px-1.5 py-0.5 font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">

--- a/frontend/src/pages/ipam/IPDetailModal.tsx
+++ b/frontend/src/pages/ipam/IPDetailModal.tsx
@@ -341,7 +341,7 @@ export function IPDetailModal({
             <Field label="Forward DNS zone">
               {addr.forward_zone_id ? (
                 <span className="font-mono text-xs">
-                  {zoneNames[addr.forward_zone_id] ?? addr.forward_zone_id}
+                  {zoneNames[addr.forward_zone_id] ?? "—"}
                 </span>
               ) : (
                 dash(null)
@@ -350,7 +350,7 @@ export function IPDetailModal({
             <Field label="Reverse DNS zone">
               {addr.reverse_zone_id ? (
                 <span className="font-mono text-xs">
-                  {zoneNames[addr.reverse_zone_id] ?? addr.reverse_zone_id}
+                  {zoneNames[addr.reverse_zone_id] ?? "—"}
                 </span>
               ) : (
                 dash(null)
@@ -370,7 +370,7 @@ export function IPDetailModal({
           </div>
 
           {/* Counters row */}
-          {(addr.alias_count || addr.nat_mapping_count) && (
+          {((addr.alias_count ?? 0) > 0 || (addr.nat_mapping_count ?? 0) > 0) && (
             <div className="flex flex-wrap items-center gap-2 text-[11px]">
               {(addr.alias_count ?? 0) > 0 && (
                 <span className="inline-flex items-center rounded bg-indigo-100 px-1.5 py-0.5 font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400">

--- a/frontend/src/pages/ipam/SeenDot.tsx
+++ b/frontend/src/pages/ipam/SeenDot.tsx
@@ -38,10 +38,12 @@ export function SeenDot({
   lastSeenAt,
   lastSeenMethod,
   size = "sm",
+  withLabel = false,
 }: {
   lastSeenAt: string | null | undefined;
   lastSeenMethod?: string | null;
   size?: "sm" | "md";
+  withLabel?: boolean;
 }) {
   const state = getSeenState(lastSeenAt);
   const dotCls = {
@@ -59,7 +61,7 @@ export function SeenDot({
     if (state === "stale") return `Stale — last seen ${rel}${via}`;
     return `Cold — last seen ${rel}${via}`;
   })();
-  return (
+  const dot = (
     <span
       className={cn(
         "inline-flex items-center justify-center rounded-full",
@@ -67,7 +69,16 @@ export function SeenDot({
         dotCls,
       )}
       title={tip}
-      aria-label={tip}
+      aria-label={withLabel ? undefined : tip}
     />
+  );
+  if (!withLabel) return dot;
+  // In-cell text label so the state does not rely on colour alone (WCAG 1.4.1)
+  // and survives on touch where there is no hover tooltip.
+  return (
+    <span className="inline-flex items-center gap-1.5" title={tip}>
+      {dot}
+      <span className="text-xs capitalize text-muted-foreground">{state}</span>
+    </span>
   );
 }


### PR DESCRIPTION
Implements the actionable outcomes of the 10-persona IPAM UX review (issue #465), then hardens them against an extra-high-effort (`xhigh`) code review.

## What's in here

**Review reports** (`docs/reviews/ipam/`) — 10 persona reviews + synthesis, committed for the record.

**Quick wins & bug fixes**
- Four confirmed UX bugs from the review (falsy-`0` counter render, zone raw-id fallbacks, etc.).
- Provenance collapsed into a single **Imported from NetBox** chip (with a dismiss ×) instead of leaking `netbox_*` key/value rows.
- `Seen` rendered as text+dot (not colour-only), accessible names on icon-only controls, filter `aria-label`s.
- `auto:<cidr>` synthetic wrapper-block names rendered as a compact `auto` badge.
- IPv6-huge subnets show `2^bits` / `∞` / `—` instead of a meaningless clamped BIGINT + 0% bar.

**Inline editing on the IP table** — double-click hostname / description / status; single-click still opens the detail modal.

**`Hide network/broadcast`** toggle to declutter protocol padding.

## Code-review hardening (the second half of this PR)

An `xhigh` recall-mode review of the above surfaced **11 issues**; all are fixed in `d283394` and verified by an adversarial fan-out (**5/5 fix-clusters `correct`, 0 regressions**):

| Severity | Issue | Fix |
|---|---|---|
| High | Select-all selected rows the `Hide` toggle was hiding → bulk op on invisible rows | shared `isPaddingRow` predicate drives both the table filter and the Select-all set |
| High | inline editors bypassed the lease/RBAC gate the rest of the row enforces | all three now gate on the row's `canEdit` |
| High | inline edits & chip-dismiss failed **silently** on 4xx | `onError` → dismissible banner / confirm-modal error |
| Med-high | `isProvenanceKey` `^netbox`/`^import` regex could fold + permanently drop an operator's NetBox-origin custom field | exact importer-key allowlist |
| Med | tree `UtilizationDot` showed green "0%" for an IPv6 /64 | same `uncountable` guard as the bar |
| Med | 3 columns dead to single-click | shared click-vs-dblclick timer restores open-on-click |
| Med-low | "Hide reserved" hid operator `reserved` allocations | now hides only `network`/`broadcast` |
| Med-low | NetBox default-name rename broke re-import idempotency | `_ensure_router` reuses a legacy-named router |
| Low | inline-clear wrote `""` not null | hostname clears to `null` |
| Cleanup | duplicated provenance split + double `realBlockName()` | extracted `splitProvenance()` + `blockLabel()` |

**Deliberately not done:** lifting inline-edit state out of per-row `useState` (the only remaining perf nit) — rows are keyed by `addr.id` so there's no stale-state bug, the hook count is within React's comfort zone, and moving `draft` to the parent would re-render the whole table on every keystroke.

## Verification
- `tsc -b` + `vite build` clean, eslint clean, ruff/black/mypy clean.
- 19/19 NetBox-import tests pass (covers the router-name + idempotency change).
- Adversarial verification workflow: all fix-clusters `correct`, regression sweep empty.

Part of #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)