### PR TITLE
feat(appliance): unattended-upgrades policy — origins / blocklist / auto-reboot (#164)

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -1563,14 +1563,16 @@ def maybe_fire_apt_reload(bundle_block: object) -> bool:
     multiple rendered files + keyring map don't fit the SNMP single-body
     shape) the host runner parses with python3:
 
-        line 1:   ``enabled`` | ``disabled`` marker
-        line 2:   config_hash (sha256 hex, blank when unmanaged)
+        line 1:   ``enabled`` | ``disabled`` marker (SOURCES management)
+        line 2:   config_hash (sha256 hex; covers the unattended policy too,
+                  so it's non-blank even when apt sources are unmanaged)
         line 3+:  JSON {sources_list, proxy_conf, auth_conf, keyrings,
-                  unattended_upgrades_enabled}
+                  unattended_upgrades_enabled, unattended}
 
-    An empty config_hash (apt_managed off) only fires a disable trigger
-    if a non-empty config was previously applied — handled by the
-    ``config_hash == applied_hash`` short-circuit inside the guard.
+    The ``config_hash == applied_hash`` short-circuit inside the guard means a
+    #164 unattended-policy change re-fires the trigger even with apt_managed
+    off (the marker stays ``disabled`` for sources; the runner still renders
+    the unattended files from the ``unattended`` blob).
     """
     if detect_deployment_kind() != "appliance":
         return False
@@ -1587,6 +1589,10 @@ def maybe_fire_apt_reload(bundle_block: object) -> bool:
             "unattended_upgrades_enabled": bool(
                 bundle_block.get("unattended_upgrades_enabled", True)
             ),
+            # #164 — the unattended-upgrades POLICY block (origins / blocklist /
+            # automatic-reboot / reboot-time). Always present so the runner can
+            # render 50unattended-upgrades even when apt sources are unmanaged.
+            "unattended": bundle_block.get("unattended") or {},
         }
     )
     payload = (

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-apt-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-apt-reload
@@ -39,8 +39,10 @@ PROXY_CONF=/etc/apt/apt.conf.d/95spatiumddi-proxy
 AUTH_CONF=/etc/apt/auth.conf.d/spatiumddi.conf
 KEYRING_DIR=/etc/apt/keyrings
 SOURCES_BAK=/etc/apt/sources.list.spatiumddi-bak
-# unattended-upgrades activation toggle (debian's 20auto-upgrades).
+# unattended-upgrades activation toggle (debian's 20auto-upgrades) + the
+# #164 policy file (origins / blocklist / automatic-reboot).
 AUTO_UPGRADES=/etc/apt/apt.conf.d/20auto-upgrades
+UNATTENDED_50=/etc/apt/apt.conf.d/50unattended-upgrades
 
 mkdir -p "$LOG_DIR" "$(dirname "$HASH_SIDECAR")" "$KEYRING_DIR"
 exec >> "$LOG" 2>&1
@@ -76,16 +78,70 @@ finish() {
     mv "$TRIGGER" "${TRIGGER}.${2}.$(date +%s)"
 }
 
-set_unattended() {
-    # set_unattended <0|1> — flip Debian's periodic Update + Unattended-
-    # Upgrade keys. Idempotent; creates the file if missing.
-    local val="$1"
-    cat > "$AUTO_UPGRADES" <<EOF
-// Managed by SpatiumDDI — Settings → Appliance → APT.
-APT::Periodic::Update-Package-Lists "$val";
-APT::Periodic::Unattended-Upgrade "$val";
-EOF
-    chmod 0644 "$AUTO_UPGRADES"
+render_unattended() {
+    # #164 — render 20auto-upgrades (the periodic-timer enable) +
+    # 50unattended-upgrades (the policy: Allowed-Origins / Package-Blacklist /
+    # Automatic-Reboot / Automatic-Reboot-Time) from the blob's ``unattended``
+    # block. Runs in BOTH the enabled + disabled SOURCES branches — the policy
+    # is orthogonal to apt_managed (an operator can set a reboot policy without
+    # taking over apt sources). Validate-before-swap: stage both files, parse
+    # the merged tree with ``apt-config``, and only install live on success so
+    # a malformed policy can't break apt / the daily unattended run.
+    local uu_stage="$STAGE/uu"
+    mkdir -p "$uu_stage"
+    if ! python3 - "$BLOB" "$uu_stage/50unattended-upgrades" "$uu_stage/20auto-upgrades" <<'PYEOF'
+import json, os, sys
+
+blob_path, policy_path, timer_path = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    with open(blob_path, encoding="utf-8") as fh:
+        data = json.load(fh)
+except (OSError, ValueError):
+    data = {}
+u = data.get("unattended") or {}
+enabled = "1" if u.get("enabled", True) else "0"
+origins = [str(o) for o in (u.get("origins") or []) if str(o).strip()]
+blocklist = [str(b) for b in (u.get("blocklist") or []) if str(b).strip()]
+auto_reboot = "true" if u.get("automatic_reboot") else "false"
+reboot_time = (str(u.get("reboot_time") or "02:00").strip() or "02:00")
+
+
+def esc(s: str) -> str:
+    # apt.conf double-quoted string: escape backslash then quote.
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+with open(timer_path, "w", encoding="utf-8") as fh:
+    fh.write("// Managed by SpatiumDDI — Settings → Appliance → APT (#164).\n")
+    fh.write(f'APT::Periodic::Update-Package-Lists "{enabled}";\n')
+    fh.write(f'APT::Periodic::Unattended-Upgrade "{enabled}";\n')
+
+lines = ["// Managed by SpatiumDDI — Settings → Appliance → APT (#164)."]
+lines.append("Unattended-Upgrade::Allowed-Origins {")
+lines += [f'    "{esc(o)}";' for o in origins]
+lines.append("};")
+lines.append("Unattended-Upgrade::Package-Blacklist {")
+lines += [f'    "{esc(b)}";' for b in blocklist]
+lines.append("};")
+lines.append(f'Unattended-Upgrade::Automatic-Reboot "{auto_reboot}";')
+lines.append(f'Unattended-Upgrade::Automatic-Reboot-Time "{esc(reboot_time)}";')
+with open(policy_path, "w", encoding="utf-8") as fh:
+    fh.write("\n".join(lines) + "\n")
+PYEOF
+    then
+        echo "  ! WARN: failed to render unattended policy from blob — leaving live files untouched"
+        return 0
+    fi
+    # Syntactic validation: apt-config must parse the staged parts tree.
+    if ! apt-config -o "Dir::Etc::main=/dev/null" -o "Dir::Etc::parts=$uu_stage" \
+            dump >/dev/null 2>"$STAGE/uu-validate.log"; then
+        echo "  ! WARN: apt-config rejected the rendered unattended policy — not swapping:"
+        sed 's/^/      /' "$STAGE/uu-validate.log" | tail -10
+        return 0
+    fi
+    install -m 0644 "$uu_stage/20auto-upgrades" "$AUTO_UPGRADES"
+    install -m 0644 "$uu_stage/50unattended-upgrades" "$UNATTENDED_50"
+    echo "  ✓ unattended policy applied (20auto-upgrades + 50unattended-upgrades)"
 }
 
 case "$MARKER" in
@@ -227,7 +283,7 @@ EOF
         else
             rm -f "$AUTH_CONF"
         fi
-        set_unattended "${UNATTENDED:-1}"
+        render_unattended
 
         echo "  applied live config; confirming with live apt-get update…"
         if apt-get update > /tmp/spatium-apt-live.log 2>&1; then
@@ -259,10 +315,15 @@ EOF
         fi
         rm -f "$MANAGED_LIST" "$PROXY_CONF" "$AUTH_CONF"
         rm -f "$KEYRING_DIR"/spatiumddi-*.asc
-        # Clear the applied-hash sidecar so the disabled state is idempotent
-        # (next bundle's empty config_hash == empty applied → no re-fire).
-        : > "$HASH_SIDECAR"
-        echo "  ✓ managed apt config removed; baked repos in effect"
+        # #164 — the unattended-upgrades policy is orthogonal to source
+        # management, so it's still applied even in the sources-disabled state.
+        render_unattended
+        # Stamp the applied-hash with THIS bundle's config_hash so the disabled
+        # state stays idempotent. #164 made the disabled config_hash non-empty
+        # (it covers the unattended policy), so clearing the sidecar to empty
+        # would mismatch the non-empty bundle hash and re-fire on every tick.
+        echo "$HASH" > "$HASH_SIDECAR"
+        echo "  ✓ managed apt sources removed; baked repos in effect (unattended policy applied)"
         finish "unmanaged" "done"
         ;;
     *)

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -339,6 +339,10 @@ backend/alembic/versions/c8e3a7f10b54_ai_usage_observability.py:drop_column:78
 backend/alembic/versions/c8e4f7a91d36_session_viewer.py:drop_column:65
 backend/alembic/versions/c8e4f7a91d36_session_viewer.py:drop_column:66
 backend/alembic/versions/c9a1f7e0b234_dns_zone_masters.py:drop_column:43
+backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:75
+backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:76
+backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:77
+backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:78
 backend/alembic/versions/c9e2b0d3a5f7_docker_integration.py:drop_column:136
 backend/alembic/versions/c9e2b0d3a5f7_docker_integration.py:drop_column:139
 backend/alembic/versions/c9e2b0d3a5f7_docker_integration.py:drop_table:141

--- a/backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py
+++ b/backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py
@@ -1,0 +1,78 @@
+"""appliance unattended-upgrades policy columns (#164)
+
+Adds the ``platform_settings.apt_unattended_*`` policy block (the WHEN/HOW of
+auto-applying updates) alongside the existing ``apt_unattended_upgrades_enabled``
+master toggle (#155). These render /etc/apt/apt.conf.d/50unattended-upgrades and
+apply orthogonally to ``apt_managed`` (the WHERE — #155's sources management), so
+an operator can set a reboot policy without taking over apt sources.
+
+``apt_unattended_origins`` seeds the security-only locked-down default so a fresh
+install matches Debian's out-of-the-box unattended behaviour.
+
+Revision ID: c9d4a1e8b672
+Revises: b1f7c3a92e04
+Create Date: 2026-07-03
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c9d4a1e8b672"
+down_revision: str | None = "b1f7c3a92e04"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+# Frozen snapshot of the model's DEFAULT_UNATTENDED_ORIGINS (inlined so the
+# migration stays an immutable historical record). apt expands ${distro_id}
+# / ${distro_codename} at runtime.
+_ORIGINS_DEFAULT = '["${distro_id}:${distro_codename}-security"]'
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "apt_unattended_origins",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text(f"'{_ORIGINS_DEFAULT}'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "apt_unattended_blocklist",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "apt_unattended_automatic_reboot",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "apt_unattended_reboot_time",
+            sa.String(length=5),
+            nullable=False,
+            server_default=sa.text("'02:00'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_settings", "apt_unattended_reboot_time")
+    op.drop_column("platform_settings", "apt_unattended_automatic_reboot")
+    op.drop_column("platform_settings", "apt_unattended_blocklist")
+    op.drop_column("platform_settings", "apt_unattended_origins")

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -243,6 +243,11 @@ class SettingsResponse(BaseModel):
     apt_proxy_no_proxy: str = ""
     apt_auth: list[dict[str, Any]] = []
     apt_unattended_upgrades_enabled: bool = True
+    # Issue #164 — unattended-upgrades policy (non-secret).
+    apt_unattended_origins: list[str] = []
+    apt_unattended_blocklist: list[str] = []
+    apt_unattended_automatic_reboot: bool = False
+    apt_unattended_reboot_time: str = "02:00"
 
     model_config = {"from_attributes": True}
 
@@ -909,6 +914,41 @@ class SettingsUpdate(BaseModel):
     apt_proxy_no_proxy: str | None = None
     apt_auth: list[AptAuthUpdate] | None = None
     apt_unattended_upgrades_enabled: bool | None = None
+    # Issue #164 — unattended-upgrades policy.
+    apt_unattended_origins: list[str] | None = None
+    apt_unattended_blocklist: list[str] | None = None
+    apt_unattended_automatic_reboot: bool | None = None
+    apt_unattended_reboot_time: str | None = None
+
+    @field_validator("apt_unattended_reboot_time")
+    @classmethod
+    def _valid_unattended_reboot_time(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        s = v.strip()
+        if not re.fullmatch(r"([01]\d|2[0-3]):[0-5]\d", s):
+            raise ValueError("reboot time must be HH:MM (24-hour), e.g. 02:00")
+        return s
+
+    @field_validator("apt_unattended_origins", "apt_unattended_blocklist")
+    @classmethod
+    def _valid_unattended_list(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        out: list[str] = []
+        for raw in v:
+            s = str(raw).strip()
+            if not s:
+                continue
+            # These land inside apt.conf double-quoted strings (the host runner
+            # escapes quotes); reject control chars + over-long entries so a
+            # value can't smuggle a newline / extra directive past the render.
+            if any(ord(c) < 0x20 for c in s) or len(s) > 200:
+                raise ValueError(
+                    "unattended origin / package entries must be printable and ≤ 200 chars"
+                )
+            out.append(s)
+        return out
 
     @field_validator("apt_proxy_http", "apt_proxy_https")
     @classmethod
@@ -1985,6 +2025,11 @@ async def update_settings(
                     "proxy_http_set": bool(settings.apt_proxy_http),
                     "proxy_https_set": bool(settings.apt_proxy_https),
                     "unattended_upgrades_enabled": bool(settings.apt_unattended_upgrades_enabled),
+                    # Issue #164 — unattended-upgrades policy summary.
+                    "unattended_origin_count": len(settings.apt_unattended_origins or []),
+                    "unattended_blocklist_count": len(settings.apt_unattended_blocklist or []),
+                    "unattended_automatic_reboot": bool(settings.apt_unattended_automatic_reboot),
+                    "unattended_reboot_time": settings.apt_unattended_reboot_time or "",
                 },
             )
         )

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -941,9 +941,10 @@ class SettingsUpdate(BaseModel):
             if not s:
                 continue
             # These land inside apt.conf double-quoted strings (the host runner
-            # escapes quotes); reject control chars + over-long entries so a
-            # value can't smuggle a newline / extra directive past the render.
-            if any(ord(c) < 0x20 for c in s) or len(s) > 200:
+            # escapes quotes); reject control chars — C0 (< 0x20) AND ASCII DEL
+            # (0x7f) — plus over-long entries so a value can't smuggle a newline
+            # / extra directive past the render.
+            if any(ord(c) < 0x20 or ord(c) == 0x7F for c in s) or len(s) > 200:
                 raise ValueError(
                     "unattended origin / package entries must be printable and ≤ 200 chars"
                 )

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -49,6 +49,15 @@ DEFAULT_APT_SOURCES: list[dict] = [
     },
 ]
 
+# Issue #164 — default Allowed-Origins for unattended-upgrades: security
+# only, the locked-down appliance default. apt expands ``${distro_id}`` /
+# ``${distro_codename}`` at runtime, so this stays correct across Debian
+# point releases + a future base-OS bump. Empty list = nothing eligible =
+# effectively no auto-upgrades even with the timer on (per #164 acceptance).
+DEFAULT_UNATTENDED_ORIGINS: list[str] = [
+    "${distro_id}:${distro_codename}-security",
+]
+
 
 class PlatformSettings(Base):
     """Singleton settings table — always exactly one row with id=1."""
@@ -521,6 +530,34 @@ class PlatformSettings(Base):
     )
     apt_unattended_upgrades_enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    # Issue #164 — unattended-upgrades POLICY (the WHEN/HOW), orthogonal to
+    # ``apt_managed`` (the WHERE, #155). These render
+    # /etc/apt/apt.conf.d/50unattended-upgrades and apply even when the
+    # operator has NOT taken over apt sources; ``apt_unattended_upgrades_
+    # enabled`` above stays the master timer toggle (20auto-upgrades).
+    apt_unattended_origins: Mapped[list[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=lambda: list(DEFAULT_UNATTENDED_ORIGINS),
+        server_default=sa_text(
+            "'" + json.dumps(DEFAULT_UNATTENDED_ORIGINS).replace("'", "''") + "'::jsonb"
+        ),
+    )
+    # Glob patterns never auto-upgraded (Unattended-Upgrade::Package-Blacklist).
+    apt_unattended_blocklist: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+    # Reboot after an upgrade that needs one. Default False — a surprise
+    # reboot is the wrong default for a DDI appliance serving DNS / DHCP.
+    apt_unattended_automatic_reboot: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    # HH:MM (24h) for Unattended-Upgrade::Automatic-Reboot-Time. apt supports
+    # a single reboot time, not a window (the #164 sketch's window_end has no
+    # apt analogue), so we model the one value apt actually honours.
+    apt_unattended_reboot_time: Mapped[str] = mapped_column(
+        String(5), nullable=False, default="02:00", server_default=sa_text("'02:00'")
     )
 
     # ── Appliance timezone (issue #165) ─────────────────────────────

--- a/backend/app/services/ai/tools/apt.py
+++ b/backend/app/services/ai/tools/apt.py
@@ -87,4 +87,9 @@ async def find_apt_settings(
         "proxy_https": settings.apt_proxy_https or "",
         "no_proxy": settings.apt_proxy_no_proxy or "",
         "unattended_upgrades_enabled": bool(settings.apt_unattended_upgrades_enabled),
+        # Issue #164 — unattended-upgrades policy (the WHEN/HOW of auto-applying).
+        "unattended_allowed_origins": list(settings.apt_unattended_origins or []),
+        "unattended_blocklist": list(settings.apt_unattended_blocklist or []),
+        "unattended_automatic_reboot": bool(settings.apt_unattended_automatic_reboot),
+        "unattended_reboot_time": settings.apt_unattended_reboot_time or "02:00",
     }

--- a/backend/app/services/appliance/apt.py
+++ b/backend/app/services/appliance/apt.py
@@ -161,31 +161,64 @@ def _decrypt(token: Any) -> str | None:
         return None
 
 
+def unattended_block(settings: PlatformSettings) -> dict[str, Any]:
+    """Issue #164 — the unattended-upgrades POLICY block.
+
+    Always shipped (independent of ``apt_managed``) so an operator can set a
+    reboot / origins / blocklist policy WITHOUT taking over apt sources; the
+    host runner renders /etc/apt/apt.conf.d/{20auto-upgrades,
+    50unattended-upgrades} from it. ``enabled`` is the master periodic-timer
+    toggle (``apt_unattended_upgrades_enabled``); an empty ``origins`` list
+    means nothing is eligible, i.e. effectively no auto-upgrades even with the
+    timer on (per the #164 acceptance criteria)."""
+    return {
+        "enabled": bool(settings.apt_unattended_upgrades_enabled),
+        "origins": [
+            str(o).strip() for o in (settings.apt_unattended_origins or []) if str(o).strip()
+        ],
+        "blocklist": [
+            str(b).strip() for b in (settings.apt_unattended_blocklist or []) if str(b).strip()
+        ],
+        "automatic_reboot": bool(settings.apt_unattended_automatic_reboot),
+        "reboot_time": (str(settings.apt_unattended_reboot_time or "02:00").strip() or "02:00"),
+    }
+
+
 def apt_bundle(settings: PlatformSettings) -> dict[str, Any]:
     """Build the ``apt_settings`` block the supervisor ConfigBundle ships.
 
-    When ``apt_managed`` is False the block is the disabled shape
-    (``enabled=False``, empty hash) — the host runner then removes the
-    managed drop-in so Debian's baked ``sources.list`` takes back over.
-    The ``config_hash`` covers every rendered artifact so any change
-    shifts it and the supervisor re-fires the host trigger.
+    When ``apt_managed`` is False the block is the disabled shape for SOURCES
+    (``enabled=False``, empty rendered files) — the host runner removes the
+    managed drop-in so Debian's baked ``sources.list`` takes back over. The
+    unattended-upgrades POLICY (#164) always rides along regardless, and the
+    ``config_hash`` covers it too so a policy change re-fires the host trigger
+    even when sources are unmanaged. The hash covers every rendered artifact so
+    any change shifts it.
     """
+    unattended = unattended_block(settings)
+
     if not settings.apt_managed:
+        # Sources unmanaged, but the unattended policy still ships + drives its
+        # own hash so a #164 policy change re-fires even with apt_managed off.
+        config_hash = hashlib.sha256(
+            json.dumps({"unattended": unattended}, sort_keys=True).encode("utf-8"),
+            usedforsecurity=False,
+        ).hexdigest()
         return {
             "enabled": False,
-            "config_hash": "",
+            "config_hash": config_hash,
             "sources_list": "",
             "proxy_conf": "",
             "auth_conf": "",
             "keyrings": {},
-            "unattended_upgrades_enabled": bool(settings.apt_unattended_upgrades_enabled),
+            "unattended_upgrades_enabled": unattended["enabled"],
+            "unattended": unattended,
         }
 
     sources_list = render_sources_list(settings)
     proxy_conf = render_proxy_conf(settings)
     auth_conf = render_auth_conf(settings)
     keyrings = apt_keyrings(settings)
-    unattended = bool(settings.apt_unattended_upgrades_enabled)
 
     # Change-detection fingerprint. NOT computed over the decrypted secrets
     # (auth_conf cleartext / keyring armour) — instead over the stable
@@ -205,7 +238,7 @@ def apt_bundle(settings: PlatformSettings) -> dict[str, Any]:
             "sources_list": sources_list,
             "proxy_conf": proxy_conf,
             "secret_material": secret_material,
-            "unattended_upgrades_enabled": unattended,
+            "unattended": unattended,
         },
         sort_keys=True,
     )
@@ -217,5 +250,6 @@ def apt_bundle(settings: PlatformSettings) -> dict[str, Any]:
         "proxy_conf": proxy_conf,
         "auth_conf": auth_conf,
         "keyrings": keyrings,
-        "unattended_upgrades_enabled": unattended,
+        "unattended_upgrades_enabled": unattended["enabled"],
+        "unattended": unattended,
     }

