### PR TITLE
fix(dhcp): omit null client-id in agent-rendered Kea reservations (#537)

### DIFF
--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -403,9 +403,14 @@ def _reservation(res: dict[str, Any]) -> dict[str, Any]:
         norm = _normalize_mac_for_kea(str(raw_hw))
         if norm is not None:
             out["hw-address"] = norm
-    if "client_id" in res:
+    # Guard on a truthy value, not key presence: the wire ScopeDef path
+    # (``_scope_to_subnet``) always injects ``client_id`` (``None`` when the
+    # static has none), and emitting ``"client-id": null`` makes kea-dhcp4
+    # REJECT the whole config on reload ("unexpected null, expecting constant
+    # string" — issue #537). Mirrors the backend driver's ``if s.client_id``.
+    if res.get("client_id"):
         out["client-id"] = res["client_id"]
-    if "duid" in res:
+    if res.get("duid"):
         out["duid"] = res["duid"]
     if "ip_address" in res or "ip" in res:
         out["ip-address"] = res.get("ip_address") or res.get("ip")

--- a/agent/dhcp/tests/test_render_kea.py
+++ b/agent/dhcp/tests/test_render_kea.py
@@ -269,6 +269,24 @@ def test_render_wire_shape_reservation_from_statics(wire_bundle: dict) -> None:
     assert resv[0]["hostname"] == "printer1"
 
 
+def test_reservation_omits_client_id_when_absent(wire_bundle: dict) -> None:
+    # #537 — the wire ScopeDef path injects ``client_id: None`` for statics
+    # with no client-id; the renderer must OMIT the key entirely rather than
+    # emit ``"client-id": null``, which makes kea-dhcp4 reject the config on
+    # reload ("unexpected null, expecting constant string").
+    out = render(wire_bundle)
+    resv = out["Dhcp4"]["subnet4"][0]["reservations"]
+    assert "client-id" not in resv[0]
+
+
+def test_reservation_emits_client_id_when_present(wire_bundle: dict) -> None:
+    # A present client-id must still round-trip through the wire ScopeDef path.
+    wire_bundle["scopes"][0]["statics"][0]["client_id"] = "01:aa:bb:cc:dd"
+    out = render(wire_bundle)
+    resv = out["Dhcp4"]["subnet4"][0]["reservations"]
+    assert resv[0]["client-id"] == "01:aa:bb:cc:dd"
+
+
 def test_render_wire_shape_client_class_match_expression(wire_bundle: dict) -> None:
     out = render(wire_bundle)
     cc = out["Dhcp4"]["client-classes"]


### PR DESCRIPTION
## Problem

On an OS-appliance deployment, creating a static DHCP reservation with no client-id makes the agent render `"client-id": null` in the Kea config. kea-dhcp4 rejects the whole file on reload:

```
DHCP4_CONFIG_LOAD_FAIL ... syntax error, unexpected null, expecting constant string
DHCP4_DYNAMIC_RECONFIGURATION_FAIL
```

This wedges config delivery for the affected server (reported in #537).

## Root cause

The agent's Kea renderer guarded the reservation client-id on **key presence**:

```python
if "client_id" in res:
    out["client-id"] = res["client_id"]
```

…but the wire-shape path `_scope_to_subnet` **always injects** `client_id: s.get("client_id")`, which is `None` for a static without one. So the key is present with a `None` value → `"client-id": null`.

The backend control-plane driver (`backend/app/drivers/dhcp/kea.py`) already guards correctly (`if s.client_id`, since #375) — but on an OS appliance the **agent** renders Kea itself from the wire bundle, so that guard never runs for this deployment. The agent renderer was missed when the backend fix landed.

This is a distinct bug from #474 (soft-deleted scope unique-slot 500) — same field reporter, different failure mode; #474's footer flagged reservation-render symptoms "to be tracked separately", and this is one of them.

## Fix

Guard on a truthy value instead of key presence, mirroring the backend driver. Same latent bug fixed on the sibling `duid` check.

## Tests

Added two regression tests to `agent/dhcp/tests/test_render_kea.py`:
- `test_reservation_omits_client_id_when_absent` — the exact repro (static with no client-id must omit the key)
- `test_reservation_emits_client_id_when_present` — a present client-id still round-trips

All 36 `test_render_kea.py` tests pass.

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)