### PR TITLE
fix(auth): refresh token to HttpOnly cookie, access token in memory (#484 L1)

### DIFF
--- a/backend/app/api/v1/auth/router.py
+++ b/backend/app/api/v1/auth/router.py
@@ -97,6 +97,11 @@ class LoginRequest(BaseModel):
 
 
 class TokenResponse(BaseModel):
+    """Internal carrier for a freshly-minted token pair. The raw refresh
+    token NEVER leaves the server in a JSON body — callers set it as an
+    HttpOnly cookie via ``_set_refresh_cookie`` and return one of the
+    refresh-free response models below (#484 / #400 L1)."""
+
     access_token: str
     refresh_token: str
     token_type: str = "bearer"
@@ -106,10 +111,11 @@ class TokenResponse(BaseModel):
 class LoginResponse(BaseModel):
     """Login response. Two shapes the caller has to handle:
 
-    1. **MFA not required.** ``access_token`` + ``refresh_token`` are
-       set; ``mfa_required`` is False; the caller stashes the tokens
-       and proceeds. Identical to ``TokenResponse``.
-    2. **MFA required.** Tokens are NOT set; ``mfa_required`` is
+    1. **MFA not required.** ``access_token`` is set; ``mfa_required`` is
+       False; the caller keeps it in memory and proceeds. The refresh
+       token is delivered out-of-band as an HttpOnly cookie (#484), never
+       in this body.
+    2. **MFA required.** ``access_token`` is NOT set; ``mfa_required`` is
        True; ``mfa_token`` carries a 5-minute JWT (claim
        ``type=mfa``) that the caller must POST to
        ``/auth/login/mfa`` along with a TOTP code or a recovery
@@ -117,11 +123,20 @@ class LoginResponse(BaseModel):
     """
 
     access_token: str | None = None
-    refresh_token: str | None = None
     token_type: str = "bearer"
     force_password_change: bool = False
     mfa_required: bool = False
     mfa_token: str | None = None
+
+
+class RefreshResponse(BaseModel):
+    """Response for ``/auth/refresh``. The rotated refresh token is set as
+    an HttpOnly cookie on the same response; only the new access token is
+    returned in the body (#484)."""
+
+    access_token: str
+    token_type: str = "bearer"
+    force_password_change: bool = False
 
 
 class MfaLoginRequest(BaseModel):
@@ -189,6 +204,35 @@ class PasswordPolicyResponse(BaseModel):
 
 def _client_ip(request: Request) -> str | None:
     return request.client.host if request.client else None
+
+
+# SECURITY (#484 / #400 L1): the refresh token is delivered ONLY as an
+# HttpOnly + Secure + SameSite=Strict cookie, never in a JSON body or URL
+# fragment, so an XSS foothold in the SPA cannot read it. The access token
+# stays short-lived and lives in JS memory only (see frontend
+# ``lib/authToken.ts``). The cookie is path-scoped to ``/api/v1/auth`` so
+# it rides only the refresh + logout calls, not every API request.
+_REFRESH_COOKIE = "spatium_refresh"
+_REFRESH_COOKIE_PATH = "/api/v1/auth"
+
+
+def _set_refresh_cookie(response: Response, request: Request, raw_refresh: str) -> None:
+    response.set_cookie(
+        _REFRESH_COOKIE,
+        raw_refresh,
+        max_age=settings.refresh_token_expire_days * 86400,
+        httponly=True,
+        samesite="strict",
+        # Mirror the OIDC/SAML flow cookies: only mark Secure when the
+        # request arrived over HTTPS, so plain-HTTP dev on localhost keeps
+        # working while real (TLS-terminated) deployments get the flag.
+        secure=request.url.scheme == "https",
+        path=_REFRESH_COOKIE_PATH,
+    )
+
+
+def _clear_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(_REFRESH_COOKIE, path=_REFRESH_COOKIE_PATH)
 
 
 async def _issue_tokens(db: DB, request: Request, user: User, auth_source: str) -> TokenResponse:
@@ -450,7 +494,7 @@ async def _try_external_password_login(
 
 
 @router.post("/login", response_model=LoginResponse)
-async def login(body: LoginRequest, request: Request, db: DB) -> LoginResponse:
+async def login(body: LoginRequest, request: Request, response: Response, db: DB) -> LoginResponse:
     # Per-IP rate limit (#4) — complements the per-account lockout, which
     # only engages once a valid username is hit. Fails open if Redis is
     # down. 429 with a generic message (no account-existence leak).
@@ -507,9 +551,9 @@ async def login(body: LoginRequest, request: Request, db: DB) -> LoginResponse:
             challenge = create_mfa_challenge_token(str(user.id))
             return LoginResponse(mfa_required=True, mfa_token=challenge)
         tokens = await _issue_tokens(db, request, user, auth_source="local")
+        _set_refresh_cookie(response, request, tokens.refresh_token)
         return LoginResponse(
             access_token=tokens.access_token,
-            refresh_token=tokens.refresh_token,
             force_password_change=tokens.force_password_change,
         )
 
@@ -518,9 +562,9 @@ async def login(body: LoginRequest, request: Request, db: DB) -> LoginResponse:
         db, request, body.username, body.password
     )
     if external_response is not None:
+        _set_refresh_cookie(response, request, external_response.refresh_token)
         return LoginResponse(
             access_token=external_response.access_token,
-            refresh_token=external_response.refresh_token,
             force_password_change=external_response.force_password_change,
         )
 
@@ -538,7 +582,9 @@ async def login(body: LoginRequest, request: Request, db: DB) -> LoginResponse:
 
 
 @router.post("/login/mfa", response_model=LoginResponse)
-async def login_mfa(body: MfaLoginRequest, request: Request, db: DB) -> LoginResponse:
+async def login_mfa(
+    body: MfaLoginRequest, request: Request, response: Response, db: DB
+) -> LoginResponse:
     """Complete a TOTP-gated login. Body carries the challenge token
     minted by ``/login`` plus a 6-digit TOTP code or a one-time recovery
     code. Either is accepted; both = 422.
@@ -647,25 +693,28 @@ async def login_mfa(body: MfaLoginRequest, request: Request, db: DB) -> LoginRes
 
     # ── Success — issue real tokens ────────────────────────────────────────
     tokens = await _issue_tokens(db, request, user, auth_source="local")
+    _set_refresh_cookie(response, request, tokens.refresh_token)
     if used_recovery:
         # The audit row was written before _issue_tokens committed; the
         # _issue_tokens commit covers it. No extra commit needed.
         logger.info("mfa_recovery_used", user_id=str(user.id))
     return LoginResponse(
         access_token=tokens.access_token,
-        refresh_token=tokens.refresh_token,
         force_password_change=tokens.force_password_change,
     )
 
 
-class RefreshRequest(BaseModel):
-    refresh_token: str
-
-
-@router.post("/refresh", response_model=TokenResponse)
-async def refresh_token_endpoint(body: RefreshRequest, db: DB) -> TokenResponse:
-    """Exchange a valid refresh token for a new access token (with token rotation)."""
-    token_hash = hash_refresh_token(body.refresh_token)
+@router.post("/refresh", response_model=RefreshResponse)
+async def refresh_token_endpoint(request: Request, response: Response, db: DB) -> RefreshResponse:
+    """Exchange the HttpOnly refresh cookie for a new access token (with
+    token rotation). The refresh token is read from the cookie set at login
+    — never from the request body — so it stays invisible to JS (#484)."""
+    raw_refresh = request.cookies.get(_REFRESH_COOKIE)
+    if not raw_refresh:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing refresh token"
+        )
+    token_hash = hash_refresh_token(raw_refresh)
 
     result = await db.execute(
         select(UserSession)
@@ -706,10 +755,10 @@ async def refresh_token_endpoint(body: RefreshRequest, db: DB) -> TokenResponse:
     access_token = create_access_token(str(user.id), jti=str(new_session.id))
     await db.commit()
 
+    _set_refresh_cookie(response, request, raw_refresh)
     logger.info("token_refreshed", user_id=str(user.id))
-    return TokenResponse(
+    return RefreshResponse(
         access_token=access_token,
-        refresh_token=raw_refresh,
         force_password_change=user.force_password_change,
     )
 
@@ -830,7 +879,8 @@ async def change_password(
 
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
-async def logout(current_user: CurrentUser, db: DB) -> None:
+async def logout(current_user: CurrentUser, response: Response, db: DB) -> None:
+    _clear_refresh_cookie(response)
     await db.execute(
         update(UserSession)
         .where(UserSession.user_id == current_user.id, UserSession.revoked.is_(False))
@@ -1398,14 +1448,17 @@ async def oidc_callback(
 
     tokens = await _issue_tokens(db, request, user, auth_source=provider.name)
 
+    # Only the short-lived access token rides the URL fragment (invisible to
+    # the server, cleared by the callback page on arrival). The refresh token
+    # is set as an HttpOnly cookie on this redirect, never exposed to JS (#484).
     frag = urlencode(
         {
             "access_token": tokens.access_token,
-            "refresh_token": tokens.refresh_token,
             "force_password_change": str(tokens.force_password_change).lower(),
         }
     )
     response = RedirectResponse(f"{_LOGIN_CALLBACK_PATH}#{frag}", status_code=302)
+    _set_refresh_cookie(response, request, tokens.refresh_token)
     response.delete_cookie(_OIDC_FLOW_COOKIE, path="/api/v1/auth/")
     return response
 
@@ -1472,14 +1525,16 @@ async def saml_callback(
         return _login_error_redirect("saml_rejected")
 
     tokens = await _issue_tokens(db, request, user, auth_source=provider.name)
+    # Only the short-lived access token rides the URL fragment; the refresh
+    # token is set as an HttpOnly cookie on this redirect (#484).
     frag = urlencode(
         {
             "access_token": tokens.access_token,
-            "refresh_token": tokens.refresh_token,
             "force_password_change": str(tokens.force_password_change).lower(),
         }
     )
     response = RedirectResponse(f"{_LOGIN_CALLBACK_PATH}#{frag}", status_code=302)
+    _set_refresh_cookie(response, request, tokens.refresh_token)
     response.delete_cookie(_SAML_FLOW_COOKIE, path="/api/v1/auth/")
     return response
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -41,12 +41,17 @@ class Settings(BaseSettings):
     # "https://ddi.example.com,https://ipam.example.com"). Default "*"
     # keeps dev / same-origin appliance deployments working out of the
     # box. When left as "*" we serve a wildcard WITHOUT
-    # ``allow_credentials`` (the API authenticates via the Bearer
-    # Authorization header, not cookies, so cross-origin credentials
-    # aren't needed) — that avoids the dangerous "reflect any origin +
-    # allow credentials" combo Starlette produces for ``["*"]`` +
+    # ``allow_credentials`` — that avoids the dangerous "reflect any origin
+    # + allow credentials" combo Starlette produces for ``["*"]`` +
     # ``allow_credentials=True``. Set explicit origins to lock the API
     # down to your frontend(s); credentials are then enabled for them.
+    #
+    # NOTE (#484): API calls authenticate via the Bearer Authorization
+    # header, but the auth endpoints under ``/api/v1/auth`` also set/read the
+    # HttpOnly ``spatium_refresh`` cookie. That cookie only matters for a
+    # cross-ORIGIN frontend, which requires explicit ``cors_origins`` anyway
+    # (wildcard mode disables credentials); the default same-origin
+    # (nginx-proxied) deployment needs no CORS credentials at all.
     #
     # SECURITY (#400 / M6): if ``"*"`` appears MIXED with explicit
     # origins (e.g. ``"*,https://app.example.com"``) we treat the whole

--- a/backend/tests/test_auth_refresh_cookie.py
+++ b/backend/tests/test_auth_refresh_cookie.py
@@ -1,0 +1,131 @@
+"""#484 / #400 L1 — the refresh token is delivered ONLY as an HttpOnly cookie.
+
+The structural fix moves the long-lived refresh token out of the JSON body
+(where the SPA used to stash it in localStorage, XSS-stealable) into an
+HttpOnly + SameSite=Strict cookie the browser manages. This pins the contract:
+
+  * /auth/login returns an access token but NO refresh_token in the body, and
+    sets the ``spatium_refresh`` cookie with HttpOnly + SameSite=strict, scoped
+    to /api/v1/auth.
+  * /auth/refresh reads the cookie (not a body field), rotates it, and returns
+    a fresh access token with no refresh_token in the body.
+  * /auth/refresh with no cookie is a clean 401, not a 422/500.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import hash_password
+from app.models.auth import User
+
+_PASSWORD = "Sup3r-secret!"
+
+
+async def _local_user(db: AsyncSession) -> User:
+    user = User(
+        username=f"cookie-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@x.com",
+        display_name="Cookie Tester",
+        hashed_password=hash_password(_PASSWORD),
+        auth_source="local",
+        is_active=True,
+        is_superadmin=False,
+    )
+    db.add(user)
+    await db.flush()
+    await db.commit()
+    return user
+
+
+def _refresh_set_cookie(resp) -> str:
+    for raw in resp.headers.get_list("set-cookie"):
+        if raw.startswith("spatium_refresh="):
+            return raw
+    raise AssertionError(f"no spatium_refresh Set-Cookie in {resp.headers.get_list('set-cookie')}")
+
+
+@pytest.mark.asyncio
+async def test_login_sets_httponly_refresh_cookie_and_no_body_token(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    user = await _local_user(db_session)
+
+    resp = await client.post(
+        "/api/v1/auth/login", json={"username": user.username, "password": _PASSWORD}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Access token present; refresh token NOT in the JSON body.
+    assert body["access_token"]
+    assert "refresh_token" not in body
+
+    # Cookie carries the refresh token with the hardening flags.
+    raw = _refresh_set_cookie(resp)
+    lower = raw.lower()
+    assert "httponly" in lower
+    assert "samesite=strict" in lower
+    assert "path=/api/v1/auth" in lower
+    # The cookie jar picked it up so it rides the next auth request.
+    assert client.cookies.get("spatium_refresh")
+
+
+@pytest.mark.asyncio
+async def test_refresh_reads_cookie_rotates_and_returns_access_only(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    user = await _local_user(db_session)
+    login = await client.post(
+        "/api/v1/auth/login", json={"username": user.username, "password": _PASSWORD}
+    )
+    assert login.status_code == 200, login.text
+    first_cookie = client.cookies.get("spatium_refresh")
+
+    # No body — the cookie carries the refresh token.
+    resp = await client.post("/api/v1/auth/refresh")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["access_token"]
+    assert "refresh_token" not in body
+
+    # Rotation: the Set-Cookie value differs from the login cookie.
+    rotated = _refresh_set_cookie(resp)
+    assert first_cookie not in rotated
+
+    # Single-use: replaying the ORIGINAL (pre-rotation) refresh token must be
+    # rejected — the old session was revoked. Without this a broken rotation
+    # that mints a new cookie but forgets ``session.revoked = True`` would
+    # still pass the value-differs check above.
+    client.cookies.clear()
+    client.cookies.set("spatium_refresh", first_cookie)
+    replay = await client.post("/api/v1/auth/refresh")
+    assert replay.status_code == 401, replay.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_without_cookie_is_401(db_session: AsyncSession, client: AsyncClient) -> None:
+    client.cookies.clear()
+    resp = await client.post("/api/v1/auth/refresh")
+    assert resp.status_code == 401, resp.text
+    assert "refresh" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_logout_clears_refresh_cookie(db_session: AsyncSession, client: AsyncClient) -> None:
+    user = await _local_user(db_session)
+    login = await client.post(
+        "/api/v1/auth/login", json={"username": user.username, "password": _PASSWORD}
+    )
+    access = login.json()["access_token"]
+
+    resp = await client.post("/api/v1/auth/logout", headers={"Authorization": f"Bearer {access}"})
+    assert resp.status_code == 204, resp.text
+    # The logout response instructs the browser to drop the cookie.
+    raw = _refresh_set_cookie(resp)
+    lower = raw.lower()
+    assert 'spatium_refresh="";' in lower.replace(" ", " ") or "max-age=0" in lower

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,7 +78,17 @@ import { SettingsPage } from "@/pages/SettingsPage";
 import { useAuth } from "@/hooks/useAuth";
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, bootstrapping } = useAuth();
+  // On a full page reload the in-memory access token is gone; the app runs
+  // one silent /auth/refresh against the HttpOnly cookie (#484). Render a
+  // loader until it resolves so a real session isn't bounced to /login.
+  if (bootstrapping) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <p className="text-sm text-muted-foreground">Restoring session…</p>
+      </div>
+    );
+  }
   return isAuthenticated ? <>{children}</> : <Navigate to="/login" replace />;
 }
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,41 +1,83 @@
-import { useState, useCallback } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 import { authApi, type LoginResponse } from "@/lib/api";
+import {
+  getAccessToken,
+  getAuthSnapshot,
+  markBooted,
+  setAccessToken,
+  subscribe,
+} from "@/lib/authToken";
 
-// SECURITY (#400, L1): both the JWT access token and the refresh
-// token are persisted in localStorage. This is XSS-stealable —
-// any script injected into the SPA's origin can read
-// localStorage.getItem("access_token") / "refresh_token" and
-// exfiltrate a full session (including the long-lived refresh
-// token). The CSP added in #400/L2 (script-src 'self', no
-// 'unsafe-inline'/'unsafe-eval') is the primary mitigation, but
-// localStorage remains the weak link.
+// SECURITY (#484 / #400 L1): the JWT access token lives ONLY in JS memory
+// (lib/authToken.ts), never localStorage — so an XSS foothold can't exfiltrate
+// a durable credential. The long-lived refresh token is an HttpOnly +
+// Secure + SameSite=Strict cookie the backend sets on /auth/login and rotates
+// on /auth/refresh; it's invisible to script entirely. On a full page reload
+// the in-memory access token is gone, so the app runs one silent
+// /auth/refresh at boot (the cookie rides that request) to restore the
+// session — see ``bootstrapAuth`` below.
+
+// Module-level so the boot-time refresh fires exactly once no matter how many
+// components mount useAuth(). The promise is memoised; ``markBooted`` flips
+// the shared ``booted`` flag when it settles either way.
 //
-// INTENDED FIX (deferred — too large for this PR): move the refresh
-// token into an HttpOnly + Secure + SameSite=Strict cookie issued by
-// the backend (/auth/login + /auth/refresh), and keep ONLY the
-// short-lived access token in JS memory (a module-level variable /
-// React context), never localStorage. The axios interceptor in
-// lib/api.ts would then call /auth/refresh with credentials:'include'
-// and read the new access token from the JSON body, with the cookie
-// invisible to JS. That refactor touches the backend auth router,
-// the login/callback pages, and this hook together, so it's tracked
-// as a follow-up rather than bundled into the #400 hardening pass.
+// KNOWN TRADEOFF (multi-tab reload): /auth/refresh rotates + revokes the old
+// session server-side. Because the access token is now memory-only, a reload
+// always boot-refreshes, so reloading two tabs at once makes both present the
+// same cookie — the loser's token is already revoked and that tab is bounced
+// to /login (fail-closed: a spurious re-login, never a privilege leak). The
+// pre-#484 localStorage flow avoided this only by not refreshing on reload at
+// all. A proper fix (cross-tab Web Locks / a short rotation grace window) is
+// tracked separately; single-tab and staggered-tab use is unaffected.
+let bootstrapPromise: Promise<void> | null = null;
+
+function bootstrapAuth(): Promise<void> {
+  if (bootstrapPromise) return bootstrapPromise;
+  bootstrapPromise = authApi
+    .refresh()
+    .then((resp) => {
+      // Only adopt the refreshed token if nothing else set one meanwhile.
+      // An explicit login() racing this boot refresh always wins — its token
+      // is at least as fresh, and we must never clobber it (nor, in the
+      // failure branch below, null it out).
+      if (resp.access_token && !getAccessToken()) {
+        setAccessToken(resp.access_token);
+      }
+    })
+    .catch(() => {
+      // No / expired cookie → stay logged out. Leave the store untouched
+      // (it starts null; a concurrent login must not be wiped). A protected
+      // route redirects to /login once ``booted`` is true.
+    })
+    .finally(() => {
+      markBooted();
+    });
+  return bootstrapPromise;
+}
 
 export function useAuth() {
-  const [isAuthenticated, setIsAuthenticated] = useState(
-    () => !!localStorage.getItem("access_token"),
-  );
+  const snapshot = useSyncExternalStore(subscribe, getAuthSnapshot);
+  const isAuthenticated = !!snapshot.accessToken;
+
+  // Fire the one-shot boot refresh. Skip it if we already have a token in
+  // memory (a fresh login this tab) — there's nothing to restore.
+  useEffect(() => {
+    if (getAccessToken()) {
+      markBooted();
+      return;
+    }
+    void bootstrapAuth();
+  }, []);
 
   /** Run the password step. Returns the raw LoginResponse so the caller
    * can inspect ``mfa_required`` and route to the TOTP prompt without
-   * touching localStorage on a half-completed login. */
+   * establishing a session on a half-completed login. */
   const login = useCallback(
     async (username: string, password: string): Promise<LoginResponse> => {
       const resp = await authApi.login(username, password);
-      if (!resp.mfa_required && resp.access_token && resp.refresh_token) {
-        localStorage.setItem("access_token", resp.access_token);
-        localStorage.setItem("refresh_token", resp.refresh_token);
-        setIsAuthenticated(true);
+      if (!resp.mfa_required && resp.access_token) {
+        setAccessToken(resp.access_token);
+        markBooted();
       }
       return resp;
     },
@@ -51,10 +93,9 @@ export function useAuth() {
       body: { code?: string; recovery_code?: string },
     ): Promise<LoginResponse> => {
       const resp = await authApi.loginMfa(mfa_token, body);
-      if (resp.access_token && resp.refresh_token) {
-        localStorage.setItem("access_token", resp.access_token);
-        localStorage.setItem("refresh_token", resp.refresh_token);
-        setIsAuthenticated(true);
+      if (resp.access_token) {
+        setAccessToken(resp.access_token);
+        markBooted();
       }
       return resp;
     },
@@ -65,11 +106,18 @@ export function useAuth() {
     try {
       await authApi.logout();
     } finally {
-      localStorage.removeItem("access_token");
-      localStorage.removeItem("refresh_token");
-      setIsAuthenticated(false);
+      setAccessToken(null);
     }
   }, []);
 
-  return { isAuthenticated, login, completeMfa, logout };
+  return {
+    isAuthenticated,
+    // True until the boot-time silent refresh resolves. A protected route
+    // renders a loader while this is true so a real session isn't mistaken
+    // for a logged-out one on reload.
+    bootstrapping: !snapshot.booted,
+    login,
+    completeMfa,
+    logout,
+  };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, type AxiosInstance } from "axios";
+import { getAccessToken, setAccessToken } from "@/lib/authToken";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "/api/v1";
 
@@ -15,14 +16,12 @@ function createClient(): AxiosInstance {
     paramsSerializer: { indexes: null },
   });
 
-  // Attach Bearer token from localStorage on every request.
-  // SECURITY (#400, L1): access + refresh tokens live in
-  // localStorage and are therefore XSS-stealable. The CSP shipped in
-  // #400/L2 is the primary mitigation; the intended structural fix
-  // (refresh token -> HttpOnly cookie, access token in memory only)
-  // is documented in hooks/useAuth.ts and deferred to a follow-up.
+  // Attach the in-memory Bearer token on every request (#484 / #400 L1).
+  // The access token lives ONLY in JS memory (lib/authToken.ts); the refresh
+  // token is an HttpOnly cookie the browser sends automatically on the
+  // path-scoped /auth/refresh + /auth/logout calls — never readable here.
   client.interceptors.request.use((config) => {
-    const token = localStorage.getItem("access_token");
+    const token = getAccessToken();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -55,13 +54,18 @@ function createClient(): AxiosInstance {
     reject: (err: unknown) => void;
   }> = [];
 
-  function isRefreshCall(url: string | undefined): boolean {
-    return !!url && url.replace(/^[^/]*\/\//, "").includes("/auth/refresh");
+  // A 401 from a credential endpoint (login / login/mfa / refresh) means bad
+  // credentials or a dead refresh token — NOT an expired access token. It must
+  // never trigger the refresh-and-retry path below: retrying a wrong-password
+  // /auth/login would double-count the failed-login audit row + lockout/
+  // rate-limit budget, and retrying /auth/refresh would loop on itself (#484).
+  function isCredentialEndpoint(url: string | undefined): boolean {
+    const path = url ? url.replace(/^[^/]*\/\//, "") : "";
+    return path.includes("/auth/login") || path.includes("/auth/refresh");
   }
 
   function forceLogin(): void {
-    localStorage.removeItem("access_token");
-    localStorage.removeItem("refresh_token");
+    setAccessToken(null);
     // Skip redirect if we're already on /login so the user doesn't
     // see a white flash when an expired session fires first.
     if (!window.location.pathname.startsWith("/login")) {
@@ -76,20 +80,19 @@ function createClient(): AxiosInstance {
         _retry?: boolean;
       };
 
-      // 401 on the refresh call itself = the refresh token is dead.
-      // Surface the original error so the caller's ``catch`` branch
-      // runs its cleanup + redirect. Don't try to refresh the refresh.
-      if (err.response?.status === 401 && isRefreshCall(originalRequest?.url)) {
+      // 401 on a credential endpoint (login / login/mfa / refresh) = bad
+      // credentials or a dead refresh token. Surface the original error so the
+      // caller's ``catch`` branch runs its cleanup + redirect. Don't refresh:
+      // the refresh call would loop on itself, and a login retry would
+      // double-charge the lockout/audit budget.
+      if (
+        err.response?.status === 401 &&
+        isCredentialEndpoint(originalRequest?.url)
+      ) {
         return Promise.reject(err);
       }
 
       if (err.response?.status === 401 && !originalRequest?._retry) {
-        const refreshToken = localStorage.getItem("refresh_token");
-        if (!refreshToken) {
-          forceLogin();
-          return Promise.reject(err);
-        }
-
         if (isRefreshing) {
           return new Promise((resolve, reject) => {
             refreshQueue.push({
@@ -106,12 +109,19 @@ function createClient(): AxiosInstance {
         originalRequest._retry = true;
         isRefreshing = true;
         try {
-          const res = await client.post("/auth/refresh", {
-            refresh_token: refreshToken,
-          });
-          const { access_token, refresh_token: newRefresh } = res.data;
-          localStorage.setItem("access_token", access_token);
-          localStorage.setItem("refresh_token", newRefresh);
+          // The refresh token rides the HttpOnly cookie automatically; the
+          // rotated refresh token comes back as a new Set-Cookie and the fresh
+          // access token in the JSON body (#484). ``withCredentials`` lets the
+          // cookie flow on a cross-ORIGIN (but same-site) API host when CORS
+          // credentials are enabled; the cookie is SameSite=Strict, so a
+          // genuinely cross-SITE SPA/API split is not supported by design.
+          const res = await client.post(
+            "/auth/refresh",
+            {},
+            { withCredentials: true },
+          );
+          const { access_token } = res.data;
+          setAccessToken(access_token);
           refreshQueue.forEach(({ resolve }) => resolve(access_token));
           refreshQueue = [];
           if (originalRequest?.headers)
@@ -2104,9 +2114,9 @@ export const ipamIoApi = {
 };
 
 export interface LoginResponse {
-  // Set when MFA is NOT required — normal token issuance.
+  // Set when MFA is NOT required — normal token issuance. The refresh token
+  // is delivered out-of-band as an HttpOnly cookie (#484), never in this body.
   access_token: string | null;
-  refresh_token: string | null;
   token_type: string;
   force_password_change: boolean;
   // Set when the user has TOTP enabled (issue #69). The frontend
@@ -4151,7 +4161,7 @@ export async function* streamChatTurn(
   },
   signal?: AbortSignal,
 ): AsyncIterable<{ event: string; data: Record<string, unknown> }> {
-  const token = localStorage.getItem("access_token");
+  const token = getAccessToken();
   const res = await fetch("/api/v1/ai/chat", {
     method: "POST",
     headers: {
@@ -7280,9 +7290,20 @@ export interface MyPermissions {
 }
 
 export const authApi = {
+  // withCredentials on the auth calls so the browser stores (login/mfa/
+  // refresh) and returns (refresh/logout) the HttpOnly refresh cookie on a
+  // cross-ORIGIN same-site API host with CORS credentials enabled (#484). The
+  // cookie is path-scoped to /api/v1/auth, so it never rides ordinary API
+  // requests. NOTE: the cookie is SameSite=Strict — a genuinely cross-SITE
+  // SPA/API split (different registrable domains) can't send it and is out of
+  // scope; the default same-origin (nginx-proxied) deployment is unaffected.
   login: (username: string, password: string) =>
     api
-      .post<LoginResponse>("/auth/login", { username, password })
+      .post<LoginResponse>(
+        "/auth/login",
+        { username, password },
+        { withCredentials: true },
+      )
       .then((r) => r.data),
   /** Complete a TOTP-gated login. Submit either ``code`` (6-digit
    * authenticator) or ``recovery_code``; submitting both 422s. */
@@ -7291,7 +7312,11 @@ export const authApi = {
     body: { code?: string; recovery_code?: string },
   ) =>
     api
-      .post<LoginResponse>("/auth/login/mfa", { mfa_token, ...body })
+      .post<LoginResponse>(
+        "/auth/login/mfa",
+        { mfa_token, ...body },
+        { withCredentials: true },
+      )
       .then((r) => r.data),
   publicProviders: () =>
     api.get<PublicAuthProvider[]>("/auth/providers").then((r) => r.data),
@@ -7300,10 +7325,12 @@ export const authApi = {
    *  before the user even submits. */
   passwordPolicy: () =>
     api.get<PasswordPolicy>("/auth/password-policy").then((r) => r.data),
-  logout: () => api.post("/auth/logout"),
-  refresh: (refreshToken: string) =>
+  logout: () => api.post("/auth/logout", undefined, { withCredentials: true }),
+  /** Exchange the HttpOnly refresh cookie for a fresh access token. No
+   *  argument — the cookie rides the request automatically (#484). */
+  refresh: () =>
     api
-      .post<LoginResponse>("/auth/refresh", { refresh_token: refreshToken })
+      .post<LoginResponse>("/auth/refresh", {}, { withCredentials: true })
       .then((r) => r.data),
   changePassword: (currentPassword: string, newPassword: string) =>
     api.post("/auth/change-password", {
@@ -10321,7 +10348,7 @@ async function* _streamApplianceLogSse(
   url: string,
   signal?: AbortSignal,
 ): AsyncIterable<string> {
-  const token = localStorage.getItem("access_token");
+  const token = getAccessToken();
   const res = await fetch(url, {
     headers: {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -10397,7 +10424,7 @@ export function streamApplianceWorkloadLogs(
 export async function* streamClusterHealth(
   signal?: AbortSignal,
 ): AsyncIterable<ClusterHealthSnapshot> {
-  const token = localStorage.getItem("access_token");
+  const token = getAccessToken();
   const res = await fetch("/api/v1/appliance/cluster/health/stream", {
     headers: {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -12185,7 +12212,7 @@ export async function* streamNmapScan(
   scanId: string,
   signal?: AbortSignal,
 ): AsyncIterable<{ data: string; done: boolean }> {
-  const token = localStorage.getItem("access_token");
+  const token = getAccessToken();
   const url = nmapApi.streamUrl(scanId);
   const res = await fetch(url, {
     headers: {

--- a/frontend/src/lib/authToken.ts
+++ b/frontend/src/lib/authToken.ts
@@ -1,0 +1,62 @@
+/**
+ * In-memory access-token store (#484 / #400 L1).
+ *
+ * SECURITY: the JWT access token lives ONLY in this module-level variable —
+ * never in localStorage / sessionStorage / a cookie readable by JS. An XSS
+ * foothold in the SPA therefore cannot exfiltrate a durable credential: the
+ * access token is short-lived and vanishes on tab close, and the long-lived
+ * refresh token is an HttpOnly cookie the backend sets on /auth/login and
+ * rotates on /auth/refresh (invisible to script entirely).
+ *
+ * Because the token is memory-only it does NOT survive a full page reload.
+ * On boot the app performs one silent /auth/refresh (the HttpOnly cookie
+ * rides that request) to mint a fresh access token — see ``useAuth``.
+ *
+ * Kept dependency-free (no import from ``lib/api``) so it can be imported by
+ * both the axios client and the auth hook without a circular import.
+ */
+
+type AuthSnapshot = {
+  /** The current access token, or null when unauthenticated. */
+  accessToken: string | null;
+  /** True once the boot-time silent refresh has resolved (either way). Until
+   *  then a protected route should render a loader rather than bounce to
+   *  /login, so a real session isn't mistaken for a logged-out one. */
+  booted: boolean;
+};
+
+let snapshot: AuthSnapshot = { accessToken: null, booted: false };
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+/** Stable snapshot for ``useSyncExternalStore`` — the reference only changes
+ *  when the state actually changes, so React re-renders exactly when needed. */
+export function getAuthSnapshot(): AuthSnapshot {
+  return snapshot;
+}
+
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getAccessToken(): string | null {
+  return snapshot.accessToken;
+}
+
+export function setAccessToken(token: string | null): void {
+  if (snapshot.accessToken === token) return;
+  snapshot = { ...snapshot, accessToken: token };
+  emit();
+}
+
+export function markBooted(): void {
+  if (snapshot.booted) return;
+  snapshot = { ...snapshot, booted: true };
+  emit();
+}

--- a/frontend/src/pages/LoginCallbackPage.tsx
+++ b/frontend/src/pages/LoginCallbackPage.tsx
@@ -1,13 +1,16 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { markBooted, setAccessToken } from "@/lib/authToken";
 
 /**
- * Landing route that consumes the tokens delivered by the OIDC/SAML callback
- * as a URL hash fragment (#access_token=…&refresh_token=…&force_password_change=…).
+ * Landing route that consumes the access token delivered by the OIDC/SAML
+ * callback as a URL hash fragment (#access_token=…&force_password_change=…).
  *
- * Hash fragments are never sent to the server, so the tokens stay on the
- * client. We lift them into localStorage (same storage the password flow
- * uses) and redirect into the app.
+ * Hash fragments are never sent to the server, so the token stays on the
+ * client. We lift the short-lived access token into JS memory (same store the
+ * password flow uses) and redirect into the app. The refresh token is NOT in
+ * the fragment — the backend set it as an HttpOnly cookie on the redirect
+ * response, invisible to script (#484).
  */
 export function LoginCallbackPage() {
   const navigate = useNavigate();
@@ -16,18 +19,17 @@ export function LoginCallbackPage() {
     const hash = window.location.hash.replace(/^#/, "");
     const params = new URLSearchParams(hash);
     const access = params.get("access_token");
-    const refresh = params.get("refresh_token");
     const forcePwd = params.get("force_password_change") === "true";
 
-    if (!access || !refresh) {
+    if (!access) {
       navigate("/login?error=oidc_no_tokens", { replace: true });
       return;
     }
 
-    localStorage.setItem("access_token", access);
-    localStorage.setItem("refresh_token", refresh);
+    setAccessToken(access);
+    markBooted();
 
-    // Clear the hash so tokens don't linger in the URL bar.
+    // Clear the hash so the token doesn't linger in the URL bar.
     window.history.replaceState(
       null,
       "",


### PR DESCRIPTION
## What

Closes the deferred **#400 / L1** hardening item tracked in **#484**: the long-lived JWT **refresh token no longer lives in `localStorage`** (XSS-stealable). It's now delivered **only** as an `HttpOnly` + `SameSite=Strict` + `Secure`(when https) cookie (`spatium_refresh`), path-scoped to `/api/v1/auth` so it rides only the refresh + logout calls. The short-lived **access token lives in JS memory** (new `lib/authToken.ts`); on a full reload the app runs one silent `/auth/refresh` against the cookie to restore the session, gated by a "Restoring session…" loader.

## Backend (`api/v1/auth/router.py`)
- `_set_refresh_cookie` / `_clear_refresh_cookie` helpers.
- `login` + `login/mfa` set the cookie; **`refresh_token` dropped from the JSON body** (new refresh-free `LoginResponse` / `RefreshResponse`).
- `/auth/refresh` reads the token **from the cookie**, rotates it, returns access-token-only body; missing cookie → clean 401.
- `logout` clears the cookie; OIDC/SAML callbacks set the cookie on the redirect and put **only the access token** in the URL fragment.

## Frontend
- `lib/authToken.ts` — in-memory access-token store (`useSyncExternalStore`), never `localStorage`.
- `api.ts` interceptor + all 5 SSE/fetch stream helpers read the memory token; the 401-refresh path posts `/auth/refresh` with `withCredentials`, no body token.
- `useAuth` — memory token + one-shot boot refresh (race-guarded against a concurrent `login()`); exposes `bootstrapping`.
- `App.tsx` `ProtectedRoute` shows a loader while the boot refresh is in flight.
- `LoginCallbackPage` consumes the access-token-only fragment.

## Code review

Ran the full multi-agent `/code-review` (8 finder angles → verify). Fixes folded into this PR:
- **Correctness:** the interceptor no longer runs refresh-and-retry on a 401 from `/auth/login` or `/auth/login/mfa` — that was double-charging the failed-login audit + lockout + rate-limit budget when a valid cookie was present.
- Corrected misleading `SameSite`/`withCredentials` comments (Strict is **not** cross-site) + the stale CORS "not cookies" comment in `config.py`.
- Strengthened the rotation test to replay the pre-rotation token and assert 401 (proves the old session is revoked).
- Documented the multi-tab reload rotation tradeoff at the boot-refresh site.

Known/intentional (documented, not changed): SameSite=Strict → cross-**site** SPA/API split unsupported by design; `Secure`-behind-double-proxy matches the existing OIDC/SAML flow-cookie heuristic (default single-nginx deploy bakes `--proxy-headers`).

## Testing
- New `backend/tests/test_auth_refresh_cookie.py` (4 tests): no-body-token + HttpOnly/SameSite/path flags, cookie-read + rotation + **old-token-revoked**, no-cookie 401, logout clears the cookie.
- Adjacent auth suite green (`test_fix_m3_m4_auth_session`, `test_maintenance_mode`, `test_reveal_mfa_reauth` = 33 passed).
- Backend ruff/black/mypy ✓ · frontend build ✓ / eslint ✓ / prettier ✓.
- Confirmed `/api/v1/auth` is in the maintenance-mode exempt prefixes, so boot-refresh works during a maintenance window.

> **Upgrade note:** existing sessions (refresh token only in old `localStorage`) hit **one forced re-login** after deploy — expected, no cookie exists yet.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)