--- a/backend/tests/test_apt_settings.py
+++ b/backend/tests/test_apt_settings.py
@@ -209,6 +209,13 @@ async def test_put_rejects_control_char_in_origin(client: AsyncClient, db_sessio
         json={"apt_unattended_origins": ['o=Debian\nUnattended-Upgrade::Foo "1"']},
     )
     assert r.status_code == 422
+    # ASCII DEL (0x7f) is a control char too and must be rejected (Copilot review).
+    r2 = await client.put(
+        "/api/v1/settings",
+        headers=_hdr(token),
+        json={"apt_unattended_blocklist": ["nvidia-\x7f"]},
+    )
+    assert r2.status_code == 422
 
 
 def test_render_auth_conf_skips_entries_without_password() -> None:

--- a/backend/tests/test_apt_settings.py
+++ b/backend/tests/test_apt_settings.py
@@ -24,6 +24,7 @@ from app.services.appliance.apt import (
     render_auth_conf,
     render_proxy_conf,
     render_sources_list,
+    unattended_block,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -56,6 +57,14 @@ def _shim(**kw) -> PlatformSettings:
     s.apt_proxy_no_proxy = kw.get("no_proxy", "")
     s.apt_auth = kw.get("auth", [])
     s.apt_unattended_upgrades_enabled = kw.get("unattended", True)
+    # Issue #164 — unattended-upgrades policy (defaults mirror the model's
+    # server_defaults so a shim behaves like a fresh row).
+    s.apt_unattended_origins = kw.get(
+        "unattended_origins", ["${distro_id}:${distro_codename}-security"]
+    )
+    s.apt_unattended_blocklist = kw.get("unattended_blocklist", [])
+    s.apt_unattended_automatic_reboot = kw.get("unattended_automatic_reboot", False)
+    s.apt_unattended_reboot_time = kw.get("unattended_reboot_time", "02:00")
     return s
 
 
@@ -103,13 +112,103 @@ def test_render_proxy_conf_includes_no_proxy_direct() -> None:
 def test_apt_bundle_disabled_when_unmanaged() -> None:
     b = apt_bundle(_shim(managed=False))
     assert b["enabled"] is False
-    assert b["config_hash"] == ""
-    # Managed flips it on with a stable non-empty hash.
+    # #164 — the sources-disabled bundle still carries the unattended policy,
+    # so its hash is non-empty (a policy change re-fires even with apt_managed
+    # off). It is deterministic for a fixed policy.
+    assert len(b["config_hash"]) == 64
+    assert "unattended" in b
+    assert apt_bundle(_shim(managed=False))["config_hash"] == b["config_hash"]
+    # Managed flips sources on with its own stable non-empty hash.
     b2 = apt_bundle(_shim(managed=True))
     assert b2["enabled"] is True
     assert len(b2["config_hash"]) == 64
     # Deterministic — same settings → same hash.
     assert apt_bundle(_shim(managed=True))["config_hash"] == b2["config_hash"]
+
+
+# ── (a2) unattended-upgrades policy (#164) ──────────────────────────
+
+
+def test_unattended_block_shape_and_normalisation() -> None:
+    u = unattended_block(
+        _shim(
+            unattended=True,
+            unattended_origins=["  origin=Debian  ", "", "o=x"],
+            unattended_blocklist=["linux-image-*", "  "],
+            unattended_automatic_reboot=True,
+            unattended_reboot_time="03:15",
+        )
+    )
+    assert u["enabled"] is True
+    # Blank entries dropped, surrounding whitespace stripped.
+    assert u["origins"] == ["origin=Debian", "o=x"]
+    assert u["blocklist"] == ["linux-image-*"]
+    assert u["automatic_reboot"] is True
+    assert u["reboot_time"] == "03:15"
+
+
+def test_apt_bundle_hash_tracks_unattended_policy_when_unmanaged() -> None:
+    # apt_managed off both times — only the unattended policy differs, and the
+    # config_hash must still shift so the supervisor re-fires the host trigger.
+    a = apt_bundle(_shim(managed=False, unattended_reboot_time="02:00"))["config_hash"]
+    b = apt_bundle(_shim(managed=False, unattended_reboot_time="04:30"))["config_hash"]
+    assert a != b
+    # And the managed-shape hash also folds the policy in.
+    c = apt_bundle(_shim(managed=True, unattended_automatic_reboot=False))["config_hash"]
+    d = apt_bundle(_shim(managed=True, unattended_automatic_reboot=True))["config_hash"]
+    assert c != d
+
+
+async def test_put_get_unattended_policy_roundtrip(client: AsyncClient, db_session):
+    _, token = await _superadmin(db_session)
+    h = _hdr(token)
+    r = await client.put(
+        "/api/v1/settings",
+        headers=h,
+        json={
+            "apt_unattended_upgrades_enabled": True,
+            "apt_unattended_origins": ["${distro_id}:${distro_codename}-security", "o=Debian"],
+            "apt_unattended_blocklist": ["linux-image-*"],
+            "apt_unattended_automatic_reboot": True,
+            "apt_unattended_reboot_time": "03:30",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["apt_unattended_origins"] == [
+        "${distro_id}:${distro_codename}-security",
+        "o=Debian",
+    ]
+    assert body["apt_unattended_blocklist"] == ["linux-image-*"]
+    assert body["apt_unattended_automatic_reboot"] is True
+    assert body["apt_unattended_reboot_time"] == "03:30"
+    # The bundle carries the policy through to the host trigger.
+    settings = await db_session.get(PlatformSettings, 1)
+    assert settings is not None
+    u = apt_bundle(settings)["unattended"]
+    assert u["automatic_reboot"] is True
+    assert u["reboot_time"] == "03:30"
+    assert "o=Debian" in u["origins"]
+
+
+async def test_put_rejects_bad_reboot_time(client: AsyncClient, db_session):
+    _, token = await _superadmin(db_session)
+    r = await client.put(
+        "/api/v1/settings",
+        headers=_hdr(token),
+        json={"apt_unattended_reboot_time": "25:99"},
+    )
+    assert r.status_code == 422
+
+
+async def test_put_rejects_control_char_in_origin(client: AsyncClient, db_session):
+    _, token = await _superadmin(db_session)
+    r = await client.put(
+        "/api/v1/settings",
+        headers=_hdr(token),
+        json={"apt_unattended_origins": ['o=Debian\nUnattended-Upgrade::Foo "1"']},
+    )
+    assert r.status_code == 422
 
 
 def test_render_auth_conf_skips_entries_without_password() -> None:

--- a/frontend/src/components/AptSection.tsx
+++ b/frontend/src/components/AptSection.tsx
@@ -95,6 +95,20 @@ export function AptSection({
   const [unattended, setUnattended] = useState(
     values.apt_unattended_upgrades_enabled,
   );
+  // Issue #164 — unattended-upgrades policy. Origins / blocklist are edited as
+  // newline-separated textareas and split to arrays on save.
+  const [uuOrigins, setUuOrigins] = useState(
+    (values.apt_unattended_origins || []).join("\n"),
+  );
+  const [uuBlocklist, setUuBlocklist] = useState(
+    (values.apt_unattended_blocklist || []).join("\n"),
+  );
+  const [uuAutoReboot, setUuAutoReboot] = useState(
+    values.apt_unattended_automatic_reboot,
+  );
+  const [uuRebootTime, setUuRebootTime] = useState(
+    values.apt_unattended_reboot_time || "02:00",
+  );
   const [touched, setTouched] = useState(false);
   const [saveErr, setSaveErr] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
@@ -141,6 +155,16 @@ export function AptSection({
         apt_proxy_no_proxy: noProxy,
         apt_auth: buildAuthUpdate(),
         apt_unattended_upgrades_enabled: unattended,
+        apt_unattended_origins: uuOrigins
+          .split("\n")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        apt_unattended_blocklist: uuBlocklist
+          .split("\n")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        apt_unattended_automatic_reboot: uuAutoReboot,
+        apt_unattended_reboot_time: uuRebootTime.trim(),
       }),
     onSuccess: (updated) => {
       qc.setQueryData(["settings"], updated);
@@ -586,6 +610,74 @@ export function AptSection({
             mark();
           }}
           disabled={ro}
+        />
+      </Field>
+
+      {/* ── Unattended-upgrades policy (issue #164) ── */}
+      <div className="space-y-2 border-t pt-3">
+        <div className="text-sm font-medium">Unattended-upgrades policy</div>
+        <div className="text-xs text-muted-foreground">
+          Controls what the daily unattended run installs and whether it
+          reboots. Applies even without managed APT sources. An empty
+          allowed-origins list means nothing is auto-upgraded.
+        </div>
+        <label className="block text-xs font-medium">
+          Allowed origins (one per line)
+        </label>
+        <textarea
+          className={cn(inputCls, "w-full font-mono text-xs")}
+          rows={3}
+          placeholder={"${distro_id}:${distro_codename}-security"}
+          value={uuOrigins}
+          disabled={ro}
+          onChange={(e) => {
+            setUuOrigins(e.target.value);
+            mark();
+          }}
+        />
+        <label className="block text-xs font-medium">
+          Package blocklist — globs never auto-upgraded (one per line)
+        </label>
+        <textarea
+          className={cn(inputCls, "w-full font-mono text-xs")}
+          rows={2}
+          placeholder={"linux-image-*\nnvidia-*"}
+          value={uuBlocklist}
+          disabled={ro}
+          onChange={(e) => {
+            setUuBlocklist(e.target.value);
+            mark();
+          }}
+        />
+      </div>
+
+      <Field
+        label="Automatic reboot after upgrades"
+        description="Reboot automatically when an installed update requires it. Off by default — a surprise reboot is risky for a DDI appliance serving DNS / DHCP."
+      >
+        <Toggle
+          checked={uuAutoReboot}
+          onChange={(v) => {
+            setUuAutoReboot(v);
+            mark();
+          }}
+          disabled={ro}
+        />
+      </Field>
+
+      <Field
+        label="Reboot time"
+        description="HH:MM (24-hour) for the automatic reboot, when enabled."
+      >
+        <input
+          className={cn(inputCls, "w-28")}
+          placeholder="02:00"
+          value={uuRebootTime}
+          disabled={ro || !uuAutoReboot}
+          onChange={(e) => {
+            setUuRebootTime(e.target.value);
+            mark();
+          }}
         />
       </Field>
 

--- a/frontend/src/components/AptSection.tsx
+++ b/frontend/src/components/AptSection.tsx
@@ -185,6 +185,13 @@ export function AptSection({
         })),
       );
       setSources(updated.apt_sources || []);
+      // #164 — re-sync the unattended policy fields from the server response
+      // so backend normalisation (dropped-empty origins, stripped whitespace)
+      // is reflected instead of the operator's raw textarea input.
+      setUuOrigins((updated.apt_unattended_origins || []).join("\n"));
+      setUuBlocklist((updated.apt_unattended_blocklist || []).join("\n"));
+      setUuAutoReboot(updated.apt_unattended_automatic_reboot);
+      setUuRebootTime(updated.apt_unattended_reboot_time || "02:00");
       setSaveErr(null);
       setTouched(false);
       setSavedAt(Date.now());

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3299,6 +3299,11 @@ export interface PlatformSettings {
   apt_proxy_no_proxy: string;
   apt_auth: AptAuthRedacted[];
   apt_unattended_upgrades_enabled: boolean;
+  // Issue #164 — unattended-upgrades policy (the WHEN/HOW of auto-applying).
+  apt_unattended_origins: string[];
+  apt_unattended_blocklist: string[];
+  apt_unattended_automatic_reboot: boolean;
+  apt_unattended_reboot_time: string;
 }
 
 /** One managed APT repo. No secrets — the armoured key lives in
@@ -3352,6 +3357,11 @@ export interface AptSettingsUpdate {
   apt_proxy_no_proxy?: string;
   apt_auth?: AptAuthUpdate[];
   apt_unattended_upgrades_enabled?: boolean;
+  // Issue #164 — unattended-upgrades policy.
+  apt_unattended_origins?: string[];
+  apt_unattended_blocklist?: string[];
+  apt_unattended_automatic_reboot?: boolean;
+  apt_unattended_reboot_time?: string;
 }
 
 export interface AptValidateRequest {


### PR DESCRIPTION
Extends the APT host-config plane (#155) with the **WHEN/HOW** of auto-applying updates, orthogonal to `apt_managed` (the **WHERE**): an operator can set an unattended-upgrades policy — allowed origins, package blocklist, automatic-reboot window — **without** taking over apt sources.

## What lands
- **Model + migration** (`c9d4a1e8b672`, chained off the verified head `b1f7c3a92e04`): four `platform_settings.apt_unattended_*` columns — `origins` (Allowed-Origins; default security-only), `blocklist` (Package-Blacklist globs), `automatic_reboot` + `reboot_time` (HH:MM).
- **Bundle + runner:** `apt_bundle` now always carries the `unattended` block (both the managed and sources-unmanaged shapes) and folds it into `config_hash`, so a policy change re-fires the host trigger **even with `apt_managed` off**. `spatiumddi-apt-reload`'s `set_unattended()` is replaced by `render_unattended()`, which stages, **validates via `apt-config`**, and installs **both** `20auto-upgrades` (the periodic-timer enable) and `50unattended-upgrades` (the policy) in both branches. Trigger is consumed on success *and* failure (#550 hardening preserved).
- **Router / schema / MCP:** four non-secret fields with HH:MM + control-char validators (a value can't smuggle a newline / extra apt.conf directive past the render); `find_apt_settings` surfaces the policy.
- **Frontend:** `AptSection` gains an **Unattended-upgrades policy** sub-section (origins/blocklist textareas, automatic-reboot toggle, reboot-time input). Fleet rollout rides the existing APT trigger / heartbeat / `apt_state` chip — no new tab or plane.

## Design note — deconfliction with #155
`apt_unattended_upgrades_enabled` (the master periodic-timer toggle) stays; the new fields are the *policy*. Ownership of `20auto-upgrades` + `50unattended-upgrades` moves entirely to `render_unattended()`, so there's no double-write. Because the policy always ships (even when sources are unmanaged), the disabled-shape `config_hash` is now **non-empty** — the runner writes the applied hash (rather than clearing it) so the disabled state stays idempotent instead of re-firing every tick.

## Acceptance (#164)
- Empty `allowed_origins` → nothing eligible → effectively no auto-upgrades even with the timer on. ✅
- The security-only default (`\${distro_id}:\${distro_codename}-security`) is the locked-down baseline. ✅

## Verification
- **16/16** `test_apt_settings` pass against a real DB — no #155 regression, plus new tests for the policy PUT→GET roundtrip, the HH:MM / control-char validators, and `config_hash` tracking the policy (managed + unmanaged).
- `render_unattended`'s file generation behaviorally tested standalone (apt.conf format, quote-escaping, empty/disabled cases, missing-blob defaults).
- ruff / black / mypy clean; migration-shape lint baselined; appliance runner-lint + `bash -n` pass; frontend `build` + eslint + prettier clean.
- ⚠️ The host runner's **live `apt-config` apply on a real appliance** can't run in CI — worth an on-appliance pass before/after merge.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)