### PR TITLE
Bug-check sweep: DHCP field triage (#475–#478) + audit findings (#479–#484)

### DIFF
--- a/agent/dhcp/spatium_dhcp_agent/kea_ctrl.py
+++ b/agent/dhcp/spatium_dhcp_agent/kea_ctrl.py
@@ -66,3 +66,28 @@ def config_reload(socket_path: Path) -> None:
     log.info("kea_config_reload_send", socket=str(socket_path))
     send_command(socket_path, "config-reload")
     log.info("kea_config_reload_ok")
+
+
+def config_test(socket_path: Path, config_doc: dict[str, Any]) -> None:
+    """Validate a rendered config WITHOUT applying it (#477).
+
+    Kea's ``config-test`` parses + sanity-checks the config passed in
+    ``arguments`` and returns result=0 when valid, or a non-zero result with
+    ``text`` describing the exact problem (e.g. a pool outside the subnet).
+    ``send_command`` raises :class:`KeaCtrlError` carrying that ``text`` on
+    rejection, so a caller can surface Kea's real reason instead of an opaque
+    "reload failed" and never reload a config the daemon will reject.
+
+    A daemon too old to know ``config-test`` answers result=2 ("command not
+    supported"); we treat that as a soft pass so the preflight degrades to a
+    plain reload rather than blocking the apply.
+    """
+    log.info("kea_config_test_send", socket=str(socket_path))
+    try:
+        send_command(socket_path, "config-test", arguments=config_doc)
+    except KeaCtrlError as e:
+        if "result=2" in str(e):  # command unsupported → skip the preflight
+            log.info("kea_config_test_unsupported", socket=str(socket_path))
+            return
+        raise
+    log.info("kea_config_test_ok")

--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -214,8 +214,15 @@ def _reservation_v6(res: dict[str, Any]) -> dict[str, Any]:
     # host-reservation-identifiers).
     if res.get("duid"):
         out["duid"] = res["duid"]
-    elif "hw_address" in res or "mac" in res:
-        out["hw-address"] = res.get("hw_address") or res.get("mac")
+    else:
+        raw_hw = res.get("hw_address") or res.get("mac")
+        if raw_hw:
+            # Same canonicalization as the v4 path (#476): a non-canonical MAC
+            # emitted verbatim makes Kea reject the whole subnet6 on reload.
+            # Drop an invalid MAC rather than emit it malformed.
+            norm = _normalize_mac_for_kea(str(raw_hw))
+            if norm is not None:
+                out["hw-address"] = norm
     addr = res.get("ip_address") or res.get("ip")
     if addr:
         out["ip-addresses"] = [addr]
@@ -383,8 +390,19 @@ def _build_drop_expression(mac_blocks: list[dict[str, Any]]) -> str:
 
 def _reservation(res: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {}
-    if "hw_address" in res or "mac" in res:
-        out["hw-address"] = res.get("hw_address") or res.get("mac")
+    raw_hw = res.get("hw_address") or res.get("mac")
+    if raw_hw:
+        # Canonicalize to Kea's lowercase colon form. A reservation MAC
+        # entered non-canonically (Cisco-dotted ``aabb.ccdd.eeff`` or
+        # run-together ``aabbccddeeff``) would otherwise be emitted verbatim
+        # and make Kea REJECT the whole ``subnet4`` on reload, or silently
+        # fail to match the client on-wire (#476). Same normalization the
+        # DROP-class path already uses. An invalid MAC is dropped with a
+        # warning rather than emitted malformed — leaving the reservation to
+        # match on client-id / duid if present, instead of tanking the config.
+        norm = _normalize_mac_for_kea(str(raw_hw))
+        if norm is not None:
+            out["hw-address"] = norm
     if "client_id" in res:
         out["client-id"] = res["client_id"]
     if "duid" in res:

--- a/agent/dhcp/spatium_dhcp_agent/sync.py
+++ b/agent/dhcp/spatium_dhcp_agent/sync.py
@@ -179,16 +179,15 @@ class SyncLoop:
                 config_test(socket_path, config_doc)
                 config_reload(socket_path)
                 return True
-            except KeaCtrlError as e:
-                # The daemon answered but rejected the config → terminal.
-                log.warning("kea_config_rejected", daemon=daemon, error=str(e))
-                self.heartbeat.daemon_status = {
-                    "status": "degraded",
-                    "reason": f"{daemon}_config_rejected: {e}",
-                }
-                return False
-            except OSError as e:
-                # Control socket not up yet (Kea still starting) → retry.
+            except (KeaCtrlError, OSError) as e:
+                # Retry BOTH classes through the deadline. An OSError is the
+                # control socket not being up yet; and during Kea's startup
+                # window the command channel can answer config-test with a
+                # *transient* KeaCtrlError (empty / non-JSON / not-ready) that a
+                # moment later succeeds — so a rejection is only treated as
+                # terminal once the retry window is exhausted. In the steady-
+                # state apply path reload_retry_timeout is 0, so a genuinely bad
+                # config still reports immediately without a spurious reload.
                 last_err = e
                 if time.monotonic() >= deadline:
                     break
@@ -200,11 +199,20 @@ class SyncLoop:
                 )
                 if self._stop.wait(_BOOTSTRAP_RELOAD_INTERVAL):
                     break
-        log.warning("kea_config_reload_failed", daemon=daemon, error=str(last_err))
-        self.heartbeat.daemon_status = {
-            "status": "degraded",
-            "reason": f"{daemon}_socket_unreachable: {last_err}",
-        }
+        # Deadline exhausted — report the reason that fits the last error: a
+        # config Kea rejected (surface its text) vs a socket we never reached.
+        if isinstance(last_err, KeaCtrlError):
+            log.warning("kea_config_rejected", daemon=daemon, error=str(last_err))
+            self.heartbeat.daemon_status = {
+                "status": "degraded",
+                "reason": f"{daemon}_config_rejected: {last_err}",
+            }
+        else:
+            log.warning("kea_config_reload_failed", daemon=daemon, error=str(last_err))
+            self.heartbeat.daemon_status = {
+                "status": "degraded",
+                "reason": f"{daemon}_socket_unreachable: {last_err}",
+            }
         return False
 
     def _apply_bundle(

--- a/agent/dhcp/spatium_dhcp_agent/sync.py
+++ b/agent/dhcp/spatium_dhcp_agent/sync.py
@@ -32,7 +32,7 @@ import structlog
 
 from .cache import load_config, save_config, save_rendered_kea, save_token
 from .config import AgentConfig
-from .kea_ctrl import KeaCtrlError, config_reload
+from .kea_ctrl import KeaCtrlError, config_reload, config_test
 from .render_kea import render as render_kea
 
 log = structlog.get_logger(__name__)
@@ -56,6 +56,7 @@ def _touch_ready_marker(state_dir: Path) -> None:
         marker.touch(exist_ok=True)
     except OSError:
         log.exception("ready_marker_touch_failed", path=str(state_dir / ".ready"))
+
 
 _FAILURE_THRESHOLD = 3  # DHCP.md §6: offline after 3 consecutive failures
 _OFFLINE_RETRY_SECONDS = 60.0
@@ -148,28 +149,51 @@ class SyncLoop:
         tmp.replace(path)
 
     def _reload_socket(
-        self, socket_path: Path, daemon: str, reload_retry_timeout: float
+        self,
+        socket_path: Path,
+        config_doc: dict[str, Any],
+        daemon: str,
+        reload_retry_timeout: float,
     ) -> bool:
-        """Ask one Kea daemon to reload, retrying until its socket answers.
+        """Preflight (config-test) then reload one Kea daemon.
 
-        Returns ``True`` on a successful reload, ``False`` otherwise. A
-        failure is logged + reflected in ``heartbeat.daemon_status`` but
-        does not raise, so a v6 reload failure can't abort the v4 apply
-        (and vice-versa). The retry covers Kea's own startup window where
-        the control socket may not exist yet.
+        Returns ``True`` on a successful reload, ``False`` otherwise. Never
+        raises, so a v6 failure can't abort the v4 apply (and vice-versa). Two
+        failure modes are now distinguished (#477):
+
+        * **Config rejected** — config-test / reload answers with a non-zero
+          result. Terminal (retrying won't fix a bad render), so surface Kea's
+          *actual* error text in ``daemon_status`` and skip the reload rather
+          than disturb a running daemon with a config it will reject. This is
+          what turns an opaque "degraded" into "pool 10.0.0.0/24 is not part
+          of the subnet …".
+        * **Socket not ready** — an ``OSError`` connecting to the control
+          socket during Kea's startup window. Retry until the deadline.
         """
         deadline = time.monotonic() + reload_retry_timeout
         last_err: Exception | None = None
         while True:
             try:
+                # config-test validates WITHOUT applying and returns the real
+                # reason on rejection; only reload once it passes.
+                config_test(socket_path, config_doc)
                 config_reload(socket_path)
                 return True
-            except (KeaCtrlError, OSError) as e:
+            except KeaCtrlError as e:
+                # The daemon answered but rejected the config → terminal.
+                log.warning("kea_config_rejected", daemon=daemon, error=str(e))
+                self.heartbeat.daemon_status = {
+                    "status": "degraded",
+                    "reason": f"{daemon}_config_rejected: {e}",
+                }
+                return False
+            except OSError as e:
+                # Control socket not up yet (Kea still starting) → retry.
                 last_err = e
                 if time.monotonic() >= deadline:
                     break
                 log.debug(
-                    "kea_config_reload_retry",
+                    "kea_reload_socket_retry",
                     daemon=daemon,
                     error=str(e),
                     wait=_BOOTSTRAP_RELOAD_INTERVAL,
@@ -179,7 +203,7 @@ class SyncLoop:
         log.warning("kea_config_reload_failed", daemon=daemon, error=str(last_err))
         self.heartbeat.daemon_status = {
             "status": "degraded",
-            "reason": f"{daemon}_reload_failed: {last_err}",
+            "reason": f"{daemon}_socket_unreachable: {last_err}",
         }
         return False
 
@@ -263,10 +287,10 @@ class SyncLoop:
             # the same retry / tolerate-missing-socket logic, and the
             # heartbeat daemon_status reflects the worst of the two.
             ok4 = self._reload_socket(
-                self.cfg.kea_control_socket, "dhcp4", reload_retry_timeout
+                self.cfg.kea_control_socket, dhcp4_doc, "dhcp4", reload_retry_timeout
             )
             ok6 = self._reload_socket(
-                self.cfg.kea_control_socket_v6, "dhcp6", reload_retry_timeout
+                self.cfg.kea_control_socket_v6, dhcp6_doc, "dhcp6", reload_retry_timeout
             )
             if ok4 and ok6:
                 self.heartbeat.daemon_status = {"status": "ok"}

--- a/agent/dhcp/tests/test_config_test_preflight.py
+++ b/agent/dhcp/tests/test_config_test_preflight.py
@@ -1,0 +1,126 @@
+"""#477 — Kea config-test preflight surfaces the real rejection reason.
+
+_apply_bundle used to write the config then immediately config-reload, logging a
+generic ``kea_config_reload_failed`` + marking the daemon "degraded" without the
+actual reason. It now runs ``config-test`` first (validates WITHOUT applying,
+returns Kea's real error text), so a bad render surfaces "pool … not in subnet"
+in daemon_status instead of an opaque "degraded", and a config Kea will reject is
+never reloaded onto a running daemon.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from spatium_dhcp_agent import kea_ctrl
+from spatium_dhcp_agent import sync as sync_mod
+from spatium_dhcp_agent.config import AgentConfig
+from spatium_dhcp_agent.kea_ctrl import KeaCtrlError
+from spatium_dhcp_agent.sync import SyncLoop
+
+
+class _FakeHeartbeat:
+    def __init__(self) -> None:
+        self.daemon_status: dict[str, Any] = {}
+        self.pending_acks: list[dict[str, Any]] = []
+
+
+def _loop(cfg: AgentConfig) -> SyncLoop:
+    return SyncLoop(cfg, token_ref=[""], heartbeat=_FakeHeartbeat())
+
+
+# ── kea_ctrl.config_test ─────────────────────────────────────────────────
+
+
+def test_config_test_sends_config_test_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[tuple[str, Any]] = []
+
+    def fake_send(sock, cmd, arguments=None, **kw):  # type: ignore[no-untyped-def]
+        seen.append((cmd, arguments))
+        return {"result": 0}
+
+    monkeypatch.setattr(kea_ctrl, "send_command", fake_send)
+    kea_ctrl.config_test(Path("/x.sock"), {"Dhcp4": {"subnet4": []}})
+    assert seen == [("config-test", {"Dhcp4": {"subnet4": []}})]
+
+
+def test_config_test_raises_the_real_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(sock, cmd, arguments=None, **kw):  # type: ignore[no-untyped-def]
+        raise KeaCtrlError(
+            "kea command 'config-test' failed: result=1 text='pool 10.0.0.0/24 not in subnet'"
+        )
+
+    monkeypatch.setattr(kea_ctrl, "send_command", boom)
+    with pytest.raises(KeaCtrlError, match="pool 10.0.0.0/24 not in subnet"):
+        kea_ctrl.config_test(Path("/x.sock"), {"Dhcp4": {}})
+
+
+def test_config_test_soft_passes_when_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An older daemon answers result=2 ("command not supported") — soft pass so
+    # the preflight degrades to a plain reload instead of blocking the apply.
+    def boom(sock, cmd, arguments=None, **kw):  # type: ignore[no-untyped-def]
+        raise KeaCtrlError(
+            "kea command 'config-test' failed: result=2 text='not supported'"
+        )
+
+    monkeypatch.setattr(kea_ctrl, "send_command", boom)
+    kea_ctrl.config_test(Path("/x.sock"), {"Dhcp4": {}})  # must NOT raise
+
+
+# ── SyncLoop._reload_socket preflight ────────────────────────────────────
+
+
+def test_reload_socket_rejection_surfaces_reason_and_skips_reload(
+    agent_cfg: AgentConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _loop(agent_cfg)
+    reloaded: list[Path] = []
+
+    def bad_test(sock, doc):  # type: ignore[no-untyped-def]
+        raise KeaCtrlError(
+            "kea command 'config-test' failed: result=1 text='pool not in subnet'"
+        )
+
+    monkeypatch.setattr(sync_mod, "config_test", bad_test)
+    monkeypatch.setattr(sync_mod, "config_reload", lambda s: reloaded.append(s))
+
+    ok = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
+    assert ok is False
+    assert reloaded == []  # never reload a config Kea rejects
+    assert loop.heartbeat.daemon_status["status"] == "degraded"
+    assert "pool not in subnet" in loop.heartbeat.daemon_status["reason"]
+
+
+def test_reload_socket_happy_path_tests_then_reloads(
+    agent_cfg: AgentConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _loop(agent_cfg)
+    calls: list[str] = []
+    monkeypatch.setattr(sync_mod, "config_test", lambda s, d: calls.append("test"))
+    monkeypatch.setattr(sync_mod, "config_reload", lambda s: calls.append("reload"))
+
+    ok = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
+    assert ok is True
+    assert calls == ["test", "reload"]  # preflight BEFORE reload
+
+
+def test_reload_socket_socket_not_ready_retries_then_reports(
+    agent_cfg: AgentConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _loop(agent_cfg)
+
+    def not_ready(sock, doc):  # type: ignore[no-untyped-def]
+        raise OSError("no such control socket")
+
+    monkeypatch.setattr(sync_mod, "config_test", not_ready)
+    monkeypatch.setattr(sync_mod, "config_reload", lambda s: None)
+
+    # timeout 0 → the OSError branch breaks immediately (no real wait).
+    ok = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
+    assert ok is False
+    assert "socket_unreachable" in loop.heartbeat.daemon_status["reason"]

--- a/agent/dhcp/tests/test_config_test_preflight.py
+++ b/agent/dhcp/tests/test_config_test_preflight.py
@@ -124,3 +124,29 @@ def test_reload_socket_socket_not_ready_retries_then_reports(
     ok = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
     assert ok is False
     assert "socket_unreachable" in loop.heartbeat.daemon_status["reason"]
+
+
+def test_reload_socket_transient_kea_error_retries_then_succeeds(
+    agent_cfg: AgentConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # During Kea's startup window config-test can answer with a *transient*
+    # KeaCtrlError that succeeds a moment later; within the retry deadline that
+    # must be retried (not treated as terminal), or the freshly-written config
+    # never reloads and the daemon stays on its launch-time config.
+    loop = _loop(agent_cfg)
+    calls = {"test": 0}
+
+    def flaky_test(sock, doc):  # type: ignore[no-untyped-def]
+        calls["test"] += 1
+        if calls["test"] == 1:
+            raise KeaCtrlError("transient: empty response from kea")
+        # second call succeeds
+
+    reloaded: list[Path] = []
+    monkeypatch.setattr(sync_mod, "config_test", flaky_test)
+    monkeypatch.setattr(sync_mod, "config_reload", lambda s: reloaded.append(s))
+
+    ok = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 5.0)
+    assert ok is True
+    assert calls["test"] == 2  # retried past the transient KeaCtrlError
+    assert reloaded  # reloaded once config-test passed

--- a/agent/dhcp/tests/test_render_kea.py
+++ b/agent/dhcp/tests/test_render_kea.py
@@ -84,6 +84,97 @@ def test_reservations_rendered(bundle: dict) -> None:
     assert resv[0]["hostname"] == "printer1"
 
 
+def _reservation_bundle(reservation: dict) -> dict:
+    return {
+        "etag": "sha256:test",
+        "schema_version": 1,
+        "server": {"name": "dhcp1", "interfaces": ["eth0"]},
+        "global_options": {"lease_time": 7200},
+        "subnets": [
+            {
+                "id": 1,
+                "subnet": "192.0.2.0/24",
+                "pools": [{"pool": "192.0.2.100 - 192.0.2.200"}],
+                "reservations": [reservation],
+                "valid_lifetime": 3600,
+            }
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "aabb.ccdd.eeff",  # Cisco-dotted
+        "aabbccddeeff",  # run-together
+        "AA-BB-CC-DD-EE-FF",  # dashed + uppercase
+        "AA:BB:CC:DD:EE:FF",  # colon but uppercase
+    ],
+)
+def test_reservation_mac_normalized_to_kea_form(raw: str) -> None:
+    # #476 — a reservation MAC entered non-canonically must be canonicalized to
+    # Kea's lowercase colon form, else Kea rejects the whole subnet4 on reload
+    # (or silently fails to match the client on-wire).
+    out = render(_reservation_bundle({"hw_address": raw, "ip_address": "192.0.2.50"}))
+    resv = out["Dhcp4"]["subnet4"][0]["reservations"]
+    assert resv[0]["hw-address"] == "aa:bb:cc:dd:ee:ff"
+
+
+def test_reservation_invalid_mac_dropped_not_emitted() -> None:
+    # An unparseable MAC is dropped (with a warning) rather than emitted
+    # malformed — a single bad row must not tank the whole Kea config. The
+    # reservation still matches on client-id (#476).
+    out = render(
+        _reservation_bundle(
+            {
+                "hw_address": "not-a-mac",
+                "ip_address": "192.0.2.50",
+                "client_id": "01:02:03:04",
+            }
+        )
+    )
+    resv = out["Dhcp4"]["subnet4"][0]["reservations"]
+    assert "hw-address" not in resv[0]
+    assert resv[0]["client-id"] == "01:02:03:04"
+
+
+def test_v6_reservation_mac_normalized() -> None:
+    # #476 — the Dhcp6 reservation path (_reservation_v6) normalizes MACs too;
+    # a non-canonical MAC would otherwise make Kea reject the whole subnet6.
+    bundle = {
+        "etag": "x",
+        "server_name": "d",
+        "driver": "kea",
+        "roles": [],
+        "scopes": [
+            {
+                "subnet_cidr": "2001:db8:0:1::/64",
+                "lease_time": 4800,
+                "address_family": "ipv6",
+                "v6_address_mode": "stateful",
+                "pools": [
+                    {
+                        "start_ip": "2001:db8:0:1::1000",
+                        "end_ip": "2001:db8:0:1::2000",
+                        "pool_type": "dynamic",
+                    }
+                ],
+                "statics": [
+                    {
+                        "ip_address": "2001:db8:0:1::50",
+                        "mac_address": "aabb.ccdd.eeff",  # Cisco-dotted
+                        "hostname": "v6host",
+                    }
+                ],
+                "ddns_enabled": False,
+            }
+        ],
+    }
+    out = render(bundle)
+    resv = out["Dhcp6"]["subnet6"][0]["reservations"]
+    assert resv[0]["hw-address"] == "aa:bb:cc:dd:ee:ff"
+
+
 def test_client_classes_rendered(bundle: dict) -> None:
     out = render(bundle)
     cc = out["Dhcp4"]["client-classes"]
@@ -266,7 +357,9 @@ def test_user_drop_class_not_clobbered() -> None:
     bundle = {
         "server": {"name": "t", "interfaces": ["eth0"]},
         "subnets": [{"id": 1, "subnet": "192.0.2.0/24", "pools": []}],
-        "client_classes": [{"name": "DROP", "match_expression": "option[60].hex == 'bad'"}],
+        "client_classes": [
+            {"name": "DROP", "match_expression": "option[60].hex == 'bad'"}
+        ],
         "mac_blocks": [
             {"mac_address": "aa:bb:cc:dd:ee:ff", "reason": "rogue", "description": ""}
         ],
@@ -517,7 +610,11 @@ def test_v4_scope_emits_relay_ip_addresses() -> None:
                 "subnet_cidr": "10.50.0.0/24",
                 "lease_time": 3600,
                 "pools": [
-                    {"start_ip": "10.50.0.10", "end_ip": "10.50.0.50", "pool_type": "dynamic"}
+                    {
+                        "start_ip": "10.50.0.10",
+                        "end_ip": "10.50.0.50",
+                        "pool_type": "dynamic",
+                    }
                 ],
                 "statics": [],
                 "relay_addresses": ["10.50.0.1", "192.0.2.250"],
@@ -575,4 +672,6 @@ def test_legacy_subnets_relay_ips_still_render() -> None:
             {"id": 1, "subnet": "10.60.0.0/24", "pools": [], "relay_ips": ["10.60.0.1"]}
         ],
     }
-    assert render(bundle)["Dhcp4"]["subnet4"][0]["relay"] == {"ip-addresses": ["10.60.0.1"]}
+    assert render(bundle)["Dhcp4"]["subnet4"][0]["relay"] == {
+        "ip-addresses": ["10.60.0.1"]
+    }

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -17,7 +17,7 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from jose import JWTError
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 
 from app.api.deps import DB
@@ -80,11 +80,28 @@ class AgentRegisterResponse(BaseModel):
 
 
 class AgentHeartbeatRequest(BaseModel):
+    # #482 — reject a wrong-envelope heartbeat loudly instead of validating
+    # into an all-default body (ops_ack=[] → the ACK loop runs 0× → 200 → the
+    # agent clears its ACK buffer, losing the ACKs). Mirrors the DNS heartbeat
+    # hardening (#430 D4). forbid requires this model to be a strict SUPERSET
+    # of every field any DHCP agent sends: the pid / status /
+    # lease_count_since_start telemetry below is accepted-but-unused so the
+    # current agent's body validates, and the Phase 8f-2 slot fields keep
+    # pre-Wave-C1 agents valid too.
+    model_config = ConfigDict(extra="forbid")
+
     agent_version: str | None = None
     daemon: dict[str, Any] = {}
     config: dict[str, Any] = {}
-    ops_ack: list[dict[str, Any]] = []
+    # Bound the ACK list so a malformed / hostile heartbeat can't pin memory.
+    ops_ack: list[dict[str, Any]] = Field(default_factory=list, max_length=5000)
     failed_ops_count: int = 0
+    # Accepted-but-unused telemetry the current DHCP agent ships every beat
+    # (agent/dhcp/spatium_dhcp_agent/heartbeat.py). Listed so extra="forbid"
+    # doesn't 422 a real heartbeat; the handler doesn't read them today.
+    pid: int | None = None
+    status: str | None = None
+    lease_count_since_start: int | None = None
     # Phase 8f-2 — agent reports its slot state + deployment environment.
     # See DNSServer agents.py for the per-field semantics. All optional
     # so older agents keep heartbeating without a 422.

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -74,11 +74,20 @@ def _normalize_options(raw: Any) -> dict[str, Any]:
 
 
 def _normalize_sync_mode(v: str | None) -> str:
-    if v in (None, "", "ipam"):
+    """Coerce a hostname→IPAM sync value to the canonical DB vocabulary
+    (``disabled`` | ``on_static_only`` | ``on_lease``).
+
+    The UI (and API) once used a separate ``none`` / ``ipam`` / ``learned``
+    vocabulary that didn't round-trip: the response echoes the stored canonical
+    value, which the old ``<select>`` couldn't render, so edits snapped back
+    (#475). The UI now speaks the canonical vocabulary directly; these legacy
+    values are still mapped in for backward-compatible API clients. Empty /
+    missing defaults to ``on_static_only`` (the model default).
+    """
+    if v in (None, ""):
         return "on_static_only"
-    if v == "learned":
-        return "on_lease"
-    return v or "on_static_only"
+    legacy = {"none": "disabled", "ipam": "on_static_only", "learned": "on_lease"}
+    return legacy.get(v, v)
 
 
 def _validate_relay_addresses(v: list[str] | None) -> list[str]:
@@ -434,13 +443,25 @@ async def update_scope(
     scope = await db.get(DHCPScope, scope_id)
     if scope is None:
         raise HTTPException(status_code=404, detail="Scope not found")
-    changes = body.model_dump(exclude_none=True)
+    # ``exclude_unset`` (not ``exclude_none``) so an explicit null clears a
+    # nullable column (e.g. resetting min_lease_time / max_lease_time to empty),
+    # while a field the client didn't send stays untouched (#475). ``exclude_none``
+    # silently dropped explicit nulls, so those fields could never be cleared.
+    changes = body.model_dump(exclude_unset=True)
     if "enabled" in changes:
         changes["is_active"] = changes.pop("enabled")
     if "hostname_sync_mode" in changes:
         changes["hostname_to_ipam_sync"] = _normalize_sync_mode(changes.pop("hostname_sync_mode"))
     elif "hostname_to_ipam_sync" in changes:
         changes["hostname_to_ipam_sync"] = _normalize_sync_mode(changes["hostname_to_ipam_sync"])
+    # Validate the resolved sync mode with the same guard as create (#475).
+    if "hostname_to_ipam_sync" in changes and changes[
+        "hostname_to_ipam_sync"
+    ] not in VALID_SYNC_MODES - {"ipam", "learned"}:
+        raise HTTPException(
+            status_code=422,
+            detail=f"invalid hostname sync mode: {changes['hostname_to_ipam_sync']}",
+        )
     if "options" in changes:
         changes["options"] = _normalize_options(changes["options"])
     # ``clear_pxe_profile=True`` is the explicit detach signal — Pydantic

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -84,7 +84,7 @@ def _normalize_sync_mode(v: str | None) -> str:
     values are still mapped in for backward-compatible API clients. Empty /
     missing defaults to ``on_static_only`` (the model default).
     """
-    if v in (None, ""):
+    if not v:  # None or ""
         return "on_static_only"
     legacy = {"none": "disabled", "ipam": "on_static_only", "learned": "on_lease"}
     return legacy.get(v, v)

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -34,6 +34,11 @@ router = APIRouter(tags=["dhcp"], dependencies=[Depends(require_resource_permiss
 
 VALID_HOSTNAME_POLICIES = {"client", "server_name", "derived", "none"}
 VALID_SYNC_MODES = {"disabled", "on_lease", "on_static_only", "ipam", "learned"}
+# Fields on ScopeUpdate an explicit ``null`` may CLEAR (#475). Every other
+# nullable column keeps its ``exclude_none`` behaviour — a stray null is dropped
+# rather than applied — so a NOT-NULL column can't 500 on ``setattr(None)`` and a
+# partial-body client can't silently wipe a column it didn't mean to touch.
+NULLABLE_CLEARABLE_SCOPE_FIELDS = {"min_lease_time", "max_lease_time"}
 # DHCPv6 operating modes (issue #52). Only meaningful for ipv6 scopes.
 VALID_V6_MODES = {"stateful", "stateless", "slaac"}
 
@@ -443,11 +448,19 @@ async def update_scope(
     scope = await db.get(DHCPScope, scope_id)
     if scope is None:
         raise HTTPException(status_code=404, detail="Scope not found")
-    # ``exclude_unset`` (not ``exclude_none``) so an explicit null clears a
+    # ``exclude_unset`` (not ``exclude_none``) so an explicit null can clear a
     # nullable column (e.g. resetting min_lease_time / max_lease_time to empty),
-    # while a field the client didn't send stays untouched (#475). ``exclude_none``
-    # silently dropped explicit nulls, so those fields could never be cleared.
-    changes = body.model_dump(exclude_unset=True)
+    # while a field the client didn't send stays untouched (#475). But keep a
+    # null only for the fields we explicitly allow to clear — otherwise an
+    # explicit null on a NOT-NULL column (name / description / is_active) would
+    # 500 on commit, and a null a partial-body client sent for an unmanaged
+    # nullable column would silently wipe it (both were dropped under
+    # ``exclude_none``).
+    changes = {
+        k: v
+        for k, v in body.model_dump(exclude_unset=True).items()
+        if v is not None or k in NULLABLE_CLEARABLE_SCOPE_FIELDS
+    }
     if "enabled" in changes:
         changes["is_active"] = changes.pop("enabled")
     if "hostname_sync_mode" in changes:

--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, field_validator
 from sqlalchemy import String, cast, func, or_, select
@@ -30,6 +31,7 @@ from app.drivers.dhcp.windows import test_winrm_credentials
 from app.models.audit import AuditLog
 from app.models.dhcp import DHCPConfigOp, DHCPLease, DHCPMACBlock, DHCPServer
 from app.models.dhcp_fingerprint import DHCPFingerprint
+from app.models.ipam import IPAddress, Subnet
 from app.models.metrics import DHCPMetricSample
 from app.services.dhcp.config_bundle import build_config_bundle
 from app.services.dhcp.pull_leases import pull_leases_from_server
@@ -53,6 +55,8 @@ router = APIRouter(
 # Sourced from the registry so new drivers (e.g. windows_dhcp) are
 # accepted automatically without having to touch this allowlist.
 VALID_DRIVERS = frozenset(_DHCP_DRIVERS.keys())
+
+logger = structlog.get_logger(__name__)
 
 
 class WindowsCredentialsInput(BaseModel):
@@ -1102,6 +1106,72 @@ async def list_leases(
         page=page,
         page_size=page_size,
     )
+
+
+@router.delete(
+    "/{server_id}/leases/{lease_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_model=None,
+)
+async def delete_lease(server_id: uuid.UUID, lease_id: uuid.UUID, db: DB, user: SuperAdmin) -> Any:
+    """Manually delete a single lease + its ``auto_from_lease`` IPAM mirror.
+
+    Agent-based (Kea) servers have no absence-delete reconciler (pull_leases is
+    agentless-only), so an ``expired`` lease otherwise lingers in the view until
+    the 24h GC sweep — this lets an operator drop one now (#478). Scoped to the
+    lease's own subnet so an overlapping same-address mirror in another
+    IPSpace/VRF is untouched; stamps ``removed`` history, revokes any DDNS the
+    mirror published, and audits.
+    """
+    lease = await db.get(DHCPLease, lease_id)
+    if lease is None or lease.server_id != server_id:
+        raise HTTPException(status_code=404, detail="Lease not found")
+
+    # Reuse the sweep's scope-FK-first / prefix-match subnet resolver so the
+    # mirror lookup is scoped exactly like the time-based cleanup (#329).
+    from app.tasks.dhcp_lease_cleanup import _resolve_lease_subnet_id
+
+    ip = str(lease.ip_address)
+    mirror_removed = False
+    subnet_id = await _resolve_lease_subnet_id(db, lease)
+    if subnet_id is not None:
+        mirror = (
+            await db.execute(
+                select(IPAddress).where(
+                    IPAddress.subnet_id == subnet_id,
+                    IPAddress.address == lease.ip_address,
+                    IPAddress.auto_from_lease.is_(True),
+                )
+            )
+        ).scalar_one_or_none()
+        if mirror is not None:
+            subnet = await db.get(Subnet, subnet_id)
+            if subnet is not None:
+                try:
+                    from app.services.dns.ddns import revoke_ddns_for_lease
+
+                    await revoke_ddns_for_lease(db, subnet=subnet, ipam_row=mirror)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("dhcp_lease_delete_ddns_revoke_failed", ip=ip, error=str(exc))
+            await db.delete(mirror)
+            mirror_removed = True
+
+    # Stamp history BEFORE deleting the row (it reads the lease's fields).
+    from app.services.dhcp.lease_history import record_lease_history
+
+    record_lease_history(db, lease, lease_state="removed", expired_at=datetime.now(UTC))
+    await db.delete(lease)
+    write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="dhcp_lease",
+        resource_id=str(lease_id),
+        resource_display=ip,
+        new_value={"ip_address": ip, "mirror_removed": mirror_removed},
+    )
+    await db.commit()
+    return None
 
 
 # --- Per-server stats (#195) ------------------------------------------------

--- a/backend/app/api/v1/dhcp/statics.py
+++ b/backend/app/api/v1/dhcp/statics.py
@@ -118,9 +118,16 @@ async def _upsert_ipam_for_static(
 
 
 async def _detach_ipam_for_static(db, st: DHCPStaticAssignment) -> None:
-    """Release the IPAM row back to `allocated` when the static is removed.
+    """Release the IPAM row back to `available` when the static is removed.
 
     Also tears down the forward A (DNS sync with action=delete).
+
+    The row is freed to ``available`` (not ``allocated``): the IP no longer
+    holds a reservation, and — crucially — a leftover ``allocated`` /
+    ``auto_from_lease=False`` row is skipped by the agent's lease-mirror refresh
+    (it only re-mirrors ``available`` or ``auto_from_lease`` rows), so it would
+    shadow a future dynamic lease at that IP AND never be reaped. ``available``
+    lets a new lease reclaim the row (#478).
     """
     from app.api.v1.ipam.router import _sync_dns_record
 
@@ -134,7 +141,7 @@ async def _detach_ipam_for_static(db, st: DHCPStaticAssignment) -> None:
                 pass
         row.static_assignment_id = None
         if row.status == "static_dhcp":
-            row.status = "allocated"
+            row.status = "available"
 
 
 async def _conflict_check(

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -1319,13 +1319,38 @@ async def _sync_dns_record(
     # ── Reverse PTR ─────────────────────────────────────────────────────────
     # A PTR points AT the forward FQDN. With no effective primary forward zone
     # ``fqdn`` is None (subnet resolved to no forward zone, or a stale/deleted
-    # primary-zone FK reset it above), so there is no name to point at — skip
-    # the PTR. The forward fan-out above already published to any extra zones
-    # via their own ``target_fqdn``. Without this guard ``ptr_value = fqdn +
-    # "."`` below raises TypeError (None + str) — reachable through the public
-    # create endpoint for a split-horizon IP with extra_zone_ids and no forward
-    # zone, or an IP whose primary forward zone was deleted (issue #480).
+    # primary-zone FK reset it above), so there is no name to point at. The
+    # forward fan-out above already published to any extra zones via their own
+    # ``target_fqdn``. Without this guard ``ptr_value = fqdn + "."`` below raises
+    # TypeError (None + str) — reachable through the public create endpoint for a
+    # split-horizon IP with extra_zone_ids and no forward zone, or an IP whose
+    # primary forward zone was deleted (issue #480).
     if fqdn is None:
+        # Don't just skip: retract any auto-generated PTR we previously
+        # published for this IP. When the primary forward zone was deleted /
+        # detached, the PTR now points at a name that can no longer be
+        # generated — leaving it stranded in DNS + DB. Retract it (Copilot
+        # review on #480).
+        stale_ptrs = (
+            (
+                await db.execute(
+                    select(DNSRecord).where(
+                        DNSRecord.ip_address_id == ip.id,
+                        DNSRecord.auto_generated.is_(True),
+                        DNSRecord.record_type == "PTR",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for rec in stale_ptrs:
+            old_zone = await db.get(DNSZone, rec.zone_id)
+            if old_zone is not None:
+                await _enqueue_dns_op(db, old_zone, "delete", rec.name, "PTR", rec.value, rec.ttl)
+            await db.delete(rec)
+        if stale_ptrs:
+            ip.reverse_zone_id = None
         return
     try:
         ip_obj = ipaddress.ip_address(str(ip.address))

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -580,18 +580,30 @@ async def _record_mac_history(db: AsyncSession, ip_id: uuid.UUID, mac_address: s
     )
 
 
+def _enforce_token_scope(user: Any, resource_type: str, resource_id: uuid.UUID) -> None:
+    """403 when a resource-scoped API token (#374) isn't bound to this resource.
+
+    No-op for sessions / unscoped tokens (``token_scope_allows`` returns True),
+    so normal callers are unaffected — only a resource-bound token is
+    constrained. Centralised so every by-id read/write handler gates the same
+    way and the check can't silently drift out of lockstep with
+    ``services.api_token_scopes.TOKEN_GRANT_RESOURCE_TYPES`` (#484 / #400 L4).
+    """
+    if not token_scope_allows(user, resource_type, resource_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"API token is not scoped to this {resource_type.replace('_', ' ')}",
+        )
+
+
 def _enforce_subnet_token_scope(user: Any, subnet_id: uuid.UUID) -> None:
     """403 when a resource-scoped API token (#374) isn't bound to this subnet.
 
-    No-op for sessions / unscoped tokens (``token_scope_allows`` returns True),
-    so normal callers are unaffected — only a subnet-bound token is constrained
-    to its subnet for IP create / edit / delete / next-IP / list operations.
+    Thin wrapper over :func:`_enforce_token_scope` — only a subnet-bound token
+    is constrained to its subnet for IP create / edit / delete / next-IP / list.
+    The "subnet" wording keeps the existing error message stable.
     """
-    if not token_scope_allows(user, "subnet", subnet_id):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="API token is not scoped to this subnet",
-        )
+    _enforce_token_scope(user, "subnet", subnet_id)
 
 
 # ── DHCP pool awareness ───────────────────────────────────────────────────────
@@ -2447,15 +2459,13 @@ async def create_space(body: IPSpaceCreate, current_user: CurrentUser, db: DB) -
 
 @router.get("/spaces/{space_id}", response_model=IPSpaceResponse)
 async def get_space(space_id: uuid.UUID, current_user: CurrentUser, db: DB) -> IPSpace:
-    # SECURITY TODO (#400 / L4): no per-row token-scope re-check here. This is
-    # currently safe ONLY because ``ip_space`` is NOT in
-    # ``services/api_token_scopes.TOKEN_GRANT_RESOURCE_TYPES`` (today: subnet,
-    # dns_zone), so a resource-scoped token can never bind to a space and
-    # ``token_scope_allows`` is irrelevant. IF ``ip_space`` is ever added to
-    # that vocabulary, this handler MUST gain a
-    # ``token_scope_allows(current_user, "ip_space", space_id)`` 403 gate (see
-    # ``_enforce_subnet_token_scope``) or a space-scoped token would read any
-    # space. Keep this in lockstep with the vocabulary so the two can't drift.
+    # Per-row token-scope gate (#484 / #400 L4). No-op for sessions / unscoped
+    # tokens; a resource-scoped token is constrained to its bound resource. This
+    # is defense-in-depth today (``ip_space`` isn't in TOKEN_GRANT_RESOURCE_TYPES
+    # yet, so no token binds to a space) that stays in lockstep with the
+    # vocabulary — the moment ``ip_space`` becomes grantable, a space-scoped
+    # token is already prevented from reading any other space.
+    _enforce_token_scope(current_user, "ip_space", space_id)
     space = await db.get(IPSpace, space_id)
     if space is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP space not found")
@@ -2834,15 +2844,12 @@ async def create_block(body: IPBlockCreate, current_user: CurrentUser, db: DB) -
 
 @router.get("/blocks/{block_id}", response_model=IPBlockResponse)
 async def get_block(block_id: uuid.UUID, current_user: CurrentUser, db: DB) -> dict[str, Any]:
-    # SECURITY TODO (#400 / L4): no per-row token-scope re-check here. This is
-    # currently safe ONLY because ``ip_block`` is NOT in
-    # ``services/api_token_scopes.TOKEN_GRANT_RESOURCE_TYPES`` (today: subnet,
-    # dns_zone), so a resource-scoped token can never bind to a block and
-    # ``token_scope_allows`` is irrelevant. IF ``ip_block`` is ever added to
-    # that vocabulary, this handler MUST gain a
-    # ``token_scope_allows(current_user, "ip_block", block_id)`` 403 gate (see
-    # ``_enforce_subnet_token_scope``) or a block-scoped token would read any
-    # block. Keep this in lockstep with the vocabulary so the two can't drift.
+    # Per-row token-scope gate (#484 / #400 L4). No-op for sessions / unscoped
+    # tokens; a resource-scoped token is constrained to its bound resource.
+    # Defense-in-depth today (``ip_block`` isn't in TOKEN_GRANT_RESOURCE_TYPES
+    # yet) that stays in lockstep with the vocabulary — the moment ``ip_block``
+    # becomes grantable, a block-scoped token can't read any other block.
+    _enforce_token_scope(current_user, "ip_block", block_id)
     block = await db.get(IPBlock, block_id)
     if block is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP block not found")

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -1305,6 +1305,16 @@ async def _sync_dns_record(
                     )
 
     # ── Reverse PTR ─────────────────────────────────────────────────────────
+    # A PTR points AT the forward FQDN. With no effective primary forward zone
+    # ``fqdn`` is None (subnet resolved to no forward zone, or a stale/deleted
+    # primary-zone FK reset it above), so there is no name to point at — skip
+    # the PTR. The forward fan-out above already published to any extra zones
+    # via their own ``target_fqdn``. Without this guard ``ptr_value = fqdn +
+    # "."`` below raises TypeError (None + str) — reachable through the public
+    # create endpoint for a split-horizon IP with extra_zone_ids and no forward
+    # zone, or an IP whose primary forward zone was deleted (issue #480).
+    if fqdn is None:
+        return
     try:
         ip_obj = ipaddress.ip_address(str(ip.address))
     except ValueError:

--- a/backend/app/drivers/dns/bind9.py
+++ b/backend/app/drivers/dns/bind9.py
@@ -197,9 +197,14 @@ class BIND9Driver(DNSDriver):
         import dns.tsigkeyring
         import dns.update
 
-        tsig_name = change.tsig_key_name or getattr(server, "tsig_key_name", None)
-        tsig_secret = getattr(server, "tsig_key_secret", None)
-        tsig_algorithm = getattr(server, "tsig_key_algorithm", "hmac-sha256")
+        # TSIG is not modelled on DNSServer (no tsig_key_* columns — the getattr
+        # shims here were always None; #483). Only change.tsig_key_name is
+        # carried on the ChangeSet today; a secret/algorithm source for this
+        # agentless RFC2136 path was never wired, so it raises below. Agent-
+        # rendered BIND9 uses group-level TSIG on DNSServerGroup via agent_config.
+        tsig_name = change.tsig_key_name
+        tsig_secret: str | None = None
+        tsig_algorithm = "hmac-sha256"
         if not tsig_name or not tsig_secret:
             raise RuntimeError("BIND9Driver.apply_record_change requires a TSIG key on the server")
 

--- a/backend/app/drivers/dns/windows.py
+++ b/backend/app/drivers/dns/windows.py
@@ -227,9 +227,13 @@ class WindowsDNSDriver(DNSDriver):
         port = getattr(server, "api_port", None) or 53
         rtype = change.record.record_type.upper()
 
-        tsig_name = change.tsig_key_name or getattr(server, "tsig_key_name", None)
-        tsig_secret = getattr(server, "tsig_key_secret", None)
-        tsig_algorithm = getattr(server, "tsig_key_algorithm", "hmac-sha256")
+        # TSIG is not modelled on DNSServer (the getattr shims were always None;
+        # #483). Only change.tsig_key_name is carried today; with no secret the
+        # signed branch is skipped and the update goes out unsigned (Windows AD
+        # zones set to "Nonsecure and secure" accept it).
+        tsig_name = change.tsig_key_name
+        tsig_secret: str | None = None
+        tsig_algorithm = "hmac-sha256"
         if tsig_name and tsig_secret:
             keyring = dns.tsigkeyring.from_text({tsig_name: tsig_secret})
             update = dns.update.Update(

--- a/backend/app/services/ai/tools/appliance.py
+++ b/backend/app/services/ai/tools/appliance.py
@@ -123,7 +123,6 @@ class FindPendingAppliancesArgs(BaseModel):
     args_model=FindPendingAppliancesArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.fleet",
 )
 async def find_pending_appliances(
     db: AsyncSession, user: User, args: FindPendingAppliancesArgs
@@ -190,7 +189,6 @@ class FindApplianceFleetArgs(BaseModel):
     args_model=FindApplianceFleetArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.fleet",
 )
 async def find_appliance_fleet(
     db: AsyncSession, user: User, args: FindApplianceFleetArgs
@@ -244,7 +242,6 @@ class FindControlPlaneVipArgs(BaseModel):
     args_model=FindControlPlaneVipArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.fleet",
 )
 async def find_control_plane_vip(
     db: AsyncSession, user: User, args: FindControlPlaneVipArgs
@@ -304,7 +301,6 @@ class FindK8sPodsArgs(BaseModel):
     args_model=FindK8sPodsArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.cluster",
 )
 async def find_k8s_pods(db: AsyncSession, user: User, args: FindK8sPodsArgs) -> dict[str, Any]:
     if (err := _superadmin_gate(user)) is not None:
@@ -372,7 +368,6 @@ class FindClusterHealthArgs(BaseModel):
     args_model=FindClusterHealthArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.cluster",
 )
 async def find_cluster_health(
     db: AsyncSession, user: User, args: FindClusterHealthArgs
@@ -448,7 +443,6 @@ class FindClusterMetricsArgs(BaseModel):
     args_model=FindClusterMetricsArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.cluster",
 )
 async def find_cluster_metrics(
     db: AsyncSession, user: User, args: FindClusterMetricsArgs
@@ -540,7 +534,6 @@ class FindEtcdSnapshotsArgs(BaseModel):
     args_model=FindEtcdSnapshotsArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.cluster",
 )
 async def find_etcd_snapshots(
     db: AsyncSession, user: User, args: FindEtcdSnapshotsArgs
@@ -622,7 +615,6 @@ class FindUpgradeImagesArgs(BaseModel):
     args_model=FindUpgradeImagesArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.fleet",
 )
 async def find_upgrade_images(
     db: AsyncSession, user: User, args: FindUpgradeImagesArgs
@@ -678,7 +670,6 @@ class FindAvailableUpgradeImagesArgs(BaseModel):
     args_model=FindAvailableUpgradeImagesArgs,
     category="admin",
     default_enabled=False,
-    module="appliance.fleet",
 )
 async def find_available_upgrade_images(
     db: AsyncSession, user: User, args: FindAvailableUpgradeImagesArgs
@@ -734,7 +725,6 @@ class ProposeApproveApplianceArgs(BaseModel):
     args_model=ProposeApproveApplianceArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.fleet",
 )
 async def propose_approve_appliance(
     db: AsyncSession, user: User, args: ProposeApproveApplianceArgs
@@ -804,7 +794,6 @@ class ProposeAssignRoleArgs(BaseModel):
     args_model=ProposeAssignRoleArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.fleet",
 )
 async def propose_assign_role(
     db: AsyncSession, user: User, args: ProposeAssignRoleArgs

--- a/backend/app/services/ai/tools/apt.py
+++ b/backend/app/services/ai/tools/apt.py
@@ -13,8 +13,10 @@ validate-before-swap host runner, and the friendly path is the
 Settings → Appliance → APT form (which has the all-important Validate
 button). Read visibility is the high value-per-token tool here.
 
-Tagged ``module="appliance.apt"`` for parity with the SNMP / NTP host-
-config tools (NN #13).
+``module=None`` (always available) — there is no ``appliance.apt``
+feature module in the catalog; appliance host-config tools are gated at
+the handler level (superadmin / appliance mode), like the SNMP / NTP
+host-config tools (issue #479).
 """
 
 from __future__ import annotations
@@ -54,7 +56,6 @@ class FindAptSettingsArgs(BaseModel):
     category="admin",
     # Default enabled (NN #13) — read-only, no secrets in response.
     default_enabled=True,
-    module="appliance.apt",
 )
 async def find_apt_settings(
     db: AsyncSession, user: User, args: FindAptSettingsArgs

--- a/backend/app/services/ai/tools/base.py
+++ b/backend/app/services/ai/tools/base.py
@@ -270,11 +270,15 @@ def effective_tool_names(
     3. If ``provider_enabled`` is non-NULL, intersect with it
        (per-provider narrowing for small-context models).
     4. If ``enabled_modules`` is non-NULL, drop every tool whose
-       ``module`` id isn't in that set. ``module=None`` is always
-       kept. This makes feature-module toggles a hard kill-switch
-       over the AI surface — disabling ``network.customer`` removes
-       the customer find/count tools regardless of any catalog or
-       provider override.
+       ``module`` id is a *known* catalog module that isn't in that
+       set. ``module=None`` is always kept, and an *unknown* module id
+       fails OPEN (tool kept) — mirroring
+       ``feature_modules.is_module_enabled``'s "unknown ⇒ True"
+       defensiveness, so a mistyped / renamed module id can never
+       silently strip a tool from the copilot surface (issue #479).
+       For a known module this is still a hard kill-switch — disabling
+       ``network.customer`` removes the customer find/count tools
+       regardless of any catalog or provider override.
 
     NULL at any layer means "no override at this layer" — the
     behaviour falls through to the wider layer.
@@ -291,10 +295,18 @@ def effective_tool_names(
     if provider_enabled is not None:
         eligible &= set(provider_enabled)
     if enabled_modules is not None:
+        # Gate only on KNOWN catalog modules. ``module=None`` and any
+        # unknown/mistyped module id fail open (tool kept) — see the
+        # docstring; ``is_known`` is imported at call time to avoid an
+        # import cycle with feature_modules (issue #479).
+        from app.services.feature_modules import is_known
+
         modules_by_tool = {t.name: t.module for t in REGISTRY.all()}
-        eligible = {
-            n
-            for n in eligible
-            if modules_by_tool.get(n) is None or modules_by_tool[n] in enabled_modules
-        }
+
+        def _module_allows(mod: str | None) -> bool:
+            if mod is None or not is_known(mod):
+                return True
+            return mod in enabled_modules
+
+        eligible = {n for n in eligible if _module_allows(modules_by_tool.get(n))}
     return eligible

--- a/backend/app/services/ai/tools/conformity.py
+++ b/backend/app/services/ai/tools/conformity.py
@@ -57,7 +57,7 @@ class ListConformityPoliciesArgs(BaseModel):
     ),
     args_model=ListConformityPoliciesArgs,
     category="compliance",
-    module="compliance",
+    module="compliance.conformity",
 )
 async def list_conformity_policies(
     db: AsyncSession, user: User, args: ListConformityPoliciesArgs
@@ -119,7 +119,7 @@ class FindConformityResultsArgs(BaseModel):
     ),
     args_model=FindConformityResultsArgs,
     category="compliance",
-    module="compliance",
+    module="compliance.conformity",
 )
 async def find_conformity_results(
     db: AsyncSession, user: User, args: FindConformityResultsArgs
@@ -172,7 +172,7 @@ class GetConformitySummaryArgs(BaseModel):
     ),
     args_model=GetConformitySummaryArgs,
     category="compliance",
-    module="compliance",
+    module="compliance.conformity",
 )
 async def get_conformity_summary(
     db: AsyncSession, user: User, args: GetConformitySummaryArgs

--- a/backend/app/services/ai/tools/diagnostics.py
+++ b/backend/app/services/ai/tools/diagnostics.py
@@ -110,7 +110,6 @@ class FindInternalErrorsArgs(BaseModel):
     args_model=FindInternalErrorsArgs,
     category="ops",
     default_enabled=False,
-    module="diagnostics",
 )
 async def find_internal_errors(
     db: AsyncSession,
@@ -159,7 +158,6 @@ class CountInternalErrorsArgs(BaseModel):
     args_model=CountInternalErrorsArgs,
     category="ops",
     default_enabled=False,
-    module="diagnostics",
 )
 async def count_internal_errors(
     db: AsyncSession,
@@ -215,7 +213,6 @@ class GetInternalErrorArgs(BaseModel):
     args_model=GetInternalErrorArgs,
     category="ops",
     default_enabled=False,
-    module="diagnostics",
 )
 async def get_internal_error(
     db: AsyncSession,

--- a/backend/app/services/ai/tools/dns.py
+++ b/backend/app/services/ai/tools/dns.py
@@ -680,7 +680,6 @@ class FindZoneDNSSECInfoArgs(BaseModel):
     ),
     args_model=FindZoneDNSSECInfoArgs,
     category="dns",
-    module="dns",
 )
 async def find_zone_dnssec_info(
     db: AsyncSession, user: User, args: FindZoneDNSSECInfoArgs
@@ -733,7 +732,6 @@ class FindDNSRateLimitSettingsArgs(BaseModel):
     ),
     args_model=FindDNSRateLimitSettingsArgs,
     category="dns",
-    module="dns",
 )
 async def find_dns_rate_limit_settings(
     db: AsyncSession, user: User, args: FindDNSRateLimitSettingsArgs
@@ -819,7 +817,6 @@ class FindZoneDriftArgs(BaseModel):
     ),
     args_model=FindZoneDriftArgs,
     category="dns",
-    module="dns",
 )
 async def find_dns_zone_drift(
     db: AsyncSession, user: User, args: FindZoneDriftArgs
@@ -869,7 +866,6 @@ class ListDNSSECPoliciesArgs(BaseModel):
     ),
     args_model=ListDNSSECPoliciesArgs,
     category="dns",
-    module="dns",
 )
 async def list_dnssec_policies(
     db: AsyncSession, user: User, args: ListDNSSECPoliciesArgs
@@ -922,7 +918,6 @@ class FindDNSQueryStatsArgs(BaseModel):
     ),
     args_model=FindDNSQueryStatsArgs,
     category="dns",
-    module="dns",
 )
 async def find_dns_query_stats(
     db: AsyncSession, user: User, args: FindDNSQueryStatsArgs

--- a/backend/app/services/ai/tools/ntp.py
+++ b/backend/app/services/ai/tools/ntp.py
@@ -49,7 +49,6 @@ class FindNTPSettingsArgs(BaseModel):
     args_model=FindNTPSettingsArgs,
     category="admin",
     default_enabled=True,
-    module="appliance.ntp",
 )
 async def find_ntp_settings(
     db: AsyncSession, user: User, args: FindNTPSettingsArgs

--- a/backend/app/services/ai/tools/pairing.py
+++ b/backend/app/services/ai/tools/pairing.py
@@ -106,7 +106,6 @@ class FindPairingCodesArgs(BaseModel):
     # (cleartext code never surfaced), no off-prem calls. Admins
     # discover it without opt-in. The superadmin gate is the real auth.
     default_enabled=True,
-    module="appliance.pairing",
 )
 async def find_pairing_codes(
     db: AsyncSession, user: User, args: FindPairingCodesArgs

--- a/backend/app/services/ai/tools/proposals.py
+++ b/backend/app/services/ai/tools/proposals.py
@@ -522,7 +522,7 @@ from app.services.ai.operations_writes import (  # noqa: E402
     writes=False,
     category="compliance",
     default_enabled=False,
-    module="compliance",
+    module="compliance.conformity",
 )
 async def propose_create_conformity_policy(
     db: AsyncSession, user: User, args: CreateConformityPolicyArgs
@@ -544,7 +544,7 @@ async def propose_create_conformity_policy(
     writes=False,
     category="compliance",
     default_enabled=False,
-    module="compliance",
+    module="compliance.conformity",
 )
 async def propose_update_conformity_policy(
     db: AsyncSession, user: User, args: UpdateConformityPolicyArgs
@@ -565,7 +565,7 @@ async def propose_update_conformity_policy(
     writes=False,
     category="compliance",
     default_enabled=False,
-    module="compliance",
+    module="compliance.conformity",
 )
 async def propose_evaluate_conformity_policy(
     db: AsyncSession, user: User, args: EvaluateConformityPolicyArgs
@@ -590,7 +590,6 @@ async def propose_evaluate_conformity_policy(
     writes=False,
     category="webhooks",
     default_enabled=False,
-    module="webhooks",
 )
 async def propose_create_webhook(
     db: AsyncSession, user: User, args: CreateWebhookArgs
@@ -610,7 +609,6 @@ async def propose_create_webhook(
     writes=False,
     category="webhooks",
     default_enabled=False,
-    module="webhooks",
 )
 async def propose_update_webhook(
     db: AsyncSession, user: User, args: UpdateWebhookArgs
@@ -630,7 +628,6 @@ async def propose_update_webhook(
     writes=False,
     category="webhooks",
     default_enabled=False,
-    module="webhooks",
 )
 async def propose_test_webhook(
     db: AsyncSession, user: User, args: TestWebhookArgs
@@ -653,7 +650,6 @@ async def propose_test_webhook(
     writes=False,
     category="dns",
     default_enabled=False,
-    module="dns",
 )
 async def propose_sign_zone_dnssec(
     db: AsyncSession, user: User, args: SignZoneDNSSECArgs
@@ -672,7 +668,6 @@ async def propose_sign_zone_dnssec(
     writes=False,
     category="dns",
     default_enabled=False,
-    module="dns",
 )
 async def propose_unsign_zone_dnssec(
     db: AsyncSession, user: User, args: UnsignZoneDNSSECArgs
@@ -755,7 +750,6 @@ async def propose_delete_multicast_domain(
     writes=False,
     category="admin",
     default_enabled=False,
-    module="appliance.snmp",
 )
 async def propose_update_snmp_settings(
     db: AsyncSession, user: User, args: UpdateSNMPSettingsArgs
@@ -774,7 +768,6 @@ async def propose_update_snmp_settings(
     writes=False,
     category="admin",
     default_enabled=False,
-    module="appliance.ntp",
 )
 async def propose_update_ntp_settings(
     db: AsyncSession, user: User, args: UpdateNTPSettingsArgs

--- a/backend/app/services/ai/tools/redis.py
+++ b/backend/app/services/ai/tools/redis.py
@@ -59,7 +59,6 @@ class GetRedisStatsArgs(BaseModel):
     args_model=GetRedisStatsArgs,
     category="ops",
     default_enabled=False,
-    module="diagnostics",
 )
 async def get_redis_stats(
     db: AsyncSession,

--- a/backend/app/services/ai/tools/snmp.py
+++ b/backend/app/services/ai/tools/snmp.py
@@ -58,7 +58,6 @@ class FindSNMPSettingsArgs(BaseModel):
     # Default enabled (NN #13) — read-only, no secrets in response,
     # no off-prem calls. Admins discover it without having to opt in.
     default_enabled=True,
-    module="appliance.snmp",
 )
 async def find_snmp_settings(
     db: AsyncSession, user: User, args: FindSNMPSettingsArgs

--- a/backend/app/services/ai/tools/webhooks.py
+++ b/backend/app/services/ai/tools/webhooks.py
@@ -69,7 +69,6 @@ class ListWebhooksArgs(BaseModel):
     ),
     args_model=ListWebhooksArgs,
     category="webhooks",
-    module="webhooks",
 )
 async def list_webhooks(
     db: AsyncSession, user: User, args: ListWebhooksArgs
@@ -118,7 +117,6 @@ class GetWebhookEventTypesArgs(BaseModel):
     ),
     args_model=GetWebhookEventTypesArgs,
     category="webhooks",
-    module="webhooks",
 )
 async def get_webhook_event_types(
     db: AsyncSession, user: User, args: GetWebhookEventTypesArgs
@@ -168,7 +166,6 @@ class FindWebhookDeliveriesArgs(BaseModel):
     ),
     args_model=FindWebhookDeliveriesArgs,
     category="webhooks",
-    module="webhooks",
 )
 async def find_webhook_deliveries(
     db: AsyncSession, user: User, args: FindWebhookDeliveriesArgs

--- a/backend/app/services/dhcp/pull_leases.py
+++ b/backend/app/services/dhcp/pull_leases.py
@@ -18,8 +18,14 @@ that implements ``get_leases`` can plug in.
    NOT appear in the wire response is gone from the DHCP server** —
    an admin deleted it, or it was released + cleaned up on the server
    before we polled. Delete the ``DHCPLease`` row and, if we created
-   the IPAM mirror (``auto_from_lease=True``), drop that too. The
-   driver's ``get_leases`` is the ground truth; absence means deleted.
+   the IPAM mirror (``auto_from_lease=True``), drop that too — first
+   revoking any DDNS records the mirror published, so a vanished lease
+   doesn't leave an orphaned A/PTR behind (#482). The driver's
+   ``get_leases`` is the ground truth; absence means deleted, **except**
+   for a wholly-empty wire response: an empty list is indistinguishable
+   from a transient driver hiccup, so the zero-wire floor guard (#482)
+   skips the absence-delete for that poll and lets the time-based
+   ``dhcp_lease_cleanup`` expiry sweep reclaim genuinely-removed leases.
 
 The time-based ``dhcp_lease_cleanup`` sweep continues to handle leases
 that drift past ``expires_at`` without being polled (e.g., between
@@ -40,7 +46,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.drivers.dhcp import get_driver, is_agentless
@@ -296,13 +302,55 @@ async def pull_leases_from_server(
     # mirror we created. Manually-allocated IPAM rows (auto_from_lease
     # False) are intentionally left alone — the operator owns those.
     wire_ips = {lease.get("ip_address") for lease in wire if lease.get("ip_address")}
-    stale_q = select(DHCPLease).where(
-        DHCPLease.server_id == server.id,
-        DHCPLease.state == "active",
+
+    # Zero-wire floor guard (#482). An empty lease response is
+    # indistinguishable from a transient driver hiccup that returned [] WITHOUT
+    # raising (e.g. Get-DhcpServerv4Scope momentarily reporting no scopes —
+    # "empty" isn't an error, so the driver's ErrorActionPreference='Stop'
+    # doesn't catch it and #426's parse-reraise doesn't fire). Rather than let
+    # a single empty poll absence-delete EVERY tracked lease + IPAM mirror,
+    # skip the sweep this cycle and let the time-based dhcp_lease_cleanup expiry
+    # sweep reclaim genuinely-removed leases once they pass expires_at.
+    # (Realistic hard failures already raise and returned above.)
+    if not wire_ips:
+        active_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(DHCPLease)
+                .where(DHCPLease.server_id == server.id, DHCPLease.state == "active")
+            )
+        ).scalar_one()
+        if active_count:
+            result.errors.append(
+                f"empty lease response with {active_count} tracked active "
+                "lease(s) — skipping absence-delete (#482); the expiry sweep "
+                "reclaims any genuinely-removed leases"
+            )
+            logger.warning(
+                "dhcp_pull_empty_wire_skip_absence_delete",
+                server=str(server.id),
+                driver=server.driver,
+                active=active_count,
+            )
+        if apply:
+            server.last_sync_at = now
+            await db.flush()
+        return result
+
+    stale_leases = list(
+        (
+            await db.execute(
+                select(DHCPLease).where(
+                    DHCPLease.server_id == server.id,
+                    DHCPLease.state == "active",
+                    ~DHCPLease.ip_address.in_(wire_ips),
+                )
+            )
+        )
+        .scalars()
+        .all()
     )
-    if wire_ips:
-        stale_q = stale_q.where(~DHCPLease.ip_address.in_(wire_ips))
-    stale_leases = list((await db.execute(stale_q)).scalars().all())
+    subnet_by_id = {s.id: s for s, _ in subnets}
     for stale in stale_leases:
         # Scope the mirror lookup to the lease's owning subnet — the same
         # discipline as the upsert/create branch above. The unscoped
@@ -327,6 +375,28 @@ async def pull_leases_from_server(
             ).scalar_one_or_none()
         if mirror is not None:
             if apply:
+                # Revoke DDNS BEFORE deleting the mirror (#482). Absence means
+                # the lease is gone from the server, so any DDNS-published
+                # forward / PTR records are stale and must be retracted — not
+                # left orphaned. Mirrors the agent /lease-events released
+                # branch; revoke reads dns_record_id / hostname off the row so
+                # it must run before the row is deleted. Best-effort: a revoke
+                # failure must not block the absence-delete sweep.
+                stale_subnet = subnet_by_id.get(stale_subnet_id)
+                if stale_subnet is not None:
+                    try:
+                        from app.services.dns.ddns import (  # noqa: PLC0415
+                            revoke_ddns_for_lease,
+                        )
+
+                        await revoke_ddns_for_lease(db, subnet=stale_subnet, ipam_row=mirror)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning(
+                            "dhcp_pull_ddns_revoke_failed",
+                            server=str(server.id),
+                            ip=stale.ip_address,
+                            error=str(exc),
+                        )
                 await db.delete(mirror)
             result.ipam_revoked += 1
         if apply:

--- a/backend/app/services/dhcp/pull_leases.py
+++ b/backend/app/services/dhcp/pull_leases.py
@@ -382,7 +382,9 @@ async def pull_leases_from_server(
                 # branch; revoke reads dns_record_id / hostname off the row so
                 # it must run before the row is deleted. Best-effort: a revoke
                 # failure must not block the absence-delete sweep.
-                stale_subnet = subnet_by_id.get(stale_subnet_id)
+                stale_subnet = (
+                    subnet_by_id.get(stale_subnet_id) if stale_subnet_id is not None else None
+                )
                 if stale_subnet is not None:
                     try:
                         from app.services.dns.ddns import (  # noqa: PLC0415

--- a/backend/app/services/dns/config_bundle.py
+++ b/backend/app/services/dns/config_bundle.py
@@ -293,13 +293,11 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         if eff.entries:
             blocklists.append(_to_blocklist_data(eff, "spatium-blocklist.rpz."))
 
-    # TSIG keys: optional; not yet modelled on DNSServer. Drivers handle empty.
+    # TSIG keys are modelled on DNSServerGroup (not DNSServer) and are delivered
+    # to agents by the live ``agent_config.build_config_bundle`` path. This
+    # (vestigial) builder never populated them — the old getattr(server, ...)
+    # shims were always None since DNSServer has no tsig_key_* columns (#483).
     tsig_keys: tuple[TsigKey, ...] = ()
-    tsig_name = getattr(server, "tsig_key_name", None)
-    tsig_secret = getattr(server, "tsig_key_secret", None)
-    tsig_algo = getattr(server, "tsig_key_algorithm", None) or "hmac-sha256"
-    if tsig_name and tsig_secret:
-        tsig_keys = (TsigKey(name=tsig_name, algorithm=tsig_algo, secret=tsig_secret),)
 
     # Collect the custom (non-"default") policies referenced by signed zones
     # so the agent has a ``dnssec-policy { ... }`` block to render for each.

--- a/backend/app/services/dns/record_ops.py
+++ b/backend/app/services/dns/record_ops.py
@@ -218,6 +218,7 @@ async def enqueue_record_op(
         return None
 
     primary_op: DNSRecordOp | None = None
+    first_op: DNSRecordOp | None = None
     for srv in agent_servers:
         row = DNSRecordOp(
             server_id=srv.id,
@@ -228,6 +229,8 @@ async def enqueue_record_op(
             state="pending",
         )
         db.add(row)
+        if first_op is None:
+            first_op = row
         if srv.id == primary.id:
             primary_op = row
     await db.flush()
@@ -236,7 +239,13 @@ async def enqueue_record_op(
     # tick. Collected here (no commit yet); the request's
     # ``wake_publishing`` dependency flushes it after the outer commit.
     collect_wake(dns_group_channel(zone.group_id))
-    return primary_op
+    # Return the primary's op when the primary is among the enabled servers,
+    # else the first enabled agent's op. The return must be truthy whenever we
+    # actually enqueued something — a disabled primary + enabled secondary still
+    # dispatches a wire op (#481) — so a caller that gates a DB delete on "was a
+    # wire op dispatched?" (e.g. dns bulk-delete) doesn't keep a row whose
+    # record was already removed on-wire.
+    return primary_op or first_op
 
 
 async def enqueue_record_ops_batch(

--- a/backend/app/services/dns/record_ops.py
+++ b/backend/app/services/dns/record_ops.py
@@ -162,28 +162,32 @@ async def enqueue_record_op(
         )
         return None
 
-    # User flipped the primary off — don't push live writes at a paused
-    # server. Record ops will queue silently for agent-based primaries
-    # (and flush when it's re-enabled); for agentless, we drop the op
-    # with a warning rather than hang on a dead WinRM/nsupdate socket.
-    if not primary.is_enabled:
-        logger.warning(
-            "record_op_dropped_server_disabled",
-            zone=zone.name,
-            server=str(primary.id),
-            driver=primary.driver,
-            op=op,
-            name=record.get("name"),
-            type=record.get("type"),
-        )
-        return None
-
     if is_agentless(primary.driver):
+        # User flipped the primary off — for agentless, drop the op with a
+        # warning rather than hang on a dead WinRM / nsupdate socket at a paused
+        # server. (Agent-based groups fall through to the fan-out below, which
+        # queues to whatever agent-based servers ARE enabled.)
+        if not primary.is_enabled:
+            logger.warning(
+                "record_op_dropped_server_disabled",
+                zone=zone.name,
+                server=str(primary.id),
+                driver=primary.driver,
+                op=op,
+                name=record.get("name"),
+                type=record.get("type"),
+            )
+            return None
         return await _apply_agentless(db, primary, zone, op, record, target_serial)
 
-    # Fan out to every enabled, agent-based server in the group. The
-    # query mirrors ``resolve_primary_server`` minus the is_primary
-    # filter; agentless servers are excluded because their write path
+    # Agent-based group: fan out to every ENABLED, agent-based server in the
+    # group, independent of whether the designated primary is currently
+    # disabled. Gating the whole group on the primary's is_enabled (as we used
+    # to) dropped the op for healthy secondaries too — and because the agent's
+    # structural_etag excludes records in a no-views group, re-enabling the
+    # primary later does NOT flush the missed op, so the edit could strand on
+    # every agent (#481). The query mirrors ``resolve_primary_server`` minus the
+    # is_primary filter; agentless servers are excluded because their write path
     # is single-server immediate-apply.
     agent_rows = (
         (
@@ -201,9 +205,16 @@ async def enqueue_record_op(
     )
     agent_servers = [s for s in agent_rows if not is_agentless(s.driver)]
     if not agent_servers:
-        # Shouldn't happen — primary is agent-based, so at least one
-        # row exists. Belt-and-braces in case the primary was just
-        # toggled agentless mid-flight.
+        # Every agent-based server in the group is disabled (incl. the primary).
+        # Nothing can converge right now; log it rather than drop silently.
+        logger.warning(
+            "record_op_dropped_no_enabled_agent",
+            zone=zone.name,
+            group_id=str(zone.group_id),
+            op=op,
+            name=record.get("name"),
+            type=record.get("type"),
+        )
         return None
 
     primary_op: DNSRecordOp | None = None
@@ -259,24 +270,25 @@ async def enqueue_record_ops_batch(
         )
         return [None] * len(ops)
 
-    if not primary.is_enabled:
-        logger.warning(
-            "record_op_batch_dropped_server_disabled",
-            zone=zone.name,
-            server=str(primary.id),
-            driver=primary.driver,
-            count=len(ops),
-        )
-        return [None] * len(ops)
+    if is_agentless(primary.driver):
+        # Agentless: drop at a paused server rather than hang on a dead socket.
+        if not primary.is_enabled:
+            logger.warning(
+                "record_op_batch_dropped_server_disabled",
+                zone=zone.name,
+                server=str(primary.id),
+                driver=primary.driver,
+                count=len(ops),
+            )
+            return [None] * len(ops)
+        return await _apply_agentless_batch(db, primary, zone, ops)
 
-    if not is_agentless(primary.driver):
-        # Agent-based: DB rows only; agent will batch at poll time.
-        return [
-            await enqueue_record_op(db, zone, o["op"], o["record"], o.get("target_serial"))
-            for o in ops
-        ]
-
-    return await _apply_agentless_batch(db, primary, zone, ops)
+    # Agent-based: DB rows only; agent will batch at poll time. Delegates to
+    # enqueue_record_op per op, which fans out to every ENABLED agent-based
+    # server regardless of whether the designated primary is disabled (#481).
+    return [
+        await enqueue_record_op(db, zone, o["op"], o["record"], o.get("target_serial")) for o in ops
+    ]
 
 
 async def enqueue_record_ops_bulk(
@@ -299,19 +311,31 @@ async def enqueue_record_ops_bulk(
         return 0
 
     primary = await resolve_primary_server(db, zone)
-    if primary is None or not primary.is_enabled:
+    if primary is None:
         logger.warning(
             "record_op_bulk_dropped",
             zone=zone.name,
             group_id=str(zone.group_id),
             count=len(ops),
-            reason="no enabled primary configured for zone",
+            reason="no primary configured for zone",
         )
         return 0
 
     if is_agentless(primary.driver):
+        # Agentless: drop at a paused server rather than hang on a dead socket.
+        if not primary.is_enabled:
+            logger.warning(
+                "record_op_bulk_dropped",
+                zone=zone.name,
+                group_id=str(zone.group_id),
+                count=len(ops),
+                reason="agentless primary is disabled",
+            )
+            return 0
         rows = await _apply_agentless_batch(db, primary, zone, ops)
         return sum(1 for r in rows if r is not None)
+    # Agent-based falls through: the fan-out below queues to every ENABLED
+    # agent-based server regardless of whether the primary is disabled (#481).
 
     # Agent-based: every enabled agent-based server in the group renders an
     # independent authoritative copy, so each needs its own op rows. Resolve

--- a/backend/app/services/dns/sync_check.py
+++ b/backend/app/services/dns/sync_check.py
@@ -42,7 +42,7 @@ class MissingItem:
     ip_id: uuid.UUID
     ip_address: str
     hostname: str
-    record_type: Literal["A", "PTR"]
+    record_type: Literal["A", "AAAA", "PTR"]
     expected_name: str
     expected_value: str
     zone_id: uuid.UUID
@@ -54,7 +54,7 @@ class MismatchItem:
     record_id: uuid.UUID
     ip_id: uuid.UUID
     ip_address: str
-    record_type: Literal["A", "PTR"]
+    record_type: Literal["A", "AAAA", "PTR"]
     zone_id: uuid.UUID
     zone_name: str
     current_name: str
@@ -382,7 +382,16 @@ async def compute_subnet_dns_drift(
                 )
             continue
 
-        ip_a_records = [r for r in recs_by_ip.get(ip.id, []) if r.record_type == "A"]
+        # Forward record family depends on the IP: AAAA for IPv6, A for IPv4.
+        # Collect BOTH so a stale/mismatched AAAA on a v6 IP is surfaced — the
+        # classifier was A-only, so IPv6 subnets never reported missing/stale
+        # AAAA and "Sync DNS" always looked clean on them (#481).
+        forward_rtype: Literal["A", "AAAA"] = (
+            "AAAA" if ipaddress.ip_address(str(ip.address)).version == 6 else "A"
+        )
+        ip_forward_records = [
+            r for r in recs_by_ip.get(ip.id, []) if r.record_type in ("A", "AAAA")
+        ]
         ip_ptr_records = [r for r in recs_by_ip.get(ip.id, []) if r.record_type == "PTR"]
 
         # The default-named gateway placeholder (`hostname == "gateway"`) is
@@ -390,16 +399,16 @@ async def compute_subnet_dns_drift(
         # ``_sync_dns_record``. Renaming the IP turns forward sync back on.
         is_default_gateway = ip.hostname == "gateway"
 
-        # ── Forward A ────────────────────────────────────────────────────────
+        # ── Forward A / AAAA ─────────────────────────────────────────────────
         if forward_zone and not is_default_gateway:
             exp_name, exp_value = _expected_a(ip.hostname, str(ip.address), forward_zone.name)
-            if not ip_a_records:
+            if not ip_forward_records:
                 report.missing.append(
                     MissingItem(
                         ip_id=ip.id,
                         ip_address=str(ip.address),
                         hostname=ip.hostname,
-                        record_type="A",
+                        record_type=forward_rtype,
                         expected_name=exp_name,
                         expected_value=exp_value,
                         zone_id=forward_zone.id,
@@ -407,14 +416,21 @@ async def compute_subnet_dns_drift(
                     )
                 )
             else:
-                for r in ip_a_records:
-                    if r.zone_id != forward_zone.id or r.name != exp_name or r.value != exp_value:
+                for r in ip_forward_records:
+                    # A wrong-family record (A on a v6 IP or vice-versa) is drift
+                    # too, so diff the type alongside zone/name/value.
+                    if (
+                        r.record_type != forward_rtype
+                        or r.zone_id != forward_zone.id
+                        or r.name != exp_name
+                        or r.value != exp_value
+                    ):
                         report.mismatched.append(
                             MismatchItem(
                                 record_id=r.id,
                                 ip_id=ip.id,
                                 ip_address=str(ip.address),
-                                record_type="A",
+                                record_type=forward_rtype,
                                 zone_id=r.zone_id,
                                 zone_name=forward_zone.name if r.zone_id == forward_zone.id else "",
                                 current_name=r.name,
@@ -424,14 +440,14 @@ async def compute_subnet_dns_drift(
                             )
                         )
         elif is_default_gateway:
-            # Forward A records for default-gateway-named IPs are stale by
+            # Forward A/AAAA records for default-gateway-named IPs are stale by
             # definition (see _sync_dns_record). Surface them so the user
             # can clean up.
-            for r in ip_a_records:
+            for r in ip_forward_records:
                 report.stale.append(
                     StaleItem(
                         record_id=r.id,
-                        record_type="A",
+                        record_type=r.record_type,
                         zone_id=r.zone_id,
                         zone_name=(
                             forward_zone.name
@@ -443,18 +459,18 @@ async def compute_subnet_dns_drift(
                         reason="default-gateway-name",
                     )
                 )
-        elif not forward_zone and ip_a_records:
-            # Forward zone was unassigned (or inherited to null) after A
+        elif not forward_zone and ip_forward_records:
+            # Forward zone was unassigned (or inherited to null) after A/AAAA
             # records were already published. No effective zone to match
             # against → mark them stale so the user can delete them. Same
             # intent as the ``no-forward-zone`` PTR branch below: keeps
             # "Sync DNS" able to clean up after a zone disassociation even
             # though the classifier otherwise has nothing to diff against.
-            for r in ip_a_records:
+            for r in ip_forward_records:
                 report.stale.append(
                     StaleItem(
                         record_id=r.id,
-                        record_type="A",
+                        record_type=r.record_type,
                         zone_id=r.zone_id,
                         zone_name="",
                         name=r.name,

--- a/backend/app/services/dns/sync_check.py
+++ b/backend/app/services/dns/sync_check.py
@@ -227,15 +227,64 @@ async def _aggregate(db: AsyncSession, subnet_ids: Sequence[uuid.UUID]) -> Drift
         reverse_zone_id=None,
         reverse_zone_name=None,
     )
+    if not subnet_ids:
+        return agg
+
+    # Bulk-load the two biggest per-subnet reads ONCE across every subnet
+    # instead of re-querying inside each compute_subnet_dns_drift call — the
+    # loop was ~2 SELECTs/subnet (IPs + their auto-generated records), i.e.
+    # O(N) round-trips for an N-subnet block (#483). The per-subnet zone
+    # resolution stays inside the callee (its inheritance walks amortize via
+    # the session identity map across sibling subnets).
+    all_ips = list(
+        (await db.execute(select(IPAddress).where(IPAddress.subnet_id.in_(subnet_ids))))
+        .scalars()
+        .all()
+    )
+    ips_by_subnet: dict[uuid.UUID, list[IPAddress]] = {}
+    for ip in all_ips:
+        ips_by_subnet.setdefault(ip.subnet_id, []).append(ip)
+
+    recs_by_ip: dict[uuid.UUID, list[DNSRecord]] = {}
+    all_ip_ids = [ip.id for ip in all_ips]
+    if all_ip_ids:
+        for r in (
+            (
+                await db.execute(
+                    select(DNSRecord).where(
+                        DNSRecord.auto_generated.is_(True),
+                        DNSRecord.ip_address_id.in_(all_ip_ids),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        ):
+            if r.ip_address_id is not None:
+                recs_by_ip.setdefault(r.ip_address_id, []).append(r)
+
     for sid in subnet_ids:
-        sub_report = await compute_subnet_dns_drift(db, sid)
+        sub_ips = ips_by_subnet.get(sid, [])
+        sub_recs = {ip.id: recs_by_ip.get(ip.id, []) for ip in sub_ips}
+        sub_report = await compute_subnet_dns_drift(
+            db, sid, preloaded_ips=sub_ips, preloaded_recs_by_ip=sub_recs
+        )
         agg.missing.extend(sub_report.missing)
         agg.mismatched.extend(sub_report.mismatched)
         agg.stale.extend(sub_report.stale)
     return agg
 
 
-async def compute_subnet_dns_drift(db: AsyncSession, subnet_id: uuid.UUID) -> DriftReport:
+async def compute_subnet_dns_drift(
+    db: AsyncSession,
+    subnet_id: uuid.UUID,
+    *,
+    preloaded_ips: list[IPAddress] | None = None,
+    preloaded_recs_by_ip: dict[uuid.UUID, list[DNSRecord]] | None = None,
+) -> DriftReport:
+    # ``preloaded_*`` let ``_aggregate`` batch the IP + auto-record loads once
+    # across a whole block/space instead of re-querying per subnet (#483). When
+    # omitted (the single-subnet call path) we load them here as before.
     subnet = await db.get(Subnet, subnet_id)
     if subnet is None:
         raise ValueError(f"Subnet {subnet_id} not found")
@@ -252,25 +301,31 @@ async def compute_subnet_dns_drift(db: AsyncSession, subnet_id: uuid.UUID) -> Dr
         reverse_zone_name=reverse_zone.name if reverse_zone else None,
     )
 
-    # All live IPs in the subnet.
-    ips_res = await db.execute(select(IPAddress).where(IPAddress.subnet_id == subnet_id))
-    ips = list(ips_res.scalars().all())
+    # All live IPs in the subnet (batched by the caller, else loaded here).
+    if preloaded_ips is not None:
+        ips = preloaded_ips
+    else:
+        ips_res = await db.execute(select(IPAddress).where(IPAddress.subnet_id == subnet_id))
+        ips = list(ips_res.scalars().all())
 
     # All auto-generated DNS records that point at IPs in this subnet.
-    if ips:
-        rec_res = await db.execute(
-            select(DNSRecord).where(
-                DNSRecord.auto_generated.is_(True),
-                DNSRecord.ip_address_id.in_([ip.id for ip in ips]),
-            )
-        )
-        records = list(rec_res.scalars().all())
+    if preloaded_recs_by_ip is not None:
+        recs_by_ip = preloaded_recs_by_ip
     else:
-        records = []
-    recs_by_ip: dict[uuid.UUID, list[DNSRecord]] = {}
-    for r in records:
-        if r.ip_address_id is not None:
-            recs_by_ip.setdefault(r.ip_address_id, []).append(r)
+        if ips:
+            rec_res = await db.execute(
+                select(DNSRecord).where(
+                    DNSRecord.auto_generated.is_(True),
+                    DNSRecord.ip_address_id.in_([ip.id for ip in ips]),
+                )
+            )
+            records = list(rec_res.scalars().all())
+        else:
+            records = []
+        recs_by_ip = {}
+        for r in records:
+            if r.ip_address_id is not None:
+                recs_by_ip.setdefault(r.ip_address_id, []).append(r)
 
     # Also pick up records that *think* they belong to a subnet IP but the IP
     # was deleted (FK is SET NULL on IPAddress delete) — these are stale.

--- a/backend/app/tasks/dhcp_lease_cleanup.py
+++ b/backend/app/tasks/dhcp_lease_cleanup.py
@@ -31,6 +31,15 @@ logger = structlog.get_logger(__name__)
 # the agent's lease-event batch interval.
 EXPIRY_GRACE = timedelta(minutes=5)
 
+# How long a lease may sit in ``expired`` before the row itself is hard-deleted.
+# Agent-based (Kea) drivers have no absence-delete reconciler — pull_leases only
+# runs for agentless drivers, and the agent's expired-event branch drops just
+# the IPAM mirror — so expired lease rows would otherwise linger in the DHCP
+# view forever (#478). Kept generous so a recent expiry stays visible for a day;
+# lease *history* is permanent regardless, so deleting the live row loses
+# nothing and a renewal just creates a fresh active row.
+EXPIRED_DELETE_GRACE = timedelta(hours=24)
+
 
 async def _resolve_lease_subnet_id(db: AsyncSession, lease: DHCPLease) -> uuid.UUID | None:
     """Find the IPAM subnet that owns this lease's address.
@@ -64,7 +73,7 @@ async def _resolve_lease_subnet_id(db: AsyncSession, lease: DHCPLease) -> uuid.U
     return best[1] if best else None
 
 
-async def _sweep() -> int:
+async def _sweep() -> tuple[int, int]:
     cutoff = datetime.now(UTC) - EXPIRY_GRACE
     async with task_session() as db:
         # Find any active-marked lease whose actual expiry passed the grace.
@@ -117,12 +126,34 @@ async def _sweep() -> int:
                         )
                 await db.delete(row)
                 cleaned += 1
+
+        # Second pass — hard-delete leases that have sat in ``expired`` past the
+        # longer grace so they stop lingering in the DHCP view (#478). History
+        # was already stamped when the lease flipped to expired, and the mirror
+        # was dropped above / by the agent, so this only removes the dead row.
+        delete_cutoff = datetime.now(UTC) - EXPIRED_DELETE_GRACE
+        stale = await db.execute(
+            select(DHCPLease).where(
+                DHCPLease.state == "expired",
+                DHCPLease.expires_at.is_not(None),
+                DHCPLease.expires_at < delete_cutoff,
+            )
+        )
+        deleted = 0
+        for lease in stale.scalars().all():
+            await db.delete(lease)
+            deleted += 1
+
         await db.commit()
-        return cleaned
+        return cleaned, deleted
 
 
 @celery_app.task(name="app.tasks.dhcp_lease_cleanup.sweep_expired_leases")
 def sweep_expired_leases() -> dict[str, int]:
-    cleaned = asyncio.run(_sweep())
-    logger.info("dhcp_lease_sweep_complete", ipam_rows_removed=cleaned)
-    return {"ipam_rows_removed": cleaned}
+    cleaned, deleted = asyncio.run(_sweep())
+    logger.info(
+        "dhcp_lease_sweep_complete",
+        ipam_rows_removed=cleaned,
+        expired_leases_deleted=deleted,
+    )
+    return {"ipam_rows_removed": cleaned, "expired_leases_deleted": deleted}

--- a/backend/tests/test_ai_tool_modules.py
+++ b/backend/tests/test_ai_tool_modules.py
@@ -1,0 +1,124 @@
+"""Guard tests for Operator-Copilot tool feature-module tags (issue #479).
+
+Every registered tool's ``module`` must be ``None`` or a real catalog id
+(``feature_modules.MODULES``). If it isn't, ``effective_tool_names`` gates
+the tool against a set that can never contain the id and silently drops it
+from the copilot / MCP surface — the #479 defect, where conformity /
+webhooks / DNS / appliance read tools were tagged with non-catalog ids
+(``"compliance"`` / ``"dns"`` / ``"webhooks"`` / ``"appliance.*"``) and so
+never made it into the effective set on any install.
+
+These fail loudly in CI if a new tool reintroduces a bogus id, prove the
+rescued tools are now reachable, and prove the gate fails OPEN on an
+unknown id as defense-in-depth.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from app.models.auth import User
+from app.services.ai.tools import REGISTRY, effective_tool_names
+from app.services.ai.tools.base import Tool
+from app.services.feature_modules import all_module_ids
+
+
+def test_every_registered_tool_module_is_catalog_valid() -> None:
+    catalog = all_module_ids()
+    offenders = {
+        t.name: t.module for t in REGISTRY.all() if t.module is not None and t.module not in catalog
+    }
+    assert not offenders, (
+        "these tools tag a feature-module id that isn't in "
+        "feature_modules.MODULES, so effective_tool_names would gate them "
+        f"against a set that can never contain it (issue #479): {offenders}"
+    )
+
+
+# The read tools #479 rescued. Before the fix each was tagged with a
+# non-catalog module id and silently dropped on every install.
+_RESCUED_ALWAYS_ON = (  # now module=None → present regardless of modules
+    "find_zone_dnssec_info",
+    "list_webhooks",
+    "get_webhook_event_types",
+    "find_webhook_deliveries",
+    "find_ntp_settings",
+    "find_snmp_settings",
+    "find_pairing_codes",
+    "find_appliance_fleet",
+    "find_pending_appliances",
+)
+_RESCUED_UNDER_CONFORMITY = (  # now module="compliance.conformity"
+    "list_conformity_policies",
+    "find_conformity_results",
+    "get_conformity_summary",
+)
+
+
+def test_rescued_read_tools_present_with_all_modules_enabled() -> None:
+    enabled = effective_tool_names(
+        platform_enabled=None,
+        provider_enabled=None,
+        enabled_modules=all_module_ids(),
+    )
+    for name in (*_RESCUED_ALWAYS_ON, *_RESCUED_UNDER_CONFORMITY):
+        assert name in enabled, f"{name} still dropped from the effective set"
+
+
+def test_always_on_tools_survive_even_with_all_modules_disabled() -> None:
+    # module=None tools stay available even when every feature module is
+    # off — they're gated at the handler (superadmin / appliance mode),
+    # not by a feature toggle.
+    enabled = effective_tool_names(
+        platform_enabled=None,
+        provider_enabled=None,
+        enabled_modules=set(),
+    )
+    for name in _RESCUED_ALWAYS_ON:
+        assert name in enabled, f"{name} should be always-on (module=None)"
+
+
+def test_conformity_tools_follow_conformity_module() -> None:
+    # The corrected id is a real, gating module: present when enabled,
+    # stripped when disabled (hard kill-switch preserved for known ids).
+    with_module = effective_tool_names(
+        platform_enabled=None,
+        provider_enabled=None,
+        enabled_modules=all_module_ids(),
+    )
+    without_module = effective_tool_names(
+        platform_enabled=None,
+        provider_enabled=None,
+        enabled_modules=all_module_ids() - {"compliance.conformity"},
+    )
+    for name in _RESCUED_UNDER_CONFORMITY:
+        assert name in with_module
+        assert name not in without_module
+
+
+class _BogusArgs(BaseModel):
+    pass
+
+
+async def _bogus_exec(db: object, user: User, args: _BogusArgs) -> None:
+    return None
+
+
+def test_unknown_module_id_fails_open(monkeypatch) -> None:
+    # Defense-in-depth: a tool tagged with an unknown/mistyped module id
+    # must be KEPT (fail open), mirroring is_module_enabled — never
+    # silently dropped the way #479's bad tags were.
+    bogus = Tool(
+        name="__test_bogus_module_tool__",
+        description="test",
+        args_model=_BogusArgs,
+        executor=_bogus_exec,
+        module="does.not.exist",
+    )
+    monkeypatch.setitem(REGISTRY._tools, bogus.name, bogus)
+    enabled = effective_tool_names(
+        platform_enabled=None,
+        provider_enabled=None,
+        enabled_modules=all_module_ids(),
+    )
+    assert bogus.name in enabled

--- a/backend/tests/test_dhcp_expired_lease_gc.py
+++ b/backend/tests/test_dhcp_expired_lease_gc.py
@@ -1,0 +1,189 @@
+"""#478 — expired agent-lease GC + manual delete-lease + static-detach status.
+
+Agent-based (Kea) servers have no absence-delete reconciler, and the agent's
+expired-event branch drops only the IPAM mirror — so ``expired`` DHCPLease rows
+piled up in the view forever. The time-based sweep now hard-deletes them past a
+24h grace, a DELETE endpoint lets an operator drop one now, and detaching a
+static frees its IPAM row to ``available`` (not ``allocated``) so a new dynamic
+lease can reclaim it instead of being shadowed.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import (
+    DHCPLease,
+    DHCPLeaseHistory,
+    DHCPScope,
+    DHCPServer,
+    DHCPServerGroup,
+    DHCPStaticAssignment,
+)
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+
+async def _server(db: AsyncSession) -> tuple[DHCPServerGroup, DHCPServer]:
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    db.add(grp)
+    await db.flush()
+    srv = DHCPServer(
+        name=f"s-{uuid.uuid4().hex[:6]}",
+        driver="kea",
+        host="127.0.0.1",
+        port=67,
+        server_group_id=grp.id,
+    )
+    db.add(srv)
+    await db.flush()
+    return grp, srv
+
+
+async def _subnet(db: AsyncSession, grp: DHCPServerGroup) -> tuple[Subnet, DHCPScope]:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/16", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.0.0.0/24", name="s")
+    db.add(subnet)
+    await db.flush()
+    scope = DHCPScope(group_id=grp.id, subnet_id=subnet.id, is_active=True)
+    db.add(scope)
+    await db.flush()
+    return subnet, scope
+
+
+async def _superadmin_token(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="T",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+@pytest.mark.asyncio
+async def test_sweep_hard_deletes_stale_expired_leases(db_session: AsyncSession) -> None:
+    import app.tasks.dhcp_lease_cleanup as cleanup
+
+    _, srv = await _server(db_session)
+    now = datetime.now(UTC)
+    stale = DHCPLease(
+        server_id=srv.id,
+        ip_address="10.0.0.10",
+        mac_address="aa:bb:cc:dd:ee:10",
+        state="expired",
+        expires_at=now - timedelta(hours=25),  # past the 24h GC grace
+    )
+    recent = DHCPLease(
+        server_id=srv.id,
+        ip_address="10.0.0.11",
+        mac_address="aa:bb:cc:dd:ee:11",
+        state="expired",
+        expires_at=now - timedelta(hours=1),  # still within grace
+    )
+    db_session.add_all([stale, recent])
+    await db_session.commit()
+
+    cleaned, deleted = await cleanup._sweep()
+    assert deleted == 1
+
+    assert (
+        await db_session.execute(select(DHCPLease).where(DHCPLease.id == stale.id))
+    ).scalar_one_or_none() is None
+    assert (
+        await db_session.execute(select(DHCPLease).where(DHCPLease.id == recent.id))
+    ).scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_lease_endpoint_removes_lease_and_mirror(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin_token(db_session)
+    grp, srv = await _server(db_session)
+    subnet, scope = await _subnet(db_session, grp)
+    lease = DHCPLease(
+        server_id=srv.id,
+        scope_id=scope.id,
+        ip_address="10.0.0.30",
+        mac_address="aa:bb:cc:dd:ee:30",
+        state="expired",
+        expires_at=datetime.now(UTC) - timedelta(hours=1),
+    )
+    mirror = IPAddress(
+        subnet_id=subnet.id,
+        address="10.0.0.30",
+        status="dhcp",
+        mac_address="aa:bb:cc:dd:ee:30",
+        auto_from_lease=True,
+    )
+    db_session.add_all([lease, mirror])
+    await db_session.commit()
+
+    r = await client.delete(
+        f"/api/v1/dhcp/servers/{srv.id}/leases/{lease.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 204, r.text
+
+    assert (
+        await db_session.execute(select(DHCPLease).where(DHCPLease.id == lease.id))
+    ).scalar_one_or_none() is None
+    assert (
+        await db_session.execute(select(IPAddress).where(IPAddress.id == mirror.id))
+    ).scalar_one_or_none() is None
+    hist = (
+        (
+            await db_session.execute(
+                select(DHCPLeaseHistory).where(DHCPLeaseHistory.server_id == srv.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert any(h.lease_state == "removed" for h in hist)
+
+
+@pytest.mark.asyncio
+async def test_detach_static_frees_ipam_row_to_available(db_session: AsyncSession) -> None:
+    from app.api.v1.dhcp.statics import _detach_ipam_for_static
+
+    grp, _srv = await _server(db_session)
+    subnet, scope = await _subnet(db_session, grp)
+    st = DHCPStaticAssignment(
+        scope_id=scope.id, ip_address="10.0.0.20", mac_address="aa:bb:cc:dd:ee:20"
+    )
+    db_session.add(st)
+    await db_session.flush()
+    row = IPAddress(
+        subnet_id=subnet.id,
+        address="10.0.0.20",
+        status="static_dhcp",
+        static_assignment_id=str(st.id),
+        auto_from_lease=False,
+    )
+    db_session.add(row)
+    await db_session.commit()
+
+    await _detach_ipam_for_static(db_session, st)
+    await db_session.flush()
+    await db_session.refresh(row)
+
+    # Freed to available (not allocated) so a new dynamic lease can reclaim it.
+    assert row.status == "available"
+    assert row.static_assignment_id is None

--- a/backend/tests/test_dhcp_heartbeat_wire_contract.py
+++ b/backend/tests/test_dhcp_heartbeat_wire_contract.py
@@ -1,0 +1,62 @@
+"""#482 — DHCP agent heartbeat wire contract is hardened.
+
+The DHCP ``AgentHeartbeatRequest`` was all-optional with no ``extra=forbid``,
+so a wrong-envelope ACK batch (a typo'd key) validated into an all-default body
+(ops_ack=[]), the ACK loop ran zero times, the endpoint returned 200, and the
+agent cleared its ACK buffer — losing the ACK. That's the same defect #430 D4
+fixed for the DNS agent; the structurally-identical DHCP model never got it.
+
+These pin the forbid behaviour and prove the model stays a strict SUPERSET of
+every DHCP agent shape (so forbid is backward-compatible).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.v1.dhcp.agents import AgentHeartbeatRequest
+
+
+def test_current_dhcp_agent_heartbeat_body_validates() -> None:
+    # The exact shape agent/dhcp/spatium_dhcp_agent/heartbeat.py ships today,
+    # including the pid / status / lease_count_since_start telemetry the
+    # handler doesn't read but forbid must still accept.
+    body = {
+        "agent_version": "1.2.3",
+        "pid": 42,
+        "status": "ok",
+        "daemon": {"status": "ok"},
+        "lease_count_since_start": 7,
+        "ops_ack": [{"op_id": "x", "status": "applied"}],
+    }
+    m = AgentHeartbeatRequest.model_validate(body)
+    assert m.agent_version == "1.2.3"
+    assert m.pid == 42
+    assert len(m.ops_ack) == 1
+
+
+def test_wrong_envelope_is_rejected() -> None:
+    # A typo'd ACK key ("ops_acks") used to silently validate into ops_ack=[].
+    with pytest.raises(ValidationError):
+        AgentHeartbeatRequest.model_validate({"ops_acks": [{"op_id": "x"}]})
+
+
+def test_legacy_slot_fields_still_accepted() -> None:
+    # Pre-Wave-C1 DHCP agents shipped slot / deployment telemetry directly to
+    # this endpoint. forbid must NOT 422 them — the model is a deliberate
+    # superset.
+    body = {
+        "agent_version": "old",
+        "deployment_kind": "appliance",
+        "current_slot": "A",
+        "is_trial_boot": False,
+        "last_upgrade_state": "ready",
+    }
+    AgentHeartbeatRequest.model_validate(body)
+
+
+def test_ops_ack_over_cap_rejected() -> None:
+    # The ACK list is bounded so a malformed / hostile heartbeat can't pin memory.
+    with pytest.raises(ValidationError):
+        AgentHeartbeatRequest.model_validate({"ops_ack": [{} for _ in range(5001)]})

--- a/backend/tests/test_dhcp_lease_scope.py
+++ b/backend/tests/test_dhcp_lease_scope.py
@@ -131,8 +131,12 @@ async def test_pull_leases_revoke_scoped_to_lease_subnet(
     db_session.add(lease)
     await db_session.commit()
 
-    # Empty wire → the lease is now stale and gets absence-deleted.
-    _patch_pull_leases(monkeypatch, [])
+    # Non-empty wire that EXCLUDES SHARED_IP → the lease is absent and gets
+    # absence-deleted. The zero-wire floor guard (#482) skips the sweep only
+    # when the ENTIRE wire is empty, so [] would no longer delete anything.
+    _patch_pull_leases(
+        monkeypatch, [{"ip_address": "203.0.113.9", "mac_address": "aa:bb:cc:dd:ee:fd"}]
+    )
     result = await pl.pull_leases_from_server(db_session, srv, apply=True)
     await db_session.commit()
 
@@ -174,7 +178,11 @@ async def test_pull_leases_revoke_scoped_via_prefix_when_no_scope(
     db_session.add(lease)
     await db_session.commit()
 
-    _patch_pull_leases(monkeypatch, [])
+    # Non-empty wire excluding SHARED_IP so absence-delete still fires under
+    # the #482 zero-wire floor guard.
+    _patch_pull_leases(
+        monkeypatch, [{"ip_address": "203.0.113.9", "mac_address": "aa:bb:cc:dd:ee:fd"}]
+    )
     result = await pl.pull_leases_from_server(db_session, srv, apply=True)
     await db_session.commit()
 

--- a/backend/tests/test_dhcp_lease_scope.py
+++ b/backend/tests/test_dhcp_lease_scope.py
@@ -235,7 +235,7 @@ async def test_cleanup_revoke_scoped_to_lease_subnet(
 
     monkeypatch.setattr(ddns, "revoke_ddns_for_lease", _noop)
 
-    cleaned = await cleanup._sweep()
+    cleaned, _deleted = await cleanup._sweep()
     assert cleaned == 1
 
     assert (

--- a/backend/tests/test_dhcp_scope_sync_mode.py
+++ b/backend/tests/test_dhcp_scope_sync_mode.py
@@ -1,0 +1,141 @@
+"""#475 — DHCP scope hostname→IPAM sync-mode vocabulary + nullable-clear on update.
+
+The scope modal emitted a ``none`` / ``ipam`` / ``learned`` vocabulary that the
+API stored (lossily) as ``disabled`` / ``on_static_only`` / ``on_lease`` and then
+echoed back raw — so the <select> couldn't render the response and edits snapped
+back. The API now round-trips the canonical vocabulary (and still accepts the
+legacy values from older clients), validates the sync mode on update, and lets an
+explicit null clear a nullable lease-time column.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPScope, DHCPServerGroup
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+CIDR = "192.0.2.0/24"
+
+
+async def _make_token(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="T",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _subnet_and_group(db: AsyncSession) -> tuple[Subnet, DHCPServerGroup]:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=CIDR, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=CIDR, name="s")
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, grp])
+    await db.flush()
+    return subnet, grp
+
+
+async def _create(
+    client: AsyncClient, h: dict, subnet: Subnet, grp: DHCPServerGroup, **extra
+) -> dict:
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet.id}/dhcp-scopes",
+        headers=h,
+        json={"group_id": str(grp.id), "name": "s", **extra},
+    )
+    assert r.status_code in (200, 201), r.text
+    return r.json()
+
+
+@pytest.mark.asyncio
+async def test_canonical_sync_mode_round_trips(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    body = await _create(client, h, subnet, grp, hostname_sync_mode="on_lease")
+    # Echoed back canonical — the <select> value survives the round-trip.
+    assert body["hostname_sync_mode"] == "on_lease"
+
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{body['id']}", headers=h, json={"hostname_sync_mode": "disabled"}
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["hostname_sync_mode"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_legacy_sync_mode_values_mapped(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _make_token(db_session)
+    h = {"Authorization": f"Bearer {token}"}
+    for legacy, canonical in (
+        ("ipam", "on_static_only"),
+        ("learned", "on_lease"),
+        ("none", "disabled"),
+    ):
+        subnet, grp = await _subnet_and_group(db_session)
+        await db_session.commit()
+        body = await _create(client, h, subnet, grp, hostname_sync_mode=legacy)
+        assert body["hostname_sync_mode"] == canonical, f"{legacy} -> {body['hostname_sync_mode']}"
+
+
+@pytest.mark.asyncio
+async def test_update_clears_nullable_lease_time(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    body = await _create(client, h, subnet, grp, min_lease_time=300, max_lease_time=600)
+    assert body["min_lease_time"] == 300
+
+    # An explicit null must clear the column (exclude_none used to drop it).
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{body['id']}", headers=h, json={"min_lease_time": None}
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["min_lease_time"] is None
+    scope = await db_session.get(DHCPScope, uuid.UUID(body["id"]))
+    await db_session.refresh(scope)
+    assert scope.min_lease_time is None
+    # An untouched field (max_lease_time) stays put.
+    assert scope.max_lease_time == 600
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_invalid_sync_mode(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    body = await _create(client, h, subnet, grp)
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{body['id']}", headers=h, json={"hostname_sync_mode": "bogus"}
+    )
+    assert r.status_code == 422

--- a/backend/tests/test_dhcp_scope_sync_mode.py
+++ b/backend/tests/test_dhcp_scope_sync_mode.py
@@ -77,7 +77,9 @@ async def test_canonical_sync_mode_round_trips(
     assert body["hostname_sync_mode"] == "on_lease"
 
     r = await client.put(
-        f"/api/v1/dhcp/scopes/{body['id']}", headers=h, json={"hostname_sync_mode": "disabled"}
+        f"/api/v1/dhcp/scopes/{body['id']}",
+        headers=h,
+        json={"hostname_sync_mode": "disabled"},
     )
     assert r.status_code == 200, r.text
     assert r.json()["hostname_sync_mode"] == "disabled"
@@ -136,6 +138,34 @@ async def test_update_rejects_invalid_sync_mode(
 
     body = await _create(client, h, subnet, grp)
     r = await client.put(
-        f"/api/v1/dhcp/scopes/{body['id']}", headers=h, json={"hostname_sync_mode": "bogus"}
+        f"/api/v1/dhcp/scopes/{body['id']}",
+        headers=h,
+        json={"hostname_sync_mode": "bogus"},
     )
     assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_explicit_null_on_notnull_field_is_ignored_not_500(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # exclude_unset lets explicit nulls through; a null on a NOT-NULL column
+    # (name / is_active) or an unmanaged nullable one must be DROPPED, not
+    # applied — else setattr(None) 500s on commit / silently wipes data.
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    body = await _create(client, h, subnet, grp, name="keep-me", description="keep-desc")
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{body['id']}",
+        headers=h,
+        json={"name": None, "description": None, "is_active": None},
+    )
+    assert r.status_code == 200, r.text
+    scope = await db_session.get(DHCPScope, uuid.UUID(body["id"]))
+    await db_session.refresh(scope)
+    assert scope.name == "keep-me"  # NOT cleared
+    assert scope.description == "keep-desc"
+    assert scope.is_active is True

--- a/backend/tests/test_dns_drift_aggregate.py
+++ b/backend/tests/test_dns_drift_aggregate.py
@@ -1,0 +1,90 @@
+"""#483 — block/space DNS-drift aggregation batches per-subnet loads.
+
+compute_block_dns_drift / compute_space_dns_drift bulk-load IPs + auto-records
+once across all subnets instead of re-querying per subnet. This proves the
+batched aggregation stays behavior-identical to summing the per-subnet
+compute_subnet_dns_drift path.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns import DNSServerGroup, DNSZone
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.dns.sync_check import compute_block_dns_drift, compute_subnet_dns_drift
+
+
+async def _setup(db: AsyncSession) -> tuple[IPBlock, list[Subnet]]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name="corp.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.corp.example.",
+        admin_email="admin.corp.example.",
+    )
+    db.add(zone)
+    await db.flush()
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.70.0.0/16", name="blk")
+    db.add(block)
+    await db.flush()
+    subnets: list[Subnet] = []
+    for i in (1, 2):
+        sn = Subnet(
+            space_id=space.id,
+            block_id=block.id,
+            network=f"10.70.{i}.0/24",
+            name=f"sn{i}",
+            dns_zone_id=str(zone.id),
+            dns_inherit_settings=False,
+        )
+        db.add(sn)
+        await db.flush()
+        # A named IP with no A record → one "missing A" per subnet.
+        ip = IPAddress(
+            subnet_id=sn.id,
+            address=f"10.70.{i}.10",
+            status="allocated",
+            hostname=f"host{i}",
+        )
+        db.add(ip)
+        await db.flush()
+        subnets.append(sn)
+    return block, subnets
+
+
+@pytest.mark.asyncio
+async def test_block_drift_matches_per_subnet_sum(db_session: AsyncSession) -> None:
+    block, subnets = await _setup(db_session)
+    await db_session.commit()
+
+    batched = await compute_block_dns_drift(db_session, block.id)
+    assert len(batched.missing) == 2
+    assert {m.record_type for m in batched.missing} == {"A"}
+
+    # The batched aggregation must equal summing the per-subnet (non-batched)
+    # path item-for-item — proves the #483 preloading is behavior-preserving.
+    per_missing: list = []
+    per_mismatched: list = []
+    per_stale: list = []
+    for sn in subnets:
+        r = await compute_subnet_dns_drift(db_session, sn.id)
+        per_missing.extend(r.missing)
+        per_mismatched.extend(r.mismatched)
+        per_stale.extend(r.stale)
+
+    assert len(batched.missing) == len(per_missing)
+    assert len(batched.mismatched) == len(per_mismatched)
+    assert len(batched.stale) == len(per_stale)
+    # Same set of expected forward names surfaced.
+    assert {m.expected_name for m in batched.missing} == {m.expected_name for m in per_missing}

--- a/backend/tests/test_dns_drift_ipv6.py
+++ b/backend/tests/test_dns_drift_ipv6.py
@@ -1,0 +1,105 @@
+"""#481 — DNS drift is IPv6-aware (AAAA), not A-only.
+
+compute_subnet_dns_drift filtered ``record_type == "A"`` only, so for an IPv6
+subnet a named IP with no AAAA record was reported as a nonsensical "missing A"
+that never cleared (the apply path writes AAAA, which the classifier couldn't
+see), and a correctly-synced AAAA looked like drift forever. The classifier is
+now family-aware.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.dns.sync_check import compute_subnet_dns_drift
+
+
+async def _v6_subnet_with_zone(db: AsyncSession) -> tuple[Subnet, DNSZone]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name="v6.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.v6.example.",
+        admin_email="admin.v6.example.",
+    )
+    db.add(zone)
+    await db.flush()
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="2001:db8::/32", name="blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network="2001:db8:0:1::/64",
+        name="sn",
+        dns_zone_id=str(zone.id),
+        dns_inherit_settings=False,
+    )
+    db.add(subnet)
+    await db.flush()
+    return subnet, zone
+
+
+@pytest.mark.asyncio
+async def test_missing_aaaa_reported_for_v6_ip(db_session: AsyncSession) -> None:
+    subnet, _zone = await _v6_subnet_with_zone(db_session)
+    ip = IPAddress(
+        subnet_id=subnet.id,
+        address="2001:db8:0:1::10",
+        status="allocated",
+        hostname="host6",
+    )
+    db_session.add(ip)
+    await db_session.flush()
+    await db_session.refresh(ip)
+    await db_session.commit()
+
+    report = await compute_subnet_dns_drift(db_session, subnet.id)
+    # The named v6 IP with no AAAA is drift — reported as missing AAAA, not A.
+    assert len(report.missing) == 1
+    assert report.missing[0].record_type == "AAAA"
+    assert report.missing[0].expected_value == str(ip.address)
+
+
+@pytest.mark.asyncio
+async def test_present_aaaa_is_not_drift(db_session: AsyncSession) -> None:
+    subnet, zone = await _v6_subnet_with_zone(db_session)
+    ip = IPAddress(
+        subnet_id=subnet.id,
+        address="2001:db8:0:1::10",
+        status="allocated",
+        hostname="host6",
+    )
+    db_session.add(ip)
+    await db_session.flush()
+    await db_session.refresh(ip)
+    rec = DNSRecord(
+        zone_id=zone.id,
+        name="host6",
+        fqdn="host6.v6.example.",
+        record_type="AAAA",
+        value=str(ip.address),
+        auto_generated=True,
+        ip_address_id=ip.id,
+    )
+    db_session.add(rec)
+    await db_session.flush()
+    await db_session.commit()
+
+    report = await compute_subnet_dns_drift(db_session, subnet.id)
+    # A correctly-synced AAAA is NOT drift (was a perpetual false-positive
+    # "missing A" before the fix).
+    assert report.missing == []
+    assert report.mismatched == []

--- a/backend/tests/test_ipam_space_block_token_scope.py
+++ b/backend/tests/test_ipam_space_block_token_scope.py
@@ -1,0 +1,131 @@
+"""#484 / #400 L4 — get_space / get_block enforce per-row API-token scope.
+
+The by-id space/block read handlers had no ``token_scope_allows`` re-check, so a
+resource-scoped token was not narrowed on them (it could read arbitrary space /
+block metadata), and — the real risk — if ``ip_space`` / ``ip_block`` were ever
+added to ``TOKEN_GRANT_RESOURCE_TYPES`` a space/block-scoped token would read any
+space/block. The handlers now gate through the centralized ``_enforce_token_scope``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, generate_api_token, hash_password
+from app.models.auth import APIToken, User
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+
+async def _make_user(db: AsyncSession) -> tuple[User, str]:
+    user = User(
+        username=f"tok-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="T",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_token(db: AsyncSession, owner: User, grants: list[dict]) -> str:
+    raw, _prefix, token_hash = generate_api_token()
+    db.add(
+        APIToken(
+            name=f"t-{uuid.uuid4().hex[:6]}",
+            token_hash=token_hash,
+            prefix=raw[:10],
+            scope="user",
+            scopes=[],
+            resource_grants=grants,
+            user_id=owner.id,
+            created_by_user_id=owner.id,
+            is_active=True,
+        )
+    )
+    await db.flush()
+    return raw
+
+
+async def _space_and_block(db: AsyncSession) -> tuple[IPSpace, IPBlock]:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/16", name="blk")
+    db.add(block)
+    await db.flush()
+    return space, block
+
+
+@pytest.mark.asyncio
+async def test_unscoped_session_reads_space_and_block(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # Regression guard: a normal (non-token) session is unaffected by the gate.
+    _, token = await _make_user(db_session)
+    space, block = await _space_and_block(db_session)
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {token}"}
+    assert (await client.get(f"/api/v1/ipam/spaces/{space.id}", headers=hdr)).status_code == 200
+    assert (await client.get(f"/api/v1/ipam/blocks/{block.id}", headers=hdr)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_subnet_scoped_token_denied_on_space_and_block(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # A subnet-scoped token is constrained to its subnet; cross-type space /
+    # block reads are now denied (previously un-narrowed — it could read them).
+    owner, _ = await _make_user(db_session)
+    space, block = await _space_and_block(db_session)
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.0.0.0/24", name="s")
+    db_session.add(subnet)
+    await db_session.flush()
+    raw = await _make_token(
+        db_session,
+        owner,
+        [{"action": "read", "resource_type": "subnet", "resource_id": str(subnet.id)}],
+    )
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {raw}"}
+    assert (await client.get(f"/api/v1/ipam/spaces/{space.id}", headers=hdr)).status_code == 403
+    assert (await client.get(f"/api/v1/ipam/blocks/{block.id}", headers=hdr)).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_space_and_block_scoped_tokens_bound_to_their_own(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # Forward-looking defense-in-depth: ip_space / ip_block aren't grantable via
+    # the create endpoint yet, but the gate already constrains such a token to
+    # its own row — so the moment they become grantable, cross-row reads can't
+    # leak. (Grants are stashed verbatim by the auth dep, so a directly-inserted
+    # grant exercises the gate.)
+    owner, _ = await _make_user(db_session)
+    space_a, block_a = await _space_and_block(db_session)
+    space_b, block_b = await _space_and_block(db_session)
+
+    space_tok = await _make_token(
+        db_session,
+        owner,
+        [{"action": "read", "resource_type": "ip_space", "resource_id": str(space_a.id)}],
+    )
+    block_tok = await _make_token(
+        db_session,
+        owner,
+        [{"action": "read", "resource_type": "ip_block", "resource_id": str(block_a.id)}],
+    )
+    await db_session.commit()
+
+    sh = {"Authorization": f"Bearer {space_tok}"}
+    assert (await client.get(f"/api/v1/ipam/spaces/{space_a.id}", headers=sh)).status_code == 200
+    assert (await client.get(f"/api/v1/ipam/spaces/{space_b.id}", headers=sh)).status_code == 403
+
+    bh = {"Authorization": f"Bearer {block_tok}"}
+    assert (await client.get(f"/api/v1/ipam/blocks/{block_a.id}", headers=bh)).status_code == 200
+    assert (await client.get(f"/api/v1/ipam/blocks/{block_b.id}", headers=bh)).status_code == 403

--- a/backend/tests/test_lease_history.py
+++ b/backend/tests/test_lease_history.py
@@ -217,7 +217,18 @@ async def test_pull_leases_records_remove(
     await _make_lease(db_session, srv, ip="10.0.0.8", mac="aa:bb:cc:dd:ee:20")
     await db_session.commit()
 
-    monkeypatch.setattr(pl, "get_driver", lambda _drv: _StubDriver([]))
+    # A non-empty wire that EXCLUDES 10.0.0.8: the lease is absent and gets
+    # absence-deleted. The zero-wire floor guard (#482) only skips the sweep
+    # when the ENTIRE wire is empty, so an empty [] would no longer delete.
+    decoy = [
+        {
+            "ip_address": "10.0.0.200",
+            "mac_address": "aa:bb:cc:dd:ee:fe",
+            "hostname": "decoy",
+            "expires_at": datetime.now(UTC) + timedelta(hours=1),
+        }
+    ]
+    monkeypatch.setattr(pl, "get_driver", lambda _drv: _StubDriver(decoy))
     monkeypatch.setattr(pl, "is_agentless", lambda _drv: True)
     import app.services.dns.ddns as ddns
 
@@ -225,6 +236,7 @@ async def test_pull_leases_records_remove(
         return None
 
     monkeypatch.setattr(ddns, "apply_ddns_for_lease", _noop)
+    monkeypatch.setattr(ddns, "revoke_ddns_for_lease", _noop)
 
     await pl.pull_leases_from_server(db_session, srv, apply=True)
     await db_session.commit()

--- a/backend/tests/test_pull_leases_floor_guard.py
+++ b/backend/tests/test_pull_leases_floor_guard.py
@@ -1,0 +1,142 @@
+"""#482 — zero-wire lease-pull floor guard.
+
+An empty ``get_leases`` response is indistinguishable from a transient driver
+hiccup that returned ``[]`` without raising (e.g. Get-DhcpServerv4Scope briefly
+reporting no scopes — "empty" isn't an error, so the driver's parse-reraise
+doesn't fire). Absence-delete would then purge EVERY tracked lease + IPAM
+mirror on that single poll. The floor guard skips the absence-delete for an
+empty wire and records a soft error; the time-based ``dhcp_lease_cleanup``
+expiry sweep still reclaims genuinely-removed leases once they pass expires_at.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp import DHCPLease, DHCPScope, DHCPServer, DHCPServerGroup
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+
+class _StubDriver:
+    def __init__(self, leases: list[dict]) -> None:
+        self._leases = leases
+
+    async def get_leases(self, _server: DHCPServer) -> list[dict]:
+        return self._leases
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, leases: list[dict]) -> None:
+    from app.services.dhcp import pull_leases as pl
+
+    monkeypatch.setattr(pl, "get_driver", lambda _drv: _StubDriver(leases))
+    monkeypatch.setattr(pl, "is_agentless", lambda _drv: True)
+    import app.services.dns.ddns as ddns
+
+    async def _noop(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(ddns, "apply_ddns_for_lease", _noop)
+    monkeypatch.setattr(ddns, "revoke_ddns_for_lease", _noop)
+
+
+async def _server_with_active_lease(
+    db: AsyncSession,
+) -> tuple[DHCPServer, DHCPLease, IPAddress]:
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    db.add(grp)
+    await db.flush()
+    srv = DHCPServer(
+        name=f"s-{uuid.uuid4().hex[:6]}",
+        driver="windows_dhcp",
+        host="127.0.0.1",
+        port=67,
+        server_group_id=grp.id,
+    )
+    db.add(srv)
+    await db.flush()
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/16", name="blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.0.0.0/24", name="sn")
+    db.add(subnet)
+    await db.flush()
+    scope = DHCPScope(group_id=grp.id, subnet_id=subnet.id, is_active=True)
+    db.add(scope)
+    await db.flush()
+    mirror = IPAddress(
+        subnet_id=subnet.id,
+        address="10.0.0.50",
+        status="dhcp",
+        mac_address="aa:bb:cc:dd:ee:01",
+        auto_from_lease=True,
+    )
+    db.add(mirror)
+    await db.flush()
+    lease = DHCPLease(
+        server_id=srv.id,
+        scope_id=scope.id,
+        ip_address="10.0.0.50",
+        mac_address="aa:bb:cc:dd:ee:01",
+        state="active",
+    )
+    db.add(lease)
+    await db.flush()
+    return srv, lease, mirror
+
+
+@pytest.mark.asyncio
+async def test_empty_wire_skips_absence_delete(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.dhcp import pull_leases as pl
+
+    srv, lease, mirror = await _server_with_active_lease(db_session)
+    await db_session.commit()
+
+    _patch(monkeypatch, [])  # empty wire
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    # Nothing deleted; a soft error is recorded so the operator sees why.
+    assert result.removed == 0
+    assert result.ipam_revoked == 0
+    assert any("absence-delete" in e for e in result.errors)
+    # Lease + mirror survive the empty poll.
+    assert (
+        await db_session.execute(select(DHCPLease).where(DHCPLease.id == lease.id))
+    ).scalar_one_or_none() is not None
+    assert (
+        await db_session.execute(select(IPAddress).where(IPAddress.id == mirror.id))
+    ).scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+async def test_nonempty_wire_still_absence_deletes(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.dhcp import pull_leases as pl
+
+    srv, lease, mirror = await _server_with_active_lease(db_session)
+    await db_session.commit()
+
+    # A non-empty wire that EXCLUDES the tracked lease → it's absent and gets
+    # deleted (the guard only skips a wholly-empty wire).
+    _patch(monkeypatch, [{"ip_address": "203.0.113.9", "mac_address": "aa:bb:cc:dd:ee:fd"}])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.removed == 1
+    assert result.ipam_revoked == 1
+    assert (
+        await db_session.execute(select(DHCPLease).where(DHCPLease.id == lease.id))
+    ).scalar_one_or_none() is None
+    assert (
+        await db_session.execute(select(IPAddress).where(IPAddress.id == mirror.id))
+    ).scalar_one_or_none() is None

--- a/backend/tests/test_record_ops_disabled_primary.py
+++ b/backend/tests/test_record_ops_disabled_primary.py
@@ -1,0 +1,106 @@
+"""#481 — a disabled agent-based primary must not drop record ops for the
+whole group.
+
+enqueue_record_op / _batch / _bulk gated the entire function on the designated
+primary's is_enabled, returning before the per-enabled-agent fan-out. So a
+record edit while the primary was paused (e.g. maintenance) queued to NO agent
+in the group — not just the disabled primary — and (in a no-views group) never
+self-healed. The fan-out now runs for every ENABLED agent-based server
+regardless of the primary's state; only agentless primaries still drop-on-paused.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns import DNSRecordOp, DNSServer, DNSServerGroup, DNSZone
+from app.services.dns.record_ops import (
+    enqueue_record_op,
+    enqueue_record_ops_bulk,
+)
+
+
+async def _group_disabled_primary_enabled_secondary(
+    db: AsyncSession,
+) -> tuple[DNSServer, DNSServer, DNSZone]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    primary = DNSServer(
+        group_id=grp.id,
+        driver="bind9",
+        host="10.0.0.1",
+        name="primary",
+        is_primary=True,
+        is_enabled=False,  # paused
+    )
+    secondary = DNSServer(
+        group_id=grp.id,
+        driver="bind9",
+        host="10.0.0.2",
+        name="secondary",
+        is_primary=False,
+        is_enabled=True,
+    )
+    db.add_all([primary, secondary])
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name="corp.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.corp.example.",
+        admin_email="admin.corp.example.",
+    )
+    db.add(zone)
+    await db.flush()
+    return primary, secondary, zone
+
+
+async def _ops_for_zone(db: AsyncSession, zone: DNSZone) -> list[DNSRecordOp]:
+    return list(
+        (await db.execute(select(DNSRecordOp).where(DNSRecordOp.zone_name == zone.name)))
+        .scalars()
+        .all()
+    )
+
+
+@pytest.mark.asyncio
+async def test_disabled_primary_still_queues_to_enabled_secondary(
+    db_session: AsyncSession,
+) -> None:
+    primary, secondary, zone = await _group_disabled_primary_enabled_secondary(db_session)
+    await db_session.commit()
+
+    await enqueue_record_op(
+        db_session, zone, "create", {"name": "web", "type": "A", "value": "10.0.0.50"}
+    )
+    await db_session.commit()
+
+    server_ids = {o.server_id for o in await _ops_for_zone(db_session, zone)}
+    assert secondary.id in server_ids  # enabled secondary got the op
+    assert primary.id not in server_ids  # disabled primary did not
+
+
+@pytest.mark.asyncio
+async def test_bulk_disabled_primary_still_queues_to_enabled_secondary(
+    db_session: AsyncSession,
+) -> None:
+    primary, secondary, zone = await _group_disabled_primary_enabled_secondary(db_session)
+    await db_session.commit()
+
+    dispatched = await enqueue_record_ops_bulk(
+        db_session,
+        zone,
+        [{"op": "create", "record": {"name": "web", "type": "A", "value": "10.0.0.50"}}],
+    )
+    await db_session.commit()
+
+    assert dispatched == 1
+    server_ids = {o.server_id for o in await _ops_for_zone(db_session, zone)}
+    assert secondary.id in server_ids
+    assert primary.id not in server_ids

--- a/backend/tests/test_record_ops_disabled_primary.py
+++ b/backend/tests/test_record_ops_disabled_primary.py
@@ -96,7 +96,12 @@ async def test_bulk_disabled_primary_still_queues_to_enabled_secondary(
     dispatched = await enqueue_record_ops_bulk(
         db_session,
         zone,
-        [{"op": "create", "record": {"name": "web", "type": "A", "value": "10.0.0.50"}}],
+        [
+            {
+                "op": "create",
+                "record": {"name": "web", "type": "A", "value": "10.0.0.50"},
+            }
+        ],
     )
     await db_session.commit()
 
@@ -104,3 +109,20 @@ async def test_bulk_disabled_primary_still_queues_to_enabled_secondary(
     server_ids = {o.server_id for o in await _ops_for_zone(db_session, zone)}
     assert secondary.id in server_ids
     assert primary.id not in server_ids
+
+
+@pytest.mark.asyncio
+async def test_enqueue_returns_truthy_op_when_fanned_out_to_secondary(
+    db_session: AsyncSession,
+) -> None:
+    # The return must be truthy whenever an op was actually enqueued — a caller
+    # that gates a DB delete on "was a wire op dispatched?" (dns bulk-delete)
+    # would otherwise keep a row whose record was already removed on-wire.
+    primary, secondary, zone = await _group_disabled_primary_enabled_secondary(db_session)
+    await db_session.commit()
+
+    op = await enqueue_record_op(
+        db_session, zone, "delete", {"name": "web", "type": "A", "value": "10.0.0.50"}
+    )
+    assert op is not None
+    assert op.server_id == secondary.id  # the enabled agent's op, not the disabled primary's

--- a/backend/tests/test_redis_stats_tool.py
+++ b/backend/tests/test_redis_stats_tool.py
@@ -36,9 +36,12 @@ def test_registration_metadata() -> None:
     t = REGISTRY.get("get_redis_stats")
     assert t is not None
     # Operationally-sensitive infra telemetry → opt-in (default-disabled),
-    # module-tagged with diagnostics, read-only.
+    # read-only. No feature-module gate: ``diagnostics`` was never a real
+    # catalog module, so the tool is module=None now (availability is the
+    # default_enabled=False opt-in + the superadmin handler gate) — a bogus
+    # module id would have silently dropped it from the surface (#479).
     assert t.default_enabled is False
-    assert t.module == "diagnostics"
+    assert t.module is None
     assert t.writes is False
 
 

--- a/backend/tests/test_sync_dns_record_no_forward_zone.py
+++ b/backend/tests/test_sync_dns_record_no_forward_zone.py
@@ -24,7 +24,7 @@ from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
 from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
 
 
-async def _subnet_with_reverse_only(db: AsyncSession) -> Subnet:
+async def _subnet_with_reverse_only(db: AsyncSession) -> tuple[Subnet, DNSZone]:
     """A subnet with a linked reverse zone but NO forward zone."""
     grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
     db.add(grp)
@@ -56,14 +56,14 @@ async def _subnet_with_reverse_only(db: AsyncSession) -> Subnet:
     )
     db.add(rev)
     await db.flush()
-    return subnet
+    return subnet, rev
 
 
 @pytest.mark.asyncio
 async def test_extra_zone_ids_without_forward_zone_does_not_crash(
     db_session: AsyncSession,
 ) -> None:
-    subnet = await _subnet_with_reverse_only(db_session)
+    subnet, _rev = await _subnet_with_reverse_only(db_session)
     ip = IPAddress(
         subnet_id=subnet.id,
         address="10.80.1.50",
@@ -95,3 +95,53 @@ async def test_extra_zone_ids_without_forward_zone_does_not_crash(
         .all()
     )
     assert ptrs == []
+
+
+@pytest.mark.asyncio
+async def test_stale_ptr_is_retracted_when_forward_zone_gone(
+    db_session: AsyncSession,
+) -> None:
+    # When the primary forward zone was deleted, an IP that HAD a PTR reaches
+    # the fqdn=None path — the guard must RETRACT the now-orphaned PTR rather
+    # than leave it pointing at a name that can no longer be generated (Copilot
+    # review on #480).
+    subnet, rev = await _subnet_with_reverse_only(db_session)
+    ip = IPAddress(
+        subnet_id=subnet.id,
+        address="10.80.1.60",
+        status="allocated",
+        hostname="host",
+        extra_zone_ids=[str(uuid.uuid4())],  # fqdn=None path
+    )
+    db_session.add(ip)
+    await db_session.flush()
+    # A pre-existing auto-generated PTR, as if a forward zone once existed.
+    db_session.add(
+        DNSRecord(
+            zone_id=rev.id,
+            name="60",
+            fqdn="60.1.80.10.in-addr.arpa.",
+            record_type="PTR",
+            value="host.old-forward.example.",
+            auto_generated=True,
+            ip_address_id=ip.id,
+        )
+    )
+    await db_session.flush()
+
+    await _sync_dns_record(db_session, ip, subnet)
+    await db_session.flush()
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(DNSRecord).where(
+                    DNSRecord.ip_address_id == ip.id,
+                    DNSRecord.record_type == "PTR",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []  # the stale PTR was retracted, not left orphaned

--- a/backend/tests/test_sync_dns_record_no_forward_zone.py
+++ b/backend/tests/test_sync_dns_record_no_forward_zone.py
@@ -1,0 +1,97 @@
+"""#480 — _sync_dns_record must not crash when an IP has no effective forward
+zone (fqdn is None) but a reverse zone still resolves.
+
+A PTR points AT the forward FQDN. With no primary forward zone ``fqdn`` is
+None, and the reverse-PTR block used to do ``ptr_value = fqdn + "."`` →
+``TypeError: NoneType + str``. The early-return guard only bailed when BOTH
+``effective_zone_id is None`` AND ``extra_zone_ids`` was empty, so a split-
+horizon IP with ``extra_zone_ids`` set but no forward zone (reachable through
+the public create endpoint) sailed past it into the crash.
+
+This pins the guard: the call returns cleanly and publishes no PTR.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.ipam.router import _sync_dns_record
+from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+
+async def _subnet_with_reverse_only(db: AsyncSession) -> Subnet:
+    """A subnet with a linked reverse zone but NO forward zone."""
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.80.0.0/16", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network="10.80.1.0/24",
+        name="s",
+        dns_zone_id=None,  # no forward zone
+        dns_inherit_settings=False,
+    )
+    db.add(subnet)
+    await db.flush()
+    rev = DNSZone(
+        group_id=grp.id,
+        name="1.80.10.in-addr.arpa",
+        zone_type="primary",
+        kind="reverse",
+        linked_subnet_id=subnet.id,
+        primary_ns="ns1.example.",
+        admin_email="admin.example.",
+    )
+    db.add(rev)
+    await db.flush()
+    return subnet
+
+
+@pytest.mark.asyncio
+async def test_extra_zone_ids_without_forward_zone_does_not_crash(
+    db_session: AsyncSession,
+) -> None:
+    subnet = await _subnet_with_reverse_only(db_session)
+    ip = IPAddress(
+        subnet_id=subnet.id,
+        address="10.80.1.50",
+        status="allocated",
+        hostname="host",
+        # Non-empty extra_zone_ids bypasses the early-return guard; a bogus id
+        # is skipped by the forward fan-out (db.get -> None -> continue), so we
+        # land in the reverse-PTR block with fqdn=None — the crash repro.
+        extra_zone_ids=[str(uuid.uuid4())],
+    )
+    db_session.add(ip)
+    await db_session.flush()
+
+    # Must not raise (was TypeError: NoneType + str).
+    await _sync_dns_record(db_session, ip, subnet)
+    await db_session.flush()
+
+    # No PTR published — there is no forward name to point at.
+    ptrs = (
+        (
+            await db_session.execute(
+                select(DNSRecord).where(
+                    DNSRecord.ip_address_id == ip.id,
+                    DNSRecord.record_type == "PTR",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert ptrs == []

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -403,7 +403,7 @@ export interface DnsSyncMissing {
   ip_id: string;
   ip_address: string;
   hostname: string;
-  record_type: "A" | "PTR";
+  record_type: "A" | "AAAA" | "PTR";
   expected_name: string;
   expected_value: string;
   zone_id: string;
@@ -414,7 +414,7 @@ export interface DnsSyncMismatch {
   record_id: string;
   ip_id: string;
   ip_address: string;
-  record_type: "A" | "PTR";
+  record_type: "A" | "AAAA" | "PTR";
   zone_id: string;
   zone_name: string;
   current_name: string;

--- a/frontend/src/pages/dhcp/CreateScopeModal.tsx
+++ b/frontend/src/pages/dhcp/CreateScopeModal.tsx
@@ -81,8 +81,11 @@ export function CreateScopeModal({
   const [pxeProfileId, setPxeProfileId] = useState<string>(
     scope?.pxe_profile_id ?? "",
   );
+  // Canonical DB vocabulary (disabled | on_static_only | on_lease). The API
+  // response echoes these, so the <select> below must speak them too or edits
+  // snap back to the first option (#475). Default matches the backend model.
   const [hostnameSync, setHostnameSync] = useState(
-    scope?.hostname_sync_mode ?? "ipam",
+    scope?.hostname_sync_mode ?? "on_static_only",
   );
   const [options, setOptions] = useState<DHCPOption[]>(scope?.options ?? []);
   // DHCPv6 mode (issue #52) — only surfaced/sent for IPv6 scopes.
@@ -619,9 +622,9 @@ export function CreateScopeModal({
             value={hostnameSync}
             onChange={(e) => setHostnameSync(e.target.value)}
           >
-            <option value="none">None</option>
-            <option value="ipam">Write to IPAM on lease</option>
-            <option value="learned">Store as learned hostname</option>
+            <option value="disabled">Don't sync to IPAM</option>
+            <option value="on_static_only">Static reservations only</option>
+            <option value="on_lease">Write to IPAM on every lease</option>
           </select>
         </Field>
 

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -7041,7 +7041,7 @@ function DriftRow({
       <span
         className={cn(
           "inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium flex-shrink-0",
-          type === "A"
+          type === "A" || type === "AAAA"
             ? "bg-blue-500/15 text-blue-600"
             : type === "PTR"
               ? "bg-cyan-500/15 text-cyan-600"


### PR DESCRIPTION
Batch fix for the `mzac-bug-check` audit findings #475–#484 — 4 field-triage DHCP bugs (#475–#478) plus 6 findings from the Copilot/MCP + DNS/DHCP integration review (#479–#484). One commit per issue.

## What's fixed

- **#475** — DHCP scope hostname→IPAM sync vocabulary didn't round-trip (edits snapped back), "Write to IPAM on lease" was mislabelled, and `update_scope` couldn't clear nullable lease-time fields. Converged on the canonical vocabulary (legacy values still accepted), fixed labels, switched to `exclude_unset` (scoped to the intended nullable fields).
- **#476** — Kea host-reservation MACs entered non-canonically (Cisco-dotted / run-together) made Kea reject the whole `subnet4`/`subnet6`; normalized in both the v4 and v6 reservation renderers.
- **#477** — DHCP agent reloaded Kea without a `config-test` preflight and surfaced an opaque "degraded"; now preflights, surfaces Kea's real error text, and retries transient startup errors.
- **#478** — expired agent (Kea) leases lingered forever: added a 24h GC pass to the cleanup sweep, a manual delete-lease endpoint, and freed a detached-static IPAM row to `available` so a new lease can reclaim it.
- **#479** — Copilot/MCP tools tagged with non-catalog `module=` ids (conformity / webhooks / DNS / appliance) were silently dropped on every install; corrected the tags, made the gate fail-open on unknown ids, added a CI guard.
- **#480** — `_sync_dns_record` raised a 500 (`None + "."`) for a split-horizon IP with `extra_zone_ids` but no forward zone; guarded.
- **#481** — DNS drift was A-only (IPv6 subnets never reported AAAA), and a disabled agent-primary dropped record ops for the whole group; made the classifier family-aware and the fan-out primary-independent.
- **#482** — DHCP agent heartbeat lacked `extra="forbid"` (+ unbounded `ops_ack`), and a zero-wire lease poll could mass-delete every tracked lease; added the wire-contract hardening + a floor guard + DDNS-revoke on absence-delete.
- **#483** — removed dead TSIG `getattr` shims (3 sites) and batched the N+1 in block/space DNS drift.
- **#484** — L4: `get_space`/`get_block` now enforce per-row API-token scope (centralized so it can't drift from the grant vocabulary).

## Code review

Ran a high-effort multi-agent review over the diff; it caught **three real regressions I'd introduced** — all fixed + regression-tested in the final commit:
- `update_scope` `exclude_unset` writing explicit `null` into NOT-NULL columns (500) / silently clearing unmanaged nullable columns → restricted to the intended clearable fields.
- `_reload_socket` treating a *transient* `config-test` error as terminal (lost the bootstrap-window retry) → retries both error classes through the deadline.
- `enqueue_record_op` returning `None` when the op fanned out to an enabled secondary → the DNS bulk-delete path kept a zombie DB row; now returns a truthy op whenever anything was enqueued.
- Plus a cosmetic: widened the frontend drift `record_type` to include `AAAA` so IPv6 items aren't a muted badge.

## Testing

Every issue ships focused tests; all pass in **per-file runs**, and `ruff` / `black` / `mypy` / the frontend `vite build` are clean. The full `pytest -n auto` suite was crashing this local box (stale per-worker test DBs after a mid-run crash), so I relied on targeted runs locally — **CI runs the full suite**. The pre-existing `test_peer_resolve.py` failures are unrelated (a `_resolved`-init footgun from #265, confirmed identical on pristine `main`).

Closes #475
Closes #476
Closes #477
Closes #478
Closes #479
Closes #480
Closes #481
Closes #482
Closes #483

Partially addresses #484 — the L4 token-scope gate landed here; L1 (move the refresh token off `localStorage` to an HttpOnly cookie) is a larger auth-flow refactor left as its own effort, so #484 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
