### PR TITLE
fix(dhcp): partial unique index so a soft-deleted scope frees its (group, subnet) slot

### DIFF
--- a/backend/alembic/versions/a3f9c1e7b2d4_dhcp_scope_partial_unique.py
+++ b/backend/alembic/versions/a3f9c1e7b2d4_dhcp_scope_partial_unique.py
@@ -1,0 +1,47 @@
+"""dhcp_scope uniqueness: partial index excluding soft-deleted rows (#474)
+
+``uq_dhcp_scope_group_subnet`` was a plain ``UNIQUE(group_id, subnet_id)``,
+but ``DHCPScope`` is soft-deletable — so a trashed scope kept occupying the
+``(group, subnet)`` slot, and re-creating a scope for that subnet (or the
+Windows lease-import auto-create in ``pull_leases``) raised a raw
+``IntegrityError`` → HTTP 500. Recover-in-place required purging the scope
+from Trash.
+
+Fix: make the uniqueness a **partial** unique index (``WHERE deleted_at IS
+NULL``) so only live scopes are unique per ``(group, subnet)``; trashed rows
+fall out of the index entirely. Active rows were already globally unique
+under the old constraint, so no dedup is needed before creating the index.
+
+Revision ID: a3f9c1e7b2d4
+Revises: b7c2f1a9d4e6
+Create Date: 2026-07-02
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "a3f9c1e7b2d4"
+down_revision = "b7c2f1a9d4e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("uq_dhcp_scope_group_subnet", "dhcp_scope", type_="unique")
+    op.create_index(
+        "uq_dhcp_scope_group_subnet",
+        "dhcp_scope",
+        ["group_id", "subnet_id"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_dhcp_scope_group_subnet", table_name="dhcp_scope")
+    op.create_unique_constraint(
+        "uq_dhcp_scope_group_subnet", "dhcp_scope", ["group_id", "subnet_id"]
+    )

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.api.v1.dhcp._audit import write_audit
@@ -385,7 +386,17 @@ async def create_scope(
         relay_addresses=body.relay_addresses,
     )
     db.add(scope)
-    await db.flush()
+    # The pre-check above can't see a soft-deleted scope, and even for
+    # live rows a concurrent create can race it, so translate the DB
+    # unique-violation into a clean 409 instead of a raw 500 (#474).
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="A scope for this group+subnet already exists",
+        ) from exc
     # Push to every Windows DHCP member of the group BEFORE commit so a
     # WinRM failure rolls the DB row back.
     await push_scope_upsert(db, scope)

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -387,12 +387,16 @@ async def create_scope(
     )
     db.add(scope)
     # The pre-check above can't see a soft-deleted scope, and even for
-    # live rows a concurrent create can race it, so translate the DB
-    # unique-violation into a clean 409 instead of a raw 500 (#474).
+    # live rows a concurrent create can race it, so translate a
+    # (group, subnet) unique-violation into a clean 409 (#474). Any other
+    # integrity failure (FK / NOT NULL / CHECK) is unexpected — roll back
+    # and let it surface as a 500 rather than masking it as a conflict.
     try:
         await db.flush()
     except IntegrityError as exc:
         await db.rollback()
+        if "uq_dhcp_scope_group_subnet" not in str(exc.orig):
+            raise
         raise HTTPException(
             status_code=409,
             detail="A scope for this group+subnet already exists",

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -270,7 +270,20 @@ class DHCPScope(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
 
     __tablename__ = "dhcp_scope"
     __table_args__ = (
-        UniqueConstraint("group_id", "subnet_id", name="uq_dhcp_scope_group_subnet"),
+        # Partial unique index (NOT a plain UniqueConstraint) so a
+        # soft-deleted scope stops occupying the (group, subnet) slot.
+        # DHCPScope is soft-deletable; with a non-partial constraint a
+        # trashed scope kept the slot, so re-creating a scope for that
+        # subnet (or the Windows lease-import auto-create) 500'd on
+        # uq_dhcp_scope_group_subnet (#474). Scoping uniqueness to live
+        # rows matches the soft-delete semantics.
+        Index(
+            "uq_dhcp_scope_group_subnet",
+            "group_id",
+            "subnet_id",
+            unique=True,
+            postgresql_where=sa_text("deleted_at IS NULL"),
+        ),
         Index("ix_dhcp_scope_group", "group_id"),
         Index("ix_dhcp_scope_subnet", "subnet_id"),
     )

--- a/backend/tests/test_dhcp_scope_soft_delete_unique.py
+++ b/backend/tests/test_dhcp_scope_soft_delete_unique.py
@@ -1,0 +1,98 @@
+"""DHCP scope uniqueness must ignore soft-deleted rows (#474).
+
+A soft-deleted scope kept occupying the ``(group, subnet)`` slot under the
+old non-partial ``UNIQUE`` constraint, so re-creating a scope for that
+subnet raised a raw ``IntegrityError`` → 500. The constraint is now a
+partial unique index (``WHERE deleted_at IS NULL``); live scopes stay
+unique per ``(group, subnet)`` but trashed rows fall out of the index.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPScope, DHCPServerGroup
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+CIDR = "10.74.0.0/24"
+
+
+async def _superadmin_token(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _subnet_and_group(db: AsyncSession) -> tuple[Subnet, DHCPServerGroup]:
+    space = IPSpace(name=f"u474-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=CIDR, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=CIDR, name="s")
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, grp])
+    await db.flush()
+    return subnet, grp
+
+
+async def _create_scope(
+    client: AsyncClient, token: str, subnet: Subnet, grp: DHCPServerGroup, name: str
+):
+    return await client.post(
+        f"/api/v1/dhcp/subnets/{subnet.id}/dhcp-scopes",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"group_id": str(grp.id), "name": name},
+    )
+
+
+async def test_recreate_scope_after_soft_delete(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+
+    r = await _create_scope(client, token, subnet, grp, "first")
+    assert r.status_code in (200, 201), r.text
+    scope_id = uuid.UUID(r.json()["id"])
+
+    # Soft-delete it (simulate Trash) directly, bypassing the approvals gate.
+    scope = await db_session.get(DHCPScope, scope_id)
+    assert scope is not None
+    scope.deleted_at = datetime.now(UTC)
+    await db_session.commit()
+
+    # Re-creating a scope for the same (group, subnet) must succeed, not 500.
+    r2 = await _create_scope(client, token, subnet, grp, "second")
+    assert r2.status_code in (200, 201), r2.text
+    assert uuid.UUID(r2.json()["id"]) != scope_id
+
+
+async def test_duplicate_active_scope_still_409(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+
+    r = await _create_scope(client, token, subnet, grp, "first")
+    assert r.status_code in (200, 201), r.text
+
+    # A second live scope for the same (group, subnet) is still rejected.
+    r2 = await _create_scope(client, token, subnet, grp, "dup")
+    assert r2.status_code == 409, r2.text


### PR DESCRIPTION
Closes #474. Field bug (Discord): re-creating a DHCP scope for a subnet whose previous scope was deleted throws `sqlalchemy.exc.IntegrityError: uq_dhcp_scope_group_subnet` (HTTP 500), and nearly led a user to reinstall.

## Root cause

DHCP scopes are **soft-deleted** (`delete_scope` stamps `deleted_at`, row stays in Trash), but `uq_dhcp_scope_group_subnet` was a **plain, non-partial** `UNIQUE(group_id, subnet_id)` — so a trashed scope kept occupying the slot. Meanwhile a `do_orm_execute` listener (`backend/app/db.py:188`) injects `deleted_at IS NULL` into every ORM SELECT, so both scope-create guards were blind to the trashed row:

- `create_scope` 409 pre-check (`scopes.py:349`) passed → blind INSERT → **raw 500**.
- The Windows lease-import auto-create (`pull_leases.py:477`) hit the same blind spot (and the pull loop has no per-scope try/except, so it could abort the whole `sync-leases`).

## Fix

- **Model + migration** (`a3f9c1e7b2d4`): replace the plain `UniqueConstraint` with a **partial unique index** `WHERE deleted_at IS NULL`, scoping uniqueness to live rows. Active rows were already globally unique, so no dedup is needed before creating the index. This resolves the 500 for **both** the `create_scope` and `pull_leases` paths.
- **`create_scope`**: catch `IntegrityError` → friendly **409** instead of a raw 500 (covers the create/restore race).
- **Test** (`test_dhcp_scope_soft_delete_unique.py`): recreating a scope after soft-delete now succeeds; a second *live* scope for the same (group, subnet) still 409s.

## Operator recovery (pre-fix installs)

Admin → Trash (`/admin/trash`) → the trashed DHCP scope for that subnet → **Restore** or **Permanently delete**, then create fresh.

## Verification

ruff · black · mypy · `scripts/lint_migrations.py` all clean; new tests pass; related scope/soft-delete/lease suites pass (21) — no regressions.

## Follow-up (noted, not in this PR)

Because a new scope can now be created while an old one sits in Trash, the **restore-from-Trash** path could momentarily create two live rows for one (group, subnet). The new 409 covers the create side; a small guard on the restore path (refuse when a live scope already exists) would close the loop.

The related bugs from the same field report are tracked separately: #475 (report-leases vocab/mislabel), #476 (reservation MAC normalization), #477 (Kea config-test preflight), #478 (expired-lease GC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)