### PR TITLE
feat(appliance): headless / unattended install via cloud-init preseed (#549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,52 @@ the formatter handles the rest.
 
 ---
 
+## Unreleased
+
+Appliance-only work; reaches nothing in-field until it ships in a
+new appliance OS release (ISO).
+
+### Added
+
+- **Headless / unattended appliance install (#549).** The disk
+  installer `spatium-install` can now run non-interactively from a
+  **preseed answer file**, for fleet rollouts, PXE/IPMI provisioning,
+  cloud images, and CI boot-tests. On boot of the installer media it
+  looks for an answer file before launching whiptail; present fields
+  skip their prompt, a fully-preseeded run (disk + `confirm_wipe:
+  true` + all fields) installs with zero console interaction, and a
+  **partial** preseed falls through to interactive prompts for only
+  the missing fields. A field that is present but invalid **halts
+  loudly** (clear console message + non-zero exit) rather than
+  silently defaulting on a disk wipe. A new parser
+  `/usr/local/bin/spatium-preseed-parse` (PyYAML) reuses the wizard's
+  own validators — hostname RFC 1123, k3s CIDR disjoint + ≤ /22 + no
+  LAN overlap, pairing code = 8 digits, control-plane URL required for
+  the appliance role. **Destructive-disk safety**: an unattended wipe
+  needs both `confirm_wipe: true` and a `target_disk` that resolves to
+  exactly one whole disk of at least the 32 GiB A/B-layout floor
+  (prefer a stable `/dev/disk/by-id` id); a supplied-but-unresolvable
+  disk drops to the interactive picker, and an under-floor disk halts
+  loudly. Static networking requires `interface` + `ip` + `prefix` +
+  `gateway` (IPv4 only) — a missing interface would otherwise silently
+  fall back to DHCP. A URL-transport preseed retries the fetch to ride
+  out network bring-up, and discovery skips a non-preseed cloud-init
+  `user-data` on the CIDATA volume so it can't shadow a real preseed on
+  another source.
+  **Secrets**: supports `admin_password_hash` (crypt(3)) so the admin
+  cleartext stays out of the file, and keeps the password + pairing
+  code out of the console dashboard, install log, and `set -x` trace
+  log. **Transports**: kernel cmdline `spatium.preseed=<url|path>`, a
+  NoCloud `CIDATA` volume carrying `spatium-preseed.yaml`, or a file
+  on the install medium — and the same `spatium_preseed:` block can be
+  embedded in a cloud-init `user-data` document, which is how the AWS
+  (`--user-data`) and Azure (`--custom-data`) cloud-image recipes
+  deliver it. Docs + annotated control-plane / appliance examples
+  under `appliance/cloud-init/`; retires the stale pre-#183 cloud-init
+  framing in APPLIANCE.md §4.
+
+---
+
 ## 2026.07.03-1 — 2026-07-03
 
 A **hardening + Wake-on-LAN** release. The headline new feature is

--- a/appliance/cloud-init/README.md
+++ b/appliance/cloud-init/README.md
@@ -1,76 +1,246 @@
-# cloud-init NoCloud — first-boot config for the SpatiumDDI appliance
+# Headless / unattended install — SpatiumDDI appliance preseed
 
-The Phase 1 appliance image ships with the
-[NoCloud](https://cloudinit.readthedocs.io/en/latest/reference/datasources/nocloud.html)
-cloud-init datasource enabled. Drop a `user-data` + `meta-data` pair
-on a CIDATA ISO, attach it as a secondary disk, and the appliance
-configures itself on first power-on.
+Issue #549. This directory holds the **answer-file preseed** that drives
+the appliance's disk installer (`spatium-install`) non-interactively, so
+a box can install to disk with **no console operator** — for fleet
+rollouts, IPMI/PXE provisioning, cloud images, and CI boot-tests.
 
-## Build a CIDATA ISO
+> **What changed (post-#183).** The install flow is the interactive
+> **whiptail** installer `spatium-install` that partitions a disk
+> (A/B slot layout) and installs SpatiumDDI onto it. The *old*
+> `user-data.example` / `meta-data.example` in this directory only
+> configured an already-running docker-compose all-in-one (the
+> superseded pre-#183 flow) — it did **not** drive the disk installer.
+> The `spatium-preseed-*.yaml.example` files here are the current path.
+
+## How it works
+
+On boot of the **installer media** (`spatium-mode=install` in the
+kernel cmdline), `spatium-install` looks for a preseed answer file
+*before* launching the whiptail wizard. If it finds one:
+
+- Every field present in the answer file **skips** its interactive
+  prompt.
+- A **fully** preseeded run (disk + `confirm_wipe: true` + all fields)
+  runs end-to-end with **zero** console interaction — no welcome, no
+  confirm.
+- A **partial** preseed falls through to the interactive prompt for
+  **only the missing fields** (e.g. preseed everything-but-the-disk and
+  let an operator pick the target).
+- A field that is **present but invalid** (bad hostname, overlapping
+  k3s CIDRs, malformed pairing code, …) **halts loudly** with a non-zero
+  exit and a clear console message — it never silently picks a default
+  on a disk wipe.
+
+The installed system is identical to an interactively-installed one:
+the preseed only replaces the wizard's question-and-answer step, then
+hands the same values to the same `do_install`. A fully-preseeded box
+presents no setup wizard afterwards (console or web).
+
+## Answer-file schema
+
+See the annotated examples:
+
+- [`spatium-preseed-control-plane.yaml.example`](spatium-preseed-control-plane.yaml.example)
+  — first node (api + db + web UI + k3s seed).
+- [`spatium-preseed-appliance.yaml.example`](spatium-preseed-appliance.yaml.example)
+  — additional node (supervisor pairs with an existing control plane).
+
+Every field is optional; anything omitted falls through to interactive.
+Summary:
+
+| Field | Notes |
+|---|---|
+| `role` | `control-plane` (aka `first-node`) or `appliance` (aka `add-node` / `application`) |
+| `confirm_wipe` | **Must be `true`** to auto-wipe a disk unattended |
+| `target_disk` | Prefer `/dev/disk/by-id/…` or `by-path/…` (stable). Absent / unresolvable ⇒ interactive picker |
+| `hostname` | RFC 1123 (alnum + hyphen, ≤ 63) |
+| `admin_user` | default `admin` |
+| `admin_password` **or** `admin_password_hash` | plaintext, or a crypt(3) hash from `openssl passwd -6` |
+| `timezone` | IANA name, default `UTC` |
+| `network.mode` | `dhcp`, or `static` with `interface` + `ip` + `prefix` + `gateway` all required (IPv4 only; optional `dns`) |
+| `k3s.pod_cidr` / `k3s.service_cidr` | default `10.42.0.0/16` / `10.43.0.0/16`; validated ≤ /22, disjoint, no LAN overlap |
+| `control_plane_url` | **required for `role: appliance`** — the control plane URL (VIP for HA) |
+| `pairing_code` | **required for `role: appliance`** — 8-digit code from Appliance → Pairing |
+
+### Secrets
+
+`admin_password` and `pairing_code` in a plaintext answer file are the
+usual preseed tradeoff. To keep the admin cleartext out of the file, use
+`admin_password_hash` with a crypt(3) hash:
+
+```sh
+openssl passwd -6                       # prompts, prints $6$… SHA-512 hash
+# or: mkpasswd --method=sha-512
+```
+
+The pairing code is single-use / short-TTL by default (mint a fresh one
+per install). Neither secret is echoed to the console dashboard or logs,
+and both are read from a mode-`0600` file during install.
+
+## Delivery transports
+
+The same answer file is consumed regardless of how it arrives. Sources,
+first match wins:
+
+1. **Kernel cmdline** — `spatium.preseed=<url|path>` (best for PXE /
+   IPMI). A `http(s)://` value is fetched with curl; anything else is a
+   path on the installer rootfs.
+2. **NoCloud CIDATA volume** — a disk labelled `CIDATA` carrying
+   `spatium-preseed.yaml` (or `.yml`, or a cloud-init `user-data`
+   document with an embedded `spatium_preseed:` block). Best for VM /
+   Proxmox.
+3. **Install medium / rootfs** — `spatium-preseed.yaml` at
+   `/run/live/medium/`, `/`, or `/etc/` on the installer image (best for
+   sneakernet or a purpose-built ISO).
+
+### Build a NoCloud CIDATA ISO
 
 ```sh
 cd appliance/cloud-init
-cp user-data.example user-data       # edit: SSH key, release pin, hostname
-cp meta-data.example meta-data
-genisoimage -output cidata.iso -volid CIDATA -joliet -rock user-data meta-data
+cp spatium-preseed-control-plane.yaml.example spatium-preseed.yaml
+$EDITOR spatium-preseed.yaml            # set disk by-id, hostname, password
+touch meta-data                          # NoCloud requires the file to exist
+genisoimage -output cidata.iso -volid CIDATA -joliet -rock \
+    spatium-preseed.yaml meta-data
 ```
 
-`genisoimage` lives in the `cdrkit` (Debian/Ubuntu) or `cdrtools`
-(Alpine) packages. macOS:
-```sh
-hdiutil makehybrid -o cidata.iso -hfs -joliet -iso \
-        -default-volume-name CIDATA cidata-source/
-```
+`genisoimage` is in `cdrkit` (Debian/Ubuntu) or `cdrtools` (Alpine).
+macOS: `hdiutil makehybrid -o cidata.iso -hfs -joliet -iso -default-volume-name CIDATA <dir>`.
 
-## Attach to the VM
+Attach `cidata.iso` as a **second** CD/DVD/disk alongside the installer
+ISO:
 
 | Hypervisor | Recipe |
 |---|---|
-| **Proxmox** | Upload `cidata.iso` to a storage pool → VM hardware → Add → CD/DVD Drive → ISO image |
-| **libvirt / virt-manager** | Add hardware → Storage → CDROM → select cidata.iso |
+| **Proxmox** | Upload `cidata.iso` → VM hardware → Add → CD/DVD Drive → ISO image |
+| **libvirt / virt-manager** | Add hardware → Storage → CDROM → `cidata.iso` |
 | **QEMU CLI** | `-drive file=cidata.iso,if=virtio,format=raw,readonly=on` |
-| **VMware ESXi** | Datastore browser → upload → VM Edit → CD/DVD → Datastore ISO file |
-| **AWS / Azure / GCP** | Cloud-specific datasource handles user-data natively (Phase 5) |
+| **VMware ESXi** | Datastore browser → upload → VM Edit → CD/DVD → Datastore ISO |
 
-## What `user-data.example` covers
+### PXE / IPMI
 
-- **Operator account** — creates an `admin` user with `wheel` + `docker`
-  groups, sudo NOPASSWD, SSH key. Root SSH login is disabled out of
-  the box.
-- **Hostname / timezone** — applied before docker comes up.
-- **Optional release pin** (`/etc/spatiumddi/release`) — pins
-  `SPATIUMDDI_VERSION` to a CalVer tag instead of `:latest`.
-- **Optional agent.env** — placeholder for Phase 4 distributed agent
-  appliances. Phase 1 is all-in-one; this section is forward-compat.
+Append to the installer boot cmdline (alongside `spatium-mode=install`):
 
-## What happens on first boot
+```
+spatium.preseed=https://provision.example.net/spatium/ddi-control-1.yaml
+```
 
-1. cloud-init runs (`cloud-init-local.service` → `cloud-init.service`
-   → `cloud-config.service` → `cloud-final.service`), applies
-   user-data: hostname, users, write_files.
-2. The `spatiumddi-firstboot.service` systemd unit starts after
-   `cloud-final.service` and:
-   - generates `/etc/spatiumddi/.env` (POSTGRES_PASSWORD, SECRET_KEY,
-     CREDENTIAL_ENCRYPTION_KEY, DNS_AGENT_KEY, DHCP_AGENT_KEY,
-     BOOTSTRAP_PAIRING_CODE on Application installs) on first run
-     only — preserved across reboots via the `/etc` overlay →
-     `/var/persist/etc` path
-   - renders the variant-specific HelmChart manifest into
-     `/var/lib/rancher/k3s/server/manifests/spatium-bootstrap.yaml`;
-     k3s's helm-controller auto-installs the chart tarball baked at
-     `/usr/lib/spatiumddi/charts/`
-   - starts `k3s.service`; containerd auto-imports the per-image
-     tarballs at `/var/lib/rancher/k3s/agent/images/*.tar.zst` so a
-     fresh boot never reaches out to ghcr.io
-   - polls `http://127.0.0.1:8000/health/live` until the api pod
-     reports ready (5 min cap)
-3. Web UI is reachable at `http://<appliance-ip>/`. Default login
-   `admin` / `admin` (forces password change on first login).
+Serve a per-host answer file from any HTTP server. This pairs well with
+the console-redirect cmdline the appliance already sets
+(`console=ttyS0,115200n8`), so an IPMI serial console shows the install
+progress with no keyboard input.
 
-Live progress:
+## Cloud images (Azure / AWS) via cloud-init user-data
+
+Public clouds hand your instance a **cloud-init user-data** document at
+first boot. Because the installer reads a top-level `spatium_preseed:`
+key directly (and cloud-init ignores that unknown key), you can put the
+preseed **inside** the user-data document. The SpatiumDDI appliance
+image ships with the NoCloud datasource; on Azure/AWS the platform
+datasource presents user-data to the same on-disk path the installer's
+CIDATA search covers.
+
+> Cloud marketplace images are a **Phase 5** deliverable. Today this
+> path is for operators building their own cloud image from the
+> appliance raw disk (`make appliance-*`) and importing it (Azure
+> Managed Image / AWS EBS snapshot + AMI). The user-data shape below is
+> what those images consume once the platform datasource is wired.
+
+### AWS EC2
+
+`target_disk` should be the stable NVMe/Xen id the instance exposes
+(e.g. `/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol…`). Pass the
+document as the instance **User data** (console → Advanced details →
+User data, or `--user-data file://user-data.yaml`):
+
+```yaml
+#cloud-config
+# Optional cloud-init directives (SSH keys, etc.) can live here too;
+# cloud-init ignores the spatium_preseed block below and the installer
+# reads it directly.
+spatium_preseed:
+  role: control-plane
+  confirm_wipe: true
+  # AWS EBS root device — use the by-id path, not /dev/xvda / /dev/nvme0n1
+  # which can renumber. `ls -l /dev/disk/by-id` on a running instance
+  # shows the stable name.
+  target_disk: /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0abc123
+  hostname: ddi-control-1
+  admin_user: admin
+  admin_password_hash: "$6$rounds=4096$examplesalt$exhash..."
+  timezone: UTC
+  network:
+    mode: dhcp        # EC2 hands out the private IP over DHCP
+  k3s:
+    pod_cidr: 10.42.0.0/16
+    service_cidr: 10.43.0.0/16
+```
+
+```sh
+aws ec2 run-instances \
+  --image-id ami-0spatiumddi... \
+  --instance-type t3.large \
+  --user-data file://user-data.yaml \
+  ...
+```
+
+### Azure VM
+
+`target_disk` is the OS disk; use its `/dev/disk/by-id/` path (Azure
+attaches the OS disk as LUN 0). Pass the document as `--custom-data`
+(cloud-init user-data) — the CLI base64-encodes the file for you:
+
+```yaml
+#cloud-config
+spatium_preseed:
+  role: appliance
+  confirm_wipe: true
+  target_disk: /dev/disk/by-id/scsi-360022480000000000000000000000000
+  hostname: dns-west-1
+  admin_user: azureadmin
+  admin_password_hash: "$6$rounds=4096$examplesalt$exhash..."
+  timezone: UTC
+  network:
+    mode: dhcp
+  k3s:
+    pod_cidr: 10.42.0.0/16
+    service_cidr: 10.43.0.0/16
+  control_plane_url: https://ddi-control.example.net/
+  pairing_code: "12345678"
+```
+
+```sh
+az vm create \
+  --resource-group spatium-rg \
+  --name dns-west-1 \
+  --image /subscriptions/…/spatiumddi-appliance \
+  --custom-data user-data.yaml \
+  --size Standard_D2s_v5 \
+  ...
+```
+
+> **Azure caveat.** Azure's own provisioning agent also wants to set the
+> hostname + admin user from the ARM request. Keep those consistent with
+> the `spatium_preseed` values (or omit them from one side) so the two
+> don't fight. On AWS there's no such overlap — user-data is the only
+> channel.
+
+## CI boot-test leverage
+
+A fully-preseeded answer file (disk by-id + `confirm_wipe: true` + all
+fields) turns an appliance ISO into an unattended install-to-disk that
+finishes without a keypress — the basis for an automated in-VM boot test
+per release (long-wanted in #134 Phase 1). Point a throwaway QEMU VM at
+the installer ISO + a CIDATA ISO, wait for the reboot, and assert
+`/health/live` comes up.
+
+## Live progress
+
 ```sh
 ssh admin@<appliance-ip>
+sudo journalctl -u spatium-install -f          # install-time
+sudo tail -f /var/log/spatium-install.log      # step log + preseed NOTEs
+# after the install reboots into the running system:
 sudo tail -f /var/log/spatiumddi/firstboot.log
-sudo journalctl -u spatiumddi-firstboot -f      # systemd transitions
-sudo spatiumddi-stack-status
 ```

--- a/appliance/cloud-init/spatium-preseed-appliance.yaml.example
+++ b/appliance/cloud-init/spatium-preseed-appliance.yaml.example
@@ -1,0 +1,42 @@
+# SpatiumDDI headless install preseed — APPLIANCE (additional node).
+# Issue #549. An appliance node runs the supervisor only; it pairs with
+# an EXISTING control plane over an 8-digit pairing code, waits in
+# pending_approval until an admin approves it in the Fleet UI, then gets
+# DNS / DHCP roles assigned. Can later be promoted into the control-plane
+# cluster for HA.
+#
+# See spatium-preseed-control-plane.yaml.example for the field-by-field
+# notes shared with this file (disk safety, password handling, network,
+# k3s CIDRs). Only the appliance-specific fields are annotated here.
+spatium_preseed:
+  # control-plane vs appliance. Aliases for appliance: add-node,
+  # additional, agent, application.
+  role: appliance
+
+  confirm_wipe: true
+  target_disk: /dev/disk/by-id/ata-QEMU_HARDDISK_QM00002
+
+  hostname: dns-east-1
+  admin_user: admin
+  admin_password: "change-me-please"
+  timezone: UTC
+
+  network:
+    mode: dhcp
+
+  k3s:
+    pod_cidr: 10.42.0.0/16
+    service_cidr: 10.43.0.0/16
+
+  # ── Control-plane join (REQUIRED for role: appliance) ───────────────
+  # Where this appliance registers. Point at the control plane's URL —
+  # for a multi-node HA control plane use the MetalLB virtual IP (VIP),
+  # NOT a single node, so the appliance survives that node going down.
+  control_plane_url: https://ddi-control-1.example.net/
+
+  # 8-digit pairing code minted at the control plane
+  # (Appliance -> Pairing -> New pairing code). Dashes / spaces from the
+  # displayed 1234-5678 form are accepted; stored single-use unless the
+  # admin minted a persistent code. Treat as a short-TTL secret — kept
+  # out of the console dashboard + logs.
+  pairing_code: "12345678"

--- a/appliance/cloud-init/spatium-preseed-control-plane.yaml.example
+++ b/appliance/cloud-init/spatium-preseed-control-plane.yaml.example
@@ -1,0 +1,67 @@
+# SpatiumDDI headless install preseed — CONTROL-PLANE (first node).
+# Issue #549. Drives `spatium-install` non-interactively at install
+# time. Copy to `spatium-preseed.yaml`, edit, and deliver it via one of
+# the transports in appliance/cloud-init/README.md (NoCloud CIDATA ISO,
+# kernel cmdline `spatium.preseed=`, or a file on the install medium).
+#
+# Every field is OPTIONAL. Anything omitted falls through to the
+# interactive whiptail prompt, so you can preseed everything-but-the-disk
+# and let an operator pick the target at the console. A field that is
+# PRESENT but invalid halts the install loudly (never a silent default).
+#
+# The block may sit at the top level of a cloud-init `user-data`
+# document too — cloud-init ignores the unknown `spatium_preseed` key,
+# and the installer reads it directly (see the Azure / AWS recipes in
+# README.md).
+spatium_preseed:
+  # ── Role ────────────────────────────────────────────────────────────
+  # control-plane = the FIRST SpatiumDDI node (api + db + web UI + k3s
+  # seed). Aliases: first-node, control.
+  role: control-plane
+
+  # ── Destructive-disk safety ─────────────────────────────────────────
+  # An unattended install WIPES this disk with no human in the loop.
+  # BOTH of these are required for the installer to auto-select + wipe:
+  #   * confirm_wipe: true
+  #   * target_disk resolving to exactly one whole disk.
+  # Prefer a STABLE id under /dev/disk/by-id or /dev/disk/by-path — a
+  # bare /dev/sda can renumber between boots. If target_disk is omitted
+  # (or unresolvable), the console disk-picker runs instead.
+  confirm_wipe: true
+  target_disk: /dev/disk/by-id/ata-QEMU_HARDDISK_QM00001
+
+  # ── Identity ────────────────────────────────────────────────────────
+  hostname: ddi-control-1          # RFC 1123: alnum + hyphen, <= 63 chars
+
+  # ── OS admin account (for SSH + sudo) ───────────────────────────────
+  admin_user: admin
+  # Supply EITHER admin_password (plaintext) OR admin_password_hash (a
+  # crypt(3) hash from e.g. `openssl passwd -6` / `mkpasswd -m sha-512`).
+  # The hash form keeps the cleartext out of the answer file. Never
+  # echoed to the console dashboard or logs.
+  admin_password: "change-me-please"
+  # admin_password_hash: "$6$rounds=4096$abcd...$..."
+
+  # ── Timezone (IANA name; default UTC) ───────────────────────────────
+  timezone: UTC
+
+  # ── Network ─────────────────────────────────────────────────────────
+  network:
+    mode: dhcp                     # dhcp | static
+    # For a static address, uncomment + fill ALL of interface/ip/prefix/
+    # gateway (all four are required for static; IPv4 only). dns is
+    # optional (defaults to 1.1.1.1 1.0.0.1):
+    # mode: static
+    # interface: eth0              # the NIC name, e.g. eth0 / enp1s0
+    # ip: 192.168.1.10
+    # prefix: 24
+    # gateway: 192.168.1.1
+    # dns: "1.1.1.1 1.0.0.1"
+
+  # ── k3s pod + service CIDRs (#302) ──────────────────────────────────
+  # Defaults match k3s upstream. Override only if your LAN already uses
+  # 10.42.x / 10.43.x. Validated: valid IPv4, <= /22, disjoint, and (on
+  # a static install) non-overlapping with the LAN subnet.
+  k3s:
+    pod_cidr: 10.42.0.0/16
+    service_cidr: 10.43.0.0/16

--- a/appliance/mkosi.conf
+++ b/appliance/mkosi.conf
@@ -202,6 +202,11 @@ Packages=
         # we need for the renderer. ~5 MiB combined.
         python3-rich
         python3-psutil
+        # python3-yaml — parses the headless-install preseed answer file
+        # (issue #549). spatium-preseed-parse reuses the wizard's
+        # validators against a YAML answer file for unattended installs.
+        # ~250 KiB.
+        python3-yaml
         # F2 Monitor on the console dashboard launches htop (under
         # `runuser -u admin` so the operator can't kill system
         # processes from the physical console). ~250 KiB.

--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -99,6 +99,10 @@ TARGET_DISK=""
 HOSTNAME=""
 ADMIN_USER="admin"
 ADMIN_PASSWORD=""
+# Optional crypt(3) admin password hash (headless preseed, issue #549).
+# When set, do_install feeds it through `chpasswd -e` instead of the
+# plaintext ADMIN_PASSWORD. Mutually exclusive with ADMIN_PASSWORD.
+ADMIN_PASSWORD_HASH=""
 NET_MODE="dhcp"
 NET_INTERFACE=""
 NET_IP=""
@@ -169,6 +173,29 @@ CONTROL_PLANE_URL=""
 # control-plane admin minted. Only meaningful when ROLE=appliance.
 BOOTSTRAP_PAIRING_CODE=""
 
+# ── Headless preseed state (issue #549) ────────────────────────────────
+# When a preseed answer file is discovered + parsed, load_preseed sets
+# PRESEED_ACTIVE=1, sources the resolved wizard variables + per-field
+# PRESEED_HAS_* markers, and computes FULLY_UNATTENDED. Each ask_*
+# prompt short-circuits when its field is preseeded; welcome + the final
+# confirm are skipped entirely on a fully-unattended run. Partial
+# preseeds fall through to the interactive prompt for missing fields.
+PRESEED_ACTIVE=0
+FULLY_UNATTENDED=0
+PRESEED_SOURCE=""
+PRESEED_ENV=/run/spatium-preseed.env
+PRESEED_SECRET_ENV=/run/spatium-preseed-secret.env
+# Candidate answer files discovered by discover_preseed, in priority
+# order (parallel arrays). KIND is "explicit" (kernel cmdline value or a
+# file literally named spatium-preseed.*) or "opportunistic" (a
+# cloud-init user-data that may or may not carry a spatium_preseed
+# block). load_preseed tries them in order, skipping ones with no
+# preseed content so a plain user-data doesn't shadow a real preseed on
+# a lower-priority source.
+PRESEED_CAND_FILE=()
+PRESEED_CAND_SRC=()
+PRESEED_CAND_KIND=()
+
 # ── Prompts ───────────────────────────────────────────────────────────────────
 
 welcome() {
@@ -189,6 +216,10 @@ Press OK to begin, or Cancel to drop to a shell." 18 70 \
 
 ask_role() {
     log "Step: ask_role"
+    if [ -n "${PRESEED_HAS_ROLE:-}" ]; then
+        log "Preseed: role=$ROLE (skipping prompt)"
+        return 0
+    fi
     # #272 UX — reframe the install role around the decision operators
     # actually make ("is this my FIRST SpatiumDDI node, or am I adding
     # one to an existing install?") instead of the jargon control-plane
@@ -259,20 +290,24 @@ ask_application_config() {
     fi
     log "Step: ask_application_config"
 
-    local default_url="${CONTROL_PLANE_URL:-https://}"
-    while true; do
-        CONTROL_PLANE_URL=$(whiptail --backtitle "$BACKTITLE" \
-            --title "Control plane URL" \
-            --cancel-button "Back" \
-            --inputbox "Where does this Application appliance register?\n\nFormat: https://<control-plane-host>/  — the URL of the SpatiumDDI control plane this supervisor pairs against. The supervisor submits its Ed25519 pubkey here, sits in pending until an admin clicks Approve, then receives a control-plane-CA-signed identity cert.\n\nHA TIP: if the control plane is a multi-node cluster, point this at the MetalLB virtual IP (VIP), NOT a single node's IP — otherwise this appliance loses its control plane whenever that one node is down. Configure the VIP under Appliance -> Network & Host on the control plane.\n\nUse https:// in production; http:// is acceptable for lab installs." \
-            21 78 "$default_url" 3>&1 1>&2 2>&3) \
-            || return 1
-        if [ -z "$CONTROL_PLANE_URL" ] || [ "$CONTROL_PLANE_URL" = "https://" ]; then
-            whiptail --msgbox "Control-plane URL is required for an Application install." 8 60 || true
-            continue
-        fi
-        break
-    done
+    if [ -n "${PRESEED_HAS_CONTROL_URL:-}" ]; then
+        log "Preseed: control_plane_url=$CONTROL_PLANE_URL (skipping prompt)"
+    else
+        local default_url="${CONTROL_PLANE_URL:-https://}"
+        while true; do
+            CONTROL_PLANE_URL=$(whiptail --backtitle "$BACKTITLE" \
+                --title "Control plane URL" \
+                --cancel-button "Back" \
+                --inputbox "Where does this Application appliance register?\n\nFormat: https://<control-plane-host>/  — the URL of the SpatiumDDI control plane this supervisor pairs against. The supervisor submits its Ed25519 pubkey here, sits in pending until an admin clicks Approve, then receives a control-plane-CA-signed identity cert.\n\nHA TIP: if the control plane is a multi-node cluster, point this at the MetalLB virtual IP (VIP), NOT a single node's IP — otherwise this appliance loses its control plane whenever that one node is down. Configure the VIP under Appliance -> Network & Host on the control plane.\n\nUse https:// in production; http:// is acceptable for lab installs." \
+                21 78 "$default_url" 3>&1 1>&2 2>&3) \
+                || return 1
+            if [ -z "$CONTROL_PLANE_URL" ] || [ "$CONTROL_PLANE_URL" = "https://" ]; then
+                whiptail --msgbox "Control-plane URL is required for an Application install." 8 60 || true
+                continue
+            fi
+            break
+        done
+    fi
 
     # Pairing code only — Application appliances never paste a long
     # bootstrap key. The supervisor generates its own Ed25519 keypair
@@ -280,6 +315,10 @@ ask_application_config() {
     # control plane stores it and waits for admin approval. The 8-digit
     # code is the only thing the operator types over an IPMI / serial
     # console.
+    if [ -n "${PRESEED_HAS_PAIRING_CODE:-}" ]; then
+        log "Preseed: pairing code supplied (skipping prompt)"
+        return 0
+    fi
     local code_val
     while true; do
         code_val=$(whiptail --backtitle "$BACKTITLE" --title "Pairing code" \
@@ -311,6 +350,10 @@ ask_application_config() {
 
 pick_disk() {
     log "Step: pick_disk"
+    if [ -n "${PRESEED_HAS_DISK:-}" ]; then
+        log "Preseed: target_disk=$TARGET_DISK (confirm_wipe authorised; skipping picker)"
+        return 0
+    fi
     local options=()
     local live_src
     live_src=$(findmnt -no SOURCE /run/live/medium 2>/dev/null || \
@@ -432,6 +475,12 @@ _control_plane_sizing_ok() {
 # costs nothing.
 confirm_partition_layout() {
     log "Step: confirm_partition_layout"
+    if [ -n "${PRESEED_HAS_DISK:-}" ]; then
+        # confirm_wipe: true in the preseed IS the wipe authorisation —
+        # don't re-prompt the layout checkbox on an unattended run.
+        log "Preseed: partition-layout confirm skipped (confirm_wipe authorised $TARGET_DISK)"
+        return 0
+    fi
     local DISK_BYTES disk_gib var_gib
     DISK_BYTES=$(blockdev --getsize64 "$TARGET_DISK" 2>/dev/null || echo 0)
     disk_gib=$((DISK_BYTES / 1024 / 1024 / 1024))
@@ -481,6 +530,10 @@ confirm_partition_layout() {
 
 ask_hostname() {
     log "Step: ask_hostname"
+    if [ -n "${PRESEED_HAS_HOSTNAME:-}" ]; then
+        log "Preseed: hostname=$HOSTNAME (skipping prompt)"
+        return 0
+    fi
     # No pre-filled default — multiple appliances on the same network
     # all named "spatiumddi" caused real-world server-name collisions
     # (the agent registers its SERVER_NAME with the control plane;
@@ -515,12 +568,24 @@ ask_hostname() {
 
 ask_user_password() {
     log "Step: ask_user_password"
-    ADMIN_USER=$(whiptail --backtitle "$BACKTITLE" --title "Admin OS user" \
-        --cancel-button "Back" \
-        --inputbox "OS-level admin username (for SSH + sudo).\n\nThe SpatiumDDI web UI uses 'admin/admin' separately - change it on first login." \
-        12 70 "$ADMIN_USER" 3>&1 1>&2 2>&3) \
-        || return 1
-    [ -z "$ADMIN_USER" ] && ADMIN_USER="admin"
+    # Username prompt is skipped when the admin user is preseeded, OR
+    # when a preseeded password makes this a headless run (in which case
+    # the ADMIN_USER default of "admin" — or a preseeded value — stands).
+    if [ -z "${PRESEED_HAS_ADMIN_USER:-}" ] && [ -z "${PRESEED_HAS_PASSWORD:-}" ]; then
+        ADMIN_USER=$(whiptail --backtitle "$BACKTITLE" --title "Admin OS user" \
+            --cancel-button "Back" \
+            --inputbox "OS-level admin username (for SSH + sudo).\n\nThe SpatiumDDI web UI uses 'admin/admin' separately - change it on first login." \
+            12 70 "$ADMIN_USER" 3>&1 1>&2 2>&3) \
+            || return 1
+        [ -z "$ADMIN_USER" ] && ADMIN_USER="admin"
+    else
+        log "Preseed: admin user=$ADMIN_USER (skipping username prompt)"
+    fi
+
+    if [ -n "${PRESEED_HAS_PASSWORD:-}" ]; then
+        log "Preseed: admin password supplied (skipping prompt)"
+        return 0
+    fi
 
     while true; do
         local p1 p2
@@ -545,6 +610,10 @@ ask_user_password() {
 
 ask_network() {
     log "Step: ask_network"
+    if [ -n "${PRESEED_HAS_NETWORK:-}" ]; then
+        log "Preseed: network=$NET_MODE (skipping prompt)"
+        return 0
+    fi
     NET_MODE=$(whiptail --backtitle "$BACKTITLE" --title "Network" \
         --cancel-button "Back" \
         --menu "How should the appliance configure its network?" 12 70 2 \
@@ -588,6 +657,10 @@ ask_network() {
 
 ask_timezone() {
     log "Step: ask_timezone"
+    if [ -n "${PRESEED_HAS_TIMEZONE:-}" ]; then
+        log "Preseed: timezone=$TIMEZONE (skipping prompt)"
+        return 0
+    fi
     TIMEZONE=$(whiptail --backtitle "$BACKTITLE" --title "Timezone" \
         --cancel-button "Back" \
         --inputbox "Timezone (IANA name, e.g. America/Toronto, Europe/Berlin, UTC):" \
@@ -617,6 +690,24 @@ ask_timezone() {
 # (between pod / service / operator's static-IP subnet) for free.
 ask_k3s_cidrs() {
     log "Step: ask_k3s_cidrs"
+    if [ -n "${PRESEED_HAS_K3S:-}" ]; then
+        if [ -n "${PRESEED_HAS_NETWORK:-}" ]; then
+            log "Preseed: k3s pod=$K3S_POD_CIDR svc=$K3S_SERVICE_CIDR (skipping prompt)"
+            return 0
+        fi
+        # k3s was preseeded but the network was chosen interactively, so
+        # the parser could not check the pod/service CIDRs against the
+        # operator's static LAN subnet. Re-run the same validator now
+        # that NET_* is known; if it passes we skip the prompt, if it
+        # flags an overlap the operator gets the interactive prompt to
+        # fix it (this only happens on a partial, already-interactive
+        # run — never a fully-unattended one).
+        if _validate_k3s_cidrs "$K3S_POD_CIDR" "$K3S_SERVICE_CIDR"; then
+            log "Preseed: k3s CIDRs validated against interactive network (skipping prompt)"
+            return 0
+        fi
+        log "Preseed: k3s CIDRs conflict with the interactively-chosen network — prompting"
+    fi
     while true; do
         local pod
         pod=$(whiptail --backtitle "$BACKTITLE" --title "k3s pod network" \
@@ -1262,10 +1353,24 @@ EOF
         # (Issue #183 Phase 7 — no docker group on the appliance.)
         chroot "$MOUNT" useradd -m -G sudo -s /bin/bash "$ADMIN_USER" \
             >> "$INSTALL_LOG" 2>&1 || true
-        echo "$ADMIN_USER:$ADMIN_PASSWORD" | chroot "$MOUNT" chpasswd \
-            >> "$INSTALL_LOG" 2>&1
-        echo "root:$ADMIN_PASSWORD" | chroot "$MOUNT" chpasswd \
-            >> "$INSTALL_LOG" 2>&1
+        # Set the admin + root passwords with tracing OFF so the
+        # plaintext / hash never lands in the set -x trace log. A
+        # preseed can supply a crypt(3) hash (ADMIN_PASSWORD_HASH) via
+        # `chpasswd -e` instead of the plaintext (#549); the interactive
+        # path always uses the plaintext ADMIN_PASSWORD.
+        { set +x; } 2>/dev/null
+        if [ -n "$ADMIN_PASSWORD_HASH" ]; then
+            echo "$ADMIN_USER:$ADMIN_PASSWORD_HASH" | chroot "$MOUNT" chpasswd -e \
+                >> "$INSTALL_LOG" 2>&1
+            echo "root:$ADMIN_PASSWORD_HASH" | chroot "$MOUNT" chpasswd -e \
+                >> "$INSTALL_LOG" 2>&1
+        else
+            echo "$ADMIN_USER:$ADMIN_PASSWORD" | chroot "$MOUNT" chpasswd \
+                >> "$INSTALL_LOG" 2>&1
+            echo "root:$ADMIN_PASSWORD" | chroot "$MOUNT" chpasswd \
+                >> "$INSTALL_LOG" 2>&1
+        fi
+        set -x
 
         # Disable cloud-init on the installed system (we configured
         # everything ourselves; cloud-init would just sit waiting for a
@@ -1618,12 +1723,263 @@ Press OK to reboot." 24 72
     systemctl reboot
 }
 
+# ── Headless preseed (issue #549) ──────────────────────────────────────────────
+
+# Fetch a URL to $2 with a bounded retry loop — the installer wizard can
+# reach discover_preseed before NetworkManager has finished DHCP, so a
+# single curl would lose the race and drop a URL-preseeded fleet box to
+# the interactive wizard. Retry ~6× over ~30 s (only the cmdline-URL
+# path pays this; file / CIDATA transports never call it). Returns 0 on
+# success.
+_fetch_preseed_url() {
+    local url="$1" dest="$2" attempt
+    for attempt in 1 2 3 4 5 6; do
+        if curl -fsSL --max-time 20 "$url" -o "$dest" 2>>"$INSTALL_LOG"; then
+            return 0
+        fi
+        log "Preseed: fetch attempt $attempt/6 for $url failed (network may still be coming up)"
+        sleep 5
+    done
+    return 1
+}
+
+# Append a discovered candidate to the parallel arrays.
+#   $1 local file path, $2 human source description, $3 kind
+_add_preseed_cand() {
+    PRESEED_CAND_FILE+=("$1")
+    PRESEED_CAND_SRC+=("$2")
+    PRESEED_CAND_KIND+=("$3")
+}
+
+# Collect every preseed answer-file candidate, in priority order, into
+# the PRESEED_CAND_* arrays. Sources:
+#   1. Kernel cmdline `spatium.preseed=<url|path>` (PXE/IPMI) — explicit.
+#   2. A block device labelled CIDATA (NoCloud): spatium-preseed.yaml /
+#      .yml (explicit) or a cloud-init user-data (opportunistic — only
+#      used if it actually carries a spatium_preseed block). VM/Proxmox.
+#   3. The live install medium / rootfs-baked spatium-preseed.yaml
+#      (sneakernet / CI) — explicit.
+# Returns 0 if at least one candidate was found; 1 otherwise.
+discover_preseed() {
+    local cmdval
+    cmdval=$(sed -n 's/.*spatium\.preseed=\([^ ]*\).*/\1/p' /proc/cmdline 2>/dev/null)
+    if [ -n "$cmdval" ]; then
+        case "$cmdval" in
+            http://*|https://*)
+                local dest=/run/spatium-cand-cmdline.yaml
+                if _fetch_preseed_url "$cmdval" "$dest"; then
+                    _add_preseed_cand "$dest" "kernel cmdline URL $cmdval" explicit
+                else
+                    log "Preseed: gave up fetching $cmdval from cmdline after retries"
+                fi
+                ;;
+            *)
+                if [ -f "$cmdval" ]; then
+                    _add_preseed_cand "$cmdval" "kernel cmdline path $cmdval" explicit
+                else
+                    log "Preseed: cmdline path $cmdval not found"
+                fi
+                ;;
+        esac
+    fi
+
+    # NoCloud CIDATA volume(s). Case-insensitive label match; try a few
+    # spellings operators use.
+    local dev label
+    for label in CIDATA cidata Cidata; do
+        dev=$(blkid -L "$label" 2>/dev/null || true)
+        [ -n "$dev" ] && break
+    done
+    if [ -n "$dev" ]; then
+        local mnt=/run/spatium-cidata
+        mkdir -p "$mnt"
+        if mount -o ro "$dev" "$mnt" 2>>"$INSTALL_LOG"; then
+            local cand kind dest i=0
+            for cand in spatium-preseed.yaml spatium-preseed.yml user-data; do
+                [ -f "$mnt/$cand" ] || continue
+                case "$cand" in
+                    user-data) kind=opportunistic ;;
+                    *)         kind=explicit ;;
+                esac
+                # Copy off the volume before we umount it.
+                dest="/run/spatium-cand-cidata-$i.yaml"
+                i=$((i + 1))
+                cp "$mnt/$cand" "$dest" 2>>"$INSTALL_LOG"
+                _add_preseed_cand "$dest" "CIDATA volume $dev ($cand)" "$kind"
+            done
+            umount "$mnt" 2>>"$INSTALL_LOG" || true
+        fi
+    fi
+
+    # Live install medium + rootfs-baked locations (all explicit).
+    local path
+    for path in \
+        /run/live/medium/spatium-preseed.yaml \
+        /lib/live/mount/medium/spatium-preseed.yaml \
+        /spatium-preseed.yaml \
+        /etc/spatium-preseed.yaml; do
+        [ -f "$path" ] && _add_preseed_cand "$path" "$path" explicit
+    done
+
+    [ "${#PRESEED_CAND_FILE[@]}" -gt 0 ]
+}
+
+# Recompute FULLY_UNATTENDED — true only when EVERY field the wizard
+# would prompt for is preseeded (so the run needs zero console input).
+# Missing anything leaves it 0 and the wizard shows welcome + the final
+# confirm around whatever prompts still fire.
+compute_unattended() {
+    FULLY_UNATTENDED=0
+    [ -n "${PRESEED_HAS_ROLE:-}" ]      || return 0
+    [ -n "${PRESEED_HAS_DISK:-}" ]      || return 0
+    [ -n "${PRESEED_HAS_HOSTNAME:-}" ]  || return 0
+    [ -n "${PRESEED_HAS_PASSWORD:-}" ]  || return 0
+    [ -n "${PRESEED_HAS_NETWORK:-}" ]   || return 0
+    [ -n "${PRESEED_HAS_TIMEZONE:-}" ]  || return 0
+    [ -n "${PRESEED_HAS_K3S:-}" ]       || return 0
+    if [ "$ROLE" = "appliance" ]; then
+        [ -n "${PRESEED_HAS_CONTROL_URL:-}" ]  || return 0
+        [ -n "${PRESEED_HAS_PAIRING_CODE:-}" ] || return 0
+    fi
+    FULLY_UNATTENDED=1
+}
+
+# Halt-loud helper — a preseed that WAS supplied but failed validation
+# (or couldn't be parsed) must stop the unattended run with a clear
+# message + non-zero exit, never silently pick a default on a wipe.
+preseed_halt() {
+    set +x
+    clear
+    cat <<EOF
+
+============================================================
+  SpatiumDDI headless install — PRESEED ERROR
+============================================================
+
+$1
+
+The preseed answer file was found but could not be used, so
+the install has stopped rather than guess a value on an
+unattended disk wipe.
+
+Fix the answer file and reboot the installer, or run
+'spatium-install' from this shell to install interactively.
+
+Source: ${PRESEED_SOURCE:-<unknown>}
+Log:    $INSTALL_LOG
+============================================================
+
+EOF
+    log "Preseed halt: $1"
+    exit 1
+}
+
+# Discover + parse a preseed, if present. Tries every discovered
+# candidate in priority order; the first one that carries real preseed
+# content is adopted. A candidate with a spatium block but an invalid
+# field halts loudly; a candidate with NO preseed content (e.g. a plain
+# cloud-init user-data) is skipped so it can't shadow a real preseed on
+# a lower-priority source. On success sources the resolved wizard
+# variables + PRESEED_HAS_* markers and sets PRESEED_ACTIVE=1.
+load_preseed() {
+    if ! discover_preseed; then
+        log "No preseed answer file found — interactive install"
+        return 0
+    fi
+
+    local i f src kind out rc chosen=""
+    for i in "${!PRESEED_CAND_FILE[@]}"; do
+        f="${PRESEED_CAND_FILE[$i]}"
+        src="${PRESEED_CAND_SRC[$i]}"
+        kind="${PRESEED_CAND_KIND[$i]}"
+        # The answer file may carry a plaintext admin password / pairing
+        # code — lock it down on the (tmpfs) live rootfs before parsing.
+        chmod 0600 "$f" 2>/dev/null || true
+        log "Preseed: trying candidate ($kind) $src -> $f"
+
+        out=$(python3 /usr/local/bin/spatium-preseed-parse \
+            "$f" "$PRESEED_ENV" "$PRESEED_SECRET_ENV" 2>&1)
+        rc=$?
+        printf '%s\n' "$out" >> "$INSTALL_LOG"
+        case "$rc" in
+            0)
+                PRESEED_SOURCE="$src"
+                chosen=1
+                break
+                ;;
+            2)
+                # Has a spatium block but a supplied field is invalid —
+                # halt regardless of source kind (it IS an intended
+                # preseed, just broken).
+                PRESEED_SOURCE="$src"
+                preseed_halt "Preseed validation failed:"$'\n\n'"$out"
+                ;;
+            3)
+                # Malformed YAML. An explicit spatium-preseed.yaml / a
+                # cmdline value the operator clearly meant as a preseed
+                # halts; an opportunistic user-data that just happens to
+                # be unparseable is not ours — skip it.
+                if [ "$kind" = "explicit" ]; then
+                    PRESEED_SOURCE="$src"
+                    preseed_halt "Preseed file could not be parsed:"$'\n\n'"$out"
+                fi
+                log "Preseed: skipping unparseable opportunistic $src"
+                ;;
+            4)
+                # Parsed fine but no spatium content (plain cloud-init
+                # user-data). Skip to the next candidate.
+                log "Preseed: $src has no spatium preseed content — trying next candidate"
+                ;;
+            *)
+                PRESEED_SOURCE="$src"
+                preseed_halt "Unexpected preseed parser error (rc=$rc):"$'\n\n'"$out"
+                ;;
+        esac
+    done
+
+    if [ -z "$chosen" ]; then
+        log "Preseed: no candidate carried preseed content — interactive install"
+        return 0
+    fi
+    log "Preseed source adopted: $PRESEED_SOURCE"
+
+    # Source the resolved non-secret values (ROLE / HOSTNAME / TARGET_DISK
+    # / NET_* / K3S_* / PRESEED_HAS_* markers). shellcheck can't follow
+    # the runtime path.
+    # shellcheck disable=SC1090
+    [ -f "$PRESEED_ENV" ] && . "$PRESEED_ENV"
+    # Secrets (admin password / hash, pairing code) with tracing OFF so
+    # they never reach the set -x trace log.
+    { set +x; } 2>/dev/null
+    # shellcheck disable=SC1090
+    [ -f "$PRESEED_SECRET_ENV" ] && . "$PRESEED_SECRET_ENV"
+    set -x
+
+    PRESEED_ACTIVE=1
+    compute_unattended
+    log "Preseed loaded: role=${ROLE} disk=${TARGET_DISK:-<interactive>} fully_unattended=$FULLY_UNATTENDED"
+    return 0
+}
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 main() {
     if [ "$(id -u)" -ne 0 ]; then
         echo "Run as root." >&2
         exit 1
+    fi
+
+    # Headless preseed (issue #549) — if an answer file is present, load
+    # + validate it first. Populated fields skip their prompt below; a
+    # fully-preseeded run skips welcome + the final confirm too. A bad
+    # preseed halts loudly here rather than falling through.
+    load_preseed
+    if [ "$PRESEED_ACTIVE" = "1" ]; then
+        if [ "$FULLY_UNATTENDED" = "1" ]; then
+            log "Preseed: fully unattended — no console interaction required"
+        else
+            log "Preseed: partial — prompting interactively for missing fields"
+        fi
     fi
 
     # State-machine wizard. Each step is one function that returns:
@@ -1644,7 +2000,10 @@ main() {
                 # welcome only returns 0 — Cancel here calls on_cancel
                 # which exec's a shell (never returns). That's the
                 # explicit "I changed my mind, don't install" path.
-                welcome
+                # Skipped entirely on a fully-unattended preseed run.
+                if [ "$FULLY_UNATTENDED" != "1" ]; then
+                    welcome
+                fi
                 step="ask_role"
                 ;;
             ask_role)
@@ -1682,7 +2041,14 @@ main() {
                 if ask_application_config; then step="confirm"; else step="ask_k3s_cidrs"; fi
                 ;;
             confirm)
-                if confirm; then step="do_install"; else step="ask_application_config"; fi
+                # Fully-unattended preseed skips the final confirm —
+                # confirm_wipe:true in the answer file already authorised
+                # the destructive install. A partial preseed still shows
+                # it (the operator was prompted for something, so give
+                # them the review screen).
+                if [ "$FULLY_UNATTENDED" = "1" ]; then
+                    step="do_install"
+                elif confirm; then step="do_install"; else step="ask_application_config"; fi
                 ;;
             do_install)
                 do_install

--- a/appliance/mkosi.extra/usr/local/bin/spatium-preseed-parse
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-preseed-parse
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+# spatium-preseed-parse — validate a headless-install answer file and
+# emit resolved values for the spatium-install bash wizard to consume
+# (issue #549).
+#
+# The interactive installer (spatium-install) drives a whiptail wizard.
+# For fleet rollouts / PXE / CI boot-tests there's no console operator,
+# so this helper lets spatium-install run non-interactively from a
+# preseed answer file. It reuses the SAME validation rules the wizard
+# enforces (hostname RFC 1123, k3s CIDR disjoint + <= /22 + no LAN
+# overlap, pairing code = 8 digits, control-plane URL required for the
+# appliance role) so a headless install can't slip past a guard the
+# interactive path would have caught.
+#
+# Contract with spatium-install:
+#   argv: <preseed.yaml> <out-env> <out-secret-env>
+#   exit 0 — parsed OK (possibly PARTIAL — missing fields fall through
+#            to the interactive prompt in the wizard).
+#   exit 2 — a field that WAS supplied failed validation. The install
+#            must halt loudly rather than silently pick a default on
+#            an unattended run (acceptance criterion in #549).
+#   exit 3 — the file could not be read / parsed as YAML at all
+#            (malformed — a loud failure since a preseed was expected).
+#   exit 4 — the file parsed but carries NO spatium preseed content
+#            (e.g. a plain cloud-init user-data with no spatium_preseed
+#            block). Safe to ignore — the wizard falls through to a
+#            fully interactive install.
+#
+# <out-env> is a shell-sourceable file of non-secret KEY=value lines
+# plus PRESEED_HAS_<field>=1 markers telling the wizard which prompts
+# to skip. <out-secret-env> (mode 0600) carries the admin password /
+# hash and the pairing code — never echoed to the console dashboard,
+# the install log, or the non-secret env.
+#
+# Dependency-light: PyYAML (python3-yaml) + stdlib only. python3-yaml
+# is in the appliance package set (mkosi.conf).
+
+import ipaddress
+import os
+import shlex
+import stat
+import sys
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - image always ships python3-yaml
+    sys.stderr.write(
+        "spatium-preseed-parse: PyYAML not available — cannot parse preseed\n"
+    )
+    sys.exit(3)
+
+# Hard disk-size floor for the A/B partition layout — mirror
+# spatium-install's MIN_DISK_GIB pick_disk guard. Keep in sync; a
+# preseeded target_disk below this halts loudly (the interactive picker
+# would have refused + re-prompted, but a headless run has no operator).
+MIN_DISK_GIB = 32
+
+
+# Accumulated resolved values (non-secret) and secrets, written out at
+# the end only if no validation error fired.
+env: dict[str, str] = {}
+secret: dict[str, str] = {}
+# Fatal validation errors on SUPPLIED fields. Any entry here => exit 2.
+errors: list[str] = []
+# Non-fatal notes surfaced to the install log (e.g. "disk unresolved,
+# falling through to interactive").
+notes: list[str] = []
+
+
+def fail(msg: str) -> None:
+    errors.append(msg)
+
+
+def note(msg: str) -> None:
+    notes.append(msg)
+
+
+def as_bool(val, field: str):
+    """Coerce a YAML scalar to a strict bool, or record an error."""
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str) and val.strip().lower() in {
+        "true", "false", "yes", "no", "1", "0",
+    }:
+        return val.strip().lower() in {"true", "yes", "1"}
+    fail(f"{field} must be a boolean (true/false); got {val!r}")
+    return None
+
+
+def as_str(val) -> str:
+    """YAML may parse a bare value as int/None; normalise to a string."""
+    if val is None:
+        return ""
+    return str(val).strip()
+
+
+# ── Load ──────────────────────────────────────────────────────────────
+
+if len(sys.argv) != 4:
+    sys.stderr.write(
+        "usage: spatium-preseed-parse <preseed.yaml> <out-env> <out-secret-env>\n"
+    )
+    sys.exit(3)
+
+preseed_path, out_env, out_secret = sys.argv[1], sys.argv[2], sys.argv[3]
+
+try:
+    with open(preseed_path, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+except (OSError, yaml.YAMLError) as exc:
+    sys.stderr.write(f"spatium-preseed-parse: cannot parse {preseed_path}: {exc}\n")
+    sys.exit(3)
+
+if doc is None:
+    sys.stderr.write(f"spatium-preseed-parse: {preseed_path} is empty\n")
+    sys.exit(3)
+if not isinstance(doc, dict):
+    sys.stderr.write(
+        f"spatium-preseed-parse: {preseed_path} top level must be a mapping\n"
+    )
+    sys.exit(3)
+
+# Accept the preseed either as a top-level `spatium_preseed:` block
+# (so it can be embedded in a cloud-init user-data document alongside
+# other keys, which cloud-init ignores) or as the whole document. The
+# hyphen spelling `spatium-preseed:` is accepted as an alias.
+ps = None
+for key in ("spatium_preseed", "spatium-preseed"):
+    if isinstance(doc.get(key), dict):
+        ps = doc[key]
+        break
+if ps is None:
+    # No wrapper block — treat the document itself as the preseed, but
+    # only if it carries at least one field we recognise (guards against
+    # pointing the installer at an unrelated YAML file).
+    known = {
+        "role", "target_disk", "confirm_wipe", "hostname", "admin_user",
+        "admin_password", "admin_password_hash", "timezone", "network",
+        "k3s", "control_plane_url", "pairing_code",
+    }
+    if known & set(doc.keys()):
+        ps = doc
+    else:
+        # Parsed fine but this isn't a preseed (e.g. a plain cloud-init
+        # user-data document). Not an error — let the installer fall
+        # through to interactive.
+        sys.stderr.write(
+            f"spatium-preseed-parse: {preseed_path} has no spatium_preseed "
+            "block and no recognised preseed fields — ignoring\n"
+        )
+        sys.exit(4)
+
+# ── Role ──────────────────────────────────────────────────────────────
+# Friendly aliases map onto the two internal role values the wizard +
+# supervisor consume (control-plane / appliance).
+ROLE_ALIASES = {
+    "control-plane": "control-plane",
+    "control_plane": "control-plane",
+    "control": "control-plane",
+    "first-node": "control-plane",
+    "first": "control-plane",
+    "appliance": "appliance",
+    "add-node": "appliance",
+    "additional": "appliance",
+    "agent": "appliance",
+    "application": "appliance",
+}
+role = None
+if "role" in ps and as_str(ps.get("role")):
+    raw = as_str(ps["role"]).lower()
+    role = ROLE_ALIASES.get(raw)
+    if role is None:
+        fail(
+            f"role {raw!r} is not valid — use 'control-plane' (first node) "
+            "or 'appliance' (additional / agent node)"
+        )
+    else:
+        env["ROLE"] = role
+        env["PRESEED_HAS_ROLE"] = "1"
+
+# ── confirm_wipe ──────────────────────────────────────────────────────
+confirm_wipe = False
+if "confirm_wipe" in ps:
+    cw = as_bool(ps["confirm_wipe"], "confirm_wipe")
+    if cw is not None:
+        confirm_wipe = cw
+
+
+# ── Target disk ───────────────────────────────────────────────────────
+# Destructive-disk safety (#549 open-question 3): an unattended wipe of
+# a disk with no human in the loop is only performed when BOTH
+#   * confirm_wipe: true, AND
+#   * target_disk resolves to exactly one existing WHOLE-disk block dev.
+# Prefer a stable id (/dev/disk/by-id/... or /dev/disk/by-path/...) that
+# survives re-enumeration; a bare sdX name is accepted but noted, since
+# it can renumber between boots. A supplied-but-unresolvable disk drops
+# to the interactive picker rather than guessing (never a silent wipe).
+def resolve_disk(spec: str):
+    real = os.path.realpath(spec)
+    try:
+        st = os.stat(real)
+    except OSError:
+        return None, f"target_disk {spec!r} does not exist"
+    if not stat.S_ISBLK(st.st_mode):
+        return None, f"target_disk {spec!r} is not a block device"
+    name = os.path.basename(real)
+    # Whole disks appear under /sys/block/<name>; partitions do not.
+    if not os.path.isdir(f"/sys/block/{name}"):
+        return None, (
+            f"target_disk {spec!r} resolves to {real} which is not a whole "
+            "disk (looks like a partition)"
+        )
+    return real, None
+
+
+def disk_size_bytes(real: str):
+    """Capacity of a whole-disk /dev node via /sys/block/<name>/size
+    (512-byte sectors). Returns None if unreadable."""
+    name = os.path.basename(real)
+    try:
+        with open(f"/sys/block/{name}/size", encoding="ascii") as fh:
+            return int(fh.read().strip()) * 512
+    except (OSError, ValueError):
+        return None
+
+
+target_spec = as_str(ps.get("target_disk"))
+if target_spec:
+    real, why = resolve_disk(target_spec)
+    if real is None:
+        # Absent / ambiguous named disk — fall through to interactive
+        # (issue #549: "Refuse and drop to interactive"). Not fatal.
+        note(f"{why}; falling through to interactive disk selection")
+    elif not confirm_wipe:
+        note(
+            f"target_disk {target_spec!r} supplied but confirm_wipe is not "
+            "true — refusing unattended wipe; disk selection is interactive"
+        )
+    else:
+        # Hard size floor — the interactive picker refuses + re-prompts
+        # below MIN_DISK_GIB; a headless run has no operator, so halt
+        # loudly instead of partitioning an undersized disk (#312).
+        nbytes = disk_size_bytes(real)
+        if nbytes is not None and nbytes < MIN_DISK_GIB * 1024**3:
+            fail(
+                f"target_disk {target_spec!r} is {nbytes // 1024**3} GiB — "
+                f"below the {MIN_DISK_GIB} GiB minimum for the A/B partition "
+                "layout; pick a larger disk"
+            )
+        else:
+            env["TARGET_DISK"] = real
+            env["PRESEED_HAS_DISK"] = "1"
+            if not target_spec.startswith("/dev/disk/by-"):
+                note(
+                    f"target_disk {target_spec!r} is not a stable "
+                    f"/dev/disk/by-id or by-path id (resolved to {real}); it "
+                    "may renumber across boots — prefer a by-id path for "
+                    "fleet rollouts"
+                )
+
+# ── Hostname (RFC 1123, matching the wizard's ask_hostname) ───────────
+hostname = as_str(ps.get("hostname"))
+if hostname:
+    ok = True
+    if len(hostname) > 63:
+        fail("hostname must be 63 characters or fewer")
+        ok = False
+    elif (
+        hostname.startswith("-")
+        or hostname.endswith("-")
+        or any(c not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-"
+               for c in hostname)
+    ):
+        fail(
+            "hostname must be alphanumeric + hyphen, not start/end with a "
+            "hyphen, and contain no spaces or dots"
+        )
+        ok = False
+    if ok:
+        env["HOSTNAME"] = hostname
+        env["PRESEED_HAS_HOSTNAME"] = "1"
+
+# ── Admin user + password ─────────────────────────────────────────────
+admin_user = as_str(ps.get("admin_user"))
+if admin_user:
+    env["ADMIN_USER"] = admin_user
+    env["PRESEED_HAS_ADMIN_USER"] = "1"
+
+pw = as_str(ps.get("admin_password"))
+pw_hash = as_str(ps.get("admin_password_hash"))
+if pw and pw_hash:
+    fail("supply only one of admin_password or admin_password_hash")
+elif pw_hash:
+    # crypt(3) hashes start with $id$ (e.g. $6$ for SHA-512, $y$ for
+    # yescrypt). Reject anything that clearly isn't one so a truncated /
+    # mis-pasted hash fails loudly instead of locking the operator out.
+    if not (pw_hash.startswith("$") and pw_hash.count("$") >= 2):
+        fail(
+            "admin_password_hash does not look like a crypt(3) hash "
+            "(expected $id$salt$hash, e.g. from `openssl passwd -6`)"
+        )
+    else:
+        secret["ADMIN_PASSWORD_HASH"] = pw_hash
+        env["PRESEED_HAS_PASSWORD"] = "1"
+elif pw:
+    secret["ADMIN_PASSWORD"] = pw
+    env["PRESEED_HAS_PASSWORD"] = "1"
+
+# ── Timezone ──────────────────────────────────────────────────────────
+tz = as_str(ps.get("timezone"))
+if tz:
+    if os.path.exists(f"/usr/share/zoneinfo/{tz}"):
+        env["TIMEZONE"] = tz
+        env["PRESEED_HAS_TIMEZONE"] = "1"
+    else:
+        fail(f"timezone {tz!r} is not a known IANA zone (/usr/share/zoneinfo)")
+
+# ── Network ───────────────────────────────────────────────────────────
+static_subnet = ""  # feeds the k3s LAN-overlap check below
+net = ps.get("network")
+if net is not None:
+    if not isinstance(net, dict):
+        fail("network must be a mapping (mode/interface/ip/prefix/gateway/dns)")
+    else:
+        mode = as_str(net.get("mode")).lower()
+        if not mode:
+            fail("network.mode is required when a network block is present")
+        elif mode not in {"dhcp", "static"}:
+            fail(f"network.mode {mode!r} must be 'dhcp' or 'static'")
+        elif mode == "dhcp":
+            env["NET_MODE"] = "dhcp"
+            env["PRESEED_HAS_NETWORK"] = "1"
+        else:  # static
+            ip = as_str(net.get("ip"))
+            prefix = as_str(net.get("prefix") if net.get("prefix") is not None else "")
+            gateway = as_str(net.get("gateway"))
+            dns = as_str(net.get("dns")) or "1.1.1.1 1.0.0.1"
+            iface = as_str(net.get("interface"))
+            static_ok = True
+            if not ip:
+                fail("network.ip is required for a static network")
+                static_ok = False
+            if not prefix:
+                fail("network.prefix is required for a static network")
+                static_ok = False
+            if not gateway:
+                fail("network.gateway is required for a static network")
+                static_ok = False
+            # The interactive wizard forces an interface pick for static;
+            # spatium-etc-render only writes the keyfile when the
+            # interface is set, else it silently falls back to DHCP. So a
+            # static preseed MUST name an interface — require it here.
+            if not iface:
+                fail(
+                    "network.interface is required for a static network "
+                    "(the NIC name, e.g. eth0 / enp1s0)"
+                )
+                static_ok = False
+            # Only IPv4 is supported end-to-end — spatium-etc-render
+            # renders an [ipv4] method=manual keyfile, so reject IPv6
+            # rather than emit a config NetworkManager will refuse.
+            if static_ok:
+                try:
+                    if ipaddress.ip_address(ip).version != 4:
+                        fail(f"network.ip {ip!r} must be an IPv4 address")
+                        static_ok = False
+                except ValueError:
+                    fail(f"network.ip {ip!r} is not a valid IPv4 address")
+                    static_ok = False
+                try:
+                    if not (0 <= int(prefix) <= 32):
+                        raise ValueError
+                except ValueError:
+                    fail(f"network.prefix {prefix!r} must be an integer 0-32")
+                    static_ok = False
+                try:
+                    if ipaddress.ip_address(gateway).version != 4:
+                        fail(f"network.gateway {gateway!r} must be IPv4")
+                        static_ok = False
+                except ValueError:
+                    fail(f"network.gateway {gateway!r} is not a valid address")
+                    static_ok = False
+            if static_ok:
+                env["NET_MODE"] = "static"
+                env["NET_INTERFACE"] = iface
+                env["NET_IP"] = ip
+                env["NET_PREFIX"] = prefix
+                env["NET_GATEWAY"] = gateway
+                env["NET_DNS"] = dns
+                env["PRESEED_HAS_NETWORK"] = "1"
+                static_subnet = f"{ip}/{prefix}"
+
+# ── k3s pod + service CIDRs (mirrors _validate_k3s_cidrs) ─────────────
+k3s = ps.get("k3s")
+if k3s is not None:
+    if not isinstance(k3s, dict):
+        fail("k3s must be a mapping (pod_cidr / service_cidr)")
+    else:
+        pod_s = as_str(k3s.get("pod_cidr")) or "10.42.0.0/16"
+        svc_s = as_str(k3s.get("service_cidr")) or "10.43.0.0/16"
+        k_ok = True
+        try:
+            pod = ipaddress.ip_network(pod_s, strict=False)
+        except ValueError as exc:
+            fail(f"k3s.pod_cidr is not a valid IPv4 network: {exc}")
+            k_ok = False
+        try:
+            svc = ipaddress.ip_network(svc_s, strict=False)
+        except ValueError as exc:
+            fail(f"k3s.service_cidr is not a valid IPv4 network: {exc}")
+            k_ok = False
+        if k_ok:
+            if pod.version != 4 or svc.version != 4:
+                fail("k3s CIDRs must be IPv4")
+                k_ok = False
+            elif pod.prefixlen > 22:
+                fail(f"k3s.pod_cidr prefix /{pod.prefixlen} too small — use /22 or wider")
+                k_ok = False
+            elif svc.prefixlen > 22:
+                fail(f"k3s.service_cidr prefix /{svc.prefixlen} too small — use /22 or wider")
+                k_ok = False
+            elif pod.overlaps(svc):
+                fail(f"k3s.pod_cidr {pod} overlaps service_cidr {svc}; must be disjoint")
+                k_ok = False
+        if k_ok and static_subnet:
+            try:
+                lan = ipaddress.ip_interface(static_subnet).network
+            except ValueError:
+                lan = None
+            if lan is not None:
+                if pod.overlaps(lan):
+                    fail(f"k3s.pod_cidr {pod} overlaps the LAN {lan}; Flannel host-gw would mask it")
+                    k_ok = False
+                elif svc.overlaps(lan):
+                    fail(f"k3s.service_cidr {svc} overlaps the LAN {lan}")
+                    k_ok = False
+        if k_ok:
+            env["K3S_POD_CIDR"] = str(pod)
+            env["K3S_SERVICE_CIDR"] = str(svc)
+            env["PRESEED_HAS_K3S"] = "1"
+
+# ── Control-plane URL + pairing code (appliance role) ─────────────────
+cp_url = as_str(ps.get("control_plane_url"))
+if cp_url and cp_url != "https://":
+    env["CONTROL_PLANE_URL"] = cp_url
+    env["PRESEED_HAS_CONTROL_URL"] = "1"
+elif cp_url == "https://":
+    fail("control_plane_url is a bare scheme with no host")
+
+code = as_str(ps.get("pairing_code"))
+if code:
+    stripped = "".join(c for c in code if c.isdigit())
+    if len(stripped) != 8 or not stripped.isdigit():
+        # Never echo the code itself — it's a secret and this message is
+        # surfaced to the install log + console on a halt.
+        fail(
+            "pairing_code must be 8 decimal digits (dashes / spaces are "
+            f"accepted as separators); got {len(stripped)} digit(s)"
+        )
+    else:
+        secret["BOOTSTRAP_PAIRING_CODE"] = stripped
+        env["PRESEED_HAS_PAIRING_CODE"] = "1"
+
+# Cross-field: the appliance role needs BOTH a control-plane URL and a
+# pairing code. If the role is explicitly appliance AND one of them was
+# supplied but the other is a supplied-and-invalid value we've already
+# failed above. A simply-absent url/code is NOT fatal here — the wizard
+# falls through to ask_application_config interactively for whatever's
+# missing. We only surface a note so a part-preseeded appliance install
+# is understandable in the log.
+if role == "appliance":
+    if "PRESEED_HAS_CONTROL_URL" not in env:
+        note("role=appliance but no control_plane_url — will prompt interactively")
+    if "PRESEED_HAS_PAIRING_CODE" not in env:
+        note("role=appliance but no pairing_code — will prompt interactively")
+
+# ── Emit ──────────────────────────────────────────────────────────────
+if errors:
+    sys.stderr.write("spatium-preseed-parse: preseed validation failed:\n")
+    for e in errors:
+        sys.stderr.write(f"  - {e}\n")
+    sys.exit(2)
+
+# Notes go to stdout so the wizard can log them; they're advisory.
+for n in notes:
+    sys.stdout.write(f"NOTE: {n}\n")
+
+
+def write_env(path: str, data: dict[str, str], mode: int) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        for k, v in data.items():
+            fh.write(f"{k}={shlex.quote(v)}\n")
+    os.chmod(path, mode)
+
+
+write_env(out_env, env, 0o644)
+write_env(out_secret, secret, 0o600)
+sys.exit(0)

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -781,33 +781,69 @@ trigger: tag push (CalVer)
 > reinstall to change `cluster-cidr` / `service-cidr`. The
 > partition layout permits keeping `/var` across reinstalls.
 
-### Phase 1 (pre-#183, replaced): headless via cloud-init NoCloud
+### Headless / unattended install — preseed the disk installer (#549)
 
-Phase 1 ships with `cloud-init` enabled and the NoCloud datasource
-active. Operators drop a CIDATA ISO with `user-data` + `meta-data`,
-attach it as a secondary drive, and the appliance configures itself
-on first power-on.
+> **Supersedes the stale Phase-1 framing.** The *old* cloud-init
+> NoCloud path in this directory only reconfigured an
+> already-running **pre-#183 docker-compose** all-in-one — it never
+> drove the disk installer. Post-#183 the install-to-disk step is the
+> whiptail installer `spatium-install`; #549 preseeds **that**.
 
-The `spatiumddi-firstboot.service` systemd unit runs after
-`cloud-final.service`:
+On boot of the **installer media** (`spatium-mode=install` in the
+kernel cmdline), `spatium-install` looks for a **preseed answer file**
+before launching whiptail. When one is present it runs the installer
+non-interactively:
 
-1. Generates `/etc/spatiumddi/.env` (POSTGRES_PASSWORD, SECRET_KEY,
-   CREDENTIAL_ENCRYPTION_KEY, DNS_AGENT_KEY, DHCP_AGENT_KEY,
-   BOOTSTRAP_PAIRING_CODE) on first run only — preserved across
-   reboots. ``BOOTSTRAP_PAIRING_CODE`` carries the operator-supplied
-   8-digit code from the installer through to the agent containers
-   on Phase 6 role-split agent appliances (see §9).
-2. **(Pre-#183)** `docker-compose pull` (first run) + `docker-compose up -d`.
-   **(Post-#183)** Writes the variant-specific bootstrap HelmChart
-   manifest into `/var/lib/rancher/k3s/server/manifests/`; k3s's
-   helm-controller picks it up + runs `helm install` against the
-   baked chart tarball.
-3. Polls `http://127.0.0.1:8000/health/live` for up to 5 min.
+- Every field present in the answer file skips its prompt.
+- A **fully** preseeded run (disk + `confirm_wipe: true` + all fields
+  for the chosen role) installs end-to-end with **zero** console
+  interaction — welcome + the final confirm are skipped too.
+- A **partial** preseed falls through to the interactive prompt for
+  **only the missing fields** (e.g. everything-but-the-disk).
+- A field that is **present but invalid** halts loudly (clear console
+  message + non-zero exit); it never silently defaults on a disk wipe.
 
-Default web-UI login is `admin / admin` with `force_password_change=True`.
+The parser (`/usr/local/bin/spatium-preseed-parse`, PyYAML) reuses the
+wizard's own validators — hostname RFC 1123, k3s CIDR disjoint + ≤ /22
++ no LAN overlap, pairing code = 8 digits, control-plane URL required
+for the appliance role. The resulting install is byte-for-byte what an
+interactive install produces (same `do_install`), so a fully-preseeded
+box presents **no** setup wizard afterwards (console or web) — parity
+with the interactive path by construction.
 
-Recipe + examples: `appliance/cloud-init/README.md` and
-`appliance/cloud-init/user-data.example`.
+**Destructive-disk safety.** An unattended wipe requires **both**
+`confirm_wipe: true` **and** a `target_disk` that resolves to exactly
+one whole disk. Prefer a stable `/dev/disk/by-id/…` or `by-path/…` id
+(a bare `sda` can renumber). A supplied-but-unresolvable disk drops to
+the interactive picker rather than guessing.
+
+**Secrets.** `admin_password` / `pairing_code` in a plaintext answer
+file is the usual preseed tradeoff. Use `admin_password_hash` (crypt(3),
+e.g. `openssl passwd -6`) to keep the cleartext out of the file, and
+mint a fresh single-use pairing code per install. Neither is echoed to
+the console dashboard, the install log, or the trace log.
+
+**Transports** (first match wins): kernel cmdline
+`spatium.preseed=<url|path>` (PXE/IPMI), a NoCloud `CIDATA`-labelled
+volume carrying `spatium-preseed.yaml` (VM/Proxmox), or a
+`spatium-preseed.yaml` on the install medium (sneakernet). The same
+`spatium_preseed:` block can be embedded in a cloud-init `user-data`
+document, which is how the **AWS** (`--user-data`) and **Azure**
+(`--custom-data`) cloud-image recipes deliver it.
+
+Once the installed system reboots, `spatiumddi-firstboot.service`
+runs as normal (identical to the interactive path): generates
+`/etc/spatiumddi/.env` (POSTGRES_PASSWORD, SECRET_KEY,
+CREDENTIAL_ENCRYPTION_KEY, DNS_AGENT_KEY, DHCP_AGENT_KEY,
+BOOTSTRAP_PAIRING_CODE) on first run, writes the bootstrap HelmChart
+manifest into `/var/lib/rancher/k3s/server/manifests/`, and polls
+`http://127.0.0.1:8000/health/live`. Default web-UI login is
+`admin / admin` with `force_password_change=True`.
+
+Recipe, schema table, and Azure / AWS / Proxmox / PXE examples:
+[`appliance/cloud-init/README.md`](../../appliance/cloud-init/README.md)
+plus `spatium-preseed-control-plane.yaml.example` +
+`spatium-preseed-appliance.yaml.example`.
 
 ### Future: interactive first-boot wizard (Phase 1.x)
 


### PR DESCRIPTION
Closes #549.

Adds a **preseed answer-file** path so the appliance disk installer (`spatium-install`) can run **non-interactively** — for fleet rollouts, PXE/IPMI provisioning, cloud images, and CI boot-tests. Appliance-only; reaches nothing in-field until it ships in a new appliance OS release (ISO).

## Behaviour
On boot of the installer media, `spatium-install` looks for a preseed before launching whiptail:
- present fields **skip** their prompt;
- a **fully** preseeded run (disk + `confirm_wipe: true` + all fields for the role) installs with **zero** console interaction — welcome + final confirm skipped too;
- a **partial** preseed falls through to interactive prompts for **only the missing fields**;
- a field **present but invalid** halts loudly (clear console message + non-zero) — never a silent default on a wipe.

The installed system is byte-compatible with an interactive install (same `do_install`), so a fully-preseeded box shows no setup wizard afterwards.

## What's here
- **`spatium-preseed-parse`** (new, PyYAML) — reuses the wizard's validators: hostname RFC 1123, k3s CIDR disjoint + ≤ /22 + no-LAN-overlap, pairing code = 8 digits, control-plane URL required for the appliance role, IPv4-only static networking, and the 32 GiB A/B disk floor.
- **Destructive-disk safety** — unattended wipe needs `confirm_wipe: true` **and** a `target_disk` resolving to one whole disk ≥ the floor (prefer a stable `/dev/disk/by-id` id); unresolvable disks drop to the interactive picker.
- **Secrets** — `admin_password_hash` (crypt) support; password + pairing code kept out of the console, install log, and `set -x` trace log (validation errors never echo the code).
- **Transports** — kernel cmdline `spatium.preseed=<url|path>` (bounded curl retry to ride out network bring-up), a NoCloud `CIDATA` volume, or a file on the install medium. The same `spatium_preseed:` block embeds in a cloud-init `user-data` → **AWS `--user-data`** / **Azure `--custom-data`** recipes. Discovery tries all candidates in priority order and skips a non-preseed `user-data` so it can't shadow a real preseed elsewhere.
- **`python3-yaml`** added to the appliance package set.
- **Docs** — rewritten `appliance/cloud-init/README.md` (schema table + Azure/AWS/Proxmox/PXE recipes), `spatium-preseed-{control-plane,appliance}.yaml.example`, and APPLIANCE.md §4 retires the stale pre-#183 cloud-init framing.

## Testing
- Parser unit-tested across exit-code paths (valid partial/full, undersized disk → halt, static-without-interface → halt, IPv6 → halt, malformed → 3, no-content → 4, pairing-code message carries no secret).
- Standalone harness verifying multi-candidate discovery adopts a real preseed over a plain/malformed cloud-init `user-data`.
- `bash -n` + `shellcheck` clean (only two pre-existing warnings); parser `ast.parse` clean.

## Notes
- A full `/code-review` pass ran on this branch; the surfaced correctness/safety/security findings (disk-floor bypass, silent-DHCP-fallback, secret leak, network race, preseed shadowing, IPv6, k3s-overlap in partial preseed) are all fixed in this PR.
- Known deferral: k3s/hostname validation is duplicated across the bash wizard and the Python parser (both agree + tested); unifying them to a single source is a follow-up refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)