### PR TITLE
Bump k3s v1.35.5+k3s1 → v1.35.6+k3s1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ appliance-clean:
 # Bump in PRs alongside the slot image cut; the fetch script caches
 # downloads under mkosi.extra/ keyed on this version so re-runs are
 # cheap when nothing's changed.
-K3S_VERSION ?= v1.35.5+k3s1
+K3S_VERSION ?= v1.35.6+k3s1
 
 # Issue #183 Phase 1 — air-gap-ready k3s baking. Downloads the pinned
 # k3s static binary + airgap images tarball + LICENSE into mkosi.extra/

--- a/appliance/scripts/fetch-k3s.sh
+++ b/appliance/scripts/fetch-k3s.sh
@@ -38,7 +38,7 @@ set -euo pipefail
 # this script directly (without ``make``); CI + the Makefile always
 # override it. Keep this in sync with the Makefile pin so a direct
 # invocation never silently pulls a stale release tag.
-K3S_VERSION="${K3S_VERSION:-v1.35.5+k3s1}"
+K3S_VERSION="${K3S_VERSION:-v1.35.6+k3s1}"
 
 # Target architecture. Defaults to the build host's arch; release CI
 # overrides per matrix entry so each arch carries its own k3s + airgap

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1107,7 +1107,7 @@ class SupervisorHeartbeatRequest(BaseModel):
     host_interfaces: list[str] | None = None
     # Issue #183 Phase 5 — operator-facing k3s metadata.
     # ``k3s_version`` is the upstream release tag the slot was baked
-    # against (e.g. ``v1.35.5+k3s1``). ``kubeconfig`` is the raw
+    # against (e.g. ``v1.35.6+k3s1``). ``kubeconfig`` is the raw
     # admin kubeconfig YAML straight off the appliance — the backend
     # rewrites ``server:`` for operator reachability + Fernet-encrypts
     # before persisting. Both ``None`` = supervisor didn't ship them

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -730,7 +730,7 @@ class Appliance(Base):
 
     # Issue #183 Phase 5 — operator-facing k3s metadata.
     # ``k3s_version`` is the upstream release tag the slot was baked
-    # against (e.g. ``v1.35.5+k3s1``); Fleet UI shows it on the row.
+    # against (e.g. ``v1.35.6+k3s1``); Fleet UI shows it on the row.
     # ``kubeconfig_encrypted`` is the supervisor-supplied admin
     # kubeconfig, Fernet-encrypted at rest. NULL until the supervisor
     # ships one (legacy compose / pre-#183 supervisors / k3s not yet

