### PR TITLE
feat: Wake-on-LAN — IP modal button, Network Tools page, and Operator Copilot (#533)

### DIFF
--- a/agent/supervisor/spatium_supervisor/nettools.py
+++ b/agent/supervisor/spatium_supervisor/nettools.py
@@ -714,6 +714,56 @@ async def _run_firewall_logs(params: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# ── wake-on-lan ──────────────────────────────────────────────────────
+
+_WOL_HEX12_RE: Final = re.compile(r"^[0-9A-Fa-f]{12}$")
+
+
+def _wol_normalize_mac(mac: str) -> str:
+    stripped = re.sub(r"[:.\-]", "", mac.strip())
+    if not _WOL_HEX12_RE.match(stripped):
+        raise NetToolArgError(f"not a valid MAC address: {mac!r}")
+    low = stripped.lower()
+    return ":".join(low[i : i + 2] for i in range(0, 12, 2))
+
+
+def _send_magic_packet(mac: str, broadcast: str, port: int) -> None:
+    mac_bytes = bytes.fromhex(_wol_normalize_mac(mac).replace(":", ""))
+    packet = b"\xff" * 6 + mac_bytes * 16  # AMD Magic Packet, 102 bytes
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.sendto(packet, (broadcast, port))
+
+
+async def _run_wol(params: dict[str, Any]) -> dict[str, Any]:
+    """Send a Wake-on-LAN magic packet from the supervisor's local vantage
+    (#533) so it originates on the target's broadcast domain. Re-validates
+    MAC + broadcast — the control plane already did; this executor is a
+    re-validation point. Returns the backend ``WolResult`` shape."""
+    mac = _wol_normalize_mac(str(params.get("mac", "")))
+    raw_bcast = str(params.get("broadcast", "")).strip()
+    try:
+        broadcast = str(ipaddress.IPv4Address(raw_bcast))
+    except ipaddress.AddressValueError as exc:
+        raise NetToolArgError(
+            f"broadcast must be an IPv4 address: {raw_bcast!r}"
+        ) from exc
+    try:
+        port = int(params.get("port", 9))
+    except (TypeError, ValueError) as exc:
+        raise NetToolArgError("port must be an integer") from exc
+    if not 1 <= port <= 65535:
+        raise NetToolArgError("port must be between 1 and 65535")
+    await asyncio.to_thread(_send_magic_packet, mac, broadcast, port)
+    return {
+        "mac": mac,
+        "broadcast": broadcast,
+        "port": port,
+        "sent": True,
+        "ran_from": "server",
+    }
+
+
 # ── dispatch ─────────────────────────────────────────────────────────
 
 # The reachability tools this executor knows how to run. Mirrors the
@@ -729,6 +779,9 @@ _RUNNERS: Final[dict[str, Any]] = {
     # #404 — appliance-diagnostic tool (not a reachability probe), dispatched
     # the same way; the backend allows it via an explicit allow-set.
     "firewall_logs": _run_firewall_logs,
+    # #533 — Wake-on-LAN. Not a reachability probe; dispatched from the IP
+    # detail modal so the packet originates on the target's segment.
+    "wol": _run_wol,
 }
 
 # True reachability probes only — keep firewall_logs out of this so the set

--- a/agent/supervisor/spatium_supervisor/nettools.py
+++ b/agent/supervisor/spatium_supervisor/nettools.py
@@ -748,6 +748,13 @@ async def _run_wol(params: dict[str, Any]) -> dict[str, Any]:
         raise NetToolArgError(
             f"broadcast must be an IPv4 address: {raw_bcast!r}"
         ) from exc
+    # Defence-in-depth SSRF denylist (same as every other network-reaching
+    # param here) — refuse loopback / link-local / metadata even if the
+    # control plane somehow enqueued one.
+    if _is_blocked_target(broadcast):
+        raise NetToolArgError(
+            f"broadcast {broadcast!r} is in a blocked range and cannot be targeted"
+        )
     try:
         port = int(params.get("port", 9))
     except (TypeError, ValueError) as exc:

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -144,6 +144,12 @@ from app.api.v1.ipam.plans import router as plans_router  # noqa: E402
 
 router.include_router(plans_router)
 
+# Wake-on-LAN (issue #533) — POST /api/v1/ipam/addresses/{id}/wake sends a
+# magic packet to the IP's MAC from the server or an appliance vantage.
+from app.api.v1.ipam.wake import router as wake_router  # noqa: E402
+
+router.include_router(wake_router)
+
 # ── Internal helpers ───────────────────────────────────────────────────────────
 
 

--- a/backend/app/api/v1/ipam/wake.py
+++ b/backend/app/api/v1/ipam/wake.py
@@ -26,9 +26,7 @@ from pydantic import BaseModel, Field
 from app.api.deps import DB, CurrentUser
 from app.api.v1.dhcp._audit import write_audit
 from app.core.permissions import require_permission
-from app.models.appliance import Appliance
 from app.services import wol
-from app.services.appliance import agent_cmd
 from app.services.nettools.schemas import NetToolTarget
 
 router = APIRouter(tags=["ipam"])
@@ -73,37 +71,7 @@ async def wake_address(
 
     wire = wol.WolWireRequest(mac=mac, broadcast=broadcast, port=body.port)
     target = body.target or NetToolTarget()
-
-    if target.kind == "server":
-        try:
-            await wol.send_magic_packet(wire.mac, wire.broadcast, wire.port)
-        except OSError as exc:
-            # No route to the broadcast (ENETUNREACH etc.) is the documented
-            # single-box limitation — surface it cleanly like the appliance
-            # path's 502 rather than a raw 500.
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=(
-                    f"Could not broadcast the magic packet from the server: {exc}. "
-                    "Try an appliance vantage on the target's segment."
-                ),
-            ) from exc
-        result = wol.WolResult(
-            mac=wire.mac,
-            broadcast=wire.broadcast,
-            port=wire.port,
-            sent=True,
-            ran_from="server",
-        )
-    elif target.kind == "appliance":
-        result = await _wake_via_appliance(db, current_user, wire, target)
-    else:
-        # dns_agent / dhcp_agent vantages are reserved in NetToolTarget but
-        # not wired for WoL yet — reject clearly rather than silently no-op.
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Wake-on-LAN cannot run from a {target.kind!r} vantage.",
-        )
+    result = await _run_wake(db, wire, target)
 
     write_audit(
         db,
@@ -124,48 +92,25 @@ async def wake_address(
     return result
 
 
-async def _wake_via_appliance(
-    db: DB,
-    current_user: CurrentUser,
-    wire: wol.WolWireRequest,
-    target: NetToolTarget,
-) -> wol.WolResult:
-    if target.id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="target.id is required when target.kind is 'appliance'.",
-        )
-    appliance = await db.get(Appliance, target.id)
-    if appliance is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Appliance not found.")
-    ready = agent_cmd.appliance_ready(state=appliance.state, last_seen_at=appliance.last_seen_at)
+async def _run_wake(db: DB, wire: wol.WolWireRequest, target: NetToolTarget) -> wol.WolResult:
+    """Send via the requested vantage, translating WolDispatchError → HTTP.
+    The heavy lifting (wake_from_server / wake_via_appliance) lives in the wol
+    service and is shared with POST /tools/wol; this is just the HTTP mapping."""
     try:
-        outcome = await agent_cmd.enqueue_command(
-            appliance.id,
-            "wol",
-            wire.model_dump(mode="json"),
-            ready=ready,
-            # Match the sibling nettool dispatch (tools/router.py): a busy
-            # supervisor mid-poll needs headroom or a healthy appliance 504s.
-            timeout=30.0,
-        )
-    except agent_cmd.ApplianceOffline as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Appliance {appliance.hostname!r} is offline or not approved.",
-        ) from exc
-    except TimeoutError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-            detail=f"Appliance {appliance.hostname!r} did not send the packet in time.",
-        ) from exc
-    if outcome.error is not None or outcome.result is None:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=(
-                f"Appliance {appliance.hostname!r} could not send the magic packet: "
-                f"{outcome.error or 'no result returned'}"
-            ),
-        )
-    result = wol.WolResult.model_validate(outcome.result)
-    return result.model_copy(update={"ran_from": f"appliance:{appliance.hostname}"})
+        if target.kind == "server":
+            return await wol.wake_from_server(wire)
+        if target.kind == "appliance":
+            if target.id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="target.id is required when target.kind is 'appliance'.",
+                )
+            return await wol.wake_via_appliance(db, target.id, wire)
+    except wol.WolDispatchError as exc:
+        raise HTTPException(status_code=exc.status, detail=str(exc)) from exc
+    # dns_agent / dhcp_agent vantages are reserved in NetToolTarget but not
+    # wired for WoL yet — reject clearly rather than silently no-op.
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"Wake-on-LAN cannot run from a {target.kind!r} vantage.",
+    )

