### PR TITLE
fix(appliance,ipam): bug sweep — #550-#555 + #516

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: python3 scripts/lint_migrations.py
 
+      # Guards the appliance host-side runner scripts (issues #550/#553):
+      # every systemd ExecStart runner must be executable in the built
+      # image (git +x OR chmod'd in mkosi.postinst) and bash -n clean.
+      # Catches the class of bug where a shipped feature is dead because
+      # its runner hit 203/EXEC. stdlib-only; runs from repo root.
+      - name: Appliance runner linter
+        working-directory: ${{ github.workspace }}
+        run: python3 scripts/lint_appliance_runners.py
+
   # The ~1900-test suite is DB-bound, so we fan it out across 4 parallel
   # jobs (free concurrent runners) via pytest-split; each job still runs
   # ``-n auto`` (4 xdist workers on a 4-vCPU runner) → ~16-way parallelism

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,16 @@
         appliance-fetch-k3s appliance-bake-chart appliance-bake-control-chart \
         appliance-bake-metallb-chart
 
+# #553 — the appliance ISO targets list their fetch/bake steps as
+# independent prerequisites with no inter-dependencies. Under ``make -j``
+# mkosi's ``appliance`` recipe reads mkosi.extra/ while the bake targets
+# are still populating it → the ISO ships without k3s / chart / images,
+# and ``appliance-iso`` / ``appliance-slot-image`` can hit "no raw image
+# found" before the raw exists. On GNU Make 4.4+ this scopes serialisation
+# to just these targets' prerequisites; on older make the target list is
+# ignored and it applies globally — either way the race is gone.
+.NOTPARALLEL: appliance-dev-iso appliance-baked-iso appliance-iso appliance-slot-image
+
 # ── Configuration ──────────────────────────────────────────────────────────────
 COMPOSE        = docker compose
 COMPOSE_DEV    = docker compose -f docker-compose.yml -f docker-compose.dev.yml
@@ -350,8 +360,13 @@ K3S_VERSION ?= v1.35.6+k3s1
 # never reaches github.com on first boot. Idempotent (cache-stamped
 # against K3S_VERSION). Runs ahead of ``appliance-bake-images`` in the
 # composed targets so the mkosi build sees both image sets.
+# #553 — pin ARCH to the IMAGE arch, not the build-host arch. fetch-k3s.sh
+# defaults ARCH to `uname -m`, but mkosi.conf hardcodes Architecture=x86-64;
+# on an arm64 build host that baked the -arm64 k3s binary + airgap tarball
+# into an amd64 rootfs (won't exec / won't import). Keep in lock-step with
+# mkosi.conf's Architecture.
 appliance-fetch-k3s:
