### PR TITLE
feat(dhcp): create/edit/delete static reservations from the Static Assignments tab

### DIFF
--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -191,24 +191,30 @@ scopes / pools / statics / classes all belong to the group). Create it from
 **DHCP → the server group → Scopes tab → New Scope**. A dynamic pool is optional;
 the scope alone is enough to emit the `subnet4` block that reservations hang off.
 
-**Create the reservation (the only working create path):**
+**Create the reservation — two equivalent paths:**
+
+*From the DHCP page:* **DHCP → the server group → "Static Assignments" tab →
+New static assignment**. Pick the scope (a picker appears when the group has
+more than one), then enter the MAC + IP + hostname and save. Edit and Delete
+live on the per-row right-click menu. Creating / editing / deleting a
+reservation requires a **superadmin**.
+
+*From IPAM (at allocation time):*
 
 1. **IPAM → select the subnet → "Allocate IP"** (the primary header button; also
    reachable from a free-range gap row or the subnet context menu).
 2. In the **Allocate IP Address** modal set **Type / Status = `static_dhcp`**.
    This reveals the **DHCP Scope** picker.
 3. Pick the **DHCP Scope**, enter the **MAC address** (required — see caveat
-   below), and set the hostname.
+   below), and set the hostname. If no scope exists for the subnet yet, the
+   picker offers a **Create a scope** button that opens the scope modal inline.
 4. Click **Allocate**. IPAM creates the address row with
    `IPAddress.status = static_dhcp` and mirrors it into the scope as a
    `DHCPStaticAssignment` (via `POST /api/v1/dhcp/scopes/{scope_id}/statics`).
-   The Kea agent picks up the new `ConfigBundle` (a group wake fires + the ETag
-   shifts) and renders the host reservation within seconds.
 
-**Viewing existing reservations.** The **DHCP → server group → "Static
-Assignments"** tab lists every reservation across the group's scopes. It is
-currently **read-only** (sort + copy IP / MAC / hostname) — it is not a create
-surface. Manage reservations from the IPAM Allocate flow above.
+Either way, the Kea agent picks up the new `ConfigBundle` (a group wake fires +
+the ETag shifts) and renders the host reservation within seconds. The **Static
+Assignments** tab lists every reservation across the group's scopes.
 
 **Caveats / common "nothing happened" traps:**
 
@@ -222,10 +228,10 @@ surface. Manage reservations from the IPAM Allocate flow above.
   subnet yet), the IPAM address is created but the mirror to Kea is **not
   attempted** — this is the real "I set it static but nothing happened" trap.
   Create a scope first (see the prerequisite above).
-- **Only fresh allocation creates a reservation.** Flipping an *existing* IP to
-  `static_dhcp` via **Edit** (or bulk-edit) updates the IPAM row but does **not**
-  create a Kea reservation. Delete and re-allocate, or add it from the Allocate
-  flow.
+- **Editing an existing IPAM row to `static_dhcp` does not create a reservation.**
+  Flipping an *existing* IP to `static_dhcp` via **Edit** (or bulk-edit) updates
+  the IPAM row but does **not** mirror it to Kea. Add the reservation from the
+  DHCP **Static Assignments** tab, or delete and re-allocate via the IPAM flow.
 - **Creating a static currently requires a superadmin.** A non-superadmin who
   allocates a `static_dhcp` IP gets the IPAM row but the mirror call returns 403.
 
@@ -237,8 +243,8 @@ array *inside* the relevant `subnet4`. If a reservation you created never shows
 up, walk this checklist — each item is a real, mostly-silent drop point:
 
 - **The static was never actually created.** Confirm it exists via
