### PR TITLE
IPAM UX round 2 — block utilization, a11y, tree filter, mobile, toolbar grammar (#465)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -197,6 +197,8 @@ backend/alembic/versions/b71d9ae34c50_windows_dhcp_support.py:drop_column:63
 backend/alembic/versions/b71d9ae34c50_windows_dhcp_support.py:drop_column:64
 backend/alembic/versions/b71d9ae34c50_windows_dhcp_support.py:drop_column:65
 backend/alembic/versions/b71d9ae34c50_windows_dhcp_support.py:drop_column:66
+backend/alembic/versions/b7c2f1a9d4e6_block_allocated_total_ips.py:drop_column:70
+backend/alembic/versions/b7c2f1a9d4e6_block_allocated_total_ips.py:drop_column:71
 backend/alembic/versions/b7e29c4f5d18_dns_dhcp_tags.py:drop_column:63
 backend/alembic/versions/b7e2a4f91d35_vrf_phase2.py:drop_column:60
 backend/alembic/versions/b7e2a4f91d35_vrf_phase2.py:drop_constraint_fk:61

--- a/backend/alembic/versions/b7c2f1a9d4e6_block_allocated_total_ips.py
+++ b/backend/alembic/versions/b7c2f1a9d4e6_block_allocated_total_ips.py
@@ -1,0 +1,71 @@
+"""block allocated_ips + total_ips cached counts
+
+Adds cached ``allocated_ips`` + ``total_ips`` columns to ``ip_block`` so block
+rows can render Used IPs (not just a utilization bar). Backfills both from the
+existing data: ``total_ips`` from the CIDR size (clamped to BIGINT for huge
+IPv6 blocks), ``allocated_ips`` from the recursive sum of descendant subnets'
+allocated_ips — mirroring ``_update_block_utilization``.
+
+Revision ID: b7c2f1a9d4e6
+Revises: 30135c361a47
+Create Date: 2026-06-28
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "b7c2f1a9d4e6"
+down_revision = "30135c361a47"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ip_block",
+        sa.Column("allocated_ips", sa.BigInteger(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "ip_block",
+        sa.Column("total_ips", sa.BigInteger(), nullable=False, server_default="0"),
+    )
+
+    # total_ips = CIDR size, clamped to BIGINT max (a /16 IPv6 block is 2^112,
+    # which overflows BIGINT — it reads as "uncountable" in the UI like a /64).
+    op.execute("""
+        UPDATE ip_block SET total_ips = LEAST(
+            CASE WHEN family(network) = 4
+                THEN (2::numeric ^ (32 - masklen(network)))
+                ELSE (2::numeric ^ (128 - masklen(network)))
+            END,
+            9223372036854775807::numeric
+        )::bigint
+        """)
+
+    # allocated_ips = sum of allocated_ips across every subnet whose block is
+    # this block or a descendant. The CTE pairs each block (root) with every
+    # node in its subtree; the aggregate sums subnets per root. Blocks with no
+    # subnets in their subtree are left at the 0 default. Mirrors the app's
+    # _update_block_utilization (which does not filter soft-deleted subnets).
+    op.execute("""
+        WITH RECURSIVE tree AS (
+            SELECT id AS root, id AS node FROM ip_block
+            UNION ALL
+            SELECT t.root, c.id
+            FROM ip_block c JOIN tree t ON c.parent_block_id = t.node
+        )
+        UPDATE ip_block b
+        SET allocated_ips = sub.total
+        FROM (
+            SELECT t.root, COALESCE(SUM(s.allocated_ips), 0) AS total
+            FROM tree t JOIN subnet s ON s.block_id = t.node
+            GROUP BY t.root
+        ) sub
+        WHERE b.id = sub.root
+        """)
+
+
+def downgrade() -> None:
+    op.drop_column("ip_block", "total_ips")
+    op.drop_column("ip_block", "allocated_ips")

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -304,6 +304,10 @@ async def _update_block_utilization(db: AsyncSession, block_id: uuid.UUID) -> No
     block.utilization_percent = (
         round(float(allocated) / block_total * 100, 2) if block_total > 0 else 0.0
     )
+    # Cache the raw counts too so block rows can render Used IPs (not just a
+    # utilization bar). total_ips clamps to BIGINT for huge IPv6 blocks.
+    block.allocated_ips = int(allocated)
+    block.total_ips = min(block_total, _BIGINT_MAX)
 
     # Walk up the tree and update each ancestor
     if block.parent_block_id:
@@ -1686,6 +1690,8 @@ class IPBlockResponse(BaseModel):
     name: str
     description: str
     utilization_percent: float
+    allocated_ips: int = 0
+    total_ips: int = 0
     tags: dict[str, Any]
     custom_fields: dict[str, Any]
     dns_group_ids: list[str] | None
@@ -2613,6 +2619,8 @@ def _block_to_response(block: IPBlock, vrf_warning: str | None) -> dict[str, Any
         "name": block.name,
         "description": block.description,
         "utilization_percent": block.utilization_percent,
+        "allocated_ips": block.allocated_ips,
+        "total_ips": block.total_ips,
         "tags": dict(block.tags or {}),
         "custom_fields": dict(block.custom_fields or {}),
         "dns_group_ids": block.dns_group_ids,

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -244,8 +244,14 @@ class IPBlock(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     description: Mapped[str] = mapped_column(Text, nullable=False, default="")
 
-    # Computed / cached
+    # Computed / cached. ``allocated_ips`` is the recursive sum of descendant
+    # subnets' allocated_ips; ``total_ips`` is the block's CIDR size clamped to
+    # BIGINT (a huge IPv6 block reads as "uncountable" in the UI, like a /64
+    # subnet). Both are populated by ``_update_block_utilization`` alongside
+    # ``utilization_percent`` so block rows can show Used IPs, not just a bar.
     utilization_percent: Mapped[float] = mapped_column(nullable=False, default=0.0)
+    allocated_ips: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    total_ips: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
 
     tags: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     custom_fields: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)

--- a/backend/app/services/netbox_import/mapping.py
+++ b/backend/app/services/netbox_import/mapping.py
@@ -431,8 +431,12 @@ def map_prefix_block(prefix: dict[str, Any], *, space_name: str | None) -> Impor
     if net is None:
         return None
     cf = _merge_custom_fields(prefix.get("custom_fields"), prefix.get("id"))
-    if prefix.get("is_pool") is not None:
-        cf["netbox_is_pool"] = prefix["is_pool"]
+    # Only stamp the meaningful True case — ``netbox_is_pool: false`` is just
+    # noise. (Translating a NetBox pool prefix into SpatiumDDI reservation
+    # behaviour is a deliberate semantic change left for its own pass; here we
+    # only preserve the flag as provenance when set.)
+    if prefix.get("is_pool"):
+        cf["netbox_is_pool"] = True
     _subnet_role, raw_role = _prefix_role(prefix)
     role_value = _subnet_role or raw_role
     if role_value:
@@ -464,8 +468,12 @@ def map_prefix_subnet(prefix: dict[str, Any], *, space_name: str | None) -> Impo
     if net is None:
         return None
     cf = _merge_custom_fields(prefix.get("custom_fields"), prefix.get("id"))
-    if prefix.get("is_pool") is not None:
-        cf["netbox_is_pool"] = prefix["is_pool"]
+    # Only stamp the meaningful True case — ``netbox_is_pool: false`` is just
+    # noise. (Translating a NetBox pool prefix into SpatiumDDI reservation
+    # behaviour is a deliberate semantic change left for its own pass; here we
+    # only preserve the flag as provenance when set.)
+    if prefix.get("is_pool"):
+        cf["netbox_is_pool"] = True
     subnet_role, raw_role = _prefix_role(prefix)
     if raw_role:
         cf.setdefault("netbox_role", raw_role)

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -2,7 +2,11 @@ import { type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { MODAL_BACKDROP_CLS, useDraggableModal } from "./use-draggable-modal";
+import {
+  MODAL_BACKDROP_CLS,
+  useDraggableModal,
+  useFocusTrap,
+} from "./use-draggable-modal";
 
 /** Tab strip for breaking long modals into themed sub-sections.
  *
@@ -81,6 +85,7 @@ export function Modal({
   wide?: boolean;
 }) {
   const { dialogStyle, dragHandleProps } = useDraggableModal(onClose);
+  const trapRef = useFocusTrap<HTMLDivElement>();
 
   // Portal to <body> so nested modals (e.g. the IPSpacePicker quick-create
   // popping up from inside the UniFi / Proxmox / Docker / Kubernetes /
@@ -92,13 +97,17 @@ export function Modal({
   const node = (
     <div className={MODAL_BACKDROP_CLS}>
       <div
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
         className={cn(
           // Flex column with header pinned + body scroll so the
           // ``Appliance · <name>`` title + close button stay visible
           // while the operator scrolls through long drilldown bodies.
           // Without flex-column, ``overflow-y-auto`` on the outer
           // container scrolled the header out of view.
-          "flex w-full flex-col rounded-lg border bg-card shadow-lg max-h-[90vh] max-w-[95vw]",
+          "flex w-full flex-col rounded-lg border bg-card shadow-lg max-h-[90vh] max-w-[95vw] focus:outline-none",
           wide ? "sm:max-w-2xl" : "sm:max-w-md",
         )}
         style={dialogStyle}
@@ -113,6 +122,7 @@ export function Modal({
           <h2 className="text-base font-semibold">{title}</h2>
           <button
             onClick={onClose}
+            aria-label="Close dialog"
             className="cursor-pointer rounded p-1 text-muted-foreground hover:text-foreground"
           >
             <X className="h-4 w-4" />

--- a/frontend/src/components/ui/status-tag.tsx
+++ b/frontend/src/components/ui/status-tag.tsx
@@ -1,0 +1,112 @@
+import {
+  Archive,
+  CheckCircle2,
+  Circle,
+  CircleDot,
+  Lock,
+  type LucideIcon,
+  Minus,
+  Radar,
+  ShieldAlert,
+  Pin,
+  Unlink,
+  Wifi,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Unified status pill — **icon + text + color** in one primitive, so a
+ * status is never communicated by color alone (WCAG 1.4.1) and stays legible
+ * to color-blind operators and on monochrome/printed output. The shape of the
+ * icon disambiguates statuses that share a hue (e.g. green `allocated` vs
+ * green `available`).
+ *
+ * One source of truth for IPAM lifecycle statuses (IP addresses, subnets,
+ * blocks). Other surfaces should import this rather than re-deriving a color
+ * map. The color values match the long-standing IPAM `StatusBadge` palette so
+ * adopting it is not a visual regression.
+ */
+
+type StatusStyle = { icon: LucideIcon; cls: string };
+
+const STATUS_STYLES: Record<string, StatusStyle> = {
+  active: {
+    icon: CheckCircle2,
+    cls: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  },
+  available: {
+    icon: Circle,
+    cls: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  },
+  allocated: {
+    icon: CircleDot,
+    cls: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+  },
+  reserved: {
+    icon: Lock,
+    cls: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  },
+  deprecated: {
+    icon: Archive,
+    cls: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  },
+  quarantine: {
+    icon: ShieldAlert,
+    cls: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  },
+  dhcp: {
+    icon: Wifi,
+    cls: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400",
+  },
+  static_dhcp: {
+    icon: Pin,
+    cls: "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400",
+  },
+  network: {
+    icon: Minus,
+    cls: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800/50 dark:text-zinc-400",
+  },
+  broadcast: {
+    icon: Minus,
+    cls: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800/50 dark:text-zinc-400",
+  },
+  orphan: {
+    icon: Unlink,
+    cls: "bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400",
+  },
+  discovered: {
+    icon: Radar,
+    cls: "bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-400",
+  },
+};
+
+const FALLBACK: StatusStyle = {
+  icon: Circle,
+  cls: "bg-muted text-muted-foreground",
+};
+
+export function StatusTag({
+  status,
+  className,
+  showIcon = true,
+}: {
+  status: string;
+  className?: string;
+  /** Drop the icon for very tight cells where text+color already suffices. */
+  showIcon?: boolean;
+}) {
+  const { icon: Icon, cls } = STATUS_STYLES[status] ?? FALLBACK;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+        cls,
+        className,
+      )}
+    >
+      {showIcon && <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />}
+      {status}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/use-draggable-modal.ts
+++ b/frontend/src/components/ui/use-draggable-modal.ts
@@ -101,9 +101,9 @@ export function useFocusTrap<T extends HTMLElement>() {
     const previouslyFocused = document.activeElement as HTMLElement | null;
 
     const focusables = () =>
-      Array.from(
-        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-      ).filter((el) => el.offsetParent !== null);
+      Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => el.offsetParent !== null,
+      );
 
     // Respect an existing autoFocus inside the dialog; otherwise focus the
     // dialog container itself (tabindex -1) so screen readers announce it and

--- a/frontend/src/components/ui/use-draggable-modal.ts
+++ b/frontend/src/components/ui/use-draggable-modal.ts
@@ -76,3 +76,70 @@ export function useDraggableModal(onClose: () => void) {
     },
   };
 }
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Modal accessibility: **initial focus + focus trap + focus return**. Attach
+ * the returned ref to the dialog container (the element that also carries
+ * ``role="dialog"`` + ``aria-modal="true"``).
+ *
+ * On open it remembers the previously-focused element and — unless a control
+ * inside already grabbed focus via ``autoFocus`` (e.g. ConfirmModal's password
+ * field) — moves focus into the dialog. Tab / Shift+Tab cycle within the
+ * dialog so keyboard focus can't escape to the page behind. On close focus
+ * returns to wherever it was, so the operator's place in the page is kept.
+ *
+ * Lives next to ``useDraggableModal`` so every modal can opt in with one line.
+ */
+export function useFocusTrap<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const focusables = () =>
+      Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => el.offsetParent !== null);
+
+    // Respect an existing autoFocus inside the dialog; otherwise focus the
+    // dialog container itself (tabindex -1) so screen readers announce it and
+    // the operator tabs into the content — never auto-landing on the close X.
+    if (!node.contains(document.activeElement)) {
+      node.setAttribute("tabindex", "-1");
+      node.focus();
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const items = focusables();
+      if (items.length === 0) {
+        e.preventDefault();
+        node.focus();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || !node.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !node.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    node.addEventListener("keydown", onKeyDown);
+    return () => {
+      node.removeEventListener("keydown", onKeyDown);
+      // Return focus to where it was before the modal opened (if still in DOM).
+      previouslyFocused?.focus?.();
+    };
+  }, []);
+  return ref;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -239,6 +239,8 @@ export interface IPBlock {
   name: string;
   description: string;
   utilization_percent: number;
+  allocated_ips?: number;
+  total_ips?: number;
   tags: Record<string, unknown>;
   custom_fields: Record<string, unknown>;
   dns_group_ids: string[] | null;

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -13921,6 +13921,12 @@ function SpaceSection({
   );
   const filterQ = filter.trim().toLowerCase();
   const filtering = filterQ.length > 0;
+  // A match on the space's own name/description reveals the entire space
+  // (rather than hiding it because no inner block/subnet happened to match).
+  const spaceMatches =
+    filtering &&
+    (space.name.toLowerCase().includes(filterQ) ||
+      (space.description ?? "").toLowerCase().includes(filterQ));
   const [showAllTop, setShowAllTop] = useState(false);
   const [showCreateSubnet, setShowCreateSubnet] = useState<
     string | true | false
@@ -13956,7 +13962,9 @@ function SpaceSection({
   const { treeBlocks, treeSubnets, matchCount } = useMemo(() => {
     const allBlocks = blocks ?? [];
     const allSubnets = subnets ?? [];
-    if (!filtering) {
+    // No filter, or the space name itself matched → show the whole space
+    // unfiltered.
+    if (!filtering || spaceMatches) {
       return {
         treeBlocks: allBlocks,
         treeSubnets: allSubnets,
@@ -14011,7 +14019,7 @@ function SpaceSection({
       treeSubnets: keptSubnets,
       matchCount: keptBlocks.length + keptSubnets.length,
     };
-  }, [blocks, subnets, filtering, filterQ]);
+  }, [blocks, subnets, filtering, filterQ, spaceMatches]);
 
   const [subnetDeleteError, setSubnetDeleteError] = useState<string | null>(
     null,
@@ -14153,7 +14161,7 @@ function SpaceSection({
 
   // Hide a whole space from the sidebar when a quick-filter is active and
   // nothing inside it matches — keeps the filtered tree to just the hits.
-  if (filtering && matchCount === 0) return null;
+  if (filtering && matchCount === 0 && !spaceMatches) return null;
 
   return (
     <div>
@@ -14245,7 +14253,7 @@ function SpaceSection({
                       <BlockTreeRow
                         key={node.block.id}
                         node={node}
-                        forceExpand={filtering}
+                        forceExpand={filtering && !spaceMatches}
                         selectedSubnetId={selectedSubnetId}
                         selectedBlockId={selectedBlockId}
                         onSelectBlock={onSelectBlock}

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -29,6 +29,7 @@ import {
   Search,
   Radar,
   Wrench,
+  Sparkles,
   Scissors,
   GitMerge,
   Maximize2,
@@ -90,6 +91,7 @@ import {
 } from "@/lib/approvalQueue";
 import { copyToClipboard } from "@/lib/clipboard";
 import { cn, swatchTintCls, zebraBodyCls } from "@/lib/utils";
+import { StatusTag } from "@/components/ui/status-tag";
 import { SwatchPicker } from "@/components/ui/swatch-picker";
 import { useStickyLocation } from "@/lib/stickyLocation";
 import { useSessionState } from "@/lib/useSessionState";
@@ -111,7 +113,8 @@ import { HeaderButton } from "@/components/ui/header-button";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { TagFilterChips } from "@/components/TagFilterChips";
 import { matchesAllTagChips } from "@/components/tag-filter-utils";
-import { AskAIButton } from "@/components/copilot/AskAIButton";
+import { askAI } from "@/components/copilot/askAI";
+import { useAiAvailable } from "@/components/copilot/useAiAvailable";
 import { ServicesUsingButton } from "@/components/ServicesUsingButton";
 import {
   ImportModal,
@@ -151,42 +154,13 @@ import {
 
 // ─── Status Badge ────────────────────────────────────────────────────────────
 
+// Thin wrapper over the shared <StatusTag> (icon + text + color). Kept as a
+// local name because the IPAM file references StatusBadge in dozens of places;
+// the icon+color source of truth now lives in components/ui/status-tag.tsx.
+// ``discovered`` is passive observation only — the Seen column's recency dot
+// tells the operator whether the row is currently up; this badge labels source.
 function StatusBadge({ status }: { status: string }) {
-  const colors: Record<string, string> = {
-    active:
-      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-    reserved:
-      "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
-    deprecated:
-      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
-    quarantine: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-    allocated:
-      "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
-    available:
-      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-    dhcp: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400",
-    static_dhcp:
-      "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400",
-    network: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800/50 dark:text-zinc-400",
-    broadcast:
-      "bg-zinc-100 text-zinc-500 dark:bg-zinc-800/50 dark:text-zinc-400",
-    orphan:
-      "bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400",
-    // ``discovered`` — passive observation only, no operator intent.
-    // The Seen column's recency dot tells the operator whether the
-    // row is currently up; the badge here just labels the source.
-    discovered: "bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-400",
-  };
-  return (
-    <span
-      className={cn(
-        "rounded-full px-2 py-0.5 text-xs font-medium",
-        colors[status] ?? "bg-muted text-muted-foreground",
-      )}
-    >
-      {status}
-    </span>
-  );
+  return <StatusTag status={status} />;
 }
 
 // Compact role badge — paired with StatusBadge in the IP table.
@@ -3952,6 +3926,7 @@ function ToolsMenu({
   onResize,
   onScan,
   onSplit,
+  onAskAi,
 }: {
   onBulkAllocate: () => void;
   onCleanOrphans: () => void;
@@ -3960,9 +3935,14 @@ function ToolsMenu({
   onResize: () => void;
   onScan: () => void;
   onSplit: () => void;
+  // Optional "Ask AI about this" entry — demoted here from a header
+  // primary action (no persona defended its prominence, #465). Only
+  // rendered when an AI provider is configured.
+  onAskAi?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const aiAvailable = useAiAvailable();
 
   useEffect(() => {
     if (!open) return;
@@ -4062,6 +4042,19 @@ function ToolsMenu({
           >
             <Scissors className="h-3.5 w-3.5" /> Split…
           </button>
+          {onAskAi && aiAvailable && (
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                onAskAi();
+              }}
+              className={cn(itemCls, "border-t")}
+            >
+              <Sparkles className="h-3.5 w-3.5 text-primary" /> Ask AI about
+              this…
+            </button>
+          )}
         </div>
       )}
     </div>
@@ -4819,26 +4812,28 @@ function SubnetDetail({
               onResize={() => setShowResizeSubnet(true)}
               onScan={() => setShowSubnetScan(true)}
               onSplit={() => setShowSplitSubnet(true)}
-            />
-            <AskAIButton
-              context={[
-                `Subnet ${subnet.network}`,
-                subnet.name ? `name: ${subnet.name}` : null,
-                subnet.description
-                  ? `description: ${subnet.description}`
-                  : null,
-                spaceName ? `space: ${spaceName}` : null,
-                block ? `block: ${block.network}` : null,
-                subnet.vlan_id != null ? `VLAN: ${subnet.vlan_id}` : null,
-                subnet.gateway ? `gateway: ${subnet.gateway}` : null,
-                `utilization: ${(subnet.utilization_percent ?? 0).toFixed(1)}%`,
-                `${subnet.allocated_ips ?? 0} of ${subnet.total_ips ?? 0} IPs allocated`,
-                `subnet_id: ${subnet.id}`,
-              ]
-                .filter(Boolean)
-                .join(", ")}
-              tooltip="Ask AI about this subnet"
-              prompt="Tell me about this subnet — utilisation, recent changes, and anything I should worry about."
+              onAskAi={() =>
+                askAI({
+                  context: [
+                    `Subnet ${subnet.network}`,
+                    subnet.name ? `name: ${subnet.name}` : null,
+                    subnet.description
+                      ? `description: ${subnet.description}`
+                      : null,
+                    spaceName ? `space: ${spaceName}` : null,
+                    block ? `block: ${block.network}` : null,
+                    subnet.vlan_id != null ? `VLAN: ${subnet.vlan_id}` : null,
+                    subnet.gateway ? `gateway: ${subnet.gateway}` : null,
+                    `utilization: ${(subnet.utilization_percent ?? 0).toFixed(1)}%`,
+                    `${subnet.allocated_ips ?? 0} of ${subnet.total_ips ?? 0} IPs allocated`,
+                    `subnet_id: ${subnet.id}`,
+                  ]
+                    .filter(Boolean)
+                    .join(", "),
+                  prompt:
+                    "Tell me about this subnet — utilisation, recent changes, and anything I should worry about.",
+                })
+              }
             />
             <ServicesUsingButton
               kind="subnet"

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -11247,6 +11247,7 @@ function BlockTreeRow({
   onCreateChildBlock,
   onAllocateIp,
   depth,
+  forceExpand = false,
 }: {
   node: BlockNode;
   selectedSubnetId: string | null;
@@ -11260,8 +11261,12 @@ function BlockTreeRow({
   onCreateChildBlock: (parentBlockId: string) => void;
   onAllocateIp?: (s: Subnet) => void;
   depth: number;
+  // Forced open by the tree quick-filter so every matching path is visible
+  // regardless of the operator's saved expand/collapse state.
+  forceExpand?: boolean;
 }) {
   const [expanded, setExpanded] = useState(true);
+  const isExpanded = forceExpand || expanded;
   const hasContent = node.children.length > 0 || node.subnets.length > 0;
   const isSelected = selectedBlockId === node.block.id;
   const {
@@ -11288,7 +11293,7 @@ function BlockTreeRow({
       role="treeitem"
       aria-label={node.block.network}
       aria-selected={isSelected}
-      aria-expanded={hasContent ? expanded : undefined}
+      aria-expanded={hasContent ? isExpanded : undefined}
     >
       {/* Block header row */}
       <ContextMenu>
@@ -11312,14 +11317,14 @@ function BlockTreeRow({
                   setExpanded((v) => !v);
                 }}
                 className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm border border-border bg-background text-[10px] font-bold text-muted-foreground hover:border-primary hover:text-primary"
-                title={expanded ? "Collapse" : "Expand"}
+                title={isExpanded ? "Collapse" : "Expand"}
                 aria-label={
-                  expanded
+                  isExpanded
                     ? `Collapse ${node.block.network}`
                     : `Expand ${node.block.network}`
                 }
               >
-                {expanded ? "−" : "+"}
+                {isExpanded ? "−" : "+"}
               </button>
             ) : (
               <div className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm border border-border/30 bg-background text-[10px] text-muted-foreground/30">
@@ -11385,7 +11390,7 @@ function BlockTreeRow({
           reads sequentially — a supernet block (e.g. 10.255.0.0/24)
           with subnets inside it lands alongside its IP-adjacent peers
           rather than being bucketed to the top or bottom. */}
-      {expanded && hasContent && (
+      {isExpanded && hasContent && (
         <div
           role="group"
           className="ml-[9px] pl-3 border-l border-border/40 space-y-0.5"
@@ -11395,6 +11400,7 @@ function BlockTreeRow({
               <BlockTreeRow
                 key={`b:${item.node.block.id}`}
                 node={item.node}
+                forceExpand={forceExpand}
                 selectedSubnetId={selectedSubnetId}
                 selectedBlockId={selectedBlockId}
                 onSelectBlock={onSelectBlock}
@@ -13741,6 +13747,7 @@ function SpaceSection({
   onSelectSpace,
   onSelectSubnet,
   onSelectBlock,
+  filter = "",
 }: {
   space: IPSpace;
   selectedSubnetId: string | null;
@@ -13749,11 +13756,17 @@ function SpaceSection({
   onSelectSpace: () => void;
   onSelectSubnet: (subnet: Subnet | null) => void;
   onSelectBlock: (b: IPBlock) => void;
+  // Tree quick-filter — case-insensitive substring over network + name.
+  // When set, non-matching nodes are hidden, ancestors of matches are kept
+  // so the path renders, and the whole space auto-expands.
+  filter?: string;
 }) {
   const [expanded, setExpanded] = useSessionState<boolean>(
     `spatium.ipam.expandedSpace.${space.id}`,
     true,
   );
+  const filterQ = filter.trim().toLowerCase();
+  const filtering = filterQ.length > 0;
   const [showCreateSubnet, setShowCreateSubnet] = useState<
     string | true | false
   >(false); // string = default block_id
@@ -13773,14 +13786,55 @@ function SpaceSection({
   const { data: subnets, isLoading } = useQuery({
     queryKey: ["subnets", space.id],
     queryFn: () => ipamApi.listSubnets({ space_id: space.id }),
-    enabled: expanded,
+    enabled: expanded || filtering,
   });
 
   const { data: blocks } = useQuery({
     queryKey: ["blocks", space.id],
     queryFn: () => ipamApi.listBlocks(space.id),
-    enabled: expanded,
+    enabled: expanded || filtering,
   });
+
+  // Apply the quick-filter: keep matching subnets/blocks plus every ancestor
+  // block of a match (so the tree path stays intact). Returns the originals
+  // untouched when no filter is active.
+  const { treeBlocks, treeSubnets, matchCount } = useMemo(() => {
+    const allBlocks = blocks ?? [];
+    const allSubnets = subnets ?? [];
+    if (!filtering) {
+      return {
+        treeBlocks: allBlocks,
+        treeSubnets: allSubnets,
+        matchCount: allBlocks.length + allSubnets.length,
+      };
+    }
+    const hit = (network: string, name?: string | null) =>
+      network.toLowerCase().includes(filterQ) ||
+      (name ?? "").toLowerCase().includes(filterQ);
+    const byId = new Map(allBlocks.map((b) => [b.id, b]));
+    const keep = new Set<string>();
+    const addAncestors = (parentId: string | null | undefined) => {
+      let cur = parentId ?? null;
+      while (cur && !keep.has(cur)) {
+        keep.add(cur);
+        cur = byId.get(cur)?.parent_block_id ?? null;
+      }
+    };
+    const keptSubnets = allSubnets.filter((s) => hit(s.network, s.name));
+    for (const s of keptSubnets) addAncestors(s.block_id);
+    for (const b of allBlocks) {
+      if (hit(b.network, b.name)) {
+        keep.add(b.id);
+        addAncestors(b.parent_block_id);
+      }
+    }
+    const keptBlocks = allBlocks.filter((b) => keep.has(b.id));
+    return {
+      treeBlocks: keptBlocks,
+      treeSubnets: keptSubnets,
+      matchCount: keptBlocks.length + keptSubnets.length,
+    };
+  }, [blocks, subnets, filtering, filterQ]);
 
   const [subnetDeleteError, setSubnetDeleteError] = useState<string | null>(
     null,
@@ -13920,6 +13974,10 @@ function SpaceSection({
 
   // (block_id is now required; all subnets appear under their block)
 
+  // Hide a whole space from the sidebar when a quick-filter is active and
+  // nothing inside it matches — keeps the filtered tree to just the hits.
+  if (filtering && matchCount === 0) return null;
+
   return (
     <div>
       {/* Space header */}
@@ -13981,7 +14039,7 @@ function SpaceSection({
       </ContextMenu>
 
       {/* Tree with vertical connecting line */}
-      {expanded && (
+      {(expanded || filtering) && (
         <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
           <div
             role="tree"
@@ -13994,13 +14052,15 @@ function SpaceSection({
               </p>
             )}
 
-            {/* Block tree (recursive) */}
+            {/* Block tree (recursive) — filtered + force-expanded when a
+                quick-filter is active. */}
             {blocks &&
               subnets &&
-              buildBlockTree(blocks, subnets, null).map((node) => (
+              buildBlockTree(treeBlocks, treeSubnets, null).map((node) => (
                 <BlockTreeRow
                   key={node.block.id}
                   node={node}
+                  forceExpand={filtering}
                   selectedSubnetId={selectedSubnetId}
                   selectedBlockId={selectedBlockId}
                   onSelectBlock={onSelectBlock}
@@ -14143,6 +14203,8 @@ export function IPAMPage() {
   const [selectedBlock, setSelectedBlock] = useState<IPBlock | null>(null);
   const [showCreateSpace, setShowCreateSpace] = useState(false);
   const [showImport, setShowImport] = useState(false);
+  // Tree quick-filter (network / name substring across every space).
+  const [treeFilter, setTreeFilter] = useState("");
   const qc = useQueryClient();
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -14365,6 +14427,32 @@ export function IPAMPage() {
           </div>
         </div>
 
+        {/* Tree quick-filter — narrows every space's tree to matching
+            blocks / subnets (by CIDR or name) and force-expands the path. */}
+        <div className="border-b px-2 py-1.5">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" />
+            <input
+              value={treeFilter}
+              onChange={(e) => setTreeFilter(e.target.value)}
+              placeholder="Filter tree — CIDR or name…"
+              aria-label="Filter the IP space tree by CIDR or name"
+              className="w-full rounded-md border bg-background py-1 pl-7 pr-7 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+            {treeFilter && (
+              <button
+                type="button"
+                onClick={() => setTreeFilter("")}
+                aria-label="Clear tree filter"
+                title="Clear filter"
+                className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-0.5 text-muted-foreground/60 hover:text-foreground"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        </div>
+
         <div className="flex-1 overflow-y-auto p-2 space-y-1">
           {isLoading && (
             <p className="px-2 py-3 text-xs text-muted-foreground">Loading…</p>
@@ -14391,6 +14479,7 @@ export function IPAMPage() {
               onSelectSpace={() => selectSpace(space)}
               onSelectSubnet={selectSubnet}
               onSelectBlock={selectBlock}
+              filter={treeFilter}
             />
           ))}
         </div>

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -471,6 +471,30 @@ function BlockNameTag({
   return <span className={className}>{name}</span>;
 }
 
+// Row-type tag for the mixed block + subnet tables. The two row kinds share
+// columns and blocks legitimately leave several blank (a block has no
+// Router / VLAN / Status), which reads as "missing data" without a cue. This
+// tag labels each row so the em-dashes read as "not applicable here". (#465)
+function RowTypeBadge({ kind }: { kind: "block" | "subnet" }) {
+  return (
+    <span
+      title={
+        kind === "block"
+          ? "IP block — a container that holds child blocks / subnets"
+          : "Subnet — holds individual IP addresses"
+      }
+      className={cn(
+        "inline-flex flex-shrink-0 items-center rounded px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide",
+        kind === "block"
+          ? "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300"
+          : "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+      )}
+    >
+      {kind}
+    </span>
+  );
+}
+
 // Double-click-to-edit cell for the IP table. Swallows single clicks so it
 // doesn't trigger the row's open-detail handler; Enter/blur commit, Escape
 // cancels. `display` is what shows when not editing; `value` seeds the input.
@@ -12396,6 +12420,7 @@ function BlockDetailView({
                             <span className="inline-flex items-center gap-1.5 font-mono font-semibold text-foreground">
                               <Layers className="h-3.5 w-3.5 flex-shrink-0 text-violet-500" />
                               {b.network}
+                              <RowTypeBadge kind="block" />
                             </span>
                           </td>
                           <td className="px-4 py-2 text-muted-foreground">
@@ -12411,20 +12436,25 @@ function BlockDetailView({
                           <td className="px-4 py-2 text-muted-foreground/40">
                             —
                           </td>
-                          <td className="px-4 py-2 text-muted-foreground/40">
-                            —
+                          <td className="px-4 py-2 tabular-nums text-muted-foreground">
+                            <UsedIps
+                              allocated={b.allocated_ips ?? 0}
+                              total={b.total_ips ?? cidrSize(b.network)}
+                            />
                           </td>
                           <td className="px-4 py-2">
-                            {b.utilization_percent > 0 ? (
-                              <UtilizationBar percent={b.utilization_percent} />
-                            ) : (
-                              <span className="text-muted-foreground/40">
-                                —
-                              </span>
-                            )}
+                            <UtilizationBar
+                              percent={b.utilization_percent}
+                              uncountable={isUncountable(
+                                b.total_ips ?? cidrSize(b.network),
+                              )}
+                            />
                           </td>
                           <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
-                            {cidrSize(b.network).toLocaleString()}
+                            {subnetSizeLabel(
+                              b.total_ips ?? cidrSize(b.network),
+                              b.network,
+                            )}
                           </td>
                           <td className="px-4 py-2 text-muted-foreground/40">
                             —
@@ -12470,6 +12500,7 @@ function BlockDetailView({
                             <span className="inline-flex items-center gap-1.5 font-mono font-medium">
                               <Network className="h-3.5 w-3.5 flex-shrink-0 text-blue-500" />
                               {s.network}
+                              <RowTypeBadge kind="subnet" />
                             </span>
                           </td>
                           <td className="px-4 py-2 text-muted-foreground">
@@ -13301,6 +13332,7 @@ function SpaceTableView({
                           <span className="inline-flex items-center gap-1.5 font-mono font-semibold text-foreground">
                             <Layers className="h-3.5 w-3.5 flex-shrink-0 text-violet-500" />
                             {b.network}
+                            <RowTypeBadge kind="block" />
                           </span>
                         </td>
                         <td className="px-4 py-2 text-muted-foreground">
@@ -13314,18 +13346,20 @@ function SpaceTableView({
                         <td className="px-4 py-2 text-muted-foreground/40">
                           —
                         </td>
-                        <td className="px-4 py-2 text-muted-foreground/40">
-                          —
+                        <td className="px-4 py-2 tabular-nums text-muted-foreground">
+                          <UsedIps
+                            allocated={b.allocated_ips ?? 0}
+                            total={b.total_ips ?? size}
+                          />
                         </td>
                         <td className="px-4 py-2">
-                          {b.utilization_percent > 0 ? (
-                            <UtilizationBar percent={b.utilization_percent} />
-                          ) : (
-                            <span className="text-muted-foreground/40">—</span>
-                          )}
+                          <UtilizationBar
+                            percent={b.utilization_percent}
+                            uncountable={isUncountable(b.total_ips ?? size)}
+                          />
                         </td>
                         <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
-                          {size.toLocaleString()}
+                          {subnetSizeLabel(b.total_ips ?? size, b.network)}
                         </td>
                         <td className="px-4 py-2 text-muted-foreground/40">
                           —
@@ -13368,6 +13402,7 @@ function SpaceTableView({
                           <span className="inline-flex items-center gap-1.5 font-mono font-medium">
                             <Network className="h-3.5 w-3.5 flex-shrink-0 text-blue-500" />
                             {s.network}
+                            <RowTypeBadge kind="subnet" />
                           </span>
                         </td>
                         <td className="px-4 py-2 text-muted-foreground">

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -30,6 +30,7 @@ import {
   Radar,
   Wrench,
   Sparkles,
+  HelpCircle,
   type LucideIcon,
   Scissors,
   GitMerge,
@@ -14364,6 +14365,66 @@ function getBlockAncestors(block: IPBlock, allBlocks: IPBlock[]): IPBlock[] {
   return ancestors;
 }
 
+// Opt-in glossary for the IPAM visual vocabulary (progressive disclosure,
+// #465). Hidden by default — toggled by the Help button so the dense view
+// stays uncluttered for experts while newcomers can decode the icons.
+function IpamHelpLegend() {
+  const seen: Array<[string, string]> = [
+    ["alive", "bg-emerald-500"],
+    ["stale", "bg-amber-500"],
+    ["cold", "bg-rose-500"],
+    ["never", "bg-zinc-300 dark:bg-zinc-600"],
+  ];
+  return (
+    <div className="border-b bg-muted/20 px-3 py-2 text-[11px] leading-relaxed text-muted-foreground">
+      <p className="mb-1.5 font-semibold text-foreground">What the icons mean</p>
+      <ul className="space-y-1.5">
+        <li className="flex items-center gap-1.5">
+          <Layers className="h-3 w-3 flex-shrink-0 text-violet-500" />
+          <span>
+            <span className="font-medium text-foreground">Block</span> — a
+            container that holds child blocks / subnets
+          </span>
+        </li>
+        <li className="flex items-center gap-1.5">
+          <Network className="h-3 w-3 flex-shrink-0 text-blue-500" />
+          <span>
+            <span className="font-medium text-foreground">Subnet</span> — holds
+            individual IP addresses
+          </span>
+        </li>
+        <li className="flex items-center gap-1.5">
+          <StatusTag status="allocated" />
+          <span>Status — the IP's lifecycle (icon + colour, never colour alone)</span>
+        </li>
+        <li className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="font-medium text-foreground">Seen</span>
+          <span>on the wire (separate from status):</span>
+          {seen.map(([label, cls]) => (
+            <span key={label} className="inline-flex items-center gap-1">
+              <span className={cn("h-2 w-2 rounded-full", cls)} />
+              {label}
+            </span>
+          ))}
+        </li>
+        <li className="flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 flex-shrink-0 rounded-full bg-green-500" />
+          <span>
+            Utilization — green &lt;80%, amber 80–95%, red ≥95% (an em-dash means
+            an IPv6 prefix too large to count)
+          </span>
+        </li>
+        <li className="flex items-center gap-1.5">
+          <span className="flex-shrink-0 rounded border border-dashed border-emerald-500/60 px-1 text-emerald-600 dark:text-emerald-400">
+            free
+          </span>
+          <span>Dashed gap row — unused addresses; click it to allocate</span>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
 // ─── Main IPAM Page ───────────────────────────────────────────────────────────
 
 export function IPAMPage() {
@@ -14375,6 +14436,13 @@ export function IPAMPage() {
   const [showImport, setShowImport] = useState(false);
   // Tree quick-filter (network / name substring across every space).
   const [treeFilter, setTreeFilter] = useState("");
+  // Progressive disclosure: dense by default, opt-in help layer. When on, a
+  // glossary of the IPAM visual vocabulary appears so newcomers aren't lost
+  // while experts keep the uncluttered default (#465). Sticky per-user.
+  const [helpMode, setHelpMode] = useSessionState<boolean>(
+    "ipam-help-mode",
+    false,
+  );
   const qc = useQueryClient();
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -14563,6 +14631,20 @@ export function IPAMPage() {
           <span className="text-sm font-semibold">IP Spaces</span>
           <div className="flex gap-1">
             <button
+              onClick={() => setHelpMode((v) => !v)}
+              className={cn(
+                "rounded p-1 hover:text-foreground",
+                helpMode
+                  ? "text-primary"
+                  : "text-muted-foreground",
+              )}
+              title={helpMode ? "Hide help" : "Show help — explain the icons"}
+              aria-label="Toggle IPAM help layer"
+              aria-pressed={helpMode}
+            >
+              <HelpCircle className="h-3.5 w-3.5" />
+            </button>
+            <button
               onClick={() => {
                 // Force refetch — bare invalidate only marks queries stale,
                 // which isn't enough when the user pressed Refresh after
@@ -14622,6 +14704,8 @@ export function IPAMPage() {
             )}
           </div>
         </div>
+
+        {helpMode && <IpamHelpLegend />}
 
         <div className="flex-1 overflow-y-auto p-2 space-y-1">
           {isLoading && (

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -323,6 +323,12 @@ function ImportedChip({
 
 const COUNTABLE_MAX = Number.MAX_SAFE_INTEGER;
 
+// Max rows rendered in a single tree sibling group before a "Show N more…"
+// reveal. Bounds the DOM for a pathologically large group (a /16 split into
+// thousands of /24s) without windowing the dnd-kit tree. Never applied while
+// the quick-filter is active.
+const TREE_GROUP_CAP = 300;
+
 // IPv6 subnets (a /64 is 2^64 addresses) overflow the BIGINT total_ips column,
 // which the API clamps to ~9.2e18. A raw "N / 9,223,372,036,854,776,000" ratio
 // and a 0% bar are meaningless, so we present such prefixes as uncountable.
@@ -11266,6 +11272,7 @@ function BlockTreeRow({
   forceExpand?: boolean;
 }) {
   const [expanded, setExpanded] = useState(true);
+  const [showAllChildren, setShowAllChildren] = useState(false);
   const isExpanded = forceExpand || expanded;
   const hasContent = node.children.length > 0 || node.subnets.length > 0;
   const isSelected = selectedBlockId === node.block.id;
@@ -11390,48 +11397,64 @@ function BlockTreeRow({
           reads sequentially — a supernet block (e.g. 10.255.0.0/24)
           with subnets inside it lands alongside its IP-adjacent peers
           rather than being bucketed to the top or bottom. */}
-      {isExpanded && hasContent && (
-        <div
-          role="group"
-          className="ml-[9px] pl-3 border-l border-border/40 space-y-0.5"
-        >
-          {sortedTreeItems(node).map((item) =>
-            item.kind === "block" ? (
-              <BlockTreeRow
-                key={`b:${item.node.block.id}`}
-                node={item.node}
-                forceExpand={forceExpand}
-                selectedSubnetId={selectedSubnetId}
-                selectedBlockId={selectedBlockId}
-                onSelectBlock={onSelectBlock}
-                onSelectSubnet={onSelectSubnet}
-                onDeleteSubnet={onDeleteSubnet}
-                onDeleteBlock={onDeleteBlock}
-                onEditBlock={onEditBlock}
-                onCreateSubnet={onCreateSubnet}
-                onCreateChildBlock={onCreateChildBlock}
-                onAllocateIp={onAllocateIp}
-                depth={depth + 1}
-              />
-            ) : (
-              <SubnetRow
-                key={`s:${item.subnet.id}`}
-                subnet={item.subnet}
-                isSelected={selectedSubnetId === item.subnet.id}
-                onSelect={() => onSelectSubnet(item.subnet)}
-                onDelete={() => onDeleteSubnet(item.subnet)}
-                onEdited={(updated) => onSelectSubnet(updated)}
-                onAllocateIp={onAllocateIp}
-              />
-            ),
-          )}
-          {node.children.length === 0 && node.subnets.length === 0 && (
-            <p className="py-0.5 pl-2 text-xs text-muted-foreground/40">
-              Empty
-            </p>
-          )}
-        </div>
-      )}
+      {isExpanded &&
+        hasContent &&
+        (() => {
+          const items = sortedTreeItems(node);
+          // Bound the DOM for a pathologically large sibling group (e.g. a /16
+          // split into thousands of /24s) — render the first TREE_GROUP_CAP and
+          // reveal the rest on demand. Never cap while filtering (forceExpand),
+          // so every match stays visible.
+          const capped =
+            !forceExpand && !showAllChildren && items.length > TREE_GROUP_CAP;
+          const shown = capped ? items.slice(0, TREE_GROUP_CAP) : items;
+          return (
+            <div
+              role="group"
+              className="ml-[9px] pl-3 border-l border-border/40 space-y-0.5"
+            >
+              {shown.map((item) =>
+                item.kind === "block" ? (
+                  <BlockTreeRow
+                    key={`b:${item.node.block.id}`}
+                    node={item.node}
+                    forceExpand={forceExpand}
+                    selectedSubnetId={selectedSubnetId}
+                    selectedBlockId={selectedBlockId}
+                    onSelectBlock={onSelectBlock}
+                    onSelectSubnet={onSelectSubnet}
+                    onDeleteSubnet={onDeleteSubnet}
+                    onDeleteBlock={onDeleteBlock}
+                    onEditBlock={onEditBlock}
+                    onCreateSubnet={onCreateSubnet}
+                    onCreateChildBlock={onCreateChildBlock}
+                    onAllocateIp={onAllocateIp}
+                    depth={depth + 1}
+                  />
+                ) : (
+                  <SubnetRow
+                    key={`s:${item.subnet.id}`}
+                    subnet={item.subnet}
+                    isSelected={selectedSubnetId === item.subnet.id}
+                    onSelect={() => onSelectSubnet(item.subnet)}
+                    onDelete={() => onDeleteSubnet(item.subnet)}
+                    onEdited={(updated) => onSelectSubnet(updated)}
+                    onAllocateIp={onAllocateIp}
+                  />
+                ),
+              )}
+              {capped && (
+                <button
+                  type="button"
+                  onClick={() => setShowAllChildren(true)}
+                  className="w-full rounded px-2 py-1 text-left text-xs text-primary hover:bg-muted/40"
+                >
+                  Show {(items.length - TREE_GROUP_CAP).toLocaleString()} more…
+                </button>
+              )}
+            </div>
+          );
+        })()}
     </div>
   );
 }
@@ -13767,6 +13790,7 @@ function SpaceSection({
   );
   const filterQ = filter.trim().toLowerCase();
   const filtering = filterQ.length > 0;
+  const [showAllTop, setShowAllTop] = useState(false);
   const [showCreateSubnet, setShowCreateSubnet] = useState<
     string | true | false
   >(false); // string = default block_id
@@ -14053,29 +14077,52 @@ function SpaceSection({
             )}
 
             {/* Block tree (recursive) — filtered + force-expanded when a
-                quick-filter is active. */}
+                quick-filter is active, and capped to TREE_GROUP_CAP top-level
+                rows with a reveal (never capped while filtering). */}
             {blocks &&
               subnets &&
-              buildBlockTree(treeBlocks, treeSubnets, null).map((node) => (
-                <BlockTreeRow
-                  key={node.block.id}
-                  node={node}
-                  forceExpand={filtering}
-                  selectedSubnetId={selectedSubnetId}
-                  selectedBlockId={selectedBlockId}
-                  onSelectBlock={onSelectBlock}
-                  onSelectSubnet={onSelectSubnet}
-                  onDeleteSubnet={(s) => setSubnetToDelete(s)}
-                  onDeleteBlock={(b) => setBlockToDelete(b)}
-                  onEditBlock={(b) => setEditBlock(b)}
-                  onCreateSubnet={(blockId) => setShowCreateSubnet(blockId)}
-                  onCreateChildBlock={(parentId) =>
-                    setShowCreateBlock(parentId)
-                  }
-                  onAllocateIp={(s) => onSelectSubnet(s)}
-                  depth={0}
-                />
-              ))}
+              (() => {
+                const top = buildBlockTree(treeBlocks, treeSubnets, null);
+                const capped =
+                  !filtering && !showAllTop && top.length > TREE_GROUP_CAP;
+                const shown = capped ? top.slice(0, TREE_GROUP_CAP) : top;
+                return (
+                  <>
+                    {shown.map((node) => (
+                      <BlockTreeRow
+                        key={node.block.id}
+                        node={node}
+                        forceExpand={filtering}
+                        selectedSubnetId={selectedSubnetId}
+                        selectedBlockId={selectedBlockId}
+                        onSelectBlock={onSelectBlock}
+                        onSelectSubnet={onSelectSubnet}
+                        onDeleteSubnet={(s) => setSubnetToDelete(s)}
+                        onDeleteBlock={(b) => setBlockToDelete(b)}
+                        onEditBlock={(b) => setEditBlock(b)}
+                        onCreateSubnet={(blockId) =>
+                          setShowCreateSubnet(blockId)
+                        }
+                        onCreateChildBlock={(parentId) =>
+                          setShowCreateBlock(parentId)
+                        }
+                        onAllocateIp={(s) => onSelectSubnet(s)}
+                        depth={0}
+                      />
+                    ))}
+                    {capped && (
+                      <button
+                        type="button"
+                        onClick={() => setShowAllTop(true)}
+                        className="w-full rounded px-2 py-1 text-left text-xs text-primary hover:bg-muted/40"
+                      >
+                        Show {(top.length - TREE_GROUP_CAP).toLocaleString()}{" "}
+                        more…
+                      </button>
+                    )}
+                  </>
+                );
+              })()}
 
             {!isLoading && !subnets?.length && !blocks?.length && (
               <p className="py-1 pl-2 text-xs text-muted-foreground">

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -9769,6 +9769,9 @@ function SubnetRow({
           {...attributes}
           {...listeners}
           onClick={onSelect}
+          role="treeitem"
+          aria-label={subnet.network}
+          aria-selected={isSelected}
           className={cn(
             "group flex cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-sm",
             isSelected
@@ -11257,7 +11260,12 @@ function BlockTreeRow({
   };
 
   return (
-    <div>
+    <div
+      role="treeitem"
+      aria-label={node.block.network}
+      aria-selected={isSelected}
+      aria-expanded={hasContent ? expanded : undefined}
+    >
       {/* Block header row */}
       <ContextMenu>
         <ContextMenuTrigger asChild>
@@ -11281,6 +11289,11 @@ function BlockTreeRow({
                 }}
                 className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-sm border border-border bg-background text-[10px] font-bold text-muted-foreground hover:border-primary hover:text-primary"
                 title={expanded ? "Collapse" : "Expand"}
+                aria-label={
+                  expanded
+                    ? `Collapse ${node.block.network}`
+                    : `Expand ${node.block.network}`
+                }
               >
                 {expanded ? "−" : "+"}
               </button>
@@ -11349,7 +11362,10 @@ function BlockTreeRow({
           with subnets inside it lands alongside its IP-adjacent peers
           rather than being bucketed to the top or bottom. */}
       {expanded && hasContent && (
-        <div className="ml-[9px] pl-3 border-l border-border/40 space-y-0.5">
+        <div
+          role="group"
+          className="ml-[9px] pl-3 border-l border-border/40 space-y-0.5"
+        >
           {sortedTreeItems(node).map((item) =>
             item.kind === "block" ? (
               <BlockTreeRow
@@ -13932,7 +13948,11 @@ function SpaceSection({
       {/* Tree with vertical connecting line */}
       {expanded && (
         <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-          <div className="ml-[9px] pl-2 border-l border-border/40 space-y-0.5">
+          <div
+            role="tree"
+            aria-label={`${space.name} — blocks and subnets`}
+            className="ml-[9px] pl-2 border-l border-border/40 space-y-0.5"
+          >
             {isLoading && (
               <p className="py-1 pl-2 text-xs text-muted-foreground">
                 Loading…

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -5237,7 +5237,54 @@ function SubnetDetail({
                   defeat the sticky thead by anchoring it to a
                   non-scrolling intermediate parent. The outer
                   ``flex-1 overflow-auto`` handles both axes. */}
-              <table className="w-full min-w-[640px] text-sm">
+              {/* Mobile "on-call mode" — the 10-column table is unusable on a
+                  phone, so under sm we render each IP as a tappable card with
+                  the triage essentials (address · status · host · seen). The
+                  full table takes over at sm+. Pool/gap marker rows are skipped
+                  on mobile. */}
+              <div className="space-y-1.5 px-1 pb-2 sm:hidden">
+                {tableRows.filter((r) => r.kind === "ip").length === 0 && (
+                  <p className="px-2 py-3 text-xs text-muted-foreground">
+                    No addresses to show.
+                  </p>
+                )}
+                {tableRows.map((row) => {
+                  if (row.kind !== "ip") return null;
+                  const addr = row.addr;
+                  const host = addr.fqdn || addr.hostname || "";
+                  return (
+                    <button
+                      key={`m-${addr.id}`}
+                      type="button"
+                      onClick={() => setViewingAddress(addr)}
+                      className="flex w-full flex-col gap-1 rounded-md border bg-card p-2.5 text-left active:bg-muted/50"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-mono text-sm font-medium">
+                          {addr.address}
+                        </span>
+                        <StatusTag status={addr.status} />
+                      </div>
+                      <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                        <span className="truncate">
+                          {host || (
+                            <span className="text-muted-foreground/40">
+                              no hostname
+                            </span>
+                          )}
+                        </span>
+                        <SeenDot
+                          lastSeenAt={addr.last_seen_at}
+                          lastSeenMethod={addr.last_seen_method}
+                          withLabel
+                        />
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+
+              <table className="hidden w-full min-w-[640px] text-sm sm:table">
                 {/* Sticky header — pinned to the parent
                       ``flex-1 overflow-auto`` scroll container so the
                       column headers stay visible while scrolling a

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -4112,13 +4112,20 @@ function HeaderMenu({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const real = items.filter(
-    (i): i is { label: string; icon?: LucideIcon; onClick: () => void; title?: string } =>
-      !!i && !!i.onClick,
+    (
+      i,
+    ): i is {
+      label: string;
+      icon?: LucideIcon;
+      onClick: () => void;
+      title?: string;
+    } => !!i && !!i.onClick,
   );
   useEffect(() => {
     if (!open) return;
     const onDocMouseDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
     };
     document.addEventListener("mousedown", onDocMouseDown);
     return () => document.removeEventListener("mousedown", onDocMouseDown);
@@ -14377,7 +14384,9 @@ function IpamHelpLegend() {
   ];
   return (
     <div className="border-b bg-muted/20 px-3 py-2 text-[11px] leading-relaxed text-muted-foreground">
-      <p className="mb-1.5 font-semibold text-foreground">What the icons mean</p>
+      <p className="mb-1.5 font-semibold text-foreground">
+        What the icons mean
+      </p>
       <ul className="space-y-1.5">
         <li className="flex items-center gap-1.5">
           <Layers className="h-3 w-3 flex-shrink-0 text-violet-500" />
@@ -14395,7 +14404,9 @@ function IpamHelpLegend() {
         </li>
         <li className="flex items-center gap-1.5">
           <StatusTag status="allocated" />
-          <span>Status — the IP's lifecycle (icon + colour, never colour alone)</span>
+          <span>
+            Status — the IP's lifecycle (icon + colour, never colour alone)
+          </span>
         </li>
         <li className="flex flex-wrap items-center gap-x-2 gap-y-1">
           <span className="font-medium text-foreground">Seen</span>
@@ -14410,8 +14421,8 @@ function IpamHelpLegend() {
         <li className="flex items-center gap-1.5">
           <span className="inline-block h-2 w-2 flex-shrink-0 rounded-full bg-green-500" />
           <span>
-            Utilization — green &lt;80%, amber 80–95%, red ≥95% (an em-dash means
-            an IPv6 prefix too large to count)
+            Utilization — green &lt;80%, amber 80–95%, red ≥95% (an em-dash
+            means an IPv6 prefix too large to count)
           </span>
         </li>
         <li className="flex items-center gap-1.5">
@@ -14634,9 +14645,7 @@ export function IPAMPage() {
               onClick={() => setHelpMode((v) => !v)}
               className={cn(
                 "rounded p-1 hover:text-foreground",
-                helpMode
-                  ? "text-primary"
-                  : "text-muted-foreground",
+                helpMode ? "text-primary" : "text-muted-foreground",
               )}
               title={helpMode ? "Hide help" : "Show help — explain the icons"}
               aria-label="Toggle IPAM help layer"

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -13967,7 +13967,27 @@ function SpaceSection({
       network.toLowerCase().includes(filterQ) ||
       (name ?? "").toLowerCase().includes(filterQ);
     const byId = new Map(allBlocks.map((b) => [b.id, b]));
-    const keep = new Set<string>();
+    // When a BLOCK matches, reveal its whole subtree (child blocks + their
+    // subnets) so a matched container doesn't render as an empty leaf —
+    // searching for a block means "show me what's in it".
+    const childrenByParent = new Map<string, IPBlock[]>();
+    for (const b of allBlocks) {
+      if (!b.parent_block_id) continue;
+      const arr = childrenByParent.get(b.parent_block_id);
+      if (arr) arr.push(b);
+      else childrenByParent.set(b.parent_block_id, [b]);
+    }
+    const inMatchedSubtree = new Set<string>();
+    const stack = allBlocks
+      .filter((b) => hit(b.network, b.name))
+      .map((b) => b.id);
+    while (stack.length) {
+      const id = stack.pop() as string;
+      if (inMatchedSubtree.has(id)) continue;
+      inMatchedSubtree.add(id);
+      for (const c of childrenByParent.get(id) ?? []) stack.push(c.id);
+    }
+    const keep = new Set<string>(inMatchedSubtree);
     const addAncestors = (parentId: string | null | undefined) => {
       let cur = parentId ?? null;
       while (cur && !keep.has(cur)) {
@@ -13975,14 +13995,16 @@ function SpaceSection({
         cur = byId.get(cur)?.parent_block_id ?? null;
       }
     };
-    const keptSubnets = allSubnets.filter((s) => hit(s.network, s.name));
+    // A subnet is kept if it matches by text, or it sits inside a matched
+    // block's subtree.
+    const keptSubnets = allSubnets.filter(
+      (s) =>
+        hit(s.network, s.name) ||
+        (s.block_id != null && inMatchedSubtree.has(s.block_id)),
+    );
     for (const s of keptSubnets) addAncestors(s.block_id);
-    for (const b of allBlocks) {
-      if (hit(b.network, b.name)) {
-        keep.add(b.id);
-        addAncestors(b.parent_block_id);
-      }
-    }
+    for (const id of inMatchedSubtree)
+      addAncestors(byId.get(id)?.parent_block_id);
     const keptBlocks = allBlocks.filter((b) => keep.has(b.id));
     return {
       treeBlocks: keptBlocks,

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -30,6 +30,7 @@ import {
   Radar,
   Wrench,
   Sparkles,
+  type LucideIcon,
   Scissors,
   GitMerge,
   Maximize2,
@@ -4085,6 +4086,71 @@ function ToolsMenu({
               this…
             </button>
           )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Generic header overflow menu — gives the Block / Space headers the same
+// "secondary actions live behind a Tools ▾ dropdown" grammar the Subnet header
+// uses, instead of a flat row of buttons (#465 level-invariant toolbar). Items
+// with no handler are skipped so call sites can conditionally include entries.
+function HeaderMenu({
+  label = "Tools",
+  items,
+}: {
+  label?: string;
+  items: Array<{
+    label: string;
+    icon?: LucideIcon;
+    onClick?: () => void;
+    title?: string;
+  } | null>;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const real = items.filter(
+    (i): i is { label: string; icon?: LucideIcon; onClick: () => void; title?: string } =>
+      !!i && !!i.onClick,
+  );
+  useEffect(() => {
+    if (!open) return;
+    const onDocMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, [open]);
+  if (real.length === 0) return null;
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+      >
+        <Wrench className="h-3.5 w-3.5" />
+        {label}
+        <ChevronDown className="h-3.5 w-3.5" />
+      </button>
+      {open && (
+        <div className="absolute right-0 z-20 mt-1 w-52 overflow-hidden rounded-md border bg-popover shadow-md">
+          {real.map((it) => (
+            <button
+              key={it.label}
+              type="button"
+              title={it.title}
+              onClick={() => {
+                setOpen(false);
+                it.onClick();
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted"
+            >
+              {it.icon && <it.icon className="h-3.5 w-3.5" />}
+              {it.label}
+            </button>
+          ))}
         </div>
       )}
     </div>
@@ -11778,40 +11844,46 @@ function BlockDetailView({
                   Sync DNS
                 </HeaderButton>
                 <ExportButton scope={{ block_id: block.id }} label="Export" />
-                {space && (
-                  <HeaderButton
-                    icon={Search}
-                    onClick={() => setShowFindFree(true)}
-                    title="Find unused CIDRs in this block"
-                  >
-                    Find Free…
-                  </HeaderButton>
-                )}
                 <ServicesUsingButton
                   kind="ip_block"
                   resourceId={block.id}
                   label={block.network}
                 />
+                {/* Structural / less-frequent actions grouped behind a Tools ▾
+                    dropdown, mirroring the Subnet header's grammar instead of a
+                    flat button row (#465). */}
+                <HeaderMenu
+                  items={[
+                    space
+                      ? {
+                          label: "Find Free…",
+                          icon: Search,
+                          onClick: () => setShowFindFree(true),
+                          title: "Find unused CIDRs in this block",
+                        }
+                      : null,
+                    {
+                      label: "Resize…",
+                      icon: Maximize2,
+                      onClick: () => setShowResizeBlock(true),
+                      title:
+                        "Grow this block to a larger CIDR (e.g. /16 → /15). Shrinking is not supported.",
+                    },
+                    {
+                      label: "Move…",
+                      onClick: () => setShowMoveBlock(true),
+                      title:
+                        "Move this block (and everything under it) to a different IP space.",
+                    },
+                    {
+                      label: "Add child block…",
+                      icon: Layers,
+                      onClick: () => setShowCreateChildBlock(true),
+                    },
+                  ]}
+                />
                 <HeaderButton icon={Pencil} onClick={() => setShowEdit(true)}>
                   Edit
-                </HeaderButton>
-                <HeaderButton
-                  onClick={() => setShowResizeBlock(true)}
-                  title="Grow this block to a larger CIDR (e.g. /16 → /15). Shrinking is not supported."
-                >
-                  Resize…
-                </HeaderButton>
-                <HeaderButton
-                  onClick={() => setShowMoveBlock(true)}
-                  title="Move this block (and everything under it) to a different IP space."
-                >
-                  Move…
-                </HeaderButton>
-                <HeaderButton
-                  icon={Layers}
-                  onClick={() => setShowCreateChildBlock(true)}
-                >
-                  Add Block
                 </HeaderButton>
                 <HeaderButton
                   variant="primary"
@@ -13151,21 +13223,25 @@ function SpaceTableView({
               Sync DNS
             </HeaderButton>
             <ExportButton scope={{ space_id: space.id }} label="Export" />
-            <HeaderButton
-              icon={Search}
-              onClick={() => setShowFindFree(true)}
-              title="Find unused CIDRs in this space"
-            >
-              Find Free…
-            </HeaderButton>
+            {/* Structural actions behind a Tools ▾ dropdown — same grammar as
+                the Block + Subnet headers (#465). */}
+            <HeaderMenu
+              items={[
+                {
+                  label: "Find Free…",
+                  icon: Search,
+                  onClick: () => setShowFindFree(true),
+                  title: "Find unused CIDRs in this space",
+                },
+                {
+                  label: "Add block…",
+                  icon: Layers,
+                  onClick: () => setShowCreateBlock(true),
+                },
+              ]}
+            />
             <HeaderButton icon={Pencil} onClick={() => setShowEditSpace(true)}>
               Edit Space
-            </HeaderButton>
-            <HeaderButton
-              icon={Layers}
-              onClick={() => setShowCreateBlock(true)}
-            >
-              Add Block
             </HeaderButton>
             <HeaderButton
               variant="primary"

--- a/frontend/src/pages/ipam/SubnetsPage.tsx
+++ b/frontend/src/pages/ipam/SubnetsPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { ipamApi, type Subnet } from "@/lib/api";
+import { StatusTag } from "@/components/ui/status-tag";
 import { zebraBodyCls } from "@/lib/utils";
 
 export function SubnetsPage() {
@@ -58,19 +59,7 @@ export function SubnetsPage() {
 }
 
 function StatusBadge({ status }: { status: string }) {
-  const colors: Record<string, string> = {
-    active: "bg-green-100 text-green-800",
-    deprecated: "bg-yellow-100 text-yellow-800",
-    reserved: "bg-blue-100 text-blue-800",
-    quarantine: "bg-red-100 text-red-800",
-  };
-  return (
-    <span
-      className={`rounded-full px-2 py-0.5 text-xs font-medium ${colors[status] ?? "bg-muted text-muted-foreground"}`}
-    >
-      {status}
-    </span>
-  );
+  return <StatusTag status={status} />;
 }
 
 function UtilizationBar({ percent }: { percent: number }) {


### PR DESCRIPTION
Completes the remaining open items from the 10-persona IPAM UX review (issue #465), after the round-1 fixes shipped in #466. Twelve commits; each built + linted per slice, with the two highest-risk slices adversarially reviewed.

## What landed

| Area | Change |
|---|---|
| **Block-level utilization** | Backend caches `allocated_ips`/`total_ips` on `ip_block` (migration `b7c2f1a9d4e6` with a recursive-CTE backfill; `total_ips` clamped to BIGINT so huge IPv6 blocks read as uncountable). Exposed on `IPBlockResponse` + the frontend type; block rows now show real **Used IPs** + size + a utilization bar instead of `—`. |
| **Row-type badge** | `BLOCK` / `SUBNET` tag in the Network cell of both block+subnet tables, so blocks' blank Router/VLAN/Status cells read as "not applicable", not "missing". |
| **Accessibility** | Shared Modal gets `role=dialog` + `aria-modal` + **focus-trap** (`useFocusTrap`: initial focus respecting `autoFocus`, Tab/Shift+Tab trapped, focus-return on close) + an accessible close button. The IP-space tree gets `role=tree`/`treeitem`/`group` + `aria-expanded` + named toggles. |
| **`StatusTag` primitive** | New shared icon+text+color status pill (kills colour-alone reliance, WCAG 1.4.1); IPAM + SubnetsPage `StatusBadge` delegate to it (consolidates a duplicate, dark-mode-less map). |
| **Tree quick-filter** | Search box over the tree — matches IP-space name/description **and** block/subnet CIDR/name, keeps ancestor paths, reveals a matched block's subtree, force-expands inner matches, hides non-matching spaces. Collapsed spaces are fetched on demand while filtering. |
| **Tree scale** | Bounded render — each sibling group caps at 300 rows with a "Show N more…" reveal (never while filtering). Chosen over windowing the @dnd-kit drag-to-reparent tree, which can't be runtime-verified here. |
| **Mobile on-call mode** | Under `sm`, the 10-column IP table is replaced by tappable cards (address · status · host · Seen) opening the detail sheet. |
| **Toolbar grammar** | New generic `HeaderMenu`; Space + Block headers now tuck structural actions behind a **Tools ▾** dropdown, matching the Subnet header's grammar. |
| **Progressive disclosure** | Dense default + a **Help (?)** toggle revealing a glossary of the IPAM visual vocabulary. Sticky per-user. |
| **Ask AI placement** | Demoted from a header primary action into the subnet Tools menu (gated on an AI provider being configured). |
| **NetBox invisible-import** | Audited — fields already map to native columns (tenant→Customer, site, role→subnet_role / IP role incl. `gateway`, VLAN, status) with custom_fields only as fallback. Cleaned the noisy `netbox_is_pool: false` stamp. |

## Verification
- `tsc -b` + vite build, eslint, prettier, typecheck — clean.
- Backend ruff/black/mypy clean; migration-lint baselined; **19/19 NetBox import tests pass**.
- Migration applied + backfill verified live (IPv6 blocks clamp → uncountable).
- Two adversarial review subagents on the app-wide modal focus-trap + the tree filter/recursion → **no high/medium regressions** (nested-modal Tab-fight provably benign; tree hook-order verified). The one UX finding — a matched block showing empty — is fixed (it now reveals its subtree).
- Stack rebuilt + healthy; drag-to-reparent / inline edit / bulk select confirmed intact.

**Deliberately not done:** windowing the dnd-kit tree (bounded render instead — see above), and translating a NetBox pool prefix into reservation behaviour (left as its own pass; the flag is preserved as provenance).

Closes #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)