### PR TITLE
feat(ipam): surface Add block as a visible space-header button (#538)

### DIFF
--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -13299,25 +13299,27 @@ function SpaceTableView({
               Sync DNS
             </HeaderButton>
             <ExportButton scope={{ space_id: space.id }} label="Export" />
-            {/* Structural actions behind a Tools ▾ dropdown — same grammar as
-                the Block + Subnet headers (#465). */}
-            <HeaderMenu
-              items={[
-                {
-                  label: "Find Free…",
-                  icon: Search,
-                  onClick: () => setShowFindFree(true),
-                  title: "Find unused CIDRs in this space",
-                },
-                {
-                  label: "Add block…",
-                  icon: Layers,
-                  onClick: () => setShowCreateBlock(true),
-                },
-              ]}
-            />
+            {/* Add block is a primary space-level structural action (blocks are
+                the top-level child of a space), so it sits as a visible button
+                next to Add Subnet rather than hidden in a Tools ▾ dropdown
+                (#538). Find Free is a low-frequency read; promoted out too so we
+                don't leave a single-item dropdown. Ordering grammar per #465. */}
+            <HeaderButton
+              icon={Search}
+              onClick={() => setShowFindFree(true)}
+              title="Find unused CIDRs in this space"
+            >
+              Find Free…
+            </HeaderButton>
             <HeaderButton icon={Pencil} onClick={() => setShowEditSpace(true)}>
               Edit Space
+            </HeaderButton>
+            <HeaderButton
+              icon={Layers}
+              onClick={() => setShowCreateBlock(true)}
+              title="Add a top-level block to this space"
+            >
+              Add block
             </HeaderButton>
             <HeaderButton
               variant="primary"


### PR DESCRIPTION
### Summary

At the **IP space** level, `Add block` was hidden inside the `Tools ▾` dropdown on the space detail header while `Add Subnet` sat right next to it as a visible primary button. Since a block is the top-level structural child of a space (blocks contain subnets), burying "Add block" behind a dropdown while "Add Subnet" is one click is backwards.

This promotes **Add block** to a visible `HeaderButton` immediately before the primary **Add Subnet**. `Find Free…` is promoted out too, so we don't leave a single-item `Tools ▾` dropdown behind.

### Changes

- `frontend/src/pages/ipam/IPAMPage.tsx` — space detail header: replace the two-item `HeaderMenu` (`Find Free…` / `Add block…`) with two visible `HeaderButton`s. `Add block` sits next to `Add Subnet`.
- Header-button ordering grammar (#465) and narrow-viewport flex-wrap preserved.
- The right-click context menu on the space tree row (already exposes `New Block…`) is untouched.

### Testing

- `npm run build` passes.

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)