-  `GET /api/v1/dhcp/scopes/{scope_id}/statics` or the group's read-only Static
-  Assignments tab. If it's absent, distinguish two cases: the allocation was
+  `GET /api/v1/dhcp/scopes/{scope_id}/statics` or the group's Static Assignments
+  tab. If it's absent, distinguish two cases: the allocation was
   **rejected** (a blank MAC 422s the whole allocation — nothing was created), or
   it **succeeded without mirroring** (a MAC was given but no scope was selected,
   or a non-superadmin hit 403 on the mirror call). See the caveats above.

--- a/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
+++ b/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
@@ -31,9 +31,9 @@ export function CreateStaticAssignmentModal({
     queryFn: () => dhcpApi.listPools(scope.id),
   });
 
-  const eligiblePools = pools.filter(
-    (p) => p.pool_type === "reserved" || p.pool_type === "dynamic",
-  );
+  // Reservations may not sit inside a dynamic pool (the backend rejects that in
+  // `_conflict_check`), so only offer reserved-pool ranges as IP hints.
+  const eligiblePools = pools.filter((p) => p.pool_type === "reserved");
 
   const mut = useMutation({
     mutationFn: () => {
@@ -85,8 +85,8 @@ export function CreateStaticAssignmentModal({
             label="IP Address"
             hint={
               eligiblePools.length > 0
-                ? `Must be within a reserved or dynamic pool of this scope.`
-                : "No pools defined yet — any IP in subnet."
+                ? `Use an IP from a reserved pool; IPs inside a dynamic pool are rejected.`
+                : "Any IP within the subnet (outside dynamic pools)."
             }
           >
             <input

--- a/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
+++ b/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
@@ -85,8 +85,8 @@ export function CreateStaticAssignmentModal({
             label="IP Address"
             hint={
               eligiblePools.length > 0
-                ? `Use an IP from a reserved pool; IPs inside a dynamic pool are rejected.`
-                : "Any IP within the subnet (outside dynamic pools)."
+                ? `Any IP in the subnet outside a dynamic pool; reserved-pool ranges are suggested below.`
+                : "Any IP within the subnet (outside a dynamic pool)."
             }
           >
             <input

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -1324,6 +1324,12 @@ function ServerPoolsOrStaticsTab({
       dhcpApi.deleteStatic(row.scope.id, row.item.id),
     onSuccess: (_r, row) => {
       qc.invalidateQueries({ queryKey: ["dhcp-statics", row.scope.id] });
+      // Delete detaches the linked IPAM row + triggers DNS sync server-side,
+      // so refresh the same IPAM/DNS keys the create/edit modal invalidates.
+      qc.invalidateQueries({ queryKey: ["addresses", row.scope.subnet_id] });
+      qc.invalidateQueries({
+        queryKey: ["subnet-dns-sync", row.scope.subnet_id],
+      });
       setDelStatic(null);
     },
   });

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -58,6 +58,8 @@ import { PauseServerModal } from "@/components/ui/pause-server-modal";
 import { CreateScopeModal } from "./CreateScopeModal";
 import { CreateClientClassModal } from "./CreateClientClassModal";
 import { CreateOptionTemplateModal } from "./CreateOptionTemplateModal";
+import { CreateStaticAssignmentModal } from "./CreateStaticAssignmentModal";
+import { usePermissions } from "@/hooks/usePermissions";
 import { MacBlocksTab } from "./MacBlocksTab";
 import { PhoneProfilesTab } from "./PhoneProfilesTab";
 import { DeleteConfirmModal, StatusDot } from "./_shared";
@@ -1306,164 +1308,256 @@ function ServerPoolsOrStaticsTab({
     },
   );
 
+  // Static reservations are created/edited here (issue #472). Creation is
+  // group-centric — the operator picks which scope the reservation lands in.
+  // Backend create/update/delete are superadmin-gated, so gate the UI too.
+  const qc = useQueryClient();
+  const { isSuperadmin } = usePermissions();
+  const [showCreate, setShowCreate] = useState(false);
+  const [createScopeId, setCreateScopeId] = useState("");
+  const [editStatic, setEditStatic] = useState<StaticRow | null>(null);
+  const [delStatic, setDelStatic] = useState<StaticRow | null>(null);
+  const createScope =
+    allScopes.find((s) => s.id === createScopeId) ?? allScopes[0] ?? null;
+  const delMut = useMutation({
+    mutationFn: (row: StaticRow) =>
+      dhcpApi.deleteStatic(row.scope.id, row.item.id),
+    onSuccess: (_r, row) => {
+      qc.invalidateQueries({ queryKey: ["dhcp-statics", row.scope.id] });
+      setDelStatic(null);
+    },
+  });
+  const canManageStatics = kind === "statics" && isSuperadmin;
+
   return (
-    <div className="rounded-lg border">
-      {rows.length === 0 ? (
-        <p className="p-6 text-center text-sm text-muted-foreground">
-          No {kind === "pools" ? "pools" : "static assignments"} yet.
-        </p>
-      ) : kind === "pools" ? (
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] text-sm">
-            <thead>
-              <tr className="border-b bg-muted/30 text-xs">
-                <SortableTh
-                  sortKey="scope"
-                  sort={poolSort}
-                  onSort={togglePoolSort}
-                  className="px-3 py-2"
-                >
-                  Scope
-                </SortableTh>
-                <SortableTh
-                  sortKey="name"
-                  sort={poolSort}
-                  onSort={togglePoolSort}
-                  className="px-3 py-2"
-                >
-                  Name
-                </SortableTh>
-                <SortableTh
-                  sortKey="start"
-                  sort={poolSort}
-                  onSort={togglePoolSort}
-                  className="px-3 py-2"
-                >
-                  Start
-                </SortableTh>
-                <SortableTh
-                  sortKey="end"
-                  sort={poolSort}
-                  onSort={togglePoolSort}
-                  className="px-3 py-2"
-                >
-                  End
-                </SortableTh>
-                <SortableTh
-                  sortKey="type"
-                  sort={poolSort}
-                  onSort={togglePoolSort}
-                  className="px-3 py-2"
-                >
-                  Type
-                </SortableTh>
-              </tr>
-            </thead>
-            <tbody className={zebraBodyCls}>
-              {poolRows.map(({ scope, item }) => {
-                const p = item;
-                return (
-                  <tr key={p.id} className="border-b last:border-0">
-                    <td className="px-3 py-2 text-xs">{scope.name}</td>
-                    <td className="px-3 py-2">{p.name || "—"}</td>
-                    <td className="px-3 py-2 font-mono text-xs">
-                      {p.start_ip}
-                    </td>
-                    <td className="px-3 py-2 font-mono text-xs">{p.end_ip}</td>
-                    <td className="px-3 py-2">
-                      <span className="rounded-full bg-muted px-2 py-0.5 text-xs">
-                        {p.pool_type}
-                      </span>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+    <div className="space-y-3">
+      {canManageStatics && allScopes.length > 0 && (
+        <div className="flex items-center justify-end gap-2">
+          {allScopes.length > 1 && (
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              Add to scope
+              <select
+                className="rounded-md border bg-background px-2 py-1 text-xs"
+                value={createScope?.id ?? ""}
+                onChange={(e) => setCreateScopeId(e.target.value)}
+              >
+                {allScopes.map((sc) => (
+                  <option key={sc.id} value={sc.id}>
+                    {sc.name || `Scope ${sc.id.slice(0, 8)}`}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          <button
+            onClick={() => setShowCreate(true)}
+            className="flex items-center gap-1 rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground hover:bg-primary/90"
+          >
+            <Plus className="h-3 w-3" /> New static assignment
+          </button>
         </div>
-      ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] text-sm">
-            <thead>
-              <tr className="border-b bg-muted/30 text-xs">
-                <SortableTh
-                  sortKey="scope"
-                  sort={staticSort}
-                  onSort={toggleStaticSort}
-                  className="px-3 py-2"
-                >
-                  Scope
-                </SortableTh>
-                <SortableTh
-                  sortKey="mac"
-                  sort={staticSort}
-                  onSort={toggleStaticSort}
-                  className="px-3 py-2"
-                >
-                  MAC
-                </SortableTh>
-                <SortableTh
-                  sortKey="ip"
-                  sort={staticSort}
-                  onSort={toggleStaticSort}
-                  className="px-3 py-2"
-                >
-                  IP
-                </SortableTh>
-                <SortableTh
-                  sortKey="hostname"
-                  sort={staticSort}
-                  onSort={toggleStaticSort}
-                  className="px-3 py-2"
-                >
-                  Hostname
-                </SortableTh>
-              </tr>
-            </thead>
-            <tbody className={zebraBodyCls}>
-              {staticRows.map(({ scope, item }) => {
-                const s = item;
-                return (
-                  <ContextMenu key={s.id}>
-                    <ContextMenuTrigger asChild>
-                      <tr className="border-b last:border-0">
-                        <td className="px-3 py-2 text-xs">{scope.name}</td>
-                        <td className="px-3 py-2 font-mono text-xs">
-                          {s.mac_address}
-                        </td>
-                        <td className="px-3 py-2 font-mono text-xs">
-                          {s.ip_address}
-                        </td>
-                        <td className="px-3 py-2">{s.hostname || "—"}</td>
-                      </tr>
-                    </ContextMenuTrigger>
-                    <ContextMenuContent>
-                      <ContextMenuLabel>{s.ip_address}</ContextMenuLabel>
-                      <ContextMenuSeparator />
-                      <ContextMenuItem
-                        onSelect={() => copyToClipboard(s.ip_address)}
-                      >
-                        Copy IP
-                      </ContextMenuItem>
-                      <ContextMenuItem
-                        onSelect={() => copyToClipboard(s.mac_address)}
-                      >
-                        Copy MAC
-                      </ContextMenuItem>
-                      {s.hostname && (
+      )}
+      <div className="rounded-lg border">
+        {rows.length === 0 ? (
+          <p className="p-6 text-center text-sm text-muted-foreground">
+            {kind === "pools"
+              ? "No pools yet."
+              : allScopes.length === 0
+                ? "No DHCP scopes in this group yet — create a scope first, then add reservations here."
+                : "No static assignments yet."}
+          </p>
+        ) : kind === "pools" ? (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30 text-xs">
+                  <SortableTh
+                    sortKey="scope"
+                    sort={poolSort}
+                    onSort={togglePoolSort}
+                    className="px-3 py-2"
+                  >
+                    Scope
+                  </SortableTh>
+                  <SortableTh
+                    sortKey="name"
+                    sort={poolSort}
+                    onSort={togglePoolSort}
+                    className="px-3 py-2"
+                  >
+                    Name
+                  </SortableTh>
+                  <SortableTh
+                    sortKey="start"
+                    sort={poolSort}
+                    onSort={togglePoolSort}
+                    className="px-3 py-2"
+                  >
+                    Start
+                  </SortableTh>
+                  <SortableTh
+                    sortKey="end"
+                    sort={poolSort}
+                    onSort={togglePoolSort}
+                    className="px-3 py-2"
+                  >
+                    End
+                  </SortableTh>
+                  <SortableTh
+                    sortKey="type"
+                    sort={poolSort}
+                    onSort={togglePoolSort}
+                    className="px-3 py-2"
+                  >
+                    Type
+                  </SortableTh>
+                </tr>
+              </thead>
+              <tbody className={zebraBodyCls}>
+                {poolRows.map(({ scope, item }) => {
+                  const p = item;
+                  return (
+                    <tr key={p.id} className="border-b last:border-0">
+                      <td className="px-3 py-2 text-xs">{scope.name}</td>
+                      <td className="px-3 py-2">{p.name || "—"}</td>
+                      <td className="px-3 py-2 font-mono text-xs">
+                        {p.start_ip}
+                      </td>
+                      <td className="px-3 py-2 font-mono text-xs">
+                        {p.end_ip}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span className="rounded-full bg-muted px-2 py-0.5 text-xs">
+                          {p.pool_type}
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30 text-xs">
+                  <SortableTh
+                    sortKey="scope"
+                    sort={staticSort}
+                    onSort={toggleStaticSort}
+                    className="px-3 py-2"
+                  >
+                    Scope
+                  </SortableTh>
+                  <SortableTh
+                    sortKey="mac"
+                    sort={staticSort}
+                    onSort={toggleStaticSort}
+                    className="px-3 py-2"
+                  >
+                    MAC
+                  </SortableTh>
+                  <SortableTh
+                    sortKey="ip"
+                    sort={staticSort}
+                    onSort={toggleStaticSort}
+                    className="px-3 py-2"
+                  >
+                    IP
+                  </SortableTh>
+                  <SortableTh
+                    sortKey="hostname"
+                    sort={staticSort}
+                    onSort={toggleStaticSort}
+                    className="px-3 py-2"
+                  >
+                    Hostname
+                  </SortableTh>
+                </tr>
+              </thead>
+              <tbody className={zebraBodyCls}>
+                {staticRows.map(({ scope, item }) => {
+                  const s = item;
+                  return (
+                    <ContextMenu key={s.id}>
+                      <ContextMenuTrigger asChild>
+                        <tr className="border-b last:border-0">
+                          <td className="px-3 py-2 text-xs">{scope.name}</td>
+                          <td className="px-3 py-2 font-mono text-xs">
+                            {s.mac_address}
+                          </td>
+                          <td className="px-3 py-2 font-mono text-xs">
+                            {s.ip_address}
+                          </td>
+                          <td className="px-3 py-2">{s.hostname || "—"}</td>
+                        </tr>
+                      </ContextMenuTrigger>
+                      <ContextMenuContent>
+                        <ContextMenuLabel>{s.ip_address}</ContextMenuLabel>
+                        <ContextMenuSeparator />
                         <ContextMenuItem
-                          onSelect={() => copyToClipboard(s.hostname!)}
+                          onSelect={() => copyToClipboard(s.ip_address)}
                         >
-                          Copy Hostname
+                          Copy IP
                         </ContextMenuItem>
-                      )}
-                    </ContextMenuContent>
-                  </ContextMenu>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                        <ContextMenuItem
+                          onSelect={() => copyToClipboard(s.mac_address)}
+                        >
+                          Copy MAC
+                        </ContextMenuItem>
+                        {s.hostname && (
+                          <ContextMenuItem
+                            onSelect={() => copyToClipboard(s.hostname!)}
+                          >
+                            Copy Hostname
+                          </ContextMenuItem>
+                        )}
+                        {canManageStatics && (
+                          <>
+                            <ContextMenuSeparator />
+                            <ContextMenuItem
+                              onSelect={() => setEditStatic({ scope, item: s })}
+                            >
+                              Edit…
+                            </ContextMenuItem>
+                            <ContextMenuItem
+                              onSelect={() => setDelStatic({ scope, item: s })}
+                            >
+                              Delete…
+                            </ContextMenuItem>
+                          </>
+                        )}
+                      </ContextMenuContent>
+                    </ContextMenu>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+      {showCreate && createScope && (
+        <CreateStaticAssignmentModal
+          scope={createScope}
+          onClose={() => setShowCreate(false)}
+        />
+      )}
+      {editStatic && (
+        <CreateStaticAssignmentModal
+          scope={editStatic.scope}
+          staticAssignment={editStatic.item}
+          onClose={() => setEditStatic(null)}
+        />
+      )}
+      {delStatic && (
+        <DeleteConfirmModal
+          title="Delete Static Assignment"
+          description={`Delete reservation ${delStatic.item.ip_address} (${delStatic.item.mac_address})?`}
+          onConfirm={() => delMut.mutate(delStatic)}
+          onClose={() => setDelStatic(null)}
+          isPending={delMut.isPending}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { DHCPSubnetPanel } from "@/pages/dhcp/DHCPSubnetPanel";
+import { CreateScopeModal } from "@/pages/dhcp/CreateScopeModal";
 import {
   useQuery,
   useQueries,
@@ -3008,6 +3009,9 @@ function AddAddressModal({
   // subnet has ``dns_split_horizon`` on (effective).
   const [extraZoneIds, setExtraZoneIds] = useState<string[]>([]);
   const [dhcpScopeId, setDhcpScopeId] = useState<string>("");
+  // Issue #472 — let the operator create a scope inline when none exists yet,
+  // instead of sending them off to the DHCP Pools tab and back.
+  const [showCreateScope, setShowCreateScope] = useState(false);
   const [aliases, setAliases] = useState<
     { name: string; record_type: "CNAME" | "A" }[]
   >([]);
@@ -3489,8 +3493,15 @@ function AddAddressModal({
           <Field label="DHCP Scope">
             {dhcpScopes.length === 0 ? (
               <div className="rounded-md border bg-amber-500/10 border-amber-500/40 px-3 py-2 text-xs">
-                No DHCP scope exists for this subnet. Create one from the{" "}
-                <span className="font-medium">DHCP Pools</span> tab first.
+                No DHCP scope exists for this subnet — a reservation needs one.
+                <button
+                  type="button"
+                  onClick={() => setShowCreateScope(true)}
+                  className="ml-1 font-medium text-primary underline hover:no-underline"
+                >
+                  Create a scope
+                </button>{" "}
+                to continue.
               </div>
             ) : (
               <select
@@ -3511,6 +3522,12 @@ function AddAddressModal({
               <p className="mt-1 text-xs text-amber-600">
                 MAC address required to create a static DHCP reservation.
               </p>
+            )}
+            {showCreateScope && (
+              <CreateScopeModal
+                subnetId={subnetId}
+                onClose={() => setShowCreateScope(false)}
+              />
             )}
           </Field>
         )}


### PR DESCRIPTION
Closes #472. Follow-up to the docs fix in #471.

## Problem

There was no way to **create** a DHCP static reservation from the DHCP UI. The server group's **Static Assignments** tab was strictly read-only (sortable table + copy-only context menu), and the purpose-built `CreateStaticAssignmentModal` / `EditStaticAssignmentModal` were **dead code, imported nowhere**. The only working create path was IPAM → Allocate IP → `static_dhcp` + scope + MAC, which is non-obvious and silently no-ops when no scope is selected. This is what a user hit (Discord) and what #471 documented.

## Changes (frontend + docs)

- **Static Assignments tab is now create-capable.** Adds a **New static assignment** button with a scope picker (shown when the group has >1 scope) and **Edit…/Delete…** on the per-row context menu, wiring in the existing `CreateStaticAssignmentModal`. Gated on **superadmin** to match the backend (`POST/PUT/DELETE /dhcp/scopes/{id}/statics` require superadmin). Empty state now distinguishes "no scopes yet" from "no reservations yet".
- **Fixed a misleading hint** in the modal: reservations can't sit inside a *dynamic* pool (the backend rejects that in `_conflict_check`), so only reserved-pool ranges are offered as IP suggestions.
- **IPAM deep-link.** The "No DHCP scope exists for this subnet" dead-end in `AddAddressModal` is now an inline **Create a scope** button that opens `CreateScopeModal`; the scope picker refreshes automatically (shared `["dhcp-scopes-subnet", id]` query key).
- **Docs.** Updated `DHCP.md` §3.1 to document both create paths and drop the "read-only tab" language.

## Verification

- `tsc -b` + `vite build` + `eslint` clean on the three changed frontend files.
- Superadmin gating verified against the backend handlers in `backend/app/api/v1/dhcp/statics.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)