-	@K3S_VERSION="$(K3S_VERSION)" bash $(APPLIANCE_DIR)/scripts/fetch-k3s.sh
+	@K3S_VERSION="$(K3S_VERSION)" ARCH=x86_64 bash $(APPLIANCE_DIR)/scripts/fetch-k3s.sh
 
 # Issue #183 Phase 3 — chart bake. Packages
 # charts/spatiumddi-appliance/ into a stable tgz at

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -419,7 +419,15 @@ def _reap_stale_inflight(
 
 
 _TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/slot-upgrade-pending")
-_REBOOT_TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/reboot-pending")
+# #553 — the FLEET reboot trigger has its own filename, distinct from the
+# web-UI local-reboot trigger (``reboot-pending``, handled by
+# spatiumddi-reboot.{path,service}). Previously both wrote ``reboot-pending``
+# so both .path units fired: the agent runner (5 s) won while the web-UI
+# service's un-``-``-prefixed mv failed on the already-renamed file, ending
+# ``failed`` on every reboot. Separate filenames = one runner per trigger.
+_REBOOT_TRIGGER_FILE = Path(
+    "/var/lib/spatiumddi-host/release-state/reboot-pending-fleet"
+)
 # Issue #386 Part B — fire-once marker. Records the last
 # ``desired_slot_image_url`` the supervisor wrote a trigger for, so a
 # failed apply (which renames the trigger to ``.failed.<ts>`` and would
@@ -1376,6 +1384,13 @@ def maybe_fire_cluster_join(
         return False
     if not server_url or not join_token:
         return False
+    # #555 — the payload is line-based (marker / server_url / join_token);
+    # a newline in either operator-influenced field would shift the lines
+    # the host runner parses. Reject control chars outright rather than
+    # smuggle a second directive into the trigger.
+    if any(c in server_url or c in join_token for c in ("\n", "\r")):
+        log.warning("supervisor.cluster_join.rejected_control_char_in_payload")
+        return False
     if _CLUSTER_JOIN_TRIGGER_FILE.exists():
         return False
     try:
@@ -1457,6 +1472,11 @@ def maybe_fire_cluster_restore(desired_restore_snapshot: str | None) -> bool:
     if detect_deployment_kind() != "appliance":
         return False
     if not desired_restore_snapshot:
+        return False
+    # #555 — line-based payload (marker / snapshot name); reject control
+    # chars so a newline can't smuggle a second directive to the runner.
+    if any(c in desired_restore_snapshot for c in ("\n", "\r")):
+        log.warning("supervisor.cluster_restore.rejected_control_char_in_snapshot")
         return False
     if _CLUSTER_RESTORE_TRIGGER_FILE.exists():
         return False

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -913,6 +913,7 @@ def _write_owner_only(tmp: Path, payload: str) -> None:
     try:
         os.unlink(tmp)  # drop our own stale temp from a crashed prior run
     except FileNotFoundError:
+        # No stale temp to remove — the normal case; nothing to clean up.
         pass
     fd = os.open(
         tmp,

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -899,8 +899,26 @@ def _write_owner_only(tmp: Path, payload: str) -> None:
     ``O_NOFOLLOW`` refuses a symlink an attacker could plant in the
     world-writable dir. The root ``.path`` runner reads as root and is
     unaffected by the tighter mode.
+
+    ``O_EXCL`` (with a best-effort unlink of our own stale temp first)
+    is required in addition to ``O_NOFOLLOW``: without it, ``O_CREAT``
+    happily opens a pre-planted *regular* file (O_NOFOLLOW only rejects
+    symlinks), the mode arg is ignored for an existing inode, and the
+    secret would be written into an attacker-owned 0644 file whose fd
+    they still hold after ``replace()``. With ``O_EXCL`` the open fails
+    closed (EEXIST) if anyone raced a file into the predictable temp
+    path; callers wrap this in ``try/except OSError`` and retry on the
+    next tick.
     """
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    try:
+        os.unlink(tmp)  # drop our own stale temp from a crashed prior run
+    except FileNotFoundError:
+        pass
+    fd = os.open(
+        tmp,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+    )
     with os.fdopen(fd, "w", encoding="utf-8") as fh:
         fh.write(payload)
 

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -986,8 +986,13 @@ def heartbeat_once(
         rendered = render_env_file(target)
         # Atomic write — partial files would confuse the compose
         # subprocess below if the supervisor crashed mid-write.
+        # #555 — owner-only (0600) at creation: role-compose.env carries
+        # DNS_AGENT_KEY / DHCP_AGENT_KEY bootstrap PSKs, and a plain
+        # write_text lands it at the umask default (0644, world-readable in
+        # the 1777 release-state dir) before any chmod. Reuse the shared
+        # O_NOFOLLOW+0600 writer.
         tmp = env_path.with_suffix(".tmp")
-        tmp.write_text(rendered, encoding="utf-8")
+        appliance_state._write_owner_only(tmp, rendered)
         tmp.replace(env_path)
         log.info(
             "supervisor.heartbeat.role_env_rendered",

--- a/agent/supervisor/spatium_supervisor/identity.py
+++ b/agent/supervisor/spatium_supervisor/identity.py
@@ -28,7 +28,6 @@ re-deriving it.
 from __future__ import annotations
 
 import hashlib
-import os
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -44,6 +43,8 @@ from cryptography.hazmat.primitives.serialization import (
     PublicFormat,
     load_pem_private_key,
 )
+
+from . import appliance_state
 
 # File names — kept module-level so tests can reference them without
 # duplicating literals.
@@ -201,13 +202,10 @@ def save_session_token(state_dir: Path, token: str) -> None:
     takes over."""
     path = _identity_dir(state_dir) / SESSION_TOKEN_FILENAME
     tmp = path.with_suffix(".tmp")
-    # #555 — set 0600 AT creation via os.open, not write_text + chmod after:
-    # the bearer token was briefly world-readable in the 0755 identity/ dir
-    # in the window before the chmod landed. O_NOFOLLOW refuses a planted
-    # symlink.
-    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as fh:
-        fh.write(token + "\n")
+    # #555 — set 0600 AT creation (not write_text + chmod after, which left
+    # the bearer token briefly world-readable). Reuse the shared owner-only
+    # writer so the O_EXCL/O_NOFOLLOW hardening lives in exactly one place.
+    appliance_state._write_owner_only(tmp, token + "\n")
     tmp.replace(path)
 
 

--- a/agent/supervisor/spatium_supervisor/identity.py
+++ b/agent/supervisor/spatium_supervisor/identity.py
@@ -28,6 +28,7 @@ re-deriving it.
 from __future__ import annotations
 
 import hashlib
+import os
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -200,8 +201,13 @@ def save_session_token(state_dir: Path, token: str) -> None:
     takes over."""
     path = _identity_dir(state_dir) / SESSION_TOKEN_FILENAME
     tmp = path.with_suffix(".tmp")
-    tmp.write_text(token + "\n")
-    tmp.chmod(0o600)
+    # #555 — set 0600 AT creation via os.open, not write_text + chmod after:
+    # the bearer token was briefly world-readable in the 0755 identity/ dir
+    # in the window before the chmod landed. O_NOFOLLOW refuses a planted
+    # symlink.
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(token + "\n")
     tmp.replace(path)
 
 

--- a/agent/supervisor/spatium_supervisor/pcap_proxy.py
+++ b/agent/supervisor/spatium_supervisor/pcap_proxy.py
@@ -70,6 +70,13 @@ import re  # noqa: E402
 
 _BPF_RE = re.compile(r"^[A-Za-z0-9_ .:\[\]()/&|!=<>+*x-]{0,1024}$")
 _IFACE_RE = re.compile(r"^[A-Za-z0-9_.:@-]{1,64}$")
+# #555 — capture_id becomes filesystem paths under _TRIGGER_DIR
+# (``{cid}.request`` / ``.pcap`` / ``.state`` / ``.cancel`` + a cleanup
+# glob), so it MUST be charset-validated like interface/bpf are — a value
+# with ``/`` or ``..`` would escape _TRIGGER_DIR. Normally a server-side
+# UUID, but a compromised/buggy control plane is exactly the threat model
+# the other validators already assume.
+_CAPTURE_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 
 
 class PcapValidationError(ValueError):
@@ -77,6 +84,9 @@ class PcapValidationError(ValueError):
 
 
 def _validate(cmd: dict[str, Any]) -> dict[str, Any]:
+    capture_id = str(cmd.get("capture_id") or "")
+    if not _CAPTURE_ID_RE.match(capture_id):
+        raise PcapValidationError(f"invalid capture_id {capture_id!r}")
     iface = (cmd.get("interface") or "any").strip() or "any"
     if not _IFACE_RE.match(iface):
         raise PcapValidationError(f"invalid interface {iface!r}")
@@ -87,7 +97,7 @@ def _validate(cmd: dict[str, Any]) -> dict[str, Any]:
             raise PcapValidationError("invalid BPF filter")
         bpf = bpf or None
     return {
-        "capture_id": str(cmd["capture_id"]),
+        "capture_id": capture_id,
         "interface": iface,
         "bpf_filter": bpf,
         "snaplen": int(cmd.get("snaplen") or 256),

--- a/agent/supervisor/spatium_supervisor/service_lifecycle.py
+++ b/agent/supervisor/spatium_supervisor/service_lifecycle.py
@@ -232,8 +232,14 @@ def _build_values(profiles: list[str], env_vars: dict[str, str]) -> dict[str, ob
             "enabled": True,
             "controlPlaneUrl": control_plane_url,
             "agentKey": env_vars.get("DHCP_AGENT_KEY", ""),
-            "serverGroupName": env_vars.get("DHCP_AGENT_GROUP", "")
-            or env_vars.get("AGENT_GROUP", ""),
+            # #555 — NO ``AGENT_GROUP`` fallback here. ``AGENT_GROUP`` is
+            # written only for DNS roles (role_orchestrator writes
+            # ``DHCP_AGENT_GROUP`` for DHCP), so the fallback could only ever
+            # pull in a DNS group name — a node with both dns + dhcp roles but
+            # no dhcp_group_name would silently register its Kea agent into
+            # the DNS group. Absent → empty, which the backend treats as the
+            # default group.
+            "serverGroupName": env_vars.get("DHCP_AGENT_GROUP", ""),
             "networkMode": env_vars.get("DHCP_NETWORK_MODE", "host"),
         },
     }

--- a/appliance/mkosi.extra/etc/systemd/system/etc.mount
+++ b/appliance/mkosi.extra/etc/systemd/system/etc.mount
@@ -13,8 +13,6 @@ After=local-fs-pre.target var.mount
 Before=local-fs.target
 Conflicts=umount.target
 Before=umount.target
-# Reconcile runs after this mount so it sees the merged view.
-RequiredBy=spatium-etc-reconcile.service
 
 [Mount]
 What=overlay
@@ -31,3 +29,9 @@ TimeoutSec=10s
 
 [Install]
 WantedBy=local-fs.target
+# #553 — RequiredBy belongs in [Install] (it's an install-time directive,
+# silently ignored under [Unit]). Ordering still holds via
+# spatium-etc-reconcile's own After= + ConditionPathIsMountPoint, so this
+# is a correctness tidy-up rather than a behaviour change. Reconcile sees
+# the merged /etc view because it runs after this mount.
+RequiredBy=spatium-etc-reconcile.service

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-reboot-agent.path
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-reboot-agent.path
@@ -6,10 +6,12 @@ Documentation=https://github.com/spatiumddi/spatiumddi/issues/138
 ConditionKernelCommandLine=!boot=live
 
 [Path]
-# PathChanged fires on close-after-write. Agent containers atomically
-# rename a .new sibling onto the trigger path so this only fires once
-# per reboot request.
-PathChanged=/var/lib/spatiumddi/release-state/reboot-pending
+# PathChanged fires on close-after-write. The supervisor atomically
+# renames a .new sibling onto the trigger path so this only fires once
+# per reboot request. #553 — dedicated ``-fleet`` filename so this and the
+# web-UI spatiumddi-reboot.path don't both fire on one write (which left
+# the web-UI service ending ``failed`` on every reboot).
+PathChanged=/var/lib/spatiumddi/release-state/reboot-pending-fleet
 
 [Install]
 WantedBy=multi-user.target

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-reboot.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-reboot.service
@@ -7,5 +7,7 @@ Type=oneshot
 # the browser before the host kills the network stack.
 ExecStartPre=/bin/sleep 10
 # Rename the trigger to .done so it doesn't re-fire on next boot.
-ExecStartPre=/bin/mv /var/lib/spatiumddi/release-state/reboot-pending /var/lib/spatiumddi/release-state/reboot-pending.done
+# ``-`` prefix (#553): tolerate an already-moved/absent trigger so this
+# oneshot never ends ``failed`` — the reboot still needs to fire.
+ExecStartPre=-/bin/mv /var/lib/spatiumddi/release-state/reboot-pending /var/lib/spatiumddi/release-state/reboot-pending.done
 ExecStart=/usr/bin/systemctl reboot

--- a/appliance/mkosi.extra/usr/local/bin/spatium-cluster-join
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-cluster-join
@@ -88,7 +88,14 @@ READY_TIMEOUT=180  # seconds to wait for the node to report Ready
 
 mkdir -p "$LOG_DIR" "$RELEASE_STATE"
 
-log() { printf '[%s] %s\n' "$(date -Iseconds)" "$*" | tee -a "$LOG"; }
+# NB: log to STDERR (not stdout). Several helpers below —
+# backup_and_wipe_identity in particular — return a value on stdout via
+# command substitution (identity_backup="$(backup_and_wipe_identity …)").
+# If log() wrote to stdout its lines would be captured into that value,
+# so the two-line result failed restore_identity's `[ -d "$bak" ]` guard
+# and a failed-join rollback silently never restored etcd/TLS/creds
+# (#551). tee still mirrors everything into $LOG.
+log() { printf '[%s] %s\n' "$(date -Iseconds)" "$*" | tee -a "$LOG" >&2; }
 
 # Clean the k3s runtime before a (re)start. k3s's `systemctl stop`
 # notoriously leaves orphaned containerd-shim processes behind (this is
@@ -172,7 +179,23 @@ backup_and_wipe_identity() {
     rm -f /run/flannel/subnet.env 2>/dev/null || true
     rm -rf /var/lib/cni/networks 2>/dev/null || true
     log "wiped cluster identity → $bak (k3s binary + airgap images kept)"
+    _prune_identity_backups
     printf '%s\n' "$bak"
+}
+
+# #555 — prune stale identity backups. Each one holds the etcd db + tls/
+# private keys (CA material) and lives in the 1777 release-state dir; the
+# old code left every join/leave backup forever ("a later sweep can prune"
+# — no sweep existed). Keep the newest 3 (a couple of promote/leave cycles
+# of manual-recovery headroom). log() goes to stderr so this never pollutes
+# the stdout path returned by backup_and_wipe_identity.
+_prune_identity_backups() {
+    local keep=3 d
+    ls -1dt "$IDENTITY_BAK_ROOT".*.* 2>/dev/null | tail -n +$((keep + 1)) | while read -r d; do
+        [ -d "$d" ] || continue
+        rm -rf "$d" 2>/dev/null || true
+        log "pruned stale identity backup: $d"
+    done
 }
 
 # Restore a cluster identity captured by backup_and_wipe_identity (used
@@ -234,8 +257,11 @@ do_join() {
         exit 0
     fi
 
-    # Validate before we touch anything destructive.
-    if ! printf '%s' "$server_url" | grep -qE '^https://[A-Za-z0-9.:_-]+:6443$'; then
+    # Validate before we touch anything destructive. #555 — the char class
+    # includes ``[`` and ``]`` (``]`` first, ``[`` + ``-`` last per POSIX
+    # bracket rules) so an IPv6-literal seed URL like
+    # ``https://[fd00::1]:6443`` is accepted; the old class rejected it.
+    if ! printf '%s' "$server_url" | grep -qE '^https://[]A-Za-z0-9._:[-]+:6443$'; then
         log "invalid server_url ($server_url) — refusing join"
         write_state failed "invalid server_url"
         mv -f "$JOIN_TRIGGER" "${JOIN_TRIGGER}.failed.$(date +%s)" || true

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -2735,17 +2735,26 @@ def render_nodes(
 
 
 def reboot_pending() -> bool:
-    """P0.9 — True when a Fleet-issued reboot is queued.
+    """P0.9 — True when a reboot is queued (fleet OR web-UI).
 
-    The supervisor writes ``reboot-pending`` (sibling to
-    ``slot-upgrade-pending``) when the control plane sets
-    ``reboot_requested`` on this appliance; the host-side
-    ``spatiumddi-reboot-agent.path`` unit then reboots after a 5 s grace.
-    Surfacing it warns the on-console operator that the box is about to
-    go offline — and that pressing F5 lets them ack it gracefully rather
-    than have the machine vanish mid-keystroke. Single ``exists()``
-    check (no subprocess)."""
-    return (_RELEASE_STATE_DIR / "reboot-pending").exists()
+    Two triggers can queue a reboot, both sibling to
+    ``slot-upgrade-pending``:
+      * ``reboot-pending-fleet`` — the supervisor writes this when the
+        control plane sets ``reboot_requested`` on this appliance; the
+        host-side ``spatiumddi-reboot-agent.path`` unit reboots after a
+        5 s grace (#553 gave the fleet path its own filename so it no
+        longer collides with the web-UI trigger).
+      * ``reboot-pending`` — the backend writes this for a web-UI
+        local reboot; ``spatiumddi-reboot.path`` reboots after a 10 s
+        grace.
+    Surfacing either warns the on-console operator that the box is about
+    to go offline — and that pressing F5 lets them ack it gracefully
+    rather than have the machine vanish mid-keystroke. Plain
+    ``exists()`` checks (no subprocess)."""
+    return (
+        (_RELEASE_STATE_DIR / "reboot-pending-fleet").exists()
+        or (_RELEASE_STATE_DIR / "reboot-pending").exists()
+    )
 
 
 def upgrade_status() -> tuple[str, str] | None:

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -23,6 +23,7 @@ import argparse
 import concurrent.futures
 import errno
 import json
+import math
 import os
 import re
 import select
@@ -236,7 +237,11 @@ def read_env(path: Path = ENV_FILE) -> dict[str, str]:
     if not path.exists():
         return {}
     out: dict[str, str] = {}
-    for line in path.read_text().splitlines():
+    # errors="replace" — a non-UTF-8 byte in .env must not raise
+    # UnicodeDecodeError on the 0.5 s render tick (read_env feeds
+    # render_header), which would soft-freeze on the last frame + spam
+    # journald at 2 Hz (#552).
+    for line in path.read_text(errors="replace").splitlines():
         line = line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
@@ -347,6 +352,24 @@ def _read_fire_state_dash(trigger_basename: str) -> tuple[str, int]:
     return parts[0], attempts
 
 
+def _metric_num(token: str, default: float = 0.0) -> float:
+    """Parse a Prometheus metric value, clamping NaN / +Inf / -Inf and
+    garbage to ``default``.
+
+    Prometheus legitimately emits ``NaN`` / ``+Inf`` for some gauges;
+    ``int(float("nan"))`` raises ValueError and ``int(float("inf"))``
+    raises OverflowError. Those parses live OUTSIDE the urlopen try/except,
+    so a single such value would crash the caller — tolerable in the
+    main-loop refresh (guarded), but fatal on the UNguarded priming
+    refresh, sending main() to exit 1 → Restart=always crash-loop with a
+    black console (#552)."""
+    try:
+        v = float(token)
+    except (ValueError, IndexError, TypeError):
+        return default
+    return v if math.isfinite(v) else default
+
+
 def fetch_etcd_health(timeout: float = 2.0) -> dict:
     """etcd health from the embedded-etcd Prometheus endpoint
     (``http://127.0.0.1:2381/metrics``, ~13 ms). stdlib urllib only — no
@@ -366,17 +389,17 @@ def fetch_etcd_health(timeout: float = 2.0) -> dict:
         # Each is a bare ``<metric> <value>`` Prometheus line; values may be
         # scientific notation (e.g. ``4.9e+06``) — float() then int() copes.
         if line.startswith("etcd_server_has_leader "):
-            out["has_leader"] = int(float(line.split()[-1]))
+            out["has_leader"] = int(_metric_num(line.split()[-1]))
         elif line.startswith("etcd_server_is_leader "):
-            out["is_leader"] = int(float(line.split()[-1]))
+            out["is_leader"] = int(_metric_num(line.split()[-1]))
         elif line.startswith("etcd_server_proposals_failed_total "):
-            out["proposals_failed"] = int(float(line.split()[-1]))
+            out["proposals_failed"] = int(_metric_num(line.split()[-1]))
         elif line.startswith("etcd_server_leader_changes_seen_total "):
-            out["leader_changes"] = int(float(line.split()[-1]))
+            out["leader_changes"] = int(_metric_num(line.split()[-1]))
         elif line.startswith("etcd_mvcc_db_total_size_in_use_in_bytes "):
-            out["db_in_use"] = float(line.split()[-1])
+            out["db_in_use"] = _metric_num(line.split()[-1])
         elif line.startswith("etcd_mvcc_db_total_size_in_bytes "):
-            out["db_size"] = float(line.split()[-1])
+            out["db_size"] = _metric_num(line.split()[-1])
     return out
 
 
@@ -453,22 +476,19 @@ def fetch_cnpg_metrics(pg_ip: str, timeout: float = 3.0) -> dict:
     }
     for line in raw.splitlines():
         if line.startswith("cnpg_backends_total{") and 'datname="spatiumddi"' in line:
-            try:
-                v = int(float(line.split()[-1]))
-            except ValueError:
-                continue
+            v = int(_metric_num(line.split()[-1]))
             if 'state="idle"' in line:
                 out["backends_idle"] += v
             elif 'state="active"' in line:
                 out["backends_active"] += v
         elif line.startswith("cnpg_backends_waiting_total "):
-            out["backends_waiting"] = int(float(line.split()[-1]))
+            out["backends_waiting"] = int(_metric_num(line.split()[-1]))
         elif line.startswith('cnpg_pg_database_size_bytes{datname="spatiumddi"}'):
-            out["db_size_bytes"] = float(line.split()[-1])
+            out["db_size_bytes"] = _metric_num(line.split()[-1])
         elif line.startswith("cnpg_pg_replication_streaming_replicas "):
-            out["streaming_replicas"] = int(float(line.split()[-1]))
+            out["streaming_replicas"] = int(_metric_num(line.split()[-1]))
         elif line.startswith("cnpg_pg_replication_in_recovery "):
-            out["in_recovery"] = int(float(line.split()[-1]))
+            out["in_recovery"] = int(_metric_num(line.split()[-1]))
     return out
 
 
@@ -1483,7 +1503,9 @@ def appliance_version_string(env: dict[str, str]) -> str:
     spddi = env.get("SPATIUMDDI_VERSION") or "?"
     if APPLIANCE_RELEASE.exists():
         try:
-            for line in APPLIANCE_RELEASE.read_text().splitlines():
+            # errors="replace" so a non-UTF-8 byte can't raise on the render
+            # tick (#552); OSError still caught for a missing/unreadable file.
+            for line in APPLIANCE_RELEASE.read_text(errors="replace").splitlines():
                 if line.startswith("APPLIANCE_VERSION="):
                     appliance = line.split("=", 1)[1].strip().strip('"')
         except OSError:
@@ -1793,7 +1815,16 @@ class KeyReader(threading.Thread):
 
             buf = b""
             while not self._stop.is_set():
-                r, _, _ = select.select([self.tty_fd], [], [], 0.1)
+                try:
+                    r, _, _ = select.select([self.tty_fd], [], [], 0.1)
+                except OSError:
+                    # bad-fd / serial hangup (IPMI SoL drop): don't let the
+                    # daemon KeyReader thread die silently — that leaves the
+                    # dashboard rendering but deaf to every F-key (incl.
+                    # F5/F6) with no visible sign (#552). Brief pause + retry;
+                    # a persistently-bad fd is a spin we can tolerate at 10 Hz.
+                    time.sleep(0.1)
+                    continue
                 if not r:
                     if buf and buf in KEY_SEQUENCES:
                         self.on_key(KEY_SEQUENCES[buf])
@@ -3882,12 +3913,34 @@ class DashboardState:
         # metrics + the etcd/api/cnpg health fetches + env re-read.
         if force or (now - self._last_data_refresh) >= DATA_REFRESH_EVERY:
             self._last_data_refresh = now
-            self.ps_rows = cluster_pods()
-            self.nodes = cluster_nodes()
-            # Phase 2 INC 4 — one kubelet Summary fetch feeds BOTH the
-            # per-pod Top-pods table AND the node-level CPU/mem/fs bars
-            # (zero extra subprocess).
-            _summary = kubelet_summary(os.uname().nodename)
+            # #552 — cluster_pods / cluster_nodes / kubelet_summary /
+            # cluster_svc_ips each fork a ~5 s-timeout kubectl and k3s_status
+            # a ~4 s systemctl+readyz. Run SERIALLY on the render thread (the
+            # old code), a *wedged* apiserver/kubelet — accepts TCP but never
+            # answers (quorum loss, memory pressure, hung stats endpoint) —
+            # froze the whole dashboard + F-key handling for ~25 s per pass,
+            # exactly when the physical-console recovery surface is needed.
+            # These five are mutually independent, so fan them out across the
+            # same pool the urllib health fetches use: wall time collapses to
+            # ~one timeout. Derived computations + the api/cnpg fetches that
+            # depend on their results run after the barrier.
+            _nodename = os.uname().nodename
+            with concurrent.futures.ThreadPoolExecutor(max_workers=6) as ex:
+                f_pods = ex.submit(cluster_pods)
+                f_nodes = ex.submit(cluster_nodes)
+                # One kubelet Summary fetch feeds BOTH the per-pod Top-pods
+                # table AND the node-level CPU/mem/fs bars (zero extra fork).
+                f_summary = ex.submit(kubelet_summary, _nodename)
+                # vip + api ClusterIP from ONE svc fetch.
+                f_svc = ex.submit(cluster_svc_ips)
+                f_k3s = ex.submit(k3s_status)
+                f_etcd = ex.submit(fetch_etcd_health)
+                self.ps_rows = f_pods.result()
+                self.nodes = f_nodes.result()
+                _summary = f_summary.result()
+                _svc = f_svc.result()
+                self.k3s_state = f_k3s.result()
+                self.etcd = f_etcd.result() or self.etcd
             self._set_node_pct(node_stats_from_summary(_summary))
             # INC 9 — cluster-wide Top-pods on a multi-node cluster; a
             # single-node box reuses the already-fetched local summary
@@ -3895,34 +3948,26 @@ class DashboardState:
             if len(self.nodes) > 1:
                 self.pod_stats = cluster_pod_stats(self.nodes)
             else:
-                _local = os.uname().nodename
                 self.pod_stats = {
-                    k: (c, mm, _local)
+                    k: (c, mm, _nodename)
                     for k, (c, mm) in pod_stats_from_summary(_summary).items()
                 }
-            # Phase 2 INC 4 — vip + api ClusterIP from ONE svc fetch
-            # (replaces the standalone cluster_vip() call).
-            _svc = cluster_svc_ips()
             self.vip = _svc.get("vip")
             self.api_ip = _svc.get("api")
-            self.k3s_state = k3s_status()
             # P0.5 — host-config apply health (pure file reads). Cached
             # here so render_header / overall_verdict read it off
             # ``state`` without touching disk on the render path.
             self.host_health = host_health_rollup()
-            # Phase 2 INC 4 — the four urllib health fetches run
-            # CONCURRENTLY behind a small pool so a single hung endpoint
-            # (3 s timeout each) can't serialise into a 12 s data-tier
-            # stall; wall time is ~max-single (~17 ms healthy). Each
-            # fetch already returns {} on error; keep-last-good on empty
-            # so a transient blip doesn't flap a box to "n/a".
+            # The api/cnpg urllib fetches depend on api_ip + the primary pg
+            # IP (both derived from the kubectl results above), so they run
+            # in a second pool after the barrier. Each fetch returns {} on
+            # error; keep-last-good on empty so a transient blip doesn't flap
+            # a box to "n/a".
             _pg_ip = _primary_pg_ip(self.ps_rows)
-            with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
-                f_etcd = ex.submit(fetch_etcd_health)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=3) as ex:
                 f_api = ex.submit(fetch_api_metrics, self.api_ip) if self.api_ip else None
                 f_ready = ex.submit(fetch_api_ready, self.api_ip) if self.api_ip else None
                 f_cnpg = ex.submit(fetch_cnpg_metrics, _pg_ip) if _pg_ip else None
-                self.etcd = f_etcd.result() or self.etcd
                 _api = (f_api.result() if f_api else {}) or {}
                 self.api_req_rate = _api.get("rate", self.api_req_rate)
                 self.api_active = _api.get("active", self.api_active)
@@ -4896,7 +4941,16 @@ def main() -> int:
     psutil.cpu_percent(interval=None)
 
     state = DashboardState(env, tail, args.tty)
-    state.refresh(force=True)  # prime cached vitals so first frame isn't all zeros
+    # Prime cached vitals so the first frame isn't all zeros. Guard it the
+    # same way the main loop guards refresh() (#552): a single bad metric or
+    # transient parse error here must NOT propagate out of main() → exit 1 →
+    # Restart=always crash-loop with a black console. DashboardState already
+    # holds sensible defaults, so a failed priming just means a sparse first
+    # frame that the next tick fills in.
+    try:
+        state.refresh(force=True)
+    except Exception as exc:  # noqa: BLE001 — recovery console must not die here
+        sys.stderr.write(f"spatium-console: priming refresh failed: {exc!r}\n")
 
     console = Console(soft_wrap=False, force_terminal=True, safe_box=True)
     state.term_size = console.size
@@ -4980,6 +5034,16 @@ def main() -> int:
                             live.stop()
                             try:
                                 if action == "login":
+                                    # do_login execvp's agetty and never
+                                    # returns, so the `finally` below never
+                                    # runs (#552): stop the app-log tail
+                                    # explicitly (else up to 12 apiserver log
+                                    # streams orphan into the agetty session),
+                                    # and exit the alternate screen so the
+                                    # login prompt doesn't render behind the
+                                    # frozen dashboard frame (serial/IPMI SoL).
+                                    app_tail.stop()
+                                    _prepare_tty_for_subprocess(args.tty)
                                     do_login(args.tty)  # noreturn
                                 elif action == "reboot":
                                     do_reboot(console)

--- a/appliance/mkosi.extra/usr/local/bin/spatium-firewall-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-firewall-reload
@@ -82,6 +82,20 @@ write_status() {
     printf '%s\n' "$1" > "$APPLIED_STATUS"
 }
 
+# #550 — on any failure path, move the trigger aside before exiting.
+# The supervisor's maybe_fire_firewall_reload bails while
+# firewall-pending exists, so an ``exit 1`` that leaves the trigger in
+# place permanently wedges the firewall plane — even a corrected value
+# never applies until someone SSHes in to delete it by hand. Renaming
+# it to ``.failed.<ts>`` (as the other reload runners do) lets the next
+# corrected heartbeat re-write the trigger; the copy stays for forensics.
+fail_release() {
+    write_status "$1"
+    [ -f "$TRIGGER_FILE" ] \
+        && mv -f "$TRIGGER_FILE" "${TRIGGER_FILE}.failed.$(date +%s)" 2>/dev/null
+    exit 1
+}
+
 if [ ! -r "$TRIGGER_FILE" ]; then
     log "no trigger file at $TRIGGER_FILE — nothing to do"
     exit 0
@@ -90,8 +104,7 @@ fi
 HASH=$(sed -n '1p' "$TRIGGER_FILE")
 if [ -z "$HASH" ]; then
     log "trigger missing hash (line 1) — refusing to apply"
-    write_status "error:missing-hash"
-    exit 1
+    fail_release "error:missing-hash"
 fi
 
 # #285 Phase 2c — a test-apply carries ``__test__ revert_seconds=N`` on line
@@ -126,8 +139,7 @@ if ! nft -c -f "$NFT_MAIN" 2>/tmp/nft-check.err; then
     log "dry-run via $NFT_MAIN failed BEFORE swap — refusing:"
     cat /tmp/nft-check.err | sed 's/^/[spatium-firewall-reload]  /'
     rm -f "$STAGING"
-    write_status "error:dry-run-pre"
-    exit 1
+    fail_release "error:dry-run-pre"
 fi
 
 # #285 Phase 2c — snapshot the current (good) drop-in + sentinel state
@@ -152,8 +164,7 @@ if ! nft -c -f "$NFT_MAIN" 2>/tmp/nft-check.err; then
     cat /tmp/nft-check.err | sed 's/^/[spatium-firewall-reload]  /'
     # Remove the bad drop-in so the master config still loads.
     rm -f "$DROP_IN"
-    write_status "error:dry-run-post"
-    exit 1
+    fail_release "error:dry-run-post"
 fi
 
 # #285 Phase 1b — bootstrap-sentinel retire/keep. The renderer stamps a
@@ -193,16 +204,14 @@ if [ "$sentinel_action" != none ]; then
             retire) mv "$SENTINEL_RETIRED" "$SENTINEL" ;;
             restore) mv "$SENTINEL" "$SENTINEL_RETIRED" ;;
         esac
-        write_status "error:sentinel-dry-run"
-        exit 1
+        fail_release "error:sentinel-dry-run"
     fi
 fi
 
 if ! nft -f "$NFT_MAIN" 2>/tmp/nft-apply.err; then
     log "nft -f $NFT_MAIN failed — runtime apply error:"
     cat /tmp/nft-apply.err | sed 's/^/[spatium-firewall-reload]  /'
-    write_status "error:apply"
-    exit 1
+    fail_release "error:apply"
 fi
 
 mkdir -p "$(dirname "$APPLIED_HASH")"

--- a/appliance/mkosi.extra/usr/local/bin/spatium-grub-render
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-grub-render
@@ -464,7 +464,18 @@ def main(argv: list[str] | None = None) -> int:
         return write_atomic(cfg, text)
 
     # LIVE mode — reconcile + spatium-upgrade-slot apply on the running host.
-    uuids = discover_live_uuids()
+    # Prefer explicit UUIDs when the caller supplies BOTH: spatium-upgrade-slot
+    # apply passes the known-good values it just probed with `blkid` directly
+    # off the device. Re-discovering here via lsblk reads the udev/blkid cache,
+    # which after a `tune2fs -U random` is only refreshed by a best-effort
+    # `udevadm trigger --settle`; if that lagged/failed, lsblk returns the
+    # STALE baked-in UUID and grub.cfg gets `root=UUID=<stale>` for the new
+    # slot → the trial reboot can't find it (#551). The direct blkid value
+    # can't be stale, so trust it when we have it.
+    if args.root_a_uuid and args.root_b_uuid:
+        uuids = {"root_a": args.root_a_uuid, "root_b": args.root_b_uuid}
+    else:
+        uuids = discover_live_uuids()
     if "root_a" not in uuids or "root_b" not in uuids:
         print(
             "ERROR: couldn't resolve both slot UUIDs via lsblk PARTLABEL "

--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -651,8 +651,11 @@ errs = []
 prefix = None
 try:
     prefix = int(prefix_s)
-    if not 0 < prefix < 32:
-        errs.append(f"Prefix must be between 1 and 31 (got {prefix_s!r}).")
+    # Allow /1../32. /32 is a valid single-host assignment (some cloud /
+    # VPS hosts hand one out with an off-link gateway reached via an
+    # on-link route); /31 is RFC 3021 point-to-point.
+    if not 0 < prefix <= 32:
+        errs.append(f"Prefix must be between 1 and 32 (got {prefix_s!r}).")
         prefix = None
 except ValueError:
     errs.append(f"Prefix must be a whole number (got {prefix_s!r}).")
@@ -672,7 +675,10 @@ else:
     except ValueError:
         errs.append(f"Gateway {gw_s!r} is not a valid IPv4 address.")
 
-if ip is not None and gw is not None and prefix is not None:
+if ip is not None and gw is not None and prefix is not None and prefix < 32:
+    # For /32 the network is the host itself, so an off-link gateway
+    # (reached via an on-link route) is normal and expected — skip the
+    # in-subnet check. For /1../31 the gateway must be on-link.
     net = ipaddress.ip_network(f"{ip_s.strip()}/{prefix}", strict=False)
     if gw not in net:
         errs.append(

--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -355,13 +355,38 @@ pick_disk() {
         return 0
     fi
     local options=()
+    # #554 — exclude EVERY disk backing the live boot medium, not just the
+    # one findmnt resolves. The old code checked only ``findmnt -no SOURCE
+    # /run/live/medium``; with ``boot=live toram`` (or a layout that
+    # unmounts the medium) that returns empty, so the boot USB — an ``sd*``
+    # device the ``grep -vE "^(sr|loop|fd|ram|zram)"`` filter does NOT
+    # exclude — appeared as a wipe target and picking it destroyed the
+    # running install media mid-install. Scan /proc/mounts for every
+    # /run/live // /lib/live mount and map each source back to its parent
+    # disk, keeping the findmnt-derived one too as belt-and-braces.
+    local -A live_disks=()
+    local _src _mnt _rest _pk
+    while read -r _src _mnt _rest; do
+        case "$_mnt" in
+            /run/live|/run/live/*|/lib/live/mount|/lib/live/mount/*)
+                case "$_src" in
+                    /dev/*)
+                        _pk=$(lsblk -no PKNAME "$_src" 2>/dev/null | head -n1)
+                        [ -z "$_pk" ] && _pk=$(basename "$_src")
+                        [ -n "$_pk" ] && live_disks["/dev/$_pk"]=1
+                        ;;
+                esac
+                ;;
+        esac
+    done < /proc/mounts
     local live_src
     live_src=$(findmnt -no SOURCE /run/live/medium 2>/dev/null || \
                findmnt -no SOURCE /lib/live/mount/medium 2>/dev/null || true)
-    # Strip partition suffix to compare against the disk node.
-    local live_disk
-    live_disk=$(lsblk -no PKNAME "$live_src" 2>/dev/null || true)
-    [ -n "$live_disk" ] && live_disk="/dev/$live_disk"
+    if [ -n "$live_src" ]; then
+        local live_disk
+        live_disk=$(lsblk -no PKNAME "$live_src" 2>/dev/null | head -n1 || true)
+        [ -n "$live_disk" ] && live_disks["/dev/$live_disk"]=1
+    fi
 
     while IFS= read -r line; do
         local name size model
@@ -369,8 +394,8 @@ pick_disk() {
         size=$(echo "$line" | awk '{print $2}')
         model=$(echo "$line" | cut -d' ' -f3- | sed 's/  */ /g')
         [ -z "$model" ] && model="(no model)"
-        # Skip the live medium itself.
-        [ "/dev/$name" = "$live_disk" ] && continue
+        # Skip any disk that backs the live boot medium.
+        [ -n "${live_disks[/dev/$name]:-}" ] && continue
         options+=("/dev/$name" "$size - $model")
     done < <(lsblk -dn -o NAME,SIZE,MODEL -r 2>/dev/null | grep -vE "^(sr|loop|fd|ram|zram)")
 
@@ -608,10 +633,79 @@ ask_user_password() {
     done
 }
 
+# #554 — validate the static-IP fields with Python's ``ipaddress`` (same
+# approach as the k3s CIDR step). Without this, a blank gateway wrote
+# ``address1=<ip>/<prefix>,`` (trailing comma) into the NetworkManager
+# keyfile → NM rejects it → the connection never loads → headless
+# appliance comes up with NO IP (console-only recovery). A typo'd
+# prefix / IP / gateway failed the same silent way. Prints the problem(s)
+# on stdout + exits 1 on any error.
+_validate_static_net() {
+    python3 - "$NET_IP" "$NET_PREFIX" "$NET_GATEWAY" "$NET_DNS" <<'PY' 2>&1
+import ipaddress
+import sys
+
+ip_s, prefix_s, gw_s, dns_s = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+errs = []
+
+prefix = None
+try:
+    prefix = int(prefix_s)
+    if not 0 < prefix < 32:
+        errs.append(f"Prefix must be between 1 and 31 (got {prefix_s!r}).")
+        prefix = None
+except ValueError:
+    errs.append(f"Prefix must be a whole number (got {prefix_s!r}).")
+
+ip = None
+try:
+    ip = ipaddress.IPv4Address(ip_s.strip())
+except ValueError:
+    errs.append(f"IP address {ip_s!r} is not a valid IPv4 address.")
+
+gw = None
+if not gw_s.strip():
+    errs.append("Gateway is required for a static install.")
+else:
+    try:
+        gw = ipaddress.IPv4Address(gw_s.strip())
+    except ValueError:
+        errs.append(f"Gateway {gw_s!r} is not a valid IPv4 address.")
+
+if ip is not None and gw is not None and prefix is not None:
+    net = ipaddress.ip_network(f"{ip_s.strip()}/{prefix}", strict=False)
+    if gw not in net:
+        errs.append(
+            f"Gateway {gw_s.strip()} is not inside {net} — the appliance "
+            "would not be able to reach it."
+        )
+
+for tok in dns_s.split():
+    try:
+        ipaddress.ip_address(tok)
+    except ValueError:
+        errs.append(f"DNS server {tok!r} is not a valid IP address.")
+
+if errs:
+    print("\n".join(errs))
+    sys.exit(1)
+PY
+}
+
 ask_network() {
     log "Step: ask_network"
     if [ -n "${PRESEED_HAS_NETWORK:-}" ]; then
         log "Preseed: network=$NET_MODE (skipping prompt)"
+        # Validate a preseeded static config too — a bad answer file would
+        # otherwise brick a fully-headless install with no way to recover.
+        if [ "$NET_MODE" = "static" ]; then
+            local perr
+            if ! perr=$(_validate_static_net); then
+                log "FATAL: preseed static network is invalid: $perr"
+                whiptail --msgbox "Preseed static network settings are invalid:\n\n$perr\n\nFix the answer file and reinstall." 16 72 || true
+                on_cancel
+            fi
+        fi
         return 0
     fi
     NET_MODE=$(whiptail --backtitle "$BACKTITLE" --title "Network" \
@@ -636,22 +730,34 @@ ask_network() {
             --cancel-button "Back" \
             --menu "Pick an interface:" 12 60 5 "${ifs[@]}" 3>&1 1>&2 2>&3) \
             || return 1
-        NET_IP=$(whiptail --backtitle "$BACKTITLE" --title "Static IP -address" \
-            --cancel-button "Back" \
-            --inputbox "IPv4 address (e.g. 192.168.1.10):" 10 60 "$NET_IP" 3>&1 1>&2 2>&3) \
-            || return 1
-        NET_PREFIX=$(whiptail --backtitle "$BACKTITLE" --title "Static IP -prefix" \
-            --cancel-button "Back" \
-            --inputbox "Prefix length:" 10 60 "$NET_PREFIX" 3>&1 1>&2 2>&3) \
-            || return 1
-        NET_GATEWAY=$(whiptail --backtitle "$BACKTITLE" --title "Static IP -gateway" \
-            --cancel-button "Back" \
-            --inputbox "Gateway:" 10 60 "$NET_GATEWAY" 3>&1 1>&2 2>&3) \
-            || return 1
-        NET_DNS=$(whiptail --backtitle "$BACKTITLE" --title "Static IP -DNS" \
-            --cancel-button "Back" \
-            --inputbox "DNS servers (space-separated):" 10 60 "$NET_DNS" 3>&1 1>&2 2>&3) \
-            || return 1
+        # #554 — collect + validate in a loop: on a validation error re-show
+        # the four fields (pre-filled with what was entered) instead of
+        # writing an invalid keyfile. Back (Cancel) on any field still exits
+        # the step backward via ``return 1``.
+        while true; do
+            NET_IP=$(whiptail --backtitle "$BACKTITLE" --title "Static IP -address" \
+                --cancel-button "Back" \
+                --inputbox "IPv4 address (e.g. 192.168.1.10):" 10 60 "$NET_IP" 3>&1 1>&2 2>&3) \
+                || return 1
+            NET_PREFIX=$(whiptail --backtitle "$BACKTITLE" --title "Static IP -prefix" \
+                --cancel-button "Back" \
+                --inputbox "Prefix length:" 10 60 "$NET_PREFIX" 3>&1 1>&2 2>&3) \
+                || return 1
+            NET_GATEWAY=$(whiptail --backtitle "$BACKTITLE" --title "Static IP -gateway" \
+                --cancel-button "Back" \
+                --inputbox "Gateway:" 10 60 "$NET_GATEWAY" 3>&1 1>&2 2>&3) \
+                || return 1
+            NET_DNS=$(whiptail --backtitle "$BACKTITLE" --title "Static IP -DNS" \
+                --cancel-button "Back" \
+                --inputbox "DNS servers (space-separated):" 10 60 "$NET_DNS" 3>&1 1>&2 2>&3) \
+                || return 1
+            local nerr
+            if nerr=$(_validate_static_net); then
+                break
+            fi
+            whiptail --backtitle "$BACKTITLE" --title "Static network — invalid" \
+                --msgbox "Please correct these before continuing:\n\n$nerr" 16 72 || true
+        done
     fi
 }
 
@@ -1493,6 +1599,19 @@ EOF
         local ROOT_A_UUID ROOT_B_UUID
         ROOT_A_UUID=$(blkid -s UUID -o value "$ROOT_A")
         ROOT_B_UUID=$(blkid -s UUID -o value "$ROOT_B")
+        # #554 — guard against an empty UUID (blkid racing the just-created
+        # filesystem). An empty value renders ``root=UUID=`` into grub.cfg —
+        # valid syntax that grub-script-check accepts but that produces an
+        # unbootable slot. Settle udev + retry once before giving up.
+        if [ -z "$ROOT_A_UUID" ] || [ -z "$ROOT_B_UUID" ]; then
+            udevadm settle 2>/dev/null || true
+            [ -z "$ROOT_A_UUID" ] && ROOT_A_UUID=$(blkid -s UUID -o value "$ROOT_A")
+            [ -z "$ROOT_B_UUID" ] && ROOT_B_UUID=$(blkid -s UUID -o value "$ROOT_B")
+        fi
+        if [ -z "$ROOT_A_UUID" ] || [ -z "$ROOT_B_UUID" ]; then
+            log "ERROR: could not read slot filesystem UUIDs (A=$ROOT_A_UUID B=$ROOT_B_UUID) — refusing to render grub with an empty root=UUID="
+            exit 1
+        fi
 
         # Write /etc/default/grub explicitly so future `update-grub`
         # runs (e.g. on kernel upgrade) get the same cmdline. We
@@ -1627,14 +1746,19 @@ EOF
         # directories on root_B so the boot-time mount units succeed.
         mkdir -p /mnt/spatium-root-b/var /mnt/spatium-root-b/home \
                  /mnt/spatium-root-b/root /mnt/spatium-root-b/boot/efi
-        umount /mnt/spatium-root-b
-        rmdir /mnt/spatium-root-b
+        umount /mnt/spatium-root-b 2>/dev/null || umount -l /mnt/spatium-root-b 2>/dev/null || true
+        rmdir /mnt/spatium-root-b 2>/dev/null || true
 
         echo "XXX"; echo "95"; echo "Unmounting..."; echo "XXX"
         for d in dev sys proc; do
             umount "$MOUNT/$d" 2>/dev/null || true
         done
-        umount "$MOUNT/boot/efi"
+        # #554 — these cleanup unmounts run AFTER the install is complete,
+        # under ``set -e``. A single busy mount (e.g. something still holding
+        # /var) would abort do_install → the EXIT trap fires → the reboot
+        # below never runs, showing "Installer exited with status N" after a
+        # SUCCESSFUL install. Make each best-effort with a lazy-unmount
+        # fallback; the imminent reboot clears anything still held.
         # Phase 8a unmount order matters:
         #   1. /home, /root            — bind mounts onto /var subdirs
         #   2. /etc (overlay)          — upper is on /var, release first
@@ -1642,12 +1766,16 @@ EOF
         #                                /var so release before /var (#276)
         #   4. /var partition          — after /etc overlay + binds + STATE
         #   5. root_A                  — last
-        umount "$MOUNT/home"
-        umount "$MOUNT/root"
-        umount "$MOUNT/etc"
-        umount "$MOUNT/var/lib/spatium-state"
-        umount "$MOUNT/var"
-        umount "$MOUNT"
+        for mp in \
+            "$MOUNT/boot/efi" \
+            "$MOUNT/home" \
+            "$MOUNT/root" \
+            "$MOUNT/etc" \
+            "$MOUNT/var/lib/spatium-state" \
+            "$MOUNT/var" \
+            "$MOUNT"; do
+            umount "$mp" 2>/dev/null || umount -l "$mp" 2>/dev/null || true
+        done
         sync
 
         echo "XXX"; echo "100"; echo "Done."; echo "XXX"
@@ -2048,7 +2176,22 @@ main() {
                 # them the review screen).
                 if [ "$FULLY_UNATTENDED" = "1" ]; then
                     step="do_install"
-                elif confirm; then step="do_install"; else step="ask_application_config"; fi
+                elif confirm; then
+                    step="do_install"
+                else
+                    # #554 — Back. ask_application_config returns 0 without
+                    # showing a screen for every role EXCEPT appliance, so
+                    # routing Back through it for a control-plane install
+                    # bounced confirm→ask_application_config→confirm forever
+                    # (the operator could never get back to hostname / tz /
+                    # disk / CIDRs). Skip straight to ask_k3s_cidrs unless the
+                    # appliance role, which has a real screen there.
+                    if [ "$ROLE" = "appliance" ]; then
+                        step="ask_application_config"
+                    else
+                        step="ask_k3s_cidrs"
+                    fi
+                fi
                 ;;
             do_install)
                 do_install

--- a/appliance/mkosi.extra/usr/local/bin/spatium-pcap-runner
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-pcap-runner
@@ -31,6 +31,11 @@ set -u
 
 PCAP_DIR=/var/lib/spatiumddi/release-state/pcap
 IFACE_RE='^[A-Za-z0-9_.:@-]{1,64}$'
+# #555 — capture_id becomes $PCAP_DIR/$cid.{pcap,cancel,state}; a value
+# with ``/`` or ``..`` would escape PCAP_DIR. Validate the charset here too
+# (the supervisor validates before writing the request, but this runner is
+# the authoritative host-side gate).
+CID_RE='^[A-Za-z0-9._-]{1,128}$'
 # The BPF filter is charset-validated upstream (control plane + supervisor)
 # and passed to tcpdump as a single quoted argv element here — never eval'd
 # or re-split — so it needs no re-validation in the runner.
@@ -82,6 +87,11 @@ while IFS= read -r line; do
 done < "$running"
 
 [ -z "$cid" ] && { rm -f "$running"; exit 0; }
+# Reject a traversal-bearing capture_id before it's used to build paths.
+if ! [[ "$cid" =~ $CID_RE ]]; then
+  rm -f "$running"
+  exit 0
+fi
 pcap="$PCAP_DIR/$cid.pcap"
 cancel="$PCAP_DIR/$cid.cancel"
 write_state "$cid" starting "" 0 ""

--- a/appliance/mkosi.extra/usr/local/bin/spatium-publish-k3s-token
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-publish-k3s-token
@@ -25,18 +25,23 @@ DEADLINE=$(( $(date +%s) + 60 ))
 
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do
     if [ -r "$TOKEN_FILE" ]; then
-        tmp="$SIDECAR.new"
+        # #555 — write via a RANDOM-named temp (mktemp creates it fresh at
+        # 0600 and won't write through a symlink an attacker pre-planted at
+        # the predictable ``$SIDECAR.new`` name in the 1777 release-state
+        # dir — the token is cluster-admin-equivalent). The FINAL sidecar
+        # stays 0644 on purpose: the supervisor's unprivileged process user
+        # (uid 100 spatium, su-exec'd from root by the entrypoint) must read
+        # it through the release-state bind mount. A 0600-root sidecar is
+        # invisible to that user → read_k3s_join_token() returns None → the
+        # seed never reports its token → promote 409s. Same 0644 precedent
+        # as firstboot's /etc/spatiumddi/.env. Single-tenant box; the host
+        # filesystem is the trust boundary, not this mode.
+        tmp="$(mktemp "$SIDECAR.XXXXXX" 2>/dev/null)" || { sleep 3; continue; }
         if tr -d '\r\n' < "$TOKEN_FILE" > "$tmp" 2>/dev/null; then
-            # 0644 so the supervisor's unprivileged process user (uid 100
-            # spatium, su-exec'd from root by the entrypoint) can read it
-            # through the release-state bind mount. A 0600-root sidecar is
-            # invisible to that user → read_k3s_join_token() returns None →
-            # the seed never reports its token → promote 409s. Same 0644
-            # precedent as firstboot's /etc/spatiumddi/.env (also secrets
-            # the unprivileged supervisor must read). Single-tenant box;
-            # the host filesystem is the trust boundary, not this mode.
             chmod 0644 "$tmp"
             mv -f "$tmp" "$SIDECAR"
+        else
+            rm -f "$tmp"
         fi
         exit 0
     fi

--- a/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
@@ -484,6 +484,8 @@ def _parent_disk(part_dev: str) -> str:
         if first:
             return "/dev/" + first
     except (FileNotFoundError, OSError):
+        # lsblk missing or failed — deliberately fall through to the
+        # suffix-strip below, which needs no external tool.
         pass
     base = os.path.basename(part_dev)
     if re.search(r"\dp\d+$", base):  # nvme0n1p5 / mmcblk0p5 / loop0p1

--- a/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
@@ -273,10 +273,15 @@ def cmd_apply(args) -> int:
     # unverified image onto a block device.
     insecure = getattr(args, "insecure", False)
     expected_sha256 = (getattr(args, "expected_sha256", None) or "").strip().lower()
-    if insecure and not (expected_sha256 or args.checksum):
+    # A ``--checksum`` sidecar is fetched over the SAME channel as the image,
+    # so with TLS verification off a MITM can serve a matching malicious
+    # image+sidecar pair — it's no verification at all (#551). Only an
+    # out-of-band ``--expected-sha256`` literal makes ``--insecure`` safe.
+    if insecure and not expected_sha256:
         print(
-            "ERROR: --insecure requires --expected-sha256 or --checksum "
-            "(bytes must be verified when TLS verification is off)",
+            "ERROR: --insecure requires --expected-sha256 (an out-of-band "
+            "literal hash; a --checksum sidecar fetched over the same "
+            "unverified channel provides no real protection)",
             file=sys.stderr,
         )
         return 2
@@ -324,8 +329,7 @@ def cmd_apply(args) -> int:
 
     _write_progress("bootloader", None, "updating bootloader + slot versions")
     print("  flushing kernel buffers + re-reading filesystem metadata…")
-    subprocess.run(["partprobe", "/dev/" + os.path.basename(target_dev).rstrip("0123456789p")],
-                   check=False)
+    subprocess.run(["partprobe", _parent_disk(target_dev)], check=False)
     subprocess.run(["udevadm", "settle"], check=False)
     staged.unlink(missing_ok=True)
 
@@ -366,8 +370,19 @@ def cmd_apply(args) -> int:
     # missing or returns non-zero (pre-#395 ESP, or a render-path bug)
     # so apply never leaves grub.cfg unstamped.
     rendered = False
+    # Pass the UUIDs we KNOW (probed via blkid directly off the devices) so
+    # the renderer doesn't re-discover them through the possibly-stale
+    # udev/lsblk cache after the tune2fs UUID randomisation (#551).
+    render_cmd = ["spatium-grub-render"]
+    slot_uuids = {
+        active.get("partlabel", ""): active.get("uuid", ""),
+        inactive.get("partlabel", ""): new_uuid or inactive.get("uuid", ""),
+    }
+    ra_uuid, rb_uuid = slot_uuids.get("root_a"), slot_uuids.get("root_b")
+    if ra_uuid and rb_uuid:
+        render_cmd += ["--root-a-uuid", ra_uuid, "--root-b-uuid", rb_uuid]
     try:
-        rc = subprocess.run(["spatium-grub-render"], check=False).returncode
+        rc = subprocess.run(render_cmd, check=False).returncode
         rendered = (rc == 0)
     except FileNotFoundError:
         rendered = False
@@ -450,6 +465,32 @@ def _refresh_baked_images(target_dev: str) -> None:
         print(f"  WARN: baked-image refresh skipped ({exc})", file=sys.stderr)
 
 
+def _parent_disk(part_dev: str) -> str:
+    """Return the whole-disk device holding a partition.
+
+    ``basename(dev).rstrip("0123456789p")`` (the old inline form) is wrong
+    on exactly the media the appliance supports: ``/dev/nvme0n1p5`` →
+    ``/dev/nvme0n`` and ``/dev/mmcblk0p5`` → ``/dev/mmcblk`` (#551). Ask
+    lsblk for the real parent (``pkname``); fall back to a suffix-strip
+    that handles both the ``p<N>`` separator (nvme/mmcblk/loop) and the
+    bare-``<N>`` form (sd/vd/hd/xvd).
+    """
+    try:
+        out = subprocess.run(
+            ["lsblk", "-no", "pkname", part_dev],
+            capture_output=True, text=True, check=False,
+        ).stdout.strip()
+        first = out.splitlines()[0].strip() if out else ""
+        if first:
+            return "/dev/" + first
+    except (FileNotFoundError, OSError):
+        pass
+    base = os.path.basename(part_dev)
+    if re.search(r"\dp\d+$", base):  # nvme0n1p5 / mmcblk0p5 / loop0p1
+        return "/dev/" + re.sub(r"p\d+$", "", base)
+    return "/dev/" + re.sub(r"\d+$", "", base)  # sda5 / vdb3
+
+
 def _blkid_uuid(device: str) -> str | None:
     """Return the filesystem UUID of the given block device, or None
     if blkid fails (uninitialised filesystem, missing tool, etc.)."""
@@ -505,7 +546,13 @@ def _patch_grub_cfg_slot_uuid(partlabel: str, new_uuid: str,
         patched_count += n
         return head + new_body + tail
 
-    new_cfg = block_re.sub(replace_block, cfg, count=1)
+    # Patch EVERY menuentry for this slot, not just the first (#551): the
+    # slot has more than one entry (``--id=slot_a``, ``--id=slot_a_verbose``,
+    # the rescue entry), all keyed off the same partition. count=1 left the
+    # verbose + rescue entries pointing at the pre-upgrade UUID → unbootable
+    # when the fallback path (no spatium-grub-render) runs. The block_re is
+    # anchored to slot_id so the OTHER slot's entries are never touched.
+    new_cfg = block_re.sub(replace_block, cfg)
     if patched_count == 0:
         print(f"WARN: couldn't locate {slot_id} menuentry in {cfg_path}; "
               "grub.cfg not updated", file=sys.stderr)

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-apt-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-apt-reload
@@ -125,14 +125,22 @@ if auth:
 
 # Keyrings are referenced by absolute path in the sources.list entries, so
 # they must exist at the live location BEFORE validation. Additive + safe.
+# Record the ones we CREATE new (didn't pre-exist) so the bash half can
+# clean them up if the validate fails — otherwise a failed enable leaves
+# orphaned keyrings under /etc/apt/keyrings (#550).
+new_keyrings = []
 for key_id, armour in (data.get("keyrings") or {}).items():
     safe = "".join(c for c in str(key_id) if c.isalnum() or c in "._-")
     if not safe:
         continue
     p = os.path.join(keyring_dir, f"spatiumddi-{safe}.asc")
+    if not os.path.exists(p):
+        new_keyrings.append(p)
     with open(p, "w", encoding="utf-8") as fh:
         fh.write(armour)
     os.chmod(p, 0o644)
+with open(os.path.join(stage, "new-keyrings.list"), "w", encoding="utf-8") as fh:
+    fh.write("\n".join(new_keyrings))
 
 # Emit the artifact paths + unattended flag for the bash half.
 with open(os.path.join(stage, "manifest.env"), "w", encoding="utf-8") as fh:
@@ -183,6 +191,14 @@ EOF
                 state="no-sources"
             fi
             echo "  classified as: $state (live config left untouched)"
+            # Clean up the keyrings we created this run (didn't pre-exist)
+            # so a failed enable doesn't leave orphans under the live
+            # keyring dir (#550). Pre-existing keyrings are left alone.
+            if [ -f "$STAGE/new-keyrings.list" ]; then
+                while IFS= read -r kp; do
+                    [ -n "$kp" ] && rm -f "$kp"
+                done < "$STAGE/new-keyrings.list"
+            fi
             finish "$state" "failed"
             exit 1
         fi

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -191,10 +191,21 @@ if [ ! -f "$ENV_FILE" ]; then
     INSTALL_CONTROL_PLANE_URL=""
     INSTALL_BOOTSTRAP_PAIRING_CODE=""
     if [ -f /etc/spatiumddi/role-config ]; then
-        # shellcheck disable=SC1091
-        . /etc/spatiumddi/role-config
-        INSTALL_CONTROL_PLANE_URL="${CONTROL_PLANE_URL:-}"
-        INSTALL_BOOTSTRAP_PAIRING_CODE="${BOOTSTRAP_PAIRING_CODE:-}"
+        # #554 — PARSE, don't source. ``. role-config`` runs shell
+        # interpretation over operator-supplied values, so a
+        # CONTROL_PLANE_URL carrying ``#`` / ``&`` / space / `` ` `` /
+        # ``$(…)`` would truncate, background, or execute under set -e.
+        # role-config carries exactly three keys; extract each with sed
+        # (last occurrence wins), stripping one layer of surrounding
+        # quotes, and never evaluate the value.
+        _rc_get() {
+            sed -n "s/^$1=//p" /etc/spatiumddi/role-config | tail -n1 \
+                | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/"
+        }
+        _RC_ROLE=$(_rc_get ROLE)
+        [ -n "$_RC_ROLE" ] && ROLE="$_RC_ROLE"
+        INSTALL_CONTROL_PLANE_URL=$(_rc_get CONTROL_PLANE_URL)
+        INSTALL_BOOTSTRAP_PAIRING_CODE=$(_rc_get BOOTSTRAP_PAIRING_CODE)
     fi
 
     BOOTSTRAP_PAIRING_CODE_VAL=""
@@ -859,6 +870,23 @@ if [ -x /usr/local/bin/spatium-upgrade-slot ] && [ -e /etc/spatiumddi/role-confi
         echo "WARN: sync-versions failed — OS Image card will show 'unknown' for slot versions"
 fi
 
+# #554 — is this a TRIAL boot (running slot != durable default)? Blocking
+# the slot commit on a host-migrate failure only matters during a trial
+# boot; on a steady-state boot there's nothing to commit, so a persistent
+# host-migrate failure should log + continue rather than exit 1 on EVERY
+# boot (which leaves the firstboot unit perpetually `failed`).
+is_trial_boot() {
+    local gbd=/boot/efi root_uuid root_dev cur saved
+    [ -f "$gbd/grub/grubenv" ] || return 1
+    root_uuid=$(awk 'BEGIN{RS=" "} /^root=UUID=/{print substr($0,11)}' /proc/cmdline 2>/dev/null | head -1)
+    [ -n "$root_uuid" ] || return 1
+    root_dev=$(blkid -U "$root_uuid" 2>/dev/null) || return 1
+    cur=$(lsblk -no PARTLABEL "$root_dev" 2>/dev/null | tr 'A-Z' 'a-z' | head -1)
+    case "$cur" in root_a) cur=slot_a ;; root_b) cur=slot_b ;; *) return 1 ;; esac
+    saved=$(grub-editenv "$gbd/grub/grubenv" list 2>/dev/null | awk -F= '/^saved_entry=/{print $2}')
+    [ -n "$saved" ] && [ "$saved" != "$cur" ]
+}
+
 # ── #395 host-migration reconcile ────────────────────────────────────────────
 # MUST run before the readyz wait so a failed grub render blocks the slot
 # commit. The current boot already loaded via grub (we're here), so a bad
@@ -867,13 +895,20 @@ fi
 # renderer's per-slot labels.
 if [ -x /usr/local/bin/spatium-host-migrate ]; then
     if ! /usr/local/bin/spatium-host-migrate; then
-        echo "ERROR: host-migration reconcile failed — NOT committing this slot." >&2
-        echo "       grub.cfg + .bak are intact; next reboot reverts (A/B one-shot)." >&2
-        # Do NOT place_deferred / commit. Mirror the not-ready tail: still
-        # release any deferred control manifest so the control plane comes up,
-        # then exit non-zero so commit_slot_if_healthy never runs.
+        echo "ERROR: host-migration reconcile failed." >&2
+        # Still release any deferred control manifest so the control plane
+        # comes up regardless.
         mv -f "${CONTROL_MANIFEST}.deferred" "$CONTROL_MANIFEST" 2>/dev/null || true
-        exit 1
+        if is_trial_boot; then
+            # Trial boot: a bad grub render risks the next reboot, so do NOT
+            # commit — exit non-zero so commit_slot_if_healthy never runs and
+            # the A/B one-shot reverts on the next reboot.
+            echo "       trial boot: NOT committing this slot; next reboot reverts." >&2
+            exit 1
+        fi
+        # Steady-state boot: nothing to commit. Log + continue so we don't
+        # leave the firstboot unit `failed` on every boot (#554).
+        echo "       steady-state boot: nothing to commit; continuing." >&2
     fi
 fi
 

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-image-prune
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-image-prune
@@ -103,7 +103,13 @@ try:
         if img:
             inuse.add(img)
 except Exception:
-    inuse = set()
+    # #555 — if the in-use query fails we CANNOT know what's running, so an
+    # empty ``inuse`` would unprotect every image whose tag doesn't match a
+    # slot version (e.g. a HelmChartConfig image.tag dev-tag override) and
+    # rmi it → imagePullPolicy:Never pods then ErrImageNeverPull on the next
+    # restart. Bail entirely (print nothing) rather than prune blind.
+    print("", end="")
+    sys.exit(0)
 
 SP = "ghcr.io/spatiumddi/"
 remove = []

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-lldp-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-lldp-reload
@@ -64,6 +64,17 @@ fi
 MARKER=$(sed -n '1p' "$TRIGGER" | tr -d '\r\n')
 HASH=$(sed -n '2p' "$TRIGGER" | tr -d '\r\n')
 DAEMON_ARGS=$(sed -n '3p' "$TRIGGER" | tr -d '\r\n')
+# DAEMON_ARGS is interpolated into a double-quoted assignment in the
+# shell-sourced /etc/default/lldpd; a stray `"`, `` ` ``, `$`, `;` or
+# newline would break out into command execution when lldpd's init
+# sources it (#550). lldpd flags are a small, boring charset — reject
+# anything outside it rather than trying to escape.
+if printf '%s' "$DAEMON_ARGS" | LC_ALL=C grep -q '[^A-Za-z0-9 _=./:,-]'; then
+    echo "  ✗ DAEMON_ARGS contains disallowed characters — refusing"
+    echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
+    mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
+    exit 1
+fi
 TMP_BODY=$(mktemp /tmp/spatium-lldpd.conf.XXXXXX)
 trap 'rm -f "$TMP_BODY"' EXIT
 tail -n +4 "$TRIGGER" > "$TMP_BODY"

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-reboot-agent
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-reboot-agent
@@ -6,9 +6,11 @@
 # Flow:
 #   1. Operator clicks Reboot in the OS Versions table → backend
 #      stamps ``reboot_requested=true`` on the agent's server row.
-#   2. ConfigBundle long-poll carries the field down → agent writes
-#      ``/var/lib/spatiumddi-host/release-state/reboot-pending`` via
-#      the bind-mounted release-state directory.
+#   2. ConfigBundle long-poll carries the field down → the supervisor
+#      writes ``/var/lib/spatiumddi-host/release-state/reboot-pending-fleet``
+#      via the bind-mounted release-state directory (#553 gave the fleet
+#      path its own filename so it no longer collides with the web-UI
+#      ``reboot-pending`` trigger).
 #   3. ``spatiumddi-reboot-agent.path`` notices the file and runs this
 #      script as root.
 #   4. Script:

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-reboot-agent
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-reboot-agent
@@ -25,7 +25,9 @@
 
 set -euo pipefail
 
-TRIGGER=/var/lib/spatiumddi/release-state/reboot-pending
+# #553 — fleet reboots use a DEDICATED trigger filename so this runner and
+# the web-UI spatiumddi-reboot.service don't both fire on a single write.
+TRIGGER=/var/lib/spatiumddi/release-state/reboot-pending-fleet
 LOG_DIR=/var/log/spatiumddi
 LOG="$LOG_DIR/reboot-agent.log"
 GRACE_SECONDS=5

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-slot-rollback
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-slot-rollback
@@ -10,10 +10,13 @@
 # Then `spatiumddi-slot-rollback.path` notices the file and runs this
 # script as root. It:
 #   1. Reads the trigger file (target slot, optional)
-#   2. Invokes /usr/local/bin/spatium-upgrade-slot commit [<slot>]
-#      which calls grub-set-default — durably flips saved_entry. The
+#   2. Invokes /usr/local/bin/spatium-upgrade-slot rollback  (no target
+#      → inactive slot) or `set-default <slot>` (explicit target), both
+#      of which call grub-set-default — durably flip saved_entry. The
 #      swap doesn't take effect until the operator reboots; the active
-#      slot keeps running until then.
+#      slot keeps running until then. (There is NO `commit` subcommand —
+#      the earlier version called one that argparse rejects, so every
+#      rollback failed, #551.)
 #   3. Renames the trigger to .done or .failed so the .path unit
 #      doesn't re-fire on the next watch.
 #
@@ -64,8 +67,13 @@ echo
 # Mark trigger as in-flight so the UI can show "applying" state.
 echo "in-flight $(date -Iseconds)" > "${TRIGGER}.state"
 
-COMMIT_ARGS=("commit")
-[ -n "$TARGET_SLOT" ] && COMMIT_ARGS+=("$TARGET_SLOT")
+# Map to the real subcommands: `rollback` targets the inactive slot with
+# no argument; `set-default <slot>` durably flips to an explicit slot.
+if [ -n "$TARGET_SLOT" ]; then
+    COMMIT_ARGS=("set-default" "$TARGET_SLOT")
+else
+    COMMIT_ARGS=("rollback")
+fi
 
 echo "  → /usr/local/bin/spatium-upgrade-slot ${COMMIT_ARGS[*]}"
 if /usr/local/bin/spatium-upgrade-slot "${COMMIT_ARGS[@]}"; then

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-slot-upgrade
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-slot-upgrade
@@ -207,6 +207,19 @@ echo "  image:    $IMAGE_SRC"
 [ -n "$INSECURE" ] && echo "  insecure-tls: yes (self-served URL; bytes verified by hash)"
 echo
 
+# #551 — insecure-tls requires an out-of-band ``sha256=`` literal. A
+# ``checksum=`` sidecar is fetched over the SAME unverified channel, so it
+# is no protection (a MITM serves a matching image+sidecar). spatium-upgrade-
+# slot now rejects ``--insecure`` without ``--expected-sha256`` (exit 2);
+# catch it here with a clear message instead of a cryptic argparse abort.
+if [ -n "$INSECURE" ] && [ -z "$EXPECTED_SHA256" ]; then
+    echo "  ERROR: insecure-tls requires an out-of-band 'sha256=<hex>'"
+    echo "         directive — a 'checksum=' sidecar over the same"
+    echo "         unverified channel provides no real protection."
+    mv "$TRIGGER" "${TRIGGER}.invalid.$(date +%s)"
+    exit 1
+fi
+
 # Mark trigger as in-flight so the UI can show "applying" state. We
 # don't rename it (the .path unit fires on close-after-write, not on
 # every read) but we do touch a sibling marker + progress. From here on

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-snmp-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-snmp-reload
@@ -117,27 +117,51 @@ echo "  body size: $(wc -c < "$TMP_BODY") bytes"
 
 case "$MARKER" in
     enabled)
-        # Validate syntax against snmpd -C -c (don't fall back to the
-        # system path; the operator-supplied body is the only thing
-        # under test here). ``snmpd -H`` is the help flag that exits
-        # 0 after dumping options; we use it as a quick "does snmpd
-        # exist?" check before the real syntax test.
         if ! command -v snmpd >/dev/null 2>&1; then
             echo "  ✗ snmpd binary not found — is net-snmp installed?"
             echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
             mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
             exit 1
         fi
-        # ``-t`` tests config + exits, ``-C`` ignores the default conf
-        # paths so only our staging file is checked.
-        if ! snmpd -t -C -c "$TMP_BODY" >/tmp/spatium-snmpd-validate.log 2>&1; then
-            echo "  ✗ snmpd -t failed for staged config:"
-            sed 's/^/      /' /tmp/spatium-snmpd-validate.log
-            echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
-            mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
-            exit 1
+        # net-snmp has NO config-test flag: ``snmpd -t`` takes a
+        # *timeout* argument, not a "test" flag — it prints "invalid
+        # option -- 't'" and exits 1 unconditionally, which is why
+        # every SNMP apply silently failed (#550). Validate instead by
+        # starting snmpd in the foreground against ONLY the staged file
+        # (``-C -c``), bound to a throwaway loopback transport so it
+        # can't collide with the live instance's :161, then killing it.
+        # A config parse/read error makes snmpd exit before it settles;
+        # a clean parse keeps it alive until we kill it.
+        SNMP_VALIDATE_LOG=/tmp/spatium-snmpd-validate.log
+        snmpd -f -C -c "$TMP_BODY" -Lf "$SNMP_VALIDATE_LOG" \
+            udp:127.0.0.1:16199 >"$SNMP_VALIDATE_LOG" 2>&1 &
+        probe_pid=$!
+        sleep 1
+        if kill -0 "$probe_pid" 2>/dev/null; then
+            # Still running → config parsed OK. Reap it.
+            kill "$probe_pid" 2>/dev/null || true
+            wait "$probe_pid" 2>/dev/null || true
+            echo "  ✓ snmpd config parse OK"
+        else
+            wait "$probe_pid" 2>/dev/null || true
+            # The probe exited early. Distinguish a genuine config
+            # rejection from an infrastructure hiccup (e.g. the
+            # throwaway port was already bound): only hard-fail when
+            # snmpd actually complained about reading/parsing the
+            # config. Otherwise let the real ``systemctl`` start below
+            # be the arbiter so we don't false-reject a valid config.
+            if grep -qiE 'error|cannot|unknown|parse|read_config|line [0-9]' \
+                    "$SNMP_VALIDATE_LOG" 2>/dev/null \
+                    && ! grep -qiE 'address already in use|bind' \
+                    "$SNMP_VALIDATE_LOG" 2>/dev/null; then
+                echo "  ✗ snmpd rejected the staged config:"
+                sed 's/^/      /' "$SNMP_VALIDATE_LOG"
+                echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
+                mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)"
+                exit 1
+            fi
+            echo "  ⚠ config probe inconclusive — relying on the real start"
         fi
-        echo "  ✓ snmpd -t passed"
 
         # Stop snmpd cleanly so the createUser lines we're about to
         # ship are read fresh on next start. Ignore failure when the

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-ssh-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-ssh-reload
@@ -72,6 +72,9 @@ SSHD_DROPIN=/etc/ssh/sshd_config.d/spatiumddi.conf
 # port-22 accept floor lives in the firewall renderer, so this only opens
 # the (possibly-non-22) configured port, source-scoped.
 NFT_DROPIN=/etc/nftables.d/50-spatium-ssh.nft
+# Master nftables config that includes the /etc/nftables.d/ drop-in glob;
+# used for the pre-reload `nft -c -f` dry-run (#550).
+NFT_MAIN=/etc/nftables.conf
 LOCK=/run/spatiumddi-ssh-reload.lock
 
 mkdir -p "$LOG_DIR" "$(dirname "$HASH_SIDECAR")" "$(dirname "$NFT_DROPIN")"
@@ -276,6 +279,21 @@ PYEOF
             fail "failed to render ssh nft drop-in"
         fi
         chmod 0644 "$NFT_DROPIN"
+        # Dry-run the FULL ruleset with the new drop-in staged, before we
+        # reload (#550). sshd has no native source filter, so a malformed
+        # CIDR renders an invalid rule; without this check `systemctl
+        # reload nftables` fails atomically and — if the ssh PORT also
+        # changed — the new port never opens (lockout), and on the next
+        # boot the bad fragment fails the whole transactional `nft -f`
+        # (fail-open, no input filtering). Mirror the firewall runner:
+        # validate, and on failure drop the fragment before erroring so
+        # the master config still loads clean.
+        if ! nft -c -f "$NFT_MAIN" 2>/tmp/spatium-ssh-nft-check.err; then
+            sed 's/^/      /' /tmp/spatium-ssh-nft-check.err
+            rm -f "$NFT_DROPIN"
+            systemctl reload nftables.service >/dev/null 2>&1 || true
+            fail "rendered ssh nft drop-in failed nft -c -f — fragment removed"
+        fi
         nft_reload
 
         reload_sshd || true
@@ -295,6 +313,12 @@ PYEOF
             nft_reload
         fi
         # Stub authorized_keys so an operator who SSHes in sees the note.
+        # Preserve any existing content first (#550): an operator may have
+        # added keys out-of-band, and silently clobbering them here could
+        # lock them out. The .pre-unmanage.bak copy is recoverable by hand.
+        if [ -s "$AK_FILE" ]; then
+            cp -f "$AK_FILE" "${AK_FILE}.pre-unmanage.bak" 2>/dev/null || true
+        fi
         if [ -d "$(dirname "$AK_FILE")" ] || install -d -o "$ADMIN_USER" -g "$ADMIN_USER" -m 0700 "$(dirname "$AK_FILE")" 2>/dev/null; then
             cat > "$AK_FILE" <<'EOF'
 # Managed by SpatiumDDI — SSH key management is currently off.

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-tz-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-tz-reload
@@ -71,12 +71,15 @@ fi
 # value — exactly the silent-fail mode we want to avoid.
 if ! timedatectl list-timezones 2>/dev/null | grep -Fxq "$tz"; then
     log "REJECT: '$tz' is not a known IANA timezone on this host"
-    # Leave the trigger in place; the supervisor will keep re-firing
-    # it which surfaces the issue in the heartbeat's last-apply
-    # status. Write the status sidecar so the heartbeat reports an
-    # operator-readable error.
+    # Write the status sidecar so the heartbeat reports an
+    # operator-readable error, then move the trigger aside. Leaving it
+    # in place would wedge the plane forever: the supervisor bails when
+    # ``tz-pending`` exists, so a corrected value would never fire
+    # (#550). Renaming it lets the next (corrected) heartbeat re-write
+    # the trigger; the ``.failed.<ts>`` copy stays for forensics.
     printf 'state=failed\nreason=unknown_timezone\nrequested=%s\napplied_at=%s\n' \
         "$tz" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+    mv -f "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" 2>/dev/null || rm -f "$TRIGGER"
     exit 1
 fi
 
@@ -92,6 +95,8 @@ else
         log "ERROR: timedatectl set-timezone failed"
         printf 'state=failed\nreason=set_timezone_failed\nrequested=%s\napplied_at=%s\n' \
             "$tz" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+        # Move the trigger aside so a retry isn't wedged (see #550).
+        mv -f "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" 2>/dev/null || rm -f "$TRIGGER"
         exit 1
     fi
 fi

--- a/appliance/mkosi.finalize
+++ b/appliance/mkosi.finalize
@@ -25,8 +25,12 @@ fi
 find "$BUILDROOT" -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
 find "$BUILDROOT" -name '*.pyc' -delete 2>/dev/null || true
 
-# Stale journal logs / machine-id / random-seed — regenerated on
-# first boot, no value in baking them in.
-rm -rf "$BUILDROOT/var/log"/*   2>/dev/null || true
+# Stale log FILES / machine-id / random-seed — regenerated on first boot,
+# no value in baking them in. #553 — delete files, not directories: a bare
+# ``rm -rf /var/log/*`` also removed /var/log/journal, which mkosi.postinst
+# creates to enable PERSISTENT journald; without the dir journald silently
+# falls back to volatile logs (no cross-reboot history — exactly what you
+# want when debugging a crash-loop).
+find "$BUILDROOT/var/log" -type f -delete 2>/dev/null || true
 truncate -s0 "$BUILDROOT/etc/machine-id" 2>/dev/null || true
 rm -f "$BUILDROOT/var/lib/systemd/random-seed" 2>/dev/null || true

--- a/appliance/mkosi.postinst
+++ b/appliance/mkosi.postinst
@@ -284,6 +284,11 @@ chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-ssh-reload.service"
 chmod 0755 "$BUILDROOT/usr/local/bin/spatiumddi-resolved-reload"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-resolved-reload.path"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-resolved-reload.service"
+# #165 GUI timezone control — this runner shipped 0644 in git so its
+# ExecStart hit 203/EXEC and every tz change silently no-op'd (#550).
+chmod 0755 "$BUILDROOT/usr/local/bin/spatiumddi-tz-reload"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-tz-reload.path"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-tz-reload.service"
 chmod 0755 "$BUILDROOT/usr/local/bin/spatiumddi-verbose-boot-reload"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-verbose-boot-reload.path"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-verbose-boot-reload.service"

--- a/appliance/scripts/build-slot-image.sh
+++ b/appliance/scripts/build-slot-image.sh
@@ -25,6 +25,10 @@
 #   <output-dir>/spatiumddi-appliance-slot-<version>.sha256
 
 set -eu
+# #553 — pipefail so a producer dying mid-stream in the `tar | tar` rootfs
+# copy fails the build instead of the consumer silently exiting 0 on a
+# truncated stream (which would ship a partial /usr or /etc slot image).
+set -o pipefail
 
 INPUT_RAW="${1:?input raw image path required}"
 OUT_DIR="${2:?output directory required}"
@@ -42,7 +46,15 @@ VERSION=$(basename "$INPUT_RAW" .raw | sed -E 's/^spatiumddi-appliance_//')
 [ -n "$VERSION" ] || VERSION="0.0.0"
 
 WORK=$(mktemp -d)
-trap 'for mp in "$WORK/src-mnt" "$WORK/slot-mnt"; do umount "$mp" 2>/dev/null || true; done; rm -rf "$WORK"' EXIT
+# #553 — RECURSIVE unmount, deepest-first. During the initramfs-regen
+# window /proc, /sys and /dev are bind-mounted UNDER slot-mnt; a plain
+# `umount "$WORK/slot-mnt"` returns EBUSY (submounts present) → swallowed
+# by `|| true` → the bind mounts stay live → `rm -rf "$WORK"` recurses
+# through the bind-mounted /dev (deleting /dev/null etc.) and leaks the
+# loop device. `umount -R` tears the submounts down first; `rm -rf
+# --one-file-system` is a belt-and-braces stop so rm never crosses a
+# still-mounted boundary even if an unmount failed.
+trap 'for mp in "$WORK/slot-mnt" "$WORK/src-mnt"; do umount -R "$mp" 2>/dev/null || umount "$mp" 2>/dev/null || true; done; rm -rf --one-file-system "$WORK"' EXIT
 
 mkdir -p "$WORK/src-mnt" "$WORK/slot-mnt"
 

--- a/appliance/scripts/wrap-iso.sh
+++ b/appliance/scripts/wrap-iso.sh
@@ -112,7 +112,11 @@ echo "→ Kernel version: $KVER"
 # update-initramfs -c -k <ver> creates /boot/initrd.img-<ver> using
 # every initramfs-tools hook now present in the rootfs (including
 # /usr/share/initramfs-tools/scripts/live from the live-boot package).
-chroot "$MOUNT_DIR" update-initramfs -c -k "$KVER" 2>&1 | grep -vE "^(I:|W: Possible missing firmware)" | tail -10
+# #553 — trailing ``|| true``: under ``set -o pipefail`` the ``grep -vE``
+# returns 1 when it filters EVERY line (all output was I:/firmware noise),
+# which would abort a step that actually succeeded. The real
+# success/failure check is the initrd.img existence test just below.
+chroot "$MOUNT_DIR" update-initramfs -c -k "$KVER" 2>&1 | grep -vE "^(I:|W: Possible missing firmware)" | tail -10 || true
 
 if [ ! -f "$MOUNT_DIR/boot/initrd.img-$KVER" ]; then
     echo "update-initramfs did not produce /boot/initrd.img-$KVER" >&2

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -2817,11 +2817,13 @@ function CreateSubnetModal({
 // ─── Add Address Modal ────────────────────────────────────────────────────────
 
 const IP_STATUS_OPTIONS = [
+  "available",
   "allocated",
   "reserved",
   "dhcp",
   "static_dhcp",
   "deprecated",
+  "discovered",
 ] as const;
 
 // Double-click-to-change status badge on the IP table (sibling of
@@ -3182,23 +3184,41 @@ function AddAddressModal({
       // into the DHCP side so the two stay in sync (the backend
       // `_upsert_ipam_for_static` helper will find the existing IPAM row and
       // just link / update it — no duplicate is created).
+      // #516 — the address IS already created at this point; a failing
+      // reservation must NOT surface as "Failed to allocate address" (the
+      // row exists, so re-submitting collides). Catch it separately and
+      // report it as a partial success instead.
+      let staticError: string | null = null;
       if (ipStatus === "static_dhcp" && dhcpScopeId && mac) {
-        await dhcpApi.createStatic(dhcpScopeId, {
-          ip_address: String(created.address),
-          mac_address: mac,
-          hostname: hostname || "",
-          description: description || "",
-        });
+        try {
+          await dhcpApi.createStatic(dhcpScopeId, {
+            ip_address: String(created.address),
+            mac_address: mac,
+            hostname: hostname || "",
+            description: description || "",
+          });
+        } catch (e) {
+          staticError = formatApiError(e, "DHCP reservation failed");
+        }
       }
-      return created;
+      return { created, staticError };
     },
-    onSuccess: () => {
+    onSuccess: ({ staticError }) => {
       qc.invalidateQueries({ queryKey: ["addresses", subnetId] });
       qc.invalidateQueries({ queryKey: ["dns-records"] });
       qc.invalidateQueries({ queryKey: ["dns-group-records"] });
       qc.invalidateQueries({ queryKey: ["dns-zones"] });
       qc.invalidateQueries({ queryKey: ["subnet-aliases", subnetId] });
       qc.invalidateQueries({ queryKey: ["subnets"] });
+      if (staticError) {
+        // Address created, reservation failed — keep the modal open so the
+        // operator sees this; the row already exists (don't re-submit).
+        setError(
+          `Address allocated, but the DHCP reservation failed: ${staticError}. ` +
+            "The address row was created — close this and edit the row to retry the reservation.",
+        );
+        return;
+      }
       onClose();
     },
     onError: (err: unknown) => {
@@ -3718,13 +3738,11 @@ function SyncMenu({
   onSyncDhcp,
   onSyncAll,
   hasDhcp,
-  isPending,
 }: {
   onSyncDns: () => void;
   onSyncDhcp: () => void;
   onSyncAll: () => void;
   hasDhcp: boolean;
-  isPending: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -3747,11 +3765,10 @@ function SyncMenu({
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        disabled={isPending}
         title="Sync IPAM with DNS and/or DHCP servers"
         className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
       >
-        <RefreshCw className={cn("h-3.5 w-3.5", isPending && "animate-spin")} />
+        <RefreshCw className="h-3.5 w-3.5" />
         Sync
         <ChevronDown className="h-3.5 w-3.5" />
       </button>
@@ -4335,6 +4352,27 @@ function SubnetDetail({
   onSubnetDeleted?: () => void;
 }) {
   const qc = useQueryClient();
+  // #516 — id→name map for the subnet's DNS zones so IPDetailModal can show
+  // real zone names instead of "—" (its zoneNameById prop was never passed).
+  const subnetDnsGroupIds = useMemo(
+    () => subnet.dns_group_ids ?? [],
+    [subnet.dns_group_ids],
+  );
+  const subnetZonesQuery = useQuery({
+    queryKey: ["dns-zones", "subnet-detail", subnet.id, subnetDnsGroupIds],
+    queryFn: async () => {
+      const lists = await Promise.all(
+        subnetDnsGroupIds.map((gid) => dnsApi.listZones(gid)),
+      );
+      return lists.flat();
+    },
+    enabled: subnetDnsGroupIds.length > 0,
+  });
+  const zoneNameById = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const z of subnetZonesQuery.data ?? []) m[z.id] = z.name;
+    return m;
+  }, [subnetZonesQuery.data]);
   const [showAddModal, setShowAddModal] = useState(false);
   // Optional seed for ``AddAddressModal`` — set when the operator clicks
   // a gap-marker row so the modal opens in manual mode constrained to
@@ -4816,6 +4854,9 @@ function SubnetDetail({
   const [confirmPurgeAddr, setConfirmPurgeAddr] = useState<IPAddress | null>(
     null,
   );
+  // #516 — surface delete/purge/restore failures (403/409/etc.) instead of
+  // silently swallowing them.
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const deleteAddr = useMutation({
     mutationFn: (id: string) => ipamApi.deleteAddress(id), // soft-delete → orphan
@@ -4827,6 +4868,8 @@ function SubnetDetail({
       qc.invalidateQueries({ queryKey: ["dns-zones"] });
       qc.invalidateQueries({ queryKey: ["subnets"] });
     },
+    onError: (e) =>
+      setActionError(formatApiError(e, "Failed to delete address.")),
   });
 
   const purgeAddr = useMutation({
@@ -4844,6 +4887,8 @@ function SubnetDetail({
       qc.invalidateQueries({ queryKey: ["dns-zones"] });
       qc.invalidateQueries({ queryKey: ["subnets"] });
     },
+    onError: (e) =>
+      setActionError(formatApiError(e, "Failed to purge address.")),
   });
 
   const restoreAddr = useMutation({
@@ -4856,6 +4901,8 @@ function SubnetDetail({
       qc.invalidateQueries({ queryKey: ["dns-zones"] });
       qc.invalidateQueries({ queryKey: ["subnets"] });
     },
+    onError: (e) =>
+      setActionError(formatApiError(e, "Failed to restore address.")),
   });
 
   // Non-editable statuses (infrastructure or orphaned addresses)
@@ -4864,6 +4911,18 @@ function SubnetDetail({
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
+      {actionError && (
+        <div className="flex items-start justify-between gap-3 border-b border-destructive/40 bg-destructive/5 px-6 py-2 text-xs text-destructive">
+          <span>{actionError}</span>
+          <button
+            type="button"
+            onClick={() => setActionError(null)}
+            className="shrink-0 font-medium hover:underline"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
       {/* Header */}
       <div className="border-b">
         {/* Top bar: breadcrumb + actions */}
@@ -4918,7 +4977,6 @@ function SubnetDetail({
             </HeaderButton>
             <SyncMenu
               hasDhcp={dhcpScopes.length > 0}
-              isPending={false}
               onSyncDns={() => setShowDnsSync(true)}
               onSyncDhcp={() => setShowDhcpSync(true)}
               onSyncAll={() => setShowSyncAll(true)}
@@ -6340,6 +6398,7 @@ function SubnetDetail({
         <IPDetailModal
           address={viewingAddress}
           subnet={subnet}
+          zoneNameById={zoneNameById}
           canEdit={
             !(
               viewingAddress.status === "network" ||
@@ -6472,34 +6531,30 @@ function DnsSyncModal({
         ? ipamApi.dnsSyncCommitBlock(scope.id, body)
         : ipamApi.dnsSyncCommitSpace(scope.id, body);
 
-  // Before we compute drift, make sure every subnet's reverse zone exists —
-  // otherwise "missing PTR" rows will show for subnets whose reverse zone
-  // hasn't been created yet, and the commit will fail. Backfill is
-  // idempotent, so it's safe to run on every modal open.
-  const [backfillDone, setBackfillDone] = useState(false);
+  // #516 — reverse (PTR) zones are backfilled as the FIRST step of Apply,
+  // NOT on modal open. Creating zones is a WRITE; firing it from a mount
+  // effect made this preview-then-commit surface mutate the moment it
+  // opened (surprising, and awkward with the #62 approvals story). The
+  // backfill is idempotent and still runs before the commit's PTR
+  // creation, so drift stays correct — it just happens on the operator's
+  // explicit Apply. "missing PTR" rows for a not-yet-created reverse zone
+  // are shown in the preview and created (zone + PTR) on commit.
+  const backfillFn =
+    scope.kind === "subnet"
+      ? ipamApi.backfillReverseZonesSubnet
+      : scope.kind === "block"
+        ? ipamApi.backfillReverseZonesBlock
+        : ipamApi.backfillReverseZonesSpace;
   const [backfillResult, setBackfillResult] = useState<{
     created: { subnet: string; zone: string }[];
     skipped: number;
   } | null>(null);
   const [backfillError, setBackfillError] = useState<string | null>(null);
-  useEffect(() => {
-    const fn =
-      scope.kind === "subnet"
-        ? ipamApi.backfillReverseZonesSubnet
-        : scope.kind === "block"
-          ? ipamApi.backfillReverseZonesBlock
-          : ipamApi.backfillReverseZonesSpace;
-    fn(scope.id)
-      .then((r) => setBackfillResult(r))
-      .catch((e: Error) => setBackfillError(e.message || "Backfill failed"))
-      .finally(() => setBackfillDone(true));
-  }, [scope.id, scope.kind]);
 
   const { data, isLoading, error, refetch, isFetching } = useQuery({
     queryKey: ["dns-sync-preview", scope.kind, scope.id],
     queryFn: fetchPreview,
     refetchOnMount: "always",
-    enabled: backfillDone,
   });
 
   // Per-row selection. Empty Set = nothing chosen → Apply disabled.
@@ -6526,8 +6581,19 @@ function DnsSyncModal({
   }, [data]);
 
   const commitMut = useMutation({
-    mutationFn: () => {
+    mutationFn: async () => {
       if (!data) throw new Error("No preview");
+      // #516 — ensure reverse (PTR) zones exist before creating PTRs.
+      // Idempotent; runs here (on Apply) rather than on modal open. A
+      // failure is surfaced but non-fatal — A records still commit and any
+      // PTRs whose zone couldn't be created come back in res.errors.
+      try {
+        setBackfillError(null);
+        const r = await backfillFn(scope.id);
+        setBackfillResult(r);
+      } catch (e) {
+        setBackfillError((e as Error).message || "Backfill failed");
+      }
       // missing items keyed as `ip_id:record_type` so a single IP can have
       // both A and PTR ticked or unticked independently. Backend just needs
       // unique IP IDs to re-sync — sync_dns_record handles both records.
@@ -6617,28 +6683,21 @@ function DnsSyncModal({
         </div>
 
         <div className="flex-1 overflow-auto px-5 py-4 space-y-5">
-          {!backfillDone && (
-            <p className="text-sm text-muted-foreground">
-              Backfilling missing reverse zones…
-            </p>
+          {backfillResult && backfillResult.created.length > 0 && (
+            <div className="rounded-md border border-blue-500/40 bg-blue-500/10 px-3 py-2 text-xs">
+              Backfill created {backfillResult.created.length} reverse zone
+              {backfillResult.created.length === 1 ? "" : "s"}:{" "}
+              <span className="font-mono">
+                {backfillResult.created.map((c) => c.zone).join(", ")}
+              </span>
+            </div>
           )}
-          {backfillDone &&
-            backfillResult &&
-            backfillResult.created.length > 0 && (
-              <div className="rounded-md border border-blue-500/40 bg-blue-500/10 px-3 py-2 text-xs">
-                Backfill created {backfillResult.created.length} reverse zone
-                {backfillResult.created.length === 1 ? "" : "s"}:{" "}
-                <span className="font-mono">
-                  {backfillResult.created.map((c) => c.zone).join(", ")}
-                </span>
-              </div>
-            )}
           {backfillError && (
             <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs">
               Reverse-zone backfill skipped: {backfillError}
             </div>
           )}
-          {backfillDone && isLoading && (
+          {isLoading && (
             <p className="text-sm text-muted-foreground">Computing drift…</p>
           )}
           {error && (
@@ -8055,11 +8114,13 @@ function SyncAllModal({
 // ─── Edit Address Modal ───────────────────────────────────────────────────────
 
 const ADDRESS_STATUSES = [
+  "available",
   "allocated",
   "reserved",
   "deprecated",
   "static_dhcp",
   "dhcp",
+  "discovered",
 ] as const;
 
 // Format a UTC ISO instant as a ``datetime-local`` value (local wall-clock,
@@ -9446,7 +9507,9 @@ function BulkEditAddressesModal({
         setError(
           `${res.updated_count} updated; ${res.skipped.length} skipped (system/orphan rows).`,
         );
-        setTimeout(onDone, 1200);
+        // #516 — 1.2 s was too short to read the skipped-rows report (the
+        // only place it surfaces). Give the operator time to see it.
+        setTimeout(onDone, 4500);
       } else {
         onDone();
       }
@@ -9883,7 +9946,8 @@ function BulkDeleteAddressesModal({
         setError(
           `${res.deleted_count} deleted; ${res.skipped.length} skipped (system rows).`,
         );
-        setTimeout(onDone, 1200);
+        // #516 — give the operator time to read the skipped-rows report.
+        setTimeout(onDone, 4500);
       } else {
         onDone();
       }
@@ -10435,7 +10499,21 @@ function EditSpaceModal({
       qc.invalidateQueries({ queryKey: ["spaces"] });
       onClose();
     },
+    // #516 — surface save failures (403/409/etc.) instead of leaving the
+    // modal open with zero feedback.
+    onError: (err: unknown) => {
+      const detail = (err as { response?: { data?: { detail?: unknown } } })
+        ?.response?.data?.detail;
+      setSaveError(
+        typeof detail === "string"
+          ? detail
+          : detail
+            ? JSON.stringify(detail)
+            : "Failed to save IP space.",
+      );
+    },
   });
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const deleteMutation = useMutation({
@@ -10672,6 +10750,11 @@ function EditSpaceModal({
         </div>
       )}
 
+      {saveError && (
+        <p className="mt-3 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {saveError}
+        </p>
+      )}
       <div className="mt-6 flex justify-end gap-2 border-t pt-3">
         <button
           onClick={onClose}
@@ -10680,7 +10763,10 @@ function EditSpaceModal({
           Cancel
         </button>
         <button
-          onClick={() => saveMutation.mutate()}
+          onClick={() => {
+            setSaveError(null);
+            saveMutation.mutate();
+          }}
           disabled={!name || saveMutation.isPending}
           className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
         >
@@ -12844,8 +12930,13 @@ function flattenToTableRows(nodes: BlockNode[], depth = 0): TreeTableItem[] {
 }
 
 function cidrSize(network: string): number {
-  const prefix = parseInt(network.split("/")[1] ?? "32");
-  return Math.pow(2, 32 - prefix);
+  // #516 — pick the width from the address family. Using 32 for an IPv6
+  // network (e.g. a /48) yielded 2^(32-48) = 2^-16, feeding garbage into
+  // UsedIps whenever total_ips was null.
+  const bits = network.includes(":") ? 128 : 32;
+  const prefix = parseInt(network.split("/")[1] ?? String(bits));
+  if (Number.isNaN(prefix)) return 0;
+  return Math.pow(2, bits - prefix);
 }
 
 /**
@@ -13880,84 +13971,82 @@ function BulkEditSubnetsModal({
   });
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/70 p-2 sm:p-4">
-      <div className="w-full max-w-[95vw] sm:max-w-md rounded-lg border bg-card p-4 sm:p-6 shadow-lg">
-        <h3 className="mb-3 text-base font-semibold">
-          Bulk edit {subnetIds.length} subnet{subnetIds.length === 1 ? "" : "s"}
-        </h3>
-        <p className="mb-3 text-xs text-muted-foreground">
-          Leave a field blank to keep it unchanged.
-        </p>
-        <div className="space-y-3 text-sm">
-          <label className="block">
-            <span className="mb-1 block text-xs text-muted-foreground">
-              Name
-            </span>
-            <input
-              className="w-full rounded border bg-background px-2 py-1"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </label>
-          <label className="block">
-            <span className="mb-1 block text-xs text-muted-foreground">
-              Description
-            </span>
-            <input
-              className="w-full rounded border bg-background px-2 py-1"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            />
-          </label>
-          <label className="block">
-            <span className="mb-1 block text-xs text-muted-foreground">
-              Status
-            </span>
-            <select
-              className="w-full rounded border bg-background px-2 py-1"
-              value={statusVal}
-              onChange={(e) => setStatusVal(e.target.value)}
-            >
-              <option value="">—</option>
-              <option value="active">active</option>
-              <option value="deprecated">deprecated</option>
-              <option value="reserved">reserved</option>
-              <option value="quarantine">quarantine</option>
-            </select>
-          </label>
-          <label className="block">
-            <span className="mb-1 block text-xs text-muted-foreground">
-              VLAN ID
-            </span>
-            <input
-              className="w-full rounded border bg-background px-2 py-1"
-              value={vlanId}
-              onChange={(e) => setVlanId(e.target.value)}
-              inputMode="numeric"
-            />
-          </label>
-        </div>
-        {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
-        <div className="mt-4 flex justify-end gap-2">
-          <button
-            onClick={onClose}
-            className="rounded border px-3 py-1 text-xs hover:bg-muted"
+    // #516 — use the shared draggable Modal (drag handle + Esc + correct
+    // backdrop) instead of a raw fixed div, per the project modal convention.
+    <Modal
+      title={`Bulk edit ${subnetIds.length} subnet${subnetIds.length === 1 ? "" : "s"}`}
+      onClose={onClose}
+    >
+      <p className="mb-3 text-xs text-muted-foreground">
+        Leave a field blank to keep it unchanged.
+      </p>
+      <div className="space-y-3 text-sm">
+        <label className="block">
+          <span className="mb-1 block text-xs text-muted-foreground">Name</span>
+          <input
+            className="w-full rounded border bg-background px-2 py-1"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-muted-foreground">
+            Description
+          </span>
+          <input
+            className="w-full rounded border bg-background px-2 py-1"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-muted-foreground">
+            Status
+          </span>
+          <select
+            className="w-full rounded border bg-background px-2 py-1"
+            value={statusVal}
+            onChange={(e) => setStatusVal(e.target.value)}
           >
-            Cancel
-          </button>
-          <button
-            disabled={mut.isPending}
-            onClick={() => {
-              setError(null);
-              mut.mutate();
-            }}
-            className="rounded bg-primary px-3 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
-          >
-            {mut.isPending ? "Applying…" : "Apply"}
-          </button>
-        </div>
+            <option value="">—</option>
+            <option value="active">active</option>
+            <option value="deprecated">deprecated</option>
+            <option value="reserved">reserved</option>
+            <option value="quarantine">quarantine</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="mb-1 block text-xs text-muted-foreground">
+            VLAN ID
+          </span>
+          <input
+            className="w-full rounded border bg-background px-2 py-1"
+            value={vlanId}
+            onChange={(e) => setVlanId(e.target.value)}
+            inputMode="numeric"
+          />
+        </label>
       </div>
-    </div>
+      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+      <div className="mt-4 flex justify-end gap-2">
+        <button
+          onClick={onClose}
+          className="rounded border px-3 py-1 text-xs hover:bg-muted"
+        >
+          Cancel
+        </button>
+        <button
+          disabled={mut.isPending}
+          onClick={() => {
+            setError(null);
+            mut.mutate();
+          }}
+          className="rounded bg-primary px-3 py-1 text-xs font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {mut.isPending ? "Applying…" : "Apply"}
+        </button>
+      </div>
+    </Modal>
   );
 }
 

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -3021,6 +3021,10 @@ function AddAddressModal({
   const [pendingWarnings, setPendingWarnings] = useState<
     CollisionWarning[] | null
   >(null);
+  // #516 — set once the IP row is created but the chained DHCP reservation
+  // failed (partial success). The row already exists, so re-submitting would
+  // collide; the footer switches from "Allocate" to "Close".
+  const [addressCreated, setAddressCreated] = useState(false);
   const needsDhcpScope = ipStatus === "dhcp" || ipStatus === "static_dhcp";
 
   // Scopes load unconditionally (cheap) so we can do the dynamic-pool
@@ -3213,6 +3217,7 @@ function AddAddressModal({
       if (staticError) {
         // Address created, reservation failed — keep the modal open so the
         // operator sees this; the row already exists (don't re-submit).
+        setAddressCreated(true);
         setError(
           `Address allocated, but the DHCP reservation failed: ${staticError}. ` +
             "The address row was created — close this and edit the row to retry the reservation.",
@@ -3642,26 +3647,39 @@ function AddAddressModal({
           <CollisionWarningBanner warnings={pendingWarnings} />
         )}
         <div className="flex justify-end gap-2 pt-2">
-          <button
-            onClick={onClose}
-            className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={() => {
-              setError(null);
-              mutation.mutate(pendingWarnings != null);
-            }}
-            disabled={!canSubmit || mutation.isPending}
-            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-          >
-            {mutation.isPending
-              ? "Allocating…"
-              : pendingWarnings
-                ? "Allocate anyway"
-                : "Allocate"}
-          </button>
+          {addressCreated ? (
+            // Partial success — the IP row exists; only offer Close so the
+            // operator can't re-submit into a collision (#516).
+            <button
+              onClick={onClose}
+              className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
+            >
+              Close
+            </button>
+          ) : (
+            <>
+              <button
+                onClick={onClose}
+                className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  setError(null);
+                  mutation.mutate(pendingWarnings != null);
+                }}
+                disabled={!canSubmit || mutation.isPending}
+                className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {mutation.isPending
+                  ? "Allocating…"
+                  : pendingWarnings
+                    ? "Allocate anyway"
+                    : "Allocate"}
+              </button>
+            </>
+          )}
         </div>
       </div>
     </Modal>
@@ -12935,7 +12953,9 @@ function cidrSize(network: string): number {
   // UsedIps whenever total_ips was null.
   const bits = network.includes(":") ? 128 : 32;
   const prefix = parseInt(network.split("/")[1] ?? String(bits));
-  if (Number.isNaN(prefix)) return 0;
+  // Clamp out-of-range prefixes (e.g. /33 on IPv4, /129 on IPv6) to 0 so a
+  // negative exponent can't feed a fractional "size" into UsedIps/UI.
+  if (Number.isNaN(prefix) || prefix < 0 || prefix > bits) return 0;
   return Math.pow(2, bits - prefix);
 }
 

--- a/frontend/src/pages/ipam/IPDetailModal.tsx
+++ b/frontend/src/pages/ipam/IPDetailModal.tsx
@@ -407,7 +407,10 @@ export function IPDetailModal({
             <Field label="Forward DNS zone">
               {addr.forward_zone_id ? (
                 <span className="font-mono text-xs">
-                  {zoneNames[addr.forward_zone_id] ?? "—"}
+                  {/* #516 — zoneNameById is now supplied by the caller (it was
+                      previously never passed, so this always rendered "—").
+                      Fall back to the raw id if the map lacks the zone. */}
+                  {zoneNames[addr.forward_zone_id] ?? addr.forward_zone_id}
                 </span>
               ) : (
                 dash(null)
@@ -416,7 +419,7 @@ export function IPDetailModal({
             <Field label="Reverse DNS zone">
               {addr.reverse_zone_id ? (
                 <span className="font-mono text-xs">
-                  {zoneNames[addr.reverse_zone_id] ?? "—"}
+                  {zoneNames[addr.reverse_zone_id] ?? addr.reverse_zone_id}
                 </span>
               ) : (
                 dash(null)

--- a/scripts/lint_appliance_runners.py
+++ b/scripts/lint_appliance_runners.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Guard for the appliance host-side runner scripts (issues #550, #553).
+
+None of the ``appliance/mkosi.extra/usr/local/bin/*`` runners are covered
+by tests, and two shipped features once shipped completely dead because a
+runner was neither executable in git NOR chmod'd in ``mkosi.postinst`` (so
+its ``.service`` ExecStart hit ``203/EXEC``). This stdlib-only linter runs
+in CI (Backend Lint job) and asserts the invariants that would have caught
+that class of bug:
+
+  1. Every ``ExecStart=/usr/local/bin/<runner>`` referenced by a shipped
+     systemd unit resolves to a runner that will be executable in the
+     built image — i.e. it is EITHER already executable in the git
+     checkout OR it is chmod'd 0755 in ``mkosi.postinst``.
+  2. Every runner named in the postinst ``chmod 0755`` block actually
+     exists on disk.
+  3. Every runner with a ``bash`` shebang is ``bash -n`` clean.
+
+Exit non-zero (with a human-readable report) on any violation.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BIN_DIR = REPO_ROOT / "appliance" / "mkosi.extra" / "usr" / "local" / "bin"
+UNIT_DIR = REPO_ROOT / "appliance" / "mkosi.extra" / "etc" / "systemd" / "system"
+POSTINST = REPO_ROOT / "appliance" / "mkosi.postinst"
+
+_CHMOD_RE = re.compile(
+    r'chmod\s+0?755\s+"\$BUILDROOT/usr/local/bin/([A-Za-z0-9._-]+)"'
+)
+_EXECSTART_RE = re.compile(
+    r"^\s*ExecStart(?:Pre|Post)?=-?(/usr/local/bin/[A-Za-z0-9._-]+)",
+    re.MULTILINE,
+)
+
+
+def _postinst_chmodded() -> set[str]:
+    if not POSTINST.is_file():
+        return set()
+    return set(_CHMOD_RE.findall(POSTINST.read_text(encoding="utf-8")))
+
+
+def _execstart_runners() -> dict[str, str]:
+    """basename -> unit filename that references it via ExecStart*."""
+    out: dict[str, str] = {}
+    for unit in sorted(UNIT_DIR.glob("*.service")):
+        text = unit.read_text(encoding="utf-8")
+        for path in _EXECSTART_RE.findall(text):
+            out.setdefault(os.path.basename(path), unit.name)
+    return out
+
+
+def _has_bash_shebang(p: Path) -> bool:
+    try:
+        first = p.read_text(encoding="utf-8", errors="replace").splitlines()[:1]
+    except OSError:
+        return False
+    return bool(first) and first[0].startswith("#!") and "bash" in first[0]
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    chmodded = _postinst_chmodded()
+
+    # (1) + (2) — chmod-referenced runners must exist.
+    for name in sorted(chmodded):
+        if not (BIN_DIR / name).is_file():
+            errors.append(
+                f"mkosi.postinst chmods 'usr/local/bin/{name}' but no such "
+                f"file exists under {BIN_DIR.relative_to(REPO_ROOT)}/"
+            )
+
+    # (1) — every unit ExecStart runner is executable in the built image.
+    for name, unit in sorted(_execstart_runners().items()):
+        src = BIN_DIR / name
+        if not src.is_file():
+            errors.append(
+                f"{unit}: ExecStart runner 'usr/local/bin/{name}' does not "
+                f"exist under {BIN_DIR.relative_to(REPO_ROOT)}/"
+            )
+            continue
+        git_exec = os.access(src, os.X_OK)
+        if not git_exec and name not in chmodded:
+            errors.append(
+                f"{unit}: ExecStart runner '{name}' is NOT executable in git "
+                f"AND is NOT chmod'd 0755 in mkosi.postinst — its ExecStart "
+                f"will hit 203/EXEC in the built image. Add a 'chmod 0755 "
+                f'"$BUILDROOT/usr/local/bin/{name}"\' line to mkosi.postinst '
+                f"(and 'git update-index --chmod=+x' the file)."
+            )
+
+    # (3) — bash -n on every bash runner.
+    for src in sorted(BIN_DIR.iterdir()):
+        if not src.is_file() or not _has_bash_shebang(src):
+            continue
+        res = subprocess.run(
+            ["bash", "-n", str(src)],
+            capture_output=True,
+            text=True,
+        )
+        if res.returncode != 0:
+            errors.append(
+                f"{src.name}: bash -n failed:\n"
+                + "\n".join("      " + ln for ln in res.stderr.splitlines())
+            )
+
+    if errors:
+        print("appliance runner lint FAILED:\n", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        print(
+            f"\n{len(errors)} problem(s) found.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("appliance runner lint OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint_appliance_runners.py
+++ b/scripts/lint_appliance_runners.py
@@ -41,6 +41,13 @@ _EXECSTART_RE = re.compile(
 )
 
 
+# Binaries fetched at build time by appliance/scripts/fetch-k3s.sh and
+# dropped into the rootfs (k3s + its kubectl/crictl/ctr symlinks). They are
+# gitignored, so they are legitimately absent from the source checkout —
+# skip them rather than flag them as missing runners.
+_BUILD_FETCHED = frozenset({"k3s", "kubectl", "crictl", "ctr"})
+
+
 def _postinst_chmodded() -> set[str]:
     if not POSTINST.is_file():
         return set()
@@ -70,8 +77,11 @@ def main() -> int:
 
     chmodded = _postinst_chmodded()
 
-    # (1) + (2) — chmod-referenced runners must exist.
+    # (1) + (2) — chmod-referenced runners must exist (build-fetched
+    # binaries excepted; they aren't in the source checkout).
     for name in sorted(chmodded):
+        if name in _BUILD_FETCHED:
+            continue
         if not (BIN_DIR / name).is_file():
             errors.append(
                 f"mkosi.postinst chmods 'usr/local/bin/{name}' but no such "
@@ -80,6 +90,8 @@ def main() -> int:
 
     # (1) — every unit ExecStart runner is executable in the built image.
     for name, unit in sorted(_execstart_runners().items()):
+        if name in _BUILD_FETCHED:
+            continue
         src = BIN_DIR / name
         if not src.is_file():
             errors.append(
@@ -89,12 +101,12 @@ def main() -> int:
             continue
         git_exec = os.access(src, os.X_OK)
         if not git_exec and name not in chmodded:
+            fix = f'chmod 0755 "$BUILDROOT/usr/local/bin/{name}"'
             errors.append(
                 f"{unit}: ExecStart runner '{name}' is NOT executable in git "
                 f"AND is NOT chmod'd 0755 in mkosi.postinst — its ExecStart "
-                f"will hit 203/EXEC in the built image. Add a 'chmod 0755 "
-                f'"$BUILDROOT/usr/local/bin/{name}"\' line to mkosi.postinst '
-                f"(and 'git update-index --chmod=+x' the file)."
+                f"will hit 203/EXEC in the built image. Add a `{fix}` line to "
+                f"mkosi.postinst (and `git update-index --chmod=+x` the file)."
             )
 
     # (3) — bash -n on every bash runner.


### PR DESCRIPTION
Fixes the seven open `bug`-labelled issues from the 2026-07-03 appliance audit plus the IPAM frontend polish grab-bag. Two commits: the sweep itself, then a follow-up addressing a high-effort code review.

## Issues

**#550 — host-config reload planes silently broken**
- tz-reload shipped `0644` → 203/EXEC (dead GUI timezone): chmod in `mkosi.postinst` + `git +x`
- snmp-reload validated with the non-existent `snmpd -t` flag → foreground started-then-killed probe on a throwaway transport
- tz + firewall runners `mv` their trigger aside on every failure path (no more wedged plane)
- ssh-reload dry-runs `nft -c -f` before reload (lockout / fail-open guard)
- LOW: ssh authorized_keys backup, lldp `DAEMON_ARGS` charset validation, apt keyring cleanup

**#551 — A/B upgrade rollback safety-nets**
- slot-rollback called a non-existent `commit` subcommand → real `rollback` / `set-default <slot>`
- cluster-join `log()` → stderr so the identity-backup capture isn't polluted (failed-join rollback restores etcd/TLS again)
- MEDIUM/LOW: grub render uses known-good blkid UUIDs, robust parent-disk derivation, `--insecure` requires `--expected-sha256`, fallback UUID patch covers all same-slot menuentries

**#552 — recovery console freeze / crash-loop**
- five blocking kubectl/systemctl calls fanned into the ThreadPool (no ~25 s freeze on a wedged cluster)
- priming refresh guarded + NaN/Inf metric parses clamped
- LOW: KeyReader select guard, Unicode-safe render reads, app-log tail stop + altscreen exit on F1

**#553 — slot-image build / systemd**
- build-slot-image trap `umount -R` + `rm -rf --one-file-system` (no recursion through live bind mounts) + `set -o pipefail`
- Makefile `.NOTPARALLEL` for ISO targets + pinned fetch-k3s `ARCH`
- split the two reboot `.path` units onto distinct trigger filenames + `-` on the web-UI mv; persistent journald; etc.mount tidy

**#554 — installer**
- validate static-network fields (ipaddress) + re-prompt loop
- fix the control-plane confirm→Back dead loop
- exclude every live-medium-backing disk from the wipe-target list
- LOW: guard empty slot UUIDs, best-effort cleanup unmounts, safe role-config parse, trial-boot-gated host-migrate failure

**#555 — supervisor + host scripts**
- drop the DHCP `AGENT_GROUP` fallback (DNS-group cross-wire)
- charset-validate pcap `capture_id` (path traversal) in proxy + runner
- role-compose.env + session token written owner-only at creation
- image-prune bails if the in-use query fails; publish-k3s-token uses a random temp; cluster-join accepts IPv6 seed URLs + prunes stale identity backups; newline-guarded join/restore payloads

**#516 — IPAM frontend polish**
- separate static-DHCP chained-create error reporting; resolve IPDetailModal zone names; `onError` on space/subnet mutations; BulkEditSubnetsModal → shared draggable Modal; DnsSyncModal backfills on Apply not open; `available`/`discovered` status options; readable skipped-rows report; IPv6-aware `cidrSize`; remove dead SyncMenu `isPending`

## New CI guard

`scripts/lint_appliance_runners.py` (wired into the Backend Lint job) asserts every systemd `ExecStart` runner is executable in the built image (git `+x` or chmod'd in `mkosi.postinst`) and `bash -n` clean — verified it catches the exact tz-reload 203/EXEC class.

## Code review

The second commit addresses a high-effort review: the console lost the fleet-reboot warning after the `reboot-pending` rename (fixed), the static validator over-rejected /32 (fixed), `_write_owner_only` gained `O_EXCL` (fail-closed secret write), the slot-upgrade self-panel refuses insecure+no-sha256 up front, and `identity` reuses the hardened writer.

## Verification

Frontend `tsc -b` + `npm run build` + prettier/eslint clean; supervisor `ruff` clean, tests 160 passed (4 pre-existing unrelated failures); all touched bash `bash -n` clean; the new runner linter green. `_write_owner_only` and the /32 validator behaviorally tested.

Closes #550, Closes #551, Closes #552, Closes #553, Closes #554, Closes #555, Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)