--- a/backend/app/api/v1/ipam/wake.py
+++ b/backend/app/api/v1/ipam/wake.py
@@ -18,7 +18,6 @@ the IP row, like the other active tools.
 
 from __future__ import annotations
 
-import ipaddress
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -28,7 +27,6 @@ from app.api.deps import DB, CurrentUser
 from app.api.v1.dhcp._audit import write_audit
 from app.core.permissions import require_permission
 from app.models.appliance import Appliance
-from app.models.ipam import IPAddress, Subnet
 from app.services import wol
 from app.services.appliance import agent_cmd
 from app.services.nettools.schemas import NetToolTarget
@@ -36,9 +34,11 @@ from app.services.nettools.schemas import NetToolTarget
 router = APIRouter(tags=["ipam"])
 
 # WoL is a network tool — reuse the existing tools permission (already seeded
-# into the Network Editor built-in role) rather than minting a new one.
+# into the Network Editor built-in role). ``read`` matches the rest of the
+# network-tools surface (ping / nmap / dig all gate on read:use_network_tools),
+# so an operator granted read to unlock the tools page can also wake a host.
 PERMISSION = "use_network_tools"
-_RequirePerm = Depends(require_permission("write", PERMISSION))
+_RequirePerm = Depends(require_permission("read", PERMISSION))
 
 
 class WakeRequest(BaseModel):
@@ -46,17 +46,6 @@ class WakeRequest(BaseModel):
     # Optional run-from vantage. None / kind="server" ⇒ the api container
     # sends; kind="appliance" + id ⇒ dispatch to that appliance's segment.
     target: NetToolTarget | None = None
-
-
-def _broadcast_for_subnet(subnet: Subnet) -> str:
-    """Directed broadcast of the IP's subnet for IPv4; the limited broadcast
-    (255.255.255.255) for an IPv6 subnet, which has no broadcast address of
-    its own — the magic packet is L2 and the target MAC is what wakes the
-    NIC, so the local-segment broadcast still delivers it."""
-    net = ipaddress.ip_network(str(subnet.network), strict=False)
-    if isinstance(net, ipaddress.IPv6Network):
-        return "255.255.255.255"
-    return str(net.broadcast_address)
 
 
 @router.post(
@@ -70,34 +59,35 @@ async def wake_address(
     db: DB,
     current_user: CurrentUser,
 ) -> wol.WolResult:
-    ip = await db.get(IPAddress, address_id)
-    if ip is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP address not found")
-    if not ip.mac_address:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="This IP has no MAC address on record — Wake-on-LAN needs one.",
-        )
-    subnet = await db.get(Subnet, ip.subnet_id)
-    if subnet is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
-
-    # Validate MAC + broadcast up front (shared with the agent wire shape).
+    # Shared resolver — same IP → (mac, broadcast) derivation the AI operation
+    # uses, so the logic + messages don't drift.
     try:
-        wire = wol.WolWireRequest(
-            mac=str(ip.mac_address),
-            broadcast=_broadcast_for_subnet(subnet),
-            port=body.port,
-        )
-    except ValueError as exc:  # bad MAC on the row
+        ip, mac, broadcast = await wol.resolve_wake_params(db, address_id)
+    except wol.WolTargetError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            status_code=(
+                status.HTTP_404_NOT_FOUND if exc.not_found else status.HTTP_422_UNPROCESSABLE_ENTITY
+            ),
+            detail=str(exc),
         ) from exc
 
+    wire = wol.WolWireRequest(mac=mac, broadcast=broadcast, port=body.port)
     target = body.target or NetToolTarget()
 
     if target.kind == "server":
