### PR TITLE
fix(ipam): medium-severity findings from the 2026-07-02 review sweep (#503-#515)

### DIFF
--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -24,7 +24,7 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - [x] #511 B23 (api) NAT mappings 500 on malformed IP literals (cast to INET DataError). `backend/app/api/v1/ipam/nat.py` ~L61/290/340.
 - [x] #512 B24 (api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving. `backend/app/services/ai/operations_risky.py` ~L246/295.
 - [x] #513 B25 (frontend) IPv6 drag-and-drop re-parent always fails — cidr.ts has no v6 containment, fails closed "does not fit inside". `frontend/src/lib/cidr.ts`; `IPAMPage.tsx` handleDragEnd.
-- [ ] #514 B26 (frontend,rbac) Select-all / shift-range ignore per-row RBAC write gate (address sets) → bulk ops partially 403. `IPAMPage.tsx` select-all + shift-range vs checkbox render.
+- [x] #514 B26 (frontend,rbac) Select-all / shift-range ignore per-row RBAC write gate (address sets) → bulk ops partially 403. `IPAMPage.tsx` select-all + shift-range vs checkbox render.
 - [ ] #515 B27 (worker) Discovery double-dispatch race — last_discovery_at stamped at completion; >60s sweeps re-dispatched each tick; concurrent reconcile collides on unique constraint. `backend/app/tasks/ipam_discovery.py` ~L118.
 
 ## Commit log (fill as we go)
@@ -37,3 +37,4 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - #511 → commit (NAT internal_ip/external_ip field validators on create+update schemas + list-filter query-param validation → 422 not 500)
 - #512 → commit (subnet soft-delete now collect_wakes affected DHCP groups; permanent delete enqueues per-record delete ops through record_ops chokepoint so agentless Windows DNS is retracted. Block/space delete analogs noted as follow-up.)
 - #513 → commit (cidr.ts cidrContains dispatches v4 int-path / v6 BigInt-path; v6 drag-drop re-parent no longer fails closed)
+- #514 → commit (select-all selectable filter + shift-range id list now gate on permitsWriteIp, matching the per-row checkbox — no un-writable rows in a delegated operator's bulk selection)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -20,7 +20,7 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - [x] #507 B19 (api) GET /subnets/{id}/effective-dns stops at root block; `_resolve_effective_dns` falls through to space → UI shows "no DNS" while records publish into space zone. `router.py` ~L4237 vs the resolver ~L317.
 - [x] #508 B20 (api,rbac) Coarse router gate: write:nat_mapping / write:custom_field can create/modify spaces/blocks/subnets (any-of gate, no per-type inline checks on structural handlers). `router.py` gate ~L78; `plans.py` gates ip_block only but creates Subnets.
 - [x] #509 B21 (api,frontend) Bulk-edit staleness: bulk_edit_addresses never recomputes utilization nor clears reserved_until on status change; FE bulk-delete misses ["subnets"] invalidation; subnet detail header snapshot never refreshed. `router.py` bulk_edit_addresses; `IPAMPage.tsx`.
-- [ ] #510 B22 (worker) Device-profiling Celery dispatch before commit — run_scan finds no row, no-ops without retry; queued scan occupies 1 of 4 per-subnet slots forever. `backend/app/services/profiling/auto_profile.py` ~L149/216; `nmap/runner.py` ~L399.
+- [x] #510 B22 (worker) Device-profiling Celery dispatch before commit — run_scan finds no row, no-ops without retry; queued scan occupies 1 of 4 per-subnet slots forever. `backend/app/services/profiling/auto_profile.py` ~L149/216; `nmap/runner.py` ~L399.
 - [ ] #511 B23 (api) NAT mappings 500 on malformed IP literals (cast to INET DataError). `backend/app/api/v1/ipam/nat.py` ~L61/290/340.
 - [ ] #512 B24 (api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving. `backend/app/services/ai/operations_risky.py` ~L246/295.
 - [ ] #513 B25 (frontend) IPv6 drag-and-drop re-parent always fails — cidr.ts has no v6 containment, fails closed "does not fit inside". `frontend/src/lib/cidr.ts`; `IPAMPage.tsx` handleDragEnd.
@@ -33,3 +33,4 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - #505 + #506 → commit (plan-apply: kind + gateway containment + placeholder rows [reverse-zone deferred]; v6 placeholder-row gate <127 in create/update_subnet)
 - #507 + #508 → commit (effective-dns endpoint space fallthrough; per-type write gate on structural handlers + plan-apply subnet-write check)
 - #509 → commit (bulk_edit recomputes subnet+block utilization, clears reserved_until on status change; FE bulk-delete invalidates [subnets]; subnet-detail header syncs from refetched list)
+- #510 → commit (run_scan raises NmapScanRowMissing on absent row; task retries only that pre-scan case with countdown, gives up gracefully after 5 — no stuck queued row)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -15,8 +15,8 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 
 - [x] #503 B15 (api) IPv6 subnet import overflows BIGINT total_ips — importer.py lacks the 2^63-1 clamp (`_total_ips` in resize.py has it). Any /64 import 500s whole commit. `backend/app/services/ipam_io/importer.py` ~L451.
 - [x] #504 B16 (api) Import robustness cluster: case-insensitive headers ("IP"/"IP Address"), export→import status round-trip rejection, unvalidated mac_address/gateway → 500 mid-commit, strategy="fail" intra-payload dup aborts after side effects. `parser.py`, `importer.py`, `export.py`.
-- [ ] #505 B17 (api) Plan apply bypasses create_subnet invariants: multicast kind, network/broadcast/gateway placeholder rows, reverse-zone auto-create, gateway containment. `backend/app/api/v1/ipam/plans.py` ~L686.
-- [ ] #506 B18 (api) IPv6 subnets never get network/gateway placeholder rows — gate `prefixlen < 31` is v4 logic; should be `< 127`. `router.py` create_subnet auto-address branch (~L3711 pre-merge; re-grep).
+- [x] #505 B17 (api) Plan apply bypasses create_subnet invariants: multicast kind, network/broadcast/gateway placeholder rows, reverse-zone auto-create, gateway containment. `backend/app/api/v1/ipam/plans.py` ~L686.
+- [x] #506 B18 (api) IPv6 subnets never get network/gateway placeholder rows — gate `prefixlen < 31` is v4 logic; should be `< 127`. `router.py` create_subnet auto-address branch (~L3711 pre-merge; re-grep).
 - [ ] #507 B19 (api) GET /subnets/{id}/effective-dns stops at root block; `_resolve_effective_dns` falls through to space → UI shows "no DNS" while records publish into space zone. `router.py` ~L4237 vs the resolver ~L317.
 - [ ] #508 B20 (api,rbac) Coarse router gate: write:nat_mapping / write:custom_field can create/modify spaces/blocks/subnets (any-of gate, no per-type inline checks on structural handlers). `router.py` gate ~L78; `plans.py` gates ip_block only but creates Subnets.
 - [ ] #509 B21 (api,frontend) Bulk-edit staleness: bulk_edit_addresses never recomputes utilization nor clears reserved_until on status change; FE bulk-delete misses ["subnets"] invalidation; subnet detail header snapshot never refreshed. `router.py` bulk_edit_addresses; `IPAMPage.tsx`.
@@ -30,3 +30,4 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 ## Commit log (fill as we go)
 
 - #503 + #504 → commit (importer BIGINT clamp; parser case-insensitive headers; status round-trip; MAC/gateway validation; intra-payload dup pre-flight)
+- #505 + #506 → commit (plan-apply: kind + gateway containment + placeholder rows [reverse-zone deferred]; v6 placeholder-row gate <127 in create/update_subnet)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -25,7 +25,7 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - [x] #512 B24 (api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving. `backend/app/services/ai/operations_risky.py` ~L246/295.
 - [x] #513 B25 (frontend) IPv6 drag-and-drop re-parent always fails — cidr.ts has no v6 containment, fails closed "does not fit inside". `frontend/src/lib/cidr.ts`; `IPAMPage.tsx` handleDragEnd.
 - [x] #514 B26 (frontend,rbac) Select-all / shift-range ignore per-row RBAC write gate (address sets) → bulk ops partially 403. `IPAMPage.tsx` select-all + shift-range vs checkbox render.
-- [ ] #515 B27 (worker) Discovery double-dispatch race — last_discovery_at stamped at completion; >60s sweeps re-dispatched each tick; concurrent reconcile collides on unique constraint. `backend/app/tasks/ipam_discovery.py` ~L118.
+- [x] #515 B27 (worker) Discovery double-dispatch race — last_discovery_at stamped at completion; >60s sweeps re-dispatched each tick; concurrent reconcile collides on unique constraint. `backend/app/tasks/ipam_discovery.py` ~L118.
 
 ## Commit log (fill as we go)
 
@@ -38,3 +38,4 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - #512 → commit (subnet soft-delete now collect_wakes affected DHCP groups; permanent delete enqueues per-record delete ops through record_ops chokepoint so agentless Windows DNS is retracted. Block/space delete analogs noted as follow-up.)
 - #513 → commit (cidr.ts cidrContains dispatches v4 int-path / v6 BigInt-path; v6 drag-drop re-parent no longer fails closed)
 - #514 → commit (select-all selectable filter + shift-range id list now gate on permitsWriteIp, matching the per-row checkbox — no un-writable rows in a delegated operator's bulk selection)
+- #515 → commit (per-subnet pg_try_advisory_lock in run_subnet_discovery; a re-dispatched in-flight sweep bows out instead of racing reconcile → no unique-constraint collision)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -17,8 +17,8 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - [x] #504 B16 (api) Import robustness cluster: case-insensitive headers ("IP"/"IP Address"), export→import status round-trip rejection, unvalidated mac_address/gateway → 500 mid-commit, strategy="fail" intra-payload dup aborts after side effects. `parser.py`, `importer.py`, `export.py`.
 - [x] #505 B17 (api) Plan apply bypasses create_subnet invariants: multicast kind, network/broadcast/gateway placeholder rows, reverse-zone auto-create, gateway containment. `backend/app/api/v1/ipam/plans.py` ~L686.
 - [x] #506 B18 (api) IPv6 subnets never get network/gateway placeholder rows — gate `prefixlen < 31` is v4 logic; should be `< 127`. `router.py` create_subnet auto-address branch (~L3711 pre-merge; re-grep).
-- [ ] #507 B19 (api) GET /subnets/{id}/effective-dns stops at root block; `_resolve_effective_dns` falls through to space → UI shows "no DNS" while records publish into space zone. `router.py` ~L4237 vs the resolver ~L317.
-- [ ] #508 B20 (api,rbac) Coarse router gate: write:nat_mapping / write:custom_field can create/modify spaces/blocks/subnets (any-of gate, no per-type inline checks on structural handlers). `router.py` gate ~L78; `plans.py` gates ip_block only but creates Subnets.
+- [x] #507 B19 (api) GET /subnets/{id}/effective-dns stops at root block; `_resolve_effective_dns` falls through to space → UI shows "no DNS" while records publish into space zone. `router.py` ~L4237 vs the resolver ~L317.
+- [x] #508 B20 (api,rbac) Coarse router gate: write:nat_mapping / write:custom_field can create/modify spaces/blocks/subnets (any-of gate, no per-type inline checks on structural handlers). `router.py` gate ~L78; `plans.py` gates ip_block only but creates Subnets.
 - [ ] #509 B21 (api,frontend) Bulk-edit staleness: bulk_edit_addresses never recomputes utilization nor clears reserved_until on status change; FE bulk-delete misses ["subnets"] invalidation; subnet detail header snapshot never refreshed. `router.py` bulk_edit_addresses; `IPAMPage.tsx`.
 - [ ] #510 B22 (worker) Device-profiling Celery dispatch before commit — run_scan finds no row, no-ops without retry; queued scan occupies 1 of 4 per-subnet slots forever. `backend/app/services/profiling/auto_profile.py` ~L149/216; `nmap/runner.py` ~L399.
 - [ ] #511 B23 (api) NAT mappings 500 on malformed IP literals (cast to INET DataError). `backend/app/api/v1/ipam/nat.py` ~L61/290/340.
@@ -31,3 +31,4 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 
 - #503 + #504 → commit (importer BIGINT clamp; parser case-insensitive headers; status round-trip; MAC/gateway validation; intra-payload dup pre-flight)
 - #505 + #506 → commit (plan-apply: kind + gateway containment + placeholder rows [reverse-zone deferred]; v6 placeholder-row gate <127 in create/update_subnet)
+- #507 + #508 → commit (effective-dns endpoint space fallthrough; per-type write gate on structural handlers + plan-apply subnet-write check)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -13,8 +13,8 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 
 ## Status
 
-- [ ] #503 B15 (api) IPv6 subnet import overflows BIGINT total_ips — importer.py lacks the 2^63-1 clamp (`_total_ips` in resize.py has it). Any /64 import 500s whole commit. `backend/app/services/ipam_io/importer.py` ~L451.
-- [ ] #504 B16 (api) Import robustness cluster: case-insensitive headers ("IP"/"IP Address"), export→import status round-trip rejection, unvalidated mac_address/gateway → 500 mid-commit, strategy="fail" intra-payload dup aborts after side effects. `parser.py`, `importer.py`, `export.py`.
+- [x] #503 B15 (api) IPv6 subnet import overflows BIGINT total_ips — importer.py lacks the 2^63-1 clamp (`_total_ips` in resize.py has it). Any /64 import 500s whole commit. `backend/app/services/ipam_io/importer.py` ~L451.
+- [x] #504 B16 (api) Import robustness cluster: case-insensitive headers ("IP"/"IP Address"), export→import status round-trip rejection, unvalidated mac_address/gateway → 500 mid-commit, strategy="fail" intra-payload dup aborts after side effects. `parser.py`, `importer.py`, `export.py`.
 - [ ] #505 B17 (api) Plan apply bypasses create_subnet invariants: multicast kind, network/broadcast/gateway placeholder rows, reverse-zone auto-create, gateway containment. `backend/app/api/v1/ipam/plans.py` ~L686.
 - [ ] #506 B18 (api) IPv6 subnets never get network/gateway placeholder rows — gate `prefixlen < 31` is v4 logic; should be `< 127`. `router.py` create_subnet auto-address branch (~L3711 pre-merge; re-grep).
 - [ ] #507 B19 (api) GET /subnets/{id}/effective-dns stops at root block; `_resolve_effective_dns` falls through to space → UI shows "no DNS" while records publish into space zone. `router.py` ~L4237 vs the resolver ~L317.
@@ -28,3 +28,5 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - [ ] #515 B27 (worker) Discovery double-dispatch race — last_discovery_at stamped at completion; >60s sweeps re-dispatched each tick; concurrent reconcile collides on unique constraint. `backend/app/tasks/ipam_discovery.py` ~L118.
 
 ## Commit log (fill as we go)
+
+- #503 + #504 → commit (importer BIGINT clamp; parser case-insensitive headers; status round-trip; MAC/gateway validation; intra-payload dup pre-flight)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -21,7 +21,7 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - [x] #508 B20 (api,rbac) Coarse router gate: write:nat_mapping / write:custom_field can create/modify spaces/blocks/subnets (any-of gate, no per-type inline checks on structural handlers). `router.py` gate ~L78; `plans.py` gates ip_block only but creates Subnets.
 - [x] #509 B21 (api,frontend) Bulk-edit staleness: bulk_edit_addresses never recomputes utilization nor clears reserved_until on status change; FE bulk-delete misses ["subnets"] invalidation; subnet detail header snapshot never refreshed. `router.py` bulk_edit_addresses; `IPAMPage.tsx`.
 - [x] #510 B22 (worker) Device-profiling Celery dispatch before commit — run_scan finds no row, no-ops without retry; queued scan occupies 1 of 4 per-subnet slots forever. `backend/app/services/profiling/auto_profile.py` ~L149/216; `nmap/runner.py` ~L399.
-- [ ] #511 B23 (api) NAT mappings 500 on malformed IP literals (cast to INET DataError). `backend/app/api/v1/ipam/nat.py` ~L61/290/340.
+- [x] #511 B23 (api) NAT mappings 500 on malformed IP literals (cast to INET DataError). `backend/app/api/v1/ipam/nat.py` ~L61/290/340.
 - [ ] #512 B24 (api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving. `backend/app/services/ai/operations_risky.py` ~L246/295.
 - [ ] #513 B25 (frontend) IPv6 drag-and-drop re-parent always fails — cidr.ts has no v6 containment, fails closed "does not fit inside". `frontend/src/lib/cidr.ts`; `IPAMPage.tsx` handleDragEnd.
 - [ ] #514 B26 (frontend,rbac) Select-all / shift-range ignore per-row RBAC write gate (address sets) → bulk ops partially 403. `IPAMPage.tsx` select-all + shift-range vs checkbox render.
@@ -34,3 +34,4 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - #507 + #508 → commit (effective-dns endpoint space fallthrough; per-type write gate on structural handlers + plan-apply subnet-write check)
 - #509 → commit (bulk_edit recomputes subnet+block utilization, clears reserved_until on status change; FE bulk-delete invalidates [subnets]; subnet-detail header syncs from refetched list)
 - #510 → commit (run_scan raises NmapScanRowMissing on absent row; task retries only that pre-scan case with countdown, gives up gracefully after 5 — no stuck queued row)
+- #511 → commit (NAT internal_ip/external_ip field validators on create+update schemas + list-filter query-param validation → 422 not 500)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -19,7 +19,7 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - [x] #506 B18 (api) IPv6 subnets never get network/gateway placeholder rows — gate `prefixlen < 31` is v4 logic; should be `< 127`. `router.py` create_subnet auto-address branch (~L3711 pre-merge; re-grep).
 - [x] #507 B19 (api) GET /subnets/{id}/effective-dns stops at root block; `_resolve_effective_dns` falls through to space → UI shows "no DNS" while records publish into space zone. `router.py` ~L4237 vs the resolver ~L317.
 - [x] #508 B20 (api,rbac) Coarse router gate: write:nat_mapping / write:custom_field can create/modify spaces/blocks/subnets (any-of gate, no per-type inline checks on structural handlers). `router.py` gate ~L78; `plans.py` gates ip_block only but creates Subnets.
-- [ ] #509 B21 (api,frontend) Bulk-edit staleness: bulk_edit_addresses never recomputes utilization nor clears reserved_until on status change; FE bulk-delete misses ["subnets"] invalidation; subnet detail header snapshot never refreshed. `router.py` bulk_edit_addresses; `IPAMPage.tsx`.
+- [x] #509 B21 (api,frontend) Bulk-edit staleness: bulk_edit_addresses never recomputes utilization nor clears reserved_until on status change; FE bulk-delete misses ["subnets"] invalidation; subnet detail header snapshot never refreshed. `router.py` bulk_edit_addresses; `IPAMPage.tsx`.
 - [ ] #510 B22 (worker) Device-profiling Celery dispatch before commit — run_scan finds no row, no-ops without retry; queued scan occupies 1 of 4 per-subnet slots forever. `backend/app/services/profiling/auto_profile.py` ~L149/216; `nmap/runner.py` ~L399.
 - [ ] #511 B23 (api) NAT mappings 500 on malformed IP literals (cast to INET DataError). `backend/app/api/v1/ipam/nat.py` ~L61/290/340.
 - [ ] #512 B24 (api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving. `backend/app/services/ai/operations_risky.py` ~L246/295.
@@ -32,3 +32,4 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - #503 + #504 → commit (importer BIGINT clamp; parser case-insensitive headers; status round-trip; MAC/gateway validation; intra-payload dup pre-flight)
 - #505 + #506 → commit (plan-apply: kind + gateway containment + placeholder rows [reverse-zone deferred]; v6 placeholder-row gate <127 in create/update_subnet)
 - #507 + #508 → commit (effective-dns endpoint space fallthrough; per-type write gate on structural handlers + plan-apply subnet-write check)
+- #509 → commit (bulk_edit recomputes subnet+block utilization, clears reserved_until on status change; FE bulk-delete invalidates [subnets]; subnet-detail header syncs from refetched list)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -22,7 +22,7 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - [x] #509 B21 (api,frontend) Bulk-edit staleness: bulk_edit_addresses never recomputes utilization nor clears reserved_until on status change; FE bulk-delete misses ["subnets"] invalidation; subnet detail header snapshot never refreshed. `router.py` bulk_edit_addresses; `IPAMPage.tsx`.
 - [x] #510 B22 (worker) Device-profiling Celery dispatch before commit — run_scan finds no row, no-ops without retry; queued scan occupies 1 of 4 per-subnet slots forever. `backend/app/services/profiling/auto_profile.py` ~L149/216; `nmap/runner.py` ~L399.
 - [x] #511 B23 (api) NAT mappings 500 on malformed IP literals (cast to INET DataError). `backend/app/api/v1/ipam/nat.py` ~L61/290/340.
-- [ ] #512 B24 (api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving. `backend/app/services/ai/operations_risky.py` ~L246/295.
+- [x] #512 B24 (api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving. `backend/app/services/ai/operations_risky.py` ~L246/295.
 - [ ] #513 B25 (frontend) IPv6 drag-and-drop re-parent always fails — cidr.ts has no v6 containment, fails closed "does not fit inside". `frontend/src/lib/cidr.ts`; `IPAMPage.tsx` handleDragEnd.
 - [ ] #514 B26 (frontend,rbac) Select-all / shift-range ignore per-row RBAC write gate (address sets) → bulk ops partially 403. `IPAMPage.tsx` select-all + shift-range vs checkbox render.
 - [ ] #515 B27 (worker) Discovery double-dispatch race — last_discovery_at stamped at completion; >60s sweeps re-dispatched each tick; concurrent reconcile collides on unique constraint. `backend/app/tasks/ipam_discovery.py` ~L118.
@@ -35,3 +35,4 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - #509 → commit (bulk_edit recomputes subnet+block utilization, clears reserved_until on status change; FE bulk-delete invalidates [subnets]; subnet-detail header syncs from refetched list)
 - #510 → commit (run_scan raises NmapScanRowMissing on absent row; task retries only that pre-scan case with countdown, gives up gracefully after 5 — no stuck queued row)
 - #511 → commit (NAT internal_ip/external_ip field validators on create+update schemas + list-filter query-param validation → 422 not 500)
+- #512 → commit (subnet soft-delete now collect_wakes affected DHCP groups; permanent delete enqueues per-record delete ops through record_ops chokepoint so agentless Windows DNS is retracted. Block/space delete analogs noted as follow-up.)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -1,0 +1,30 @@
+# IPAM medium bugs — work tracker (branch `ipam-medium-bugs`)
+
+Working through the medium-severity findings from the 2026-07-02 IPAM review
+(#503–#515). Commit after each item so disk state is always current and a fresh
+session can resume. `#516` (B28) is **low** (frontend polish grab-bag) — out of
+scope for this branch.
+
+Verify gate before each push: host `ruff`/`black`/`mypy` (venv), `eslint`,
+`prettier --check src`, `tsc -b`/`vite build` (frontend), migration-shape linter,
+single alembic head. No Postgres in the sandbox → DB-backed pytest runs in CI.
+
+Current single alembic head (before this branch): `b1f7c3a92e04`.
+
+## Status
+
+- [ ] #503 B15 (api) IPv6 subnet import overflows BIGINT total_ips — importer.py lacks the 2^63-1 clamp (`_total_ips` in resize.py has it). Any /64 import 500s whole commit. `backend/app/services/ipam_io/importer.py` ~L451.
+- [ ] #504 B16 (api) Import robustness cluster: case-insensitive headers ("IP"/"IP Address"), export→import status round-trip rejection, unvalidated mac_address/gateway → 500 mid-commit, strategy="fail" intra-payload dup aborts after side effects. `parser.py`, `importer.py`, `export.py`.
+- [ ] #505 B17 (api) Plan apply bypasses create_subnet invariants: multicast kind, network/broadcast/gateway placeholder rows, reverse-zone auto-create, gateway containment. `backend/app/api/v1/ipam/plans.py` ~L686.
+- [ ] #506 B18 (api) IPv6 subnets never get network/gateway placeholder rows — gate `prefixlen < 31` is v4 logic; should be `< 127`. `router.py` create_subnet auto-address branch (~L3711 pre-merge; re-grep).
+- [ ] #507 B19 (api) GET /subnets/{id}/effective-dns stops at root block; `_resolve_effective_dns` falls through to space → UI shows "no DNS" while records publish into space zone. `router.py` ~L4237 vs the resolver ~L317.
+- [ ] #508 B20 (api,rbac) Coarse router gate: write:nat_mapping / write:custom_field can create/modify spaces/blocks/subnets (any-of gate, no per-type inline checks on structural handlers). `router.py` gate ~L78; `plans.py` gates ip_block only but creates Subnets.
+- [ ] #509 B21 (api,frontend) Bulk-edit staleness: bulk_edit_addresses never recomputes utilization nor clears reserved_until on status change; FE bulk-delete misses ["subnets"] invalidation; subnet detail header snapshot never refreshed. `router.py` bulk_edit_addresses; `IPAMPage.tsx`.
+- [ ] #510 B22 (worker) Device-profiling Celery dispatch before commit — run_scan finds no row, no-ops without retry; queued scan occupies 1 of 4 per-subnet slots forever. `backend/app/services/profiling/auto_profile.py` ~L149/216; `nmap/runner.py` ~L399.
+- [ ] #511 B23 (api) NAT mappings 500 on malformed IP literals (cast to INET DataError). `backend/app/api/v1/ipam/nat.py` ~L61/290/340.
+- [ ] #512 B24 (api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving. `backend/app/services/ai/operations_risky.py` ~L246/295.
+- [ ] #513 B25 (frontend) IPv6 drag-and-drop re-parent always fails — cidr.ts has no v6 containment, fails closed "does not fit inside". `frontend/src/lib/cidr.ts`; `IPAMPage.tsx` handleDragEnd.
+- [ ] #514 B26 (frontend,rbac) Select-all / shift-range ignore per-row RBAC write gate (address sets) → bulk ops partially 403. `IPAMPage.tsx` select-all + shift-range vs checkbox render.
+- [ ] #515 B27 (worker) Discovery double-dispatch race — last_discovery_at stamped at completion; >60s sweeps re-dispatched each tick; concurrent reconcile collides on unique constraint. `backend/app/tasks/ipam_discovery.py` ~L118.
+
+## Commit log (fill as we go)

--- a/MEDIUM-BUGS-PROGRESS.md
+++ b/MEDIUM-BUGS-PROGRESS.md
@@ -23,7 +23,7 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - [x] #510 B22 (worker) Device-profiling Celery dispatch before commit — run_scan finds no row, no-ops without retry; queued scan occupies 1 of 4 per-subnet slots forever. `backend/app/services/profiling/auto_profile.py` ~L149/216; `nmap/runner.py` ~L399.
 - [x] #511 B23 (api) NAT mappings 500 on malformed IP literals (cast to INET DataError). `backend/app/api/v1/ipam/nat.py` ~L61/290/340.
 - [x] #512 B24 (api) Subnet soft-delete skips collect_wake for DHCP channels (12s tick); permanent delete bulk-drops DNSRecord rows without enqueue_record_op → agentless Windows DNS keeps serving. `backend/app/services/ai/operations_risky.py` ~L246/295.
-- [ ] #513 B25 (frontend) IPv6 drag-and-drop re-parent always fails — cidr.ts has no v6 containment, fails closed "does not fit inside". `frontend/src/lib/cidr.ts`; `IPAMPage.tsx` handleDragEnd.
+- [x] #513 B25 (frontend) IPv6 drag-and-drop re-parent always fails — cidr.ts has no v6 containment, fails closed "does not fit inside". `frontend/src/lib/cidr.ts`; `IPAMPage.tsx` handleDragEnd.
 - [ ] #514 B26 (frontend,rbac) Select-all / shift-range ignore per-row RBAC write gate (address sets) → bulk ops partially 403. `IPAMPage.tsx` select-all + shift-range vs checkbox render.
 - [ ] #515 B27 (worker) Discovery double-dispatch race — last_discovery_at stamped at completion; >60s sweeps re-dispatched each tick; concurrent reconcile collides on unique constraint. `backend/app/tasks/ipam_discovery.py` ~L118.
 
@@ -36,3 +36,4 @@ Current single alembic head (before this branch): `b1f7c3a92e04`.
 - #510 → commit (run_scan raises NmapScanRowMissing on absent row; task retries only that pre-scan case with countdown, gives up gracefully after 5 — no stuck queued row)
 - #511 → commit (NAT internal_ip/external_ip field validators on create+update schemas + list-filter query-param validation → 422 not 500)
 - #512 → commit (subnet soft-delete now collect_wakes affected DHCP groups; permanent delete enqueues per-record delete ops through record_ops chokepoint so agentless Windows DNS is retracted. Block/space delete analogs noted as follow-up.)
+- #513 → commit (cidr.ts cidrContains dispatches v4 int-path / v6 BigInt-path; v6 drag-drop re-parent no longer fails closed)

--- a/backend/app/api/v1/ipam/nat.py
+++ b/backend/app/api/v1/ipam/nat.py
@@ -23,6 +23,7 @@ gets to write a half-formed row. Audit goes through the standard
 
 from __future__ import annotations
 
+import ipaddress
 import uuid
 from datetime import datetime
 from typing import Annotated, Any
@@ -77,6 +78,18 @@ class NATMappingBase(BaseModel):
         if v not in _VALID_KINDS:
             raise ValueError(f"kind must be one of {sorted(_VALID_KINDS)}")
         return v
+
+    @field_validator("internal_ip", "external_ip")
+    @classmethod
+    def _valid_ip(cls, v: str | None) -> str | None:
+        # Validate here so a malformed literal is a 422, not an asyncpg
+        # DataError → 500 when it reaches the INET column / CAST (#511).
+        if v is None or not v.strip():
+            return None
+        try:
+            return str(ipaddress.ip_address(v.strip()))
+        except ValueError:
+            raise ValueError(f"not a valid IP address: {v!r}") from None
 
     @field_validator("protocol")
     @classmethod
@@ -165,6 +178,17 @@ class NATMappingUpdate(BaseModel):
         if v is not None and v not in _VALID_KINDS:
             raise ValueError(f"kind must be one of {sorted(_VALID_KINDS)}")
         return v
+
+    @field_validator("internal_ip", "external_ip")
+    @classmethod
+    def _valid_ip(cls, v: str | None) -> str | None:
+        # 422 on a malformed literal, not a DataError → 500 at the INET column (#511).
+        if v is None or not v.strip():
+            return None
+        try:
+            return str(ipaddress.ip_address(v.strip()))
+        except ValueError:
+            raise ValueError(f"not a valid IP address: {v!r}") from None
 
     @field_validator("protocol")
     @classmethod
@@ -337,10 +361,20 @@ async def list_nat_mappings(
                 status_code=422, detail=f"kind must be one of {sorted(_VALID_KINDS)}"
             )
         base = base.where(NATMapping.kind == kind)
+    for _label, _val in (("internal_ip", internal_ip), ("external_ip", external_ip)):
+        # Validate the filter literal — comparing the INET column against a
+        # malformed string casts it and raises a DataError → 500 (#511).
+        if _val is not None:
+            try:
+                ipaddress.ip_address(_val.strip())
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=422, detail=f"{_label} must be a valid IP address"
+                ) from exc
     if internal_ip is not None:
-        base = base.where(NATMapping.internal_ip == internal_ip)
+        base = base.where(NATMapping.internal_ip == internal_ip.strip())
     if external_ip is not None:
-        base = base.where(NATMapping.external_ip == external_ip)
+        base = base.where(NATMapping.external_ip == external_ip.strip())
     if q:
         like = f"%{q}%"
         base = base.where(

--- a/backend/app/api/v1/ipam/plans.py
+++ b/backend/app/api/v1/ipam/plans.py
@@ -28,7 +28,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.deps import DB, CurrentUser
 from app.api.v1.dhcp._audit import write_audit
 from app.core.permissions import require_resource_permission
-from app.models.ipam import IPBlock, IPSpace, Subnet, SubnetPlan
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet, SubnetPlan
+
+_V4_MULTICAST = ipaddress.ip_network("224.0.0.0/4")
+_V6_MULTICAST = ipaddress.ip_network("ff00::/8")
+
+
+def _subnet_kind(net: ipaddress.IPv4Network | ipaddress.IPv6Network) -> str:
+    """Mirror create_subnet's #126 discriminator so a planned multicast leaf
+    isn't left ``unicast`` (which would wrongly accept per-IP allocation) (#505)."""
+    mcast = _V4_MULTICAST if isinstance(net, ipaddress.IPv4Network) else _V6_MULTICAST
+    return "multicast" if net.subnet_of(mcast) else "unicast"  # type: ignore[arg-type]
+
 
 router = APIRouter(
     prefix="/plans",
@@ -694,6 +705,24 @@ async def apply_plan(plan_id: uuid.UUID, current_user: CurrentUser, db: DB) -> A
                 total = node_net.num_addresses - 2
             dns_explicit = bool(node.dns_group_id or node.dns_zone_id)
             dhcp_explicit = bool(node.dhcp_server_group_id)
+            node_kind = _subnet_kind(node_net)
+            # Validate the gateway is inside the subnet — create_subnet enforces
+            # this and plan-apply didn't, so a bad gateway could land unchecked
+            # (#505).
+            gateway = node.gateway or None
+            if gateway is not None:
+                try:
+                    gw = ipaddress.ip_address(gateway)
+                except ValueError as exc:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=f"Invalid gateway {gateway!r} on {node.network}",
+                    ) from exc
+                if gw not in node_net:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=f"Gateway {gateway} is not within subnet {node.network}",
+                    )
             subnet = Subnet(
                 space_id=plan.space_id,
                 block_id=parent_block_id,
@@ -703,6 +732,7 @@ async def apply_plan(plan_id: uuid.UUID, current_user: CurrentUser, db: DB) -> A
                 total_ips=total,
                 allocated_ips=0,
                 utilization_percent=0.0,
+                kind=node_kind,
                 dns_group_ids=[node.dns_group_id] if node.dns_group_id else None,
                 dns_zone_id=node.dns_zone_id,
                 dns_inherit_settings=not dns_explicit,
@@ -711,11 +741,47 @@ async def apply_plan(plan_id: uuid.UUID, current_user: CurrentUser, db: DB) -> A
                 ),
                 dhcp_inherit_settings=not dhcp_explicit,
                 vlan_ref_id=(uuid.UUID(node.vlan_ref_id) if node.vlan_ref_id else None),
-                gateway=node.gateway or None,
+                gateway=gateway,
             )
             db.add(subnet)
             await db.flush()
             created_subnets.append(str(subnet.id))