--- a/backend/tests/test_cluster_health.py
+++ b/backend/tests/test_cluster_health.py
@@ -45,7 +45,7 @@ def _node(name: str = "ddi1", *, ready: bool = True, cpu: str = "4", mem: str = 
             ],
             "addresses": [{"type": "InternalIP", "address": "192.168.0.199"}],
             "nodeInfo": {
-                "kubeletVersion": "v1.35.5+k3s1",
+                "kubeletVersion": "v1.35.6+k3s1",
                 "osImage": "Debian GNU/Linux 13 (trixie)",
                 "kernelVersion": "6.12.90",
                 "containerRuntimeVersion": "containerd://2.2.3-k3s1",
@@ -165,7 +165,7 @@ def test_get_cluster_health_rollup(monkeypatch) -> None:
     assert snap["control_plane_nodes"] == 1
     assert snap["is_ha"] is False
     assert snap["metrics_available"] is True
-    assert snap["kubelet_version"] == "v1.35.5+k3s1"
+    assert snap["kubelet_version"] == "v1.35.6+k3s1"
 
     # Live per-node usage flowed through from the kubelet summary.
     node = snap["nodes"][0]

--- a/backend/tests/test_cluster_health.py
+++ b/backend/tests/test_cluster_health.py
@@ -48,7 +48,7 @@ def _node(name: str = "ddi1", *, ready: bool = True, cpu: str = "4", mem: str = 
                 "kubeletVersion": "v1.35.6+k3s1",
                 "osImage": "Debian GNU/Linux 13 (trixie)",
                 "kernelVersion": "6.12.90",
-                "containerRuntimeVersion": "containerd://2.2.5-k3s2", 
+                "containerRuntimeVersion": "containerd://2.2.5-k3s2",
                 "architecture": "amd64",
             },
             "capacity": {"cpu": cpu, "memory": mem, "pods": "110"},

--- a/backend/tests/test_cluster_health.py
+++ b/backend/tests/test_cluster_health.py
@@ -48,7 +48,7 @@ def _node(name: str = "ddi1", *, ready: bool = True, cpu: str = "4", mem: str = 
                 "kubeletVersion": "v1.35.6+k3s1",
                 "osImage": "Debian GNU/Linux 13 (trixie)",
                 "kernelVersion": "6.12.90",
-                "containerRuntimeVersion": "containerd://2.2.3-k3s1",
+                "containerRuntimeVersion": "containerd://2.2.5-k3s2", 
                 "architecture": "amd64",
             },
             "capacity": {"cpu": cpu, "memory": mem, "pods": "110"},

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9766,7 +9766,7 @@ export interface ApplianceRow {
     pods_total?: number;
     pods_by_phase?: Record<string, number>;
   };
-  // Issue #183 Phase 5 — installed k3s version (e.g. ``v1.35.5+k3s1``).
+  // Issue #183 Phase 5 — installed k3s version (e.g. ``v1.35.6+k3s1``).
   // Null on legacy compose / pre-#183 supervisors.
   k3s_version: string | null;
   // Issue #183 Phase 5 — boolean "supervisor has shipped a kubeconfig".


### PR DESCRIPTION
Closes #547

Patch bump of the appliance's pinned k3s release the slot image bakes,
`v1.35.5+k3s1` → [`v1.35.6+k3s1`](https://github.com/k3s-io/k3s/releases/tag/v1.35.6%2Bk3s1).

## Why it's safe
- **Same-minor patch** (Kubernetes 1.35.5 → 1.35.6, Go 1.25.11). No API
  removals, no manifest/chart edits, snapshot + rolling-upgrade compat
  preserved (etcd v3.6.12-k3s1 is a forward patch within 3.6.x).
- **The advertised breaking change does not apply.** v1.35.6 bumps the
  Traefik chart to v40.x (renames the ingress-nginx-migration provider
  `kubernetesIngressNginx` → `kubernetesIngressNGINX`). The appliance
  **disables the bundled Traefik** (`disable: [traefik, servicelb,
  metrics-server]` in `config.yaml`) and uses nginx + MetalLB, so the
  rename can't bite.
- **Bundled fixes help us:** klipper-helm CVE fix (we run MetalLB + the
  umbrella chart as HelmChart CRDs via the helm-controller/klipper-helm),
  containerd v2.2.5-k3s2 env-var-string handling correction, runc v1.4.2.
- **Reversible delivery.** The k3s binary/airgap tarball/`.version` stamp
  are gitignored build artifacts regenerated from the pin at build time;
  the bump ships in the next OS release via the A/B slot image
  (whole-rootfs re-image + reboot), not a live in-place swap. Rollback is
  the A/B slot revert. Same shape as the prior #325 bump.

## Notes
- Reaches field appliances only via a new OS release + slot upgrade (or
  fresh install) — not an in-place k3s upgrade on running nodes.
- containerd stays within major v2.2.x (no 1.x → 2.x jump).

## Changes
- `Makefile` — canonical `K3S_VERSION` pin
- `appliance/scripts/fetch-k3s.sh` — direct-invocation default fallback (kept in sync)
- Cosmetic: `v1.35.5` → `v1.35.6` example strings in the cluster-health
  test fixtures + `k3s_version` doc comments

CHANGELOG entry deferred to the next release-prep per convention.

## Verification
- All four `v1.35.6+k3s1` release assets (amd64/arm64 binary + airgap
  tarball) return HTTP 200.
- `make ci` green (backend lint/mypy, frontend lint/typecheck/build).
- Built a baked test ISO (`dev-350f350-786b`) with the bake log confirming
  `✓ k3s v1.35.6+k3s1 baked into mkosi.extra/`; staged on Proxmox for VM
  boot testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)