### PR TITLE
feat(appliance): console operator-UX — control-plane reachability chip + cancel-pending-reboot (#556)

### DIFF
--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -4278,8 +4278,14 @@ def do_cancel_reboot(console: Console) -> None:
     for name in ("reboot-pending", "reboot-pending-fleet"):
         try:
             (_RELEASE_STATE_DIR / name).unlink()
-        except OSError:
+        except FileNotFoundError:
+            # Expected: the reboot service may have already renamed the
+            # trigger to .done before we stopped it — nothing to remove.
             pass
+        except OSError as exc:
+            # Non-fatal — the service is already stopped, so the reboot is
+            # cancelled regardless of whether the trigger file lingers.
+            console.print(f"[dim](left {name}: {exc})[/dim]")
     console.print("[green]Reboot cancelled.[/green]\n")
     time.sleep(1.5)
 

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -29,6 +29,7 @@ import re
 import select
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tarfile
@@ -37,6 +38,7 @@ import termios
 import threading
 import time
 import tty
+import urllib.parse
 import urllib.request
 from collections import deque
 from datetime import datetime
@@ -1769,10 +1771,11 @@ KEY_SEQUENCES: dict[bytes, str] = {
     b"\x1b[18~": "F7", b"\x1b[19~": "F8", b"\x1b[20~": "F9",
     b"\x1b[21~": "F10", b"\x1b[23~": "F11", b"\x1b[24~": "F12",
     # P1.5 — number-key mirror. Serial / IPMI-SoL terminals (vt220 keymaps,
-    # emulators) routinely eat F-keys, so 1-7 trigger the same footer
+    # emulators) routinely eat F-keys, so 1-9 trigger the same footer
     # actions. The dashboard has no text input, so the digits are free.
+    # (9 → F9 cancel-pending-reboot, #556.)
     b"1": "F1", b"2": "F2", b"3": "F3", b"4": "F4",
-    b"5": "F5", b"6": "F6", b"7": "F7", b"8": "F8",
+    b"5": "F5", b"6": "F6", b"7": "F7", b"8": "F8", b"9": "F9",
 }
 
 
@@ -2234,6 +2237,16 @@ def render_header(
     identity.append("   ·   ", style="dim")
     identity.append("Build ", style="dim")
     identity.append(build)
+    # #556 — control-plane reachability chip (appliance role only; the probe
+    # returns None on control-plane, so this stays off there). Lets an
+    # operator distinguish "unapproved" from "can't reach the control plane".
+    if state.cp_reachable is not None:
+        identity.append("   ·   ", style="dim")
+        identity.append("CP ", style="dim")
+        if state.cp_reachable:
+            identity.append("reachable", style="bold green")
+        else:
+            identity.append("UNREACHABLE", style="bold red")
     # INC 9 — MetalLB speaker health. A speaker down WITH a VIP assigned
     # means the control-plane VIP may be unreachable; warn loudly. Quiet
     # when there's no VIP or no MetalLB (single-node).
@@ -2965,6 +2978,38 @@ def k3s_status() -> tuple[str, str] | None:
     return (f"{version} · active · api {proc.returncode}", "yellow")
 
 
+def control_plane_reachable(env: dict[str, str], timeout: float = 2.0) -> bool | None:
+    """#556 — TCP-reachability probe for the appliance role's control plane.
+
+    Returns ``True``/``False`` from a plain TCP connect to the host:port of
+    ``CONTROL_PLANE_URL``, or ``None`` when there's nothing to probe
+    (control-plane role leaves the var empty, or it's unparseable). Lets the
+    console tell **network-partitioned** apart from **unapproved** — the two
+    look identical on ``pairing_status`` alone.
+
+    Total by design (never raises): it runs inside the data-tier pool, so a
+    raise would only cost a skipped frame, but staying total keeps even that
+    off the table. Any resolve/connect failure is ``False`` (unreachable); a
+    missing/blank URL is ``None`` (nothing to show)."""
+    url = (env.get("CONTROL_PLANE_URL") or "").strip()
+    if not url:
+        return None
+    try:
+        parsed = urllib.parse.urlparse(url if "://" in url else f"https://{url}")
+        host = parsed.hostname
+        if not host:
+            return None
+        scheme = parsed.scheme or "https"
+        port = parsed.port or (443 if scheme == "https" else 80)
+    except (ValueError, TypeError):
+        return None
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
 def pairing_status(env: dict[str, str], role: str, ps_rows: list[dict]) -> tuple[str, str] | None:
     """#170 — derive a (label, style) tuple for the console's
     'Identity' row, or ``None`` when the role doesn't pair against
@@ -3102,6 +3147,11 @@ def render_footer(message: str = "", role: str = "control-plane") -> Text:
     ]
     if role in ("appliance", "application"):
         keys.append(("F8", "Re-pair"))
+    # #556 — F9 aborts a queued reboot; shown only while one is pending
+    # (a couple of cheap file stats, no subprocess) so the strip stays
+    # uncluttered the rest of the time.
+    if reboot_pending():
+        keys.append(("F9", "Cancel reboot"))
     t = Text(no_wrap=True, overflow="ellipsis")
     t.append(" ")
     for i, (k, label) in enumerate(keys):
@@ -3579,7 +3629,9 @@ def render_kpi_slot(state: "DashboardState") -> Panel:
         rows.append(t)
         border = "yellow"
     elif reboot_pending():
-        rows.append(Text("REBOOT pending — F5", style="bold bright_yellow"))
+        # #556 — F5 acks (reboots now), F9 aborts the queued reboot.
+        rows.append(Text("REBOOT pending — F5 now · F9 cancel",
+                         style="bold bright_yellow"))
         border = "yellow"
     elif ustatus is not None:
         ulabel, ustyle = ustatus
@@ -3873,6 +3925,9 @@ class DashboardState:
         self.node_cpu_pct: float | None = None
         self.node_mem_pct: float | None = None
         self.node_fs_pct: float | None = None
+        # #556 — control-plane TCP reachability (appliance role only).
+        # None = nothing to probe / not yet sampled; True/False = reachable.
+        self.cp_reachable: bool | None = None
 
     def _set_node_pct(self, raw: dict) -> None:
         """Derive node CPU/mem/fs percentages from the kubelet .node section
@@ -3934,7 +3989,7 @@ class DashboardState:
             # ~one timeout. Derived computations + the api/cnpg fetches that
             # depend on their results run after the barrier.
             _nodename = os.uname().nodename
-            with concurrent.futures.ThreadPoolExecutor(max_workers=6) as ex:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=7) as ex:
                 f_pods = ex.submit(cluster_pods)
                 f_nodes = ex.submit(cluster_nodes)
                 # One kubelet Summary fetch feeds BOTH the per-pod Top-pods
@@ -3944,12 +3999,21 @@ class DashboardState:
                 f_svc = ex.submit(cluster_svc_ips)
                 f_k3s = ex.submit(k3s_status)
                 f_etcd = ex.submit(fetch_etcd_health)
+                # #556 — control-plane reachability (appliance role only);
+                # fanned out here so its ≤2 s connect timeout overlaps the
+                # kubectl forks instead of adding to the data-tier wall time.
+                f_cp = (
+                    ex.submit(control_plane_reachable, self.env)
+                    if self.role in ("appliance", "application")
+                    else None
+                )
                 self.ps_rows = f_pods.result()
                 self.nodes = f_nodes.result()
                 _summary = f_summary.result()
                 _svc = f_svc.result()
                 self.k3s_state = f_k3s.result()
                 self.etcd = f_etcd.result() or self.etcd
+                self.cp_reachable = f_cp.result() if f_cp else None
             self._set_node_pct(node_stats_from_summary(_summary))
             # INC 9 — cluster-wide Top-pods on a multi-node cluster; a
             # single-node box reuses the already-fetched local summary
@@ -4174,6 +4238,50 @@ def do_shutdown(console: Console) -> None:
         console.clear()
         console.print("\n\n[bold yellow]Powering off…[/bold yellow]\n")
         subprocess.run(["systemctl", "poweroff"], check=False)
+
+
+def do_cancel_reboot(console: Console) -> None:
+    """#556 — abort a queued reboot from the physical console.
+
+    A queued reboot runs a systemd service that *sleeps* for a grace
+    window before ``systemctl reboot`` — 10 s for the web-UI path
+    (``spatiumddi-reboot.service``, which sleeps then renames the
+    trigger, so ``reboot-pending`` stays visible for the whole window)
+    and 5 s for the fleet path (``spatiumddi-reboot-agent.service``).
+    Cancelling = ``systemctl stop`` that service mid-grace (kills the
+    sleep before the reboot ExecStart) + remove the trigger so the edge-
+    triggered ``.path`` unit has nothing to re-fire on.
+
+    Best-effort: if the grace already elapsed there's nothing to stop and
+    the box reboots anyway — same as before this key existed. Stopping an
+    inactive unit is a harmless no-op."""
+    if not reboot_pending():
+        console.clear()
+        console.print("\n\n[dim]No reboot is currently pending.[/dim]\n")
+        time.sleep(1.5)
+        return
+    if not confirm_modal(console, "Cancel the pending reboot?"):
+        return
+    console.clear()
+    console.print("\n\n[bold yellow]Cancelling pending reboot…[/bold yellow]\n")
+    # Stop both reboot services — one owns the web-UI path, the other the
+    # fleet path; only one is active, and stopping the idle one is a no-op.
+    subprocess.run(
+        ["systemctl", "stop",
+         "spatiumddi-reboot.service", "spatiumddi-reboot-agent.service"],
+        check=False,
+    )
+    # Remove the trigger(s) so reboot_pending() clears and the .path units
+    # (edge-triggered on PathChanged, not level-triggered) have nothing to
+    # re-fire on. The services rename the trigger to .done as part of their
+    # run; unlink the live form if the service was stopped before it did.
+    for name in ("reboot-pending", "reboot-pending-fleet"):
+        try:
+            (_RELEASE_STATE_DIR / name).unlink()
+        except OSError:
+            pass
+    console.print("[green]Reboot cancelled.[/green]\n")
+    time.sleep(1.5)
 
 
 def _term_env() -> dict[str, str]:
@@ -4983,6 +5091,10 @@ def main() -> int:
         elif key == "F8":
             # Re-pair (application roles only; do_pair() hard-refuses elsewhere).
             state.set_action("pair")
+        elif key == "F9":
+            # #556 — cancel a pending reboot. do_cancel_reboot() no-ops
+            # with a note when nothing is queued, so a stray press is safe.
+            state.set_action("cancel_reboot")
 
     keys = KeyReader(on_key)
     keys.start()
@@ -5058,6 +5170,8 @@ def main() -> int:
                                     do_reboot(console)
                                 elif action == "shutdown":
                                     do_shutdown(console)
+                                elif action == "cancel_reboot":
+                                    do_cancel_reboot(console)
                                 elif action == "monitor":
                                     do_monitor(console, args.tty)
                                 elif action == "containers":


### PR DESCRIPTION
Implements two of the #556 console operator-UX wins for the headless recovery dashboard (`spatium-console`).

## Control-plane reachability chip (appliance role)
A ≤2s TCP probe of `CONTROL_PLANE_URL`, fanned out in the existing data-tier `ThreadPoolExecutor` so it overlaps the kubectl forks instead of adding to the wall time. Renders `CP reachable` / `CP UNREACHABLE` on the header identity row (height-safe `no_wrap`+ellipsis line). Lets an operator tell **network-partitioned** apart from **unapproved** — indistinguishable from `pairing_status` alone. Returns `None` on the control-plane role (empty URL) so the chip stays off there.

## Cancel pending reboot (F9)
`systemctl stop`s the reboot service mid-grace (kills the sleep before the `systemctl reboot` ExecStart) + removes the trigger, aborting a queued web-UI / fleet reboot from the physical console. The footer shows **F9 Cancel reboot** only while a reboot is pending; the Slot indicator now reads `REBOOT pending — F5 now · F9 cancel`. Mapped on both the escape-seq and the digit-mirror (`9`) paths.

## Notes
- Persistent journald (the 3rd #556 item) already landed with the #553 `mkosi.finalize` fix.
- **Deferred** (not in this PR): QR-of-Web-UI-URL (needs a vendored QR encoder + a real scan test) and per-pod `describe` (needs pod-row selection plumbing). #556 stays open for those.
- ⚠️ **Testing:** the reachability *helper* is behaviorally tested standalone (parse + connect across empty / reachable / closed / no-scheme cases), and the file passes `py_compile` + `scripts/lint_appliance_runners.py`. But the **F-key dispatch + Rich render wiring** can't be exercised in CI — it needs an on-hardware console pass before merge.

Refs #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)