### PR TITLE
ipam: address pagination/search, table windowing + sort, cross-subnet bulk, util recount + perf (#517 #519 #520 #521 #522)

### DIFF
--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -6413,15 +6413,22 @@ async def list_addresses(
         base = base.where(cond)
     base = apply_tag_filter(base, IPAddress.tags, tag)
 
-    total = await db.scalar(select(func.count()).select_from(base.subquery()))
-    response.headers["X-Total-Count"] = str(total or 0)
-
     query = base.order_by(*_address_order_by(sort, order))
     if offset:
         query = query.offset(offset)
     if limit is not None:
         query = query.limit(limit)
     rows = list((await db.execute(query)).scalars().all())
+
+    # X-Total-Count carries the match total *before* the window. When no window
+    # is applied (the default, backward-compatible per-subnet call) the returned
+    # rows ARE the full match set, so skip the extra COUNT(*) on that hot path.
+    if limit is None and not offset:
+        total = len(rows)
+    else:
+        total = await db.scalar(select(func.count()).select_from(base.subquery())) or 0
+    response.headers["X-Total-Count"] = str(total)
+
     await _enrich_addresses(db, rows)
     return rows
 

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -12,10 +12,11 @@ from datetime import UTC, date, datetime, timedelta
 from typing import Any, cast
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
-from sqlalchemy import func, select, text
+from sqlalchemy import String, asc, desc, func, or_, select, text
+from sqlalchemy import cast as sa_cast
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -23,6 +24,7 @@ from sqlalchemy.orm import selectinload
 from app.api.deps import DB, CurrentUser
 from app.api.v1.ipam.io_router import router as io_router
 from app.core.permissions import (
+    is_effective_superadmin,
     require_any_resource_or_scoped,
     token_scope_allows,
     user_has_permission,
@@ -2461,6 +2463,48 @@ class IPAddressResponse(BaseModel):
     @classmethod
     def coerce_inet(cls, v: Any) -> Any:
         return str(v) if v is not None else v
+
+
+class IPAddressSearchItem(IPAddressResponse):
+    """Cross-subnet address search row (issues #517 #3 / #520).
+
+    Mirrors :class:`IPAddressResponse` and joins the parent subnet + space
+    so a global search result can render the network context and group
+    hits without a second round-trip. ``subnet_cidr`` / ``subnet_name`` /
+    ``space_name`` are populated from the JOIN; ``space_id`` is the parent
+    space UUID.
+    """
+
+    subnet_cidr: str
+    subnet_name: str | None = None
+    space_id: uuid.UUID
+    space_name: str | None = None
+
+
+class AddressSearchResponse(BaseModel):
+    """Paginated envelope for ``GET /ipam/addresses/search``.
+
+    Distinct from the per-subnet list endpoint (which stays a bare
+    ``list[IPAddressResponse]`` for backward compat) because the
+    cross-subnet surface needs the total + window echoed back for
+    client-side pagination.
+    """
+
+    items: list[IPAddressSearchItem]
+    total: int
+    limit: int
+    offset: int
+
+
+class AddressSearchIdsResponse(BaseModel):
+    """Id-only envelope for ``GET /ipam/addresses/search/ids`` — feeds the
+    frontend "select all matches → bulk-edit / bulk-delete" flow. ``ids`` is
+    capped (see ``_SEARCH_IDS_CAP``); ``capped`` is ``True`` when ``total``
+    exceeds the cap so the UI can warn that not every match was selected."""
+
+    ids: list[str]
+    total: int
+    capped: bool
 
 
 class NextIPRequest(BaseModel):
@@ -6200,27 +6244,99 @@ async def _nat_mapping_counts_for(db: AsyncSession, ips: list[IPAddress]) -> dic
     return counts
 
 
-@router.get("/subnets/{subnet_id}/addresses", response_model=list[IPAddressResponse])
-async def list_addresses(
-    subnet_id: uuid.UUID,
-    current_user: CurrentUser,
-    db: DB,
-    status_filter: str | None = None,
-    tag: list[str] = Query(default_factory=list),
-) -> list[IPAddress]:
-    if await db.get(Subnet, subnet_id) is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
-    _enforce_subnet_token_scope(current_user, subnet_id)
+# ── Address search / filter / sort shared helpers (issues #517 / #520) ─────────
+#
+# Both the per-subnet address list and the cross-subnet search endpoint share
+# the same substring / hostname / MAC / status filter grammar and the same
+# sort-key set. Keeping the WHERE-condition + ORDER-BY builders here means the
+# two surfaces can never drift apart.
 
-    query = (
-        select(IPAddress)
-        .where(IPAddress.subnet_id == subnet_id)
-        .order_by(text("CAST(address AS inet)"))
-    )
+_ADDRESS_SORT_KEYS = {"address", "hostname", "status", "mac", "last_seen", "description"}
+
+# Cap on the id-only search endpoint (#520). Aligns with the bulk-op blast
+# radius: the frontend feeds these ids straight into bulk-edit / bulk-delete.
+_SEARCH_IDS_CAP = 5000
+
+
+def _address_search_conditions(
+    *,
+    q: str | None,
+    hostname: str | None,
+    mac: str | None,
+    status_filter: str | None,
+) -> list[Any]:
+    """Build the shared WHERE conditions for an ``IPAddress`` filter.
+
+    ``q`` is a case-insensitive substring matched across the host form of
+    the address, hostname, FQDN, description and MAC. ``hostname`` / ``mac``
+    are targeted ``ILIKE %..%`` filters. All conditions AND together (and
+    with any tag filter the caller applies separately).
+    """
+    conds: list[Any] = []
     if status_filter:
-        query = query.where(IPAddress.status == status_filter)
-    query = apply_tag_filter(query, IPAddress.tags, tag)
-    rows = list((await db.execute(query)).scalars().all())
+        conds.append(IPAddress.status == status_filter)
+    if hostname:
+        conds.append(IPAddress.hostname.ilike(f"%{hostname}%"))
+    if mac:
+        conds.append(sa_cast(IPAddress.mac_address, String).ilike(f"%{mac}%"))
+    if q:
+        pat = f"%{q}%"
+        conds.append(
+            or_(
+                func.host(IPAddress.address).ilike(pat),
+                IPAddress.hostname.ilike(pat),
+                IPAddress.fqdn.ilike(pat),
+                IPAddress.description.ilike(pat),
+                sa_cast(IPAddress.mac_address, String).ilike(pat),
+            )
+        )
+    return conds
+
+
+def _address_order_by(sort: str | None, order: str) -> list[Any]:
+    """ORDER-BY clause list for the address surfaces.
+
+    Default (``sort`` unset or ``"address"``) preserves the historical
+    ``CAST(address AS inet)`` numeric ordering. Other keys sort on the
+    matching column with a stable inet tiebreak so equal keys page
+    deterministically.
+    """
+    descending = order.lower() == "desc"
+    inet_expr = text("CAST(address AS inet) DESC" if descending else "CAST(address AS inet) ASC")
+    if not sort or sort == "address":
+        return [inet_expr]
+    colmap = {
+        "hostname": IPAddress.hostname,
+        "status": IPAddress.status,
+        "mac": IPAddress.mac_address,
+        "last_seen": IPAddress.last_seen_at,
+        "description": IPAddress.description,
+    }
+    col = colmap[sort]
+    primary = desc(col) if descending else asc(col)
+    return [primary, text("CAST(address AS inet) ASC")]
+
+
+def _validate_sort_order(sort: str | None, order: str) -> None:
+    if sort is not None and sort not in _ADDRESS_SORT_KEYS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"sort must be one of: {', '.join(sorted(_ADDRESS_SORT_KEYS))}",
+        )
+    if order.lower() not in ("asc", "desc"):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="order must be 'asc' or 'desc'",
+        )
+
+
+async def _enrich_addresses(db: AsyncSession, rows: list[IPAddress]) -> None:
+    """Stamp alias / NAT-mapping counts + OUI vendor onto a page of IP rows.
+
+    Mutates the ORM objects in place (the response schema reads the extra
+    attributes via ``from_attributes``). Only ever called on the returned
+    page — never the whole matching set — so the bulk lookups stay cheap.
+    """
     counts = await _alias_counts_for(db, rows)
     nat_counts = await _nat_mapping_counts_for(db, rows)
     vendors = await bulk_lookup_vendors(
@@ -6233,6 +6349,80 @@ async def list_addresses(
         vendor = vendors.get(key) if key else None
         ip.vendor = vendor  # type: ignore[attr-defined]
         ip.is_voip_phone = is_voip_phone_vendor(vendor)  # type: ignore[attr-defined]
+
+
+async def _readable_subnet_ids(
+    db: AsyncSession, user: Any, structural_conds: list[Any]
+) -> list[uuid.UUID] | None:
+    """Resolve which subnets ``user`` may READ, for cross-subnet address search.
+
+    Returns ``None`` for an effective superadmin — "no restriction", the
+    caller should skip the ``IN()`` filter entirely. Otherwise returns the
+    concrete list of subnet ids the caller can read, computed by enumerating
+    the candidate subnets (already narrowed by the structural filters) and
+    running the authoritative per-row :func:`user_has_permission` check
+    (which folds in RBAC + time-bound grants + resource-scoped API-token
+    narrowing, #374). Subnets are orders of magnitude fewer than IPs, so this
+    scales with the structural filter, not the address count — and the
+    resulting id list is pushed back into the SQL ``WHERE`` so pagination /
+    totals are computed post-permission-filter (never a post-limit slice).
+    """
+    if is_effective_superadmin(user):
+        return None
+    q = select(Subnet.id)
+    for cond in structural_conds:
+        q = q.where(cond)
+    candidate_ids = [row[0] for row in (await db.execute(q)).all()]
+    return [sid for sid in candidate_ids if user_has_permission(user, "read", "subnet", sid)]
+
+
+@router.get("/subnets/{subnet_id}/addresses", response_model=list[IPAddressResponse])
+async def list_addresses(
+    subnet_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: DB,
+    response: Response,
+    status_filter: str | None = None,
+    tag: list[str] = Query(default_factory=list),
+    q: str | None = None,
+    hostname: str | None = None,
+    mac: str | None = None,
+    sort: str | None = None,
+    order: str = "asc",
+    limit: int | None = Query(default=None, ge=1),
+    offset: int = Query(default=0, ge=0),
+) -> list[IPAddress]:
+    """List a subnet's IPs.
+
+    Backward compatible: with no filter / sort / paging params this returns
+    the full inet-sorted ``list[IPAddressResponse]`` as before. New optional
+    params (#517) add substring search (``q``), targeted ``hostname`` / ``mac``
+    filters, column ``sort`` + ``order``, and ``limit`` / ``offset`` windowing.
+    ``X-Total-Count`` always carries the total matching rows *before* the
+    limit/offset window (exposed to the browser via CORS ``expose_headers``).
+    """
+    if await db.get(Subnet, subnet_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
+    _enforce_subnet_token_scope(current_user, subnet_id)
+    _validate_sort_order(sort, order)
+
+    base = select(IPAddress).where(IPAddress.subnet_id == subnet_id)
+    for cond in _address_search_conditions(
+        q=q, hostname=hostname, mac=mac, status_filter=status_filter
+    ):
+        base = base.where(cond)
+    base = apply_tag_filter(base, IPAddress.tags, tag)
+
+    total = await db.scalar(select(func.count()).select_from(base.subquery()))
+    response.headers["X-Total-Count"] = str(total or 0)
+
+    query = base.order_by(*_address_order_by(sort, order))
+    if offset:
+        query = query.offset(offset)
+    if limit is not None:
+        query = query.limit(limit)
+    rows = list((await db.execute(query)).scalars().all())
+    await _enrich_addresses(db, rows)
     return rows
 
 
@@ -6383,6 +6573,138 @@ async def create_address(
         "ip_address_created", ip_id=str(ip.id), address=body.address, subnet_id=str(subnet_id)
     )
     return ip
+
+
+def _search_structural_conds(
+    space_id: uuid.UUID | None,
+    block_id: uuid.UUID | None,
+    subnet_id: uuid.UUID | None,
+) -> list[Any]:
+    """Subnet-level WHERE conditions for the cross-subnet search scope narrowers."""
+    conds: list[Any] = []
+    if space_id is not None:
+        conds.append(Subnet.space_id == space_id)
+    if block_id is not None:
+        conds.append(Subnet.block_id == block_id)
+    if subnet_id is not None:
+        conds.append(Subnet.id == subnet_id)
+    return conds
+
+
+# NOTE: ``/addresses/search`` + ``/addresses/search/ids`` are declared BEFORE
+# ``/addresses/{address_id}`` so the literal paths win over the UUID-path
+# route. (Starlette's ``uuid`` path convertor already refuses to match the
+# non-UUID segment ``search``, but keeping the declaration order explicit
+# guards against a future switch to a permissive path type.)
+@router.get("/addresses/search", response_model=AddressSearchResponse)
+async def search_addresses(
+    current_user: CurrentUser,
+    db: DB,
+    q: str | None = None,
+    status_filter: str | None = None,
+    tag: list[str] = Query(default_factory=list),
+    hostname: str | None = None,
+    mac: str | None = None,
+    space_id: uuid.UUID | None = None,
+    block_id: uuid.UUID | None = None,
+    subnet_id: uuid.UUID | None = None,
+    sort: str | None = None,
+    order: str = "asc",
+    limit: int = Query(default=100, ge=1, le=1000),
+    offset: int = Query(default=0, ge=0),
+) -> AddressSearchResponse:
+    """Cross-subnet IP address search (issues #517 #3 / #520).
+
+    Same filter grammar as the per-subnet list plus ``space_id`` /
+    ``block_id`` / ``subnet_id`` scope narrowers. Only returns IPs in subnets
+    the caller may READ — the permission filter is pushed into the SQL
+    (``Subnet.id IN (readable)``) so ``total`` and the limit/offset window are
+    both computed post-permission-filter, never as a slice after the fact.
+    Each item joins the parent subnet CIDR / name + space id / name so the UI
+    can render + group hits without a second round-trip.
+    """
+    _validate_sort_order(sort, order)
+    structural = _search_structural_conds(space_id, block_id, subnet_id)
+    readable = await _readable_subnet_ids(db, current_user, structural)
+
+    def _scoped(stmt: Any) -> Any:
+        stmt = stmt.join(Subnet, Subnet.id == IPAddress.subnet_id).join(
+            IPSpace, IPSpace.id == Subnet.space_id
+        )
+        for cond in structural:
+            stmt = stmt.where(cond)
+        for cond in _address_search_conditions(
+            q=q, hostname=hostname, mac=mac, status_filter=status_filter
+        ):
+            stmt = stmt.where(cond)
+        stmt = apply_tag_filter(stmt, IPAddress.tags, tag)
+        if readable is not None:
+            stmt = stmt.where(Subnet.id.in_(readable))
+        return stmt
+
+    count_stmt = _scoped(select(IPAddress.id))
+    total = await db.scalar(select(func.count()).select_from(count_stmt.subquery())) or 0
+
+    data_stmt = (
+        _scoped(select(IPAddress, Subnet.network, Subnet.name, Subnet.space_id, IPSpace.name))
+        .order_by(*_address_order_by(sort, order))
+        .offset(offset)
+        .limit(limit)
+    )
+    result_rows = (await db.execute(data_stmt)).all()
+    ip_rows = [row[0] for row in result_rows]
+    await _enrich_addresses(db, ip_rows)
+
+    items: list[IPAddressSearchItem] = []
+    for ip, net, sub_name, sp_id, sp_name in result_rows:
+        ip.subnet_cidr = str(net)  # type: ignore[attr-defined]
+        ip.subnet_name = sub_name or None  # type: ignore[attr-defined]
+        ip.space_id = sp_id  # type: ignore[attr-defined]
+        ip.space_name = sp_name or None  # type: ignore[attr-defined]
+        items.append(IPAddressSearchItem.model_validate(ip))
+    return AddressSearchResponse(items=items, total=total, limit=limit, offset=offset)
+
+
+@router.get("/addresses/search/ids", response_model=AddressSearchIdsResponse)
+async def search_address_ids(
+    current_user: CurrentUser,
+    db: DB,
+    q: str | None = None,
+    status_filter: str | None = None,
+    tag: list[str] = Query(default_factory=list),
+    hostname: str | None = None,
+    mac: str | None = None,
+    space_id: uuid.UUID | None = None,
+    block_id: uuid.UUID | None = None,
+    subnet_id: uuid.UUID | None = None,
+) -> AddressSearchIdsResponse:
+    """Id-only companion to ``/addresses/search`` (issue #520).
+
+    Same filters + read-permission scoping, no sort / limit / offset. Returns
+    every matching id up to ``_SEARCH_IDS_CAP`` (``capped=True`` when the true
+    total exceeds the cap). Feeds the "select all matches → bulk-edit /
+    bulk-delete" flow — those bulk endpoints re-check per-IP token scope +
+    write delegation, so this list is a selection convenience, not an
+    authorization bypass.
+    """
+    structural = _search_structural_conds(space_id, block_id, subnet_id)
+    readable = await _readable_subnet_ids(db, current_user, structural)
+
+    stmt = select(IPAddress.id).join(Subnet, Subnet.id == IPAddress.subnet_id)
+    for cond in structural:
+        stmt = stmt.where(cond)
+    for cond in _address_search_conditions(
+        q=q, hostname=hostname, mac=mac, status_filter=status_filter
+    ):
+        stmt = stmt.where(cond)
+    stmt = apply_tag_filter(stmt, IPAddress.tags, tag)
+    if readable is not None:
+        stmt = stmt.where(Subnet.id.in_(readable))
+
+    total = await db.scalar(select(func.count()).select_from(stmt.subquery())) or 0
+    capped_stmt = stmt.order_by(text("CAST(address AS inet) ASC")).limit(_SEARCH_IDS_CAP)
+    ids = [str(row[0]) for row in (await db.execute(capped_stmt)).all()]
+    return AddressSearchIdsResponse(ids=ids, total=total, capped=total > _SEARCH_IDS_CAP)
 
 
 @router.get("/addresses/{address_id}", response_model=IPAddressResponse)

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -9,6 +9,7 @@ celery_app = Celery(
     backend=settings.celery_result_backend,
     include=[
         "app.tasks.ipam_dns_sync",
+        "app.tasks.ipam_utilization_recount",
         "app.tasks.dns",
         "app.tasks.dns_pull",
         "app.tasks.dhcp_health",
@@ -71,6 +72,7 @@ celery_app.conf.update(
     worker_prefetch_multiplier=1,
     task_routes={
         "app.tasks.ipam_dns_sync.*": {"queue": "ipam"},
+        "app.tasks.ipam_utilization_recount.*": {"queue": "ipam"},
         "app.tasks.dns.*": {"queue": "dns"},
         "app.tasks.dns_pull.*": {"queue": "dns"},
         "app.tasks.dhcp_health.*": {"queue": "dhcp"},
@@ -152,6 +154,17 @@ celery_app.conf.update(
         "ipam-dns-auto-sync": {
             "task": "app.tasks.ipam_dns_sync.auto_sync_ipam_dns",
             "schedule": schedule(run_every=60.0),
+        },
+        # Every hour, recount cached IPAM utilization counters
+        # (``Subnet.allocated_ips`` / ``utilization_percent`` + the
+        # recursive ``IPBlock`` rollups) against the live row counts,
+        # correcting drift from the estimate-a-delta code paths (address
+        # importer, bulk integration reconcilers). Issue #521. Idempotent
+        # + always-safe — it only touches derived counters, so there's no
+        # opt-out gate; a converged install writes (and audits) nothing.
+        "ipam-utilization-recount": {
+            "task": "app.tasks.ipam_utilization_recount.recount_ipam_utilization",
+            "schedule": schedule(run_every=3600.0),
         },
         # Every 60 s, dispatch IP-discovery sweeps for subnets whose
         # per-subnet interval has elapsed (issue #23). Per-subnet gating

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -627,6 +627,12 @@ def create_app() -> FastAPI:
         allow_credentials=_cors_origins != ["*"],
         allow_methods=["*"],
         allow_headers=["*"],
+        # Custom response headers the browser must be allowed to read via
+        # fetch(). ``X-Total-Count`` backs server-side pagination on the IPAM
+        # address list + cross-subnet search (issues #517 / #520). Without
+        # this the header is present on the wire but the JS layer can't read
+        # it under CORS.
+        expose_headers=["X-Total-Count"],
     )
 
     # SECURITY (#400 / L3): Host-header allow-list. Added LAST so — given

--- a/backend/app/services/ai/tools/ipam.py
+++ b/backend/app/services/ai/tools/ipam.py
@@ -17,7 +17,7 @@ import uuid
 from typing import Any
 
 from pydantic import BaseModel, Field
-from sqlalchemy import cast, func, literal, or_, select
+from sqlalchemy import String, cast, func, literal, or_, select
 from sqlalchemy.dialects.postgresql import INET
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -651,6 +651,134 @@ async def find_ip(db: AsyncSession, user: User, args: FindIPArgs) -> dict[str, A
             }
         )
     return {"matches": out}
+
+
+# ── find_ip_addresses (cross-subnet search) ───────────────────────────
+
+
+class FindIPAddressesArgs(BaseModel):
+    q: str | None = Field(
+        default=None,
+        description=(
+            "Case-insensitive substring matched across the address, hostname, "
+            "FQDN, description and MAC. Use for open-ended 'find any IP that "
+            "mentions X' questions."
+        ),
+    )
+    hostname: str | None = Field(default=None, description="Substring match on hostname only.")
+    mac: str | None = Field(default=None, description="Substring match on the MAC address.")
+    status: str | None = Field(
+        default=None,
+        description="Exact status filter (e.g. 'allocated', 'reserved', 'static_dhcp', 'orphan').",
+    )
+    space_id: str | None = Field(
+        default=None, description="Restrict to one IP space — UUID or case-insensitive name."
+    )
+    subnet_id: str | None = Field(default=None, description="Restrict to one subnet UUID.")
+    limit: int = Field(default=100, ge=1, le=500, description="Max rows to return (1–500).")
+
+
+@register_tool(
+    name="find_ip_addresses",
+    description=(
+        "Search IP addresses ACROSS every subnet by substring (``q``), "
+        "hostname, MAC or status — the cross-subnet companion to ``find_ip`` "
+        "(which needs an exact address). Returns each hit's address, "
+        "hostname, MAC, status, and which subnet + space it lives in. Use "
+        "for 'find all IPs named web-*', 'which IPs have MAC prefix aa:bb', "
+        "'list reserved IPs in the DMZ space', etc. Only returns IPs in "
+        "subnets you can read."
+    ),
+    args_model=FindIPAddressesArgs,
+    category="ipam",
+)
+async def find_ip_addresses(
+    db: AsyncSession, user: User, args: FindIPAddressesArgs
+) -> dict[str, Any]:
+    from app.core.permissions import (  # noqa: PLC0415 — avoid import cycle
+        is_effective_superadmin,
+        user_has_permission,
+    )
+
+    structural: list[Any] = []
+    if args.space_id:
+        space_uuid = await _resolve_space_ref(db, args.space_id)
+        if space_uuid is None:
+            return {"error": f"no IP space matches {args.space_id!r}."}
+        structural.append(Subnet.space_id == space_uuid)
+    if args.subnet_id:
+        try:
+            structural.append(Subnet.id == uuid.UUID(args.subnet_id))
+        except ValueError:
+            return {"error": f"subnet_id {args.subnet_id!r} is not a valid UUID."}
+
+    # Read-permission scope pushed into SQL so the capped page is drawn from
+    # only the readable set (never a post-limit slice). Superadmin skips it.
+    readable: list[uuid.UUID] | None = None
+    if not is_effective_superadmin(user):
+        idq = select(Subnet.id)
+        for cond in structural:
+            idq = idq.where(cond)
+        cand = [r[0] for r in (await db.execute(idq)).all()]
+        readable = [s for s in cand if user_has_permission(user, "read", "subnet", s)]
+
+    stmt = (
+        select(IPAddress, Subnet.network, Subnet.name, IPSpace.name)
+        .join(Subnet, Subnet.id == IPAddress.subnet_id)
+        .join(IPSpace, IPSpace.id == Subnet.space_id)
+    )
+    for cond in structural:
+        stmt = stmt.where(cond)
+    if args.status:
+        stmt = stmt.where(IPAddress.status == args.status)
+    if args.hostname:
+        stmt = stmt.where(IPAddress.hostname.ilike(f"%{args.hostname}%"))
+    if args.mac:
+        stmt = stmt.where(cast(IPAddress.mac_address, String).ilike(f"%{args.mac}%"))
+    if args.q:
+        pat = f"%{args.q}%"
+        stmt = stmt.where(
+            or_(
+                func.host(IPAddress.address).ilike(pat),
+                IPAddress.hostname.ilike(pat),
+                IPAddress.fqdn.ilike(pat),
+                IPAddress.description.ilike(pat),
+                cast(IPAddress.mac_address, String).ilike(pat),
+            )
+        )
+    if readable is not None:
+        stmt = stmt.where(Subnet.id.in_(readable))
+    stmt = stmt.order_by(IPAddress.address).limit(args.limit)
+
+    rows = (await db.execute(stmt)).all()
+    ip_objs = [r[0] for r in rows]
+    vendors = await bulk_lookup_vendors(
+        db, [str(ip.mac_address) if ip.mac_address else None for ip in ip_objs]
+    )
+    matches: list[dict[str, Any]] = []
+    for ip, net, sub_name, sp_name in rows:
+        mac_key = normalize_mac_key(str(ip.mac_address)) if ip.mac_address else None
+        vendor = vendors.get(mac_key) if mac_key else None
+        matches.append(
+            {
+                "id": str(ip.id),
+                "address": str(ip.address),
+                "hostname": ip.hostname,
+                "fqdn": ip.fqdn,
+                "mac_address": str(ip.mac_address) if ip.mac_address else None,
+                "mac_vendor": vendor,
+                "is_voip_phone": is_voip_phone_vendor(vendor),
+                "status": ip.status,
+                "role": ip.role,
+                "description": ip.description,
+                "subnet_id": str(ip.subnet_id),
+                "subnet_cidr": str(net),
+                "subnet_name": sub_name or None,
+                "space_name": sp_name or None,
+                "tags": ip.tags or {},
+            }
+        )
+    return {"matches": matches, "returned": len(matches), "capped": len(matches) >= args.limit}
 
 
 # ── find_by_tag ───────────────────────────────────────────────────────

--- a/backend/app/services/ipam_io/importer.py
+++ b/backend/app/services/ipam_io/importer.py
@@ -1020,9 +1020,12 @@ async def commit_address_import(
             "the subnet or any address set you can write — nothing was imported."
         )
 
-    # Keep the subnet's utilization counters roughly honest. The periodic
-    # allocation-recount task corrects drift, but users expect the UI to
-    # reflect the new row count immediately.
+    # Keep the subnet's utilization counters roughly honest by applying the
+    # net delta here — users expect the UI to reflect the new row count
+    # immediately. This is an estimate (a re-imported existing row bumps the
+    # delta but not the true count); the hourly
+    # ``app.tasks.ipam_utilization_recount.recount_ipam_utilization`` sweep
+    # reconciles any resulting drift against the live row count.
     if allocated_delta:
         subnet.allocated_ips = (subnet.allocated_ips or 0) + allocated_delta
         if subnet.total_ips:

--- a/backend/app/tasks/dhcp_lease_cleanup.py
+++ b/backend/app/tasks/dhcp_lease_cleanup.py
@@ -41,7 +41,34 @@ EXPIRY_GRACE = timedelta(minutes=5)
 EXPIRED_DELETE_GRACE = timedelta(hours=24)
 
 
-async def _resolve_lease_subnet_id(db: AsyncSession, lease: DHCPLease) -> uuid.UUID | None:
+async def _load_subnet_cache(
+    db: AsyncSession,
+) -> list[tuple[uuid.UUID, ipaddress.IPv4Network | ipaddress.IPv6Network]]:
+    """Load ``(subnet_id, parsed_network)`` for every subnet ONCE per sweep.
+
+    ``_resolve_lease_subnet_id`` used to run a full ``SELECT id, network
+    FROM subnet`` for every stale lease when it lacked a scope backlink —
+    O(stale_leases × subnets) round-trips + reparse per lease. Loading the
+    list once (and pre-parsing each CIDR) keeps the longest-prefix fallback
+    at a single query per sweep, mirroring the pull-leases path. Unparseable
+    networks are dropped up front so the per-lease loop stays clean.
+    """
+    cache: list[tuple[uuid.UUID, ipaddress.IPv4Network | ipaddress.IPv6Network]] = []
+    for sid, network in (await db.execute(select(Subnet.id, Subnet.network))).all():
+        try:
+            cache.append((sid, ipaddress.ip_network(str(network), strict=False)))
+        except (ValueError, TypeError):
+            continue
+    return cache
+
+
+async def _resolve_lease_subnet_id(
+    db: AsyncSession,
+    lease: DHCPLease,
+    subnet_cache: (
+        list[tuple[uuid.UUID, ipaddress.IPv4Network | ipaddress.IPv6Network]] | None
+    ) = None,
+) -> uuid.UUID | None:
     """Find the IPAM subnet that owns this lease's address.
 
     SpatiumDDI allows overlapping private ranges across IPSpaces/VRFs, so
@@ -49,7 +76,9 @@ async def _resolve_lease_subnet_id(db: AsyncSession, lease: DHCPLease) -> uuid.U
     mirror in multiple subnets. Scope the mirror cleanup to the lease's
     own subnet so expiring one subnet's lease can't drop another's
     mirror. Prefer the lease's scope FK (DHCPScope.subnet_id); fall back
-    to longest-prefix match when the lease has no scope backlink.
+    to longest-prefix match over ``subnet_cache`` when the lease has no
+    scope backlink. The sweep passes a cache loaded ONCE per run; the
+    single-lease delete path leaves it None and we load it on demand.
     """
     if lease.scope_id is not None:
         subnet_id = (
@@ -62,12 +91,10 @@ async def _resolve_lease_subnet_id(db: AsyncSession, lease: DHCPLease) -> uuid.U
         addr = ipaddress.ip_address(str(lease.ip_address))
     except (ValueError, TypeError):
         return None
+    if subnet_cache is None:
+        subnet_cache = await _load_subnet_cache(db)
     best: tuple[int, uuid.UUID] | None = None
-    for sid, network in (await db.execute(select(Subnet.id, Subnet.network))).all():
-        try:
-            net = ipaddress.ip_network(str(network), strict=False)
-        except (ValueError, TypeError):
-            continue
+    for sid, net in subnet_cache:
         if addr in net and (best is None or net.prefixlen > best[0]):
             best = (net.prefixlen, sid)
     return best[1] if best else None
@@ -91,6 +118,9 @@ async def _sweep() -> tuple[int, int]:
         from app.services.dns.ddns import revoke_ddns_for_lease  # noqa: PLC0415
 
         now_ts = datetime.now(UTC)
+        # Load the subnet list once for the longest-prefix fallback in
+        # _resolve_lease_subnet_id instead of re-querying per stale lease.
+        subnet_cache = await _load_subnet_cache(db)
         for lease in res.scalars().all():
             # Stamp lease history before flipping state. ``expired`` is
             # the time-based sweep label (vs ``removed`` from the
@@ -101,7 +131,7 @@ async def _sweep() -> tuple[int, int]:
             # Remove the mirrored IPAM row if auto_from_lease — but only
             # within this lease's owning subnet. An address-only lookup
             # would delete same-address mirrors in other subnets too.
-            subnet_id = await _resolve_lease_subnet_id(db, lease)
+            subnet_id = await _resolve_lease_subnet_id(db, lease, subnet_cache)
             if subnet_id is None:
                 continue
             ipam_res = await db.execute(

--- a/backend/app/tasks/ipam_dns_sync.py
+++ b/backend/app/tasks/ipam_dns_sync.py
@@ -23,7 +23,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.celery_app import celery_app
@@ -36,6 +36,68 @@ from app.models.settings import PlatformSettings
 logger = structlog.get_logger(__name__)
 
 _SINGLETON_ID = 1
+
+# Pre-filter (issue #522): only subnets that could resolve an effective DNS
+# zone/group — or fire DDNS — do any work inside ``compute_subnet_dns_drift``
+# / the DDNS re-apply. Walking every subnet ran the (multi-query) drift
+# computation for subnets with no DNS binding anywhere in their inheritance
+# chain, which is the common case on integration-mirrored / lab spaces.
+#
+# This returns a deliberate SUPERSET of the truly-eligible set — including a
+# subnet that turns out to resolve no zone is behaviour-preserving (the drift
+# computation early-returns empty for it, exactly as before); EXCLUDING one
+# that would resolve a zone would change behaviour, so we never do that. A
+# subnet is a candidate when ANY of these carries a binding:
+#   * the subnet's own dns_zone_id / dns_group_ids / dns_additional_zone_ids,
+#     or ddns_enabled;
+#   * any ancestor block (or the subnet's own block) carries one — captured
+#     via the recursive descendant walk from every DNS/DDNS-bearing block;
+#   * the containing IPSpace carries one;
+#   * a reverse DNSZone is linked to the subnet.
+# The inherit flags are intentionally ignored here (over-inclusion is safe);
+# ``_resolve_effective_dns`` / ``resolve_effective_ddns`` remain the source of
+# truth for what a candidate actually publishes.
+_CANDIDATE_SUBNET_SQL = text("""
+    WITH RECURSIVE dns_block AS (
+        SELECT id FROM ip_block
+        WHERE deleted_at IS NULL
+          AND (
+            dns_zone_id IS NOT NULL
+            OR (dns_group_ids IS NOT NULL AND dns_group_ids <> '[]'::jsonb)
+            OR (dns_additional_zone_ids IS NOT NULL
+                AND dns_additional_zone_ids <> '[]'::jsonb)
+            OR ddns_enabled = true
+          )
+    ),
+    dns_block_subtree AS (
+        SELECT id FROM dns_block
+        UNION
+        SELECT b.id FROM ip_block b
+            JOIN dns_block_subtree t ON b.parent_block_id = t.id
+        WHERE b.deleted_at IS NULL
+    )
+    SELECT s.id
+    FROM subnet s
+    JOIN ip_space sp ON sp.id = s.space_id
+    WHERE s.deleted_at IS NULL
+      AND (
+        s.block_id IN (SELECT id FROM dns_block_subtree)
+        OR s.dns_zone_id IS NOT NULL
+        OR (s.dns_group_ids IS NOT NULL AND s.dns_group_ids <> '[]'::jsonb)
+        OR (s.dns_additional_zone_ids IS NOT NULL
+            AND s.dns_additional_zone_ids <> '[]'::jsonb)
+        OR s.ddns_enabled = true
+        OR sp.dns_zone_id IS NOT NULL
+        OR (sp.dns_group_ids IS NOT NULL AND sp.dns_group_ids <> '[]'::jsonb)
+        OR (sp.dns_additional_zone_ids IS NOT NULL
+            AND sp.dns_additional_zone_ids <> '[]'::jsonb)
+        OR sp.ddns_enabled = true
+        OR EXISTS (
+            SELECT 1 FROM dns_zone z
+            WHERE z.linked_subnet_id = s.id AND z.kind = 'reverse'
+        )
+      )
+""")
 
 
 async def _auto_from_lease_ip_ids(db: Any, subnet_id: Any) -> set[Any]:
@@ -119,7 +181,9 @@ async def _run_auto_sync() -> dict[str, Any]:
                         "wait_seconds": int((interval - elapsed).total_seconds()),
                     }
 
-            subnets = list((await db.execute(select(Subnet.id))).scalars().all())
+            # Only subnets with some DNS/DDNS binding do work (issue #522) —
+            # skip the drift computation for the (common) no-binding majority.
+            subnets = list((await db.execute(_CANDIDATE_SUBNET_SQL)).scalars().all())
 
             total_created = 0
             total_updated = 0

--- a/backend/app/tasks/ipam_utilization_recount.py
+++ b/backend/app/tasks/ipam_utilization_recount.py
@@ -1,0 +1,233 @@
+"""Periodic IPAM utilization recount sweep (issue #521).
+
+Recomputes ``Subnet.allocated_ips`` + ``utilization_percent`` for every
+non-deleted subnet, and the recursive ``allocated_ips`` / ``total_ips`` /
+``utilization_percent`` rollups on ``IPBlock``, correcting any drift that
+crept into the cached counters. Drift accumulates from the handful of code
+paths that adjust a counter by an estimated delta rather than a fresh count
+— the CSV/XLSX address importer bumps ``subnet.allocated_ips`` by a
+computed delta, bulk integration reconcilers insert rows in bulk, and any
+partial-failure path that mutates a row but not the cache leaves the two
+out of step.
+
+Idempotent + cheap by design:
+
+  * ONE grouped ``COUNT(*) WHERE status != 'available'`` over
+    ``ip_address`` (grouped by subnet_id) — NOT a per-subnet ORM loop, so
+    it scales to 10k+ subnets on a single round-trip.
+  * A single in-memory pass over the block tree for the recursive rollup
+    (mirrors ``_update_block_utilization`` in the IPAM router — full-CIDR
+    denominator, BIGINT-clamped ``total_ips``, ``deleted_at IS NULL``
+    guards on both blocks and subnets).
+  * Only rows whose cached value actually drifted are written, so a
+    converged install commits nothing and writes no audit row.
+
+Always safe to run — it never touches semantic state, only derived
+counters — so there's no platform-settings gate; the beat entry fires it
+hourly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.celery_app import celery_app
+from app.db import task_session
+from app.models.audit import AuditLog
+
+logger = structlog.get_logger(__name__)
+
+_SINGLETON_ID = 1
+# Mirror of ``_BIGINT_MAX`` in the IPAM router — the ``total_ips`` columns
+# are BIGINT, so a huge IPv6 block (e.g. a /48) is clamped rather than
+# overflowing.
+_BIGINT_MAX = 2**63 - 1
+
+
+def _num_addresses(network: Any) -> int:
+    """Full CIDR size for a block/subnet network value (asyncpg returns an
+    ``ip_network`` object for CIDR columns; ``str()`` handles both that and
+    a plain string)."""
+    return int(ipaddress.ip_network(str(network), strict=False).num_addresses)
+
+
+async def _recount_subnets(db: AsyncSession) -> int:
+    """Recompute per-subnet ``allocated_ips`` + ``utilization_percent``.
+
+    Returns the number of subnet rows whose cached values drifted and were
+    corrected. Writes only the changed rows.
+    """
+    # One grouped count over the whole address table (ip_address has no
+    # soft-delete column, so every row counts; the subnet-side deleted_at
+    # guard is applied when we select the target rows below).
+    counts: dict[str, int] = {}
+    for sid, cnt in (
+        await db.execute(
+            text(
+                "SELECT subnet_id, COUNT(*) FROM ip_address "
+                "WHERE status != 'available' GROUP BY subnet_id"
+            )
+        )
+    ).all():
+        counts[str(sid)] = int(cnt)
+
+    changes: list[dict[str, Any]] = []
+    for sid, total_ips, allocated_ips, util in (
+        await db.execute(
+            text(
+                "SELECT id, total_ips, allocated_ips, utilization_percent "
+                "FROM subnet WHERE deleted_at IS NULL"
+            )
+        )
+    ).all():
+        new_alloc = counts.get(str(sid), 0)
+        new_util = round(new_alloc / total_ips * 100, 2) if total_ips and total_ips > 0 else 0.0
+        if new_alloc != int(allocated_ips) or abs(new_util - float(util)) > 0.001:
+            changes.append({"id": str(sid), "a": new_alloc, "u": new_util})
+
+    if changes:
+        await db.execute(
+            text(
+                "UPDATE subnet SET allocated_ips = :a, utilization_percent = :u "
+                "WHERE id = CAST(:id AS uuid)"
+            ),
+            changes,
+        )
+    return len(changes)
+
+
+async def _recount_blocks(db: AsyncSession) -> int:
+    """Recompute the recursive ``allocated_ips`` / ``total_ips`` /
+    ``utilization_percent`` rollups on every non-deleted block.
+
+    Reads the (already-corrected) per-subnet ``allocated_ips`` and rolls it
+    up the block tree in a single in-memory pass. Returns the number of
+    block rows corrected.
+    """
+    block_rows = (
+        await db.execute(
+            text(
+                "SELECT id, parent_block_id, network, allocated_ips, total_ips, "
+                "utilization_percent FROM ip_block WHERE deleted_at IS NULL"
+            )
+        )
+    ).all()
+    if not block_rows:
+        return 0
+
+    parent: dict[str, str | None] = {}
+    current: dict[str, tuple[int, int, float]] = {}
+    networks: dict[str, Any] = {}
+    for bid, pbid, network, allocated_ips, total_ips, util in block_rows:
+        key = str(bid)
+        parent[key] = str(pbid) if pbid is not None else None
+        current[key] = (int(allocated_ips), int(total_ips), float(util))
+        networks[key] = network
+
+    # Direct allocation per block = sum of its own subnets' allocated_ips
+    # (non-deleted subnets only), matching the router's recursive CTE which
+    # guards ``s.deleted_at IS NULL``.
+    subtree: dict[str, int] = {key: 0 for key in current}
+    for bid, direct in (
+        await db.execute(
+            text(
+                "SELECT block_id, COALESCE(SUM(allocated_ips), 0) FROM subnet "
+                "WHERE deleted_at IS NULL GROUP BY block_id"
+            )
+        )
+    ).all():
+        key = str(bid)
+        if key in subtree:  # a subnet under a soft-deleted block is ignored
+            subtree[key] = int(direct)
+
+    # Roll child sums up into parents. Process deepest-first so each block's
+    # subtree is fully accumulated before it contributes to its parent. A
+    # block whose parent is soft-deleted (parent not in the map) stops
+    # there — the router's CTE likewise never crosses a deleted ancestor.
+    def _depth(key: str) -> int:
+        d = 0
+        cur = parent.get(key)
+        guard = 0
+        while cur is not None and cur in subtree and guard < 100000:
+            d += 1
+            cur = parent.get(cur)
+            guard += 1
+        return d
+
+    for key in sorted(subtree, key=_depth, reverse=True):
+        pkey = parent.get(key)
+        if pkey is not None and pkey in subtree:
+            subtree[pkey] += subtree[key]
+
+    changes: list[dict[str, Any]] = []
+    for key, (old_alloc, old_total, old_util) in current.items():
+        alloc = subtree[key]
+        block_total = _num_addresses(networks[key])
+        new_total = min(block_total, _BIGINT_MAX)
+        new_util = round(alloc / block_total * 100, 2) if block_total > 0 else 0.0
+        if alloc != old_alloc or new_total != old_total or abs(new_util - old_util) > 0.001:
+            changes.append({"id": key, "a": alloc, "t": new_total, "u": new_util})
+
+    if changes:
+        await db.execute(
+            text(
+                "UPDATE ip_block SET allocated_ips = :a, total_ips = :t, "
+                "utilization_percent = :u WHERE id = CAST(:id AS uuid)"
+            ),
+            changes,
+        )
+    return len(changes)
+
+
+async def recount_utilization(db: AsyncSession) -> dict[str, int]:
+    """Core recount pass against an open session. Subnets first (blocks read
+    the corrected per-subnet counts), then the block rollup, then a single
+    audit row when anything drifted. Does NOT commit — the caller owns the
+    transaction boundary."""
+    subnets_corrected = await _recount_subnets(db)
+    blocks_corrected = await _recount_blocks(db)
+
+    if subnets_corrected or blocks_corrected:
+        db.add(
+            AuditLog(
+                user_display_name="<system>",
+                auth_source="system",
+                action="ipam-utilization-recount",
+                resource_type="platform",
+                resource_id=str(_SINGLETON_ID),
+                resource_display="utilization-recount",
+                result="success",
+                new_value={
+                    "subnets_corrected": subnets_corrected,
+                    "blocks_corrected": blocks_corrected,
+                },
+            )
+        )
+    return {"subnets_corrected": subnets_corrected, "blocks_corrected": blocks_corrected}
+
+
+async def _run_recount() -> dict[str, int]:
+    async with task_session() as db:
+        result = await recount_utilization(db)
+        await db.commit()
+        return result
+
+
+@celery_app.task(name="app.tasks.ipam_utilization_recount.recount_ipam_utilization")
+def recount_ipam_utilization() -> dict[str, int]:
+    """Celery beat entrypoint — fires hourly. Idempotent: corrects cached
+    subnet/block utilization counters that drifted from the live row counts,
+    writing (and auditing) only what changed."""
+    result = asyncio.run(_run_recount())
+    logger.info(
+        "ipam_utilization_recount_completed",
+        subnets_corrected=result["subnets_corrected"],
+        blocks_corrected=result["blocks_corrected"],
+    )
+    return result

--- a/backend/tests/test_ipam_address_search.py
+++ b/backend/tests/test_ipam_address_search.py
@@ -1,0 +1,325 @@
+"""HTTP-level tests for the IPAM address search / pagination surfaces.
+
+Covers issues #517 (per-subnet address pagination + search + X-Total-Count)
+and #520 (cross-subnet ``/addresses/search`` + ``/addresses/search/ids``,
+including read-permission scoping).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import Group, Role, User
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+
+async def _user(
+    db: AsyncSession,
+    *,
+    name: str = "u",
+    permissions: list[dict] | None = None,
+    superadmin: bool = False,
+) -> tuple[User, str]:
+    user = User(
+        username=f"{name}-{uuid.uuid4().hex[:8]}",
+        email=f"{name}-{uuid.uuid4().hex[:8]}@t.io",
+        display_name=name,
+        hashed_password=hash_password("password123"),
+        is_superadmin=superadmin,
+    )
+    user.groups = []
+    if permissions:
+        role = Role(name=f"role-{uuid.uuid4().hex[:8]}", permissions=permissions)
+        group = Group(name=f"grp-{uuid.uuid4().hex[:8]}")
+        group.roles = [role]
+        user.groups = [group]
+        db.add_all([role, group])
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _subnet(
+    db: AsyncSession,
+    *,
+    network: str = "10.0.5.0/24",
+    block_net: str = "10.0.0.0/16",
+    name: str = "s",
+) -> Subnet:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=block_net, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=network, name=name)
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _ip(
+    db: AsyncSession,
+    subnet: Subnet,
+    address: str,
+    *,
+    hostname: str | None = None,
+    status: str = "allocated",
+) -> IPAddress:
+    row = IPAddress(subnet_id=subnet.id, address=address, hostname=hostname, status=status)
+    db.add(row)
+    await db.flush()
+    return row
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── 517: per-subnet list pagination + header ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_addresses_pagination_and_total_header(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _user(db_session, superadmin=True)
+    subnet = await _subnet(db_session)
+    for i in range(1, 6):
+        await _ip(db_session, subnet, f"10.0.5.{i}", hostname=f"host-{i}")
+
+    res = await client.get(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses?limit=2&offset=0",
+        headers=_auth(token),
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert len(body) == 2
+    assert res.headers["X-Total-Count"] == "5"
+    # Default order = ascending inet.
+    assert body[0]["address"] == "10.0.5.1"
+    assert body[1]["address"] == "10.0.5.2"
+
+    # Second page.
+    res2 = await client.get(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses?limit=2&offset=2",
+        headers=_auth(token),
+    )
+    assert [r["address"] for r in res2.json()] == ["10.0.5.3", "10.0.5.4"]
+    assert res2.headers["X-Total-Count"] == "5"
+
+
+@pytest.mark.asyncio
+async def test_list_addresses_backward_compatible_no_params(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _user(db_session, superadmin=True)
+    subnet = await _subnet(db_session)
+    for i in range(1, 4):
+        await _ip(db_session, subnet, f"10.0.5.{i}")
+
+    res = await client.get(f"/api/v1/ipam/subnets/{subnet.id}/addresses", headers=_auth(token))
+    assert res.status_code == 200
+    body = res.json()
+    assert isinstance(body, list)
+    assert len(body) == 3  # full unsliced list
+    assert res.headers["X-Total-Count"] == "3"
+
+
+@pytest.mark.asyncio
+async def test_list_addresses_q_filter(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _user(db_session, superadmin=True)
+    subnet = await _subnet(db_session)
+    await _ip(db_session, subnet, "10.0.5.1", hostname="web-prod")
+    await _ip(db_session, subnet, "10.0.5.2", hostname="db-prod")
+    await _ip(db_session, subnet, "10.0.5.3", hostname="web-stage")
+
+    res = await client.get(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses?q=web", headers=_auth(token)
+    )
+    assert res.status_code == 200
+    hosts = sorted(r["hostname"] for r in res.json())
+    assert hosts == ["web-prod", "web-stage"]
+    assert res.headers["X-Total-Count"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_list_addresses_sort_desc(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _user(db_session, superadmin=True)
+    subnet = await _subnet(db_session)
+    await _ip(db_session, subnet, "10.0.5.1", hostname="alpha")
+    await _ip(db_session, subnet, "10.0.5.2", hostname="charlie")
+    await _ip(db_session, subnet, "10.0.5.3", hostname="bravo")
+
+    res = await client.get(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses?sort=hostname&order=desc",
+        headers=_auth(token),
+    )
+    assert res.status_code == 200
+    assert [r["hostname"] for r in res.json()] == ["charlie", "bravo", "alpha"]
+
+
+@pytest.mark.asyncio
+async def test_list_addresses_bad_sort_422(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _user(db_session, superadmin=True)
+    subnet = await _subnet(db_session)
+    res = await client.get(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses?sort=bogus", headers=_auth(token)
+    )
+    assert res.status_code == 422
+
+
+# ── 520: cross-subnet search envelope ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_envelope_and_joined_fields(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _user(db_session, superadmin=True)
+    subnet = await _subnet(db_session, network="10.9.0.0/24", name="mynet")
+    await _ip(db_session, subnet, "10.9.0.5", hostname="needle-1")
+
+    res = await client.get("/api/v1/ipam/addresses/search?q=needle", headers=_auth(token))
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert set(body.keys()) == {"items", "total", "limit", "offset"}
+    assert body["total"] == 1
+    assert body["limit"] == 100
+    assert body["offset"] == 0
+    item = body["items"][0]
+    assert item["hostname"] == "needle-1"
+    assert item["subnet_cidr"] == "10.9.0.0/24"
+    assert item["subnet_name"] == "mynet"
+    assert item["space_id"] == str(subnet.space_id)
+    assert item["space_name"] is not None
+
+
+@pytest.mark.asyncio
+async def test_search_spans_multiple_subnets(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _user(db_session, superadmin=True)
+    s1 = await _subnet(db_session, network="10.1.0.0/24", block_net="10.1.0.0/16")
+    s2 = await _subnet(db_session, network="10.2.0.0/24", block_net="10.2.0.0/16")
+    await _ip(db_session, s1, "10.1.0.5", hostname="shared-a")
+    await _ip(db_session, s2, "10.2.0.5", hostname="shared-b")
+
+    res = await client.get("/api/v1/ipam/addresses/search?q=shared", headers=_auth(token))
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 2
+    subnet_ids = {i["subnet_id"] for i in body["items"]}
+    assert subnet_ids == {str(s1.id), str(s2.id)}
+
+
+@pytest.mark.asyncio
+async def test_search_space_filter(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _user(db_session, superadmin=True)
+    s1 = await _subnet(db_session, network="10.3.0.0/24", block_net="10.3.0.0/16")
+    s2 = await _subnet(db_session, network="10.4.0.0/24", block_net="10.4.0.0/16")
+    await _ip(db_session, s1, "10.3.0.5", hostname="x")
+    await _ip(db_session, s2, "10.4.0.5", hostname="x")
+
+    res = await client.get(
+        f"/api/v1/ipam/addresses/search?space_id={s1.space_id}", headers=_auth(token)
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 1
+    assert body["items"][0]["subnet_id"] == str(s1.id)
+
+
+# ── 520: permission scoping ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_read_permission_scoping(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A user readable on only subnet1 must not see subnet2's IPs."""
+    s1 = await _subnet(db_session, network="10.5.0.0/24", block_net="10.5.0.0/16")
+    s2 = await _subnet(db_session, network="10.6.0.0/24", block_net="10.6.0.0/16")
+    await _ip(db_session, s1, "10.5.0.5", hostname="visible")
+    await _ip(db_session, s2, "10.6.0.5", hostname="hidden")
+
+    # read:ip_address (type-level) clears the coarse router gate; read:subnet is
+    # scoped to s1 only, so _readable_subnet_ids should exclude s2.
+    _, token = await _user(
+        db_session,
+        permissions=[
+            {"action": "read", "resource_type": "ip_address"},
+            {"action": "read", "resource_type": "subnet", "resource_id": str(s1.id)},
+        ],
+    )
+
+    res = await client.get("/api/v1/ipam/addresses/search", headers=_auth(token))
+    assert res.status_code == 200, res.text
+    body = res.json()
+    hosts = {i["hostname"] for i in body["items"]}
+    assert hosts == {"visible"}
+    assert body["total"] == 1
+
+
+# ── 520: id-only endpoint + cap ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_ids_envelope(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _user(db_session, superadmin=True)
+    subnet = await _subnet(db_session, network="10.7.0.0/24", block_net="10.7.0.0/16")
+    ip_a = await _ip(db_session, subnet, "10.7.0.1", hostname="pick")
+    ip_b = await _ip(db_session, subnet, "10.7.0.2", hostname="pick")
+    await _ip(db_session, subnet, "10.7.0.3", hostname="skip")
+
+    res = await client.get("/api/v1/ipam/addresses/search/ids?q=pick", headers=_auth(token))
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert set(body.keys()) == {"ids", "total", "capped"}
+    assert body["total"] == 2
+    assert body["capped"] is False
+    assert set(body["ids"]) == {str(ip_a.id), str(ip_b.id)}
+
+
+@pytest.mark.asyncio
+async def test_search_ids_cap(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.api.v1.ipam import router as ipam_router
+
+    monkeypatch.setattr(ipam_router, "_SEARCH_IDS_CAP", 2)
+    _, token = await _user(db_session, superadmin=True)
+    subnet = await _subnet(db_session, network="10.8.0.0/24", block_net="10.8.0.0/16")
+    for i in range(1, 4):  # 3 matching rows, cap 2
+        await _ip(db_session, subnet, f"10.8.0.{i}", hostname="capme")
+
+    res = await client.get("/api/v1/ipam/addresses/search/ids?q=capme", headers=_auth(token))
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 3
+    assert body["capped"] is True
+    assert len(body["ids"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_search_ids_permission_scoping(client: AsyncClient, db_session: AsyncSession) -> None:
+    s1 = await _subnet(db_session, network="10.10.0.0/24", block_net="10.10.0.0/16")
+    s2 = await _subnet(db_session, network="10.11.0.0/24", block_net="10.11.0.0/16")
+    keep = await _ip(db_session, s1, "10.10.0.5", hostname="both")
+    await _ip(db_session, s2, "10.11.0.5", hostname="both")
+
+    _, token = await _user(
+        db_session,
+        permissions=[
+            {"action": "read", "resource_type": "ip_address"},
+            {"action": "read", "resource_type": "subnet", "resource_id": str(s1.id)},
+        ],
+    )
+    res = await client.get("/api/v1/ipam/addresses/search/ids?q=both", headers=_auth(token))
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ids"] == [str(keep.id)]
+    assert body["total"] == 1

--- a/backend/tests/test_ipam_utilization_recount.py
+++ b/backend/tests/test_ipam_utilization_recount.py
@@ -1,0 +1,95 @@
+"""IPAM utilization recount sweep (issue #521).
+
+The hourly ``recount_ipam_utilization`` task recomputes cached
+``Subnet.allocated_ips`` / ``utilization_percent`` from the live row counts
+and rolls the totals up the ``IPBlock`` tree, correcting drift left by the
+estimate-a-delta code paths (the address importer, bulk reconcilers).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import AuditLog
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.tasks.ipam_utilization_recount import recount_utilization
+
+
+async def _seed(db: AsyncSession) -> tuple[Subnet, IPBlock, IPBlock]:
+    """A /16 parent block → /24 child block → /24 subnet with 3 allocated +
+    1 available address, and deliberately-wrong cached counters."""
+    space = IPSpace(name=f"util-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+
+    parent = IPBlock(space_id=space.id, network="10.50.0.0/16", name="parent")
+    db.add(parent)
+    await db.flush()
+    child = IPBlock(
+        space_id=space.id, network="10.50.0.0/24", name="child", parent_block_id=parent.id
+    )
+    db.add(child)
+    await db.flush()
+
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=child.id,
+        network="10.50.0.0/24",
+        name="s",
+        # Deliberately-wrong cache to prove the recount corrects it.
+        total_ips=254,
+        allocated_ips=999,
+        utilization_percent=99.9,
+    )
+    db.add(subnet)
+    await db.flush()
+
+    for i, st in enumerate(("allocated", "allocated", "reserved", "available")):
+        db.add(IPAddress(subnet_id=subnet.id, address=f"10.50.0.{10 + i}", status=st))
+    await db.flush()
+    return subnet, child, parent
+
+
+async def test_recount_corrects_subnet_and_block_rollup(db_session: AsyncSession) -> None:
+    subnet, child, parent = await _seed(db_session)
+
+    result = await recount_utilization(db_session)
+
+    assert result == {"subnets_corrected": 1, "blocks_corrected": 2}
+
+    # 3 non-available addresses (2 allocated + 1 reserved); .13 is available.
+    await db_session.refresh(subnet)
+    assert subnet.allocated_ips == 3
+    assert subnet.utilization_percent == round(3 / 254 * 100, 2)
+
+    # Child /24 rollup: full-CIDR denominator (256), BIGINT-clamped total.
+    await db_session.refresh(child)
+    assert child.allocated_ips == 3
+    assert child.total_ips == 256
+    assert child.utilization_percent == round(3 / 256 * 100, 2)
+
+    # Parent /16 recursively includes the child's subnet allocation.
+    await db_session.refresh(parent)
+    assert parent.allocated_ips == 3
+    assert parent.total_ips == 65536
+    assert parent.utilization_percent == round(3 / 65536 * 100, 2)
+
+    # A single audit row records the correction.
+    audit = (await db_session.execute(AuditLog.__table__.select())).mappings().all()
+    recount_rows = [a for a in audit if a["action"] == "ipam-utilization-recount"]
+    assert len(recount_rows) == 1
+    assert recount_rows[0]["new_value"]["subnets_corrected"] == 1
+    assert recount_rows[0]["new_value"]["blocks_corrected"] == 2
+
+
+async def test_recount_is_idempotent(db_session: AsyncSession) -> None:
+    await _seed(db_session)
+
+    first = await recount_utilization(db_session)
+    assert first["subnets_corrected"] == 1
+
+    # A converged install writes nothing on the second pass.
+    second = await recount_utilization(db_session)
+    assert second == {"subnets_corrected": 0, "blocks_corrected": 0}

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribe to a CSS media query and re-render on match changes.
+ *
+ * Used to render either the mobile card list OR the desktop table in
+ * IPAM — never both — so a busy subnet doesn't mount two full copies of
+ * every row (one CSS-hidden). Returns ``false`` during SSR / before the
+ * first effect runs; the app is a client-only SPA so that first paint is
+ * effectively immediate.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -782,6 +782,64 @@ export interface IPAddress {
   modified_at?: string;
 }
 
+/** A cross-subnet search hit (issue #520). Extends {@link IPAddress}
+ *  with the joined subnet + space identity so the UI can render + group
+ *  results that span many subnets. Returned by ``GET
+ *  /ipam/addresses/search``. */
+export interface IPAddressSearchItem extends IPAddress {
+  subnet_cidr: string;
+  subnet_name: string | null;
+  space_id: string;
+  space_name: string | null;
+}
+
+/** Envelope for ``GET /ipam/addresses/search`` (issue #520). */
+export interface AddressSearchResponse {
+  items: IPAddressSearchItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/** Envelope for ``GET /ipam/addresses/search/ids`` — used by the
+ *  "select all N matches" cross-subnet bulk flow. ``ids`` is capped at
+ *  5000 server-side; ``capped`` is true when ``total`` exceeded that. */
+export interface AddressSearchIdsResponse {
+  ids: string[];
+  total: number;
+  capped: boolean;
+}
+
+/** Optional query params for the per-subnet address list + the
+ *  cross-subnet search (issue #517 / #519 / #520). All fields are
+ *  optional; an empty object reproduces the legacy full-list behavior. */
+export interface AddressQueryParams {
+  q?: string;
+  hostname?: string;
+  mac?: string;
+  status_filter?: string;
+  /** Repeatable ``k:v`` tag filters. */
+  tag?: string[];
+  sort?:
+    | "address"
+    | "hostname"
+    | "status"
+    | "mac"
+    | "last_seen"
+    | "description";
+  order?: "asc" | "desc";
+  limit?: number;
+  offset?: number;
+}
+
+/** Cross-subnet search params — {@link AddressQueryParams} plus the
+ *  scope narrowers. */
+export interface AddressSearchParams extends AddressQueryParams {
+  space_id?: string;
+  block_id?: string;
+  subnet_id?: string;
+}
+
 /** Joined view of the ``dhcp_fingerprint`` row (passive-layer Phase 2)
  *  that matches an IP's MAC. Surfaced in the IP detail modal's "Device
  *  profile" section under a "Raw signature" disclosure. */
@@ -1634,9 +1692,39 @@ export const ipamApi = {
       )
       .then((r) => r.data),
 
-  listAddresses: (subnetId: string) =>
+  listAddresses: (subnetId: string, params?: AddressQueryParams) =>
     api
-      .get<IPAddress[]>(`/ipam/subnets/${subnetId}/addresses`)
+      .get<IPAddress[]>(`/ipam/subnets/${subnetId}/addresses`, {
+        params,
+      })
+      .then((r) => r.data),
+  /** Same as {@link listAddresses} but also returns the ``X-Total-Count``
+   *  header (total matching rows BEFORE limit/offset) so the UI can
+   *  paginate server-side. axios's ``.then(r => r.data)`` drops headers,
+   *  so this variant reads the header explicitly. */
+  listAddressesPaged: (
+    subnetId: string,
+    params?: AddressQueryParams,
+  ): Promise<{ items: IPAddress[]; total: number }> =>
+    api
+      .get<IPAddress[]>(`/ipam/subnets/${subnetId}/addresses`, { params })
+      .then((r) => ({
+        items: r.data,
+        total: Number(r.headers["x-total-count"] ?? r.data.length),
+      })),
+  /** Cross-subnet IP search (issue #520). Results are permission-scoped
+   *  server-side — only IPs in subnets the caller can read come back. */
+  searchAddresses: (params: AddressSearchParams) =>
+    api
+      .get<AddressSearchResponse>(`/ipam/addresses/search`, { params })
+      .then((r) => r.data),
+  /** Gather the ids of every match (capped at 5000) for the "select all
+   *  N matches → bulk edit/delete" flow. */
+  searchAddressIds: (
+    params: Omit<AddressSearchParams, "sort" | "order" | "limit" | "offset">,
+  ) =>
+    api
+      .get<AddressSearchIdsResponse>(`/ipam/addresses/search/ids`, { params })
       .then((r) => r.data),
   createAddress: (
     data: Partial<IPAddress> & {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1698,20 +1698,6 @@ export const ipamApi = {
         params,
       })
       .then((r) => r.data),
-  /** Same as {@link listAddresses} but also returns the ``X-Total-Count``
-   *  header (total matching rows BEFORE limit/offset) so the UI can
-   *  paginate server-side. axios's ``.then(r => r.data)`` drops headers,
-   *  so this variant reads the header explicitly. */
-  listAddressesPaged: (
-    subnetId: string,
-    params?: AddressQueryParams,
-  ): Promise<{ items: IPAddress[]; total: number }> =>
-    api
-      .get<IPAddress[]>(`/ipam/subnets/${subnetId}/addresses`, { params })
-      .then((r) => ({
-        items: r.data,
-        total: Number(r.headers["x-total-count"] ?? r.data.length),
-      })),
   /** Cross-subnet IP search (issue #520). Results are permission-scoped
    *  server-side — only IPs in subnets the caller can read come back. */
   searchAddresses: (params: AddressSearchParams) =>

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -81,6 +81,7 @@ import {
   type MacHistoryEntry,
   type NATMapping,
   type NetworkContextEntry,
+  type IPAddressSearchItem,
   type AddressSet,
   type AddressSetCreate,
   type AddressSetUpdate,
@@ -98,6 +99,7 @@ import { StatusTag } from "@/components/ui/status-tag";
 import { SwatchPicker } from "@/components/ui/swatch-picker";
 import { useStickyLocation } from "@/lib/stickyLocation";
 import { useSessionState } from "@/lib/useSessionState";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useRowHighlight } from "@/lib/useRowHighlight";
 import { Modal, ModalTabs } from "@/components/ui/modal";
 import { AsnPicker } from "@/components/ipam/asn-picker";
@@ -332,6 +334,27 @@ const COUNTABLE_MAX = Number.MAX_SAFE_INTEGER;
 // the quick-filter is active.
 const TREE_GROUP_CAP = 300;
 
+// Max IP rows painted in the per-subnet address table before a
+// "Show N more…" reveal (issue #517). A busy /16 can carry tens of
+// thousands of rows, each wrapped in a ContextMenu + inline-edit cells;
+// mounting them all locks the tab for seconds. The cap bounds the DOM
+// while every filter / select-all / shift-range op still runs over the
+// FULL filtered set (only the *rendering* is windowed).
+const ADDRESS_ROW_CAP = 500;
+
+// Sortable columns for the per-subnet IP table (issue #519). Client-side
+// sort over the already-loaded page; ``null`` = the API's native inet
+// order (which also keeps the DHCP-pool / gap boundary rows meaningful).
+type AddressSortKey =
+  | "address"
+  | "hostname"
+  | "mac"
+  | "description"
+  | "status"
+  | "dns"
+  | "last_seen";
+type AddressSortState = { key: AddressSortKey; dir: "asc" | "desc" };
+
 // IPv6 subnets (a /64 is 2^64 addresses) overflow the BIGINT total_ips column,
 // which the API clamps to ~9.2e18. A raw "N / 9,223,372,036,854,776,000" ratio
 // and a 0% bar are meaningless, so we present such prefixes as uncountable.
@@ -504,43 +527,73 @@ function RowTypeBadge({ kind }: { kind: "block" | "subnet" }) {
   );
 }
 
-// Double-click-to-edit cell for the IP table. Swallows single clicks so it
-// doesn't trigger the row's open-detail handler; Enter/blur commit, Escape
-// cancels. `display` is what shows when not editing; `value` seeds the input.
-// One shared timer for click-vs-double-click discrimination on inline-editable
-// cells. A single click opens the row detail (consistent with the rest of the
-// row), a double-click edits — but a double-click fires `click` twice then
-// `dblclick`, so we defer the single-click action briefly and cancel it when a
-// double-click lands. User interaction is serial, so one module-level timer is
-// safe and keeps these cells hook-free for the discrimination logic.
-let _inlineClickTimer: ReturnType<typeof setTimeout> | null = null;
-function deferRowActivate(fn: () => void) {
-  if (_inlineClickTimer) clearTimeout(_inlineClickTimer);
-  _inlineClickTimer = setTimeout(() => {
-    _inlineClickTimer = null;
-    fn();
-  }, 220);
-}
-function cancelRowActivate() {
-  if (_inlineClickTimer) {
-    clearTimeout(_inlineClickTimer);
-    _inlineClickTimer = null;
-  }
+// Cycle a sort spec asc → desc → cleared for a clicked column (issue #519).
+function cycleSort(
+  prev: AddressSortState | null,
+  key: AddressSortKey,
+): AddressSortState | null {
+  if (!prev || prev.key !== key) return { key, dir: "asc" };
+  if (prev.dir === "asc") return { key, dir: "desc" };
+  return null;
 }
 
+// Clickable column-header label that toggles the table sort. Renders a
+// ▲/▼ indicator for the active column and a faint ⇅ otherwise. Kept
+// separate from the per-column filter toggle so both affordances coexist.
+function SortLabel({
+  label,
+  sortKey,
+  state,
+  onSort,
+  className,
+}: {
+  label: string;
+  sortKey: AddressSortKey;
+  state: AddressSortState | null;
+  onSort: (key: AddressSortKey) => void;
+  className?: string;
+}) {
+  const active = state?.key === sortKey;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(sortKey)}
+      title={`Sort by ${label}`}
+      aria-label={`Sort by ${label}`}
+      className={cn(
+        "inline-flex items-center gap-1 hover:text-foreground",
+        active ? "text-primary" : "",
+        className,
+      )}
+    >
+      <span className="capitalize">{label}</span>
+      <span className="text-[9px] leading-none">
+        {active ? (state?.dir === "asc" ? "▲" : "▼") : "⇅"}
+      </span>
+    </button>
+  );
+}
+
+// Double-click-to-edit cell for the IP table. Enter/blur commit, Escape
+// cancels. `display` is what shows when not editing; `value` seeds the input.
+// #522#4: a single click now enters edit mode immediately — the prior
+// module-level 220 ms defer (which existed to disambiguate a single-click
+// "open detail" from a double-click "edit") added a perceptible lag on
+// every inline edit. Editable cells now edit on click; the read-only
+// detail modal stays reachable by clicking any non-editable cell of the
+// row (address / MAC / tags / pool / DNS / Seen / Network) or the row's
+// right-click menu. Double-click still enters edit for muscle memory.
 function InlineEditableText({
   value,
   placeholder,
   display,
   onSave,
-  onActivate,
   disabled = false,
 }: {
   value: string;
   placeholder: string;
   display: React.ReactNode;
   onSave: (next: string) => void;
-  onActivate?: () => void;
   disabled?: boolean;
 }) {
   const [editing, setEditing] = useState(false);
@@ -574,19 +627,16 @@ function InlineEditableText({
       />
     );
   }
+  const enterEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDraft(value);
+    setEditing(true);
+  };
   return (
     <span
-      onClick={(e) => {
-        e.stopPropagation();
-        if (onActivate) deferRowActivate(onActivate);
-      }}
-      onDoubleClick={(e) => {
-        e.stopPropagation();
-        cancelRowActivate();
-        setDraft(value);
-        setEditing(true);
-      }}
-      title="Click to open · double-click to edit"
+      onClick={enterEdit}
+      onDoubleClick={enterEdit}
+      title="Click to edit"
       className="cursor-text"
     >
       {display}
@@ -2833,12 +2883,10 @@ function InlineStatusSelect({
   status,
   disabled = false,
   onSave,
-  onActivate,
 }: {
   status: string;
   disabled?: boolean;
   onSave: (next: string) => void;
-  onActivate?: () => void;
 }) {
   const [editing, setEditing] = useState(false);
   if (disabled) return <StatusBadge status={status} />;
@@ -2875,18 +2923,15 @@ function InlineStatusSelect({
       </select>
     );
   }
+  const enterEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditing(true);
+  };
   return (
     <span
-      onClick={(e) => {
-        e.stopPropagation();
-        if (onActivate) deferRowActivate(onActivate);
-      }}
-      onDoubleClick={(e) => {
-        e.stopPropagation();
-        cancelRowActivate();
-        setEditing(true);
-      }}
-      title="Click to open · double-click to change status"
+      onClick={enterEdit}
+      onDoubleClick={enterEdit}
+      title="Click to change status"
       className="cursor-pointer"
     >
       <StatusBadge status={status} />
@@ -4578,6 +4623,20 @@ function SubnetDetail({
     {},
   );
   const [openFilterMenu, setOpenFilterMenu] = useState<string | null>(null);
+  // Client-side sort of the IP table (issue #519). ``null`` = the API's
+  // native inet order (which also keeps DHCP-pool / gap boundary rows
+  // meaningful; those are suppressed under any custom sort).
+  const [sortState, setSortState] = useState<AddressSortState | null>(null);
+  const onSort = (key: AddressSortKey) =>
+    setSortState((prev) => cycleSort(prev, key));
+  // Row-window reveal (issue #517) — the table paints at most
+  // ADDRESS_ROW_CAP rows until the operator opts into the full list.
+  const [showAllAddressRows, setShowAllAddressRows] = useState(false);
+  // #517: render EITHER the mobile card list OR the desktop table — never
+  // both. Previously both were always in the DOM (one CSS-hidden), doubling
+  // the mounted element count on a busy subnet. Matches the ``sm`` (640px)
+  // Tailwind breakpoint the table's ``sm:table`` / ``sm:hidden`` used.
+  const isMobile = useMediaQuery("(max-width: 639px)");
 
   // Clear column filters whenever the viewed subnet changes
   useEffect(() => {
@@ -4595,6 +4654,8 @@ function SubnetDetail({
     setShowFilters(false);
     setAddressTagFilters([]);
     setSelectedIpIds(new Set());
+    setSortState(null);
+    setShowAllAddressRows(false);
   }, [subnet.id]);
 
   const { data: addresses, isLoading } = useQuery({
@@ -4647,32 +4708,31 @@ function SubnetDetail({
     qc.invalidateQueries({ queryKey: ["subnet-aliases", subnet.id] });
   };
 
+  // #522#3: precompute each pool's integer [start,end] bounds ONCE per
+  // ``allPools`` change instead of re-parsing ``start_ip`` / ``end_ip``
+  // for every pool on every row on every render. ``ipPoolInfo`` then just
+  // does an int range compare. IPv4-only, matching the prior code.
+  const poolBounds = useMemo(
+    () =>
+      allPools
+        .map((p) => ({
+          type: p.pool_type,
+          name: p.name || p.pool_type,
+          startInt: ipStringToInt(p.start_ip),
+          endInt: ipStringToInt(p.end_ip),
+        }))
+        .filter(
+          (p) => Number.isFinite(p.startInt) && Number.isFinite(p.endInt),
+        ),
+    [allPools],
+  );
+
   function ipPoolInfo(addr: IPAddress): { type: string; name: string } | null {
-    const ipParts = String(addr.address).split(".").map(Number);
-    if (ipParts.length !== 4) return null;
-    const ipInt =
-      ((ipParts[0] << 24) |
-        (ipParts[1] << 16) |
-        (ipParts[2] << 8) |
-        ipParts[3]) >>>
-      0;
-    for (const p of allPools) {
-      const sParts = p.start_ip.split(".").map(Number);
-      const eParts = p.end_ip.split(".").map(Number);
-      const sInt =
-        ((sParts[0] << 24) |
-          (sParts[1] << 16) |
-          (sParts[2] << 8) |
-          sParts[3]) >>>
-        0;
-      const eInt =
-        ((eParts[0] << 24) |
-          (eParts[1] << 16) |
-          (eParts[2] << 8) |
-          eParts[3]) >>>
-        0;
-      if (ipInt >= sInt && ipInt <= eInt)
-        return { type: p.pool_type, name: p.name || p.pool_type };
+    const ipInt = ipStringToInt(String(addr.address));
+    if (!Number.isFinite(ipInt)) return null;
+    for (const p of poolBounds) {
+      if (ipInt >= p.startInt && ipInt <= p.endInt)
+        return { type: p.type, name: p.name };
     }
     return null;
   }
@@ -4722,59 +4782,133 @@ function SubnetDetail({
     return v.includes(f);
   }
 
-  const filteredAddresses = addresses?.filter((a) => {
-    const cf = colFilters;
-    const fm = filterModes;
-    if (!applyFilter(a.address, cf.address, fm.address)) return false;
-    if (!applyFilter(a.hostname ?? "", cf.hostname, fm.hostname)) return false;
-    // MAC column filters either the MAC itself (with punctuation stripped
-    // so ``00:11`` and ``0011`` both match) or the OUI vendor name, so
-    // "apple" / "cisco" work when the operator knows the maker but not
-    // the prefix. Vendor only matches when OUI lookup is enabled and the
-    // row carries a vendor value.
-    const macNorm = (a.mac_address ?? "").replace(/[:\-.]/g, "");
-    const macFilter = cf.mac.replace(/[:\-.]/g, "");
-    const macHit = applyFilter(macNorm, macFilter, fm.mac);
-    const vendorHit = applyFilter(a.vendor ?? "", cf.mac, fm.mac);
-    if (cf.mac && !macHit && !vendorHit) return false;
-    if (!applyFilter(a.description ?? "", cf.description, fm.description))
-      return false;
-    if (cf.tags) {
-      // Tag filter matches either `key`, `value`, or `key=value`. Clicking a
-      // chip in the row fills in the exact `key=value` form for an exact hit.
-      const t = (a.tags as Record<string, unknown> | null) ?? {};
-      const entries = Object.entries(t).map(
-        ([k, v]) => `${k}=${v == null ? "" : String(v)}`,
-      );
-      const hay = [
-        ...Object.keys(t),
-        ...Object.values(t).map((v) => (v == null ? "" : String(v))),
-        ...entries,
-      ].join("\n");
-      if (!applyFilter(hay, cf.tags, fm.tags)) return false;
-    }
-    if (
-      addressTagFilters.length > 0 &&
-      !matchesAllTagChips(
-        (a.tags as Record<string, unknown> | null) ?? {},
-        addressTagFilters,
-      )
-    )
-      return false;
-    if (cf.status && a.status !== cf.status) return false;
-    if (cf.dns && ipDnsState(a) !== cf.dns) return false;
-    return true;
-  });
+  // #517: memoize the filtered list so a keystroke in an unrelated field
+  // (or any parent re-render) doesn't re-scan every address. Keyed on the
+  // raw list + the filter inputs + the DNS drift report (which drives the
+  // ``dns`` column filter via ``ipDnsState``).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const filteredAddresses = useMemo(
+    () =>
+      addresses?.filter((a) => {
+        const cf = colFilters;
+        const fm = filterModes;
+        if (!applyFilter(a.address, cf.address, fm.address)) return false;
+        if (!applyFilter(a.hostname ?? "", cf.hostname, fm.hostname))
+          return false;
+        // MAC column filters either the MAC itself (with punctuation stripped
+        // so ``00:11`` and ``0011`` both match) or the OUI vendor name, so
+        // "apple" / "cisco" work when the operator knows the maker but not
+        // the prefix. Vendor only matches when OUI lookup is enabled and the
+        // row carries a vendor value.
+        const macNorm = (a.mac_address ?? "").replace(/[:\-.]/g, "");
+        const macFilter = cf.mac.replace(/[:\-.]/g, "");
+        const macHit = applyFilter(macNorm, macFilter, fm.mac);
+        const vendorHit = applyFilter(a.vendor ?? "", cf.mac, fm.mac);
+        if (cf.mac && !macHit && !vendorHit) return false;
+        if (!applyFilter(a.description ?? "", cf.description, fm.description))
+          return false;
+        if (cf.tags) {
+          // Tag filter matches either `key`, `value`, or `key=value`. Clicking a
+          // chip in the row fills in the exact `key=value` form for an exact hit.
+          const t = (a.tags as Record<string, unknown> | null) ?? {};
+          const entries = Object.entries(t).map(
+            ([k, v]) => `${k}=${v == null ? "" : String(v)}`,
+          );
+          const hay = [
+            ...Object.keys(t),
+            ...Object.values(t).map((v) => (v == null ? "" : String(v))),
+            ...entries,
+          ].join("\n");
+          if (!applyFilter(hay, cf.tags, fm.tags)) return false;
+        }
+        if (
+          addressTagFilters.length > 0 &&
+          !matchesAllTagChips(
+            (a.tags as Record<string, unknown> | null) ?? {},
+            addressTagFilters,
+          )
+        )
+          return false;
+        if (cf.status && a.status !== cf.status) return false;
+        if (cf.dns && ipDnsState(a) !== cf.dns) return false;
+        return true;
+      }),
+    [
+      addresses,
+      colFilters,
+      filterModes,
+      addressTagFilters,
+      dnsDrift,
+      subnetHasDnsZone,
+    ],
+  );
   const hasActiveFilter =
     Object.values(colFilters).some(Boolean) || addressTagFilters.length > 0;
+
+  // #519: apply the client-side column sort. ``null`` keeps the API's
+  // native inet order (the default, and the only order in which the
+  // pool-boundary + gap marker rows below make sense).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const sortedAddresses = useMemo(() => {
+    if (!filteredAddresses || !sortState) return filteredAddresses;
+    const { key, dir } = sortState;
+    const mul = dir === "asc" ? 1 : -1;
+    const strOf = (a: IPAddress): string => {
+      switch (key) {
+        case "hostname":
+          return (a.fqdn || a.hostname || "").toLowerCase();
+        case "mac":
+          return (a.mac_address || a.vendor || "").toLowerCase();
+        case "description":
+          return (a.description || "").toLowerCase();
+        case "status":
+          return a.status || "";
+        case "dns":
+          return ipDnsState(a);
+        default:
+          return "";
+      }
+    };
+    // Directional compare (a<b ⇒ negative). ``last_seen`` nulls always
+    // sort last irrespective of direction (handled before the mul).
+    return [...filteredAddresses].sort((a, b) => {
+      if (key === "last_seen") {
+        const at = a.last_seen_at ? Date.parse(a.last_seen_at) : null;
+        const bt = b.last_seen_at ? Date.parse(b.last_seen_at) : null;
+        if (at === null && bt === null) return 0;
+        if (at === null) return 1;
+        if (bt === null) return -1;
+        return mul * (at - bt);
+      }
+      if (key === "address") {
+        const ai = ipStringToInt(String(a.address));
+        const bi = ipStringToInt(String(b.address));
+        if (Number.isFinite(ai) && Number.isFinite(bi)) return mul * (ai - bi);
+        return mul * String(a.address).localeCompare(String(b.address));
+      }
+      return mul * strOf(a).localeCompare(strOf(b));
+    });
+  }, [filteredAddresses, sortState, dnsDrift, subnetHasDnsZone]);
 
   // Interleave DHCP pool boundary markers with the IP rows so the user
   // can see where a pool begins / ends, even when no IPs are assigned
   // inside it yet. Dynamic pools are the important case (they can't be
   // manually allocated); static / excluded pools are shown for parity.
   // IPv4-only — matches the existing ``ipPoolInfo`` helper.
-  const tableRows = (() => {
-    if (!filteredAddresses) return [] as AddressOrPoolRow[];
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const tableRows = useMemo<AddressOrPoolRow[]>(() => {
+    if (!sortedAddresses) return [] as AddressOrPoolRow[];
+    // Under a custom column sort the inet-order-dependent pool-boundary
+    // and gap marker rows no longer make sense, so render a plain list of
+    // IP rows (pool membership still shows per-row via ``ipPoolInfo``).
+    if (sortState) {
+      const flat = sortedAddresses.map(
+        (addr) => ({ kind: "ip", addr }) as AddressOrPoolRow,
+      );
+      return hideReserved
+        ? flat.filter((r) => r.kind !== "ip" || !isPaddingRow(r.addr))
+        : flat;
+    }
     const rows: AddressOrPoolRow[] = [];
     const sortedPools = [...allPools]
       .map((p) => ({
@@ -4815,7 +4949,7 @@ function SubnetDetail({
       );
 
     let prevIpInt: number | null = null;
-    for (const addr of filteredAddresses) {
+    for (const addr of sortedAddresses) {
       const ipInt = ipStringToInt(String(addr.address));
       if (!Number.isFinite(ipInt)) {
         rows.push({ kind: "ip", addr });
@@ -4864,7 +4998,17 @@ function SubnetDetail({
     if (hideReserved)
       return rows.filter((r) => r.kind !== "ip" || !isPaddingRow(r.addr));
     return rows;
-  })();
+  }, [sortedAddresses, sortState, allPools, hasActiveFilter, hideReserved]);
+
+  // #517: window the painted rows. Every op that walks the data
+  // (select-all, shift-range, filtering) still uses the full ``tableRows``
+  // / ``filteredAddresses`` — only the DOM output is capped.
+  const visibleRows = useMemo(
+    () =>
+      showAllAddressRows ? tableRows : tableRows.slice(0, ADDRESS_ROW_CAP),
+    [tableRows, showAllAddressRows],
+  );
+  const hiddenRowCount = tableRows.length - visibleRows.length;
 
   const [confirmDeleteAddr, setConfirmDeleteAddr] = useState<IPAddress | null>(
     null,
@@ -5413,177 +5557,111 @@ function SubnetDetail({
                   phone, so under sm we render each IP as a tappable card with
                   the triage essentials (address · status · host · seen). The
                   full table takes over at sm+. Pool/gap marker rows are skipped
-                  on mobile. */}
-              <div className="space-y-1.5 px-1 pb-2 sm:hidden">
-                {tableRows.filter((r) => r.kind === "ip").length === 0 && (
-                  <p className="px-2 py-3 text-xs text-muted-foreground">
-                    No addresses to show.
-                  </p>
-                )}
-                {tableRows.map((row) => {
-                  if (row.kind !== "ip") return null;
-                  const addr = row.addr;
-                  const host = addr.fqdn || addr.hostname || "";
-                  return (
+                  on mobile. #517: gated on a JS breakpoint (not just
+                  ``sm:hidden``) so the desktop path never mounts these cards. */}
+              {isMobile && (
+                <div className="space-y-1.5 px-1 pb-2">
+                  {visibleRows.filter((r) => r.kind === "ip").length === 0 && (
+                    <p className="px-2 py-3 text-xs text-muted-foreground">
+                      No addresses to show.
+                    </p>
+                  )}
+                  {visibleRows.map((row) => {
+                    if (row.kind !== "ip") return null;
+                    const addr = row.addr;
+                    const host = addr.fqdn || addr.hostname || "";
+                    return (
+                      <button
+                        key={`m-${addr.id}`}
+                        type="button"
+                        onClick={() => setViewingAddress(addr)}
+                        className="flex w-full flex-col gap-1 rounded-md border bg-card p-2.5 text-left active:bg-muted/50"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="font-mono text-sm font-medium">
+                            {addr.address}
+                          </span>
+                          <StatusTag status={addr.status} />
+                        </div>
+                        <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                          <span className="truncate">
+                            {host || (
+                              <span className="text-muted-foreground/40">
+                                no hostname
+                              </span>
+                            )}
+                          </span>
+                          <SeenDot
+                            lastSeenAt={addr.last_seen_at}
+                            lastSeenMethod={addr.last_seen_method}
+                            withLabel
+                          />
+                        </div>
+                      </button>
+                    );
+                  })}
+                  {hiddenRowCount > 0 && (
                     <button
-                      key={`m-${addr.id}`}
                       type="button"
-                      onClick={() => setViewingAddress(addr)}
-                      className="flex w-full flex-col gap-1 rounded-md border bg-card p-2.5 text-left active:bg-muted/50"
+                      onClick={() => setShowAllAddressRows(true)}
+                      className="w-full rounded-md border border-dashed py-2 text-xs text-muted-foreground hover:bg-muted/40"
                     >
-                      <div className="flex items-center justify-between gap-2">
-                        <span className="font-mono text-sm font-medium">
-                          {addr.address}
-                        </span>
-                        <StatusTag status={addr.status} />
-                      </div>
-                      <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
-                        <span className="truncate">
-                          {host || (
-                            <span className="text-muted-foreground/40">
-                              no hostname
-                            </span>
-                          )}
-                        </span>
-                        <SeenDot
-                          lastSeenAt={addr.last_seen_at}
-                          lastSeenMethod={addr.last_seen_method}
-                          withLabel
-                        />
-                      </div>
+                      Show {hiddenRowCount.toLocaleString()} more…
                     </button>
-                  );
-                })}
-              </div>
+                  )}
+                </div>
+              )}
 
-              <table className="hidden w-full min-w-[640px] text-sm sm:table">
-                {/* Sticky header — pinned to the parent
+              {!isMobile && (
+                <table className="w-full min-w-[640px] text-sm">
+                  {/* Sticky header — pinned to the parent
                       ``flex-1 overflow-auto`` scroll container so the
                       column headers stay visible while scrolling a
                       long IP list. ``bg-card`` is an opaque base so
                       the muted overlay on the <tr> doesn't let body
                       rows bleed through as the user scrolls. */}
-                <thead className="sticky top-0 z-10 bg-card">
-                  <tr className="border-b bg-muted/40 text-xs">
-                    <th className="w-8 px-2 py-2">
-                      {(() => {
-                        const selectable = (filteredAddresses ?? []).filter(
-                          (a: IPAddress) =>
-                            a.status !== "network" &&
-                            a.status !== "broadcast" &&
-                            !a.auto_from_lease &&
-                            // Never select a row the table is currently hiding.
-                            !(hideReserved && isPaddingRow(a)) &&
-                            // Only rows the caller can actually write — matches
-                            // the per-row checkbox gate so a delegated operator
-                            // (address sets, #103) can't select rows a bulk op
-                            // would then partially 403 (#514).
-                            permitsWriteIp(a.address),
-                        );
-                        const allSelected =
-                          selectable.length > 0 &&
-                          selectable.every((a: IPAddress) =>
-                            selectedIpIds.has(a.id),
+                  <thead className="sticky top-0 z-10 bg-card">
+                    <tr className="border-b bg-muted/40 text-xs">
+                      <th className="w-8 px-2 py-2">
+                        {(() => {
+                          const selectable = (filteredAddresses ?? []).filter(
+                            (a: IPAddress) =>
+                              a.status !== "network" &&
+                              a.status !== "broadcast" &&
+                              !a.auto_from_lease &&
+                              // Never select a row the table is currently hiding.
+                              !(hideReserved && isPaddingRow(a)) &&
+                              // Only rows the caller can actually write — matches
+                              // the per-row checkbox gate so a delegated operator
+                              // (address sets, #103) can't select rows a bulk op
+                              // would then partially 403 (#514).
+                              permitsWriteIp(a.address),
                           );
-                        return (
-                          <input
-                            type="checkbox"
-                            checked={allSelected}
-                            aria-label="Select all"
-                            onChange={(e) => {
-                              if (e.target.checked) {
-                                setSelectedIpIds(
-                                  new Set(
-                                    selectable.map((a: IPAddress) => a.id),
-                                  ),
-                                );
-                              } else {
-                                setSelectedIpIds(new Set());
-                              }
-                            }}
-                          />
-                        );
-                      })()}
-                    </th>
-                    {(
-                      [
-                        "address",
-                        "hostname",
-                        "mac",
-                        "description",
-                        "tags",
-                        "status",
-                        "pool",
-                        "dns",
-                      ] as const
-                    ).map((col) => {
-                      const label =
-                        col === "mac"
-                          ? "MAC"
-                          : col === "dns"
-                            ? "DNS"
-                            : col === "pool"
-                              ? "DHCP Pool"
-                              : col;
-                      return (
-                        <th
-                          key={col}
-                          className="px-4 py-2 text-left font-medium"
-                        >
-                          <span className="inline-flex items-center gap-1">
-                            <span className="capitalize">{label}</span>
-                            <button
-                              onClick={() => setShowFilters((v) => !v)}
-                              title={`Filter by ${label}`}
-                              className={cn(
-                                "rounded p-0.5 hover:bg-accent",
-                                colFilters[col]
-                                  ? "text-primary"
-                                  : showFilters
-                                    ? "text-primary/40"
-                                    : "text-muted-foreground/30 hover:text-muted-foreground",
-                              )}
-                            >
-                              <Filter className="h-2.5 w-2.5" />
-                            </button>
-                          </span>
-                        </th>
-                      );
-                    })}
-                    <th
-                      className="px-4 py-2 text-center font-medium"
-                      title="Alive: green = seen <24h, amber = 24h–7d, red = >7d, grey = never"
-                    >
-                      Seen
-                    </th>
-                    <th className="px-4 py-2 text-left font-medium">Network</th>
-                    <th className="px-4 py-2 text-right">
-                      {hasActiveFilter && (
-                        <button
-                          onClick={() => {
-                            setColFilters({
-                              address: "",
-                              hostname: "",
-                              mac: "",
-                              description: "",
-                              tags: "",
-                              status: "",
-                              dns: "",
-                              pool: "",
-                            });
-                            setFilterModes({});
-                          }}
-                          title="Clear all filters"
-                          className="rounded p-0.5 text-primary hover:text-destructive"
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
-                      )}
-                    </th>
-                  </tr>
-                  {showFilters && (
-                    <tr className="border-b bg-muted/10 text-xs">
-                      <td />
+                          const allSelected =
+                            selectable.length > 0 &&
+                            selectable.every((a: IPAddress) =>
+                              selectedIpIds.has(a.id),
+                            );
+                          return (
+                            <input
+                              type="checkbox"
+                              checked={allSelected}
+                              aria-label="Select all"
+                              onChange={(e) => {
+                                if (e.target.checked) {
+                                  setSelectedIpIds(
+                                    new Set(
+                                      selectable.map((a: IPAddress) => a.id),
+                                    ),
+                                  );
+                                } else {
+                                  setSelectedIpIds(new Set());
+                                }
+                              }}
+                            />
+                          );
+                        })()}
+                      </th>
                       {(
                         [
                           "address",
@@ -5595,358 +5673,548 @@ function SubnetDetail({
                           "pool",
                           "dns",
                         ] as const
-                      ).map((col) => (
-                        <td key={col} className="px-2 py-1">
-                          {col === "status" ? (
-                            <select
-                              value={colFilters.status}
-                              onChange={(e) =>
-                                setColFilters((p) => ({
-                                  ...p,
-                                  status: e.target.value,
-                                }))
-                              }
-                              className="w-full rounded border bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
-                            >
-                              <option value="">All</option>
-                              {[
-                                "allocated",
-                                "available",
-                                "reserved",
-                                "dhcp",
-                                "static_dhcp",
-                                "network",
-                                "broadcast",
-                                "orphan",
-                              ].map((s) => (
-                                <option key={s} value={s}>
-                                  {s}
-                                </option>
-                              ))}
-                            </select>
-                          ) : col === "dns" ? (
-                            <select
-                              value={colFilters.dns}
-                              onChange={(e) =>
-                                setColFilters((p) => ({
-                                  ...p,
-                                  dns: e.target.value,
-                                }))
-                              }
-                              className="w-full rounded border bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
-                            >
-                              <option value="">All</option>
-                              <option value="in-sync">In sync</option>
-                              <option value="out-of-sync">Out of sync</option>
-                              <option value="n/a">N/A</option>
-                            </select>
-                          ) : (
-                            <div className="flex items-center">
-                              <input
-                                type="text"
-                                value={colFilters[col]}
+                      ).map((col) => {
+                        const label =
+                          col === "mac"
+                            ? "MAC"
+                            : col === "dns"
+                              ? "DNS"
+                              : col === "pool"
+                                ? "DHCP Pool"
+                                : col;
+                        // #519: address / hostname / mac / description /
+                        // status / dns are client-sortable. tags + pool are
+                        // not (composite / order-dependent).
+                        const sortKey = (
+                          {
+                            address: "address",
+                            hostname: "hostname",
+                            mac: "mac",
+                            description: "description",
+                            status: "status",
+                            dns: "dns",
+                          } as Record<string, AddressSortKey | undefined>
+                        )[col];
+                        return (
+                          <th
+                            key={col}
+                            className="px-4 py-2 text-left font-medium"
+                          >
+                            <span className="inline-flex items-center gap-1">
+                              {sortKey ? (
+                                <SortLabel
+                                  label={label}
+                                  sortKey={sortKey}
+                                  state={sortState}
+                                  onSort={onSort}
+                                />
+                              ) : (
+                                <span className="capitalize">{label}</span>
+                              )}
+                              <button
+                                onClick={() => setShowFilters((v) => !v)}
+                                title={`Filter by ${label}`}
+                                className={cn(
+                                  "rounded p-0.5 hover:bg-accent",
+                                  colFilters[col]
+                                    ? "text-primary"
+                                    : showFilters
+                                      ? "text-primary/40"
+                                      : "text-muted-foreground/30 hover:text-muted-foreground",
+                                )}
+                              >
+                                <Filter className="h-2.5 w-2.5" />
+                              </button>
+                            </span>
+                          </th>
+                        );
+                      })}
+                      <th
+                        className="px-4 py-2 text-center font-medium"
+                        title="Alive: green = seen <24h, amber = 24h–7d, red = >7d, grey = never"
+                      >
+                        <SortLabel
+                          label="Seen"
+                          sortKey="last_seen"
+                          state={sortState}
+                          onSort={onSort}
+                        />
+                      </th>
+                      <th className="px-4 py-2 text-left font-medium">
+                        Network
+                      </th>
+                      <th className="px-4 py-2 text-right">
+                        {hasActiveFilter && (
+                          <button
+                            onClick={() => {
+                              setColFilters({
+                                address: "",
+                                hostname: "",
+                                mac: "",
+                                description: "",
+                                tags: "",
+                                status: "",
+                                dns: "",
+                                pool: "",
+                              });
+                              setFilterModes({});
+                            }}
+                            title="Clear all filters"
+                            className="rounded p-0.5 text-primary hover:text-destructive"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        )}
+                      </th>
+                    </tr>
+                    {showFilters && (
+                      <tr className="border-b bg-muted/10 text-xs">
+                        <td />
+                        {(
+                          [
+                            "address",
+                            "hostname",
+                            "mac",
+                            "description",
+                            "tags",
+                            "status",
+                            "pool",
+                            "dns",
+                          ] as const
+                        ).map((col) => (
+                          <td key={col} className="px-2 py-1">
+                            {col === "status" ? (
+                              <select
+                                value={colFilters.status}
                                 onChange={(e) =>
                                   setColFilters((p) => ({
                                     ...p,
-                                    [col]: e.target.value,
+                                    status: e.target.value,
                                   }))
                                 }
-                                placeholder="Filter…"
-                                aria-label="Filter"
-                                className="w-full min-w-0 rounded-l border border-r-0 bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
-                              />
-                              <div className="relative">
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    setOpenFilterMenu(
-                                      openFilterMenu === col ? null : col,
-                                    )
+                                className="w-full rounded border bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                              >
+                                <option value="">All</option>
+                                {[
+                                  "allocated",
+                                  "available",
+                                  "reserved",
+                                  "dhcp",
+                                  "static_dhcp",
+                                  "network",
+                                  "broadcast",
+                                  "orphan",
+                                ].map((s) => (
+                                  <option key={s} value={s}>
+                                    {s}
+                                  </option>
+                                ))}
+                              </select>
+                            ) : col === "dns" ? (
+                              <select
+                                value={colFilters.dns}
+                                onChange={(e) =>
+                                  setColFilters((p) => ({
+                                    ...p,
+                                    dns: e.target.value,
+                                  }))
+                                }
+                                className="w-full rounded border bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                              >
+                                <option value="">All</option>
+                                <option value="in-sync">In sync</option>
+                                <option value="out-of-sync">Out of sync</option>
+                                <option value="n/a">N/A</option>
+                              </select>
+                            ) : (
+                              <div className="flex items-center">
+                                <input
+                                  type="text"
+                                  value={colFilters[col]}
+                                  onChange={(e) =>
+                                    setColFilters((p) => ({
+                                      ...p,
+                                      [col]: e.target.value,
+                                    }))
                                   }
-                                  className="rounded-r border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent"
-                                  title="Filter mode"
-                                >
-                                  {filterModes[col] === "begins"
-                                    ? "^"
-                                    : filterModes[col] === "ends"
-                                      ? "$"
-                                      : filterModes[col] === "regex"
-                                        ? ".*"
-                                        : "⊂"}
-                                </button>
-                                {openFilterMenu === col && (
-                                  <div className="absolute left-0 top-full z-30 mt-0.5 w-32 rounded-md border bg-popover shadow-md">
-                                    {(
-                                      [
-                                        "contains",
-                                        "begins",
-                                        "ends",
-                                        "regex",
-                                      ] as const
-                                    ).map((m) => (
-                                      <button
-                                        key={m}
-                                        type="button"
-                                        onClick={() => {
-                                          setFilterModes((p) => ({
-                                            ...p,
-                                            [col]: m,
-                                          }));
-                                          setOpenFilterMenu(null);
-                                        }}
-                                        className={cn(
-                                          "w-full px-3 py-1.5 text-left text-xs hover:bg-accent",
-                                          filterModes[col] === m &&
-                                            "font-semibold text-primary",
-                                        )}
-                                      >
-                                        {m === "contains"
-                                          ? "⊂ Contains"
-                                          : m === "begins"
-                                            ? "^ Begins"
-                                            : m === "ends"
-                                              ? "$ Ends"
-                                              : ".* Regex"}
-                                      </button>
-                                    ))}
-                                  </div>
-                                )}
+                                  placeholder="Filter…"
+                                  aria-label="Filter"
+                                  className="w-full min-w-0 rounded-l border border-r-0 bg-background px-1.5 py-0.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                                />
+                                <div className="relative">
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      setOpenFilterMenu(
+                                        openFilterMenu === col ? null : col,
+                                      )
+                                    }
+                                    className="rounded-r border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent"
+                                    title="Filter mode"
+                                  >
+                                    {filterModes[col] === "begins"
+                                      ? "^"
+                                      : filterModes[col] === "ends"
+                                        ? "$"
+                                        : filterModes[col] === "regex"
+                                          ? ".*"
+                                          : "⊂"}
+                                  </button>
+                                  {openFilterMenu === col && (
+                                    <div className="absolute left-0 top-full z-30 mt-0.5 w-32 rounded-md border bg-popover shadow-md">
+                                      {(
+                                        [
+                                          "contains",
+                                          "begins",
+                                          "ends",
+                                          "regex",
+                                        ] as const
+                                      ).map((m) => (
+                                        <button
+                                          key={m}
+                                          type="button"
+                                          onClick={() => {
+                                            setFilterModes((p) => ({
+                                              ...p,
+                                              [col]: m,
+                                            }));
+                                            setOpenFilterMenu(null);
+                                          }}
+                                          className={cn(
+                                            "w-full px-3 py-1.5 text-left text-xs hover:bg-accent",
+                                            filterModes[col] === m &&
+                                              "font-semibold text-primary",
+                                          )}
+                                        >
+                                          {m === "contains"
+                                            ? "⊂ Contains"
+                                            : m === "begins"
+                                              ? "^ Begins"
+                                              : m === "ends"
+                                                ? "$ Ends"
+                                                : ".* Regex"}
+                                        </button>
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
                               </div>
-                            </div>
-                          )}
-                        </td>
-                      ))}
-                      {/* Network column has no filter input yet — operators
+                            )}
+                          </td>
+                        ))}
+                        {/* Network column has no filter input yet — operators
                             can still filter via the per-device pages. */}
-                      <td />
-                      <td />
-                    </tr>
-                  )}
-                </thead>
-                <tbody className={zebraBodyCls}>
-                  {filteredAddresses?.length === 0 && (
-                    <tr>
-                      <td
-                        colSpan={12}
-                        className="px-4 py-6 text-center text-sm text-muted-foreground"
-                      >
-                        No addresses match the active filters.
-                      </td>
-                    </tr>
-                  )}
-                  {tableRows.map((row, rowIdx) => {
-                    if (row.kind === "pool-boundary") {
-                      const pool = row.pool;
-                      const isDynamic = pool.pool_type === "dynamic";
-                      const tint = isDynamic
-                        ? "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 border-y border-cyan-500/30"
-                        : pool.pool_type === "reserved"
-                          ? "bg-violet-500/10 text-violet-700 dark:text-violet-300 border-y border-violet-500/30"
-                          : "bg-zinc-500/10 text-zinc-700 dark:text-zinc-300 border-y border-zinc-500/30";
-                      const arrow = row.boundary === "start" ? "▼" : "▲";
-                      const label =
-                        row.boundary === "start"
-                          ? `Start of ${pool.pool_type} pool`
-                          : `End of ${pool.pool_type} pool`;
-                      const anchorIp =
-                        row.boundary === "start" ? pool.start_ip : pool.end_ip;
-                      return (
-                        <tr key={`pool-${pool.id}-${row.boundary}-${rowIdx}`}>
-                          <td colSpan={12} className={cn("px-4 py-1.5", tint)}>
-                            <span className="mr-2 font-mono text-xs">
-                              {arrow}
-                            </span>
-                            <span className="text-xs font-semibold uppercase tracking-wide">
-                              {label}
-                            </span>
-                            {pool.name && (
-                              <span className="ml-2 text-xs">
-                                — {pool.name}
-                              </span>
-                            )}
-                            <span className="ml-2 font-mono text-xs opacity-80">
-                              {anchorIp}
-                            </span>
-                            <span className="ml-3 text-[11px] opacity-70">
-                              range {pool.start_ip} – {pool.end_ip}
-                            </span>
-                          </td>
-                        </tr>
-                      );
-                    }
-                    if (row.kind === "gap") {
-                      const count = row.endIpInt - row.startIpInt + 1;
-                      const startIp = intToIpv4(row.startIpInt);
-                      const endIp = intToIpv4(row.endIpInt);
-                      const label =
-                        count === 1 ? startIp : `${startIp} – ${endIp}`;
-                      return (
-                        <tr
-                          key={`gap-${row.startIpInt}-${row.endIpInt}`}
-                          aria-label={`${count} unallocated IP${count === 1 ? "" : "s"} between rows`}
-                          className="cursor-pointer hover:bg-emerald-500/[0.10]"
-                          onClick={() => {
-                            setAddModalRange({
-                              startIpInt: row.startIpInt,
-                              endIpInt: row.endIpInt,
-                            });
-                            setShowAddModal(true);
-                          }}
-                          title={`Allocate an IP from this free range (${count} available)`}
+                        <td />
+                        <td />
+                      </tr>
+                    )}
+                  </thead>
+                  <tbody className={zebraBodyCls}>
+                    {filteredAddresses?.length === 0 && (
+                      <tr>
+                        <td
+                          colSpan={12}
+                          className="px-4 py-6 text-center text-sm text-muted-foreground"
                         >
-                          <td
-                            colSpan={12}
-                            className="border-y border-dashed border-emerald-400/30 bg-emerald-500/[0.04] px-4 py-0.5 text-[11px] text-emerald-700/80 dark:border-emerald-500/30 dark:text-emerald-300/70"
-                          >
-                            <span className="font-mono">{label}</span>
-                            <span className="ml-2 opacity-70">
-                              · {count} free
-                            </span>
-                            <span className="ml-2 opacity-60">
-                              · click to allocate
-                            </span>
-                          </td>
-                        </tr>
-                      );
-                    }
-                    const addr = row.addr;
-                    const dnsState = ipDnsState(addr);
-                    const systemRow =
-                      addr.status === "network" ||
-                      addr.status === "broadcast" ||
-                      !!addr.auto_from_lease;
-                    const rowSelected = selectedIpIds.has(addr.id);
-                    // RBAC gate (#103/#449): subnet-write OR the IP falls
-                    // inside an address set the operator can write. The
-                    // server is the real gate — this only hides affordances.
-                    const permitsWrite = permitsWriteIp(addr.address);
-                    const canEdit =
-                      !systemRow &&
-                      addr.status !== "orphan" &&
-                      !isReadOnly(addr.status) &&
-                      permitsWrite;
-                    return (
-                      <ContextMenu key={addr.id}>
-                        <ContextMenuTrigger asChild>
+                          No addresses match the active filters.
+                        </td>
+                      </tr>
+                    )}
+                    {visibleRows.map((row, rowIdx) => {
+                      if (row.kind === "pool-boundary") {
+                        const pool = row.pool;
+                        const isDynamic = pool.pool_type === "dynamic";
+                        const tint = isDynamic
+                          ? "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300 border-y border-cyan-500/30"
+                          : pool.pool_type === "reserved"
+                            ? "bg-violet-500/10 text-violet-700 dark:text-violet-300 border-y border-violet-500/30"
+                            : "bg-zinc-500/10 text-zinc-700 dark:text-zinc-300 border-y border-zinc-500/30";
+                        const arrow = row.boundary === "start" ? "▼" : "▲";
+                        const label =
+                          row.boundary === "start"
+                            ? `Start of ${pool.pool_type} pool`
+                            : `End of ${pool.pool_type} pool`;
+                        const anchorIp =
+                          row.boundary === "start"
+                            ? pool.start_ip
+                            : pool.end_ip;
+                        return (
+                          <tr key={`pool-${pool.id}-${row.boundary}-${rowIdx}`}>
+                            <td
+                              colSpan={12}
+                              className={cn("px-4 py-1.5", tint)}
+                            >
+                              <span className="mr-2 font-mono text-xs">
+                                {arrow}
+                              </span>
+                              <span className="text-xs font-semibold uppercase tracking-wide">
+                                {label}
+                              </span>
+                              {pool.name && (
+                                <span className="ml-2 text-xs">
+                                  — {pool.name}
+                                </span>
+                              )}
+                              <span className="ml-2 font-mono text-xs opacity-80">
+                                {anchorIp}
+                              </span>
+                              <span className="ml-3 text-[11px] opacity-70">
+                                range {pool.start_ip} – {pool.end_ip}
+                              </span>
+                            </td>
+                          </tr>
+                        );
+                      }
+                      if (row.kind === "gap") {
+                        const count = row.endIpInt - row.startIpInt + 1;
+                        const startIp = intToIpv4(row.startIpInt);
+                        const endIp = intToIpv4(row.endIpInt);
+                        const label =
+                          count === 1 ? startIp : `${startIp} – ${endIp}`;
+                        return (
                           <tr
-                            ref={registerHighlightRow(addr.id)}
-                            onClick={() => setViewingAddress(addr)}
-                            className={cn(
-                              "group/addr border-b last:border-0 hover:bg-muted/20 cursor-pointer",
-                              (addr.status === "network" ||
-                                addr.status === "broadcast") &&
-                                "opacity-50",
-                              addr.status === "orphan" && "opacity-40",
-                              // Gray out rows the operator can't write
-                              // (no subnet-write + not in a writable set).
-                              // Read stays active (row click → detail).
-                              !systemRow &&
-                                addr.status !== "orphan" &&
-                                !permitsWrite &&
-                                "opacity-50",
-                              rowSelected && "bg-primary/5",
-                              isHighlightedRow(addr.id) &&
-                                "spatium-row-highlight",
-                            )}
+                            key={`gap-${row.startIpInt}-${row.endIpInt}`}
+                            aria-label={`${count} unallocated IP${count === 1 ? "" : "s"} between rows`}
+                            className="cursor-pointer hover:bg-emerald-500/[0.10]"
+                            onClick={() => {
+                              setAddModalRange({
+                                startIpInt: row.startIpInt,
+                                endIpInt: row.endIpInt,
+                              });
+                              setShowAddModal(true);
+                            }}
+                            title={`Allocate an IP from this free range (${count} available)`}
                           >
                             <td
-                              className="w-8 px-2 py-2"
-                              onClick={(e) => e.stopPropagation()}
+                              colSpan={12}
+                              className="border-y border-dashed border-emerald-400/30 bg-emerald-500/[0.04] px-4 py-0.5 text-[11px] text-emerald-700/80 dark:border-emerald-500/30 dark:text-emerald-300/70"
                             >
-                              {!systemRow && permitsWrite && (
-                                <input
-                                  type="checkbox"
-                                  checked={rowSelected}
-                                  aria-label={`Select ${addr.address}`}
-                                  onClick={(e) => {
-                                    // ``onClick`` fires before ``onChange``
-                                    // and exposes shiftKey; stash it so
-                                    // the change handler can decide
-                                    // single vs. range toggle.
-                                    shiftDownAtClickRef.current = e.shiftKey;
-                                  }}
-                                  onChange={(e) => {
-                                    const newChecked = e.target.checked;
-                                    const lastId = lastClickedIpIdRef.current;
-                                    const useRange =
-                                      shiftDownAtClickRef.current &&
-                                      lastId !== null &&
-                                      lastId !== addr.id;
-                                    shiftDownAtClickRef.current = false;
-                                    lastClickedIpIdRef.current = addr.id;
-
-                                    setSelectedIpIds((prev) => {
-                                      const next = new Set(prev);
-                                      if (useRange) {
-                                        // Build the IP-only selectable
-                                        // order from the same tableRows
-                                        // that drives rendering, so the
-                                        // range matches what the user
-                                        // sees on screen.
-                                        const ids: string[] = [];
-                                        for (const r of tableRows) {
-                                          if (r.kind !== "ip") continue;
-                                          const a = r.addr;
-                                          if (
-                                            a.status === "network" ||
-                                            a.status === "broadcast" ||
-                                            a.auto_from_lease ||
-                                            // Skip rows the caller can't write so
-                                            // a shift-range can't sweep in
-                                            // un-writable rows (#514).
-                                            !permitsWriteIp(a.address)
-                                          )
-                                            continue;
-                                          ids.push(a.id);
-                                        }
-                                        const lo = ids.indexOf(lastId!);
-                                        const hi = ids.indexOf(addr.id);
-                                        if (lo !== -1 && hi !== -1) {
-                                          const [s, e2] =
-                                            lo < hi ? [lo, hi] : [hi, lo];
-                                          for (let i = s; i <= e2; i++) {
-                                            if (newChecked) next.add(ids[i]);
-                                            else next.delete(ids[i]);
-                                          }
-                                          return next;
-                                        }
-                                      }
-                                      if (newChecked) next.add(addr.id);
-                                      else next.delete(addr.id);
-                                      return next;
-                                    });
-                                  }}
-                                />
-                              )}
-                            </td>
-                            <td className="px-4 py-2 font-mono font-medium">
-                              <span className="inline-flex items-center gap-0.5">
-                                {addr.address}
-                                <CopyButton text={addr.address} />
+                              <span className="font-mono">{label}</span>
+                              <span className="ml-2 opacity-70">
+                                · {count} free
+                              </span>
+                              <span className="ml-2 opacity-60">
+                                · click to allocate
                               </span>
                             </td>
-                            <td className="px-4 py-2">
-                              <span className="inline-flex items-center gap-1.5">
+                          </tr>
+                        );
+                      }
+                      const addr = row.addr;
+                      const dnsState = ipDnsState(addr);
+                      const systemRow =
+                        addr.status === "network" ||
+                        addr.status === "broadcast" ||
+                        !!addr.auto_from_lease;
+                      const rowSelected = selectedIpIds.has(addr.id);
+                      // RBAC gate (#103/#449): subnet-write OR the IP falls
+                      // inside an address set the operator can write. The
+                      // server is the real gate — this only hides affordances.
+                      const permitsWrite = permitsWriteIp(addr.address);
+                      const canEdit =
+                        !systemRow &&
+                        addr.status !== "orphan" &&
+                        !isReadOnly(addr.status) &&
+                        permitsWrite;
+                      return (
+                        <ContextMenu key={addr.id}>
+                          <ContextMenuTrigger asChild>
+                            <tr
+                              ref={registerHighlightRow(addr.id)}
+                              onClick={() => setViewingAddress(addr)}
+                              className={cn(
+                                "group/addr border-b last:border-0 hover:bg-muted/20 cursor-pointer",
+                                (addr.status === "network" ||
+                                  addr.status === "broadcast") &&
+                                  "opacity-50",
+                                addr.status === "orphan" && "opacity-40",
+                                // Gray out rows the operator can't write
+                                // (no subnet-write + not in a writable set).
+                                // Read stays active (row click → detail).
+                                !systemRow &&
+                                  addr.status !== "orphan" &&
+                                  !permitsWrite &&
+                                  "opacity-50",
+                                rowSelected && "bg-primary/5",
+                                isHighlightedRow(addr.id) &&
+                                  "spatium-row-highlight",
+                              )}
+                            >
+                              <td
+                                className="w-8 px-2 py-2"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                {!systemRow && permitsWrite && (
+                                  <input
+                                    type="checkbox"
+                                    checked={rowSelected}
+                                    aria-label={`Select ${addr.address}`}
+                                    onClick={(e) => {
+                                      // ``onClick`` fires before ``onChange``
+                                      // and exposes shiftKey; stash it so
+                                      // the change handler can decide
+                                      // single vs. range toggle.
+                                      shiftDownAtClickRef.current = e.shiftKey;
+                                    }}
+                                    onChange={(e) => {
+                                      const newChecked = e.target.checked;
+                                      const lastId = lastClickedIpIdRef.current;
+                                      const useRange =
+                                        shiftDownAtClickRef.current &&
+                                        lastId !== null &&
+                                        lastId !== addr.id;
+                                      shiftDownAtClickRef.current = false;
+                                      lastClickedIpIdRef.current = addr.id;
+
+                                      setSelectedIpIds((prev) => {
+                                        const next = new Set(prev);
+                                        if (useRange) {
+                                          // Build the IP-only selectable
+                                          // order from the same tableRows
+                                          // that drives rendering, so the
+                                          // range matches what the user
+                                          // sees on screen.
+                                          const ids: string[] = [];
+                                          for (const r of tableRows) {
+                                            if (r.kind !== "ip") continue;
+                                            const a = r.addr;
+                                            if (
+                                              a.status === "network" ||
+                                              a.status === "broadcast" ||
+                                              a.auto_from_lease ||
+                                              // Skip rows the caller can't write so
+                                              // a shift-range can't sweep in
+                                              // un-writable rows (#514).
+                                              !permitsWriteIp(a.address)
+                                            )
+                                              continue;
+                                            ids.push(a.id);
+                                          }
+                                          const lo = ids.indexOf(lastId!);
+                                          const hi = ids.indexOf(addr.id);
+                                          if (lo !== -1 && hi !== -1) {
+                                            const [s, e2] =
+                                              lo < hi ? [lo, hi] : [hi, lo];
+                                            for (let i = s; i <= e2; i++) {
+                                              if (newChecked) next.add(ids[i]);
+                                              else next.delete(ids[i]);
+                                            }
+                                            return next;
+                                          }
+                                        }
+                                        if (newChecked) next.add(addr.id);
+                                        else next.delete(addr.id);
+                                        return next;
+                                      });
+                                    }}
+                                  />
+                                )}
+                              </td>
+                              <td className="px-4 py-2 font-mono font-medium">
+                                <span className="inline-flex items-center gap-0.5">
+                                  {addr.address}
+                                  <CopyButton text={addr.address} />
+                                </span>
+                              </td>
+                              <td className="px-4 py-2">
+                                <span className="inline-flex items-center gap-1.5">
+                                  <InlineEditableText
+                                    value={addr.hostname ?? ""}
+                                    placeholder="hostname"
+                                    disabled={!canEdit}
+                                    onSave={(v) =>
+                                      inlineEditMut.mutate({
+                                        id: addr.id,
+                                        data: { hostname: v.trim() || null },
+                                      })
+                                    }
+                                    display={
+                                      addr.fqdn ? (
+                                        <span className="font-mono text-xs">
+                                          {addr.fqdn}
+                                        </span>
+                                      ) : addr.hostname ? (
+                                        <span className="text-muted-foreground">
+                                          {addr.hostname}
+                                        </span>
+                                      ) : (
+                                        <span className="text-muted-foreground/40">
+                                          —
+                                        </span>
+                                      )
+                                    }
+                                  />
+                                  {(addr.alias_count ?? 0) > 0 && (
+                                    <span
+                                      className="inline-flex items-center rounded bg-indigo-100 px-1.5 py-0.5 text-[10px] font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400"
+                                      title={`${addr.alias_count} alias${(addr.alias_count ?? 0) === 1 ? "" : "es"} — edit IP to view`}
+                                    >
+                                      +{addr.alias_count}{" "}
+                                      {addr.alias_count === 1
+                                        ? "alias"
+                                        : "aliases"}
+                                    </span>
+                                  )}
+                                  {(addr.nat_mapping_count ?? 0) > 0 && (
+                                    <button
+                                      type="button"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        setNatModalIp(addr);
+                                      }}
+                                      className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50"
+                                      title={`Click to view ${addr.nat_mapping_count} NAT mapping${(addr.nat_mapping_count ?? 0) === 1 ? "" : "s"}`}
+                                    >
+                                      NAT {addr.nat_mapping_count}
+                                    </button>
+                                  )}
+                                </span>
+                              </td>
+                              <td className="px-4 py-2 font-mono text-xs">
+                                {addr.mac_address ? (
+                                  <>
+                                    {addr.mac_address}
+                                    {addr.is_voip_phone && (
+                                      <span
+                                        title={
+                                          addr.vendor
+                                            ? `VoIP phone — ${addr.vendor}`
+                                            : "VoIP phone"
+                                        }
+                                        className="inline-flex"
+                                      >
+                                        <Phone
+                                          className="ml-1 inline h-3 w-3 align-text-bottom text-sky-600 dark:text-sky-400"
+                                          aria-label="VoIP phone"
+                                        />
+                                      </span>
+                                    )}
+                                    {addr.vendor && (
+                                      <span className="ml-1 font-sans text-[11px] text-muted-foreground">
+                                        ({addr.vendor})
+                                      </span>
+                                    )}
+                                  </>
+                                ) : (
+                                  <span className="text-muted-foreground/40">
+                                    —
+                                  </span>
+                                )}
+                              </td>
+                              <td className="px-4 py-2 text-muted-foreground">
                                 <InlineEditableText
-                                  value={addr.hostname ?? ""}
-                                  placeholder="hostname"
+                                  value={addr.description ?? ""}
+                                  placeholder="description"
                                   disabled={!canEdit}
-                                  onActivate={() => setViewingAddress(addr)}
                                   onSave={(v) =>
                                     inlineEditMut.mutate({
                                       id: addr.id,
-                                      data: { hostname: v.trim() || null },
+                                      data: { description: v.trim() },
                                     })
                                   }
                                   display={
-                                    addr.fqdn ? (
-                                      <span className="font-mono text-xs">
-                                        {addr.fqdn}
-                                      </span>
-                                    ) : addr.hostname ? (
-                                      <span className="text-muted-foreground">
-                                        {addr.hostname}
-                                      </span>
+                                    addr.description ? (
+                                      <>{addr.description}</>
                                     ) : (
                                       <span className="text-muted-foreground/40">
                                         —
@@ -5954,343 +6222,285 @@ function SubnetDetail({
                                     )
                                   }
                                 />
-                                {(addr.alias_count ?? 0) > 0 && (
-                                  <span
-                                    className="inline-flex items-center rounded bg-indigo-100 px-1.5 py-0.5 text-[10px] font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400"
-                                    title={`${addr.alias_count} alias${(addr.alias_count ?? 0) === 1 ? "" : "es"} — edit IP to view`}
-                                  >
-                                    +{addr.alias_count}{" "}
-                                    {addr.alias_count === 1
-                                      ? "alias"
-                                      : "aliases"}
-                                  </span>
-                                )}
-                                {(addr.nat_mapping_count ?? 0) > 0 && (
-                                  <button
-                                    type="button"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      setNatModalIp(addr);
-                                    }}
-                                    className="inline-flex items-center rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50"
-                                    title={`Click to view ${addr.nat_mapping_count} NAT mapping${(addr.nat_mapping_count ?? 0) === 1 ? "" : "s"}`}
-                                  >
-                                    NAT {addr.nat_mapping_count}
-                                  </button>
-                                )}
-                              </span>
-                            </td>
-                            <td className="px-4 py-2 font-mono text-xs">
-                              {addr.mac_address ? (
-                                <>
-                                  {addr.mac_address}
-                                  {addr.is_voip_phone && (
+                              </td>
+                              <td className="px-4 py-2">
+                                {(() => {
+                                  const t =
+                                    (addr.tags as Record<
+                                      string,
+                                      unknown
+                                    > | null) ?? {};
+                                  const entries = Object.entries(t);
+                                  if (entries.length === 0)
+                                    return (
+                                      <span className="text-muted-foreground/40">
+                                        —
+                                      </span>
+                                    );
+                                  return (
+                                    <div className="flex flex-wrap gap-1">
+                                      {entries.map(([k, v]) => {
+                                        const vStr = v == null ? "" : String(v);
+                                        const label = vStr ? `${k}=${vStr}` : k;
+                                        return (
+                                          <button
+                                            key={k}
+                                            type="button"
+                                            onClick={() => {
+                                              setColFilters((p) => ({
+                                                ...p,
+                                                tags: label,
+                                              }));
+                                              setShowFilters(true);
+                                            }}
+                                            title={`Filter by ${label}`}
+                                            className="inline-flex max-w-[14rem] items-center truncate rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] font-medium text-sky-700 hover:border-sky-300 hover:bg-sky-100 dark:border-sky-900/60 dark:bg-sky-900/30 dark:text-sky-300 dark:hover:bg-sky-900/50"
+                                          >
+                                            {label}
+                                          </button>
+                                        );
+                                      })}
+                                    </div>
+                                  );
+                                })()}
+                              </td>
+                              <td className="px-4 py-2">
+                                <span className="inline-flex items-center">
+                                  <InlineStatusSelect
+                                    status={addr.status}
+                                    disabled={!canEdit}
+                                    onSave={(v) =>
+                                      inlineEditMut.mutate({
+                                        id: addr.id,
+                                        data: { status: v },
+                                      })
+                                    }
+                                  />
+                                  {addr.role ? (
+                                    <RoleBadge role={addr.role} />
+                                  ) : null}
+                                </span>
+                              </td>
+                              <td className="px-4 py-2">
+                                {(() => {
+                                  const pi = ipPoolInfo(addr);
+                                  if (!pi)
+                                    return (
+                                      <span className="text-muted-foreground/40">
+                                        —
+                                      </span>
+                                    );
+                                  const cls =
+                                    pi.type === "dynamic"
+                                      ? "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400"
+                                      : pi.type === "reserved"
+                                        ? "bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-400"
+                                        : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800/30 dark:text-zinc-400";
+                                  return (
                                     <span
-                                      title={
-                                        addr.vendor
-                                          ? `VoIP phone — ${addr.vendor}`
-                                          : "VoIP phone"
-                                      }
-                                      className="inline-flex"
+                                      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}
                                     >
-                                      <Phone
-                                        className="ml-1 inline h-3 w-3 align-text-bottom text-sky-600 dark:text-sky-400"
-                                        aria-label="VoIP phone"
-                                      />
-                                    </span>
-                                  )}
-                                  {addr.vendor && (
-                                    <span className="ml-1 font-sans text-[11px] text-muted-foreground">
-                                      ({addr.vendor})
-                                    </span>
-                                  )}
-                                </>
-                              ) : (
-                                <span className="text-muted-foreground/40">
-                                  —
-                                </span>
-                              )}
-                            </td>
-                            <td className="px-4 py-2 text-muted-foreground">
-                              <InlineEditableText
-                                value={addr.description ?? ""}
-                                placeholder="description"
-                                disabled={!canEdit}
-                                onActivate={() => setViewingAddress(addr)}
-                                onSave={(v) =>
-                                  inlineEditMut.mutate({
-                                    id: addr.id,
-                                    data: { description: v.trim() },
-                                  })
-                                }
-                                display={
-                                  addr.description ? (
-                                    <>{addr.description}</>
-                                  ) : (
-                                    <span className="text-muted-foreground/40">
-                                      —
-                                    </span>
-                                  )
-                                }
-                              />
-                            </td>
-                            <td className="px-4 py-2">
-                              {(() => {
-                                const t =
-                                  (addr.tags as Record<
-                                    string,
-                                    unknown
-                                  > | null) ?? {};
-                                const entries = Object.entries(t);
-                                if (entries.length === 0)
-                                  return (
-                                    <span className="text-muted-foreground/40">
-                                      —
+                                      {pi.name}
                                     </span>
                                   );
-                                return (
-                                  <div className="flex flex-wrap gap-1">
-                                    {entries.map(([k, v]) => {
-                                      const vStr = v == null ? "" : String(v);
-                                      const label = vStr ? `${k}=${vStr}` : k;
-                                      return (
-                                        <button
-                                          key={k}
-                                          type="button"
-                                          onClick={() => {
-                                            setColFilters((p) => ({
-                                              ...p,
-                                              tags: label,
-                                            }));
-                                            setShowFilters(true);
-                                          }}
-                                          title={`Filter by ${label}`}
-                                          className="inline-flex max-w-[14rem] items-center truncate rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[10px] font-medium text-sky-700 hover:border-sky-300 hover:bg-sky-100 dark:border-sky-900/60 dark:bg-sky-900/30 dark:text-sky-300 dark:hover:bg-sky-900/50"
-                                        >
-                                          {label}
-                                        </button>
-                                      );
-                                    })}
-                                  </div>
-                                );
-                              })()}
-                            </td>
-                            <td className="px-4 py-2">
-                              <span className="inline-flex items-center">
-                                <InlineStatusSelect
-                                  status={addr.status}
-                                  disabled={!canEdit}
-                                  onActivate={() => setViewingAddress(addr)}
-                                  onSave={(v) =>
-                                    inlineEditMut.mutate({
-                                      id: addr.id,
-                                      data: { status: v },
-                                    })
-                                  }
-                                />
-                                {addr.role ? (
-                                  <RoleBadge role={addr.role} />
-                                ) : null}
-                              </span>
-                            </td>
-                            <td className="px-4 py-2">
-                              {(() => {
-                                const pi = ipPoolInfo(addr);
-                                if (!pi)
-                                  return (
-                                    <span className="text-muted-foreground/40">
-                                      —
-                                    </span>
-                                  );
-                                const cls =
-                                  pi.type === "dynamic"
-                                    ? "bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-400"
-                                    : pi.type === "reserved"
-                                      ? "bg-violet-100 text-violet-800 dark:bg-violet-900/30 dark:text-violet-400"
-                                      : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800/30 dark:text-zinc-400";
-                                return (
+                                })()}
+                              </td>
+                              <td className="px-4 py-2">
+                                {dnsState === "in-sync" ? (
                                   <span
-                                    className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}
+                                    className="inline-flex items-center gap-1 text-xs text-emerald-600"
+                                    title="DNS records match IPAM"
                                   >
-                                    {pi.name}
+                                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                                    in sync
                                   </span>
-                                );
-                              })()}
-                            </td>
-                            <td className="px-4 py-2">
-                              {dnsState === "in-sync" ? (
-                                <span
-                                  className="inline-flex items-center gap-1 text-xs text-emerald-600"
-                                  title="DNS records match IPAM"
-                                >
-                                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                                  in sync
-                                </span>
-                              ) : dnsState === "out-of-sync" ? (
-                                <span
-                                  className="inline-flex items-center gap-1 text-xs text-amber-600"
-                                  title="DNS records are missing or differ — open Sync DNS to reconcile"
-                                >
-                                  <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500" />
-                                  out of sync
-                                </span>
-                              ) : (
-                                <span className="text-muted-foreground/40">
-                                  —
-                                </span>
-                              )}
-                            </td>
-                            {/* Seen — recency dot derived from
+                                ) : dnsState === "out-of-sync" ? (
+                                  <span
+                                    className="inline-flex items-center gap-1 text-xs text-amber-600"
+                                    title="DNS records are missing or differ — open Sync DNS to reconcile"
+                                  >
+                                    <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500" />
+                                    out of sync
+                                  </span>
+                                ) : (
+                                  <span className="text-muted-foreground/40">
+                                    —
+                                  </span>
+                                )}
+                              </td>
+                              {/* Seen — recency dot derived from
                                   ``last_seen_at``. Orthogonal to status:
                                   an ``allocated`` row can still be cold,
                                   a ``discovered`` row can be alive right
                                   now. Tooltip carries exact age + method. */}
-                            <td className="px-4 py-2">
-                              <SeenDot
-                                lastSeenAt={addr.last_seen_at}
-                                lastSeenMethod={addr.last_seen_method}
-                                withLabel
-                              />
-                            </td>
-                            {/* Network discovery — switch / port / VLAN
+                              <td className="px-4 py-2">
+                                <SeenDot
+                                  lastSeenAt={addr.last_seen_at}
+                                  lastSeenMethod={addr.last_seen_method}
+                                  withLabel
+                                />
+                              </td>
+                              {/* Network discovery — switch / port / VLAN
                                   from the SNMP-discovered FDB. May render
                                   multiple lines for trunk ports / hypervisor
                                   hosts where one MAC is learned across VLANs. */}
-                            <td className="px-4 py-2">
-                              <NetworkContextCell
-                                entries={subnetNetworkContext?.[addr.id] ?? []}
-                              />
-                            </td>
-                            <td
-                              className="px-4 py-2 text-right"
-                              onClick={(e) => e.stopPropagation()}
+                              <td className="px-4 py-2">
+                                <NetworkContextCell
+                                  entries={
+                                    subnetNetworkContext?.[addr.id] ?? []
+                                  }
+                                />
+                              </td>
+                              <td
+                                className="px-4 py-2 text-right"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <div className="flex items-center justify-end gap-1">
+                                  {addr.status === "orphan" ? (
+                                    <>
+                                      <button
+                                        onClick={() =>
+                                          restoreAddr.mutate(addr.id)
+                                        }
+                                        disabled={restoreAddr.isPending}
+                                        className="rounded p-1 text-xs text-muted-foreground hover:text-green-600"
+                                        title="Restore (mark as allocated)"
+                                      >
+                                        <RefreshCw className="h-3.5 w-3.5" />
+                                      </button>
+                                      <button
+                                        onClick={() =>
+                                          setConfirmPurgeAddr(addr)
+                                        }
+                                        className="rounded p-1 text-muted-foreground hover:text-destructive"
+                                        title="Permanently delete"
+                                      >
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                      </button>
+                                    </>
+                                  ) : addr.auto_from_lease ? (
+                                    // Mirror of a dynamic DHCP lease — the DHCP
+                                    // server owns the state; editing or deleting
+                                    // from IPAM would just get overwritten on
+                                    // the next pull. Show a lock hint instead.
+                                    <span
+                                      className="inline-flex items-center rounded p-1 text-muted-foreground/60"
+                                      title="Managed by DHCP server — edit the lease or reservation at the source. This row is refreshed by the lease-pull task."
+                                    >
+                                      <Lock className="h-3.5 w-3.5" />
+                                    </span>
+                                  ) : !isReadOnly(addr.status) ? (
+                                    <>
+                                      <button
+                                        onClick={() => setEditingAddress(addr)}
+                                        className="rounded p-1 text-muted-foreground hover:text-foreground"
+                                        title={`Edit ${addr.address}`}
+                                        aria-label={`Edit ${addr.address}`}
+                                      >
+                                        <Pencil className="h-3.5 w-3.5" />
+                                      </button>
+                                      <button
+                                        onClick={() =>
+                                          setConfirmDeleteAddr(addr)
+                                        }
+                                        className="rounded p-1 text-muted-foreground hover:text-destructive"
+                                        title={`Delete ${addr.address}`}
+                                        aria-label={`Delete ${addr.address}`}
+                                      >
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                      </button>
+                                    </>
+                                  ) : null}
+                                </div>
+                              </td>
+                            </tr>
+                          </ContextMenuTrigger>
+                          <ContextMenuContent>
+                            <ContextMenuLabel>{addr.address}</ContextMenuLabel>
+                            <ContextMenuSeparator />
+                            <ContextMenuItem
+                              onSelect={() => copyToClipboard(addr.address)}
                             >
-                              <div className="flex items-center justify-end gap-1">
-                                {addr.status === "orphan" ? (
-                                  <>
-                                    <button
-                                      onClick={() =>
-                                        restoreAddr.mutate(addr.id)
-                                      }
-                                      disabled={restoreAddr.isPending}
-                                      className="rounded p-1 text-xs text-muted-foreground hover:text-green-600"
-                                      title="Restore (mark as allocated)"
-                                    >
-                                      <RefreshCw className="h-3.5 w-3.5" />
-                                    </button>
-                                    <button
-                                      onClick={() => setConfirmPurgeAddr(addr)}
-                                      className="rounded p-1 text-muted-foreground hover:text-destructive"
-                                      title="Permanently delete"
-                                    >
-                                      <Trash2 className="h-3.5 w-3.5" />
-                                    </button>
-                                  </>
-                                ) : addr.auto_from_lease ? (
-                                  // Mirror of a dynamic DHCP lease — the DHCP
-                                  // server owns the state; editing or deleting
-                                  // from IPAM would just get overwritten on
-                                  // the next pull. Show a lock hint instead.
-                                  <span
-                                    className="inline-flex items-center rounded p-1 text-muted-foreground/60"
-                                    title="Managed by DHCP server — edit the lease or reservation at the source. This row is refreshed by the lease-pull task."
-                                  >
-                                    <Lock className="h-3.5 w-3.5" />
-                                  </span>
-                                ) : !isReadOnly(addr.status) ? (
-                                  <>
-                                    <button
-                                      onClick={() => setEditingAddress(addr)}
-                                      className="rounded p-1 text-muted-foreground hover:text-foreground"
-                                      title={`Edit ${addr.address}`}
-                                      aria-label={`Edit ${addr.address}`}
-                                    >
-                                      <Pencil className="h-3.5 w-3.5" />
-                                    </button>
-                                    <button
-                                      onClick={() => setConfirmDeleteAddr(addr)}
-                                      className="rounded p-1 text-muted-foreground hover:text-destructive"
-                                      title={`Delete ${addr.address}`}
-                                      aria-label={`Delete ${addr.address}`}
-                                    >
-                                      <Trash2 className="h-3.5 w-3.5" />
-                                    </button>
-                                  </>
-                                ) : null}
-                              </div>
-                            </td>
-                          </tr>
-                        </ContextMenuTrigger>
-                        <ContextMenuContent>
-                          <ContextMenuLabel>{addr.address}</ContextMenuLabel>
-                          <ContextMenuSeparator />
-                          <ContextMenuItem
-                            onSelect={() => copyToClipboard(addr.address)}
+                              Copy IP
+                            </ContextMenuItem>
+                            {addr.fqdn && (
+                              <ContextMenuItem
+                                onSelect={() => copyToClipboard(addr.fqdn!)}
+                              >
+                                Copy FQDN
+                              </ContextMenuItem>
+                            )}
+                            {addr.mac_address && (
+                              <ContextMenuItem
+                                onSelect={() =>
+                                  copyToClipboard(addr.mac_address!)
+                                }
+                              >
+                                Copy MAC
+                              </ContextMenuItem>
+                            )}
+                            {canEdit && (
+                              <>
+                                <ContextMenuSeparator />
+                                <ContextMenuItem
+                                  onSelect={() => setEditingAddress(addr)}
+                                >
+                                  Edit…
+                                </ContextMenuItem>
+                                <ContextMenuItem
+                                  destructive
+                                  onSelect={() => setConfirmDeleteAddr(addr)}
+                                >
+                                  Delete…
+                                </ContextMenuItem>
+                              </>
+                            )}
+                            {addr.status === "orphan" && (
+                              <>
+                                <ContextMenuSeparator />
+                                <ContextMenuItem
+                                  onSelect={() => restoreAddr.mutate(addr.id)}
+                                >
+                                  Restore
+                                </ContextMenuItem>
+                                <ContextMenuItem
+                                  destructive
+                                  onSelect={() => setConfirmPurgeAddr(addr)}
+                                >
+                                  Delete Forever…
+                                </ContextMenuItem>
+                              </>
+                            )}
+                            {addr.auto_from_lease && (
+                              <>
+                                <ContextMenuSeparator />
+                                <ContextMenuItem disabled>
+                                  Managed by DHCP — read-only
+                                </ContextMenuItem>
+                              </>
+                            )}
+                          </ContextMenuContent>
+                        </ContextMenu>
+                      );
+                    })}
+                    {hiddenRowCount > 0 && (
+                      <tr>
+                        <td colSpan={12} className="px-4 py-2 text-center">
+                          <button
+                            type="button"
+                            onClick={() => setShowAllAddressRows(true)}
+                            className="rounded-md border border-dashed px-3 py-1 text-xs text-muted-foreground hover:bg-muted/40"
+                            title="Rendering is capped for performance on large subnets"
                           >
-                            Copy IP
-                          </ContextMenuItem>
-                          {addr.fqdn && (
-                            <ContextMenuItem
-                              onSelect={() => copyToClipboard(addr.fqdn!)}
-                            >
-                              Copy FQDN
-                            </ContextMenuItem>
-                          )}
-                          {addr.mac_address && (
-                            <ContextMenuItem
-                              onSelect={() =>
-                                copyToClipboard(addr.mac_address!)
-                              }
-                            >
-                              Copy MAC
-                            </ContextMenuItem>
-                          )}
-                          {canEdit && (
-                            <>
-                              <ContextMenuSeparator />
-                              <ContextMenuItem
-                                onSelect={() => setEditingAddress(addr)}
-                              >
-                                Edit…
-                              </ContextMenuItem>
-                              <ContextMenuItem
-                                destructive
-                                onSelect={() => setConfirmDeleteAddr(addr)}
-                              >
-                                Delete…
-                              </ContextMenuItem>
-                            </>
-                          )}
-                          {addr.status === "orphan" && (
-                            <>
-                              <ContextMenuSeparator />
-                              <ContextMenuItem
-                                onSelect={() => restoreAddr.mutate(addr.id)}
-                              >
-                                Restore
-                              </ContextMenuItem>
-                              <ContextMenuItem
-                                destructive
-                                onSelect={() => setConfirmPurgeAddr(addr)}
-                              >
-                                Delete Forever…
-                              </ContextMenuItem>
-                            </>
-                          )}
-                          {addr.auto_from_lease && (
-                            <>
-                              <ContextMenuSeparator />
-                              <ContextMenuItem disabled>
-                                Managed by DHCP — read-only
-                              </ContextMenuItem>
-                            </>
-                          )}
-                        </ContextMenuContent>
-                      </ContextMenu>
-                    );
-                  })}
-                </tbody>
-              </table>
+                            Show {hiddenRowCount.toLocaleString()} more row
+                            {hiddenRowCount === 1 ? "" : "s"}…
+                          </button>
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              )}
             </>
           )}
         </div>
@@ -9369,7 +9579,11 @@ function BulkEditAddressesModal({
   onDone,
 }: {
   ipIds: string[];
-  subnetId: string;
+  // Absent when editing a cross-subnet selection from the global IP search
+  // (issue #520). In that mode the subnet-scoped DNS-zone assignment and
+  // "replace all tags" affordances are hidden (both need a single subnet's
+  // effective config / full row set to be correct).
+  subnetId?: string;
   onClose: () => void;
   onDone: () => void;
 }) {
@@ -9405,8 +9619,9 @@ function BulkEditAddressesModal({
   // for the subnet, then restrict the picker to explicit primary + additional
   // zones. Falling back to all group zones only when nothing is pinned.
   const { data: effectiveDns } = useQuery({
-    queryKey: ["effective-dns-subnet", subnetId],
-    queryFn: () => ipamApi.getEffectiveSubnetDns(subnetId),
+    queryKey: ["effective-dns-subnet", subnetId ?? "none"],
+    queryFn: () => ipamApi.getEffectiveSubnetDns(subnetId as string),
+    enabled: !!subnetId,
     staleTime: 30_000,
   });
   const zoneGroupIds: string[] = effectiveDns?.dns_group_ids ?? [];
@@ -9443,8 +9658,9 @@ function BulkEditAddressesModal({
   // Needed for "replace all tags" mode: we need the union of existing keys
   // across the selected IPs so we can null them out server-side.
   const { data: subnetAddresses = [] } = useQuery({
-    queryKey: ["addresses", subnetId],
-    queryFn: () => ipamApi.listAddresses(subnetId),
+    queryKey: ["addresses", subnetId ?? "none"],
+    queryFn: () => ipamApi.listAddresses(subnetId as string),
+    enabled: !!subnetId,
   });
   const selectedIpSet = new Set(ipIds);
   const existingTagKeys = new Set<string>();
@@ -9516,11 +9732,17 @@ function BulkEditAddressesModal({
       return ipamApi.bulkEditAddresses({ ip_ids: ipIds, changes });
     },
     onSuccess: (res) => {
-      qc.invalidateQueries({ queryKey: ["addresses", subnetId] });
+      // Cross-subnet edit (no subnetId) → invalidate broadly so every
+      // affected subnet's list refetches.
+      qc.invalidateQueries({
+        queryKey: subnetId ? ["addresses", subnetId] : ["addresses"],
+      });
       qc.invalidateQueries({ queryKey: ["dns-records"] });
       qc.invalidateQueries({ queryKey: ["dns-group-records"] });
       qc.invalidateQueries({ queryKey: ["dns-zones"] });
-      qc.invalidateQueries({ queryKey: ["subnet-aliases", subnetId] });
+      qc.invalidateQueries({ queryKey: ["subnets"] });
+      if (subnetId)
+        qc.invalidateQueries({ queryKey: ["subnet-aliases", subnetId] });
       if (res.skipped.length > 0) {
         setError(
           `${res.updated_count} updated; ${res.skipped.length} skipped (system/orphan rows).`,
@@ -9710,14 +9932,20 @@ function BulkEditAddressesModal({
           </label>
           {editTags && (
             <>
-              <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                <input
-                  type="checkbox"
-                  checked={replaceAllTags}
-                  onChange={(e) => setReplaceAllTags(e.target.checked)}
-                />
-                Replace all tags (clear existing keys that aren't listed below)
-              </label>
+              {/* "Replace all" needs the union of existing keys across the
+                  selection, which we only load for a single subnet. Hidden
+                  in cross-subnet mode (#520). */}
+              {subnetId && (
+                <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={replaceAllTags}
+                    onChange={(e) => setReplaceAllTags(e.target.checked)}
+                  />
+                  Replace all tags (clear existing keys that aren't listed
+                  below)
+                </label>
+              )}
               <p className="text-[11px] text-muted-foreground">
                 {replaceAllTags ? (
                   <>
@@ -9941,7 +10169,8 @@ function BulkDeleteAddressesModal({
   onDone,
 }: {
   ipIds: string[];
-  subnetId: string;
+  // Absent for a cross-subnet selection from the global IP search (#520).
+  subnetId?: string;
   onClose: () => void;
   onDone: () => void;
 }) {
@@ -9952,14 +10181,17 @@ function BulkDeleteAddressesModal({
   const mutation = useMutation({
     mutationFn: () => ipamApi.bulkDeleteAddresses({ ip_ids: ipIds, permanent }),
     onSuccess: (res) => {
-      qc.invalidateQueries({ queryKey: ["addresses", subnetId] });
+      qc.invalidateQueries({
+        queryKey: subnetId ? ["addresses", subnetId] : ["addresses"],
+      });
       // Refresh subnet utilization (tree dot + space-table "Used IPs") the way
       // the single-delete path does — bulk-delete was missing this (#509).
       qc.invalidateQueries({ queryKey: ["subnets"] });
       qc.invalidateQueries({ queryKey: ["dns-records"] });
       qc.invalidateQueries({ queryKey: ["dns-group-records"] });
       qc.invalidateQueries({ queryKey: ["dns-zones"] });
-      qc.invalidateQueries({ queryKey: ["subnet-aliases", subnetId] });
+      if (subnetId)
+        qc.invalidateQueries({ queryKey: ["subnet-aliases", subnetId] });
       if (res.skipped.length > 0) {
         setError(
           `${res.deleted_count} deleted; ${res.skipped.length} skipped (system rows).`,
@@ -14645,6 +14877,353 @@ function IpamHelpLegend() {
   );
 }
 
+// ─── Global cross-subnet IP search (issue #520) ──────────────────────────────
+//
+// A "find IP anywhere" surface: search every subnet the operator can read
+// (server enforces read-permission scoping), group hits by subnet, select
+// rows across pages (or "select all N matches" via the ids endpoint), then
+// hand the selection to the EXISTING cross-subnet-safe bulk edit / delete
+// modals. No bulk plumbing is duplicated — only the selection is gathered.
+function GlobalIpSearchModal({ onClose }: { onClose: () => void }) {
+  const SEARCH_PAGE_SIZE = 100;
+  // Draft inputs vs. the applied query (applied on Search / Enter) so we
+  // don't fire a request on every keystroke.
+  const [qDraft, setQDraft] = useState("");
+  const [statusDraft, setStatusDraft] = useState("");
+  const [applied, setApplied] = useState<{ q: string; status: string }>({
+    q: "",
+    status: "",
+  });
+  const [offset, setOffset] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selectAllError, setSelectAllError] = useState<string | null>(null);
+  const [selectingAll, setSelectingAll] = useState(false);
+  const [showBulkEdit, setShowBulkEdit] = useState(false);
+  const [showBulkDelete, setShowBulkDelete] = useState(false);
+
+  const params = {
+    q: applied.q || undefined,
+    status_filter: applied.status || undefined,
+    limit: SEARCH_PAGE_SIZE,
+    offset,
+  };
+  const hasQuery = !!(applied.q || applied.status);
+  const { data, isFetching, error } = useQuery({
+    queryKey: ["ip-search", applied.q, applied.status, offset],
+    queryFn: () => ipamApi.searchAddresses(params),
+    enabled: hasQuery,
+    placeholderData: (prev) => prev,
+  });
+
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  const runSearch = () => {
+    setOffset(0);
+    setApplied({ q: qDraft.trim(), status: statusDraft });
+  };
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const selectAllMatches = async () => {
+    setSelectAllError(null);
+    setSelectingAll(true);
+    try {
+      const res = await ipamApi.searchAddressIds({
+        q: applied.q || undefined,
+        status_filter: applied.status || undefined,
+      });
+      setSelected(new Set(res.ids));
+      if (res.capped)
+        setSelectAllError(
+          `Selection capped at ${res.ids.length.toLocaleString()} of ${res.total.toLocaleString()} matches (server limit). Narrow the search to act on the rest.`,
+        );
+    } catch (e) {
+      setSelectAllError(formatApiError(e, "Failed to gather matching IPs."));
+    } finally {
+      setSelectingAll(false);
+    }
+  };
+
+  // Group the current page by subnet for readable rendering.
+  const grouped = useMemo(() => {
+    const map = new Map<
+      string,
+      {
+        cidr: string;
+        name: string | null;
+        space: string | null;
+        rows: IPAddressSearchItem[];
+      }
+    >();
+    for (const it of items) {
+      const key = it.subnet_id;
+      if (!map.has(key))
+        map.set(key, {
+          cidr: it.subnet_cidr,
+          name: it.subnet_name,
+          space: it.space_name,
+          rows: [],
+        });
+      map.get(key)!.rows.push(it);
+    }
+    return [...map.values()];
+  }, [items]);
+
+  const pageStart = total === 0 ? 0 : offset + 1;
+  const pageEnd = Math.min(offset + SEARCH_PAGE_SIZE, total);
+
+  return (
+    <>
+      <Modal title="Find IP addresses — all subnets" onClose={onClose} wide>
+        <div className="space-y-3">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              runSearch();
+            }}
+            className="flex flex-wrap items-end gap-2"
+          >
+            <div className="min-w-[12rem] flex-1">
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Search (IP · hostname · MAC · description)
+              </label>
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" />
+                <input
+                  autoFocus
+                  value={qDraft}
+                  onChange={(e) => setQDraft(e.target.value)}
+                  placeholder="e.g. 10.0.5 · db01 · aa:bb:cc"
+                  className="w-full rounded-md border bg-background py-1.5 pl-7 pr-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Status
+              </label>
+              <select
+                value={statusDraft}
+                onChange={(e) => setStatusDraft(e.target.value)}
+                className="rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                <option value="">Any</option>
+                {IP_STATUS_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              type="submit"
+              className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
+            >
+              Search
+            </button>
+          </form>
+
+          {!hasQuery && (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              Enter a search above to find IP addresses across every subnet you
+              can read.
+            </p>
+          )}
+
+          {error && (
+            <p className="text-sm text-destructive">
+              {formatApiError(error, "Search failed.")}
+            </p>
+          )}
+
+          {hasQuery && (
+            <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+              <span>
+                {isFetching ? (
+                  "Searching…"
+                ) : (
+                  <>
+                    Showing {pageStart.toLocaleString()}–
+                    {pageEnd.toLocaleString()} of {total.toLocaleString()} match
+                    {total === 1 ? "" : "es"}
+                  </>
+                )}
+              </span>
+              <div className="flex items-center gap-2">
+                {selected.size > 0 && (
+                  <span className="font-medium text-foreground">
+                    {selected.size.toLocaleString()} selected
+                  </span>
+                )}
+                {total > 0 && (
+                  <button
+                    type="button"
+                    onClick={selectAllMatches}
+                    disabled={selectingAll}
+                    className="rounded border px-2 py-0.5 hover:bg-muted disabled:opacity-50"
+                  >
+                    {selectingAll
+                      ? "Selecting…"
+                      : `Select all ${total.toLocaleString()} matches`}
+                  </button>
+                )}
+                {selected.size > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setSelected(new Set())}
+                    className="rounded border px-2 py-0.5 hover:bg-muted"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
+          {selectAllError && (
+            <p className="text-xs text-amber-600">{selectAllError}</p>
+          )}
+
+          {hasQuery && (
+            <div className="max-h-[45vh] overflow-auto rounded-md border">
+              {items.length === 0 && !isFetching ? (
+                <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+                  No IP addresses match.
+                </p>
+              ) : (
+                grouped.map((g) => (
+                  <div key={g.cidr} className="border-b last:border-0">
+                    <div className="sticky top-0 flex items-center gap-2 bg-muted/60 px-3 py-1 text-xs font-medium backdrop-blur">
+                      <Network className="h-3 w-3 text-blue-500" />
+                      <span className="font-mono">{g.cidr}</span>
+                      {g.name && (
+                        <span className="text-muted-foreground">
+                          — {g.name}
+                        </span>
+                      )}
+                      {g.space && (
+                        <span className="ml-auto text-muted-foreground/70">
+                          {g.space}
+                        </span>
+                      )}
+                    </div>
+                    {g.rows.map((it) => (
+                      <label
+                        key={it.id}
+                        className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-muted/30"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selected.has(it.id)}
+                          onChange={() => toggle(it.id)}
+                        />
+                        <span className="w-36 font-mono font-medium">
+                          {it.address}
+                        </span>
+                        <span className="w-40 truncate text-muted-foreground">
+                          {it.fqdn || it.hostname || "—"}
+                        </span>
+                        <span className="w-32 truncate font-mono text-xs text-muted-foreground">
+                          {it.mac_address || "—"}
+                        </span>
+                        <StatusTag status={it.status} />
+                      </label>
+                    ))}
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+
+          {hasQuery && total > SEARCH_PAGE_SIZE && (
+            <div className="flex items-center justify-between text-xs">
+              <button
+                type="button"
+                disabled={offset === 0 || isFetching}
+                onClick={() =>
+                  setOffset((o) => Math.max(0, o - SEARCH_PAGE_SIZE))
+                }
+                className="rounded border px-2 py-1 hover:bg-muted disabled:opacity-40"
+              >
+                ← Prev
+              </button>
+              <span className="text-muted-foreground">
+                Page {Math.floor(offset / SEARCH_PAGE_SIZE) + 1} of{" "}
+                {Math.ceil(total / SEARCH_PAGE_SIZE)}
+              </span>
+              <button
+                type="button"
+                disabled={pageEnd >= total || isFetching}
+                onClick={() => setOffset((o) => o + SEARCH_PAGE_SIZE)}
+                className="rounded border px-2 py-1 hover:bg-muted disabled:opacity-40"
+              >
+                Next →
+              </button>
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-2 border-t pt-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+            >
+              Close
+            </button>
+            <button
+              type="button"
+              disabled={selected.size === 0}
+              onClick={() => setShowBulkDelete(true)}
+              className="inline-flex items-center gap-1.5 rounded-md border border-destructive/40 px-3 py-1.5 text-sm text-destructive hover:bg-destructive/10 disabled:opacity-40"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete {selected.size > 0 ? selected.size.toLocaleString() : ""}…
+            </button>
+            <button
+              type="button"
+              disabled={selected.size === 0}
+              onClick={() => setShowBulkEdit(true)}
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-40"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              Bulk edit{" "}
+              {selected.size > 0 ? selected.size.toLocaleString() : ""}…
+            </button>
+          </div>
+        </div>
+      </Modal>
+
+      {showBulkEdit && (
+        <BulkEditAddressesModal
+          ipIds={[...selected]}
+          onClose={() => setShowBulkEdit(false)}
+          onDone={() => {
+            setShowBulkEdit(false);
+            setSelected(new Set());
+          }}
+        />
+      )}
+      {showBulkDelete && (
+        <BulkDeleteAddressesModal
+          ipIds={[...selected]}
+          onClose={() => setShowBulkDelete(false)}
+          onDone={() => {
+            setShowBulkDelete(false);
+            setSelected(new Set());
+          }}
+        />
+      )}
+    </>
+  );
+}
+
 // ─── Main IPAM Page ───────────────────────────────────────────────────────────
 
 export function IPAMPage() {
@@ -14654,6 +15233,8 @@ export function IPAMPage() {
   const [selectedBlock, setSelectedBlock] = useState<IPBlock | null>(null);
   const [showCreateSpace, setShowCreateSpace] = useState(false);
   const [showImport, setShowImport] = useState(false);
+  // Global cross-subnet IP search + bulk (issue #520).
+  const [showIpSearch, setShowIpSearch] = useState(false);
   // Tree quick-filter (network / name substring across every space).
   const [treeFilter, setTreeFilter] = useState("");
   // Progressive disclosure: dense by default, opt-in help layer. When on, a
@@ -14890,6 +15471,14 @@ export function IPAMPage() {
               <RefreshCw className="h-3.5 w-3.5" />
             </button>
             <button
+              onClick={() => setShowIpSearch(true)}
+              className="rounded p-1 text-muted-foreground hover:text-foreground"
+              title="Find IP addresses across all subnets"
+              aria-label="Find IP addresses across all subnets"
+            >
+              <Search className="h-3.5 w-3.5" />
+            </button>
+            <button
               onClick={() => setShowImport(true)}
               disabled={!spaces || spaces.length === 0}
               className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-40"
@@ -15035,6 +15624,9 @@ export function IPAMPage() {
 
       {showCreateSpace && (
         <CreateSpaceModal onClose={() => setShowCreateSpace(false)} />
+      )}
+      {showIpSearch && (
+        <GlobalIpSearchModal onClose={() => setShowIpSearch(false)} />
       )}
       {showImport && spaces && (
         <ImportModal

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -14920,6 +14920,11 @@ function GlobalIpSearchModal({ onClose }: { onClose: () => void }) {
 
   const runSearch = () => {
     setOffset(0);
+    // Clear any prior selection — a stale selection from the previous query
+    // would otherwise stay live under a new result set, so a bulk delete/edit
+    // would act on IPs the operator is no longer looking at.
+    setSelected(new Set());
+    setSelectAllError(null);
     setApplied({ q: qDraft.trim(), status: statusDraft });
   };
 
@@ -14956,6 +14961,7 @@ function GlobalIpSearchModal({ onClose }: { onClose: () => void }) {
     const map = new Map<
       string,
       {
+        id: string;
         cidr: string;
         name: string | null;
         space: string | null;
@@ -14966,6 +14972,7 @@ function GlobalIpSearchModal({ onClose }: { onClose: () => void }) {
       const key = it.subnet_id;
       if (!map.has(key))
         map.set(key, {
+          id: it.subnet_id,
           cidr: it.subnet_cidr,
           name: it.subnet_name,
           space: it.space_name,
@@ -15099,7 +15106,7 @@ function GlobalIpSearchModal({ onClose }: { onClose: () => void }) {
                 </p>
               ) : (
                 grouped.map((g) => (
-                  <div key={g.cidr} className="border-b last:border-0">
+                  <div key={g.id} className="border-b last:border-0">
                     <div className="sticky top-0 flex items-center gap-2 bg-muted/60 px-3 py-1 text-xs font-medium backdrop-blur">
                       <Network className="h-3 w-3 text-blue-500" />
                       <span className="font-mono">{g.cidr}</span>

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -554,12 +554,23 @@ function SortLabel({
   className?: string;
 }) {
   const active = state?.key === sortKey;
+  // Reflect the current sort state + what a click does next (cycle is
+  // asc → desc → cleared) so screen readers and tooltips aren't blind to it.
+  const sortedDesc = active
+    ? `sorted ${state?.dir === "asc" ? "ascending" : "descending"}`
+    : "not sorted";
+  const nextDesc = !active
+    ? "sort ascending"
+    : state?.dir === "asc"
+      ? "sort descending"
+      : "clear the sort";
+  const a11yLabel = `${label} — ${sortedDesc}. Activate to ${nextDesc}.`;
   return (
     <button
       type="button"
       onClick={() => onSort(sortKey)}
-      title={`Sort by ${label}`}
-      aria-label={`Sort by ${label}`}
+      title={a11yLabel}
+      aria-label={a11yLabel}
       className={cn(
         "inline-flex items-center gap-1 hover:text-foreground",
         active ? "text-primary" : "",
@@ -4869,25 +4880,42 @@ function SubnetDetail({
           return "";
       }
     };
+    // Precompute one sort key per row so the comparator does no parsing
+    // (``Date.parse`` / ``ipStringToInt``) — O(n) key extraction instead of
+    // the O(n log n) parsing a comparator-side parse would cost on a large
+    // subnet. ``num`` carries the numeric key (last_seen epoch / address int,
+    // NaN for a non-v4 address), ``str`` the string key.
+    const decorated = filteredAddresses.map((addr) => {
+      let num: number | null = null;
+      let str = "";
+      if (key === "last_seen") {
+        num = addr.last_seen_at ? Date.parse(addr.last_seen_at) : null;
+      } else if (key === "address") {
+        const ai = ipStringToInt(String(addr.address));
+        num = Number.isFinite(ai) ? ai : NaN;
+        str = String(addr.address);
+      } else {
+        str = strOf(addr);
+      }
+      return { addr, num, str };
+    });
     // Directional compare (a<b ⇒ negative). ``last_seen`` nulls always
     // sort last irrespective of direction (handled before the mul).
-    return [...filteredAddresses].sort((a, b) => {
+    decorated.sort((a, b) => {
       if (key === "last_seen") {
-        const at = a.last_seen_at ? Date.parse(a.last_seen_at) : null;
-        const bt = b.last_seen_at ? Date.parse(b.last_seen_at) : null;
-        if (at === null && bt === null) return 0;
-        if (at === null) return 1;
-        if (bt === null) return -1;
-        return mul * (at - bt);
+        if (a.num === null && b.num === null) return 0;
+        if (a.num === null) return 1;
+        if (b.num === null) return -1;
+        return mul * (a.num - b.num);
       }
       if (key === "address") {
-        const ai = ipStringToInt(String(a.address));
-        const bi = ipStringToInt(String(b.address));
-        if (Number.isFinite(ai) && Number.isFinite(bi)) return mul * (ai - bi);
-        return mul * String(a.address).localeCompare(String(b.address));
+        if (Number.isFinite(a.num) && Number.isFinite(b.num))
+          return mul * ((a.num as number) - (b.num as number));
+        return mul * a.str.localeCompare(b.str);
       }
-      return mul * strOf(a).localeCompare(strOf(b));
+      return mul * a.str.localeCompare(b.str);
     });
+    return decorated.map((d) => d.addr);
   }, [filteredAddresses, sortState, dnsDrift, subnetHasDnsZone]);
 
   // Interleave DHCP pool boundary markers with the IP rows so the user

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -12287,15 +12287,21 @@ function BlockDetailView({
                       title:
                         "Move this block (and everything under it) to a different IP space.",
                     },
-                    {
-                      label: "Add child block…",
-                      icon: Layers,
-                      onClick: () => setShowCreateChildBlock(true),
-                    },
                   ]}
                 />
                 <HeaderButton icon={Pencil} onClick={() => setShowEdit(true)}>
                   Edit
+                </HeaderButton>
+                {/* Blocks can nest inside blocks, so "Add child block" is a
+                    visible structural action next to New Subnet rather than
+                    buried in the Tools ▾ dropdown — mirrors the space header's
+                    "Add block" grammar (#538). */}
+                <HeaderButton
+                  icon={Layers}
+                  onClick={() => setShowCreateChildBlock(true)}
+                  title="Add a block inside this block"
+                >
+                  Add child block
                 </HeaderButton>
                 <HeaderButton
                   variant="primary"


### PR DESCRIPTION
Implements the 2026-07-02 IPAM review sweep — five interlocking IPAM items — across backend, worker, and frontend. Delivered by coordinated agents against a shared API contract, followed by an 8-angle code-review whose confirmed findings are fixed in the final commit.

## What shipped

**#517 — server-side pagination + search + IP-table windowing**
- `GET /ipam/subnets/{id}/addresses` gains optional `q`/`hostname`/`mac`/`sort`/`order`/`limit`/`offset` (backward-compatible — bare-list response unchanged) + `X-Total-Count` header (CORS-exposed). COUNT(*) is skipped on the unwindowed hot path.
- Frontend memoizes `filteredAddresses`/`sortedAddresses`/`tableRows`, caps rendered rows at 500 with a "show all" opt-in, and renders the mobile card list **or** the desktop table (new `useMediaQuery` hook) instead of both.

**#519 — column sorting** — clickable sortable headers (`SortHeader` + `cycleSort`, asc→desc→cleared) on the IP table.

**#520 — cross-subnet bulk from search** — new `GET /ipam/addresses/search` (paginated envelope with joined subnet/space context) + `GET /ipam/addresses/search/ids` (capped id list), both read-permission-scoped in SQL. New `GlobalIpSearchModal` with "select all matches" feeding the existing bulk-edit/delete plumbing. New `find_ip_addresses` MCP tool.

**#521 — utilization recount sweep** — new hourly idempotent `recount_ipam_utilization` task (single grouped SQL + batched block rollups, not per-subnet loops); imported/mirrored subnets no longer show 0% until an interactive edit. Fixes the misleading importer comment.

**#522 — perf niggles** — (1) `dhcp_lease_cleanup` loads the subnet cache once per sweep; (2) `ipam_dns_sync` pre-filters to zone-bound subnets via CTE; (3) pool integer bounds precomputed once (`poolBounds` memo); (4) removed the 220 ms `deferRowActivate` delay on the row-open path.

## Code-review (8 angles, verified) — confirmed findings fixed
- Cross-subnet search results keyed on subnet CIDR collided when two subnets share a CIDR across spaces/VRFs → keyed on subnet id.
- A new search left a stale selection live → cleared on `runSearch` so a bulk delete can't hit the wrong IPs.
- Redundant `COUNT(*)` on the default per-subnet path removed.
- Dead `listAddressesPaged` client helper removed.

Reported-but-deferred (design calls, not blockers): the per-subnet table still fetches all rows and caps client-side (the cap + memoization fixes the lock-up symptom; server-pagination params exist for API/MCP consumers); recount/MCP-tool duplication of router helpers; per-subnet-list vs cross-subnet-search permission-model difference; unescaped LIKE `%`/`_` in search. Refuted: a soft-deleted-subnet DNS-sync concern (the ORM's global `deleted_at IS NULL` filter makes the new CTE behavior-preserving).

## Checks run locally
- Backend lint (`ruff check app tests`, `black --check app tests`, `mypy app` — 633 files): **clean**.
- Frontend (`eslint`, `prettier --check`, `tsc`, `vite build`): **clean**.
- Targeted tests: address-search 12/12 pass; recount + touched-endpoint regression sets pass.
- Full `pytest -n auto` suite intentionally deferred to the GitHub backend-tests runner (the full suite OOMs the local Proxmox VM).

Closes #517
Closes #519
Closes #520
Closes #521
Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)