### PR TITLE
fix(dhcp): idempotent lease→IPAM mirror insert + Celery schema-behind guard (#564 #565)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,15 @@ POSTGRES_PASSWORD=changeme
 SECRET_KEY=change-me-to-a-random-32-char-string
 # STRICT_SECRET_KEY=true
 
+# When true, the Celery worker refuses to run tasks (Reject + requeue)
+# while the DB schema is behind the Alembic head bundled in the image —
+# i.e. the app was deployed before "alembic upgrade head" ran. Default
+# off: the drift is always logged loudly + raised as an alert, but a
+# transient mid-rollout window doesn't hard-stop the worker. Turn on in
+# environments where a stale-schema task run is worse than a deferred
+# one. See #565.
+# STRICT_SCHEMA_CHECK=true
+
 # Fernet key for at-rest encryption of stored secrets (auth_provider configs,
 # integration credentials, AI provider API keys, backup-target passwords).
 #   Generate:  python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -2,197 +2,48 @@
 
 import asyncio
 from collections.abc import Awaitable
-from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
 from time import monotonic
 from typing import Any, cast
 
 import structlog
 from fastapi import APIRouter
 from sqlalchemy import text
-from sqlalchemy.exc import ProgrammingError
 from starlette import status
 from starlette.responses import JSONResponse
 
+from app.core.schema_check import schema_at_head
 from app.db import AsyncSessionLocal
 
 logger = structlog.get_logger(__name__)
 router = APIRouter(tags=["health"])
 
 
-# ── Schema-at-head cache (issue #299 phase 1) ──────────────────────
+# ── Schema-at-head check (issue #299 phase 1) ──────────────────────
 #
-# The api image bundles a fixed set of alembic revisions, so the
-# "expected head" is constant for the lifetime of the process — read
-# it once, cache it, never re-read. On the appliance shape the
-# migrate Job lands the head into the DB AFTER the api Deployment
-# starts (CNPG bootstrap takes 1-2 min on a multi-node cluster), so
-# without a schema-aware readiness probe the api passes /health/ready
-# the moment Postgres accepts a SELECT 1 — even though every route
-# handler then 500s against missing tables. The operator-visible
-# symptom is a ~1-2 min window of bare nginx 502s on every login
-# attempt (issue #299). Fixing /health/ready to require the schema
-# at head makes the k8s readinessProbe accurately reflect "can serve
-# traffic"; the readinessProbe controlling the Service endpoint set
-# is what nginx upstream resolution depends on.
+# On the appliance shape the migrate Job lands the head into the DB
+# AFTER the api Deployment starts (CNPG bootstrap takes 1-2 min on a
+# multi-node cluster), so without a schema-aware readiness probe the
+# api passes /health/ready the moment Postgres accepts a SELECT 1 —
+# even though every route handler then 500s against missing tables.
+# The operator-visible symptom is a ~1-2 min window of bare nginx
+# 502s on every login attempt (issue #299). Fixing /health/ready to
+# require the schema at head makes the k8s readinessProbe accurately
+# reflect "can serve traffic".
 #
-# Single dataclass instance instead of parallel scalars so the
-# linter sees one used global instead of two it doesn't recognise
-# via the ``global`` declaration. Same semantics — ``head`` is set
-# once on success, ``error`` is set on "no head revision" config
-# bugs (also persistent), and transient exceptions are NOT cached
-# (the function re-tries on the next probe).
-@dataclass(slots=True)
-class _SchemaHeadCache:
-    head: str | None = None
-    error: str | None = None
-
-
-_head_cache = _SchemaHeadCache()
-
-
-def _locate_alembic_ini() -> Path | None:
-    """Find ``alembic.ini`` for the running process.
-
-    Two production deployments + the test path each put the file in
-    a different place:
-
-    * **Container image** (api / migrate Job) — baked at
-      ``/app/alembic.ini`` by the Dockerfile's ``COPY``. This is
-      where every appliance + helm install reads it.
-    * **CI ``Backend — Tests``** — pytest runs against the source
-      tree directly, working dir ``backend/``, so the file is at
-      ``./alembic.ini`` relative to cwd.
-    * **Dev (host venv)** — same as CI; pytest from ``backend/``.
-
-    Search order: container path → relative to this module → cwd.
-    Returns ``None`` if no candidate exists; caller surfaces a clear
-    "could not read alembic head" message.
-    """
-    candidates = [
-        Path("/app/alembic.ini"),
-        # ``app/api/health.py`` → ``app/api`` → ``app`` → ``backend``,
-        # where alembic.ini lives.
-        Path(__file__).resolve().parent.parent.parent / "alembic.ini",
-        Path.cwd() / "alembic.ini",
-    ]
-    for candidate in candidates:
-        if candidate.is_file():
-            return candidate
-    return None
-
-
-def _expected_alembic_head() -> tuple[str | None, str | None]:
-    """Read + cache the bundled alembic head.
-
-    Returns ``(head, None)`` on success, ``(None, error_str)`` if the
-    alembic.ini / scripts directory is missing or malformed.
-
-    Cached at first call. Re-reading the script directory on every
-    readiness probe call would be wasteful (and confusing during a
-    multi-node rolling upgrade where the head DOES change between
-    different api pods running different image tags — but each pod
-    has its own image, so each pod's cache is correct for itself).
-    """
-    if _head_cache.head is not None or _head_cache.error is not None:
-        return _head_cache.head, _head_cache.error
-    ini_path = _locate_alembic_ini()
-    if ini_path is None:
-        # Don't cache — the absence may be a packaging bug operators
-        # need to see, but tests / dev environments swap in a fresh
-        # working dir between fixtures and we want the next probe to
-        # re-find the file.
-        msg = "alembic.ini not found (looked in /app, source tree, cwd)"
-        logger.warning("readiness_schema_head_read_failed", error=msg)
-        return None, msg
-    try:
-        # Same ScriptDirectory pattern as
-        # app/services/backup/migrations.py. ScriptDirectory.
-        # get_current_head() walks the versions/ tree and returns the
-        # leaf revision (single-head schemas only; multi-head
-        # environments aren't supported by the SpatiumDDI shape).
-        from alembic.config import Config  # noqa: PLC0415
-        from alembic.script import ScriptDirectory  # noqa: PLC0415
-
-        cfg = Config(str(ini_path))
-        script = ScriptDirectory.from_config(cfg)
-        head = script.get_current_head()
-        if head is None:
-            _head_cache.error = "no head revision in script directory"
-            return None, _head_cache.error
-        _head_cache.head = head
-        logger.info("readiness_schema_head_cached", expected_head=head, ini_path=str(ini_path))
-        return head, None
-    except Exception as exc:  # noqa: BLE001 — surface ANY exception
-        # Don't cache transient errors — if the container's alembic
-        # files genuinely missing this is a config bug operators need
-        # to see; if it's a one-off blip, the next probe re-reads.
-        msg = f"could not read alembic head: {exc}"
-        logger.warning("readiness_schema_head_read_failed", error=str(exc))
-        return None, msg
-
-
+# The comparison itself lives in the framework-agnostic
+# ``app.core.schema_check`` module (extracted in #565 so the Celery
+# worker/beat startup + periodic checks share one implementation);
+# this wrapper keeps the ``("ok"|"error", detail)`` shape the
+# readiness verdict folds in alongside DB + Redis.
 async def _check_schema_ready() -> tuple[str, str]:
     """Verify the DB schema is at the head this api image expects.
 
-    Returns ``("ok", "<detail>")`` if the schema matches; otherwise
-    ``("error", "<detail>")`` with a message the operator can act on
-    ("migrate not run", "schema at X, image expects Y", etc.). The
-    caller folds this into the readiness verdict alongside DB + Redis.
-
-    Failure modes covered (each gets a distinct operator-actionable
-    detail string so the cause isn't ambiguous):
-
-    * ``alembic_version`` table doesn't exist — the migrate Job hasn't
-      created the schema at all. SQLAlchemy ``ProgrammingError``
-      wrapping asyncpg ``UndefinedTableError``, message contains
-      ``does not exist``. Reported as ``schema not initialised: …``.
-    * Other ``ProgrammingError`` shapes — permission denied,
-      malformed schema, etc. Reported as
-      ``schema check failed: …`` so operators don't get misled into
-      thinking migrations need to run (review polish from #301).
-    * ``alembic_version`` row missing — alembic stamp / upgrade was
-      interrupted. Reported as ``alembic_version row missing — …``.
-    * ``version_num != expected_head`` — schema is behind (migrate
-      still running, or a rolling upgrade started but didn't finish).
-      Reported with both revisions so operators can compare.
-    * Any other exception (asyncio timeout, connection blip not
-      caught upstream by the SELECT 1 check, …). Reported as
-      ``schema check failed: …``.
+    Returns ``("ok", "<detail>")`` if the schema matches, else
+    ``("error", "<detail>")`` with an operator-actionable message.
     """
-    expected, head_err = _expected_alembic_head()
-    if head_err is not None:
-        return "error", head_err
-    try:
-        async with AsyncSessionLocal() as session:
-            result = await session.execute(text("SELECT version_num FROM alembic_version"))
-            row = result.fetchone()
-    except ProgrammingError as exc:
-        # asyncpg.exceptions.UndefinedTableError → "relation
-        # 'alembic_version' does not exist". Other ProgrammingError
-        # shapes (permission denied, syntax error, etc.) are real
-        # config bugs the operator needs to see — don't lump them in
-        # with the "schema not initialised" cold-boot case.
-        logger.warning("readiness_schema_check_failed", error=str(exc), expected_head=expected)
-        short = str(exc).splitlines()[0][:160]
-        if "does not exist" in short:
-            return "error", f"schema not initialised: {short}"
-        return "error", f"schema check failed: {short}"
-    except Exception as exc:  # noqa: BLE001 — surface ANY exception
-        # Any other DB error — connection blip after the SELECT 1
-        # succeeded, statement timeout against a wedged server, etc.
-        # Don't claim "schema not initialised" — operators chasing a
-        # connection issue shouldn't be sent down the migrate path.
-        logger.warning("readiness_schema_check_failed", error=str(exc), expected_head=expected)
-        short = str(exc).splitlines()[0][:160]
-        return "error", f"schema check failed: {short}"
-    if row is None:
-        return "error", "alembic_version row missing — migrate not stamped"
-    actual = row[0]
-    if actual != expected:
-        return "error", f"schema at {actual}, image expects {expected}"
-    return "ok", f"schema at head {expected}"
+    result = await schema_at_head()
+    return ("ok" if result.ok else "error"), result.detail
 
 
 @router.get("/health/live", status_code=status.HTTP_200_OK)

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -49,6 +49,7 @@ from app.services.dhcp.agent_token import (
     verify_agent_token,
 )
 from app.services.dhcp.config_bundle import build_config_bundle
+from app.services.dhcp.ipam_mirror import insert_ipam_mirror_row
 
 logger = structlog.get_logger(__name__)
 router = APIRouter(prefix="/agents", tags=["dhcp-agents"])
@@ -887,6 +888,14 @@ async def agent_lease_events(
         (row.subnet_id, row.address): row for row in ipam_existing
     }
 
+    def _apply_lease_fields(row: IPAddress, ev: Any, lease: Any) -> None:
+        """Stamp lease state onto a mirror row we own (auto/available)."""
+        row.hostname = (ev.hostname or row.hostname or "")[:253]
+        row.mac_address = ev.mac_address
+        row.status = "dhcp"
+        row.auto_from_lease = True
+        row.dhcp_lease_id = str(lease.id) if lease.id else None
+
     # ── IPAM mirror pass ────────────────────────────────────────────────
     for ev in events:
         subnet = subnet_for_ip.get(ev.ip_address)
@@ -898,7 +907,7 @@ async def agent_lease_events(
         is_active = ev.state == "active"
         if is_active:
             if ipam_row is None:
-                ipam_row = IPAddress(
+                candidate = IPAddress(
                     subnet_id=subnet.id,
                     address=ev.ip_address,
                     hostname=(ev.hostname or "")[:253],
@@ -907,14 +916,20 @@ async def agent_lease_events(
                     auto_from_lease=True,
                     dhcp_lease_id=str(lease.id) if lease.id else None,
                 )
-                db.add(ipam_row)
+                # #564 — a concurrent Sync-DHCP / static-reservation
+                # writer may have already committed this
+                # (subnet_id, address) pair. Insert inside a savepoint
+                # so a unique-violation self-heals into the incumbent
+                # row instead of 500-ing on uq_ip_address_subnet_address.
+                ipam_row, created = await insert_ipam_mirror_row(db, candidate)
                 ipam_by_key[(subnet.id, ev.ip_address)] = ipam_row
+                # A fresh insert already carries the right fields; only a
+                # race-lost incumbent we own gets the same update a
+                # pre-existing row would take (never a manual/static row).
+                if not created and (ipam_row.status == "available" or ipam_row.auto_from_lease):
+                    _apply_lease_fields(ipam_row, ev, lease)
             elif ipam_row.status in ("available",) or ipam_row.auto_from_lease:
-                ipam_row.hostname = (ev.hostname or ipam_row.hostname or "")[:253]
-                ipam_row.mac_address = ev.mac_address
-                ipam_row.status = "dhcp"
-                ipam_row.auto_from_lease = True
-                ipam_row.dhcp_lease_id = str(lease.id) if lease.id else None
+                _apply_lease_fields(ipam_row, ev, lease)
             # else: manual/static — leave it alone
 
             # New-device watch: record the MAC sighting for this lease,
@@ -1089,16 +1104,29 @@ async def agent_mac_sightings(
             continue
         row = by_key.get((subnet.id, s.ip_address))
         if row is None:
-            row = IPAddress(
-                subnet_id=subnet.id,
-                address=s.ip_address,
-                status="discovered",
-                mac_address=s.mac_address,
-                last_seen_at=now,
-                last_seen_method="l2_sniff",
+            # #564 — a concurrent lease-event / Sync-DHCP writer may have
+            # already committed this (subnet_id, address). Insert inside a
+            # savepoint so the unique-violation self-heals into the
+            # incumbent instead of poisoning the whole sightings batch on
+            # the shared flush below.
+            row, created = await insert_ipam_mirror_row(
+                db,
+                IPAddress(
+                    subnet_id=subnet.id,
+                    address=s.ip_address,
+                    status="discovered",
+                    mac_address=s.mac_address,
+                    last_seen_at=now,
+                    last_seen_method="l2_sniff",
+                ),
             )
-            db.add(row)
             by_key[(subnet.id, s.ip_address)] = row
+            if not created:
+                # Lost the race — just bump the sighting timestamp on the
+                # incumbent (don't clobber its status/mac; the observation
+                # below records the MAC either way).
+                row.last_seen_at = now
+                row.last_seen_method = "l2_sniff"
         else:
             row.last_seen_at = now
             row.last_seen_method = "l2_sniff"

--- a/backend/app/api/v1/dhcp/statics.py
+++ b/backend/app/api/v1/dhcp/statics.py
@@ -17,6 +17,7 @@ from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.permissions import require_resource_permission
 from app.models.dhcp import DHCPPool, DHCPScope, DHCPStaticAssignment
 from app.models.ipam import IPAddress, Subnet
+from app.services.dhcp.ipam_mirror import insert_ipam_mirror_row
 from app.services.dhcp.windows_writethrough import push_static_change
 from app.services.tags import apply_tag_filter
 
@@ -98,8 +99,14 @@ async def _upsert_ipam_for_static(
     )
     row = res.scalar_one_or_none()
     if row is None:
-        row = IPAddress(subnet_id=scope.subnet_id, address=ip_str, status="static_dhcp")
-        db.add(row)
+        # #564 — a concurrent Kea agent lease-event / Sync-DHCP writer
+        # may have already mirrored a dynamic lease at this IP. Insert
+        # inside a savepoint so the unique-violation self-heals into the
+        # incumbent row (which we then overwrite to static_dhcp — the
+        # static is the source of truth) instead of 500-ing on
+        # uq_ip_address_subnet_address.
+        candidate = IPAddress(subnet_id=scope.subnet_id, address=ip_str, status="static_dhcp")
+        row, _created = await insert_ipam_mirror_row(db, candidate)
     row.hostname = st.hostname or row.hostname
     row.mac_address = str(st.mac_address)
     row.status = "static_dhcp"

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -60,6 +60,7 @@ celery_app = Celery(
         "app.tasks.acme",
         "app.tasks.tls_certs",
         "app.tasks.dnsbl_sweep",
+        "app.tasks.schema_check",
     ],
 )
 
@@ -121,6 +122,7 @@ celery_app.conf.update(
         "app.tasks.change_request_expiry.*": {"queue": "default"},
         "app.tasks.acme.*": {"queue": "default"},
         "app.tasks.tls_certs.*": {"queue": "default"},
+        "app.tasks.schema_check.*": {"queue": "default"},
     },
     beat_schedule={
         # Every 60 s, mark DNS agents as ``unreachable`` if their
@@ -555,6 +557,18 @@ celery_app.conf.update(
             "task": "app.tasks.tls_certs.prune_probes",
             "schedule": crontab(hour=3, minute=50),
         },
+        # Every 5 min, re-check that the DB schema is at the Alembic
+        # head bundled in this image (issue #565). Opens/resolves the
+        # ``schema-behind-head`` alert on drift. Complements the api's
+        # /health/ready gate — the worker/beat had no equivalent, so a
+        # "code deployed before migrate ran" window failed background
+        # tasks silently. The startup check (worker_ready/beat_init)
+        # catches the cold-boot case; this periodic tick catches a
+        # later divergence (stale image / mid-rollout).
+        "schema-at-head-check": {
+            "task": "app.tasks.schema_check.check_schema_at_head",
+            "schedule": schedule(run_every=300.0),
+        },
     },
 )
 
@@ -583,6 +597,14 @@ if settings.celery_broker_url.startswith(("sentinel://", "redis+sentinel://")):
 # worker``. ``task_revoked`` and ``task_unknown`` are deliberately
 # *not* hooked — those are operational signals, not bugs.
 from celery.signals import task_failure  # noqa: E402
+
+# Schema-at-head signal registration (issue #565). ``app.tasks.
+# schema_check`` connects ``worker_ready`` / ``beat_init`` /
+# ``task_prerun`` handlers at import time. The ``include=[…]`` list only
+# imports task modules in the *worker* bootstrap — beat loads the config
+# (schedule) but not the task modules — so import it here explicitly to
+# guarantee the startup check + strict gate register in every process.
+from app.tasks import schema_check as _schema_check  # noqa: E402,F401
 
 
 @task_failure.connect

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,3 +1,5 @@
+import importlib
+
 from celery import Celery
 from celery.schedules import crontab, schedule
 
@@ -604,7 +606,9 @@ from celery.signals import task_failure  # noqa: E402
 # imports task modules in the *worker* bootstrap — beat loads the config
 # (schedule) but not the task modules — so import it here explicitly to
 # guarantee the startup check + strict gate register in every process.
-from app.tasks import schema_check as _schema_check  # noqa: E402,F401
+# Use import_module (not a bound ``import … as _x``) so static analysis
+# doesn't flag a side-effect-only import as unused.
+importlib.import_module("app.tasks.schema_check")
 
 
 @task_failure.connect

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -127,6 +127,16 @@ class Settings(BaseSettings):
     # warning regardless of this flag. See #216.
     strict_secret_key: bool = False
 
+    # #565 — when ``True``, the Celery worker refuses to process tasks
+    # while the DB schema is behind the bundled Alembic head (mirrors
+    # ``strict_secret_key``'s opt-in shape). Default ``False`` so a
+    # transient mid-rollout window (code up before ``alembic upgrade
+    # head`` finishes) doesn't hard-stop the worker — the schema drift
+    # is logged loudly + raised as an ``AlertEvent`` regardless. Set to
+    # ``True`` in environments where a stale-schema task run is worse
+    # than a deferred one.
+    strict_schema_check: bool = False
+
     # #296 Phase B — slot-image mirror config.
     #
     # ``slot_image_mirror_url`` — when set, the slot-image upload +

--- a/backend/app/core/schema_check.py
+++ b/backend/app/core/schema_check.py
@@ -1,0 +1,202 @@
+"""Shared DB-schema-at-head check (#299 / #565).
+
+The api / worker / migrate images all bundle the same fixed set of
+Alembic revisions, so the "expected head" is a constant for the
+lifetime of a process. Comparing that bundled head against
+``SELECT version_num FROM alembic_version`` tells us whether the
+running code is *ahead* of the DB schema — the "code deployed before
+migrate ran" footgun:
+
+* On the **api** it's the #299 cold-boot case — the pod serves 500s
+  against missing tables until the migrate Job lands head. Guarded by
+  ``/health/ready`` keeping the pod out of the Service endpoint set.
+* On the **Celery worker + beat** (#565) there is no readiness gate —
+  they start on whatever schema is present and fail tasks silently in
+  the background. An operator's env logged the same
+  ``UndefinedColumnError`` ~2440× in a tight retry loop because the
+  DHCP config long-poll hammers ``db.get(PlatformSettings, 1)`` while
+  the DB was still on the old schema.
+
+This module holds the framework-agnostic core so ``app/api/health.py``
+and the Celery startup / periodic checks share one implementation. It
+does pure DB + bundled-migration-file introspection — **no docker /
+k8s-specific code** — so it behaves identically in docker-compose and
+k8s (an explicit requirement of #565).
+
+Known limitation (scoped out for v1, per #565): a ``version_num``-vs-
+head comparison catches "DB behind code" but NOT the rarer
+"stamped-forward, DDL never ran" drift (``alembic_version`` == head
+but a column is actually missing). That needs real schema
+introspection (``alembic check`` / ``information_schema`` diff), which
+is heavier and false-positive-prone; tracked separately.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NamedTuple
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
+
+logger = structlog.get_logger(__name__)
+
+
+class SchemaCheck(NamedTuple):
+    """Result of a schema-at-head comparison.
+
+    * ``ok`` — ``True`` only when the DB's ``alembic_version`` matches
+      the bundled head.
+    * ``expected`` — the bundled head revision (``None`` if the
+      migration files couldn't be read).
+    * ``actual`` — the DB's current ``version_num`` (``None`` if the
+      table / row is missing or the read failed).
+    * ``detail`` — an operator-actionable one-liner describing the
+      state ("schema at head …", "migrate not run", "schema at X,
+      image expects Y", …).
+    """
+
+    ok: bool
+    expected: str | None
+    actual: str | None
+    detail: str
+
+
+# ── Bundled-head cache ─────────────────────────────────────────────
+#
+# The bundled revisions are fixed for the process lifetime, so read
+# the head once and cache it. Single dataclass instance instead of
+# parallel scalars so the linter sees one used global. ``head`` is set
+# once on success; ``error`` is set on persistent config bugs ("no
+# head revision"); transient exceptions are NOT cached (re-tried on
+# the next call).
+@dataclass(slots=True)
+class _SchemaHeadCache:
+    head: str | None = None
+    error: str | None = None
+
+
+_head_cache = _SchemaHeadCache()
+
+
+def _locate_alembic_ini() -> Path | None:
+    """Find ``alembic.ini`` for the running process.
+
+    Two production deployments + the test path each put the file in a
+    different place:
+
+    * **Container image** (api / worker / migrate) — baked at
+      ``/app/alembic.ini`` by the Dockerfile's ``COPY``.
+    * **CI ``Backend — Tests`` / dev host venv** — pytest runs from
+      ``backend/`` so the file is at ``./alembic.ini``.
+
+    Search order: container path → relative to this module → cwd.
+    Returns ``None`` if no candidate exists.
+    """
+    candidates = [
+        Path("/app/alembic.ini"),
+        # ``app/core/schema_check.py`` → ``app/core`` → ``app`` →
+        # ``backend``, where alembic.ini lives.
+        Path(__file__).resolve().parent.parent.parent / "alembic.ini",
+        Path.cwd() / "alembic.ini",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def expected_alembic_head() -> tuple[str | None, str | None]:
+    """Read + cache the bundled alembic head.
+
+    Returns ``(head, None)`` on success, ``(None, error_str)`` if the
+    alembic.ini / scripts directory is missing or malformed.
+    """
+    if _head_cache.head is not None or _head_cache.error is not None:
+        return _head_cache.head, _head_cache.error
+    ini_path = _locate_alembic_ini()
+    if ini_path is None:
+        # Don't cache — the absence may be a packaging bug operators
+        # need to see, but tests / dev swap in a fresh working dir
+        # between fixtures and we want the next call to re-find it.
+        msg = "alembic.ini not found (looked in /app, source tree, cwd)"
+        logger.warning("schema_head_read_failed", error=msg)
+        return None, msg
+    try:
+        from alembic.config import Config  # noqa: PLC0415
+        from alembic.script import ScriptDirectory  # noqa: PLC0415
+
+        cfg = Config(str(ini_path))
+        script = ScriptDirectory.from_config(cfg)
+        head = script.get_current_head()
+        if head is None:
+            _head_cache.error = "no head revision in script directory"
+            return None, _head_cache.error
+        _head_cache.head = head
+        logger.info("schema_head_cached", expected_head=head, ini_path=str(ini_path))
+        return head, None
+    except Exception as exc:  # noqa: BLE001 — surface ANY exception
+        # Don't cache transient errors — genuinely-missing alembic
+        # files are a config bug operators need to see; a one-off blip
+        # re-reads on the next call.
+        msg = f"could not read alembic head: {exc}"
+        logger.warning("schema_head_read_failed", error=str(exc))
+        return None, msg
+
+
+async def schema_at_head(session_factory=None) -> SchemaCheck:
+    """Compare the DB's ``alembic_version`` against the bundled head.
+
+    ``session_factory`` defaults to ``app.db.AsyncSessionLocal``;
+    callers may pass an alternative for testing. Pure DB +
+    bundled-file introspection — identical behaviour under
+    docker-compose and k8s.
+
+    Failure modes (each gets a distinct operator-actionable detail so
+    the cause isn't ambiguous):
+
+    * ``alembic_version`` table doesn't exist — migrate hasn't created
+      the schema at all → ``schema not initialised: …``.
+    * Other ``ProgrammingError`` shapes (permission denied, malformed
+      schema) → ``schema check failed: …`` so operators aren't misled
+      into thinking migrations need to run.
+    * ``alembic_version`` row missing — stamp/upgrade interrupted →
+      ``alembic_version row missing — migrate not stamped``.
+    * ``version_num != head`` — schema behind → reports both revisions.
+    * Any other exception → ``schema check failed: …``.
+    """
+    if session_factory is None:
+        from app.db import AsyncSessionLocal  # noqa: PLC0415
+
+        session_factory = AsyncSessionLocal
+
+    expected, head_err = expected_alembic_head()
+    if head_err is not None:
+        return SchemaCheck(False, None, None, head_err)
+    try:
+        async with session_factory() as session:
+            result = await session.execute(text("SELECT version_num FROM alembic_version"))
+            row = result.fetchone()
+    except ProgrammingError as exc:
+        # asyncpg UndefinedTableError → "relation 'alembic_version'
+        # does not exist". Other ProgrammingError shapes are real
+        # config bugs — don't lump them into the cold-boot case.
+        logger.warning("schema_check_failed", error=str(exc), expected_head=expected)
+        short = str(exc).splitlines()[0][:160]
+        if "does not exist" in short:
+            return SchemaCheck(False, expected, None, f"schema not initialised: {short}")
+        return SchemaCheck(False, expected, None, f"schema check failed: {short}")
+    except Exception as exc:  # noqa: BLE001 — surface ANY exception
+        logger.warning("schema_check_failed", error=str(exc), expected_head=expected)
+        short = str(exc).splitlines()[0][:160]
+        return SchemaCheck(False, expected, None, f"schema check failed: {short}")
+    if row is None:
+        return SchemaCheck(
+            False, expected, None, "alembic_version row missing — migrate not stamped"
+        )
+    actual = row[0]
+    if actual != expected:
+        return SchemaCheck(False, expected, actual, f"schema at {actual}, image expects {expected}")
+    return SchemaCheck(True, expected, actual, f"schema at head {expected}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -394,6 +394,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await seed_audit_chain_alert_rule()
     except Exception as exc:  # noqa: BLE001
         logger.debug("audit_chain_alert_rule_seed_skipped", reason=str(exc))
+    # schema-behind-head alert rule — singleton, enabled by default
+    # (issue #565). Fires when the Celery worker/beat finds the DB
+    # schema behind the bundled Alembic head. Idempotent seed.
+    try:
+        from app.services.alerts import seed_schema_behind_head_alert_rule  # noqa: PLC0415
+
+        await seed_schema_behind_head_alert_rule()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("schema_behind_head_alert_rule_seed_skipped", reason=str(exc))
     # cluster-upgrade-failed alert rule — singleton, enabled by default
     # (issue #296 Phase F). Fires when the rolling-upgrade orchestrator
     # flips a SystemUpgradeRun to ``state='failed'``.

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -100,6 +100,13 @@ RULE_TYPE_SERVICE_RESOURCE_ORPHANED = "service_resource_orphaned"
 # without exploding into N near-identical rule_type rows.
 RULE_TYPE_COMPLIANCE_CHANGE = "compliance_change"
 RULE_TYPE_AUDIT_CHAIN_BROKEN = "audit_chain_broken"
+# Issue #565 — the Celery worker/beat found the DB schema behind the
+# bundled Alembic head ("code deployed before migrate ran"). Subject =
+# the platform (a single singleton event). Managed directly by the
+# ``app.tasks.schema_check`` periodic task (like ``audit_chain_broken``
+# above), not the generic evaluator — the task opens/resolves the
+# event itself off the version-vs-head comparison.
+RULE_TYPE_SCHEMA_BEHIND_HEAD = "schema_behind_head"
 # Voice-VLAN client-count drop — issue #112 phase 2. Counts active
 # DHCP leases on every subnet tagged ``subnet_role='voice'``; fires
 # when the count drops below ``threshold_percent`` (reused as a raw
@@ -261,6 +268,7 @@ RULE_TYPES = frozenset(
         RULE_TYPE_SERVICE_RESOURCE_ORPHANED,
         RULE_TYPE_COMPLIANCE_CHANGE,
         RULE_TYPE_AUDIT_CHAIN_BROKEN,
+        RULE_TYPE_SCHEMA_BEHIND_HEAD,
         RULE_TYPE_VOICE_LEASE_COUNT_BELOW,
         RULE_TYPE_K3S_API_CERT_EXPIRING,
         RULE_TYPE_STALE_IP_COUNT,
@@ -2600,6 +2608,51 @@ async def seed_audit_chain_alert_rule() -> None:
                     "that finds the chain back in sync."
                 ),
                 rule_type=RULE_TYPE_AUDIT_CHAIN_BROKEN,
+                severity="critical",
+                enabled=True,
+                notify_syslog=True,
+                notify_webhook=True,
+                notify_smtp=True,
+            )
+        )
+        await session.commit()
+
+
+_SCHEMA_BEHIND_HEAD_RULE_NAME = "schema-behind-head"
+
+
+async def seed_schema_behind_head_alert_rule() -> None:
+    """Seed the singleton ``schema-behind-head`` rule (issue #565).
+
+    Enabled by default — a worker running against a DB behind the
+    bundled migrations is a real "code deployed before migrate ran"
+    footgun that every deployment wants surfaced loudly instead of a
+    silent background retry loop. Keyed on ``name`` (one rule per
+    platform); an operator who disables / renames it is never
+    overridden by a later boot.
+    """
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+    from app.models.alerts import AlertRule  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as session:
+        existing = await session.scalar(
+            select(AlertRule).where(AlertRule.name == _SCHEMA_BEHIND_HEAD_RULE_NAME)
+        )
+        if existing is not None:
+            return
+        session.add(
+            AlertRule(
+                name=_SCHEMA_BEHIND_HEAD_RULE_NAME,
+                description=(
+                    "Fires when the Celery worker/beat finds the database schema "
+                    "behind the Alembic head bundled in the running image — i.e. "
+                    "the app was deployed before 'alembic upgrade head' ran, so "
+                    "background tasks fail against missing tables/columns. "
+                    "Auto-resolves on the next check that finds the schema back "
+                    "at head. Set STRICT_SCHEMA_CHECK=true to also refuse to "
+                    "process tasks while behind."
+                ),
+                rule_type=RULE_TYPE_SCHEMA_BEHIND_HEAD,
                 severity="critical",
                 enabled=True,
                 notify_syslog=True,

--- a/backend/app/services/dhcp/ipam_mirror.py
+++ b/backend/app/services/dhcp/ipam_mirror.py
@@ -1,0 +1,85 @@
+"""Idempotent IPAM mirror-row creation for DHCP lease ingestion (#564).
+
+Several DHCP lease-ingestion paths mirror a lease (or static
+reservation) into an ``ip_address`` row with an unguarded
+``SELECT (subnet_id, address); if None: INSERT`` pattern:
+
+* Kea agent lease push — ``api/v1/dhcp/agents.py``
+* poll/sync path — ``services/dhcp/pull_leases.py`` (reachable from
+  the **Sync DHCP** button)
+* static-reservation mirroring — ``api/v1/dhcp/statics.py``
+
+Under concurrency (the agent pushing ``/lease-events`` while an
+operator clicks **Sync DHCP**, or a static reservation created for an
+IP that currently holds a dynamic lease) two writers both look up the
+address, both see "no row", both ``INSERT``, and the loser hits
+``uq_ip_address_subnet_address`` — a 500 whose
+``PendingRollbackError`` tail then poisons the rest of the batch. On a
+busy DHCP host new leases arrive continuously, so it recurs and
+*feels* persistent, though each occurrence self-heals.
+
+The codebase already hardened this exact race elsewhere — the
+``pg_try_advisory_lock`` guard in ``tasks/ipam_discovery.py`` (#515)
+and the conflict-SELECT guard in ``unifi/reconcile.py``. This helper
+brings the same protection to the DHCP paths using the savepoint
+fall-through style: attempt the ``INSERT`` inside a SAVEPOINT so a
+unique-violation rolls back only the nested transaction (leaving the
+outer session usable — no ``PendingRollbackError`` tail), then
+re-select the row the concurrent writer committed and hand it back so
+the caller falls through to its update path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.models.ipam import IPAddress
+
+
+async def insert_ipam_mirror_row(db: Any, row: IPAddress) -> tuple[IPAddress, bool]:
+    """INSERT ``row`` idempotently under concurrency.
+
+    Adds ``row`` to the session and flushes it inside a SAVEPOINT.
+
+    * On success returns ``(row, True)`` — ``row`` now has its PK
+      assigned by the flush.
+    * If a concurrent writer already committed the same
+      ``(subnet_id, address)`` pair (the ``uq_ip_address_subnet_address``
+      unique violation) the savepoint is rolled back — keeping the
+      outer session alive, no ``PendingRollbackError`` tail — and the
+      incumbent row is re-selected and returned as ``(existing, False)``
+      so the caller can fall through to its update path.
+
+    An ``IntegrityError`` that is *not* our ``(subnet_id, address)``
+    tuple (i.e. re-selecting the pair finds nothing) is re-raised
+    rather than swallowed, so an unrelated constraint violation still
+    surfaces.
+    """
+    # Capture the identifying pair before the flush — after a savepoint
+    # rollback ``row`` is expunged from the session, but these plain
+    # attributes stay readable for the re-select.
+    subnet_id = row.subnet_id
+    address = row.address
+    try:
+        async with db.begin_nested():
+            db.add(row)
+            await db.flush()
+        return row, True
+    except IntegrityError:
+        existing = (
+            await db.execute(
+                select(IPAddress).where(
+                    IPAddress.subnet_id == subnet_id,
+                    IPAddress.address == address,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            # The violation wasn't the (subnet_id, address) tuple we
+            # tried to insert — surface it instead of masking an
+            # unrelated integrity error.
+            raise
+        return existing, False

--- a/backend/app/services/dhcp/pull_leases.py
+++ b/backend/app/services/dhcp/pull_leases.py
@@ -58,7 +58,20 @@ from app.models.dhcp import (
     DHCPStaticAssignment,
 )
 from app.models.ipam import IPAddress, Subnet
+from app.services.dhcp.ipam_mirror import insert_ipam_mirror_row
 from app.services.dhcp.lease_history import record_lease_history
+
+
+def _refresh_lease_owned_row(
+    row: IPAddress, lease: dict[str, Any], mac: str, now: datetime
+) -> None:
+    """Refresh an auto-from-lease mirror row from the wire lease."""
+    row.mac_address = mac
+    if lease.get("hostname"):
+        row.hostname = lease.get("hostname")
+    row.last_seen_at = now
+    row.last_seen_method = "dhcp"
+
 
 logger = structlog.get_logger(__name__)
 
@@ -236,7 +249,7 @@ async def pull_leases_from_server(
 
         if ipam_row is None:
             if apply:
-                ipam_row = IPAddress(
+                candidate = IPAddress(
                     subnet_id=containing.id,
                     address=ip,
                     status="dhcp",
@@ -246,18 +259,31 @@ async def pull_leases_from_server(
                     last_seen_method="dhcp",
                     auto_from_lease=True,
                 )
-                db.add(ipam_row)
-                await db.flush()  # assign PK so _sync_dns_record can reference it
-            result.ipam_created += 1
+                # #564 — insert inside a savepoint so a concurrent Kea
+                # agent lease-event / static-reservation writer racing
+                # on the same (subnet_id, address) doesn't 500 the whole
+                # sync on uq_ip_address_subnet_address. The helper flush
+                # also assigns the PK so _sync_dns_record can reference
+                # it below.
+                ipam_row, created = await insert_ipam_mirror_row(db, candidate)
+                if created:
+                    result.ipam_created += 1
+                elif ipam_row.auto_from_lease:
+                    # Lost the race to a lease-owned row — refresh it
+                    # like the elif path below.
+                    _refresh_lease_owned_row(ipam_row, lease, mac, now)
+                    result.ipam_refreshed += 1
+                else:
+                    # Lost the race to a manual/static row — leave it
+                    # alone and skip DDNS, mirroring the manual branch.
+                    continue
+            else:
+                result.ipam_created += 1
         elif ipam_row.auto_from_lease:
             # Only refresh rows we own. Manually-allocated rows are left
             # alone — the lease + IPAM coexist.
             if apply:
-                ipam_row.mac_address = mac
-                if lease.get("hostname"):
-                    ipam_row.hostname = lease.get("hostname")
-                ipam_row.last_seen_at = now
-                ipam_row.last_seen_method = "dhcp"
+                _refresh_lease_owned_row(ipam_row, lease, mac, now)
             result.ipam_refreshed += 1
         else:
             # Manual allocation — skip DDNS entirely. Whatever hostname

--- a/backend/app/tasks/schema_check.py
+++ b/backend/app/tasks/schema_check.py
@@ -1,0 +1,293 @@
+"""Celery-side DB-schema-at-head guard (issue #565).
+
+The api already gates on the schema being at the bundled Alembic head
+via ``/health/ready`` (#299 / #301) — a pod stays out of the Service
+endpoint set until the migrate Job lands head. The Celery **worker +
+beat** had no equivalent: they start on whatever schema is present and
+fail tasks silently in the background. An operator's env logged the
+same ``UndefinedColumnError`` ~2440× in a tight retry loop because the
+DHCP config long-poll hammers ``db.get(PlatformSettings, 1)`` while the
+DB was still on the old schema.
+
+This module reuses the framework-agnostic
+``app.core.schema_check.schema_at_head`` comparison for Celery:
+
+1. **Startup check** — ``worker_ready`` / ``beat_init`` run the check
+   once and log a loud structured warning if the DB is behind.
+2. **Periodic re-check** — the ``check_schema_at_head`` beat task
+   re-runs the comparison, logs a warning + opens/refreshes an
+   ``AlertEvent`` against the ``schema-behind-head`` rule on drift, and
+   auto-resolves it once the schema is back at head. Covers "worker
+   started before migrate finished" and "worker running a stale image"
+   where a one-shot startup check would miss a later divergence.
+3. **Opt-in strict mode** — ``STRICT_SCHEMA_CHECK=true`` makes the
+   ``task_prerun`` gate ``Reject(requeue=True)`` tasks while the schema
+   is behind (mirrors ``STRICT_SECRET_KEY``). Default off so a
+   transient mid-rollout window doesn't hard-stop the worker.
+
+Because the check compares packaged migration files against the DB's
+``alembic_version``, the exact same helper works in docker-compose and
+k8s with zero orchestration-specific branching.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from time import monotonic
+
+import structlog
+from celery import shared_task
+from celery.exceptions import Reject
+from celery.signals import beat_init, task_prerun, worker_ready
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.config import settings
+from app.core.schema_check import SchemaCheck, schema_at_head
+
+logger = structlog.get_logger(__name__)
+
+_RULE_NAME = "schema-behind-head"
+
+
+# Per-process throttle for the strict ``task_prerun`` gate — a fresh
+# ``schema_at_head`` DB round-trip on *every* task would defeat the
+# purpose. Cache the last verdict for this long; the periodic task +
+# startup check keep the operator-facing signal fresh independently.
+_STRICT_CACHE_TTL_SECONDS = 30.0
+
+
+@dataclass(slots=True)
+class _StrictCache:
+    checked_at: float | None = None
+    behind: bool = False
+
+
+_strict_cache = _StrictCache()
+
+# Tasks that must run even while the schema is behind — the strict
+# gate would otherwise deadlock the very check that clears it (and the
+# beat heartbeat that proves beat is alive).
+_STRICT_EXEMPT_TASKS = frozenset(
+    {
+        "app.tasks.schema_check.check_schema_at_head",
+        "app.tasks.heartbeat.beat_tick",
+    }
+)
+
+
+async def _check() -> SchemaCheck:
+    """Run the schema comparison on a per-call engine.
+
+    Celery's ``asyncio.run(...)`` pattern spins a fresh event loop per
+    invocation; the shared ``AsyncSessionLocal`` engine binds asyncpg
+    connections to the *first* loop, so a later reuse raises
+    ``RuntimeError: Future attached to a different loop`` (see
+    ``app.db.task_session``). Every Celery-side caller here must use
+    ``task_session`` (a throwaway engine scoped to the current loop),
+    not the default ``AsyncSessionLocal`` the FastAPI readiness probe
+    uses.
+    """
+    from app.db import task_session  # noqa: PLC0415
+
+    return await schema_at_head(session_factory=task_session)
+
+
+def _log_startup(result: SchemaCheck, *, who: str) -> None:
+    if result.ok:
+        logger.info("schema_check_startup_ok", who=who, detail=result.detail)
+    else:
+        # Loud — this is the "code deployed before migrate ran" footgun
+        # that would otherwise be a silent background retry storm.
+        logger.warning(
+            "schema_behind_bundled_head",
+            who=who,
+            detail=result.detail,
+            expected=result.expected,
+            actual=result.actual,
+            strict=settings.strict_schema_check,
+        )
+
+
+@worker_ready.connect
+def _worker_ready_schema_check(**_: object) -> None:
+    """One-shot schema-at-head check when the worker finishes booting."""
+    try:
+        result = asyncio.run(_check())
+    except Exception as exc:  # noqa: BLE001 — never block worker start
+        logger.warning("schema_check_startup_failed", who="worker", error=str(exc))
+        return
+    _log_startup(result, who="worker")
+    _strict_cache.checked_at = monotonic()
+    _strict_cache.behind = not result.ok
+
+
+@beat_init.connect
+def _beat_init_schema_check(**_: object) -> None:
+    """One-shot schema-at-head check when beat starts."""
+    try:
+        result = asyncio.run(_check())
+    except Exception as exc:  # noqa: BLE001 — never block beat start
+        logger.warning("schema_check_startup_failed", who="beat", error=str(exc))
+        return
+    _log_startup(result, who="beat")
+
+
+@task_prerun.connect
+def _strict_schema_gate(sender: object | None = None, **_: object) -> None:
+    """Refuse to run tasks while the schema is behind, when strict.
+
+    Off by default. When ``STRICT_SCHEMA_CHECK=true`` and a throttled
+    check finds the DB behind the bundled head, ``Reject(requeue=True)``
+    sends the message back to the broker for redelivery instead of
+    running the task against a schema it can't satisfy. The exempt set
+    keeps the check task + beat heartbeat runnable so the gate can
+    clear itself.
+    """
+    if not settings.strict_schema_check:
+        return
+    task_name = getattr(sender, "name", None)
+    if task_name in _STRICT_EXEMPT_TASKS:
+        return
+
+    checked_at = _strict_cache.checked_at
+    now = monotonic()
+    if checked_at is None or (now - checked_at) > _STRICT_CACHE_TTL_SECONDS:
+        try:
+            result = asyncio.run(_check())
+        except Exception as exc:  # noqa: BLE001 — fail open, don't wedge on a blip
+            logger.warning("strict_schema_gate_check_failed", error=str(exc))
+            return
+        _strict_cache.checked_at = now
+        _strict_cache.behind = not result.ok
+
+    if _strict_cache.behind:
+        logger.warning(
+            "strict_schema_gate_rejecting_task",
+            task=task_name,
+            detail="DB schema behind bundled head; STRICT_SCHEMA_CHECK deferring task",
+        )
+        # Reject raised from a task_prerun receiver IS honored: Celery's
+        # tracer sends the prerun signal inside the same try/except that
+        # catches Reject, so requeue=True bounces the message back to the
+        # broker (not a permanent failure). TRADEOFF: requeue has no
+        # delay, so during the (short, opt-in) behind-schema window
+        # non-exempt tasks redeliver-and-re-reject in a busy loop until
+        # migrate lands head. That's the deliberate cost of a hard-stop
+        # — STRICT_SCHEMA_CHECK is off by default precisely so the
+        # common mid-rollout window just warns + alerts instead.
+        raise Reject("schema behind bundled head (STRICT_SCHEMA_CHECK)", requeue=True)
+
+
+async def _async_check_and_alert() -> dict:
+    from app.db import task_session  # noqa: PLC0415
+    from app.models.alerts import AlertEvent, AlertRule  # noqa: PLC0415
+
+    result = await _check()
+
+    # Refresh the strict-gate cache off the periodic check too so a
+    # drift/recovery is reflected without waiting for the TTL to lapse
+    # in the prerun path.
+    _strict_cache.checked_at = monotonic()
+    _strict_cache.behind = not result.ok
+
+    async with task_session() as db:
+        rule = (
+            await db.execute(select(AlertRule).where(AlertRule.name == _RULE_NAME))
+        ).scalar_one_or_none()
+
+        if result.ok:
+            logger.info("schema_check_ok", detail=result.detail)
+            # Auto-resolve EVERY open drift event now the schema caught
+            # up — the drift path keys dedupe on subject_id (the behind
+            # revision), so passing through several behind revisions
+            # (A → B → head) can leave more than one open event. Resolve
+            # them all in one OK tick, not one-per-tick.
+            if rule is not None:
+                open_events = (
+                    (
+                        await db.execute(
+                            select(AlertEvent)
+                            .where(AlertEvent.rule_id == rule.id)
+                            .where(AlertEvent.resolved_at.is_(None))
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                if open_events:
+                    resolved_at = datetime.now(UTC)
+                    for open_evt in open_events:
+                        open_evt.resolved_at = resolved_at
+                    await db.commit()
+            return {"ok": True, "detail": result.detail}
+
+        logger.warning(
+            "schema_behind_bundled_head",
+            who="periodic",
+            detail=result.detail,
+            expected=result.expected,
+            actual=result.actual,
+            strict=settings.strict_schema_check,
+        )
+
+        if rule is None:
+            # Seeder ran late / operator deleted the rule. The drift
+            # itself is the important signal — log it, don't crash.
+            logger.error("schema_behind_head_no_rule", detail=result.detail)
+            return {"ok": False, "detail": result.detail, "no_rule": True}
+
+        # Dedupe: one open event covers the drift. Subject id is the
+        # observed (behind) version so a fresh drift to a *different*
+        # actual version opens a distinct event.
+        subject_id = result.actual or "uninitialised"
+        existing = (
+            await db.execute(
+                select(AlertEvent)
+                .where(AlertEvent.rule_id == rule.id)
+                .where(AlertEvent.resolved_at.is_(None))
+                .where(AlertEvent.subject_id == subject_id)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            return {"ok": False, "detail": result.detail, "deduped": True}
+
+        evt = AlertEvent(
+            rule_id=rule.id,
+            subject_type="platform",
+            subject_id=subject_id,
+            subject_display="database schema",
+            severity="critical",
+            message=(
+                f"Celery worker/beat found the DB schema behind the bundled "
+                f"Alembic head: {result.detail}. Run 'alembic upgrade head' "
+                f"(the migrate step). Background tasks may fail against missing "
+                f"tables/columns until the schema catches up."
+            ),
+            fired_at=datetime.now(UTC),
+            last_observed_value={
+                "expected_head": result.expected,
+                "actual_version": result.actual,
+                "detail": result.detail,
+            },
+        )
+        db.add(evt)
+        await db.commit()
+        return {"ok": False, "detail": result.detail}
+
+
+@shared_task(
+    name="app.tasks.schema_check.check_schema_at_head",
+    bind=True,
+    autoretry_for=(SQLAlchemyError, ConnectionError, OSError),
+    retry_backoff=True,
+    retry_backoff_max=300,
+    retry_jitter=True,
+    max_retries=3,
+)
+def check_schema_at_head(self: object) -> dict:  # type: ignore[type-arg]
+    """Periodic beat entry point. Idempotent + self-resolving."""
+    return asyncio.run(_async_check_and_alert())

--- a/backend/tests/test_health_schema_check.py
+++ b/backend/tests/test_health_schema_check.py
@@ -1,7 +1,11 @@
-"""Schema-at-head readiness check (#299 phase 1).
+"""Schema-at-head readiness check (#299 phase 1 / #565).
 
-Covers the new ``_check_schema_ready`` helper + its integration into
-``/health/ready``:
+The comparison core lives in ``app.core.schema_check`` (extracted in
+#565 so the Celery worker/beat share it); ``app.api.health.
+_check_schema_ready`` is a thin ``("ok"|"error", detail)`` wrapper over
+``schema_at_head`` folded into ``/health/ready``.
+
+Covers:
 
 * ``alembic_version`` at the bundled head → readiness check says ``ok``.
 * ``alembic_version`` table missing → check says ``error`` with the
@@ -20,7 +24,6 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from unittest.mock import patch
 
 import pytest
 from httpx import AsyncClient
@@ -28,6 +31,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 
 from app.api import health as health_module
+from app.core import schema_check as schema_module
 from app.db import AsyncSessionLocal
 
 
@@ -35,13 +39,13 @@ from app.db import AsyncSessionLocal
 def _reset_head_cache() -> None:
     """Clear the module-level head cache before every test.
 
-    ``_expected_alembic_head`` caches the result of
+    ``expected_alembic_head`` caches the result of
     ``ScriptDirectory.get_current_head()`` to avoid re-walking the
     versions directory on every probe; the cache survives across
     tests in the same worker without this fixture.
     """
-    health_module._head_cache.head = None
-    health_module._head_cache.error = None
+    schema_module._head_cache.head = None
+    schema_module._head_cache.error = None
 
 
 @pytest.fixture(autouse=True)
@@ -59,7 +63,7 @@ async def _seed_alembic_version() -> AsyncIterator[None]:
     let individual tests mutate it (DELETE row, UPDATE to fake
     revision, etc.) to exercise the failure modes.
     """
-    expected, _ = health_module._expected_alembic_head()
+    expected, _ = schema_module.expected_alembic_head()
     async with AsyncSessionLocal() as s:
         await s.execute(
             text(
@@ -86,7 +90,7 @@ async def _seed_alembic_version() -> AsyncIterator[None]:
 async def test_schema_check_ok_when_at_head() -> None:
     """The check_schema_ready helper returns ok when version_num
     matches the bundled head."""
-    expected, err = health_module._expected_alembic_head()
+    expected, err = schema_module.expected_alembic_head()
     assert err is None
     assert expected is not None  # alembic.ini + versions/ are bundled
 
@@ -102,7 +106,7 @@ async def test_schema_check_ok_when_at_head() -> None:
 async def test_schema_check_reports_mismatch() -> None:
     """When alembic_version says a non-head revision, the check
     returns error + names both versions."""
-    expected, _ = health_module._expected_alembic_head()
+    expected, _ = schema_module.expected_alembic_head()
     assert expected is not None
 
     # Mutate alembic_version to a fake revision and assert the helper
@@ -130,7 +134,7 @@ async def test_schema_check_reports_missing_row() -> None:
     """alembic_version table exists but is empty — common right after
     a migrate failure or a botched ``alembic stamp``. The helper
     reports the missing row explicitly so operators see the cause."""
-    expected, _ = health_module._expected_alembic_head()
+    expected, _ = schema_module.expected_alembic_head()
     assert expected is not None
 
     async with AsyncSessionLocal() as s:
@@ -182,8 +186,8 @@ async def test_schema_check_reports_missing_table() -> None:
     async def _fake_session_factory() -> AsyncIterator[_FakeSession]:
         yield _FakeSession()
 
-    with patch.object(health_module, "AsyncSessionLocal", _fake_session_factory):
-        verdict, detail = await health_module._check_schema_ready()
+    _result = await schema_module.schema_at_head(session_factory=_fake_session_factory)
+    verdict, detail = ("ok" if _result.ok else "error"), _result.detail
     assert verdict == "error"
     assert "schema not initialised" in detail
     assert "alembic_version" in detail
@@ -214,8 +218,8 @@ async def test_schema_check_reports_other_programming_error() -> None:
     async def _fake_session_factory() -> AsyncIterator[_FakeSession]:
         yield _FakeSession()
 
-    with patch.object(health_module, "AsyncSessionLocal", _fake_session_factory):
-        verdict, detail = await health_module._check_schema_ready()
+    _result = await schema_module.schema_at_head(session_factory=_fake_session_factory)
+    verdict, detail = ("ok" if _result.ok else "error"), _result.detail
     assert verdict == "error"
     # NOT "schema not initialised" — operator needs to see "permission
     # denied" or similar, not be sent down the migrate path.
@@ -244,8 +248,8 @@ async def test_schema_check_reports_generic_exception() -> None:
     async def _fake_session_factory() -> AsyncIterator[_FakeSession]:
         yield _FakeSession()
 
-    with patch.object(health_module, "AsyncSessionLocal", _fake_session_factory):
-        verdict, detail = await health_module._check_schema_ready()
+    _result = await schema_module.schema_at_head(session_factory=_fake_session_factory)
+    verdict, detail = ("ok" if _result.ok else "error"), _result.detail
     assert verdict == "error"
     assert "schema check failed" in detail
     assert "timed out" in detail
@@ -256,7 +260,7 @@ async def test_readiness_endpoint_503_on_schema_mismatch(client: AsyncClient) ->
     """End-to-end: the readiness endpoint folds the schema check into
     its rollup. Postgres is up + Redis is up but schema is behind →
     503 with the schema-specific detail in the ``checks`` block."""
-    expected, _ = health_module._expected_alembic_head()
+    expected, _ = schema_module.expected_alembic_head()
     assert expected is not None
 
     async with AsyncSessionLocal() as s:

--- a/backend/tests/test_ipam_mirror_race.py
+++ b/backend/tests/test_ipam_mirror_race.py
@@ -1,0 +1,98 @@
+"""#564 — DHCP lease→IPAM mirror insert race guard.
+
+Several DHCP lease-ingestion paths mirror a lease into an
+``ip_address`` row with an unguarded ``SELECT; if None: INSERT``.
+Under concurrency two writers both see "no row", both INSERT, and the
+loser hits ``uq_ip_address_subnet_address`` — a 500 whose
+``PendingRollbackError`` tail poisons the rest of the batch.
+
+``insert_ipam_mirror_row`` makes the INSERT idempotent: it attempts
+the insert inside a SAVEPOINT so a unique-violation rolls back only
+the nested transaction (leaving the outer session usable) and returns
+the row a concurrent writer already committed.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.dhcp.ipam_mirror import insert_ipam_mirror_row
+
+
+async def _make_subnet(db: AsyncSession) -> Subnet:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.9.0.0/16", name="blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.9.0.0/24", name="sn")
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+@pytest.mark.asyncio
+async def test_insert_creates_when_absent(db_session: AsyncSession) -> None:
+    subnet = await _make_subnet(db_session)
+    row, created = await insert_ipam_mirror_row(
+        db_session,
+        IPAddress(subnet_id=subnet.id, address="10.9.0.10", status="dhcp", auto_from_lease=True),
+    )
+    assert created is True
+    assert row.id is not None  # flush inside the savepoint assigned the PK
+    assert str(row.address) == "10.9.0.10"
+
+
+@pytest.mark.asyncio
+async def test_insert_returns_incumbent_on_conflict(db_session: AsyncSession) -> None:
+    """A committed row at (subnet, address) → the second insert
+    self-heals into the incumbent instead of raising on the unique
+    constraint, and the outer session stays usable."""
+    subnet = await _make_subnet(db_session)
+    incumbent = IPAddress(
+        subnet_id=subnet.id,
+        address="10.9.0.20",
+        status="static_dhcp",
+        mac_address="aa:bb:cc:dd:ee:01",
+    )
+    db_session.add(incumbent)
+    await db_session.commit()
+
+    # A fresh candidate object for the SAME (subnet_id, address) — the
+    # concurrent-writer shape. The DB already holds the incumbent.
+    row, created = await insert_ipam_mirror_row(
+        db_session,
+        IPAddress(subnet_id=subnet.id, address="10.9.0.20", status="dhcp", auto_from_lease=True),
+    )
+    assert created is False
+    assert row.id == incumbent.id  # the committed row came back
+    assert row.status == "static_dhcp"  # untouched — caller decides how to update
+
+    # The outer session survived the rolled-back savepoint (no
+    # PendingRollbackError tail) — a follow-up insert + commit works.
+    other, other_created = await insert_ipam_mirror_row(
+        db_session,
+        IPAddress(subnet_id=subnet.id, address="10.9.0.21", status="dhcp", auto_from_lease=True),
+    )
+    assert other_created is True
+    await db_session.commit()
+    assert (
+        await db_session.execute(select(IPAddress).where(IPAddress.id == other.id))
+    ).scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+async def test_unrelated_integrity_error_reraises(db_session: AsyncSession) -> None:
+    """An IntegrityError that ISN'T our (subnet, address) tuple (here a
+    bogus subnet_id FK) re-raises rather than being masked as a
+    self-heal — re-selecting the pair finds nothing."""
+    bogus = IPAddress(subnet_id=uuid.uuid4(), address="10.9.0.30", status="dhcp")
+    with pytest.raises(IntegrityError):
+        await insert_ipam_mirror_row(db_session, bogus)

--- a/backend/tests/test_schema_check_task.py
+++ b/backend/tests/test_schema_check_task.py
@@ -1,0 +1,136 @@
+"""#565 — Celery-side DB-schema-at-head guard.
+
+The api gates ``/health/ready`` on the schema being at the bundled
+Alembic head (#299); the worker/beat had no equivalent and failed
+tasks silently against a behind schema. These tests cover the two
+Celery-side surfaces built on the shared ``schema_at_head`` helper:
+
+* the periodic ``check_schema_at_head`` task opens a
+  ``schema-behind-head`` ``AlertEvent`` on drift and auto-resolves it
+  once the schema is back at head;
+* the opt-in ``STRICT_SCHEMA_CHECK`` ``task_prerun`` gate ``Reject``s
+  tasks while behind (and no-ops when disabled / for exempt tasks).
+"""
+
+from __future__ import annotations
+
+import pytest
+from celery.exceptions import Reject
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings as app_settings
+from app.core.schema_check import SchemaCheck
+from app.models.alerts import AlertEvent, AlertRule
+from app.tasks import schema_check as sc
+
+_BEHIND = SchemaCheck(False, "headrev", "oldrev", "schema at oldrev, image expects headrev")
+_OK = SchemaCheck(True, "headrev", "headrev", "schema at head headrev")
+
+
+class _Sender:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+@pytest.mark.asyncio
+async def test_periodic_check_opens_and_resolves_alert(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.alerts import seed_schema_behind_head_alert_rule
+
+    await seed_schema_behind_head_alert_rule()
+    # Capture the id as a plain local — task_session (a separate
+    # session) commits between queries, and a lazy reload of an ORM
+    # attribute while building later query expressions would raise
+    # MissingGreenlet. The ``resolved_at IS NULL`` SQL filter already
+    # reflects committed cross-session state, so no expire is needed.
+    rule_id = (
+        await db_session.execute(select(AlertRule.id).where(AlertRule.name == "schema-behind-head"))
+    ).scalar_one()
+
+    async def _behind(**_: object) -> SchemaCheck:
+        return _BEHIND
+
+    monkeypatch.setattr(sc, "schema_at_head", _behind)
+    out = await sc._async_check_and_alert()
+    assert out["ok"] is False
+
+    open_events = (
+        (
+            await db_session.execute(
+                select(AlertEvent)
+                .where(AlertEvent.rule_id == rule_id)
+                .where(AlertEvent.resolved_at.is_(None))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(open_events) == 1
+    assert open_events[0].subject_id == "oldrev"
+
+    # A second behind-check dedupes onto the same open event.
+    assert (await sc._async_check_and_alert())["deduped"] is True
+    still_open = (
+        await db_session.execute(
+            select(AlertEvent.id)
+            .where(AlertEvent.rule_id == rule_id)
+            .where(AlertEvent.resolved_at.is_(None))
+        )
+    ).all()
+    assert len(still_open) == 1
+
+    # Schema catches up → the open event auto-resolves.
+    async def _ok(**_: object) -> SchemaCheck:
+        return _OK
+
+    monkeypatch.setattr(sc, "schema_at_head", _ok)
+    assert (await sc._async_check_and_alert())["ok"] is True
+    remaining = (
+        await db_session.execute(
+            select(AlertEvent.id)
+            .where(AlertEvent.rule_id == rule_id)
+            .where(AlertEvent.resolved_at.is_(None))
+        )
+    ).all()
+    assert remaining == []
+
+
+def _arm_gate(monkeypatch: pytest.MonkeyPatch, result: SchemaCheck, *, strict: bool) -> None:
+    async def _fake(**_: object) -> SchemaCheck:
+        return result
+
+    monkeypatch.setattr(sc, "schema_at_head", _fake)
+    monkeypatch.setattr(app_settings, "strict_schema_check", strict)
+    sc._strict_cache.checked_at = None
+    sc._strict_cache.behind = False
+
+
+def test_strict_gate_rejects_when_behind(monkeypatch: pytest.MonkeyPatch) -> None:
+    _arm_gate(monkeypatch, _BEHIND, strict=True)
+    with pytest.raises(Reject):
+        sc._strict_schema_gate(sender=_Sender("app.tasks.some.task"))
+
+
+def test_strict_gate_allows_when_at_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    _arm_gate(monkeypatch, _OK, strict=True)
+    assert sc._strict_schema_gate(sender=_Sender("app.tasks.some.task")) is None
+
+
+def test_strict_gate_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Behind, but strict mode off → never rejects (default posture).
+    _arm_gate(monkeypatch, _BEHIND, strict=False)
+    assert sc._strict_schema_gate(sender=_Sender("app.tasks.some.task")) is None
+
+
+def test_strict_gate_exempts_self_and_heartbeat(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Behind + strict, but the check task + beat heartbeat must still
+    # run so the gate can clear itself.
+    _arm_gate(monkeypatch, _BEHIND, strict=True)
+    sc._strict_cache.behind = True  # pretend a prior check already saw it
+    assert (
+        sc._strict_schema_gate(sender=_Sender("app.tasks.schema_check.check_schema_at_head"))
+        is None
+    )
+    assert sc._strict_schema_gate(sender=_Sender("app.tasks.heartbeat.beat_tick")) is None


### PR DESCRIPTION
Two independent reliability fixes.

## #564 — DHCP lease→IPAM mirror insert races on `uq_ip_address_subnet_address`

Concurrent writers each did an unguarded `SELECT (subnet_id, address); if None: INSERT`, so the loser hit the unique constraint — a 500 whose `PendingRollbackError` tail poisoned the rest of the batch. On a busy DHCP host it recurred and *felt* persistent, though each occurrence self-heals.

New shared `insert_ipam_mirror_row()` inserts inside a SAVEPOINT (`begin_nested`) and, on the unique-violation, rolls back only the nested transaction (outer session stays usable) and re-selects the committed incumbent — matching the guard style already in `unifi/reconcile.py` and `ipam_discovery.py`. Wired into **all four** mirror-insert sites:

- Kea agent `/lease-events` push — `api/v1/dhcp/agents.py`
- poll/sync path (Sync-DHCP button) — `services/dhcp/pull_leases.py`
- static-reservation mirroring — `api/v1/dhcp/statics.py`
- l2-sniff new-device-watch — `api/v1/dhcp/agents.py` (the 4th site the issue didn't enumerate; found in review)

## #565 — Celery worker/beat should detect DB schema behind bundled migrations

The api gates `/health/ready` on the schema being at the bundled Alembic head (#299/#301), but the worker/beat had no equivalent — they run on whatever schema is present and fail tasks silently when code is deployed ahead of migrate (an operator's env logged the same `UndefinedColumnError` ~2440× in a tight loop).

- Extracted the version-vs-head comparison into framework-agnostic `app.core.schema_check.schema_at_head()`, shared by `health.py` and the new Celery callers (pure DB + bundled-migration-file introspection; identical under docker-compose and k8s).
- `worker_ready` / `beat_init` startup check — loud structured warning if behind.
- 5-min periodic `check_schema_at_head` task — opens/auto-resolves a `schema-behind-head` alert on drift (startup-seeded, like `audit-chain-broken`).
- Opt-in `STRICT_SCHEMA_CHECK` `task_prerun` gate — `Reject(requeue=True)`s tasks while behind (default off; mirrors `STRICT_SECRET_KEY`).
- All Celery-side checks use `task_session` so the per-invocation event loop doesn't reuse a dead-loop-bound asyncpg connection (per `app.db` contract).

**Scope-out (per issue #565):** catches "DB behind code", not the rarer "stamped-forward, DDL never ran" drift. No migration (alert rule is startup-seeded).

## Testing

New: `test_ipam_mirror_race.py` (create / conflict-fallthrough / session-still-usable / unrelated-error-reraise), `test_schema_check_task.py` (alert open/dedupe/resolve + strict-gate reject/allow/disabled/exempt). Updated `test_health_schema_check.py` for the extracted module. All affected tests pass; `ruff`/`black`/`mypy` clean.

A `high`-effort `/code-review` pass ran on this change; 4 correctness findings (shared-engine loop bug, the 4th mirror site, resolve-all-open-events, strict-gate loop) and 2 duplication cleanups were folded in before this PR.

Closes #564, Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)