### PR TITLE
fix(ipam): critical + high findings from the 2026-07-02 review sweep (#489-#502)

### DIFF
--- a/IPAM-REVIEW-ISSUES.md
+++ b/IPAM-REVIEW-ISSUES.md
@@ -1,0 +1,64 @@
+# IPAM review 2026-07-02 — issue creation tracker
+
+Source: full IPAM review sweep (backend router/models, services/tasks, frontend, product coverage).
+Check off each item with its issue number as created. Labels: bugs get `bug` + severity
+(`critical`/`high`/`medium`/`low`) + component (`api`/`frontend`/`worker`); improvements get
+`enhancement`; features get `enhancement` + `idea`.
+
+## Bugs
+
+- [x] #489 B1 (critical, api) Next-IP allocation materializes entire host list — DoS. `_pick_next_available_ip` router.py:763 (v6 seq: `list(net.hosts())[:max_search]` on /64 → 2^64 objs; nothing enforces ">= /112") and :804 (v4: both arms fully materialize; /8 = 16.7M objs). Hangs holding subnet FOR UPDATE lock. Fix: itertools.islice.
+- [x] #490 B2 (high, api) Raw-SQL overlap checks bypass soft-delete filter → 30-day phantom conflicts. `_assert_no_overlap` router.py:169, `_assert_no_block_overlap` :207, available-subnets :3065, resize.py:310/383/425/468 all `text()` SQL without `deleted_at IS NULL` (ORM hook only rewrites ORM SELECTs). Trash subnet → recreate/grow neighbor → 409 naming invisible row. Also block-utilization CTE :287 counts trashed subnets. Same class as shipped DHCP fix b67286f. create_block :2818 does it right.
+- [x] #491 B3 (high, api) Soft-deleted IP space holds unique name → 500 on recreate. create_space ORM pre-check passes, full unique index `ix_ip_space_name` fires IntegrityError. Needs partial unique index `WHERE deleted_at IS NULL`. update_space rename has no pre-check at all. router.py:2456, models/ipam.py:114.
+- [x] #492 B4 (high, api+dns-agent) Hostname rename leaks old A/AAAA RRset on live nameserver. `_sync_dns_record` update branch (router.py:1300) renames DB row, ships one `update` op with only new name; bind9 agent does replace(new_name) — old RRset never deleted; drift compare is DB-vs-IPAM so invisible. agent/dns/.../bind9.py:766.
+- [x] #493 B5 (high, api+frontend) Per-IP DNS zone override lost on unrelated edits. Server: update_address passes zone_id=None on hostname-only edit; `_sync_dns_record` prefers subnet effective zone over forward_zone_id → record moves zones (router.py:6418, :1090). Client: EditAddressModal pre-selects subnet primary zone not address.forward_zone_id → no-op Save moves record, or creates one for "no DNS" IPs (IPAMPage.tsx:8155).
+- [x] #494 B6 (high, api) Template carve_children snaps CIDRs downward → overlapping subnets. templates.py:352-397: cursor advances, next child ip_network(strict=False) masks down; [/26,/25] on /24 → /25 overlaps /26; inserted with no overlap check. Also carved subnets total_ips=0 forever + no multicast kind detection.
+- [x] #495 B7 (high, api) Subnet importer commit has no overlap validation. ipam_io/importer.py:350-488 exact-CIDR match only; 10.0.0.0/23 into space with 10.0.0.0/24 commits overlap; auto-parent blocks skip `_assert_no_block_overlap` (:426). NetBox committer does it right (netbox_import/commit.py:513).
+- [x] #496 B8 (high, api) `dns_split_horizon` never serialized on blocks — toggle flips itself off on next save. `_block_to_response` router.py:2652 omits key → response always False. #25 block-level split-horizon unusable via API.
+- [x] #497 B9 (high, api) create_subnet never validates subnet fits inside block (reparent path does). router.py:3615. 192.168.1.0/24 into 10.0.0.0/16 block corrupts free-space math.
+- [x] #498 B10 (high, api) bulk-allocate commit 500s when `description` omitted. Schema None → ORM constructor suppresses default → NOT NULL violation, batch rolls back. router.py:7011/:7294, models/ipam.py:832.
+- [x] #499 B11 (high, api) bulk-delete bypasses auto_from_lease mirror guard (single delete 409s :6739, bulk edit skips :8320; bulk-delete :8104 has no check) — hard-delete retracts live DDNS records for active leases.
+- [x] #500 B12 (high, frontend) reserved_until drifts by UTC offset each Edit open→save. toISOString().slice(0,16) (UTC) into datetime-local (local). IPAMPage.tsx:8064 init, :8178 save.
+- [x] #501 B13 (high, frontend) Gap-marker rows computed from *filtered* list — filters fabricate clickable "free" ranges over allocated IPs. tableRows IIFE IPAMPage.tsx:4720, gaps :4776. Suppress when hasActiveFilter.
+- [x] #502 B14 (high, api+frontend) Cannot clear fields via edit; delete flows misstate permanence. FE: `value || undefined` + backend exclude_unset = silent no-op clearing hostname/MAC/desc/gateway (IPAMPage.tsx:8182, 7250, 11102; inline editor does `|| null` right :5848). BE: update_space/block/subnet exclude_none + hand-picked re-inject → cannot clear vrf_id/customer_id/gateway/ddns_* (router.py:2509/:2945/:4410). Also single-subnet delete says "permanent, cannot be undone" but is a soft-delete to Trash (client never sends permanent=true); bulk flow says Trash correctly (IPAMPage.tsx:7390 vs 13758).
+- [x] #503 B15 (medium, api) IPv6 subnet import overflows BIGINT total_ips — importer lacks the 2^63-1 clamp (router.py:145 has it). Any /64 import 500s whole commit. importer.py:451.
+- [x] #504 B16 (medium, api) Import robustness cluster: non-lowercase headers ("IP") silently import 0 rows (parser.py:171/289; "IP Address" routes to subnet branch); export→import round trip rejects legit statuses available/discovered/placeholders (importer.py:518 vs export.py:43 contract); unvalidated mac_address/gateway → DataError 500 mid-commit (:594/:366); strategy="fail" intra-payload duplicate aborts after earlier rows already pushed live records to agentless Windows DNS (:857).
+- [x] #505 B17 (medium, api) Plan apply bypasses create_subnet invariants: no multicast kind detection, no network/broadcast/gateway placeholder rows, no reverse-zone auto-create, no gateway containment. plans.py:686-718.
+- [x] #506 B18 (medium, api) IPv6 subnets never get network/gateway placeholder rows — gate `prefixlen < 31` is v4 logic, v6 branch dead; should be < 127. router.py:3711-3760.
+- [x] #507 B19 (medium, api) GET /subnets/{id}/effective-dns stops at root block; `_resolve_effective_dns` falls through to space → UI shows "no DNS" while records publish into space zone. router.py:4237 vs :317.
+- [x] #508 B20 (medium, api) Coarse router RBAC gate: write:nat_mapping or write:custom_field grants can create/modify spaces/blocks/subnets (any-of gate router.py:78, no per-type inline checks on structural handlers; plans.py:36 gates ip_block only but creates Subnets).
+- [x] #509 B21 (medium, api+frontend) Bulk-edit staleness: bulk_edit_addresses never recomputes utilization nor clears reserved_until on status change (router.py:8232); FE bulk-delete misses ["subnets"] invalidation (IPAMPage.tsx:9826); subnet detail header is a snapshot never refreshed after IP mutations (:14490).
+- [x] #510 B22 (medium, worker) Device-profiling Celery dispatch before commit — run_scan finds no row, no-ops without retry; queued scan permanently occupies 1 of 4 per-subnet auto-profile slots. auto_profile.py:149/216, nmap/runner.py:399.
+- [x] #511 B23 (medium, api) NAT mappings 500 on malformed IP literals (no validation; cast to INET DataError). nat.py:61/:290/:340.
+- [x] #512 B24 (medium, api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving deleted records. operations_risky.py:246/:295.
+- [x] #513 B25 (medium, frontend) IPv6 drag-and-drop re-parent always fails — cidr.ts has no v6 containment, fails closed "does not fit inside". IPAMPage.tsx:14140/:14156.
+- [x] #514 B26 (medium, frontend) Select-all / shift-range ignore per-row RBAC write gate (address sets #103/#449) → bulk ops partially 403. IPAMPage.tsx:5389/:5800 vs checkbox :5770.
+- [x] #515 B27 (medium, worker) Discovery double-dispatch race — last_discovery_at stamped at completion; >60s sweeps re-dispatched each beat tick; concurrent reconcile collides on unique constraint. ipam_discovery.py:118-152.
+- [x] #516 B28 (low, frontend) Frontend polish grab-bag: static-DHCP chained create misreports as allocation failure + invites dup retry (:3181); IPDetailModal zone fields always "—" (dead zoneNameById prop); EditSpaceModal/delete mutations no onError (silent failures :10368/:4815); BulkEditSubnetsModal raw div not shared draggable Modal (:13829); DnsSyncModal fires reverse-zone backfill on open (:6465); status dropdowns omit available/discovered (:2819/:8041); skipped-rows feedback 1.2s flash (:9397); cidrSize wrong for v6 (:12795); SyncMenu isPending hardwired false (:4916).
+
+## Improvements
+
+- [x] #517 I1 (enhancement, api+frontend) Server-side pagination + search for addresses/subnets/blocks + table windowing. listAddresses has no params; /16 renders ~65k <tr> with per-row ContextMenu, no useMemo; all filtering client-side, no cross-subnet search. ?q=&status=&limit=&offset= + windowing. Highest-value item.
+- [x] #518 I2 (enhancement) IPv6 parity umbrella: gap rows/pool columns unhinted no-op on v6, B18 placeholders, B25 drag-drop, cidrSize, B15 import overflow, B1 sequential guard.
+- [x] #519 I3 (enhancement, frontend) Column sorting on IP/block/space tables (filters exist in 4 modes, no sort; Seen/vendor/hostname).
+- [x] #520 I4 (enhancement) Cross-subnet bulk operations from filter results (selection confined to one subnet; "deprecate every IP tagged env=legacy" has no surface).
+- [x] #521 I5 (enhancement, worker) Utilization recount sweep — NetBox import + lease mirrors never maintain allocated_ips (0% heatmap until interactive edit); importer.py:912 comment claims a sweep exists that doesn't.
+- [x] #522 I6 (enhancement) Perf niggles: dhcp_lease_cleanup full subnet scan per unmatched stale lease (:66); ipam_dns_sync walks every subnet (pre-filter zone-bound); FE precompute pool int bounds (:4594); 220ms deferRowActivate delay (:516).
+- [x] #523 I7 (enhancement, api) API symmetry: subnet-scoped tokens read all via list endpoints; preview_next_ip ignores address-set delegation (:7427); allocate_next_ip lacks public-facing warning + extra_zone_ids (:7484 vs :6141); CSV export formula-injection hardening.
+
+## New features
+
+- [x] #524 F1 IPv6 RA management (managed radvd rendered from subnet data: prefix, M/O flags, RDNSS) + rogue-RA detection (v6 twin of shipped rogue-DHCP probe).
+- [x] #525 F2 NAC-lite: MAB RADIUS responder answering switch MAC-auth from the IPAM MAC allowlist (accept/reject + optional VLAN attribute).
+- [x] #526 F3 Managed TFTP/HTTP boot service + ZTP (per-device config templates via DHCP opts 66/67; completes PXE profiles story).
+- [x] #527 F4 BGP prefix-hijack detection via RIS Live for tracked ASNs/prefixes (origin-AS mismatch alert; extends ASN alert family).
+- [x] #528 F5 DNSBL/RBL monitoring for public + NAT egress IPs (daily sweep, ip_blocklisted alert rule).
+- [x] #529 F6 Auto-drawn L2/L3 topology map from LLDP + SNMP FDB/ARP (global view; reuse SD-WAN SVG approach).
+- [x] #530 F7 GeoDNS / topology-aware steering for GSLB pools (BIND views + GeoIP ACLs; dovetails with DNS-views wiring).
+- [x] #531 F8 DANE/TLSA + SSHFP record automation from cert monitor + DNSSEC (drift alert on cert-rotated-record-stale).
+- [x] #532 F9 Private ACME CA for internal names (issue certs to LAN services via ACME against internal zones; root distributable from UI).
+- [x] #533 F10 Wake-on-LAN action on IP detail modal / device rows (Tools family).
+
+## Docs
+
+- [x] #534 D1 CLAUDE.md pending-roadmap staleness cleanup (#22 #24 #40 #42 #44 #46 #129 no longer open; Windows Path B remainder lives in #444).

--- a/IPAM-REVIEW-ISSUES.md
+++ b/IPAM-REVIEW-ISSUES.md
@@ -5,6 +5,12 @@ Check off each item with its issue number as created. Labels: bugs get `bug` + s
 (`critical`/`high`/`medium`/`low`) + component (`api`/`frontend`/`worker`); improvements get
 `enhancement`; features get `enhancement` + `idea`.
 
+> **Fixes implemented on branch `ipam-review-2026-07-02`:** the critical + all
+> high-severity bugs — #489–#502 (B1–B14). Verified: ruff / black / mypy,
+> eslint, `tsc -b` + vite build, migration-shape linter, single alembic head.
+> DB-backed pytest runs in CI (no Postgres in the dev sandbox). Medium/low bugs,
+> improvements, and features remain open.
+
 ## Bugs
 
 - [x] #489 B1 (critical, api) Next-IP allocation materializes entire host list — DoS. `_pick_next_available_ip` router.py:763 (v6 seq: `list(net.hosts())[:max_search]` on /64 → 2^64 objs; nothing enforces ">= /112") and :804 (v4: both arms fully materialize; /8 = 16.7M objs). Hangs holding subnet FOR UPDATE lock. Fix: itertools.islice.

--- a/backend/alembic/versions/b1f7c3a92e04_ip_space_name_partial_unique.py
+++ b/backend/alembic/versions/b1f7c3a92e04_ip_space_name_partial_unique.py
@@ -1,0 +1,46 @@
+"""ip_space.name uniqueness: partial index excluding soft-deleted rows (#491)
+
+``ix_ip_space_name`` was a plain unique index (``name`` column had
+``unique=True``), but ``IPSpace`` is soft-deletable — so a trashed space
+kept occupying its name slot, and re-creating a space with that name (the
+ORM create pre-check is auto-filtered to ``deleted_at IS NULL`` and so
+can't see the trashed row) raised a raw ``IntegrityError`` → HTTP 500, with
+the name unusable until the 30-day purge.
+
+Fix: make the uniqueness a **partial** unique index (``WHERE deleted_at IS
+NULL``) so only live spaces are unique by name; trashed rows fall out of
+the index. Active rows were already globally unique under the old index, so
+no dedup is needed before creating the new one. Same pattern as
+``uq_dhcp_scope_group_subnet`` (a3f9c1e7b2d4).
+
+Revision ID: b1f7c3a92e04
+Revises: a3f9c1e7b2d4
+Create Date: 2026-07-02
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "b1f7c3a92e04"
+down_revision = "a3f9c1e7b2d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_ip_space_name", table_name="ip_space")
+    op.create_index(
+        "ix_ip_space_name",
+        "ip_space",
+        ["name"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ip_space_name", table_name="ip_space")
+    op.create_index("ix_ip_space_name", "ip_space", ["name"], unique=True)

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -6566,17 +6566,25 @@ async def update_address(
     # IP's forward_zone_id (#493). Only honour a caller-supplied zone (or an
     # explicit null = clear) when dns_zone_id is actually in the payload.
     dns_zone_explicit = "dns_zone_id" in body.model_fields_set
+    # Operator explicitly chose "None (remove DNS record)" — an empty/null
+    # dns_zone_id that was actually sent (vs omitted, which means "keep").
+    zone_cleared = dns_zone_explicit and not body.dns_zone_id
     hostname_cleared = "hostname" in changes and not ip.hostname
-    if subnet and hostname_cleared:
-        # Clearing the hostname removes the IP's DNS presence. Route through
-        # "delete" — an "update" early-returns on an empty hostname and would
-        # leave the old A/PTR records live on the server (#502).
+    if subnet and (hostname_cleared or zone_cleared):
+        # Clearing the hostname OR explicitly picking "None" removes the IP's
+        # DNS presence. Route through "delete" — an "update" with zone_id=None
+        # falls back to the subnet's effective zone (and early-returns on an
+        # empty hostname), so it would NOT actually remove the records
+        # (#502, and the bot review of the #493 fix).
         await _sync_dns_record(db, ip, subnet, action="delete")
+        if zone_cleared:
+            # Make the removal stick: without this a later unrelated edit
+            # would preserve forward_zone_id and re-create the record.
+            ip.forward_zone_id = None
     elif subnet and ("hostname" in changes or dns_zone_explicit or extras_changed):
-        if dns_zone_explicit:
-            zone_id = uuid.UUID(body.dns_zone_id) if body.dns_zone_id else None
-        else:
-            zone_id = ip.forward_zone_id
+        # zone_cleared is handled above, so an explicit zone here is a real
+        # UUID; otherwise preserve the IP's current forward zone (#493).
+        zone_id = uuid.UUID(body.dns_zone_id) if dns_zone_explicit else ip.forward_zone_id
         await _sync_dns_record(db, ip, subnet, zone_id=zone_id, action="update")
     elif subnet and restoring:
         await _sync_dns_record(db, ip, subnet, zone_id=ip.forward_zone_id, action="create")

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -4,6 +4,7 @@ import contextlib
 import contextvars
 import hashlib
 import ipaddress
+import itertools
 import re
 import string
 import uuid
@@ -15,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -166,9 +168,13 @@ async def _assert_no_overlap(
     exclude_id: uuid.UUID | None = None,
 ) -> None:
     """Raise 409 if the given network overlaps with any existing subnet in the space."""
+    # deleted_at IS NULL: this is raw SQL, so the ORM soft-delete filter
+    # (do_orm_execute in app.db) does NOT apply — a trashed subnet must free
+    # its CIDR for recreate/resize, matching the DHCP-scope fix b67286f (#490).
     q = (
         "SELECT network FROM subnet "
-        "WHERE space_id = CAST(:space_id AS uuid) AND network && CAST(:network AS cidr)"
+        "WHERE space_id = CAST(:space_id AS uuid) AND network && CAST(:network AS cidr) "
+        "AND deleted_at IS NULL"
     )
     params: dict[str, Any] = {"space_id": str(space_id), "network": network}
     if exclude_id:
@@ -204,10 +210,13 @@ async def _assert_no_block_overlap(
     (operator should set ``parent_block_id`` to that sibling
     instead), or any partial overlap.
     """
+    # deleted_at IS NULL: raw SQL bypasses the ORM soft-delete filter, so a
+    # trashed block must free its CIDR for recreate/reparent (#490).
     q = (
         "SELECT id, network FROM ip_block "
         "WHERE space_id = CAST(:space_id AS uuid) "
-        "AND network && CAST(:network AS cidr)"
+        "AND network && CAST(:network AS cidr) "
+        "AND deleted_at IS NULL"
     )
     params: dict[str, Any] = {"space_id": str(space_id), "network": network}
     if parent_block_id is None:
@@ -283,17 +292,22 @@ async def _update_block_utilization(db: AsyncSession, block_id: uuid.UUID) -> No
         return
 
     # Sum allocated_ips for all subnets in this block and all descendant blocks
+    # deleted_at IS NULL guards: raw SQL bypasses the ORM soft-delete filter,
+    # so trashed blocks/subnets would otherwise inflate the rollup (#490).
     result = await db.execute(
         text("""
             WITH RECURSIVE descendants AS (
-                SELECT id FROM ip_block WHERE id = CAST(:block_id AS uuid)
+                SELECT id FROM ip_block
+                WHERE id = CAST(:block_id AS uuid) AND deleted_at IS NULL
                 UNION ALL
                 SELECT b.id FROM ip_block b
                     INNER JOIN descendants d ON b.parent_block_id = d.id
+                WHERE b.deleted_at IS NULL
             )
             SELECT COALESCE(SUM(s.allocated_ips), 0)
             FROM subnet s
             WHERE s.block_id IN (SELECT id FROM descendants)
+              AND s.deleted_at IS NULL
         """),
         {"block_id": str(block_id)},
     )
@@ -760,7 +774,10 @@ async def _pick_next_available_ip(
             # useless for /64 but surface the result so the UI can tell
             # the user "no free hosts" rather than spin forever.
             max_search = 65536
-            for host in list(net.hosts())[:max_search]:
+            # islice, not list(...)[:cap]: a /64 has 2**64 hosts, so
+            # materializing the full iterator before slicing OOMs/hangs the
+            # worker while it holds the subnet FOR UPDATE lock (#489).
+            for host in itertools.islice(net.hosts(), max_search):
                 if str(host) in used:
                     continue
                 if dynamic_ranges and _ip_int_in_dynamic_pool(int(host), dynamic_ranges):
@@ -798,10 +815,15 @@ async def _pick_next_available_ip(
             return candidate
         return None
 
-    # ── IPv4 (unchanged) ──────────────────────────────────────────────
+    # ── IPv4 ──────────────────────────────────────────────────────────
     # Cap the linear search at 65k hosts for very large IPv4 subnets.
+    # islice, not list(...)[:cap]: a /8 has ~16.7M hosts and the old
+    # ``list(net.hosts())[:max_search]`` materialized the whole iterator
+    # before slicing, stalling the worker under the subnet lock (#489).
+    # A /16 (65534 hosts) still materializes fully — under the cap — so the
+    # common case is unchanged; only oversized subnets are bounded.
     max_search = 65536
-    hosts = list(net.hosts()) if net.prefixlen >= 16 else list(net.hosts())[:max_search]
+    hosts = list(itertools.islice(net.hosts(), max_search))
 
     if strategy == "random":
         import random  # noqa: PLC0415 — local import mirrors the legacy site
@@ -1298,14 +1320,44 @@ async def _sync_dns_record(
                     ttl,
                 )
             else:
-                changed = existing.name != ip.hostname or existing.value != str(ip.address)
+                old_name = existing.name
+                old_value = existing.value
+                name_changed = old_name != ip.hostname
+                value_changed = old_value != str(ip.address)
+                if name_changed:
+                    # A rename is delete-at-old-name + create-at-new-name at
+                    # the driver level: the agent's "update" op replaces the
+                    # RRset AT a given name and never removes the old name, so
+                    # a bare update would leave the old name (e.g. web01) live
+                    # on the server after renaming to web02 (#492). Emit the
+                    # delete for the old RRset before recreating under the new
+                    # name.
+                    await _enqueue_dns_op(
+                        db,
+                        target_zone,
+                        "delete",
+                        old_name,
+                        forward_rtype,
+                        old_value,
+                        existing.ttl,
+                    )
                 existing.name = ip.hostname
                 existing.fqdn = target_fqdn
                 existing.value = str(ip.address)
                 if desired_zone_id == effective_zone_id:
                     ip.dns_record_id = existing.id
                     ip.forward_zone_id = effective_zone_id
-                if changed:
+                if name_changed:
+                    await _enqueue_dns_op(
+                        db,
+                        target_zone,
+                        "create",
+                        ip.hostname,
+                        forward_rtype,
+                        str(ip.address),
+                        existing.ttl,
+                    )
+                elif value_changed:
                     await _enqueue_dns_op(
                         db,
                         target_zone,
@@ -2465,7 +2517,20 @@ async def create_space(body: IPSpaceCreate, current_user: CurrentUser, db: DB) -
         )
     space = IPSpace(**body.model_dump())
     db.add(space)
-    await db.flush()
+    # The pre-check above (an ORM SELECT) can't see a soft-deleted space and a
+    # concurrent create can race it, so translate the name unique-violation
+    # into a clean 409 (#491). Any other integrity failure is unexpected — roll
+    # back and let it surface as a 500 rather than masking it.
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        if "ix_ip_space_name" not in str(exc.orig):
+            raise
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"An IP space named {body.name!r} already exists",
+        ) from exc
     db.add(
         _audit(
             current_user,
@@ -2506,13 +2571,42 @@ async def update_space(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP space not found")
 
     old = {"name": space.name, "description": space.description, "tags": space.tags}
-    changes = body.model_dump(exclude_none=True, exclude={"dhcp_server_group_id"})
+    # Rename uniqueness pre-check (#491): the partial unique index on name
+    # would otherwise raise a raw IntegrityError → 500 on a colliding rename.
+    if body.name is not None and body.name != space.name:
+        clash = await db.execute(
+            select(IPSpace.id).where(IPSpace.name == body.name, IPSpace.id != space_id)
+        )
+        if clash.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"An IP space named {body.name!r} already exists",
+            )
+    # Nullable columns the operator must be able to clear; excluded from the
+    # exclude_none dump and applied explicitly below so a null clears them
+    # rather than being silently dropped (#502).
+    _space_nullable_clearable = (
+        "dns_zone_id",
+        "vrf_id",
+        "asn_id",
+        "customer_id",
+        "ddns_domain_override",
+        "ddns_ttl",
+    )
+    changes = body.model_dump(
+        exclude_none=True, exclude={"dhcp_server_group_id", *_space_nullable_clearable}
+    )
     # ``color`` is nullable and NULL is a meaningful intent ("clear the
     # color"). Re-inject when explicitly set to None in the payload.
     if "color" in body.model_fields_set and body.color is None:
         changes["color"] = None
     for field, value in changes.items():
         setattr(space, field, value)
+    for field in _space_nullable_clearable:
+        if field in body.model_fields_set:
+            val = getattr(body, field)
+            setattr(space, field, val)
+            changes[field] = str(val) if isinstance(val, uuid.UUID) else val
     # Handle DHCP fields explicitly so explicit null (clear) is preserved.
     if "dhcp_server_group_id" in body.model_fields_set:
         space.dhcp_server_group_id = body.dhcp_server_group_id
@@ -2672,6 +2766,10 @@ def _block_to_response(block: IPBlock, vrf_warning: str | None) -> dict[str, Any
         "dns_zone_id": block.dns_zone_id,
         "dns_additional_zone_ids": block.dns_additional_zone_ids,
         "dns_inherit_settings": block.dns_inherit_settings,
+        # Was omitted (#496): IPBlockResponse defaulted it to False on every
+        # read, so enabling split-horizon on a block appeared to save then
+        # showed off on re-open, and re-saving the form wrote False back.
+        "dns_split_horizon": block.dns_split_horizon,
         "dhcp_server_group_id": block.dhcp_server_group_id,
         "dhcp_inherit_settings": block.dhcp_inherit_settings,
         "ddns_enabled": block.ddns_enabled,
@@ -2942,6 +3040,17 @@ async def update_block(
         )
         block.parent_block_id = new_parent_id
 
+    # Nullable columns the operator must be able to clear; excluded from the
+    # exclude_none dump and applied explicitly below so a null clears them
+    # instead of being silently dropped (#502).
+    _block_nullable_clearable = (
+        "vrf_id",
+        "asn_id",
+        "customer_id",
+        "site_id",
+        "ddns_domain_override",
+        "ddns_ttl",
+    )
     changes = body.model_dump(
         exclude_none=True,
         exclude={
@@ -2952,10 +3061,16 @@ async def update_block(
             "dhcp_server_group_id",
             "dhcp_inherit_settings",
             "parent_block_id",
+            *_block_nullable_clearable,
         },
     )
     for field, value in changes.items():
         setattr(block, field, value)
+    for field in _block_nullable_clearable:
+        if field in body.model_fields_set:
+            val = getattr(body, field)
+            setattr(block, field, val)
+            changes[field] = str(val) if isinstance(val, uuid.UUID) else val
     # Handle DNS fields explicitly so boolean False and explicit null are preserved
     dns_fields = {"dns_group_ids", "dns_zone_id", "dns_additional_zone_ids", "dns_inherit_settings"}
     for field in dns_fields & body.model_fields_set:
@@ -3065,7 +3180,8 @@ async def get_available_subnets(
     result = await db.execute(
         text(
             "SELECT network FROM subnet "
-            "WHERE space_id = CAST(:sid AS uuid) AND network && CAST(:net AS cidr)"
+            "WHERE space_id = CAST(:sid AS uuid) AND network && CAST(:net AS cidr) "
+            "AND deleted_at IS NULL"  # raw SQL skips the ORM soft-delete filter (#490)
         ),
         {"sid": str(block.space_id), "net": str(block.network)},
     )
@@ -3616,6 +3732,18 @@ async def create_subnet(body: SubnetCreate, current_user: CurrentUser, db: DB) -
     if block is None or block.space_id != body.space_id:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Block not found in this space"
+        )
+
+    # The subnet CIDR must fit inside its parent block. The reparent path in
+    # update_subnet already enforces this, but create didn't — so an
+    # out-of-range child could be inserted, corrupting the block's free-space
+    # math and allocate-subnet accounting (#497).
+    _subnet_net = _parse_network(body.network)
+    _block_net = _parse_network(str(block.network))
+    if _subnet_net.version != _block_net.version or not _subnet_net.subnet_of(_block_net):  # type: ignore[arg-type]
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Subnet {body.network} is not contained within block {block.network}",
         )
 
     # IPAM template pre-fill (issue #26). Mutates ``body`` in place
@@ -4406,6 +4534,13 @@ async def update_subnet(
         # null, so handle it explicitly through the model_fields_set
         # block below — same pattern as the DNS / DHCP fields.
         "decom_date",
+        # Other nullable columns that exclude_none would strip on a clear,
+        # applied explicitly below so a null actually clears them (#502).
+        "gateway",
+        "customer_id",
+        "site_id",
+        "ddns_domain_override",
+        "ddns_ttl",
     }
     changes = body.model_dump(exclude_none=True, exclude=exclude_fields)
     changes_for_audit = body.model_dump(mode="json", exclude_none=True, exclude=exclude_fields)
@@ -4429,6 +4564,15 @@ async def update_subnet(
         changes_for_audit["decom_date"] = (
             body.decom_date.isoformat() if body.decom_date is not None else None
         )
+
+    # Nullable scalars/FKs the operator must be able to clear (#502) — same
+    # explicit model_fields_set treatment as decom_date, because exclude_none
+    # drops a null and the clear would otherwise be a silent no-op.
+    for _field in ("gateway", "customer_id", "site_id", "ddns_domain_override", "ddns_ttl"):
+        if _field in body.model_fields_set:
+            _val = getattr(body, _field)
+            setattr(subnet, _field, _val)
+            changes_for_audit[_field] = str(_val) if isinstance(_val, uuid.UUID) else _val
 
     # Handle add/remove of auto-created network/broadcast/gateway records.
     # Kubernetes-semantics subnets (pod / service CIDRs) are routed
@@ -6415,8 +6559,24 @@ async def update_address(
     # pure extras edit (no hostname / zone change) still triggers the
     # add / delete of the per-zone records.
     extras_changed = "extra_zone_ids" in changes
-    if subnet and ("hostname" in changes or body.dns_zone_id is not None or extras_changed):
-        zone_id = uuid.UUID(body.dns_zone_id) if body.dns_zone_id else None
+    # Distinguish "dns_zone_id omitted" from "explicitly set (incl. null)".
+    # On a hostname-only edit the operator's per-IP zone override must be
+    # preserved — passing zone_id=None would let _sync_dns_record recompute
+    # the subnet's effective zone and silently re-home the record out of the
+    # IP's forward_zone_id (#493). Only honour a caller-supplied zone (or an
+    # explicit null = clear) when dns_zone_id is actually in the payload.
+    dns_zone_explicit = "dns_zone_id" in body.model_fields_set
+    hostname_cleared = "hostname" in changes and not ip.hostname
+    if subnet and hostname_cleared:
+        # Clearing the hostname removes the IP's DNS presence. Route through
+        # "delete" — an "update" early-returns on an empty hostname and would
+        # leave the old A/PTR records live on the server (#502).
+        await _sync_dns_record(db, ip, subnet, action="delete")
+    elif subnet and ("hostname" in changes or dns_zone_explicit or extras_changed):
+        if dns_zone_explicit:
+            zone_id = uuid.UUID(body.dns_zone_id) if body.dns_zone_id else None
+        else:
+            zone_id = ip.forward_zone_id
         await _sync_dns_record(db, ip, subnet, zone_id=zone_id, action="update")
     elif subnet and restoring:
         await _sync_dns_record(db, ip, subnet, zone_id=ip.forward_zone_id, action="create")
@@ -7291,7 +7451,11 @@ async def bulk_allocate_commit(
                 address=item.address,
                 status=body.status,
                 hostname=item.hostname,
-                description=body.description,
+                # Coalesce: description is `str | None` on the request but the
+                # column is NOT NULL. Passing None to the constructor marks the
+                # attribute set, suppressing the model default="" → NOT NULL
+                # violation → 500, rolling back the whole batch (#498).
+                description=body.description or "",
                 tags=dict(body.tags),
                 custom_fields=dict(body.custom_fields),
                 created_by_user_id=current_user.id,
@@ -8103,6 +8267,13 @@ async def bulk_delete_addresses(
 
     for ip in rows:
         if ip.status in ("network", "broadcast"):
+            skipped.append(ip.id)
+            continue
+        # Dynamic-lease mirrors are owned by the DHCP server. Single-delete
+        # 409s them and bulk-edit skips them; bulk-delete must skip too, or a
+        # permanent delete retracts live DDNS records for an active lease and a
+        # soft delete just gets recreated on the next pull cycle (#499).
+        if ip.auto_from_lease:
             skipped.append(ip.id)
             continue
         if not body.permanent and ip.status == "orphan":

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -110,8 +110,23 @@ class IPSpace(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     """VRF / isolated routing domain. IPs in different spaces may overlap."""
 
     __tablename__ = "ip_space"
+    __table_args__ = (
+        # Partial unique index (NOT column-level unique=True) so a
+        # soft-deleted space stops occupying its name slot. IPSpace is
+        # soft-deletable; a plain unique index kept the trashed name, so the
+        # ORM create pre-check (auto-filtered to deleted_at IS NULL) couldn't
+        # see it and the INSERT 500'd on the constraint (#491). Scoping
+        # uniqueness to live rows matches the soft-delete semantics — same
+        # pattern as uq_dhcp_scope_group_subnet (b67286f).
+        Index(
+            "ix_ip_space_name",
+            "name",
+            unique=True,
+            postgresql_where=sa_text("deleted_at IS NULL"),
+        ),
+    )
 
-    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False, default="")
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     tags: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)

--- a/backend/app/services/ipam/resize.py
+++ b/backend/app/services/ipam/resize.py
@@ -310,7 +310,8 @@ async def _overlap_conflicts_space_subnets(
     q = (
         "SELECT id, network FROM subnet "
         "WHERE space_id = CAST(:space_id AS uuid) "
-        "AND network && CAST(:network AS cidr)"
+        "AND network && CAST(:network AS cidr) "
+        "AND deleted_at IS NULL"  # raw SQL skips the ORM soft-delete filter (#490)
     )
     params: dict[str, Any] = {"space_id": str(space_id), "network": new_cidr}
     if exclude_subnet_id:
@@ -382,7 +383,8 @@ async def _overlap_conflicts_space_blocks_for_subnet(
     q = (
         "SELECT id, network FROM ip_block "
         "WHERE space_id = CAST(:space_id AS uuid) "
-        "AND network && CAST(:network AS cidr)"
+        "AND network && CAST(:network AS cidr) "
+        "AND deleted_at IS NULL"  # raw SQL skips the ORM soft-delete filter (#490)
     )
     params: dict[str, Any] = {"space_id": str(space_id), "network": new_cidr}
     rows = (await db.execute(text(q), params)).fetchall()
@@ -425,7 +427,8 @@ async def _overlap_conflicts_space_blocks(
     q = (
         "SELECT id, network FROM ip_block "
         "WHERE space_id = CAST(:space_id AS uuid) "
-        "AND network && CAST(:network AS cidr)"
+        "AND network && CAST(:network AS cidr) "
+        "AND deleted_at IS NULL"  # raw SQL skips the ORM soft-delete filter (#490)
     )
     params: dict[str, Any] = {"space_id": str(space_id), "network": new_cidr}
     if exclude_block_id:
@@ -469,6 +472,7 @@ async def _overlap_conflicts_space_subnets_for_block(
         "SELECT id, network FROM subnet "
         "WHERE space_id = CAST(:space_id AS uuid) "
         "AND network && CAST(:network AS cidr) "
+        "AND deleted_at IS NULL "  # raw SQL skips the ORM soft-delete filter (#490)
         "AND (block_id IS NULL OR block_id NOT IN ("
         "  WITH RECURSIVE descendants AS ("
         "    SELECT id FROM ip_block WHERE id = CAST(:bid AS uuid)"

--- a/backend/app/services/ipam/templates.py
+++ b/backend/app/services/ipam/templates.py
@@ -38,6 +38,30 @@ class TemplateError(Exception):
         self.status_code = status_code
 
 
+_BIGINT_MAX = 2**63 - 1
+_V4_MULTICAST = ipaddress.ip_network("224.0.0.0/4")
+_V6_MULTICAST = ipaddress.ip_network("ff00::/8")
+
+
+def _total_ips(net: ipaddress.IPv4Network | ipaddress.IPv6Network) -> int:
+    """Mirror ``app.api.v1.ipam.router._total_ips`` so carved subnets carry
+    the same ``total_ips`` create_subnet would compute (was left 0 → the
+    utilization bar read 0/0 forever, #494)."""
+    if isinstance(net, ipaddress.IPv6Network):
+        return min(net.num_addresses, _BIGINT_MAX)
+    if net.prefixlen >= 31:
+        return net.num_addresses
+    return net.num_addresses - 2
+
+
+def _subnet_kind(net: ipaddress.IPv4Network | ipaddress.IPv6Network) -> str:
+    """Mirror create_subnet's #126 multicast discriminator so a carved
+    multicast leaf isn't left ``unicast`` (which would wrongly accept
+    per-IP allocation, #494)."""
+    mcast = _V4_MULTICAST if isinstance(net, ipaddress.IPv4Network) else _V6_MULTICAST
+    return "multicast" if net.subnet_of(mcast) else "unicast"  # type: ignore[arg-type]
+
+
 _TEMPLATE_FIELDS_COMMON: tuple[str, ...] = (
     "tags",
     "custom_fields",
@@ -347,6 +371,7 @@ async def carve_children(
     parent_net = ipaddress.ip_network(str(block.network), strict=False)
     spec = _validate_child_layout(template.child_layout, parent_net.prefixlen)
     existing = await _existing_subnets_under_block(db, block)
+    existing_nets = [ipaddress.ip_network(c, strict=False) for c in existing]
     results: list[CarvedChild] = []
 
     cursor = int(parent_net.network_address)
@@ -354,30 +379,44 @@ async def carve_children(
     for idx, entry in enumerate(spec, start=1):
         prefix = entry["prefix"]
         size = 1 << ((parent_net.max_prefixlen) - prefix)
-        if cursor + size - 1 > end:
+        # Align the cursor UP to this child's prefix boundary. A /p network
+        # must start on a multiple of its size; the old code snapped the
+        # cursor DOWN (ip_network(..., strict=False)), which for a layout
+        # like [/26, /25] on a /24 rewound the /25 back over the /26 and
+        # created two overlapping subnets (#494). Rounding up leaves a gap
+        # instead — valid, non-overlapping CIDR.
+        aligned = (cursor + size - 1) & ~(size - 1)
+        if aligned + size - 1 > end:
             raise TemplateError(
                 f"child_layout overflows the carrier {block.network}: "
                 f"child[{idx-1}] /{prefix} would extend past the block range."
             )
-        child_net = ipaddress.ip_network(
-            (
-                ipaddress.IPv4Address(cursor)
-                if isinstance(parent_net, ipaddress.IPv4Network)
-                else ipaddress.IPv6Address(cursor)
-            ),
+        aligned_addr = (
+            ipaddress.IPv4Address(aligned)
+            if isinstance(parent_net, ipaddress.IPv4Network)
+            else ipaddress.IPv6Address(aligned)
         )
-        # Snap to the prefix boundary
-        child_net = ipaddress.ip_network(f"{child_net.network_address}/{prefix}", strict=False)
+        child_net = ipaddress.ip_network(f"{aligned_addr}/{prefix}", strict=True)
         cidr = str(child_net)
         rendered_name = (
             _render_child_name(entry["name_template"] or "", network=child_net, index=idx)
             if entry["name_template"]
             else ""
         )
+        cursor = aligned + size
         if cidr in existing:
             results.append(CarvedChild(cidr=cidr, name=rendered_name, skipped=True))
-            cursor += size
             continue
+        # Idempotency is exact-CIDR above; also refuse to carve into a
+        # *different* subnet that already overlaps this range rather than
+        # silently creating an overlap the model has no DB constraint to
+        # catch (#494).
+        clash = next((n for n in existing_nets if n.overlaps(child_net)), None)
+        if clash is not None:
+            raise TemplateError(
+                f"child_layout child /{prefix} at {cidr} overlaps existing "
+                f"subnet {clash} under block {block.network}."
+            )
         # Carved subnets skip the network/broadcast auto-address rows
         # because we're not going through ``create_subnet``. Operator
         # can flesh them out via the IPAM UI afterward; the row exists
@@ -391,10 +430,12 @@ async def carve_children(
             tags=entry["tags"],
             custom_fields=entry["custom_fields"],
             applied_template_id=template.id,
+            total_ips=_total_ips(child_net),
+            kind=_subnet_kind(child_net),
         )
         db.add(sub)
+        existing_nets.append(child_net)
         results.append(CarvedChild(cidr=cidr, name=rendered_name, skipped=False))
-        cursor += size
 
     return results
 

--- a/backend/app/services/ipam_io/importer.py
+++ b/backend/app/services/ipam_io/importer.py
@@ -158,6 +158,26 @@ def _find_parent_block(
     return candidates[0]
 
 
+def _first_overlap(
+    net: ipaddress.IPv4Network | ipaddress.IPv6Network,
+    others: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+) -> ipaddress.IPv4Network | ipaddress.IPv6Network | None:
+    """First network in ``others`` that overlaps ``net`` but is not identical.
+
+    The importer keys existing subnets/blocks by exact canonical CIDR, so
+    exact matches are handled separately (skip/overwrite/fail). This catches
+    the *partial/containment* overlaps that the exact-match dict misses — e.g.
+    importing 10.0.0.0/23 into a space that already holds 10.0.0.0/24, which
+    the subnet model has no DB constraint to reject (#495).
+    """
+    for other in others:
+        if other.version != net.version:
+            continue
+        if other != net and other.overlaps(net):
+            return other
+    return None
+
+
 # ── Preview ────────────────────────────────────────────────────────────────────
 
 
@@ -178,6 +198,9 @@ async def preview_import(
 
     # Track auto-created blocks in this preview so the summary is consistent.
     planned_block_nets: set[str] = set()
+    # Networks queued to be created in this same payload — so an intra-payload
+    # overlap is caught in preview the way commit catches it (#495).
+    planned_subnet_nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
 
     seen_networks: set[str] = set()
     for row in payload.subnets:
@@ -239,6 +262,26 @@ async def preview_import(
 
         existing = existing_subnets.get(canonical)
         if existing is None:
+            # Flag non-exact overlaps here so the preview matches what commit
+            # will reject — otherwise the operator sees a clean "create" for a
+            # row commit turns into an error (#495).
+            clash = _first_overlap(
+                subnet_net,
+                [ipaddress.ip_network(c, strict=False) for c in existing_subnets]
+                + list(planned_subnet_nets),
+            )
+            if clash is not None:
+                preview.errors.append(
+                    DiffRow(
+                        kind="subnet",
+                        action="error",
+                        network=canonical,
+                        reason=f"Overlaps existing subnet {clash}",
+                        details=row,
+                    )
+                )
+                continue
+            planned_subnet_nets.append(subnet_net)
             preview.creates.append(
                 DiffRow(
                     kind="subnet",
@@ -420,9 +463,32 @@ async def commit_import(
                 detail=f"Subnet {canonical} already exists",
             )
 
+        # Reject a non-exact overlap with an existing (or already-imported)
+        # subnet rather than silently creating an overlapping row — the model
+        # has no DB overlap constraint, so this is the only guard (#495).
+        clash = _first_overlap(
+            subnet_net,
+            [ipaddress.ip_network(c, strict=False) for c in existing_subnets],
+        )
+        if clash is not None:
+            result_obj.errors.append(f"{canonical}: overlaps existing subnet {clash}")
+            continue
+
         # Find or auto-create the parent block
         parent = _find_parent_block(subnet_net, existing_blocks)
         if parent is None:
+            # _find_parent_block found no *containing* block; before carving a
+            # new top-level block at this CIDR, make sure it doesn't partially
+            # overlap (or swallow) an existing block (#495).
+            block_clash = _first_overlap(
+                subnet_net,
+                [ipaddress.ip_network(str(b.network), strict=False) for b in existing_blocks],
+            )
+            if block_clash is not None:
+                result_obj.errors.append(
+                    f"{canonical}: auto-parent block would overlap existing block {block_clash}"
+                )
+                continue
             parent = IPBlock(
                 space_id=space.id,
                 parent_block_id=None,

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -8087,6 +8087,13 @@ function EditAddressModal({
     (address.custom_fields as Record<string, unknown>) ?? {},
   );
   const [dnsZoneId, setDnsZoneId] = useState<string>("");
+  // Whether the operator actually interacted with the zone picker. The
+  // pre-select effect sets dnsZoneId programmatically (not via onChange), so
+  // this stays false until a real selection. It lets the mutation send an
+  // explicit zone (incl. null for "None") only on a deliberate change, while
+  // an untouched save omits dns_zone_id so the backend preserves the IP's
+  // current zone (#493 / bot review of #502).
+  const [dnsZoneTouched, setDnsZoneTouched] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showMacHistory, setShowMacHistory] = useState(false);
   const [pendingWarnings, setPendingWarnings] = useState<
@@ -8210,7 +8217,11 @@ function EditAddressModal({
         mac_address: macAddress || null,
         status,
         custom_fields: customFields,
-        dns_zone_id: dnsZoneId || undefined,
+        // Send the zone only on a deliberate pick: a real zone moves the
+        // record, "" (the None option) sends null to remove it, and an
+        // untouched picker omits the field so the backend keeps the current
+        // zone (#493 / bot review of #502).
+        dns_zone_id: dnsZoneTouched ? dnsZoneId || null : undefined,
         role: (role || null) as IPRole | null,
         reserved_until: reservedIso,
         force,
@@ -8333,7 +8344,10 @@ function EditAddressModal({
                 <select
                   className={inputCls}
                   value={dnsZoneId}
-                  onChange={(e) => setDnsZoneId(e.target.value)}
+                  onChange={(e) => {
+                    setDnsZoneId(e.target.value);
+                    setDnsZoneTouched(true);
+                  }}
                 >
                   <ZoneOptions
                     zones={availableZones}

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -4773,7 +4773,12 @@ function SubnetDetail({
       // when a pool boundary just got emitted (the boundary already
       // signals the discontinuity) or when the gap falls inside a
       // dynamic pool (DHCP-owned, not operator-allocatable).
-      if (prevIpInt !== null && ipInt - prevIpInt > 1) {
+      //
+      // Also skipped whenever a filter is active: gaps are computed from the
+      // *filtered* list, so a filter that hides allocated rows would fabricate
+      // a clickable "N free" range over addresses that are actually in use —
+      // and the allocate modal it opens would then collide (#501).
+      if (!hasActiveFilter && prevIpInt !== null && ipInt - prevIpInt > 1) {
         const lastWasPool = rows[rows.length - 1]?.kind === "pool-boundary";
         const gapStart = prevIpInt + 1;
         const gapEnd = ipInt - 1;
@@ -7250,7 +7255,9 @@ function EditSubnetModal({
       return ipamApi.updateSubnet(subnet.id, {
         name: name || undefined,
         description,
-        gateway: gateway || undefined,
+        // Explicit null so the operator can clear the gateway (nullable
+        // column); ``|| undefined`` was silently dropped (#502).
+        gateway: gateway || null,
         vlan_ref_id: vlanRefId,
         vxlan_id: vxlanId.trim() ? Number(vxlanId.trim()) : null,
         status,
@@ -7389,16 +7396,15 @@ function EditSubnetModal({
   // ── Delete step 2 ──
   if (deleteStep === 2) {
     return (
-      <Modal title="Confirm Permanent Deletion" onClose={resetDelete}>
+      <Modal title="Delete subnet" onClose={resetDelete}>
         <div className="space-y-4">
-          <p className="text-sm font-medium text-destructive">
-            This action cannot be undone.
-          </p>
           <p className="text-sm text-muted-foreground">
             <strong className="font-mono text-foreground">
               {subnet.network}
             </strong>{" "}
-            and all its contents will be permanently removed.
+            and its DHCP scopes will be moved to Trash. You can restore them
+            together within 30 days from Administration → Trash; after that the
+            nightly purge removes them for good.
           </p>
           <label className="flex cursor-pointer items-start gap-2 text-sm">
             <input
@@ -7407,8 +7413,8 @@ function EditSubnetModal({
               checked={deleteChecked}
               onChange={(e) => setDeleteChecked(e.target.checked)}
             />
-            I understand {subnet.network} and all its contents will be
-            permanently deleted.
+            I understand {subnet.network} and its contents will be moved to
+            Trash.
           </label>
           {deleteError && (
             <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
@@ -7430,7 +7436,7 @@ function EditSubnetModal({
               disabled={!deleteChecked || deleteMutation.isPending}
               className="rounded-md bg-destructive px-3 py-1.5 text-sm text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
             >
-              {deleteMutation.isPending ? "Deleting…" : "Delete permanently"}
+              {deleteMutation.isPending ? "Deleting…" : "Move to Trash"}
             </button>
           </div>
         </div>
@@ -7660,9 +7666,10 @@ function EditSubnetModal({
       {tab === "danger" && onDeleted && (
         <div className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            Deleting a subnet permanently removes every IP address record inside
-            it, plus any DHCP scopes and DNS records derived from them. The
-            deletion is gated by a typed confirm in the next step.
+            Deleting a subnet moves it and its DHCP scopes to Trash (restorable
+            for 30 days); the IP address rows inside it are removed, and any
+            DHCP-lease DNS records are revoked. The deletion is gated by a
+            confirm in the next step.
           </p>
           <button
             onClick={() => setDeleteStep(1)}
@@ -8046,6 +8053,17 @@ const ADDRESS_STATUSES = [
   "dhcp",
 ] as const;
 
+// Format a UTC ISO instant as a ``datetime-local`` value (local wall-clock,
+// ``YYYY-MM-DDTHH:MM``, no TZ suffix). Naively slicing ``toISOString()``
+// yields the *UTC* wall-clock, which the local-time input then misreads — so
+// every open→save cycle drifted the reservation by the browser's UTC offset
+// (#500). Shifting by the offset first makes the sliced string local, matching
+// how ``new Date(value)`` re-parses it on save.
+function toLocalDatetimeInput(iso: string): string {
+  const d = new Date(iso);
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+}
+
 function EditAddressModal({
   address,
   onClose,
@@ -8059,12 +8077,9 @@ function EditAddressModal({
   const [macAddress, setMacAddress] = useState(address.mac_address ?? "");
   const [status, setStatus] = useState(address.status);
   const [role, setRole] = useState<string>(address.role ?? "");
-  // datetime-local needs ``YYYY-MM-DDTHH:MM`` (no seconds, no TZ).
-  // Trim trailing seconds + drop the trailing ``Z`` if present.
+  // datetime-local needs ``YYYY-MM-DDTHH:MM`` in *local* wall-clock (#500).
   const [reservedUntil, setReservedUntil] = useState<string>(
-    address.reserved_until
-      ? new Date(address.reserved_until).toISOString().slice(0, 16)
-      : "",
+    address.reserved_until ? toLocalDatetimeInput(address.reserved_until) : "",
   );
   const [customFields, setCustomFields] = useState<Record<string, unknown>>(
     (address.custom_fields as Record<string, unknown>) ?? {},
@@ -8151,17 +8166,20 @@ function EditAddressModal({
       ? allGroupZones.filter((z: DNSZone) => explicitZoneIds.includes(z.id))
       : allGroupZones;
 
-  // Pre-select zone from current FQDN or primary zone
+  // Pre-select the IP's *current* forward zone — NOT the subnet's primary.
+  // Defaulting to the primary meant a no-op (or hostname-only) Save re-homed
+  // the A/AAAA record into the primary zone, silently moving it off an
+  // explicitly-chosen additional zone (#493). An IP with no forward zone
+  // stays on the "None" option so an unrelated edit doesn't fabricate a
+  // record; the operator can still pick a zone explicitly to add one.
   useEffect(() => {
     if (!dnsZoneId && availableZones.length > 0) {
-      const primary = effectiveDns?.dns_zone_id;
-      setDnsZoneId(
-        primary && availableZones.some((z: DNSZone) => z.id === primary)
-          ? primary
-          : availableZones[0].id,
-      );
+      const current = address.forward_zone_id;
+      if (current && availableZones.some((z: DNSZone) => z.id === current)) {
+        setDnsZoneId(current);
+      }
     }
-  }, [availableZones.length, effectiveDns?.dns_zone_id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [availableZones.length, address.forward_zone_id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const selectedZone = availableZones.find((z: DNSZone) => z.id === dnsZoneId);
   const fqdnPreview =
@@ -8180,9 +8198,14 @@ function EditAddressModal({
           ? new Date(reservedUntil).toISOString()
           : null;
       return ipamApi.updateAddress(address.id, {
-        hostname: hostname || undefined,
-        description: description || undefined,
-        mac_address: macAddress || undefined,
+        // Send explicit null/"" so an operator can *clear* a field — the old
+        // ``value || undefined`` was dropped by axios and ignored by the
+        // backend's exclude_unset, making a clear a silent no-op (#502).
+        // hostname + mac are nullable columns → null; description is NOT NULL
+        // → "" clears it.
+        hostname: hostname || null,
+        description,
+        mac_address: macAddress || null,
         status,
         custom_fields: customFields,
         dns_zone_id: dnsZoneId || undefined,

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -8061,7 +8061,9 @@ const ADDRESS_STATUSES = [
 // how ``new Date(value)`` re-parses it on save.
 function toLocalDatetimeInput(iso: string): string {
   const d = new Date(iso);
-  return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 16);
 }
 
 function EditAddressModal({


### PR DESCRIPTION
Fixes the one **critical** and all thirteen **high**-severity IPAM bugs from the 2026-07-02 review sweep. Medium/low bugs, improvements, and features remain open on their own issues.

## Crash / DoS
- **#489** — next-IP allocation used `list(net.hosts())[:cap]`, materializing the whole iterator before slicing. A `/64` sequential or `/8` tried to build billions of address objects while holding the subnet `FOR UPDATE` lock. Now `itertools.islice`.
- **#498** — bulk-allocate 500'd when the optional `description` was omitted (None to the ORM ctor suppressed the `""` default → NOT NULL). Coalesce to `""`.

## Soft-delete / uniqueness (raw SQL bypasses the ORM soft-delete filter)
- **#490** — overlap / free-space / utilization raw queries in `router.py` + `resize.py` now filter `deleted_at IS NULL`, so a trashed subnet/block frees its CIDR (matches the DHCP fix `b67286f`).
- **#491** — `ip_space.name` is now a partial unique index (`WHERE deleted_at IS NULL`) via migration `b1f7c3a92e04`; create/update translate the violation to 409 and update adds a rename pre-check.

## DNS record correctness
- **#492** — a hostname rename shipped only the new name to the agent (replace-at-name), leaving the old A/AAAA RRset live. Now delete-old + create-new.
- **#493** — a hostname-only edit re-homed the record into the subnet's effective zone; preserve `forward_zone_id` when `dns_zone_id` isn't in the payload, and the edit modal pre-selects the IP's current zone.

## Overlap / containment validation
- **#494** — template `carve_children` snapped children DOWN (`strict=False`) → overlapping subnets; align UP, run an overlap check, and stamp `total_ips` + multicast `kind`.
- **#495** — the subnet importer only matched exact CIDRs; add partial-overlap guards (subnet + auto-parent block) in both preview and commit.
- **#497** — `create_subnet` never checked the subnet fits inside its block (the reparent path did) — add the `subnet_of` containment check.

## Guards / serialization
- **#496** — `_block_to_response` omitted `dns_split_horizon`, so the toggle read `False` and flipped itself off on re-save.
- **#499** — bulk-delete skipped the `auto_from_lease` guard that single-delete and bulk-edit have — it could retract live DDNS for an active lease.

## Frontend UX
- **#500** — `reserved_until` drifted by the UTC offset every open→save (`toISOString` into a local `datetime-local` input) — format/parse in local time.
- **#501** — gap-marker rows were computed from the filtered list, fabricating clickable "N free" ranges over allocated IPs — suppress when a filter is active.
- **#502** — edit modals couldn't clear fields (`value || undefined` dropped by `exclude_unset`) and the subnet delete modal claimed "permanent" for a recoverable soft-delete. Send explicit null/`""` (clearing hostname now deletes DNS), allow clearing nullable columns on `update_space`/`block`/`subnet`, and correct the delete copy to "Move to Trash".

## Verification
ruff / black / mypy, eslint, `tsc -b` + vite build, migration-shape linter, single alembic head — all pass. Carve alignment, islice bounding, and overlap detection verified standalone. DB-backed pytest runs in CI (no Postgres in the dev sandbox).

## Scope notes
- Left the block/space *delete* copy alone (only the subnet flow was verified; blocks have their own restore-semantics question worth a separate pass).
- Did **not** fold in the medium BIGINT-overflow one line away in the importer (#503) to keep this PR mapped to critical + high.

Closes #489
Closes #490
Closes #491
Closes #492
Closes #493
Closes #494
Closes #495
Closes #496
Closes #497
Closes #498
Closes #499
Closes #500
Closes #501
Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)