### PR TITLE
refactor(auth): dedicated frontend RefreshResponse type + clearer boot-catch comment

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -45,9 +45,12 @@ function bootstrapAuth(): Promise<void> {
       }
     })
     .catch(() => {
-      // No / expired cookie → stay logged out. Leave the store untouched
-      // (it starts null; a concurrent login must not be wiped). A protected
-      // route redirects to /login once ``booted`` is true.
+      // ANY refresh failure — a missing/expired cookie (401) but also a
+      // network error or 5xx — just means "couldn't restore a session on
+      // boot", so we stay logged out. Leave the store untouched (it starts
+      // null; a concurrent login must not be wiped). A protected route
+      // redirects to /login once ``booted`` is true; a real request the user
+      // then makes re-drives auth through the 401 interceptor.
     })
     .finally(() => {
       markBooted();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -115,7 +115,7 @@ function createClient(): AxiosInstance {
           // cookie flow on a cross-ORIGIN (but same-site) API host when CORS
           // credentials are enabled; the cookie is SameSite=Strict, so a
           // genuinely cross-SITE SPA/API split is not supported by design.
-          const res = await client.post(
+          const res = await client.post<RefreshResponse>(
             "/auth/refresh",
             {},
             { withCredentials: true },
@@ -2124,6 +2124,16 @@ export interface LoginResponse {
   // with this challenge token + the second factor.
   mfa_required?: boolean;
   mfa_token?: string | null;
+}
+
+// Mirrors the backend `RefreshResponse` (#484): /auth/refresh returns only a
+// fresh access token (the rotated refresh token rides the HttpOnly cookie),
+// with none of LoginResponse's MFA/login-only fields. Typed separately so a
+// refresh caller can't accidentally depend on `mfa_required` / `mfa_token`.
+export interface RefreshResponse {
+  access_token: string;
+  token_type: string;
+  force_password_change: boolean;
 }
 
 export interface MfaStatusResponse {
@@ -7330,7 +7340,7 @@ export const authApi = {
    *  argument — the cookie rides the request automatically (#484). */
   refresh: () =>
     api
-      .post<LoginResponse>("/auth/refresh", {}, { withCredentials: true })
+      .post<RefreshResponse>("/auth/refresh", {}, { withCredentials: true })
       .then((r) => r.data),
   changePassword: (currentPassword: string, newPassword: string) =>
     api.post("/auth/change-password", {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2126,10 +2126,11 @@ export interface LoginResponse {
   mfa_token?: string | null;
 }
 
-// Mirrors the backend `RefreshResponse` (#484): /auth/refresh returns only a
-// fresh access token (the rotated refresh token rides the HttpOnly cookie),
-// with none of LoginResponse's MFA/login-only fields. Typed separately so a
-// refresh caller can't accidentally depend on `mfa_required` / `mfa_token`.
+// Mirrors the backend `RefreshResponse` (#484): /auth/refresh returns a fresh
+// access token plus `token_type` + `force_password_change` (the rotated refresh
+// token rides the HttpOnly cookie), but NONE of LoginResponse's MFA/login-only
+// fields. Typed separately so a refresh caller can't accidentally depend on
+// `mfa_required` / `mfa_token`.
 export interface RefreshResponse {
   access_token: string;
   token_type: string;


### PR DESCRIPTION
Copilot review follow-up to #487 (the #484 L1 HttpOnly-refresh-cookie change). All comment/type-only — no runtime behavior change.

## Changes
- **`RefreshResponse` frontend type** (mirrors the backend `RefreshResponse` model): `/auth/refresh` returns an access-token-only body, so `authApi.refresh()` and the axios 401-interceptor refresh call are now typed `RefreshResponse` instead of reusing `LoginResponse`. Prevents a refresh caller from accidentally depending on login/MFA-only fields (`mfa_required` / `mfa_token`).
- **`bootstrapAuth()` catch comment** clarified: it swallows *all* refresh failures (network / 5xx as well as a missing/expired-cookie 401), not just the cookie case.

## Testing
- Frontend build ✓ / eslint ✓ / prettier ✓.

Addresses the three Copilot review comments on #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)