+            # Placeholder network/broadcast/gateway rows, mirroring create_subnet
+            # (#505). Multicast leaves and v4 /31+/32 / v6 /127+/128 get none.
+            is_v6 = isinstance(node_net, ipaddress.IPv6Network)
+            if node_kind != "multicast" and node_net.prefixlen < (127 if is_v6 else 31):
+                db.add(
+                    IPAddress(
+                        subnet_id=subnet.id,
+                        address=str(node_net.network_address),
+                        status="network",
+                        description="Network address",
+                        created_by_user_id=current_user.id,
+                    )
+                )
+                if not is_v6:
+                    db.add(
+                        IPAddress(
+                            subnet_id=subnet.id,
+                            address=str(node_net.broadcast_address),
+                            status="broadcast",
+                            description="Broadcast address",
+                            created_by_user_id=current_user.id,
+                        )
+                    )
+                gw_addr = gateway or str(node_net.network_address + 1)
+                db.add(
+                    IPAddress(
+                        subnet_id=subnet.id,
+                        address=gw_addr,
+                        status="reserved",
+                        description="Gateway",
+                        hostname="gateway",
+                        created_by_user_id=current_user.id,
+                    )
+                )
+                subnet.gateway = gw_addr
+                await db.flush()
 
     await materialise(tree, None, is_root=True)
 