-        await wol.send_magic_packet(wire.mac, wire.broadcast, wire.port)
+        try:
+            await wol.send_magic_packet(wire.mac, wire.broadcast, wire.port)
+        except OSError as exc:
+            # No route to the broadcast (ENETUNREACH etc.) is the documented
+            # single-box limitation — surface it cleanly like the appliance
+            # path's 502 rather than a raw 500.
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=(
+                    f"Could not broadcast the magic packet from the server: {exc}. "
+                    "Try an appliance vantage on the target's segment."
+                ),
+            ) from exc
         result = wol.WolResult(
             mac=wire.mac,
             broadcast=wire.broadcast,
@@ -155,7 +145,9 @@ async def _wake_via_appliance(
             "wol",
             wire.model_dump(mode="json"),
             ready=ready,
-            timeout=15.0,
+            # Match the sibling nettool dispatch (tools/router.py): a busy
+            # supervisor mid-poll needs headroom or a healthy appliance 504s.
+            timeout=30.0,
         )
     except agent_cmd.ApplianceOffline as exc:
         raise HTTPException(

--- a/backend/app/api/v1/ipam/wake.py
+++ b/backend/app/api/v1/ipam/wake.py
@@ -1,0 +1,179 @@
+"""Wake-on-LAN action for an IP address (issue #533).
+
+A single ``POST /ipam/addresses/{id}/wake`` that sends a magic packet to
+the IP's MAC. The broadcast target is derived from the IP's subnet, so the
+UI just needs the address id. Two vantages, mirroring the network-tools
+pattern:
+
+* ``server`` (default) — the api container broadcasts directly. Only wakes
+  hosts on a segment the control plane can reach (the common single-box
+  case).
+* ``appliance`` — dispatch to a Fleet appliance whose NIC sits on the
+  target's segment, so the packet originates in the right broadcast
+  domain. Reuses the generic nettool command channel (``agent_cmd``).
+
+Gated by ``use_network_tools`` (WoL is a network tool) and audited against
+the IP row, like the other active tools.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from app.api.deps import DB, CurrentUser
+from app.api.v1.dhcp._audit import write_audit
+from app.core.permissions import require_permission
+from app.models.appliance import Appliance
+from app.models.ipam import IPAddress, Subnet
+from app.services import wol
+from app.services.appliance import agent_cmd
+from app.services.nettools.schemas import NetToolTarget
+
+router = APIRouter(tags=["ipam"])
+
+# WoL is a network tool — reuse the existing tools permission (already seeded
+# into the Network Editor built-in role) rather than minting a new one.
+PERMISSION = "use_network_tools"
+_RequirePerm = Depends(require_permission("write", PERMISSION))
+
+
+class WakeRequest(BaseModel):
+    port: int = Field(default=9, ge=1, le=65535)
+    # Optional run-from vantage. None / kind="server" ⇒ the api container
+    # sends; kind="appliance" + id ⇒ dispatch to that appliance's segment.
+    target: NetToolTarget | None = None
+
+
+def _broadcast_for_subnet(subnet: Subnet) -> str:
+    """Directed broadcast of the IP's subnet for IPv4; the limited broadcast
+    (255.255.255.255) for an IPv6 subnet, which has no broadcast address of
+    its own — the magic packet is L2 and the target MAC is what wakes the
+    NIC, so the local-segment broadcast still delivers it."""
+    net = ipaddress.ip_network(str(subnet.network), strict=False)
+    if isinstance(net, ipaddress.IPv6Network):
+        return "255.255.255.255"
+    return str(net.broadcast_address)
+
+
+@router.post(
+    "/addresses/{address_id}/wake",
+    response_model=wol.WolResult,
+    dependencies=[_RequirePerm],
+)
+async def wake_address(
+    address_id: uuid.UUID,
+    body: WakeRequest,
+    db: DB,
+    current_user: CurrentUser,
+) -> wol.WolResult:
+    ip = await db.get(IPAddress, address_id)
+    if ip is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP address not found")
+    if not ip.mac_address:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="This IP has no MAC address on record — Wake-on-LAN needs one.",
+        )
+    subnet = await db.get(Subnet, ip.subnet_id)
+    if subnet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
+
+    # Validate MAC + broadcast up front (shared with the agent wire shape).
+    try:
+        wire = wol.WolWireRequest(
+            mac=str(ip.mac_address),
+            broadcast=_broadcast_for_subnet(subnet),
+            port=body.port,
+        )
+    except ValueError as exc:  # bad MAC on the row
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
+
+    target = body.target or NetToolTarget()
+
+    if target.kind == "server":
+        await wol.send_magic_packet(wire.mac, wire.broadcast, wire.port)
+        result = wol.WolResult(
+            mac=wire.mac,
+            broadcast=wire.broadcast,
+            port=wire.port,
+            sent=True,
+            ran_from="server",
+        )
+    elif target.kind == "appliance":
+        result = await _wake_via_appliance(db, current_user, wire, target)
+    else:
+        # dns_agent / dhcp_agent vantages are reserved in NetToolTarget but
+        # not wired for WoL yet — reject clearly rather than silently no-op.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Wake-on-LAN cannot run from a {target.kind!r} vantage.",
+        )
+
+    write_audit(
+        db,
+        user=current_user,
+        action="wake_on_lan",
+        resource_type="ip_address",
+        resource_id=str(ip.id),
+        resource_display=str(ip.address),
+        new_value={
+            "mac": wire.mac,
+            "broadcast": wire.broadcast,
+            "port": wire.port,
+            "ran_from": result.ran_from,
+        },
+        result="success" if result.sent else "failure",
+    )
+    await db.commit()
+    return result
+
+
+async def _wake_via_appliance(
+    db: DB,
+    current_user: CurrentUser,
+    wire: wol.WolWireRequest,
+    target: NetToolTarget,
+) -> wol.WolResult:
+    if target.id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="target.id is required when target.kind is 'appliance'.",
+        )
+    appliance = await db.get(Appliance, target.id)
+    if appliance is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Appliance not found.")
+    ready = agent_cmd.appliance_ready(state=appliance.state, last_seen_at=appliance.last_seen_at)
+    try:
+        outcome = await agent_cmd.enqueue_command(
+            appliance.id,
+            "wol",
+            wire.model_dump(mode="json"),
+            ready=ready,
+            timeout=15.0,
+        )
+    except agent_cmd.ApplianceOffline as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Appliance {appliance.hostname!r} is offline or not approved.",
+        ) from exc
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=f"Appliance {appliance.hostname!r} did not send the packet in time.",
+        ) from exc
+    if outcome.error is not None or outcome.result is None:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                f"Appliance {appliance.hostname!r} could not send the magic packet: "
+                f"{outcome.error or 'no result returned'}"
+            ),
+        )
+    result = wol.WolResult.model_validate(outcome.result)
+    return result.model_copy(update={"ran_from": f"appliance:{appliance.hostname}"})

--- a/backend/app/api/v1/tools/router.py
+++ b/backend/app/api/v1/tools/router.py
@@ -75,6 +75,7 @@ from app.services.nettools import (
     test_port,
 )
 from app.services.nettools.runner import NetToolArgError
+from app.services.nettools.schemas import is_blocked_target
 from app.services.nettools.throttle import RateLimitDefault, RateLimitOffprem
 from app.services.oui import bulk_lookup_vendors, is_voip_phone_vendor, normalize_mac_key
 
@@ -477,9 +478,17 @@ class WolToolRequest(BaseModel):
         if v is None or not v.strip():
             return None
         try:
-            return str(ipaddress.IPv4Address(v.strip()))
+            canonical = str(ipaddress.IPv4Address(v.strip()))
         except ipaddress.AddressValueError as exc:
             raise ValueError(f"broadcast must be an IPv4 address: {v!r}") from exc
+        # Same SSRF denylist as the rest of the network-tools surface — WoL
+        # must not become a way to fire UDP at loopback / link-local / metadata.
+        if is_blocked_target(canonical):
+            raise ValueError(
+                f"broadcast {canonical} is in a blocked range (loopback / "
+                "link-local / cloud-metadata) and cannot be targeted"
+            )
+        return canonical
 
 
 @router.post("/wol", response_model=wol.WolResult, dependencies=[_RequirePerm])

--- a/backend/app/api/v1/tools/router.py
+++ b/backend/app/api/v1/tools/router.py
@@ -29,11 +29,12 @@ stay server-only and reject a non-server target.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import time
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from app.api.deps import DB, CurrentUser
 from app.api.v1.dns_tools import (
@@ -62,6 +63,7 @@ from app.core.permissions import require_permission
 from app.models.appliance import Appliance
 from app.models.audit import AuditLog
 from app.models.settings import PlatformSettings
+from app.services import wol
 from app.services.appliance import agent_cmd
 from app.services.nettools import (
     inspect_tls_cert,
@@ -450,3 +452,81 @@ async def mac_vendor(body: MacVendorRequest, db: DB, _rl=RateLimitDefault) -> Ma
             )
         )
     return MacVendorResult(oui_enabled=oui_enabled, entries=entries)
+
+
+class WolToolRequest(BaseModel):
+    """Standalone Wake-on-LAN request (#533) — keyed on a MAC, not an IP row.
+
+    ``broadcast`` is optional: omit it to hit the local segment's limited
+    broadcast (255.255.255.255). ``target`` picks the vantage like the other
+    reachability tools."""
+
+    mac: str
+    broadcast: str | None = None
+    port: int = Field(default=9, ge=1, le=65535)
+    target: NetToolTarget | None = None
+
+    @field_validator("mac")
+    @classmethod
+    def _v_mac(cls, v: str) -> str:
+        return wol.normalize_mac(v)
+
+    @field_validator("broadcast")
+    @classmethod
+    def _v_broadcast(cls, v: str | None) -> str | None:
+        if v is None or not v.strip():
+            return None
+        try:
+            return str(ipaddress.IPv4Address(v.strip()))
+        except ipaddress.AddressValueError as exc:
+            raise ValueError(f"broadcast must be an IPv4 address: {v!r}") from exc
+
+
+@router.post("/wol", response_model=wol.WolResult, dependencies=[_RequirePerm])
+async def wol_wake(
+    body: WolToolRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
+) -> wol.WolResult:
+    """Send a Wake-on-LAN magic packet to a MAC from the server or an
+    appliance vantage. Audited (`action="wake_on_lan"`)."""
+    wire = wol.WolWireRequest(
+        mac=body.mac, broadcast=body.broadcast or "255.255.255.255", port=body.port
+    )
+    target = body.target or NetToolTarget()
+    try:
+        if target.kind == "server":
+            result = await wol.wake_from_server(wire)
+        elif target.kind == "appliance":
+            if target.id is None:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    "target.id is required when target.kind is 'appliance'.",
+                )
+            result = await wol.wake_via_appliance(db, target.id, wire)
+        else:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                f"Wake-on-LAN cannot run from a {target.kind!r} vantage.",
+            )
+    except wol.WolDispatchError as exc:
+        raise HTTPException(exc.status, str(exc)) from exc
+
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="wake_on_lan",
+            resource_type="wake_on_lan",
+            resource_id=wire.mac,
+            resource_display=wire.mac,
+            result="success",
+            new_value={
+                "mac": wire.mac,
+                "broadcast": wire.broadcast,
+                "port": wire.port,
+                "ran_from": result.ran_from,
+            },
+        )
+    )
+    await db.commit()
+    return result

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -515,6 +515,114 @@ register(
 )
 
 
+# ── wake_host operation (issue #533) ───────────────────────────────────
+
+
+class WakeHostArgs(BaseModel):
+    """Args for ``wake_host`` — send a Wake-on-LAN magic packet to an IP."""
+
+    address_id: str = Field(
+        description=(
+            "UUID of the ip_address row to wake. The MAC + subnet broadcast "
+            "are resolved server-side, so resolve the IP first with find_ip "
+            "and pass its id."
+        ),
+    )
+    port: int = Field(default=9, description="UDP port for the magic packet (default 9).")
+
+
+async def _load_wake_target(db: AsyncSession, args: WakeHostArgs) -> tuple[Any, str, str]:
+    """Resolve (ip_row, mac, broadcast) or raise ValueError with a reason."""
+    import ipaddress  # noqa: PLC0415
+    import uuid as _uuid  # noqa: PLC0415
+
+    from app.models.ipam import IPAddress, Subnet  # noqa: PLC0415
+    from app.services import wol  # noqa: PLC0415
+
+    try:
+        aid = _uuid.UUID(args.address_id)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"address_id is not a valid UUID: {args.address_id!r}") from exc
+    ip = await db.get(IPAddress, aid)
+    if ip is None:
+        raise ValueError("IP address not found")
+    if not ip.mac_address:
+        raise ValueError("This IP has no MAC address on record — Wake-on-LAN needs one.")
+    subnet = await db.get(Subnet, ip.subnet_id)
+    if subnet is None:
+        raise ValueError("Subnet not found")
+    net = ipaddress.ip_network(str(subnet.network), strict=False)
+    broadcast = (
+        "255.255.255.255" if isinstance(net, ipaddress.IPv6Network) else str(net.broadcast_address)
+    )
+    return ip, wol.normalize_mac(str(ip.mac_address)), broadcast
+
+
+async def _preview_wake_host(db: AsyncSession, user: User, args: WakeHostArgs) -> PreviewResult:
+    try:
+        ip, mac, broadcast = await _load_wake_target(db, args)
+    except ValueError as exc:
+        return PreviewResult(ok=False, detail=str(exc))
+    return PreviewResult(
+        ok=True,
+        detail="ready",
+        preview_text=(
+            f"Send a Wake-on-LAN magic packet to `{mac}` for `{ip.address}` "
+            f"(broadcast `{broadcast}:{args.port}`). This wakes the host only "
+            "if the packet reaches its L2 segment."
+        ),
+    )
+
+
+async def _apply_wake_host(db: AsyncSession, user: User, args: WakeHostArgs) -> dict[str, Any]:
+    from app.api.v1.dhcp._audit import write_audit  # noqa: PLC0415
+    from app.services import wol  # noqa: PLC0415
+
+    enforce_operation_permission(user, _OPERATIONS["wake_host"])
+    ip, mac, broadcast = await _load_wake_target(db, args)
+    await wol.send_magic_packet(mac, broadcast, args.port)
+    write_audit(
+        db,
+        user=user,
+        action="wake_on_lan",
+        resource_type="ip_address",
+        resource_id=str(ip.id),
+        resource_display=str(ip.address),
+        new_value={
+            "mac": mac,
+            "broadcast": broadcast,
+            "port": args.port,
+            "ran_from": "server",
+            "via": "ai_proposal",
+        },
+    )
+    await db.commit()
+    return {
+        "address": str(ip.address),
+        "mac": mac,
+        "broadcast": broadcast,
+        "port": args.port,
+        "sent": True,
+        "hint": "Magic packet broadcast from the control plane.",
+    }
+
+
+register(
+    Operation(
+        name="wake_host",
+        description=(
+            "Send a Wake-on-LAN magic packet to an IP's MAC. Always go "
+            "through propose_wake_host — never call this directly."
+        ),
+        args_model=WakeHostArgs,
+        preview=_preview_wake_host,
+        apply=_apply_wake_host,
+        category="network",
+        required_permission=("write", "use_network_tools"),
+    )
+)
+
+
 # ── run_cert_probe operation (issue #118) ──────────────────────────────
 
 

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -528,34 +528,27 @@ class WakeHostArgs(BaseModel):
             "and pass its id."
         ),
     )
-    port: int = Field(default=9, description="UDP port for the magic packet (default 9).")
+    port: int = Field(
+        default=9,
+        ge=1,
+        le=65535,
+        description="UDP port for the magic packet (default 9).",
+    )
 
 
 async def _load_wake_target(db: AsyncSession, args: WakeHostArgs) -> tuple[Any, str, str]:
-    """Resolve (ip_row, mac, broadcast) or raise ValueError with a reason."""
-    import ipaddress  # noqa: PLC0415
+    """Resolve (ip_row, mac, broadcast) or raise ValueError. Delegates to the
+    shared ``wol.resolve_wake_params`` so this path can't drift from the REST
+    endpoint; only the UUID parse is operation-specific."""
     import uuid as _uuid  # noqa: PLC0415
 
-    from app.models.ipam import IPAddress, Subnet  # noqa: PLC0415
     from app.services import wol  # noqa: PLC0415
 
     try:
         aid = _uuid.UUID(args.address_id)
     except (ValueError, TypeError) as exc:
         raise ValueError(f"address_id is not a valid UUID: {args.address_id!r}") from exc
-    ip = await db.get(IPAddress, aid)
-    if ip is None:
-        raise ValueError("IP address not found")
-    if not ip.mac_address:
-        raise ValueError("This IP has no MAC address on record — Wake-on-LAN needs one.")
-    subnet = await db.get(Subnet, ip.subnet_id)
-    if subnet is None:
-        raise ValueError("Subnet not found")
-    net = ipaddress.ip_network(str(subnet.network), strict=False)
-    broadcast = (
-        "255.255.255.255" if isinstance(net, ipaddress.IPv6Network) else str(net.broadcast_address)
-    )
-    return ip, wol.normalize_mac(str(ip.mac_address)), broadcast
+    return await wol.resolve_wake_params(db, aid)
 
 
 async def _preview_wake_host(db: AsyncSession, user: User, args: WakeHostArgs) -> PreviewResult:
@@ -580,7 +573,13 @@ async def _apply_wake_host(db: AsyncSession, user: User, args: WakeHostArgs) -> 
 
     enforce_operation_permission(user, _OPERATIONS["wake_host"])
     ip, mac, broadcast = await _load_wake_target(db, args)
-    await wol.send_magic_packet(mac, broadcast, args.port)
+    try:
+        await wol.send_magic_packet(mac, broadcast, args.port)
+    except OSError as exc:
+        raise ValueError(
+            f"Could not broadcast the magic packet from the server: {exc}. "
+            "The control plane may have no route to the target's segment."
+        ) from exc
     write_audit(
         db,
         user=user,
@@ -618,7 +617,8 @@ register(
         preview=_preview_wake_host,
         apply=_apply_wake_host,
         category="network",
-        required_permission=("write", "use_network_tools"),
+        # ``read`` matches the rest of the network-tools surface.
+        required_permission=("read", "use_network_tools"),
     )
 )
 

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -573,13 +573,11 @@ async def _apply_wake_host(db: AsyncSession, user: User, args: WakeHostArgs) -> 
 
     enforce_operation_permission(user, _OPERATIONS["wake_host"])
     ip, mac, broadcast = await _load_wake_target(db, args)
+    # AI proposals always send from the control-plane (server) vantage.
     try:
-        await wol.send_magic_packet(mac, broadcast, args.port)
-    except OSError as exc:
-        raise ValueError(
-            f"Could not broadcast the magic packet from the server: {exc}. "
-            "The control plane may have no route to the target's segment."
-        ) from exc
+        await wol.wake_from_server(wol.WolWireRequest(mac=mac, broadcast=broadcast, port=args.port))
+    except wol.WolDispatchError as exc:
+        raise ValueError(str(exc)) from exc
     write_audit(
         db,
         user=user,

--- a/backend/app/services/ai/tools/proposals.py
+++ b/backend/app/services/ai/tools/proposals.py
@@ -37,6 +37,7 @@ from app.services.ai.operations import (
     CreateIPAddressArgs,
     CreateMulticastGroupArgs,
     RunNmapScanArgs,
+    WakeHostArgs,
 )
 from app.services.ai.tools.base import register_tool
 
@@ -212,6 +213,43 @@ async def propose_run_nmap_scan(
         db,
         user=user,
         operation="run_nmap_scan",
+        args=args.model_dump(),
+        preview_text=preview.preview_text,
+    )
+    return _proposal_result(proposal, preview_text=preview.preview_text)
+
+
+# ── propose_wake_host ─────────────────────────────────────────────────
+
+
+@register_tool(
+    name="propose_wake_host",
+    description=(
+        "Prepare a Wake-on-LAN proposal for an IP. The operator must "
+        "click Apply to actually send the magic packet — WoL touches the "
+        "network. Resolve the IP first with find_ip and pass its id as "
+        "address_id. Returns kind='proposal' — surface the preview and "
+        "wait for the operator's decision."
+    ),
+    args_model=WakeHostArgs,
+    writes=False,  # The propose tool is read-only; apply is the send.
+    category="network",
+)
+async def propose_wake_host(db: AsyncSession, user: User, args: WakeHostArgs) -> dict[str, Any]:
+    op = operations.get_operation("wake_host")
+    if op is None:
+        return {"error": "Operation 'wake_host' is not registered"}
+    preview = await op.preview(db, user, args)
+    if not preview.ok:
+        return {
+            "kind": "proposal_rejected",
+            "operation": "wake_host",
+            "detail": preview.detail,
+        }
+    proposal = await _persist_proposal(
+        db,
+        user=user,
+        operation="wake_host",
         args=args.model_dump(),
         preview_text=preview.preview_text,
     )

--- a/backend/app/services/wol.py
+++ b/backend/app/services/wol.py
@@ -17,8 +17,15 @@ import asyncio
 import ipaddress
 import re
 import socket
+import uuid
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field, field_validator
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.models.ipam import IPAddress
 
 _HEX12_RE = re.compile(r"^[0-9A-Fa-f]{12}$")
 
@@ -94,3 +101,44 @@ class WolResult(BaseModel):
     sent: bool
     ran_from: str = "server"
     error: str | None = None
+
+
+class WolTargetError(ValueError):
+    """A wake target couldn't be resolved. ``not_found`` distinguishes a
+    missing row (→ 404) from a present-but-unwakeable one (→ 422)."""
+
+    def __init__(self, message: str, *, not_found: bool = False) -> None:
+        super().__init__(message)
+        self.not_found = not_found
+
+
+def broadcast_for_network(network: str) -> str:
+    """Directed broadcast of an IPv4 subnet; the limited broadcast
+    (255.255.255.255) for an IPv6 subnet, which has no broadcast of its own —
+    the magic packet is L2 and the target MAC is what wakes the NIC, so the
+    local-segment broadcast still delivers it."""
+    net = ipaddress.ip_network(network, strict=False)
+    if isinstance(net, ipaddress.IPv6Network):
+        return "255.255.255.255"
+    return str(net.broadcast_address)
+
+
+async def resolve_wake_params(
+    db: AsyncSession, address_id: uuid.UUID
+) -> tuple[IPAddress, str, str]:
+    """Load the IP, require a MAC, and derive ``(ip_row, mac, broadcast)``.
+
+    Single source of truth shared by the REST endpoint and the AI operation so
+    the resolution + error messages don't drift. Raises :class:`WolTargetError`.
+    """
+    from app.models.ipam import IPAddress, Subnet  # noqa: PLC0415 — avoid import cycle
+
+    ip = await db.get(IPAddress, address_id)
+    if ip is None:
+        raise WolTargetError("IP address not found", not_found=True)
+    if not ip.mac_address:
+        raise WolTargetError("This IP has no MAC address on record — Wake-on-LAN needs one.")
+    subnet = await db.get(Subnet, ip.subnet_id)
+    if subnet is None:
+        raise WolTargetError("Subnet not found", not_found=True)
+    return ip, normalize_mac(str(ip.mac_address)), broadcast_for_network(str(subnet.network))

--- a/backend/app/services/wol.py
+++ b/backend/app/services/wol.py
@@ -1,0 +1,96 @@
+"""Wake-on-LAN magic packet (issue #533).
+
+Pure-Python magic-packet build + UDP broadcast send. The control-plane
+(server vantage) uses this directly; the appliance vantage runs an
+equivalent ``_run_wol`` on the supervisor agent so the packet originates
+on the target's L2 segment (WoL only wakes a NIC that receives the frame
+on its own broadcast domain).
+
+WoL is IPv4-only here: the magic packet rides a UDP broadcast and IPv6 has
+no broadcast address. The 102-byte AMD Magic Packet is 6×0xFF followed by
+16 repetitions of the target MAC.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import re
+import socket
+
+from pydantic import BaseModel, Field, field_validator
+
+_HEX12_RE = re.compile(r"^[0-9A-Fa-f]{12}$")
+
+
+def normalize_mac(mac: str) -> str:
+    """Return the canonical lowercase colon form (``aa:bb:cc:dd:ee:ff``).
+
+    Accepts colon / hyphen / dot separators or a bare 12-hex string.
+    Raises ``ValueError`` on anything else so callers can surface a 422.
+    """
+    stripped = re.sub(r"[:.\-]", "", mac.strip())
+    if not _HEX12_RE.match(stripped):
+        raise ValueError(f"not a valid MAC address: {mac!r}")
+    low = stripped.lower()
+    return ":".join(low[i : i + 2] for i in range(0, 12, 2))
+
+
+def build_magic_packet(mac: str) -> bytes:
+    """Build the 102-byte AMD Magic Packet for ``mac``."""
+    mac_bytes = bytes.fromhex(normalize_mac(mac).replace(":", ""))
+    return b"\xff" * 6 + mac_bytes * 16
+
+
+def _send_sync(packet: bytes, broadcast: str, port: int) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.sendto(packet, (broadcast, port))
+
+
+async def send_magic_packet(mac: str, broadcast: str, port: int = 9) -> None:
+    """Build + broadcast the magic packet, off the event loop.
+
+    ``broadcast`` is the IPv4 broadcast address to send to (the subnet's
+    directed broadcast, or ``255.255.255.255`` for the local segment);
+    ``port`` is conventionally 9 (discard) or 7 (echo).
+    """
+    packet = build_magic_packet(mac)
+    await asyncio.to_thread(_send_sync, packet, broadcast, port)
+
+
+class WolWireRequest(BaseModel):
+    """Params shipped to (and re-validated on) an appliance agent, and the
+    validated shape the server-vantage send uses. Validators double as the
+    SSRF/arg guard: a bad MAC or non-IPv4 broadcast is rejected before any
+    packet is built."""
+
+    mac: str
+    broadcast: str
+    port: int = Field(default=9, ge=1, le=65535)
+
+    @field_validator("mac")
+    @classmethod
+    def _v_mac(cls, v: str) -> str:
+        return normalize_mac(v)
+
+    @field_validator("broadcast")
+    @classmethod
+    def _v_broadcast(cls, v: str) -> str:
+        try:
+            return str(ipaddress.IPv4Address(v.strip()))
+        except ipaddress.AddressValueError as exc:
+            raise ValueError(f"broadcast must be an IPv4 address: {v!r}") from exc
+
+
+class WolResult(BaseModel):
+    """Uniform WoL send result. ``ran_from`` mirrors the network-tools
+    convention: ``server`` for the api-container send, ``appliance:<name>``
+    when a Fleet appliance sent it."""
+
+    mac: str
+    broadcast: str
+    port: int
+    sent: bool
+    ran_from: str = "server"
+    error: str | None = None

--- a/backend/app/services/wol.py
+++ b/backend/app/services/wol.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel, Field, field_validator
 
 if TYPE_CHECKING:
+    import uuid as _uuid_t
+
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from app.models.ipam import IPAddress
@@ -142,3 +144,70 @@ async def resolve_wake_params(
     if subnet is None:
         raise WolTargetError("Subnet not found", not_found=True)
     return ip, normalize_mac(str(ip.mac_address)), broadcast_for_network(str(subnet.network))
+
+
+class WolDispatchError(Exception):
+    """A send failed. ``status`` is the HTTP status the API layer should map
+    to (kept out of the raise sites so callers translate it uniformly)."""
+
+    def __init__(self, message: str, status: int) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+async def wake_from_server(wire: WolWireRequest) -> WolResult:
+    """Broadcast the magic packet from the control-plane container. Raises
+    :class:`WolDispatchError` (502) when there's no route to the broadcast —
+    the documented single-box limitation — rather than a bare OSError."""
+    try:
+        await send_magic_packet(wire.mac, wire.broadcast, wire.port)
+    except OSError as exc:
+        raise WolDispatchError(
+            f"Could not broadcast the magic packet from the server: {exc}. "
+            "Try an appliance vantage on the target's segment.",
+            502,
+        ) from exc
+    return WolResult(
+        mac=wire.mac, broadcast=wire.broadcast, port=wire.port, sent=True, ran_from="server"
+    )
+
+
+async def wake_via_appliance(
+    db: AsyncSession, appliance_id: _uuid_t.UUID, wire: WolWireRequest
+) -> WolResult:
+    """Dispatch the send to a Fleet appliance so the packet originates on the
+    target's segment. Reuses the generic nettool command channel. Raises
+    :class:`WolDispatchError` (404 / 503 / 504 / 502) on any failure."""
+    from app.models.appliance import Appliance  # noqa: PLC0415 — avoid import cycle
+    from app.services.appliance import agent_cmd  # noqa: PLC0415
+
+    appliance = await db.get(Appliance, appliance_id)
+    if appliance is None:
+        raise WolDispatchError("Appliance not found.", 404)
+    ready = agent_cmd.appliance_ready(state=appliance.state, last_seen_at=appliance.last_seen_at)
+    try:
+        outcome = await agent_cmd.enqueue_command(
+            appliance.id,
+            "wol",
+            wire.model_dump(mode="json"),
+            ready=ready,
+            # Match the sibling nettool dispatch — a busy supervisor mid-poll
+            # needs headroom or a healthy appliance 504s.
+            timeout=30.0,
+        )
+    except agent_cmd.ApplianceOffline as exc:
+        raise WolDispatchError(
+            f"Appliance {appliance.hostname!r} is offline or not approved.", 503
+        ) from exc
+    except TimeoutError as exc:
+        raise WolDispatchError(
+            f"Appliance {appliance.hostname!r} did not send the packet in time.", 504
+        ) from exc
+    if outcome.error is not None or outcome.result is None:
+        raise WolDispatchError(
+            f"Appliance {appliance.hostname!r} could not send the magic packet: "
+            f"{outcome.error or 'no result returned'}",
+            502,
+        )
+    result = WolResult.model_validate(outcome.result)
+    return result.model_copy(update={"ran_from": f"appliance:{appliance.hostname}"})

--- a/backend/app/services/wol.py
+++ b/backend/app/services/wol.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.services.nettools.schemas import is_blocked_target
+
 if TYPE_CHECKING:
     import uuid as _uuid_t
 
@@ -87,9 +89,19 @@ class WolWireRequest(BaseModel):
     @classmethod
     def _v_broadcast(cls, v: str) -> str:
         try:
-            return str(ipaddress.IPv4Address(v.strip()))
+            canonical = str(ipaddress.IPv4Address(v.strip()))
         except ipaddress.AddressValueError as exc:
             raise ValueError(f"broadcast must be an IPv4 address: {v!r}") from exc
+        # Apply the same SSRF denylist the other network tools use so WoL can't
+        # fire a UDP payload at loopback / link-local / metadata ranges (a
+        # legit broadcast — 255.255.255.255 or an RFC1918 directed broadcast —
+        # is never in a blocked range, so this doesn't reject real use).
+        if is_blocked_target(canonical):
+            raise ValueError(
+                f"broadcast {canonical} is in a blocked range (loopback / "
+                "link-local / cloud-metadata) and cannot be targeted"
+            )
+        return canonical
 
 
 class WolResult(BaseModel):
@@ -143,7 +155,12 @@ async def resolve_wake_params(
     subnet = await db.get(Subnet, ip.subnet_id)
     if subnet is None:
         raise WolTargetError("Subnet not found", not_found=True)
-    return ip, normalize_mac(str(ip.mac_address)), broadcast_for_network(str(subnet.network))
+    broadcast = broadcast_for_network(str(subnet.network))
+    # A loopback / link-local subnet would derive a blocked broadcast — refuse
+    # cleanly (422) rather than letting the wire-schema validator 500 later.
+    if is_blocked_target(broadcast):
+        raise WolTargetError(f"Subnet {subnet.network} derives a blocked broadcast ({broadcast}).")
+    return ip, normalize_mac(str(ip.mac_address)), broadcast
 
 
 class WolDispatchError(Exception):

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -191,6 +191,31 @@ IPAddress
 
 Returns the allocated IPAddress. Allocation is atomic (uses DB-level `SELECT ... FOR UPDATE` on the subnet row to prevent race conditions). The picker skips network/broadcast placeholders and any IP inside a dynamic DHCP pool.
 
+### Wake-on-LAN (#533)
+
+`POST /api/v1/ipam/addresses/{id}/wake`
+
+Sends a Wake-on-LAN magic packet to the IP's MAC. The MAC comes from the
+address row and the IPv4 broadcast target is derived from the IP's subnet, so
+the request body only needs an optional `port` (default 9) and an optional
+run-from `target`:
+
+```json
+{ "port": 9, "target": { "kind": "server" } }
+```
+
+- `target.kind = "server"` (default) — the control-plane container broadcasts.
+  Only wakes hosts on a segment the api container can reach (the common
+  single-box case).
+- `target.kind = "appliance"` + `target.id` — dispatch to a Fleet appliance
+  whose NIC sits on the target's segment, so the packet originates in the right
+  broadcast domain (reuses the generic nettool command channel).
+
+Gated by the `use_network_tools` permission and audited against the IP
+(`action="wake_on_lan"`). Surfaced as a **Wake** button on the IP detail modal
+(shown only when the IP has a MAC) and as the `propose_wake_host` Operator
+Copilot tool. WoL is IPv4-only — the magic packet rides a UDP broadcast.
+
 ---
 
 ## 6. Custom Fields

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12491,6 +12491,16 @@ export interface NetToolMacVendorResult {
   entries: NetToolMacVendorEntry[];
 }
 
+// Wake-on-LAN result (#533) — mirrors backend WolResult.
+export interface NetToolWolResult {
+  mac: string;
+  broadcast: string;
+  port: number;
+  sent: boolean;
+  ran_from: string;
+  error: string | null;
+}
+
 // Fold the routing-only ``target`` into a reachability-tool body only
 // when it points at an appliance — a "server" target (or none) is the
 // back-compatible inline run, so we omit the field entirely.
@@ -12555,6 +12565,15 @@ export const networkToolsApi = {
   macVendor: (macs: string[]) =>
     api
       .post<NetToolMacVendorResult>("/tools/mac-vendor", { macs })
+      .then((r) => r.data),
+  // Wake-on-LAN (#533) — MAC-based; broadcast optional (defaults to the local
+  // segment 255.255.255.255 server-side). Runs from the server or an appliance.
+  wol: (
+    body: { mac: string; broadcast?: string | null; port?: number },
+    target?: NetToolTarget,
+  ) =>
+    api
+      .post<NetToolWolResult>("/tools/wol", withTarget(body, target))
       .then((r) => r.data),
   // #404 — tail an appliance's nftables drop logs. Always appliance-targeted
   // (the api can't read host kernel logs); poll with the returned cursor.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1673,6 +1673,30 @@ export const ipamApi = {
         status: string;
       }>(`/ipam/addresses/${id}/profile`, { preset: preset ?? null })
       .then((r) => r.data),
+  /** Wake-on-LAN (#533) — send a magic packet to this IP's MAC. The
+   *  broadcast target is derived server-side from the IP's subnet. Omit
+   *  the vantage to send from the control plane; pass an appliance target
+   *  to originate the packet on that appliance's segment. */
+  wakeAddress: (
+    id: string,
+    opts?: {
+      port?: number;
+      target?: { kind: "server" | "appliance"; id?: string };
+    },
+  ) =>
+    api
+      .post<{
+        mac: string;
+        broadcast: string;
+        port: number;
+        sent: boolean;
+        ran_from: string;
+        error: string | null;
+      }>(`/ipam/addresses/${id}/wake`, {
+        port: opts?.port ?? 9,
+        target: opts?.target ?? null,
+      })
+      .then((r) => r.data),
   /** Fetch the passive DHCP fingerprint joined to this IP's MAC.
    *  404 when the IP has no MAC or no fingerprint has been captured
    *  yet — callers should swallow that and treat it as "no data". */

--- a/frontend/src/pages/ipam/IPDetailModal.tsx
+++ b/frontend/src/pages/ipam/IPDetailModal.tsx
@@ -164,11 +164,16 @@ export function IPDetailModal({
       });
     },
     onError: (err: unknown) => {
-      const detail = (err as { response?: { data?: { detail?: string } } })
+      // detail is a string for our HTTPExceptions but a list of objects for a
+      // Pydantic 422 — only render it when it's actually a string.
+      const detail = (err as { response?: { data?: { detail?: unknown } } })
         ?.response?.data?.detail;
       setWakeMsg({
         ok: false,
-        text: detail || "Failed to send the magic packet.",
+        text:
+          typeof detail === "string"
+            ? detail
+            : "Failed to send the magic packet.",
       });
     },
   });

--- a/frontend/src/pages/ipam/IPDetailModal.tsx
+++ b/frontend/src/pages/ipam/IPDetailModal.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   Pencil,
   Phone,
+  Power,
   Radar,
   Radio,
   RefreshCw,
@@ -144,6 +145,34 @@ export function IPDetailModal({
   const { dialogStyle, dragHandleProps } = useDraggableModal(onClose);
   const zoneNames = zoneNameById ?? {};
 
+  // Wake-on-LAN (#533) — self-contained like the "Re-profile now" action.
+  // Fire-and-forget: no data changes, so no query invalidation; we just
+  // surface a transient result line under the header.
+  const [wakeMsg, setWakeMsg] = useState<{ ok: boolean; text: string } | null>(
+    null,
+  );
+  const wake = useMutation({
+    mutationFn: () => ipamApi.wakeAddress(addr.id),
+    onSuccess: (data) => {
+      const via =
+        data.ran_from === "server"
+          ? "the server"
+          : data.ran_from.replace(":", " ");
+      setWakeMsg({
+        ok: true,
+        text: `Magic packet sent to ${data.mac} via ${via}.`,
+      });
+    },
+    onError: (err: unknown) => {
+      const detail = (err as { response?: { data?: { detail?: string } } })
+        ?.response?.data?.detail;
+      setWakeMsg({
+        ok: false,
+        text: detail || "Failed to send the magic packet.",
+      });
+    },
+  });
+
   const tagEntries = Object.entries(addr.tags ?? {});
   const cfEntries = Object.entries(addr.custom_fields ?? {});
 
@@ -245,6 +274,25 @@ export function IPDetailModal({
             >
               <Radar className="h-3.5 w-3.5" /> Scan with Nmap
             </button>
+            {addr.mac_address && (
+              <button
+                type="button"
+                onClick={() => {
+                  setWakeMsg(null);
+                  wake.mutate();
+                }}
+                disabled={wake.isPending}
+                className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs hover:bg-accent disabled:opacity-50"
+                title="Send a Wake-on-LAN magic packet to this MAC"
+              >
+                {wake.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Power className="h-3.5 w-3.5" />
+                )}{" "}
+                Wake
+              </button>
+            )}
             {canEdit && (
               <button
                 type="button"
@@ -276,6 +324,19 @@ export function IPDetailModal({
 
         {/* Body */}
         <div className="space-y-5 p-4 sm:p-5">
+          {wakeMsg && (
+            <div
+              className={
+                "flex items-center gap-2 rounded-md border px-3 py-2 text-xs " +
+                (wakeMsg.ok
+                  ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                  : "border-destructive/40 bg-destructive/5 text-destructive")
+              }
+            >
+              <Power className="h-3.5 w-3.5 shrink-0" />
+              {wakeMsg.text}
+            </div>
+          )}
           {/* Identity grid */}
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Field label="Hostname">{dash(addr.hostname)}</Field>

--- a/frontend/src/pages/tools/NetworkToolsPage.tsx
+++ b/frontend/src/pages/tools/NetworkToolsPage.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   Network,
   Plug,
+  Power,
   Route,
   Search,
   ShieldCheck,
@@ -20,6 +21,7 @@ import {
   type NetToolPortTestResult,
   type NetToolTarget,
   type NetToolTlsCertResult,
+  type NetToolWolResult,
   type PropagationCheckResult,
   applianceApprovalApi,
   networkToolsApi,
@@ -38,7 +40,8 @@ type ToolId =
   | "port-test"
   | "tls-cert"
   | "dns-propagation"
-  | "mac-vendor";
+  | "mac-vendor"
+  | "wol";
 
 interface ToolDef {
   id: ToolId;
@@ -113,6 +116,13 @@ const TOOLS: ToolDef[] = [
     label: "MAC vendor",
     icon: Award,
     blurb: "Resolve OUI vendor names for a batch of MACs.",
+  },
+  {
+    id: "wol",
+    label: "Wake-on-LAN",
+    icon: Power,
+    blurb: "Send a magic packet to a MAC — from the server or an appliance.",
+    reachability: true,
   },
 ];
 
@@ -230,9 +240,9 @@ export function NetworkToolsPage() {
         </div>
         <p className="mt-1 max-w-3xl text-xs text-muted-foreground">
           Stateless ping / traceroute / MTR / dig / whois / port-test / TLS-cert
-          / DNS-propagation / MAC-vendor utilities. Reachability tools can run
-          from the control-plane server or a Fleet appliance's vantage;
-          rate-limited per user.
+          / DNS-propagation / MAC-vendor / Wake-on-LAN utilities. Reachability
+          tools can run from the control-plane server or a Fleet appliance's
+          vantage; rate-limited per user.
         </p>
       </div>
 
@@ -355,6 +365,7 @@ function ToolPanel({
       {tool.id === "tls-cert" && <TlsCertTool target={target} />}
       {tool.id === "dns-propagation" && <PropagationTool />}
       {tool.id === "mac-vendor" && <MacVendorTool />}
+      {tool.id === "wol" && <WolTool target={target} />}
     </div>
   );
 }
@@ -1103,6 +1114,98 @@ function MacVendorTool() {
               ))}
             </tbody>
           </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── wake-on-lan ───────────────────────────────────────────────────────
+
+function WolTool({ target }: { target?: NetToolTarget }) {
+  const [mac, setMac] = useState("");
+  const [broadcast, setBroadcast] = useState("");
+  const [port, setPort] = useState("9");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [res, setRes] = useState<NetToolWolResult | null>(null);
+
+  const ranRemote = target?.kind === "appliance";
+
+  const run = async () => {
+    if (!mac.trim()) {
+      setErr("MAC address is required");
+      return;
+    }
+    setErr(null);
+    setRes(null);
+    setBusy(true);
+    try {
+      setRes(
+        await networkToolsApi.wol(
+          {
+            mac: mac.trim(),
+            broadcast: broadcast.trim() || null,
+            port: Number(port) || 9,
+          },
+          target,
+        ),
+      );
+    } catch (e) {
+      setErr(toolError(e, ranRemote));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className={labelCls}>MAC address</label>
+        <input
+          className={cn(inputCls, "font-mono")}
+          value={mac}
+          onChange={(e) => setMac(e.target.value)}
+          placeholder="e.g. aa:bb:cc:dd:ee:ff"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className={labelCls}>Broadcast (optional)</label>
+          <input
+            className={cn(inputCls, "font-mono")}
+            value={broadcast}
+            onChange={(e) => setBroadcast(e.target.value)}
+            placeholder="255.255.255.255"
+          />
+        </div>
+        <div>
+          <label className={labelCls}>Port</label>
+          <input
+            className={cn(inputCls, "font-mono")}
+            type="number"
+            min={1}
+            max={65535}
+            value={port}
+            onChange={(e) => setPort(e.target.value)}
+          />
+        </div>
+      </div>
+      <p className="text-[11px] text-muted-foreground">
+        Wake-on-LAN only reaches a host on the segment the packet is broadcast
+        to — use an appliance vantage on the target's subnet for remote wakes.
+        Leave the broadcast blank to hit the local segment.
+      </p>
+      {err && <ErrorBanner msg={err} />}
+      <RunButton busy={busy} onClick={run} label="wake" />
+      {res && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 p-2 text-xs text-emerald-700 dark:text-emerald-400">
+          <Power className="h-3.5 w-3.5" />
+          Magic packet sent to <span className="font-mono">
+            {res.mac}
+          </span> via <span className="font-mono">{res.broadcast}</span>:
+          {res.port}
+          <RanFrom value={res.ran_from} />
         </div>
       )}
     </div>


### PR DESCRIPTION
Implements Wake-on-LAN end-to-end (#533): a magic-packet service plus three operator surfaces, with two vantages (control-plane server or a Fleet appliance on the target's L2 segment).

## What's included

**Backend service** (`app/services/wol.py`)
- `build_magic_packet` / `send_magic_packet` (102-byte AMD magic packet, MAC normalization, off-loop UDP broadcast).
- `WolWireRequest` / `WolResult` schemas + `resolve_wake_params` (IP → mac + subnet broadcast).
- Shared dispatch: `wake_from_server` / `wake_via_appliance` / `WolDispatchError` — one implementation used by every entrypoint.

**Surfaces**
- **IP detail modal** — a **Wake** button, shown only when the IP has a MAC; resolves MAC + subnet broadcast server-side. `POST /ipam/addresses/{id}/wake`.
- **Network Tools page** — a MAC-based **Wake-on-LAN** tool (MAC + optional broadcast + port + server/appliance vantage). `POST /tools/wol`.
- **Operator Copilot** — `propose_wake_host` (propose → Apply flow, like `propose_run_nmap_scan`).

**Appliance vantage** — a `wol` runner added to the supervisor's nettool executor (`agent/supervisor/.../nettools.py`) so the packet originates on the target's segment, reusing the existing generic nettool command channel (no new transport).

**Cross-cutting** — gated `read:use_network_tools` (matches the rest of the network-tools surface), audited (`action="wake_on_lan"`) at every entrypoint. WoL is IPv4-only (the magic packet rides a UDP broadcast). No new migration, permission, or feature module.

## Self-review

Ran `/code-review` at high effort; the 6 real findings are all fixed in `e6c2b2c` + `c43fec9`:
- permission action `write` → `read` (parity with ping/nmap/dig),
- server-vantage `OSError` → clean 502 (was a raw 500),
- `WakeHostArgs.port` bounds,
- **de-duplicated** the IP→(mac,broadcast) resolution and the appliance-dispatch/error-mapping into the shared `wol` service,
- appliance dispatch timeout 15s → 30s,
- frontend renders `detail` only when it's a string (a Pydantic 422 detail is a list).

## Verification

ruff / black / mypy on all changed backend + agent files; eslint (`--max-warnings 0`) / prettier / `tsc -b` + vite build on frontend; app boots with both routes live (`/api/v1/ipam/addresses/{id}/wake`, `/api/v1/tools/wol`) and `wake_host` registered at `read:use_network_tools`. Exercised end-to-end against the local Docker stack.

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)