--- a/backend/app/api/v1/ipam/plans.py
+++ b/backend/app/api/v1/ipam/plans.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import DB, CurrentUser
 from app.api.v1.dhcp._audit import write_audit
-from app.core.permissions import require_resource_permission
+from app.core.permissions import require_resource_permission, user_has_permission
 from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet, SubnetPlan
 
 _V4_MULTICAST = ipaddress.ip_network("224.0.0.0/4")
@@ -624,6 +624,14 @@ async def apply_plan(plan_id: uuid.UUID, current_user: CurrentUser, db: DB) -> A
     conflict is present, returns 409 with the full conflict list and
     nothing is written.
     """
+    # The plans router gates on ``ip_block`` write, but apply also materialises
+    # Subnets — require subnet write too so a block-only grant can't create
+    # subnets through the plan path (#508). Superadmin/wildcard pass.
+    if not user_has_permission(current_user, "write", "subnet"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permission denied: applying a plan needs 'write' on 'subnet'",
+        )
     plan = await db.get(SubnetPlan, plan_id)
     if plan is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plan not found")

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -8491,6 +8491,8 @@ async def bulk_edit_addresses(
     not_found = [i for i in body.ip_ids if i not in found_ids]
     updated = 0
     skipped: list[uuid.UUID] = []
+    # Subnets whose utilization must be recomputed after the batch (#509).
+    touched_subnets: set[uuid.UUID] = set()
 
     tags_patch = body.changes.tags
     cf_patch = body.changes.custom_fields
@@ -8567,6 +8569,17 @@ async def bulk_edit_addresses(
                 old[k] = getattr(ip, k, None)
             for k, v in scalar_changes.items():
                 setattr(ip, k, v)
+            # Mirror single-edit (#509): moving off "reserved" clears the TTL so
+            # the reservation sweeper can't later flip the row unexpectedly.
+            if "status" in scalar_changes and ip.status != "reserved":
+                ip.reserved_until = None
+            # A status change alters the allocated/available split, so the
+            # subnet (and its block rollup) utilization must be recomputed —
+            # single-edit does this; bulk-edit didn't, leaving bars + the
+            # dashboard heatmap stale until some other mutation touched the
+            # subnet (#509).
+            if "status" in scalar_changes:
+                touched_subnets.add(ip.subnet_id)
 
             if tags_patch is not None:
                 merged = dict(ip.tags or {})
@@ -8611,6 +8624,14 @@ async def bulk_edit_addresses(
                 )
             )
             updated += 1
+
+    # Recompute utilization for every subnet whose status mix changed, plus
+    # the block rollups above them (#509).
+    for sid in touched_subnets:
+        await _update_utilization(db, sid)
+        sn = subnet_cache.get(sid) or await db.get(Subnet, sid)
+        if sn is not None and sn.block_id is not None:
+            await _update_block_utilization(db, sn.block_id)
 
     await db.commit()
     logger.info(

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -28,6 +28,7 @@ from app.core.permissions import (
     user_has_permission,
 )
 from app.models.audit import AuditLog
+from app.models.auth import User
 from app.models.dhcp import DHCPPool, DHCPScope, DHCPStaticAssignment
 from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
 from app.models.ipam import (
@@ -103,6 +104,22 @@ router = APIRouter(
         )
     ]
 )
+
+
+def _require_type_write(current_user: User, resource_type: str) -> None:
+    """Per-type inline gate for the structural IPAM handlers (space/block/subnet
+    create + update). The router-level gate admits an any-of grant over the
+    whole IPAM surface — including peripheral types like ``nat_mapping`` and
+    ``custom_field`` — so without this a ``write:nat_mapping`` grant could
+    create or mutate core structure it holds no write on (#508). Superadmin and
+    wildcard grants pass via ``user_has_permission``."""
+    if not user_has_permission(current_user, "write", resource_type):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Permission denied: need 'write' on '{resource_type}'",
+        )
+
+
 router.include_router(io_router)
 
 # NAT mappings — operator-curated metadata cross-referenced from IPAM
@@ -2507,6 +2524,7 @@ async def list_spaces(
 
 @router.post("/spaces", response_model=IPSpaceResponse, status_code=status.HTTP_201_CREATED)
 async def create_space(body: IPSpaceCreate, current_user: CurrentUser, db: DB) -> IPSpace:
+    _require_type_write(current_user, "ip_space")
     # Pre-check the unique-name constraint so we can return a clean 409
     # instead of letting the DB raise an IntegrityError (→ 500).
     existing = await db.execute(select(IPSpace).where(IPSpace.name == body.name))
@@ -2566,6 +2584,7 @@ async def get_space(space_id: uuid.UUID, current_user: CurrentUser, db: DB) -> I
 async def update_space(
     space_id: uuid.UUID, body: IPSpaceUpdate, current_user: CurrentUser, db: DB
 ) -> IPSpace:
+    _require_type_write(current_user, "ip_space")
     space = await db.get(IPSpace, space_id)
     if space is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP space not found")
@@ -2817,6 +2836,7 @@ async def list_blocks(
 
 @router.post("/blocks", response_model=IPBlockResponse, status_code=status.HTTP_201_CREATED)
 async def create_block(body: IPBlockCreate, current_user: CurrentUser, db: DB) -> dict[str, Any]:
+    _require_type_write(current_user, "ip_block")
     # Verify space exists
     if await db.get(IPSpace, body.space_id) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP space not found")
@@ -2984,6 +3004,7 @@ async def get_block(block_id: uuid.UUID, current_user: CurrentUser, db: DB) -> d
 async def update_block(
     block_id: uuid.UUID, body: IPBlockUpdate, current_user: CurrentUser, db: DB
 ) -> dict[str, Any]:
+    _require_type_write(current_user, "ip_block")
     block = await db.get(IPBlock, block_id)
     if block is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP block not found")
@@ -3725,6 +3746,7 @@ async def create_subnet(body: SubnetCreate, current_user: CurrentUser, db: DB) -
             status_code=status.HTTP_403_FORBIDDEN,
             detail="API token is bound to a specific subnet and cannot create new subnets",
         )
+    _require_type_write(current_user, "subnet")
     if await db.get(IPSpace, body.space_id) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP space not found")
 
@@ -4400,6 +4422,18 @@ async def get_effective_subnet_dns(
         if current.parent_block_id:
             current = await db.get(IPBlock, current.parent_block_id)
         else:
+            # Reached the root block — fall through to the space, mirroring
+            # _resolve_effective_dns (the actual record-routing path). Without
+            # this the endpoint returned empty while allocations still
+            # published into the space's zone, so the UI showed "no DNS" (#507).
+            space = await db.get(IPSpace, current.space_id)
+            if space is not None:
+                return EffectiveDnsResponse(
+                    dns_group_ids=space.dns_group_ids or [],
+                    dns_zone_id=space.dns_zone_id,
+                    dns_additional_zone_ids=space.dns_additional_zone_ids or [],
+                    inherited_from_block_id=None,
+                )
             current = None
 
     return EffectiveDnsResponse(
@@ -4462,6 +4496,7 @@ async def update_subnet(
     if subnet is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
     _enforce_subnet_token_scope(current_user, subnet_id)
+    _require_type_write(current_user, "subnet")
 
     old_block_id = subnet.block_id
 

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -3846,7 +3846,16 @@ async def create_subnet(body: SubnetCreate, current_user: CurrentUser, db: DB) -
     # doesn't apply.
     auto_created: list[str] = []
     is_v6 = isinstance(net, ipaddress.IPv6Network)
-    if net.prefixlen < 31 and not body.skip_auto_addresses and subnet_kind != "multicast":
+    # Threshold is version-aware: a v4 /31+/32 has no network/broadcast concept
+    # (RFC 3021), and the v6 analogue is /127+/128. The old flat ``< 31`` was v4
+    # logic, so EVERY realistic v6 subnet (/48, /64, /112) fell through and got
+    # no network/gateway pseudo-rows despite the branch's IPv6 handling (#506).
+    placeholder_threshold = 127 if is_v6 else 31
+    if (
+        net.prefixlen < placeholder_threshold
+        and not body.skip_auto_addresses
+        and subnet_kind != "multicast"
+    ):
         # Network address (e.g. 10.0.1.0 / 2001:db8::)
         db.add(
             IPAddress(
@@ -4580,8 +4589,10 @@ async def update_subnet(
     # operator can't accidentally stamp placeholder rows on them.
     if body.manage_auto_addresses is not None and not subnet.kubernetes_semantics:
         net = _parse_network(str(subnet.network))
-        if net.prefixlen < 31:
-            is_v6 = isinstance(net, ipaddress.IPv6Network)
+        # Version-aware threshold (see create_subnet, #506): v4 /31+/32 and v6
+        # /127+/128 have no network/broadcast pseudo-rows.
+        is_v6 = isinstance(net, ipaddress.IPv6Network)
+        if net.prefixlen < (127 if is_v6 else 31):
             auto_statuses = {"network", "broadcast"}
             existing_result = await db.execute(
                 select(IPAddress).where(

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -58,6 +58,7 @@ from fastapi import HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models.auth import User
 from app.services.ai.operations import (
@@ -246,6 +247,23 @@ async def _apply_delete_subnet(
     if not args.permanent:
         await _revoke_subnet_lease_mirrors(db, subnet)
 
+        # Wake DHCP agents for groups whose scopes are being trashed: soft-delete
+        # stamps the scopes deleted, changing rendered Kea config, but without a
+        # wake convergence waits for the 12s safety tick (#512). Capture the
+        # group ids BEFORE the soft-delete filter hides the scope rows.
+        from app.core.agent_wake import collect_wake, dhcp_group_channel  # noqa: PLC0415
+        from app.models.dhcp import DHCPScope as _DHCPScope  # noqa: PLC0415
+
+        wake_group_ids = set(
+            (
+                await db.execute(
+                    select(_DHCPScope.group_id).where(_DHCPScope.subnet_id == args.subnet_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
         batch = await collect_soft_delete_batch(db, subnet)
         apply_soft_delete(batch, user.id)
         for row in batch.rows:
@@ -260,6 +278,8 @@ async def _apply_delete_subnet(
                 )
             )
         await db.commit()
+        for gid in wake_group_ids:
+            collect_wake(dhcp_group_channel(gid))
         return {"subnet_id": str(args.subnet_id), "mode": "soft_delete"}
 
     require_superadmin(user)
@@ -300,6 +320,37 @@ async def _apply_delete_subnet(
     )
     record_ids = [rid for rid in addr_result.scalars().all() if rid is not None]
     if record_ids:
+        # Enqueue a delete op per record through the record-ops chokepoint BEFORE
+        # dropping the rows. Agent-based zones re-converge via the full-zone
+        # bundle, but an agentless (Windows DNS) primary is only retracted by an
+        # explicit op — a bare sa_delete left those A/PTR records live on the
+        # server (#512).
+        from app.services.dns.record_ops import enqueue_record_op  # noqa: PLC0415
+
+        recs = (
+            (
+                await db.execute(
+                    select(DNSRecord)
+                    .where(DNSRecord.id.in_(record_ids))
+                    .options(selectinload(DNSRecord.zone))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for rec in recs:
+            if rec.zone is not None:
+                await enqueue_record_op(
+                    db,
+                    rec.zone,
+                    "delete",
+                    {
+                        "name": rec.name,
+                        "type": rec.record_type,
+                        "value": rec.value,
+                        "ttl": rec.ttl,
+                    },
+                )
         await db.execute(sa_delete(DNSRecord).where(DNSRecord.id.in_(record_ids)))
 
     await db.execute(

--- a/backend/app/services/ipam_io/importer.py
+++ b/backend/app/services/ipam_io/importer.py
@@ -421,14 +421,20 @@ async def commit_import(
         vxlan_id = row.get("vxlan_id")
         gateway = row.get("gateway") or None
         # Validate the gateway before it reaches the INET column — a malformed
-        # literal would otherwise raise a DataError → 500 mid-commit (#504).
+        # literal would otherwise raise a DataError → 500 mid-commit (#504) —
+        # and enforce the same in-subnet / same-family invariant create_subnet
+        # applies, so the importer can't land a Subnet later endpoints assume
+        # is valid (Copilot review of #504).
         if gateway is not None:
             try:
-                ipaddress.ip_address(str(gateway).strip())
+                gw_addr = ipaddress.ip_address(str(gateway).strip())
             except ValueError:
                 result_obj.errors.append(f"{canonical}: invalid gateway {gateway!r}")
                 continue
-            gateway = str(gateway).strip()
+            if gw_addr not in subnet_net:
+                result_obj.errors.append(f"{canonical}: gateway {gateway} is not within the subnet")
+                continue
+            gateway = str(gw_addr)
         custom_fields = row.get("custom_fields") or {}
 
         existing = existing_subnets.get(canonical)

--- a/backend/app/services/ipam_io/importer.py
+++ b/backend/app/services/ipam_io/importer.py
@@ -21,6 +21,7 @@ auto-created as a parent (because subnets require ``block_id``).
 from __future__ import annotations
 
 import ipaddress
+import re
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -32,7 +33,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.audit import AuditLog
-from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.models.ipam import IP_STATUSES, IPAddress, IPBlock, IPSpace, Subnet
+from app.services.ipam.resize import _total_ips
 from app.services.ipam_io.parser import ParsedPayload
 
 logger = structlog.get_logger(__name__)
@@ -375,19 +377,30 @@ async def commit_import(
     existing_blocks = await _load_existing_blocks(db, space.id)
     existing_subnets = await _load_existing_subnets(db, space.id)
 
-    # Pre-flight: if fail-strategy and any subnet conflicts, bail out early.
+    # Pre-flight: if fail-strategy and any subnet conflicts, bail out early —
+    # BEFORE the mutation loop runs any side effects. Catches both pre-existing
+    # rows and intra-payload duplicates; without the latter, the second copy of
+    # a duplicated row hit the in-loop 409 only after the first was created and
+    # its DNS records pushed live (#504).
     if strategy == "fail":
-        conflicts = [
-            row.get("network")
-            for row in payload.subnets
-            if isinstance(row.get("network"), str)
-            and _safe_canon(row["network"]) in existing_subnets
-        ]
+        conflicts: list[str] = []
+        seen_canon: set[str] = set()
+        for row in payload.subnets:
+            net = row.get("network")
+            if not isinstance(net, str):
+                continue
+            canon = _safe_canon(net)
+            if canon in existing_subnets:
+                conflicts.append(net)
+            elif canon in seen_canon:
+                conflicts.append(net)
+            else:
+                seen_canon.add(canon)
         if conflicts:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail=f"{len(conflicts)} subnet(s) already exist; "
-                "re-run with strategy='skip' or 'overwrite'",
+                detail=f"{len(conflicts)} subnet(s) conflict (already exist or duplicated "
+                "in the file); re-run with strategy='skip' or 'overwrite'",
             )
 
     for row in payload.subnets:
@@ -407,6 +420,15 @@ async def commit_import(
         vlan_id = row.get("vlan_id")
         vxlan_id = row.get("vxlan_id")
         gateway = row.get("gateway") or None
+        # Validate the gateway before it reaches the INET column — a malformed
+        # literal would otherwise raise a DataError → 500 mid-commit (#504).
+        if gateway is not None:
+            try:
+                ipaddress.ip_address(str(gateway).strip())
+            except ValueError:
+                result_obj.errors.append(f"{canonical}: invalid gateway {gateway!r}")
+                continue
+            gateway = str(gateway).strip()
         custom_fields = row.get("custom_fields") or {}
 
         existing = existing_subnets.get(canonical)
@@ -514,9 +536,10 @@ async def commit_import(
                 )
             )
 
-        total = (
-            subnet_net.num_addresses if subnet_net.prefixlen >= 31 else subnet_net.num_addresses - 2
-        )
+        # Use the shared clamped helper (mirrors the router / resize paths):
+        # a raw ``num_addresses`` for an IPv6 /64 is 2**64, which overflows the
+        # BIGINT column and 500s the whole commit (#503).
+        total = _total_ips(subnet_net)
         subnet = Subnet(
             space_id=space.id,
             block_id=parent.id,
@@ -581,8 +604,18 @@ def _safe_canon(value: str) -> str:
 # hides user mistakes.
 
 
-_VALID_ADDRESS_STATUSES = frozenset(
-    {"allocated", "reserved", "dhcp", "static_dhcp", "deprecated", "orphan"}
+# Accept every status the exporter can emit so a subnet's own export
+# round-trips cleanly (#504): operator-settable + integration-owned (via
+# IP_STATUSES) plus the network/broadcast placeholders. Rows match on
+# (subnet, address), so re-importing an integration/placeholder row updates
+# the existing row rather than creating a bogus duplicate.
+_VALID_ADDRESS_STATUSES = IP_STATUSES | frozenset({"network", "broadcast"})
+
+# Common MAC notations Postgres MACADDR accepts: 6 hex pairs (``:``/``-``/bare)
+# or 3 hex quads (Cisco ``aabb.ccdd.eeff``). Validate before flush so a
+# malformed value is an error row, not a DataError → 500 (#504).
+_MAC_RE = re.compile(
+    r"^[0-9A-Fa-f]{2}([:-]?[0-9A-Fa-f]{2}){5}$|^[0-9A-Fa-f]{4}(\.[0-9A-Fa-f]{4}){2}$"
 )
 
 
@@ -660,6 +693,8 @@ def _row_address_fields(
     if (m := row.get("mac_address")) is not None:
         m = str(m).strip() or None
         if m:
+            if not _MAC_RE.match(m):
+                return None, {}, f"Invalid MAC address {m!r}"
             fields["mac_address"] = m
     if (d := row.get("description")) is not None:
         d = str(d).strip()
@@ -826,20 +861,24 @@ async def commit_address_import(
     # permission-blocked import can't masquerade as a generic 0-created
     # success (#7).
     if strategy == "fail":
+        seen_addr: set[str] = set()
         for row in payload.addresses:
             canonical, _, err = _row_address_fields(row)
             if err or canonical is None:
                 continue
             if can_write_ip is not None and not can_write_ip(canonical):
                 continue
-            if canonical in existing:
+            # Reject pre-existing AND intra-payload duplicates up front, before
+            # the mutation loop runs any create + DNS side effect (#504).
+            if canonical in existing or canonical in seen_addr:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=(
-                        f"{canonical} already exists in {subnet.network}; "
-                        "re-run with strategy='skip' or 'overwrite'"
+                        f"{canonical} already exists in {subnet.network} or is duplicated "
+                        "in the file; re-run with strategy='skip' or 'overwrite'"
                     ),
                 )
+            seen_addr.add(canonical)
 
     allocated_delta = 0
     for row in payload.addresses:

--- a/backend/app/services/ipam_io/parser.py
+++ b/backend/app/services/ipam_io/parser.py
@@ -106,6 +106,28 @@ def _row_to_subnet(row: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+_ADDRESS_COLUMN_KEYS = ("address", "ip", "ip_address")
+
+
+def _norm_header(h: Any) -> str:
+    """Canonicalise a header/key: lowercase + spaces → underscores. So ``IP``,
+    ``ip`` and ``IP Address`` all collapse to a recognised column name. The
+    row-coercers already normalise this way; detection + presence checks must
+    match or a non-lowercase header silently imports zero rows (#504)."""
+    return str(h).strip().lower().replace(" ", "_")
+
+
+def _row_has_address(row: dict[str, Any]) -> bool:
+    """True if any address column (case/space-insensitive) has a non-empty
+    value — replaces exact-case ``row.get("ip")`` checks that missed ``IP``."""
+    for raw_key, value in row.items():
+        if raw_key is None:
+            continue
+        if _norm_header(raw_key) in _ADDRESS_COLUMN_KEYS and value not in (None, ""):
+            return True
+    return False
+
+
 def _row_to_address(row: dict[str, Any]) -> dict[str, Any]:
     """Coerce a generic row dict into an IPAddress dict with custom_fields.
 
@@ -153,10 +175,10 @@ def _csv_is_address_payload(headers: list[str]) -> bool:
     ``network`` column wins and the row is treated as a subnet) — the
     two formats shouldn't mix in a single file.
     """
-    norm = {h.strip().lower() for h in headers if h}
+    norm = {_norm_header(h) for h in headers if h}
     if "network" in norm:
         return False
-    return bool({"address", "ip", "ip_address"} & norm)
+    return bool(set(_ADDRESS_COLUMN_KEYS) & norm)
 
 
 def parse_csv(data: bytes) -> ParsedPayload:
@@ -168,7 +190,7 @@ def parse_csv(data: bytes) -> ParsedPayload:
         if not any((v or "").strip() for v in row.values() if isinstance(v, str)):
             continue
         if is_addresses:
-            if not any(row.get(k) for k in ("address", "ip", "ip_address")):
+            if not _row_has_address(row):
                 continue
             payload.addresses.append(_row_to_address(row))
         else:
@@ -193,7 +215,7 @@ def parse_json(data: bytes) -> ParsedPayload:
         # and route accordingly. Mixed lists aren't supported (don't do that).
         first = next((x for x in decoded if isinstance(x, dict)), None)
         is_addresses = first is not None and any(
-            k.lower() in ("address", "ip", "ip_address") for k in first.keys()
+            _norm_header(k) in _ADDRESS_COLUMN_KEYS for k in first.keys()
         )
         for item in decoded:
             if not isinstance(item, dict):
@@ -280,13 +302,13 @@ def parse_xlsx(data: bytes) -> ParsedPayload:
         ws = wb[first_sheet]
         headers_iter = ws.iter_rows(min_row=1, max_row=1, values_only=True)
         first_row = next(iter(headers_iter), ())
-        headers_norm = {(str(h).strip().lower() if h is not None else "") for h in first_row}
-        is_addresses = bool({"address", "ip", "ip_address"} & headers_norm) and (
+        headers_norm = {(_norm_header(h) if h is not None else "") for h in first_row}
+        is_addresses = bool(set(_ADDRESS_COLUMN_KEYS) & headers_norm) and (
             "network" not in headers_norm
         )
         for row in _sheet_rows(first_sheet):
             if is_addresses:
-                if not any(row.get(k) for k in ("address", "ip", "ip_address")):
+                if not _row_has_address(row):
                     continue
                 payload.addresses.append(_row_to_address(row))
             else:
@@ -296,7 +318,7 @@ def parse_xlsx(data: bytes) -> ParsedPayload:
 
     if "addresses" in wb.sheetnames:
         for row in _sheet_rows("addresses"):
-            if not any(row.get(k) for k in ("address", "ip", "ip_address")):
+            if not _row_has_address(row):
                 continue
             payload.addresses.append(_row_to_address(row))
 

--- a/backend/app/services/nmap/runner.py
+++ b/backend/app/services/nmap/runner.py
@@ -107,6 +107,15 @@ class NmapArgError(ValueError):
     """Raised when operator-supplied arguments fail validation."""
 
 
+class NmapScanRowMissing(LookupError):
+    """The NmapScan row wasn't visible when the worker picked up the task.
+
+    Almost always the dispatcher committed *after* the worker started (the
+    row is flushed but the caller's transaction hasn't committed yet, #510).
+    The Celery wrapper retries a few times; if the row never appears the
+    caller's transaction rolled back and there is nothing to run."""
+
+
 _HOSTNAME_RE: Final = re.compile(
     # RFC 1123 / 952 hostname: labels of [A-Za-z0-9-] up to 63 chars,
     # joined by dots, no leading/trailing hyphen per label, total
@@ -398,8 +407,11 @@ async def run_scan(scan_id: uuid.UUID) -> None:
         async with factory() as db:
             scan = await db.get(NmapScan, scan_id)
             if scan is None:
+                # Not visible yet — signal the wrapper to retry (commit race)
+                # rather than silently no-op'ing and leaving the row stuck in
+                # "queued" forever, occupying a per-subnet profile slot (#510).
                 logger.warning("nmap_run_scan_missing", scan_id=str(scan_id))
-                return
+                raise NmapScanRowMissing(str(scan_id))
 
             # Operator cancelled before we picked it up — bow out.
             if scan.status == "cancelled":

--- a/backend/app/tasks/ipam_discovery.py
+++ b/backend/app/tasks/ipam_discovery.py
@@ -28,7 +28,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.celery_app import celery_app
@@ -38,6 +38,11 @@ from app.models.ipam import Subnet
 from app.services.ipam.discovery import reconcile_subnet, sweep_subnet
 
 logger = structlog.get_logger(__name__)
+
+# Namespace for the per-subnet discovery advisory lock (#515). The second key
+# is hashtext(subnet_id); this int just separates the keyspace from any other
+# two-int advisory lock in the app.
+_DISCOVERY_LOCK_NS = 0x1DA_D15C  # "IPAM DISC"
 
 
 async def _run_subnet_discovery_async(subnet_id_str: str) -> dict[str, Any]:
@@ -49,6 +54,20 @@ async def _run_subnet_discovery_async(subnet_id_str: str) -> dict[str, Any]:
         return {"status": "skipped", "reason": "bad_subnet_id"}
     try:
         async with factory() as db:
+            # Per-subnet session advisory lock: the dispatcher gates on
+            # last_discovery_at, which is only stamped at completion, so a sweep
+            # slower than the 60s beat tick gets re-dispatched while still
+            # running — two runs then race to insert the same discovered IP and
+            # collide on uq_ip_address_subnet_address, aborting one whole commit.
+            # try-lock and bow out if another run holds it (#515). Released when
+            # engine.dispose() closes the connection in the finally below.
+            locked = await db.scalar(
+                text("SELECT pg_try_advisory_lock(:ns, hashtext(:sid))"),
+                {"ns": _DISCOVERY_LOCK_NS, "sid": subnet_id_str},
+            )
+            if not locked:
+                logger.info("ipam.discovery.already_running", subnet_id=subnet_id_str)
+                return {"status": "skipped", "reason": "already_running"}
             # Subnet.id is UUID(as_uuid=True) — pass a real UUID, not the
             # raw string, so the bind is unambiguous on asyncpg/psycopg
             # (matches the convention in the other Celery tasks).

--- a/backend/app/tasks/nmap.py
+++ b/backend/app/tasks/nmap.py
@@ -23,7 +23,7 @@ from app.services.nmap.runner import NmapScanRowMissing, run_scan
 logger = structlog.get_logger(__name__)
 
 
-@celery_app.task(name="app.tasks.nmap.run_scan", bind=True, max_retries=5)
+@celery_app.task(name="app.tasks.nmap.run_scan", bind=True, max_retries=8)
 def run_scan_task(self: Any, scan_id_str: str) -> dict[str, str]:
     """Drive one nmap scan from start to finish.
 
@@ -36,12 +36,15 @@ def run_scan_task(self: Any, scan_id_str: str) -> dict[str, str]:
     try:
         asyncio.run(run_scan(scan_id))
     except NmapScanRowMissing as exc:
-        # The dispatcher flushed the row but hadn't committed when we picked
-        # up the task. Retry a few times; if it never appears the caller's
-        # transaction rolled back and there's nothing (and no stuck row) to
-        # run (#510).
+        # The dispatcher flushed the row but hadn't committed when we picked up
+        # the task. Retry with capped exponential backoff — a lease-event
+        # dispatch commits at the end of a potentially large batch, so the row
+        # can legitimately be invisible for >10s (Copilot review of #510). 8
+        # retries at 1,2,4,8,16,30,30,30s cover ~2min before we conclude the
+        # caller's transaction rolled back (nothing, and no stuck row, to run).
+        countdown = min(2**self.request.retries, 30)
         try:
-            raise self.retry(exc=exc, countdown=2) from exc
+            raise self.retry(exc=exc, countdown=countdown) from exc
         except self.MaxRetriesExceededError:
             logger.warning("nmap_run_scan_never_appeared", scan_id=scan_id_str)
             return {"scan_id": scan_id_str, "status": "missing"}

--- a/backend/app/tasks/nmap.py
+++ b/backend/app/tasks/nmap.py
@@ -2,9 +2,11 @@
 
 The runner in :mod:`app.services.nmap.runner` does all the real work;
 this module exists purely so the API can dispatch a scan onto a
-worker and return 202 immediately. Scans are explicitly **not
-retried** — the operator triggers them, and re-running on a worker
-crash would replay potentially noisy port traffic without consent.
+worker and return 202 immediately. A *started* scan is never retried —
+re-running on a worker crash would replay potentially noisy port
+traffic without consent. The **only** retry is for a not-yet-visible
+row (``NmapScanRowMissing``): that fires before any scan traffic and
+absorbs the dispatch-before-commit race (#510).
 """
 
 from __future__ import annotations
@@ -16,13 +18,13 @@ from typing import Any
 import structlog
 
 from app.celery_app import celery_app
-from app.services.nmap.runner import run_scan
+from app.services.nmap.runner import NmapScanRowMissing, run_scan
 
 logger = structlog.get_logger(__name__)
 
 
-@celery_app.task(name="app.tasks.nmap.run_scan", bind=True, max_retries=0)
-def run_scan_task(self: Any, scan_id_str: str) -> dict[str, str]:  # noqa: ARG001
+@celery_app.task(name="app.tasks.nmap.run_scan", bind=True, max_retries=5)
+def run_scan_task(self: Any, scan_id_str: str) -> dict[str, str]:
     """Drive one nmap scan from start to finish.
 
     The runner persists everything it needs into the row as it goes,
@@ -31,5 +33,16 @@ def run_scan_task(self: Any, scan_id_str: str) -> dict[str, str]:  # noqa: ARG00
     """
     scan_id = uuid.UUID(scan_id_str)
     logger.info("nmap_run_scan_task_started", scan_id=scan_id_str)
-    asyncio.run(run_scan(scan_id))
+    try:
+        asyncio.run(run_scan(scan_id))
+    except NmapScanRowMissing as exc:
+        # The dispatcher flushed the row but hadn't committed when we picked
+        # up the task. Retry a few times; if it never appears the caller's
+        # transaction rolled back and there's nothing (and no stuck row) to
+        # run (#510).
+        try:
+            raise self.retry(exc=exc, countdown=2) from exc
+        except self.MaxRetriesExceededError:
+            logger.warning("nmap_run_scan_never_appeared", scan_id=scan_id_str)
+            return {"scan_id": scan_id_str, "status": "missing"}
     return {"scan_id": scan_id_str}

--- a/frontend/src/lib/cidr.ts
+++ b/frontend/src/lib/cidr.ts
@@ -1,5 +1,6 @@
-// Minimal IPv4 CIDR utilities for client-side validation of drag-drop targets.
-// IPv6 is not supported here (matches Phase-1 IPAM scope).
+// CIDR utilities for client-side validation of drag-drop targets. IPv4 uses a
+// fast 32-bit int path; IPv6 containment goes through a BigInt path so a v6
+// re-parent isn't rejected client-side (#513).
 
 function ipToInt(ip: string): number | null {
   const parts = ip.split(".");
@@ -34,14 +35,36 @@ export function parseCidr(cidr: string): ParsedCidr | null {
 
 /**
  * Return true if `child` CIDR is fully contained within `parent` CIDR.
- * (A network is a subnet of itself.) IPv4 only.
+ * (A network is a subnet of itself.) Handles IPv4 and IPv6; a mixed-family
+ * pair is never contained.
  */
 export function cidrContains(parent: string, child: string): boolean {
-  const p = parseCidr(parent);
-  const c = parseCidr(child);
-  if (!p || !c) return false;
-  if (c.prefix < p.prefix) return false;
-  return (c.base & p.mask) >>> 0 === p.base;
+  const pV6 = parent.includes(":");
+  const cV6 = child.includes(":");
+  if (pV6 !== cV6) return false;
+  if (!pV6) {
+    // IPv4 fast path (unchanged).
+    const p = parseCidr(parent);
+    const c = parseCidr(child);
+    if (!p || !c) return false;
+    if (c.prefix < p.prefix) return false;
+    return (c.base & p.mask) >>> 0 === p.base;
+  }
+  // IPv6 — BigInt containment (parseCidr is 32-bit only).
+  const [pIp, pPre] = parent.split("/");
+  const [cIp, cPre] = child.split("/");
+  if (pPre === undefined || cPre === undefined) return false;
+  const pPrefix = Number(pPre);
+  const cPrefix = Number(cPre);
+  if (!Number.isInteger(pPrefix) || !Number.isInteger(cPrefix)) return false;
+  if (pPrefix < 0 || pPrefix > 128 || cPrefix < 0 || cPrefix > 128)
+    return false;
+  if (cPrefix < pPrefix) return false;
+  const mask =
+    pPrefix === 0
+      ? 0n
+      : ((1n << BigInt(pPrefix)) - 1n) << BigInt(128 - pPrefix);
+  return (addressToBigInt(cIp) & mask) === (addressToBigInt(pIp) & mask);
 }
 
 /**

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -5397,7 +5397,12 @@ function SubnetDetail({
                             a.status !== "broadcast" &&
                             !a.auto_from_lease &&
                             // Never select a row the table is currently hiding.
-                            !(hideReserved && isPaddingRow(a)),
+                            !(hideReserved && isPaddingRow(a)) &&
+                            // Only rows the caller can actually write — matches
+                            // the per-row checkbox gate so a delegated operator
+                            // (address sets, #103) can't select rows a bulk op
+                            // would then partially 403 (#514).
+                            permitsWriteIp(a.address),
                         );
                         const allSelected =
                           selectable.length > 0 &&
@@ -5809,7 +5814,11 @@ function SubnetDetail({
                                           if (
                                             a.status === "network" ||
                                             a.status === "broadcast" ||
-                                            a.auto_from_lease
+                                            a.auto_from_lease ||
+                                            // Skip rows the caller can't write so
+                                            // a shift-range can't sweep in
+                                            // un-writable rows (#514).
+                                            !permitsWriteIp(a.address)
                                           )
                                             continue;
                                           ids.push(a.id);

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -9863,6 +9863,9 @@ function BulkDeleteAddressesModal({
     mutationFn: () => ipamApi.bulkDeleteAddresses({ ip_ids: ipIds, permanent }),
     onSuccess: (res) => {
       qc.invalidateQueries({ queryKey: ["addresses", subnetId] });
+      // Refresh subnet utilization (tree dot + space-table "Used IPs") the way
+      // the single-delete path does — bulk-delete was missing this (#509).
+      qc.invalidateQueries({ queryKey: ["subnets"] });
       qc.invalidateQueries({ queryKey: ["dns-records"] });
       qc.invalidateQueries({ queryKey: ["dns-group-records"] });
       qc.invalidateQueries({ queryKey: ["dns-zones"] });
@@ -14686,6 +14689,18 @@ export function IPAMPage() {
     queryFn: () => ipamApi.listSubnets({ space_id: activeSpaceId }),
     enabled: !!activeSpaceId,
   });
+
+  // Keep the subnet-detail header in sync with the refetched list.
+  // selectedSubnet is a snapshot set only on click/edit, so IP mutations that
+  // invalidate ["subnets"] refreshed the tree but left the header's
+  // "Allocated N / M" + utilization bar (and the Ask-AI context) stale (#509).
+  useEffect(() => {
+    if (!selectedSubnet || !detailSubnets) return;
+    const fresh = detailSubnets.find((s) => s.id === selectedSubnet.id);
+    if (fresh && JSON.stringify(fresh) !== JSON.stringify(selectedSubnet)) {
+      setSelectedSubnet(fresh);
+    }
+  }, [detailSubnets, selectedSubnet]);
 
   function selectSubnet(subnet: Subnet | null) {
     setSelectedSubnet(subnet);


### PR DESCRIPTION
Fixes all thirteen **medium**-severity IPAM bugs from the 2026-07-02 review sweep. Each is its own commit; the low-severity frontend polish grab-bag (#516) is out of scope for this PR.

## Import / IPv6
- **#503** — the importer re-implemented the total-IP math without the `2**63-1` clamp, so an IPv6 `/64` overflowed the BIGINT `total_ips` and 500'd the whole commit. Reuse the shared `_total_ips`.
- **#504** — importer robustness cluster: normalise headers (lower + space→underscore) so `IP` / `IP Address` import instead of silently yielding zero rows; accept every exported status so a subnet's own export round-trips; validate `mac_address` + `gateway` before flush (error row, not a DataError → 500); catch intra-payload duplicates in the fail-strategy pre-flight before any create/DNS side effect.
- **#506** — the network/broadcast/gateway placeholder-row gate was a flat `prefixlen < 31` (v4 logic), so every realistic IPv6 subnet got no placeholder rows; make it version-aware (`< 127` for v6) in both `create_subnet` and `update_subnet`.
- **#513** — `cidr.ts` was IPv4-only, so `cidrContains` failed closed for IPv6 and the tree's drag-drop re-parent rejected every legal v6 move. Add a BigInt containment path for v6.

## Invariants / validation
- **#505** — `plan-apply` now stamps the multicast `kind` (was always `unicast`, defeating the #126 discriminator), validates the gateway is inside the subnet, and creates placeholder rows like `create_subnet`. (Reverse-zone auto-create deferred — DNS convenience, not data integrity.)
- **#511** — NAT `internal_ip` / `external_ip` reached the INET column unvalidated → asyncpg DataError → 500. Add field validators on the create + update schemas and validate the `?internal_ip=` / `?external_ip=` list filters → 422.

## RBAC
- **#508** — the router-level gate admits an any-of grant over the whole IPAM surface (incl. `nat_mapping` / `custom_field`), and the structural handlers had no inline per-type check — so a peripheral grant could create/mutate spaces, blocks, and subnets. Add a `_require_type_write` gate to create/update space/block/subnet, and require subnet write in plan-apply (router gates `ip_block` only).
- **#514** — select-all and shift-range selection excluded only system/lease rows, not un-writable ones — so an address-set-delegated operator (#103) could select rows a bulk op would then partially 403. Filter both on `permitsWriteIp`, matching the per-row checkbox.

## Convergence / correctness
- **#507** — `GET /subnets/{id}/effective-dns` stopped at the root block and returned empty, while `_resolve_effective_dns` (the record-routing path) falls through to the space — so the UI showed 'no DNS' while allocations published into the space zone. Mirror the space fallthrough.
- **#509** — `bulk_edit_addresses` now clears `reserved_until` on a status change and recomputes subnet + block-rollup utilization; the frontend bulk-delete invalidates `['subnets']` and the subnet-detail header syncs from the refetched list, so its 'Allocated N / M' + utilization bar no longer freeze.
- **#510** — auto-profile dispatched the scan task before the caller's commit; a worker that picked it up first found no row, no-op'd, and left the scan stuck `queued` forever, occupying a per-subnet slot. `run_scan` now raises `NmapScanRowMissing` and the task retries only that pre-scan case (never a started scan).
- **#512** — subnet soft-delete now `collect_wake`s the DHCP groups whose scopes it trashes (was waiting on the 12s tick), and permanent delete enqueues a delete op per DNS record through the record-ops chokepoint so an agentless (Windows DNS) primary is retracted (a bare `sa_delete` left the records live). Block/space delete analogs noted as follow-up.
- **#515** — `dispatch_due_subnets` gates on `last_discovery_at` (stamped only at completion), so a sweep slower than the 60s tick got re-dispatched and two reconcile passes raced to insert the same discovered IP, colliding on the unique constraint. `run_subnet_discovery` now takes a per-subnet advisory lock and bows out if another run holds it (migration-free).

## Verification
ruff / black / mypy clean on all 9 changed backend files; eslint (`--max-warnings 0`) / prettier / `tsc -b` + vite build clean on frontend; single alembic head (no new migration); migration-shape linter OK; backend imports smoke-tested. DB-backed pytest runs in CI (no Postgres in the sandbox).

## Deliberate partials (noted, not regressions)
- #505 reverse-zone auto-create on plan-apply (DNS convenience).
- #512 block/space delete wake analogs (same pattern, cascades through subnet scopes).

Closes #503
Closes #504
Closes #505
Closes #506
Closes #507
Closes #508
Closes #509
Closes #510
Closes #511
Closes #512
Closes #513
Closes #514
Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)