### PR TITLE
feat: BGP Looking Glass — receive-only collector, sessions + RIB grid (Phase 1+2, #566)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,14 @@ DNS_AGENT_KEY=
 # rotating JWT + DHCPServer row.
 DHCP_AGENT_KEY=
 
+# Pre-shared key shared by every BGP Looking Glass collector (issue #566).
+# Required only if you run the `looking-glass` profile (or any standalone
+# collector via docker-compose.agent-looking-glass.yml).
+#   Generate:  openssl rand -hex 32
+# The collector is receive-only — it never advertises a route back to your
+# network. Must match on the control plane and on every collector container.
+LG_AGENT_KEY=
+
 # ──────────────────────────────────────────────────────────────────────────────
 # 2. Image / version pin
 # ──────────────────────────────────────────────────────────────────────────────
@@ -114,6 +122,13 @@ SPATIUMDDI_VERSION=latest
 #                  peer on top of the primary. Pair the two servers in
 #                  Admin → Failover Channels with peer URLs
 #                  `http://dhcp-kea:8000/` + `http://dhcp-kea-2:8000/`.
+#   looking-glass — start the receive-only BGP Looking Glass collector
+#                  (issue #566) on this host. Uses `network_mode: host` so
+#                  the BGP session originates from the host's real NIC, and
+#                  reaches the API at http://127.0.0.1:${API_PORT}. Set
+#                  LG_AGENT_KEY above; peer it under Network → Looking Glass.
+#                  For a collector on a *separate* VM use
+#                  docker-compose.agent-looking-glass.yml instead.
 #
 # Equivalent CLI: `docker compose --profile dns-bind9 --profile dhcp --profile dhcp-ha up -d`
 COMPOSE_PROFILES=
@@ -364,6 +379,15 @@ DHCP_LEASE_SYNC_INTERVAL_MINUTES=5
 # port 8000). The partner peer hits this for heartbeats + lease updates.
 # DHCP_HA_HOST_PORT=8001
 # DHCP_HA_HOST_PORT_2=8002
+
+# ── Standalone BGP Looking Glass collector (issue #566) ─────────────────────
+# Consumed by docker-compose.agent-looking-glass.yml when the receive-only
+# collector runs on a separate VM with a real routable NIC. Reuses
+# CONTROL_PLANE_URL + LG_AGENT_KEY (section 1) above.
+#
+# Friendly name + hostname advertised to the control plane; also the
+# LookingGlassCollector row name. Must be unique per collector.
+# LG_HOSTNAME=core-collector-1
 
 # Skip TLS verification when the agent calls the control plane API.
 # Leave at "1" for self-signed labs; flip to "0" once you have a trusted

--- a/.github/workflows/build-looking-glass-images.yml
+++ b/.github/workflows/build-looking-glass-images.yml
@@ -1,0 +1,96 @@
+name: Build Looking Glass Agent Images
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-*"
+    paths:
+      - "agent/looking-glass/**"
+      - ".github/workflows/build-looking-glass-images.yml"
+  pull_request:
+    paths:
+      - "agent/looking-glass/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [gobgp]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/spatiumddi/looking-glass
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short
+
+      - name: Build (PR — single-arch, load locally for Trivy)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: agent/looking-glass/images/${{ matrix.flavor }}/Dockerfile
+          # Single-arch on PR: ``--load`` only accepts one platform,
+          # and the runner is amd64. Release builds (push branch) do
+          # the multi-arch manifest list.
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ghcr.io/spatiumddi/looking-glass:pr-scan
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=looking-glass-${{ matrix.flavor }}
+          cache-to: type=gha,mode=max,scope=looking-glass-${{ matrix.flavor }}
+
+      - name: Build and push (main / tag — multi-arch, push to ghcr)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: agent/looking-glass/images/${{ matrix.flavor }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=looking-glass-${{ matrix.flavor }}
+          cache-to: type=gha,mode=max,scope=looking-glass-${{ matrix.flavor }}
+
+      - name: Trivy scan
+        if: github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@master
+        with:
+          # Reference the locally-loaded image from the PR build step
+          # above — same fix as build-dns-images.yml/build-dhcp-images.yml:
+          # a ``ghcr.io/...:${{ github.sha }}`` reference never resolves
+          # (metadata-action emits ``sha-<short>``, not raw full SHAs, and
+          # on PR nothing gets pushed) so Trivy 404s with MANIFEST_UNKNOWN.
+          image-ref: ghcr.io/spatiumddi/looking-glass:pr-scan
+          format: table
+          severity: HIGH,CRITICAL
+          # Fail the PR on any HIGH/CRITICAL CVE that has a fix available —
+          # `ignore-unfixed: true` keeps us unblocked on vulns that have no
+          # upstream patch yet (base image issues we can't fix locally).
+          exit-code: "1"
+          ignore-unfixed: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Always read the relevant spec doc(s) before writing code for a feature area.
 | `docs/features/ACME.md` | ACME DNS-01 provider — acme-dns-compatible HTTP surface for LE / public-CA cert issuance |
 | `docs/features/INTEGRATIONS.md` | Read-only Kubernetes + Docker mirror integrations; setup, semantics, dashboard surface |
 | `docs/features/MIGRATION.md` | One-shot importers — DNS (BIND9 / Windows DNS / PowerDNS) + DHCP (Kea / Windows DHCP / ISC dhcpd.conf) into native rows; preview → commit, provenance, IPAM linkage |
+| `docs/features/LOOKING_GLASS.md` | BGP Looking Glass — receive-only GoBGP collector peering with operator routers; Sessions + Routes grid; distinct from the #527 public-table hijack monitor and the deferred MetalLB BGP-mode VIP advertiser |
 | `docs/PERMISSIONS.md` | RBAC permission grammar (`{action, resource_type, resource_id?}`), builtin roles, wildcards |
 | `docs/features/SYSTEM_ADMIN.md` | System config, health dashboard, notifications, backup/restore, service control |
 | `docs/deployment/APPLIANCE.md` | OS appliance build, base OS selection, licensing |

--- a/NOTICE
+++ b/NOTICE
@@ -23,6 +23,7 @@ components. Grouped by role; license + project URL for each.
 - Flannel (CNI) — Apache 2.0 — https://github.com/flannel-io/flannel
 - Helm — Apache 2.0 — https://helm.sh
 - MetalLB (L2 load balancer / control-plane VIP) — Apache 2.0 — https://metallb.io
+- FRRouting (BGP daemon, via MetalLB's frr-k8s backend) — GPL v2 — https://frrouting.org
 - CloudNativePG (PostgreSQL operator) — Apache 2.0 — https://cloudnative-pg.io
 
 ── Data services ──────────────────────────────────────────────────────────

--- a/NOTICE
+++ b/NOTICE
@@ -31,12 +31,13 @@ components. Grouped by role; license + project URL for each.
 - Prometheus (+ client libs) — Apache 2.0 — https://prometheus.io
 - node-exporter / kube-state-metrics — Apache 2.0 — https://prometheus.io
 
-── DNS / DHCP service engines ─────────────────────────────────────────────
+── DNS / DHCP / routing service engines ────────────────────────────────────
 - ISC Kea DHCP — MPL 2.0 — https://kea.isc.org
 - radvd (IPv6 Router Advertisement Daemon) — BSD-style — https://radvd.litech.org
 - ISC BIND 9 — MPL 2.0 — https://isc.org/bind
 - PowerDNS Authoritative Server — GPL v2 — https://powerdns.com
 - PowerDNS dnsdist — GPL v2 — https://dnsdist.org
+- GoBGP (BGP Looking Glass collector, issue #566) — Apache 2.0 — https://github.com/osrg/gobgp
 
 ── Backend (Python) ───────────────────────────────────────────────────────
 - Python — PSF License — https://python.org

--- a/agent/looking-glass/README.md
+++ b/agent/looking-glass/README.md
@@ -1,0 +1,93 @@
+# spatium-lg-agent
+
+Sidecar agent baked into the SpatiumDDI managed GoBGP Looking Glass
+collector container image (`ghcr.io/spatiumddi/looking-glass`).
+
+The BGP Looking Glass collector is a **receive-only** BGP speaker: it
+peers passively with the operator's edge/core routers, accepts their
+routing table, and never advertises a route back. See
+[`docs/features/`](../../docs/features/) (Looking Glass doc, once it
+lands) and `spatium_lg_agent/gobgp.py`'s module docstring for the full
+receive-only enforcement writeup — that file is the single review gate
+for anything that touches how gobgpd's config is rendered.
+
+## Environment
+
+| Variable | Purpose |
+|---|---|
+| `CONTROL_PLANE_URL` | e.g. `https://api.spatiumddi.example` (required) |
+| `LG_AGENT_KEY` | Bootstrap pre-shared key (required) |
+| `SERVER_NAME` / `AGENT_HOSTNAME` | Hostname reported to the control plane |
+| `AGENT_STATE_DIR` | State directory (default `/var/lib/spatium-lg-agent`) |
+| `GOBGPD_CONFIG_PATH` | Rendered gobgpd config path (default `/etc/gobgp/gobgpd.json`) |
+| `GOBGPD_BIN` | Path to the `gobgpd` daemon binary (default `/usr/local/bin/gobgpd`) |
+| `GOBGP_BIN` | Path to the `gobgp` CLI binary (default `/usr/local/bin/gobgp`) |
+| `GOBGP_GRPC_HOST` / `GOBGP_GRPC_PORT` | gobgpd's local gRPC listener (default `127.0.0.1` / `50051`) |
+| `RIB_POLL_INTERVAL` | Seconds between RIB + neighbor-state polls (default `30`) |
+| `HEARTBEAT_INTERVAL` | Seconds between heartbeats (default `30`) |
+| `LONGPOLL_TIMEOUT` | Seconds the control plane holds the config long-poll (default `30`) |
+| `TLS_CA_PATH` | Optional custom CA bundle |
+| `SPATIUM_INSECURE_SKIP_TLS_VERIFY=1` | Dev only |
+
+## Cache layout
+
+State directory (must be a persistent volume — see non-negotiable #5,
+"config caching on agents"):
+
+```
+/var/lib/spatium-lg-agent/
+├── agent-id                     # stable UUID, 0600
+├── agent_token.jwt              # current JWT, 0600
+├── config/
+│   ├── current.json             # last-known-good peer-config bundle
+│   ├── current.etag
+│   └── previous.json
+├── rendered/
+│   └── gobgpd.json              # last rendered gobgpd config (for audit)
+└── .ready                       # stamped after the first successful RIB poll+push
+```
+
+On startup the agent preloads and re-applies the cached bundle to gobgpd
+**before** its first successful poll of the control plane — already
+configured BGP sessions stay up even if the control plane is unreachable.
+
+## Control-plane contract
+
+Matches `backend/app/api/v1/looking_glass/agents.py` exactly (both
+`AgentHeartbeatRequest`/`PeerStateReport` and `RoutesPushRequest`/
+`RouteEntry` are `extra="forbid"` — an unrecognised field 422s the whole
+call, not just that field):
+
+- `POST /api/v1/looking-glass/agents/register` — PSK bootstrap
+  (`X-LG-Agent-Key` header), body `{hostname, version, fingerprint,
+  agent_id}`, mints a rotating JWT. No server-group concept (unlike
+  DNS/DHCP) and no approval flow.
+- `GET /api/v1/looking-glass/agents/config` — ConfigBundle long-poll
+  (`If-None-Match`), returns `{collector_id, etag, bundle: {collector_name,
+  peers: [...]}}` — peers keyed on `peer_id`, each carrying its own
+  required `local_asn` (there is no daemon-wide "global AS" field; see
+  `gobgp.py::render_config`'s docstring for how the agent picks one).
+- `POST /api/v1/looking-glass/agents/heartbeat` — body `{agent_version,
+  peers: [{peer_id, session_state, uptime_started_at, prefixes_received,
+  prefixes_accepted, last_state_change, last_flap_at}]}` + JWT rotation
+  (`rotated_token` in the response).
+- `POST /api/v1/looking-glass/agents/routes` — **one call per peer**:
+  `{peer_id, snapshot: true, routes: [{prefix, next_hop, origin_asn,
+  as_path, local_pref, med, communities, large_communities,
+  ext_communities, is_best}]}`. Absence-reconciled server-side (mirrors
+  `pull_leases.py`'s upsert + absence-delete shape), with a zero-wire
+  floor guard evaluated per peer against that peer's last-heartbeated
+  `prefixes_received` — the agent always pushes a snapshot for every
+  configured peer every cycle (even an empty one) so the backend gets a
+  chance to apply that guard.
+
+## Receive-only guarantee
+
+Enforced in `spatium_lg_agent/gobgp.py::render_config` via a **global**
+`apply-policy.config.default-export-policy = "reject-route"` (verified
+against a live gobgpd — a per-neighbor `apply-policy` block alone does
+NOT block export for a normal, non-route-server peer) plus a hard runtime
+assertion (`_assert_receive_only`) that refuses to write or apply any
+config that doesn't satisfy the invariant. Per-peer `max-prefixes` is
+rendered into `afi-safis[].prefix-limit.config.max-prefixes` so a
+misbehaving/full-table peer can't blow up the daemon's memory.

--- a/agent/looking-glass/README.md
+++ b/agent/looking-glass/README.md
@@ -6,8 +6,8 @@ collector container image (`ghcr.io/spatiumddi/looking-glass`).
 The BGP Looking Glass collector is a **receive-only** BGP speaker: it
 peers passively with the operator's edge/core routers, accepts their
 routing table, and never advertises a route back. See
-[`docs/features/`](../../docs/features/) (Looking Glass doc, once it
-lands) and `spatium_lg_agent/gobgp.py`'s module docstring for the full
+[`docs/features/LOOKING_GLASS.md`](../../docs/features/LOOKING_GLASS.md)
+and `spatium_lg_agent/gobgp.py`'s module docstring for the full
 receive-only enforcement writeup — that file is the single review gate
 for anything that touches how gobgpd's config is rendered.
 

--- a/agent/looking-glass/images/gobgp/Dockerfile
+++ b/agent/looking-glass/images/gobgp/Dockerfile
@@ -8,7 +8,7 @@
 # global default-export-policy is always "reject-route" and no
 # export-policy-list is ever populated, so the daemon can receive routes
 # from every configured peer but can never advertise one back.
-ARG GOBGP_VERSION=4.5.0
+ARG GOBGP_VERSION=4.7.0
 
 FROM alpine:3.22 AS agent-build
 RUN apk add --no-cache python3 py3-pip py3-wheel
@@ -18,34 +18,40 @@ COPY agent/looking-glass/spatium_lg_agent /src/spatium_lg_agent
 COPY agent/looking-glass/README.md /src/README.md
 RUN python3 -m pip install --prefix=/install --no-cache-dir --break-system-packages .
 
-# ── GoBGP binaries ──────────────────────────────────────────────────────
-# No apk/apt package exists upstream (GoBGP is not packaged by Alpine or
-# Debian), so fetch the official prebuilt release tarball straight from
-# GitHub Releases and verify it against a pinned SHA-256 for both
-# amd64 + arm64 (docker buildx sets TARGETARCH automatically per platform
-# in the multi-arch build below). gobgp/gobgpd are statically-linked
-# pure-Go binaries (verified via `file`/`ldd` during development — no
-# dynamic deps), so they drop straight into an Alpine (musl) runtime with
-# no compatibility shims needed.
+# ── GoBGP binaries — built from source ──────────────────────────────────
+# GoBGP ships no apk/apt package, and its prebuilt release binaries are
+# compiled with whatever Go toolchain upstream had at release time — so the
+# embedded ``stdlib`` carries every Go CVE disclosed AFTER that build (Trivy
+# scans the Go version baked into the binary and fails HIGH/CRITICAL). We
+# therefore build gobgp/gobgpd from the pinned source tag with the CURRENT Go
+# toolchain, which keeps the embedded stdlib on the latest patch (CVE-clean)
+# independent of GoBGP's own release cadence. gobgp/gobgpd are pure-Go, so
+# CGO_ENABLED=0 yields fully static binaries that drop straight into the
+# Alpine (musl) runtime with no shims.
 #
-# Bump GOBGP_VERSION + both SHA256 pins together from
-# https://github.com/osrg/gobgp/releases/download/v<version>/gobgp_<version>_checksums.txt
-FROM alpine:3.22 AS gobgp-fetch
+# ``--platform=$BUILDPLATFORM`` + GOOS/GOARCH from the buildx TARGET* args
+# cross-compiles with the native toolchain (fast, no QEMU) for both
+# linux/amd64 + linux/arm64. Bump GOBGP_VERSION (a git tag from
+# https://github.com/osrg/gobgp/tags) + the golang base image together; the
+# repo's committed go.sum verifies every module checksum during the build.
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS gobgp-build
 ARG GOBGP_VERSION
+ARG TARGETOS
 ARG TARGETARCH
-RUN apk add --no-cache curl
-WORKDIR /fetch
-RUN set -eu; \
-    case "${TARGETARCH}" in \
-      amd64) SHA256="e098e1d47db93463506e3dc5bb49bb93c9347837e8bf5e2d202c1fe7016385c7" ;; \
-      arm64) SHA256="0f83a928848c8c6a01304f6336205b1e4cd29f0f2d24568f6305bf8314dc8717" ;; \
-      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
-    esac; \
-    URL="https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/gobgp_${GOBGP_VERSION}_linux_${TARGETARCH}.tar.gz"; \
-    curl -fsSL -o gobgp.tar.gz "${URL}"; \
-    echo "${SHA256}  gobgp.tar.gz" | sha256sum -c -; \
-    tar xzf gobgp.tar.gz gobgp gobgpd; \
-    chmod +x gobgp gobgpd
+RUN apk add --no-cache git
+WORKDIR /src
+RUN git clone --depth 1 --branch "v${GOBGP_VERSION}" https://github.com/osrg/gobgp .
+# Bump vulnerable transitive deps above the versions gobgp pins so Trivy
+# (HIGH/CRITICAL) stays green. gobgp v4.7.0 pins golang.org/x/net v0.48,
+# which carries several HIGH CVEs (html XSS, IDNA punycode privilege
+# escalation, HTTP/2 DoS — fixed in 0.55). Re-check + drop/bump this pin
+# when GoBGP's own go.mod moves past it.
+RUN go get golang.org/x/net@v0.56.0
+ENV CGO_ENABLED=0
+RUN GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+      go build -trimpath -ldflags="-s -w" -o /out/gobgpd ./cmd/gobgpd \
+ && GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+      go build -trimpath -ldflags="-s -w" -o /out/gobgp ./cmd/gobgp
 
 FROM alpine:3.22 AS runtime
 # ``libcap`` brings in ``setcap`` so gobgpd can bind BGP's privileged
@@ -73,8 +79,8 @@ RUN apk upgrade --no-cache \
  && chown -R spatium:spatium /var/lib/spatium-lg-agent /etc/gobgp
 
 COPY --from=agent-build /install /usr/local
-COPY --from=gobgp-fetch /fetch/gobgp /usr/local/bin/gobgp
-COPY --from=gobgp-fetch /fetch/gobgpd /usr/local/bin/gobgpd
+COPY --from=gobgp-build /out/gobgp /usr/local/bin/gobgp
+COPY --from=gobgp-build /out/gobgpd /usr/local/bin/gobgpd
 RUN setcap cap_net_bind_service=+ep /usr/local/bin/gobgpd
 COPY agent/looking-glass/images/gobgp/gobgpd-idle.json /etc/gobgp/gobgpd.json
 COPY agent/looking-glass/images/gobgp/entrypoint.sh /usr/local/bin/spatium-lg-entrypoint

--- a/agent/looking-glass/images/gobgp/Dockerfile
+++ b/agent/looking-glass/images/gobgp/Dockerfile
@@ -1,0 +1,104 @@
+# syntax=docker/dockerfile:1.7
+# SpatiumDDI BGP Looking Glass collector container — receive-only GoBGP +
+# spatium-lg-agent. Multi-arch: linux/amd64, linux/arm64 (non-negotiable #11)
+#
+# RECEIVE-ONLY SAFETY INVARIANT — see spatium_lg_agent/gobgp.py's module
+# docstring for the full writeup + empirical verification notes. This
+# image runs gobgpd purely as a passive collector: the rendered config's
+# global default-export-policy is always "reject-route" and no
+# export-policy-list is ever populated, so the daemon can receive routes
+# from every configured peer but can never advertise one back.
+ARG GOBGP_VERSION=4.5.0
+
+FROM alpine:3.22 AS agent-build
+RUN apk add --no-cache python3 py3-pip py3-wheel
+WORKDIR /src
+COPY agent/looking-glass/pyproject.toml /src/pyproject.toml
+COPY agent/looking-glass/spatium_lg_agent /src/spatium_lg_agent
+COPY agent/looking-glass/README.md /src/README.md
+RUN python3 -m pip install --prefix=/install --no-cache-dir --break-system-packages .
+
+# ── GoBGP binaries ──────────────────────────────────────────────────────
+# No apk/apt package exists upstream (GoBGP is not packaged by Alpine or
+# Debian), so fetch the official prebuilt release tarball straight from
+# GitHub Releases and verify it against a pinned SHA-256 for both
+# amd64 + arm64 (docker buildx sets TARGETARCH automatically per platform
+# in the multi-arch build below). gobgp/gobgpd are statically-linked
+# pure-Go binaries (verified via `file`/`ldd` during development — no
+# dynamic deps), so they drop straight into an Alpine (musl) runtime with
+# no compatibility shims needed.
+#
+# Bump GOBGP_VERSION + both SHA256 pins together from
+# https://github.com/osrg/gobgp/releases/download/v<version>/gobgp_<version>_checksums.txt
+FROM alpine:3.22 AS gobgp-fetch
+ARG GOBGP_VERSION
+ARG TARGETARCH
+RUN apk add --no-cache curl
+WORKDIR /fetch
+RUN set -eu; \
+    case "${TARGETARCH}" in \
+      amd64) SHA256="e098e1d47db93463506e3dc5bb49bb93c9347837e8bf5e2d202c1fe7016385c7" ;; \
+      arm64) SHA256="0f83a928848c8c6a01304f6336205b1e4cd29f0f2d24568f6305bf8314dc8717" ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    URL="https://github.com/osrg/gobgp/releases/download/v${GOBGP_VERSION}/gobgp_${GOBGP_VERSION}_linux_${TARGETARCH}.tar.gz"; \
+    curl -fsSL -o gobgp.tar.gz "${URL}"; \
+    echo "${SHA256}  gobgp.tar.gz" | sha256sum -c -; \
+    tar xzf gobgp.tar.gz gobgp gobgpd; \
+    chmod +x gobgp gobgpd
+
+FROM alpine:3.22 AS runtime
+# ``libcap`` brings in ``setcap`` so gobgpd can bind BGP's privileged
+# TCP/179 as the unprivileged ``spatium`` user (same pattern as
+# kea-dhcp4/6 + named/pdns_server in the DHCP/DNS images — a
+# container-level ``cap_add``/``securityContext.capabilities.add`` only
+# sets the bounding set, which su-exec's setuid drops on the privilege
+# drop; the capability has to live on the binary as a file cap to
+# survive it).
+#
+# ``apk upgrade --no-cache`` runs BEFORE ``apk add`` so the package
+# database is fresh and any previously-baked layer carrying an older
+# libssl/libcrypto (or other base) version gets re-resolved against the
+# current alpine 3.22 index rather than serving a stale GitHub Actions
+# layer cache that Trivy would then flag.
+RUN apk upgrade --no-cache \
+ && apk add --no-cache \
+      tini su-exec \
+      python3 py3-pip \
+      libcap \
+      ca-certificates tzdata \
+ && addgroup -S spatium \
+ && adduser -S -G spatium spatium \
+ && mkdir -p /var/lib/spatium-lg-agent /etc/gobgp \
+ && chown -R spatium:spatium /var/lib/spatium-lg-agent /etc/gobgp
+
+COPY --from=agent-build /install /usr/local
+COPY --from=gobgp-fetch /fetch/gobgp /usr/local/bin/gobgp
+COPY --from=gobgp-fetch /fetch/gobgpd /usr/local/bin/gobgpd
+RUN setcap cap_net_bind_service=+ep /usr/local/bin/gobgpd
+COPY agent/looking-glass/images/gobgp/gobgpd-idle.json /etc/gobgp/gobgpd.json
+COPY agent/looking-glass/images/gobgp/entrypoint.sh /usr/local/bin/spatium-lg-entrypoint
+RUN chmod +x /usr/local/bin/spatium-lg-entrypoint \
+ && chown spatium:spatium /etc/gobgp/gobgpd.json \
+ && { \
+      echo "alpine_release=$(cat /etc/alpine-release)"; \
+      echo "gobgp=${GOBGP_VERSION}"; \
+    } > /etc/spatiumddi-versions
+
+ENV AGENT_STATE_DIR=/var/lib/spatium-lg-agent \
+    GOBGPD_CONFIG_PATH=/etc/gobgp/gobgpd.json \
+    GOBGPD_BIN=/usr/local/bin/gobgpd \
+    GOBGP_BIN=/usr/local/bin/gobgp \
+    GOBGP_GRPC_HOST=127.0.0.1 \
+    GOBGP_GRPC_PORT=50051 \
+    PYTHONPATH=/usr/local/lib/python3.12/site-packages \
+    LOG_LEVEL=INFO
+
+VOLUME ["/var/lib/spatium-lg-agent"]
+# BGP (receive-only — see spatium_lg_agent/gobgp.py's module docstring)
+EXPOSE 179/tcp
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s \
+  CMD /usr/local/bin/gobgp -u 127.0.0.1 -p 50051 -j neighbor >/dev/null 2>&1 || exit 1
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/spatium-lg-entrypoint"]

--- a/agent/looking-glass/images/gobgp/entrypoint.sh
+++ b/agent/looking-glass/images/gobgp/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Container entrypoint — delegates to the Python supervisor, which owns
+# the gobgpd subprocess directly (mirrors
+# agent/dns/images/bind9/entrypoint.sh — a single managed daemon, unlike
+# Kea's three-daemon shell supervise loop). tini is PID 1.
+set -eu
+
+: "${CONTROL_PLANE_URL:?CONTROL_PLANE_URL is required}"
+: "${LG_AGENT_KEY:?LG_AGENT_KEY is required. Pairing-code exchange was removed in #170 Wave A3 -- paste the long hex key directly. Application appliances receive it via the supervisor role-compose.env automatically.}"
+
+# Ensure state + config dirs are writable by the agent user. named/kea's
+# equivalent images do the same dance -- the image bakes an initial
+# (root-owned, from COPY) idle gobgpd.json, but spatium_lg_agent needs to
+# be able to overwrite it in place once it has a real peer-config bundle.
+mkdir -p /var/lib/spatium-lg-agent /etc/gobgp
+chown -R spatium:spatium /var/lib/spatium-lg-agent /etc/gobgp || true
+
+# Supervise: agent process manages gobgpd lifecycle (spawn, SIGHUP
+# reload, dead-process detection -> exit(2) -> container restart).
+exec su-exec spatium:spatium /usr/local/bin/spatium-lg-agent

--- a/agent/looking-glass/images/gobgp/gobgpd-idle.json
+++ b/agent/looking-glass/images/gobgp/gobgpd-idle.json
@@ -1,0 +1,16 @@
+{
+  "global": {
+    "config": {
+      "as": 4200000000,
+      "router-id": "192.0.2.1",
+      "port": 179
+    },
+    "apply-policy": {
+      "config": {
+        "default-import-policy": "accept-route",
+        "default-export-policy": "reject-route"
+      }
+    }
+  },
+  "neighbors": []
+}

--- a/agent/looking-glass/pyproject.toml
+++ b/agent/looking-glass/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "spatium-lg-agent"
+version = "2026.07.04.1"
+description = "SpatiumDDI sidecar agent for the receive-only BGP Looking Glass collector (GoBGP)"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "Apache-2.0" }
+authors = [{ name = "SpatiumDDI Contributors" }]
+dependencies = [
+  "httpx>=0.27",
+  "structlog>=24.1",
+  "pydantic>=2.6",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "pytest-asyncio>=0.23", "ruff>=0.4", "mypy>=1.10"]
+
+[project.scripts]
+spatium-lg-agent = "spatium_lg_agent.__main__:main"
+
+[tool.setuptools.packages.find]
+include = ["spatium_lg_agent*"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"

--- a/agent/looking-glass/spatium_lg_agent/__init__.py
+++ b/agent/looking-glass/spatium_lg_agent/__init__.py
@@ -1,0 +1,4 @@
+"""SpatiumDDI BGP Looking Glass collector agent — supervises a receive-only
+GoBGP daemon and syncs with the control plane (issue #566)."""
+
+__version__ = "2026.07.04.1"

--- a/agent/looking-glass/spatium_lg_agent/__main__.py
+++ b/agent/looking-glass/spatium_lg_agent/__main__.py
@@ -1,0 +1,22 @@
+"""CLI entrypoint — ``spatium-lg-agent`` / ``python -m spatium_lg_agent``."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from .cache import ensure_layout
+from .config import AgentConfig
+from .log import configure_logging
+from .supervisor import run
+
+
+def main() -> int:
+    configure_logging(level=os.environ.get("LOG_LEVEL", "INFO"))
+    cfg = AgentConfig.from_env()
+    ensure_layout(cfg.state_dir)
+    return run(cfg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent/looking-glass/spatium_lg_agent/bootstrap.py
+++ b/agent/looking-glass/spatium_lg_agent/bootstrap.py
@@ -1,0 +1,105 @@
+"""Bootstrap / registration loop for the BGP Looking Glass collector agent.
+
+Tries the cached JWT first; on missing/expired token falls back to PSK
+registration against ``POST /api/v1/looking-glass/agents/register`` using
+``cfg.lg_agent_key``.
+
+There is NO pairing-code ``/pair`` endpoint here — that flow was removed
+under #170 Wave A3 for every DNS/DHCP-style agent kind, and the Looking
+Glass collector is a new agent kind, not a re-use of the supervisor's own
+pairing-code registration. Standalone docker-compose / K8s collectors
+require ``LG_AGENT_KEY`` directly; Application appliances receive the key
+via the supervisor's ``role-compose.env`` (#170 Wave C2).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import time
+
+import httpx
+import structlog
+
+from . import __version__
+from .cache import load_or_create_agent_id, load_token, save_token
+from .config import AgentConfig
+
+log = structlog.get_logger(__name__)
+
+
+def _fingerprint(agent_id: str) -> str:
+    """SHA-256 fingerprint derived from the agent id."""
+    return hashlib.sha256(agent_id.encode()).hexdigest()
+
+
+def _client(cfg: AgentConfig) -> httpx.Client:
+    return httpx.Client(
+        base_url=cfg.control_plane_url,
+        verify=cfg.httpx_verify(),
+        timeout=30.0,
+    )
+
+
+def register(cfg: AgentConfig) -> tuple[str, str, dict]:
+    """Perform PSK bootstrap. Returns (agent_id, token, response_body).
+
+    Requires ``LG_AGENT_KEY`` set in the environment (validated in
+    ``AgentConfig.from_env``).
+
+    Request/response shape matches
+    ``backend/app/api/v1/looking_glass/agents.py``'s
+    ``AgentRegisterRequest``/``AgentRegisterResponse`` exactly — the
+    ``LookingGlassCollector`` row has no server-group concept (unlike
+    DNS/DHCP servers), so there is no ``roles``/``group_name`` field to
+    send.
+    """
+    agent_id = load_or_create_agent_id(cfg.state_dir)
+    bootstrap_key = cfg.lg_agent_key
+    body = {
+        "hostname": cfg.server_name,
+        "version": __version__,
+        "fingerprint": _fingerprint(agent_id),
+        "agent_id": agent_id,
+    }
+    backoff = 2.0
+    while True:
+        try:
+            with _client(cfg) as c:
+                resp = c.post(
+                    "/api/v1/looking-glass/agents/register",
+                    json=body,
+                    headers={"X-LG-Agent-Key": bootstrap_key},
+                )
+            if resp.status_code == 200:
+                data = resp.json()
+                token = data.get("agent_token")
+                if not token:
+                    log.error("register_response_missing_token", body=str(data)[:400])
+                else:
+                    save_token(cfg.state_dir, token)
+                    log.info(
+                        "lg_agent_registered",
+                        collector_id=data.get("collector_id"),
+                    )
+                    return agent_id, token, data
+            else:
+                log.warning(
+                    "register_failed", status=resp.status_code, body=resp.text[:400]
+                )
+        except httpx.HTTPError as e:
+            log.warning("register_http_error", error=str(e))
+        # jittered exponential backoff, cap 5 min
+        sleep_for = min(backoff + random.uniform(0, 2), 300.0)
+        time.sleep(sleep_for)
+        backoff = min(backoff * 2, 300.0)
+
+
+def ensure_token(cfg: AgentConfig) -> tuple[str, str]:
+    """Load cached token or re-register. Returns (agent_id, token)."""
+    agent_id = load_or_create_agent_id(cfg.state_dir)
+    token = load_token(cfg.state_dir)
+    if token:
+        return agent_id, token
+    agent_id, token, _ = register(cfg)
+    return agent_id, token

--- a/agent/looking-glass/spatium_lg_agent/cache.py
+++ b/agent/looking-glass/spatium_lg_agent/cache.py
@@ -1,0 +1,140 @@
+"""On-disk cache for the LG collector agent (non-negotiable #5).
+
+Layout under /var/lib/spatium-lg-agent/:
+    agent-id                       # UUID, 0600
+    agent_token.jwt                # current JWT, 0600
+    config/current.json            # last-known-good peer-config ConfigBundle
+    config/current.etag
+    config/previous.json
+    rendered/gobgpd.json           # last rendered gobgpd config (for audit/debug)
+    .ready                         # stamped after the first successful RIB poll+apply
+
+This is the non-negotiable #5 last-known-good peer-config cache: on
+startup the agent preloads and re-applies the cached bundle to gobgpd
+BEFORE its first successful poll of the control plane, so already-configured
+BGP sessions stay up (and freshly-booted ones can still come up) even if
+the control plane is unreachable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+
+# Schema version for the cached ConfigBundle.
+CACHE_SCHEMA_VERSION = 1
+
+
+def ensure_layout(state_dir: Path) -> None:
+    for sub in ("config", "rendered"):
+        (state_dir / sub).mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(state_dir, 0o700)
+    except PermissionError:
+        # Volume-mount owner may differ; best-effort only.
+        pass
+
+
+def load_or_create_agent_id(state_dir: Path) -> str:
+    path = state_dir / "agent-id"
+    if path.exists():
+        return path.read_text().strip()
+    aid = str(uuid.uuid4())
+    path.write_text(aid)
+    try:
+        os.chmod(path, 0o600)
+    except PermissionError:
+        pass
+    return aid
+
+
+def load_token(state_dir: Path) -> str | None:
+    path = state_dir / "agent_token.jwt"
+    if not path.exists():
+        return None
+    tok = path.read_text().strip()
+    return tok or None
+
+
+def save_token(state_dir: Path, token: str) -> None:
+    path = state_dir / "agent_token.jwt"
+    tmp = path.with_suffix(".jwt.tmp")
+    tmp.write_text(token)
+    try:
+        os.chmod(tmp, 0o600)
+    except (PermissionError, FileNotFoundError):
+        pass
+    try:
+        tmp.replace(path)
+    except FileNotFoundError:
+        # Another thread already moved our tmp (concurrent save_token).
+        pass
+
+
+def load_config(state_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
+    cfg_path = state_dir / "config" / "current.json"
+    etag_path = state_dir / "config" / "current.etag"
+    if not cfg_path.exists():
+        return None, None
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except json.JSONDecodeError:
+        return None, None
+    etag = etag_path.read_text().strip() if etag_path.exists() else None
+    return cfg, etag
+
+
+def _chmod_600(path: Path) -> None:
+    """0600 a just-written file, best-effort (mirrors save_token / the
+    agent-id writer). Both the cached bundle and the rendered gobgpd
+    config embed the plaintext TCP-MD5 peer password, so they must not be
+    world-readable on disk."""
+    try:
+        os.chmod(path, 0o600)
+    except (PermissionError, FileNotFoundError):
+        pass
+
+
+def save_config(state_dir: Path, bundle: dict[str, Any], etag: str) -> None:
+    """Atomic replace — write new, move current→previous, rename tmp→current."""
+    cfg_dir = state_dir / "config"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    current = cfg_dir / "current.json"
+    previous = cfg_dir / "previous.json"
+    tmp = cfg_dir / "current.json.tmp"
+    stamped = dict(bundle)
+    stamped.setdefault("_schema_version", CACHE_SCHEMA_VERSION)
+    tmp.write_text(json.dumps(stamped, indent=2, sort_keys=True))
+    # chmod the tmp file BEFORE the rename so the secret is never briefly
+    # world-readable at the final path (matches save_token's pattern).
+    _chmod_600(tmp)
+    if current.exists():
+        current.replace(previous)
+    tmp.replace(current)
+    (cfg_dir / "current.etag").write_text(etag)
+
+
+def save_rendered_gobgpd(state_dir: Path, rendered: dict[str, Any]) -> Path:
+    """Write the rendered gobgpd config under rendered/ for audit/debug."""
+    path = state_dir / "rendered" / "gobgpd.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(rendered, indent=2, sort_keys=True))
+    # The rendered neighbor block carries auth-password in plaintext.
+    _chmod_600(tmp)
+    tmp.replace(path)
+    return path
+
+
+def touch_ready_marker(state_dir: Path) -> None:
+    """Stamp ``<state_dir>/.ready`` after the first successful RIB poll+apply.
+
+    Caller (``rib.py``) MUST only invoke this after a successful GoBGP
+    poll + control-plane push — a failed cycle must not flip readiness
+    true. Idempotent — touching an already-stamped marker is a no-op.
+    """
+    marker = state_dir / ".ready"
+    marker.touch(exist_ok=True)

--- a/agent/looking-glass/spatium_lg_agent/cache.py
+++ b/agent/looking-glass/spatium_lg_agent/cache.py
@@ -47,6 +47,7 @@ def load_or_create_agent_id(state_dir: Path) -> str:
     try:
         os.chmod(path, 0o600)
     except PermissionError:
+        # Volume-mount owner may differ; the 0600 hardening is best-effort.
         pass
     return aid
 
@@ -66,6 +67,8 @@ def save_token(state_dir: Path, token: str) -> None:
     try:
         os.chmod(tmp, 0o600)
     except (PermissionError, FileNotFoundError):
+        # Best-effort 0600 (volume-mount owner may differ); a racing
+        # save_token may already have moved the tmp out from under us.
         pass
     try:
         tmp.replace(path)
@@ -95,6 +98,8 @@ def _chmod_600(path: Path) -> None:
     try:
         os.chmod(path, 0o600)
     except (PermissionError, FileNotFoundError):
+        # Best-effort (volume-mount owner may differ); a concurrent writer
+        # may have already replaced the file. See docstring above.
         pass
 
 

--- a/agent/looking-glass/spatium_lg_agent/config.py
+++ b/agent/looking-glass/spatium_lg_agent/config.py
@@ -1,0 +1,103 @@
+"""Agent runtime configuration loaded from env vars."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    """Runtime configuration for the BGP Looking Glass collector agent.
+
+    Env vars:
+        CONTROL_PLANE_URL         — control-plane base URL (required)
+        LG_AGENT_KEY              — bootstrap pre-shared key (required)
+        AGENT_STATE_DIR           — state directory (default /var/lib/spatium-lg-agent)
+        GOBGPD_CONFIG_PATH        — rendered gobgpd config path (default /etc/gobgp/gobgpd.json)
+        GOBGPD_BIN                — path to the ``gobgpd`` daemon binary (default /usr/local/bin/gobgpd)
+        GOBGP_BIN                 — path to the ``gobgp`` CLI binary (default /usr/local/bin/gobgp)
+        GOBGP_GRPC_HOST           — gobgpd's local gRPC listener host (default 127.0.0.1 — loopback only)
+        GOBGP_GRPC_PORT           — gobgpd's local gRPC listener port (default 50051)
+        RIB_POLL_INTERVAL         — seconds between RIB + neighbor-state polls (default 30)
+        HEARTBEAT_INTERVAL        — seconds between heartbeats (default 30)
+        LONGPOLL_TIMEOUT          — seconds the control plane holds the config long-poll (default 30)
+        SERVER_NAME / AGENT_HOSTNAME — hostname reported to the control plane
+        TLS_CA_PATH               — optional custom CA bundle
+        SPATIUM_INSECURE_SKIP_TLS_VERIFY=1  — dev only
+    """
+
+    control_plane_url: str
+    # Long-PSK bootstrap key. Mirrors DNS_AGENT_KEY / SPATIUM_AGENT_KEY —
+    # issue #246 removed the pairing-code exchange via the now-gone
+    # ``POST /api/v1/appliance/pair`` endpoint (retired in #170 Wave A3).
+    # There is no equivalent ``/pair`` flow for a brand-new agent kind;
+    # standalone agents paste the long hex key directly, Application
+    # appliances receive it via the supervisor's ``role-compose.env``.
+    lg_agent_key: str
+    server_name: str
+    state_dir: Path
+    gobgpd_config_path: Path
+    gobgpd_bin: str
+    gobgp_bin: str
+    gobgp_grpc_host: str
+    gobgp_grpc_port: int
+    tls_ca_path: str | None
+    insecure_skip_tls_verify: bool
+    heartbeat_interval: float = 30.0
+    longpoll_timeout: float = 30.0
+    rib_poll_interval: float = 30.0
+
+    def httpx_verify(self) -> bool | str:
+        """Resolve the ``verify=`` argument for ``httpx.Client`` calls.
+
+        Single source of truth (mirrors DHCP issue #266): the dev-only
+        ``insecure_skip_tls_verify`` override wins over a custom CA
+        bundle; the default is full verification.
+        """
+        if self.insecure_skip_tls_verify:
+            return False
+        if self.tls_ca_path:
+            return self.tls_ca_path
+        return True
+
+    @classmethod
+    def from_env(cls) -> "AgentConfig":
+        cp = os.environ.get("CONTROL_PLANE_URL", "").rstrip("/")
+        if not cp:
+            raise RuntimeError("CONTROL_PLANE_URL is required")
+        key = os.environ.get("LG_AGENT_KEY", "")
+        if not key:
+            raise RuntimeError(
+                "LG_AGENT_KEY is required. Issue #246 removed the "
+                "pairing-code → PSK exchange (the underlying control-plane "
+                "endpoint was retired in #170 Wave A3); paste the long hex "
+                "key directly. Application appliances receive it via the "
+                "supervisor's role-compose.env automatically."
+            )
+        return cls(
+            control_plane_url=cp,
+            lg_agent_key=key,
+            server_name=(
+                os.environ.get("SERVER_NAME")
+                or os.environ.get("AGENT_HOSTNAME")
+                or os.uname().nodename
+            ),
+            state_dir=Path(
+                os.environ.get("AGENT_STATE_DIR", "/var/lib/spatium-lg-agent")
+            ),
+            gobgpd_config_path=Path(
+                os.environ.get("GOBGPD_CONFIG_PATH", "/etc/gobgp/gobgpd.json")
+            ),
+            gobgpd_bin=os.environ.get("GOBGPD_BIN", "/usr/local/bin/gobgpd"),
+            gobgp_bin=os.environ.get("GOBGP_BIN", "/usr/local/bin/gobgp"),
+            gobgp_grpc_host=os.environ.get("GOBGP_GRPC_HOST", "127.0.0.1"),
+            gobgp_grpc_port=int(os.environ.get("GOBGP_GRPC_PORT", "50051")),
+            tls_ca_path=os.environ.get("TLS_CA_PATH") or None,
+            insecure_skip_tls_verify=os.environ.get("SPATIUM_INSECURE_SKIP_TLS_VERIFY")
+            == "1",
+            heartbeat_interval=float(os.environ.get("HEARTBEAT_INTERVAL", "30")),
+            longpoll_timeout=float(os.environ.get("LONGPOLL_TIMEOUT", "30")),
+            rib_poll_interval=float(os.environ.get("RIB_POLL_INTERVAL", "30")),
+        )

--- a/agent/looking-glass/spatium_lg_agent/gobgp.py
+++ b/agent/looking-glass/spatium_lg_agent/gobgp.py
@@ -1,0 +1,507 @@
+"""GoBGP config rendering + live-apply for the receive-only BGP collector.
+
+===========================================================================
+RECEIVE-ONLY SAFETY INVARIANT (issue #566) — READ BEFORE TOUCHING THIS FILE
+===========================================================================
+The BGP Looking Glass collector is a pure sink: it must NEVER advertise a
+route back to the operator's network, under any circumstance. This module
+is the single place that enforcement is implemented, and any change to
+:func:`render_config` or :func:`_render_neighbor` is a first-class review
+gate for that guarantee.
+
+**Enforcement point**: ``render_config()`` sets
+``global.apply-policy.config.default-export-policy = "reject-route"`` at
+the GLOBAL (daemon-wide) level, and never populates an
+``export-policy-list`` anywhere. :func:`_assert_receive_only` re-checks
+this on every render and raises :class:`ReceiveOnlyViolation` — a hard
+crash, not a soft warning — if it is ever violated.
+
+**Why the GLOBAL level, not a per-neighbor ``apply-policy`` block**: this
+was verified empirically against a live gobgpd v4.5.0 binary with a 3-node
+B->A->C topology (B advertises a prefix, A is the collector-under-test
+peered receive-only with both B and C, C is a stand-in for "the operator's
+other router"). Setting ``default-export-policy: reject-route`` only under
+``neighbors[].apply-policy`` did **not** stop A from re-advertising the
+prefix it learned from B to C — gobgpd's static config loader
+(``pkg/config/config.go``'s ``assignGlobalpolicy``, called from
+``InitialConfig``/``UpdateConfig``) only wires ``global.apply-policy``
+into a real policy assignment at daemon (re)start; for a normal
+(non-route-server) peer, every neighbor's adj-rib-out lookup resolves to
+the shared ``GLOBAL_RIB_NAME`` policy assignment
+(``pkg/server/peer.go``'s ``peer.TableID()``), so a per-neighbor
+``apply-policy`` block is parsed into the config struct but is otherwise
+dead configuration for this code path. Moving the identical
+``default-export-policy: reject-route`` setting to ``global.apply-policy``
+blocked the leak completely (confirmed: the downstream peer's RIB stayed
+empty and its "#Received" counter for the collector stayed 0). We still
+set the per-neighbor block too, defensively — it costs nothing and
+protects against a future gobgpd version that starts honoring it per-peer.
+
+The other load-bearing safety knob is the per-peer, per-AFI
+``prefix-limit.config.max-prefixes`` (issue #566 decision D4) — also
+verified empirically: exceeding the configured cap logs
+``"prefix limit reached"`` and gobgpd stops *accepting* further prefixes
+from that peer (a soft cap that protects the RIB from a full-table blow-up
+without tearing down the BGP session).
+
+Config is written as JSON (gobgpd's ``--config-type json`` — JSON is a
+strict subset of YAML 1.2, so writing JSON avoids a PyYAML dependency
+without losing anything gobgpd's config loader understands) and applied
+live via ``SIGHUP`` (gobgpd's own documented reload mechanism —
+``cmd/gobgpd/main.go`` calls ``config.ReadConfigFile`` + ``UpdateConfig``
+on receipt; unlike an unhandled signal this does NOT terminate the
+process). The container also runs gobgpd with ``--config-auto-reload``
+(fsnotify-based, see the image entrypoint) as a second, independent
+delivery path for the same reload — belt-and-braces, mirroring the
+ETag-poll-is-authoritative / wake-is-advisory pattern used elsewhere in
+the fleet (CLAUDE.md cross-cutting pattern #2).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import signal
+import socket
+import subprocess
+import threading
+from typing import Any
+
+import structlog
+
+from .cache import save_rendered_gobgpd
+from .config import AgentConfig
+
+log = structlog.get_logger(__name__)
+
+# Parsed IP network types the scope filter works with.
+_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+# gobgpd's own SIGHUP-triggered reload only re-reads its config file — it
+# does not fsnotify-watch by itself unless started with this flag. We pass
+# BOTH: ``--config-auto-reload`` as an independent, automatic delivery
+# path, and an explicit SIGHUP (see ``reload``) as a deterministic one the
+# Python agent can rely on right after writing a new file. Neither is the
+# sole path (mirrors the ETag-poll-is-authoritative / wake-is-advisory
+# pattern used elsewhere in the fleet).
+_GOBGPD_ARGS = ("-t", "json", "-l", "info", "--config-auto-reload", "--pprof-disable")
+
+# v1 scope (issue #566 Phase 1+2) — VPNv4/VPNv6 + multicast address
+# families are explicitly out of scope (see the implementation plan §2,
+# deferred-phase table). Anything else is logged + skipped rather than
+# failing the whole peer, since a single bad address-family string must
+# not take the collector offline.
+_KNOWN_AFI_SAFIS = {"ipv4-unicast", "ipv6-unicast"}
+_DEFAULT_BGP_PORT = 179
+_SHUTDOWN_THRESHOLD_PCT = 90
+_DEFAULT_MAX_PREFIXES = 10000  # issue #566 decision D4
+# The collector's own daemon-wide fallback identity when no peer is
+# configured yet (idle state — matches images/gobgp/gobgpd-idle.json's
+# baked-in placeholder exactly, so a freshly-applied empty bundle renders
+# to the same values the image already boots with). Neither value carries
+# operational meaning for a receive-only eBGP collector with no
+# route-reflection/iBGP in play — GoBGP just requires *a* syntactically
+# valid AS + router-id to start.
+_PLACEHOLDER_AS = 4200000000  # RFC 6996 private-use 4-byte ASN range start
+_PLACEHOLDER_ROUTER_ID = "192.0.2.1"  # RFC 5737 TEST-NET-1 (documentation-only)
+
+
+class GoBGPCliError(RuntimeError):
+    """Raised when the ``gobgp`` CLI exits non-zero or can't be reached."""
+
+
+class ReceiveOnlyViolation(RuntimeError):
+    """A bug turned the collector into a transit path.
+
+    This must never fire in production — it is a hard fail-safe, not a
+    soft warning. See the module docstring.
+    """
+
+
+def _derive_router_id() -> str:
+    """Best-effort local router-id when the bundle carries none.
+
+    Neither ``LookingGlassCollector`` nor ``BGPLGPeer`` carries a
+    router-id field on the control-plane side (see
+    ``backend/app/models/bgp_looking_glass.py``) — GoBGP requires a
+    syntactically valid one to start, but for a receive-only eBGP
+    collector with no route-reflection/iBGP in play, its exact value has
+    no operational meaning (it never triggers a BGP identifier tie-break
+    or otherwise resolves any protocol comparison here). Try to derive
+    something unique-ish per host for cosmetic/debug value; fall back to
+    the same documentation-only placeholder the baked idle image ships.
+    """
+    try:
+        return socket.gethostbyname(socket.gethostname())
+    except OSError:
+        return _PLACEHOLDER_ROUTER_ID
+
+
+def render_config(bundle: dict[str, Any]) -> dict[str, Any]:
+    """Render a gobgpd JSON config document from a control-plane peer bundle.
+
+    Bundle shape — the ``bundle`` object nested inside
+    ``GET /api/v1/looking-glass/agents/config``'s response (see
+    ``backend/app/services/looking_glass/config_bundle.py``'s
+    ``LGConfigBundle``/``LGPeerDef``; ``sync.py`` unwraps the outer
+    ``{collector_id, etag, bundle}`` envelope before calling this)::
+
+        {
+          "collector_name": "...",
+          "peers": [
+            {
+              "peer_id": "...", "name": "...",
+              "peer_address": "203.0.113.1",
+              "peer_asn": 65001,
+              "local_asn": 65000,             # REQUIRED on every peer row
+              "address_families": ["ipv4-unicast", "ipv6-unicast"],
+              "max_prefixes": 10000,
+              "import_filter": {"mode": "accept_all"} | {"mode": "scope", ...},
+              "md5_password": "secret" | null,
+              "md5_password_set": true
+            },
+            ...
+          ]
+        }
+
+    There is no daemon-wide "global AS" field anywhere in the data model
+    — each peer declares its own required ``local_asn`` (a collector could
+    in principle peer as different local ASNs to different neighbors).
+    GoBGP itself requires exactly one ``global.config.as``, so we pick the
+    first enabled peer's ``local_asn`` as the daemon-wide value and render
+    a per-neighbor ``local-as`` override (see :func:`_render_neighbor`) for
+    any peer whose own ``local_asn`` differs — falling back to a fixed
+    placeholder when there are no peers yet (matches the baked idle image
+    config so a freshly-emptied bundle doesn't shift anything).
+
+    Peers missing required fields are skipped (logged, never a hard
+    failure) — a single malformed peer row must not take the whole
+    collector offline.
+
+    ``import_filter.mode == "scope"`` (restrict the reported RIB to
+    specific IPAM-scoped prefixes) is enforced AGENT-SIDE, in
+    :mod:`spatium_lg_agent.rib` — NOT via a rendered GoBGP import policy.
+    Two empirically-verified facts against gobgpd v4.5.0 force this:
+    (1) gobgpd does not load ``defined-sets`` / ``policy-definitions`` from
+    the static config file at all (``gobgp policy prefix`` reports "Nothing
+    defined yet" and a referenced-but-unloaded import policy silently
+    falls back to accept-all — the exact "silently ignored" failure mode
+    this would be meant to fix); and (2) the collector reads each peer's
+    **Adj-RIB-In** (the raw received table, pre-import-policy), so a GoBGP
+    import policy — which only filters the post-selection Loc-RIB — could
+    never change what the collector observes anyway. So the scope is
+    applied where it actually works: ``rib.py`` filters each peer's parsed
+    adj-in routes against the scope prefix set before pushing. See
+    ``gobgp.peer_import_scopes`` + ``RibPoller._poll_adj_in``. The
+    receive-only invariant is orthogonal and untouched (import-side
+    filtering only narrows what's reported; it can never cause an export).
+    """
+    peers_in = [p for p in (bundle.get("peers") or []) if p.get("enabled", True)]
+    global_as = _PLACEHOLDER_AS
+    for p in peers_in:
+        local_asn = p.get("local_asn")
+        if local_asn:
+            try:
+                global_as = int(local_asn)
+                break
+            except (TypeError, ValueError):
+                continue
+    router_id = _derive_router_id()
+
+    neighbors: list[dict[str, Any]] = []
+    for peer in peers_in:
+        try:
+            neighbors.append(_render_neighbor(peer, global_as))
+        except (KeyError, ValueError, TypeError) as e:
+            log.warning(
+                "lg_peer_render_skipped", peer=peer.get("peer_id"), error=str(e)
+            )
+
+    rendered: dict[str, Any] = {
+        "global": {
+            "config": {
+                "as": global_as,
+                "router-id": router_id,
+                "port": _DEFAULT_BGP_PORT,
+            },
+            # ── THE receive-only enforcement point — see module docstring.
+            "apply-policy": {
+                "config": {
+                    "default-import-policy": "accept-route",
+                    "default-export-policy": "reject-route",
+                }
+            },
+        },
+        "neighbors": neighbors,
+    }
+    _assert_receive_only(rendered)
+    return rendered
+
+
+def _render_neighbor(peer: dict[str, Any], global_as: int) -> dict[str, Any]:
+    address = str(peer["peer_address"])
+    peer_asn = int(peer["peer_asn"])
+    peer_id = str(peer["peer_id"])
+
+    # NOTE: import_filter.mode == "scope" is intentionally NOT rendered
+    # into a GoBGP import policy here — it is enforced agent-side in
+    # rib.py (see render_config's docstring for the empirical reason).
+
+    conf: dict[str, Any] = {
+        "neighbor-address": address,
+        "peer-as": peer_asn,
+    }
+    local_asn = peer.get("local_asn")
+    if local_asn and int(local_asn) != global_as:
+        conf["local-as"] = int(local_asn)
+    md5 = peer.get("md5_password")
+    if md5:
+        conf["auth-password"] = str(md5)
+
+    afi_safis: list[dict[str, Any]] = []
+    try:
+        max_prefixes = int(peer.get("max_prefixes") or _DEFAULT_MAX_PREFIXES)
+    except (TypeError, ValueError):
+        max_prefixes = _DEFAULT_MAX_PREFIXES
+    families = peer.get("address_families") or ["ipv4-unicast"]
+    for fam in families:
+        if fam not in _KNOWN_AFI_SAFIS:
+            log.warning("lg_peer_unknown_afi_safi", peer=peer_id, family=fam)
+            continue
+        afi_safis.append(
+            {
+                "config": {"afi-safi-name": fam},
+                # D4 (max-prefix cap) — MUST be rendered here, not just
+                # stored in the DB. See module docstring for the
+                # empirical verification of this behavior.
+                "prefix-limit": {
+                    "config": {
+                        "max-prefixes": max_prefixes,
+                        "shutdown-threshold-pct": _SHUTDOWN_THRESHOLD_PCT,
+                    }
+                },
+            }
+        )
+    if not afi_safis:
+        raise ValueError(f"peer {peer_id} has no usable address families")
+
+    neighbor: dict[str, Any] = {
+        "config": conf,
+        "afi-safis": afi_safis,
+        # Defense-in-depth only — NOT the enforcement point (see the
+        # module docstring). gobgpd's static config loader does not
+        # currently wire a per-neighbor apply-policy block into a real
+        # policy assignment for a normal peer, but setting it defensively
+        # costs nothing and protects against a future gobgpd version that
+        # DOES start honoring it per-peer.
+        "apply-policy": {
+            "config": {
+                "default-import-policy": "accept-route",
+                "default-export-policy": "reject-route",
+            }
+        },
+    }
+    return neighbor
+
+
+def _assert_receive_only(rendered: dict[str, Any]) -> None:
+    """Hard fail-safe — never a soft warning.
+
+    Every rendered config, no matter how peers were constructed above,
+    must satisfy this before it is ever written to disk or handed to
+    gobgpd. This is the review gate the module docstring refers to.
+    """
+    g = rendered.get("global", {})
+    default_export = (
+        g.get("apply-policy", {}).get("config", {}).get("default-export-policy")
+    )
+    if default_export != "reject-route":
+        raise ReceiveOnlyViolation(
+            "global.apply-policy.config.default-export-policy must be "
+            f"'reject-route', got {default_export!r}"
+        )
+    for n in rendered.get("neighbors", []):
+        conf = n.get("config", {})
+        if "export-policy-list" in n.get("apply-policy", {}).get("config", {}):
+            raise ReceiveOnlyViolation(
+                f"neighbor {conf.get('neighbor-address')} carries an "
+                "export-policy-list — the receive-only collector must "
+                "never define one"
+            )
+        if n.get("route-server", {}).get("config", {}).get("route-server-client"):
+            raise ReceiveOnlyViolation(
+                f"neighbor {conf.get('neighbor-address')} has "
+                "route-server-client set — never valid for this collector"
+            )
+
+
+def write_config(cfg: AgentConfig, bundle: dict[str, Any]) -> dict[str, Any]:
+    """Render + atomically write the gobgpd config file.
+
+    Also stashes a copy under the agent state dir's ``rendered/`` for
+    audit/debug (mirrors the DHCP agent's ``rendered/kea-dhcp4.json``
+    convention).
+    """
+    rendered = render_config(bundle)
+    target = cfg.gobgpd_config_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(rendered, indent=2, sort_keys=True))
+    tmp.replace(target)
+    save_rendered_gobgpd(cfg.state_dir, rendered)
+    return rendered
+
+
+def start_daemon(cfg: AgentConfig) -> subprocess.Popen[bytes]:
+    """Launch gobgpd as a tracked child process (mirrors the DNS agent's
+    ``Bind9Driver.start_daemon`` — the Python agent owns the daemon
+    subprocess directly rather than a shell-level supervise loop, since
+    there is exactly one daemon to manage here, same as BIND9's single
+    ``named``).
+
+    The image ships a valid "idle" config at ``cfg.gobgpd_config_path``
+    (empty neighbor list, receive-only global policy already set) so this
+    always has something to boot from — the first successful
+    :func:`apply_config` (from cache, or from the control plane) rewrites
+    it in place and reloads.
+    """
+    proc = subprocess.Popen(
+        [
+            cfg.gobgpd_bin,
+            "-f",
+            str(cfg.gobgpd_config_path),
+            "--api-hosts",
+            f"{cfg.gobgp_grpc_host}:{cfg.gobgp_grpc_port}",
+            *_GOBGPD_ARGS,
+        ]
+    )
+    log.info("gobgpd_started", pid=proc.pid)
+    return proc
+
+
+def daemon_running(proc: subprocess.Popen[bytes] | None) -> bool:
+    return proc is not None and proc.poll() is None
+
+
+def reload(proc: subprocess.Popen[bytes] | None) -> None:
+    """Signal a running gobgpd to re-read its config file.
+
+    gobgpd's own SIGHUP handler (``cmd/gobgpd/main.go``) calls
+    ``config.ReadConfigFile`` + ``UpdateConfig`` on receipt — this is
+    upstream's own documented reload mechanism, not a SpatiumDDI
+    invention, and (unlike an unhandled signal) does NOT terminate the
+    process. Best-effort: if the process is gone, the main supervisor
+    loop's ``daemon_running`` check will notice and exit(2) so the
+    container restarts — this function never raises.
+    """
+    if proc is None or proc.poll() is not None:
+        log.warning("gobgpd_reload_not_running")
+        return
+    try:
+        os.kill(proc.pid, signal.SIGHUP)
+        log.info("gobgpd_reload_sighup_sent", pid=proc.pid)
+    except ProcessLookupError:
+        log.warning("gobgpd_reload_pid_not_running", pid=proc.pid)
+
+
+def apply_config(
+    cfg: AgentConfig, bundle: dict[str, Any], proc: subprocess.Popen[bytes] | None
+) -> dict[str, Any]:
+    """Render + write + reload in one call.
+
+    This is what ``SyncLoop`` invokes on every bundle change, and once at
+    startup from the on-disk cache (non-negotiable #5 — the collector's
+    BGP sessions stay up from cache if the control plane is unreachable).
+    ``proc`` may be ``None`` when applying the cache before gobgpd has
+    even been started yet (the config file write still happens — the
+    daemon picks it up on its own first read).
+    """
+    rendered = write_config(cfg, bundle)
+    if proc is not None:
+        reload(proc)
+    return rendered
+
+
+def peer_address_map(bundle: dict[str, Any]) -> dict[str, str]:
+    """``peer_address -> peer_id`` map used by :mod:`spatium_lg_agent.rib`
+    to know which ``bgp_lg_peer`` row (``peer_id`` in the wire bundle —
+    see ``LGPeerDef.peer_id``) each neighbor's Adj-RIB-In belongs to when
+    it polls per-neighbor ``gobgp neighbor <peer_address> adj-in``."""
+    out: dict[str, str] = {}
+    for peer in bundle.get("peers") or []:
+        addr = peer.get("peer_address")
+        pid = peer.get("peer_id")
+        if addr and pid:
+            out[str(addr)] = str(pid)
+    return out
+
+
+def peer_import_scopes(bundle: dict[str, Any]) -> dict[str, list[_IPNetwork]]:
+    """``peer_id -> [parsed scope networks]`` for every scope-mode peer.
+
+    Used by :mod:`spatium_lg_agent.rib` to filter each peer's Adj-RIB-In
+    down to the scoped prefixes before pushing (see ``render_config``'s
+    docstring for why the scope is enforced agent-side rather than as a
+    GoBGP import policy). ``accept_all`` peers are ABSENT from the map —
+    ``rib.py`` treats "peer_id not in map" as "no filter, report
+    everything". A scope-mode peer with an empty/all-invalid prefix list
+    maps to ``[]``, which means "report nothing" (the literal meaning of
+    restricting to zero prefixes) — logged so the operator can see why a
+    scoped peer is reporting no routes."""
+    out: dict[str, list[_IPNetwork]] = {}
+    for peer in bundle.get("peers") or []:
+        if not peer.get("enabled", True):
+            continue
+        pid = peer.get("peer_id")
+        imp = peer.get("import_filter") or {}
+        if not pid or imp.get("mode") != "scope":
+            continue
+        nets: list[_IPNetwork] = []
+        for p in imp.get("prefixes") or []:
+            try:
+                nets.append(ipaddress.ip_network(str(p), strict=False))
+            except ValueError:
+                log.warning("lg_scope_prefix_invalid", peer=str(pid), prefix=p)
+        if not nets:
+            log.warning("lg_scope_empty", peer=str(pid))
+        out[str(pid)] = nets
+    return out
+
+
+# Serializes CLI invocations so two threads (e.g. a slow rib poll + an
+# operator-triggered debug call) don't interleave subprocess launches
+# unnecessarily. gobgpd's gRPC server itself is safe for concurrent
+# access; this lock is just to keep our own subprocess bookkeeping simple.
+_cli_lock = threading.Lock()
+
+
+def run_gobgp_cli(cfg: AgentConfig, *args: str, timeout: float = 15.0) -> str:
+    """Shell out to the ``gobgp`` CLI against the local gobgpd gRPC listener.
+
+    Uses ``-u <host> -p <port>`` (both loopback-only by default — see the
+    image's ``--api-hosts=127.0.0.1:50051``). Returns raw stdout; raises
+    :class:`GoBGPCliError` on a non-zero exit or if the binary/daemon
+    can't be reached.
+    """
+    cmd = [
+        cfg.gobgp_bin,
+        "-u",
+        cfg.gobgp_grpc_host,
+        "-p",
+        str(cfg.gobgp_grpc_port),
+        *args,
+    ]
+    with _cli_lock:
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout, check=False
+            )
+        except (OSError, subprocess.TimeoutExpired) as e:
+            raise GoBGPCliError(f"failed to run {' '.join(cmd)}: {e}") from e
+    if result.returncode != 0:
+        raise GoBGPCliError(
+            f"{' '.join(cmd)} exited {result.returncode}: "
+            f"{result.stderr.strip()[:400]}"
+        )
+    return result.stdout

--- a/agent/looking-glass/spatium_lg_agent/heartbeat.py
+++ b/agent/looking-glass/spatium_lg_agent/heartbeat.py
@@ -1,0 +1,123 @@
+"""Heartbeat loop — per-peer BGP session state + token rotation.
+
+``peer_states`` is populated by :class:`spatium_lg_agent.rib.RibPoller` after
+each ``gobgp neighbor -j`` poll (mirrors the DHCP agent's
+``HeartbeatClient.daemon_status`` shared-mutable-dict convention — one
+thread writes, the heartbeat thread reads on its own cadence, no lock
+needed since dict item assignment is atomic enough for this use).
+
+Body shape matches
+``backend/app/api/v1/looking_glass/agents.py``'s
+``AgentHeartbeatRequest``/``PeerStateReport`` EXACTLY — both carry
+``model_config = ConfigDict(extra="forbid")``, so anything not in the
+allowed field set (a stray top-level ``pid``/``status``, say) 422s the
+*entire* heartbeat, not just the extra field. Only ``agent_version`` +
+``peers[]`` travel at the top level; each peer entry is restricted to
+``_PEER_STATE_FIELDS`` before being sent.
+
+Note: ``rpki_invalid_count`` is never populated here even though
+``PeerStateReport`` accepts it — RPKI validation is computed server-side
+at route-ingest time (``derive_rpki_status`` — see the routes-push
+contract in ``rib.py``'s docstring); the collector itself has no local
+RPKI validator to consult, so that counter is backend-owned bookkeeping
+derived from ingested ``bgp_lg_route`` rows, not agent-reported telemetry.
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+from typing import Any
+
+import httpx
+import structlog
+
+from . import __version__
+from .cache import save_token
+from .config import AgentConfig
+
+log = structlog.get_logger(__name__)
+
+# Exactly the fields ``PeerStateReport`` accepts besides ``peer_id`` —
+# anything else in a ``rib.py``-populated peer_states entry is dropped
+# before it hits the wire (extra="forbid" would otherwise 422 the whole
+# heartbeat).
+_PEER_STATE_FIELDS = (
+    "session_state",
+    "uptime_started_at",
+    "prefixes_received",
+    "prefixes_accepted",
+    "last_state_change",
+    "last_flap_at",
+    "rpki_invalid_count",
+)
+
+
+class HeartbeatClient:
+    def __init__(self, cfg: AgentConfig, token_ref: list[str]):
+        self.cfg = cfg
+        self.token_ref = token_ref
+        self._stop = threading.Event()
+        # Internal-only degraded-state note (e.g. set by SyncLoop on a
+        # render failure) — logged locally, NOT sent upstream (the real
+        # heartbeat schema has no room for it; see module docstring).
+        self.daemon_status: dict[str, Any] = {}
+        # peer_id -> {session_state, uptime_started_at, prefixes_received,
+        #             prefixes_accepted, last_state_change, last_flap_at}.
+        # Written by RibPoller.
+        self.peer_states: dict[str, dict[str, Any]] = {}
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=15.0,
+        )
+
+    def send_once(self) -> None:
+        # Snapshot to avoid mutation from RibPoller mid-serialize.
+        peers = [
+            {
+                "peer_id": peer_id,
+                **{k: v for k, v in state.items() if k in _PEER_STATE_FIELDS},
+            }
+            for peer_id, state in dict(self.peer_states).items()
+        ]
+        body: dict[str, Any] = {
+            "agent_version": __version__,
+            "peers": peers,
+        }
+        try:
+            with self._client() as c:
+                resp = c.post(
+                    "/api/v1/looking-glass/agents/heartbeat",
+                    json=body,
+                    headers={"Authorization": f"Bearer {self.token_ref[0]}"},
+                )
+            if resp.status_code == 200:
+                data = resp.json()
+                rotated = data.get("rotated_token")
+                if rotated:
+                    self.token_ref[0] = rotated
+                    save_token(self.cfg.state_dir, rotated)
+                    log.info("lg_agent_token_rotated")
+            elif resp.status_code in (401, 404):
+                # Token invalidated or collector row deleted — clear token
+                # and exit so supervisor restarts the container (→
+                # re-bootstrap). Mirrors DHCP/DNS's 401/404 recovery.
+                log.warning("heartbeat_will_rebootstrap", status=resp.status_code)
+                save_token(self.cfg.state_dir, "")
+                self._stop.set()
+            else:
+                log.warning("heartbeat_failed", status=resp.status_code)
+        except httpx.HTTPError as e:
+            log.warning("heartbeat_http_error", error=str(e))
+
+    def run(self) -> None:
+        while not self._stop.is_set():
+            self.send_once()
+            interval = self.cfg.heartbeat_interval + random.uniform(-3, 3)
+            self._stop.wait(timeout=max(5.0, interval))

--- a/agent/looking-glass/spatium_lg_agent/log.py
+++ b/agent/looking-glass/spatium_lg_agent/log.py
@@ -1,0 +1,32 @@
+"""Structured JSON logging for the agent (non-negotiable #7)."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import structlog
+
+
+def configure_logging(level: str = "INFO") -> None:
+    logging.basicConfig(
+        format="%(message)s",
+        stream=sys.stdout,
+        level=getattr(logging, level.upper(), logging.INFO),
+    )
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(
+            getattr(logging, level.upper(), logging.INFO)
+        ),
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+    structlog.contextvars.bind_contextvars(service="spatium-lg-agent")

--- a/agent/looking-glass/spatium_lg_agent/rib.py
+++ b/agent/looking-glass/spatium_lg_agent/rib.py
@@ -229,7 +229,10 @@ def _parse_path(
                 try:
                     communities.append(_decode_community(int(c)))
                 except (TypeError, ValueError):
-                    pass
+                    # Skip a non-integer/garbage community value rather than
+                    # drop the whole route; the rest of its attributes are
+                    # still worth ingesting.
+                    continue
         elif t == _ATTR_LARGE_COMMUNITY:
             for lc in attr.get("large_communities") or []:
                 decoded = _decode_large_community(lc) if isinstance(lc, dict) else None

--- a/agent/looking-glass/spatium_lg_agent/rib.py
+++ b/agent/looking-glass/spatium_lg_agent/rib.py
@@ -1,0 +1,650 @@
+"""RIB + per-neighbor session-state poller.
+
+Polls each peer's **Adj-RIB-In** (via ``gobgp neighbor <peer_address>
+adj-in -j``, one call per configured neighbor) — NOT the post-best-path
+Loc-RIB (``gobgp global rib``). This distinction is load-bearing for the
+feature: the Loc-RIB has already run best-path selection and dropped every
+non-winning path, so two peers announcing the same prefix collapse to one
+row there. The Looking Glass is specifically for seeing *every* path a
+prefix was learned over, side by side across peers, so it must read the
+raw received table (Adj-RIB-In) for each neighbor before selection.
+
+Adj-RIB-In reports ``best: false`` on every path (verified live — it is
+the raw received table, pre-selection), so the ``is_best`` flag the
+backend surfaces is cross-referenced from a single supplementary
+``gobgp global rib -j`` poll that yields the winning
+``(peer_address, prefix, next_hop)`` tuples. That global-rib poll is used
+ONLY to mark winners — route attribution comes entirely from which
+neighbor's adj-in a path was read from, so there is no fragile
+peer-address→peer-id guessing on the global-rib side anymore. A failed
+best-set poll is non-fatal (routes still push, just with ``is_best`` all
+false that cycle).
+
+Feeds two consumers:
+
+  - :class:`spatium_lg_agent.heartbeat.HeartbeatClient` — session state,
+    uptime, prefix counts (``heartbeat.peer_states``, keyed by peer_id).
+  - ``POST /api/v1/looking-glass/agents/routes`` — the Adj-RIB-In push,
+    ONE call per peer (see :meth:`RibPoller._push_one_peer` for the exact
+    JSON contract — matches ``backend/app/api/v1/looking_glass/agents.py``'s
+    ``RoutesPushRequest``/``RouteEntry`` schemas exactly, both of which
+    carry ``model_config = ConfigDict(extra="forbid")``).
+
+v1 design (issue #566 plan decision D6): full-snapshot push + periodic
+reconcile, no per-UPDATE delta streaming. Every poll cycle pushes a
+snapshot for EVERY currently-configured peer — even an empty one (0
+routes) — because the backend's own zero-wire floor guard
+(``services.looking_glass.routes_ingest.ingest_routes``) needs to see the
+call happen to reason about it (it compares against the peer's own
+persisted ``prefixes_received`` from the last heartbeat to decide whether
+an empty snapshot is a genuine full withdrawal or a collector hiccup); a
+peer the collector silently skips calling for is a peer the backend never
+gets a chance to reconcile at all.
+
+Field-name/shape notes below (marked "verified live") come from smoke
+testing against a real gobgpd v4.5.0 binary (3-node topology) during
+development of this module — GoBGP's CLI JSON output is not treated as a
+stable API by upstream and has changed across major versions, so anything
+NOT marked verified is a best-effort parse, logged and dropped rather than
+guessed at.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import random
+import threading
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from .cache import touch_ready_marker
+from .config import AgentConfig
+from .gobgp import GoBGPCliError, run_gobgp_cli
+
+log = structlog.get_logger(__name__)
+
+_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+# RFC 4271 §8.2.2 FSM state numbering — GoBGP uses the same 1..6 range
+# (verified live: a peer shown as "Active" in ``gobgp neighbor``'s
+# plain-text view reported ``session_state: 3`` in ``-j`` output; an
+# Established peer reported 6).
+_SESSION_STATES = {
+    1: "idle",
+    2: "connect",
+    3: "active",
+    4: "opensent",
+    5: "openconfirm",
+    6: "established",
+}
+
+# RFC 4271 §4.3 BGP path-attribute type codes. Types 1/2/3/4/8 shapes are
+# verified live against gobgpd v4.5.0; 5/7/16/32 follow the RFC + gobgp
+# source field names but were not exercised by a live session in this
+# module's own development (EBGP strips LOCAL_PREF on send, and no
+# ext/large-community test route was advertised) — anything that doesn't
+# parse cleanly is logged and dropped, never guessed at.
+_ATTR_ORIGIN = 1
+_ATTR_AS_PATH = 2
+_ATTR_NEXT_HOP = 3
+_ATTR_MED = 4
+_ATTR_LOCAL_PREF = 5
+_ATTR_AGGREGATOR = 7
+_ATTR_COMMUNITY = 8
+_ATTR_EXT_COMMUNITY = 16
+_ATTR_LARGE_COMMUNITY = 32
+
+
+def _decode_community(raw: int) -> str:
+    """RFC 1997 4-byte community -> "ASN:VALUE".
+
+    Verified live: advertising community ``65001:100`` round-tripped to
+    raw uint32 ``4259905636 == (65001 << 16) | 100``.
+    """
+    return f"{(raw >> 16) & 0xFFFF}:{raw & 0xFFFF}"
+
+
+def _decode_large_community(entry: dict[str, Any]) -> str | None:
+    """RFC 8092 large community -> "GLOBAL:LOCAL1:LOCAL2".
+
+    Key spelling NOT verified live (see module docstring) — tries the
+    plausible snake_case spellings consistent with everything else this
+    gobgp version emits, and gives up (returning None) rather than
+    guessing wrong.
+    """
+    global_admin = entry.get("global_admin", entry.get("global_administrator"))
+    local1 = entry.get("local_data1", entry.get("local_data_part1"))
+    local2 = entry.get("local_data2", entry.get("local_data_part2"))
+    if global_admin is None or local1 is None or local2 is None:
+        return None
+    return f"{global_admin}:{local1}:{local2}"
+
+
+def _flatten_as_path(as_path_attr: dict[str, Any]) -> list[int]:
+    out: list[int] = []
+    for seg in as_path_attr.get("as_paths") or []:
+        out.extend(int(a) for a in seg.get("asns") or [])
+    return out
+
+
+def _path_next_hop(path: dict[str, Any]) -> str | None:
+    for attr in path.get("attrs") or []:
+        if attr.get("type") == _ATTR_NEXT_HOP:
+            return attr.get("nexthop") or attr.get("next_hop")
+    return None
+
+
+def _iter_rib_items(raw: Any) -> list[tuple[Any, Any]]:
+    """Normalise a ``gobgp ... -j`` RIB document to ``[(prefix, paths)]``.
+
+    Verified live: both ``gobgp global rib -j`` and
+    ``gobgp neighbor <addr> adj-in -j`` emit ``{"<prefix>": [path, ...]}``.
+    Tolerate a flat ``[{"prefix": ..., "paths": [...]}]`` too, in case a
+    future/older CLI version changes shape.
+    """
+    if isinstance(raw, dict):
+        return list(raw.items())
+    if isinstance(raw, list):
+        return [
+            (entry.get("prefix"), entry.get("paths", []))
+            for entry in raw
+            if isinstance(entry, dict)
+        ]
+    return []
+
+
+def _extract_best_set(raw: Any) -> set[tuple[str, str, str]]:
+    """Pull the winning ``(peer_address, prefix, next_hop)`` tuples out of a
+    ``gobgp global rib -j`` document.
+
+    Adj-RIB-In reports ``best: false`` universally (it is pre-selection),
+    so ``is_best`` on the pushed rows is cross-referenced against this
+    Loc-RIB winner set. Keyed on ``peer_address`` too (not just
+    ``(prefix, next_hop)``) so that in the rare case two peers announce the
+    same prefix with an unchanged next-hop, only the actual Loc-RIB winner
+    is flagged.
+    """
+    best: set[tuple[str, str, str]] = set()
+    for prefix, paths in _iter_rib_items(raw):
+        if not prefix or not isinstance(paths, list):
+            continue
+        for path in paths:
+            if not isinstance(path, dict) or not path.get("best"):
+                continue
+            peer_address = (
+                path.get("peer-address")
+                or path.get("neighbor-ip")
+                or path.get("neighbor_ip")
+            )
+            next_hop = _path_next_hop(path)
+            if peer_address and next_hop:
+                best.add((str(peer_address), str(prefix), str(next_hop)))
+    return best
+
+
+def _parse_path(
+    prefix: str,
+    path: dict[str, Any],
+    peer_id: str,
+    peer_address: str,
+    best_set: set[tuple[str, str, str]],
+) -> dict[str, Any] | None:
+    """Parse one Adj-RIB-In path entry into an internal route dict keyed on
+    the fields the control-plane's ``RouteEntry`` schema accepts, plus
+    ``peer_id`` (stripped back out before the wire push — see
+    :meth:`RibPoller._push_routes`).
+
+    ``peer_id`` / ``peer_address`` are known from which neighbor's adj-in
+    this path was read from (no attribution guessing). Returns ``None`` if
+    the path has no ``next_hop`` (``RouteEntry.next_hop`` is required,
+    non-nullable — pushing ``null`` there would 422 the whole per-peer
+    request). ``is_best`` is set from the Loc-RIB ``best_set``, since
+    adj-in itself always reports ``best: false``.
+    """
+    next_hop: str | None = None
+    origin_asn: int | None = None
+    as_path: list[int] = []
+    med: int | None = None
+    local_pref: int | None = None
+    communities: list[str] = []
+    large_communities: list[str] = []
+    ext_communities: list[str] = []
+
+    for attr in path.get("attrs") or []:
+        t = attr.get("type")
+        if t == _ATTR_AS_PATH:
+            as_path = _flatten_as_path(attr)
+        elif t == _ATTR_NEXT_HOP:
+            next_hop = attr.get("nexthop") or attr.get("next_hop")
+        elif t == _ATTR_MED:
+            med = attr.get("metric", attr.get("value"))
+        elif t == _ATTR_LOCAL_PREF:
+            local_pref = attr.get("value")
+        elif t == _ATTR_COMMUNITY:
+            for c in attr.get("communities") or []:
+                try:
+                    communities.append(_decode_community(int(c)))
+                except (TypeError, ValueError):
+                    pass
+        elif t == _ATTR_LARGE_COMMUNITY:
+            for lc in attr.get("large_communities") or []:
+                decoded = _decode_large_community(lc) if isinstance(lc, dict) else None
+                if decoded:
+                    large_communities.append(decoded)
+                else:
+                    log.debug("lg_large_community_unparsed", raw=lc)
+        elif t == _ATTR_EXT_COMMUNITY:
+            raw_ext = attr.get("communities") or attr.get("extended_communities") or []
+            ext_communities.extend(str(v) for v in raw_ext)
+        elif t in (_ATTR_ORIGIN, _ATTR_AGGREGATOR):
+            pass  # not modeled on bgp_lg_route — informational only
+        else:
+            log.debug("lg_path_attr_unparsed", attr_type=t)
+
+    if not next_hop:
+        log.warning("lg_route_missing_next_hop", peer_id=peer_id, prefix=prefix)
+        return None
+
+    if as_path:
+        origin_asn = as_path[-1]
+
+    return {
+        "peer_id": peer_id,
+        "prefix": prefix,
+        "next_hop": next_hop,
+        "origin_asn": origin_asn,
+        "as_path": as_path,
+        "med": med,
+        "local_pref": local_pref,
+        "communities": communities,
+        "large_communities": large_communities,
+        "ext_communities": ext_communities,
+        "is_best": (peer_address, prefix, next_hop) in best_set,
+    }
+
+
+def _parse_adj_in(
+    raw: Any,
+    peer_id: str,
+    peer_address: str,
+    best_set: set[tuple[str, str, str]],
+) -> list[dict[str, Any]]:
+    """Parse one neighbor's ``adj-in -j`` document into route dicts, all
+    attributed to that neighbor's ``peer_id`` (known — no guessing)."""
+    routes: list[dict[str, Any]] = []
+    for prefix, paths in _iter_rib_items(raw):
+        if not prefix or not isinstance(paths, list):
+            continue
+        for path in paths:
+            if not isinstance(path, dict):
+                continue
+            row = _parse_path(str(prefix), path, peer_id, peer_address, best_set)
+            if row is not None:
+                routes.append(row)
+    return routes
+
+
+def _prefix_in_scope(prefix: str, scope_nets: list[_IPNetwork]) -> bool:
+    """True if ``prefix`` is equal to or more-specific than any scope net.
+
+    A route is "in scope" when its prefix falls WITHIN one of the
+    operator's scope prefixes (``subnet_of`` — a network is a subnet of
+    itself, so an exact match counts). Same-version compares only. An
+    unparseable prefix is out of scope (dropped) — it would fail the
+    backend's CIDR validation on push anyway.
+    """
+    try:
+        net = ipaddress.ip_network(prefix, strict=False)
+    except ValueError:
+        return False
+    for s in scope_nets:
+        # isinstance (not a .version compare) so the concrete network type
+        # is narrowed for the version-specific subnet_of overload.
+        if isinstance(net, ipaddress.IPv4Network) and isinstance(
+            s, ipaddress.IPv4Network
+        ):
+            if net.subnet_of(s):
+                return True
+        elif isinstance(net, ipaddress.IPv6Network) and isinstance(
+            s, ipaddress.IPv6Network
+        ):
+            if net.subnet_of(s):
+                return True
+    return False
+
+
+def _apply_scope(
+    routes: list[dict[str, Any]], scope_nets: list[_IPNetwork]
+) -> list[dict[str, Any]]:
+    """Filter a peer's parsed adj-in rows down to the scoped prefixes.
+
+    See ``gobgp.render_config``'s docstring for why the scope is enforced
+    here (agent-side, on the raw Adj-RIB-In) rather than as a GoBGP import
+    policy. An empty ``scope_nets`` means "report nothing" — the literal
+    meaning of restricting to zero prefixes (already warned about at
+    scope-map build time in ``gobgp.peer_import_scopes``)."""
+    return [r for r in routes if _prefix_in_scope(str(r["prefix"]), scope_nets)]
+
+
+def _sum_afi_safi_counts(neighbor: dict[str, Any], key: str) -> int:
+    """Verified live: each ``afi_safis[].state`` entry carries ``received``
+    / ``accepted`` int counters once a session reaches Established."""
+    total = 0
+    for afi_safi in neighbor.get("afi_safis") or []:
+        state = afi_safi.get("state") or {}
+        try:
+            total += int(state.get(key) or 0)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _epoch_to_iso(seconds: Any) -> str | None:
+    try:
+        return datetime.fromtimestamp(int(seconds), tz=UTC).isoformat()
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _parse_neighbor(neighbor: dict[str, Any]) -> tuple[str | None, dict[str, Any]]:
+    """Parse one ``gobgp neighbor -j`` entry into
+    ``(peer_address, state_dict)``.
+
+    ``state_dict`` keys match ``PeerStateReport`` (see
+    ``backend/app/api/v1/looking_glass/agents.py``) exactly:
+    ``session_state`` / ``uptime_started_at`` / ``prefixes_received`` /
+    ``prefixes_accepted`` / ``last_state_change`` / ``last_flap_at`` — all
+    but ``session_state`` optional (``None`` when unknown), and
+    ``uptime_started_at`` / ``last_state_change`` / ``last_flap_at`` are
+    ISO-8601 datetimes, not durations.
+
+    GoBGP's ``timers.state`` carries an epoch-timestamp ``downtime.seconds``
+    even for a peer that has never gone down (verified live — present
+    alongside ``uptime.seconds`` with the identical value on a peer's
+    first-ever Established transition), so it's treated here as "the
+    timestamp of the most recent FSM state change" for ``last_state_change``
+    unconditionally, and additionally surfaced as ``last_flap_at`` only
+    while the peer is NOT currently established (i.e. "down since") — a
+    currently-Established session isn't presently flapping.
+    """
+    conf = neighbor.get("conf") or {}
+    state = neighbor.get("state") or {}
+    address = state.get("neighbor_address") or conf.get("neighbor_address")
+    if not address:
+        return None, {}
+
+    raw_session_state = state.get("session_state")
+    session_state = "unknown"
+    if raw_session_state is not None:
+        try:
+            session_state = _SESSION_STATES.get(int(raw_session_state), "unknown")
+        except (TypeError, ValueError):
+            session_state = "unknown"
+
+    timers = (neighbor.get("timers") or {}).get("state") or {}
+
+    uptime_started_at = None
+    if session_state == "established":
+        up = timers.get("uptime")
+        if isinstance(up, dict):
+            uptime_started_at = _epoch_to_iso(up.get("seconds"))
+
+    down = timers.get("downtime")
+    last_state_change = (
+        _epoch_to_iso(down.get("seconds")) if isinstance(down, dict) else None
+    )
+    last_flap_at = last_state_change if session_state != "established" else None
+
+    return str(address), {
+        "session_state": session_state,
+        "uptime_started_at": uptime_started_at,
+        "prefixes_received": _sum_afi_safi_counts(neighbor, "received"),
+        "prefixes_accepted": _sum_afi_safi_counts(neighbor, "accepted"),
+        "last_state_change": last_state_change,
+        "last_flap_at": last_flap_at,
+    }
+
+
+class RibPoller:
+    def __init__(self, cfg: AgentConfig, token_ref: list[str], heartbeat: Any):
+        self.cfg = cfg
+        self.token_ref = token_ref
+        self.heartbeat = heartbeat
+        self._stop = threading.Event()
+        # peer_address -> peer_id, refreshed by SyncLoop after every
+        # bundle apply (including the pre-first-poll cache preload) so
+        # this poller can attribute paths + neighbor rows to the right
+        # ``bgp_lg_peer`` row even before its own first successful poll.
+        self._peer_addr_map: dict[str, str] = {}
+        self._known_peer_ids: set[str] = set()
+        # peer_id -> [scope networks]; a peer absent from the map has no
+        # import scope (report everything). See gobgp.peer_import_scopes.
+        self._scope_map: dict[str, list[_IPNetwork]] = {}
+
+    def set_peers(
+        self,
+        peer_addr_map: dict[str, str],
+        scope_map: dict[str, list[_IPNetwork]] | None = None,
+    ) -> None:
+        self._peer_addr_map = dict(peer_addr_map)
+        self._known_peer_ids = set(self._peer_addr_map.values())
+        self._scope_map = dict(scope_map or {})
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=30.0,
+        )
+
+    def _poll_best_set(self) -> set[tuple[str, str, str]]:
+        """Loc-RIB winners as ``(peer_address, prefix, next_hop)`` tuples,
+        used only to mark ``is_best`` on the adj-in rows (adj-in itself
+        always reports ``best: false``). Non-fatal: on failure return an
+        empty set and every route pushes this cycle with ``is_best=False``
+        — a cosmetic degradation, never a route drop."""
+        best: set[tuple[str, str, str]] = set()
+        for afi in ("ipv4", "ipv6"):
+            try:
+                raw_text = run_gobgp_cli(self.cfg, "global", "rib", "-a", afi, "-j")
+            except GoBGPCliError as e:
+                log.warning("lg_best_set_poll_failed", afi=afi, error=str(e))
+                continue
+            try:
+                raw = json.loads(raw_text) if raw_text.strip() else {}
+            except ValueError:
+                log.warning("lg_best_set_poll_bad_json", afi=afi)
+                continue
+            best |= _extract_best_set(raw)
+        return best
+
+    def _poll_adj_in(
+        self, peer_address: str, peer_id: str, best_set: set[tuple[str, str, str]]
+    ) -> list[dict[str, Any]]:
+        """Poll one neighbor's Adj-RIB-In (every received path, pre-best-
+        path-selection) across v4 + v6. A per-AFI CLI failure (e.g. the
+        session isn't Established yet) is logged and skipped — the peer
+        still gets an empty push, which the backend zero-wire guard
+        handles against its last-heartbeated ``prefixes_received``.
+
+        When the peer has an import scope (``import_filter.mode ==
+        "scope"``), the parsed rows are filtered down to the scoped
+        prefixes here — see ``_apply_scope`` / ``gobgp.render_config``'s
+        docstring for why the scope is enforced agent-side."""
+        routes: list[dict[str, Any]] = []
+        for afi in ("ipv4", "ipv6"):
+            try:
+                raw_text = run_gobgp_cli(
+                    self.cfg, "neighbor", peer_address, "adj-in", "-a", afi, "-j"
+                )
+            except GoBGPCliError as e:
+                log.warning(
+                    "lg_adj_in_poll_failed",
+                    peer_id=peer_id,
+                    peer_address=peer_address,
+                    afi=afi,
+                    error=str(e),
+                )
+                continue
+            try:
+                raw = json.loads(raw_text) if raw_text.strip() else {}
+            except ValueError:
+                log.warning("lg_adj_in_poll_bad_json", peer_id=peer_id, afi=afi)
+                continue
+            routes.extend(_parse_adj_in(raw, peer_id, peer_address, best_set))
+        scope_nets = self._scope_map.get(peer_id)
+        if scope_nets is not None:
+            before = len(routes)
+            routes = _apply_scope(routes, scope_nets)
+            if before != len(routes):
+                log.info(
+                    "lg_adj_in_scope_filtered",
+                    peer_id=peer_id,
+                    kept=len(routes),
+                    dropped=before - len(routes),
+                )
+        return routes
+
+    def _poll_neighbors(self) -> dict[str, dict[str, Any]]:
+        """Returns ``peer_id -> state_dict`` for every neighbor gobgpd
+        knows about that we can attribute to a currently-configured peer.
+        """
+        try:
+            raw_text = run_gobgp_cli(self.cfg, "-j", "neighbor")
+        except GoBGPCliError as e:
+            log.warning("lg_neighbor_poll_failed", error=str(e))
+            return {}
+        try:
+            raw = json.loads(raw_text) if raw_text.strip() else []
+        except ValueError:
+            log.warning("lg_neighbor_poll_bad_json")
+            return {}
+        if not isinstance(raw, list):
+            raw = [raw]
+
+        out: dict[str, dict[str, Any]] = {}
+        for neighbor in raw:
+            if not isinstance(neighbor, dict):
+                continue
+            address, state = _parse_neighbor(neighbor)
+            if not address:
+                continue
+            peer_id = self._peer_addr_map.get(address)
+            if not peer_id:
+                continue
+            out[peer_id] = state
+        return out
+
+    def _push_one_peer(self, peer_id: str, routes: list[dict[str, Any]]) -> None:
+        """POST one peer's full-snapshot routes push.
+
+        Contract — ``POST /api/v1/looking-glass/agents/routes`` (matches
+        ``RoutesPushRequest``/``RouteEntry`` exactly, both
+        ``extra="forbid"``)::
+
+            {
+              "peer_id": "<uuid>",
+              "snapshot": true,
+              "routes": [
+                {
+                  "prefix": "203.0.113.0/24", "next_hop": "203.0.113.1",
+                  "origin_asn": 65001, "as_path": [65001, 65002],
+                  "local_pref": 100, "med": 0,
+                  "communities": ["65001:100"], "large_communities": [],
+                  "ext_communities": [], "is_best": true
+                },
+                ...
+              ]
+            }
+
+        Pushed for EVERY known peer every cycle, even with an empty
+        ``routes`` list — see module docstring for why an empty push must
+        still happen rather than being skipped.
+        """
+        body = {"peer_id": peer_id, "snapshot": True, "routes": routes}
+        try:
+            with self._client() as c:
+                resp = c.post(
+                    "/api/v1/looking-glass/agents/routes",
+                    json=body,
+                    headers={"Authorization": f"Bearer {self.token_ref[0]}"},
+                )
+            if resp.status_code != 200:
+                log.warning(
+                    "lg_routes_push_failed",
+                    peer_id=peer_id,
+                    status=resp.status_code,
+                    body=resp.text[:300],
+                )
+        except httpx.HTTPError as e:
+            log.warning("lg_routes_push_http_error", peer_id=peer_id, error=str(e))
+
+    def _push_routes(self, routes: list[dict[str, Any]]) -> None:
+        by_peer: dict[str, list[dict[str, Any]]] = {
+            pid: [] for pid in self._known_peer_ids
+        }
+        for r in routes:
+            peer_id = r.get("peer_id")
+            bucket = by_peer.get(peer_id) if peer_id else None
+            if bucket is None:
+                continue
+            bucket.append(
+                {
+                    "prefix": r["prefix"],
+                    "next_hop": r["next_hop"],
+                    "origin_asn": r.get("origin_asn"),
+                    "as_path": r.get("as_path") or [],
+                    "local_pref": r.get("local_pref"),
+                    "med": r.get("med"),
+                    "communities": r.get("communities") or [],
+                    "large_communities": r.get("large_communities") or [],
+                    "ext_communities": r.get("ext_communities") or [],
+                    "is_best": bool(r.get("is_best", False)),
+                }
+            )
+        for peer_id, peer_routes in by_peer.items():
+            self._push_one_peer(peer_id, peer_routes)
+
+    def _poll_once(self) -> None:
+        # Readiness = "the poll loop is running and gobgpd is reachable" —
+        # an internal-state condition, NOT "the control plane 200'd our
+        # push" (mirrors the DNS agent's ``_touch_ready_marker``). A fresh
+        # collector's normal steady state is ZERO peers configured, so the
+        # marker MUST be stamped in that path too; otherwise the K8s
+        # readinessProbe never flips and the pod is NotReady forever. Stamp
+        # first, before the no-peers early return.
+        touch_ready_marker(self.cfg.state_dir)
+        if not self._known_peer_ids:
+            # No peers configured — nothing to poll or push, but we are
+            # ready (see above).
+            return
+        neighbor_states = self._poll_neighbors()
+        self.heartbeat.peer_states = neighbor_states
+        # Adj-RIB-In per neighbor (all received paths), with a single
+        # supplementary Loc-RIB poll to mark best-path winners (see module
+        # docstring). Route attribution is by which neighbor we polled — no
+        # global-rib peer-address guessing.
+        best_set = self._poll_best_set()
+        routes: list[dict[str, Any]] = []
+        for peer_address, peer_id in self._peer_addr_map.items():
+            routes.extend(self._poll_adj_in(peer_address, peer_id, best_set))
+        self._push_routes(routes)
+
+    def run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self._poll_once()
+            except Exception:  # noqa: BLE001 — never let the poll loop die
+                log.exception("lg_rib_poll_cycle_failed")
+            interval = self.cfg.rib_poll_interval + random.uniform(-3, 3)
+            self._stop.wait(timeout=max(5.0, interval))
+
+
+__all__ = ["RibPoller"]

--- a/agent/looking-glass/spatium_lg_agent/supervisor.py
+++ b/agent/looking-glass/spatium_lg_agent/supervisor.py
@@ -1,0 +1,90 @@
+"""Supervisor — starts gobgpd, then runs sync + RIB-poll + heartbeat threads.
+
+Mirrors the DNS agent's ``supervisor.py``: the Python agent process owns
+the daemon subprocess directly (``gobgp.start_daemon`` — there is exactly
+one daemon to manage here, same as BIND9's single ``named``), rather than
+a shell-level supervise loop. If gobgpd dies, or any agent thread dies
+(and doesn't recover — a 401/404 sets its own stop event, see ``sync.py``
+/ ``heartbeat.py``), the process exits non-zero so the container
+orchestrator restarts everything, which re-bootstraps from the cached PSK
+and re-launches gobgpd from the last-known-good on-disk config (non-
+negotiable #5).
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+import threading
+import time
+
+import structlog
+
+from . import gobgp
+from .bootstrap import ensure_token
+from .config import AgentConfig
+from .heartbeat import HeartbeatClient
+from .rib import RibPoller
+from .sync import SyncLoop
+
+log = structlog.get_logger(__name__)
+
+
+def run(cfg: AgentConfig) -> int:
+    _agent_id, token = ensure_token(cfg)
+    token_ref = [token]
+
+    proc = gobgp.start_daemon(cfg)
+
+    heartbeat = HeartbeatClient(cfg, token_ref)
+    rib = RibPoller(cfg, token_ref, heartbeat)
+    syncer = SyncLoop(cfg, token_ref, heartbeat, rib, proc)
+
+    threads = [
+        threading.Thread(target=syncer.run, name="sync", daemon=True),
+        threading.Thread(target=rib.run, name="rib-poll", daemon=True),
+        threading.Thread(target=heartbeat.run, name="heartbeat", daemon=True),
+    ]
+    for t in threads:
+        t.start()
+
+    stopping = threading.Event()
+
+    def _sig(_signum, _frame):  # noqa: ANN001
+        log.info("lg_agent_signal_received")
+        stopping.set()
+        heartbeat.stop()
+        syncer.stop()
+        rib.stop()
+        if gobgp.daemon_running(proc):
+            proc.terminate()
+
+    signal.signal(signal.SIGTERM, _sig)
+    signal.signal(signal.SIGINT, _sig)
+
+    while not stopping.is_set():
+        time.sleep(1.0)
+        if not gobgp.daemon_running(proc):
+            log.error("lg_gobgpd_exited")
+            return 2
+        # If any agent thread died (e.g. sync/heartbeat dropped its token
+        # after a 401/404 and self-stopped), exit so the container
+        # orchestrator restarts us — bootstrap then re-registers from PSK
+        # with a fresh empty token cache.
+        dead = [t.name for t in threads if not t.is_alive()]
+        if dead:
+            log.error("lg_agent_thread_died", threads=dead)
+            return 2
+
+    log.info("lg_agent_exiting")
+    return 0
+
+
+def main_entry() -> int:
+    cfg = AgentConfig.from_env()
+    cfg.state_dir.mkdir(parents=True, exist_ok=True)
+    return run(cfg)
+
+
+if __name__ == "__main__":
+    sys.exit(main_entry())

--- a/agent/looking-glass/spatium_lg_agent/sync.py
+++ b/agent/looking-glass/spatium_lg_agent/sync.py
@@ -1,0 +1,192 @@
+"""Config long-poll loop — fetches the peer-config bundle and re-renders
+gobgpd's config on every change.
+
+Cloned from ``agent/dns/spatium_dns_agent/sync.py``'s ``SyncLoop`` shape
+(GET with ``If-None-Match``, preload+apply the cached bundle before the
+first poll, atomic-swap to disk on 200, 401/404 -> clear token + stop).
+Unlike the DNS agent there is no structural-vs-record-only split here —
+every ``bgp_lg_peer`` change is a full peer-set re-render (GoBGP's
+``apply_config`` is cheap: render + write + SIGHUP, no daemon restart), so
+any 200 response with a new etag triggers :func:`spatium_lg_agent.gobgp.
+apply_config`.
+
+``GET /api/v1/looking-glass/agents/config`` (see
+``backend/app/api/v1/looking_glass/agents.py::agent_config_longpoll``)
+returns an envelope, not a bare bundle::
+
+    {"collector_id": "...", "etag": "...", "bundle": {"collector_name": ...,
+     "peers": [...]}}
+
+This loop unwraps ``bundle`` before handing it to ``gobgp.py`` /
+``rib.py`` — the cache on disk stores the unwrapped inner bundle (that's
+what actually gets rendered), with the etag tracked alongside it. There is
+no ``pending_approval`` gate here (unlike the DHCP/DNS agent protocol) —
+the collector identity row has no approval flow, per the agents.py module
+docstring.
+"""
+
+from __future__ import annotations
+
+import random
+import subprocess
+import threading
+import time
+from typing import Any
+
+import httpx
+import structlog
+
+from . import gobgp
+from .cache import load_config, save_config, save_token
+from .config import AgentConfig
+
+log = structlog.get_logger(__name__)
+
+# Jittered exponential backoff for a persistently-failing bundle apply
+# (mirrors bootstrap.py's register loop). Bounded so a bad bundle can't
+# hammer the /config long-poll or peg the CPU, but small enough that a
+# transient failure recovers within a poll or two.
+_APPLY_BACKOFF_BASE = 2.0
+_APPLY_BACKOFF_CAP = 45.0
+
+
+class SyncLoop:
+    def __init__(
+        self,
+        cfg: AgentConfig,
+        token_ref: list[str],
+        heartbeat: Any,
+        rib: Any,
+        gobgpd_proc: "subprocess.Popen[bytes] | None",
+    ):
+        self.cfg = cfg
+        self.token_ref = token_ref
+        self.heartbeat = heartbeat
+        self.rib = rib
+        self.gobgpd_proc = gobgpd_proc
+        self._stop = threading.Event()
+        self._current_etag: str | None = None
+        # Grows on consecutive apply failures, resets to base on success.
+        self._apply_backoff = _APPLY_BACKOFF_BASE
+
+        # Preload cached bundle (non-negotiable #5 — offline-operation
+        # guarantee). Applying it BEFORE the first network poll is what
+        # keeps already-configured BGP sessions up if the control plane
+        # is unreachable at container start.
+        bundle, etag = load_config(self.cfg.state_dir)
+        if bundle is not None:
+            self._current_etag = etag
+            try:
+                gobgp.apply_config(self.cfg, bundle, self.gobgpd_proc)
+                self.rib.set_peers(
+                    gobgp.peer_address_map(bundle),
+                    gobgp.peer_import_scopes(bundle),
+                )
+                log.info("lg_agent_bootstrap_from_cache", etag=etag)
+            except Exception:
+                log.exception("lg_bootstrap_cache_apply_failed")
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _client(self) -> httpx.Client:
+        # Server holds the long-poll for ~cfg.longpoll_timeout; give the
+        # client meaningfully more so a slow-but-alive control plane
+        # doesn't look like a network error.
+        return httpx.Client(
+            base_url=self.cfg.control_plane_url,
+            verify=self.cfg.httpx_verify(),
+            timeout=60.0,
+        )
+
+    def _poll_once(self) -> None:
+        headers = {"Authorization": f"Bearer {self.token_ref[0]}"}
+        if self._current_etag:
+            headers["If-None-Match"] = self._current_etag
+        try:
+            with self._client() as c:
+                resp = c.get("/api/v1/looking-glass/agents/config", headers=headers)
+        except httpx.HTTPError as e:
+            log.warning("lg_sync_http_error", error=str(e))
+            time.sleep(5.0)
+            return
+
+        if resp.status_code == 304:
+            return
+        if resp.status_code in (401, 404):
+            # 401 = token expired/invalid. 404 = the collector row was
+            # deleted on the control plane. Both recover the same way:
+            # drop the cached token and let the supervisor's dead-thread
+            # detection restart the container -> re-bootstrap from PSK.
+            log.warning(
+                "lg_sync_will_rebootstrap",
+                status=resp.status_code,
+                reason=(
+                    "token_invalid" if resp.status_code == 401 else "collector_missing"
+                ),
+            )
+            save_token(self.cfg.state_dir, "")
+            self._stop.set()
+            return
+        if resp.status_code != 200:
+            log.warning("lg_sync_unexpected_status", status=resp.status_code)
+            time.sleep(5.0)
+            return
+
+        envelope = resp.json()
+        etag = envelope.get("etag") or resp.headers.get("ETag")
+        if not etag:
+            log.warning("lg_sync_bundle_missing_etag")
+            return
+        # Unwrap the envelope — ``bundle`` (collector_name + peers) is what
+        # gobgp.py actually renders from; see module docstring.
+        inner_bundle = envelope.get("bundle") or {}
+
+        # Atomic-swap cache always — cache is the source of truth across
+        # restarts, even before we know the apply below succeeds. We cache
+        # the unwrapped inner bundle (matches what the constructor's
+        # ``load_config`` preload path expects to hand to ``gobgp.py``).
+        save_config(self.cfg.state_dir, inner_bundle, etag)
+
+        try:
+            gobgp.apply_config(self.cfg, inner_bundle, self.gobgpd_proc)
+        except Exception as e:
+            log.exception("lg_sync_apply_failed")
+            self.heartbeat.daemon_status = {
+                **self.heartbeat.daemon_status,
+                "status": "degraded",
+                "reason": f"config_render_failed: {e}",
+            }
+            # Bounded backoff so a persistently-bad bundle (e.g. a
+            # ReceiveOnlyViolation, a malformed peer set) can't spin the
+            # bare ``run()`` loop: we deliberately DON'T advance
+            # ``_current_etag``, so the next poll re-fetches the SAME
+            # bundle to retry the apply — but only after sleeping, instead
+            # of immediately re-hitting /config with the stale
+            # If-None-Match and pegging the CPU. ``_stop.wait`` so a
+            # shutdown signal interrupts the sleep promptly.
+            sleep_for = min(
+                self._apply_backoff + random.uniform(0, 2), _APPLY_BACKOFF_CAP
+            )
+            log.warning("lg_sync_apply_backoff", seconds=round(sleep_for, 1))
+            self._stop.wait(sleep_for)
+            self._apply_backoff = min(self._apply_backoff * 2, _APPLY_BACKOFF_CAP)
+            return
+
+        # Apply succeeded — reset the backoff so the next failure (if any)
+        # starts from the base again.
+        self._apply_backoff = _APPLY_BACKOFF_BASE
+        self.rib.set_peers(
+            gobgp.peer_address_map(inner_bundle),
+            gobgp.peer_import_scopes(inner_bundle),
+        )
+        self._current_etag = etag
+        log.info(
+            "lg_config_applied",
+            etag=etag,
+            peer_count=len(inner_bundle.get("peers") or []),
+        )
+
+    def run(self) -> None:
+        while not self._stop.is_set():
+            self._poll_once()

--- a/agent/supervisor/spatium_supervisor/firewall_renderer.py
+++ b/agent/supervisor/spatium_supervisor/firewall_renderer.py
@@ -153,6 +153,11 @@ class FirewallProfile:
 _ROLE_PORTS_TCP: dict[str, list[int]] = {
     "dns-bind9": [53],
     "dns-powerdns": [53],
+    # BGP (#566). The collector normally DIALS the router (outbound, allowed
+    # by default egress), but opening inbound tcp/179 lets the router initiate
+    # the session (passive collector) and keeps firewall drift-detection aware
+    # of the port for the looking-glass role.
+    "looking-glass": [179],
 }
 _ROLE_PORTS_UDP: dict[str, list[int]] = {
     "dns-bind9": [53],

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -817,6 +817,12 @@ def heartbeat_once(
         ml_vip = body_out.get("desired_control_plane_vip") or ""
         # #285 Phase 6 — source-scope the VIP path too (loadBalancerSourceRanges).
         web_ui_cidrs = body_out.get("web_ui_allowed_cidrs") or []
+        # #566 decision D1 — BGP mode (export path: advertise the VIP to
+        # upstream routers). Folded into the SAME apply_metallb_overrides
+        # call below (one combined HelmChartConfig body).
+        ml_bgp_enabled = bool(body_out.get("desired_metallb_bgp_enabled"))
+        ml_bgp_peers = body_out.get("desired_metallb_bgp_peers") or []
+        ml_bgp_advertisements = body_out.get("desired_metallb_bgp_advertisements") or []
 
         cp_changed, cp_err = k8s_api.apply_control_plane_overrides(
             cp_size, str(ml_vip), web_ui_allowed_cidrs=list(web_ui_cidrs)
@@ -852,13 +858,18 @@ def heartbeat_once(
             )
 
         bs_changed, bs_err = k8s_api.apply_metallb_overrides(
-            metallb_enabled=ml_enabled, pool_addresses=list(ml_pool)
+            metallb_enabled=ml_enabled,
+            pool_addresses=list(ml_pool),
+            bgp_enabled=ml_bgp_enabled,
+            bgp_peers=list(ml_bgp_peers),
+            bgp_advertisements=list(ml_bgp_advertisements),
         )
         if bs_changed:
             log.info(
                 "supervisor.heartbeat.metallb_overrides_applied",
                 enabled=ml_enabled,
                 pool=list(ml_pool),
+                bgp_enabled=ml_bgp_enabled,
             )
         elif bs_err:
             log.warning("supervisor.heartbeat.metallb_overrides_failed", error=bs_err)

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -142,7 +142,18 @@ def _effective_control_plane_url(cfg: SupervisorConfig) -> str:
 # to be sending heartbeats, the images are there. Hardcoded to True
 # instead of probing /var/run/docker.sock (which doesn't exist
 # anymore — the appliance is k3s-only).
-_CAPABILITY_FLAGS = ("can_run_dns_bind9", "can_run_dns_powerdns", "can_run_dhcp")
+#
+# Issue #566 — ``can_run_looking_glass`` (the BGP Looking Glass
+# collector, GoBGP) joins this tuple rather than getting its own
+# bespoke always-true literal (like ``can_run_observer`` below): it
+# has a real service container (the ``looking-glass`` image), baked
+# into every slot per decision D3, so it belongs alongside DNS/DHCP.
+_CAPABILITY_FLAGS = (
+    "can_run_dns_bind9",
+    "can_run_dns_powerdns",
+    "can_run_dhcp",
+    "can_run_looking_glass",
+)
 
 
 def _detect_storage_type() -> str:
@@ -223,9 +234,10 @@ def _capabilities_payload() -> dict[str, Any]:
     capability reporting"):
 
     * ``can_run_dns_bind9`` / ``can_run_dns_powerdns`` /
-      ``can_run_dhcp`` — hardcoded ``True`` post-Phase-7. The slot's
-      containerd content store is preloaded with every service
-      image; if we're heartbeating, the images are there.
+      ``can_run_dhcp`` / ``can_run_looking_glass`` — hardcoded
+      ``True`` post-Phase-7 (looking-glass joins under #566). The
+      slot's containerd content store is preloaded with every
+      service image; if we're heartbeating, the images are there.
     * ``can_run_observer`` — always true. The observer role is a
       pure supervisor-side metrics/log shipper with no separate
       service container, so any approved supervisor can run it.

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -606,20 +606,75 @@ def apply_control_plane_overrides(
 
 
 def apply_metallb_overrides(
-    *, metallb_enabled: bool, pool_addresses: list[str]
+    *,
+    metallb_enabled: bool,
+    pool_addresses: list[str],
+    bgp_enabled: bool = False,
+    bgp_peers: list[dict] | None = None,
+    bgp_advertisements: list[dict] | None = None,
 ) -> tuple[bool, str | None]:
-    """Durably set the MetalLB overrides (enabled + L2 pool) on the
-    spatium-metallb HelmChartConfig (#272).
+    """Durably set the MetalLB overrides (L2 pool + BGP mode) on the
+    spatium-metallb HelmChartConfig (#272 / #566).
 
     MetalLB moved out of the spatium-bootstrap chart into its own
     spatium-metallb chart (deployed in the metallb-system namespace), so
     the override targets that chart's HelmChartConfig now. The value
     paths are unchanged (``metallb.enabled`` + ``metallb.ipPool
-    .addresses``) — the wrapper chart reads the same keys."""
+    .addresses``) — the wrapper chart reads the same keys.
+
+    ``bgp_peers`` / ``bgp_advertisements`` are plain dicts in the
+    snake_case shape the PlatformSettings JSONB columns store
+    (``my_asn`` / ``peer_asn`` / ``peer_address`` / ``peer_port`` /
+    ``hold_time`` and ``ip_address_pools`` / ``communities`` /
+    ``aggregation_length``) — translated here to the chart's camelCase
+    BGPPeer/BGPAdvertisement CR field names (myASN/peerASN/peerAddress/
+    peerPort/holdTime, ipAddressPools/communities/aggregationLength).
+    ``frrk8s.enabled`` is driven by the SAME ``bgp_enabled`` flag as
+    ``bgp.enabled`` — the chart's speaker/controller only wire up to
+    frr-k8s when frrk8s.enabled is true, and BGP peers/advertisements
+    are inert without it. ``speaker.frr.enabled`` is NEVER written here
+    — it stays the chart's baked ``false`` (mutually exclusive with
+    frrk8s.enabled; the chart's own template hard-``fail``s if both are
+    true).
+
+    MUST render every MetalLB-related key in ONE combined body —
+    ``_helmchartconfig_upsert`` replaces the whole valuesContent string,
+    so calling this (or a sibling function targeting the same
+    HelmChartConfig) twice per tick would have the second call blank
+    out the first's keys."""
     pool_json = json.dumps([a.strip() for a in pool_addresses if a and a.strip()])
+
+    def _peer(p: dict) -> dict:
+        out: dict = {
+            "myASN": p["my_asn"],
+            "peerASN": p["peer_asn"],
+            "peerAddress": p["peer_address"],
+        }
+        if p.get("peer_port"):
+            out["peerPort"] = p["peer_port"]
+        if p.get("hold_time"):
+            out["holdTime"] = p["hold_time"]
+        return out
+
+    def _adv(a: dict) -> dict:
+        out: dict = {
+            "ipAddressPools": a.get("ip_address_pools") or ["spatium-control-plane"]
+        }
+        if a.get("communities"):
+            out["communities"] = a["communities"]
+        if a.get("aggregation_length"):
+            out["aggregationLength"] = a["aggregation_length"]
+        return out
+
+    peers_json = json.dumps([_peer(p) for p in (bgp_peers or [])])
+    adv_json = json.dumps([_adv(a) for a in (bgp_advertisements or [])])
     values = (
         f"metallb:\n  enabled: {'true' if metallb_enabled else 'false'}\n"
         f"  ipPool:\n    addresses: {pool_json}\n"
+        f"  frrk8s:\n    enabled: {'true' if bgp_enabled else 'false'}\n"
+        f"  bgp:\n    enabled: {'true' if bgp_enabled else 'false'}\n"
+        f"    peers: {peers_json}\n"
+        f"    advertisements: {adv_json}\n"
     )
     return _helmchartconfig_upsert("spatium-metallb", values)
 

--- a/agent/supervisor/spatium_supervisor/role_orchestrator.py
+++ b/agent/supervisor/spatium_supervisor/role_orchestrator.py
@@ -5,13 +5,14 @@ into a docker-compose env file the supervisor uses to bring up /
 down the service containers:
 
 * ``COMPOSE_PROFILES`` carries the subset of
-  ``dns-bind9`` / ``dns-powerdns`` / ``dhcp`` the supervisor needs
-  to start.
-* ``DNS_AGENT_KEY`` / ``DHCP_AGENT_KEY`` / ``AGENT_GROUP`` /
-  ``CONTROL_PLANE_URL`` carry the service-container env so the
-  dns-bind9 / dhcp-kea agent sidecar can register against the
-  control plane's per-service ``/dns/agents/register`` /
-  ``/dhcp/agents/register`` endpoints without operator input.
+  ``dns-bind9`` / ``dns-powerdns`` / ``dhcp`` / ``looking-glass`` the
+  supervisor needs to start.
+* ``DNS_AGENT_KEY`` / ``DHCP_AGENT_KEY`` / ``LG_AGENT_KEY`` /
+  ``AGENT_GROUP`` / ``CONTROL_PLANE_URL`` carry the service-container
+  env so the dns-bind9 / dhcp-kea / looking-glass agent sidecar can
+  register against the control plane's per-service
+  ``/dns/agents/register`` / ``/dhcp/agents/register`` /
+  ``/looking-glass/agents/register`` endpoints without operator input.
 * ``DHCP_NETWORK_MODE`` toggles ``network_mode: host`` (default)
   vs ``ports: ["67:67/udp"]`` (bridged, for relay deployments).
   The compose template selects between two service definitions
@@ -43,7 +44,10 @@ log = structlog.get_logger(__name__)
 # Roles the supervisor knows how to start a service container for.
 # ``observer`` + ``custom`` are reserved (no compose profile yet);
 # the supervisor recognises them on heartbeat but does nothing.
-_SERVICE_ROLES = {"dns-bind9", "dns-powerdns", "dhcp"}
+# ``looking-glass`` (#566) joined DNS/DHCP here — the BGP Looking
+# Glass collector is a real service container (GoBGP), not a
+# supervisor-side-only role like observer.
+_SERVICE_ROLES = {"dns-bind9", "dns-powerdns", "dhcp", "looking-glass"}
 
 
 # Issue #237 — values from the heartbeat response land in a docker-
@@ -182,6 +186,19 @@ def compute_target_env(role_assignment: dict[str, Any] | None) -> TargetEnv:
         env_lines.append(f"DHCP_NETWORK_MODE={dhcp_network_mode}")
         if dhcp_agent_key:
             env_lines.append(f"DHCP_AGENT_KEY={dhcp_agent_key}")
+
+    # Looking Glass (BGP collector, #566) — no group concept (LG peers
+    # aren't grouped like DNS/DHCP server groups; peer config itself
+    # rides the collector's own ConfigBundle long-poll, not this env
+    # file). Only the bootstrap PSK is needed here so the GoBGP
+    # sidecar can register against ``/looking-glass/agents/register``
+    # without operator input — same shape + validation as DNS/DHCP.
+    lg_agent_key = _safe_env_value(
+        "lg_agent_key", role_assignment.get("lg_agent_key"), _AGENT_KEY_RE
+    )
+    if "looking-glass" in roles:
+        if lg_agent_key:
+            env_lines.append(f"LG_AGENT_KEY={lg_agent_key}")
 
     return TargetEnv(env_lines=env_lines, profiles=profiles)
 

--- a/agent/supervisor/spatium_supervisor/service_lifecycle.py
+++ b/agent/supervisor/spatium_supervisor/service_lifecycle.py
@@ -65,7 +65,17 @@ class LifecycleResult:
 # Service names the appliance can run. Match the chart's component
 # names (``app.kubernetes.io/component`` labels). The watchdog uses
 # this set to enumerate "which pods should I expect".
-SUPERVISED_SERVICES: tuple[str, ...] = ("dns-bind9", "dns-powerdns", "dhcp-kea")
+#
+# #566 — ``looking-glass`` (the BGP Looking Glass / GoBGP collector)
+# uses an identity profile↔component mapping, same as the DNS roles
+# (only ``dhcp``'s profile token diverges from its ``dhcp-kea``
+# component name).
+SUPERVISED_SERVICES: tuple[str, ...] = (
+    "dns-bind9",
+    "dns-powerdns",
+    "dhcp-kea",
+    "looking-glass",
+)
 
 log = structlog.get_logger(__name__)
 
@@ -89,6 +99,7 @@ _PROFILE_TO_HELM_KEY = {
     "dns-bind9": "dnsBind9",
     "dns-powerdns": "dnsPowerdns",
     "dhcp": "dhcpKea",
+    "looking-glass": "lookingGlass",
 }
 
 # Phase 10 (#183) — every role the chart templates have a per-role
@@ -105,6 +116,9 @@ _ROLE_LABEL_KEYS = {
     "dns-bind9": "spatium.io/role-dns-bind9",
     "dns-powerdns": "spatium.io/role-dns-powerdns",
     "dhcp": "spatium.io/role-dhcp",
+    # #566 — BGP Looking Glass collector (GoBGP). Same per-role
+    # node-label gating shape as DNS/DHCP (non-negotiable #16).
+    "looking-glass": "spatium.io/role-looking-glass",
     # #272 — gate the umbrella chart's frontend / api / worker / beat /
     # postgres / redis workloads onto the control-plane variant (never
     # an appliance). Multi-node HA selects between control-plane members
@@ -122,10 +136,11 @@ _ROLE_LABEL_KEYS = {
 # Two variants, and only ``control-plane`` is forced:
 #   * control-plane — forces the control-plane label so the umbrella
 #     workloads (api / frontend / db / redis / worker / beat) never
-#     lose their node. DNS/DHCP are NOT forced here AND NOT auto-
-#     assigned at register — the operator enables them per node via
-#     the Fleet role toggle (so the data plane is always a deliberate
-#     fleet decision, and a promoted control-plane node can shed them).
+#     lose their node. DNS/DHCP/looking-glass are NOT forced here AND
+#     NOT auto-assigned at register — the operator enables them per
+#     node via the Fleet role toggle (so the data plane is always a
+#     deliberate fleet decision, and a promoted control-plane node can
+#     shed them).
 #   * appliance — nothing forced. Operator-assigned roles only.
 # Forcing DNS/DHCP here would re-add the labels every tick and make the
 # Fleet toggle a no-op, so they must stay out of every forced set.
@@ -241,6 +256,17 @@ def _build_values(profiles: list[str], env_vars: dict[str, str]) -> dict[str, ob
             # default group.
             "serverGroupName": env_vars.get("DHCP_AGENT_GROUP", ""),
             "networkMode": env_vars.get("DHCP_NETWORK_MODE", "host"),
+        },
+        # #566 — BGP Looking Glass collector (GoBGP). ``enabled: True``
+        # unconditionally, same release-ownership-not-scheduling-scope
+        # convention as every other role block above — pod scheduling
+        # is gated purely by the ``spatium.io/role-looking-glass`` node
+        # label. No group/serverGroupName concept (LG peers aren't
+        # grouped like DNS/DHCP server groups).
+        "lookingGlass": {
+            "enabled": True,
+            "controlPlaneUrl": control_plane_url,
+            "agentKey": env_vars.get("LG_AGENT_KEY", ""),
         },
     }
     return values

--- a/agent/supervisor/spatium_supervisor/watchdog.py
+++ b/agent/supervisor/spatium_supervisor/watchdog.py
@@ -60,11 +60,13 @@ log = structlog.get_logger(__name__)
 # Compose-profile-name → chart-component name. ``COMPOSE_PROFILES``
 # in role-compose.env carries profile values; pod labels carry the
 # chart component. ``dhcp`` profile maps to ``dhcp-kea`` component;
-# everything else is identity.
+# everything else is identity. ``looking-glass`` (#566) is identity,
+# same as the DNS roles.
 _PROFILE_TO_SERVICE: dict[str, str] = {
     "dns-bind9": "dns-bind9",
     "dns-powerdns": "dns-powerdns",
     "dhcp": "dhcp-kea",
+    "looking-glass": "looking-glass",
 }
 
 

--- a/agent/supervisor/tests/test_cnpg_scale.py
+++ b/agent/supervisor/tests/test_cnpg_scale.py
@@ -116,3 +116,60 @@ def test_dataplane_vip_overrides_empty_disables(monkeypatch) -> None:
     assert "useMetalLBVIP: false" in vals
     assert 'vip: ""' in vals
     assert 'relayVIP: ""' in vals
+
+
+# ── issue #566 decision D1 — MetalLB BGP mode overrides ────────────────
+
+
+def test_metallb_bgp_overrides_render(monkeypatch) -> None:
+    # No existing HelmChartConfig (404) → create POST carrying the values.
+    rec = _Recorder(404, "")
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.apply_metallb_overrides(
+        metallb_enabled=True,
+        pool_addresses=["192.168.0.240/32"],
+        bgp_enabled=True,
+        bgp_peers=[
+            {
+                "my_asn": 65000,
+                "peer_asn": 65001,
+                "peer_address": "203.0.113.1",
+                "peer_port": 1179,
+                "hold_time": "90s",
+            }
+        ],
+        bgp_advertisements=[{"ip_address_pools": ["spatium-control-plane"]}],
+    )
+
+    assert (changed, err) == (True, None)
+    body = next(json.loads(b) for m, _, b in rec.calls if m == "POST" and b)
+    vals = body["spec"]["valuesContent"]
+    assert "frrk8s:\n    enabled: true" in vals
+    assert "bgp:\n    enabled: true" in vals
+    assert '"myASN": 65000' in vals
+    assert '"peerASN": 65001' in vals
+    assert '"peerAddress": "203.0.113.1"' in vals
+    assert '"peerPort": 1179' in vals
+    assert '"holdTime": "90s"' in vals
+    assert '"ipAddressPools": ["spatium-control-plane"]' in vals
+
+
+def test_metallb_bgp_overrides_disabled_shape(monkeypatch) -> None:
+    # No peers / bgp_enabled=False (default) — L2-only shape, matching
+    # today's behavior unchanged. Also the shape a heartbeat renders
+    # when the operator hasn't configured BGP at all.
+    rec = _Recorder(404, "")
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.apply_metallb_overrides(
+        metallb_enabled=True, pool_addresses=["192.168.0.240/32"]
+    )
+
+    assert (changed, err) == (True, None)
+    body = next(json.loads(b) for m, _, b in rec.calls if m == "POST" and b)
+    vals = body["spec"]["valuesContent"]
+    assert "frrk8s:\n    enabled: false" in vals
+    assert "bgp:\n    enabled: false" in vals
+    assert "peers: []" in vals
+    assert "advertisements: []" in vals

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -106,7 +106,9 @@ ROLE_SERVICES = {
 # of these is actually in ``docker ps`` onto the base
 # ``ROLE_SERVICES["application"]`` list rather than rendering a
 # permanent ``(not running)`` row for every unassigned role.
-SUPERVISOR_DYNAMIC_SERVICES = ("dns-bind9", "dns-powerdns", "dhcp-kea")
+# #566 — ``looking-glass`` (BGP Looking Glass collector) joins the
+# DNS/DHCP roles here.
+SUPERVISOR_DYNAMIC_SERVICES = ("dns-bind9", "dns-powerdns", "dhcp-kea", "looking-glass")
 
 # Supervisor's role-compose.env on the host (the dashboard reads it
 # read-only to discover the watchdog-expected services so a
@@ -121,6 +123,7 @@ _PROFILE_TO_SERVICE_DASH: dict[str, str] = {
     "dns-bind9": "dns-bind9",
     "dns-powerdns": "dns-powerdns",
     "dhcp": "dhcp-kea",
+    "looking-glass": "looking-glass",
 }
 
 

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -550,6 +550,26 @@ place_metallb_crds() {
     fi
 }
 
+# Issue #566 decision D1 — pre-load the frr-k8s CRDs (frrk8s.metallb.io
+# group: FRRConfiguration / FRRNodeState / BGPSessionState) the SAME
+# way place_metallb_crds pre-loads the metallb.io group above. BGP mode
+# starts disabled (frrk8s.enabled=false) and is turned on later by the
+# seed supervisor writing the spatium-metallb HelmChartConfig once an
+# operator configures a BGP peer; the frr-k8s subchart's OWN nested
+# CRDs dependency stays off (frr-k8s.crds.enabled=false in
+# charts/spatiumddi-metallb/values.yaml) to avoid a double-owner
+# conflict, so without this pre-load enabling BGP mode later 404s with
+# "no matches for kind FRRConfiguration".
+place_metallb_frrk8s_crds() {
+    local src=/usr/local/share/spatiumddi/frrk8s-crds.yaml
+    if [ -r "$src" ]; then
+        install -m 0644 "$src" "$K3S_MANIFESTS_DIR/spatium-metallb-frrk8s-crds.yaml"
+        echo "Placed frr-k8s CRDs at $K3S_MANIFESTS_DIR/spatium-metallb-frrk8s-crds.yaml"
+    else
+        echo "WARN: $src missing — frr-k8s CRDs not pre-loaded; enabling MetalLB BGP mode later will fail."
+    fi
+}
+
 # Renders the control-plane HelmChart CR for the control-plane
 # role. Args:
 #   $1 — chart_content_b64
@@ -742,6 +762,8 @@ case "$APPLIANCE_ROLE_VAL" in
         # control-plane node; CRDs are cluster-scoped so doing it here
         # covers any node later promoted into the cluster).
         place_metallb_crds
+        # #566 decision D1 — same reasoning, frrk8s.metallb.io group.
+        place_metallb_frrk8s_crds
         # #272 — render the spatium-metallb HelmChart (MetalLB in its own
         # metallb-system namespace). Applied always but starts DISABLED;
         # the seed supervisor enables it + writes the pool via the

--- a/appliance/mkosi.extra/usr/local/share/spatiumddi/frrk8s-crds.yaml
+++ b/appliance/mkosi.extra/usr/local/share/spatiumddi/frrk8s-crds.yaml
@@ -1,0 +1,653 @@
+# frr-k8s CRDs (frrk8s.metallb.io group — FRRConfiguration,
+# FRRNodeState, BGPSessionState) — vendored from the frr-k8s v0.0.21
+# Helm chart's own ``charts/crds`` sub-subchart (nested inside the
+# metallb v0.15.3 chart's ``charts/frr-k8s`` dependency), rendered with
+# --namespace metallb-system so any namespaced defaults line up with
+# where frr-k8s actually runs (issue #566 decision D1 — BGP mode).
+#
+# Pre-loaded as a k3s auto-deploy manifest by spatiumddi-firstboot
+# (place_metallb_frrk8s_crds) BEFORE the spatium-metallb HelmChart, so
+# the frr-k8s subchart runs with crds.enabled=false (no double-owner
+# conflict) — same reasoning as metallb-crds.yaml for the metallb.io
+# CRD group.
+#
+# Keep in lock-step with charts/spatiumddi-metallb's pinned frr-k8s
+# subchart version (currently 0.0.21, vendored inside the metallb
+# 0.15.3 package). Regenerate after a version bump with:
+#   tar xzf charts/spatiumddi-metallb/charts/metallb-0.15.3.tgz -C <tmpdir>
+#   helm template frrk8s-crds \
+#     <tmpdir>/metallb/charts/frr-k8s/charts/crds \
+#     --namespace metallb-system
+# Do NOT hand-edit.
+---
+# Source: crds/templates/frrk8s.metallb.io_bgpsessionstates.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: bgpsessionstates.frrk8s.metallb.io
+spec:
+  group: frrk8s.metallb.io
+  names:
+    kind: BGPSessionState
+    listKind: BGPSessionStateList
+    plural: bgpsessionstates
+    singular: bgpsessionstate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.node
+      name: Node
+      type: string
+    - jsonPath: .status.peer
+      name: Peer
+      type: string
+    - jsonPath: .status.vrf
+      name: VRF
+      type: string
+    - jsonPath: .status.bgpStatus
+      name: BGP
+      type: string
+    - jsonPath: .status.bfdStatus
+      name: BFD
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BGPSessionState exposes the status of a BGP Session from the
+          FRR instance running on the node.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BGPSessionStateSpec defines the desired state of BGPSessionState.
+            type: object
+          status:
+            description: BGPSessionStateStatus defines the observed state of BGPSessionState.
+            properties:
+              bfdStatus:
+                type: string
+              bgpStatus:
+                type: string
+              node:
+                type: string
+              peer:
+                type: string
+              vrf:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: frrconfigurations.frrk8s.metallb.io
+spec:
+  group: frrk8s.metallb.io
+  names:
+    kind: FRRConfiguration
+    listKind: FRRConfigurationList
+    plural: frrconfigurations
+    singular: frrconfiguration
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: FRRConfiguration is a piece of FRR configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FRRConfigurationSpec defines the desired state of FRRConfiguration.
+            properties:
+              bgp:
+                description: BGP is the configuration related to the BGP protocol.
+                properties:
+                  bfdProfiles:
+                    description: BFDProfiles is the list of bfd profiles to be used
+                      when configuring the neighbors.
+                    items:
+                      description: |-
+                        BFDProfile is the configuration related to the BFD protocol associated
+                        to a BGP session.
+                      properties:
+                        detectMultiplier:
+                          description: |-
+                            Configures the detection multiplier to determine
+                            packet loss. The remote transmission interval will be multiplied
+                            by this value to determine the connection loss detection timer.
+                          format: int32
+                          maximum: 255
+                          minimum: 2
+                          type: integer
+                        echoInterval:
+                          description: |-
+                            Configures the minimal echo receive transmission
+                            interval that this system is capable of handling in milliseconds.
+                            Defaults to 50ms
+                          format: int32
+                          maximum: 60000
+                          minimum: 10
+                          type: integer
+                        echoMode:
+                          description: |-
+                            Enables or disables the echo transmission mode.
+                            This mode is disabled by default, and not supported on multi
+                            hops setups.
+                          type: boolean
+                        minimumTtl:
+                          description: |-
+                            For multi hop sessions only: configure the minimum
+                            expected TTL for an incoming BFD control packet.
+                          format: int32
+                          maximum: 254
+                          minimum: 1
+                          type: integer
+                        name:
+                          description: |-
+                            The name of the BFD Profile to be referenced in other parts
+                            of the configuration.
+                          type: string
+                        passiveMode:
+                          description: |-
+                            Mark session as passive: a passive session will not
+                            attempt to start the connection and will wait for control packets
+                            from peer before it begins replying.
+                          type: boolean
+                        receiveInterval:
+                          description: |-
+                            The minimum interval that this system is capable of
+                            receiving control packets in milliseconds.
+                            Defaults to 300ms.
+                          format: int32
+                          maximum: 60000
+                          minimum: 10
+                          type: integer
+                        transmitInterval:
+                          description: |-
+                            The minimum transmission interval (less jitter)
+                            that this system wants to use to send BFD control packets in
+                            milliseconds. Defaults to 300ms
+                          format: int32
+                          maximum: 60000
+                          minimum: 10
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  routers:
+                    description: Routers is the list of routers we want FRR to configure
+                      (one per VRF).
+                    items:
+                      description: Router represent a neighbor router we want FRR
+                        to connect to.
+                      properties:
+                        asn:
+                          description: ASN is the AS number to use for the local end
+                            of the session.
+                          format: int32
+                          maximum: 4294967295
+                          minimum: 0
+                          type: integer
+                        id:
+                          description: ID is the BGP router ID
+                          type: string
+                        imports:
+                          description: Imports is the list of imported VRFs we want
+                            for this router / vrf.
+                          items:
+                            description: Import represents the possible imported VRFs
+                              to a given router.
+                            properties:
+                              vrf:
+                                description: Vrf is the vrf we want to import from
+                                type: string
+                            type: object
+                          type: array
+                        neighbors:
+                          description: Neighbors is the list of neighbors we want
+                            to establish BGP sessions with.
+                          items:
+                            description: Neighbor represents a BGP Neighbor we want
+                              FRR to connect to.
+                            properties:
+                              address:
+                                description: Address is the IP address to establish
+                                  the session with.
+                                type: string
+                              asn:
+                                description: |-
+                                  ASN is the AS number to use for the local end of the session.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                                format: int32
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              bfdProfile:
+                                description: |-
+                                  BFDProfile is the name of the BFD Profile to be used for the BFD session associated
+                                  to the BGP session. If not set, the BFD session won't be set up.
+                                type: string
+                              connectTime:
+                                description: Requested BGP connect time, controls
+                                  how long BGP waits between connection attempts to
+                                  a neighbor.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: connect time should be between 1 seconds
+                                    to 65535
+                                  rule: duration(self).getSeconds() >= 1 && duration(self).getSeconds()
+                                    <= 65535
+                                - message: connect time should contain a whole number
+                                    of seconds
+                                  rule: duration(self).getMilliseconds() % 1000 ==
+                                    0
+                              disableMP:
+                                default: false
+                                description: |-
+                                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                                type: boolean
+                              dualStackAddressFamily:
+                                default: false
+                                description: |-
+                                  To set if we want to enable the neighbor not only for the ipfamily related to its session,
+                                  but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa.
+                                type: boolean
+                              dynamicASN:
+                                description: |-
+                                  DynamicASN detects the AS number to use for the local end of the session
+                                  without explicitly setting it via the ASN field. Limited to:
+                                  internal - if the neighbor's ASN is different than the router's the connection is denied.
+                                  external - if the neighbor's ASN is the same as the router's the connection is denied.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                                enum:
+                                - internal
+                                - external
+                                type: string
+                              ebgpMultiHop:
+                                description: EBGPMultiHop indicates if the BGPPeer
+                                  is multi-hops away.
+                                type: boolean
+                              enableGracefulRestart:
+                                description: |-
+                                  EnableGracefulRestart allows BGP peer to continue to forward data packets along
+                                  known routes while the routing protocol information is being restored. If
+                                  the session is already established, the configuration will have effect
+                                  after reconnecting to the peer
+                                type: boolean
+                              holdTime:
+                                description: |-
+                                  HoldTime is the requested BGP hold time, per RFC4271.
+                                  Defaults to 180s.
+                                type: string
+                              interface:
+                                description: |-
+                                  Interface is the node interface over which the unnumbered BGP peering will
+                                  be established. No API validation takes place as that string value
+                                  represents an interface name on the host and if user provides an invalid
+                                  value, only the actual BGP session will not be established.
+                                  Address and Interface are mutually exclusive and one of them must be specified.
+                                  Note: when enabling unnumbered, the neighbor will be enabled for both
+                                  IPv4 and IPv6 address families.
+                                type: string
+                              keepaliveTime:
+                                description: |-
+                                  KeepaliveTime is the requested BGP keepalive time, per RFC4271.
+                                  Defaults to 60s.
+                                type: string
+                              password:
+                                description: |-
+                                  Password to be used for establishing the BGP session.
+                                  Password and PasswordSecret are mutually exclusive.
+                                type: string
+                              passwordSecret:
+                                description: |-
+                                  PasswordSecret is name of the authentication secret for the neighbor.
+                                  the secret must be of type "kubernetes.io/basic-auth", and created in the
+                                  same namespace as the frr-k8s daemon. The password is stored in the
+                                  secret as the key "password".
+                                  Password and PasswordSecret are mutually exclusive.
+                                properties:
+                                  name:
+                                    description: name is unique within a namespace
+                                      to reference a secret resource.
+                                    type: string
+                                  namespace:
+                                    description: namespace defines the space within
+                                      which the secret name must be unique.
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              port:
+                                description: |-
+                                  Port is the port to dial when establishing the session.
+                                  Defaults to 179.
+                                maximum: 16384
+                                minimum: 0
+                                type: integer
+                              sourceaddress:
+                                description: |-
+                                  SourceAddress is the IPv4 or IPv6 source address to use for the BGP
+                                  session to this neighbour, may be specified as either an IP address
+                                  directly or as an interface name
+                                type: string
+                              toAdvertise:
+                                description: |-
+                                  ToAdvertise represents the list of prefixes to advertise to the given neighbor
+                                  and the associated properties.
+                                properties:
+                                  allowed:
+                                    description: |-
+                                      Allowed is is the list of prefixes allowed to be propagated to
+                                      this neighbor. They must match the prefixes defined in the router.
+                                    properties:
+                                      mode:
+                                        default: filtered
+                                        description: |-
+                                          Mode is the mode to use when handling the prefixes.
+                                          When set to "filtered", only the prefixes in the given list will be allowed.
+                                          When set to "all", all the prefixes configured on the router will be allowed.
+                                        enum:
+                                        - all
+                                        - filtered
+                                        type: string
+                                      prefixes:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  withCommunity:
+                                    description: |-
+                                      PrefixesWithCommunity is a list of prefixes that are associated to a
+                                      bgp community when being advertised. The prefixes associated to a given local pref
+                                      must be in the prefixes allowed to be advertised.
+                                    items:
+                                      description: CommunityPrefixes is a list of
+                                        prefixes associated to a community.
+                                      properties:
+                                        community:
+                                          description: Community is the community
+                                            associated to the prefixes.
+                                          type: string
+                                        prefixes:
+                                          description: Prefixes is the list of prefixes
+                                            associated to the community.
+                                          format: cidr
+                                          items:
+                                            type: string
+                                          minItems: 1
+                                          type: array
+                                      type: object
+                                    type: array
+                                  withLocalPref:
+                                    description: |-
+                                      PrefixesWithLocalPref is a list of prefixes that are associated to a local
+                                      preference when being advertised. The prefixes associated to a given local pref
+                                      must be in the prefixes allowed to be advertised.
+                                    items:
+                                      description: LocalPrefPrefixes is a list of
+                                        prefixes associated to a local preference.
+                                      properties:
+                                        localPref:
+                                          description: LocalPref is the local preference
+                                            associated to the prefixes.
+                                          format: int32
+                                          type: integer
+                                        prefixes:
+                                          description: Prefixes is the list of prefixes
+                                            associated to the local preference.
+                                          format: cidr
+                                          items:
+                                            type: string
+                                          minItems: 1
+                                          type: array
+                                      type: object
+                                    type: array
+                                type: object
+                              toReceive:
+                                description: ToReceive represents the list of prefixes
+                                  to receive from the given neighbor.
+                                properties:
+                                  allowed:
+                                    description: |-
+                                      Allowed is the list of prefixes allowed to be received from
+                                      this neighbor.
+                                    properties:
+                                      mode:
+                                        default: filtered
+                                        description: |-
+                                          Mode is the mode to use when handling the prefixes.
+                                          When set to "filtered", only the prefixes in the given list will be allowed.
+                                          When set to "all", all the prefixes configured on the router will be allowed.
+                                        enum:
+                                        - all
+                                        - filtered
+                                        type: string
+                                      prefixes:
+                                        items:
+                                          description: PrefixSelector is a filter
+                                            of prefixes to receive.
+                                          properties:
+                                            ge:
+                                              description: |-
+                                                The prefix length modifier. This selector accepts any matching prefix with length
+                                                greater or equal the given value.
+                                              format: int32
+                                              maximum: 128
+                                              minimum: 1
+                                              type: integer
+                                            le:
+                                              description: |-
+                                                The prefix length modifier. This selector accepts any matching prefix with length
+                                                less or equal the given value.
+                                              format: int32
+                                              maximum: 128
+                                              minimum: 1
+                                              type: integer
+                                            prefix:
+                                              format: cidr
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                            type: object
+                          type: array
+                        prefixes:
+                          description: Prefixes is the list of prefixes we want to
+                            advertise from this router instance.
+                          items:
+                            type: string
+                          type: array
+                        vrf:
+                          description: VRF is the host vrf used to establish sessions
+                            from this router.
+                          type: string
+                      required:
+                      - asn
+                      type: object
+                    type: array
+                type: object
+              nodeSelector:
+                description: |-
+                  NodeSelector limits the nodes that will attempt to apply this config.
+                  When specified, the configuration will be considered only on nodes
+                  whose labels match the specified selectors.
+                  When it is not specified all nodes will attempt to apply this config.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              raw:
+                description: |-
+                  Raw is a snippet of raw frr configuration that gets appended to the
+                  one rendered translating the type safe API.
+                properties:
+                  priority:
+                    description: |-
+                      Priority is the order with this configuration is appended to the
+                      bottom of the rendered configuration. A higher value means the
+                      raw config is appended later in the configuration file.
+                    type: integer
+                  rawConfig:
+                    description: |-
+                      Config is a raw FRR configuration to be appended to the configuration
+                      rendered via the k8s api.
+                    type: string
+                type: object
+            type: object
+          status:
+            description: FRRConfigurationStatus defines the observed state of FRRConfiguration.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: crds/templates/frrk8s.metallb.io_frrnodestates.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: frrnodestates.frrk8s.metallb.io
+spec:
+  group: frrk8s.metallb.io
+  names:
+    kind: FRRNodeState
+    listKind: FRRNodeStateList
+    plural: frrnodestates
+    singular: frrnodestate
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: FRRNodeState exposes the status of the FRR instance running on
+          each node.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FRRNodeStateSpec defines the desired state of FRRNodeState.
+            type: object
+          status:
+            description: FRRNodeStateStatus defines the observed state of FRRNodeState.
+            properties:
+              lastConversionResult:
+                description: LastConversionResult is the status of the last translation
+                  between the `FRRConfiguration`s resources and FRR's configuration,
+                  contains "success" or an error.
+                type: string
+              lastReloadResult:
+                description: LastReloadResult represents the status of the last configuration
+                  update operation by FRR, contains "success" or an error.
+                type: string
+              runningConfig:
+                description: RunningConfig represents the current FRR running config,
+                  which is the configuration the FRR instance is currently running
+                  with.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/appliance/scripts/bake-images.sh
+++ b/appliance/scripts/bake-images.sh
@@ -106,13 +106,6 @@ OBSERVABILITY_IMAGES=(
 # appVersion. Baked so multi-node HA promotion works in air-gapped
 # environments with zero outbound pulls — same as every other image.
 #
-# L2 (native) mode only: ``metallb.speaker.frr.enabled=false`` AND
-# ``metallb.frrk8s.enabled=false`` in charts/spatiumddi-metallb/
-# values.yaml (the 0.15.3 chart defaults speaker.frr.enabled TRUE), so
-# the quay.io/metallb/frr-k8s + quay.io/frrouting/frr images are
-# intentionally NOT baked. If/when BGP mode lands (Phase 10), enable
-# frrk8s + add those two images here.
-#
 # KEEP these refs in lock-step with the metallb.controller.image /
 # metallb.speaker.image pins + the metallb dependency version in
 # charts/spatiumddi-metallb (#286 moved MetalLB into its own wrapper
@@ -125,9 +118,25 @@ OBSERVABILITY_IMAGES=(
 # work (its speaker probe hits /healthz:17472, which v0.15.3 doesn't
 # serve → crashloop), so charts/spatiumddi-metallb pins the 0.15.3 chart
 # end-to-end. Bump back to the chart default once #3063 is fixed upstream.
+#
+# #566 decision D1 — BGP mode (frr-k8s backend). Bake all three images
+# the frr-k8s DaemonSet's pod spec pulls unconditionally: the FRR daemon
+# itself (GPL v2 — flag distinctly in NOTICE), the frr-k8s reconciler
+# (Apache 2.0), and the kube-rbac-proxy metrics sidecar (present TWICE
+# per pod, same image, Apache 2.0) that the vendored charts/frr-k8s
+# templates/controller.yaml wires in unconditionally. Tags verified
+# against charts/frr-k8s/values.yaml inside the vendored
+# metallb-0.15.3.tgz (frr-k8s@0.0.21) — keep in lock-step with the
+# charts/spatiumddi-metallb/values.yaml `metallb.frr-k8s.frrk8s.image` /
+# `.frr.image` pins. ``metallb.speaker.frr.enabled`` stays FALSE (the
+# in-speaker FRR sidecar is mutually exclusive with the frr-k8s backend
+# and unused either way) so no image is baked for that path.
 METALLB_IMAGES=(
     "quay.io/metallb/controller:v0.15.3"
     "quay.io/metallb/speaker:v0.15.3"
+    "quay.io/metallb/frr-k8s:v0.0.21"
+    "quay.io/frrouting/frr:10.4.1"
+    "gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0"
 )
 
 # CloudNativePG (#272 / #277) — PostgreSQL is CNPG on every appliance

--- a/appliance/scripts/bake-images.sh
+++ b/appliance/scripts/bake-images.sh
@@ -52,6 +52,10 @@ IMAGES=(
     "ghcr.io/spatiumddi/dns-bind9"
     "ghcr.io/spatiumddi/dns-powerdns"
     "ghcr.io/spatiumddi/dhcp-kea"
+    # Issue #566 — BGP Looking Glass collector (GoBGP). Baked into
+    # every slot per decision D3 (can_run_looking_glass hardcodes
+    # True the same way DNS/DHCP do — not a conditional/optional add).
+    "ghcr.io/spatiumddi/looking-glass"
     # Phase 11 (#183) — control-plane images for the AIO + Core
     # install variants. Application-role appliances don't run these
     # pods, but baking them keeps the slot consistent across all

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -61,6 +61,8 @@ backend/alembic/versions/4c9e1f82a3b7_add_dns_schema.py:drop_table:195
 backend/alembic/versions/4c9e1f82a3b7_add_dns_schema.py:drop_table:196
 backend/alembic/versions/4c9e1f82a3b7_add_dns_schema.py:drop_table:197
 backend/alembic/versions/4c9e1f82a3b7_add_dns_schema.py:drop_table:198
+backend/alembic/versions/531494dbf44c_bgp_lg_alerts_dashboard.py:drop_column:71
+backend/alembic/versions/531494dbf44c_bgp_lg_alerts_dashboard.py:drop_column:73
 backend/alembic/versions/5443d2756647_approvals_protect_controls.py:drop_column:40
 backend/alembic/versions/5d2a8f91c4e6_add_dns_settings_and_fix_session_timeout.py:drop_column:39
 backend/alembic/versions/5d2a8f91c4e6_add_dns_settings_and_fix_session_timeout.py:drop_column:40

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -376,6 +376,9 @@ backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_table:199
 backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_table:201
 backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_table:203
 backend/alembic/versions/c9f2a83b04d7_appliance_certificate.py:drop_table:90
+backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:291
+backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:297
+backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:304
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:107
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:110
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_table:112

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -655,3 +655,6 @@ backend/alembic/versions/fe6715916c27_add_dhcp_default_options_to_platform_.py:d
 backend/alembic/versions/fe6715916c27_add_dhcp_default_options_to_platform_.py:drop_column:53
 backend/alembic/versions/fe6715916c27_add_dhcp_default_options_to_platform_.py:drop_column:54
 backend/alembic/versions/f7883fa6d413_bgp_lg_route_distinguisher.py:drop_column:69
+backend/alembic/versions/1440e72b9297_metallb_bgp_mode.py:drop_column:73
+backend/alembic/versions/1440e72b9297_metallb_bgp_mode.py:drop_column:74
+backend/alembic/versions/1440e72b9297_metallb_bgp_mode.py:drop_column:75

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -654,3 +654,4 @@ backend/alembic/versions/fe6715916c27_add_dhcp_default_options_to_platform_.py:d
 backend/alembic/versions/fe6715916c27_add_dhcp_default_options_to_platform_.py:drop_column:52
 backend/alembic/versions/fe6715916c27_add_dhcp_default_options_to_platform_.py:drop_column:53
 backend/alembic/versions/fe6715916c27_add_dhcp_default_options_to_platform_.py:drop_column:54
+backend/alembic/versions/f7883fa6d413_bgp_lg_route_distinguisher.py:drop_column:69

--- a/backend/alembic/versions/1440e72b9297_metallb_bgp_mode.py
+++ b/backend/alembic/versions/1440e72b9297_metallb_bgp_mode.py
@@ -1,0 +1,75 @@
+"""platform_settings MetalLB BGP mode (issue #566 decision D1)
+
+Adds the BGP-advertise (export path) knobs to the ``platform_settings``
+singleton, layered on top of the existing L2/ARP MetalLB VIP columns
+(``metallb_enabled`` / ``metallb_pool_addresses`` / ``control_plane_vip``,
+added by ``e7a2c91d4f60``):
+
+* ``metallb_bgp_enabled`` — master switch for BGP mode. Requires
+  ``metallb_enabled=True`` (enforced at the API layer, not the DB).
+* ``metallb_bgp_peers`` — JSONB list of ``{my_asn, peer_asn,
+  peer_address, peer_port, hold_time}`` dicts, one BGPPeer CR per entry.
+* ``metallb_bgp_advertisements`` — JSONB list of ``{ip_address_pools,
+  communities, aggregation_length}`` dicts, one BGPAdvertisement CR per
+  entry.
+
+The seed supervisor reads these back on heartbeat and folds them into
+the SAME ``apply_metallb_overrides`` HelmChartConfig write as the L2
+pool (one combined ``valuesContent`` body — see
+``agent/supervisor/spatium_supervisor/k8s_api.py``). Enabling this
+activates the GPL-v2 FRRouting BGP daemon inside the cluster via
+MetalLB's frr-k8s backend (see ``NOTICE``) — opt-in only, stays
+dormant until an operator configures a peer.
+
+Revision ID: 1440e72b9297
+Revises: f7883fa6d413
+Create Date: 2026-07-05 17:10:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision = "1440e72b9297"
+down_revision = "f7883fa6d413"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "metallb_bgp_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "metallb_bgp_peers",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "metallb_bgp_advertisements",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_settings", "metallb_bgp_advertisements")
+    op.drop_column("platform_settings", "metallb_bgp_peers")
+    op.drop_column("platform_settings", "metallb_bgp_enabled")

--- a/backend/alembic/versions/531494dbf44c_bgp_lg_alerts_dashboard.py
+++ b/backend/alembic/versions/531494dbf44c_bgp_lg_alerts_dashboard.py
@@ -1,0 +1,73 @@
+"""bgp looking glass — alert-family columns (issue #566 Phase 5)
+
+Revision ID: 531494dbf44c
+Revises: cb279a6afd70
+Create Date: 2026-07-05 10:35:27.376300
+
+Two additive columns backing the bgp_lg_* alert family:
+
+* ``subnet.bgp_should_advertise`` — pure operator intent ("this subnet
+  is supposed to be carrying traffic over BGP somewhere"), consulted by
+  the ``bgp_lg_missing_advertisement`` alert. Partial index (WHERE true)
+  since only a small subset of subnets will ever be flagged.
+* ``bgp_lg_route.last_flap_at`` — timestamp of the most recent
+  absence-withdraw bump on a learned route (routes_ingest.py already
+  bumps ``flap_count``; this adds the recency dimension so the
+  ``bgp_lg_route_flap`` alert can require a RECENT flap, not just a
+  lifetime count, and auto-resolve once the route settles).
+
+No AlertRule schema changes — all six rule types reuse existing
+generic columns (route_flap's flap-count floor reuses
+``threshold_percent``, same as ``voice_lease_count_below`` /
+``stale_ip_count``); the six AlertRule seed rows are inserted by
+``seed_bgp_lg_alert_rules()`` at app startup (main.py), not here — see
+the alert-seeding convention documented in ``services/alerts.py``.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "531494dbf44c"
+down_revision: Union[str, None] = "cb279a6afd70"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "subnet",
+        sa.Column(
+            "bgp_should_advertise",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.create_index(
+        "ix_subnet_bgp_should_advertise",
+        "subnet",
+        ["bgp_should_advertise"],
+        postgresql_where=sa.text("bgp_should_advertise = true"),
+    )
+    op.add_column(
+        "bgp_lg_route",
+        sa.Column(
+            "last_flap_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_bgp_lg_route_last_flap_at",
+        "bgp_lg_route",
+        ["last_flap_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_bgp_lg_route_last_flap_at", table_name="bgp_lg_route")
+    op.drop_column("bgp_lg_route", "last_flap_at")
+    op.drop_index("ix_subnet_bgp_should_advertise", table_name="subnet")
+    op.drop_column("subnet", "bgp_should_advertise")

--- a/backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py
+++ b/backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py
@@ -1,0 +1,305 @@
+"""bgp looking glass — collector + peers + learned RIB (issue #566)
+
+Revision ID: cb279a6afd70
+Revises: c9f2e1a4d7b6
+Create Date: 2026-07-04 00:00:00.000000
+
+Issue #566 — receive-only BGP Looking Glass. Three new tables + one
+``feature_module`` seed row:
+
+* ``looking_glass_collector`` — the GoBGP collector-daemon agent identity
+  row (one per node), upserted by the register/heartbeat endpoints keyed on
+  ``agent_id``. Shaped like ``dhcp_server`` / ``dns_server``.
+* ``bgp_lg_peer`` — a configured receive-only BGP session. Carries the config
+  the collector renders into the GoBGP neighbor block (``peer_asn`` /
+  ``peer_address`` / ``address_families`` / ``max_prefixes`` / Fernet MD5)
+  plus collector-reported runtime state (``session_state`` / ``prefixes_*``).
+* ``bgp_lg_route`` — the learned RIB mirror, one row per
+  ``(peer, prefix, next_hop)``. Absence-reconcile sets ``withdrawn_at`` rather
+  than hard-deleting. ``matched_*_id`` FKs (SET NULL) link a learned route to
+  the IPAM block / subnet / space / ASN / VRF it falls under (populated by a
+  later phase; columns ship now so no follow-up migration is needed).
+
+Seeds the ``network.looking_glass`` feature module (enabled — discovery
+default per non-negotiable #14; the collector does nothing until a peer is
+configured).
+
+Additive only. Downgrade drops the three tables + the feature-module seed row
+(new-table-only, so ``scripts/lint_migrations.py`` does not flag it).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "cb279a6afd70"
+down_revision: Union[str, None] = "c9f2e1a4d7b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "looking_glass_collector",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), server_default=sa.text("''"), nullable=False),
+        sa.Column("host", sa.String(length=255), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=50),
+            server_default=sa.text("'unknown'"),
+            nullable=False,
+        ),
+        sa.Column("enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("agent_id", sa.String(length=128), nullable=True),
+        sa.Column(
+            "agent_registered",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column("agent_token_hash", sa.String(length=128), nullable=True),
+        sa.Column("agent_version", sa.String(length=64), nullable=True),
+        sa.Column("last_seen_ip", sa.String(length=45), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_health_check_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("appliance_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["appliance_id"], ["appliance.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("agent_id", name="uq_looking_glass_collector_agent_id"),
+    )
+    op.create_index(
+        op.f("ix_looking_glass_collector_appliance_id"),
+        "looking_glass_collector",
+        ["appliance_id"],
+    )
+    op.create_index("ix_looking_glass_collector_name", "looking_glass_collector", ["name"])
+
+    op.create_table(
+        "bgp_lg_peer",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("collector_id", sa.UUID(), nullable=False),
+        sa.Column("local_asn", sa.BigInteger(), nullable=False),
+        sa.Column("peer_asn", sa.BigInteger(), nullable=False),
+        sa.Column("peer_address", postgresql.INET(), nullable=False),
+        sa.Column("matched_asn_id", sa.UUID(), nullable=True),
+        sa.Column("peer_router_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "address_families",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text('\'["ipv4-unicast"]\'::jsonb'),
+            nullable=False,
+        ),
+        sa.Column("md5_password_encrypted", sa.LargeBinary(), nullable=True),
+        sa.Column(
+            "max_prefixes",
+            sa.Integer(),
+            server_default=sa.text("10000"),
+            nullable=False,
+        ),
+        sa.Column(
+            "import_filter",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text('\'{"mode": "accept_all"}\'::jsonb'),
+            nullable=False,
+        ),
+        sa.Column("enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("description", sa.Text(), server_default=sa.text("''"), nullable=False),
+        sa.Column(
+            "session_state",
+            sa.String(length=24),
+            server_default=sa.text("'idle'"),
+            nullable=False,
+        ),
+        sa.Column("uptime_started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "prefixes_received", sa.Integer(), server_default=sa.text("0"), nullable=False
+        ),
+        sa.Column(
+            "prefixes_accepted", sa.Integer(), server_default=sa.text("0"), nullable=False
+        ),
+        sa.Column("last_state_change", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_flap_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "rpki_invalid_count", sa.Integer(), server_default=sa.text("0"), nullable=False
+        ),
+        sa.Column("down_since", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["collector_id"], ["looking_glass_collector.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["matched_asn_id"], ["asn.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["peer_router_id"], ["network_device.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("collector_id", "peer_address", name="uq_bgp_lg_peer_addr"),
+    )
+    op.create_index("ix_bgp_lg_peer_collector", "bgp_lg_peer", ["collector_id"])
+    op.create_index("ix_bgp_lg_peer_enabled", "bgp_lg_peer", ["enabled"])
+    op.create_index(op.f("ix_bgp_lg_peer_matched_asn_id"), "bgp_lg_peer", ["matched_asn_id"])
+    op.create_index(op.f("ix_bgp_lg_peer_peer_router_id"), "bgp_lg_peer", ["peer_router_id"])
+
+    op.create_table(
+        "bgp_lg_route",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("peer_id", sa.UUID(), nullable=False),
+        sa.Column("prefix", postgresql.CIDR(), nullable=False),
+        sa.Column("origin_asn", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "as_path",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("next_hop", postgresql.INET(), nullable=False),
+        sa.Column("local_pref", sa.Integer(), nullable=True),
+        sa.Column("med", sa.Integer(), nullable=True),
+        sa.Column(
+            "communities",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "large_communities",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "ext_communities",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "rpki_status",
+            sa.String(length=12),
+            server_default=sa.text("'unknown'"),
+            nullable=False,
+        ),
+        sa.Column("is_best", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("matched_block_id", sa.UUID(), nullable=True),
+        sa.Column("matched_subnet_id", sa.UUID(), nullable=True),
+        sa.Column("matched_space_id", sa.UUID(), nullable=True),
+        sa.Column("matched_asn_id", sa.UUID(), nullable=True),
+        sa.Column("matched_vrf_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "first_seen_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("withdrawn_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("flap_count", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("detail", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["matched_asn_id"], ["asn.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["matched_block_id"], ["ip_block.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["matched_space_id"], ["ip_space.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["matched_subnet_id"], ["subnet.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["matched_vrf_id"], ["vrf.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["peer_id"], ["bgp_lg_peer.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("peer_id", "prefix", "next_hop", name="uq_bgp_lg_route"),
+    )
+    op.create_index(
+        "ix_bgp_lg_route_active",
+        "bgp_lg_route",
+        ["peer_id", "prefix"],
+        postgresql_where=sa.text("withdrawn_at IS NULL"),
+    )
+    op.create_index("ix_bgp_lg_route_matched_asn", "bgp_lg_route", ["matched_asn_id"])
+    op.create_index("ix_bgp_lg_route_matched_block", "bgp_lg_route", ["matched_block_id"])
+    op.create_index("ix_bgp_lg_route_matched_space", "bgp_lg_route", ["matched_space_id"])
+    op.create_index("ix_bgp_lg_route_matched_subnet", "bgp_lg_route", ["matched_subnet_id"])
+    op.create_index("ix_bgp_lg_route_matched_vrf", "bgp_lg_route", ["matched_vrf_id"])
+    op.create_index("ix_bgp_lg_route_origin_asn", "bgp_lg_route", ["origin_asn"])
+    op.create_index("ix_bgp_lg_route_peer", "bgp_lg_route", ["peer_id"])
+    op.create_index("ix_bgp_lg_route_prefix", "bgp_lg_route", ["prefix"])
+    op.create_index("ix_bgp_lg_route_rpki_status", "bgp_lg_route", ["rpki_status"])
+
+    # Feature-module seed (non-negotiable #14). Enabled = discovery default.
+    op.execute(
+        sa.text(
+            "INSERT INTO feature_module (id, enabled) "
+            "VALUES ('network.looking_glass', TRUE) "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("DELETE FROM feature_module WHERE id = 'network.looking_glass'")
+    )
+
+    op.drop_index("ix_bgp_lg_route_rpki_status", table_name="bgp_lg_route")
+    op.drop_index("ix_bgp_lg_route_prefix", table_name="bgp_lg_route")
+    op.drop_index("ix_bgp_lg_route_peer", table_name="bgp_lg_route")
+    op.drop_index("ix_bgp_lg_route_origin_asn", table_name="bgp_lg_route")
+    op.drop_index("ix_bgp_lg_route_matched_vrf", table_name="bgp_lg_route")
+    op.drop_index("ix_bgp_lg_route_matched_subnet", table_name="bgp_lg_route")
+    op.drop_index("ix_bgp_lg_route_matched_space", table_name="bgp_lg_route")
+    op.drop_index("ix_bgp_lg_route_matched_block", table_name="bgp_lg_route")
+    op.drop_index("ix_bgp_lg_route_matched_asn", table_name="bgp_lg_route")
+    op.drop_index("ix_bgp_lg_route_active", table_name="bgp_lg_route")
+    op.drop_table("bgp_lg_route")
+
+    op.drop_index(op.f("ix_bgp_lg_peer_peer_router_id"), table_name="bgp_lg_peer")
+    op.drop_index(op.f("ix_bgp_lg_peer_matched_asn_id"), table_name="bgp_lg_peer")
+    op.drop_index("ix_bgp_lg_peer_enabled", table_name="bgp_lg_peer")
+    op.drop_index("ix_bgp_lg_peer_collector", table_name="bgp_lg_peer")
+    op.drop_table("bgp_lg_peer")
+
+    op.drop_index("ix_looking_glass_collector_name", table_name="looking_glass_collector")
+    op.drop_index(
+        op.f("ix_looking_glass_collector_appliance_id"),
+        table_name="looking_glass_collector",
+    )
+    op.drop_table("looking_glass_collector")

--- a/backend/alembic/versions/f7883fa6d413_bgp_lg_route_distinguisher.py
+++ b/backend/alembic/versions/f7883fa6d413_bgp_lg_route_distinguisher.py
@@ -1,0 +1,69 @@
+"""bgp lg route: route_distinguisher for VPNv4/VPNv6 (issue #566 Phase 6)
+
+Revision ID: f7883fa6d413
+Revises: 531494dbf44c
+Create Date: 2026-07-05 16:30:00.000000
+
+Adds ``bgp_lg_route.route_distinguisher`` (NOT NULL, default ``''``) so a
+VPNv4/VPNv6 path's Route Distinguisher participates in the row's identity.
+
+Without this, two different VRFs' overlapping customer prefixes learned
+via the same peer + next-hop (an ordinary shape — the PE's own loopback
+is the next-hop for every VRF it serves) collide on the existing
+``uq_bgp_lg_route (peer_id, prefix, next_hop)`` constraint and silently
+overwrite each other — RD's entire purpose per RFC 4364 is disambiguating
+exactly this. ``''`` (not NULL) for plain ipv4-unicast/ipv6-unicast
+routes, since Postgres treats every NULL as distinct in a UNIQUE
+constraint — a nullable column here would silently defeat the existing
+dedup semantics for ordinary unicast routes.
+
+Widens ``uq_bgp_lg_route`` to
+``(peer_id, prefix, next_hop, route_distinguisher)`` and adds a partial
+index over ``route_distinguisher != ''`` (the VRF "Learned VPN Routes"
+tab / admin debug queries).
+
+Additive only. Downgrade drops the column/constraint/index — this makes
+``scripts/lint_migrations.py`` flag the downgrade ``drop_column``; run
+``python3 scripts/lint_migrations.py --baseline`` and commit the updated
+baseline file alongside this migration.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f7883fa6d413"
+down_revision: Union[str, None] = "531494dbf44c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "bgp_lg_route",
+        sa.Column(
+            "route_distinguisher", sa.String(length=64), nullable=False, server_default=""
+        ),
+    )
+    op.drop_constraint("uq_bgp_lg_route", "bgp_lg_route", type_="unique")
+    op.create_unique_constraint(
+        "uq_bgp_lg_route",
+        "bgp_lg_route",
+        ["peer_id", "prefix", "next_hop", "route_distinguisher"],
+    )
+    op.create_index(
+        "ix_bgp_lg_route_rd",
+        "bgp_lg_route",
+        ["route_distinguisher"],
+        postgresql_where=sa.text("route_distinguisher != ''"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_bgp_lg_route_rd", table_name="bgp_lg_route")
+    op.drop_constraint("uq_bgp_lg_route", "bgp_lg_route", type_="unique")
+    op.create_unique_constraint(
+        "uq_bgp_lg_route", "bgp_lg_route", ["peer_id", "prefix", "next_hop"]
+    )
+    op.drop_column("bgp_lg_route", "route_distinguisher")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1347,6 +1347,13 @@ class SupervisorHeartbeatResponse(BaseModel):
     # hostNetwork data plane (single-node default).
     desired_dns_vip: str = ""
     desired_dhcp_relay_vip: str = ""
+    # #566 decision D1 — BGP mode. Acted on only by the seed via the
+    # SAME apply_metallb_overrides call as the L2 pool (one combined
+    # HelmChartConfig body — see k8s_api.py). Empty/false = L2-only
+    # MetalLB (today's behaviour, unchanged).
+    desired_metallb_bgp_enabled: bool = False
+    desired_metallb_bgp_peers: list[dict] = Field(default_factory=list)
+    desired_metallb_bgp_advertisements: list[dict] = Field(default_factory=list)
     # #272 Phase 9 — dead-node replacement. Hostnames of k8s Nodes the
     # SEED should evict (delete the Node → k3s removes the etcd member).
     # Populated from rows flagged ``evict_requested``; only the
@@ -2039,6 +2046,10 @@ async def supervisor_heartbeat(
     # #272 Phase 10 — data-plane resolver VIPs (only the seed acts).
     dns_vip = (cfg_row.dns_vip or "") if cfg_row else ""
     dhcp_relay_vip = (cfg_row.dhcp_relay_vip or "") if cfg_row else ""
+    # #566 decision D1 — BGP mode (only the seed acts).
+    metallb_bgp_enabled = bool(cfg_row.metallb_bgp_enabled) if cfg_row else False
+    metallb_bgp_peers = list(cfg_row.metallb_bgp_peers or []) if cfg_row else []
+    metallb_bgp_advertisements = list(cfg_row.metallb_bgp_advertisements or []) if cfg_row else []
     # Issue #165 — operator-set timezone. Empty string = no override.
     desired_timezone = (cfg_row.timezone or "") if cfg_row else ""
     # #393 — appliance console mode (grubenv-driven, applies next reboot).
@@ -2199,6 +2210,9 @@ async def supervisor_heartbeat(
         desired_control_plane_vip=metallb_vip,
         desired_dns_vip=dns_vip,
         desired_dhcp_relay_vip=dhcp_relay_vip,
+        desired_metallb_bgp_enabled=metallb_bgp_enabled,
+        desired_metallb_bgp_peers=metallb_bgp_peers,
+        desired_metallb_bgp_advertisements=metallb_bgp_advertisements,
         evict_node_names=evict_names,
         desired_timezone=desired_timezone,
         desired_console_mode=desired_console_mode,
@@ -4158,6 +4172,44 @@ def _vip_in_pool(vip: str, pool: list[str]) -> bool:
     return False
 
 
+# issue #566 decision D1 — BGP mode. ``_ASN_MIN``/``_ASN_MAX`` mirror
+# ``looking_glass/schemas.py``'s local copy (kept separate rather than
+# imported — zero code coupling between the two BGP surfaces per
+# docs/features/LOOKING_GLASS.md's "share only the UI concept" framing).
+_ASN_MIN, _ASN_MAX = 1, 4_294_967_295
+
+
+class MetalLBBgpPeer(BaseModel):
+    """One BGPPeer CR — a router SpatiumDDI advertises the VIP to."""
+
+    my_asn: int
+    peer_asn: int
+    peer_address: str
+    peer_port: int | None = None
+    hold_time: str | None = None  # e.g. "90s" — passed through verbatim to the CR
+
+    @field_validator("my_asn", "peer_asn")
+    @classmethod
+    def _v_asn(cls, v: int) -> int:
+        if not (_ASN_MIN <= v <= _ASN_MAX):
+            raise ValueError(f"AS number must be between {_ASN_MIN} and {_ASN_MAX}")
+        return v
+
+    @field_validator("peer_address")
+    @classmethod
+    def _v_addr(cls, v: str) -> str:
+        ipaddress.ip_address(v.strip())  # raises ValueError -> 422
+        return v.strip()
+
+
+class MetalLBBgpAdvertisement(BaseModel):
+    """One BGPAdvertisement CR — the pool(s)/attributes advertised."""
+
+    ip_address_pools: list[str] = Field(default_factory=lambda: ["spatium-control-plane"])
+    communities: list[str] = Field(default_factory=list)
+    aggregation_length: int | None = None
+
+
 class MetalLBConfigResponse(BaseModel):
     """Cluster-wide MetalLB / control-plane-VIP config + live status."""
 
@@ -4169,6 +4221,12 @@ class MetalLBConfigResponse(BaseModel):
     # :53; ``dhcp_relay_vip`` fronts the Kea relay→server :67 forward.
     dns_vip: str = ""
     dhcp_relay_vip: str = ""
+    # issue #566 decision D1 — BGP mode (export path: advertise the VIP
+    # to upstream routers). Layered on top of the same MetalLB install;
+    # requires ``enabled=True``.
+    bgp_enabled: bool = False
+    bgp_peers: list[MetalLBBgpPeer] = Field(default_factory=list)
+    bgp_advertisements: list[MetalLBBgpAdvertisement] = Field(default_factory=list)
     # #272 — live readiness, best-effort from the spatium-namespace pod
     # list (reuses the api's existing pod-read RBAC). All zero/false when
     # kubeapi is unreachable (docker/k8s control plane) or MetalLB is off.
@@ -4226,6 +4284,9 @@ def _metallb_response(row: PlatformSettings) -> MetalLBConfigResponse:
         control_plane_vip=row.control_plane_vip or "",
         dns_vip=row.dns_vip or "",
         dhcp_relay_vip=row.dhcp_relay_vip or "",
+        bgp_enabled=row.metallb_bgp_enabled,
+        bgp_peers=row.metallb_bgp_peers or [],
+        bgp_advertisements=row.metallb_bgp_advertisements or [],
         controller_ready=controller_ready,
         speakers_ready=speakers_ready,
         speakers_total=speakers_total,
@@ -4247,6 +4308,10 @@ class MetalLBConfigUpdate(BaseModel):
     # #272 Phase 10 — data-plane resolver VIPs (optional; same pool).
     dns_vip: str = ""
     dhcp_relay_vip: str = ""
+    # issue #566 decision D1 — BGP mode (optional; export path).
+    bgp_enabled: bool = False
+    bgp_peers: list[MetalLBBgpPeer] = Field(default_factory=list)
+    bgp_advertisements: list[MetalLBBgpAdvertisement] = Field(default_factory=list)
 
     @field_validator("pool_addresses")
     @classmethod
@@ -4319,6 +4384,24 @@ class MetalLBConfigUpdate(BaseModel):
                     f"{label} {vip} is not inside the address pool "
                     "(widen metallb_pool_addresses to include every VIP)"
                 )
+        # issue #566 decision D1 — BGP mode. An "export" path layered on
+        # top of the same MetalLB install: requires MetalLB itself on +
+        # at least one peer, since there's nothing to advertise-to
+        # otherwise. Activates the GPL-v2 FRRouting image via MetalLB's
+        # frr-k8s backend once applied — see NOTICE.
+        if self.bgp_enabled:
+            if not self.enabled:
+                raise ValueError("BGP mode requires MetalLB to be enabled")
+            if not self.bgp_peers:
+                raise ValueError("at least one BGP peer is required when bgp_enabled")
+            if not self.bgp_advertisements:
+                # Auto-derive the same "advertise the control-plane VIP
+                # pool" default the plain-VIP path already assumes, so a
+                # v1 operator only has to type peer info — mirrors the
+                # auto-derived /32 pool convenience above.
+                self.bgp_advertisements = [
+                    MetalLBBgpAdvertisement(ip_address_pools=["spatium-control-plane"])
+                ]
         return self
 
 
@@ -4376,18 +4459,27 @@ async def put_metallb_config(
         "control_plane_vip": row.control_plane_vip or "",
         "dns_vip": row.dns_vip or "",
         "dhcp_relay_vip": row.dhcp_relay_vip or "",
+        "bgp_enabled": row.metallb_bgp_enabled,
+        "bgp_peers": list(row.metallb_bgp_peers or []),
+        "bgp_advertisements": list(row.metallb_bgp_advertisements or []),
     }
     row.metallb_enabled = body.enabled
     row.metallb_pool_addresses = body.pool_addresses
     row.control_plane_vip = body.control_plane_vip
     row.dns_vip = body.dns_vip
     row.dhcp_relay_vip = body.dhcp_relay_vip
+    row.metallb_bgp_enabled = body.bgp_enabled
+    row.metallb_bgp_peers = [p.model_dump() for p in body.bgp_peers]
+    row.metallb_bgp_advertisements = [a.model_dump() for a in body.bgp_advertisements]
     new = {
         "enabled": body.enabled,
         "pool_addresses": body.pool_addresses,
         "control_plane_vip": body.control_plane_vip,
         "dns_vip": body.dns_vip,
         "dhcp_relay_vip": body.dhcp_relay_vip,
+        "bgp_enabled": body.bgp_enabled,
+        "bgp_peers": row.metallb_bgp_peers,
+        "bgp_advertisements": row.metallb_bgp_advertisements,
     }
     db.add(
         AuditLog(

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -203,6 +203,7 @@ class SupervisorCapabilities(BaseModel):
     can_run_dns_bind9: bool = False
     can_run_dns_powerdns: bool = False
     can_run_dhcp: bool = False
+    can_run_looking_glass: bool = False
     can_run_observer: bool = False
     has_baked_images: bool = False
     baked_images_version: str | None = None
@@ -1215,6 +1216,13 @@ class SupervisorRoleAssignment(BaseModel):
     dhcp_group_name: str | None = None
     dhcp_network_mode: str | None = None  # host / bridged
     dhcp_agent_key: str | None = None
+    # #566 — platform-level Looking Glass collector PSK (mirror of
+    # ``settings.lg_agent_key``). Populated only when the ``looking-glass``
+    # role is assigned; the supervisor writes ``LG_AGENT_KEY=<this>`` into
+    # role-compose.env so the collector container can register against
+    # ``/api/v1/looking-glass/agents/register`` without operator-side .env
+    # edits. There is no group concept for the collector (like DNS/DHCP).
+    lg_agent_key: str | None = None
     # #170 Wave C3 — operator-pasted nft fragment rendered after the
     # role-driven mgmt + per-role blocks. NULL / empty → role-driven
     # rules only.
@@ -2260,6 +2268,7 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     assigned_roles = list(row.assigned_roles or [])
     dns_role_assigned = "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
     dhcp_role_assigned = "dhcp" in assigned_roles
+    lg_role_assigned = "looking-glass" in assigned_roles
 
     dns_engine: str | None = None
     if "dns-bind9" in assigned_roles:
@@ -2292,6 +2301,9 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     dhcp_agent_key: str | None = None
     if dhcp_role_assigned:
         dhcp_agent_key = app_settings.dhcp_agent_key or None
+    lg_agent_key: str | None = None
+    if lg_role_assigned:
+        lg_agent_key = app_settings.lg_agent_key or None
 
     return SupervisorRoleAssignment(
         roles=assigned_roles,
@@ -2303,6 +2315,7 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
         dhcp_group_name=dhcp_group_name,
         dhcp_network_mode=dhcp_network_mode,
         dhcp_agent_key=dhcp_agent_key,
+        lg_agent_key=lg_agent_key,
         firewall_extra=row.firewall_extra,
         kubeapi_expose_cidrs=list(row.kubeapi_expose_cidrs or []),
     )
@@ -3189,7 +3202,7 @@ async def rekey_appliance(
 # ── Admin: role assignment + tags (#170 Wave C2) ──────────────────
 
 
-_VALID_ROLES = {"dns-bind9", "dns-powerdns", "dhcp", "observer", "custom"}
+_VALID_ROLES = {"dns-bind9", "dns-powerdns", "dhcp", "looking-glass", "observer", "custom"}
 _DNS_ROLES = {"dns-bind9", "dns-powerdns"}
 
 
@@ -3205,8 +3218,8 @@ class ApplianceRolesUpdate(BaseModel):
     roles: list[str] | None = Field(
         default=None,
         description=(
-            "Subset of dns-bind9 / dns-powerdns / dhcp / observer / "
-            "custom. dns-bind9 and dns-powerdns are mutually exclusive."
+            "Subset of dns-bind9 / dns-powerdns / dhcp / looking-glass / "
+            "observer / custom. dns-bind9 and dns-powerdns are mutually exclusive."
         ),
     )
     dns_group_id: uuid.UUID | None = None
@@ -3279,6 +3292,7 @@ async def update_appliance_roles(
                 "dns-bind9": "can_run_dns_bind9",
                 "dns-powerdns": "can_run_dns_powerdns",
                 "dhcp": "can_run_dhcp",
+                "looking-glass": "can_run_looking_glass",
                 "observer": "can_run_observer",
             }.get(r)
             if cap_key is not None and not caps.get(cap_key, False):

--- a/backend/app/api/v1/looking_glass/agents.py
+++ b/backend/app/api/v1/looking_glass/agents.py
@@ -116,6 +116,13 @@ class RouteEntry(BaseModel):
     communities: list[str] = Field(default_factory=list)
     large_communities: list[str] = Field(default_factory=list)
     ext_communities: list[str] = Field(default_factory=list)
+    # Route Distinguisher (RFC 4364) — vpnv4/vpnv6 paths only. Optional
+    # because the collector-side GoBGP RIB poll doesn't populate this yet
+    # (issue #566 Phase 6 lands the API + ingest-side identity/matching;
+    # the agent's VPNv4/VPNv6 wire support is a follow-up). ``None``/absent
+    # is treated as "" (plain ipv4-unicast/ipv6-unicast path) by
+    # ``routes_ingest.ingest_routes``.
+    route_distinguisher: str | None = None
     is_best: bool = False
 
 

--- a/backend/app/api/v1/looking_glass/agents.py
+++ b/backend/app/api/v1/looking_glass/agents.py
@@ -1,0 +1,424 @@
+"""BGP Looking Glass collector agent endpoints: register, config long-poll,
+heartbeat (session-state), RIB push.
+
+Mirrors ``app.api.v1.dhcp.agents`` — the collector reuses the DNS/DHCP agent
+protocol (PSK→JWT bootstrap, ConfigBundle ETag long-poll + Redis wake,
+telemetry push). It is trimmed to the leaner ``LookingGlassCollector``
+identity row (no server-group, no approval flow, no config-op queue, no
+fleet/host-config plumbing — those ride the supervisor, not the LG agent).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import os
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
+from jose import JWTError
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+
+from app.api.deps import DB
+from app.api.v1.dhcp._audit import write_audit
+from app.core.agent_wake import (
+    WAKE_TICK_SECONDS,
+    looking_glass_wake_channels,
+    wake_subscription,
+)
+from app.models.bgp_looking_glass import BGPLGPeer, LookingGlassCollector
+from app.services.looking_glass.agent_token import (
+    hash_token,
+    mint_agent_token,
+    needs_rotation,
+    verify_agent_token,
+)
+from app.services.looking_glass.config_bundle import build_lg_config_bundle
+from app.services.looking_glass.routes_ingest import ingest_routes
+
+logger = structlog.get_logger(__name__)
+router = APIRouter(prefix="/agents", tags=["looking-glass-agents"])
+
+LONGPOLL_TIMEOUT_SECONDS = int(os.environ.get("LG_AGENT_LONGPOLL_TIMEOUT", "30"))
+
+
+# ── Schemas ─────────────────────────────────────────────────────────────────
+
+
+class AgentRegisterRequest(BaseModel):
+    hostname: str
+    version: str | None = None
+    fingerprint: str
+    agent_id: str | None = None
+
+
+class AgentRegisterResponse(BaseModel):
+    collector_id: str
+    agent_id: str
+    agent_token: str
+    token_expires_at: datetime
+    config_etag: str | None
+
+
+class PeerStateReport(BaseModel):
+    """One per-peer runtime observation the collector relays each heartbeat.
+
+    Every field except ``peer_id`` is optional so the handler only overwrites
+    the columns the agent actually sent (leaving previously-known state intact
+    for anything omitted), mirroring the DHCP slot-state discipline.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    peer_id: str
+    session_state: str | None = None
+    uptime_started_at: datetime | None = None
+    prefixes_received: int | None = None
+    prefixes_accepted: int | None = None
+    last_state_change: datetime | None = None
+    last_flap_at: datetime | None = None
+    rpki_invalid_count: int | None = None
+
+
+class AgentHeartbeatRequest(BaseModel):
+    # extra="forbid": reject a wrong-envelope heartbeat loudly instead of
+    # validating into an all-default body that would silently drop the
+    # per-peer state reports (mirrors the DHCP #482 hardening).
+    model_config = ConfigDict(extra="forbid")
+
+    agent_version: str | None = None
+    peers: list[PeerStateReport] = Field(default_factory=list, max_length=5000)
+
+
+class AgentHeartbeatResponse(BaseModel):
+    collector_id: str
+    status: str
+    acknowledged_at: datetime
+    rotated_token: str | None = None
+    rotated_expires_at: datetime | None = None
+
+
+class RouteEntry(BaseModel):
+    """One learned path in a peer's Adj-RIB-In pushed by the collector."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    prefix: str
+    next_hop: str
+    origin_asn: int | None = None
+    as_path: list[int] = Field(default_factory=list)
+    local_pref: int | None = None
+    med: int | None = None
+    communities: list[str] = Field(default_factory=list)
+    large_communities: list[str] = Field(default_factory=list)
+    ext_communities: list[str] = Field(default_factory=list)
+    is_best: bool = False
+
+
+class RoutesPushRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    peer_id: str
+    # snapshot=True → the full current RIB for this peer (runs the
+    # absence-withdraw sweep); False → a delta batch (upsert-only).
+    snapshot: bool = True
+    # Generous cap so a full-table-ish snapshot fits one POST while a
+    # malformed/hostile client still can't ship an unbounded batch.
+    routes: list[RouteEntry] = Field(default_factory=list, max_length=100000)
+
+
+# ── Auth ────────────────────────────────────────────────────────────────────
+
+
+def _require_bootstrap_key(
+    x_lg_agent_key: str | None = Header(default=None, alias="X-LG-Agent-Key"),
+) -> str:
+    expected = os.environ.get("LG_AGENT_KEY", "")
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="LG_AGENT_KEY is not configured on the control plane",
+        )
+    if not x_lg_agent_key or not hmac.compare_digest(x_lg_agent_key, expected):
+        raise HTTPException(status_code=401, detail="Invalid bootstrap key")
+    return x_lg_agent_key
+
+
+async def _auth_agent(
+    db: DB, authorization: str | None = Header(default=None)
+) -> tuple[LookingGlassCollector, dict[str, Any]]:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="Missing Bearer token")
+    token = authorization.split(None, 1)[1].strip()
+    try:
+        payload = verify_agent_token(token)
+    except JWTError as e:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {e}") from e
+    collector_id = payload.get("sub")
+    if not collector_id:
+        raise HTTPException(status_code=401, detail="Token missing subject")
+    collector = await db.get(LookingGlassCollector, uuid.UUID(collector_id))
+    if collector is None:
+        raise HTTPException(status_code=404, detail="Collector not found")
+    if collector.agent_token_hash and collector.agent_token_hash != hash_token(token):
+        raise HTTPException(status_code=401, detail="Stale token")
+    return collector, payload
+
+
+# ── Endpoints ───────────────────────────────────────────────────────────────
+
+
+@router.post("/register", response_model=AgentRegisterResponse)
+async def agent_register(
+    request: Request,
+    body: AgentRegisterRequest,
+    db: DB,
+    _psk: str = Depends(_require_bootstrap_key),
+) -> AgentRegisterResponse:
+    """Bootstrap registration — PSK → per-collector JWT. Idempotent on agent_id."""
+    collector: LookingGlassCollector | None = None
+    if body.agent_id:
+        res = await db.execute(
+            select(LookingGlassCollector).where(LookingGlassCollector.agent_id == body.agent_id)
+        )
+        collector = res.scalar_one_or_none()
+    if collector is None:
+        res = await db.execute(
+            select(LookingGlassCollector).where(LookingGlassCollector.name == body.hostname)
+        )
+        collector = res.scalar_one_or_none()
+
+    now = datetime.now(UTC)
+    agent_id = body.agent_id or str(uuid.uuid4())
+    if collector is None:
+        collector = LookingGlassCollector(
+            name=body.hostname,
+            host=body.hostname,
+            status="active",
+            agent_id=agent_id,
+            agent_registered=True,
+            agent_version=body.version,
+            description=(
+                f"auto-registered agent v{body.version}" if body.version else "auto-registered"
+            ),
+            last_seen_at=now,
+        )
+        if request.client is not None:
+            collector.last_seen_ip = request.client.host
+        db.add(collector)
+        await db.flush()
+    else:
+        collector.host = body.hostname
+        collector.status = "active"
+        collector.agent_registered = True
+        collector.agent_version = body.version
+        collector.last_seen_at = now
+        if collector.agent_id is None:
+            collector.agent_id = agent_id
+        if request.client is not None:
+            collector.last_seen_ip = request.client.host
+
+    token, exp = mint_agent_token(
+        collector_id=str(collector.id),
+        agent_id=str(collector.agent_id),
+        fingerprint=body.fingerprint,
+    )
+    collector.agent_token_hash = hash_token(token)
+
+    # Compute the current bundle ETag so the agent's first /config poll can
+    # immediately 304 if nothing has changed since register.
+    bundle = await build_lg_config_bundle(db, collector)
+
+    write_audit(
+        db,
+        user=None,
+        action="looking_glass.agent.register",
+        resource_type="looking_glass_collector",
+        resource_id=str(collector.id),
+        resource_display=body.hostname,
+        new_value={"version": body.version},
+    )
+    await db.commit()
+    await db.refresh(collector)
+
+    logger.info(
+        "lg_agent_registered",
+        collector_id=str(collector.id),
+        hostname=body.hostname,
+    )
+    return AgentRegisterResponse(
+        collector_id=str(collector.id),
+        agent_id=str(collector.agent_id),
+        agent_token=token,
+        token_expires_at=exp,
+        config_etag=bundle.etag,
+    )
+
+
+@router.get("/config")
+async def agent_config_longpoll(
+    db: DB,
+    response: Response,
+    if_none_match: str | None = Header(default=None, alias="If-None-Match"),
+    auth: tuple[LookingGlassCollector, dict[str, Any]] = Depends(_auth_agent),
+) -> Any:
+    """Long-poll for peer-config changes. 304 if unchanged, bundle JSON otherwise."""
+    collector, _payload = auth
+
+    deadline = asyncio.get_running_loop().time() + LONGPOLL_TIMEOUT_SECONDS
+    async with wake_subscription(looking_glass_wake_channels(collector)) as wake:
+        # #358 — subscribe before the first bundle build so a committed +
+        # published peer change wakes this poll immediately; Redis-down
+        # degrades to the WAKE_TICK_SECONDS sleep (the ETag compare stays
+        # authoritative either way).
+        while True:
+            bundle = await build_lg_config_bundle(db, collector)
+            etag = bundle.etag
+            if etag != if_none_match:
+                logger.info(
+                    "lg_agent_config_200",
+                    collector_id=str(collector.id),
+                    etag=etag,
+                    if_none_match=if_none_match,
+                )
+                response.headers["ETag"] = etag
+                return {
+                    "collector_id": str(collector.id),
+                    "etag": etag,
+                    "bundle": {
+                        "collector_name": bundle.collector_name,
+                        "peers": [
+                            {
+                                "peer_id": p.peer_id,
+                                "name": p.name,
+                                "peer_address": p.peer_address,
+                                "peer_asn": p.peer_asn,
+                                "local_asn": p.local_asn,
+                                "address_families": list(p.address_families),
+                                "max_prefixes": p.max_prefixes,
+                                "import_filter": p.import_filter,
+                                # Decrypted MD5 secret — delivered ONLY here,
+                                # over TLS, to the JWT-authed collector; never
+                                # surfaced on an operator API.
+                                "md5_password": p.md5_password,
+                                "md5_password_set": p.md5_password_set,
+                            }
+                            for p in bundle.peers
+                        ],
+                    },
+                }
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                return Response(status_code=304, headers={"ETag": etag})
+            await wake.wait(min(WAKE_TICK_SECONDS, remaining))
+
+
+@router.post("/heartbeat", response_model=AgentHeartbeatResponse)
+async def agent_heartbeat(
+    request: Request,
+    body: AgentHeartbeatRequest,
+    db: DB,
+    auth: tuple[LookingGlassCollector, dict[str, Any]] = Depends(_auth_agent),
+) -> AgentHeartbeatResponse:
+    collector, payload = auth
+    now = datetime.now(UTC)
+    collector.last_seen_at = now
+    collector.last_health_check_at = now
+    collector.status = "active"
+    if request.client is not None:
+        collector.last_seen_ip = request.client.host
+    if body.agent_version:
+        collector.agent_version = body.agent_version
+
+    # Per-peer runtime state — only overwrite the columns the agent sent.
+    for rep in body.peers:
+        try:
+            pid = uuid.UUID(rep.peer_id)
+        except ValueError:
+            continue
+        peer = await db.get(BGPLGPeer, pid)
+        if peer is None or peer.collector_id != collector.id:
+            continue
+        if rep.session_state is not None:
+            peer.session_state = rep.session_state
+        # uptime_started_at is only meaningful while the session is
+        # Established. A plain ``is not None`` merge can't tell an
+        # agent-sent explicit null (session flapped down) from an omitted
+        # field, so on a flap-down the stale established-at timestamp would
+        # freeze and consumers would report a bogus multi-hour uptime for a
+        # session that is actually down. Clear it whenever the collector
+        # reports a non-established state; apply the agent's value otherwise.
+        if rep.uptime_started_at is not None:
+            peer.uptime_started_at = rep.uptime_started_at
+        elif rep.session_state is not None and rep.session_state != "established":
+            peer.uptime_started_at = None
+        if rep.prefixes_received is not None:
+            peer.prefixes_received = rep.prefixes_received
+        if rep.prefixes_accepted is not None:
+            peer.prefixes_accepted = rep.prefixes_accepted
+        if rep.last_state_change is not None:
+            peer.last_state_change = rep.last_state_change
+        if rep.last_flap_at is not None:
+            peer.last_flap_at = rep.last_flap_at
+        if rep.rpki_invalid_count is not None:
+            peer.rpki_invalid_count = rep.rpki_invalid_count
+
+    rotated_token = None
+    rotated_exp = None
+    if needs_rotation(payload):
+        rotated_token, rotated_exp = mint_agent_token(
+            collector_id=str(collector.id),
+            agent_id=str(collector.agent_id),
+            fingerprint=payload.get("fingerprint", ""),
+        )
+        collector.agent_token_hash = hash_token(rotated_token)
+
+    await db.commit()
+    return AgentHeartbeatResponse(
+        collector_id=str(collector.id),
+        status=collector.status,
+        acknowledged_at=now,
+        rotated_token=rotated_token,
+        rotated_expires_at=rotated_exp,
+    )
+
+
+@router.post("/routes")
+async def agent_routes(
+    body: RoutesPushRequest,
+    db: DB,
+    auth: tuple[LookingGlassCollector, dict[str, Any]] = Depends(_auth_agent),
+) -> dict[str, Any]:
+    """Ingest a peer's pushed Adj-RIB-In and reconcile into ``BGPLGRoute``.
+
+    A ``snapshot`` push is the peer's complete current RIB and runs the
+    absence-withdraw sweep (with the zero-wire floor guard); a delta push
+    is upsert-only. See ``services.looking_glass.routes_ingest``.
+    """
+    collector, _ = auth
+    try:
+        pid = uuid.UUID(body.peer_id)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=f"Invalid peer_id: {e}") from e
+    peer = await db.get(BGPLGPeer, pid)
+    if peer is None or peer.collector_id != collector.id:
+        raise HTTPException(status_code=404, detail="Peer not found")
+
+    result = await ingest_routes(
+        db,
+        peer,
+        [r.model_dump() for r in body.routes],
+        snapshot=body.snapshot,
+    )
+    await db.commit()
+    return {
+        "wire_routes": result.wire_routes,
+        "imported": result.imported,
+        "refreshed": result.refreshed,
+        "withdrawn": result.withdrawn,
+        "errors": result.errors,
+    }

--- a/backend/app/api/v1/looking_glass/router.py
+++ b/backend/app/api/v1/looking_glass/router.py
@@ -41,6 +41,7 @@ CLAUDE.md non-negotiable #4.
 from __future__ import annotations
 
 import ipaddress
+import re
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -60,6 +61,7 @@ from app.models.auth import User
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
 from app.models.network import NetworkDevice
 from app.services.bgp.hijack_monitor import RPKI_INVALID
+from app.services.looking_glass.as_path_query import as_path_regexp_clause
 from app.services.looking_glass.reverse_lookup import best_route_for_ip
 
 from .schemas import (
@@ -444,6 +446,15 @@ async def list_routes(
     prefix: str | None = Query(None, description="contains-or-within CIDR match"),
     origin_asn: int | None = None,
     community: str | None = Query(None, description="matches communities or large_communities"),
+    as_path_regexp: str | None = Query(
+        None,
+        max_length=128,
+        description=(
+            "AS-path regex (Cisco/Juniper '_' boundary convention), matched "
+            "against the space-joined AS path — e.g. '_65001_' (anywhere) or "
+            "'65001_$' (origin). See as_path_query.translate_as_path_regexp."
+        ),
+    ),
     rpki_status: str | None = None,
     peer_id: uuid.UUID | None = None,
     matched_block_id: uuid.UUID | None = None,
@@ -461,6 +472,9 @@ async def list_routes(
     Mirrors ``GET /ipam/addresses/search``'s ``{items,total}`` envelope —
     the RIB is "low thousands" scoped per issue #566's v1 design, so
     server-side pagination (not client windowing) is the right shape.
+    ``as_path_regexp`` (#566 Phase 4) matches the Cisco/Juniper ``_``
+    boundary-token convention against the space-joined AS path — see
+    ``app.services.looking_glass.as_path_query``.
     """
     q = select(BGPLGRoute)
 
@@ -478,6 +492,11 @@ async def list_routes(
                 BGPLGRoute.large_communities.contains([community]),
             )
         )
+    if as_path_regexp:
+        try:
+            q = q.where(as_path_regexp_clause(as_path_regexp))
+        except re.error as exc:
+            raise HTTPException(status_code=422, detail=f"invalid as_path_regexp: {exc}") from exc
     if rpki_status:
         q = q.where(BGPLGRoute.rpki_status == rpki_status)
     if peer_id is not None:

--- a/backend/app/api/v1/looking_glass/router.py
+++ b/backend/app/api/v1/looking_glass/router.py
@@ -53,11 +53,12 @@ from __future__ import annotations
 import ipaddress
 import re
 import uuid
+from collections import Counter
 from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -65,6 +66,7 @@ from app.api.deps import DB, CurrentUser
 from app.core.agent_wake import collect_wake, looking_glass_collector_channel
 from app.core.crypto import encrypt_str
 from app.core.permissions import require_resource_permission
+from app.models.alerts import AlertEvent, AlertRule
 from app.models.asn import ASN
 from app.models.audit import AuditLog
 from app.models.auth import User
@@ -84,6 +86,15 @@ from .schemas import (
     LookingGlassDashboardSummary,
     MulticastReachabilityResponse,
     PeerCreate,
+    PeerDetailAlert,
+    PeerDetailCollector,
+    PeerDetailCommunityCount,
+    PeerDetailMatchedAsn,
+    PeerDetailOriginAsnCount,
+    PeerDetailResponse,
+    PeerDetailRouter,
+    PeerDetailRouteStats,
+    PeerDetailRpkiBreakdown,
     PeerRead,
     PeerUpdate,
     RouteForIpResponse,
@@ -296,6 +307,177 @@ async def get_peer(peer_id: uuid.UUID, db: DB, _: CurrentUser) -> PeerRead:
     if p is None:
         raise HTTPException(status_code=404, detail="Peer not found")
     return _peer_to_read(p)
+
+
+@router.get("/peers/{peer_id}/detail", response_model=PeerDetailResponse)
+async def get_peer_detail(peer_id: uuid.UUID, db: DB, _: CurrentUser) -> PeerDetailResponse:
+    """Rich rollup backing the Sessions-tab peer detail modal (issue #566).
+
+    Composes the peer's own config + runtime state (``PeerRead`` already
+    carries every session-state field) with its collector, its matched
+    ASN/router links (when set), an aggregate view over its learned RIB
+    (``bgp_lg_route`` rows for this peer), and any open ``bgp_lg_*`` alerts
+    that reference it — either directly (``bgp_lg_session_down``, subject
+    type ``bgp_lg_peer``) or via one of its routes (every other
+    ``bgp_lg_*`` rule type, subject type ``bgp_lg_route``).
+    """
+    p = await db.get(BGPLGPeer, peer_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Peer not found")
+
+    collector = await db.get(LookingGlassCollector, p.collector_id)
+    if collector is None:
+        # FK is NOT NULL + CASCADE — a peer never outlives its collector.
+        raise HTTPException(status_code=500, detail="Peer's collector is missing")
+
+    matched_asn: PeerDetailMatchedAsn | None = None
+    if p.matched_asn_id is not None:
+        asn = await db.get(ASN, p.matched_asn_id)
+        if asn is not None:
+            matched_asn = PeerDetailMatchedAsn(id=asn.id, number=asn.number, name=asn.name)
+
+    peer_router: PeerDetailRouter | None = None
+    if p.peer_router_id is not None:
+        device = await db.get(NetworkDevice, p.peer_router_id)
+        if device is not None:
+            peer_router = PeerDetailRouter(id=device.id, name=device.name)
+
+    # ── Route-stats rollup ───────────────────────────────────────────
+    active_where = (BGPLGRoute.peer_id == p.id, BGPLGRoute.withdrawn_at.is_(None))
+
+    active_total = (
+        await db.execute(select(func.count()).select_from(BGPLGRoute).where(*active_where))
+    ).scalar_one()
+    withdrawn_total = (
+        await db.execute(
+            select(func.count())
+            .select_from(BGPLGRoute)
+            .where(BGPLGRoute.peer_id == p.id, BGPLGRoute.withdrawn_at.is_not(None))
+        )
+    ).scalar_one()
+    best_count = (
+        await db.execute(
+            select(func.count())
+            .select_from(BGPLGRoute)
+            .where(*active_where, BGPLGRoute.is_best.is_(True))
+        )
+    ).scalar_one()
+    has_vpn_routes = (
+        await db.execute(
+            select(func.count())
+            .select_from(BGPLGRoute)
+            .where(*active_where, BGPLGRoute.route_distinguisher != "")
+        )
+    ).scalar_one() > 0
+
+    rpki_rows = (
+        await db.execute(
+            select(BGPLGRoute.rpki_status, func.count())
+            .where(*active_where)
+            .group_by(BGPLGRoute.rpki_status)
+        )
+    ).all()
+    rpki_counts = {status: n for status, n in rpki_rows}
+    rpki = PeerDetailRpkiBreakdown(
+        valid=rpki_counts.get("valid", 0),
+        invalid=rpki_counts.get(RPKI_INVALID, 0),
+        unknown=rpki_counts.get("unknown", 0),
+    )
+
+    origin_rows = (
+        await db.execute(
+            select(BGPLGRoute.origin_asn, func.count())
+            .where(*active_where, BGPLGRoute.origin_asn.is_not(None))
+            .group_by(BGPLGRoute.origin_asn)
+            .order_by(func.count().desc())
+            .limit(5)
+        )
+    ).all()
+    top_origin_asns = [
+        PeerDetailOriginAsnCount(asn=asn, count=n) for asn, n in origin_rows if asn is not None
+    ]
+
+    # Community counting done in Python over the fetched rows — this
+    # peer's active RIB is small (per-peer scope, not the whole table), so
+    # unnest-in-SQL would be needless ceremony for a correctness-equivalent
+    # result.
+    community_rows = (
+        await db.execute(
+            select(BGPLGRoute.communities, BGPLGRoute.large_communities).where(*active_where)
+        )
+    ).all()
+    community_counter: Counter[str] = Counter()
+    for communities, large_communities in community_rows:
+        for c in communities or []:
+            community_counter[str(c)] += 1
+        for c in large_communities or []:
+            community_counter[str(c)] += 1
+    top_communities = [
+        PeerDetailCommunityCount(value=v, count=n) for v, n in community_counter.most_common(8)
+    ]
+
+    sample_rows = (
+        (
+            await db.execute(
+                select(BGPLGRoute).where(*active_where).order_by(BGPLGRoute.prefix).limit(8)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    route_stats = PeerDetailRouteStats(
+        active_total=active_total,
+        withdrawn_total=withdrawn_total,
+        best_count=best_count,
+        rpki=rpki,
+        top_origin_asns=top_origin_asns,
+        top_communities=top_communities,
+        has_vpn_routes=has_vpn_routes,
+        sample_routes=[_route_to_read(r) for r in sample_rows],
+    )
+
+    # ── Active bgp_lg_* alerts referencing this peer or its routes ────
+    route_ids = (
+        (await db.execute(select(BGPLGRoute.id).where(BGPLGRoute.peer_id == p.id))).scalars().all()
+    )
+    subject_match = [
+        and_(AlertEvent.subject_type == "bgp_lg_peer", AlertEvent.subject_id == str(p.id))
+    ]
+    if route_ids:
+        route_id_strs = [str(rid) for rid in route_ids]
+        subject_match.append(
+            and_(
+                AlertEvent.subject_type == "bgp_lg_route", AlertEvent.subject_id.in_(route_id_strs)
+            )
+        )
+
+    alert_rows = (
+        await db.execute(
+            select(
+                AlertEvent.severity, AlertEvent.message, AlertRule.rule_type, AlertEvent.fired_at
+            )
+            .join(AlertRule, AlertRule.id == AlertEvent.rule_id)
+            .where(
+                AlertEvent.resolved_at.is_(None),
+                AlertRule.rule_type.like("bgp_lg_%"),
+                or_(*subject_match),
+            )
+            .order_by(AlertEvent.fired_at.desc())
+        )
+    ).all()
+    active_alerts = [
+        PeerDetailAlert(severity=severity, message=message, rule_type=rule_type, fired_at=fired_at)
+        for severity, message, rule_type, fired_at in alert_rows
+    ]
+
+    return PeerDetailResponse(
+        peer=_peer_to_read(p),
+        collector=PeerDetailCollector.model_validate(collector),
+        matched_asn=matched_asn,
+        peer_router=peer_router,
+        route_stats=route_stats,
+        active_alerts=active_alerts,
+    )
 
 
 @router.patch("/peers/{peer_id}", response_model=PeerRead)

--- a/backend/app/api/v1/looking_glass/router.py
+++ b/backend/app/api/v1/looking_glass/router.py
@@ -1,0 +1,506 @@
+"""BGP Looking Glass — operator CRUD + read surface (issue #566).
+
+Mounted at ``/looking-glass`` (NOT ``/bgp`` — that's the #527 public-table
+hijack monitor router, gated on the ``network.asn`` module). This router is
+gated on its own ``network.looking_glass`` feature module by the top-level
+``app.api.v1.router`` include (not wired here — see that file).
+
+Endpoints:
+
+* ``/collectors`` — list/get/rename/enable/disable/delete. Registration is
+  agent-side (``POST /looking-glass/agents/register`` in ``agents.py``);
+  operators never create a collector row directly. Deleting a collector
+  cascades its peers (``bgp_lg_peer.collector_id`` FK ``ON DELETE CASCADE``)
+  and, transitively, their routes (``bgp_lg_route.peer_id`` FK
+  ``ON DELETE CASCADE``) — no manual cleanup needed here.
+* ``/peers`` — full CRUD on a configured BGP session. The MD5 password is
+  Fernet-encrypted on write and never returned in plaintext; responses carry
+  ``md5_password_set: bool`` instead. Every mutation collects a wake on the
+  owning collector's channel (post-commit flush is the caller's
+  ``wake_publishing`` router dependency, wired by the integrator) so the
+  collector's ConfigBundle long-poll re-fetches its peer set promptly
+  instead of waiting for the 12s safety tick.
+* ``/sessions`` — read-only per-peer runtime-state rollup (collector +
+  peer joined), the Sessions-tab feed.
+* ``/routes`` — the learned RIB, server-paginated + filterable. ``/routes``
+  (list) and ``/routes/{prefix:path}`` (all paths for one exact prefix) are
+  distinct URL shapes (different segment counts) so there's no route
+  collision regardless of declaration order.
+
+Every write handler writes an ``AuditLog`` row before ``commit()`` per
+CLAUDE.md non-negotiable #4.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import func, or_, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import DB, CurrentUser
+from app.core.agent_wake import collect_wake, looking_glass_collector_channel
+from app.core.crypto import encrypt_str
+from app.core.permissions import require_resource_permission
+from app.models.asn import ASN
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
+from app.models.network import NetworkDevice
+
+from .schemas import (
+    CollectorRead,
+    CollectorUpdate,
+    PeerCreate,
+    PeerRead,
+    PeerUpdate,
+    RouteListResponse,
+    RouteRead,
+    SessionRead,
+)
+
+router = APIRouter(
+    tags=["looking-glass"],
+    dependencies=[Depends(require_resource_permission("bgp_lg_peer"))],
+)
+
+
+# ── Audit helper (mirrors app.api.v1.dhcp._audit.write_audit) ──────────
+
+
+def _write_audit(
+    db: AsyncSession,
+    *,
+    user: User | None,
+    action: str,
+    resource_type: str,
+    resource_id: uuid.UUID,
+    resource_display: str,
+    changed_fields: list[str] | None = None,
+    new_value: dict[str, Any] | None = None,
+) -> None:
+    db.add(
+        AuditLog(
+            user_id=user.id if user else None,
+            user_display_name=user.display_name if user else "system",
+            auth_source=getattr(user, "auth_source", "local") or "local",
+            action=action,
+            resource_type=resource_type,
+            resource_id=str(resource_id),
+            resource_display=resource_display,
+            changed_fields=changed_fields,
+            new_value=new_value,
+        )
+    )
+
+
+# ── Collectors ──────────────────────────────────────────────────────────
+
+
+def _collector_to_read(c: LookingGlassCollector) -> CollectorRead:
+    return CollectorRead.model_validate(c)
+
+
+@router.get("/collectors", response_model=list[CollectorRead])
+async def list_collectors(db: DB, _: CurrentUser) -> list[CollectorRead]:
+    rows = (
+        (await db.execute(select(LookingGlassCollector).order_by(LookingGlassCollector.name)))
+        .scalars()
+        .all()
+    )
+    return [_collector_to_read(c) for c in rows]
+
+
+@router.get("/collectors/{collector_id}", response_model=CollectorRead)
+async def get_collector(collector_id: uuid.UUID, db: DB, _: CurrentUser) -> CollectorRead:
+    c = await db.get(LookingGlassCollector, collector_id)
+    if c is None:
+        raise HTTPException(status_code=404, detail="Collector not found")
+    return _collector_to_read(c)
+
+
+@router.patch("/collectors/{collector_id}", response_model=CollectorRead)
+async def update_collector(
+    collector_id: uuid.UUID, body: CollectorUpdate, db: DB, user: CurrentUser
+) -> CollectorRead:
+    c = await db.get(LookingGlassCollector, collector_id)
+    if c is None:
+        raise HTTPException(status_code=404, detail="Collector not found")
+
+    changes = body.model_dump(exclude_unset=True)
+    for k, v in changes.items():
+        setattr(c, k, v)
+
+    _write_audit(
+        db,
+        user=user,
+        action="update",
+        resource_type="looking_glass_collector",
+        resource_id=c.id,
+        resource_display=c.name,
+        changed_fields=list(changes.keys()),
+        new_value=changes,
+    )
+    await db.commit()
+    await db.refresh(c)
+    return _collector_to_read(c)
+
+
+@router.delete(
+    "/collectors/{collector_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None
+)
+async def delete_collector(collector_id: uuid.UUID, db: DB, user: CurrentUser) -> None:
+    c = await db.get(LookingGlassCollector, collector_id)
+    if c is None:
+        raise HTTPException(status_code=404, detail="Collector not found")
+
+    _write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="looking_glass_collector",
+        resource_id=c.id,
+        resource_display=c.name,
+    )
+    # FK CASCADE sweeps bgp_lg_peer rows (and, transitively, their
+    # bgp_lg_route rows) — no manual cleanup needed.
+    await db.delete(c)
+    await db.commit()
+    return None
+
+
+# ── Peers ───────────────────────────────────────────────────────────────
+
+
+def _peer_to_read(p: BGPLGPeer) -> PeerRead:
+    return PeerRead(
+        id=p.id,
+        name=p.name,
+        collector_id=p.collector_id,
+        local_asn=p.local_asn,
+        peer_asn=p.peer_asn,
+        peer_address=p.peer_address,
+        matched_asn_id=p.matched_asn_id,
+        peer_router_id=p.peer_router_id,
+        address_families=list(p.address_families or []),
+        md5_password_set=bool(p.md5_password_encrypted),
+        max_prefixes=p.max_prefixes,
+        import_filter=p.import_filter or {"mode": "accept_all"},
+        enabled=p.enabled,
+        description=p.description,
+        session_state=p.session_state,
+        uptime_started_at=p.uptime_started_at,
+        prefixes_received=p.prefixes_received,
+        prefixes_accepted=p.prefixes_accepted,
+        last_state_change=p.last_state_change,
+        last_flap_at=p.last_flap_at,
+        rpki_invalid_count=p.rpki_invalid_count,
+        down_since=p.down_since,
+        created_at=p.created_at,
+        modified_at=p.modified_at,
+    )
+
+
+@router.get("/peers", response_model=list[PeerRead])
+async def list_peers(
+    db: DB, _: CurrentUser, collector_id: uuid.UUID | None = None
+) -> list[PeerRead]:
+    q = select(BGPLGPeer).order_by(BGPLGPeer.name)
+    if collector_id is not None:
+        q = q.where(BGPLGPeer.collector_id == collector_id)
+    rows = (await db.execute(q)).scalars().all()
+    return [_peer_to_read(p) for p in rows]
+
+
+@router.post("/peers", response_model=PeerRead, status_code=status.HTTP_201_CREATED)
+async def create_peer(body: PeerCreate, db: DB, user: CurrentUser) -> PeerRead:
+    if (await db.get(LookingGlassCollector, body.collector_id)) is None:
+        raise HTTPException(status_code=422, detail="collector_id not found")
+    if body.matched_asn_id is not None and (await db.get(ASN, body.matched_asn_id)) is None:
+        raise HTTPException(status_code=422, detail="matched_asn_id not found")
+    if (
+        body.peer_router_id is not None
+        and (await db.get(NetworkDevice, body.peer_router_id)) is None
+    ):
+        raise HTTPException(status_code=422, detail="peer_router_id not found")
+
+    payload = body.model_dump(exclude={"md5_password"})
+    p = BGPLGPeer(**payload)
+    if body.md5_password:
+        p.md5_password_encrypted = encrypt_str(body.md5_password)
+    db.add(p)
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A peer for {body.peer_address} already exists on this collector.",
+        ) from exc
+
+    audit_payload = body.model_dump(mode="json", exclude={"md5_password"})
+    audit_payload["md5_password_set"] = bool(body.md5_password)
+    _write_audit(
+        db,
+        user=user,
+        action="create",
+        resource_type="bgp_lg_peer",
+        resource_id=p.id,
+        resource_display=p.name,
+        new_value=audit_payload,
+    )
+    collect_wake(looking_glass_collector_channel(p.collector_id))
+    await db.commit()
+    await db.refresh(p)
+    return _peer_to_read(p)
+
+
+@router.get("/peers/{peer_id}", response_model=PeerRead)
+async def get_peer(peer_id: uuid.UUID, db: DB, _: CurrentUser) -> PeerRead:
+    p = await db.get(BGPLGPeer, peer_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Peer not found")
+    return _peer_to_read(p)
+
+
+@router.patch("/peers/{peer_id}", response_model=PeerRead)
+async def update_peer(peer_id: uuid.UUID, body: PeerUpdate, db: DB, user: CurrentUser) -> PeerRead:
+    p = await db.get(BGPLGPeer, peer_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Peer not found")
+
+    old_collector_id = p.collector_id
+    was_enabled = p.enabled
+
+    raw_changes = body.model_dump(exclude_unset=True)
+    md5_password = raw_changes.pop("md5_password", None)
+    changes = raw_changes
+
+    if (
+        "collector_id" in changes
+        and (await db.get(LookingGlassCollector, changes["collector_id"])) is None
+    ):
+        raise HTTPException(status_code=422, detail="collector_id not found")
+    if (
+        changes.get("matched_asn_id") is not None
+        and (await db.get(ASN, changes["matched_asn_id"])) is None
+    ):
+        raise HTTPException(status_code=422, detail="matched_asn_id not found")
+    if (
+        changes.get("peer_router_id") is not None
+        and (await db.get(NetworkDevice, changes["peer_router_id"])) is None
+    ):
+        raise HTTPException(status_code=422, detail="peer_router_id not found")
+
+    for k, v in changes.items():
+        setattr(p, k, v)
+
+    # md5_password: truthy -> rotate; "" -> clear; omitted/None -> keep
+    # (mirrors NetworkDeviceUpdate's secret-rotation convention).
+    changed_fields = list(changes.keys())
+    if md5_password:
+        p.md5_password_encrypted = encrypt_str(md5_password)
+        changed_fields.append("md5_password_rotated")
+    elif md5_password == "":
+        p.md5_password_encrypted = None
+        changed_fields.append("md5_password_cleared")
+
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A peer for {p.peer_address} already exists on this collector.",
+        ) from exc
+
+    # Disabling a peer removes it from the config bundle, so the collector
+    # stops pushing for it and absence-reconcile never runs — its learned
+    # routes would otherwise stay "active" forever. Mark them withdrawn now.
+    # (Deleting a peer instead sweeps its routes via FK CASCADE.)
+    if was_enabled and not p.enabled:
+        await db.execute(
+            update(BGPLGRoute)
+            .where(BGPLGRoute.peer_id == p.id, BGPLGRoute.withdrawn_at.is_(None))
+            .values(withdrawn_at=datetime.now(UTC))
+        )
+
+    audit_payload = body.model_dump(mode="json", exclude_unset=True, exclude={"md5_password"})
+    _write_audit(
+        db,
+        user=user,
+        action="update",
+        resource_type="bgp_lg_peer",
+        resource_id=p.id,
+        resource_display=p.name,
+        changed_fields=changed_fields,
+        new_value=audit_payload,
+    )
+    # Wake the (possibly new) owning collector; if the peer moved to a
+    # different collector, also wake the old one so it drops the peer.
+    collect_wake(looking_glass_collector_channel(p.collector_id))
+    if p.collector_id != old_collector_id:
+        collect_wake(looking_glass_collector_channel(old_collector_id))
+    await db.commit()
+    await db.refresh(p)
+    return _peer_to_read(p)
+
+
+@router.delete("/peers/{peer_id}", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
+async def delete_peer(peer_id: uuid.UUID, db: DB, user: CurrentUser) -> None:
+    p = await db.get(BGPLGPeer, peer_id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="Peer not found")
+
+    _write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="bgp_lg_peer",
+        resource_id=p.id,
+        resource_display=p.name,
+    )
+    collector_id = p.collector_id
+    # FK CASCADE sweeps this peer's bgp_lg_route rows.
+    await db.delete(p)
+    collect_wake(looking_glass_collector_channel(collector_id))
+    await db.commit()
+    return None
+
+
+# ── Sessions (read-only per-peer state rollup) ───────────────────────────
+
+
+@router.get("/sessions", response_model=list[SessionRead])
+async def list_sessions(
+    db: DB, _: CurrentUser, collector_id: uuid.UUID | None = None
+) -> list[SessionRead]:
+    q = (
+        select(BGPLGPeer, LookingGlassCollector)
+        .join(LookingGlassCollector, LookingGlassCollector.id == BGPLGPeer.collector_id)
+        .order_by(LookingGlassCollector.name, BGPLGPeer.name)
+    )
+    if collector_id is not None:
+        q = q.where(BGPLGPeer.collector_id == collector_id)
+    rows = (await db.execute(q)).all()
+    return [
+        SessionRead(
+            peer_id=p.id,
+            peer_name=p.name,
+            collector_id=c.id,
+            collector_name=c.name,
+            collector_status=c.status,
+            local_asn=p.local_asn,
+            peer_asn=p.peer_asn,
+            peer_address=p.peer_address,
+            enabled=p.enabled,
+            session_state=p.session_state,
+            uptime_started_at=p.uptime_started_at,
+            prefixes_received=p.prefixes_received,
+            prefixes_accepted=p.prefixes_accepted,
+            last_state_change=p.last_state_change,
+            last_flap_at=p.last_flap_at,
+            rpki_invalid_count=p.rpki_invalid_count,
+            down_since=p.down_since,
+        )
+        for p, c in rows
+    ]
+
+
+# ── Routes (the learned RIB) ─────────────────────────────────────────────
+
+
+def _route_to_read(r: BGPLGRoute) -> RouteRead:
+    return RouteRead.model_validate(r)
+
+
+def _parse_prefix(raw: str) -> str:
+    try:
+        return str(ipaddress.ip_network(raw, strict=False))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=f"invalid prefix: {raw!r}") from exc
+
+
+@router.get("/routes", response_model=RouteListResponse)
+async def list_routes(
+    db: DB,
+    _: CurrentUser,
+    prefix: str | None = Query(None, description="contains-or-within CIDR match"),
+    origin_asn: int | None = None,
+    community: str | None = Query(None, description="matches communities or large_communities"),
+    rpki_status: str | None = None,
+    peer_id: uuid.UUID | None = None,
+    best_path_only: bool = False,
+    withdrawn: bool = Query(False, description="include withdrawn routes (hidden by default)"),
+    limit: int = Query(default=100, ge=1, le=1000),
+    offset: int = Query(default=0, ge=0),
+) -> RouteListResponse:
+    """Server-paginated, filterable view over the learned RIB.
+
+    Mirrors ``GET /ipam/addresses/search``'s ``{items,total}`` envelope —
+    the RIB is "low thousands" scoped per issue #566's v1 design, so
+    server-side pagination (not client windowing) is the right shape.
+    """
+    q = select(BGPLGRoute)
+
+    if prefix:
+        net = _parse_prefix(prefix)
+        # contains-or-within: match routes that are a supernet of, equal
+        # to, or a subnet of the requested prefix.
+        q = q.where(or_(BGPLGRoute.prefix.op(">>=")(net), BGPLGRoute.prefix.op("<<=")(net)))
+    if origin_asn is not None:
+        q = q.where(BGPLGRoute.origin_asn == origin_asn)
+    if community:
+        q = q.where(
+            or_(
+                BGPLGRoute.communities.contains([community]),
+                BGPLGRoute.large_communities.contains([community]),
+            )
+        )
+    if rpki_status:
+        q = q.where(BGPLGRoute.rpki_status == rpki_status)
+    if peer_id is not None:
+        q = q.where(BGPLGRoute.peer_id == peer_id)
+    if best_path_only:
+        q = q.where(BGPLGRoute.is_best.is_(True))
+    if not withdrawn:
+        q = q.where(BGPLGRoute.withdrawn_at.is_(None))
+
+    total = (
+        await db.execute(select(func.count()).select_from(q.order_by(None).subquery()))
+    ).scalar_one()
+    q = q.order_by(BGPLGRoute.prefix, BGPLGRoute.peer_id).offset(offset).limit(limit)
+    rows = (await db.execute(q)).scalars().all()
+    return RouteListResponse(
+        items=[_route_to_read(r) for r in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/routes/{prefix:path}", response_model=list[RouteRead])
+async def get_route(
+    prefix: str,
+    db: DB,
+    _: CurrentUser,
+    withdrawn: bool = Query(False, description="include withdrawn paths"),
+) -> list[RouteRead]:
+    """All paths for one exact prefix, across every peer.
+
+    Distinct from the ``prefix`` filter on ``GET /routes`` (which is a
+    contains-or-within match): this is an exact-prefix lookup, feeding the
+    "show ip bgp <prefix>" style detail view (and the future Query tab).
+    """
+    net = _parse_prefix(prefix)
+    q = select(BGPLGRoute).where(BGPLGRoute.prefix == net)
+    if not withdrawn:
+        q = q.where(BGPLGRoute.withdrawn_at.is_(None))
+    q = q.order_by(BGPLGRoute.peer_id)
+    rows = (await db.execute(q)).scalars().all()
+    return [_route_to_read(r) for r in rows]

--- a/backend/app/api/v1/looking_glass/router.py
+++ b/backend/app/api/v1/looking_glass/router.py
@@ -33,6 +33,16 @@ Endpoints:
   Dashboard's "Looking Glass health" card (issue #566 Phase 5). See
   ``LookingGlassDashboardSummary`` for why this is its own shape rather than
   the Integrations dashboard tab's ``IntegrationPanel``.
+* ``/vrf-rt-matches/{vrf_id}`` — issue #566 Phase 6. Which of a VRF's own
+  import/export route targets actually appear on a currently-active route
+  matched to that VRF (``matched_vrf_id``, which the VPNv4/VPNv6
+  Route-Target cross-check in ``app.services.looking_glass.vrf_match`` now
+  populates ahead of the plain IPAM-effective match). Feeds the VRF detail
+  page's "Learned VPN Routes" tab.
+* ``/multicast-reachability`` — issue #566 Phase 6, read-only. Cross-checks
+  PIM domain rendezvous-point addresses and multicast-group producer
+  source subnets against the learned RIB. See
+  ``app.services.looking_glass.reachability.multicast_bgp_reachability``.
 
 Every write handler writes an ``AuditLog`` row before ``commit()`` per
 CLAUDE.md non-negotiable #4.
@@ -60,14 +70,19 @@ from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
 from app.models.network import NetworkDevice
+from app.models.vrf import VRF
 from app.services.bgp.hijack_monitor import RPKI_INVALID
 from app.services.looking_glass.as_path_query import as_path_regexp_clause
 from app.services.looking_glass.reverse_lookup import best_route_for_ip
+from app.services.looking_glass.vrf_match import normalize_rt
 
 from .schemas import (
     CollectorRead,
     CollectorUpdate,
+    DomainReachability,
+    GroupSourceReachability,
     LookingGlassDashboardSummary,
+    MulticastReachabilityResponse,
     PeerCreate,
     PeerRead,
     PeerUpdate,
@@ -75,6 +90,8 @@ from .schemas import (
     RouteListResponse,
     RouteRead,
     SessionRead,
+    VrfRtMatchRow,
+    VrfRtMatchSummary,
 )
 
 router = APIRouter(
@@ -611,4 +628,103 @@ async def dashboard_summary(db: DB, _: CurrentUser) -> LookingGlassDashboardSumm
         peers_down=peers_down,
         routes_rpki_invalid=rpki_invalid,
         routes_flapping=flapping,
+    )
+
+
+# ── VRF Route-Target cross-check (issue #566 Phase 6) ───────────────────
+
+
+@router.get("/vrf-rt-matches/{vrf_id}", response_model=VrfRtMatchSummary)
+async def get_vrf_rt_matches(vrf_id: uuid.UUID, db: DB, _: CurrentUser) -> VrfRtMatchSummary:
+    """Which of a VRF's own import/export route targets actually show up on
+    a currently-active learned route matched to that VRF. Feeds the VRF
+    detail page's "Learned VPN Routes" tab RT cross-check — the routes
+    themselves are already reachable via ``GET /looking-glass/routes
+    ?matched_vrf_id=<vrf_id>`` (Phase 3); this endpoint answers "which RTs
+    are actually being hit" without the caller having to walk every
+    matched route's ``ext_communities`` client-side.
+    """
+    vrf = await db.get(VRF, vrf_id)
+    if vrf is None:
+        raise HTTPException(status_code=404, detail="VRF not found")
+
+    import_set = set(vrf.import_targets or [])
+    export_set = set(vrf.export_targets or [])
+
+    rows = (
+        (
+            await db.execute(
+                select(BGPLGRoute.ext_communities).where(
+                    BGPLGRoute.matched_vrf_id == vrf.id,
+                    BGPLGRoute.withdrawn_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    counts: dict[tuple[str, str], int] = {}
+    for ext_communities in rows:
+        hits: set[tuple[str, str]] = set()
+        for raw in ext_communities or []:
+            norm = normalize_rt(str(raw))
+            if norm in import_set:
+                hits.add((norm, "import"))
+            if norm in export_set:
+                hits.add((norm, "export"))
+        for key in hits:
+            counts[key] = counts.get(key, 0) + 1
+
+    route_targets = [
+        VrfRtMatchRow(route_target=rt, kind=kind, matched_route_count=n)
+        for (rt, kind), n in sorted(counts.items())
+    ]
+    return VrfRtMatchSummary(
+        vrf_id=vrf.id,
+        vrf_name=vrf.name,
+        matched_route_count=len(rows),
+        route_targets=route_targets,
+    )
+
+
+# ── Multicast BGP reachability cross-reference (issue #566 Phase 6) ─────
+
+
+@router.get("/multicast-reachability", response_model=MulticastReachabilityResponse)
+async def get_multicast_reachability(db: DB, _: CurrentUser) -> MulticastReachabilityResponse:
+    """Read-only cross-reference of multicast PIM RP addresses / producer
+    source subnets against the learned RIB. See
+    ``app.services.looking_glass.reachability.multicast_bgp_reachability``.
+
+    Sits under this router's ``network.looking_glass`` module gate but does
+    NOT also check ``network.multicast`` — reading multicast rows when that
+    module is toggled off is harmless (module-off only hides a surface, it
+    never deletes data, same as every other feature-module precedent in
+    this codebase).
+    """
+    from app.services.looking_glass.reachability import multicast_bgp_reachability
+
+    result = await multicast_bgp_reachability(db)
+    return MulticastReachabilityResponse(
+        domains=[
+            DomainReachability(
+                domain_id=d.domain_id,
+                domain_name=d.domain_name,
+                rp_address=d.rp_address,
+                covering_route=_route_to_read(d.covering_route) if d.covering_route else None,
+            )
+            for d in result.domains
+        ],
+        groups=[
+            GroupSourceReachability(
+                group_id=g.group_id,
+                group_name=g.group_name,
+                group_address=g.group_address,
+                source_subnet_id=g.source_subnet_id,
+                source_subnet=g.source_subnet,
+                covering_route=_route_to_read(g.covering_route) if g.covering_route else None,
+            )
+            for g in result.groups
+        ],
     )

--- a/backend/app/api/v1/looking_glass/router.py
+++ b/backend/app/api/v1/looking_glass/router.py
@@ -22,10 +22,13 @@ Endpoints:
   instead of waiting for the 12s safety tick.
 * ``/sessions`` — read-only per-peer runtime-state rollup (collector +
   peer joined), the Sessions-tab feed.
-* ``/routes`` — the learned RIB, server-paginated + filterable. ``/routes``
-  (list) and ``/routes/by-prefix?prefix=`` (all paths for one exact prefix,
-  the CIDR passed as a query param so its slash / IPv6 colons encode cleanly)
-  are distinct URL shapes so there's no route collision.
+* ``/routes`` — the learned RIB, server-paginated + filterable, including by
+  the ``matched_{block,subnet,space,asn,vrf}_id`` linkage columns populated by
+  ``app.services.looking_glass.ipam_link`` (issue #566 Phase 3). ``/routes``
+  (list), ``/routes/by-prefix?prefix=`` (all paths for one exact prefix, the
+  CIDR passed as a query param so its slash / IPv6 colons encode cleanly), and
+  ``/routes/for-ip?ip=`` (reverse LPM-by-single-address, Phase 3) are distinct
+  URL shapes so there's no route collision.
 
 Every write handler writes an ``AuditLog`` row before ``commit()`` per
 CLAUDE.md non-negotiable #4.
@@ -52,6 +55,7 @@ from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
 from app.models.network import NetworkDevice
+from app.services.looking_glass.reverse_lookup import best_route_for_ip
 
 from .schemas import (
     CollectorRead,
@@ -59,6 +63,7 @@ from .schemas import (
     PeerCreate,
     PeerRead,
     PeerUpdate,
+    RouteForIpResponse,
     RouteListResponse,
     RouteRead,
     SessionRead,
@@ -435,6 +440,11 @@ async def list_routes(
     community: str | None = Query(None, description="matches communities or large_communities"),
     rpki_status: str | None = None,
     peer_id: uuid.UUID | None = None,
+    matched_block_id: uuid.UUID | None = None,
+    matched_subnet_id: uuid.UUID | None = None,
+    matched_space_id: uuid.UUID | None = None,
+    matched_asn_id: uuid.UUID | None = None,
+    matched_vrf_id: uuid.UUID | None = None,
     best_path_only: bool = False,
     withdrawn: bool = Query(False, description="include withdrawn routes (hidden by default)"),
     limit: int = Query(default=100, ge=1, le=1000),
@@ -466,6 +476,16 @@ async def list_routes(
         q = q.where(BGPLGRoute.rpki_status == rpki_status)
     if peer_id is not None:
         q = q.where(BGPLGRoute.peer_id == peer_id)
+    if matched_block_id is not None:
+        q = q.where(BGPLGRoute.matched_block_id == matched_block_id)
+    if matched_subnet_id is not None:
+        q = q.where(BGPLGRoute.matched_subnet_id == matched_subnet_id)
+    if matched_space_id is not None:
+        q = q.where(BGPLGRoute.matched_space_id == matched_space_id)
+    if matched_asn_id is not None:
+        q = q.where(BGPLGRoute.matched_asn_id == matched_asn_id)
+    if matched_vrf_id is not None:
+        q = q.where(BGPLGRoute.matched_vrf_id == matched_vrf_id)
     if best_path_only:
         q = q.where(BGPLGRoute.is_best.is_(True))
     if not withdrawn:
@@ -508,3 +528,24 @@ async def get_route(
     q = q.order_by(BGPLGRoute.peer_id)
     rows = (await db.execute(q)).scalars().all()
     return [_route_to_read(r) for r in rows]
+
+
+@router.get("/routes/for-ip", response_model=RouteForIpResponse)
+async def get_route_for_ip(
+    db: DB,
+    _: CurrentUser,
+    ip: str = Query(..., description="A single IP address, v4 or v6."),
+) -> RouteForIpResponse:
+    """Reverse longest-prefix-match: which active route covers this one IP
+    address? Feeds the IP detail modal's "covering BGP route" section
+    (issue #566 Phase 3). Shares its LPM implementation with the
+    ``find_bgp_route_for_ip`` MCP tool via ``reverse_lookup.best_route_for_ip``
+    so the two surfaces can't drift.
+    """
+    result = await best_route_for_ip(db, ip)
+    if result is None:
+        return RouteForIpResponse(ip=ip, found=False)
+    route, alt_count = result
+    return RouteForIpResponse(
+        ip=ip, found=True, route=_route_to_read(route), alternate_paths_count=alt_count
+    )

--- a/backend/app/api/v1/looking_glass/router.py
+++ b/backend/app/api/v1/looking_glass/router.py
@@ -26,9 +26,12 @@ Endpoints:
   the ``matched_{block,subnet,space,asn,vrf}_id`` linkage columns populated by
   ``app.services.looking_glass.ipam_link`` (issue #566 Phase 3). ``/routes``
   (list), ``/routes/by-prefix?prefix=`` (all paths for one exact prefix, the
-  CIDR passed as a query param so its slash / IPv6 colons encode cleanly), and
-  ``/routes/for-ip?ip=`` (reverse LPM-by-single-address, Phase 3) are distinct
-  URL shapes so there's no route collision.
+  CIDR passed as a query param so its slash / IPv6 colons encode cleanly),
+  ``/routes/detail?prefix=`` (the same all-paths set, enriched with peer/
+  collector names + a server-computed summary/IPAM-context rollup — backs the
+  Routes-tab detail modal), and ``/routes/for-ip?ip=`` (reverse
+  LPM-by-single-address, Phase 3) are distinct URL shapes so there's no route
+  collision.
 * ``/dashboard-summary`` — single-shot peer/route rollup backing the main
   Dashboard's "Looking Glass health" card (issue #566 Phase 5). See
   ``LookingGlassDashboardSummary`` for why this is its own shape rather than
@@ -71,6 +74,7 @@ from app.models.asn import ASN
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
+from app.models.ipam import IPBlock, IPSpace, Subnet
 from app.models.network import NetworkDevice
 from app.models.vrf import VRF
 from app.services.bgp.hijack_monitor import RPKI_INVALID
@@ -97,6 +101,10 @@ from .schemas import (
     PeerDetailRpkiBreakdown,
     PeerRead,
     PeerUpdate,
+    RouteDetailIpamContext,
+    RouteDetailPath,
+    RouteDetailResponse,
+    RouteDetailSummary,
     RouteForIpResponse,
     RouteListResponse,
     RouteRead,
@@ -752,6 +760,162 @@ async def get_route(
     q = q.order_by(BGPLGRoute.peer_id)
     rows = (await db.execute(q)).scalars().all()
     return [_route_to_read(r) for r in rows]
+
+
+def _pick_matched_id(paths: list[RouteDetailPath], attr: str) -> uuid.UUID | None:
+    """Prefer the current best path's linkage; fall back to the first path
+    carrying a non-NULL value for this ``matched_*_id`` attribute. See
+    ``RouteDetailIpamContext``'s docstring for why paths can legitimately
+    disagree (VPNv4/VPNv6 per-route Route-Target VRF matching)."""
+    for path in paths:
+        if path.is_best and getattr(path, attr) is not None:
+            return getattr(path, attr)  # type: ignore[no-any-return]
+    for path in paths:
+        value = getattr(path, attr)
+        if value is not None:
+            return value  # type: ignore[no-any-return]
+    return None
+
+
+async def _build_route_ipam_context(
+    db: AsyncSession, paths: list[RouteDetailPath]
+) -> RouteDetailIpamContext:
+    ctx = RouteDetailIpamContext(
+        subnet_id=_pick_matched_id(paths, "matched_subnet_id"),
+        block_id=_pick_matched_id(paths, "matched_block_id"),
+        space_id=_pick_matched_id(paths, "matched_space_id"),
+        asn_id=_pick_matched_id(paths, "matched_asn_id"),
+        vrf_id=_pick_matched_id(paths, "matched_vrf_id"),
+    )
+    if ctx.subnet_id is not None:
+        subnet = await db.get(Subnet, ctx.subnet_id)
+        if subnet is not None:
+            ctx.subnet_name = subnet.name or str(subnet.network)
+    if ctx.block_id is not None:
+        block = await db.get(IPBlock, ctx.block_id)
+        if block is not None:
+            ctx.block_name = block.name or str(block.network)
+    if ctx.space_id is not None:
+        space = await db.get(IPSpace, ctx.space_id)
+        if space is not None:
+            ctx.space_name = space.name
+    if ctx.asn_id is not None:
+        asn = await db.get(ASN, ctx.asn_id)
+        if asn is not None:
+            ctx.asn_number = asn.number
+            ctx.asn_name = asn.name
+    if ctx.vrf_id is not None:
+        vrf = await db.get(VRF, ctx.vrf_id)
+        if vrf is not None:
+            ctx.vrf_name = vrf.name
+    return ctx
+
+
+@router.get("/routes/detail", response_model=RouteDetailResponse)
+async def get_route_detail(
+    db: DB,
+    _: CurrentUser,
+    prefix: str = Query(..., description="exact CIDR, e.g. 10.0.0.0/24 or 2001:db8::/32"),
+    withdrawn: bool = Query(False, description="include withdrawn paths"),
+) -> RouteDetailResponse:
+    """The rich per-prefix rollup backing the Routes-tab detail modal
+    (issue #566).
+
+    Same exact-prefix scope as ``/routes/by-prefix`` — every path across
+    every peer — but each path is enriched with its announcing peer +
+    collector name (avoiding an N-round-trip client-side join against
+    ``/peers``/``/collectors``), and a server-computed ``summary`` surfaces
+    the two headline signals up front:
+
+    * ``multi_origin`` — more than one *origin* ASN announcing this exact
+      prefix. This is the hijack/route-leak signal regardless of how many
+      peers/routers see it.
+    * ``anycast_candidate`` — the same prefix learned from more than one
+      router/peer. Combined with a single origin ASN this is the normal
+      anycast/multi-homed shape; combined with ``multi_origin`` it's a
+      stronger corroboration that this is either broad anycast or a
+      widely-visible hijack.
+
+    ``ipam`` carries the covering IPAM subnet/block/space plus the ASN/VRF
+    a path resolved against, so the modal can deep-link straight into IPAM
+    without a second lookup.
+    """
+    net = _parse_prefix(prefix)
+    q = (
+        select(BGPLGRoute, BGPLGPeer, LookingGlassCollector)
+        .join(BGPLGPeer, BGPLGPeer.id == BGPLGRoute.peer_id)
+        .join(LookingGlassCollector, LookingGlassCollector.id == BGPLGPeer.collector_id)
+        .where(BGPLGRoute.prefix == net)
+    )
+    if not withdrawn:
+        q = q.where(BGPLGRoute.withdrawn_at.is_(None))
+    q = q.order_by(LookingGlassCollector.name, BGPLGPeer.name)
+    rows = (await db.execute(q)).all()
+
+    paths = [
+        RouteDetailPath(
+            route_id=r.id,
+            peer_id=p.id,
+            peer_name=p.name,
+            collector_name=c.name,
+            origin_asn=r.origin_asn,
+            next_hop=str(r.next_hop),
+            local_pref=r.local_pref,
+            med=r.med,
+            as_path=list(r.as_path or []),
+            communities=list(r.communities or []),
+            large_communities=list(r.large_communities or []),
+            ext_communities=list(r.ext_communities or []),
+            route_distinguisher=r.route_distinguisher,
+            rpki_status=r.rpki_status,
+            is_best=r.is_best,
+            first_seen_at=r.first_seen_at,
+            last_seen_at=r.last_seen_at,
+            flap_count=r.flap_count,
+            withdrawn_at=r.withdrawn_at,
+            matched_subnet_id=r.matched_subnet_id,
+            matched_block_id=r.matched_block_id,
+            matched_space_id=r.matched_space_id,
+            matched_asn_id=r.matched_asn_id,
+            matched_vrf_id=r.matched_vrf_id,
+        )
+        for r, p, c in rows
+    ]
+
+    peer_count = len({path.peer_id for path in paths})
+    distinct_origin_asns = sorted(
+        {path.origin_asn for path in paths if path.origin_asn is not None}
+    )
+
+    rpki_counter: Counter[str] = Counter(path.rpki_status for path in paths)
+    rpki = PeerDetailRpkiBreakdown(
+        valid=rpki_counter.get("valid", 0),
+        invalid=rpki_counter.get(RPKI_INVALID, 0),
+        unknown=rpki_counter.get("unknown", 0),
+    )
+
+    origin_names: dict[int, str] = {}
+    if distinct_origin_asns:
+        asn_rows = (
+            await db.execute(
+                select(ASN.number, ASN.name).where(ASN.number.in_(distinct_origin_asns))
+            )
+        ).all()
+        origin_names = {int(number): name for number, name in asn_rows}
+
+    summary = RouteDetailSummary(
+        path_count=len(paths),
+        peer_count=peer_count,
+        distinct_origin_asns=distinct_origin_asns,
+        multi_origin=len(distinct_origin_asns) > 1,
+        anycast_candidate=peer_count > 1,
+        rpki=rpki,
+        origin_names=origin_names,
+    )
+
+    ipam = await _build_route_ipam_context(db, paths)
+
+    return RouteDetailResponse(prefix=net, paths=paths, summary=summary, ipam=ipam)
 
 
 @router.get("/routes/for-ip", response_model=RouteForIpResponse)

--- a/backend/app/api/v1/looking_glass/router.py
+++ b/backend/app/api/v1/looking_glass/router.py
@@ -29,6 +29,10 @@ Endpoints:
   CIDR passed as a query param so its slash / IPv6 colons encode cleanly), and
   ``/routes/for-ip?ip=`` (reverse LPM-by-single-address, Phase 3) are distinct
   URL shapes so there's no route collision.
+* ``/dashboard-summary`` — single-shot peer/route rollup backing the main
+  Dashboard's "Looking Glass health" card (issue #566 Phase 5). See
+  ``LookingGlassDashboardSummary`` for why this is its own shape rather than
+  the Integrations dashboard tab's ``IntegrationPanel``.
 
 Every write handler writes an ``AuditLog`` row before ``commit()`` per
 CLAUDE.md non-negotiable #4.
@@ -55,11 +59,13 @@ from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
 from app.models.network import NetworkDevice
+from app.services.bgp.hijack_monitor import RPKI_INVALID
 from app.services.looking_glass.reverse_lookup import best_route_for_ip
 
 from .schemas import (
     CollectorRead,
     CollectorUpdate,
+    LookingGlassDashboardSummary,
     PeerCreate,
     PeerRead,
     PeerUpdate,
@@ -548,4 +554,42 @@ async def get_route_for_ip(
     route, alt_count = result
     return RouteForIpResponse(
         ip=ip, found=True, route=_route_to_read(route), alternate_paths_count=alt_count
+    )
+
+
+@router.get("/dashboard-summary", response_model=LookingGlassDashboardSummary)
+async def dashboard_summary(db: DB, _: CurrentUser) -> LookingGlassDashboardSummary:
+    """Single-shot rollup backing the Dashboard's Looking Glass health
+    card. Peers/sessions are cheap to enumerate in full (bounded, like
+    ``list_sessions``); route counts use ``func.count()`` so the
+    "low-thousands" RIB is never pulled client-side just to compute a
+    KPI number.
+    """
+    peers = (await db.execute(select(BGPLGPeer).where(BGPLGPeer.enabled.is_(True)))).scalars().all()
+    peers_total = len(peers)
+    peers_established = sum(1 for p in peers if p.session_state == "established")
+    peers_down = peers_total - peers_established
+
+    rpki_invalid = (
+        await db.execute(
+            select(func.count())
+            .select_from(BGPLGRoute)
+            .where(BGPLGRoute.rpki_status == RPKI_INVALID, BGPLGRoute.withdrawn_at.is_(None))
+        )
+    ).scalar_one()
+
+    flapping = (
+        await db.execute(
+            select(func.count())
+            .select_from(BGPLGRoute)
+            .where(BGPLGRoute.flap_count >= 1, BGPLGRoute.withdrawn_at.is_(None))
+        )
+    ).scalar_one()
+
+    return LookingGlassDashboardSummary(
+        peers_total=peers_total,
+        peers_established=peers_established,
+        peers_down=peers_down,
+        routes_rpki_invalid=rpki_invalid,
+        routes_flapping=flapping,
     )

--- a/backend/app/api/v1/looking_glass/router.py
+++ b/backend/app/api/v1/looking_glass/router.py
@@ -23,9 +23,9 @@ Endpoints:
 * ``/sessions`` — read-only per-peer runtime-state rollup (collector +
   peer joined), the Sessions-tab feed.
 * ``/routes`` — the learned RIB, server-paginated + filterable. ``/routes``
-  (list) and ``/routes/{prefix:path}`` (all paths for one exact prefix) are
-  distinct URL shapes (different segment counts) so there's no route
-  collision regardless of declaration order.
+  (list) and ``/routes/by-prefix?prefix=`` (all paths for one exact prefix,
+  the CIDR passed as a query param so its slash / IPv6 colons encode cleanly)
+  are distinct URL shapes so there's no route collision.
 
 Every write handler writes an ``AuditLog`` row before ``commit()`` per
 CLAUDE.md non-negotiable #4.
@@ -484,14 +484,18 @@ async def list_routes(
     )
 
 
-@router.get("/routes/{prefix:path}", response_model=list[RouteRead])
+@router.get("/routes/by-prefix", response_model=list[RouteRead])
 async def get_route(
-    prefix: str,
     db: DB,
     _: CurrentUser,
+    prefix: str = Query(..., description="exact CIDR, e.g. 10.0.0.0/24 or 2001:db8::/32"),
     withdrawn: bool = Query(False, description="include withdrawn paths"),
 ) -> list[RouteRead]:
     """All paths for one exact prefix, across every peer.
+
+    ``prefix`` is a query parameter (not a path segment) so the CIDR slash +
+    IPv6 colons encode cleanly through proxies — a path-param ``{prefix:path}``
+    would need raw slashes that some proxies / %2F-decoders mangle.
 
     Distinct from the ``prefix`` filter on ``GET /routes`` (which is a
     contains-or-within match): this is an exact-prefix lookup, feeding the

--- a/backend/app/api/v1/looking_glass/schemas.py
+++ b/backend/app/api/v1/looking_glass/schemas.py
@@ -434,3 +434,92 @@ class MulticastReachabilityResponse(BaseModel):
 
     domains: list[DomainReachability]
     groups: list[GroupSourceReachability]
+
+
+# ── Peer detail rollup (issue #566 — Sessions-tab detail modal) ────────
+
+
+class PeerDetailCollector(BaseModel):
+    """Slim collector rollup for the peer detail modal — a subset of
+    ``CollectorRead`` (drops the registration bookkeeping fields the modal
+    has no use for)."""
+
+    id: uuid.UUID
+    name: str
+    host: str | None
+    status: str
+    last_seen_ip: str | None
+    agent_version: str | None
+    enabled: bool
+
+    model_config = {"from_attributes": True}
+
+
+class PeerDetailMatchedAsn(BaseModel):
+    id: uuid.UUID
+    number: int
+    name: str
+
+
+class PeerDetailRouter(BaseModel):
+    id: uuid.UUID
+    name: str
+
+
+class PeerDetailRpkiBreakdown(BaseModel):
+    valid: int = 0
+    invalid: int = 0
+    unknown: int = 0
+
+
+class PeerDetailOriginAsnCount(BaseModel):
+    asn: int
+    count: int
+
+
+class PeerDetailCommunityCount(BaseModel):
+    value: str
+    count: int
+
+
+class PeerDetailRouteStats(BaseModel):
+    """Rollup over this peer's ``bgp_lg_route`` rows."""
+
+    active_total: int
+    withdrawn_total: int
+    best_count: int
+    rpki: PeerDetailRpkiBreakdown
+    top_origin_asns: list[PeerDetailOriginAsnCount]
+    top_communities: list[PeerDetailCommunityCount]
+    # True when at least one active route carries a non-empty
+    # ``route_distinguisher`` — i.e. this peer has VPNv4/VPNv6 (RFC 4364)
+    # paths in its RIB, not just plain ipv4/ipv6-unicast.
+    has_vpn_routes: bool
+    # First ~8 active routes, for the modal's preview table.
+    sample_routes: list[RouteRead]
+
+
+class PeerDetailAlert(BaseModel):
+    """One open ``AlertEvent`` whose rule references this peer or one of
+    its learned routes (``bgp_lg_*`` rule types only)."""
+
+    severity: str
+    message: str
+    rule_type: str
+    fired_at: datetime
+
+
+class PeerDetailResponse(BaseModel):
+    """``GET /looking-glass/peers/{peer_id}/detail`` — the rich rollup
+    backing the Sessions-tab peer detail modal. Composes the peer's own
+    config + runtime state (``peer``, already carrying every session-state
+    field — see ``PeerRead``) with its collector, matched ASN/router links,
+    an aggregate view over its learned RIB, and any open ``bgp_lg_*``
+    alerts that reference it."""
+
+    peer: PeerRead
+    collector: PeerDetailCollector
+    matched_asn: PeerDetailMatchedAsn | None
+    peer_router: PeerDetailRouter | None
+    route_stats: PeerDetailRouteStats
+    active_alerts: list[PeerDetailAlert]

--- a/backend/app/api/v1/looking_glass/schemas.py
+++ b/backend/app/api/v1/looking_glass/schemas.py
@@ -523,3 +523,99 @@ class PeerDetailResponse(BaseModel):
     peer_router: PeerDetailRouter | None
     route_stats: PeerDetailRouteStats
     active_alerts: list[PeerDetailAlert]
+
+
+# ── Route detail rollup (issue #566 — Routes-tab detail modal) ─────────
+
+
+class RouteDetailPath(BaseModel):
+    """One peer's Adj-RIB-In path for the prefix, enriched with the
+    announcing peer + collector name so the modal's comparison table
+    doesn't need a second round-trip per row."""
+
+    route_id: uuid.UUID
+    peer_id: uuid.UUID
+    peer_name: str
+    collector_name: str
+    origin_asn: int | None
+    next_hop: str
+    local_pref: int | None
+    med: int | None
+    as_path: list[int]
+    communities: list[str]
+    large_communities: list[str]
+    ext_communities: list[str]
+    route_distinguisher: str
+    rpki_status: str
+    is_best: bool
+    first_seen_at: datetime
+    last_seen_at: datetime
+    flap_count: int
+    withdrawn_at: datetime | None
+    matched_subnet_id: uuid.UUID | None
+    matched_block_id: uuid.UUID | None
+    matched_space_id: uuid.UUID | None
+    matched_asn_id: uuid.UUID | None
+    matched_vrf_id: uuid.UUID | None
+
+    @field_validator("next_hop", mode="before")
+    @classmethod
+    def _coerce_next_hop(cls, v: Any) -> Any:
+        # asyncpg returns INET columns as ipaddress.IPv4Address/IPv6Address.
+        return str(v) if v is not None else v
+
+
+class RouteDetailSummary(BaseModel):
+    """Server-computed rollup over every path returned for the prefix — the
+    headline signal the modal leads with. ``anycast_candidate`` (same
+    prefix, multiple routers, single origin) and ``multi_origin`` (more
+    than one origin ASN announcing it) are mutually informative but NOT
+    mutually exclusive: an anycast deployment is multi-homed by design
+    (``anycast_candidate``), while ``multi_origin`` on its own — regardless
+    of peer count — is the hijack/leak signal."""
+
+    path_count: int
+    peer_count: int
+    distinct_origin_asns: list[int]
+    multi_origin: bool
+    anycast_candidate: bool
+    rpki: PeerDetailRpkiBreakdown
+    # origin ASN -> tracked ASN row's name, only for origins that match a
+    # row in the ASN catalog (unmatched origins are simply absent here).
+    origin_names: dict[int, str]
+
+
+class RouteDetailIpamContext(BaseModel):
+    """The covering IPAM object(s) for this prefix, plus the ASN/VRF a path
+    resolved against — read off the ``matched_*_id`` columns already
+    populated at ingest by ``app.services.looking_glass.ipam_link`` (and,
+    for ``vrf_id``, by the Phase 6 Route-Target cross-check). Preference is
+    given to the current best path's linkage when paths disagree (VPNv4/
+    VPNv6's per-route-target VRF match can legitimately differ path to
+    path); falls back to the first path carrying a non-NULL value."""
+
+    subnet_id: uuid.UUID | None = None
+    subnet_name: str | None = None
+    block_id: uuid.UUID | None = None
+    block_name: str | None = None
+    space_id: uuid.UUID | None = None
+    space_name: str | None = None
+    asn_id: uuid.UUID | None = None
+    asn_number: int | None = None
+    asn_name: str | None = None
+    vrf_id: uuid.UUID | None = None
+    vrf_name: str | None = None
+
+
+class RouteDetailResponse(BaseModel):
+    """``GET /looking-glass/routes/detail`` — the rich per-prefix rollup
+    backing the Routes-tab detail modal (issue #566). Unlike
+    ``GET /routes/by-prefix`` (a flat ``list[RouteRead]``), this composes
+    every active (or, with ``?withdrawn=true``, every) path for the exact
+    prefix with peer/collector names, a server-computed summary the modal
+    leads its banner with, and the covering IPAM/ASN/VRF context."""
+
+    prefix: str
+    paths: list[RouteDetailPath]
+    summary: RouteDetailSummary
+    ipam: RouteDetailIpamContext

--- a/backend/app/api/v1/looking_glass/schemas.py
+++ b/backend/app/api/v1/looking_glass/schemas.py
@@ -340,3 +340,16 @@ class RouteListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class RouteForIpResponse(BaseModel):
+    """``GET /looking-glass/routes/for-ip`` — reverse LPM-by-address lookup.
+
+    Mirrors the ``find_bgp_route_for_ip`` MCP tool's response shape (see
+    ``app.services.ai.tools.bgp_lg``) so the two surfaces stay in sync.
+    """
+
+    ip: str
+    found: bool
+    route: RouteRead | None = None
+    alternate_paths_count: int = 0

--- a/backend/app/api/v1/looking_glass/schemas.py
+++ b/backend/app/api/v1/looking_glass/schemas.py
@@ -1,0 +1,342 @@
+"""Pydantic v2 schemas for the BGP Looking Glass operator CRUD + read surface.
+
+Mirrors two conventions established elsewhere in the codebase:
+
+* The ``asns`` router's CIDR/INET ``@field_validator(..., mode="before")``
+  coercion — asyncpg returns ``CIDR``/``INET`` columns as
+  ``ipaddress.IPv4Network`` / ``IPv4Address`` instances (etc.), not ``str``,
+  so every read schema touching ``prefix`` / ``peer_address`` / ``next_hop``
+  needs the coercion or the response 500s.
+* The ``network`` router's Fernet ``_set`` boolean pattern — the plaintext
+  ``md5_password`` is never returned; presence is signalled by
+  ``PeerRead.md5_password_set``, computed inline from
+  ``bool(peer.md5_password_encrypted)`` in the router.
+
+See ``app.models.bgp_looking_glass`` for the underlying SQLAlchemy models.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+# v1 address-family scope — VPNv4/VPNv6/EVPN are a later phase (issue #566
+# plan §3.4/§6). Reject anything else at the API boundary rather than
+# silently accepting a family the collector daemon can't render.
+_VALID_ADDRESS_FAMILIES = frozenset({"ipv4-unicast", "ipv6-unicast"})
+
+# ``import_filter`` shape: {"mode": "accept_all"} or
+# {"mode": "scope", "prefixes": [...]}. See ``BGPLGPeer.import_filter``.
+_VALID_IMPORT_FILTER_MODES = frozenset({"accept_all", "scope"})
+
+# 32-bit AS-number range (RFC 7607 reserves 0). Mirrors ``asns/router.py``'s
+# ``_AS_MIN`` / ``_AS_MAX`` — kept as a local copy rather than importing from
+# that router module, since ``local_asn`` / ``peer_asn`` here are plain
+# BigIntegers, not necessarily backed by a tracked ``ASN`` row.
+_AS_MIN = 1
+_AS_MAX = 4_294_967_295
+
+
+def _validate_asn(v: int) -> int:
+    if not (_AS_MIN <= v <= _AS_MAX):
+        raise ValueError(
+            f"AS number must be between {_AS_MIN} and {_AS_MAX} (32-bit range; "
+            "0 is reserved per RFC 7607 and not allowed)"
+        )
+    return v
+
+
+def _validate_peer_address(v: str) -> str:
+    try:
+        ipaddress.ip_address(v)
+    except ValueError as exc:
+        raise ValueError(f"peer_address must be a bare IP address: {v!r}") from exc
+    return v
+
+
+def _validate_address_families(v: list[str]) -> list[str]:
+    bad = sorted({af for af in v if af not in _VALID_ADDRESS_FAMILIES})
+    if bad:
+        raise ValueError(
+            f"unsupported address_families {bad}; only "
+            f"{sorted(_VALID_ADDRESS_FAMILIES)} are supported in this phase "
+            "(VPNv4/VPNv6/EVPN deferred)"
+        )
+    return v
+
+
+def _validate_import_filter(v: dict[str, Any]) -> dict[str, Any]:
+    mode = v.get("mode")
+    if mode not in _VALID_IMPORT_FILTER_MODES:
+        raise ValueError(f"import_filter.mode must be one of {sorted(_VALID_IMPORT_FILTER_MODES)}")
+    if mode == "scope" and not isinstance(v.get("prefixes"), list):
+        raise ValueError("import_filter.prefixes must be a list when mode='scope'")
+    return v
+
+
+# ── Collector ─────────────────────────────────────────────────────────
+
+
+class CollectorRead(BaseModel):
+    """A ``LookingGlassCollector`` row — the agent-registration identity.
+
+    Registration/heartbeat fields (``agent_id``, ``agent_registered``,
+    ``last_seen_*``, ...) are agent-owned; operators may only rename,
+    enable/disable, or delete (see ``CollectorUpdate``).
+    """
+
+    id: uuid.UUID
+    name: str
+    description: str
+    host: str | None
+    status: str
+    enabled: bool
+    agent_id: str | None
+    agent_registered: bool
+    agent_version: str | None
+    last_seen_ip: str | None
+    last_seen_at: datetime | None
+    last_health_check_at: datetime | None
+    appliance_id: uuid.UUID | None
+    created_at: datetime
+    modified_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class CollectorUpdate(BaseModel):
+    """Operator rename / enable / disable.
+
+    Registration + host/agent identity are agent-owned (set by the
+    register/heartbeat endpoints, not here) — omitted fields are left
+    untouched (``exclude_unset`` semantics in the router).
+    """
+
+    name: str | None = None
+    description: str | None = None
+    enabled: bool | None = None
+
+
+# ── Peer ──────────────────────────────────────────────────────────────
+
+
+class PeerCreate(BaseModel):
+    name: str
+    collector_id: uuid.UUID
+    local_asn: int
+    peer_asn: int
+    peer_address: str
+    # Denormalised link to a tracked ASN row when one exists (raw
+    # ``peer_asn`` stays the source of truth).
+    matched_asn_id: uuid.UUID | None = None
+    # Optional link to the SNMP-polled device this session terminates on.
+    peer_router_id: uuid.UUID | None = None
+    address_families: list[str] = Field(default_factory=lambda: ["ipv4-unicast"])
+    # Plaintext MD5 password — Fernet-encrypted before storage, never
+    # echoed back. See ``PeerRead.md5_password_set``.
+    md5_password: str | None = None
+    max_prefixes: int = 10000
+    import_filter: dict[str, Any] = Field(default_factory=lambda: {"mode": "accept_all"})
+    enabled: bool = True
+    description: str = ""
+
+    @field_validator("local_asn", "peer_asn")
+    @classmethod
+    def _v_asn(cls, v: int) -> int:
+        return _validate_asn(v)
+
+    @field_validator("peer_address")
+    @classmethod
+    def _v_peer_address(cls, v: str) -> str:
+        return _validate_peer_address(v)
+
+    @field_validator("address_families")
+    @classmethod
+    def _v_afs(cls, v: list[str]) -> list[str]:
+        return _validate_address_families(v)
+
+    @field_validator("import_filter")
+    @classmethod
+    def _v_filter(cls, v: dict[str, Any]) -> dict[str, Any]:
+        return _validate_import_filter(v)
+
+    @field_validator("max_prefixes")
+    @classmethod
+    def _v_max_prefixes(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("max_prefixes must be >= 1")
+        return v
+
+
+class PeerUpdate(BaseModel):
+    """Partial update. ``exclude_unset`` semantics in the router.
+
+    ``md5_password``: a non-empty value rotates the stored ciphertext; an
+    explicit empty string (``""``) clears it; omitting the field (the
+    default ``None``) leaves the stored value untouched — mirrors
+    ``NetworkDeviceUpdate``'s secret-rotation convention.
+    """
+
+    name: str | None = None
+    collector_id: uuid.UUID | None = None
+    local_asn: int | None = None
+    peer_asn: int | None = None
+    peer_address: str | None = None
+    matched_asn_id: uuid.UUID | None = None
+    peer_router_id: uuid.UUID | None = None
+    address_families: list[str] | None = None
+    md5_password: str | None = None
+    max_prefixes: int | None = None
+    import_filter: dict[str, Any] | None = None
+    enabled: bool | None = None
+    description: str | None = None
+
+    @field_validator("local_asn", "peer_asn")
+    @classmethod
+    def _v_asn(cls, v: int | None) -> int | None:
+        return _validate_asn(v) if v is not None else v
+
+    @field_validator("peer_address")
+    @classmethod
+    def _v_peer_address(cls, v: str | None) -> str | None:
+        return _validate_peer_address(v) if v is not None else v
+
+    @field_validator("address_families")
+    @classmethod
+    def _v_afs(cls, v: list[str] | None) -> list[str] | None:
+        return _validate_address_families(v) if v is not None else v
+
+    @field_validator("import_filter")
+    @classmethod
+    def _v_filter(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        return _validate_import_filter(v) if v is not None else v
+
+    @field_validator("max_prefixes")
+    @classmethod
+    def _v_max_prefixes(cls, v: int | None) -> int | None:
+        if v is not None and v < 1:
+            raise ValueError("max_prefixes must be >= 1")
+        return v
+
+
+class PeerRead(BaseModel):
+    id: uuid.UUID
+    name: str
+    collector_id: uuid.UUID
+    local_asn: int
+    peer_asn: int
+    peer_address: str
+    matched_asn_id: uuid.UUID | None
+    peer_router_id: uuid.UUID | None
+    address_families: list[str]
+    md5_password_set: bool
+    max_prefixes: int
+    import_filter: dict[str, Any]
+    enabled: bool
+    description: str
+    # Runtime state (collector-reported via heartbeat).
+    session_state: str
+    uptime_started_at: datetime | None
+    prefixes_received: int
+    prefixes_accepted: int
+    last_state_change: datetime | None
+    last_flap_at: datetime | None
+    rpki_invalid_count: int
+    down_since: datetime | None
+    created_at: datetime
+    modified_at: datetime
+
+    @field_validator("peer_address", mode="before")
+    @classmethod
+    def _coerce_peer_address(cls, v: Any) -> Any:
+        # asyncpg returns INET columns as ipaddress.IPv4Address/IPv6Address.
+        return str(v) if v is not None else v
+
+
+# ── Sessions (per-peer state rollup) ───────────────────────────────────
+
+
+class SessionRead(BaseModel):
+    """One row per configured peer, joined with its owning collector.
+
+    Drives the Sessions-tab feed — the runtime BGP-session state next to
+    enough collector/peer context to render without a second round-trip.
+    """
+
+    peer_id: uuid.UUID
+    peer_name: str
+    collector_id: uuid.UUID
+    collector_name: str
+    collector_status: str
+    local_asn: int
+    peer_asn: int
+    peer_address: str
+    enabled: bool
+    session_state: str
+    uptime_started_at: datetime | None
+    prefixes_received: int
+    prefixes_accepted: int
+    last_state_change: datetime | None
+    last_flap_at: datetime | None
+    rpki_invalid_count: int
+    down_since: datetime | None
+
+    @field_validator("peer_address", mode="before")
+    @classmethod
+    def _coerce_peer_address(cls, v: Any) -> Any:
+        return str(v) if v is not None else v
+
+
+# ── Routes (the learned RIB) ───────────────────────────────────────────
+
+
+class RouteRead(BaseModel):
+    id: uuid.UUID
+    peer_id: uuid.UUID
+    prefix: str
+    origin_asn: int | None
+    as_path: list[int]
+    next_hop: str
+    local_pref: int | None
+    med: int | None
+    communities: list[str]
+    large_communities: list[str]
+    ext_communities: list[str]
+    rpki_status: str
+    is_best: bool
+    matched_block_id: uuid.UUID | None
+    matched_subnet_id: uuid.UUID | None
+    matched_space_id: uuid.UUID | None
+    matched_asn_id: uuid.UUID | None
+    matched_vrf_id: uuid.UUID | None
+    first_seen_at: datetime
+    last_seen_at: datetime
+    withdrawn_at: datetime | None
+    flap_count: int
+    detail: dict[str, Any] | None
+    created_at: datetime
+    modified_at: datetime
+
+    model_config = {"from_attributes": True}
+
+    @field_validator("prefix", "next_hop", mode="before")
+    @classmethod
+    def _coerce_ip(cls, v: Any) -> Any:
+        # asyncpg returns CIDR/INET columns as IPv4Network/IPv4Address (etc.)
+        # instances. Coerce to str so JSON serialisation has something to work
+        # with — see asns/router.py::ASNRpkiRoaRead._coerce_prefix.
+        return str(v) if v is not None else v
+
+
+class RouteListResponse(BaseModel):
+    """Server-paginated envelope for ``GET /looking-glass/routes`` — mirrors
+    ``AddressSearchResponse`` (``GET /ipam/addresses/search``)."""
+
+    items: list[RouteRead]
+    total: int
+    limit: int
+    offset: int

--- a/backend/app/api/v1/looking_glass/schemas.py
+++ b/backend/app/api/v1/looking_glass/schemas.py
@@ -24,10 +24,15 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
-# v1 address-family scope — VPNv4/VPNv6/EVPN are a later phase (issue #566
-# plan §3.4/§6). Reject anything else at the API boundary rather than
-# silently accepting a family the collector daemon can't render.
-_VALID_ADDRESS_FAMILIES = frozenset({"ipv4-unicast", "ipv6-unicast"})
+# v1 scope — EVPN is a later phase; VPNv4/VPNv6 landed in Phase 6 (issue
+# #566). Reject anything else at the API boundary rather than silently
+# accepting a family the collector daemon can't render. Note: the
+# collector-side GoBGP config render + RIB poll (agent/looking-glass/) is a
+# follow-up — this widening lands the API + control-plane VRF RT-matching
+# (app.services.looking_glass.vrf_match) now so peers can be configured and
+# ext_communities-carrying routes cross-checked against VRF import/export
+# targets ahead of the agent-side wire work.
+_VALID_ADDRESS_FAMILIES = frozenset({"ipv4-unicast", "ipv6-unicast", "vpnv4", "vpnv6"})
 
 # ``import_filter`` shape: {"mode": "accept_all"} or
 # {"mode": "scope", "prefixes": [...]}. See ``BGPLGPeer.import_filter``.
@@ -64,7 +69,7 @@ def _validate_address_families(v: list[str]) -> list[str]:
         raise ValueError(
             f"unsupported address_families {bad}; only "
             f"{sorted(_VALID_ADDRESS_FAMILIES)} are supported in this phase "
-            "(VPNv4/VPNv6/EVPN deferred)"
+            "(EVPN deferred)"
         )
     return v
 
@@ -306,6 +311,9 @@ class RouteRead(BaseModel):
     communities: list[str]
     large_communities: list[str]
     ext_communities: list[str]
+    # Route Distinguisher (RFC 4364) — non-empty only for vpnv4/vpnv6 paths;
+    # part of the row's identity server-side (issue #566 Phase 6).
+    route_distinguisher: str
     rpki_status: str
     is_best: bool
     matched_block_id: uuid.UUID | None
@@ -369,3 +377,60 @@ class LookingGlassDashboardSummary(BaseModel):
     peers_down: int
     routes_rpki_invalid: int
     routes_flapping: int
+
+
+# ── VRF Route-Target cross-check (issue #566 Phase 6) ──────────────────
+
+
+class VrfRtMatchRow(BaseModel):
+    """One of a VRF's own import/export route targets that actually shows up
+    on at least one currently-active learned route matched to that VRF."""
+
+    route_target: str
+    kind: str  # "import" | "export"
+    matched_route_count: int
+
+
+class VrfRtMatchSummary(BaseModel):
+    """``GET /looking-glass/vrf-rt-matches/{vrf_id}`` — feeds the VRF detail
+    page's "Learned VPN Routes" tab RT cross-check. ``matched_route_count``
+    is every active route currently linked to this VRF (via
+    ``BGPLGRoute.matched_vrf_id``, which Phase 6 sets from a Route-Target
+    match when one exists — see ``app.services.looking_glass.vrf_match`` —
+    falling back to the IPAM-effective VRF otherwise); ``route_targets``
+    breaks that count down by which of the VRF's own RTs were actually seen
+    in a matched route's ``ext_communities``."""
+
+    vrf_id: uuid.UUID
+    vrf_name: str
+    matched_route_count: int
+    route_targets: list[VrfRtMatchRow]
+
+
+# ── Multicast <-> BGP reachability cross-reference (issue #566 Phase 6) ──
+
+
+class DomainReachability(BaseModel):
+    domain_id: uuid.UUID
+    domain_name: str
+    rp_address: str
+    covering_route: RouteRead | None
+
+
+class GroupSourceReachability(BaseModel):
+    group_id: uuid.UUID
+    group_name: str
+    group_address: str
+    source_subnet_id: uuid.UUID
+    source_subnet: str
+    covering_route: RouteRead | None
+
+
+class MulticastReachabilityResponse(BaseModel):
+    """``GET /looking-glass/multicast-reachability`` — read-only, computed on
+    demand (no persisted columns; see
+    ``app.services.looking_glass.reachability.multicast_bgp_reachability``).
+    """
+
+    domains: list[DomainReachability]
+    groups: list[GroupSourceReachability]

--- a/backend/app/api/v1/looking_glass/schemas.py
+++ b/backend/app/api/v1/looking_glass/schemas.py
@@ -353,3 +353,19 @@ class RouteForIpResponse(BaseModel):
     found: bool
     route: RouteRead | None = None
     alternate_paths_count: int = 0
+
+
+class LookingGlassDashboardSummary(BaseModel):
+    """Single-shot rollup for the Dashboard's Looking Glass health card
+    (issue #566 Phase 5). Deliberately NOT shaped like the Integrations
+    dashboard tab's ``IntegrationPanel`` (``api/v1/dashboards/integrations.py``)
+    — that shape keys off pull-reconciler fields
+    (``last_synced_at``/``sync_interval_seconds``) that
+    ``LookingGlassCollector`` doesn't have (it's agent-push-registered,
+    like DNSServer/DHCPServer)."""
+
+    peers_total: int
+    peers_established: int
+    peers_down: int
+    routes_rpki_invalid: int
+    routes_flapping: int

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -45,6 +45,8 @@ from app.api.v1.groups.time_bound_grants import router as time_bound_grants_rout
 from app.api.v1.ipam.router import router as ipam_router
 from app.api.v1.kubernetes import router as kubernetes_router
 from app.api.v1.logs import logs_router
+from app.api.v1.looking_glass.agents import router as looking_glass_agents_router
+from app.api.v1.looking_glass.router import router as looking_glass_router
 from app.api.v1.metrics import router as metrics_router
 from app.api.v1.multicast import router as multicast_router
 from app.api.v1.netbox_import.router import router as netbox_import_router
@@ -270,6 +272,24 @@ api_v1_router.include_router(
     dependencies=[Depends(require_module("integrations.kubernetes"))],
 )
 api_v1_router.include_router(logs_router, prefix="/logs", tags=["logs"])
+# BGP Looking Glass (#566). Operator CRUD carries wake_publishing so a peer
+# config change wakes the parked collector long-poll; the agent router (which
+# holds that long-poll) is included without it, mirroring dns-agents.
+api_v1_router.include_router(
+    looking_glass_router,
+    prefix="/looking-glass",
+    tags=["looking-glass"],
+    dependencies=[
+        Depends(require_module("network.looking_glass")),
+        Depends(wake_publishing),
+    ],
+)
+api_v1_router.include_router(
+    looking_glass_agents_router,
+    prefix="/looking-glass",
+    tags=["looking-glass-agents"],
+    dependencies=[Depends(require_module("network.looking_glass"))],
+)
 api_v1_router.include_router(metrics_router, prefix="/metrics", tags=["metrics"])
 api_v1_router.include_router(
     multicast_router,

--- a/backend/app/api/v1/tools/router.py
+++ b/backend/app/api/v1/tools/router.py
@@ -16,14 +16,19 @@ The router itself is module-gated at the ``include_router`` site in
 ``app/api/v1/router.py`` via ``require_module("tools.network")`` (404s
 the whole surface when the feature module is off).
 
-Agent-perspective dispatch (this PR): every *reachability* tool (ping /
-traceroute / dig / port-test / tls-cert) accepts an optional ``target``.
-``target`` omitted or ``kind="server"`` runs inline on the api container
-exactly as before (``ran_from="server"``). ``kind="appliance"`` resolves
-the Fleet appliance row, re-validates server-side, and dispatches the
+Agent-perspective dispatch: every *reachability* tool (ping / traceroute /
+dig / port-test / tls-cert) accepts an optional ``target``. ``target``
+omitted or ``kind="server"`` runs inline on the api container exactly as
+before (``ran_from="server"``). ``kind="appliance"`` resolves the Fleet
+appliance row, re-validates server-side, and dispatches the
 already-validated job to the supervisor over the outbound poll channel
-(``ran_from="appliance:<name>"``). whois / mac-vendor / dns-propagation
-stay server-only and reject a non-server target.
+(``ran_from="appliance:<name>"``). ``kind="bgp_lg_collector"`` (#566
+Phase 4) resolves a ``LookingGlassCollector`` row to the ``Appliance`` it
+runs on and dispatches through the exact same channel, labelled
+``ran_from="looking_glass:<collector-name>"`` — see
+``_resolve_lg_collector_vantage`` / ``_dispatch_reachability``. whois /
+mac-vendor / dns-propagation stay server-only and reject a non-server
+target.
 """
 
 from __future__ import annotations
@@ -31,6 +36,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import time
+import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -62,6 +68,7 @@ from app.api.v1.tools.schemas import (
 from app.core.permissions import require_permission
 from app.models.appliance import Appliance
 from app.models.audit import AuditLog
+from app.models.bgp_looking_glass import LookingGlassCollector
 from app.models.settings import PlatformSettings
 from app.services import wol
 from app.services.appliance import agent_cmd
@@ -106,6 +113,11 @@ async def _dispatch_to_appliance[ResultT: BaseModel](
     db: DB,
     current_user: CurrentUser,
     allowed: frozenset[str] = agent_cmd.REACHABILITY_TOOLS,
+    appliance: Appliance | None = None,
+    vantage_label: str | None = None,
+    audit_resource_type: str = "appliance",
+    audit_resource_id: uuid.UUID | None = None,
+    audit_resource_display: str | None = None,
 ) -> ResultT:
     """Run a reachability tool FROM a Fleet appliance's vantage.
 
@@ -115,7 +127,11 @@ async def _dispatch_to_appliance[ResultT: BaseModel](
        guarantees this — only reachability endpoints call us — but we
        re-check so a future caller can't dispatch a server-only tool.)
        → 400.
-    b. Resolve the ``Appliance`` row. Unknown id → 404.
+    b. Resolve the ``Appliance`` row. Unknown id → 404. Skipped when
+       ``appliance`` is already supplied by the caller — see
+       ``_resolve_lg_collector_vantage`` (#566 Phase 4), which resolves a
+       collector-kind target to its owning appliance before calling in
+       here.
     c. RE-VALIDATE the request server-side through the SAME Pydantic
        schema the endpoint used (which re-runs ``assert_target_allowed``
        on every network-reaching field). We NEVER trust the supervisor
@@ -124,7 +140,12 @@ async def _dispatch_to_appliance[ResultT: BaseModel](
        → 502.
 
     Every appliance-targeted run is audit-logged (non-negotiable #4)
-    with the tool, the target appliance id+name, and the target host.
+    with the tool, the target host, and — by default — the appliance's
+    id/hostname. A caller dispatching on behalf of a different resource
+    (e.g. a Looking Glass collector) can override ``audit_resource_*`` /
+    ``vantage_label`` so the audit row + ``ran_from`` stamp describe the
+    resource the operator actually asked for, while the dispatch itself
+    still targets the resolved ``Appliance``.
     """
     # (a) dispatch gate — reachability tools by default; callers pass an
     # explicit allow-set for appliance-diagnostic tools (e.g. firewall_logs).
@@ -133,16 +154,18 @@ async def _dispatch_to_appliance[ResultT: BaseModel](
             status.HTTP_400_BAD_REQUEST,
             f"Tool {tool!r} cannot be run from an appliance vantage.",
         )
-    if target.id is None:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            "target.id is required when target.kind is 'appliance'.",
-        )
 
-    # (b) resolve the appliance row.
-    appliance = await db.get(Appliance, target.id)
+    # (b) resolve the appliance row, unless the caller already resolved it
+    # (e.g. from a bgp_lg_collector target via _resolve_lg_collector_vantage).
     if appliance is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Appliance not found.")
+        if target.id is None:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                "target.id is required when target.kind is 'appliance'.",
+            )
+        appliance = await db.get(Appliance, target.id)
+        if appliance is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "Appliance not found.")
 
     # (c) re-validate the params server-side through the same schema.
     # The request that reached this handler was already validated by
@@ -173,11 +196,15 @@ async def _dispatch_to_appliance[ResultT: BaseModel](
             user_display_name=current_user.display_name,
             auth_source=current_user.auth_source,
             action="tools.run_from_appliance",
-            resource_type="appliance",
-            resource_id=str(appliance.id),
-            resource_display=appliance.hostname,
+            resource_type=audit_resource_type,
+            resource_id=str(audit_resource_id or appliance.id),
+            resource_display=audit_resource_display or appliance.hostname,
             result="success",
-            new_value={"tool": tool, "target_host": target_host},
+            new_value={
+                "tool": tool,
+                "target_host": target_host,
+                **({"appliance": appliance.hostname} if audit_resource_type != "appliance" else {}),
+            },
         )
     )
     await db.commit()
@@ -211,7 +238,101 @@ async def _dispatch_to_appliance[ResultT: BaseModel](
 
     result = result_model.model_validate(outcome.result)
     # Stamp the vantage label so the UI can show where it ran.
-    return result.model_copy(update={"ran_from": f"appliance:{appliance.hostname}"})
+    return result.model_copy(
+        update={"ran_from": vantage_label or f"appliance:{appliance.hostname}"}
+    )
+
+
+async def _resolve_lg_collector_vantage(
+    db: DB, collector_id: uuid.UUID | None
+) -> tuple[LookingGlassCollector, Appliance]:
+    """Resolve a ``bgp_lg_collector`` target to the ``Appliance`` it runs
+    on (#566 Phase 4).
+
+    The collector container runs ``network_mode: host`` / ``hostNetwork:
+    true`` (shares the node's network namespace with the supervisor), so
+    dispatching to its owning appliance's supervisor is an exact vantage
+    match, not an approximation.
+
+    Raises:
+        400 — ``collector_id`` missing, or the collector exists but isn't
+          appliance-managed (a standalone docker-compose/K8s collector has
+          no inbound command channel — see the Phase 4 spec's Part A3
+          decision; run from Server instead).
+        404 — collector not found, or its ``appliance_id`` FK is somehow
+          dangling (shouldn't happen — ``ON DELETE CASCADE`` — defensive
+          only).
+    """
+    if collector_id is None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "target.id is required when target.kind is 'bgp_lg_collector'.",
+        )
+    collector = await db.get(LookingGlassCollector, collector_id)
+    if collector is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Collector not found.")
+    if collector.appliance_id is None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"Collector {collector.name!r} is not appliance-managed "
+            "(standalone docker/K8s deployment) and has no dispatchable "
+            "vantage — run from Server instead.",
+        )
+    appliance = await db.get(Appliance, collector.appliance_id)
+    if appliance is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            "The collector's owning appliance was not found.",
+        )
+    return collector, appliance
+
+
+async def _dispatch_reachability[ResultT: BaseModel](
+    *,
+    tool: str,
+    body: BaseModel,
+    request_model: type[BaseModel],
+    result_model: type[ResultT],
+    db: DB,
+    current_user: CurrentUser,
+) -> ResultT | None:
+    """Dispatch a reachability tool off-server if ``body.target`` asks for
+    it; returns ``None`` when the caller should run the tool inline
+    (server vantage — today's default behaviour).
+
+    Centralises the ``appliance`` vs ``bgp_lg_collector`` branch (#566
+    Phase 4) so each reachability handler (ping/traceroute/dig/port-test/
+    tls-cert) doesn't hand-roll it.
+    """
+    target: NetToolTarget | None = getattr(body, "target", None)
+    if _server_target(target):
+        return None
+    assert target is not None
+    if target.kind == "bgp_lg_collector":
+        collector, appliance = await _resolve_lg_collector_vantage(db, target.id)
+        return await _dispatch_to_appliance(
+            tool=tool,
+            params=body.model_dump(mode="json"),
+            request_model=request_model,
+            result_model=result_model,
+            target=NetToolTarget(kind="appliance", id=appliance.id),
+            db=db,
+            current_user=current_user,
+            appliance=appliance,
+            vantage_label=f"looking_glass:{collector.name}",
+            audit_resource_type="looking_glass_collector",
+            audit_resource_id=collector.id,
+            audit_resource_display=collector.name,
+        )
+    return await _dispatch_to_appliance(
+        tool=tool,
+        params=body.model_dump(mode="json"),
+        request_model=request_model,
+        result_model=result_model,
+        target=target,
+        db=db,
+        current_user=current_user,
+    )
 
 
 # ── subprocess tools (default budget) ───────────────────────────────
@@ -239,17 +360,16 @@ def _reject_non_server(tool: str, target: NetToolTarget | None) -> None:
 async def ping(
     body: HostRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> CommandResult:
-    if not _server_target(body.target):
-        assert body.target is not None  # narrowed by _server_target
-        return await _dispatch_to_appliance(
-            tool="ping",
-            params=body.model_dump(mode="json"),
-            request_model=HostRequest,
-            result_model=CommandResult,
-            target=body.target,
-            db=db,
-            current_user=current_user,
-        )
+    dispatched = await _dispatch_reachability(
+        tool="ping",
+        body=body,
+        request_model=HostRequest,
+        result_model=CommandResult,
+        db=db,
+        current_user=current_user,
+    )
+    if dispatched is not None:
+        return dispatched
     try:
         return await run_ping(body.host)
     except NetToolArgError as exc:
@@ -260,17 +380,16 @@ async def ping(
 async def traceroute(
     body: HostRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> CommandResult:
-    if not _server_target(body.target):
-        assert body.target is not None
-        return await _dispatch_to_appliance(
-            tool="traceroute",
-            params=body.model_dump(mode="json"),
-            request_model=HostRequest,
-            result_model=CommandResult,
-            target=body.target,
-            db=db,
-            current_user=current_user,
-        )
+    dispatched = await _dispatch_reachability(
+        tool="traceroute",
+        body=body,
+        request_model=HostRequest,
+        result_model=CommandResult,
+        db=db,
+        current_user=current_user,
+    )
+    if dispatched is not None:
+        return dispatched
     try:
         return await run_traceroute(body.host)
     except NetToolArgError as exc:
@@ -294,17 +413,16 @@ async def mtr(body: HostRequest, _rl=RateLimitDefault) -> CommandResult:
 async def dig(
     body: DigRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> CommandResult:
-    if not _server_target(body.target):
-        assert body.target is not None
-        return await _dispatch_to_appliance(
-            tool="dig",
-            params=body.model_dump(mode="json"),
-            request_model=DigRequest,
-            result_model=CommandResult,
-            target=body.target,
-            db=db,
-            current_user=current_user,
-        )
+    dispatched = await _dispatch_reachability(
+        tool="dig",
+        body=body,
+        request_model=DigRequest,
+        result_model=CommandResult,
+        db=db,
+        current_user=current_user,
+    )
+    if dispatched is not None:
+        return dispatched
     try:
         return await run_dig(body.name, body.record_type, body.server)
     except NetToolArgError as exc:
@@ -329,17 +447,16 @@ async def whois(body: WhoisRequest, _rl=RateLimitOffprem) -> CommandResult:
 async def port_test(
     body: PortTestRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> PortTestResult:
-    if not _server_target(body.target):
-        assert body.target is not None
-        return await _dispatch_to_appliance(
-            tool="port-test",
-            params=body.model_dump(mode="json"),
-            request_model=PortTestRequest,
-            result_model=PortTestResult,
-            target=body.target,
-            db=db,
-            current_user=current_user,
-        )
+    dispatched = await _dispatch_reachability(
+        tool="port-test",
+        body=body,
+        request_model=PortTestRequest,
+        result_model=PortTestResult,
+        db=db,
+        current_user=current_user,
+    )
+    if dispatched is not None:
+        return dispatched
     return await test_port(body.host, body.port, body.protocol, body.timeout_seconds)
 
 
@@ -347,17 +464,16 @@ async def port_test(
 async def tls_cert(
     body: TlsCertRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> TlsCertResult:
-    if not _server_target(body.target):
-        assert body.target is not None
-        return await _dispatch_to_appliance(
-            tool="tls-cert",
-            params=body.model_dump(mode="json"),
-            request_model=TlsCertRequest,
-            result_model=TlsCertResult,
-            target=body.target,
-            db=db,
-            current_user=current_user,
-        )
+    dispatched = await _dispatch_reachability(
+        tool="tls-cert",
+        body=body,
+        request_model=TlsCertRequest,
+        result_model=TlsCertResult,
+        db=db,
+        current_user=current_user,
+    )
+    if dispatched is not None:
+        return dispatched
     return await inspect_tls_cert(body.host, body.port, body.server_name, body.timeout_seconds)
 
 

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -14,6 +14,7 @@ celery_app = Celery(
         "app.tasks.ipam_utilization_recount",
         "app.tasks.dns",
         "app.tasks.dns_pull",
+        "app.tasks.looking_glass",
         "app.tasks.dhcp_health",
         "app.tasks.dhcp_lease_cleanup",
         "app.tasks.dhcp_mac_blocks",
@@ -136,6 +137,12 @@ celery_app.conf.update(
         # stayed ``status='active'`` forever).
         "dns-agent-stale-sweep": {
             "task": "app.tasks.dns.agent_stale_sweep",
+            "schedule": schedule(run_every=60.0),
+        },
+        # Every 60s, flip a Looking Glass collector to ``unreachable`` when its
+        # heartbeat has gone silent past the staleness window (#566).
+        "lg-collector-stale-sweep": {
+            "task": "app.tasks.looking_glass.collector_stale_sweep",
             "schedule": schedule(run_every=60.0),
         },
         # Every 60s, fan-out health checks to every registered DNS server.

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -145,6 +145,14 @@ celery_app.conf.update(
             "task": "app.tasks.looking_glass.collector_stale_sweep",
             "schedule": schedule(run_every=60.0),
         },
+        # Every 5 min, re-run the IPAM/ASN/VRF matcher over every active
+        # Looking Glass route — catches IPAM edits made between RIB
+        # pushes that a route's own re-announce wouldn't otherwise
+        # trigger a fresh resolve for (#566 Phase 3).
+        "lg-route-reresolve-sweep": {
+            "task": "app.tasks.looking_glass.reresolve_route_links",
+            "schedule": schedule(run_every=300.0),
+        },
         # Every 60s, fan-out health checks to every registered DNS server.
         "dns-health-sweep": {
             "task": "app.tasks.dns.check_all_dns_servers_health",

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -101,6 +101,9 @@ class Settings(BaseSettings):
     dhcp_agent_key: str = ""
     dhcp_agent_token_ttl_hours: int = 24
     dhcp_agent_longpoll_timeout: int = 30
+
+    # BGP Looking Glass collector agent (#566)
+    lg_agent_key: str = ""
     dhcp_require_agent_approval: bool = False
     dhcp_sync_interval_seconds: int = 60
     dhcp_lease_sync_interval_minutes: int = 5

--- a/backend/app/core/agent_wake.py
+++ b/backend/app/core/agent_wake.py
@@ -100,6 +100,10 @@ def dhcp_server_channel(server_id: uuid.UUID | str) -> str:
     return _ch("dhcp", "server", str(server_id))
 
 
+def looking_glass_collector_channel(collector_id: uuid.UUID | str) -> str:
+    return _ch("looking_glass", "collector", str(collector_id))
+
+
 def appliance_channel(appliance_id: uuid.UUID | str) -> str:
     """Per-appliance channel for the heartbeat-gated supervisor signals
     (#358 Phase 1): fleet OS/slot upgrade, reboot, role assignment, and
@@ -134,6 +138,15 @@ def dhcp_wake_channels(server: Any) -> list[str]:
         channels.append(dhcp_group_channel(server.server_group_id))
     channels.append(HOSTCONFIG_ALL)
     return channels
+
+
+def looking_glass_wake_channels(collector: Any) -> list[str]:
+    """Channel a Looking Glass collector's config long-poll subscribes to:
+    just its own collector row. A wake here means a peer was created /
+    edited / deleted and the collector should re-fetch its peer set. LG
+    has no group fan-out (peers hang directly off the collector).
+    """
+    return [looking_glass_collector_channel(collector.id)]
 
 
 def appliance_wake_channels(appliance: Any) -> list[str]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -486,6 +486,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await seed_bgp_hijack_alert_rules()
     except Exception as exc:  # noqa: BLE001
         logger.debug("bgp_hijack_alert_rules_seed_skipped", reason=str(exc))
+    # BGP Looking Glass troubleshooting alert rules — six, DISABLED by
+    # default (issue #566 Phase 5). Fire only once peers are configured
+    # (session_down / rpki_invalid_route / route_flap / a peer's own
+    # feed) and, for unexpected_origin / more_specific, at least one
+    # BGPTrackedPrefix owned-prefix row exists via the #527 UI; for
+    # missing_advertisement, at least one Subnet has
+    # bgp_should_advertise=true.
+    try:
+        from app.services.alerts import seed_bgp_lg_alert_rules  # noqa: PLC0415
+
+        await seed_bgp_lg_alert_rules()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("bgp_lg_alert_rules_seed_skipped", reason=str(exc))
     # DNSBL / RBL reputation catalog + alert rule (issue #528). The catalog
     # seeds the curated blocklists as platform rows (all disabled); the
     # ip_blocklisted alert rule seeds disabled. No off-prem calls at seed time.

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -21,6 +21,7 @@ from app.models.auth import APIToken, Group, Role, User, UserSession, user_group
 from app.models.auth_provider import AuthGroupMapping, AuthProvider
 from app.models.backup import BackupTarget
 from app.models.base import Base
+from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
 from app.models.bgp_monitor import BGPHijackDetection, BGPTrackedPrefix
 from app.models.change_request import ApprovalPolicy, ChangeRequest
 from app.models.circuit import Circuit
@@ -148,6 +149,9 @@ __all__ = [
     "BGPPeering",
     "BGPTrackedPrefix",
     "BGPHijackDetection",
+    "LookingGlassCollector",
+    "BGPLGPeer",
+    "BGPLGRoute",
     "User",
     "Group",
     "Role",

--- a/backend/app/models/bgp_looking_glass.py
+++ b/backend/app/models/bgp_looking_glass.py
@@ -1,0 +1,323 @@
+"""BGP Looking Glass — receive-only collector, sessions + learned RIB (issue #566).
+
+The internal-table companion to the #527 public-table hijack monitor. Where
+that watches the *public* routing table via RIPEstat / RIS Live, the Looking
+Glass peers with the operator's own routers over real BGP sessions and turns
+the live Adj-RIB-In into an operator surface — every prefix, origin ASN and
+community linked back into IPAM / the ASN catalog / the community catalog.
+
+Three tables:
+
+* ``looking_glass_collector`` — the agent-registration identity row for a
+  GoBGP collector daemon, one per appliance node (or standalone box). Shaped
+  like ``DNSServer`` / ``DHCPServer``: the register/heartbeat endpoints upsert
+  it keyed on ``agent_id``; ``BGPLGPeer.collector_id`` FKs to it. The daemon is
+  a **pure sink** — no export policy, receive-only.
+
+* ``bgp_lg_peer`` — a configured BGP session (one row per peer router). Carries
+  the config the collector renders into the GoBGP neighbor block
+  (``peer_asn`` / ``peer_address`` / ``address_families`` / ``max_prefixes`` /
+  optional Fernet MD5) plus collector-reported runtime state
+  (``session_state`` / ``prefixes_received`` / ``last_flap_at`` / …). The
+  ``max_prefixes`` cap is a hard safety limit rendered into the daemon's
+  ``prefix-limit`` — it protects the collector from a full-table blow-up.
+
+* ``bgp_lg_route`` — the learned RIB, control-plane-side source of truth for the
+  UI / IPAM linkage / alerts. One row per ``(peer, prefix, next_hop)`` path.
+  Absence-reconcile marks a route ``withdrawn_at`` (NOT a hard delete) when it
+  drops out of the peer's feed — mirroring the DHCP ``pull_leases`` shape, with
+  the same zero-wire floor guard on the ingest side. ``matched_*_id`` FKs link a
+  learned route to the IPAM block / subnet / space / ASN / VRF it falls under
+  (populated by a later phase; the columns ship now so no migration is needed).
+  ``rpki_status`` reuses ``derive_rpki_status()`` from the #527 hijack monitor.
+
+Distinct from #527 (public-table hijack monitor) and from the MetalLB VIP
+advertiser — the collector *receives* routes, it never advertises.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy import text as sa_text
+from sqlalchemy.dialects.postgresql import CIDR, INET, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class LookingGlassCollector(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A GoBGP receive-only collector daemon — the agent identity row.
+
+    Upserted by the register/heartbeat endpoints keyed on ``agent_id``. Shaped
+    like ``DNSServer`` / ``DHCPServer`` (agent bookkeeping) since it is itself an
+    agent-managed resource, not a passively-polled discovery target.
+    """
+
+    __tablename__ = "looking_glass_collector"
+    __table_args__ = (
+        UniqueConstraint("agent_id", name="uq_looking_glass_collector_agent_id"),
+        Index("ix_looking_glass_collector_name", "name"),
+    )
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=sa_text("''")
+    )
+    # Populated by the agent on register (its routable host / hostname).
+    host: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # status: unknown | active | unreachable | error
+    status: Mapped[str] = mapped_column(
+        String(50), nullable=False, default="unknown", server_default=sa_text("'unknown'")
+    )
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+
+    # Agent bookkeeping — mirrors DNSServer / DHCPServer.
+    agent_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    agent_registered: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    agent_token_hash: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    agent_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Source IP of the most recent agent heartbeat — operator-visible so a
+    # NAT'd / distributed collector can be identified. See dns_server.last_seen_ip.
+    last_seen_ip: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_health_check_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Issue #197 shape — deleting the owning appliance sweeps its collector
+    # rows via ON DELETE CASCADE. NULL for standalone / operator-registered
+    # collectors (off-fleet box, manual register).
+    appliance_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("appliance.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+
+
+class BGPLGPeer(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A configured receive-only BGP session held by a collector."""
+
+    __tablename__ = "bgp_lg_peer"
+    __table_args__ = (
+        # One receive-only session per (collector, neighbor address) — BGP has
+        # a single session per neighbor IP, and two peers sharing a collector +
+        # peer_address would render two GoBGP neighbor blocks with an identical
+        # neighbor-address and collapse into one RIB attribution slot.
+        UniqueConstraint("collector_id", "peer_address", name="uq_bgp_lg_peer_addr"),
+        Index("ix_bgp_lg_peer_collector", "collector_id"),
+        Index("ix_bgp_lg_peer_enabled", "enabled"),
+    )
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    collector_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("looking_glass_collector.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # ── Session config (rendered into the GoBGP neighbor block) ──────────
+    local_asn: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    peer_asn: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    peer_address: Mapped[str] = mapped_column(INET, nullable=False)
+
+    # Denormalised link to a tracked ASN row when one exists (raw ``peer_asn``
+    # stays the source of truth — a peer AS may have no local ASN row).
+    matched_asn_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("asn.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # Optional link to the SNMP-polled device this session terminates on.
+    peer_router_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("network_device.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # Address families to negotiate, e.g. ["ipv4-unicast", "ipv6-unicast"].
+    # VPNv4/VPNv6/EVPN are a later phase — v1 defaults to unicast.
+    address_families: Mapped[list] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=sa_text("'[\"ipv4-unicast\"]'::jsonb"),
+    )
+    # Fernet-encrypted TCP-MD5 password. Never returned in plaintext; the API
+    # exposes ``md5_password_set: bool`` computed inline. Rotate by supplying a
+    # new value; omit/blank on PATCH keeps the stored ciphertext.
+    md5_password_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+
+    # Hard per-peer safety cap rendered into the GoBGP prefix-limit — protects
+    # the sink from a full-table blow-up. Default enterprise-internal scale;
+    # raise for full-table feeds. See issue #566 (decision D4).
+    max_prefixes: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=10000, server_default=sa_text("10000")
+    )
+    # {"mode": "accept_all"} | {"mode": "scope", "prefixes": [...]} — scope the
+    # accepted RIB to configured IPAM spaces / an explicit prefix list.
+    import_filter: Mapped[dict] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=lambda: {"mode": "accept_all"},
+        server_default=sa_text('\'{"mode": "accept_all"}\'::jsonb'),
+    )
+
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    description: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=sa_text("''")
+    )
+
+    # ── Runtime state (collector-reported via heartbeat; "only overwrite when
+    #    the agent actually sends a value") ────────────────────────────────
+    # session_state: idle | connect | active | opensent | openconfirm | established
+    session_state: Mapped[str] = mapped_column(
+        String(24), nullable=False, default="idle", server_default=sa_text("'idle'")
+    )
+    uptime_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    prefixes_received: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=sa_text("0")
+    )
+    prefixes_accepted: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=sa_text("0")
+    )
+    last_state_change: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_flap_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rpki_invalid_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=sa_text("0")
+    )
+    # Watermark for the deferred bgp_lg_session_down grace-window alert
+    # (harmless to ship the column now).
+    down_since: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class BGPLGRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A learned route in a peer's Adj-RIB-In — the control-plane RIB mirror.
+
+    Absence-reconcile sets ``withdrawn_at`` (never a hard delete) when the route
+    drops out of the peer's feed. ``matched_*_id`` FKs link the route to the
+    IPAM object it falls under (populated by a later phase; columns ship now).
+    """
+
+    __tablename__ = "bgp_lg_route"
+    __table_args__ = (
+        UniqueConstraint("peer_id", "prefix", "next_hop", name="uq_bgp_lg_route"),
+        Index("ix_bgp_lg_route_peer", "peer_id"),
+        Index("ix_bgp_lg_route_origin_asn", "origin_asn"),
+        Index("ix_bgp_lg_route_prefix", "prefix"),
+        Index("ix_bgp_lg_route_rpki_status", "rpki_status"),
+        # The "active RIB" scan — everything not withdrawn.
+        Index(
+            "ix_bgp_lg_route_active",
+            "peer_id",
+            "prefix",
+            postgresql_where=sa_text("withdrawn_at IS NULL"),
+        ),
+        Index("ix_bgp_lg_route_matched_block", "matched_block_id"),
+        Index("ix_bgp_lg_route_matched_subnet", "matched_subnet_id"),
+        Index("ix_bgp_lg_route_matched_space", "matched_space_id"),
+        Index("ix_bgp_lg_route_matched_asn", "matched_asn_id"),
+        Index("ix_bgp_lg_route_matched_vrf", "matched_vrf_id"),
+    )
+
+    peer_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("bgp_lg_peer.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    prefix: Mapped[str] = mapped_column(CIDR, nullable=False)
+    # Denormalised origin (last AS in as_path) for the mismatch/link compares.
+    origin_asn: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # JSONB list[int] (no native ARRAY anywhere in this repo — convention).
+    as_path: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+    next_hop: Mapped[str] = mapped_column(INET, nullable=False)
+    local_pref: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    med: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Community wire-forms as JSONB list[str]; matched against the BGPCommunity
+    # catalog by value at render time (no FK — same precedent as the ASN/hijack
+    # subsystem).
+    communities: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+    large_communities: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+    # Extended communities carry RD/RT for the deferred VPNv4/VPNv6 phase.
+    ext_communities: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+
+    # valid | invalid | unknown — reuses derive_rpki_status() at ingest.
+    rpki_status: Mapped[str] = mapped_column(
+        String(12), nullable=False, default="unknown", server_default=sa_text("'unknown'")
+    )
+    is_best: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+
+    # IPAM / entity linkage — SET NULL so deleting an IPAM row never corrupts
+    # the live RIB row (the link is re-resolved on the next reconcile pass).
+    # Populated Phase 3/6; columns present now so no later migration is needed.
+    matched_block_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("ip_block.id", ondelete="SET NULL"), nullable=True
+    )
+    matched_subnet_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("subnet.id", ondelete="SET NULL"), nullable=True
+    )
+    matched_space_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("ip_space.id", ondelete="SET NULL"), nullable=True
+    )
+    matched_asn_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("asn.id", ondelete="SET NULL"), nullable=True
+    )
+    matched_vrf_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("vrf.id", ondelete="SET NULL"), nullable=True
+    )
+
+    first_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=sa_text("now()")
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=sa_text("now()")
+    )
+    # Absence-reconcile marker — set when the route leaves the peer's feed.
+    withdrawn_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    flap_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=sa_text("0")
+    )
+    # Vendor-attribute escape hatch (mirrors BGPHijackDetection.detail).
+    detail: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+
+__all__ = ["LookingGlassCollector", "BGPLGPeer", "BGPLGRoute"]

--- a/backend/app/models/bgp_looking_glass.py
+++ b/backend/app/models/bgp_looking_glass.py
@@ -27,8 +27,12 @@ Three tables:
   Absence-reconcile marks a route ``withdrawn_at`` (NOT a hard delete) when it
   drops out of the peer's feed — mirroring the DHCP ``pull_leases`` shape, with
   the same zero-wire floor guard on the ingest side. ``matched_*_id`` FKs link a
-  learned route to the IPAM block / subnet / space / ASN / VRF it falls under
-  (populated by a later phase; the columns ship now so no migration is needed).
+  learned route to the IPAM block / subnet / space / ASN / VRF it falls under,
+  populated at ingest by ``app.services.looking_glass.ipam_link`` (Phase 3) and,
+  for ``matched_vrf_id`` specifically, overridden by a Route-Target cross-check
+  against ``vrf.import_targets``/``export_targets`` when the route's
+  ``ext_communities`` carry a hit (``app.services.looking_glass.vrf_match``,
+  Phase 6) — see that module for the precedence rule.
   ``rpki_status`` reuses ``derive_rpki_status()`` from the #527 hijack monitor.
 
 Distinct from #527 (public-table hijack monitor) and from the MetalLB VIP
@@ -157,7 +161,10 @@ class BGPLGPeer(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     # Address families to negotiate, e.g. ["ipv4-unicast", "ipv6-unicast"].
-    # VPNv4/VPNv6/EVPN are a later phase — v1 defaults to unicast.
+    # vpnv4/vpnv6 accepted since issue #566 Phase 6 (see
+    # app.services.looking_glass.vrf_match for the VRF Route-Target
+    # cross-check that reads a matching route's ext_communities). EVPN
+    # remains a later phase.
     address_families: Mapped[list] = mapped_column(
         JSONB,
         nullable=False,
@@ -223,12 +230,24 @@ class BGPLGRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     Absence-reconcile sets ``withdrawn_at`` (never a hard delete) when the route
     drops out of the peer's feed. ``matched_*_id`` FKs link the route to the
-    IPAM object it falls under (populated by a later phase; columns ship now).
+    IPAM object it falls under (populated at ingest; see the module docstring).
     """
 
     __tablename__ = "bgp_lg_route"
     __table_args__ = (
-        UniqueConstraint("peer_id", "prefix", "next_hop", name="uq_bgp_lg_route"),
+        # ``route_distinguisher`` joined the identity in issue #566 Phase 6 —
+        # a VPNv4/VPNv6 path's RD (RFC 4364) is the whole reason two VRFs can
+        # originate the SAME customer prefix without collision; without it
+        # here, two different VRFs' overlapping prefixes learned via the
+        # same peer + next-hop (an ordinary shape — the PE's own loopback is
+        # the next-hop for every VRF it serves) would silently overwrite
+        # each other on this constraint. '' (not NULL) for plain
+        # ipv4-unicast/ipv6-unicast routes — Postgres treats every NULL as
+        # distinct in a UNIQUE constraint, so a nullable column here would
+        # silently defeat the existing dedup semantics for ordinary routes.
+        UniqueConstraint(
+            "peer_id", "prefix", "next_hop", "route_distinguisher", name="uq_bgp_lg_route"
+        ),
         Index("ix_bgp_lg_route_peer", "peer_id"),
         Index("ix_bgp_lg_route_origin_asn", "origin_asn"),
         Index("ix_bgp_lg_route_prefix", "prefix"),
@@ -246,6 +265,13 @@ class BGPLGRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         Index("ix_bgp_lg_route_matched_asn", "matched_asn_id"),
         Index("ix_bgp_lg_route_matched_vrf", "matched_vrf_id"),
         Index("ix_bgp_lg_route_last_flap_at", "last_flap_at"),
+        # Supports the VRF "Learned VPN Routes" tab / admin debug queries
+        # filtering to VPN-carrying rows specifically.
+        Index(
+            "ix_bgp_lg_route_rd",
+            "route_distinguisher",
+            postgresql_where=sa_text("route_distinguisher != ''"),
+        ),
     )
 
     peer_id: Mapped[uuid.UUID] = mapped_column(
@@ -274,9 +300,28 @@ class BGPLGRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     large_communities: Mapped[list] = mapped_column(
         JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
     )
-    # Extended communities carry RD/RT for the deferred VPNv4/VPNv6 phase.
+    # Extended communities carry the Route Target for VPNv4/VPNv6 routes;
+    # matched against vrf.import_targets/export_targets at ingest (and by the
+    # periodic re-resolve sweep) to populate matched_vrf_id — see
+    # app.services.looking_glass.vrf_match (issue #566 Phase 6). This match
+    # takes precedence over the plain IPAM-effective-VRF match (see
+    # app.services.looking_glass.ipam_link) when a Route Target hit is
+    # found. Note: this column does NOT carry the Route Distinguisher — RD
+    # is part of the VPN-IPv4/VPN-IPv6 NLRI (RFC 4364), not an extended
+    # community; it lives in the dedicated ``route_distinguisher`` column
+    # below.
     ext_communities: Mapped[list] = mapped_column(
         JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+    # Route Distinguisher for VPNv4/VPNv6 paths (RFC 4364) — part of the
+    # NLRI, not an extended community. '' (not NULL) for plain
+    # ipv4-unicast/ipv6-unicast routes (see the migration docstring and
+    # uq_bgp_lg_route above for why NULL would silently break dedup).
+    # Participates in route identity because RD's entire purpose is
+    # letting two VRFs originate the same customer prefix without
+    # collision (issue #566 Phase 6).
+    route_distinguisher: Mapped[str] = mapped_column(
+        String(64), nullable=False, default="", server_default=sa_text("''")
     )
 
     # valid | invalid | unknown — reuses derive_rpki_status() at ingest.

--- a/backend/app/models/bgp_looking_glass.py
+++ b/backend/app/models/bgp_looking_glass.py
@@ -245,6 +245,7 @@ class BGPLGRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         Index("ix_bgp_lg_route_matched_space", "matched_space_id"),
         Index("ix_bgp_lg_route_matched_asn", "matched_asn_id"),
         Index("ix_bgp_lg_route_matched_vrf", "matched_vrf_id"),
+        Index("ix_bgp_lg_route_last_flap_at", "last_flap_at"),
     )
 
     peer_id: Mapped[uuid.UUID] = mapped_column(
@@ -316,6 +317,15 @@ class BGPLGRoute(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     flap_count: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default=sa_text("0")
     )
+    # Timestamp of the most recent absence-withdraw bump on this row
+    # (issue #566 Phase 5) — lets bgp_lg_route_flap require a RECENT
+    # flap, not just a lifetime count, so a route that flapped a lot
+    # months ago but has been stable since doesn't page forever. Stamped
+    # by routes_ingest.py's absence-withdraw branch alongside
+    # flap_count. Distinct from BGPLGPeer.last_flap_at (a peer SESSION
+    # flap, different model/table) — this is a per-route
+    # announce/withdraw flap.
+    last_flap_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # Vendor-attribute escape hatch (mirrors BGPHijackDetection.detail).
     detail: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -444,6 +444,11 @@ class Subnet(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     __table_args__ = (
         Index("ix_subnet_network", "network"),
         Index("ix_subnet_decom_date", "decom_date"),
+        Index(
+            "ix_subnet_bgp_should_advertise",
+            "bgp_should_advertise",
+            postgresql_where=sa_text("bgp_should_advertise = true"),
+        ),
         # Subnets cannot overlap within the same IP space (enforced at application layer)
     )
 
@@ -667,6 +672,17 @@ class Subnet(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     # so existing rows are not retroactively misclassified. Values:
     # ``data`` / ``voice`` / ``management`` / ``guest``.
     subnet_role: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    # BGP Looking Glass "should be advertised" flag (issue #566 Phase
+    # 5). Pure operator intent — the collector is receive-only and
+    # never advertises anything; this just marks "the network is
+    # SUPPOSED to be carrying this prefix over BGP somewhere" so the
+    # bgp_lg_missing_advertisement alert has an owned-intent signal to
+    # check the live RIB against. Indexed (partial, WHERE true) so the
+    # alert's scan stays cheap regardless of subnet-table size.
+    bgp_should_advertise: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
 
     # Kubernetes integration provenance. When set, the subnet was auto-
     # created by the Kubernetes reconciler for this cluster; the FK

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -930,6 +930,33 @@ class PlatformSettings(Base):
         String(64), nullable=False, default="", server_default=sa_text("''")
     )
 
+    # ── MetalLB BGP mode (issue #566 decision D1) ───────────────────
+    # Distinct from the L2/ARP ``metallb_enabled`` above — BGP mode is
+    # an ADDITIONAL export path (advertise the control-plane VIP + any
+    # data-plane VIPs to real upstream routers via BGP) layered on top
+    # of the same MetalLB install. Requires ``metallb_enabled=True``
+    # (BGP peers/advertisements without a running MetalLB are inert).
+    # Applied by the seed supervisor via the SAME apply_metallb_overrides
+    # call as the L2 pool (one combined HelmChartConfig valuesContent —
+    # see k8s_api.py comment). Activates the GPL-v2 FRRouting image via
+    # MetalLB's frr-k8s backend — see NOTICE.
+    metallb_bgp_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    # List of {"my_asn": int, "peer_asn": int, "peer_address": str,
+    # "peer_port": int|None, "hold_time": str|None} dicts — one BGPPeer
+    # CR per entry (chart already renders this; see metallb-bgp.yaml).
+    metallb_bgp_peers: Mapped[list[dict]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+    # List of {"ip_address_pools": [str], "communities": [str]|None,
+    # "aggregation_length": int|None} dicts — one BGPAdvertisement CR
+    # per entry. Empty list + bgp_enabled=True is invalid (validated at
+    # the API layer, not the DB) — nothing gets advertised.
+    metallb_bgp_advertisements: Mapped[list[dict]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+
     # ── Embedded ACME client — Let's Encrypt for the Web UI (issue #438) ─
     # SpatiumDDI acting as an ACME client against a public CA to issue a
     # CA-trusted TLS cert for the appliance Web UI, solving DNS-01 through

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -3789,3 +3789,239 @@ register(
         required_permission=("write", "dhcp_server"),
     )
 )
+
+
+# ── create_lg_peer (issue #566 — BGP Looking Glass) ─────────────────────
+#
+# Creates a configured, receive-only bgp_lg_peer session on a collector.
+# The hard safety invariant (no export policy — the collector never
+# advertises back to the peer) lives in the daemon's rendered config, not
+# here; this operation only validates + persists the session row.
+
+_LG_ASN_MIN = 1
+_LG_ASN_MAX = 4_294_967_295
+# v1 only negotiates unicast AFI/SAFIs — VPNv4/VPNv6/EVPN are a later
+# phase (issue #566 §6). Rejecting anything else here keeps a bad
+# address_families value from reaching the GoBGP config renderer.
+_LG_ADDRESS_FAMILIES = frozenset({"ipv4-unicast", "ipv6-unicast"})
+
+
+class CreateLgPeerArgs(BaseModel):
+    """Args for the ``create_lg_peer`` operation."""
+
+    collector_id: UUID = Field(description="The looking_glass_collector this session runs on.")
+    name: str = Field(description="Operator-facing label for the peer session.")
+    local_asn: int = Field(description="The collector's own AS number for this session.")
+    peer_asn: int = Field(description="The remote router's AS number.")
+    peer_address: str = Field(description="The remote router's IP address (v4 or v6).")
+    peer_router_id: UUID | None = Field(
+        default=None,
+        description="Optional link to an existing network_device (SNMP-polled inventory) row.",
+    )
+    address_families: list[str] | None = Field(
+        default=None,
+        description=(
+            "AFI/SAFIs to negotiate. Defaults to ['ipv4-unicast']. Supported "
+            "today: ipv4-unicast, ipv6-unicast (VPNv4/EVPN are a later phase)."
+        ),
+    )
+    max_prefixes: int | None = Field(
+        default=None,
+        description=(
+            "Hard prefix-limit cap rendered into the GoBGP peer config as a "
+            "safety guard. Defaults to 10000; raise for a full-table feed."
+        ),
+    )
+    md5_password: str | None = Field(
+        default=None,
+        description=(
+            "Optional TCP-MD5 session password. Fernet-encrypted at rest; "
+            "never returned in plaintext by any read surface."
+        ),
+    )
+    import_filter: dict[str, Any] | None = Field(
+        default=None,
+        description="Route acceptance scope. Defaults to {'mode': 'accept_all'}.",
+    )
+    enabled: bool = Field(default=True)
+    description: str = Field(default="", description="Free-form note.")
+
+
+async def _validate_lg_peer_args(
+    db: AsyncSession, args: CreateLgPeerArgs
+) -> tuple[Any, str | None]:
+    """Shared validation for preview + apply. Returns ``(collector, error)``
+    — ``error`` is a human-readable rejection reason, or ``None`` when the
+    args are clean. No writes."""
+    from app.models.bgp_looking_glass import LookingGlassCollector  # noqa: PLC0415
+    from app.models.network import NetworkDevice  # noqa: PLC0415
+
+    collector = await db.get(LookingGlassCollector, args.collector_id)
+    if collector is None:
+        return None, f"Collector {args.collector_id} not found."
+
+    for label, number in (("local_asn", args.local_asn), ("peer_asn", args.peer_asn)):
+        if not (_LG_ASN_MIN <= number <= _LG_ASN_MAX):
+            return None, (
+                f"{label} must be between {_LG_ASN_MIN} and {_LG_ASN_MAX} (32-bit AS range)."
+            )
+
+    try:
+        ipaddress.ip_address(args.peer_address)
+    except ValueError:
+        return None, f"Invalid peer_address {args.peer_address!r}."
+
+    families = args.address_families or ["ipv4-unicast"]
+    unsupported = [af for af in families if af not in _LG_ADDRESS_FAMILIES]
+    if unsupported:
+        return None, (
+            f"Unsupported address_families {unsupported} — v1 only supports "
+            f"{sorted(_LG_ADDRESS_FAMILIES)}."
+        )
+
+    if args.max_prefixes is not None and args.max_prefixes <= 0:
+        return None, "max_prefixes must be a positive integer."
+
+    if args.peer_router_id is not None:
+        device = await db.get(NetworkDevice, args.peer_router_id)
+        if device is None:
+            return None, f"Network device {args.peer_router_id} not found."
+
+    return collector, None
+
+
+async def _preview_create_lg_peer(
+    db: AsyncSession, user: User, args: CreateLgPeerArgs
+) -> PreviewResult:
+    from app.models.bgp_looking_glass import BGPLGPeer  # noqa: PLC0415
+
+    collector, error = await _validate_lg_peer_args(db, args)
+    if error is not None:
+        return PreviewResult(ok=False, detail=error)
+
+    # Conflict probe — do NOT reject in preview; surface as a hint (BGP
+    # allows multiple sessions to the same address is unusual but not
+    # invalid, so this stays informational like create_dhcp_static's
+    # collision suffix).
+    existing = (
+        await db.execute(
+            select(BGPLGPeer).where(
+                BGPLGPeer.collector_id == args.collector_id,
+                BGPLGPeer.peer_address == args.peer_address,
+            )
+        )
+    ).scalar_one_or_none()
+    suffix = ""
+    if existing is not None:
+        suffix = (
+            f" — note: this collector already has a peer for {args.peer_address} "
+            f"({existing.name!r}); this creates a second session, not a replacement"
+        )
+
+    families = args.address_families or ["ipv4-unicast"]
+    max_prefixes = args.max_prefixes or 10000
+    parts = [
+        f"Create receive-only BGP Looking Glass peer `{args.name}` on collector "
+        f"`{collector.name}`",
+        f"peer_asn={args.peer_asn}",
+        f"peer_address={args.peer_address}",
+        f"address_families={families}",
+        f"max_prefixes={max_prefixes}",
+        f"md5_password={'set' if args.md5_password else 'not set'}",
+    ]
+    return PreviewResult(
+        ok=True,
+        detail="ready",
+        preview_text=(
+            ", ".join(parts) + suffix + ". SpatiumDDI never advertises routes "
+            "back to this peer (receive-only, no export policy)."
+        ),
+    )
+
+
+async def _apply_create_lg_peer(
+    db: AsyncSession, user: User, args: CreateLgPeerArgs
+) -> dict[str, Any]:
+    from app.api.v1.dhcp._audit import write_audit  # noqa: PLC0415
+    from app.core.agent_wake import looking_glass_collector_channel, publish_wake  # noqa: PLC0415
+    from app.core.crypto import encrypt_str  # noqa: PLC0415
+    from app.models.bgp_looking_glass import BGPLGPeer  # noqa: PLC0415
+
+    # SECURITY (#400, C2): RBAC backstop — matches the Looking Glass peers
+    # router's require_resource_permission("bgp_lg_peer") write gate.
+    enforce_operation_permission(user, _OPERATIONS["create_lg_peer"])
+
+    collector, error = await _validate_lg_peer_args(db, args)
+    if error is not None:
+        raise ValueError(error)
+
+    row = BGPLGPeer(
+        name=args.name,
+        collector_id=collector.id,
+        local_asn=args.local_asn,
+        peer_asn=args.peer_asn,
+        peer_address=args.peer_address,
+        peer_router_id=args.peer_router_id,
+        address_families=args.address_families or ["ipv4-unicast"],
+        max_prefixes=args.max_prefixes or 10000,
+        import_filter=args.import_filter or {"mode": "accept_all"},
+        enabled=args.enabled,
+        description=args.description or "",
+        md5_password_encrypted=encrypt_str(args.md5_password) if args.md5_password else None,
+    )
+    db.add(row)
+    await db.flush()
+
+    write_audit(
+        db,
+        user=user,
+        action="create",
+        resource_type="bgp_lg_peer",
+        resource_id=str(row.id),
+        resource_display=f"{args.name} ({args.peer_address})",
+        new_value={
+            "collector_id": str(collector.id),
+            "peer_asn": args.peer_asn,
+            "peer_address": args.peer_address,
+            "address_families": row.address_families,
+            "max_prefixes": row.max_prefixes,
+            "md5_password_set": bool(args.md5_password),
+            "via": "ai_proposal",
+        },
+    )
+    await db.commit()
+    await db.refresh(row)
+    # Cross-cutting pattern #2 — wake the collector's ConfigBundle long-poll
+    # so the new session is rendered without waiting for the belt-and-braces
+    # tick. Uses publish_wake directly (not collect_wake): the /api/v1/ai
+    # router has no wake_publishing dependency, so the collect_wake bucket is
+    # never opened and would silently no-op — mirrors the DNS-record op above.
+    await publish_wake(looking_glass_collector_channel(collector.id))
+    return {
+        "id": str(row.id),
+        "collector_id": str(collector.id),
+        "name": row.name,
+        "peer_asn": row.peer_asn,
+        "peer_address": args.peer_address,
+        "md5_password_set": bool(row.md5_password_encrypted),
+    }
+
+
+register(
+    Operation(
+        name="create_lg_peer",
+        description=(
+            "Create a BGP Looking Glass peer session — a configured, "
+            "receive-only BGP session on a collector. SpatiumDDI never "
+            "advertises routes back to the peer (no export policy). Always "
+            "route via propose_create_lg_peer — this touches the operator's "
+            "live BGP config on the collector's next apply, so operator "
+            "approval is required."
+        ),
+        args_model=CreateLgPeerArgs,
+        preview=_preview_create_lg_peer,
+        apply=_apply_create_lg_peer,
+        category="network",
+        required_permission=("write", "bgp_lg_peer"),
+    )
+)

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -15,6 +15,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     auth_grants,
     backup,
     bgp,
+    bgp_lg,
     bgp_monitor,
     certificates,
     changes,

--- a/backend/app/services/ai/tools/bgp_lg.py
+++ b/backend/app/services/ai/tools/bgp_lg.py
@@ -45,6 +45,11 @@ def _route_dict(row: BGPLGRoute) -> dict[str, Any]:
         "ext_communities": list(row.ext_communities or []),
         "rpki_status": row.rpki_status,
         "is_best": row.is_best,
+        "matched_block_id": str(row.matched_block_id) if row.matched_block_id else None,
+        "matched_subnet_id": str(row.matched_subnet_id) if row.matched_subnet_id else None,
+        "matched_space_id": str(row.matched_space_id) if row.matched_space_id else None,
+        "matched_asn_id": str(row.matched_asn_id) if row.matched_asn_id else None,
+        "matched_vrf_id": str(row.matched_vrf_id) if row.matched_vrf_id else None,
         "first_seen_at": row.first_seen_at.isoformat() if row.first_seen_at else None,
         "last_seen_at": row.last_seen_at.isoformat() if row.last_seen_at else None,
         "withdrawn_at": row.withdrawn_at.isoformat() if row.withdrawn_at else None,
@@ -269,42 +274,23 @@ class FindBgpRouteForIpArgs(BaseModel):
 async def find_bgp_route_for_ip(
     db: AsyncSession, user: User, args: FindBgpRouteForIpArgs
 ) -> dict[str, Any]:
-    try:
-        ip_obj = ipaddress.ip_address(args.ip)
-    except ValueError:
-        return {"ip": args.ip, "found": False, "note": "not a valid IP address"}
+    from app.services.looking_glass.reverse_lookup import best_route_for_ip  # noqa: PLC0415
 
-    stmt = select(BGPLGRoute).where(
-        BGPLGRoute.prefix.op(">>=")(str(ip_obj)),
-        BGPLGRoute.withdrawn_at.is_(None),
-    )
-    rows = (await db.execute(stmt)).scalars().all()
-
-    covering = []
-    for row in rows:
+    result = await best_route_for_ip(db, args.ip)
+    if result is None:
         try:
-            net = ipaddress.ip_network(str(row.prefix), strict=False)
+            ipaddress.ip_address(args.ip)
+            note = "no covering route in the current RIB"
         except ValueError:
-            continue
-        if net.version != ip_obj.version:
-            continue
-        if ip_obj not in net:
-            continue
-        covering.append((net, row))
+            note = "not a valid IP address"
+        return {"ip": args.ip, "found": False, "note": note}
 
-    if not covering:
-        return {"ip": args.ip, "found": False, "note": "no covering route in the current RIB"}
-
-    # Deterministic tie-break: longest prefix wins; among ties prefer the
-    # best path, then order by peer id so the result never depends on
-    # iteration/DB order (mirrors the RIS Live _match_tracked() precedent).
-    covering.sort(key=lambda t: (-t[0].prefixlen, 0 if t[1].is_best else 1, str(t[1].peer_id)))
-    net, best = covering[0]
-    result = _route_dict(best)
-    result["ip"] = args.ip
-    result["found"] = True
-    result["alternate_paths_count"] = len(covering) - 1
-    return result
+    best, alt_count = result
+    out = _route_dict(best)
+    out["ip"] = args.ip
+    out["found"] = True
+    out["alternate_paths_count"] = alt_count
+    return out
 
 
 # ── find_bgp_lg_sessions ─────────────────────────────────────────────

--- a/backend/app/services/ai/tools/bgp_lg.py
+++ b/backend/app/services/ai/tools/bgp_lg.py
@@ -1,0 +1,402 @@
+"""Operator Copilot tools — BGP Looking Glass (issue #566).
+
+Read-only surface over the ``bgp_lg_route`` / ``bgp_lg_peer`` /
+``looking_glass_collector`` tables the collector daemon maintains via its
+register/heartbeat/routes-push agent chain, plus one ``propose_*`` write to
+create a new peer session. All tagged ``module="network.looking_glass"`` so
+they disappear when the feature module is off.
+
+Reads default-enabled — no secrets ever surface (``md5_password_encrypted``
+is never returned, only implied by the peer row's own read surface); the
+write proposal defaults OFF like every other ``propose_*`` tool, since
+creating a peer is a config mutation that touches the operator's live BGP
+sessions on the collector's next apply.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
+from app.services.ai.tools.base import register_tool
+
+_MODULE = "network.looking_glass"
+
+
+def _route_dict(row: BGPLGRoute) -> dict[str, Any]:
+    return {
+        "id": str(row.id),
+        "peer_id": str(row.peer_id),
+        "prefix": str(row.prefix),
+        "origin_asn": int(row.origin_asn) if row.origin_asn is not None else None,
+        "as_path": list(row.as_path or []),
+        "next_hop": str(row.next_hop),
+        "local_pref": row.local_pref,
+        "med": row.med,
+        "communities": list(row.communities or []),
+        "large_communities": list(row.large_communities or []),
+        "ext_communities": list(row.ext_communities or []),
+        "rpki_status": row.rpki_status,
+        "is_best": row.is_best,
+        "first_seen_at": row.first_seen_at.isoformat() if row.first_seen_at else None,
+        "last_seen_at": row.last_seen_at.isoformat() if row.last_seen_at else None,
+        "withdrawn_at": row.withdrawn_at.isoformat() if row.withdrawn_at else None,
+        "flap_count": row.flap_count,
+    }
+
+
+def _session_dict(peer: BGPLGPeer, collector_name: str | None) -> dict[str, Any]:
+    return {
+        "id": str(peer.id),
+        "name": peer.name,
+        "collector_id": str(peer.collector_id),
+        "collector_name": collector_name,
+        "peer_asn": int(peer.peer_asn),
+        "peer_address": str(peer.peer_address),
+        "session_state": peer.session_state,
+        "uptime_started_at": (
+            peer.uptime_started_at.isoformat() if peer.uptime_started_at else None
+        ),
+        "prefixes_received": peer.prefixes_received,
+        "prefixes_accepted": peer.prefixes_accepted,
+        "last_state_change": (
+            peer.last_state_change.isoformat() if peer.last_state_change else None
+        ),
+        "last_flap_at": peer.last_flap_at.isoformat() if peer.last_flap_at else None,
+        "rpki_invalid_count": peer.rpki_invalid_count,
+        "enabled": peer.enabled,
+    }
+
+
+# ── find_bgp_routes ──────────────────────────────────────────────────
+
+
+class FindBgpRoutesArgs(BaseModel):
+    peer_id: UUID | None = Field(default=None, description="Restrict to one Looking Glass peer.")
+    prefix: str | None = Field(
+        default=None, description="Exact prefix match, e.g. '10.0.0.0/24' or '2001:db8::/32'."
+    )
+    origin_asn: int | None = Field(default=None, description="Filter to this origin AS number.")
+    community: str | None = Field(
+        default=None,
+        description=(
+            "Wire-form community string (e.g. '65000:100') to match against "
+            "the route's standard/large/extended community lists."
+        ),
+    )
+    rpki_status: str | None = Field(
+        default=None, description="'valid' | 'invalid' | 'unknown' (from ROA coverage at ingest)."
+    )
+    best_path_only: bool = Field(default=False, description="Only the best path per prefix.")
+    include_withdrawn: bool = Field(
+        default=False, description="Include routes that have been withdrawn from the RIB."
+    )
+    limit: int = Field(default=50, ge=1, le=500)
+
+
+@register_tool(
+    name="find_bgp_routes",
+    description=(
+        "List routes learned by a BGP Looking Glass collector — the live "
+        "Adj-RIB-In mirrored from the operator's own routers (distinct from "
+        "the public-table hijack monitor). Filter by peer, prefix, origin "
+        "ASN, community, or RPKI status. Each row carries the AS path, "
+        "next-hop, local-pref/MED, communities, and RPKI validity computed "
+        "at ingest. Use for 'show ip bgp' style questions like 'what routes "
+        "do we have for 10.0.0.0/8?' or 'any RPKI-invalid routes right now?'."
+    ),
+    args_model=FindBgpRoutesArgs,
+    category="network",
+    module=_MODULE,
+    default_enabled=True,
+)
+async def find_bgp_routes(db: AsyncSession, user: User, args: FindBgpRoutesArgs) -> dict[str, Any]:
+    stmt = select(BGPLGRoute)
+    if args.peer_id is not None:
+        stmt = stmt.where(BGPLGRoute.peer_id == args.peer_id)
+    if args.prefix:
+        try:
+            normalized = str(ipaddress.ip_network(args.prefix, strict=False))
+        except ValueError:
+            return {"routes": [], "count": 0, "note": f"invalid prefix {args.prefix!r}"}
+        stmt = stmt.where(BGPLGRoute.prefix == normalized)
+    if args.origin_asn is not None:
+        stmt = stmt.where(BGPLGRoute.origin_asn == args.origin_asn)
+    if args.community:
+        stmt = stmt.where(
+            or_(
+                BGPLGRoute.communities.contains([args.community]),
+                BGPLGRoute.large_communities.contains([args.community]),
+                BGPLGRoute.ext_communities.contains([args.community]),
+            )
+        )
+    if args.rpki_status:
+        stmt = stmt.where(BGPLGRoute.rpki_status == args.rpki_status)
+    if args.best_path_only:
+        stmt = stmt.where(BGPLGRoute.is_best.is_(True))
+    if not args.include_withdrawn:
+        stmt = stmt.where(BGPLGRoute.withdrawn_at.is_(None))
+    stmt = stmt.order_by(BGPLGRoute.prefix).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return {"routes": [_route_dict(r) for r in rows], "count": len(rows)}
+
+
+# ── count_bgp_routes ─────────────────────────────────────────────────
+
+
+class CountBgpRoutesArgs(BaseModel):
+    peer_id: UUID | None = Field(default=None, description="Restrict to one Looking Glass peer.")
+    include_withdrawn: bool = Field(default=False)
+
+
+@register_tool(
+    name="count_bgp_routes",
+    description=(
+        "Count routes in the BGP Looking Glass RIB, broken down by RPKI "
+        "status and by peer. Use for a quick 'how big is our learned "
+        "routing table?' or 'how many invalid routes per peer?' health check."
+    ),
+    args_model=CountBgpRoutesArgs,
+    category="network",
+    module=_MODULE,
+    default_enabled=True,
+)
+async def count_bgp_routes(
+    db: AsyncSession, user: User, args: CountBgpRoutesArgs
+) -> dict[str, Any]:
+    stmt = (
+        select(BGPLGRoute.peer_id, BGPLGPeer.name, BGPLGRoute.rpki_status, func.count())
+        .select_from(BGPLGRoute)
+        .join(BGPLGPeer, BGPLGRoute.peer_id == BGPLGPeer.id)
+        .group_by(BGPLGRoute.peer_id, BGPLGPeer.name, BGPLGRoute.rpki_status)
+    )
+    if args.peer_id is not None:
+        stmt = stmt.where(BGPLGRoute.peer_id == args.peer_id)
+    if not args.include_withdrawn:
+        stmt = stmt.where(BGPLGRoute.withdrawn_at.is_(None))
+    rows = (await db.execute(stmt)).all()
+    total = 0
+    by_rpki: dict[str, int] = {}
+    by_peer: dict[str, dict[str, Any]] = {}
+    for peer_id, peer_name, rpki_status, count in rows:
+        total += count
+        by_rpki[rpki_status] = by_rpki.get(rpki_status, 0) + count
+        entry = by_peer.setdefault(str(peer_id), {"name": peer_name, "count": 0})
+        entry["count"] += count
+    return {"total": total, "by_rpki_status": by_rpki, "by_peer": by_peer}
+
+
+# ── get_bgp_route ────────────────────────────────────────────────────
+
+
+class GetBgpRouteArgs(BaseModel):
+    prefix: str = Field(description="Exact prefix, e.g. '10.0.0.0/24' or '2001:db8::/32'.")
+    include_withdrawn: bool = Field(
+        default=False, description="Include paths that have since been withdrawn."
+    )
+
+
+@register_tool(
+    name="get_bgp_route",
+    description=(
+        "Get every path a BGP Looking Glass collector has learned for one "
+        "exact prefix — the 'show ip bgp <prefix>' detail view. Returns "
+        "one entry per peer advertising the prefix, each with its own AS "
+        "path, next-hop, and RPKI status."
+    ),
+    args_model=GetBgpRouteArgs,
+    category="network",
+    module=_MODULE,
+    default_enabled=True,
+)
+async def get_bgp_route(db: AsyncSession, user: User, args: GetBgpRouteArgs) -> dict[str, Any]:
+    try:
+        normalized = str(ipaddress.ip_network(args.prefix, strict=False))
+    except ValueError:
+        return {"prefix": args.prefix, "paths": [], "count": 0, "note": "invalid prefix"}
+
+    stmt = (
+        select(BGPLGRoute, BGPLGPeer.name)
+        .join(BGPLGPeer, BGPLGRoute.peer_id == BGPLGPeer.id)
+        .where(BGPLGRoute.prefix == normalized)
+    )
+    if not args.include_withdrawn:
+        stmt = stmt.where(BGPLGRoute.withdrawn_at.is_(None))
+    stmt = stmt.order_by(BGPLGRoute.is_best.desc(), BGPLGRoute.last_seen_at.desc())
+    rows = (await db.execute(stmt)).all()
+    if not rows:
+        return {
+            "prefix": normalized,
+            "paths": [],
+            "count": 0,
+            "note": "not found in the current RIB",
+        }
+    paths = []
+    for route, peer_name in rows:
+        d = _route_dict(route)
+        d["peer_name"] = peer_name
+        paths.append(d)
+    return {"prefix": normalized, "paths": paths, "count": len(paths)}
+
+
+# ── find_bgp_route_for_ip ────────────────────────────────────────────
+
+
+class FindBgpRouteForIpArgs(BaseModel):
+    ip: str = Field(description="A single IP address to reverse-lookup against the learned RIB.")
+
+
+@register_tool(
+    name="find_bgp_route_for_ip",
+    description=(
+        "Reverse longest-prefix-match lookup: given a single IP address, "
+        "find the most-specific active BGP Looking Glass route that covers "
+        "it, returning the covering prefix, origin ASN, and next-hop. Use "
+        "for 'what route covers 8.8.8.8 in our table?' style questions."
+    ),
+    args_model=FindBgpRouteForIpArgs,
+    category="network",
+    module=_MODULE,
+    default_enabled=True,
+)
+async def find_bgp_route_for_ip(
+    db: AsyncSession, user: User, args: FindBgpRouteForIpArgs
+) -> dict[str, Any]:
+    try:
+        ip_obj = ipaddress.ip_address(args.ip)
+    except ValueError:
+        return {"ip": args.ip, "found": False, "note": "not a valid IP address"}
+
+    stmt = select(BGPLGRoute).where(
+        BGPLGRoute.prefix.op(">>=")(str(ip_obj)),
+        BGPLGRoute.withdrawn_at.is_(None),
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+
+    covering = []
+    for row in rows:
+        try:
+            net = ipaddress.ip_network(str(row.prefix), strict=False)
+        except ValueError:
+            continue
+        if net.version != ip_obj.version:
+            continue
+        if ip_obj not in net:
+            continue
+        covering.append((net, row))
+
+    if not covering:
+        return {"ip": args.ip, "found": False, "note": "no covering route in the current RIB"}
+
+    # Deterministic tie-break: longest prefix wins; among ties prefer the
+    # best path, then order by peer id so the result never depends on
+    # iteration/DB order (mirrors the RIS Live _match_tracked() precedent).
+    covering.sort(key=lambda t: (-t[0].prefixlen, 0 if t[1].is_best else 1, str(t[1].peer_id)))
+    net, best = covering[0]
+    result = _route_dict(best)
+    result["ip"] = args.ip
+    result["found"] = True
+    result["alternate_paths_count"] = len(covering) - 1
+    return result
+
+
+# ── find_bgp_lg_sessions ─────────────────────────────────────────────
+
+
+class FindLgSessionsArgs(BaseModel):
+    collector_id: UUID | None = Field(default=None, description="Restrict to one collector.")
+    session_state: str | None = Field(
+        default=None,
+        description="Filter by state: idle/connect/active/opensent/openconfirm/established.",
+    )
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+@register_tool(
+    name="find_bgp_lg_sessions",
+    description=(
+        "List BGP Looking Glass peer sessions with their current state "
+        "(established/idle/etc.), uptime, and received/accepted prefix "
+        "counts — the Sessions-tab feed. Use for 'which BGP sessions are "
+        "down?' or 'how many prefixes is each peer sending us?'."
+    ),
+    args_model=FindLgSessionsArgs,
+    category="network",
+    module=_MODULE,
+    default_enabled=True,
+)
+async def find_bgp_lg_sessions(
+    db: AsyncSession, user: User, args: FindLgSessionsArgs
+) -> dict[str, Any]:
+    stmt = select(BGPLGPeer, LookingGlassCollector.name).join(
+        LookingGlassCollector, BGPLGPeer.collector_id == LookingGlassCollector.id
+    )
+    if args.collector_id is not None:
+        stmt = stmt.where(BGPLGPeer.collector_id == args.collector_id)
+    if args.session_state:
+        stmt = stmt.where(BGPLGPeer.session_state == args.session_state)
+    stmt = stmt.order_by(BGPLGPeer.name).limit(args.limit)
+    rows = (await db.execute(stmt)).all()
+    return {
+        "sessions": [_session_dict(peer, collector_name) for peer, collector_name in rows],
+        "count": len(rows),
+    }
+
+
+# ── propose_create_lg_peer ───────────────────────────────────────────
+
+
+class CreateLgPeerArgs(BaseModel):
+    collector_id: UUID = Field(description="The looking_glass_collector this session runs on.")
+    name: str = Field(description="Operator-facing label for the peer session.")
+    local_asn: int = Field(description="The collector's own AS number for this session.")
+    peer_asn: int = Field(description="The remote router's AS number.")
+    peer_address: str = Field(description="The remote router's IP address (v4 or v6).")
+    peer_router_id: UUID | None = Field(
+        default=None, description="Optional link to an existing network_device row."
+    )
+    address_families: list[str] | None = Field(
+        default=None,
+        description="AFI/SAFIs to negotiate. Defaults to ['ipv4-unicast'].",
+    )
+    max_prefixes: int | None = Field(
+        default=None, description="Hard prefix-limit safety cap. Defaults to 10000."
+    )
+    md5_password: str | None = Field(
+        default=None, description="Optional TCP-MD5 session password (Fernet-encrypted at rest)."
+    )
+    import_filter: dict[str, Any] | None = Field(
+        default=None, description="Route acceptance scope. Defaults to {'mode': 'accept_all'}."
+    )
+    enabled: bool = Field(default=True)
+    description: str = Field(default="", description="Free-form note.")
+
+
+@register_tool(
+    name="propose_create_lg_peer",
+    description=(
+        "Prepare a proposal to create a new BGP Looking Glass peer session "
+        "(a receive-only BGP session on a collector — SpatiumDDI never "
+        "advertises routes back to the peer). The operator must click "
+        "Apply in the chat drawer to commit. Returns a kind='proposal' "
+        "payload — surface the preview and wait for their decision."
+    ),
+    args_model=CreateLgPeerArgs,
+    writes=False,  # propose is read-only; the apply endpoint is the write.
+    category="network",
+    module=_MODULE,
+    default_enabled=False,
+)
+async def propose_create_lg_peer(
+    db: AsyncSession, user: User, args: CreateLgPeerArgs
+) -> dict[str, Any]:
+    from app.services.ai.tools.proposals import _propose_via  # noqa: PLC0415
+
+    return await _propose_via(db=db, user=user, operation_name="create_lg_peer", args=args)

--- a/backend/app/services/ai/tools/bgp_lg.py
+++ b/backend/app/services/ai/tools/bgp_lg.py
@@ -16,6 +16,7 @@ sessions on the collector's next apply.
 from __future__ import annotations
 
 import ipaddress
+import re
 from typing import Any
 from uuid import UUID
 
@@ -26,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.auth import User
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
 from app.services.ai.tools.base import register_tool
+from app.services.looking_glass.as_path_query import as_path_regexp_clause
 
 _MODULE = "network.looking_glass"
 
@@ -96,6 +98,14 @@ class FindBgpRoutesArgs(BaseModel):
             "the route's standard/large/extended community lists."
         ),
     )
+    as_path_regexp: str | None = Field(
+        default=None,
+        max_length=128,
+        description=(
+            "AS-path regex (Cisco/Juniper '_' boundary convention) matched "
+            "against the space-joined AS path, e.g. '_65001_'."
+        ),
+    )
     rpki_status: str | None = Field(
         default=None, description="'valid' | 'invalid' | 'unknown' (from ROA coverage at ingest)."
     )
@@ -142,6 +152,15 @@ async def find_bgp_routes(db: AsyncSession, user: User, args: FindBgpRoutesArgs)
                 BGPLGRoute.ext_communities.contains([args.community]),
             )
         )
+    if args.as_path_regexp:
+        try:
+            stmt = stmt.where(as_path_regexp_clause(args.as_path_regexp))
+        except re.error:
+            return {
+                "routes": [],
+                "count": 0,
+                "note": f"invalid as_path_regexp {args.as_path_regexp!r}",
+            }
     if args.rpki_status:
         stmt = stmt.where(BGPLGRoute.rpki_status == args.rpki_status)
     if args.best_path_only:

--- a/backend/app/services/ai/tools/bgp_lg.py
+++ b/backend/app/services/ai/tools/bgp_lg.py
@@ -45,6 +45,7 @@ def _route_dict(row: BGPLGRoute) -> dict[str, Any]:
         "communities": list(row.communities or []),
         "large_communities": list(row.large_communities or []),
         "ext_communities": list(row.ext_communities or []),
+        "route_distinguisher": row.route_distinguisher,
         "rpki_status": row.rpki_status,
         "is_best": row.is_best,
         "matched_block_id": str(row.matched_block_id) if row.matched_block_id else None,
@@ -293,10 +294,10 @@ class FindBgpRouteForIpArgs(BaseModel):
 async def find_bgp_route_for_ip(
     db: AsyncSession, user: User, args: FindBgpRouteForIpArgs
 ) -> dict[str, Any]:
-    from app.services.looking_glass.reverse_lookup import best_route_for_ip  # noqa: PLC0415
+    from app.services.looking_glass.reachability import find_covering_routes  # noqa: PLC0415
 
-    result = await best_route_for_ip(db, args.ip)
-    if result is None:
+    routes = await find_covering_routes(db, args.ip)
+    if not routes:
         try:
             ipaddress.ip_address(args.ip)
             note = "no covering route in the current RIB"
@@ -304,11 +305,10 @@ async def find_bgp_route_for_ip(
             note = "not a valid IP address"
         return {"ip": args.ip, "found": False, "note": note}
 
-    best, alt_count = result
-    out = _route_dict(best)
+    out = _route_dict(routes[0])
     out["ip"] = args.ip
     out["found"] = True
-    out["alternate_paths_count"] = alt_count
+    out["alternate_paths_count"] = len(routes) - 1
     return out
 
 
@@ -352,6 +352,96 @@ async def find_bgp_lg_sessions(
     return {
         "sessions": [_session_dict(peer, collector_name) for peer, collector_name in rows],
         "count": len(rows),
+    }
+
+
+# ── find_vrf_learned_routes ──────────────────────────────────────────
+
+
+class FindVrfLearnedRoutesArgs(BaseModel):
+    vrf_id: UUID = Field(description="The VRF to find learned VPNv4/VPNv6 routes for.")
+    include_withdrawn: bool = Field(default=False)
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+@register_tool(
+    name="find_vrf_learned_routes",
+    description=(
+        "List BGP Looking Glass routes matched to a VRF by Route-Target "
+        "cross-check (issue #566 Phase 6) — the routes whose "
+        "extended-community route target fell in the VRF's import/export "
+        "lists at ingest (falling back to whichever route just happens to "
+        "fall under the VRF's IPAM block/space when there's no RT hit). "
+        "Use for 'what routes has this VRF learned?' or 'is this VRF "
+        "actually receiving any VPN routes?' questions."
+    ),
+    args_model=FindVrfLearnedRoutesArgs,
+    category="network",
+    module=_MODULE,
+    default_enabled=True,
+)
+async def find_vrf_learned_routes(
+    db: AsyncSession, user: User, args: FindVrfLearnedRoutesArgs
+) -> dict[str, Any]:
+    stmt = select(BGPLGRoute).where(BGPLGRoute.matched_vrf_id == args.vrf_id)
+    if not args.include_withdrawn:
+        stmt = stmt.where(BGPLGRoute.withdrawn_at.is_(None))
+    stmt = stmt.order_by(BGPLGRoute.prefix).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return {"routes": [_route_dict(r) for r in rows], "count": len(rows)}
+
+
+# ── find_multicast_bgp_reachability ───────────────────────────────────
+
+
+class FindMulticastBgpReachabilityArgs(BaseModel):
+    """No filters — the underlying tables (PIM domains, multicast groups)
+    are small; this is a whole-fleet snapshot."""
+
+
+@register_tool(
+    name="find_multicast_bgp_reachability",
+    description=(
+        "Cross-reference multicast PIM domains' rendezvous-point addresses "
+        "and multicast groups' producer source subnets against the BGP "
+        "Looking Glass learned RIB (issue #566 Phase 6) — is the RP / "
+        "source actually reachable per the current routing table? Use for "
+        "'is our multicast RP reachable?' or 'is this source subnet "
+        "actually being routed?' sanity checks."
+    ),
+    args_model=FindMulticastBgpReachabilityArgs,
+    category="network",
+    module=_MODULE,
+    default_enabled=True,
+)
+async def find_multicast_bgp_reachability(
+    db: AsyncSession, user: User, args: FindMulticastBgpReachabilityArgs
+) -> dict[str, Any]:
+    from app.services.looking_glass.reachability import multicast_bgp_reachability  # noqa: PLC0415
+
+    result = await multicast_bgp_reachability(db)
+    return {
+        "domains": [
+            {
+                "domain_id": str(d.domain_id),
+                "domain_name": d.domain_name,
+                "rp_address": d.rp_address,
+                "covering_route": _route_dict(d.covering_route) if d.covering_route else None,
+                "reachable": d.covering_route is not None,
+            }
+            for d in result.domains
+        ],
+        "groups": [
+            {
+                "group_id": str(g.group_id),
+                "group_name": g.group_name,
+                "group_address": g.group_address,
+                "source_subnet": g.source_subnet,
+                "covering_route": _route_dict(g.covering_route) if g.covering_route else None,
+                "reachable": g.covering_route is not None,
+            }
+            for g in result.groups
+        ],
     }
 
 

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -40,7 +40,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.alerts import AlertEvent, AlertRule
 from app.models.asn import ASN, ASNRpkiRoa
 from app.models.audit import AuditLog
-from app.models.bgp_monitor import BGPHijackDetection
+from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
+from app.models.bgp_monitor import BGPHijackDetection, BGPTrackedPrefix
 from app.models.circuit import Circuit
 from app.models.dhcp import (
     DHCPLease,
@@ -65,6 +66,11 @@ from app.models.tls_cert import (
 )
 from app.models.vrf import VRF
 from app.services import audit_forward
+from app.services.bgp.hijack_monitor import (
+    RPKI_INVALID,
+    expected_origin_set,
+    severity_for_rpki,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -84,6 +90,21 @@ RULE_TYPE_RPKI_ROA_EXPIRED = "rpki_roa_expired"
 # RPKI-unknown) rides through as a severity override.
 RULE_TYPE_BGP_PREFIX_HIJACK = "bgp_prefix_hijack"
 RULE_TYPE_BGP_MORE_SPECIFIC = "bgp_more_specific_announced"
+# BGP Looking Glass internal-RIB alert family — issue #566 Phase 5.
+# Companion to the #527 public-table hijack monitor above: that watches
+# the public routing table via RIPEstat/RIS Live, these watch the
+# operator's OWN live table via the receive-only Looking Glass
+# collector (bgp_lg_peer / bgp_lg_route). unexpected_origin and
+# more_specific deliberately reuse the SAME BGPTrackedPrefix config
+# table #527 already has (an operator's "prefixes I own + expected
+# origin ASN" list, curated once at /asns/{id}/tracked-prefixes) —
+# both the external and internal monitors read it.
+RULE_TYPE_BGP_LG_SESSION_DOWN = "bgp_lg_session_down"
+RULE_TYPE_BGP_LG_RPKI_INVALID_ROUTE = "bgp_lg_rpki_invalid_route"
+RULE_TYPE_BGP_LG_UNEXPECTED_ORIGIN = "bgp_lg_unexpected_origin"
+RULE_TYPE_BGP_LG_MORE_SPECIFIC = "bgp_lg_more_specific"
+RULE_TYPE_BGP_LG_ROUTE_FLAP = "bgp_lg_route_flap"
+RULE_TYPE_BGP_LG_MISSING_ADVERTISEMENT = "bgp_lg_missing_advertisement"
 # Domain rule types — Phase 2 of issue #87.
 RULE_TYPE_DOMAIN_EXPIRING = "domain_expiring"
 RULE_TYPE_DOMAIN_NS_DRIFT = "domain_nameserver_drift"
@@ -258,6 +279,12 @@ RULE_TYPES = frozenset(
         RULE_TYPE_RPKI_ROA_EXPIRED,
         RULE_TYPE_BGP_PREFIX_HIJACK,
         RULE_TYPE_BGP_MORE_SPECIFIC,
+        RULE_TYPE_BGP_LG_SESSION_DOWN,
+        RULE_TYPE_BGP_LG_RPKI_INVALID_ROUTE,
+        RULE_TYPE_BGP_LG_UNEXPECTED_ORIGIN,
+        RULE_TYPE_BGP_LG_MORE_SPECIFIC,
+        RULE_TYPE_BGP_LG_ROUTE_FLAP,
+        RULE_TYPE_BGP_LG_MISSING_ADVERTISEMENT,
         RULE_TYPE_DOMAIN_EXPIRING,
         RULE_TYPE_DOMAIN_NS_DRIFT,
         RULE_TYPE_DOMAIN_REGISTRAR_CHANGED,
@@ -386,6 +413,29 @@ _ORPHAN_RESOURCE_MODELS: dict[str, Any] = {
 # operator-noteworthy. ``active`` ↔ ``pending`` flips during
 # commissioning are routine and don't fire.
 _CIRCUIT_STATUS_CHANGE_DESTS: frozenset[str] = frozenset({"suspended", "decom"})
+
+# BGP Looking Glass alert-family constants (issue #566 Phase 5).
+# Fixed windows, not operator-tunable columns — same precedent as
+# _FIREWALL_STALE_GRACE / _DNS_ANOMALY_WINDOW above.
+#
+# session_down: a peer flapping momentarily (TCP reset, brief
+# reconnect) shouldn't page; only a sustained down state does. Anchored
+# on BGPLGPeer.down_since, which THIS module stamps (see
+# _matching_bgp_lg_session_down_subjects) — mirrors
+# _FIREWALL_STALE_GRACE's stalled_since pattern exactly.
+_BGP_LG_SESSION_DOWN_GRACE = timedelta(minutes=2)
+
+# route_flap: a route counts as "flapping" once its lifetime
+# withdraw-count crosses the floor AND the most recent flap was within
+# this trailing window — so a route that flapped a lot long ago but has
+# been stable since ages out instead of paging forever.
+_BGP_LG_FLAP_WINDOW = timedelta(minutes=10)
+_BGP_LG_FLAP_COUNT_DEFAULT = 5
+
+# Defensive cap mirroring _IP_HYGIENE_MAX_EVENTS — a freshly-enabled
+# rule against a large RIB shouldn't open thousands of AlertEvents in
+# one 60s tick. Logs a warning when truncated (no silent cap).
+_BGP_LG_MAX_EVENTS = 500
 
 # Default consecutive-failure threshold for ``asn_whois_unreachable``.
 _ASN_WHOIS_UNREACHABLE_THRESHOLD = 3
@@ -1143,6 +1193,256 @@ async def _matching_bgp_hijack_subjects(
             f"RPKI {row.rpki_status}"
         )
         matches.append((str(row.id), display, message, row.severity))
+    return matches
+
+
+async def _matching_bgp_lg_session_down_subjects(
+    db: AsyncSession,
+    rule: AlertRule,  # noqa: ARG001 — symmetry with sibling evaluators
+    now: datetime,
+) -> list[tuple[str, str, str]]:
+    """``bgp_lg_session_down`` — an enabled peer whose session is not
+    Established, sustained past a grace window.
+
+    Grace is anchored on ``BGPLGPeer.down_since``, a watermark THIS
+    function stamps on first non-established observation and clears the
+    moment the session re-establishes — mirrors
+    ``_matching_firewall_apply_stalled_subjects``'s ``stalled_since``
+    pattern exactly. A converged session auto-resolves via
+    ``evaluate_all``'s standard "subject no longer matches" diff; no
+    explicit resolve logic needed here.
+    """
+    rows = (
+        await db.execute(
+            select(BGPLGPeer, LookingGlassCollector)
+            .join(LookingGlassCollector, LookingGlassCollector.id == BGPLGPeer.collector_id)
+            .where(BGPLGPeer.enabled.is_(True))
+        )
+    ).all()
+
+    matches: list[tuple[str, str, str]] = []
+    for peer, collector in rows:
+        if peer.session_state == "established":
+            if peer.down_since is not None:
+                peer.down_since = None
+            continue
+        if peer.down_since is None:
+            peer.down_since = now  # first observation — start the grace clock
+            continue
+        if (now - peer.down_since) <= _BGP_LG_SESSION_DOWN_GRACE:
+            continue
+        collector_note = (
+            f"collector '{collector.name}' is also reporting {collector.status}"
+            if collector.status != "active"
+            else f"collector '{collector.name}' is reporting normally"
+        )
+        display = f"{peer.name} (AS{peer.peer_asn} @ {peer.peer_address})"
+        message = (
+            f"BGP Looking Glass session '{peer.name}' to AS{peer.peer_asn} "
+            f"({peer.peer_address}) has been {peer.session_state} since "
+            f"{peer.down_since.isoformat()} — last known {peer.prefixes_received} "
+            f"prefixes received; {collector_note}."
+        )
+        matches.append((str(peer.id), display, message))
+    return matches
+
+
+async def _matching_bgp_lg_rpki_invalid_route_subjects(
+    db: AsyncSession,
+    rule: AlertRule,  # noqa: ARG001
+) -> list[tuple[str, str, str, str | None]]:
+    """``bgp_lg_rpki_invalid_route`` — every active learned route whose
+    RPKI status is ``invalid`` (computed at ingest via
+    ``derive_rpki_status_batch``, no re-validation needed here). Always
+    rides in at ``critical`` severity via a severity override — RPKI
+    invalidity on YOUR OWN table is the strongest possible in-network
+    leak/misconfig signal (mirrors ``severity_for_rpki``'s "invalid ⇒
+    critical" mapping from the #527 hijack monitor)."""
+    rows = (
+        await db.execute(
+            select(BGPLGRoute, BGPLGPeer)
+            .join(BGPLGPeer, BGPLGPeer.id == BGPLGRoute.peer_id)
+            .where(BGPLGRoute.rpki_status == RPKI_INVALID, BGPLGRoute.withdrawn_at.is_(None))
+            .limit(_BGP_LG_MAX_EVENTS)
+        )
+    ).all()
+    matches: list[tuple[str, str, str, str | None]] = []
+    for route, peer in rows:
+        display = f"{route.prefix} ← AS{route.origin_asn}"
+        message = (
+            f"RPKI-invalid route in the Looking Glass RIB: {route.prefix} originated by "
+            f"AS{route.origin_asn}, learned from peer '{peer.name}' (AS{peer.peer_asn}) — "
+            f"no covering ROA authorises this origin/length."
+        )
+        matches.append((str(route.id), display, message, severity_for_rpki(RPKI_INVALID)))
+    if len(rows) >= _BGP_LG_MAX_EVENTS:
+        logger.warning("bgp_lg_rpki_invalid_route_truncated", cap=_BGP_LG_MAX_EVENTS)
+    return matches
+
+
+async def _matching_bgp_lg_unexpected_origin_subjects(
+    db: AsyncSession,
+    rule: AlertRule,  # noqa: ARG001
+) -> list[tuple[str, str, str]]:
+    """``bgp_lg_unexpected_origin`` — an owned tracked prefix (exact
+    CIDR match against ``BGPTrackedPrefix``) learned in the live RIB
+    with an origin ASN outside ``expected_origin_set(tracked)``. Same
+    "internal hijack / fat-fingered redistribute / route leak" shape as
+    #527's exact-prefix detector, reading the internal RIB instead of
+    RIPEstat."""
+    rows = (
+        await db.execute(
+            select(BGPLGRoute, BGPTrackedPrefix, BGPLGPeer)
+            .join(BGPTrackedPrefix, BGPTrackedPrefix.prefix == BGPLGRoute.prefix)
+            .join(BGPLGPeer, BGPLGPeer.id == BGPLGRoute.peer_id)
+            .where(
+                BGPTrackedPrefix.enabled.is_(True),
+                BGPLGRoute.withdrawn_at.is_(None),
+                BGPLGRoute.origin_asn.is_not(None),
+            )
+            .limit(_BGP_LG_MAX_EVENTS)
+        )
+    ).all()
+    matches: list[tuple[str, str, str]] = []
+    for route, tracked, peer in rows:
+        if route.origin_asn in expected_origin_set(tracked):
+            continue
+        display = (
+            f"{route.prefix} ← AS{route.origin_asn} (expected AS{tracked.expected_origin_asn})"
+        )
+        message = (
+            f"Tracked prefix {tracked.prefix} is learned with unexpected origin "
+            f"AS{route.origin_asn} (expected AS{tracked.expected_origin_asn}) via peer "
+            f"'{peer.name}' — possible internal leak or misconfigured redistribution."
+        )
+        matches.append((str(route.id), display, message))
+    return matches
+
+
+async def _matching_bgp_lg_more_specific_subjects(
+    db: AsyncSession,
+    rule: AlertRule,  # noqa: ARG001
+) -> list[tuple[str, str, str]]:
+    """``bgp_lg_more_specific`` — a route STRICTLY more specific
+    (Postgres ``<<``, contained-and-not-equal) than an owned tracked
+    aggregate, with an unexpected origin. The classic internal
+    sub-prefix leak that wins BGP best-path over your aggregate via
+    longest-match. Same origin-allowlist semantics as
+    ``_matching_bgp_lg_unexpected_origin_subjects`` — only the
+    containment operator differs (exact ``==`` there, strict ``<<``
+    here)."""
+    rows = (
+        await db.execute(
+            select(BGPLGRoute, BGPTrackedPrefix, BGPLGPeer)
+            .join(BGPTrackedPrefix, BGPLGRoute.prefix.op("<<")(BGPTrackedPrefix.prefix))
+            .join(BGPLGPeer, BGPLGPeer.id == BGPLGRoute.peer_id)
+            .where(
+                BGPTrackedPrefix.enabled.is_(True),
+                BGPLGRoute.withdrawn_at.is_(None),
+                BGPLGRoute.origin_asn.is_not(None),
+            )
+            .limit(_BGP_LG_MAX_EVENTS)
+        )
+    ).all()
+    matches: list[tuple[str, str, str]] = []
+    for route, tracked, peer in rows:
+        if route.origin_asn in expected_origin_set(tracked):
+            continue
+        display = f"{route.prefix} (more-specific of {tracked.prefix}) ← AS{route.origin_asn}"
+        message = (
+            f"More-specific {route.prefix} of owned aggregate {tracked.prefix} learned with "
+            f"unexpected origin AS{route.origin_asn} (expected AS{tracked.expected_origin_asn}) "
+            f"via peer '{peer.name}' — this sub-prefix wins best-path over your aggregate."
+        )
+        matches.append((str(route.id), display, message))
+    return matches
+
+
+async def _matching_bgp_lg_route_flap_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+    now: datetime,
+) -> list[tuple[str, str, str]]:
+    """``bgp_lg_route_flap`` — an active route whose lifetime flap count
+    (``BGPLGRoute.flap_count``, bumped once per absence-withdraw in
+    ``routes_ingest.py``) has crossed ``rule.threshold_percent`` (reused
+    as a raw flap-count floor — same int-as-count convention as
+    ``voice_lease_count_below`` / ``stale_ip_count``), AND the most
+    recent flap (``last_flap_at``) is within the trailing
+    ``_BGP_LG_FLAP_WINDOW``. The recency gate is what makes this a
+    "currently unstable" predicate rather than a permanent scar —
+    once no new flap lands for the window, the route drops out of the
+    match set and the AlertEvent auto-resolves via the standard diff.
+    """
+    threshold = rule.threshold_percent or _BGP_LG_FLAP_COUNT_DEFAULT
+    since = now - _BGP_LG_FLAP_WINDOW
+    rows = (
+        await db.execute(
+            select(BGPLGRoute, BGPLGPeer)
+            .join(BGPLGPeer, BGPLGPeer.id == BGPLGRoute.peer_id)
+            .where(
+                BGPLGRoute.flap_count >= threshold,
+                BGPLGRoute.last_flap_at.is_not(None),
+                BGPLGRoute.last_flap_at >= since,
+            )
+            .limit(_BGP_LG_MAX_EVENTS)
+        )
+    ).all()
+    matches: list[tuple[str, str, str]] = []
+    win_min = int(_BGP_LG_FLAP_WINDOW.total_seconds() // 60)
+    for route, peer in rows:
+        display = f"{route.prefix} via {peer.name}"
+        message = (
+            f"Route {route.prefix} via peer '{peer.name}' (AS{peer.peer_asn}) has flapped "
+            f"{route.flap_count} times, most recently {route.last_flap_at.isoformat()} "
+            f"(threshold {threshold} within the trailing ~{win_min} min) — unstable path."
+        )
+        matches.append((str(route.id), display, message))
+    return matches
+
+
+async def _matching_bgp_lg_missing_advertisement_subjects(
+    db: AsyncSession,
+    rule: AlertRule,  # noqa: ARG001
+) -> list[tuple[str, str, str]]:
+    """``bgp_lg_missing_advertisement`` — a subnet flagged
+    ``bgp_should_advertise`` with NO active learned route covering it
+    (Postgres ``>>=``, contains-or-equal) across ANY peer.
+
+    Deliberately does NOT wait on Phase 3's ``matched_subnet_id``
+    resolution — that FK is populated by a longest-prefix-match
+    reconcile that may not exist yet. This does the CIDR containment
+    check directly against ``BGPLGRoute.prefix`` so the alert works
+    whether or not Phase 3 has landed. ``Subnet``'s global soft-delete
+    query filter (``app.db._filter_soft_deleted``) already excludes
+    trashed subnets — no explicit ``deleted_at`` predicate needed.
+    """
+    covering_exists = (
+        select(BGPLGRoute.id)
+        .where(BGPLGRoute.withdrawn_at.is_(None), BGPLGRoute.prefix.op(">>=")(Subnet.network))
+        .correlate(Subnet)
+        .exists()
+    )
+    rows = (
+        (
+            await db.execute(
+                select(Subnet)
+                .where(Subnet.bgp_should_advertise.is_(True), ~covering_exists)
+                .limit(_BGP_LG_MAX_EVENTS)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    matches: list[tuple[str, str, str]] = []
+    for subnet in rows:
+        display = f"{subnet.network} ({subnet.name})" if subnet.name else str(subnet.network)
+        message = (
+            f"Subnet {subnet.network} is flagged 'should advertise via BGP' but no active "
+            f"Looking Glass peer is currently learning a covering route — check redistribution "
+            f"on your edge routers."
+        )
+        matches.append((str(subnet.id), display, message))
     return matches
 
 
@@ -3050,6 +3350,121 @@ async def seed_bgp_hijack_alert_rules() -> None:
         await session.commit()
 
 
+async def seed_bgp_lg_alert_rules() -> None:
+    """Seed the six ``bgp_lg_*`` rules (issue #566 Phase 5), DISABLED by
+    default — the Looking Glass collector needs an operator-configured
+    peer (and, for unexpected_origin/more_specific, at least one
+    BGPTrackedPrefix owned-prefix row from the #527 UI) before any of
+    these mean anything. Discoverable-but-off, matching the
+    bgp_prefix_hijack / bgp_more_specific_announced precedent
+    (``seed_bgp_hijack_alert_rules`` above). Keyed on ``rule_type``; an
+    operator who enables/renames one is never overridden.
+    """
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+    from app.models.alerts import AlertRule  # noqa: PLC0415
+
+    seeds: tuple[tuple[str, str, str, int | None], ...] = (
+        (
+            RULE_TYPE_BGP_LG_SESSION_DOWN,
+            "BGP Looking Glass session down",
+            (
+                "Fires when a configured Looking Glass peer session drops out of "
+                "Established for longer than a short grace window. Shows the last "
+                "known prefix count and cross-references the owning collector's "
+                "own health. Auto-resolves the moment the session re-establishes. "
+                "Enable once you've configured at least one peer under "
+                "Network → BGP Looking Glass."
+            ),
+            None,
+        ),
+        (
+            RULE_TYPE_BGP_LG_RPKI_INVALID_ROUTE,
+            "BGP Looking Glass RPKI-invalid route",
+            (
+                "Fires when a route in YOUR live routing table (not the public "
+                "table — see the separate BGP prefix hijack rule for that) has an "
+                "RPKI status of invalid: a ROA covers the prefix but does not "
+                "authorise the observed origin/length. Always critical severity. "
+                "Auto-resolves when the route withdraws or its RPKI status "
+                "changes. The strongest in-network leak/misconfig signal."
+            ),
+            None,
+        ),
+        (
+            RULE_TYPE_BGP_LG_UNEXPECTED_ORIGIN,
+            "BGP Looking Glass unexpected origin",
+            (
+                "Fires when one of your tracked/owned prefixes (configured under "
+                "an ASN's Tracked Prefixes — the same list the BGP prefix hijack "
+                "rule reads) is learned in your OWN live table with an origin ASN "
+                "outside the expected/allowlisted set. Catches internal leaks and "
+                "fat-fingered redistribution before they reach the public table. "
+                "Requires at least one enabled tracked prefix to ever fire."
+            ),
+            None,
+        ),
+        (
+            RULE_TYPE_BGP_LG_MORE_SPECIFIC,
+            "BGP Looking Glass more-specific announced",
+            (
+                "Fires when a route strictly more-specific than one of your "
+                "tracked/owned aggregates is learned in your live table with an "
+                "unexpected origin ASN — the classic internal sub-prefix leak "
+                "that wins best-path over your aggregate via longest-match. "
+                "Requires at least one enabled tracked prefix to ever fire."
+            ),
+            None,
+        ),
+        (
+            RULE_TYPE_BGP_LG_ROUTE_FLAP,
+            "BGP Looking Glass route flap",
+            (
+                "Fires when a learned route's flap count (announce/withdraw "
+                "churn) crosses the configured threshold (Threshold %, reused "
+                "here as a raw flap-count floor — default 5) with the most "
+                "recent flap inside the trailing ~10 minutes. Auto-resolves once "
+                "the route stops flapping for that window."
+            ),
+            _BGP_LG_FLAP_COUNT_DEFAULT,
+        ),
+        (
+            RULE_TYPE_BGP_LG_MISSING_ADVERTISEMENT,
+            "BGP Looking Glass missing advertisement",
+            (
+                "Fires when a subnet flagged 'should advertise via BGP' "
+                "(Subnet.bgp_should_advertise) has no active learned route "
+                "covering it across any configured peer — catches 'why is this "
+                "network unreachable' before the tickets come in. Requires "
+                "flagging at least one subnet as bgp_should_advertise=true to "
+                "ever fire."
+            ),
+            None,
+        ),
+    )
+
+    async with AsyncSessionLocal() as session:
+        for rule_type, name, description, default_threshold in seeds:
+            existing = await session.scalar(
+                select(AlertRule).where(AlertRule.rule_type == rule_type)
+            )
+            if existing is not None:
+                continue
+            session.add(
+                AlertRule(
+                    name=name,
+                    description=description,
+                    rule_type=rule_type,
+                    severity="warning",
+                    enabled=False,
+                    notify_syslog=True,
+                    notify_webhook=True,
+                    notify_smtp=False,
+                    threshold_percent=default_threshold,
+                )
+            )
+        await session.commit()
+
+
 async def seed_builtin_compliance_alert_rules() -> None:
     """Insert the three disabled compliance-change rules on first
     boot. Idempotent — only inserts a row when no rule with the same
@@ -3442,6 +3857,29 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
             elif rule.rule_type == RULE_TYPE_BGP_MORE_SPECIFIC:
                 matches = await _matching_bgp_hijack_subjects(db, rule, "more_specific")
                 subject_type = "bgp_hijack"
+            elif rule.rule_type == RULE_TYPE_BGP_LG_SESSION_DOWN:
+                base = await _matching_bgp_lg_session_down_subjects(db, rule, now)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "bgp_lg_peer"
+            elif rule.rule_type == RULE_TYPE_BGP_LG_RPKI_INVALID_ROUTE:
+                matches = await _matching_bgp_lg_rpki_invalid_route_subjects(db, rule)
+                subject_type = "bgp_lg_route"
+            elif rule.rule_type == RULE_TYPE_BGP_LG_UNEXPECTED_ORIGIN:
+                base = await _matching_bgp_lg_unexpected_origin_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "bgp_lg_route"
+            elif rule.rule_type == RULE_TYPE_BGP_LG_MORE_SPECIFIC:
+                base = await _matching_bgp_lg_more_specific_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "bgp_lg_route"
+            elif rule.rule_type == RULE_TYPE_BGP_LG_ROUTE_FLAP:
+                base = await _matching_bgp_lg_route_flap_subjects(db, rule, now)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "bgp_lg_route"
+            elif rule.rule_type == RULE_TYPE_BGP_LG_MISSING_ADVERTISEMENT:
+                base = await _matching_bgp_lg_missing_advertisement_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "subnet"
             elif rule.rule_type == RULE_TYPE_DOMAIN_EXPIRING:
                 expiring = await _matching_domain_expiring_subjects(db, rule, now)
                 matches = [(sid, disp, msg, sev) for sid, disp, msg, sev in expiring]

--- a/backend/app/services/bgp/hijack_monitor.py
+++ b/backend/app/services/bgp/hijack_monitor.py
@@ -30,6 +30,7 @@ RPKI status semantics (reusing the ROA data already pulled by
 from __future__ import annotations
 
 import ipaddress
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -132,6 +133,64 @@ async def derive_rpki_status(
             return RPKI_VALID
 
     return RPKI_INVALID if covering else RPKI_UNKNOWN
+
+
+async def derive_rpki_status_batch(
+    db: AsyncSession,
+    pairs: Iterable[tuple[str, int]],
+) -> dict[tuple[str, int], str]:
+    """Classify many ``(prefix, origin)`` announcements in ONE ROA load.
+
+    ``derive_rpki_status`` issues one covering-ROA query per call; a pushed
+    BGP RIB snapshot has thousands of distinct announcements, so calling it
+    per-prefix means thousands of serial round-trips inside the ingest
+    transaction. This loads the ROA table once and matches every pair in
+    memory with byte-identical semantics to the single-shot function.
+    """
+    wanted = {(str(p), int(o)) for p, o in pairs}
+    if not wanted:
+        return {}
+
+    rows = (
+        await db.execute(
+            select(ASNRpkiRoa.prefix, ASNRpkiRoa.max_length, ASN.number).join(
+                ASN, ASNRpkiRoa.asn_id == ASN.id
+            )
+        )
+    ).all()
+    # Pre-parse the ROA set once.
+    roas: list[tuple[Any, int, int]] = []
+    for roa_prefix, max_length, asn_number in rows:
+        net = _parse_net(str(roa_prefix))
+        if net is None:
+            continue
+        roas.append((net, int(asn_number), int(max_length)))
+
+    out: dict[tuple[str, int], str] = {}
+    for prefix, origin in wanted:
+        obs = _parse_net(prefix)
+        if obs is None:
+            out[(prefix, origin)] = RPKI_UNKNOWN
+            continue
+        covering = False
+        status = RPKI_UNKNOWN
+        for net, roa_origin, max_length in roas:
+            if net.version != obs.version:
+                continue
+            try:
+                contains = net.supernet_of(obs)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                contains = False
+            if not contains:
+                continue
+            covering = True
+            if roa_origin == origin and obs.prefixlen <= max_length:
+                status = RPKI_VALID
+                break
+        if status != RPKI_VALID:
+            status = RPKI_INVALID if covering else RPKI_UNKNOWN
+        out[(prefix, origin)] = status
+    return out
 
 
 def expected_origin_set(tracked: BGPTrackedPrefix) -> set[int]:

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -125,6 +125,18 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         group="Network",
         description="Multicast group registry — addresses + producer/consumer memberships for SMPTE 2110 / Dante / NDI / market-data deployments. Niche but high-value when operators need it.",
     ),
+    # BGP Looking Glass (#566) — a receive-only GoBGP collector peers with the
+    # operator's routers and mirrors the live Adj-RIB-In, linking every learned
+    # prefix / origin ASN / community back into IPAM. Default-ENABLED for
+    # discovery: the Sessions/Routes surface appears, but the collector does
+    # NOTHING until an operator configures a peer (the only secret is the
+    # Fernet-encrypted MD5 password). Receive-only — never advertises.
+    ModuleSpec(
+        id="network.looking_glass",
+        label="BGP Looking Glass",
+        group="Network",
+        description="Receive-only BGP collector that peers with your routers and surfaces the live routing table — every learned prefix, origin ASN and community linked back into IPAM / the ASN + community catalogs, RPKI-validated. Never advertises routes to your network. Discovery toggle only; the collector does nothing until you configure a peer.",
+    ),
     ModuleSpec(
         id="ipam.address_sets",
         label="Address sets",

--- a/backend/app/services/looking_glass/agent_token.py
+++ b/backend/app/services/looking_glass/agent_token.py
@@ -1,0 +1,67 @@
+"""JWT mint/verify/rotate for BGP Looking Glass collectors.
+
+Mirrors ``app.services.dhcp.agent_token`` — the collector is an
+agent-managed resource, so it reuses the identical PSK→JWT bootstrap and
+near-expiry rotation shape. The only difference is the token ``typ``
+(``lg_agent``) so a DHCP / DNS token can't be replayed against the
+Looking Glass agent endpoints.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from jose import JWTError, jwt
+
+from app.config import settings
+
+ALGORITHM = "HS256"
+DEFAULT_TTL_HOURS = 24
+ROTATION_WINDOW_HOURS = 12
+
+
+def mint_agent_token(
+    collector_id: str,
+    agent_id: str,
+    fingerprint: str,
+    ttl_hours: int = DEFAULT_TTL_HOURS,
+) -> tuple[str, datetime]:
+    expire = datetime.now(UTC) + timedelta(hours=ttl_hours)
+    payload: dict[str, Any] = {
+        "sub": collector_id,
+        "agent_id": agent_id,
+        "fingerprint": fingerprint,
+        "typ": "lg_agent",
+        "exp": expire,
+    }
+    token = jwt.encode(payload, settings.secret_key, algorithm=ALGORITHM)
+    return token, expire
+
+
+def verify_agent_token(token: str) -> dict[str, Any]:
+    payload = jwt.decode(token, settings.secret_key, algorithms=[ALGORITHM])
+    if payload.get("typ") != "lg_agent":
+        raise JWTError("Not a Looking Glass agent token")
+    return payload
+
+
+def needs_rotation(payload: dict[str, Any]) -> bool:
+    exp = payload.get("exp")
+    if not exp:
+        return True
+    expire = datetime.fromtimestamp(int(exp), UTC)
+    return (expire - datetime.now(UTC)) < timedelta(hours=ROTATION_WINDOW_HOURS)
+
+
+def hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+__all__ = [
+    "mint_agent_token",
+    "verify_agent_token",
+    "needs_rotation",
+    "hash_token",
+]

--- a/backend/app/services/looking_glass/as_path_query.py
+++ b/backend/app/services/looking_glass/as_path_query.py
@@ -1,0 +1,75 @@
+"""Shared AS-path regex query helper for the Looking Glass RIB (#566 Phase 4).
+
+Used by both ``GET /looking-glass/routes?as_path_regexp=`` (see
+``app.api.v1.looking_glass.router.list_routes``) and the ``find_bgp_routes``
+Operator Copilot tool (``app.services.ai.tools.bgp_lg``) so the Cisco/
+Juniper ``_`` boundary-token translation lives in exactly one place.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from sqlalchemy import Text, cast, func
+
+from app.models.bgp_looking_glass import BGPLGRoute
+
+
+def translate_as_path_regexp(raw: str) -> str:
+    """Translate ``_`` boundary tokens (Cisco/Juniper AS-path regexp
+    convention) into a Postgres POSIX ERE fragment matching against the
+    space-delimited, space-bounded rendering of ``as_path`` (see
+    :func:`as_path_regexp_clause`).
+
+    * A leading ``_`` -> ``(^|[[:space:]])``
+    * A trailing ``_`` -> ``([[:space:]]|$)``
+    * Any other ``_`` -> ``[[:space:]]``
+
+    Everything else in ``raw`` passes through untouched — operators may use
+    plain POSIX ERE (Postgres's regex engine, not PCRE) alongside ``_``.
+    """
+    n = len(raw)
+    out: list[str] = []
+    for i, ch in enumerate(raw):
+        if ch != "_":
+            out.append(ch)
+        elif i == 0:
+            out.append("(^|[[:space:]])")
+        elif i == n - 1:
+            out.append("([[:space:]]|$)")
+        else:
+            out.append("[[:space:]]")
+    return "".join(out)
+
+
+def as_path_regexp_clause(pattern: str) -> Any:
+    """Build the WHERE clause for an AS-path regexp match against
+    ``BGPLGRoute.as_path``.
+
+    Raises ``re.error`` if the translated pattern doesn't compile under
+    Python's ``re`` — a friendly pre-check (the grammars aren't perfectly
+    equivalent, but this catches the common unbalanced paren/bracket
+    mistake before it reaches Postgres as a raw asyncpg error). Callers
+    should catch ``re.error`` and turn it into a 422 / tool-note.
+    """
+    translated = translate_as_path_regexp(pattern)
+    re.compile(translated)  # raises re.error on malformed input
+    # Render as_path (JSONB "[64500, 65001]") to a clean space-delimited string
+    # "64500 65001": strip the brackets/commas to spaces, collapse the runs
+    # (``, `` -> two spaces, plus the bracket spaces) and trim the ends. Without
+    # the collapse+trim the leading "[" and trailing "]" leave boundary spaces
+    # that break ``^``/``$`` (origin/tail) anchoring — a pattern like ``_65001$``
+    # would never match because the text ends in a space, not the last ASN.
+    path_text = func.trim(
+        func.regexp_replace(
+            func.translate(cast(BGPLGRoute.as_path, Text), "[],", "   "),
+            "[[:space:]]+",
+            " ",
+            "g",
+        )
+    )
+    return path_text.op("~")(translated)
+
+
+__all__ = ["as_path_regexp_clause", "translate_as_path_regexp"]

--- a/backend/app/services/looking_glass/config_bundle.py
+++ b/backend/app/services/looking_glass/config_bundle.py
@@ -1,0 +1,152 @@
+"""Assemble a neutral peer-config bundle for a Looking Glass collector.
+
+The GoBGP collector long-polls ``GET /looking-glass/agents/config`` with
+its last-seen ETag; the api handler rebuilds this bundle from the
+collector's enabled ``BGPLGPeer`` rows, hashes it to an ETag, and returns
+the new bundle the instant the ETag shifts (cross-cutting pattern #2).
+
+Every field that affects the rendered GoBGP neighbor config MUST flow
+into ``compute_etag`` — miss one and a peer edit never re-renders on the
+collector (the ETag never moves, the long-poll 304s forever). Mirrors
+``app.drivers.dhcp.base.ConfigBundle.compute_etag``.
+
+The decrypted TCP-MD5 password rides **only** inside the bundle body,
+which is delivered over TLS to the JWT-authed agent. It is never returned
+on any operator-facing surface (the CRUD router exposes
+``md5_password_set: bool`` instead).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import decrypt_str
+from app.models.bgp_looking_glass import BGPLGPeer, LookingGlassCollector
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class LGPeerDef:
+    """One receive-only BGP neighbor the collector renders + peers with."""
+
+    peer_id: str
+    name: str
+    peer_address: str
+    peer_asn: int
+    local_asn: int
+    address_families: tuple[str, ...]
+    max_prefixes: int
+    import_filter: dict
+    # Decrypted TCP-MD5 password — present ONLY in the bundle sent over
+    # TLS to the authed agent. Never surfaced on an operator API.
+    md5_password: str | None = None
+    md5_password_set: bool = False
+
+
+@dataclass
+class LGConfigBundle:
+    collector_id: str
+    collector_name: str
+    peers: tuple[LGPeerDef, ...] = ()
+    generated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    etag: str = ""
+
+    def compute_etag(self) -> str:
+        """Stable SHA-256 over every config-affecting field.
+
+        Excludes ``generated_at`` / ``etag`` (non-deterministic /
+        derived). Includes the decrypted ``md5_password`` so rotating a
+        peer's MD5 secret shifts the ETag and re-renders the neighbor;
+        the resulting hash is irreversible and safe to hand to the agent
+        as the ``ETag`` header.
+        """
+        payload = {
+            "collector_id": self.collector_id,
+            "collector_name": self.collector_name,
+            "peers": [asdict(p) for p in self.peers],
+        }
+        blob = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+        return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+async def build_lg_config_bundle(
+    db: AsyncSession, collector: LookingGlassCollector
+) -> LGConfigBundle:
+    """Build the peer-config bundle for ``collector`` from its enabled peers.
+
+    A collector toggled ``enabled=False`` renders an EMPTY peer set — the
+    ETag shifts, the agent re-renders to zero neighbors, and every session is
+    torn down. So the operator's disable actually takes effect on the box.
+    """
+    peers: list[LGPeerDef] = []
+
+    if collector.enabled:
+        rows = list(
+            (
+                await db.execute(
+                    select(BGPLGPeer)
+                    .where(
+                        BGPLGPeer.collector_id == collector.id,
+                        BGPLGPeer.enabled.is_(True),
+                    )
+                    .order_by(BGPLGPeer.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        for p in rows:
+            md5_plain: str | None = None
+            if p.md5_password_encrypted:
+                try:
+                    md5_plain = decrypt_str(p.md5_password_encrypted)
+                except Exception:  # noqa: BLE001 — corrupt/unrotatable secret
+                    # Never ship a SILENTLY unauthenticated neighbor: a peer
+                    # configured WITH an MD5 password whose ciphertext won't
+                    # decrypt (SECRET_KEY / CREDENTIAL_ENCRYPTION_KEY changed,
+                    # corrupt column) is EXCLUDED from the bundle rather than
+                    # rendered without auth. The session drops — the safe
+                    # failure mode for an auth-config problem — and the loud
+                    # log tells the operator to re-enter the key.
+                    logger.error(
+                        "lg_peer_md5_decrypt_failed",
+                        collector_id=str(collector.id),
+                        peer_id=str(p.id),
+                        peer_address=str(p.peer_address),
+                    )
+                    continue
+            peers.append(
+                LGPeerDef(
+                    peer_id=str(p.id),
+                    name=p.name,
+                    peer_address=str(p.peer_address),
+                    peer_asn=p.peer_asn,
+                    local_asn=p.local_asn,
+                    address_families=tuple(p.address_families or ()),
+                    max_prefixes=p.max_prefixes,
+                    import_filter=dict(p.import_filter or {}),
+                    md5_password=md5_plain,
+                    md5_password_set=bool(p.md5_password_encrypted),
+                )
+            )
+
+    bundle = LGConfigBundle(
+        collector_id=str(collector.id),
+        collector_name=collector.name,
+        peers=tuple(peers),
+        generated_at=datetime.now(UTC),
+    )
+    bundle.etag = bundle.compute_etag()
+    return bundle
+
+
+__all__ = ["LGConfigBundle", "LGPeerDef", "build_lg_config_bundle"]

--- a/backend/app/services/looking_glass/ipam_link.py
+++ b/backend/app/services/looking_glass/ipam_link.py
@@ -19,14 +19,17 @@ pushes.
   (e.g. advertising a whole ``/16`` containing many ``/24`` subnets) can
   match an enclosing **block** but no single subnet — that's intentional,
   an aggregate doesn't "belong to" one leaf subnet.
-* ``matched_vrf_id`` is NOT RD-based VRF matching. ``ext_communities``
-  (which would carry RD/RT for a real VPNv4/VPNv6 match) is an explicitly
-  deferred later phase — there is no VPN AFI/SAFI data to parse yet.
-  ``matched_vrf_id`` here means "the VRF assigned to whichever IPAM
-  block/space this prefix falls under" (first non-NULL ``vrf_id`` walking
-  block -> parent_block_id chain -> space), the only VRF signal available
-  pre-VPNv4. A future VPNv4 phase must not assume this field already means
-  RD-matched.
+* ``resolve_route_links``'s ``vrf_id`` is NOT RT-based VRF matching — it
+  means "the VRF assigned to whichever IPAM block/space this prefix falls
+  under" (first non-NULL ``vrf_id`` walking block -> parent_block_id chain
+  -> space). Issue #566 Phase 6 adds a separate Route-Target cross-check
+  (``app.services.looking_glass.vrf_match.match_vrf_for_route``, matched
+  against a route's ``ext_communities``) that callers overlay on TOP of
+  this result — a Route-Target hit takes precedence over this
+  IPAM-effective value for the route's persisted ``matched_vrf_id``. This
+  function itself is unaware of that overlay; see ``routes_ingest.py`` and
+  ``app.tasks.looking_glass.reresolve_route_links`` for where the
+  precedence is actually applied.
 * ``matched_asn_id`` is a raw ``origin_asn == ASN.number`` match, NOT "the
   ASN assigned to the matched IPAM object." A route whose origin AS has no
   tracked ``ASN`` row gets ``matched_asn_id = None`` even if its prefix

--- a/backend/app/services/looking_glass/ipam_link.py
+++ b/backend/app/services/looking_glass/ipam_link.py
@@ -1,0 +1,227 @@
+"""BGP Looking Glass — IPAM / ASN / VRF linkage resolver (issue #566 Phase 3).
+
+Resolves a learned route's ``(prefix, origin_asn)`` against the IPAM tree so
+``BGPLGRoute.matched_{block,subnet,space,asn,vrf}_id`` can be populated — both
+at ingest time (``routes_ingest.py``) and by the periodic re-resolve sweep
+(``app.tasks.looking_glass``) that catches IPAM edits made between RIB
+pushes.
+
+**Semantics (read before changing anything):**
+
+* ``matched_subnet_id`` wins over ``matched_block_id`` when both could
+  match — a subnet is always the more specific/leaf entity. If a subnet
+  matches, ``matched_block_id`` is read straight off ``subnet.block_id``
+  (no separate block LPM needed).
+* Containment direction: a route's ``prefix`` matches an IPAM object when
+  the IPAM object's CIDR is a supernet of, or equal to, the route prefix
+  (``target.subnet_of(net)``) — i.e. the route is same-or-more-specific
+  than the IPAM object. An aggregate route covering several IPAM subnets
+  (e.g. advertising a whole ``/16`` containing many ``/24`` subnets) can
+  match an enclosing **block** but no single subnet — that's intentional,
+  an aggregate doesn't "belong to" one leaf subnet.
+* ``matched_vrf_id`` is NOT RD-based VRF matching. ``ext_communities``
+  (which would carry RD/RT for a real VPNv4/VPNv6 match) is an explicitly
+  deferred later phase — there is no VPN AFI/SAFI data to parse yet.
+  ``matched_vrf_id`` here means "the VRF assigned to whichever IPAM
+  block/space this prefix falls under" (first non-NULL ``vrf_id`` walking
+  block -> parent_block_id chain -> space), the only VRF signal available
+  pre-VPNv4. A future VPNv4 phase must not assume this field already means
+  RD-matched.
+* ``matched_asn_id`` is a raw ``origin_asn == ASN.number`` match, NOT "the
+  ASN assigned to the matched IPAM object." A route whose origin AS has no
+  tracked ``ASN`` row gets ``matched_asn_id = None`` even if its prefix
+  falls inside a block that itself has an ``asn_id`` — these are two
+  different concepts (who announced it vs. who's supposed to own the
+  address space) and only the former is resolved here.
+
+**Why a TTL cache (mirrors ``app.services.rpki_roa``):** each collector
+pushes one full-snapshot POST per peer roughly every 30s (jittered). A
+deployment with N peers calls ``ingest_routes()`` roughly N times per 30s
+window, so rebuilding the full subnet+block+space+ASN scan on every single
+call scales with peer count for no benefit — IPAM structure doesn't change
+every 30 seconds. The 15s TTL cache caps rebuilds at ~2 per 30s window
+regardless of peer count while staying fresh enough for the common case;
+the periodic re-resolve sweep is the correctness backstop for the rest.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import time
+import uuid
+from dataclasses import dataclass, field
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.asn import ASN
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+_CACHE_TTL_SECONDS = 15.0  # mirrors rpki_roa.py's _CACHE_TTL_SECONDS pattern
+
+_cache: tuple[float, LinkResolutionCache] | None = None
+
+
+def _parse_net(value: str | None) -> ipaddress._BaseNetwork | None:
+    if not value:
+        return None
+    try:
+        return ipaddress.ip_network(str(value), strict=False)
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class ResolvedLinks:
+    block_id: uuid.UUID | None = None
+    subnet_id: uuid.UUID | None = None
+    space_id: uuid.UUID | None = None
+    asn_id: uuid.UUID | None = None
+    vrf_id: uuid.UUID | None = None
+
+
+@dataclass
+class LinkResolutionCache:
+    subnets: list[tuple[Subnet, ipaddress._BaseNetwork]] = field(default_factory=list)
+    blocks: list[tuple[IPBlock, ipaddress._BaseNetwork]] = field(default_factory=list)
+    blocks_by_id: dict[uuid.UUID, IPBlock] = field(default_factory=dict)
+    spaces_by_id: dict[uuid.UUID, IPSpace] = field(default_factory=dict)
+    asn_by_number: dict[int, uuid.UUID] = field(default_factory=dict)
+
+
+async def build_resolution_cache(db: AsyncSession) -> LinkResolutionCache:
+    """Uncached — always hits the DB. Use ``get_resolution_cache()`` for the
+    TTL-cached wrapper; call this directly only from the periodic re-resolve
+    sweep, which wants a fresh read every time it runs."""
+    cache = LinkResolutionCache()
+
+    for s in (await db.execute(select(Subnet))).scalars().all():
+        net = _parse_net(str(s.network))
+        if net is not None:
+            cache.subnets.append((s, net))
+
+    all_blocks = (await db.execute(select(IPBlock))).scalars().all()
+    for b in all_blocks:
+        cache.blocks_by_id[b.id] = b
+        net = _parse_net(str(b.network))
+        if net is not None:
+            cache.blocks.append((b, net))
+
+    for sp in (await db.execute(select(IPSpace))).scalars().all():
+        cache.spaces_by_id[sp.id] = sp
+
+    for number, asn_id in (await db.execute(select(ASN.number, ASN.id))).all():
+        cache.asn_by_number[int(number)] = asn_id
+
+    return cache
+
+
+async def get_resolution_cache(db: AsyncSession) -> LinkResolutionCache:
+    """TTL-cached wrapper — avoids a full subnet+block+space+ASN table scan
+    on every single ~30s-per-peer RIB push (see module docstring). Mirrors
+    ``app.services.rpki_roa``'s ``_get_cached_roas()`` pattern exactly."""
+    global _cache
+    now = time.monotonic()
+    if _cache is not None and (now - _cache[0]) < _CACHE_TTL_SECONDS:
+        return _cache[1]
+    fresh = await build_resolution_cache(db)
+    _cache = (now, fresh)
+    return fresh
+
+
+def _best_containing(
+    candidates: list[tuple],
+    target: ipaddress._BaseNetwork,
+):
+    """Most-specific (longest-prefix) candidate whose network is a supernet
+    of, or equal to, ``target``. Mirrors
+    ``cloud/reconcile.py::_find_enclosing_block``'s ``net.subnet_of()``
+    check, generalised over both ``Subnet`` and ``IPBlock`` candidate
+    lists."""
+    best = None
+    best_prefixlen = -1
+    for obj, net in candidates:
+        if net.version != target.version:
+            continue
+        try:
+            contains = target.subnet_of(net)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            contains = False
+        if contains and net.prefixlen > best_prefixlen:
+            best = obj
+            best_prefixlen = net.prefixlen
+    return best
+
+
+def _effective_vrf_id(block_id: uuid.UUID, cache: LinkResolutionCache) -> uuid.UUID | None:
+    """First non-NULL ``vrf_id`` walking ``block -> parent_block_id`` chain
+    -> space. No inherit-toggle exists on ``IPBlock``/``IPSpace`` for
+    ``vrf_id``/``asn_id`` (unlike DDNS's ``ddns_inherit_settings``) — first
+    non-NULL wins."""
+    start = cache.blocks_by_id.get(block_id)
+    if start is None:
+        return None
+    space_id = start.space_id
+    seen: set[uuid.UUID] = set()
+    current: IPBlock | None = start
+    while current is not None and current.id not in seen:
+        seen.add(current.id)
+        if current.vrf_id is not None:
+            return current.vrf_id
+        current = (
+            cache.blocks_by_id.get(current.parent_block_id) if current.parent_block_id else None
+        )
+    space = cache.spaces_by_id.get(space_id)
+    return space.vrf_id if space is not None else None
+
+
+def resolve_route_links(
+    cache: LinkResolutionCache, prefix: str, origin_asn: int | None
+) -> ResolvedLinks:
+    """Pure, in-memory match against a pre-built cache. Called once per
+    route inside ``ingest_routes()``'s upsert loop and once per active
+    route inside the periodic re-resolve sweep."""
+    try:
+        target = ipaddress.ip_network(str(prefix), strict=False)
+    except ValueError:
+        return ResolvedLinks()
+
+    subnet = _best_containing(cache.subnets, target)
+    block_id: uuid.UUID | None
+    subnet_id: uuid.UUID | None = None
+    space_id: uuid.UUID | None = None
+
+    if subnet is not None:
+        subnet_id = subnet.id
+        block_id = subnet.block_id
+        space_id = subnet.space_id
+    else:
+        block = _best_containing(cache.blocks, target)
+        block_id = block.id if block else None
+        space_id = block.space_id if block else None
+
+    vrf_id = _effective_vrf_id(block_id, cache) if block_id is not None else None
+    asn_id = cache.asn_by_number.get(int(origin_asn)) if origin_asn is not None else None
+
+    return ResolvedLinks(
+        block_id=block_id,
+        subnet_id=subnet_id,
+        space_id=space_id,
+        asn_id=asn_id,
+        vrf_id=vrf_id,
+    )
+
+
+def _clear_cache_for_test() -> None:
+    global _cache
+    _cache = None
+
+
+__all__ = [
+    "ResolvedLinks",
+    "LinkResolutionCache",
+    "build_resolution_cache",
+    "get_resolution_cache",
+    "resolve_route_links",
+    "_clear_cache_for_test",
+]

--- a/backend/app/services/looking_glass/reachability.py
+++ b/backend/app/services/looking_glass/reachability.py
@@ -1,0 +1,203 @@
+"""Read-only BGP reachability helpers (issue #566 Phase 6).
+
+1. ``find_covering_routes`` — longest-prefix-match against the learned RIB
+   for a single IP. Hoisted out of
+   ``app.services.ai.tools.bgp_lg.find_bgp_route_for_ip`` (its only caller
+   before this phase, sharing an implementation with
+   ``app.services.looking_glass.reverse_lookup.best_route_for_ip`` which the
+   ``GET /looking-glass/routes/for-ip`` endpoint uses) so the multicast
+   cross-reference below can share the identical LPM + tie-break semantics
+   instead of a third hand-rolled copy.
+2. ``multicast_bgp_reachability`` — cross-references every PIM domain's
+   rendezvous-point address and every multicast group's producer source
+   subnet against the learned RIB. Computed on demand, nothing persisted —
+   a much looser/lighter signal than VRF RT matching (``vrf_match.py``),
+   not worth a schema change.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.bgp_looking_glass import BGPLGRoute
+from app.models.ipam import IPAddress, Subnet
+from app.models.multicast import MulticastDomain, MulticastGroup, MulticastMembership
+from app.models.network import NetworkDevice
+
+
+async def _covering_candidates(
+    db: AsyncSession, network_or_ip: str
+) -> list[tuple[Any, BGPLGRoute]]:
+    stmt = select(BGPLGRoute).where(
+        BGPLGRoute.prefix.op(">>=")(network_or_ip),
+        BGPLGRoute.withdrawn_at.is_(None),
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    out: list[tuple[Any, BGPLGRoute]] = []
+    for row in rows:
+        try:
+            net = ipaddress.ip_network(str(row.prefix), strict=False)
+        except ValueError:
+            continue
+        out.append((net, row))
+    return out
+
+
+def _sort_candidates(candidates: list[tuple[Any, BGPLGRoute]]) -> list[BGPLGRoute]:
+    # Longest prefix wins; among ties prefer the best path, then order by
+    # peer id so the result never depends on iteration/DB order (mirrors
+    # reverse_lookup.best_route_for_ip's tie-break).
+    candidates.sort(key=lambda t: (-t[0].prefixlen, 0 if t[1].is_best else 1, str(t[1].peer_id)))
+    return [row for _net, row in candidates]
+
+
+async def find_covering_routes(db: AsyncSession, ip: str) -> list[BGPLGRoute]:
+    """Every active route covering a single IP, longest-prefix-first."""
+    try:
+        ip_obj = ipaddress.ip_address(ip)
+    except ValueError:
+        return []
+    candidates = [
+        (net, row)
+        for net, row in await _covering_candidates(db, str(ip_obj))
+        if net.version == ip_obj.version and ip_obj in net
+    ]
+    return _sort_candidates(candidates)
+
+
+async def find_covering_route_for_subnet(db: AsyncSession, subnet_cidr: str) -> BGPLGRoute | None:
+    """Best active route that is a supernet-or-equal of ``subnet_cidr`` —
+    i.e. the WHOLE subnet is reachable, not just its base address.
+    Deliberately distinct from ``find_covering_routes``'s single-IP
+    semantics: a /32 host route sitting on the subnet's network address
+    would satisfy a plain point LPM without covering the rest of the
+    subnet, which would be a wrong answer for "is this source subnet
+    reachable?".
+    """
+    try:
+        subnet_net = ipaddress.ip_network(subnet_cidr, strict=False)
+    except ValueError:
+        return None
+    candidates = [
+        (net, row)
+        for net, row in await _covering_candidates(db, str(subnet_net))
+        if net.version == subnet_net.version and net.prefixlen <= subnet_net.prefixlen
+    ]
+    sorted_routes = _sort_candidates(candidates)
+    return sorted_routes[0] if sorted_routes else None
+
+
+@dataclass
+class DomainReachabilityResult:
+    domain_id: uuid.UUID
+    domain_name: str
+    rp_address: str
+    covering_route: BGPLGRoute | None
+
+
+@dataclass
+class GroupReachabilityResult:
+    group_id: uuid.UUID
+    group_name: str
+    group_address: str
+    source_subnet_id: uuid.UUID
+    source_subnet: str
+    covering_route: BGPLGRoute | None
+
+
+@dataclass
+class MulticastReachabilityResult:
+    domains: list[DomainReachabilityResult]
+    groups: list[GroupReachabilityResult]
+
+
+async def _resolve_domain_rp(db: AsyncSession, domain: MulticastDomain) -> str | None:
+    if domain.rendezvous_point_address:
+        return domain.rendezvous_point_address
+    if domain.rendezvous_point_device_id:
+        device = await db.get(NetworkDevice, domain.rendezvous_point_device_id)
+        if device is not None:
+            return str(device.ip_address)
+    return None
+
+
+async def multicast_bgp_reachability(db: AsyncSession) -> MulticastReachabilityResult:
+    """PIM-domain RP reachability + multicast-group producer-subnet
+    reachability against the learned RIB, in one call.
+
+    Only domains in ``pim_mode`` ``sparse``/``bidir`` are RP-reachability
+    checked — those are the only modes where an RP is meaningful
+    (``MulticastDomain``'s own docstring in ``app.models.multicast``).
+    """
+    domain_rows = (
+        (
+            await db.execute(
+                select(MulticastDomain).where(MulticastDomain.pim_mode.in_(("sparse", "bidir")))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    domains: list[DomainReachabilityResult] = []
+    for d in domain_rows:
+        rp = await _resolve_domain_rp(db, d)
+        if not rp:
+            continue
+        routes = await find_covering_routes(db, rp)
+        domains.append(
+            DomainReachabilityResult(
+                domain_id=d.id,
+                domain_name=d.name,
+                rp_address=rp,
+                covering_route=routes[0] if routes else None,
+            )
+        )
+
+    # Producer memberships -> IPAddress -> enclosing Subnet. A group with
+    # multiple producers in different subnets yields multiple rows (each
+    # subnet checked once); dedupe (group, subnet) pairs.
+    group_rows = (
+        await db.execute(
+            select(MulticastGroup, Subnet)
+            .join(MulticastMembership, MulticastMembership.group_id == MulticastGroup.id)
+            .where(MulticastMembership.role == "producer")
+            .join(IPAddress, IPAddress.id == MulticastMembership.ip_address_id)
+            .join(Subnet, Subnet.id == IPAddress.subnet_id)
+        )
+    ).all()
+    groups: list[GroupReachabilityResult] = []
+    seen: set[tuple[uuid.UUID, uuid.UUID]] = set()
+    for group, subnet in group_rows:
+        key = (group.id, subnet.id)
+        if key in seen:
+            continue
+        seen.add(key)
+        route = await find_covering_route_for_subnet(db, str(subnet.network))
+        groups.append(
+            GroupReachabilityResult(
+                group_id=group.id,
+                group_name=group.name,
+                group_address=str(group.address),
+                source_subnet_id=subnet.id,
+                source_subnet=str(subnet.network),
+                covering_route=route,
+            )
+        )
+
+    return MulticastReachabilityResult(domains=domains, groups=groups)
+
+
+__all__ = [
+    "DomainReachabilityResult",
+    "GroupReachabilityResult",
+    "MulticastReachabilityResult",
+    "find_covering_route_for_subnet",
+    "find_covering_routes",
+    "multicast_bgp_reachability",
+]

--- a/backend/app/services/looking_glass/reverse_lookup.py
+++ b/backend/app/services/looking_glass/reverse_lookup.py
@@ -3,17 +3,19 @@
 Shared by the operator-facing ``GET /looking-glass/routes/for-ip`` endpoint
 and the ``find_bgp_route_for_ip`` MCP tool — one implementation, two
 callers, so the LPM-by-single-IP semantics can't drift between the two
-surfaces.
+surfaces. The actual LPM + tie-break now lives in
+``app.services.looking_glass.reachability.find_covering_routes`` (issue
+#566 Phase 6 hoisted it out so the multicast reachability cross-reference
+could share it too); this module keeps its own thin ``(route, alt_count)``
+wrapper so its two existing callers don't need to change shape.
 """
 
 from __future__ import annotations
 
-import ipaddress
-
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.bgp_looking_glass import BGPLGRoute
+from app.services.looking_glass.reachability import find_covering_routes
 
 
 async def best_route_for_ip(db: AsyncSession, ip: str) -> tuple[BGPLGRoute, int] | None:
@@ -24,39 +26,10 @@ async def best_route_for_ip(db: AsyncSession, ip: str) -> tuple[BGPLGRoute, int]
     tie-break: longest prefix wins; among ties prefer the best path, then
     order by peer id.
     """
-    try:
-        ip_obj = ipaddress.ip_address(ip)
-    except ValueError:
+    routes = await find_covering_routes(db, ip)
+    if not routes:
         return None
-
-    rows = (
-        (
-            await db.execute(
-                select(BGPLGRoute).where(
-                    BGPLGRoute.prefix.op(">>=")(str(ip_obj)),
-                    BGPLGRoute.withdrawn_at.is_(None),
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-
-    covering: list[tuple[ipaddress._BaseNetwork, BGPLGRoute]] = []
-    for row in rows:
-        try:
-            net = ipaddress.ip_network(str(row.prefix), strict=False)
-        except ValueError:
-            continue
-        if net.version != ip_obj.version or ip_obj not in net:
-            continue
-        covering.append((net, row))
-
-    if not covering:
-        return None
-
-    covering.sort(key=lambda t: (-t[0].prefixlen, 0 if t[1].is_best else 1, str(t[1].peer_id)))
-    return covering[0][1], len(covering) - 1
+    return routes[0], len(routes) - 1
 
 
 __all__ = ["best_route_for_ip"]

--- a/backend/app/services/looking_glass/reverse_lookup.py
+++ b/backend/app/services/looking_glass/reverse_lookup.py
@@ -1,0 +1,62 @@
+"""Reverse IP -> BGP Looking Glass route lookup (issue #566 Phase 3).
+
+Shared by the operator-facing ``GET /looking-glass/routes/for-ip`` endpoint
+and the ``find_bgp_route_for_ip`` MCP tool — one implementation, two
+callers, so the LPM-by-single-IP semantics can't drift between the two
+surfaces.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.bgp_looking_glass import BGPLGRoute
+
+
+async def best_route_for_ip(db: AsyncSession, ip: str) -> tuple[BGPLGRoute, int] | None:
+    """Longest-prefix-match a single IP against the active learned RIB.
+
+    Returns ``(best_route, alternate_paths_count)`` or ``None`` when ``ip``
+    doesn't parse or nothing in the active RIB covers it. Deterministic
+    tie-break: longest prefix wins; among ties prefer the best path, then
+    order by peer id.
+    """
+    try:
+        ip_obj = ipaddress.ip_address(ip)
+    except ValueError:
+        return None
+
+    rows = (
+        (
+            await db.execute(
+                select(BGPLGRoute).where(
+                    BGPLGRoute.prefix.op(">>=")(str(ip_obj)),
+                    BGPLGRoute.withdrawn_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    covering: list[tuple[ipaddress._BaseNetwork, BGPLGRoute]] = []
+    for row in rows:
+        try:
+            net = ipaddress.ip_network(str(row.prefix), strict=False)
+        except ValueError:
+            continue
+        if net.version != ip_obj.version or ip_obj not in net:
+            continue
+        covering.append((net, row))
+
+    if not covering:
+        return None
+
+    covering.sort(key=lambda t: (-t[0].prefixlen, 0 if t[1].is_best else 1, str(t[1].peer_id)))
+    return covering[0][1], len(covering) - 1
+
+
+__all__ = ["best_route_for_ip"]

--- a/backend/app/services/looking_glass/routes_ingest.py
+++ b/backend/app/services/looking_glass/routes_ingest.py
@@ -19,6 +19,14 @@ guard, differing only in the withdrawal semantics:
    the #527 hijack monitor, deduped per distinct ``(prefix, origin_asn)``
    so a full snapshot makes one ROA lookup per unique announcement, not
    one per path.
+ * ``matched_{block,subnet,space,asn,vrf}_id`` are resolved at ingest via
+   ``app.services.looking_glass.ipam_link.resolve_route_links`` against a
+   TTL-cached preload of the IPAM tree + ASN catalog (issue #566 Phase 3).
+   This is the write path the columns were shipped for in Phase 1 — see
+   that module for the containment/inheritance semantics. A periodic
+   re-resolve sweep (``app.tasks.looking_glass.reresolve_route_links``)
+   re-runs the same matcher over every active route so an IPAM edit made
+   between RIB pushes still converges within a few minutes.
  * **Absence-withdraw (full snapshot only):** every tracked row for this
    peer with ``withdrawn_at IS NULL`` that is NOT in the wire set has left
    the peer's feed — set ``withdrawn_at=now()`` and bump ``flap_count``.
@@ -49,6 +57,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute
 from app.services.bgp.hijack_monitor import derive_rpki_status_batch
+from app.services.looking_glass.ipam_link import (
+    get_resolution_cache,
+    resolve_route_links,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -145,6 +157,12 @@ async def ingest_routes(
     }
     rpki_cache = await derive_rpki_status_batch(db, rpki_pairs)
 
+    # ── IPAM / ASN / VRF linkage — one preload for the whole snapshot ────
+    # (TTL-cached — see ipam_link.py's module docstring for why a fresh
+    # subnet+block+space+ASN scan per ingest call would scale with peer
+    # count for no benefit.)
+    link_cache = await get_resolution_cache(db)
+
     # ── Upsert every wire path ───────────────────────────────────────────
     wire_keys: set[tuple[str, str]] = set()
     for r in valid:
@@ -153,6 +171,7 @@ async def ingest_routes(
         wire_keys.add((prefix, next_hop))
         origin = r.get("origin_asn")
         rpki = rpki_cache.get((prefix, int(origin)), "unknown") if origin is not None else "unknown"
+        links = resolve_route_links(link_cache, prefix, origin)
 
         row = by_key.get((prefix, next_hop))
         if row is None:
@@ -171,6 +190,11 @@ async def ingest_routes(
                         ext_communities=list(r.get("ext_communities") or []),
                         rpki_status=rpki,
                         is_best=bool(r.get("is_best", False)),
+                        matched_block_id=links.block_id,
+                        matched_subnet_id=links.subnet_id,
+                        matched_space_id=links.space_id,
+                        matched_asn_id=links.asn_id,
+                        matched_vrf_id=links.vrf_id,
                         first_seen_at=now,
                         last_seen_at=now,
                     )
@@ -187,6 +211,11 @@ async def ingest_routes(
                 row.ext_communities = list(r.get("ext_communities") or [])
                 row.rpki_status = rpki
                 row.is_best = bool(r.get("is_best", False))
+                row.matched_block_id = links.block_id
+                row.matched_subnet_id = links.subnet_id
+                row.matched_space_id = links.space_id
+                row.matched_asn_id = links.asn_id
+                row.matched_vrf_id = links.vrf_id
                 row.last_seen_at = now
                 # Re-announce of a previously-withdrawn path — clear the marker.
                 row.withdrawn_at = None

--- a/backend/app/services/looking_glass/routes_ingest.py
+++ b/backend/app/services/looking_glass/routes_ingest.py
@@ -29,7 +29,10 @@ guard, differing only in the withdrawal semantics:
    between RIB pushes still converges within a few minutes.
  * **Absence-withdraw (full snapshot only):** every tracked row for this
    peer with ``withdrawn_at IS NULL`` that is NOT in the wire set has left
-   the peer's feed — set ``withdrawn_at=now()`` and bump ``flap_count``.
+   the peer's feed — set ``withdrawn_at=now()``, bump ``flap_count``, and
+   stamp ``last_flap_at=now()`` (issue #566 Phase 5 — the recency
+   dimension the ``bgp_lg_route_flap`` alert needs so a route that flapped
+   a lot long ago but has been stable since doesn't page forever).
    Withdrawn rows are **never hard-deleted** — ``withdrawn_at`` is the
    designed history marker (the UI / alerts read it).
 
@@ -228,6 +231,7 @@ async def ingest_routes(
                 if apply:
                     row.withdrawn_at = now
                     row.flap_count = (row.flap_count or 0) + 1
+                    row.last_flap_at = now
                 result.withdrawn += 1
 
     if apply:

--- a/backend/app/services/looking_glass/routes_ingest.py
+++ b/backend/app/services/looking_glass/routes_ingest.py
@@ -7,9 +7,13 @@ guard, differing only in the withdrawal semantics:
 
 **Semantics — set-reconcile (upsert + absence-withdraw):**
 
- * The route identity key is ``(prefix, next_hop)`` — BGP allows multiple
-   paths per prefix (unlike DHCP's ``(server_id, ip)``), so a prefix with
-   two next-hops is two rows.
+ * The route identity key is ``(prefix, next_hop, route_distinguisher)`` —
+   BGP allows multiple paths per prefix (unlike DHCP's ``(server_id, ip)``),
+   so a prefix with two next-hops is two rows. ``route_distinguisher``
+   joined the key in issue #566 Phase 6: a VPNv4/VPNv6 path's RD (RFC 4364)
+   is the whole reason two VRFs can originate the SAME customer prefix
+   without collision — plain ipv4-unicast/ipv6-unicast paths always carry
+   ``""`` here, so this is a no-op widening for the pre-Phase-6 shape.
  * Upsert one ``BGPLGRoute`` per wire path: new keys insert with
    ``first_seen_at=now``; existing keys refresh the mutable attributes
    (``as_path`` / ``local_pref`` / ``med`` / communities / ``is_best`` /
@@ -27,6 +31,14 @@ guard, differing only in the withdrawal semantics:
    re-resolve sweep (``app.tasks.looking_glass.reresolve_route_links``)
    re-runs the same matcher over every active route so an IPAM edit made
    between RIB pushes still converges within a few minutes.
+ * ``matched_vrf_id`` specifically gets a second, higher-priority pass
+   (issue #566 Phase 6): a route's ``ext_communities`` are cross-checked
+   against every VRF's ``import_targets``/``export_targets`` via
+   ``app.services.looking_glass.vrf_match``. A Route-Target hit overrides
+   the plain IPAM-effective VRF from ``resolve_route_links`` — real
+   VPNv4/VPNv6 signal beats "whichever IPAM block this prefix happens to
+   fall under." Routes with no ext_communities RT hit keep the
+   IPAM-effective value (or ``None``) exactly as before.
  * **Absence-withdraw (full snapshot only):** every tracked row for this
    peer with ``withdrawn_at IS NULL`` that is NOT in the wire set has left
    the peer's feed — set ``withdrawn_at=now()``, bump ``flap_count``, and
@@ -64,6 +76,7 @@ from app.services.looking_glass.ipam_link import (
     get_resolution_cache,
     resolve_route_links,
 )
+from app.services.looking_glass.vrf_match import build_vrf_rt_index, match_vrf_for_route
 
 logger = structlog.get_logger(__name__)
 
@@ -101,12 +114,13 @@ async def ingest_routes(
     #    DataError at flush and 500 the WHOLE push. Parse-and-skip instead so
     #    one bad path can't discard a good snapshot. ip_network(strict=True)
     #    matches Postgres CIDR strictness (rejects non-network host bits).
-    #  * Dedup on the ``(prefix, next_hop)`` identity: two wire entries with
-    #    the same key would both take the insert branch (``by_key`` is built
-    #    once from the DB and not updated mid-loop) and collide on
-    #    ``uq_bgp_lg_route``. Normalising through ipaddress also canonicalises
-    #    the strings so they match the DB round-trip. Last write wins.
-    deduped: dict[tuple[str, str], dict[str, Any]] = {}
+    #  * Dedup on the ``(prefix, next_hop, route_distinguisher)`` identity:
+    #    two wire entries with the same key would both take the insert
+    #    branch (``by_key`` is built once from the DB and not updated
+    #    mid-loop) and collide on ``uq_bgp_lg_route``. Normalising through
+    #    ipaddress also canonicalises the strings so they match the DB
+    #    round-trip. Last write wins.
+    deduped: dict[tuple[str, str, str], dict[str, Any]] = {}
     for r in wire:
         prefix_raw, next_hop_raw = r.get("prefix"), r.get("next_hop")
         if not prefix_raw or not next_hop_raw:
@@ -117,7 +131,13 @@ async def ingest_routes(
         except ValueError:
             result.errors.append(f"skipped malformed route {prefix_raw!r} via {next_hop_raw!r}")
             continue
-        deduped[(prefix, next_hop)] = {**r, "prefix": prefix, "next_hop": next_hop}
+        rd = str(r.get("route_distinguisher") or "")
+        deduped[(prefix, next_hop, rd)] = {
+            **r,
+            "prefix": prefix,
+            "next_hop": next_hop,
+            "route_distinguisher": rd,
+        }
     valid = list(deduped.values())
     result.wire_routes = len(valid)
 
@@ -127,8 +147,8 @@ async def ingest_routes(
     existing_rows = list(
         (await db.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))).scalars().all()
     )
-    by_key: dict[tuple[str, str], BGPLGRoute] = {
-        (str(r.prefix), str(r.next_hop)): r for r in existing_rows
+    by_key: dict[tuple[str, str, str], BGPLGRoute] = {
+        (str(r.prefix), str(r.next_hop), r.route_distinguisher): r for r in existing_rows
     }
 
     # ── Zero-wire floor guard (#482) ────────────────────────────────────
@@ -166,17 +186,30 @@ async def ingest_routes(
     # count for no benefit.)
     link_cache = await get_resolution_cache(db)
 
+    # ── VRF Route-Target reverse index — one preload for the whole
+    # snapshot (issue #566 Phase 6). Not TTL-cached — VRF counts are small
+    # and each ingest call already only builds this once. See
+    # vrf_match.py's module docstring for the precedence rule.
+    vrf_rt_index = await build_vrf_rt_index(db)
+
     # ── Upsert every wire path ───────────────────────────────────────────
-    wire_keys: set[tuple[str, str]] = set()
+    wire_keys: set[tuple[str, str, str]] = set()
     for r in valid:
         prefix = str(r["prefix"])
         next_hop = str(r["next_hop"])
-        wire_keys.add((prefix, next_hop))
+        rd = str(r.get("route_distinguisher") or "")
+        wire_keys.add((prefix, next_hop, rd))
         origin = r.get("origin_asn")
         rpki = rpki_cache.get((prefix, int(origin)), "unknown") if origin is not None else "unknown"
         links = resolve_route_links(link_cache, prefix, origin)
+        ext_communities = list(r.get("ext_communities") or [])
+        # Route-Target cross-check takes precedence over the plain
+        # IPAM-effective VRF when it matches (issue #566 Phase 6 — see the
+        # ingest_routes docstring above).
+        vpn_matched_vrf_id = match_vrf_for_route(ext_communities, vrf_rt_index)
+        matched_vrf_id = vpn_matched_vrf_id if vpn_matched_vrf_id is not None else links.vrf_id
 
-        row = by_key.get((prefix, next_hop))
+        row = by_key.get((prefix, next_hop, rd))
         if row is None:
             if apply:
                 db.add(
@@ -186,18 +219,19 @@ async def ingest_routes(
                         origin_asn=origin,
                         as_path=list(r.get("as_path") or []),
                         next_hop=next_hop,
+                        route_distinguisher=rd,
                         local_pref=r.get("local_pref"),
                         med=r.get("med"),
                         communities=list(r.get("communities") or []),
                         large_communities=list(r.get("large_communities") or []),
-                        ext_communities=list(r.get("ext_communities") or []),
+                        ext_communities=ext_communities,
                         rpki_status=rpki,
                         is_best=bool(r.get("is_best", False)),
                         matched_block_id=links.block_id,
                         matched_subnet_id=links.subnet_id,
                         matched_space_id=links.space_id,
                         matched_asn_id=links.asn_id,
-                        matched_vrf_id=links.vrf_id,
+                        matched_vrf_id=matched_vrf_id,
                         first_seen_at=now,
                         last_seen_at=now,
                     )
@@ -211,14 +245,14 @@ async def ingest_routes(
                 row.med = r.get("med")
                 row.communities = list(r.get("communities") or [])
                 row.large_communities = list(r.get("large_communities") or [])
-                row.ext_communities = list(r.get("ext_communities") or [])
+                row.ext_communities = ext_communities
                 row.rpki_status = rpki
                 row.is_best = bool(r.get("is_best", False))
                 row.matched_block_id = links.block_id
                 row.matched_subnet_id = links.subnet_id
                 row.matched_space_id = links.space_id
                 row.matched_asn_id = links.asn_id
-                row.matched_vrf_id = links.vrf_id
+                row.matched_vrf_id = matched_vrf_id
                 row.last_seen_at = now
                 # Re-announce of a previously-withdrawn path — clear the marker.
                 row.withdrawn_at = None

--- a/backend/app/services/looking_glass/routes_ingest.py
+++ b/backend/app/services/looking_glass/routes_ingest.py
@@ -1,0 +1,210 @@
+"""Reconcile a Looking Glass collector's pushed Adj-RIB-In into the DB.
+
+Called by ``POST /looking-glass/agents/routes``. Cloned from
+``app.services.dhcp.pull_leases`` — the RIB is a set-reconcile just like
+the DHCP lease table, with the same absence-marker + zero-wire floor
+guard, differing only in the withdrawal semantics:
+
+**Semantics — set-reconcile (upsert + absence-withdraw):**
+
+ * The route identity key is ``(prefix, next_hop)`` — BGP allows multiple
+   paths per prefix (unlike DHCP's ``(server_id, ip)``), so a prefix with
+   two next-hops is two rows.
+ * Upsert one ``BGPLGRoute`` per wire path: new keys insert with
+   ``first_seen_at=now``; existing keys refresh the mutable attributes
+   (``as_path`` / ``local_pref`` / ``med`` / communities / ``is_best`` /
+   ``rpki_status``), bump ``last_seen_at``, and **clear ``withdrawn_at``**
+   (a re-announce of a previously-withdrawn path).
+ * ``rpki_status`` is computed at ingest via ``derive_rpki_status`` from
+   the #527 hijack monitor, deduped per distinct ``(prefix, origin_asn)``
+   so a full snapshot makes one ROA lookup per unique announcement, not
+   one per path.
+ * **Absence-withdraw (full snapshot only):** every tracked row for this
+   peer with ``withdrawn_at IS NULL`` that is NOT in the wire set has left
+   the peer's feed — set ``withdrawn_at=now()`` and bump ``flap_count``.
+   Withdrawn rows are **never hard-deleted** — ``withdrawn_at`` is the
+   designed history marker (the UI / alerts read it).
+
+**Zero-wire floor guard (correctness-critical, cloned from #482):** an
+EMPTY snapshot from a peer whose ``prefixes_received > 0`` is
+indistinguishable from a collector hiccup (gRPC timeout, session flap
+yielding a momentary empty ``ListPath``). Rather than let one empty poll
+withdraw the entire RIB, skip the absence-withdraw for that snapshot and
+log a warning; a genuine full withdrawal arrives as a real wire snapshot
+whose keys the reconcile still processes, not as silence.
+
+Idempotent (non-negotiable #9): a second identical snapshot is a no-op.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from ipaddress import ip_address, ip_network
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute
+from app.services.bgp.hijack_monitor import derive_rpki_status_batch
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class RoutesIngestResult:
+    wire_routes: int = 0  # count of valid paths in the pushed snapshot
+    imported: int = 0  # new BGPLGRoute rows inserted
+    refreshed: int = 0  # existing rows updated in place (incl. re-announce)
+    withdrawn: int = 0  # rows marked withdrawn_at by absence-reconcile
+    errors: list[str] = field(default_factory=list)
+
+
+async def ingest_routes(
+    db: AsyncSession,
+    peer: BGPLGPeer,
+    wire: list[dict[str, Any]],
+    *,
+    snapshot: bool = True,
+    apply: bool = True,
+) -> RoutesIngestResult:
+    """Reconcile ``wire`` (the collector's pushed paths) into ``BGPLGRoute``.
+
+    ``snapshot=True`` treats ``wire`` as the peer's COMPLETE current RIB and
+    runs the absence-withdraw sweep; ``snapshot=False`` is a delta batch
+    (upsert-only, no withdraws). ``apply=False`` computes the counters
+    without writing (dry-run preview).
+    """
+    result = RoutesIngestResult()
+    now = datetime.now(UTC)
+
+    # Validate + dedup wire paths up front:
+    #  * ``prefix`` / ``next_hop`` are strict Postgres CIDR / INET columns, so
+    #    a malformed value (host bits set, garbage, wrong family) would raise
+    #    DataError at flush and 500 the WHOLE push. Parse-and-skip instead so
+    #    one bad path can't discard a good snapshot. ip_network(strict=True)
+    #    matches Postgres CIDR strictness (rejects non-network host bits).
+    #  * Dedup on the ``(prefix, next_hop)`` identity: two wire entries with
+    #    the same key would both take the insert branch (``by_key`` is built
+    #    once from the DB and not updated mid-loop) and collide on
+    #    ``uq_bgp_lg_route``. Normalising through ipaddress also canonicalises
+    #    the strings so they match the DB round-trip. Last write wins.
+    deduped: dict[tuple[str, str], dict[str, Any]] = {}
+    for r in wire:
+        prefix_raw, next_hop_raw = r.get("prefix"), r.get("next_hop")
+        if not prefix_raw or not next_hop_raw:
+            continue
+        try:
+            prefix = str(ip_network(str(prefix_raw), strict=True))
+            next_hop = str(ip_address(str(next_hop_raw)))
+        except ValueError:
+            result.errors.append(f"skipped malformed route {prefix_raw!r} via {next_hop_raw!r}")
+            continue
+        deduped[(prefix, next_hop)] = {**r, "prefix": prefix, "next_hop": next_hop}
+    valid = list(deduped.values())
+    result.wire_routes = len(valid)
+
+    # Bulk-preload every tracked path for this peer once (avoid the per-path
+    # N+1). Keyed on the route identity — stringified so wire strings match
+    # asyncpg's IPv4Network / IPv4Address round-trip.
+    existing_rows = list(
+        (await db.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))).scalars().all()
+    )
+    by_key: dict[tuple[str, str], BGPLGRoute] = {
+        (str(r.prefix), str(r.next_hop)): r for r in existing_rows
+    }
+
+    # ── Zero-wire floor guard (#482) ────────────────────────────────────
+    # An empty snapshot from an established peer that has learned prefixes
+    # is a collector hiccup, not a genuine full withdrawal. Skip the sweep
+    # and let the next real snapshot reconcile.
+    if snapshot and not valid:
+        if peer.prefixes_received and peer.prefixes_received > 0:
+            msg = (
+                f"empty RIB snapshot from peer with prefixes_received="
+                f"{peer.prefixes_received} — skipping absence-withdraw (#482)"
+            )
+            result.errors.append(msg)
+            logger.warning(
+                "lg_routes_empty_wire_skip_withdraw",
+                peer=str(peer.id),
+                prefixes_received=peer.prefixes_received,
+            )
+            return result
+        # prefixes_received == 0: nothing to protect — fall through so any
+        # lingering active rows get withdrawn below.
+
+    # ── RPKI status per distinct (prefix, origin) — one batched ROA load ──
+    # (not one DB round-trip per prefix: a full snapshot has thousands of
+    # distinct announcements, and per-call querying would serialise thousands
+    # of covering-ROA lookups inside this one ingest transaction).
+    rpki_pairs = {
+        (str(r["prefix"]), int(r["origin_asn"])) for r in valid if r.get("origin_asn") is not None
+    }
+    rpki_cache = await derive_rpki_status_batch(db, rpki_pairs)
+
+    # ── Upsert every wire path ───────────────────────────────────────────
+    wire_keys: set[tuple[str, str]] = set()
+    for r in valid:
+        prefix = str(r["prefix"])
+        next_hop = str(r["next_hop"])
+        wire_keys.add((prefix, next_hop))
+        origin = r.get("origin_asn")
+        rpki = rpki_cache.get((prefix, int(origin)), "unknown") if origin is not None else "unknown"
+
+        row = by_key.get((prefix, next_hop))
+        if row is None:
+            if apply:
+                db.add(
+                    BGPLGRoute(
+                        peer_id=peer.id,
+                        prefix=prefix,
+                        origin_asn=origin,
+                        as_path=list(r.get("as_path") or []),
+                        next_hop=next_hop,
+                        local_pref=r.get("local_pref"),
+                        med=r.get("med"),
+                        communities=list(r.get("communities") or []),
+                        large_communities=list(r.get("large_communities") or []),
+                        ext_communities=list(r.get("ext_communities") or []),
+                        rpki_status=rpki,
+                        is_best=bool(r.get("is_best", False)),
+                        first_seen_at=now,
+                        last_seen_at=now,
+                    )
+                )
+            result.imported += 1
+        else:
+            if apply:
+                row.origin_asn = origin
+                row.as_path = list(r.get("as_path") or [])
+                row.local_pref = r.get("local_pref")
+                row.med = r.get("med")
+                row.communities = list(r.get("communities") or [])
+                row.large_communities = list(r.get("large_communities") or [])
+                row.ext_communities = list(r.get("ext_communities") or [])
+                row.rpki_status = rpki
+                row.is_best = bool(r.get("is_best", False))
+                row.last_seen_at = now
+                # Re-announce of a previously-withdrawn path — clear the marker.
+                row.withdrawn_at = None
+            result.refreshed += 1
+
+    # ── Absence-withdraw (full snapshot only) ────────────────────────────
+    if snapshot:
+        for key, row in by_key.items():
+            if row.withdrawn_at is None and key not in wire_keys:
+                if apply:
+                    row.withdrawn_at = now
+                    row.flap_count = (row.flap_count or 0) + 1
+                result.withdrawn += 1
+
+    if apply:
+        await db.flush()
+
+    return result
+
+
+__all__ = ["RoutesIngestResult", "ingest_routes"]

--- a/backend/app/services/looking_glass/vrf_match.py
+++ b/backend/app/services/looking_glass/vrf_match.py
@@ -1,0 +1,87 @@
+"""Cross-reference a learned route's ``ext_communities`` against VRF
+route-target lists (issue #566 Phase 6).
+
+``VRF.import_targets`` / ``VRF.export_targets`` (``app.models.vrf``) are
+always the bare canonical ``"ASN:N"`` / ``"IP:N"`` form (``_RD_RT_RE`` in
+``app.api.v1.vrfs.router``). What a route's ``ext_communities`` actually
+contain on the wire is NOT verified live — the agent-side GoBGP RIB poll
+(``agent/looking-glass/spatium_lg_agent/rib.py``) stringifies whatever
+GoBGP's ``-j`` output gives back for the extended-community attribute
+verbatim, and that module's own docstring flags it as "not exercised by a
+live session" — so normalization here is defensive: strip a handful of
+plausible vendor-style label prefixes down to the bare form before
+comparing, rather than assuming the agent always emits the bare form.
+
+This match takes **precedence** over the plain IPAM-effective-VRF match
+(``app.services.looking_glass.ipam_link.resolve_route_links``) whenever a
+Route Target hit is found — a VPNv4/VPNv6 route's RD/RT is the actual
+protocol-level signal for VRF membership; the IPAM-effective match is only
+a fallback for routes with no VPN attributes at all. Callers
+(``routes_ingest.ingest_routes`` and the periodic
+``app.tasks.looking_glass.reresolve_route_links`` sweep) are responsible
+for applying that precedence — this module only computes the RT-based
+half.
+
+VRF counts are small (tens to low hundreds, never RIB-scale), so building
+the whole reverse index once per ingest call is cheap — same justification
+as ``derive_rpki_status_batch``'s one-batched-ROA-load shape
+(``app.services.bgp.hijack_monitor``).
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from collections import defaultdict
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.vrf import VRF
+
+_RT_PREFIX_RE = re.compile(r"^(rt|target|route-target)\s*[:=]\s*", re.IGNORECASE)
+
+
+def normalize_rt(raw: str) -> str:
+    """Strip a vendor-style label prefix down to the bare 'ASN:N'/'IP:N' value."""
+    return _RT_PREFIX_RE.sub("", raw.strip())
+
+
+async def build_vrf_rt_index(db: AsyncSession) -> dict[str, list[uuid.UUID]]:
+    """``RT value -> [vrf_id, ...]``, over the union of every VRF's
+    ``import_targets`` + ``export_targets``.
+
+    Uncached, unlike ``ipam_link.get_resolution_cache`` — VRF rows are cheap
+    to scan and callers (one ingest call, one re-resolve sweep run) already
+    control their own cadence, so a second TTL cache here would just add
+    staleness without saving anything meaningful.
+    """
+    index: dict[str, list[uuid.UUID]] = defaultdict(list)
+    rows = (await db.execute(select(VRF.id, VRF.import_targets, VRF.export_targets))).all()
+    for vrf_id, imp, exp in rows:
+        for rt in {*(imp or []), *(exp or [])}:
+            index[rt].append(vrf_id)
+    return dict(index)
+
+
+def match_vrf_for_route(
+    ext_communities: list[str], index: dict[str, list[uuid.UUID]]
+) -> uuid.UUID | None:
+    """First matching VRF id for a route's ``ext_communities``, or ``None``.
+
+    A route whose normalized RT hits more than one VRF (two VRFs sharing an
+    RT is a legitimate hub-and-spoke pattern) picks deterministically —
+    lowest-UUID VRF wins, so the result never depends on dict/scan order
+    (mirrors the tie-break convention in
+    ``app.services.looking_glass.reachability`` / the pre-existing
+    ``find_bgp_route_for_ip`` LPM tie-break).
+    """
+    candidates: set[uuid.UUID] = set()
+    for raw in ext_communities:
+        candidates.update(index.get(normalize_rt(str(raw)), ()))
+    if not candidates:
+        return None
+    return min(candidates, key=str)
+
+
+__all__ = ["build_vrf_rt_index", "match_vrf_for_route", "normalize_rt"]

--- a/backend/app/services/nettools/schemas.py
+++ b/backend/app/services/nettools/schemas.py
@@ -186,12 +186,20 @@ def validate_host_or_cidr(value: str) -> str:
 # ``kind="appliance"`` dispatches the (server-re-validated) job to a
 # supervisor-managed Fleet appliance over the existing outbound poll
 # channel and labels the result ``ran_from="appliance:<name>"``.
+# ``kind="bgp_lg_collector"`` (#566 Phase 4) resolves ``id`` to a
+# ``LookingGlassCollector`` row and dispatches to the appliance it runs on
+# (the collector container shares the node's network namespace via
+# ``network_mode: host`` / ``hostNetwork: true``), labelling the result
+# ``ran_from="looking_glass:<collector-name>"``. Rejected with a 400 when
+# the collector isn't appliance-managed (standalone docker/K8s deployment
+# — no dispatchable command channel).
 #
 # The ``Literal`` already lists ``dns_agent`` / ``dhcp_agent`` so the
 # wire shape is forward-compatible: the DNS / DHCP service-container
 # vantage is a deferred follow-up (the router rejects those kinds until
 # their dispatch path lands), but a client serialising one today won't
-# fail validation. Only ``server`` + ``appliance`` are wired in this PR.
+# fail validation. Only ``server`` + ``appliance`` + ``bgp_lg_collector``
+# are wired today.
 
 
 class NetToolTarget(BaseModel):
@@ -199,10 +207,13 @@ class NetToolTarget(BaseModel):
 
     ``id`` identifies the appliance (or, later, the DNS/DHCP agent) row
     when ``kind != "server"``; it's ignored — and may be omitted — for
-    ``kind="server"``.
+    ``kind="server"``. ``kind="bgp_lg_collector"`` (#566 Phase 4) resolves
+    ``id`` to a ``LookingGlassCollector`` row and dispatches to the
+    appliance it runs on — see ``app.api.v1.tools.router
+    ._resolve_lg_collector_vantage``.
     """
 
-    kind: Literal["server", "appliance", "dns_agent", "dhcp_agent"] = "server"
+    kind: Literal["server", "appliance", "dns_agent", "dhcp_agent", "bgp_lg_collector"] = "server"
     id: uuid.UUID | None = None
 
 

--- a/backend/app/tasks/looking_glass.py
+++ b/backend/app/tasks/looking_glass.py
@@ -1,0 +1,62 @@
+"""BGP Looking Glass collector housekeeping tasks (issue #566).
+
+``collector_stale_sweep`` mirrors ``app.tasks.dns.agent_stale_sweep``:
+a beat task that flips a ``LookingGlassCollector`` to ``unreachable`` once
+its heartbeat has been silent past the staleness window, so a dead collector
+doesn't sit frozen at ``active`` forever in the Sessions / Fleet UI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.celery_app import celery_app
+from app.config import settings
+from app.models.bgp_looking_glass import LookingGlassCollector
+
+logger = structlog.get_logger(__name__)
+
+# Generous multiple of the collector heartbeat interval so a single missed
+# beat doesn't flap the row to unreachable.
+COLLECTOR_STALE_AFTER_SECONDS = 180
+
+
+async def _collector_stale_sweep_async() -> dict[str, int]:
+    """Flip collectors to ``unreachable`` when no heartbeat seen past the window.
+
+    Idempotent — only touches rows currently ``active`` whose ``last_seen_at``
+    is beyond the cutoff.
+    """
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            cutoff = datetime.now(UTC) - timedelta(seconds=COLLECTOR_STALE_AFTER_SECONDS)
+            res = await db.execute(
+                update(LookingGlassCollector)
+                .where(
+                    LookingGlassCollector.status == "active",
+                    LookingGlassCollector.last_seen_at.isnot(None),
+                    LookingGlassCollector.last_seen_at < cutoff,
+                )
+                .values(status="unreachable")
+                .returning(LookingGlassCollector.id)
+            )
+            changed = len(res.all())
+            await db.commit()
+            if changed:
+                logger.info("lg_collector_stale_sweep", marked_unreachable=changed)
+            return {"marked_unreachable": changed}
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(name="app.tasks.looking_glass.collector_stale_sweep")
+def collector_stale_sweep() -> dict[str, int]:
+    """Celery beat task — flips stale Looking Glass collectors to 'unreachable'."""
+    return asyncio.run(_collector_stale_sweep_async())

--- a/backend/app/tasks/looking_glass.py
+++ b/backend/app/tasks/looking_glass.py
@@ -4,6 +4,11 @@
 a beat task that flips a ``LookingGlassCollector`` to ``unreachable`` once
 its heartbeat has been silent past the staleness window, so a dead collector
 doesn't sit frozen at ``active`` forever in the Sessions / Fleet UI.
+
+``reresolve_route_links`` (Phase 3) is the periodic correctness backstop for
+the IPAM/ASN/VRF linkage resolved at ingest time — it re-runs the same
+matcher over every active route so an IPAM edit made *between* RIB pushes
+(no new wire snapshot to trigger a fresh resolve) still converges.
 """
 
 from __future__ import annotations
@@ -12,12 +17,16 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 
 import structlog
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.celery_app import celery_app
 from app.config import settings
-from app.models.bgp_looking_glass import LookingGlassCollector
+from app.models.bgp_looking_glass import BGPLGRoute, LookingGlassCollector
+from app.services.looking_glass.ipam_link import (
+    build_resolution_cache,
+    resolve_route_links,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -60,3 +69,64 @@ async def _collector_stale_sweep_async() -> dict[str, int]:
 def collector_stale_sweep() -> dict[str, int]:
     """Celery beat task — flips stale Looking Glass collectors to 'unreachable'."""
     return asyncio.run(_collector_stale_sweep_async())
+
+
+async def _reresolve_route_links_async() -> dict[str, int]:
+    """Re-run the IPAM/ASN/VRF matcher over every still-active route.
+
+    Catches the case an ingest-time resolve can't: an IPAM edit made
+    *after* a route was last pushed (new subnet carved under an
+    already-advertised block, a block's vrf_id/asn_id reassigned, a new
+    ASN row created for a previously-untracked origin) with no new RIB
+    push to trigger a fresh resolve. Idempotent — a no-op recompute
+    changes nothing.
+    """
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            active = (
+                (await db.execute(select(BGPLGRoute).where(BGPLGRoute.withdrawn_at.is_(None))))
+                .scalars()
+                .all()
+            )
+            if not active:
+                return {"checked": 0, "changed": 0}
+
+            cache = await build_resolution_cache(db)  # always fresh, bypass TTL
+            changed = 0
+            for route in active:
+                links = resolve_route_links(cache, str(route.prefix), route.origin_asn)
+                before = (
+                    route.matched_block_id,
+                    route.matched_subnet_id,
+                    route.matched_space_id,
+                    route.matched_asn_id,
+                    route.matched_vrf_id,
+                )
+                after = (
+                    links.block_id,
+                    links.subnet_id,
+                    links.space_id,
+                    links.asn_id,
+                    links.vrf_id,
+                )
+                if before != after:
+                    route.matched_block_id = links.block_id
+                    route.matched_subnet_id = links.subnet_id
+                    route.matched_space_id = links.space_id
+                    route.matched_asn_id = links.asn_id
+                    route.matched_vrf_id = links.vrf_id
+                    changed += 1
+            await db.commit()
+            if changed:
+                logger.info("lg_route_links_reresolved", checked=len(active), changed=changed)
+            return {"checked": len(active), "changed": changed}
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(name="app.tasks.looking_glass.reresolve_route_links")
+def reresolve_route_links() -> dict[str, int]:
+    """Celery beat task — re-resolves matched_*_id for every active route."""
+    return asyncio.run(_reresolve_route_links_async())

--- a/backend/app/tasks/looking_glass.py
+++ b/backend/app/tasks/looking_glass.py
@@ -8,7 +8,12 @@ doesn't sit frozen at ``active`` forever in the Sessions / Fleet UI.
 ``reresolve_route_links`` (Phase 3) is the periodic correctness backstop for
 the IPAM/ASN/VRF linkage resolved at ingest time — it re-runs the same
 matcher over every active route so an IPAM edit made *between* RIB pushes
-(no new wire snapshot to trigger a fresh resolve) still converges.
+(no new wire snapshot to trigger a fresh resolve) still converges. Issue
+#566 Phase 6 extends it to also re-run the VRF Route-Target cross-check
+(``app.services.looking_glass.vrf_match``) so a VRF's import/export target
+list edited after a route's last ingest still converges here too — same
+precedence rule as ``routes_ingest.py``: an RT hit wins over the plain
+IPAM-effective VRF.
 """
 
 from __future__ import annotations
@@ -27,6 +32,7 @@ from app.services.looking_glass.ipam_link import (
     build_resolution_cache,
     resolve_route_links,
 )
+from app.services.looking_glass.vrf_match import build_vrf_rt_index, match_vrf_for_route
 
 logger = structlog.get_logger(__name__)
 
@@ -94,9 +100,17 @@ async def _reresolve_route_links_async() -> dict[str, int]:
                 return {"checked": 0, "changed": 0}
 
             cache = await build_resolution_cache(db)  # always fresh, bypass TTL
+            vrf_rt_index = await build_vrf_rt_index(db)  # also always fresh
             changed = 0
             for route in active:
                 links = resolve_route_links(cache, str(route.prefix), route.origin_asn)
+                # Route-Target cross-check takes precedence over the plain
+                # IPAM-effective VRF (issue #566 Phase 6 — mirrors
+                # routes_ingest.py's ingest-time precedence rule).
+                vpn_matched_vrf_id = match_vrf_for_route(
+                    list(route.ext_communities or []), vrf_rt_index
+                )
+                vrf_id = vpn_matched_vrf_id if vpn_matched_vrf_id is not None else links.vrf_id
                 before = (
                     route.matched_block_id,
                     route.matched_subnet_id,
@@ -109,14 +123,14 @@ async def _reresolve_route_links_async() -> dict[str, int]:
                     links.subnet_id,
                     links.space_id,
                     links.asn_id,
-                    links.vrf_id,
+                    vrf_id,
                 )
                 if before != after:
                     route.matched_block_id = links.block_id
                     route.matched_subnet_id = links.subnet_id
                     route.matched_space_id = links.space_id
                     route.matched_asn_id = links.asn_id
-                    route.matched_vrf_id = links.vrf_id
+                    route.matched_vrf_id = vrf_id
                     changed += 1
             await db.commit()
             if changed:

--- a/backend/tests/test_alert_bgp_lg.py
+++ b/backend/tests/test_alert_bgp_lg.py
@@ -1,0 +1,354 @@
+"""BGP Looking Glass troubleshooting alert family (issue #566 Phase 5).
+
+Unit tests over the six ``bgp_lg_*`` matchers (session grace window,
+RPKI-invalid severity override, tracked-prefix origin mismatch —
+exact vs strictly-more-specific, flap threshold + recency window,
+missing-advertisement CIDR containment) plus one end-to-end
+``evaluate_all`` smoke test confirming AlertEvent open/auto-resolve.
+
+Local helper duplication (``_make_collector`` / ``_make_peer``) rather
+than cross-importing from ``test_looking_glass.py`` /
+``test_bgp_hijack_monitor.py`` — matches this repo's existing
+per-file-helper convention.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.alerts import AlertEvent, AlertRule
+from app.models.asn import ASN
+from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
+from app.models.bgp_monitor import BGPTrackedPrefix
+from app.models.ipam import IPBlock, IPSpace, Subnet
+from app.services import alerts as alerts_svc
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+async def _make_collector(db: AsyncSession, **kw: object) -> LookingGlassCollector:
+    col = LookingGlassCollector(
+        name=kw.pop("name", f"col-{uuid.uuid4().hex[:8]}"),
+        agent_id=kw.pop("agent_id", uuid.uuid4().hex),
+        agent_registered=True,
+        status=kw.pop("status", "active"),
+        **kw,
+    )
+    db.add(col)
+    await db.flush()
+    return col
+
+
+async def _make_peer(db: AsyncSession, collector: LookingGlassCollector, **kw: object) -> BGPLGPeer:
+    peer = BGPLGPeer(
+        name=kw.pop("name", f"peer-{uuid.uuid4().hex[:8]}"),
+        collector_id=collector.id,
+        local_asn=kw.pop("local_asn", 65000),
+        peer_asn=kw.pop("peer_asn", 65001),
+        peer_address=kw.pop("peer_address", "192.0.2.1"),
+        **kw,
+    )
+    db.add(peer)
+    await db.flush()
+    return peer
+
+
+async def _make_route(db: AsyncSession, peer: BGPLGPeer, prefix: str, **kw: object) -> BGPLGRoute:
+    route = BGPLGRoute(
+        peer_id=peer.id,
+        prefix=prefix,
+        next_hop=kw.pop("next_hop", "192.0.2.1"),
+        **kw,
+    )
+    db.add(route)
+    await db.flush()
+    return route
+
+
+async def _asn(db: AsyncSession, number: int = 64500) -> ASN:
+    row = ASN(number=number, name=f"AS{number}", kind="public", registry="arin")
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def _tracked(
+    db: AsyncSession, asn: ASN, prefix: str, *, allowed: list[int] | None = None
+) -> BGPTrackedPrefix:
+    row = BGPTrackedPrefix(
+        asn_id=asn.id,
+        prefix=prefix,
+        expected_origin_asn=int(asn.number),
+        source="manual",
+        enabled=True,
+        allowed_origins=allowed or [],
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def _make_subnet(db: AsyncSession, *, network: str, should_advertise: bool) -> Subnet:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/8", name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network=network,
+        name=f"sn-{uuid.uuid4().hex[:6]}",
+        total_ips=254,
+        bgp_should_advertise=should_advertise,
+    )
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _rule(db: AsyncSession, rule_type: str, **kw: object) -> AlertRule:
+    rule = AlertRule(
+        name=rule_type,
+        rule_type=rule_type,
+        severity="warning",
+        enabled=True,
+        notify_syslog=False,
+        notify_webhook=False,
+        notify_smtp=False,
+        **kw,
+    )
+    db.add(rule)
+    await db.flush()
+    return rule
+
+
+# ── bgp_lg_session_down ───────────────────────────────────────────────────
+
+
+async def test_session_down_grace_window(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col, session_state="active")
+    rule = SimpleNamespace()
+
+    t0 = datetime.now(UTC)
+    # First observation — stamps the watermark, doesn't fire yet.
+    matches = await alerts_svc._matching_bgp_lg_session_down_subjects(db_session, rule, t0)
+    assert matches == []
+    assert peer.down_since == t0
+
+    # Still within the grace window.
+    matches = await alerts_svc._matching_bgp_lg_session_down_subjects(
+        db_session, rule, t0 + timedelta(seconds=30)
+    )
+    assert matches == []
+
+    # Past the grace window — fires.
+    matches = await alerts_svc._matching_bgp_lg_session_down_subjects(
+        db_session, rule, t0 + timedelta(minutes=3)
+    )
+    assert len(matches) == 1
+    assert matches[0][0] == str(peer.id)
+
+    # Re-established — watermark clears, no match.
+    peer.session_state = "established"
+    matches = await alerts_svc._matching_bgp_lg_session_down_subjects(
+        db_session, rule, t0 + timedelta(minutes=4)
+    )
+    assert matches == []
+    assert peer.down_since is None
+
+
+# ── bgp_lg_rpki_invalid_route ──────────────────────────────────────────────
+
+
+async def test_rpki_invalid_route_severity_critical(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    await _make_route(db_session, peer, "192.0.2.0/24", origin_asn=65001, rpki_status="valid")
+    invalid = await _make_route(
+        db_session, peer, "198.51.100.0/24", origin_asn=65002, rpki_status="invalid"
+    )
+    await db_session.commit()
+
+    rule = SimpleNamespace()
+    matches = await alerts_svc._matching_bgp_lg_rpki_invalid_route_subjects(db_session, rule)
+    assert len(matches) == 1
+    sid, _disp, _msg, severity = matches[0]
+    assert sid == str(invalid.id)
+    assert severity == "critical"
+
+
+# ── bgp_lg_unexpected_origin ───────────────────────────────────────────────
+
+
+async def test_unexpected_origin_requires_tracked_prefix(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    asn = await _asn(db_session, 64500)
+    route = await _make_route(db_session, peer, "192.0.2.0/24", origin_asn=64999)
+    await db_session.commit()
+
+    rule = SimpleNamespace()
+
+    # No tracked prefix at all → zero matches even with a suspicious route.
+    matches = await alerts_svc._matching_bgp_lg_unexpected_origin_subjects(db_session, rule)
+    assert matches == []
+
+    # Tracked with a DIFFERENT expected origin → matches.
+    tracked = await _tracked(db_session, asn, "192.0.2.0/24")
+    await db_session.commit()
+    matches = await alerts_svc._matching_bgp_lg_unexpected_origin_subjects(db_session, rule)
+    assert len(matches) == 1
+    assert matches[0][0] == str(route.id)
+
+    # Same origin as expected → no match.
+    route.origin_asn = int(asn.number)
+    await db_session.commit()
+    matches = await alerts_svc._matching_bgp_lg_unexpected_origin_subjects(db_session, rule)
+    assert matches == []
+
+    # Origin explicitly allowlisted → no match.
+    route.origin_asn = 64999
+    tracked.allowed_origins = [64999]
+    await db_session.commit()
+    matches = await alerts_svc._matching_bgp_lg_unexpected_origin_subjects(db_session, rule)
+    assert matches == []
+
+
+# ── bgp_lg_more_specific ───────────────────────────────────────────────────
+
+
+async def test_more_specific_strict_containment(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    asn = await _asn(db_session, 64500)
+    await _tracked(db_session, asn, "10.0.0.0/16")
+
+    # Exact match at the tracked prefix — NOT more_specific's job.
+    exact = await _make_route(db_session, peer, "10.0.0.0/16", origin_asn=64999)
+    # Strictly-contained sub-prefix with an unexpected origin — IS a match.
+    sub = await _make_route(db_session, peer, "10.0.1.0/24", origin_asn=64999)
+    await db_session.commit()
+
+    rule = SimpleNamespace()
+    matches = await alerts_svc._matching_bgp_lg_more_specific_subjects(db_session, rule)
+    ids = {sid for sid, _disp, _msg in matches}
+    assert str(sub.id) in ids
+    assert str(exact.id) not in ids
+
+
+# ── bgp_lg_route_flap ──────────────────────────────────────────────────────
+
+
+async def test_route_flap_threshold_and_window(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    now = datetime.now(UTC)
+
+    below_threshold = await _make_route(
+        db_session, peer, "10.1.0.0/24", flap_count=1, last_flap_at=now
+    )
+    stale = await _make_route(
+        db_session,
+        peer,
+        "10.2.0.0/24",
+        flap_count=5,
+        last_flap_at=now - timedelta(minutes=20),
+    )
+    recent = await _make_route(
+        db_session,
+        peer,
+        "10.3.0.0/24",
+        flap_count=5,
+        last_flap_at=now - timedelta(minutes=2),
+    )
+    await db_session.commit()
+
+    rule = SimpleNamespace(threshold_percent=3)
+    matches = await alerts_svc._matching_bgp_lg_route_flap_subjects(db_session, rule, now)
+    ids = {sid for sid, _disp, _msg in matches}
+    assert ids == {str(recent.id)}
+    assert str(below_threshold.id) not in ids
+    assert str(stale.id) not in ids
+
+
+# ── bgp_lg_missing_advertisement ───────────────────────────────────────────
+
+
+async def test_missing_advertisement_covering_route(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+
+    flagged = await _make_subnet(db_session, network="10.5.0.0/24", should_advertise=True)
+    await _make_subnet(db_session, network="10.6.0.0/24", should_advertise=False)
+    await db_session.commit()
+
+    rule = SimpleNamespace()
+
+    # No covering route yet → matches.
+    matches = await alerts_svc._matching_bgp_lg_missing_advertisement_subjects(db_session, rule)
+    ids = {sid for sid, _disp, _msg in matches}
+    assert str(flagged.id) in ids
+
+    # A covering (supernet-or-equal) active route appears → no longer matches.
+    covering = await _make_route(db_session, peer, "10.5.0.0/16")
+    await db_session.commit()
+    matches = await alerts_svc._matching_bgp_lg_missing_advertisement_subjects(db_session, rule)
+    ids = {sid for sid, _disp, _msg in matches}
+    assert str(flagged.id) not in ids
+
+    # Route withdraws → matches again.
+    covering.withdrawn_at = datetime.now(UTC)
+    await db_session.commit()
+    matches = await alerts_svc._matching_bgp_lg_missing_advertisement_subjects(db_session, rule)
+    ids = {sid for sid, _disp, _msg in matches}
+    assert str(flagged.id) in ids
+
+
+# ── end-to-end evaluate_all() — open + auto-resolve ────────────────────────
+
+
+async def test_evaluate_all_opens_and_autoresolves_rpki_invalid(
+    db_session: AsyncSession,
+) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    route = await _make_route(
+        db_session, peer, "203.0.113.0/24", origin_asn=64999, rpki_status="invalid"
+    )
+    rule = await _rule(db_session, alerts_svc.RULE_TYPE_BGP_LG_RPKI_INVALID_ROUTE)
+    await db_session.commit()
+
+    summary = await alerts_svc.evaluate_all(db_session)
+    assert summary["opened"] >= 1
+    events = (
+        (await db_session.execute(select(AlertEvent).where(AlertEvent.rule_id == rule.id)))
+        .scalars()
+        .all()
+    )
+    assert len(events) == 1
+    assert events[0].subject_type == "bgp_lg_route"
+    assert events[0].severity == "critical"
+    assert events[0].resolved_at is None
+
+    # Route withdraws → the matcher stops returning it → auto-resolve.
+    route.withdrawn_at = datetime.now(UTC)
+    await db_session.commit()
+    await alerts_svc.evaluate_all(db_session)
+    event = (
+        (await db_session.execute(select(AlertEvent).where(AlertEvent.rule_id == rule.id)))
+        .scalars()
+        .one()
+    )
+    assert event.resolved_at is not None

--- a/backend/tests/test_appliance_control_plane_promote.py
+++ b/backend/tests/test_appliance_control_plane_promote.py
@@ -447,6 +447,149 @@ async def test_metallb_non_superadmin_refused(
     assert resp.status_code == 403
 
 
+# ── BGP mode (issue #566 decision D1) ────────────────────────────────
+
+
+async def test_metallb_bgp_requires_enabled(db_session: AsyncSession, client: AsyncClient) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": False,
+            "pool_addresses": [],
+            "control_plane_vip": "",
+            "bgp_enabled": True,
+            "bgp_peers": [{"my_asn": 65000, "peer_asn": 65001, "peer_address": "203.0.113.1"}],
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 422
+    assert "BGP mode requires MetalLB" in resp.text
+
+
+async def test_metallb_bgp_requires_peers(db_session: AsyncSession, client: AsyncClient) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": True,
+            "pool_addresses": [],
+            "control_plane_vip": "192.168.0.241",
+            "bgp_enabled": True,
+            "bgp_peers": [],
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 422
+    assert "at least one BGP peer is required" in resp.text
+
+
+async def test_metallb_bgp_invalid_asn(db_session: AsyncSession, client: AsyncClient) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": True,
+            "pool_addresses": [],
+            "control_plane_vip": "192.168.0.241",
+            "bgp_enabled": True,
+            "bgp_peers": [{"my_asn": 0, "peer_asn": 65001, "peer_address": "203.0.113.1"}],
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 422
+
+    resp2 = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": True,
+            "pool_addresses": [],
+            "control_plane_vip": "192.168.0.241",
+            "bgp_enabled": True,
+            "bgp_peers": [
+                {
+                    "my_asn": 65000,
+                    "peer_asn": 4_294_967_296,
+                    "peer_address": "203.0.113.1",
+                }
+            ],
+        },
+        headers=_hdr(token),
+    )
+    assert resp2.status_code == 422
+
+
+async def test_metallb_bgp_put_and_get(db_session: AsyncSession, client: AsyncClient) -> None:
+    token = await _admin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": True,
+            "pool_addresses": [],
+            "control_plane_vip": "192.168.0.241",
+            "bgp_enabled": True,
+            "bgp_peers": [
+                {
+                    "my_asn": 65000,
+                    "peer_asn": 65001,
+                    "peer_address": "203.0.113.1",
+                    "peer_port": 1179,
+                    "hold_time": "90s",
+                }
+            ],
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["bgp_enabled"] is True
+    assert body["bgp_peers"] == [
+        {
+            "my_asn": 65000,
+            "peer_asn": 65001,
+            "peer_address": "203.0.113.1",
+            "peer_port": 1179,
+            "hold_time": "90s",
+        }
+    ]
+    # bgp_advertisements auto-derived since none were supplied.
+    assert body["bgp_advertisements"] == [
+        {
+            "ip_address_pools": ["spatium-control-plane"],
+            "communities": [],
+            "aggregation_length": None,
+        }
+    ]
+
+    got = await client.get(_METALLB_URL, headers=_hdr(token))
+    got_body = got.json()
+    assert got_body["bgp_enabled"] is True
+    assert got_body["bgp_peers"][0]["peer_address"] == "203.0.113.1"
+
+
+async def test_metallb_bgp_non_superadmin_refused(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    token = await _admin(db_session, superadmin=False, username="plainuser")
+    await db_session.commit()
+    resp = await client.put(
+        _METALLB_URL,
+        json={
+            "enabled": True,
+            "pool_addresses": [],
+            "control_plane_vip": "192.168.0.241",
+            "bgp_enabled": True,
+            "bgp_peers": [{"my_asn": 65000, "peer_asn": 65001, "peer_address": "203.0.113.1"}],
+        },
+        headers=_hdr(token),
+    )
+    assert resp.status_code == 403
+
+
 # ── data-plane resolver VIPs (Phase 10) ──────────────────────────────
 
 

--- a/backend/tests/test_as_path_query.py
+++ b/backend/tests/test_as_path_query.py
@@ -1,0 +1,54 @@
+"""AS-path regexp query helper tests — issue #566 Phase 4.
+
+Pure-function coverage for the Cisco/Juniper ``_`` boundary-token
+translation (``translate_as_path_regexp``) plus a sanity check that
+``as_path_regexp_clause`` rejects a malformed pattern with ``re.error``
+(the router / MCP tool both catch this and turn it into a friendly
+422 / tool-note rather than a raw asyncpg error).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.services.looking_glass.as_path_query import (
+    as_path_regexp_clause,
+    translate_as_path_regexp,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # No underscore at all — passes through untouched.
+        ("65001", "65001"),
+        ("^65001$", "^65001$"),
+        # Leading underscore only.
+        ("_65001", "(^|[[:space:]])65001"),
+        # Trailing underscore only.
+        ("65001_", "65001([[:space:]]|$)"),
+        # Both ends — the canonical "contains AS 65001 anywhere" pattern.
+        ("_65001_", "(^|[[:space:]])65001([[:space:]]|$)"),
+        # Internal underscore between two AS numbers.
+        ("65001_65002", "65001[[:space:]]65002"),
+        # Leading + internal + trailing all in one pattern.
+        ("_65001_65002_", "(^|[[:space:]])65001[[:space:]]65002([[:space:]]|$)"),
+    ],
+)
+def test_translate_as_path_regexp(raw: str, expected: str) -> None:
+    assert translate_as_path_regexp(raw) == expected
+
+
+def test_as_path_regexp_clause_builds_for_valid_pattern() -> None:
+    # Should not raise — a well-formed pattern compiles fine under re.
+    clause = as_path_regexp_clause("_65001_")
+    assert clause is not None
+
+
+def test_as_path_regexp_clause_raises_re_error_on_malformed_pattern() -> None:
+    # Unbalanced parenthesis — the common operator typo this pre-check
+    # is meant to catch before it reaches Postgres as a raw asyncpg error.
+    with pytest.raises(re.error):
+        as_path_regexp_clause("(unbalanced")

--- a/backend/tests/test_looking_glass.py
+++ b/backend/tests/test_looking_glass.py
@@ -1,10 +1,16 @@
-"""BGP Looking Glass tests — issue #566 Phase 1+2.
+"""BGP Looking Glass tests — issue #566 Phase 1+2 (+ Phase 6 additions).
 
 Covers the correctness-critical RIB reconcile (``ingest_routes`` — the
 zero-wire floor guard, absence-withdraw, idempotency, re-announce), the peer
 CRUD surface (Fernet ``md5_password`` never echoed, audit row written), the
 feature-module gate, the routes search filters, and the agent register +
 routes-push end-to-end path.
+
+Phase 6 additions (bottom of file): vpnv4/vpnv6 address-family acceptance,
+the VRF Route-Target cross-check (``matched_vrf_id`` precedence over the
+plain IPAM-effective match, the re-resolve sweep, the
+``/vrf-rt-matches/{vrf_id}`` endpoint), and the multicast <-> BGP
+reachability cross-reference.
 """
 
 from __future__ import annotations
@@ -21,9 +27,21 @@ from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
 from app.models.feature_module import FeatureModule
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.models.multicast import MulticastDomain, MulticastGroup, MulticastMembership
+from app.models.vrf import VRF
 from app.services import feature_modules
+from app.services.ai.tools.bgp_lg import (
+    FindMulticastBgpReachabilityArgs,
+    FindVrfLearnedRoutesArgs,
+    find_multicast_bgp_reachability,
+    find_vrf_learned_routes,
+)
+from app.services.looking_glass import ipam_link
 from app.services.looking_glass.config_bundle import build_lg_config_bundle
+from app.services.looking_glass.reachability import multicast_bgp_reachability
 from app.services.looking_glass.routes_ingest import ingest_routes
+from app.tasks.looking_glass import _reresolve_route_links_async
 
 # ── helpers ────────────────────────────────────────────────────────────
 
@@ -512,3 +530,379 @@ async def test_disabled_collector_bundle_is_empty(db_session: AsyncSession) -> N
     await db_session.flush()
     bundle = await build_lg_config_bundle(db_session, col)
     assert bundle.peers == ()
+
+
+# ── Phase 6 — vpnv4/vpnv6 address families ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_peer_accepts_vpnv4_rejects_evpn(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.post(
+        "/api/v1/looking-glass/peers",
+        headers=hdr,
+        json={
+            "name": "vpn-peer",
+            "collector_id": str(col.id),
+            "local_asn": 65000,
+            "peer_asn": 65001,
+            "peer_address": "192.0.2.20",
+            "address_families": ["vpnv4", "vpnv6"],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    assert resp.json()["address_families"] == ["vpnv4", "vpnv6"]
+
+    resp = await client.post(
+        "/api/v1/looking-glass/peers",
+        headers=hdr,
+        json={
+            "name": "evpn-peer",
+            "collector_id": str(col.id),
+            "local_asn": 65000,
+            "peer_asn": 65001,
+            "peer_address": "192.0.2.21",
+            "address_families": ["evpn"],
+        },
+    )
+    assert resp.status_code == 422, resp.text
+
+
+# ── Phase 6 — route_distinguisher joins route identity ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_rd_identity_no_collision(db_session: AsyncSession) -> None:
+    """Two VRFs' overlapping (prefix, next_hop) must NOT collide when their
+    route_distinguisher differs — the core correctness fix behind widening
+    uq_bgp_lg_route to include route_distinguisher (issue #566 Phase 6)."""
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+
+    result = await ingest_routes(
+        db_session,
+        peer,
+        [
+            _route("10.50.0.0/24", origin_asn=65001, route_distinguisher="65001:1"),
+            _route("10.50.0.0/24", origin_asn=65001, route_distinguisher="65001:2"),
+        ],
+        snapshot=True,
+    )
+    assert result.imported == 2  # NOT silently overwritten into one row
+
+    rows = (
+        (
+            await db_session.execute(
+                select(BGPLGRoute).where(
+                    BGPLGRoute.peer_id == peer.id, BGPLGRoute.prefix == "10.50.0.0/24"
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {r.route_distinguisher for r in rows} == {"65001:1", "65001:2"}
+
+
+@pytest.mark.asyncio
+async def test_rd_ingest_idempotent(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    wire = [_route("10.51.0.0/24", origin_asn=65001, route_distinguisher="65001:1")]
+
+    r1 = await ingest_routes(db_session, peer, wire, snapshot=True)
+    assert r1.imported == 1 and r1.refreshed == 0
+
+    r2 = await ingest_routes(db_session, peer, wire, snapshot=True)
+    assert r2.imported == 0 and r2.refreshed == 1  # re-ingest refreshes, doesn't duplicate
+
+
+# ── Phase 6 — VRF Route-Target cross-check ───────────────────────────────
+
+
+async def _make_vrf(db: AsyncSession, **kw) -> VRF:
+    vrf = VRF(
+        name=kw.pop("name", f"vrf-{uuid.uuid4().hex[:8]}"),
+        import_targets=kw.pop("import_targets", []),
+        export_targets=kw.pop("export_targets", []),
+        **kw,
+    )
+    db.add(vrf)
+    await db.flush()
+    return vrf
+
+
+@pytest.mark.asyncio
+async def test_vrf_rt_match_sets_matched_vrf_id(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    vrf = await _make_vrf(db_session, import_targets=["65001:100"])
+
+    result = await ingest_routes(
+        db_session,
+        peer,
+        [
+            _route("10.0.0.0/24", origin_asn=65001, ext_communities=["65001:100"]),
+            # Vendor-style "target:" label prefix — exercises normalize_rt.
+            _route("10.0.1.0/24", origin_asn=65001, ext_communities=["target:65001:100"]),
+            # No matching RT at all.
+            _route("10.0.2.0/24", origin_asn=65001, ext_communities=["65099:1"]),
+        ],
+        snapshot=True,
+    )
+    assert result.imported == 3
+
+    rows = {
+        str(r.prefix): r.matched_vrf_id
+        for r in (await db_session.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id)))
+        .scalars()
+        .all()
+    }
+    assert rows["10.0.0.0/24"] == vrf.id
+    assert rows["10.0.1.0/24"] == vrf.id
+    assert rows["10.0.2.0/24"] is None
+
+
+@pytest.mark.asyncio
+async def test_vrf_rt_match_precedence_over_ipam_effective(db_session: AsyncSession) -> None:
+    """A Route-Target hit against VRF B wins even when the route's prefix
+    falls inside an IPAM block/space whose vrf_id points at a different
+    VRF A (the plain IPAM-effective match)."""
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    vrf_a = await _make_vrf(db_session, name="vrf-a-ipam")
+    vrf_b = await _make_vrf(db_session, name="vrf-b-rt", import_targets=["65001:200"])
+
+    space = IPSpace(name=f"space-{uuid.uuid4().hex[:8]}", vrf_id=vrf_a.id)
+    db_session.add(space)
+    await db_session.flush()
+    block = IPBlock(space_id=space.id, name="b", network="10.9.0.0/16", vrf_id=vrf_a.id)
+    db_session.add(block)
+    await db_session.flush()
+    ipam_link._clear_cache_for_test()  # force a fresh IPAM scan for this test's fixtures
+
+    await ingest_routes(
+        db_session,
+        peer,
+        [_route("10.9.1.0/24", origin_asn=65001, ext_communities=["65001:200"])],
+        snapshot=True,
+    )
+    row = (
+        await db_session.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))
+    ).scalar_one()
+    assert row.matched_block_id == block.id  # IPAM linkage still resolved…
+    assert row.matched_vrf_id == vrf_b.id  # …but the RT match wins over vrf_a.
+
+
+@pytest.mark.asyncio
+async def test_reresolve_sweep_applies_vrf_rt_match(db_session: AsyncSession) -> None:
+    """A VRF created AFTER a route's last ingest still converges via the
+    periodic re-resolve sweep — same precedence rule as ingest time."""
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    await ingest_routes(
+        db_session,
+        peer,
+        [_route("10.20.0.0/24", origin_asn=65001, ext_communities=["65005:300"])],
+        snapshot=True,
+    )
+    row = (
+        await db_session.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))
+    ).scalar_one()
+    assert row.matched_vrf_id is None  # no VRF existed yet at ingest time
+
+    vrf = await _make_vrf(db_session, import_targets=["65005:300"])
+    await db_session.commit()  # the sweep opens its own engine/connection
+
+    stats = await _reresolve_route_links_async()
+    assert stats["checked"] >= 1
+    assert stats["changed"] >= 1
+
+    await db_session.refresh(row)
+    assert row.matched_vrf_id == vrf.id
+
+
+@pytest.mark.asyncio
+async def test_vrf_rt_matches_endpoint(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    vrf = await _make_vrf(db_session, import_targets=["65001:100"], export_targets=["65001:200"])
+    await ingest_routes(
+        db_session,
+        peer,
+        [
+            _route("10.30.0.0/24", origin_asn=65001, ext_communities=["65001:100"]),
+            _route("10.30.1.0/24", origin_asn=65001, ext_communities=["65001:100"]),
+            _route("10.30.2.0/24", origin_asn=65001, ext_communities=["65001:200"]),
+        ],
+        snapshot=True,
+    )
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.get(f"/api/v1/looking-glass/vrf-rt-matches/{vrf.id}", headers=hdr)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["matched_route_count"] == 3
+    by_rt = {
+        (row["route_target"], row["kind"]): row["matched_route_count"]
+        for row in body["route_targets"]
+    }
+    assert by_rt[("65001:100", "import")] == 2
+    assert by_rt[("65001:200", "export")] == 1
+
+    # 404 for an unknown VRF id.
+    resp = await client.get(f"/api/v1/looking-glass/vrf-rt-matches/{uuid.uuid4()}", headers=hdr)
+    assert resp.status_code == 404
+
+
+# ── Phase 6 — multicast <-> BGP reachability cross-reference ─────────────
+
+
+@pytest.mark.asyncio
+async def test_multicast_bgp_reachability_domain_rp(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    domain = MulticastDomain(
+        name=f"dom-{uuid.uuid4().hex[:8]}",
+        pim_mode="sparse",
+        rendezvous_point_address="192.168.50.1",
+    )
+    db_session.add(domain)
+    await db_session.flush()
+
+    # No covering route yet.
+    result = await multicast_bgp_reachability(db_session)
+    unreachable = next(d for d in result.domains if d.domain_id == domain.id)
+    assert unreachable.covering_route is None
+
+    await ingest_routes(
+        db_session, peer, [_route("192.168.50.0/24", origin_asn=65001)], snapshot=True
+    )
+    result = await multicast_bgp_reachability(db_session)
+    reachable = next(d for d in result.domains if d.domain_id == domain.id)
+    assert reachable.covering_route is not None
+    assert str(reachable.covering_route.prefix) == "192.168.50.0/24"
+
+
+@pytest.mark.asyncio
+async def test_multicast_bgp_reachability_group_source_subnet(
+    db_session: AsyncSession,
+) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    space = IPSpace(name=f"mc-space-{uuid.uuid4().hex[:8]}")
+    db_session.add(space)
+    await db_session.flush()
+    block = IPBlock(space_id=space.id, name="b", network="10.40.0.0/16")
+    db_session.add(block)
+    await db_session.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, name="s", network="10.40.1.0/24")
+    db_session.add(subnet)
+    await db_session.flush()
+    ip = IPAddress(subnet_id=subnet.id, address="10.40.1.5", status="allocated")
+    db_session.add(ip)
+    await db_session.flush()
+
+    mgroup = MulticastGroup(space_id=space.id, address="239.1.1.1", name="mg")
+    db_session.add(mgroup)
+    await db_session.flush()
+    db_session.add(MulticastMembership(group_id=mgroup.id, ip_address_id=ip.id, role="producer"))
+    await db_session.flush()
+
+    # A /32 route sitting on the subnet's base address must NOT count as
+    # covering the WHOLE subnet (negative case).
+    await ingest_routes(db_session, peer, [_route("10.40.1.0/32", origin_asn=65001)], snapshot=True)
+    result = await multicast_bgp_reachability(db_session)
+    group_result = next(g for g in result.groups if g.group_id == mgroup.id)
+    assert group_result.covering_route is None
+
+    # A route covering the whole /24 counts.
+    await ingest_routes(
+        db_session, peer, [_route("10.40.0.0/16", origin_asn=65001)], snapshot=False
+    )
+    result = await multicast_bgp_reachability(db_session)
+    group_result = next(g for g in result.groups if g.group_id == mgroup.id)
+    assert group_result.covering_route is not None
+    assert str(group_result.covering_route.prefix) == "10.40.0.0/16"
+
+
+@pytest.mark.asyncio
+async def test_multicast_reachability_endpoint(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    domain = MulticastDomain(
+        name=f"dom-{uuid.uuid4().hex[:8]}",
+        pim_mode="sparse",
+        rendezvous_point_address="192.168.60.1",
+    )
+    db_session.add(domain)
+    await db_session.flush()
+    await ingest_routes(
+        db_session, peer, [_route("192.168.60.0/24", origin_asn=65001)], snapshot=True
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/looking-glass/multicast-reachability",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    dom = next(d for d in body["domains"] if d["domain_id"] == str(domain.id))
+    assert dom["covering_route"]["prefix"] == "192.168.60.0/24"
+
+
+# ── Phase 6 — Operator Copilot tools ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_find_vrf_learned_routes_tool(db_session: AsyncSession) -> None:
+    user, _ = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    vrf = await _make_vrf(db_session, import_targets=["65001:900"])
+    await ingest_routes(
+        db_session,
+        peer,
+        [_route("10.60.0.0/24", origin_asn=65001, ext_communities=["65001:900"])],
+        snapshot=True,
+    )
+
+    out = await find_vrf_learned_routes(db_session, user, FindVrfLearnedRoutesArgs(vrf_id=vrf.id))
+    assert out["count"] == 1
+    assert out["routes"][0]["prefix"] == "10.60.0.0/24"
+
+
+@pytest.mark.asyncio
+async def test_find_multicast_bgp_reachability_tool(db_session: AsyncSession) -> None:
+    user, _ = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    domain = MulticastDomain(
+        name=f"dom-{uuid.uuid4().hex[:8]}",
+        pim_mode="sparse",
+        rendezvous_point_address="192.168.70.1",
+    )
+    db_session.add(domain)
+    await db_session.flush()
+    await ingest_routes(
+        db_session, peer, [_route("192.168.70.0/24", origin_asn=65001)], snapshot=True
+    )
+
+    out = await find_multicast_bgp_reachability(
+        db_session, user, FindMulticastBgpReachabilityArgs()
+    )
+    dom = next(d for d in out["domains"] if d["domain_id"] == str(domain.id))
+    assert dom["reachable"] is True
+    assert dom["covering_route"]["prefix"] == "192.168.70.0/24"

--- a/backend/tests/test_looking_glass.py
+++ b/backend/tests/test_looking_glass.py
@@ -1,0 +1,456 @@
+"""BGP Looking Glass tests — issue #566 Phase 1+2.
+
+Covers the correctness-critical RIB reconcile (``ingest_routes`` — the
+zero-wire floor guard, absence-withdraw, idempotency, re-announce), the peer
+CRUD surface (Fernet ``md5_password`` never echoed, audit row written), the
+feature-module gate, the routes search filters, and the agent register +
+routes-push end-to-end path.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
+from app.models.feature_module import FeatureModule
+from app.services import feature_modules
+from app.services.looking_glass.config_bundle import build_lg_config_bundle
+from app.services.looking_glass.routes_ingest import ingest_routes
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+async def _make_admin(db: AsyncSession) -> tuple[User, str]:
+    user = User(
+        username=f"lg-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="LG Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_collector(db: AsyncSession, **kw) -> LookingGlassCollector:
+    col = LookingGlassCollector(
+        name=kw.pop("name", f"col-{uuid.uuid4().hex[:8]}"),
+        agent_id=kw.pop("agent_id", uuid.uuid4().hex),
+        agent_registered=True,
+        status="active",
+        **kw,
+    )
+    db.add(col)
+    await db.flush()
+    return col
+
+
+async def _make_peer(db: AsyncSession, collector: LookingGlassCollector, **kw) -> BGPLGPeer:
+    peer = BGPLGPeer(
+        name=kw.pop("name", f"peer-{uuid.uuid4().hex[:8]}"),
+        collector_id=collector.id,
+        local_asn=kw.pop("local_asn", 65000),
+        peer_asn=kw.pop("peer_asn", 65001),
+        peer_address=kw.pop("peer_address", "192.0.2.1"),
+        **kw,
+    )
+    db.add(peer)
+    await db.flush()
+    return peer
+
+
+def _route(prefix: str, next_hop: str = "192.0.2.1", **kw) -> dict:
+    return {"prefix": prefix, "next_hop": next_hop, **kw}
+
+
+# ── ingest_routes — the correctness-critical reconcile ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_ingest_inserts_then_idempotent(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+
+    wire = [_route("10.0.0.0/24", origin_asn=65001), _route("10.0.1.0/24", origin_asn=65001)]
+    r1 = await ingest_routes(db_session, peer, wire, snapshot=True)
+    assert r1.imported == 2 and r1.refreshed == 0 and r1.withdrawn == 0
+
+    # A second identical snapshot is a pure no-op insert-wise (idempotent #9).
+    r2 = await ingest_routes(db_session, peer, wire, snapshot=True)
+    assert r2.imported == 0 and r2.refreshed == 2 and r2.withdrawn == 0
+
+    live = (
+        await db_session.execute(
+            select(func.count()).select_from(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id)
+        )
+    ).scalar_one()
+    assert live == 2
+
+
+@pytest.mark.asyncio
+async def test_ingest_absence_withdraws_missing_prefix(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    await ingest_routes(
+        db_session,
+        peer,
+        [_route("10.0.0.0/24", origin_asn=65001), _route("10.0.1.0/24", origin_asn=65001)],
+        snapshot=True,
+    )
+
+    # Second snapshot drops 10.0.1.0/24 → it must be marked withdrawn, not deleted.
+    r = await ingest_routes(
+        db_session, peer, [_route("10.0.0.0/24", origin_asn=65001)], snapshot=True
+    )
+    assert r.withdrawn == 1
+
+    gone = (
+        await db_session.execute(
+            select(BGPLGRoute).where(
+                BGPLGRoute.peer_id == peer.id, BGPLGRoute.prefix == "10.0.1.0/24"
+            )
+        )
+    ).scalar_one()
+    assert gone.withdrawn_at is not None  # soft-marked, still present
+    assert gone.flap_count == 1
+
+
+@pytest.mark.asyncio
+async def test_zero_wire_floor_guard_skips_mass_withdraw(db_session: AsyncSession) -> None:
+    """An empty snapshot from an established peer (prefixes_received>0) must NOT
+    withdraw the whole RIB — the #482 zero-wire floor guard."""
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    await ingest_routes(db_session, peer, [_route("10.0.0.0/24", origin_asn=65001)], snapshot=True)
+
+    peer.prefixes_received = 5  # collector reported it has learned prefixes
+    await db_session.flush()
+
+    r = await ingest_routes(db_session, peer, [], snapshot=True)
+    assert r.withdrawn == 0  # guard fired
+    assert any("skipping absence-withdraw" in e for e in r.errors)
+
+    still = (
+        await db_session.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))
+    ).scalar_one()
+    assert still.withdrawn_at is None  # survived the empty poll
+
+
+@pytest.mark.asyncio
+async def test_reannounce_clears_withdrawn(db_session: AsyncSession) -> None:
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    await ingest_routes(db_session, peer, [_route("10.0.0.0/24", origin_asn=65001)], snapshot=True)
+    await ingest_routes(db_session, peer, [], snapshot=True)  # withdraw (prefixes_received==0)
+
+    row = (
+        await db_session.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))
+    ).scalar_one()
+    assert row.withdrawn_at is not None
+
+    # Re-announce → withdrawn_at cleared.
+    await ingest_routes(db_session, peer, [_route("10.0.0.0/24", origin_asn=65001)], snapshot=True)
+    await db_session.refresh(row)
+    assert row.withdrawn_at is None
+
+
+# ── peer CRUD — Fernet secret handling + audit ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_peer_crud_fernet_and_audit(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {token}"}
+
+    # Create with an MD5 password — response must NOT echo the plaintext.
+    resp = await client.post(
+        "/api/v1/looking-glass/peers",
+        headers=hdr,
+        json={
+            "name": "Core-1",
+            "collector_id": str(col.id),
+            "local_asn": 65000,
+            "peer_asn": 65001,
+            "peer_address": "192.0.2.1",
+            "md5_password": "s3cr3t",
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    body = resp.json()
+    peer_id = body["id"]
+    assert body["md5_password_set"] is True
+    assert "md5_password" not in body and "s3cr3t" not in resp.text
+
+    # Stored ciphertext, never plaintext.
+    row = (
+        await db_session.execute(select(BGPLGPeer).where(BGPLGPeer.id == uuid.UUID(peer_id)))
+    ).scalar_one()
+    assert row.md5_password_encrypted is not None
+    assert b"s3cr3t" not in row.md5_password_encrypted
+
+    # A mutation wrote an audit row.
+    n_audit = (await db_session.execute(select(func.count()).select_from(AuditLog))).scalar_one()
+    assert n_audit >= 1
+
+    # PATCH without md5_password keeps it; explicit "" clears it.
+    resp = await client.patch(
+        f"/api/v1/looking-glass/peers/{peer_id}", headers=hdr, json={"description": "edge"}
+    )
+    assert resp.status_code == 200 and resp.json()["md5_password_set"] is True
+    resp = await client.patch(
+        f"/api/v1/looking-glass/peers/{peer_id}", headers=hdr, json={"md5_password": ""}
+    )
+    assert resp.status_code == 200 and resp.json()["md5_password_set"] is False
+
+    resp = await client.delete(f"/api/v1/looking-glass/peers/{peer_id}", headers=hdr)
+    assert resp.status_code in (200, 204)
+
+
+# ── feature-module gate ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_module_gate_404_when_disabled(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_admin(db_session)
+    db_session.add(FeatureModule(id="network.looking_glass", enabled=False))
+    await db_session.flush()
+    feature_modules.invalidate_cache()
+    try:
+        resp = await client.get(
+            "/api/v1/looking-glass/peers", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert resp.status_code == 404
+    finally:
+        feature_modules.invalidate_cache()
+
+
+# ── routes search filters ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_routes_search_filters(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    await ingest_routes(
+        db_session,
+        peer,
+        [
+            _route("10.0.0.0/24", origin_asn=65001),
+            _route("10.0.1.0/24", origin_asn=65002),
+        ],
+        snapshot=True,
+    )
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.get("/api/v1/looking-glass/routes", headers=hdr)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 2 and len(body["items"]) == 2
+
+    resp = await client.get("/api/v1/looking-glass/routes?origin_asn=65002", headers=hdr)
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1 and items[0]["prefix"] == "10.0.1.0/24"
+
+
+# ── agent register + routes push (end-to-end, real JWT) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_register_and_push(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+) -> None:
+    monkeypatch.setenv("LG_AGENT_KEY", "bootstrap-secret")
+
+    # Bad key → 401.
+    bad = await client.post(
+        "/api/v1/looking-glass/agents/register",
+        headers={"X-LG-Agent-Key": "wrong"},
+        json={"hostname": "collector-1", "fingerprint": "fp-1"},
+    )
+    assert bad.status_code == 401
+
+    # Good key → token + collector_id.
+    resp = await client.post(
+        "/api/v1/looking-glass/agents/register",
+        headers={"X-LG-Agent-Key": "bootstrap-secret"},
+        json={"hostname": "collector-1", "fingerprint": "fp-1", "version": "0.1"},
+    )
+    assert resp.status_code == 200, resp.text
+    reg = resp.json()
+    token = reg["agent_token"]
+    collector_id = reg["collector_id"]
+
+    # A peer under that collector (direct insert — operator would normally POST it).
+    peer = await _make_peer(
+        db_session, await db_session.get(LookingGlassCollector, uuid.UUID(collector_id))
+    )
+    await db_session.flush()
+
+    # Push a snapshot with the agent JWT → routes land.
+    push = await client.post(
+        "/api/v1/looking-glass/agents/routes",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "peer_id": str(peer.id),
+            "snapshot": True,
+            "routes": [{"prefix": "203.0.113.0/24", "next_hop": "192.0.2.1", "origin_asn": 65001}],
+        },
+    )
+    assert push.status_code in (200, 201), push.text
+
+    landed = (
+        await db_session.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))
+    ).scalar_one()
+    assert str(landed.prefix) == "203.0.113.0/24"
+
+
+# ── review-fix regressions ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ingest_dedups_duplicate_wire_key(db_session: AsyncSession) -> None:
+    """#1 — two wire entries sharing (prefix,next_hop) must not double-insert
+    and blow up on the unique constraint."""
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    r = await ingest_routes(
+        db_session,
+        peer,
+        [
+            _route("10.0.0.0/24", origin_asn=65001, local_pref=100),
+            _route("10.0.0.0/24", origin_asn=65001, local_pref=200),  # dup key
+        ],
+        snapshot=True,
+    )
+    assert r.imported == 1  # collapsed, no UniqueViolation
+    row = (
+        await db_session.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))
+    ).scalar_one()
+    assert row.local_pref == 200  # last write wins
+
+
+@pytest.mark.asyncio
+async def test_ingest_skips_malformed_prefix(db_session: AsyncSession) -> None:
+    """#4 — a malformed CIDR (host bits set / garbage) is skipped, not a 500,
+    and valid rows in the same push still land."""
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    r = await ingest_routes(
+        db_session,
+        peer,
+        [
+            _route("10.0.0.1/24", origin_asn=65001),  # host bits set — invalid CIDR
+            _route("not-an-ip"),  # garbage
+            _route("10.0.2.0/24", origin_asn=65001),  # valid
+        ],
+        snapshot=True,
+    )
+    assert r.imported == 1
+    assert any("malformed" in e for e in r.errors)
+    row = (
+        await db_session.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))
+    ).scalar_one()
+    assert str(row.prefix) == "10.0.2.0/24"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_clears_uptime_on_flap_down(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+) -> None:
+    """#9 — a heartbeat reporting a non-established state clears uptime_started_at."""
+    from datetime import UTC, datetime
+
+    monkeypatch.setenv("LG_AGENT_KEY", "bootstrap-secret")
+    reg = (
+        await client.post(
+            "/api/v1/looking-glass/agents/register",
+            headers={"X-LG-Agent-Key": "bootstrap-secret"},
+            json={"hostname": "c1", "fingerprint": "fp"},
+        )
+    ).json()
+    token, cid = reg["agent_token"], reg["collector_id"]
+    col = await db_session.get(LookingGlassCollector, uuid.UUID(cid))
+    peer = await _make_peer(db_session, col, session_state="established")
+    peer.uptime_started_at = datetime.now(UTC)
+    await db_session.commit()
+
+    hb = await client.post(
+        "/api/v1/looking-glass/agents/heartbeat",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"peers": [{"peer_id": str(peer.id), "session_state": "active"}]},
+    )
+    assert hb.status_code == 200, hb.text
+    await db_session.refresh(peer)
+    assert peer.session_state == "active"
+    assert peer.uptime_started_at is None  # cleared
+
+
+@pytest.mark.asyncio
+async def test_duplicate_peer_address_409(client: AsyncClient, db_session: AsyncSession) -> None:
+    """#10 — a second peer with the same collector+peer_address is rejected 409."""
+    _, token = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {token}"}
+    body = {
+        "name": "A",
+        "collector_id": str(col.id),
+        "local_asn": 65000,
+        "peer_asn": 65001,
+        "peer_address": "192.0.2.9",
+    }
+    assert (
+        await client.post("/api/v1/looking-glass/peers", headers=hdr, json=body)
+    ).status_code in (
+        200,
+        201,
+    )
+    dup = await client.post("/api/v1/looking-glass/peers", headers=hdr, json={**body, "name": "B"})
+    assert dup.status_code == 409, dup.text
+
+
+@pytest.mark.asyncio
+async def test_disabling_peer_withdraws_routes(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """#11 — disabling a peer marks its learned routes withdrawn."""
+    _, token = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    await ingest_routes(db_session, peer, [_route("10.9.0.0/24", origin_asn=65001)], snapshot=True)
+    await db_session.commit()
+
+    resp = await client.patch(
+        f"/api/v1/looking-glass/peers/{peer.id}",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"enabled": False},
+    )
+    assert resp.status_code == 200, resp.text
+    row = (
+        await db_session.execute(select(BGPLGRoute).where(BGPLGRoute.peer_id == peer.id))
+    ).scalar_one()
+    assert row.withdrawn_at is not None
+
+
+@pytest.mark.asyncio
+async def test_disabled_collector_bundle_is_empty(db_session: AsyncSession) -> None:
+    """#12 — a collector toggled enabled=False renders zero peers so sessions drop."""
+    col = await _make_collector(db_session, enabled=False)
+    await _make_peer(db_session, col)
+    await db_session.flush()
+    bundle = await build_lg_config_bundle(db_session, col)
+    assert bundle.peers == ()

--- a/backend/tests/test_looking_glass.py
+++ b/backend/tests/test_looking_glass.py
@@ -266,6 +266,64 @@ async def test_routes_search_filters(client: AsyncClient, db_session: AsyncSessi
     assert len(items) == 1 and items[0]["prefix"] == "10.0.1.0/24"
 
 
+@pytest.mark.asyncio
+async def test_routes_as_path_regexp_filter(client: AsyncClient, db_session: AsyncSession) -> None:
+    """#566 Phase 4 — the ``_`` boundary-token AS-path regexp filter."""
+    _, token = await _make_admin(db_session)
+    col = await _make_collector(db_session)
+    peer = await _make_peer(db_session, col)
+    await ingest_routes(
+        db_session,
+        peer,
+        [
+            # 65001 appears as origin (last hop).
+            _route("10.0.0.0/24", origin_asn=65001, as_path=[65003, 65001]),
+            # 65001 appears mid-path only, not as origin.
+            _route("10.0.1.0/24", origin_asn=65002, as_path=[65001, 65002]),
+            # 65001 doesn't appear at all.
+            _route("10.0.2.0/24", origin_asn=65004, as_path=[65004]),
+        ],
+        snapshot=True,
+    )
+    await db_session.commit()
+    hdr = {"Authorization": f"Bearer {token}"}
+
+    # "_65001_" — anywhere in the path — matches the first two routes.
+    resp = await client.get("/api/v1/looking-glass/routes?as_path_regexp=_65001_", headers=hdr)
+    assert resp.status_code == 200, resp.text
+    prefixes = {r["prefix"] for r in resp.json()["items"]}
+    assert prefixes == {"10.0.0.0/24", "10.0.1.0/24"}
+
+    # A pattern with no matches at all.
+    resp = await client.get("/api/v1/looking-glass/routes?as_path_regexp=_65999_", headers=hdr)
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+
+    # "_65001$" — origin (last hop) only — matches ONLY the route where 65001
+    # is the origin, not the one where it's mid-path. Regression: the rendered
+    # path text must be trimmed/collapsed so the trailing "]" space doesn't
+    # defeat the "$" anchor.
+    resp = await client.get("/api/v1/looking-glass/routes?as_path_regexp=_65001$", headers=hdr)
+    assert resp.status_code == 200, resp.text
+    assert {r["prefix"] for r in resp.json()["items"]} == {"10.0.0.0/24"}
+
+    # "^65001" — first hop only — matches ONLY the route starting with 65001.
+    resp = await client.get("/api/v1/looking-glass/routes?as_path_regexp=^65001", headers=hdr)
+    assert resp.status_code == 200
+    assert {r["prefix"] for r in resp.json()["items"]} == {"10.0.1.0/24"}
+
+
+@pytest.mark.asyncio
+async def test_routes_as_path_regexp_malformed_422(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A malformed regexp (unbalanced paren) 422s instead of 500ing."""
+    _, token = await _make_admin(db_session)
+    hdr = {"Authorization": f"Bearer {token}"}
+    resp = await client.get("/api/v1/looking-glass/routes?as_path_regexp=(unbalanced", headers=hdr)
+    assert resp.status_code == 422, resp.text
+
+
 # ── agent register + routes push (end-to-end, real JWT) ─────────────────
 
 

--- a/backend/tests/test_tools_router.py
+++ b/backend/tests/test_tools_router.py
@@ -20,12 +20,15 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.tools.schemas import CommandResult, PortTestResult, TlsCertResult
 from app.core.security import create_access_token, hash_password
 from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
+from app.models.audit import AuditLog
 from app.models.auth import Group, Role, User
+from app.models.bgp_looking_glass import LookingGlassCollector
 from app.models.feature_module import FeatureModule
 from app.services import feature_modules
 from app.services.appliance import agent_cmd
@@ -118,6 +121,24 @@ async def _make_appliance(
     db.add(appliance)
     await db.flush()
     return appliance
+
+
+async def _make_lg_collector(
+    db: AsyncSession, *, appliance_id: uuid.UUID | None = None
+) -> LookingGlassCollector:
+    """Create a Looking Glass collector row (#566 Phase 4 vantage tests).
+    ``appliance_id=None`` (the default) is a standalone / non-appliance-
+    managed collector — no dispatchable vantage."""
+    collector = LookingGlassCollector(
+        name=f"col-{uuid.uuid4().hex[:6]}",
+        agent_id=uuid.uuid4().hex,
+        agent_registered=True,
+        status="active",
+        appliance_id=appliance_id,
+    )
+    db.add(collector)
+    await db.flush()
+    return collector
 
 
 async def test_ping_200_with_perm(client: AsyncClient, db_session: AsyncSession) -> None:
@@ -464,3 +485,109 @@ async def test_server_target_explicit_still_runs_inline(
     assert r.status_code == 200, r.text
     assert r.json()["ran_from"] == "server"
     mock_enqueue.assert_not_awaited()
+
+
+# ── bgp_lg_collector vantage (#566 Phase 4) ──────────────────────────
+
+
+async def test_bgp_lg_collector_target_not_appliance_managed_400(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A standalone (non-appliance-managed) collector has no dispatchable
+    vantage — reject with a clear 400 rather than silently running on the
+    server or 500ing on a missing appliance."""
+    _, token = await _make_superadmin(db_session)
+    collector = await _make_lg_collector(db_session)  # appliance_id=None
+    with (
+        patch("app.api.v1.tools.router.agent_cmd.enqueue_command", AsyncMock()) as mock_enqueue,
+        patch(
+            "app.services.nettools.throttle.make_async_redis",
+            return_value=_no_limit_redis(),
+        ),
+    ):
+        r = await client.post(
+            "/api/v1/tools/ping",
+            json={
+                "host": "1.1.1.1",
+                "target": {"kind": "bgp_lg_collector", "id": str(collector.id)},
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 400, r.text
+    assert "not appliance-managed" in r.json()["detail"]
+    mock_enqueue.assert_not_awaited()
+
+
+async def test_bgp_lg_collector_target_unknown_collector_404(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    with patch(
+        "app.services.nettools.throttle.make_async_redis",
+        return_value=_no_limit_redis(),
+    ):
+        r = await client.post(
+            "/api/v1/tools/traceroute",
+            json={
+                "host": "1.1.1.1",
+                "target": {"kind": "bgp_lg_collector", "id": str(uuid.uuid4())},
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 404, r.text
+
+
+async def test_bgp_lg_collector_target_dispatches_and_labels_ran_from(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An appliance-managed collector dispatches through the exact same
+    ``agent_cmd`` channel as an ``appliance`` target, but the result is
+    labelled with the collector's vantage and the audit row's resource is
+    the collector (not the appliance)."""
+    _, token = await _make_superadmin(db_session)
+    appliance = await _make_appliance(db_session)
+    collector = await _make_lg_collector(db_session, appliance_id=appliance.id)
+
+    supervisor_result = agent_cmd.NetToolResult(
+        request_id="x",
+        result={"tool": "ping", "argv": ["ping"], "available": True, "exit_code": 0},
+    )
+    with (
+        patch(
+            "app.api.v1.tools.router.agent_cmd.enqueue_command",
+            AsyncMock(return_value=supervisor_result),
+        ) as mock_enqueue,
+        patch(
+            "app.services.nettools.throttle.make_async_redis",
+            return_value=_no_limit_redis(),
+        ),
+    ):
+        r = await client.post(
+            "/api/v1/tools/ping",
+            json={
+                "host": "1.1.1.1",
+                "target": {"kind": "bgp_lg_collector", "id": str(collector.id)},
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["available"] is True
+    assert body["ran_from"] == f"looking_glass:{collector.name}"
+
+    # Dispatched to the collector's owning appliance.
+    mock_enqueue.assert_awaited_once()
+    call = mock_enqueue.await_args
+    assert call.args[0] == appliance.id
+
+    # Audit row's resource is the collector, not the appliance — but the
+    # appliance hostname is still captured for traceability.
+    row = (
+        await db_session.execute(
+            select(AuditLog).where(AuditLog.action == "tools.run_from_appliance")
+        )
+    ).scalar_one()
+    assert row.resource_type == "looking_glass_collector"
+    assert row.resource_id == str(collector.id)
+    assert row.resource_display == collector.name
+    assert row.new_value["appliance"] == appliance.hostname

--- a/charts/spatiumddi-appliance/README.md
+++ b/charts/spatiumddi-appliance/README.md
@@ -27,6 +27,9 @@ appliance's *local* k3s, deploying the per-role service workloads:
 - `dnsBind9` — Deployment + Service. BIND9 authoritative DNS.
 - `dnsPowerdns` — Deployment + Service. PowerDNS alternative.
 - `dhcpKea` — DaemonSet with `hostNetwork: true`. Kea DHCPv4/v6.
+- `lookingGlass` — DaemonSet with `hostNetwork: true`. Receive-only
+  BGP collector (GoBGP, issue #566) — see
+  `docs/features/LOOKING_GLASS.md`.
 - `supervisor` — DaemonSet, privileged. The reconciler itself.
 
 Each role is gated on a `<role>.enabled` flag. Mutual exclusion

--- a/charts/spatiumddi-appliance/templates/looking-glass.yaml
+++ b/charts/spatiumddi-appliance/templates/looking-glass.yaml
@@ -1,0 +1,114 @@
+{{- /* Issue #566 — BGP Looking Glass collector (GoBGP).
+       DaemonSet, same shape as dns-bind9.yaml / dhcp-kea.yaml:
+       ``hostNetwork: true`` so the collector's BGP TCP/179 session
+       originates from the node's real routable IP — a router has no
+       route to a pod-CNI IP. Receive-only: the collector never
+       advertises a route back to the operator's network (see
+       agent/looking-glass/ + docs/features/LOOKING_GLASS.md for the
+       invariant enforced in the rendered GoBGP config).
+
+       Phase 10 wave 2 convention — ``.enabled`` is release-ownership
+       scope (bootstrap=false, appliance=true), NOT role-scope. The
+       supervisor's spatiumddi-appliance HelmChart sets
+       ``lookingGlass.enabled=true``; pod scheduling is gated purely
+       by the ``spatium.io/role-looking-glass=true`` node label —
+       role swap = pure label flip, no chart upgrade.
+
+       No Service: the collector is receive-only and peers OUT to the
+       operator's routers (or accepts inbound sessions the router
+       initiates) — nothing in-cluster needs to route TO it. No extra
+       Linux capabilities: TCP/179 is a normal socket, unlike Kea's
+       raw-broadcast read path. */}}
+{{- if .Values.lookingGlass.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: looking-glass
+  labels:
+    {{- include "spatiumddi-appliance.labels" . | nindent 4 }}
+    app.kubernetes.io/component: looking-glass
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: looking-glass
+  # #566 — RollingUpdate, NOT OnDelete, mirroring dns-bind9.yaml /
+  # dhcp-kea.yaml: OnDelete strands a pod on a stale pre-URL-known
+  # spec forever; RollingUpdate auto-rolls on template/env change.
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        app.kubernetes.io/name: looking-glass
+        app.kubernetes.io/component: looking-glass
+    spec:
+      nodeSelector:
+        {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+        # Phase 10 (#183) per-role scheduling label pattern, extended
+        # to the Looking Glass role under #566. Pod stays Pending
+        # until the supervisor's role-apply path labels the node with
+        # ``spatium.io/role-looking-glass=true``.
+        spatium.io/role-looking-glass: "true"
+      # The collector's BGP session must originate from the node's
+      # real routable IP so the operator's router has a return path —
+      # same rationale as dns-bind9.yaml / dhcp-kea.yaml.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      # A live BGP session holding a full RIB benefits from a
+      # deliberate drain grace, same family as DHCP's 60s (a GoBGP
+      # graceful-restart/notification exchange takes longer than a
+      # DNS query flush).
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: looking-glass
+          image: {{ include "spatiumddi-appliance.imageRef" (dict "global" .Values.global "repository" .Values.lookingGlass.image.repository) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            # spatium_lg_agent.config.AgentConfig.from_env() contract
+            # (agent/looking-glass/): CONTROL_PLANE_URL + LG_AGENT_KEY.
+            # #292 / #409 precedence — see dns-bind9.yaml for the full
+            # in-cluster-vs-external-URL rationale.
+            - name: CONTROL_PLANE_URL
+              value: {{ .Values.lookingGlass.controlPlaneUrl | default .Values.lookingGlass.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
+            {{- if .Values.lookingGlass.controlPlaneUrl }}
+            - name: SPATIUM_INSECURE_SKIP_TLS_VERIFY
+              value: "1"
+            {{- end }}
+            - name: LG_AGENT_KEY
+              value: {{ .Values.lookingGlass.agentKey | quote }}
+            {{- with .Values.global.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          # ``.ready`` is stamped by the agent's sync loop after the
+          # first successful ConfigBundle fetch + GoBGP peer apply —
+          # same convention as the DNS/DHCP agents. Persists across
+          # restarts on the hostPath volume so a warm-restart pod is
+          # Ready immediately.
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "test -f /var/lib/spatium-lg-agent/.ready"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          volumeMounts:
+            # #5 — the cached ConfigBundle (peer set + max-prefix +
+            # AF) is what lets the collector keep its BGP sessions
+            # alive from last-known-good config when the control
+            # plane is unreachable.
+            - name: agent-state
+              mountPath: /var/lib/spatium-lg-agent
+      # Per-node hostPath, NOT a shared RWO PVC and NOT emptyDir — see
+      # dns-bind9.yaml / dhcp-kea.yaml for the full rationale.
+      volumes:
+        - name: agent-state
+          hostPath:
+            path: /var/lib/spatiumddi/agents/looking-glass/state
+            type: DirectoryOrCreate
+{{- end }}

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -116,6 +116,27 @@ dhcpKea:
   # different pool than DNS.
   relayVIPPool: ""
 
+# Looking Glass — receive-only BGP collector (GoBGP). Issue #566. Peers
+# passively with the operator's edge/core routers over the node's real
+# routable IP (hostNetwork, like DNS/DHCP) and never advertises a route
+# back — see agent/looking-glass/ + docs/features/LOOKING_GLASS.md for
+# the collector daemon + the hard receive-only invariant.
+lookingGlass:
+  enabled: false
+  image:
+    repository: ghcr.io/spatiumddi/looking-glass
+  # Same precedence + rationale as dnsBind9.controlPlaneUrl /
+  # inClusterApiUrl above: external operator-facing URL (Application
+  # appliance, self-signed) takes priority over the in-cluster Service
+  # default.
+  controlPlaneUrl: ""
+  inClusterApiUrl: ""  # #292 — see dnsBind9.inClusterApiUrl
+  agentKey: ""
+  # #566 — per-node hostPath state under /var/lib/spatiumddi/agents/
+  # looking-glass/ (agent cache — cached ConfigBundle + peer config the
+  # collector re-applies from if the control plane is unreachable, non-
+  # negotiable #5), NOT a PVC. See dnsBind9 for the full rationale.
+
 # #272 Phase 5 — DNS resolver VIP (default off, full wiring is Phase 10).
 # When ``useMetalLBVIP: true`` the bind9 + powerdns Pods DROP
 # hostNetwork:53 and sit behind a single L2 LoadBalancer Service at

--- a/charts/spatiumddi-metallb/values.yaml
+++ b/charts/spatiumddi-metallb/values.yaml
@@ -70,13 +70,91 @@ metallb:
     # does exactly that. Flip true only for generic LB auto-assignment.
     autoAssign: false
 
-  # ── BGP (spec-only, Phase 5 runway) ───────────────────────────────
+  # ── BGP (issue #566 decision D1 — light-up) ───────────────────────
   # No behavior change while ``enabled: false``. Real peering needs an
-  # FRR backend (frrk8s.enabled=true + baking the frr images).
+  # FRR backend — the seed supervisor flips BOTH this AND
+  # ``frrk8s.enabled`` above together (apply_metallb_overrides) the
+  # instant an operator configures a BGP peer via Fleet → Network &
+  # Host, so the two flags never drift apart in practice.
   bgp:
     enabled: false
     peers: []
     advertisements: []
+
+  # ── frr-k8s subchart config (issue #566 decision D1 — BGP mode) ────
+  # NOTE the hyphen: this is a DIFFERENT key from `frrk8s:` above, and
+  # it MUST live nested inside this `metallb:` block (same indent as
+  # `frrk8s:` / `speaker:` / `bgp:`), NOT as a top-level sibling of
+  # `metallb:` — Helm only threads subchart overrides through a chart's
+  # OWN values scope. Our wrapper Chart.yaml depends on `metallb`
+  # (unaliased), so wrapper `metallb.*` becomes the metallb chart's own
+  # `.Values.*`; the metallb chart's OWN Chart.yaml then depends on
+  # `frr-k8s` (also unaliased), so ITS `.Values.frr-k8s.*` — i.e. our
+  # `metallb.frr-k8s.*` — is what reaches the nested frr-k8s dependency.
+  # A top-level (0-indent) `frr-k8s:` key here never reaches it at all
+  # (verified empirically via `helm template` — every field silently
+  # fell back to the frr-k8s chart's own bundled defaults, including
+  # `crds.enabled: true`, re-introducing the double-owner CRD conflict
+  # §0c exists to avoid).
+  #
+  # `frrk8s:` (no hyphen, above) is the metallb chart's own "am I
+  # frrk8s-backed" flag; `frr-k8s:` (hyphen) is the values block for the
+  # nested frr-k8s dependency chart itself (matches its Chart.yaml
+  # `name:`).
+  #
+  # A SECOND, easy-to-miss nesting quirk lives one level further down:
+  # the frr-k8s chart's OWN values.yaml has a top-level `crds:` key
+  # (its nested CRDs sub-subchart, gated by `condition: crds.enabled`
+  # in ITS Chart.yaml — reached at exactly `frr-k8s.crds.enabled` from
+  # here) but puts image/nodeSelector/frr-image config under its OWN
+  # internal (also no-hyphen) `frrk8s:` key instead of at its top level
+  # — verified against the vendored tarball's
+  # `charts/frr-k8s/templates/controller.yaml`, which reads
+  # `.Values.frrk8s.image.repository` / `.Values.frrk8s.nodeSelector` /
+  # `.Values.frrk8s.frr.image...`. So from OUR root values.yaml, the
+  # working paths are `metallb.frr-k8s.crds.enabled` (no extra nesting)
+  # but `metallb.frr-k8s.frrk8s.nodeSelector` /
+  # `metallb.frr-k8s.frrk8s.image.*` /
+  # `metallb.frr-k8s.frrk8s.frr.image.*` (one extra `frrk8s:` level) —
+  # confirmed empirically via `helm template` after the first attempt
+  # (image/nodeSelector at `frr-k8s.*` directly) silently no-op'd and
+  # every field rendered as the chart's own bundled default instead.
+  #
+  # Gated off in step with `frrk8s.enabled` above — the frr-k8s
+  # DaemonSet only actually deploys when BOTH `metallb.enabled` AND
+  # `metallb.frrk8s.enabled` are true (see the metallb chart's
+  # speaker.yaml / controller.yaml
+  # `{{- if or .Values.frrk8s.enabled .Values.frrk8s.external }}` gates),
+  # so leaving this block populated while frrk8s.enabled stays false is
+  # inert.
+  frr-k8s:
+    # CRDs (frrconfigurations / frrnodestates / bgpsessionstates,
+    # frrk8s.metallb.io group) are pre-loaded outside Helm exactly like
+    # the metallb.io CRDs above — same "no double-owner conflict" reason.
+    crds:
+      enabled: false
+    # frr-k8s chart's OWN internal `frrk8s:` key (see the long comment
+    # above) — nodeSelector / image / frr-image config all live here,
+    # NOT at this block's top level.
+    frrk8s:
+      # Same control-plane-only placement as the speaker/controller
+      # above (non-negotiable #16) — BGP is a control-plane concern.
+      nodeSelector:
+        spatium.io/role-control-plane: "true"
+      # Explicit image tags, locked to what the vendored 0.15.3 metallb
+      # package's frr-k8s@0.0.21 subchart defaults to (verified by
+      # inspecting charts/frr-k8s/values.yaml + Chart.yaml inside the
+      # tarball) — pin explicitly so a `helm dependency update` re-fetch
+      # that silently changes upstream defaults can't drift the pin
+      # unnoticed. KEEP in lock-step with
+      # appliance/scripts/bake-images.sh ``METALLB_IMAGES``.
+      image:
+        repository: quay.io/metallb/frr-k8s
+        tag: v0.0.21
+      frr:
+        image:
+          repository: quay.io/frrouting/frr
+          tag: 10.4.1
 
 # Cross-namespace pod-read for the control-plane api SA so the
 # Network & Host MetalLB status card works now that MetalLB is in

--- a/docker-compose.agent-looking-glass.yml
+++ b/docker-compose.agent-looking-glass.yml
@@ -1,0 +1,68 @@
+name: spatiumddi-agent-looking-glass
+
+# ── Standalone BGP Looking Glass collector compose file ───────────────
+#
+# For running the receive-only GoBGP collector on a machine *without*
+# the SpatiumDDI control plane — the same distributed-deployment shape
+# as docker-compose.agent-dhcp.yml / docker-compose.agent-dns.yml:
+#
+#   * Control plane (api, db, redis, frontend, worker) runs on one VM
+#     via ``docker-compose.yml``.
+#   * This compose file runs on a VM with a real routable NIC that can
+#     reach the operator's edge/core routers over BGP (TCP/179),
+#     pointing at the control plane's API URL.
+#
+# RECEIVE-ONLY: this collector never advertises a route back to your
+# network — see agent/looking-glass/spatium_lg_agent/gobgp.py's module
+# docstring for the enforcement details.
+#
+# Quickstart:
+#
+#   export CONTROL_PLANE_URL=https://spatium.example.com
+#   export LG_AGENT_KEY=$(openssl rand -hex 32)
+#
+#   # Register the key on the control plane first (Settings → Agent
+#   # Keys) so the collector can bootstrap.
+#
+#   docker compose -f docker-compose.agent-looking-glass.yml up -d
+#
+# ──────────────────────────────────────────────────────────────────────
+
+services:
+
+  looking-glass:
+    image: ghcr.io/spatiumddi/looking-glass:${SPATIUMDDI_VERSION:-latest}
+    restart: unless-stopped
+    hostname: ${LG_HOSTNAME:-looking-glass}
+    # BGP needs the real routable interface — a bridged network only
+    # sees relayed/NATed traffic, and the operator's router needs to
+    # dial (or accept a dial from) this collector's real IP on TCP/179.
+    network_mode: host
+    environment:
+      # ── Required ──────────────────────────────────────────────────
+      # URL of the SpatiumDDI control plane API.
+      CONTROL_PLANE_URL: ${CONTROL_PLANE_URL:?CONTROL_PLANE_URL required}
+      # Pre-shared key registered on the control plane first.
+      LG_AGENT_KEY: ${LG_AGENT_KEY:?LG_AGENT_KEY required}
+
+      # ── Registration ──────────────────────────────────────────────
+      SERVER_NAME: ${LG_HOSTNAME:-looking-glass}
+
+      # ── TLS ───────────────────────────────────────────────────────
+      # Flip to 0 once your control plane has a trusted cert. Default
+      # is 1 for lab / self-signed testing.
+      SPATIUM_INSECURE_SKIP_TLS_VERIFY: "${SPATIUM_INSECURE_SKIP_TLS_VERIFY:-1}"
+      # TLS_CA_PATH: /etc/ssl/spatium-ca.crt
+
+      # ── Tuning (optional, defaults shown) ─────────────────────────
+      # LOG_LEVEL: INFO
+      # HEARTBEAT_INTERVAL: "30"
+      # LONGPOLL_TIMEOUT: "30"
+      # RIB_POLL_INTERVAL: "30"
+    volumes:
+      - lg_agent_state:/var/lib/spatium-lg-agent
+      # Optional: mount a CA bundle to verify the control plane.
+      # - /etc/ssl/certs:/etc/ssl/certs:ro
+
+volumes:
+  lg_agent_state:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -427,6 +427,40 @@ services:
       - NET_BIND_SERVICE
       - NET_RAW  # #365 — raw sockets for direct-attached DHCP (see dhcp-kea)
 
+  # ── BGP Looking Glass collector (receive-only, issue #566) ────────────
+  # Only starts with `--profile looking-glass`. Builds the GoBGP collector
+  # image from source. Receive-only — never advertises a route back. Peers
+  # are configured under Network → Looking Glass. Uses host networking so
+  # the BGP session originates from the host's real NIC; it therefore
+  # reaches the API on the published host port, not the `api` bridge alias.
+  looking-glass:
+    profiles: ["looking-glass"]
+    image: spatiumddi-looking-glass:dev
+    build:
+      context: .
+      dockerfile: agent/looking-glass/images/gobgp/Dockerfile
+    restart: unless-stopped
+    hostname: ${LG_HOSTNAME:-looking-glass}
+    network_mode: host
+    environment:
+      # ── Required ──────────────────────────────────────────────────
+      CONTROL_PLANE_URL: http://127.0.0.1:${API_PORT:-8000}
+      LG_AGENT_KEY: ${LG_AGENT_KEY:-changeme-lg-agent-key}
+      # ── Registration ──────────────────────────────────────────────
+      SERVER_NAME: ${LG_HOSTNAME:-looking-glass}
+      # ── TLS ───────────────────────────────────────────────────────
+      SPATIUM_INSECURE_SKIP_TLS_VERIFY: "1"
+      # ── Tuning (optional, defaults shown) ─────────────────────────
+      # LOG_LEVEL: INFO
+      # HEARTBEAT_INTERVAL: "30"
+      # LONGPOLL_TIMEOUT: "30"
+      # RIB_POLL_INTERVAL: "30"
+    volumes:
+      - lg_agent_state:/var/lib/spatium-lg-agent
+    depends_on:
+      api:
+        condition: service_started
+
 
 networks:
   spatiumddi:
@@ -443,5 +477,7 @@ volumes:
   dhcp_kea_leases:
   dhcp_kea_state_2:
   dhcp_kea_leases_2:
+  # Looking Glass collector last-known-good config cache (issue #566).
+  lg_agent_state:
   spatium_backups:
   spatium_slot_images:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -407,6 +407,48 @@ services:
       - NET_BIND_SERVICE
       - NET_RAW  # #365 — raw sockets for direct-attached DHCP (see dhcp-kea)
 
+  # ── BGP Looking Glass collector (receive-only, issue #566) ────────────
+  # Only starts with `--profile looking-glass`. Peers with your edge/core
+  # routers and ingests their Adj-RIB-In — it NEVER advertises a route back
+  # (default-export reject-route + per-peer max-prefix cap). Configure peers
+  # under Network → Looking Glass. For a collector on a *separate* VM use
+  # docker-compose.agent-looking-glass.yml instead.
+  looking-glass:
+    profiles: ["looking-glass"]
+    image: ghcr.io/spatiumddi/looking-glass:${SPATIUMDDI_VERSION:-latest}
+    restart: unless-stopped
+    hostname: ${LG_HOSTNAME:-looking-glass}
+    # BGP needs the host's real routable interface — a router has no route
+    # to a bridged/NATed container IP, and TCP/179 must originate from the
+    # host IP the peer expects. Because of host networking the collector
+    # reaches the API on the published host port, not the `api` bridge alias.
+    network_mode: host
+    environment:
+      # ── Required ──────────────────────────────────────────────────
+      # API on the same host, via its published port (see api `ports:`).
+      CONTROL_PLANE_URL: http://127.0.0.1:${API_PORT:-8000}
+      # Pre-shared key exchanged for a rotating JWT on first join.
+      LG_AGENT_KEY: ${LG_AGENT_KEY:-changeme-lg-agent-key}
+
+      # ── Registration ──────────────────────────────────────────────
+      # Collector name (LookingGlassCollector row); unique per collector.
+      SERVER_NAME: ${LG_HOSTNAME:-looking-glass}
+
+      # ── TLS ───────────────────────────────────────────────────────
+      # Loopback to the same-host API — TLS verify off is fine.
+      SPATIUM_INSECURE_SKIP_TLS_VERIFY: "1"
+
+      # ── Tuning (optional, defaults shown) ─────────────────────────
+      # LOG_LEVEL: INFO
+      # HEARTBEAT_INTERVAL: "30"
+      # LONGPOLL_TIMEOUT: "30"
+      # RIB_POLL_INTERVAL: "30"
+    volumes:
+      - lg_agent_state:/var/lib/spatium-lg-agent
+    depends_on:
+      api:
+        condition: service_started
+
 networks:
   spatiumddi:
     driver: bridge
@@ -422,6 +464,10 @@ volumes:
   dhcp_kea_leases:
   dhcp_kea_state_2:
   dhcp_kea_leases_2:
+  # Looking Glass collector last-known-good config cache (issue #566) —
+  # keeps BGP sessions up when the control plane is briefly unreachable
+  # (non-negotiable #5). Only used by the `looking-glass` profile.
+  lg_agent_state:
   # Backup local-volume target (issue #117). Uncomment when using
   # a Backup Target with kind ``local_volume``; see the comments
   # on the api + worker services. Safe to leave commented for

--- a/docs/features/LOOKING_GLASS.md
+++ b/docs/features/LOOKING_GLASS.md
@@ -1,0 +1,90 @@
+---
+layout: default
+title: BGP Looking Glass
+---
+
+# BGP Looking Glass
+
+Issue [#566](https://github.com/spatiumddi/spatiumddi/issues/566). A per-appliance-node
+**receive-only** BGP collector that peers with the operator's edge/core routers,
+accepts their routing table, and turns the live Adj-RIB-In into an operator surface
+where every prefix, origin ASN, and BGP community is a clickable link back into
+IPAM / the ASN catalog / the community catalog.
+
+> **This document is a stub.** Full data-model, API, and UI documentation lands
+> alongside the feature's Phase 1+2 implementation (see `CLAUDE.md`'s roadmap for
+> current status). This page exists now so the receive-only invariant and the
+> collector's relationship to the two adjacent BGP surfaces is written down before
+> the feature ships.
+
+---
+
+## Hard safety invariant: receive-only
+
+**The collector is a pure sink. It never advertises a route back to the operator's
+network.** No export policy, no next-hop-self, no redistribution — import-only,
+every session. A per-peer `max-prefixes` cap protects the collector daemon from a
+full-table blow-up, and that cap is rendered directly into the daemon's peer
+config (not merely stored in the database).
+
+> SpatiumDDI never advertises routes to your network from this session.
+
+This is a first-class review criterion on every change that touches the rendered
+collector config — a rendering bug that adds an export policy would turn a passive
+observability tool into a transit path on the operator's network.
+
+## Architecture
+
+The collector (`agent/looking-glass/`, image `ghcr.io/spatiumddi/looking-glass`)
+reuses the DNS/DHCP agent architecture wholesale: PSK→JWT bootstrap, ConfigBundle
+ETag long-poll + Redis wake, absence-reconcile telemetry push, ready-marker
+readiness gate, and the same supervisor role model (`can_run_looking_glass`
+capability, `spatium.io/role-looking-glass` per-node label, `LG_AGENT_KEY`
+bootstrap secret). See `docs/deployment/DNS_AGENT.md` for the shared agent
+architecture this collector clones.
+
+The collector engine is [GoBGP](https://github.com/osrg/gobgp) (Apache 2.0) — a
+single Go binary with a gRPC RIB-read API, chosen for its clean receive-only
+posture and easy programmatic peer management (no daemon restart needed to
+add/remove a peer).
+
+It runs as a DaemonSet with `hostNetwork: true` (see
+`charts/spatiumddi-appliance/templates/looking-glass.yaml`) so the BGP TCP/179
+session originates from the node's real routable IP — a router has no route to a
+pod-CNI address. Per-node hostPath state (`/var/lib/spatiumddi/agents/looking-glass/`)
+caches the last-known-good peer config so sessions stay up when the control plane
+is briefly unreachable (non-negotiable #5).
+
+## Relationship to two adjacent BGP surfaces (don't conflate)
+
+- **[#527 BGP prefix-hijack monitoring](../OBSERVABILITY.md#91a-bgp-prefix-hijack-monitoring-527)**
+  is the *public*-table companion: it polls RIPEstat / RIPE RIS Live for signals
+  about SpatiumDDI-tracked prefixes as seen from the *global* Internet routing
+  table. The Looking Glass is the *internal*-table view: it peers directly with
+  the operator's own routers and shows what that specific router's Adj-RIB-In
+  actually contains. They share no code — the hijack monitor never opens a BGP
+  session; the Looking Glass never talks to RIPEstat.
+- **The MetalLB VIP advertiser (BGP mode)** is a *separate, deferred* piece of
+  work: lighting up `frrk8s.enabled=true` on `charts/spatiumddi-metallb/` so
+  MetalLB can *advertise* the control-plane VIP to upstream routers via FRRouting
+  (GPL v2). That is an **export** path (SpatiumDDI → router); the Looking Glass is
+  an **import** path (router → SpatiumDDI) and requires none of the FRR/GPL-v2
+  surface. The two features share only the UI concept of "a peer address + ASN" —
+  zero code. See `charts/spatiumddi-metallb/values.yaml`'s `bgp:` block for the
+  current (gated-off) state of that work.
+
+## Scope (Phase 1 + 2, this cut)
+
+- Collector registration + peer session management (Sessions tab).
+- RIB ingest with absence-reconcile (a route disappearing from a live snapshot is
+  marked withdrawn, not deleted) and a zero-wire floor guard (an empty snapshot
+  from a peer that was previously receiving routes is treated as a collector
+  hiccup, not a genuine full withdrawal).
+- Routes grid: searchable/filterable RIB browser with origin-ASN links, AS-path,
+  community-catalog rendering, and RPKI status computed at ingest.
+
+Deferred to later phases: IPAM prefix-match linkage (subnet/block/space chips,
+IP reverse-lookup), the Query tab (`show route` / AS-path regex / community
+filter), ping/traceroute from the collector's vantage point, `bgp_lg_*` alert
+rules + a Dashboard health card, and VPNv4/VPNv6 + multicast address-family
+support. See the issue and its linked implementation plan for the full phasing.

--- a/docs/features/LOOKING_GLASS.md
+++ b/docs/features/LOOKING_GLASS.md
@@ -54,6 +54,45 @@ pod-CNI address. Per-node hostPath state (`/var/lib/spatiumddi/agents/looking-gl
 caches the last-known-good peer config so sessions stay up when the control plane
 is briefly unreachable (non-negotiable #5).
 
+## Configuring the collector
+
+The collector is configured exactly like the BIND9 / Kea agents — a shared
+`LG_AGENT_KEY` pre-shared key plus one of three deploy shapes. Generate the key
+once (`openssl rand -hex 32`) and use the **same** value on the control plane and
+every collector.
+
+**1. Same host as the control plane (Docker Compose).** Set `LG_AGENT_KEY` in
+`.env` and turn on the `looking-glass` profile — the mirror of `COMPOSE_PROFILES=dns,dhcp`:
+
+```bash
+# .env
+LG_AGENT_KEY=<openssl rand -hex 32>
+LG_HOSTNAME=core-collector-1          # optional friendly name
+
+COMPOSE_PROFILES=looking-glass docker compose up -d
+#   …or add `looking-glass` alongside your existing profiles.
+```
+
+The service (`looking-glass` in `docker-compose.yml`) runs with
+`network_mode: host` so BGP originates from the host's real NIC, and reaches the
+API at `http://127.0.0.1:${API_PORT}`.
+
+**2. A separate VM (standalone collector).** Use
+`docker-compose.agent-looking-glass.yml` — the mirror of the standalone
+`docker-compose.agent-dns-bind9.yml` / `agent-dhcp.yml`. Set `CONTROL_PLANE_URL`,
+`LG_AGENT_KEY`, and `LG_HOSTNAME` in that host's `.env`, then
+`docker compose -f docker-compose.agent-looking-glass.yml up -d`.
+
+**3. On the k3s appliance (a node role).** Assign the **looking-glass** role to a
+node from *Fleet* — same as assigning the BIND9 or Kea role. The supervisor
+injects `LG_AGENT_KEY`, stamps the per-node `spatium.io/role-looking-glass` label,
+and the DaemonSet (`charts/spatiumddi-appliance/templates/looking-glass.yaml`,
+`hostNetwork: true`) schedules onto that node. Nothing to hand-edit — the key and
+the TCP/179 nftables opening are wired by the role assignment.
+
+Whichever shape you use, the collector self-registers and shows up under *Network
+→ Looking Glass* as a collector row; then add peers to it as below.
+
 ## Peering a router with the collector
 
 You configure **your** router to peer with the collector and advertise your routing
@@ -152,17 +191,38 @@ router bgp 64500
 
 ### FRRouting (FRR / vtysh)
 
+> **Modern FRR (≥ 7.4) enforces RFC 8212** (`bgp ebgp-requires-policy` is on by
+> default), so an eBGP session advertises **nothing** without an *explicit
+> outbound policy* — removing your `out` filter makes it send zero routes, not
+> every route. To advertise your whole table, attach a **permit-all** prefix-list.
+> Note the `le 32`: a bare `permit 0.0.0.0/0` matches only the default route;
+> `0.0.0.0/0 le 32` matches a prefix of **any** length.
+
 ```
+! Permit-all outbound so the collector sees your entire table (RFC 8212).
+ip prefix-list LG-ALLOW-ALL seq 5 permit 0.0.0.0/0 le 32
+!
 router bgp 64500
  neighbor 192.0.2.10 remote-as 65000
  neighbor 192.0.2.10 description SpatiumDDI-LookingGlass
  neighbor 192.0.2.10 password <md5-secret>            ! optional
  address-family ipv4 unicast
   neighbor 192.0.2.10 activate
+  neighbor 192.0.2.10 prefix-list LG-ALLOW-ALL out    ! advertise the whole RIB
   neighbor 192.0.2.10 send-community all
   ! iBGP full-table: neighbor 192.0.2.10 route-reflector-client
  exit-address-family
+!
+! IPv6 peers need their own catch-all under `address-family ipv6 unicast`:
+!   ipv6 prefix-list LG-ALLOW-ALL6 seq 5 permit ::/0 le 128
+!   neighbor 2001:db8::10 prefix-list LG-ALLOW-ALL6 out
 ```
+
+After changing an outbound policy, re-advertise the existing table with
+`clear bgp 192.0.2.10 soft out`. (The blunt alternative to the permit-all list
+is `no bgp ebgp-requires-policy` under `router bgp` — it reverts to advertising
+best paths with no explicit policy, but an allow-all list is the cleaner, more
+intentional form.)
 
 ### BIRD 2.x
 

--- a/docs/features/LOOKING_GLASS.md
+++ b/docs/features/LOOKING_GLASS.md
@@ -225,14 +225,21 @@ advertised — each origin ASN and community clickable back into SpatiumDDI.
   the operator's own routers and shows what that specific router's Adj-RIB-In
   actually contains. They share no code — the hijack monitor never opens a BGP
   session; the Looking Glass never talks to RIPEstat.
-- **The MetalLB VIP advertiser (BGP mode)** is a *separate, deferred* piece of
-  work: lighting up `frrk8s.enabled=true` on `charts/spatiumddi-metallb/` so
-  MetalLB can *advertise* the control-plane VIP to upstream routers via FRRouting
-  (GPL v2). That is an **export** path (SpatiumDDI → router); the Looking Glass is
-  an **import** path (router → SpatiumDDI) and requires none of the FRR/GPL-v2
-  surface. The two features share only the UI concept of "a peer address + ASN" —
-  zero code. See `charts/spatiumddi-metallb/values.yaml`'s `bgp:` block for the
-  current (gated-off) state of that work.
+- **The MetalLB VIP advertiser (BGP mode)** is a *separate* piece of work
+  (issue #566 decision D1): lighting up `frrk8s.enabled=true` on
+  `charts/spatiumddi-metallb/` so MetalLB can *advertise* the control-plane VIP
+  (and optionally data-plane VIPs) to upstream routers via FRRouting (GPL v2).
+  That is an **export** path (SpatiumDDI → router); the Looking Glass is an
+  **import** path (router → SpatiumDDI) and requires none of the FRR/GPL-v2
+  surface. The two features share only the UI concept of "a peer address + ASN"
+  — zero code (the Sessions tab's Add-peer modal offers a one-directional,
+  UI-only prefill button sourced from a configured MetalLB BGP peer, nothing
+  more). Configured from Fleet → Network & Host (`MetalLBConfigCard`'s
+  "BGP mode" disclosure) — see `backend/app/models/settings.py`'s
+  `metallb_bgp_enabled` / `metallb_bgp_peers` / `metallb_bgp_advertisements`
+  columns and `charts/spatiumddi-metallb/values.yaml`'s `bgp:` + `frr-k8s:`
+  blocks for the chart-level wiring. Stays opt-in — both `frrk8s.enabled` and
+  `bgp.enabled` default `false` until an operator configures a peer.
 
 ## Scope (Phase 1 + 2, this cut)
 

--- a/docs/features/LOOKING_GLASS.md
+++ b/docs/features/LOOKING_GLASS.md
@@ -11,11 +11,10 @@ accepts their routing table, and turns the live Adj-RIB-In into an operator surf
 where every prefix, origin ASN, and BGP community is a clickable link back into
 IPAM / the ASN catalog / the community catalog.
 
-> **This document is a stub.** Full data-model, API, and UI documentation lands
-> alongside the feature's Phase 1+2 implementation (see `CLAUDE.md`'s roadmap for
-> current status). This page exists now so the receive-only invariant and the
-> collector's relationship to the two adjacent BGP surfaces is written down before
-> the feature ships.
+> **Documentation is in progress.** The receive-only invariant, the collector
+> architecture, and the router/firewall peering examples below are current for the
+> Phase 1+2 cut; the full data-model / API / UI reference lands as later phases
+> ship (see `CLAUDE.md`'s roadmap and issue #566 for status).
 
 ---
 
@@ -54,6 +53,168 @@ session originates from the node's real routable IP — a router has no route to
 pod-CNI address. Per-node hostPath state (`/var/lib/spatiumddi/agents/looking-glass/`)
 caches the last-known-good peer config so sessions stay up when the control plane
 is briefly unreachable (non-negotiable #5).
+
+## Peering a router with the collector
+
+You configure **your** router to peer with the collector and advertise your routing
+table to it. The collector is receive-only — it accepts your routes and never sends
+one back, so no inbound filtering/route-map is needed on your side to protect the
+router. The collector normally **initiates** the TCP session outbound to the router,
+so the router only has to (a) have the collector configured as a BGP neighbor and
+(b) permit inbound TCP/179 from the collector's IP (see [Firewall](#firewall-tcp179)).
+
+**Fill in these three values** (from the peer you create under *Network → Looking
+Glass → Add peer*):
+
+| Placeholder | Where it comes from | Example |
+|---|---|---|
+| Collector IP | the appliance node's routable IP (the collector uses `hostNetwork`) | `192.0.2.10` |
+| Collector ASN | the peer's **Local ASN** field | `65000` |
+| Your router ASN | the peer's **Peer ASN** field | `64500` |
+| MD5 secret | the peer's optional **MD5 password** field | *(omit if unset)* |
+
+> **eBGP vs iBGP.** The simplest setup is **eBGP** — give the collector a private
+> ASN (e.g. `65000`) different from your router's, and the router advertises its
+> best paths automatically. If you want the collector to see **every** path (not
+> just the best) or you run it inside your own AS, use **iBGP** and mark the
+> collector a **route-reflector-client** so the router reflects its full RIB; add
+> **add-path / additional-paths send** to expose non-best paths. Either way, enable
+> **send-community** so the Routes grid can render your communities.
+
+### Cisco IOS / IOS-XE
+
+```
+router bgp 64500
+ neighbor 192.0.2.10 remote-as 65000
+ neighbor 192.0.2.10 description SpatiumDDI-LookingGlass
+ neighbor 192.0.2.10 password <md5-secret>          ! optional; must match the peer
+ address-family ipv4 unicast
+  neighbor 192.0.2.10 activate
+  neighbor 192.0.2.10 send-community both            ! so communities show in the LG
+  ! full-table visibility (optional): neighbor 192.0.2.10 additional-paths send
+ exit-address-family
+```
+
+### Cisco IOS-XR
+
+IOS-XR denies eBGP advertisement by default, so attach a pass route-policy outbound:
+
+```
+route-policy PASS
+  pass
+end-policy
+!
+router bgp 64500
+ neighbor 192.0.2.10
+  remote-as 65000
+  description SpatiumDDI-LookingGlass
+  password encrypted <md5-secret>                    ! optional
+  address-family ipv4 unicast
+   route-policy PASS out
+   send-community-ebgp
+```
+
+### Juniper Junos
+
+```
+protocols {
+    bgp {
+        group spatiumddi-lg {
+            type external;                            ## iBGP: set `type internal` + cluster
+            local-as 64500;
+            peer-as 65000;
+            export send-table;                        ## advertise your routes to the collector
+            neighbor 192.0.2.10 {
+                description "SpatiumDDI Looking Glass (receive-only)";
+                authentication-key "<md5-secret>";    ## optional
+            }
+        }
+    }
+}
+policy-options {
+    policy-statement send-table {
+        term all { then accept; }                     ## scope to taste
+    }
+}
+```
+
+### Arista EOS
+
+```
+router bgp 64500
+   neighbor 192.0.2.10 remote-as 65000
+   neighbor 192.0.2.10 description SpatiumDDI-LookingGlass
+   neighbor 192.0.2.10 password <md5-secret>          ! optional
+   neighbor 192.0.2.10 send-community
+   address-family ipv4
+      neighbor 192.0.2.10 activate
+```
+
+### FRRouting (FRR / vtysh)
+
+```
+router bgp 64500
+ neighbor 192.0.2.10 remote-as 65000
+ neighbor 192.0.2.10 description SpatiumDDI-LookingGlass
+ neighbor 192.0.2.10 password <md5-secret>            ! optional
+ address-family ipv4 unicast
+  neighbor 192.0.2.10 activate
+  neighbor 192.0.2.10 send-community all
+  ! iBGP full-table: neighbor 192.0.2.10 route-reflector-client
+ exit-address-family
+```
+
+### BIRD 2.x
+
+```
+protocol bgp spatiumddi_lg {
+    local as 64500;
+    neighbor 192.0.2.10 as 65000;
+    password "<md5-secret>";                          # optional
+    ipv4 {
+        import none;                                  # the collector never sends us routes
+        export all;                                   # advertise our table to the collector
+    };
+}
+```
+
+Other platforms (Nokia SR OS, MikroTik RouterOS 7, VyOS, …) follow the same shape:
+a normal BGP neighbor pointing at the collector IP/ASN, an outbound policy that
+advertises your table, `send-community`, and an inbound firewall rule for TCP/179.
+
+### Firewall (TCP/179)
+
+The collector dials the router, so the **router side** must accept inbound TCP/179
+from the collector's IP (allow both directions if you'd rather the router initiate).
+
+```
+! Cisco IOS extended ACL
+ip access-list extended BGP-LG
+ permit tcp host 192.0.2.10 any eq bgp
+ permit tcp host 192.0.2.10 eq bgp any
+
+! Cisco ASA
+access-list OUTSIDE_IN extended permit tcp host 192.0.2.10 host <router-ip> eq bgp
+```
+
+```bash
+# Linux firewall in the path — nftables
+nft add rule inet filter input ip saddr 192.0.2.10 tcp dport 179 accept
+# …or iptables
+iptables -A INPUT -p tcp -s 192.0.2.10 --dport 179 -j ACCEPT
+```
+
+On the **SpatiumDDI appliance** side there is nothing to do: assigning the
+`looking-glass` role opens TCP/179 automatically through the per-role nftables
+drop-in (`spatium.io/role-looking-glass`). On a standalone Docker/K8s collector the
+container uses host networking, so TCP/179 is governed by the host's own firewall.
+
+### Verify
+
+Once the router config + firewall are in place, *Network → Looking Glass → Sessions*
+shows the peer transition to **Established** (green) within a few seconds, its
+prefix counters climb, and the *Routes* tab fills with the prefixes the router
+advertised — each origin ASN and community clickable back into SpatiumDDI.
 
 ## Relationship to two adjacent BGP surfaces (don't conflate)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ Open-source DDI platform — unified DNS, DHCP, and IP Address Management.
 - [Auth & Permissions](features/AUTH.md) — LDAP, OIDC, SAML, RADIUS, TACACS+, roles, API tokens
 - [ACME DNS-01 Provider](features/ACME.md) — acme-dns-compatible surface for LE / public-CA cert issuance against SpatiumDDI-managed zones
 - [Integrations](features/INTEGRATIONS.md) — read-only Kubernetes + Docker + Proxmox VE + Tailscale + Cloud (AWS/Azure/GCP) mirrors into IPAM; per-integration setup, mirror semantics, dashboard surface, roadmap
+- [BGP Looking Glass](features/LOOKING_GLASS.md) — receive-only BGP collector (GoBGP) peering with the operator's routers; Sessions + Routes grid, RPKI status at ingest
 - [System Admin](features/SYSTEM_ADMIN.md) — config, health dashboard, backup/restore
 
 ## Deployment

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import { AsnsPage } from "@/pages/network/AsnsPage";
 import { AsnDetailPage } from "@/pages/network/AsnDetailPage";
 import { CertificatesPage } from "@/pages/network/CertificatesPage";
 import { CircuitsPage } from "@/pages/network/CircuitsPage";
+import { LookingGlassPage } from "@/pages/network/looking-glass/LookingGlassPage";
 import { MulticastGroupsPage } from "@/pages/network/MulticastGroupsPage";
 import { CustomersPage } from "@/pages/network/CustomersPage";
 import { OverlaysPage } from "@/pages/network/OverlaysPage";
@@ -137,6 +138,7 @@ export default function App() {
         <Route path="network/certificates" element={<CertificatesPage />} />
         <Route path="network/circuits" element={<CircuitsPage />} />
         <Route path="network/customers" element={<CustomersPage />} />
+        <Route path="network/looking-glass" element={<LookingGlassPage />} />
         <Route path="network/multicast" element={<MulticastGroupsPage />} />
         {/* Old separate-route deep links redirect to the sub-tab so
             existing bookmarks keep working. */}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -45,6 +45,7 @@ import {
   Wifi,
   Waypoints,
   Radio,
+  Binoculars,
   Shuffle,
   Trash2,
   History,
@@ -176,6 +177,12 @@ const networkInfrastructureNav = [
     icon: Cable,
     to: "/network/devices",
     module: "network.device",
+  },
+  {
+    label: "Looking Glass",
+    icon: Binoculars,
+    to: "/network/looking-glass",
+    module: "network.looking_glass",
   },
   {
     label: "Multicast",

--- a/frontend/src/components/network/bgp-lg-chips.tsx
+++ b/frontend/src/components/network/bgp-lg-chips.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { lookingGlassApi, type BGPLGRoute } from "@/lib/api";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
+import { cn } from "@/lib/utils";
+
+// Issue #566 Phase 3 — per-space-scoped shared route fetch backing the
+// "BGP" chip rendered on subnet + block rows in the IPAM tree. Mirrors
+// the CustomerChip/SiteChip dedup pattern
+// (frontend/src/components/ownership/pickers.tsx): every chip instance
+// on a page shares one underlying React Query fetch instead of firing
+// its own network call. Unlike customer_id/site_id (a raw FK column on
+// the row itself), "does this subnet/block have an advertised route"
+// lives on the *other* side of the relationship
+// (BGPLGRoute.matched_subnet_id / matched_block_id), so the shared
+// query here is a space-scoped route fetch rather than a per-row FK
+// lookup.
+
+const chipBaseCls =
+  "inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium";
+
+const RPKI_CHIP_COLOR: Record<string, string> = {
+  invalid: "border-rose-500/40 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+  unknown:
+    "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  valid:
+    "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+};
+
+/** One shared per-space route fetch backing every BgpAdvertisedChip on
+ *  the page (subnet rows + block rows both call this with the same
+ *  spaceId, so React Query dedupes to one request). */
+function useBgpLgSpaceRoutes(spaceId: string, enabledModule: boolean) {
+  const q = useQuery({
+    queryKey: ["bgp-lg-routes-by-space", spaceId],
+    queryFn: () =>
+      lookingGlassApi.searchRoutes({
+        matched_space_id: spaceId,
+        withdrawn: false,
+        limit: 1000,
+      }),
+    enabled: enabledModule && !!spaceId,
+    staleTime: 30_000,
+  });
+  return useMemo(() => {
+    const bySubnet = new Map<string, BGPLGRoute[]>();
+    const byBlock = new Map<string, BGPLGRoute[]>();
+    for (const r of q.data?.items ?? []) {
+      if (r.matched_subnet_id) {
+        const list = bySubnet.get(r.matched_subnet_id) ?? [];
+        list.push(r);
+        bySubnet.set(r.matched_subnet_id, list);
+      }
+      if (r.matched_block_id) {
+        const list = byBlock.get(r.matched_block_id) ?? [];
+        list.push(r);
+        byBlock.set(r.matched_block_id, list);
+      }
+    }
+    return { bySubnet, byBlock };
+  }, [q.data]);
+}
+
+function worstRpki(routes: BGPLGRoute[]): string {
+  // invalid > unknown > valid, worst-first for the chip's colour.
+  if (routes.some((r) => r.rpki_status === "invalid")) return "invalid";
+  if (routes.some((r) => r.rpki_status === "unknown")) return "unknown";
+  return "valid";
+}
+
+/** Small "BGP" chip for a subnet or block row in the IPAM tree — shows
+ *  when the row has at least one active advertised route, colour-coded
+ *  by the worst RPKI status among its matched routes. Renders null when
+ *  the network.looking_glass module is off or nothing matches. */
+export function BgpAdvertisedChip({
+  spaceId,
+  subnetId,
+  blockId,
+}: {
+  spaceId: string;
+  subnetId?: string;
+  blockId?: string;
+}) {
+  const { enabled } = useFeatureModules();
+  const lgEnabled = enabled("network.looking_glass");
+  const { bySubnet, byBlock } = useBgpLgSpaceRoutes(spaceId, lgEnabled);
+  if (!lgEnabled) return null;
+  const routes = subnetId
+    ? bySubnet.get(subnetId)
+    : blockId
+      ? byBlock.get(blockId)
+      : undefined;
+  if (!routes || routes.length === 0) return null;
+  const worst = worstRpki(routes);
+  return (
+    <span
+      className={cn(chipBaseCls, RPKI_CHIP_COLOR[worst])}
+      title={`Advertised by BGP — ${routes.length} route${routes.length === 1 ? "" : "s"}, worst RPKI: ${worst}`}
+    >
+      BGP
+    </span>
+  );
+}

--- a/frontend/src/components/network/bgp-route-table.tsx
+++ b/frontend/src/components/network/bgp-route-table.tsx
@@ -52,27 +52,66 @@ export function usePeerNameById() {
   }, [q.data]);
 }
 
+/** Strip a vendor-style label prefix down to the bare "ASN:N"/"IP:N" RT
+ *  value — mirrors the backend's ``normalize_rt`` in
+ *  ``app.services.looking_glass.vrf_match`` (issue #566 Phase 6). Kept in
+ *  sync by hand since this is the one frontend call site that needs it. */
+function normalizeRt(raw: string): string {
+  return raw.replace(/^(rt|target|route-target)\s*[:=]\s*/i, "").trim();
+}
+
+/** A VRF's import/export route-target lists — passed in by the VRF
+ *  "Routes" tab (issue #566 Phase 6) to render an RD + route-target
+ *  cross-check column on top of the base table. Omitted by every other
+ *  caller (subnet/block/ASN tabs, Query tab), which just get the
+ *  original five columns. */
+export interface VrfRtContext {
+  importTargets: string[];
+  exportTargets: string[];
+}
+
 /** Prefix / peer / origin ASN / RPKI / best-path table. Read-only —
  *  every caller so far just wants "which routes matched this IPAM
  *  object/ASN/VRF", not an editable grid. */
-export function BgpRouteMiniTable({ items }: { items: BGPLGRoute[] }) {
+export function BgpRouteMiniTable({
+  items,
+  vrfRtContext,
+}: {
+  items: BGPLGRoute[];
+  vrfRtContext?: VrfRtContext;
+}) {
   const peerNameById = usePeerNameById();
+  const importSet = useMemo(
+    () => new Set(vrfRtContext?.importTargets ?? []),
+    [vrfRtContext],
+  );
+  const exportSet = useMemo(
+    () => new Set(vrfRtContext?.exportTargets ?? []),
+    [vrfRtContext],
+  );
   return (
     <div className="overflow-x-auto rounded-md border">
       <table className="w-full text-xs">
         <thead>
           <tr className="border-b bg-muted/30 text-left text-[10px] uppercase tracking-wider text-muted-foreground">
             <th className="px-3 py-2">Prefix</th>
+            {vrfRtContext && <th className="px-3 py-2">RD</th>}
             <th className="px-3 py-2">Peer</th>
             <th className="px-3 py-2">Origin ASN</th>
             <th className="px-3 py-2">RPKI</th>
             <th className="px-3 py-2">Best</th>
+            {vrfRtContext && <th className="px-3 py-2">Route targets</th>}
           </tr>
         </thead>
         <tbody>
           {items.map((r) => (
             <tr key={r.id} className="border-b last:border-0 hover:bg-muted/20">
               <td className="break-all px-3 py-2 font-mono">{r.prefix}</td>
+              {vrfRtContext && (
+                <td className="px-3 py-2 font-mono text-muted-foreground">
+                  {r.route_distinguisher || "—"}
+                </td>
+              )}
               <td className="px-3 py-2">
                 {peerNameById.get(r.peer_id) ?? "—"}
               </td>
@@ -83,6 +122,39 @@ export function BgpRouteMiniTable({ items }: { items: BGPLGRoute[] }) {
                 <RpkiPill status={r.rpki_status} />
               </td>
               <td className="px-3 py-2">{r.is_best ? "✓" : "—"}</td>
+              {vrfRtContext && (
+                <td className="px-3 py-2">
+                  <div className="flex flex-wrap gap-1">
+                    {r.ext_communities.length === 0 && (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                    {r.ext_communities.map((rt) => {
+                      const norm = normalizeRt(rt);
+                      const kind = importSet.has(norm)
+                        ? "import"
+                        : exportSet.has(norm)
+                          ? "export"
+                          : null;
+                      return (
+                        <span
+                          key={rt}
+                          className={cn(
+                            "rounded px-1.5 py-0.5 font-mono text-[11px]",
+                            kind === "import" &&
+                              "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+                            kind === "export" &&
+                              "bg-sky-500/15 text-sky-700 dark:text-sky-400",
+                            !kind && "bg-muted text-muted-foreground",
+                          )}
+                        >
+                          {rt}
+                          {kind ? ` (${kind})` : ""}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </td>
+              )}
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/network/bgp-route-table.tsx
+++ b/frontend/src/components/network/bgp-route-table.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  lookingGlassApi,
+  type BGPLGRoute,
+  type BGPLGRpkiStatus,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+/** Shared RPKI pill colours + mini route table, reused across every
+ *  BGP-linkage surface issue #566 Phase 3 adds (subnet BGP tab, block
+ *  BGP panel, ASN "Learned Routes" tab, VRF "Routes" tab) instead of a
+ *  fourth copy-pasted table. Mirrors the RPKI_COLOR/Pill pair already
+ *  duplicated in RoutesTab.tsx and BgpMonitorTab.tsx — not hoisted into
+ *  this file to avoid churning those two, but new call sites should
+ *  import from here. */
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const RPKI_COLOR: Record<BGPLGRpkiStatus, string> = {
+  invalid: "bg-rose-500/15 text-rose-700 dark:text-rose-400",
+  unknown: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  valid: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+};
+
+export function RpkiPill({ status }: { status: BGPLGRpkiStatus }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+        RPKI_COLOR[status],
+      )}
+    >
+      {status}
+    </span>
+  );
+}
+
+/** One shared peer_id -> peer_name lookup backing every mini-table below —
+ *  React Query dedupes the ``listSessions()`` call across instances. */
+// eslint-disable-next-line react-refresh/only-export-components
+export function usePeerNameById() {
+  const q = useQuery({
+    queryKey: ["bgp-lg-sessions"],
+    queryFn: () => lookingGlassApi.listSessions(),
+    staleTime: 30_000,
+  });
+  return useMemo(() => {
+    const m = new Map<string, string>();
+    for (const s of q.data ?? []) m.set(s.peer_id, s.peer_name);
+    return m;
+  }, [q.data]);
+}
+
+/** Prefix / peer / origin ASN / RPKI / best-path table. Read-only —
+ *  every caller so far just wants "which routes matched this IPAM
+ *  object/ASN/VRF", not an editable grid. */
+export function BgpRouteMiniTable({ items }: { items: BGPLGRoute[] }) {
+  const peerNameById = usePeerNameById();
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="border-b bg-muted/30 text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+            <th className="px-3 py-2">Prefix</th>
+            <th className="px-3 py-2">Peer</th>
+            <th className="px-3 py-2">Origin ASN</th>
+            <th className="px-3 py-2">RPKI</th>
+            <th className="px-3 py-2">Best</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((r) => (
+            <tr key={r.id} className="border-b last:border-0 hover:bg-muted/20">
+              <td className="break-all px-3 py-2 font-mono">{r.prefix}</td>
+              <td className="px-3 py-2">
+                {peerNameById.get(r.peer_id) ?? "—"}
+              </td>
+              <td className="px-3 py-2 font-mono">
+                {r.origin_asn == null ? "—" : `AS${r.origin_asn}`}
+              </td>
+              <td className="px-3 py-2">
+                <RpkiPill status={r.rpki_status} />
+              </td>
+              <td className="px-3 py-2">{r.is_best ? "✓" : "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9771,6 +9771,7 @@ export interface SupervisorCapabilities {
   can_run_dns_bind9?: boolean;
   can_run_dns_powerdns?: boolean;
   can_run_dhcp?: boolean;
+  can_run_looking_glass?: boolean;
   can_run_observer?: boolean;
   has_baked_images?: boolean;
   baked_images_version?: string;
@@ -13092,6 +13093,231 @@ export interface BGPCommunityUpdate {
   outbound_action?: string;
   tags?: Record<string, unknown>;
 }
+
+// ── BGP Looking Glass (issue #566) ─────────────────────────────────
+//
+// A receive-only BGP collector: a per-appliance-node GoBGP daemon peers
+// passively with the operator's edge/core routers and turns the live
+// Adj-RIB-In into an operator surface. Distinct from ``bgpApi`` (the
+// RIPEstat public-data proxy) and ``asnsApi``'s BGP sub-namespaces
+// (peering / community catalog / #527 public-table hijack monitor) —
+// this is the real internal routing table, mounted at
+// ``/looking-glass`` (not ``/bgp``).
+
+export type BGPLGAddressFamily = "ipv4-unicast" | "ipv6-unicast";
+
+// idle | connect | active | opensent | openconfirm | established (GoBGP FSM).
+export type BGPLGSessionState =
+  | "idle"
+  | "connect"
+  | "active"
+  | "opensent"
+  | "openconfirm"
+  | "established";
+
+export type BGPLGRpkiStatus = "valid" | "invalid" | "unknown";
+
+export interface BGPLGImportFilter {
+  mode: "accept_all" | "scope";
+  prefixes?: string[];
+}
+
+export interface BGPLGCollector {
+  id: string;
+  name: string;
+  description: string;
+  host: string | null;
+  status: string;
+  enabled: boolean;
+  agent_id: string | null;
+  agent_registered: boolean;
+  agent_version: string | null;
+  last_seen_ip: string | null;
+  last_seen_at: string | null;
+  last_health_check_at: string | null;
+  appliance_id: string | null;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface BGPLGPeerCreate {
+  name: string;
+  collector_id: string;
+  local_asn: number;
+  peer_asn: number;
+  peer_address: string;
+  matched_asn_id?: string | null;
+  peer_router_id?: string | null;
+  address_families?: BGPLGAddressFamily[];
+  /** Plaintext MD5 password — Fernet-encrypted server-side, never echoed
+   *  back. See ``BGPLGPeer.md5_password_set``. */
+  md5_password?: string | null;
+  max_prefixes?: number;
+  import_filter?: BGPLGImportFilter;
+  enabled?: boolean;
+  description?: string;
+}
+
+/** Partial update. ``md5_password``: non-empty rotates, ``""`` clears,
+ *  omitted (default) leaves the stored ciphertext untouched. */
+export interface BGPLGPeerUpdate {
+  name?: string;
+  collector_id?: string;
+  local_asn?: number;
+  peer_asn?: number;
+  peer_address?: string;
+  matched_asn_id?: string | null;
+  peer_router_id?: string | null;
+  address_families?: BGPLGAddressFamily[];
+  md5_password?: string | null;
+  max_prefixes?: number;
+  import_filter?: BGPLGImportFilter;
+  enabled?: boolean;
+  description?: string;
+}
+
+export interface BGPLGPeer {
+  id: string;
+  name: string;
+  collector_id: string;
+  local_asn: number;
+  peer_asn: number;
+  peer_address: string;
+  matched_asn_id: string | null;
+  peer_router_id: string | null;
+  address_families: BGPLGAddressFamily[];
+  md5_password_set: boolean;
+  max_prefixes: number;
+  import_filter: BGPLGImportFilter;
+  enabled: boolean;
+  description: string;
+  // Runtime state (collector-reported via heartbeat).
+  session_state: BGPLGSessionState;
+  uptime_started_at: string | null;
+  prefixes_received: number;
+  prefixes_accepted: number;
+  last_state_change: string | null;
+  last_flap_at: string | null;
+  rpki_invalid_count: number;
+  down_since: string | null;
+  created_at: string;
+  modified_at: string;
+}
+
+/** One row per configured peer, joined with its owning collector — the
+ *  Sessions-tab feed (``GET /looking-glass/sessions``). */
+export interface BGPLGSession {
+  peer_id: string;
+  peer_name: string;
+  collector_id: string;
+  collector_name: string;
+  collector_status: string;
+  local_asn: number;
+  peer_asn: number;
+  peer_address: string;
+  enabled: boolean;
+  session_state: BGPLGSessionState;
+  uptime_started_at: string | null;
+  prefixes_received: number;
+  prefixes_accepted: number;
+  last_state_change: string | null;
+  last_flap_at: string | null;
+  rpki_invalid_count: number;
+  down_since: string | null;
+}
+
+export interface BGPLGRoute {
+  id: string;
+  peer_id: string;
+  prefix: string;
+  origin_asn: number | null;
+  as_path: number[];
+  next_hop: string;
+  local_pref: number | null;
+  med: number | null;
+  communities: string[];
+  large_communities: string[];
+  ext_communities: string[];
+  rpki_status: BGPLGRpkiStatus;
+  is_best: boolean;
+  matched_block_id: string | null;
+  matched_subnet_id: string | null;
+  matched_space_id: string | null;
+  matched_asn_id: string | null;
+  matched_vrf_id: string | null;
+  first_seen_at: string;
+  last_seen_at: string;
+  withdrawn_at: string | null;
+  flap_count: number;
+  detail: Record<string, unknown> | null;
+  created_at: string;
+  modified_at: string;
+}
+
+/** Server-paginated envelope for ``GET /looking-glass/routes`` — mirrors
+ *  ``AddressSearchResponse`` (``GET /ipam/addresses/search``). */
+export interface BGPLGRouteListResponse {
+  items: BGPLGRoute[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface BGPLGRouteQuery {
+  /** Contains-or-within CIDR match (not an exact-prefix lookup). */
+  prefix?: string;
+  origin_asn?: number;
+  /** Matches against either ``communities`` or ``large_communities``. */
+  community?: string;
+  rpki_status?: BGPLGRpkiStatus;
+  peer_id?: string;
+  best_path_only?: boolean;
+  /** Withdrawn routes are hidden by default. */
+  withdrawn?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export const lookingGlassApi = {
+  // Collectors — agent-registration identity rows (one per GoBGP daemon).
+  // Registration itself is agent-side; operators only read the list here.
+  listCollectors: () =>
+    api.get<BGPLGCollector[]>("/looking-glass/collectors").then((r) => r.data),
+
+  // Peers — configured receive-only BGP sessions.
+  listPeers: (params?: { collector_id?: string }) =>
+    api
+      .get<BGPLGPeer[]>("/looking-glass/peers", { params })
+      .then((r) => r.data),
+  createPeer: (data: BGPLGPeerCreate) =>
+    api.post<BGPLGPeer>("/looking-glass/peers", data).then((r) => r.data),
+  updatePeer: (id: string, data: BGPLGPeerUpdate) =>
+    api
+      .patch<BGPLGPeer>(`/looking-glass/peers/${id}`, data)
+      .then((r) => r.data),
+  deletePeer: (id: string) => api.delete(`/looking-glass/peers/${id}`),
+
+  // Sessions — read-only per-peer runtime-state rollup (collector + peer
+  // joined). Not paginated — peer counts are bounded (a handful per
+  // collector), unlike the RIB.
+  listSessions: (params?: { collector_id?: string }) =>
+    api
+      .get<BGPLGSession[]>("/looking-glass/sessions", { params })
+      .then((r) => r.data),
+
+  // Routes — the learned RIB, server-paginated + filterable (the RIB can
+  // hold thousands of rows, unlike peers/sessions/collectors).
+  searchRoutes: (params?: BGPLGRouteQuery) =>
+    api
+      .get<BGPLGRouteListResponse>("/looking-glass/routes", { params })
+      .then((r) => r.data),
+  /** All paths for one *exact* prefix, across every peer — distinct from
+   *  ``searchRoutes({prefix})``'s contains-or-within match. */
+  getRoute: (prefix: string) =>
+    api
+      .get<BGPLGRoute[]>(`/looking-glass/routes/${prefix}`)
+      .then((r) => r.data),
+};
 
 // ── Logical ownership entities (issue #91) ─────────────────────────
 //

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12621,7 +12621,7 @@ export const pcapApi = {
 // Fleet appliance's supervisor. The matching result carries
 // ``ran_from`` ("server" or "appliance:<hostname>").
 export interface NetToolTarget {
-  kind: "server" | "appliance";
+  kind: "server" | "appliance" | "bgp_lg_collector";
   id: string;
 }
 
@@ -12694,10 +12694,13 @@ export interface NetToolWolResult {
 }
 
 // Fold the routing-only ``target`` into a reachability-tool body only
-// when it points at an appliance — a "server" target (or none) is the
-// back-compatible inline run, so we omit the field entirely.
+// when it points somewhere other than the control-plane server — a
+// "server" target (or none) is the back-compatible inline run, so we
+// omit the field entirely. ``appliance`` and ``bgp_lg_collector`` (#566
+// Phase 4 — ping/traceroute from a Looking Glass collector's vantage)
+// both ride the wire the same way.
 function withTarget<T extends object>(body: T, target?: NetToolTarget): T {
-  if (target && target.kind === "appliance") {
+  if (target && target.kind !== "server") {
     return { ...body, target };
   }
   return body;
@@ -13279,6 +13282,11 @@ export interface BGPLGRouteQuery {
   best_path_only?: boolean;
   /** Withdrawn routes are hidden by default. */
   withdrawn?: boolean;
+  /** AS-path regex ('_' boundary convention), matched against the
+   *  space-joined AS path — e.g. '_65001_' (anywhere) or '65001_$'-style
+   *  (near the end, i.e. toward the origin AS). See the Query tab's
+   *  ``show route regexp`` command (#566 Phase 4). */
+  as_path_regexp?: string;
   limit?: number;
   offset?: number;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13437,6 +13437,81 @@ export interface BGPLGPeerDetail {
   active_alerts: BGPLGPeerDetailAlert[];
 }
 
+// GET /looking-glass/routes/detail — the rich per-prefix rollup backing
+// the Routes-tab detail modal (issue #566). Distinct from
+// ``getRoute()``/``/routes/by-prefix`` (a flat ``BGPLGRoute[]``): every
+// path here is enriched with its peer + collector name, and the response
+// carries a server-computed summary + covering IPAM/ASN/VRF context.
+export interface BGPLGRouteDetailPath {
+  route_id: string;
+  peer_id: string;
+  peer_name: string;
+  collector_name: string;
+  origin_asn: number | null;
+  next_hop: string;
+  local_pref: number | null;
+  med: number | null;
+  as_path: number[];
+  communities: string[];
+  large_communities: string[];
+  ext_communities: string[];
+  route_distinguisher: string;
+  rpki_status: BGPLGRpkiStatus;
+  is_best: boolean;
+  first_seen_at: string;
+  last_seen_at: string;
+  flap_count: number;
+  withdrawn_at: string | null;
+  matched_subnet_id: string | null;
+  matched_block_id: string | null;
+  matched_space_id: string | null;
+  matched_asn_id: string | null;
+  matched_vrf_id: string | null;
+}
+
+export interface BGPLGRouteDetailRpkiBreakdown {
+  valid: number;
+  invalid: number;
+  unknown: number;
+}
+
+/** The headline server-computed rollup the detail modal's banner leads
+ *  with. ``multi_origin`` (more than one origin ASN) is the hijack/leak
+ *  signal; ``anycast_candidate`` (more than one peer/router) alone is the
+ *  normal anycast/multi-homed shape. Both can be true at once. */
+export interface BGPLGRouteDetailSummary {
+  path_count: number;
+  peer_count: number;
+  distinct_origin_asns: number[];
+  multi_origin: boolean;
+  anycast_candidate: boolean;
+  rpki: BGPLGRouteDetailRpkiBreakdown;
+  /** Origin ASN (as a string key) -> tracked ASN row's name, only for
+   *  origins that match a row in the ASN catalog. */
+  origin_names: Record<string, string>;
+}
+
+export interface BGPLGRouteDetailIpamContext {
+  subnet_id: string | null;
+  subnet_name: string | null;
+  block_id: string | null;
+  block_name: string | null;
+  space_id: string | null;
+  space_name: string | null;
+  asn_id: string | null;
+  asn_number: number | null;
+  asn_name: string | null;
+  vrf_id: string | null;
+  vrf_name: string | null;
+}
+
+export interface BGPLGRouteDetail {
+  prefix: string;
+  paths: BGPLGRouteDetailPath[];
+  summary: BGPLGRouteDetailSummary;
+  ipam: BGPLGRouteDetailIpamContext;
+}
+
 export const lookingGlassApi = {
   // Collectors — agent-registration identity rows (one per GoBGP daemon).
   // Registration itself is agent-side; operators only read the list here.
@@ -13503,6 +13578,15 @@ export const lookingGlassApi = {
   getPeerDetail: (peerId: string) =>
     api
       .get<BGPLGPeerDetail>(`/looking-glass/peers/${peerId}/detail`)
+      .then((r) => r.data),
+  /** Rich rollup backing the Routes-tab detail modal — every path for the
+   *  exact prefix across every peer, enriched with peer/collector names +
+   *  a server-computed multi-origin/anycast summary + IPAM context. */
+  getRouteDetail: (prefix: string, params?: { withdrawn?: boolean }) =>
+    api
+      .get<BGPLGRouteDetail>("/looking-glass/routes/detail", {
+        params: { prefix, ...params },
+      })
       .then((r) => r.data),
 };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13315,7 +13315,9 @@ export const lookingGlassApi = {
    *  ``searchRoutes({prefix})``'s contains-or-within match. */
   getRoute: (prefix: string) =>
     api
-      .get<BGPLGRoute[]>(`/looking-glass/routes/${prefix}`)
+      .get<BGPLGRoute[]>("/looking-glass/routes/by-prefix", {
+        params: { prefix },
+      })
       .then((r) => r.data),
 };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9395,6 +9395,22 @@ export interface FleetAgentRow {
   reboot_requested_at: string | null;
 }
 
+// issue #566 decision D1 — MetalLB BGP mode (export path: advertise the
+// VIP to upstream routers). One entry per BGPPeer / BGPAdvertisement CR.
+export interface MetalLBBgpPeer {
+  my_asn: number;
+  peer_asn: number;
+  peer_address: string;
+  peer_port?: number | null;
+  hold_time?: string | null;
+}
+
+export interface MetalLBBgpAdvertisement {
+  ip_address_pools: string[];
+  communities?: string[];
+  aggregation_length?: number | null;
+}
+
 // #272 Phase 7c — cluster-wide MetalLB / control-plane-VIP config.
 export interface MetalLBConfig {
   enabled: boolean;
@@ -9405,6 +9421,13 @@ export interface MetalLBConfig {
   // bind9/powerdns :53; dhcp_relay_vip fronts the Kea relay→server :67.
   dns_vip?: string;
   dhcp_relay_vip?: string;
+  // issue #566 decision D1 — BGP mode. Layered on top of the same
+  // MetalLB install; requires `enabled: true`. bgp_advertisements is
+  // auto-derived server-side when omitted (see the backend cross-field
+  // validator), so the form only needs to manage bgp_peers.
+  bgp_enabled?: boolean;
+  bgp_peers?: MetalLBBgpPeer[];
+  bgp_advertisements?: MetalLBBgpAdvertisement[];
   // #272 — live readiness from the GET (best-effort; absent/zero when
   // kubeapi is unreachable). Not sent on PUT.
   controller_ready?: boolean;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13271,11 +13271,24 @@ export interface BGPLGRouteQuery {
   community?: string;
   rpki_status?: BGPLGRpkiStatus;
   peer_id?: string;
+  matched_block_id?: string;
+  matched_subnet_id?: string;
+  matched_space_id?: string;
+  matched_asn_id?: string;
+  matched_vrf_id?: string;
   best_path_only?: boolean;
   /** Withdrawn routes are hidden by default. */
   withdrawn?: boolean;
   limit?: number;
   offset?: number;
+}
+
+/** GET /looking-glass/routes/for-ip — reverse LPM-by-address lookup. */
+export interface BGPLGRouteForIpResponse {
+  ip: string;
+  found: boolean;
+  route: BGPLGRoute | null;
+  alternate_paths_count: number;
 }
 
 export const lookingGlassApi = {
@@ -13317,6 +13330,13 @@ export const lookingGlassApi = {
     api
       .get<BGPLGRoute[]>("/looking-glass/routes/by-prefix", {
         params: { prefix },
+      })
+      .then((r) => r.data),
+  /** Reverse LPM-by-address lookup — "what route covers this IP?" */
+  routeForIp: (ip: string) =>
+    api
+      .get<BGPLGRouteForIpResponse>("/looking-glass/routes/for-ip", {
+        params: { ip },
       })
       .then((r) => r.data),
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13107,7 +13107,14 @@ export interface BGPCommunityUpdate {
 // this is the real internal routing table, mounted at
 // ``/looking-glass`` (not ``/bgp``).
 
-export type BGPLGAddressFamily = "ipv4-unicast" | "ipv6-unicast";
+// vpnv4/vpnv6 (issue #566 Phase 6) — MP-BGP VPNv4/VPNv6 (RFC 4364). EVPN
+// stays out of scope. Not yet exercised against a live gobgpd VPNv4/VPNv6
+// session — see the collector's own "verified live" convention.
+export type BGPLGAddressFamily =
+  | "ipv4-unicast"
+  | "ipv6-unicast"
+  | "vpnv4"
+  | "vpnv6";
 
 // idle | connect | active | opensent | openconfirm | established (GoBGP FSM).
 export type BGPLGSessionState =
@@ -13241,6 +13248,9 @@ export interface BGPLGRoute {
   communities: string[];
   large_communities: string[];
   ext_communities: string[];
+  /** Route Distinguisher (RFC 4364) — non-empty only for vpnv4/vpnv6
+   *  paths; part of the row's identity server-side (issue #566 Phase 6). */
+  route_distinguisher: string;
   rpki_status: BGPLGRpkiStatus;
   is_best: boolean;
   matched_block_id: string | null;
@@ -13309,6 +13319,31 @@ export interface BGPLGDashboardSummary {
   routes_flapping: number;
 }
 
+// GET /looking-glass/multicast-reachability (issue #566 Phase 6) —
+// read-only cross-reference of PIM rendezvous-point addresses + multicast
+// group producer source subnets against the learned RIB. Computed live,
+// nothing persisted.
+export interface MulticastDomainReachability {
+  domain_id: string;
+  domain_name: string;
+  rp_address: string;
+  covering_route: BGPLGRoute | null;
+}
+
+export interface MulticastGroupReachability {
+  group_id: string;
+  group_name: string;
+  group_address: string;
+  source_subnet_id: string;
+  source_subnet: string;
+  covering_route: BGPLGRoute | null;
+}
+
+export interface MulticastReachabilityResponse {
+  domains: MulticastDomainReachability[];
+  groups: MulticastGroupReachability[];
+}
+
 export const lookingGlassApi = {
   // Collectors — agent-registration identity rows (one per GoBGP daemon).
   // Registration itself is agent-side; operators only read the list here.
@@ -13361,6 +13396,14 @@ export const lookingGlassApi = {
   getDashboardSummary: () =>
     api
       .get<BGPLGDashboardSummary>("/looking-glass/dashboard-summary")
+      .then((r) => r.data),
+  /** Multicast PIM-RP + producer-subnet reachability against the learned
+   *  RIB (issue #566 Phase 6) — read-only, computed on demand. */
+  getMulticastReachability: () =>
+    api
+      .get<MulticastReachabilityResponse>(
+        "/looking-glass/multicast-reachability",
+      )
       .then((r) => r.data),
 };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13367,6 +13367,76 @@ export interface MulticastReachabilityResponse {
   groups: MulticastGroupReachability[];
 }
 
+// GET /looking-glass/peers/{peer_id}/detail — the rich rollup backing the
+// Sessions-tab peer detail modal (issue #566).
+export interface BGPLGPeerDetailCollector {
+  id: string;
+  name: string;
+  host: string | null;
+  status: string;
+  last_seen_ip: string | null;
+  agent_version: string | null;
+  enabled: boolean;
+}
+
+export interface BGPLGPeerDetailMatchedAsn {
+  id: string;
+  number: number;
+  name: string;
+}
+
+export interface BGPLGPeerDetailRouter {
+  id: string;
+  name: string;
+}
+
+export interface BGPLGPeerDetailRpkiBreakdown {
+  valid: number;
+  invalid: number;
+  unknown: number;
+}
+
+export interface BGPLGPeerDetailOriginAsnCount {
+  asn: number;
+  count: number;
+}
+
+export interface BGPLGPeerDetailCommunityCount {
+  value: string;
+  count: number;
+}
+
+export interface BGPLGPeerDetailRouteStats {
+  active_total: number;
+  withdrawn_total: number;
+  best_count: number;
+  rpki: BGPLGPeerDetailRpkiBreakdown;
+  top_origin_asns: BGPLGPeerDetailOriginAsnCount[];
+  top_communities: BGPLGPeerDetailCommunityCount[];
+  /** True when at least one active route carries a non-empty RD —
+   *  i.e. this peer has VPNv4/VPNv6 (RFC 4364) paths, not just plain
+   *  ipv4/ipv6-unicast. */
+  has_vpn_routes: boolean;
+  /** First ~8 active routes, for the modal's preview mini-table. */
+  sample_routes: BGPLGRoute[];
+}
+
+export interface BGPLGPeerDetailAlert {
+  severity: string;
+  message: string;
+  rule_type: string;
+  fired_at: string;
+}
+
+export interface BGPLGPeerDetail {
+  peer: BGPLGPeer;
+  collector: BGPLGPeerDetailCollector;
+  matched_asn: BGPLGPeerDetailMatchedAsn | null;
+  peer_router: BGPLGPeerDetailRouter | null;
+  route_stats: BGPLGPeerDetailRouteStats;
+  active_alerts: BGPLGPeerDetailAlert[];
+}
+
 export const lookingGlassApi = {
   // Collectors — agent-registration identity rows (one per GoBGP daemon).
   // Registration itself is agent-side; operators only read the list here.
@@ -13427,6 +13497,12 @@ export const lookingGlassApi = {
       .get<MulticastReachabilityResponse>(
         "/looking-glass/multicast-reachability",
       )
+      .then((r) => r.data),
+  /** Rich rollup backing the Sessions-tab peer detail modal — collector,
+   *  matched ASN/router, RIB stats, open bgp_lg_* alerts. */
+  getPeerDetail: (peerId: string) =>
+    api
+      .get<BGPLGPeerDetail>(`/looking-glass/peers/${peerId}/detail`)
       .then((r) => r.data),
 };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13291,6 +13291,16 @@ export interface BGPLGRouteForIpResponse {
   alternate_paths_count: number;
 }
 
+/** GET /looking-glass/dashboard-summary — single-shot rollup backing the
+ *  Dashboard's "Looking Glass health" card. */
+export interface BGPLGDashboardSummary {
+  peers_total: number;
+  peers_established: number;
+  peers_down: number;
+  routes_rpki_invalid: number;
+  routes_flapping: number;
+}
+
 export const lookingGlassApi = {
   // Collectors — agent-registration identity rows (one per GoBGP daemon).
   // Registration itself is agent-side; operators only read the list here.
@@ -13338,6 +13348,11 @@ export const lookingGlassApi = {
       .get<BGPLGRouteForIpResponse>("/looking-glass/routes/for-ip", {
         params: { ip },
       })
+      .then((r) => r.data),
+  /** Single-shot rollup for the Dashboard's Looking Glass health card. */
+  getDashboardSummary: () =>
+    api
+      .get<BGPLGDashboardSummary>("/looking-glass/dashboard-summary")
       .then((r) => r.data),
 };
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -25,6 +25,7 @@ import {
   Lock,
   Network,
   Plug,
+  Radio,
   RefreshCw,
   Route,
   Server,
@@ -57,6 +58,7 @@ import {
   dashboardsApi,
   tlsCertsApi,
   newDeviceApi,
+  lookingGlassApi,
   type IPSpace,
   type Subnet,
   type DNSServer,
@@ -871,6 +873,126 @@ function SubnetDecomCard() {
   );
 }
 
+// ── Looking Glass health card ────────────────────────────────────────────────
+
+function LookingGlassHealthCard() {
+  const { enabled, ready } = useFeatureModules();
+  const moduleOn = ready && enabled("network.looking_glass");
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["lg-dashboard-summary"],
+    queryFn: () => lookingGlassApi.getDashboardSummary(),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+    enabled: moduleOn,
+  });
+
+  // When the module is off the gated endpoint 404s — render nothing (the
+  // grid just collapses) instead of a red error card, matching the other
+  // module-gated summary cards on this tab.
+  if (!moduleOn) return null;
+
+  const inner = (() => {
+    if (isLoading) {
+      return (
+        <div className="mt-3 space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-4 animate-pulse rounded bg-muted"
+              style={{ width: `${60 + i * 10}%` }}
+            />
+          ))}
+        </div>
+      );
+    }
+    if (isError) {
+      return (
+        <p className="mt-3 text-xs text-red-600 dark:text-red-400">
+          Failed to load Looking Glass data.
+        </p>
+      );
+    }
+    if (!data || data.peers_total === 0) {
+      return (
+        <div className="mt-3 flex-1 flex flex-col justify-between">
+          <p className="text-xs text-muted-foreground">
+            No Looking Glass peers configured.
+          </p>
+          <Link
+            to="/network/looking-glass"
+            className="mt-2 text-[11px] text-primary hover:underline"
+          >
+            Configure a peer →
+          </Link>
+        </div>
+      );
+    }
+    return (
+      <div className="mt-3 flex-1 flex flex-col justify-between gap-2">
+        <div className="space-y-1.5">
+          <div className="flex flex-wrap items-center gap-1.5">
+            {data.peers_established > 0 && (
+              <span className="flex items-center gap-1 text-[11px]">
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                <span className="text-emerald-700 dark:text-emerald-400">
+                  {data.peers_established} established
+                </span>
+              </span>
+            )}
+            {data.peers_down > 0 && (
+              <span className="flex items-center gap-1 text-[11px]">
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-red-500" />
+                <span className="text-red-600 dark:text-red-400">
+                  {data.peers_down} down
+                </span>
+              </span>
+            )}
+          </div>
+          {(data.routes_rpki_invalid > 0 || data.routes_flapping > 0) && (
+            <div className="flex flex-wrap gap-1">
+              {data.routes_rpki_invalid > 0 && (
+                <StatusChip
+                  tone="red"
+                  label={`${data.routes_rpki_invalid} RPKI-invalid`}
+                />
+              )}
+              {data.routes_flapping > 0 && (
+                <StatusChip
+                  tone="amber"
+                  label={`${data.routes_flapping} flapping`}
+                />
+              )}
+            </div>
+          )}
+        </div>
+        <Link
+          to="/network/looking-glass"
+          className="text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          View all →
+        </Link>
+      </div>
+    );
+  })();
+
+  return (
+    <div className="rounded-lg border bg-card p-4 flex flex-col">
+      <div className="flex items-center justify-between">
+        <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Looking Glass
+        </p>
+        <Radio className="h-3.5 w-3.5 text-muted-foreground" />
+      </div>
+      {!isLoading && !isError && data && data.peers_total > 0 && (
+        <p className="mt-1.5 text-2xl font-bold tabular-nums">
+          {data.peers_total}
+        </p>
+      )}
+      {inner}
+    </div>
+  );
+}
+
 // ── Page ────────────────────────────────────────────────────────────────────
 
 type DashboardTab =
@@ -1379,6 +1501,7 @@ export function DashboardPage() {
             <VrfSummaryCard />
             <DomainsSummaryCard />
             <SubnetDecomCard />
+            <LookingGlassHealthCard />
           </div>
         )}
 

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -139,6 +139,8 @@ function capabilityChips(caps: SupervisorCapabilities): {
   if (caps.can_run_dns_powerdns)
     out.push({ key: "powerdns", label: "PowerDNS" });
   if (caps.can_run_dhcp) out.push({ key: "dhcp", label: "DHCP" });
+  if (caps.can_run_looking_glass)
+    out.push({ key: "looking-glass", label: "Looking Glass" });
   if (caps.can_run_observer) out.push({ key: "observer", label: "Observer" });
   return out;
 }
@@ -180,6 +182,12 @@ function serviceChips(row: ApplianceRow): {
     });
   if (roles.includes("dhcp"))
     out.push({ key: "dhcp", label: "DHCP", status: serviceStatus });
+  if (roles.includes("looking-glass"))
+    out.push({
+      key: "looking-glass",
+      label: "Looking Glass",
+      status: serviceStatus,
+    });
   if (roles.includes("observer"))
     out.push({ key: "observer", label: "Observer", status: "neutral" });
   return out;
@@ -2364,6 +2372,7 @@ function ApplianceDrilldownModal({
             <CapRow label="DNS — BIND9" on={!!caps.can_run_dns_bind9} />
             <CapRow label="DNS — PowerDNS" on={!!caps.can_run_dns_powerdns} />
             <CapRow label="DHCP" on={!!caps.can_run_dhcp} />
+            <CapRow label="Looking Glass" on={!!caps.can_run_looking_glass} />
             <CapRow label="Observer" on={!!caps.can_run_observer} />
           </div>
           <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs">
@@ -2580,6 +2589,11 @@ const ROLE_OPTIONS: { value: string; label: string; capKey?: string }[] = [
     capKey: "can_run_dns_powerdns",
   },
   { value: "dhcp", label: "DHCP", capKey: "can_run_dhcp" },
+  {
+    value: "looking-glass",
+    label: "Looking Glass",
+    capKey: "can_run_looking_glass",
+  },
   { value: "observer", label: "Observer", capKey: "can_run_observer" },
 ];
 
@@ -4987,6 +5001,7 @@ const _ROLE_PORT_KEYS: Record<string, string[]> = {
   "dns-bind9": ["udp_53", "tcp_53"],
   "dns-powerdns": ["udp_53", "tcp_53"],
   dhcp: ["udp_67"],
+  "looking-glass": ["tcp_179"],
 };
 
 function _formatPortKey(key: string): string {

--- a/frontend/src/pages/appliance/NetworkTab.tsx
+++ b/frontend/src/pages/appliance/NetworkTab.tsx
@@ -16,6 +16,7 @@ import {
   authApi,
   formatApiError,
   settingsApi,
+  type MetalLBBgpPeer,
   type MetalLBConfig,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -350,6 +351,12 @@ function MetalLBConfigCard() {
   const [dhcpRelayVip, setDhcpRelayVip] = useState("");
   const [dirty, setDirty] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  // issue #566 decision D1 — BGP mode (export path). Repeatable peer
+  // rows; bgp_advertisements is auto-derived server-side so the form
+  // only manages peers.
+  const [bgpEnabled, setBgpEnabled] = useState(false);
+  const [bgpPeers, setBgpPeers] = useState<MetalLBBgpPeer[]>([]);
+  const [showBgp, setShowBgp] = useState(false);
 
   // Seed the form from the server once it loads (and re-seed after a
   // save) — but never clobber in-progress operator edits.
@@ -361,6 +368,8 @@ function MetalLBConfigCard() {
       setVip(data.control_plane_vip ?? "");
       setDnsVip(data.dns_vip ?? "");
       setDhcpRelayVip(data.dhcp_relay_vip ?? "");
+      setBgpEnabled(data.bgp_enabled ?? false);
+      setBgpPeers(data.bgp_peers ?? []);
       // Auto-reveal the Advanced pool field when the saved pool is a
       // real range (not just the auto-derived <vip>/32) so editing an
       // existing custom pool isn't hidden behind the disclosure. A
@@ -372,6 +381,8 @@ function MetalLBConfigCard() {
         pool.length > 1 || (pool.length === 1 && !autoPool.includes(pool[0]));
       if (isCustom || data.dns_vip || data.dhcp_relay_vip)
         setShowAdvanced(true);
+      if (data.bgp_enabled || (data.bgp_peers ?? []).length > 0)
+        setShowBgp(true);
     }
   }, [data, dirty]);
 
@@ -417,6 +428,12 @@ function MetalLBConfigCard() {
       // pool-only edit can't silently drop a configured resolver VIP.
       dns_vip: dnsVip.trim(),
       dhcp_relay_vip: dhcpRelayVip.trim(),
+      // issue #566 decision D1 — BGP mode. Sent unconditionally (same
+      // "no auto-derive" treatment as the data-plane VIPs above) —
+      // bgp_advertisements is auto-derived server-side, so the form
+      // never needs an advertisements sub-editor for v1.
+      bgp_enabled: bgpEnabled,
+      bgp_peers: bgpPeers,
     });
   };
 
@@ -600,6 +617,139 @@ function MetalLBConfigCard() {
                       so it outlives a single Kea node. Kea keeps{" "}
                       <code>hostNetwork</code>:67 for direct-attached broadcast
                       — this VIP only fronts the relay→server unicast forward.
+                    </span>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* issue #566 decision D1 — BGP mode. Export path: advertise
+              the VIP to upstream routers over BGP. Layered on top of the
+              same MetalLB install; hidden by default like Advanced. */}
+            <div className="flex flex-col gap-1">
+              <button
+                type="button"
+                onClick={() => setShowBgp((v) => !v)}
+                className="self-start text-xs text-muted-foreground underline decoration-dotted underline-offset-2 hover:text-foreground"
+              >
+                {showBgp ? "▾" : "▸"} BGP mode — advertise to upstream routers
+              </button>
+              {showBgp && (
+                <div className="flex flex-col gap-3">
+                  <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs font-medium text-amber-800 dark:text-amber-300">
+                    BGP mode activates FRRouting (GPL v2) inside the cluster via
+                    MetalLB's frr-k8s backend — a distinct component from the
+                    Apache-2.0 MetalLB images already running. See NOTICE.
+                  </div>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={bgpEnabled}
+                      onChange={(e) => {
+                        setBgpEnabled(e.target.checked);
+                        setDirty(true);
+                      }}
+                    />
+                    Enable BGP — advertise the VIP pool to upstream routers
+                  </label>
+                  <div className="flex flex-col gap-2">
+                    {bgpPeers.map((peer, i) => (
+                      <div
+                        key={i}
+                        className="grid grid-cols-1 gap-2 rounded-md border p-2 sm:grid-cols-[2fr_1fr_1fr_auto]"
+                      >
+                        <div className="flex flex-col gap-1">
+                          <span className="text-[11px] text-muted-foreground">
+                            Peer address
+                          </span>
+                          <input
+                            value={peer.peer_address}
+                            onChange={(e) => {
+                              const next = [...bgpPeers];
+                              next[i] = {
+                                ...peer,
+                                peer_address: e.target.value,
+                              };
+                              setBgpPeers(next);
+                              setDirty(true);
+                            }}
+                            placeholder="203.0.113.1"
+                            className="w-full rounded-md border bg-background px-2 py-1 font-mono text-xs"
+                          />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                          <span className="text-[11px] text-muted-foreground">
+                            Peer ASN
+                          </span>
+                          <input
+                            value={peer.peer_asn}
+                            onChange={(e) => {
+                              const next = [...bgpPeers];
+                              next[i] = {
+                                ...peer,
+                                peer_asn: Number(e.target.value) || 0,
+                              };
+                              setBgpPeers(next);
+                              setDirty(true);
+                            }}
+                            placeholder="65001"
+                            className="w-full rounded-md border bg-background px-2 py-1 font-mono text-xs"
+                          />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                          <span className="text-[11px] text-muted-foreground">
+                            My ASN
+                          </span>
+                          <input
+                            value={peer.my_asn}
+                            onChange={(e) => {
+                              const next = [...bgpPeers];
+                              next[i] = {
+                                ...peer,
+                                my_asn: Number(e.target.value) || 0,
+                              };
+                              setBgpPeers(next);
+                              setDirty(true);
+                            }}
+                            placeholder="65000"
+                            className="w-full rounded-md border bg-background px-2 py-1 font-mono text-xs"
+                          />
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setBgpPeers(bgpPeers.filter((_, j) => j !== i));
+                            setDirty(true);
+                          }}
+                          className="self-end rounded-md border px-2 py-1 text-xs text-muted-foreground hover:text-destructive"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const last = bgpPeers[bgpPeers.length - 1];
+                        const nextPeer: MetalLBBgpPeer = {
+                          my_asn: last?.my_asn ?? 0,
+                          peer_asn: 0,
+                          peer_address: "",
+                        };
+                        setBgpPeers([...bgpPeers, nextPeer]);
+                        setDirty(true);
+                      }}
+                      className="self-start rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                    >
+                      + Add peer
+                    </button>
+                    <span className="text-[11px] text-muted-foreground">
+                      One BGPPeer session per row. The advertised pool defaults
+                      to the control-plane VIP (widen the Advanced pool above
+                      for more). <strong>Firewall</strong>: the frr-k8s BGP
+                      session listens on tcp/179 on every control-plane node —
+                      open tcp/179 on your upstream router / any path-transiting
+                      firewall for this peer.
                     </span>
                   </div>
                 </div>

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -61,6 +61,7 @@ import {
   vrfsApi,
   multicastApi,
   addressSetsApi,
+  lookingGlassApi,
   IP_ROLE_OPTIONS,
   SUBNET_ROLES,
   SUBNET_ROLE_LABELS,
@@ -110,6 +111,9 @@ import {
   SiteChip,
   SitePicker,
 } from "@/components/ownership/pickers";
+import { BgpAdvertisedChip } from "@/components/network/bgp-lg-chips";
+import { BgpRouteMiniTable } from "@/components/network/bgp-route-table";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
 import {
   MODAL_BACKDROP_CLS,
   useDraggableModal,
@@ -4601,8 +4605,9 @@ function SubnetDetail({
     onError: (e) => setInlineEditError(formatApiError(e)),
   });
   const [activeSubnetTab, setActiveSubnetTab] = useState<
-    "addresses" | "dhcp" | "aliases" | "nat" | "trend" | "address-sets"
+    "addresses" | "dhcp" | "aliases" | "nat" | "trend" | "address-sets" | "bgp"
   >("addresses");
+  const { enabled: featureEnabled } = useFeatureModules();
   const [natModalIp, setNatModalIp] = useState<IPAddress | null>(null);
   const [selectedIpIds, setSelectedIpIds] = useState<Set<string>>(new Set());
   // Shift-click range select. ``onChange`` doesn't carry shiftKey, so we
@@ -5457,6 +5462,20 @@ function SubnetDetail({
           >
             Trend
           </button>
+          {featureEnabled("network.looking_glass") && (
+            <button
+              onClick={() => setActiveSubnetTab("bgp")}
+              className={cn(
+                "px-3 py-2 text-xs font-medium border-b-2 -mb-px transition-colors",
+                activeSubnetTab === "bgp"
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+              )}
+              title="BGP routes learned for this subnet's CIDR"
+            >
+              BGP
+            </button>
+          )}
           {activeSubnetTab === "addresses" && selectedIpIds.size > 0 && (
             <div className="ml-auto flex items-center gap-2 py-1">
               <span className="text-xs font-medium text-muted-foreground">
@@ -5504,6 +5523,12 @@ function SubnetDetail({
       {activeSubnetTab === "nat" && (
         <div className="flex-1 overflow-auto">
           <NatSubnetPanel subnetId={subnet.id} />
+        </div>
+      )}
+
+      {activeSubnetTab === "bgp" && (
+        <div className="flex-1 overflow-auto">
+          <BgpSubnetPanel subnetId={subnet.id} />
         </div>
       )}
 
@@ -9045,6 +9070,39 @@ function NatRowsTable({
   );
 }
 
+function BgpSubnetPanel({ subnetId }: { subnetId: string }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["bgp-lg-routes-by-subnet", subnetId],
+    queryFn: () =>
+      lookingGlassApi.searchRoutes({
+        matched_subnet_id: subnetId,
+        withdrawn: false,
+        limit: 200,
+      }),
+    staleTime: 15_000,
+  });
+
+  if (isLoading) {
+    return <p className="px-6 py-4 text-sm text-muted-foreground">Loading…</p>;
+  }
+  const items = data?.items ?? [];
+  if (items.length === 0) {
+    return (
+      <p className="px-6 py-4 text-sm text-muted-foreground">
+        No active BGP route covers this subnet's CIDR.
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-2 p-2">
+      <p className="px-3 pt-1 text-xs text-muted-foreground">
+        Every active BGP Looking Glass route matched to this subnet.
+      </p>
+      <BgpRouteMiniTable items={items} />
+    </div>
+  );
+}
+
 function NatSubnetPanel({ subnetId }: { subnetId: string }) {
   const { data = [], isLoading } = useQuery({
     queryKey: ["subnet-nat-mappings", subnetId],
@@ -10356,6 +10414,7 @@ function SubnetRow({
           </div>
           <CustomerChip customerId={subnet.customer_id} />
           <SiteChip siteId={subnet.site_id} />
+          <BgpAdvertisedChip spaceId={subnet.space_id} subnetId={subnet.id} />
           <UtilizationDot
             percent={subnet.utilization_percent}
             uncountable={isUncountable(subnet.total_ips)}
@@ -11916,6 +11975,10 @@ function BlockTreeRow({
               />
               <CustomerChip customerId={node.block.customer_id} />
               <SiteChip siteId={node.block.site_id} />
+              <BgpAdvertisedChip
+                spaceId={node.block.space_id}
+                blockId={node.block.id}
+              />
             </button>
           </div>
         </ContextMenuTrigger>
@@ -12655,8 +12718,9 @@ function BlockDetailView({
       </div>
       <div className="flex-1 overflow-auto">
         {space && (
-          <div className="px-6 pt-3">
+          <div className="space-y-3 px-6 pt-3">
             <MulticastGroupsPanel space={space} block={block} />
+            <BgpBlockPanel block={block} />
           </div>
         )}
         {(() => {
@@ -13277,6 +13341,45 @@ function isMulticastCidr(cidr: string): boolean {
   // IPv4: first octet 224..239 lies inside 224.0.0.0/4
   const first = parseInt(base.split(".")[0] ?? "0", 10);
   return first >= 224 && first <= 239;
+}
+
+function BgpBlockPanel({ block }: { block: IPBlock }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["bgp-lg-routes-by-block", block.id],
+    queryFn: () =>
+      lookingGlassApi.searchRoutes({
+        matched_block_id: block.id,
+        withdrawn: false,
+        limit: 200,
+      }),
+    staleTime: 15_000,
+  });
+  if (isLoading) return null;
+  const items = data?.items ?? [];
+  if (items.length === 0) return null;
+
+  return (
+    <div className="mb-3 rounded-md border bg-sky-50/40 dark:bg-sky-950/20">
+      <div className="flex items-center justify-between gap-3 border-b px-4 py-2">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          BGP Routes
+          <span className="text-xs font-normal text-muted-foreground">
+            {items.length} route{items.length === 1 ? "" : "s"} covering{" "}
+            {block.network}
+          </span>
+        </div>
+        <Link
+          to="/network/looking-glass"
+          className="inline-flex items-center gap-1 rounded-md border bg-background px-3 py-1.5 text-xs font-medium hover:bg-muted"
+        >
+          Open Looking Glass →
+        </Link>
+      </div>
+      <div className="p-2">
+        <BgpRouteMiniTable items={items} />
+      </div>
+    </div>
+  );
 }
 
 function MulticastGroupsPanel({

--- a/frontend/src/pages/ipam/IPDetailModal.tsx
+++ b/frontend/src/pages/ipam/IPDetailModal.tsx
@@ -10,6 +10,7 @@ import {
   Radar,
   Radio,
   RefreshCw,
+  Route as RouteIcon,
   ShieldAlert,
   ShieldCheck,
   Trash2,
@@ -19,6 +20,7 @@ import {
 import {
   dnsblApi,
   ipamApi,
+  lookingGlassApi,
   multicastApi,
   nmapApi,
   tlsCertsApi,
@@ -38,6 +40,7 @@ import { AskAIButton } from "@/components/copilot/AskAIButton";
 import { IPNetworkTab } from "./IPNetworkTab";
 import { SeenDot } from "./SeenDot";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
+import { RpkiPill } from "@/components/network/bgp-route-table";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -551,6 +554,11 @@ export function IPDetailModal({
               the network.multicast feature module is disabled. */}
           <MulticastMembershipsSection addressId={addr.id} />
 
+          {/* Covering BGP route (issue #566 Phase 3). Hidden when the
+              network.looking_glass module is off or nothing in the
+              active RIB covers this address. */}
+          <BgpRouteLookupSection address={addr.address} />
+
           <CertsSection addressId={addr.id} />
 
           {/* Reputation — DNSBL / RBL listing status (issue #528). Hidden
@@ -761,6 +769,47 @@ function MulticastMembershipsSection({ addressId }: { addressId: string }) {
             ))}
           </tbody>
         </table>
+      </div>
+    </div>
+  );
+}
+
+/** Reverse LPM-by-address lookup — "what BGP route covers this exact
+ *  IP?" (issue #566 Phase 3). Self-hides when the network.looking_glass
+ *  module is off or nothing in the active RIB covers the address. */
+function BgpRouteLookupSection({ address }: { address: string }) {
+  const { enabled } = useFeatureModules();
+  const lgEnabled = enabled("network.looking_glass");
+
+  const q = useQuery({
+    queryKey: ["bgp-lg-route-for-ip", address],
+    queryFn: () => lookingGlassApi.routeForIp(address),
+    enabled: lgEnabled,
+    staleTime: 30_000,
+  });
+
+  if (!lgEnabled) return null;
+  if (!q.data?.found || !q.data.route) return null;
+  const r = q.data.route;
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        <RouteIcon className="h-3 w-3" /> BGP route
+      </div>
+      <div className="space-y-1 rounded-md border px-3 py-2 text-xs">
+        <div className="flex items-center justify-between">
+          <span className="font-mono">{r.prefix}</span>
+          <RpkiPill status={r.rpki_status} />
+        </div>
+        <div className="text-muted-foreground">
+          Origin {r.origin_asn == null ? "—" : `AS${r.origin_asn}`} via{" "}
+          {r.next_hop}
+          {q.data.alternate_paths_count > 0 &&
+            ` · +${q.data.alternate_paths_count} more path${
+              q.data.alternate_paths_count === 1 ? "" : "s"
+            }`}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/network/AsnDetailPage.tsx
+++ b/frontend/src/pages/network/AsnDetailPage.tsx
@@ -19,10 +19,12 @@ import {
 import { HeaderButton } from "@/components/ui/header-button";
 import { RdapPanel } from "@/components/network/rdap-panel";
 import { cn } from "@/lib/utils";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { CommunitiesTab } from "./CommunitiesTab";
 import { PeeringsTab } from "./PeeringsTab";
 import { BgpFootprintTab } from "./BgpFootprintTab";
 import { BgpMonitorTab } from "./BgpMonitorTab";
+import { LearnedRoutesTab } from "./LearnedRoutesTab";
 
 import { errMsg, humanTime } from "./_shared";
 
@@ -31,6 +33,7 @@ type Tab =
   | "rpki"
   | "footprint"
   | "monitor"
+  | "learned"
   | "bgp"
   | "communities"
   | "ipam"
@@ -129,6 +132,7 @@ export function AsnDetailPage() {
   const { id = "" } = useParams<{ id: string }>();
   const qc = useQueryClient();
   const [tab, setTab] = useState<Tab>("whois");
+  const { enabled: featureEnabled } = useFeatureModules();
 
   const {
     data: asn,
@@ -256,6 +260,13 @@ export function AsnDetailPage() {
     ["rpki", "RPKI ROAs"],
     ["footprint", "BGP Footprint"],
     ["monitor", "BGP Monitoring"],
+    // Learned Routes (issue #566 Phase 3) — the internal Looking Glass
+    // RIB view, next to BGP Monitoring's external hijack-detection view.
+    // Hidden when network.looking_glass is off, unlike the tabs above
+    // which all sit behind this page's own network.asn module.
+    ...(featureEnabled("network.looking_glass")
+      ? ([["learned", "Learned Routes"]] as Array<[Tab, string]>)
+      : []),
     ["bgp", "BGP Peering"],
     ["communities", "Communities"],
     ["ipam", "IP Spaces / Blocks"],
@@ -507,6 +518,10 @@ export function AsnDetailPage() {
         )}
 
         {tab === "monitor" && <BgpMonitorTab asnId={id} asnKind={asn.kind} />}
+
+        {tab === "learned" && (
+          <LearnedRoutesTab asnNumber={asn.number} asnId={id} />
+        )}
 
         {tab === "bgp" && <PeeringsTab asnId={id} />}
 

--- a/frontend/src/pages/network/LearnedRoutesTab.tsx
+++ b/frontend/src/pages/network/LearnedRoutesTab.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { lookingGlassApi } from "@/lib/api";
+import { BgpRouteMiniTable } from "@/components/network/bgp-route-table";
+
+/** "Learned Routes" tab on the ASN detail page (issue #566 Phase 3) —
+ *  the internal Looking Glass RIB view, sitting next to BGP Monitoring's
+ *  external hijack-detection view.
+ *
+ *  Filters by ``origin_asn`` (the raw wire value), NOT ``matched_asn_id``
+ *  — origin_asn is always immediately correct on ingest, while
+ *  matched_asn_id only gets populated once the ingest/re-resolve cache
+ *  has run (up to a 5-minute lag on a route that was already in the RIB
+ *  before this ASN row was created). Filtering by origin_asn avoids a
+ *  confusing "empty tab" window for an ASN the operator just tracked.
+ */
+export function LearnedRoutesTab({
+  asnNumber,
+  asnId,
+}: {
+  asnNumber: number;
+  asnId: string;
+}) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["bgp-lg-routes-by-asn", asnId, asnNumber],
+    queryFn: () =>
+      lookingGlassApi.searchRoutes({
+        origin_asn: asnNumber,
+        withdrawn: false,
+        limit: 200,
+      }),
+    staleTime: 15_000,
+  });
+
+  if (isLoading) {
+    return <p className="p-6 text-sm text-muted-foreground">Loading…</p>;
+  }
+  const items = data?.items ?? [];
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 p-10 text-center">
+        <p className="text-sm text-muted-foreground">
+          No routes with origin AS{asnNumber} in the current RIB.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        Every active BGP Looking Glass route whose origin AS is AS
+        {asnNumber}.
+      </p>
+      <BgpRouteMiniTable items={items} />
+    </div>
+  );
+}

--- a/frontend/src/pages/network/MulticastGroupsPage.tsx
+++ b/frontend/src/pages/network/MulticastGroupsPage.tsx
@@ -4,6 +4,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ListPlus, Pencil, Plus, RefreshCw, Trash2, X } from "lucide-react";
 
 import { MulticastDomainsTab } from "./MulticastDomainsPage";
+import { MulticastReachabilityTab } from "./MulticastReachabilityTab";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
 import {
   customersApi,
   ipamApi,
@@ -970,8 +972,17 @@ export function MulticastGroupsPage() {
   const [showNew, setShowNew] = useState(false);
   const [showBulk, setShowBulk] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const tab: "groups" | "domains" =
-    searchParams.get("tab") === "domains" ? "domains" : "groups";
+  const { enabled: featureEnabled } = useFeatureModules();
+  // BGP Looking Glass reachability cross-check (issue #566 Phase 6) is
+  // only meaningful when the Looking Glass module is on — no RIB to
+  // cross-reference against otherwise.
+  const lgEnabled = featureEnabled("network.looking_glass");
+  const tab: "groups" | "domains" | "reachability" =
+    searchParams.get("tab") === "domains"
+      ? "domains"
+      : searchParams.get("tab") === "reachability" && lgEnabled
+        ? "reachability"
+        : "groups";
 
   // Keep ``?space=<uuid>`` in the URL in sync with the dropdown.
   useEffect(() => {
@@ -986,7 +997,7 @@ export function MulticastGroupsPage() {
     );
   }, [spaceFilter, setSearchParams]);
 
-  function selectTab(next: "groups" | "domains") {
+  function selectTab(next: "groups" | "domains" | "reachability") {
     setSearchParams(
       (prev) => {
         const params = new URLSearchParams(prev);
@@ -1105,9 +1116,18 @@ export function MulticastGroupsPage() {
             onClick={() => selectTab("domains")}
             label="Domains"
           />
+          {lgEnabled && (
+            <TabPill
+              active={tab === "reachability"}
+              onClick={() => selectTab("reachability")}
+              label="BGP Reachability"
+            />
+          )}
         </div>
 
-        {tab === "domains" ? (
+        {tab === "reachability" && lgEnabled ? (
+          <MulticastReachabilityTab />
+        ) : tab === "domains" ? (
           <MulticastDomainsTab />
         ) : (
           <GroupsTabBody

--- a/frontend/src/pages/network/MulticastReachabilityTab.tsx
+++ b/frontend/src/pages/network/MulticastReachabilityTab.tsx
@@ -1,0 +1,141 @@
+import { useQuery } from "@tanstack/react-query";
+import { CheckCircle2, XCircle } from "lucide-react";
+
+import { lookingGlassApi } from "@/lib/api";
+import { zebraBodyCls } from "@/lib/utils";
+
+/** Read-only cross-reference of PIM rendezvous-point addresses + multicast
+ *  group producer source subnets against the BGP Looking Glass learned RIB
+ *  (issue #566 Phase 6). Nothing persisted — computed on every load.
+ *  Mounted only when the parent `MulticastGroupsPage` tab bar shows this
+ *  entry, which is itself gated on the `network.looking_glass` feature
+ *  module — see that file's `lgEnabled` check. */
+
+function ReachBadge({ reachable }: { reachable: boolean }) {
+  return reachable ? (
+    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-400">
+      <CheckCircle2 className="h-3 w-3" /> Reachable
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 rounded-full bg-rose-500/15 px-2 py-0.5 text-[10px] font-medium text-rose-700 dark:text-rose-400">
+      <XCircle className="h-3 w-3" /> No route
+    </span>
+  );
+}
+
+export function MulticastReachabilityTab() {
+  const { data, isFetching, error } = useQuery({
+    queryKey: ["bgp-lg-multicast-reachability"],
+    queryFn: () => lookingGlassApi.getMulticastReachability(),
+  });
+
+  const domains = data?.domains ?? [];
+  const groups = data?.groups ?? [];
+
+  return (
+    <div className="space-y-6">
+      <p className="text-xs text-muted-foreground">
+        Cross-references PIM rendezvous-point addresses and multicast-group
+        producer source subnets against the BGP Looking Glass learned RIB (issue
+        #566 Phase 6) — read-only, computed live on every load.
+      </p>
+      {error && (
+        <p className="text-sm text-destructive">Failed to load reachability.</p>
+      )}
+
+      <div>
+        <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          PIM domain rendezvous points ({domains.length})
+        </div>
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-xs">
+            <thead className="bg-muted/30 text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+              <tr className="border-b">
+                <th className="px-3 py-2">Domain</th>
+                <th className="px-3 py-2">RP address</th>
+                <th className="px-3 py-2">Covering route</th>
+                <th className="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody className={zebraBodyCls}>
+              {domains.length === 0 && !isFetching && (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-3 py-6 text-center text-muted-foreground"
+                  >
+                    No sparse/bidir PIM domains with a resolvable RP address.
+                  </td>
+                </tr>
+              )}
+              {domains.map((d) => (
+                <tr
+                  key={d.domain_id}
+                  className="border-b last:border-0 hover:bg-muted/20"
+                >
+                  <td className="px-3 py-2 font-medium">{d.domain_name}</td>
+                  <td className="px-3 py-2 font-mono text-muted-foreground">
+                    {d.rp_address}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-muted-foreground">
+                    {d.covering_route ? d.covering_route.prefix : "—"}
+                  </td>
+                  <td className="px-3 py-2">
+                    <ReachBadge reachable={!!d.covering_route} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div>
+        <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Multicast group source subnets ({groups.length})
+        </div>
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-xs">
+            <thead className="bg-muted/30 text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+              <tr className="border-b">
+                <th className="px-3 py-2">Group</th>
+                <th className="px-3 py-2">Source subnet</th>
+                <th className="px-3 py-2">Covering route</th>
+                <th className="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody className={zebraBodyCls}>
+              {groups.length === 0 && !isFetching && (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="px-3 py-6 text-center text-muted-foreground"
+                  >
+                    No multicast groups with a producer membership yet.
+                  </td>
+                </tr>
+              )}
+              {groups.map((g) => (
+                <tr
+                  key={`${g.group_id}-${g.source_subnet_id}`}
+                  className="border-b last:border-0 hover:bg-muted/20"
+                >
+                  <td className="px-3 py-2 font-medium">{g.group_name}</td>
+                  <td className="px-3 py-2 font-mono text-muted-foreground">
+                    {g.source_subnet}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-muted-foreground">
+                    {g.covering_route ? g.covering_route.prefix : "—"}
+                  </td>
+                  <td className="px-3 py-2">
+                    <ReachBadge reachable={!!g.covering_route} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/network/looking-glass/LookingGlassPage.tsx
+++ b/frontend/src/pages/network/looking-glass/LookingGlassPage.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Binoculars, Plus, RefreshCw } from "lucide-react";
+
+import { lookingGlassApi, type BGPLGPeer } from "@/lib/api";
+import { HeaderButton } from "@/components/ui/header-button";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
+import { cn } from "@/lib/utils";
+
+import { PeerFormModal, SessionsTab } from "./SessionsTab";
+import { RoutesTab } from "./RoutesTab";
+
+type LGTab = "sessions" | "routes";
+
+function TabPill({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "border-b-2 px-3 py-2 text-sm font-medium transition-colors -mb-px",
+        active
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function LookingGlassPage() {
+  const qc = useQueryClient();
+  const { enabled, ready } = useFeatureModules();
+  const moduleOn = enabled("network.looking_glass");
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab: LGTab =
+    searchParams.get("tab") === "routes" ? "routes" : "sessions";
+
+  const [showPeerModal, setShowPeerModal] = useState(false);
+  const [editingPeer, setEditingPeer] = useState<BGPLGPeer | null>(null);
+
+  const collectorsQ = useQuery({
+    queryKey: ["bgp-lg-collectors"],
+    queryFn: () => lookingGlassApi.listCollectors(),
+    enabled: ready && moduleOn,
+    staleTime: 30_000,
+  });
+  const collectors = collectorsQ.data ?? [];
+
+  function selectTab(next: LGTab) {
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        if (next === "sessions") params.delete("tab");
+        else params.set("tab", next);
+        return params;
+      },
+      { replace: true },
+    );
+  }
+
+  function openAddPeer() {
+    setEditingPeer(null);
+    setShowPeerModal(true);
+  }
+
+  function openEditPeer(peer: BGPLGPeer) {
+    setEditingPeer(peer);
+    setShowPeerModal(true);
+  }
+
+  function refresh() {
+    void qc.invalidateQueries({
+      predicate: (q) =>
+        typeof q.queryKey[0] === "string" &&
+        (q.queryKey[0] as string).startsWith("bgp-lg-"),
+    });
+  }
+
+  if (ready && !moduleOn) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+        The BGP Looking Glass is disabled. An administrator can enable the
+        "network.looking_glass" feature module in Settings → Features.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="border-b bg-card px-6 py-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <h1 className="flex items-center gap-2 text-lg font-semibold">
+              <Binoculars className="h-5 w-5 text-muted-foreground" />
+              BGP Looking Glass
+            </h1>
+            <p className="mt-1 max-w-3xl text-xs text-muted-foreground">
+              A receive-only BGP collector — peers passively with your edge /
+              core routers and shows the live routing table it learns.
+              SpatiumDDI never advertises routes to your network from these
+              sessions.
+            </p>
+          </div>
+          <div className="flex flex-shrink-0 items-center gap-2">
+            <HeaderButton
+              icon={RefreshCw}
+              onClick={refresh}
+              iconClassName={
+                collectorsQ.isFetching ? "animate-spin" : undefined
+              }
+            >
+              Refresh
+            </HeaderButton>
+            <HeaderButton
+              variant="primary"
+              icon={Plus}
+              onClick={openAddPeer}
+              disabled={ready && collectors.length === 0}
+              title={
+                ready && collectors.length === 0
+                  ? "No collector has registered yet — install a Looking Glass agent first."
+                  : undefined
+              }
+            >
+              Add Peer
+            </HeaderButton>
+          </div>
+        </div>
+
+        <div className="mt-3 flex gap-1 border-b">
+          <TabPill
+            active={tab === "sessions"}
+            onClick={() => selectTab("sessions")}
+            label="Sessions"
+          />
+          <TabPill
+            active={tab === "routes"}
+            onClick={() => selectTab("routes")}
+            label="Routes"
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto p-6">
+        {tab === "sessions" ? (
+          <SessionsTab collectors={collectors} onEdit={openEditPeer} />
+        ) : (
+          <RoutesTab />
+        )}
+      </div>
+
+      {showPeerModal && (
+        <PeerFormModal
+          existing={editingPeer}
+          collectors={collectors}
+          onClose={() => {
+            setShowPeerModal(false);
+            setEditingPeer(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/network/looking-glass/LookingGlassPage.tsx
+++ b/frontend/src/pages/network/looking-glass/LookingGlassPage.tsx
@@ -51,6 +51,9 @@ export function LookingGlassPage() {
       : searchParams.get("tab") === "query"
         ? "query"
         : "sessions";
+  // Set only when the Routes tab was reached via the peer-detail modal's
+  // "View all routes" link — pre-filters RoutesTab's Peer picker.
+  const routesPeerFilter = searchParams.get("peer") ?? undefined;
 
   const [showPeerModal, setShowPeerModal] = useState(false);
   const [editingPeer, setEditingPeer] = useState<BGPLGPeer | null>(null);
@@ -69,6 +72,22 @@ export function LookingGlassPage() {
         const params = new URLSearchParams(prev);
         if (next === "sessions") params.delete("tab");
         else params.set("tab", next);
+        // A manual tab-pill click starts fresh — the peer filter only
+        // makes sense as a one-shot deep link from the detail modal.
+        params.delete("peer");
+        return params;
+      },
+      { replace: true },
+    );
+  }
+
+  // Deep-link from the peer detail modal's "View all routes" button.
+  function viewPeerRoutes(peerId: string) {
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        params.set("tab", "routes");
+        params.set("peer", peerId);
         return params;
       },
       { replace: true },
@@ -165,9 +184,13 @@ export function LookingGlassPage() {
 
       <div className="flex-1 overflow-auto p-6">
         {tab === "sessions" ? (
-          <SessionsTab collectors={collectors} onEdit={openEditPeer} />
+          <SessionsTab
+            collectors={collectors}
+            onEdit={openEditPeer}
+            onViewRoutes={viewPeerRoutes}
+          />
         ) : tab === "routes" ? (
-          <RoutesTab />
+          <RoutesTab initialPeerId={routesPeerFilter} />
         ) : (
           <QueryTab collectors={collectors} />
         )}

--- a/frontend/src/pages/network/looking-glass/LookingGlassPage.tsx
+++ b/frontend/src/pages/network/looking-glass/LookingGlassPage.tsx
@@ -10,8 +10,9 @@ import { cn } from "@/lib/utils";
 
 import { PeerFormModal, SessionsTab } from "./SessionsTab";
 import { RoutesTab } from "./RoutesTab";
+import { QueryTab } from "./QueryTab";
 
-type LGTab = "sessions" | "routes";
+type LGTab = "sessions" | "routes" | "query";
 
 function TabPill({
   active,
@@ -45,7 +46,11 @@ export function LookingGlassPage() {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const tab: LGTab =
-    searchParams.get("tab") === "routes" ? "routes" : "sessions";
+    searchParams.get("tab") === "routes"
+      ? "routes"
+      : searchParams.get("tab") === "query"
+        ? "query"
+        : "sessions";
 
   const [showPeerModal, setShowPeerModal] = useState(false);
   const [editingPeer, setEditingPeer] = useState<BGPLGPeer | null>(null);
@@ -150,14 +155,21 @@ export function LookingGlassPage() {
             onClick={() => selectTab("routes")}
             label="Routes"
           />
+          <TabPill
+            active={tab === "query"}
+            onClick={() => selectTab("query")}
+            label="Query"
+          />
         </div>
       </div>
 
       <div className="flex-1 overflow-auto p-6">
         {tab === "sessions" ? (
           <SessionsTab collectors={collectors} onEdit={openEditPeer} />
-        ) : (
+        ) : tab === "routes" ? (
           <RoutesTab />
+        ) : (
+          <QueryTab collectors={collectors} />
         )}
       </div>
 

--- a/frontend/src/pages/network/looking-glass/PeerDetailModal.tsx
+++ b/frontend/src/pages/network/looking-glass/PeerDetailModal.tsx
@@ -1,0 +1,537 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { ArrowRight, RefreshCw, Route as RouteIcon } from "lucide-react";
+
+import {
+  asnsApi,
+  lookingGlassApi,
+  type BGPLGAddressFamily,
+  type BGPLGPeer,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { Modal } from "@/components/ui/modal";
+import { HeaderButton } from "@/components/ui/header-button";
+import { BgpRouteMiniTable } from "@/components/network/bgp-route-table";
+import { errMsg, humanDuration, humanTime } from "../_shared";
+import { FALLBACK_STATE_COLOR, STATE_COLOR } from "./SessionsTab";
+
+const AF_LABELS: Partial<Record<BGPLGAddressFamily, string>> = {
+  "ipv4-unicast": "IPv4 unicast",
+  "ipv6-unicast": "IPv6 unicast",
+  vpnv4: "VPNv4",
+  vpnv6: "VPNv6",
+};
+
+const COLLECTOR_STATUS_DOT: Record<string, string> = {
+  active: "bg-emerald-500",
+  unreachable: "bg-rose-500",
+  error: "bg-rose-500",
+  unknown: "bg-zinc-400",
+};
+
+function StatePill({ state }: { state: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-wide",
+        STATE_COLOR[state as keyof typeof STATE_COLOR] ?? FALLBACK_STATE_COLOR,
+      )}
+    >
+      {state}
+    </span>
+  );
+}
+
+function SectionCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-md border p-3">
+      <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      <div className="space-y-1.5 text-xs">{children}</div>
+    </div>
+  );
+}
+
+function StatRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="min-w-0 truncate text-right font-medium">{value}</span>
+    </div>
+  );
+}
+
+/** Coloured stacked meter over the peer's active-route RPKI mix, with a
+ *  direct-labelled legend underneath so status is never colour-alone. */
+function RpkiMeter({
+  valid,
+  invalid,
+  unknown,
+}: {
+  valid: number;
+  invalid: number;
+  unknown: number;
+}) {
+  const total = valid + invalid + unknown;
+  const pct = (n: number) => (total === 0 ? 0 : (n / total) * 100);
+  return (
+    <div className="space-y-1.5">
+      <div className="flex h-2 w-full gap-0.5 overflow-hidden rounded-full bg-muted">
+        {valid > 0 && (
+          <div
+            className="h-full rounded-full bg-emerald-500"
+            style={{ width: `${pct(valid)}%` }}
+          />
+        )}
+        {invalid > 0 && (
+          <div
+            className="h-full rounded-full bg-rose-500"
+            style={{ width: `${pct(invalid)}%` }}
+          />
+        )}
+        {unknown > 0 && (
+          <div
+            className="h-full rounded-full bg-zinc-400 dark:bg-zinc-500"
+            style={{ width: `${pct(unknown)}%` }}
+          />
+        )}
+      </div>
+      <div className="flex flex-wrap gap-3 text-[11px] text-muted-foreground">
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-emerald-500" /> Valid {valid}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-rose-500" /> Invalid{" "}
+          {invalid}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-2 w-2 rounded-full bg-zinc-400 dark:bg-zinc-500" />{" "}
+          Unknown {unknown}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function SeverityBadge({ severity }: { severity: string }) {
+  const cls =
+    severity === "critical"
+      ? "bg-red-100 text-red-700 dark:bg-red-950/30 dark:text-red-400"
+      : severity === "warning"
+        ? "bg-amber-100 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400"
+        : "bg-blue-100 text-blue-700 dark:bg-blue-950/30 dark:text-blue-400";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider",
+        cls,
+      )}
+    >
+      {severity}
+    </span>
+  );
+}
+
+export function PeerDetailModal({
+  peerId,
+  onClose,
+  onEdit,
+  onDelete,
+  onViewRoutes,
+}: {
+  peerId: string;
+  onClose: () => void;
+  /** Closes this modal and hands the full peer object to the caller's
+   *  existing edit-form flow. */
+  onEdit: (peer: BGPLGPeer) => void;
+  /** Closes this modal and hands the full peer object to the caller's
+   *  existing delete-confirm flow. */
+  onDelete: (peer: BGPLGPeer) => void;
+  /** Deep-links into the Routes tab, pre-filtered to this peer. */
+  onViewRoutes: (peerId: string) => void;
+}) {
+  const qc = useQueryClient();
+
+  // Live-ticking clock — re-render every second while the session is
+  // established so "Up for Xm Ys" counts up smoothly instead of jumping
+  // only when the 15s session/detail polls land.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const detailQ = useQuery({
+    queryKey: ["bgp-lg-peer-detail", peerId],
+    queryFn: () => lookingGlassApi.getPeerDetail(peerId),
+    refetchInterval: 15_000,
+  });
+
+  const communitiesQ = useQuery({
+    queryKey: ["bgp-communities-standard"],
+    queryFn: () => asnsApi.listStandardCommunities(),
+    staleTime: 5 * 60_000,
+  });
+  const communityNameByValue = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of communitiesQ.data ?? []) map.set(c.value, c.name);
+    return map;
+  }, [communitiesQ.data]);
+
+  function refresh() {
+    void detailQ.refetch();
+    void qc.invalidateQueries({ queryKey: ["bgp-lg-sessions"] });
+  }
+
+  if (detailQ.isLoading) {
+    return (
+      <Modal title="Peer detail" onClose={onClose} wide>
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Loading…
+        </p>
+      </Modal>
+    );
+  }
+  if (detailQ.isError || !detailQ.data) {
+    return (
+      <Modal title="Peer detail" onClose={onClose} wide>
+        <p className="text-sm text-destructive">
+          {errMsg(detailQ.error, "Failed to load peer detail.")}
+        </p>
+      </Modal>
+    );
+  }
+
+  const d = detailQ.data;
+  const peer = d.peer;
+  const rs = d.route_stats;
+
+  const uptimeSeconds =
+    peer.session_state === "established" && peer.uptime_started_at
+      ? Math.max(
+          0,
+          Math.floor(
+            (Date.now() - new Date(peer.uptime_started_at).getTime()) / 1000,
+          ),
+        )
+      : null;
+
+  return (
+    <Modal title={peer.name} onClose={onClose} wide>
+      <div className="space-y-4">
+        {/* Header strip */}
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b pb-3">
+          <div className="min-w-0 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <StatePill state={peer.session_state} />
+              <span
+                className={cn(
+                  "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+                  peer.enabled
+                    ? "bg-muted text-muted-foreground"
+                    : "bg-zinc-200 text-zinc-700 dark:bg-zinc-700/50 dark:text-zinc-300",
+                )}
+              >
+                {peer.enabled ? "Enabled" : "Disabled"}
+              </span>
+              <span className="break-all font-mono text-xs text-muted-foreground">
+                {peer.peer_address}
+              </span>
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {uptimeSeconds != null
+                ? `Up for ${humanDuration(uptimeSeconds)}`
+                : peer.down_since
+                  ? `Down since ${humanTime(peer.down_since)}`
+                  : "Not established"}
+            </div>
+          </div>
+          <HeaderButton
+            icon={RefreshCw}
+            onClick={refresh}
+            iconClassName={detailQ.isFetching ? "animate-spin" : undefined}
+          >
+            Refresh
+          </HeaderButton>
+        </div>
+
+        {/* Card grid */}
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <SectionCard title="Session">
+            <StatRow
+              label="Uptime"
+              value={uptimeSeconds != null ? humanDuration(uptimeSeconds) : "—"}
+            />
+            <StatRow label="Last flap" value={humanTime(peer.last_flap_at)} />
+            <StatRow label="Down since" value={humanTime(peer.down_since)} />
+            <StatRow
+              label="Prefixes recv / accepted"
+              value={`${peer.prefixes_received.toLocaleString()} / ${peer.prefixes_accepted.toLocaleString()}`}
+            />
+            <StatRow
+              label="RPKI invalid"
+              value={
+                peer.rpki_invalid_count > 0 ? (
+                  <span className="font-semibold text-rose-600 dark:text-rose-400">
+                    {peer.rpki_invalid_count}
+                  </span>
+                ) : (
+                  "0"
+                )
+              }
+            />
+          </SectionCard>
+
+          <SectionCard title="BGP configuration">
+            <div className="flex items-center justify-center gap-2 rounded-md bg-muted/40 px-2 py-1.5 font-mono text-sm">
+              <span>AS{peer.local_asn}</span>
+              <ArrowRight className="h-3.5 w-3.5 text-muted-foreground" />
+              <span>AS{peer.peer_asn}</span>
+            </div>
+            <div className="flex flex-wrap gap-1 pt-1">
+              {peer.address_families.map((af) => (
+                <span
+                  key={af}
+                  className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium"
+                >
+                  {AF_LABELS[af] ?? af}
+                </span>
+              ))}
+            </div>
+            <StatRow
+              label="Max prefixes"
+              value={peer.max_prefixes.toLocaleString()}
+            />
+            <StatRow
+              label="Import filter"
+              value={
+                peer.import_filter.mode === "accept_all"
+                  ? "Accept all"
+                  : `Scoped (${(peer.import_filter.prefixes ?? []).length} prefixes)`
+              }
+            />
+            <StatRow
+              label="MD5 auth"
+              value={peer.md5_password_set ? "Set" : "None"}
+            />
+            {peer.description && (
+              <div className="border-t pt-1.5 text-muted-foreground">
+                {peer.description}
+              </div>
+            )}
+          </SectionCard>
+
+          <SectionCard title="Collector">
+            <StatRow label="Name" value={d.collector.name} />
+            <StatRow label="Host" value={d.collector.host ?? "—"} />
+            <StatRow
+              label="Status"
+              value={
+                <span className="inline-flex items-center gap-1.5">
+                  <span
+                    className={cn(
+                      "h-1.5 w-1.5 rounded-full",
+                      COLLECTOR_STATUS_DOT[d.collector.status] ?? "bg-zinc-400",
+                    )}
+                  />
+                  {d.collector.status}
+                </span>
+              }
+            />
+            <StatRow
+              label="Last-seen IP"
+              value={d.collector.last_seen_ip ?? "—"}
+            />
+            <StatRow
+              label="Agent version"
+              value={d.collector.agent_version ?? "—"}
+            />
+          </SectionCard>
+
+          <SectionCard title="Linked">
+            <StatRow
+              label="Remote ASN"
+              value={
+                d.matched_asn ? (
+                  <Link
+                    to={`/network/asns/${d.matched_asn.id}`}
+                    className="text-primary hover:underline"
+                  >
+                    AS{peer.peer_asn} · {d.matched_asn.name}
+                  </Link>
+                ) : (
+                  `AS${peer.peer_asn} (unlinked)`
+                )
+              }
+            />
+            <StatRow
+              label="Peer device"
+              value={
+                d.peer_router ? (
+                  <Link
+                    to={`/network/devices/${d.peer_router.id}`}
+                    className="text-primary hover:underline"
+                  >
+                    {d.peer_router.name}
+                  </Link>
+                ) : (
+                  "—"
+                )
+              }
+            />
+            <StatRow
+              label="VPN routes"
+              value={rs.has_vpn_routes ? "Yes (RD present)" : "No"}
+            />
+          </SectionCard>
+        </div>
+
+        {/* Learned routes */}
+        <div className="rounded-md border p-3">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              <RouteIcon className="h-3 w-3" /> Learned routes
+            </div>
+            <button
+              type="button"
+              onClick={() => onViewRoutes(peerId)}
+              className="text-xs text-primary hover:underline"
+            >
+              View all {rs.active_total.toLocaleString()} routes →
+            </button>
+          </div>
+
+          <div className="mb-3 flex flex-wrap gap-6">
+            <div>
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Active
+              </div>
+              <div className="text-sm font-semibold">
+                {rs.active_total.toLocaleString()}
+              </div>
+            </div>
+            <div>
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Withdrawn
+              </div>
+              <div className="text-sm font-semibold">
+                {rs.withdrawn_total.toLocaleString()}
+              </div>
+            </div>
+            <div>
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                Best path
+              </div>
+              <div className="text-sm font-semibold">
+                {rs.best_count.toLocaleString()}
+              </div>
+            </div>
+          </div>
+
+          <div className="mb-3">
+            <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+              RPKI mix
+            </div>
+            <RpkiMeter
+              valid={rs.rpki.valid}
+              invalid={rs.rpki.invalid}
+              unknown={rs.rpki.unknown}
+            />
+          </div>
+
+          {rs.top_origin_asns.length > 0 && (
+            <div className="mb-3">
+              <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                Top origin ASNs
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {rs.top_origin_asns.map((o) => (
+                  <span
+                    key={o.asn}
+                    className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px]"
+                  >
+                    AS{o.asn} · {o.count}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {rs.top_communities.length > 0 && (
+            <div className="mb-3">
+              <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                Top communities
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {rs.top_communities.map((c) => (
+                  <span
+                    key={c.value}
+                    title={communityNameByValue.get(c.value)}
+                    className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px]"
+                  >
+                    {c.value} · {c.count}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {rs.sample_routes.length > 0 ? (
+            <div>
+              <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                Sample routes
+              </div>
+              <BgpRouteMiniTable items={rs.sample_routes} />
+            </div>
+          ) : (
+            <p className="text-xs italic text-muted-foreground">
+              No active routes learned from this peer yet.
+            </p>
+          )}
+        </div>
+
+        {/* Active alerts */}
+        {d.active_alerts.length > 0 && (
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3">
+            <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-300">
+              Active alerts
+            </div>
+            <ul className="space-y-1.5">
+              {d.active_alerts.map((a, i) => (
+                <li
+                  key={`${a.rule_type}-${i}`}
+                  className="flex flex-wrap items-start gap-2 text-xs"
+                >
+                  <SeverityBadge severity={a.severity} />
+                  <span className="min-w-0 flex-1">{a.message}</span>
+                  <span className="whitespace-nowrap text-muted-foreground">
+                    {humanTime(a.fired_at)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t pt-3">
+          <HeaderButton onClick={onClose}>Close</HeaderButton>
+          <HeaderButton variant="destructive" onClick={() => onDelete(peer)}>
+            Delete
+          </HeaderButton>
+          <HeaderButton variant="primary" onClick={() => onEdit(peer)}>
+            Edit
+          </HeaderButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/network/looking-glass/QueryTab.tsx
+++ b/frontend/src/pages/network/looking-glass/QueryTab.tsx
@@ -1,0 +1,293 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Terminal } from "lucide-react";
+
+import {
+  asnsApi,
+  lookingGlassApi,
+  type BGPLGCollector,
+  type BGPLGRoute,
+  type NetToolTarget,
+} from "@/lib/api";
+import { BgpRouteMiniTable } from "@/components/network/bgp-route-table";
+import { CommandTool } from "@/pages/tools/NetworkToolsPage";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
+import { useSessionState } from "@/lib/useSessionState";
+import { cn } from "@/lib/utils";
+import { Field, errMsg, inputCls } from "../_shared";
+
+// ── command grammar (#566 Phase 4) ───────────────────────────────────
+//
+//   show route <prefix-or-ip> [exact]
+//   show route regexp <as-path-regex>
+//   show route community <value>
+//
+// A bare prefix/IP with no "show route" prefix is accepted too, as a
+// convenience (treated as `show route <input>`).
+
+type ParsedQuery =
+  | { kind: "prefix"; value: string; exact: boolean }
+  | { kind: "regexp"; value: string }
+  | { kind: "community"; value: string }
+  | { kind: "error"; message: string };
+
+function parseLgCommand(raw: string): ParsedQuery {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return {
+      kind: "error",
+      message: "Type a command, e.g. show route 10.0.0.0/24",
+    };
+  }
+  const tokens = trimmed.split(/\s+/);
+  const lower = tokens.map((t) => t.toLowerCase());
+  if (lower[0] !== "show" || lower[1] !== "route") {
+    return { kind: "prefix", value: trimmed, exact: false };
+  }
+  const rest = tokens.slice(2);
+  if (rest.length === 0) {
+    return {
+      kind: "error",
+      message:
+        "Expected a prefix, 'regexp <pattern>', or 'community <value>' after 'show route'.",
+    };
+  }
+  if (rest[0].toLowerCase() === "regexp") {
+    const pattern = rest.slice(1).join(" ").trim();
+    if (!pattern) {
+      return {
+        kind: "error",
+        message: "Expected an AS-path regex after 'regexp'.",
+      };
+    }
+    return { kind: "regexp", value: pattern };
+  }
+  if (rest[0].toLowerCase() === "community") {
+    const value = rest.slice(1).join(" ").trim();
+    if (!value) {
+      return {
+        kind: "error",
+        message: "Expected a community value after 'community'.",
+      };
+    }
+    return { kind: "community", value };
+  }
+  const exact = rest[rest.length - 1].toLowerCase() === "exact";
+  const value = (exact ? rest.slice(0, -1) : rest).join("");
+  return { kind: "prefix", value, exact };
+}
+
+const HISTORY_KEY = "bgp-lg-query-history";
+const HISTORY_CAP = 20;
+
+export function QueryTab({ collectors }: { collectors: BGPLGCollector[] }) {
+  const [draft, setDraft] = useState("");
+  const [submitted, setSubmitted] = useState<ParsedQuery | null>(null);
+  const [history, setHistory] = useSessionState<string[]>(HISTORY_KEY, []);
+
+  const communitiesQ = useQuery({
+    queryKey: ["bgp-communities-standard"],
+    queryFn: () => asnsApi.listStandardCommunities(),
+    staleTime: 5 * 60_000,
+  });
+
+  function submit(raw: string) {
+    const parsed = parseLgCommand(raw);
+    setSubmitted(parsed);
+    if (parsed.kind !== "error") {
+      const trimmed = raw.trim();
+      setHistory((prev) =>
+        [trimmed, ...prev.filter((h) => h !== trimmed)].slice(0, HISTORY_CAP),
+      );
+    }
+  }
+
+  function run() {
+    submit(draft);
+  }
+
+  function runFromHistory(h: string) {
+    setDraft(h);
+    setSubmitted(parseLgCommand(h));
+  }
+
+  const queryQ = useQuery({
+    queryKey: ["bgp-lg-query", submitted],
+    queryFn: async (): Promise<{ items: BGPLGRoute[]; total?: number }> => {
+      if (!submitted || submitted.kind === "error") return { items: [] };
+      if (submitted.kind === "prefix") {
+        if (submitted.exact) {
+          const items = await lookingGlassApi.getRoute(submitted.value);
+          return { items };
+        }
+        const res = await lookingGlassApi.searchRoutes({
+          prefix: submitted.value,
+          limit: 200,
+        });
+        return { items: res.items, total: res.total };
+      }
+      if (submitted.kind === "regexp") {
+        const res = await lookingGlassApi.searchRoutes({
+          as_path_regexp: submitted.value,
+          limit: 200,
+        });
+        return { items: res.items, total: res.total };
+      }
+      // community — accept either the raw wire value or a friendly catalog
+      // name (resolve name -> value against the same catalog RoutesTab
+      // uses).
+      const byName = (communitiesQ.data ?? []).find(
+        (c) => c.name === submitted.value,
+      );
+      const res = await lookingGlassApi.searchRoutes({
+        community: byName?.value ?? submitted.value,
+        limit: 200,
+      });
+      return { items: res.items, total: res.total };
+    },
+    enabled: submitted !== null && submitted.kind !== "error",
+  });
+
+  // ── vantage tools (ping / traceroute from a collector) ─────────────
+  const { enabled: moduleEnabled } = useFeatureModules();
+  const netToolsEnabled = moduleEnabled("tools.network");
+
+  const [runFrom, setRunFrom] = useState("server");
+  const [vantageTool, setVantageTool] = useState<"ping" | "traceroute">("ping");
+  const selectedCollector = collectors.find((c) => c.id === runFrom);
+  const target: NetToolTarget | undefined =
+    runFrom === "server" || !selectedCollector?.appliance_id
+      ? undefined
+      : { kind: "bgp_lg_collector", id: runFrom };
+
+  const items = queryQ.data?.items ?? [];
+  const total = queryQ.data?.total;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border bg-card p-3">
+        <div className="flex items-center gap-2">
+          <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            className={cn(inputCls, "font-mono")}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && run()}
+            placeholder="show route 10.0.0.0/24 · show route regexp _65001_ · show route community 65535:666"
+          />
+          <button
+            type="button"
+            onClick={run}
+            className="shrink-0 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
+          >
+            Run
+          </button>
+        </div>
+        <p className="mt-1.5 text-[11px] text-muted-foreground/70">
+          AS-path regex uses the Cisco/Juniper "_" boundary convention (a space,
+          start, or end of path) — e.g. "_65001_" matches AS65001 anywhere in
+          the path, "_65001$"-style trailing forms match it as the origin (the
+          last hop in the stored path). Plain POSIX regex is otherwise
+          supported.
+        </p>
+        {history.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {history.map((h) => (
+              <button
+                key={h}
+                type="button"
+                onClick={() => runFromHistory(h)}
+                className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground hover:text-foreground"
+              >
+                {h}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {submitted?.kind === "error" && (
+        <p className="text-sm text-destructive">{submitted.message}</p>
+      )}
+      {queryQ.error && (
+        <p className="text-sm text-destructive">
+          {errMsg(queryQ.error, "Query failed.")}
+        </p>
+      )}
+
+      {submitted && submitted.kind !== "error" && (
+        <div className="space-y-2">
+          {!queryQ.isFetching && (
+            <p className="text-xs text-muted-foreground">
+              {items.length === 0
+                ? "No routes match."
+                : total !== undefined && total > items.length
+                  ? `Showing ${items.length.toLocaleString()} of ${total.toLocaleString()} matching routes (narrow the query to see more).`
+                  : `${items.length.toLocaleString()} matching route${items.length === 1 ? "" : "s"}.`}
+            </p>
+          )}
+          <BgpRouteMiniTable items={items} />
+        </div>
+      )}
+
+      {/* Vantage tools — ping / traceroute FROM a collector's network
+          position (or the control-plane server). Only appliance-managed
+          collectors (appliance_id set) have a dispatchable command
+          channel — see #566 Phase 4 spec Part A3. */}
+      <div className="rounded-md border bg-card p-3">
+        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Vantage tools
+        </h3>
+        {netToolsEnabled ? (
+          <>
+            <p className="mb-3 text-[11px] text-muted-foreground/70">
+              Run ping / traceroute from a collector's own network position.
+              Standalone (non-appliance) collectors have no command channel and
+              aren't selectable — run from Server instead.
+            </p>
+            <div className="mb-3 flex flex-wrap items-end gap-3">
+              <Field label="Run from">
+                <select
+                  className={inputCls}
+                  value={runFrom}
+                  onChange={(e) => setRunFrom(e.target.value)}
+                >
+                  <option value="server">Server (control plane)</option>
+                  {collectors.map((c) => (
+                    <option key={c.id} value={c.id} disabled={!c.appliance_id}>
+                      {c.name}
+                      {!c.appliance_id ? " — not appliance-managed" : ""}
+                    </option>
+                  ))}
+                </select>
+              </Field>
+              <div className="flex gap-1 pb-1.5">
+                {(["ping", "traceroute"] as const).map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => setVantageTool(k)}
+                    className={cn(
+                      "rounded-md px-2.5 py-1 text-xs capitalize",
+                      vantageTool === k
+                        ? "bg-primary/10 text-primary"
+                        : "text-muted-foreground hover:bg-muted",
+                    )}
+                  >
+                    {k}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <CommandTool kind={vantageTool} target={target} />
+          </>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Vantage tools need the "tools.network" feature module, which is
+            disabled. An administrator can enable it in Settings → Features.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/network/looking-glass/RouteDetailModal.tsx
+++ b/frontend/src/pages/network/looking-glass/RouteDetailModal.tsx
@@ -1,0 +1,575 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { AlertTriangle, Check, Copy, Info, Star } from "lucide-react";
+
+import {
+  asnsApi,
+  lookingGlassApi,
+  type BGPLGRouteDetailPath,
+  type BGPLGRpkiStatus,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { Modal } from "@/components/ui/modal";
+import { HeaderButton } from "@/components/ui/header-button";
+import { AskAIButton } from "@/components/copilot/AskAIButton";
+import { RpkiPill } from "@/components/network/bgp-route-table";
+import { errMsg, humanTime } from "../_shared";
+
+/** Compact "first seen / last seen" caption shown under the AS-path cell —
+ *  answers "is this path fresh, or has it been stable for weeks?" without
+ *  spending a whole extra column on it. */
+function SeenCaption({ path }: { path: BGPLGRouteDetailPath }) {
+  return (
+    <div
+      className="text-[10px] text-muted-foreground"
+      title={`First seen ${path.first_seen_at}`}
+    >
+      seen {humanTime(path.last_seen_at)}
+      {path.flap_count > 0 &&
+        ` · ${path.flap_count} flap${path.flap_count === 1 ? "" : "s"}`}
+    </div>
+  );
+}
+
+/** Worst-first aggregate across a set of per-path RPKI statuses — used for
+ *  the header chip + the plain-English prefix-context note. "Worst" means
+ *  "least trustworthy", so a single invalid path colours the whole prefix
+ *  invalid even if the other paths are valid/unknown. */
+function worstRpki(rpki: {
+  valid: number;
+  invalid: number;
+  unknown: number;
+}): BGPLGRpkiStatus {
+  if (rpki.invalid > 0) return "invalid";
+  if (rpki.unknown > 0) return "unknown";
+  return "valid";
+}
+
+const RPKI_NOTE: Record<BGPLGRpkiStatus, string> = {
+  valid:
+    "All paths are covered by a valid RPKI ROA — the origin ASN is cryptographically authorised to announce this prefix.",
+  invalid:
+    "At least one path is RPKI INVALID — an origin ASN not authorised by a ROA is announcing this prefix. Treat with suspicion.",
+  unknown:
+    "No RPKI ROA covers this prefix (or the ROA cache hasn't been checked) — announcements can't be cryptographically verified either way.",
+};
+
+type WinnerResult = { winner: BGPLGRouteDetailPath | null; reason: string };
+
+/** A simplified, client-side approximation of the BGP best-path algorithm,
+ *  restricted to the attributes a receive-only collector actually gives
+ *  us: local-pref (higher wins) -> AS-path length (shorter wins) -> MED
+ *  (lower wins). Each path's own ``is_best`` flag is the collector's
+ *  per-peer Adj-RIB-In decision (trivially true for a single-homed
+ *  session), NOT a cross-router comparison — this helper is what answers
+ *  "which router's view would actually win" when that's determinable. */
+function pickOverallWinner(paths: BGPLGRouteDetailPath[]): WinnerResult {
+  if (paths.length === 0) return { winner: null, reason: "No paths." };
+  if (paths.length === 1) {
+    return {
+      winner: paths[0],
+      reason: "Only one path is known for this prefix.",
+    };
+  }
+
+  let candidates = paths;
+  const localPrefs = candidates
+    .map((p) => p.local_pref)
+    .filter((v): v is number => v != null);
+  if (localPrefs.length > 0) {
+    const maxLocalPref = Math.max(...localPrefs);
+    const withMax = candidates.filter(
+      (p) => (p.local_pref ?? -Infinity) === maxLocalPref,
+    );
+    if (withMax.length === 1) {
+      return {
+        winner: withMax[0],
+        reason: `Highest local-pref (${maxLocalPref}).`,
+      };
+    }
+    if (withMax.length < candidates.length) candidates = withMax;
+  }
+
+  const minAsPathLen = Math.min(...candidates.map((p) => p.as_path.length));
+  const afterAsPath = candidates.filter(
+    (p) => p.as_path.length === minAsPathLen,
+  );
+  if (afterAsPath.length === 1) {
+    const qualifier = localPrefs.length > 0 ? ", after local-pref" : "";
+    return {
+      winner: afterAsPath[0],
+      reason: `Shortest AS-path (${minAsPathLen} hop${minAsPathLen === 1 ? "" : "s"})${qualifier}.`,
+    };
+  }
+  candidates = afterAsPath;
+
+  const withMed = candidates.filter((p) => p.med != null);
+  if (withMed.length > 0) {
+    const minMed = Math.min(...withMed.map((p) => p.med as number));
+    const afterMed = withMed.filter((p) => p.med === minMed);
+    if (afterMed.length === 1) {
+      return {
+        winner: afterMed[0],
+        reason: `Lowest MED (${minMed}), after local-pref and AS-path length.`,
+      };
+    }
+  }
+
+  return {
+    winner: null,
+    reason:
+      "These paths tie on local-pref, AS-path length, and MED — no single winner is distinguishable from what the collector receives. Each row's checkmark is that router's own Adj-RIB-In best.",
+  };
+}
+
+function SectionCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-md border p-3">
+      <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      <div className="space-y-1.5 text-xs">{children}</div>
+    </div>
+  );
+}
+
+function StatRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="min-w-0 truncate text-right font-medium">{value}</span>
+    </div>
+  );
+}
+
+/** True when the column has more than one distinct non-null value across
+ *  every path AND this path's own value differs from the reference
+ *  (the overall winner when one was found, otherwise the first path) —
+ *  drives the "router A sends X, router B sends Y" highlight. */
+function isDivergent<T>(
+  path: BGPLGRouteDetailPath,
+  paths: BGPLGRouteDetailPath[],
+  reference: BGPLGRouteDetailPath,
+  getter: (p: BGPLGRouteDetailPath) => T,
+): boolean {
+  const values = new Set(paths.map(getter).filter((v) => v != null));
+  if (values.size <= 1) return false;
+  return getter(path) !== getter(reference);
+}
+
+const DIVERGENT_CLS = "font-semibold text-amber-700 dark:text-amber-400";
+
+export function RouteDetailModal({
+  prefix,
+  onClose,
+}: {
+  prefix: string;
+  onClose: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const detailQ = useQuery({
+    queryKey: ["bgp-lg-route-detail", prefix],
+    queryFn: () => lookingGlassApi.getRouteDetail(prefix),
+  });
+
+  const communitiesQ = useQuery({
+    queryKey: ["bgp-communities-standard"],
+    queryFn: () => asnsApi.listStandardCommunities(),
+    staleTime: 5 * 60_000,
+  });
+  const communityNameByValue = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of communitiesQ.data ?? []) map.set(c.value, c.name);
+    return map;
+  }, [communitiesQ.data]);
+
+  async function copyPrefix() {
+    try {
+      await navigator.clipboard.writeText(prefix);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable — operator can still select+copy */
+    }
+  }
+
+  if (detailQ.isLoading) {
+    return (
+      <Modal title="Route detail" onClose={onClose} wide>
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          Loading…
+        </p>
+      </Modal>
+    );
+  }
+  if (detailQ.isError || !detailQ.data) {
+    return (
+      <Modal title="Route detail" onClose={onClose} wide>
+        <p className="text-sm text-destructive">
+          {errMsg(detailQ.error, "Failed to load route detail.")}
+        </p>
+      </Modal>
+    );
+  }
+
+  const d = detailQ.data;
+  const paths = d.paths;
+  const summary = d.summary;
+  const ipam = d.ipam;
+  const rpki = worstRpki(summary.rpki);
+
+  const { winner, reason: winnerReason } = pickOverallWinner(paths);
+  const referencePath = winner ?? paths.find((p) => p.is_best) ?? paths[0];
+
+  const originLabels = summary.distinct_origin_asns.map((asn) => {
+    const name = summary.origin_names[String(asn)];
+    return name ? `AS${asn} (${name})` : `AS${asn}`;
+  });
+
+  return (
+    <Modal title="Route detail" onClose={onClose} wide>
+      <div className="space-y-4">
+        {/* Header */}
+        <div className="flex flex-wrap items-start justify-between gap-3 border-b pb-3">
+          <div className="min-w-0 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="break-all font-mono text-xl font-semibold">
+                {d.prefix}
+              </span>
+              <RpkiPill status={rpki} />
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {summary.path_count} path{summary.path_count === 1 ? "" : "s"}{" "}
+              from {summary.peer_count} router
+              {summary.peer_count === 1 ? "" : "s"}
+            </div>
+          </div>
+        </div>
+
+        {/* Headline banner */}
+        {summary.multi_origin ? (
+          <div
+            className={cn(
+              "flex items-start gap-2 rounded-md border p-3 text-sm",
+              summary.rpki.invalid > 0
+                ? "border-rose-500/40 bg-rose-500/5 text-rose-800 dark:text-rose-300"
+                : "border-amber-500/40 bg-amber-500/5 text-amber-800 dark:text-amber-300",
+            )}
+          >
+            <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <div className="space-y-1">
+              <div className="font-semibold">
+                Announced with {summary.distinct_origin_asns.length} different
+                origin ASNs ({originLabels.join(", ")}) — anycast, or a possible
+                origin hijack / route leak.
+              </div>
+              <div className="text-xs opacity-90">
+                Review the origins in the table below. If this prefix isn&apos;t
+                intentionally announced from multiple ASes, this may indicate a
+                hijack or route leak in progress.
+              </div>
+            </div>
+          </div>
+        ) : summary.anycast_candidate ? (
+          <div className="flex items-start gap-2 rounded-md border border-sky-500/40 bg-sky-500/5 p-3 text-sm text-sky-800 dark:text-sky-300">
+            <Info className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <div>
+              <span className="font-semibold">Anycast / multi-homed:</span> this
+              prefix is learned from {summary.peer_count} routers, all
+              originated by {originLabels.join(", ")}.
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Single path — learned from one router only, one origin ASN.
+          </p>
+        )}
+
+        {/* All-paths comparison table */}
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b bg-muted/30 text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+                <th className="px-3 py-2">Router / peer</th>
+                <th className="px-3 py-2">Origin ASN</th>
+                <th className="px-3 py-2">Next-hop</th>
+                <th className="px-3 py-2">Local-pref</th>
+                <th className="px-3 py-2">MED</th>
+                <th className="px-3 py-2">AS-path</th>
+                <th className="px-3 py-2">Communities</th>
+                <th className="px-3 py-2">RPKI</th>
+                <th className="px-3 py-2">Best</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paths.map((p) => {
+                const allCommunities = [
+                  ...p.communities,
+                  ...p.large_communities,
+                ];
+                const isWinner = winner?.route_id === p.route_id;
+                return (
+                  <tr
+                    key={p.route_id}
+                    className={cn(
+                      "border-b last:border-0",
+                      isWinner
+                        ? "bg-emerald-500/5"
+                        : p.withdrawn_at
+                          ? "opacity-50"
+                          : undefined,
+                    )}
+                  >
+                    <td className="px-3 py-2 align-top">
+                      <div className="font-medium">{p.peer_name}</div>
+                      <div className="text-[10px] text-muted-foreground">
+                        via {p.collector_name}
+                      </div>
+                      <SeenCaption path={p} />
+                    </td>
+                    <td
+                      className={cn(
+                        "px-3 py-2 align-top font-mono",
+                        isDivergent(
+                          p,
+                          paths,
+                          referencePath,
+                          (x) => x.origin_asn,
+                        ) && DIVERGENT_CLS,
+                      )}
+                    >
+                      {p.origin_asn == null ? (
+                        "—"
+                      ) : p.matched_asn_id ? (
+                        <Link
+                          to={`/network/asns/${p.matched_asn_id}`}
+                          className="hover:text-primary hover:underline"
+                        >
+                          AS{p.origin_asn}
+                        </Link>
+                      ) : (
+                        `AS${p.origin_asn}`
+                      )}
+                    </td>
+                    <td
+                      className={cn(
+                        "px-3 py-2 align-top break-all font-mono",
+                        isDivergent(
+                          p,
+                          paths,
+                          referencePath,
+                          (x) => x.next_hop,
+                        ) && DIVERGENT_CLS,
+                      )}
+                    >
+                      {p.next_hop}
+                    </td>
+                    <td
+                      className={cn(
+                        "px-3 py-2 align-top tabular-nums",
+                        isDivergent(
+                          p,
+                          paths,
+                          referencePath,
+                          (x) => x.local_pref,
+                        ) && DIVERGENT_CLS,
+                      )}
+                    >
+                      {p.local_pref ?? "—"}
+                    </td>
+                    <td
+                      className={cn(
+                        "px-3 py-2 align-top tabular-nums",
+                        isDivergent(p, paths, referencePath, (x) => x.med) &&
+                          DIVERGENT_CLS,
+                      )}
+                    >
+                      {p.med ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <div className="break-all font-mono text-muted-foreground">
+                        {p.as_path.length ? p.as_path.join(" ") : "—"}
+                      </div>
+                      <div className="text-[10px] text-muted-foreground">
+                        {p.as_path.length} hop
+                        {p.as_path.length === 1 ? "" : "s"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 align-top break-all font-mono text-muted-foreground">
+                      {allCommunities.length === 0 ? (
+                        "—"
+                      ) : (
+                        <div className="flex flex-wrap gap-1">
+                          {allCommunities.map((cVal, idx) => (
+                            <span
+                              key={`${cVal}-${idx}`}
+                              title={communityNameByValue.get(cVal)}
+                              className="rounded bg-muted px-1 py-0.5"
+                            >
+                              {cVal}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <RpkiPill status={p.rpki_status} />
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <div className="flex items-center gap-1">
+                        {p.is_best ? (
+                          <Check className="h-3.5 w-3.5 text-emerald-500" />
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                        {isWinner && (
+                          <Star
+                            className="h-3.5 w-3.5 text-amber-500"
+                            fill="currentColor"
+                            aria-label="Overall winner"
+                          />
+                        )}
+                      </div>
+                      {p.withdrawn_at && (
+                        <span className="text-[10px] text-muted-foreground">
+                          withdrawn
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Best-path explanation */}
+        <div className="rounded-md border bg-muted/20 p-3 text-xs text-muted-foreground">
+          <p>
+            BGP best-path selection prefers, in order: highest local-pref →
+            shortest AS-path → lowest origin type → lowest MED → eBGP over iBGP
+            → lowest IGP metric → oldest route → lowest router ID. Since this is
+            a receive-only collector, each row&apos;s ✓ reflects what{" "}
+            <em>that router itself</em> considers best in its own Adj-RIB-In —
+            not a cross-router comparison.
+          </p>
+          <p className="mt-1.5 flex items-center gap-1.5">
+            {winner ? (
+              <Star
+                className="h-3 w-3 flex-shrink-0 text-amber-500"
+                fill="currentColor"
+              />
+            ) : null}
+            <span>
+              {winner ? (
+                <>
+                  <span className="font-medium text-foreground">
+                    {winner.peer_name}
+                  </span>{" "}
+                  is the closest thing to an overall winner across routers:{" "}
+                  {winnerReason}
+                </>
+              ) : (
+                winnerReason
+              )}
+            </span>
+          </p>
+        </div>
+
+        {/* Prefix context */}
+        <SectionCard title="Prefix context">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <StatRow
+                label="Subnet"
+                value={
+                  ipam.subnet_id ? (
+                    <Link
+                      to={`/ipam?subnet=${ipam.subnet_id}`}
+                      className="text-primary hover:underline"
+                    >
+                      {ipam.subnet_name}
+                    </Link>
+                  ) : (
+                    "—"
+                  )
+                }
+              />
+              <StatRow label="Block" value={ipam.block_name ?? "—"} />
+              <StatRow label="Space" value={ipam.space_name ?? "—"} />
+            </div>
+            <div className="space-y-1.5">
+              <StatRow
+                label="ASN"
+                value={
+                  ipam.asn_id ? (
+                    <Link
+                      to={`/network/asns/${ipam.asn_id}`}
+                      className="text-primary hover:underline"
+                    >
+                      AS{ipam.asn_number} · {ipam.asn_name}
+                    </Link>
+                  ) : (
+                    "—"
+                  )
+                }
+              />
+              <StatRow label="VRF" value={ipam.vrf_name ?? "—"} />
+            </div>
+          </div>
+          <p className="border-t pt-1.5 text-muted-foreground">
+            {RPKI_NOTE[rpki]}
+          </p>
+        </SectionCard>
+
+        {/* Footer */}
+        <div className="flex flex-wrap justify-between gap-2 border-t pt-3">
+          <div className="flex flex-wrap gap-2">
+            <AskAIButton
+              context={[
+                `BGP prefix ${d.prefix}`,
+                `${summary.path_count} paths from ${summary.peer_count} routers`,
+                `origin ASN${summary.distinct_origin_asns.length === 1 ? "" : "s"}: ${originLabels.join(", ")}`,
+                summary.multi_origin
+                  ? "multiple distinct origin ASNs (possible hijack/leak)"
+                  : null,
+                ipam.subnet_name
+                  ? `covering subnet: ${ipam.subnet_name}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(". ")}
+              prompt={`Is the BGP prefix ${d.prefix} being announced normally, or does this look like a route leak / hijack?`}
+              tooltip="Ask AI about this prefix"
+            />
+            {ipam.subnet_id && (
+              <HeaderButton
+                onClick={() => {
+                  window.location.href = `/ipam?subnet=${ipam.subnet_id}`;
+                }}
+              >
+                View in IPAM
+              </HeaderButton>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <HeaderButton icon={Copy} onClick={copyPrefix}>
+              {copied ? "Copied!" : "Copy prefix"}
+            </HeaderButton>
+            <HeaderButton variant="primary" onClick={onClose}>
+              Close
+            </HeaderButton>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/network/looking-glass/RoutesTab.tsx
+++ b/frontend/src/pages/network/looking-glass/RoutesTab.tsx
@@ -1,0 +1,491 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { Check } from "lucide-react";
+
+import {
+  asnsApi,
+  lookingGlassApi,
+  type BGPLGRoute,
+  type BGPLGRouteQuery,
+  type BGPLGRpkiStatus,
+} from "@/lib/api";
+import { cn, zebraBodyCls } from "@/lib/utils";
+import { Field, errMsg, inputCls } from "../_shared";
+
+const SEARCH_PAGE_SIZE = 100;
+
+const RPKI_COLOR: Record<BGPLGRpkiStatus, string> = {
+  invalid: "bg-rose-500/15 text-rose-700 dark:text-rose-400",
+  unknown: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  valid: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+};
+
+function Pill({ text, cls }: { text: string; cls: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+        cls,
+      )}
+    >
+      {text}
+    </span>
+  );
+}
+
+type RouteSortKey = "prefix" | "origin_asn" | "local_pref" | "med";
+type RouteSortState = { key: RouteSortKey; dir: "asc" | "desc" };
+
+// Cycle a sort spec asc → desc → cleared for a clicked column, mirroring
+// the IPAM address table's ``cycleSort`` (issue #519). Client-side only —
+// applied over whatever page is currently loaded, since the server always
+// orders by (prefix, peer_id).
+function cycleRouteSort(
+  prev: RouteSortState | null,
+  key: RouteSortKey,
+): RouteSortState | null {
+  if (!prev || prev.key !== key) return { key, dir: "asc" };
+  if (prev.dir === "asc") return { key, dir: "desc" };
+  return null;
+}
+
+function compareRoutes(
+  a: BGPLGRoute,
+  b: BGPLGRoute,
+  key: RouteSortKey,
+): number {
+  switch (key) {
+    case "prefix":
+      return a.prefix.localeCompare(b.prefix);
+    case "origin_asn":
+      return (a.origin_asn ?? -1) - (b.origin_asn ?? -1);
+    case "local_pref":
+      return (a.local_pref ?? -1) - (b.local_pref ?? -1);
+    case "med":
+      return (a.med ?? -1) - (b.med ?? -1);
+    default:
+      return 0;
+  }
+}
+
+function RouteSortLabel({
+  label,
+  sortKey,
+  state,
+  onSort,
+}: {
+  label: string;
+  sortKey: RouteSortKey;
+  state: RouteSortState | null;
+  onSort: (key: RouteSortKey) => void;
+}) {
+  const active = state?.key === sortKey;
+  const sortedDesc = active
+    ? `sorted ${state?.dir === "asc" ? "ascending" : "descending"}`
+    : "not sorted";
+  const nextDesc = !active
+    ? "sort ascending"
+    : state?.dir === "asc"
+      ? "sort descending"
+      : "clear the sort";
+  const a11yLabel = `${label} — ${sortedDesc}. Activate to ${nextDesc}.`;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(sortKey)}
+      title={a11yLabel}
+      aria-label={a11yLabel}
+      className={cn(
+        "inline-flex items-center gap-1 hover:text-foreground",
+        active && "text-primary",
+      )}
+    >
+      <span>{label}</span>
+      <span className="text-[9px] leading-none">
+        {active ? (state?.dir === "asc" ? "▲" : "▼") : "⇅"}
+      </span>
+    </button>
+  );
+}
+
+function toOptionalInt(s: string): number | undefined {
+  if (!s.trim()) return undefined;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+type AppliedFilters = {
+  prefix: string;
+  originAsn: string;
+  community: string;
+  rpki: BGPLGRpkiStatus | "";
+  peerId: string;
+  bestPathOnly: boolean;
+  withdrawn: boolean;
+};
+
+const EMPTY_FILTERS: AppliedFilters = {
+  prefix: "",
+  originAsn: "",
+  community: "",
+  rpki: "",
+  peerId: "",
+  bestPathOnly: false,
+  withdrawn: false,
+};
+
+export function RoutesTab() {
+  const [prefixDraft, setPrefixDraft] = useState("");
+  const [originAsnDraft, setOriginAsnDraft] = useState("");
+  const [communityDraft, setCommunityDraft] = useState("");
+  const [rpkiDraft, setRpkiDraft] = useState<BGPLGRpkiStatus | "">("");
+  const [peerIdDraft, setPeerIdDraft] = useState("");
+  const [bestPathOnlyDraft, setBestPathOnlyDraft] = useState(false);
+  const [withdrawnDraft, setWithdrawnDraft] = useState(false);
+
+  const [applied, setApplied] = useState<AppliedFilters>(EMPTY_FILTERS);
+  const [offset, setOffset] = useState(0);
+  const [sort, setSort] = useState<RouteSortState | null>(null);
+
+  function runSearch() {
+    setOffset(0);
+    setApplied({
+      prefix: prefixDraft.trim(),
+      originAsn: originAsnDraft.trim(),
+      community: communityDraft.trim(),
+      rpki: rpkiDraft,
+      peerId: peerIdDraft,
+      bestPathOnly: bestPathOnlyDraft,
+      withdrawn: withdrawnDraft,
+    });
+  }
+
+  function onFilterKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") runSearch();
+  }
+
+  const peersQ = useQuery({
+    queryKey: ["bgp-lg-peers"],
+    queryFn: () => lookingGlassApi.listPeers(),
+    staleTime: 30_000,
+  });
+  const peers = peersQ.data ?? [];
+
+  // One shared cached query for the well-known community catalog — avoids
+  // an N+1 per-row lookup (mirrors the CustomerChip precedent).
+  const communitiesQ = useQuery({
+    queryKey: ["bgp-communities-standard"],
+    queryFn: () => asnsApi.listStandardCommunities(),
+    staleTime: 5 * 60_000,
+  });
+  const communityNameByValue = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const c of communitiesQ.data ?? []) map.set(c.value, c.name);
+    return map;
+  }, [communitiesQ.data]);
+
+  const params: BGPLGRouteQuery = {
+    prefix: applied.prefix || undefined,
+    origin_asn: toOptionalInt(applied.originAsn),
+    community: applied.community || undefined,
+    rpki_status: applied.rpki || undefined,
+    peer_id: applied.peerId || undefined,
+    best_path_only: applied.bestPathOnly || undefined,
+    withdrawn: applied.withdrawn || undefined,
+    limit: SEARCH_PAGE_SIZE,
+    offset,
+  };
+
+  const { data, isFetching, error } = useQuery({
+    queryKey: [
+      "bgp-lg-routes",
+      applied.prefix,
+      applied.originAsn,
+      applied.community,
+      applied.rpki,
+      applied.peerId,
+      applied.bestPathOnly,
+      applied.withdrawn,
+      offset,
+    ],
+    queryFn: () => lookingGlassApi.searchRoutes(params),
+    placeholderData: (prev) => prev,
+  });
+
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  const sortedItems = useMemo(() => {
+    if (!sort) return items;
+    const dir = sort.dir === "asc" ? 1 : -1;
+    return [...items].sort((a, b) => compareRoutes(a, b, sort.key) * dir);
+  }, [items, sort]);
+
+  const pageStart = total === 0 ? 0 : offset + 1;
+  const pageEnd = Math.min(offset + SEARCH_PAGE_SIZE, total);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-3 rounded-md border bg-card p-3">
+        <Field label="Prefix">
+          <input
+            className={cn(inputCls, "w-40")}
+            value={prefixDraft}
+            onChange={(e) => setPrefixDraft(e.target.value)}
+            onKeyDown={onFilterKeyDown}
+            placeholder="10.0.0.0/8"
+          />
+        </Field>
+        <Field label="Origin ASN">
+          <input
+            className={cn(inputCls, "w-28")}
+            value={originAsnDraft}
+            onChange={(e) => setOriginAsnDraft(e.target.value)}
+            onKeyDown={onFilterKeyDown}
+            placeholder="65001"
+          />
+        </Field>
+        <Field label="Community">
+          <input
+            className={cn(inputCls, "w-32")}
+            value={communityDraft}
+            onChange={(e) => setCommunityDraft(e.target.value)}
+            onKeyDown={onFilterKeyDown}
+            placeholder="65535:666"
+          />
+        </Field>
+        <Field label="RPKI">
+          <select
+            className={inputCls}
+            value={rpkiDraft}
+            onChange={(e) =>
+              setRpkiDraft(e.target.value as BGPLGRpkiStatus | "")
+            }
+          >
+            <option value="">Any</option>
+            <option value="valid">Valid</option>
+            <option value="invalid">Invalid</option>
+            <option value="unknown">Unknown</option>
+          </select>
+        </Field>
+        <Field label="Peer">
+          <select
+            className={inputCls}
+            value={peerIdDraft}
+            onChange={(e) => setPeerIdDraft(e.target.value)}
+          >
+            <option value="">Any</option>
+            {peers.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <label className="flex items-center gap-1.5 pb-1.5 text-sm">
+          <input
+            type="checkbox"
+            checked={bestPathOnlyDraft}
+            onChange={(e) => setBestPathOnlyDraft(e.target.checked)}
+          />
+          Best path only
+        </label>
+        <label className="flex items-center gap-1.5 pb-1.5 text-sm">
+          <input
+            type="checkbox"
+            checked={withdrawnDraft}
+            onChange={(e) => setWithdrawnDraft(e.target.checked)}
+          />
+          Show withdrawn
+        </label>
+        <button
+          type="button"
+          onClick={runSearch}
+          className="mb-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
+        >
+          Search
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-destructive">
+          {errMsg(error, "Failed to load routes.")}
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span>
+          {isFetching ? (
+            "Loading…"
+          ) : (
+            <>
+              Showing {pageStart.toLocaleString()}–{pageEnd.toLocaleString()} of{" "}
+              {total.toLocaleString()} route{total === 1 ? "" : "s"}
+            </>
+          )}
+        </span>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border">
+        {items.length === 0 && !isFetching ? (
+          <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+            No routes match. Once a peer session reaches Established, its
+            learned routes appear here.
+          </p>
+        ) : (
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b bg-muted/30 text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+                <th className="px-3 py-2">
+                  <RouteSortLabel
+                    label="Prefix"
+                    sortKey="prefix"
+                    state={sort}
+                    onSort={(k) => setSort((p) => cycleRouteSort(p, k))}
+                  />
+                </th>
+                <th className="px-3 py-2">
+                  <RouteSortLabel
+                    label="Origin ASN"
+                    sortKey="origin_asn"
+                    state={sort}
+                    onSort={(k) => setSort((p) => cycleRouteSort(p, k))}
+                  />
+                </th>
+                <th className="px-3 py-2">AS path</th>
+                <th className="px-3 py-2">Next hop</th>
+                <th className="px-3 py-2">
+                  <RouteSortLabel
+                    label="Local pref"
+                    sortKey="local_pref"
+                    state={sort}
+                    onSort={(k) => setSort((p) => cycleRouteSort(p, k))}
+                  />
+                </th>
+                <th className="px-3 py-2">
+                  <RouteSortLabel
+                    label="MED"
+                    sortKey="med"
+                    state={sort}
+                    onSort={(k) => setSort((p) => cycleRouteSort(p, k))}
+                  />
+                </th>
+                <th className="px-3 py-2">Communities</th>
+                <th className="px-3 py-2">RPKI</th>
+                <th className="px-3 py-2">Best</th>
+              </tr>
+            </thead>
+            <tbody className={zebraBodyCls}>
+              {sortedItems.map((r) => {
+                const allCommunities = [
+                  ...r.communities,
+                  ...r.large_communities,
+                ];
+                return (
+                  <tr
+                    key={r.id}
+                    className={cn(
+                      "border-b last:border-0 hover:bg-muted/20",
+                      r.withdrawn_at && "opacity-50",
+                    )}
+                  >
+                    <td className="px-3 py-2 align-top font-mono">
+                      {r.prefix}
+                    </td>
+                    <td className="px-3 py-2 align-top font-mono">
+                      {r.origin_asn == null ? (
+                        "—"
+                      ) : r.matched_asn_id ? (
+                        <Link
+                          to={`/network/asns/${r.matched_asn_id}`}
+                          className="hover:text-primary hover:underline"
+                        >
+                          AS{r.origin_asn}
+                        </Link>
+                      ) : (
+                        `AS${r.origin_asn}`
+                      )}
+                    </td>
+                    <td className="px-3 py-2 align-top break-all font-mono text-muted-foreground">
+                      {r.as_path.length ? r.as_path.join(" ") : "—"}
+                    </td>
+                    <td className="px-3 py-2 align-top break-all font-mono text-muted-foreground">
+                      {r.next_hop}
+                    </td>
+                    <td className="px-3 py-2 align-top tabular-nums">
+                      {r.local_pref ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 align-top tabular-nums">
+                      {r.med ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 align-top break-all font-mono text-muted-foreground">
+                      {allCommunities.length === 0 ? (
+                        "—"
+                      ) : (
+                        <div className="flex flex-wrap gap-1">
+                          {allCommunities.map((cVal, idx) => (
+                            <span
+                              key={`${cVal}-${idx}`}
+                              title={communityNameByValue.get(cVal)}
+                              className="rounded bg-muted px-1 py-0.5"
+                            >
+                              {cVal}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <Pill
+                        text={r.rpki_status}
+                        cls={RPKI_COLOR[r.rpki_status]}
+                      />
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      {r.is_best ? (
+                        <Check className="h-3.5 w-3.5 text-emerald-500" />
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                      {r.withdrawn_at && (
+                        <span className="ml-1 text-[10px] text-muted-foreground">
+                          withdrawn
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {total > SEARCH_PAGE_SIZE && (
+        <div className="flex items-center justify-between text-xs">
+          <button
+            type="button"
+            disabled={offset === 0 || isFetching}
+            onClick={() => setOffset((o) => Math.max(0, o - SEARCH_PAGE_SIZE))}
+            className="rounded border px-2 py-1 hover:bg-muted disabled:opacity-40"
+          >
+            ← Prev
+          </button>
+          <span className="text-muted-foreground">
+            Page {Math.floor(offset / SEARCH_PAGE_SIZE) + 1} of{" "}
+            {Math.ceil(total / SEARCH_PAGE_SIZE)}
+          </span>
+          <button
+            type="button"
+            disabled={pageEnd >= total || isFetching}
+            onClick={() => setOffset((o) => o + SEARCH_PAGE_SIZE)}
+            className="rounded border px-2 py-1 hover:bg-muted disabled:opacity-40"
+          >
+            Next →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/network/looking-glass/RoutesTab.tsx
+++ b/frontend/src/pages/network/looking-glass/RoutesTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { Check } from "lucide-react";
@@ -135,18 +135,40 @@ const EMPTY_FILTERS: AppliedFilters = {
   withdrawn: false,
 };
 
-export function RoutesTab() {
+export function RoutesTab({
+  initialPeerId,
+}: {
+  /** Pre-select the Peer filter — set when the tab is reached via the
+   *  Sessions-tab peer detail modal's "View all routes" deep link
+   *  (``?tab=routes&peer=<id>``). */
+  initialPeerId?: string;
+}) {
   const [prefixDraft, setPrefixDraft] = useState("");
   const [originAsnDraft, setOriginAsnDraft] = useState("");
   const [communityDraft, setCommunityDraft] = useState("");
   const [rpkiDraft, setRpkiDraft] = useState<BGPLGRpkiStatus | "">("");
-  const [peerIdDraft, setPeerIdDraft] = useState("");
+  const [peerIdDraft, setPeerIdDraft] = useState(initialPeerId ?? "");
   const [bestPathOnlyDraft, setBestPathOnlyDraft] = useState(false);
   const [withdrawnDraft, setWithdrawnDraft] = useState(false);
 
-  const [applied, setApplied] = useState<AppliedFilters>(EMPTY_FILTERS);
+  const [applied, setApplied] = useState<AppliedFilters>({
+    ...EMPTY_FILTERS,
+    peerId: initialPeerId ?? "",
+  });
   const [offset, setOffset] = useState(0);
   const [sort, setSort] = useState<RouteSortState | null>(null);
+
+  // The tab is remounted fresh on every navigation into it (see
+  // LookingGlassPage's conditional render), so a plain useState
+  // initializer normally suffices — but guard with an effect too in
+  // case a future caller keeps the tab mounted across peer changes.
+  useEffect(() => {
+    if (!initialPeerId) return;
+    setPeerIdDraft(initialPeerId);
+    setApplied((prev) => ({ ...prev, peerId: initialPeerId }));
+    setOffset(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialPeerId]);
 
   function runSearch() {
     setOffset(0);

--- a/frontend/src/pages/network/looking-glass/RoutesTab.tsx
+++ b/frontend/src/pages/network/looking-glass/RoutesTab.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/api";
 import { cn, zebraBodyCls } from "@/lib/utils";
 import { Field, errMsg, inputCls } from "../_shared";
+import { RouteDetailModal } from "./RouteDetailModal";
 
 const SEARCH_PAGE_SIZE = 100;
 
@@ -157,6 +158,7 @@ export function RoutesTab({
   });
   const [offset, setOffset] = useState(0);
   const [sort, setSort] = useState<RouteSortState | null>(null);
+  const [viewingPrefix, setViewingPrefix] = useState<string | null>(null);
 
   // The tab is remounted fresh on every navigation into it (see
   // LookingGlassPage's conditional render), so a plain useState
@@ -408,14 +410,18 @@ export function RoutesTab({
                   <tr
                     key={r.id}
                     className={cn(
-                      "border-b last:border-0 hover:bg-muted/20",
+                      "cursor-pointer border-b last:border-0 hover:bg-muted/20",
                       r.withdrawn_at && "opacity-50",
                     )}
+                    onClick={() => setViewingPrefix(r.prefix)}
                   >
                     <td className="px-3 py-2 align-top font-mono">
                       {r.prefix}
                     </td>
-                    <td className="px-3 py-2 align-top font-mono">
+                    <td
+                      className="px-3 py-2 align-top font-mono"
+                      onClick={(e) => r.matched_asn_id && e.stopPropagation()}
+                    >
                       {r.origin_asn == null ? (
                         "—"
                       ) : r.matched_asn_id ? (
@@ -507,6 +513,13 @@ export function RoutesTab({
             Next →
           </button>
         </div>
+      )}
+
+      {viewingPrefix && (
+        <RouteDetailModal
+          prefix={viewingPrefix}
+          onClose={() => setViewingPrefix(null)}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/network/looking-glass/SessionsTab.tsx
+++ b/frontend/src/pages/network/looking-glass/SessionsTab.tsx
@@ -22,9 +22,13 @@ import { Modal } from "@/components/ui/modal";
 import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { HeaderButton } from "@/components/ui/header-button";
 import { Field, errMsg, humanDuration, humanTime, inputCls } from "../_shared";
+import { PeerDetailModal } from "./PeerDetailModal";
 
 // Established = green, the transitional FSM states = amber, Idle = rose.
-const STATE_COLOR: Partial<Record<BGPLGSessionState, string>> = {
+// Exported so PeerDetailModal's header chip reuses the exact same
+// mapping instead of a second copy that could drift.
+// eslint-disable-next-line react-refresh/only-export-components
+export const STATE_COLOR: Partial<Record<BGPLGSessionState, string>> = {
   established: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
   active: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
   connect: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
@@ -32,7 +36,7 @@ const STATE_COLOR: Partial<Record<BGPLGSessionState, string>> = {
   openconfirm: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
   idle: "bg-rose-500/15 text-rose-700 dark:text-rose-400",
 };
-const FALLBACK_STATE_COLOR =
+export const FALLBACK_STATE_COLOR =
   "bg-zinc-100 text-zinc-700 dark:bg-zinc-500/15 dark:text-zinc-300";
 
 function Pill({ text, cls }: { text: string; cls: string }) {
@@ -51,12 +55,17 @@ function Pill({ text, cls }: { text: string; cls: string }) {
 export function SessionsTab({
   collectors,
   onEdit,
+  onViewRoutes,
 }: {
   collectors: BGPLGCollector[];
   onEdit: (peer: BGPLGPeer) => void;
+  /** Deep-links into the Routes tab, pre-filtered to one peer — passed
+   *  through to the peer detail modal's "View all routes" link. */
+  onViewRoutes: (peerId: string) => void;
 }) {
   const qc = useQueryClient();
   const [deleteTarget, setDeleteTarget] = useState<BGPLGPeer | null>(null);
+  const [viewingPeerId, setViewingPeerId] = useState<string | null>(null);
 
   // Session-state rows are live telemetry — poll modestly so a flap shows up
   // without the operator hammering Refresh.
@@ -152,7 +161,8 @@ export function SessionsTab({
               return (
                 <tr
                   key={s.peer_id}
-                  className="border-b last:border-0 hover:bg-muted/20"
+                  className="cursor-pointer border-b last:border-0 hover:bg-muted/20"
+                  onClick={() => setViewingPeerId(s.peer_id)}
                 >
                   <td className="px-3 py-2 align-top">
                     <div className="font-medium">{s.peer_name}</div>
@@ -167,6 +177,7 @@ export function SessionsTab({
                     {peer?.matched_asn_id ? (
                       <Link
                         to={`/network/asns/${peer.matched_asn_id}`}
+                        onClick={(e) => e.stopPropagation()}
                         className="hover:text-primary hover:underline"
                       >
                         AS{s.peer_asn}
@@ -205,7 +216,10 @@ export function SessionsTab({
                       "0"
                     )}
                   </td>
-                  <td className="px-3 py-2 align-top text-right">
+                  <td
+                    className="px-3 py-2 align-top text-right"
+                    onClick={(e) => e.stopPropagation()}
+                  >
                     {peer && (
                       <div className="flex justify-end gap-1">
                         <button
@@ -248,6 +262,25 @@ export function SessionsTab({
         onClose={() => setDeleteTarget(null)}
         onConfirm={() => deleteTarget && deleteM.mutate(deleteTarget.id)}
       />
+
+      {viewingPeerId && (
+        <PeerDetailModal
+          peerId={viewingPeerId}
+          onClose={() => setViewingPeerId(null)}
+          onEdit={(peer) => {
+            setViewingPeerId(null);
+            onEdit(peer);
+          }}
+          onDelete={(peer) => {
+            setViewingPeerId(null);
+            setDeleteTarget(peer);
+          }}
+          onViewRoutes={(peerId) => {
+            setViewingPeerId(null);
+            onViewRoutes(peerId);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/network/looking-glass/SessionsTab.tsx
+++ b/frontend/src/pages/network/looking-glass/SessionsTab.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { Pencil, Trash2 } from "lucide-react";
 
 import {
+  applianceApprovalApi,
   asnsApi,
   lookingGlassApi,
   networkApi,
@@ -14,6 +15,7 @@ import {
   type BGPLGPeerCreate,
   type BGPLGPeerUpdate,
   type BGPLGSessionState,
+  type MetalLBBgpPeer,
 } from "@/lib/api";
 import { cn, zebraBodyCls } from "@/lib/utils";
 import { Modal } from "@/components/ui/modal";
@@ -328,6 +330,29 @@ export function PeerFormModal({
     staleTime: 60_000,
   });
 
+  // issue #566 decision D1 — MetalLB BGP mode ships its own "peer
+  // address + ASN" concept (the export path: advertise our VIP to a
+  // router); this is a pure UI convenience prefilling THIS form's
+  // fields from one, since the same physical router is plausibly both
+  // a MetalLB BGP-mode upstream and a Looking Glass (import) peer. Zero
+  // backend coupling — same React Query key as NetworkTab so it's
+  // already warm if the operator visited Network & Host first. Only on
+  // add (never on edit) and never overwrites `name` (MetalLB peers
+  // aren't named).
+  const metallbQ = useQuery({
+    queryKey: ["appliance", "metallb"],
+    queryFn: applianceApprovalApi.getMetalLBConfig,
+    staleTime: 30_000,
+    enabled: !isEdit,
+  });
+  const metallbBgpPeers = metallbQ.data?.bgp_peers ?? [];
+
+  function prefillFromMetalLB(p: MetalLBBgpPeer) {
+    setLocalAsn(String(p.my_asn));
+    setPeerAsn(String(p.peer_asn));
+    setPeerAddress(p.peer_address);
+  }
+
   function toggleFamily(af: BGPLGAddressFamily) {
     setFamilies((prev) =>
       prev.includes(af) ? prev.filter((f) => f !== af) : [...prev, af],
@@ -423,6 +448,22 @@ export function PeerFormModal({
         {err && (
           <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
             {err}
+          </div>
+        )}
+
+        {!isEdit && metallbBgpPeers.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span>Prefill from a configured MetalLB BGP peer:</span>
+            {metallbBgpPeers.map((p, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => prefillFromMetalLB(p)}
+                className="rounded-md border px-2 py-1 font-mono hover:bg-muted"
+              >
+                {p.peer_address} (AS{p.peer_asn})
+              </button>
+            ))}
           </div>
         )}
 

--- a/frontend/src/pages/network/looking-glass/SessionsTab.tsx
+++ b/frontend/src/pages/network/looking-glass/SessionsTab.tsx
@@ -1,0 +1,624 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { Pencil, Trash2 } from "lucide-react";
+
+import {
+  asnsApi,
+  lookingGlassApi,
+  networkApi,
+  type BGPLGAddressFamily,
+  type BGPLGCollector,
+  type BGPLGImportFilter,
+  type BGPLGPeer,
+  type BGPLGPeerCreate,
+  type BGPLGPeerUpdate,
+  type BGPLGSessionState,
+} from "@/lib/api";
+import { cn, zebraBodyCls } from "@/lib/utils";
+import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { HeaderButton } from "@/components/ui/header-button";
+import { Field, errMsg, humanDuration, humanTime, inputCls } from "../_shared";
+
+// Established = green, the transitional FSM states = amber, Idle = rose.
+const STATE_COLOR: Partial<Record<BGPLGSessionState, string>> = {
+  established: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+  active: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  connect: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  opensent: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  openconfirm: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  idle: "bg-rose-500/15 text-rose-700 dark:text-rose-400",
+};
+const FALLBACK_STATE_COLOR =
+  "bg-zinc-100 text-zinc-700 dark:bg-zinc-500/15 dark:text-zinc-300";
+
+function Pill({ text, cls }: { text: string; cls: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+        cls,
+      )}
+    >
+      {text}
+    </span>
+  );
+}
+
+export function SessionsTab({
+  collectors,
+  onEdit,
+}: {
+  collectors: BGPLGCollector[];
+  onEdit: (peer: BGPLGPeer) => void;
+}) {
+  const qc = useQueryClient();
+  const [deleteTarget, setDeleteTarget] = useState<BGPLGPeer | null>(null);
+
+  // Session-state rows are live telemetry — poll modestly so a flap shows up
+  // without the operator hammering Refresh.
+  const sessionsQ = useQuery({
+    queryKey: ["bgp-lg-sessions"],
+    queryFn: () => lookingGlassApi.listSessions(),
+    refetchInterval: 15_000,
+  });
+  // Peers carry the full config (matched_asn_id, collector, description, …)
+  // that SessionRead doesn't — needed for the ASN link + the edit/delete
+  // actions on each row.
+  const peersQ = useQuery({
+    queryKey: ["bgp-lg-peers"],
+    queryFn: () => lookingGlassApi.listPeers(),
+    refetchInterval: 15_000,
+  });
+
+  const peersById = useMemo(() => {
+    const map = new Map<string, BGPLGPeer>();
+    for (const p of peersQ.data ?? []) map.set(p.id, p);
+    return map;
+  }, [peersQ.data]);
+
+  const sessions = sessionsQ.data ?? [];
+
+  const deleteM = useMutation({
+    mutationFn: (id: string) => lookingGlassApi.deletePeer(id),
+    onSuccess: () => {
+      setDeleteTarget(null);
+      void qc.invalidateQueries({ queryKey: ["bgp-lg-sessions"] });
+      void qc.invalidateQueries({ queryKey: ["bgp-lg-peers"] });
+    },
+  });
+
+  if (sessionsQ.isLoading || peersQ.isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading sessions…</p>;
+  }
+  if (sessionsQ.isError) {
+    return (
+      <p className="text-sm text-destructive">
+        {errMsg(sessionsQ.error, "Failed to load BGP sessions.")}
+      </p>
+    );
+  }
+
+  if (collectors.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+        No BGP Looking Glass collector has registered yet. Install and start a
+        Looking Glass agent against this control plane, then come back here to
+        add a peer.
+      </div>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+        No peers configured yet — click "Add Peer" above to peer with a router.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b bg-muted/30 text-left text-[10px] uppercase tracking-wider text-muted-foreground">
+              <th className="px-3 py-2">Peer / router</th>
+              <th className="px-3 py-2">Remote ASN</th>
+              <th className="px-3 py-2">State</th>
+              <th className="px-3 py-2">Uptime</th>
+              <th className="px-3 py-2">Prefixes recv / accepted</th>
+              <th className="px-3 py-2">Last flap</th>
+              <th className="px-3 py-2">RPKI invalid</th>
+              <th className="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className={zebraBodyCls}>
+            {sessions.map((s) => {
+              const peer = peersById.get(s.peer_id);
+              const uptimeSeconds =
+                s.session_state === "established" && s.uptime_started_at
+                  ? Math.max(
+                      0,
+                      Math.floor(
+                        (Date.now() - new Date(s.uptime_started_at).getTime()) /
+                          1000,
+                      ),
+                    )
+                  : null;
+              return (
+                <tr
+                  key={s.peer_id}
+                  className="border-b last:border-0 hover:bg-muted/20"
+                >
+                  <td className="px-3 py-2 align-top">
+                    <div className="font-medium">{s.peer_name}</div>
+                    <div className="break-all font-mono text-[10px] text-muted-foreground">
+                      {s.peer_address}
+                    </div>
+                    <div className="text-[10px] text-muted-foreground/70">
+                      {s.collector_name}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2 align-top font-mono">
+                    {peer?.matched_asn_id ? (
+                      <Link
+                        to={`/network/asns/${peer.matched_asn_id}`}
+                        className="hover:text-primary hover:underline"
+                      >
+                        AS{s.peer_asn}
+                      </Link>
+                    ) : (
+                      `AS${s.peer_asn}`
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <Pill
+                      text={s.session_state}
+                      cls={STATE_COLOR[s.session_state] ?? FALLBACK_STATE_COLOR}
+                    />
+                    {!s.enabled && (
+                      <span className="ml-1 text-[10px] text-muted-foreground">
+                        (disabled)
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top text-muted-foreground">
+                    {uptimeSeconds != null ? humanDuration(uptimeSeconds) : "—"}
+                  </td>
+                  <td className="px-3 py-2 align-top tabular-nums">
+                    {s.prefixes_received.toLocaleString()} /{" "}
+                    {s.prefixes_accepted.toLocaleString()}
+                  </td>
+                  <td className="px-3 py-2 align-top text-muted-foreground">
+                    {humanTime(s.last_flap_at)}
+                  </td>
+                  <td className="px-3 py-2 align-top tabular-nums">
+                    {s.rpki_invalid_count > 0 ? (
+                      <span className="font-medium text-rose-600 dark:text-rose-400">
+                        {s.rpki_invalid_count}
+                      </span>
+                    ) : (
+                      "0"
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top text-right">
+                    {peer && (
+                      <div className="flex justify-end gap-1">
+                        <button
+                          type="button"
+                          title="Edit peer"
+                          className="rounded p-1 hover:bg-muted"
+                          onClick={() => onEdit(peer)}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          title="Delete peer"
+                          className="rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                          onClick={() => setDeleteTarget(peer)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <ConfirmModal
+        open={!!deleteTarget}
+        title="Delete peer"
+        message={
+          deleteTarget
+            ? `Delete the BGP session to "${deleteTarget.name}" (AS${deleteTarget.peer_asn} at ${deleteTarget.peer_address})? Its learned routes are removed too. This only tears down the receive-only session on the collector — it does not affect the router on the other end.`
+            : ""
+        }
+        confirmLabel="Delete"
+        tone="destructive"
+        loading={deleteM.isPending}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={() => deleteTarget && deleteM.mutate(deleteTarget.id)}
+      />
+    </div>
+  );
+}
+
+// ── Add / Edit peer modal ──────────────────────────────────────────────
+
+const AF_OPTIONS: { value: BGPLGAddressFamily; label: string }[] = [
+  { value: "ipv4-unicast", label: "IPv4 unicast" },
+  { value: "ipv6-unicast", label: "IPv6 unicast" },
+];
+
+export function PeerFormModal({
+  existing,
+  collectors,
+  onClose,
+}: {
+  existing: BGPLGPeer | null;
+  collectors: BGPLGCollector[];
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const isEdit = !!existing;
+
+  const [name, setName] = useState(existing?.name ?? "");
+  const [collectorId, setCollectorId] = useState(
+    existing?.collector_id ?? collectors[0]?.id ?? "",
+  );
+  const [localAsn, setLocalAsn] = useState(String(existing?.local_asn ?? ""));
+  const [peerAsn, setPeerAsn] = useState(String(existing?.peer_asn ?? ""));
+  const [peerAddress, setPeerAddress] = useState(existing?.peer_address ?? "");
+  const [families, setFamilies] = useState<BGPLGAddressFamily[]>(
+    existing?.address_families ?? ["ipv4-unicast"],
+  );
+  const [md5Password, setMd5Password] = useState("");
+  const [clearMd5, setClearMd5] = useState(false);
+  const [maxPrefixes, setMaxPrefixes] = useState(
+    String(existing?.max_prefixes ?? 10000),
+  );
+  const [filterMode, setFilterMode] = useState<"accept_all" | "scope">(
+    existing?.import_filter.mode ?? "accept_all",
+  );
+  const [filterPrefixesText, setFilterPrefixesText] = useState(
+    (existing?.import_filter.prefixes ?? []).join("\n"),
+  );
+  const [matchedAsnId, setMatchedAsnId] = useState(
+    existing?.matched_asn_id ?? "",
+  );
+  const [peerRouterId, setPeerRouterId] = useState(
+    existing?.peer_router_id ?? "",
+  );
+  const [enabled, setEnabled] = useState(existing?.enabled ?? true);
+  const [description, setDescription] = useState(existing?.description ?? "");
+  const [err, setErr] = useState<string | null>(null);
+
+  // The collector list can still be loading the first time the modal opens
+  // (the header's Add-Peer button only disables once we know for sure it's
+  // empty) — default to the first one once it lands, if nothing is picked.
+  useEffect(() => {
+    if (!collectorId && collectors.length > 0) {
+      setCollectorId(collectors[0].id);
+    }
+  }, [collectors, collectorId]);
+
+  const asnsQ = useQuery({
+    queryKey: ["asns-picker"],
+    queryFn: () => asnsApi.list({ limit: 500 }),
+    staleTime: 60_000,
+  });
+  const devicesQ = useQuery({
+    queryKey: ["network-devices-picker"],
+    queryFn: () => networkApi.listDevices({ page_size: 500 }),
+    staleTime: 60_000,
+  });
+
+  function toggleFamily(af: BGPLGAddressFamily) {
+    setFamilies((prev) =>
+      prev.includes(af) ? prev.filter((f) => f !== af) : [...prev, af],
+    );
+  }
+
+  function buildImportFilter(): BGPLGImportFilter {
+    if (filterMode === "accept_all") return { mode: "accept_all" };
+    const prefixes = filterPrefixesText
+      .split(/[\n,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return { mode: "scope", prefixes };
+  }
+
+  const createM = useMutation({
+    mutationFn: (body: BGPLGPeerCreate) => lookingGlassApi.createPeer(body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["bgp-lg-sessions"] });
+      void qc.invalidateQueries({ queryKey: ["bgp-lg-peers"] });
+      onClose();
+    },
+    onError: (e) => setErr(errMsg(e, "Failed to create peer.")),
+  });
+
+  const updateM = useMutation({
+    mutationFn: (body: BGPLGPeerUpdate) =>
+      lookingGlassApi.updatePeer(existing!.id, body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["bgp-lg-sessions"] });
+      void qc.invalidateQueries({ queryKey: ["bgp-lg-peers"] });
+      onClose();
+    },
+    onError: (e) => setErr(errMsg(e, "Failed to update peer.")),
+  });
+
+  const pending = createM.isPending || updateM.isPending;
+
+  function handleSubmit() {
+    setErr(null);
+    const localAsnNum = Number(localAsn);
+    const peerAsnNum = Number(peerAsn);
+    if (!name.trim() || !collectorId || !peerAddress.trim()) {
+      setErr("Name, collector, and peer address are required.");
+      return;
+    }
+    if (!Number.isFinite(localAsnNum) || !Number.isFinite(peerAsnNum)) {
+      setErr("Local ASN and peer ASN must be numbers.");
+      return;
+    }
+
+    const shared = {
+      name: name.trim(),
+      collector_id: collectorId,
+      local_asn: localAsnNum,
+      peer_asn: peerAsnNum,
+      peer_address: peerAddress.trim(),
+      matched_asn_id: matchedAsnId || null,
+      peer_router_id: peerRouterId || null,
+      address_families: families,
+      max_prefixes: Number(maxPrefixes) || 10000,
+      import_filter: buildImportFilter(),
+      enabled,
+      description,
+    };
+
+    if (isEdit) {
+      // "" explicitly clears the stored password; omitting (undefined)
+      // leaves it untouched; a typed value rotates it.
+      const md5_password = clearMd5 ? "" : md5Password || undefined;
+      updateM.mutate({ ...shared, md5_password });
+    } else {
+      createM.mutate({ ...shared, md5_password: md5Password || undefined });
+    }
+  }
+
+  return (
+    <Modal
+      title={isEdit ? `Edit peer — ${existing!.name}` : "Add BGP peer"}
+      onClose={onClose}
+      wide
+    >
+      <div className="space-y-4">
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs font-medium text-amber-800 dark:text-amber-300">
+          Receive-only session — SpatiumDDI never advertises routes to your
+          network from this session. Every peer is configured as a pure sink:
+          import-only, no export policy, no next-hop-self, no redistribution.
+        </div>
+
+        {err && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            {err}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label="Name">
+            <input
+              className={inputCls}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="core-rtr1"
+            />
+          </Field>
+          <Field label="Collector">
+            <select
+              className={inputCls}
+              value={collectorId}
+              onChange={(e) => setCollectorId(e.target.value)}
+            >
+              <option value="" disabled>
+                Select a collector…
+              </option>
+              {collectors.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name} ({c.status})
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Local ASN">
+            <input
+              className={inputCls}
+              type="number"
+              value={localAsn}
+              onChange={(e) => setLocalAsn(e.target.value)}
+              placeholder="65000"
+            />
+          </Field>
+          <Field label="Peer ASN">
+            <input
+              className={inputCls}
+              type="number"
+              value={peerAsn}
+              onChange={(e) => setPeerAsn(e.target.value)}
+              placeholder="65001"
+            />
+          </Field>
+          <Field
+            label="Peer address"
+            hint="Bare IP — the router's BGP source address"
+          >
+            <input
+              className={inputCls}
+              value={peerAddress}
+              onChange={(e) => setPeerAddress(e.target.value)}
+              placeholder="203.0.113.1"
+            />
+          </Field>
+          <Field
+            label="Max prefixes"
+            hint="Hard safety cap rendered into the collector's prefix-limit"
+          >
+            <input
+              className={inputCls}
+              type="number"
+              min={1}
+              value={maxPrefixes}
+              onChange={(e) => setMaxPrefixes(e.target.value)}
+            />
+          </Field>
+        </div>
+
+        <Field label="Address families">
+          <div className="flex gap-4">
+            {AF_OPTIONS.map((af) => (
+              <label
+                key={af.value}
+                className="flex items-center gap-1.5 text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={families.includes(af.value)}
+                  onChange={() => toggleFamily(af.value)}
+                />
+                {af.label}
+              </label>
+            ))}
+          </div>
+        </Field>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field
+            label="Matched ASN (optional)"
+            hint="Links the remote ASN column to the tracked ASN catalog"
+          >
+            <select
+              className={inputCls}
+              value={matchedAsnId}
+              onChange={(e) => setMatchedAsnId(e.target.value)}
+            >
+              <option value="">None</option>
+              {(asnsQ.data?.items ?? []).map((a) => (
+                <option key={a.id} value={a.id}>
+                  AS{a.number} — {a.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Peer router device (optional)">
+            <select
+              className={inputCls}
+              value={peerRouterId}
+              onChange={(e) => setPeerRouterId(e.target.value)}
+            >
+              <option value="">None</option>
+              {(devicesQ.data?.items ?? []).map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.name} ({d.ip_address})
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <Field
+          label={
+            isEdit
+              ? `TCP-MD5 password${existing?.md5_password_set ? " (currently set)" : ""}`
+              : "TCP-MD5 password (optional)"
+          }
+        >
+          <input
+            className={inputCls}
+            type="password"
+            autoComplete="new-password"
+            value={md5Password}
+            onChange={(e) => setMd5Password(e.target.value)}
+            placeholder={
+              isEdit && existing?.md5_password_set
+                ? "•••••• (unchanged)"
+                : undefined
+            }
+            disabled={clearMd5}
+          />
+          {isEdit && existing?.md5_password_set && (
+            <label className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={clearMd5}
+                onChange={(e) => {
+                  setClearMd5(e.target.checked);
+                  if (e.target.checked) setMd5Password("");
+                }}
+              />
+              Clear stored password
+            </label>
+          )}
+        </Field>
+
+        <Field label="Import filter">
+          <select
+            className={inputCls}
+            value={filterMode}
+            onChange={(e) =>
+              setFilterMode(e.target.value as "accept_all" | "scope")
+            }
+          >
+            <option value="accept_all">Accept all routes</option>
+            <option value="scope">Scope to specific prefixes</option>
+          </select>
+          {filterMode === "scope" && (
+            <textarea
+              className={cn(inputCls, "mt-2 h-20 font-mono text-xs")}
+              value={filterPrefixesText}
+              onChange={(e) => setFilterPrefixesText(e.target.value)}
+              placeholder={"192.0.2.0/24\n198.51.100.0/24"}
+            />
+          )}
+        </Field>
+
+        <Field label="Description">
+          <textarea
+            className={cn(inputCls, "h-16")}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </Field>
+
+        <label className="flex items-center gap-1.5 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />
+          Enabled
+        </label>
+
+        <div className="flex justify-end gap-2 border-t pt-3">
+          <HeaderButton onClick={onClose}>Cancel</HeaderButton>
+          <HeaderButton
+            variant="primary"
+            onClick={handleSubmit}
+            disabled={pending}
+          >
+            {pending ? "Saving…" : isEdit ? "Save changes" : "Add peer"}
+          </HeaderButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/network/looking-glass/SessionsTab.tsx
+++ b/frontend/src/pages/network/looking-glass/SessionsTab.tsx
@@ -380,7 +380,10 @@ export function PeerFormModal({
       matched_asn_id: matchedAsnId || null,
       peer_router_id: peerRouterId || null,
       address_families: families,
-      max_prefixes: Number(maxPrefixes) || 10000,
+      // Only default an EMPTY field to 10000. An explicit 0 / invalid value
+      // must reach the backend (which rejects max_prefixes < 1 with 422)
+      // rather than being silently coerced up to the default cap.
+      max_prefixes: maxPrefixes.trim() === "" ? 10000 : Number(maxPrefixes),
       import_filter: buildImportFilter(),
       enabled,
       description,

--- a/frontend/src/pages/network/looking-glass/SessionsTab.tsx
+++ b/frontend/src/pages/network/looking-glass/SessionsTab.tsx
@@ -255,7 +255,15 @@ export function SessionsTab({
 const AF_OPTIONS: { value: BGPLGAddressFamily; label: string }[] = [
   { value: "ipv4-unicast", label: "IPv4 unicast" },
   { value: "ipv6-unicast", label: "IPv6 unicast" },
+  { value: "vpnv4", label: "VPNv4" },
+  { value: "vpnv6", label: "VPNv6" },
 ];
+
+// vpnv4/vpnv6 (issue #566 Phase 6, MP-BGP / RFC 4364) haven't been
+// exercised against a live gobgpd VPNv4/VPNv6 session the way plain
+// ipv4/ipv6-unicast peering has — flag them as advanced/unverified so an
+// operator enabling one for the first time knows what to expect.
+const VPN_FAMILIES: BGPLGAddressFamily[] = ["vpnv4", "vpnv6"];
 
 export function PeerFormModal({
   existing,
@@ -487,7 +495,7 @@ export function PeerFormModal({
         </div>
 
         <Field label="Address families">
-          <div className="flex gap-4">
+          <div className="flex flex-wrap gap-4">
             {AF_OPTIONS.map((af) => (
               <label
                 key={af.value}
@@ -502,6 +510,14 @@ export function PeerFormModal({
               </label>
             ))}
           </div>
+          {families.some((f) => VPN_FAMILIES.includes(f)) && (
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              Advanced — VPNv4/VPNv6 (MP-BGP L3VPN) support is new and hasn't
+              been verified against a live VPNv4/VPNv6 session yet. Route
+              Distinguisher + Route-Target cross-check against VRFs is on the
+              Routes tab of each matched VRF once routes start flowing.
+            </p>
+          )}
         </Field>
 
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/frontend/src/pages/tools/NetworkToolsPage.tsx
+++ b/frontend/src/pages/tools/NetworkToolsPage.tsx
@@ -429,7 +429,7 @@ function CommandOutput({ res }: { res: NetToolCommandResult }) {
 
 // ── ping / traceroute / mtr ───────────────────────────────────────────
 
-function CommandTool({
+export function CommandTool({
   kind,
   target,
 }: {
@@ -441,7 +441,10 @@ function CommandTool({
   const [err, setErr] = useState<string | null>(null);
   const [res, setRes] = useState<NetToolCommandResult | null>(null);
 
-  const ranRemote = target?.kind === "appliance";
+  // Generalised beyond "appliance" so a bgp_lg_collector vantage (#566
+  // Phase 4 — ping/traceroute from a Looking Glass collector) also gets
+  // the friendly remote-error copy in ``toolError`` below.
+  const ranRemote = !!target && target.kind !== "server";
 
   const run = async () => {
     if (!host.trim()) {

--- a/frontend/src/pages/vrfs/VRFDetailPage.tsx
+++ b/frontend/src/pages/vrfs/VRFDetailPage.tsx
@@ -2,12 +2,20 @@ import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, Loader2, Pencil, Route as RouteIcon } from "lucide-react";
-import { asnsApi, ipamApi, vrfsApi } from "@/lib/api";
+import {
+  asnsApi,
+  ipamApi,
+  lookingGlassApi,
+  vrfsApi,
+  type VRF,
+} from "@/lib/api";
 import { HeaderButton } from "@/components/ui/header-button";
 import { ServicesUsingButton } from "@/components/ServicesUsingButton";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
+import { BgpRouteMiniTable } from "@/components/network/bgp-route-table";
 import { VRFEditorModal } from "./VRFsPage";
 
-type Tab = "spaces" | "blocks";
+type Tab = "spaces" | "blocks" | "routes";
 
 function Card({
   title,
@@ -38,6 +46,49 @@ function RtChips({ values }: { values: string[] }) {
           {v}
         </span>
       ))}
+    </div>
+  );
+}
+
+// Issue #566 Phase 3 — "matched_vrf_id" means "the VRF assigned to
+// whichever IPAM block/space this route's prefix falls under" (the
+// effective-VRF walk in backend/app/services/looking_glass/ipam_link.py),
+// NOT an RD/RT match against this VRF's import/export targets — there's
+// no VPNv4/VPNv6 AFI data to parse yet (ext_communities parsing is a
+// deferred later phase). Don't imply a match/no-match badge against the
+// RTs above; this panel just lists routes whose matched IPAM footprint
+// happens to sit in this VRF.
+function VrfRoutesPanel({ vrf }: { vrf: VRF }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["bgp-lg-routes-by-vrf", vrf.id],
+    queryFn: () =>
+      lookingGlassApi.searchRoutes({
+        matched_vrf_id: vrf.id,
+        withdrawn: false,
+        limit: 200,
+      }),
+    staleTime: 15_000,
+  });
+  if (isLoading) {
+    return <p className="p-6 text-sm text-muted-foreground">Loading…</p>;
+  }
+  const items = data?.items ?? [];
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 p-10 text-center">
+        <p className="text-sm text-muted-foreground">
+          No BGP routes matched to this VRF's IPAM footprint.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        Every active BGP Looking Glass route whose matched IPAM block or space
+        carries this VRF.
+      </p>
+      <BgpRouteMiniTable items={items} />
     </div>
   );
 }
@@ -80,6 +131,7 @@ export function VRFDetailPage() {
   const { id = "" } = useParams<{ id: string }>();
   const [tab, setTab] = useState<Tab>("spaces");
   const [showEdit, setShowEdit] = useState(false);
+  const { enabled: featureEnabled } = useFeatureModules();
 
   const {
     data: vrf,
@@ -177,6 +229,9 @@ export function VRFDetailPage() {
             [
               ["spaces", `IP Spaces (${spaces.length})`],
               ["blocks", `IP Blocks (${blocks.length})`],
+              ...(featureEnabled("network.looking_glass")
+                ? [["routes", "Routes"] as [Tab, string]]
+                : []),
             ] as Array<[Tab, string]>
           ).map(([key, label]) => (
             <button
@@ -347,6 +402,8 @@ export function VRFDetailPage() {
             )}
           </div>
         )}
+
+        {tab === "routes" && <VrfRoutesPanel vrf={vrf} />}
       </div>
 
       {showEdit && (

--- a/frontend/src/pages/vrfs/VRFDetailPage.tsx
+++ b/frontend/src/pages/vrfs/VRFDetailPage.tsx
@@ -12,7 +12,10 @@ import {
 import { HeaderButton } from "@/components/ui/header-button";
 import { ServicesUsingButton } from "@/components/ServicesUsingButton";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
-import { BgpRouteMiniTable } from "@/components/network/bgp-route-table";
+import {
+  BgpRouteMiniTable,
+  type VrfRtContext,
+} from "@/components/network/bgp-route-table";
 import { VRFEditorModal } from "./VRFsPage";
 
 type Tab = "spaces" | "blocks" | "routes";
@@ -50,14 +53,18 @@ function RtChips({ values }: { values: string[] }) {
   );
 }
 
-// Issue #566 Phase 3 — "matched_vrf_id" means "the VRF assigned to
-// whichever IPAM block/space this route's prefix falls under" (the
-// effective-VRF walk in backend/app/services/looking_glass/ipam_link.py),
-// NOT an RD/RT match against this VRF's import/export targets — there's
-// no VPNv4/VPNv6 AFI data to parse yet (ext_communities parsing is a
-// deferred later phase). Don't imply a match/no-match badge against the
-// RTs above; this panel just lists routes whose matched IPAM footprint
-// happens to sit in this VRF.
+// Issue #566 Phase 3 introduced "matched_vrf_id" meaning "the VRF assigned
+// to whichever IPAM block/space this route's prefix falls under" (the
+// effective-VRF walk in backend/app/services/looking_glass/ipam_link.py).
+// Phase 6 adds a second, DISTINCT way a route ends up with this VRF's id:
+// a direct Route-Target cross-check against ``ext_communities`` for
+// vpnv4/vpnv6 paths (backend/app/services/looking_glass/vrf_match.py),
+// which takes precedence over the IPAM walk when a route carries a
+// Route Distinguisher. This panel doesn't need to tell the two apart at
+// the query level (both set ``matched_vrf_id``) — it just renders the
+// RT cross-check columns (via ``vrfRtContext``) whenever a row happens to
+// carry ``ext_communities``/``route_distinguisher``; plain ipv4/ipv6-unicast
+// routes matched purely by IPAM footprint show "—" in those columns.
 function VrfRoutesPanel({ vrf }: { vrf: VRF }) {
   const { data, isLoading } = useQuery({
     queryKey: ["bgp-lg-routes-by-vrf", vrf.id],
@@ -82,13 +89,20 @@ function VrfRoutesPanel({ vrf }: { vrf: VRF }) {
       </div>
     );
   }
+  const rtContext: VrfRtContext = {
+    importTargets: vrf.import_targets,
+    exportTargets: vrf.export_targets,
+  };
   return (
     <div className="space-y-2">
       <p className="text-xs text-muted-foreground">
         Every active BGP Looking Glass route whose matched IPAM block or space
-        carries this VRF.
+        carries this VRF, or (issue #566 Phase 6) whose VPNv4/VPNv6 Route Target
+        matched this VRF's import/export lists directly. The "Route targets"
+        column highlights which of this VRF's RTs a route's extended communities
+        hit.
       </p>
-      <BgpRouteMiniTable items={items} />
+      <BgpRouteMiniTable items={items} vrfRtContext={rtContext} />
     </div>
   );
 }


### PR DESCRIPTION
Implements **Phase 1 + 2** of the BGP Looking Glass (#566): a **receive-only** GoBGP collector that peers with the operator's routers, ingests the live Adj-RIB-In, and links every learned prefix / origin ASN / community back into IPAM — RPKI-validated.

> **Safety invariant:** the collector never advertises routes to your network. Global `default-export-policy: reject-route`, no export policy, and a per-peer `max-prefixes` cap are rendered into the daemon config, re-checked by `_assert_receive_only`, and confirmed by a live 3-node leak test (downstream peer's adj-in-from-collector is empty).

## Scope
- **Phase 1** — collector + Sessions tab (peer with a router, watch sessions reach Established).
- **Phase 2** — RIB ingest + searchable Routes grid (origin-ASN links, community-catalog rendering).
- **RPKI-at-ingest** pulled forward from Phase 3 (reuses #527's `derive_rpki_status`).

**Deferred** (the data model ships all their columns now, so no later migration is needed): MetalLB BGP-mode light-up · IPAM chips/panels + reverse-lookup + ASN "Learned routes" tab (P3) · Query tab + vantage ping/traceroute (P4) · `bgp_lg_*` alert family (P5) · VRF/multicast (P6).

Decisions: **GoBGP** (Apache-2.0) · default **max-prefixes 10,000** · MetalLB-BGP deferred to a follow-up.

## What's included
- **Backend** — 3 models (`looking_glass_collector` / `bgp_lg_peer` / `bgp_lg_route`, migration `cb279a6afd70`) behind the default-on `network.looking_glass` feature module; operator CRUD (Fernet `md5_password` never echoed, audit, `require_module`); agent plane (register/config/heartbeat/routes) with JWT bootstrap, ConfigBundle ETag long-poll + Redis wake, and RIB ingest with the `pull_leases` **zero-wire floor guard**; 6 MCP tools + `propose_create_lg_peer`; collector stale-sweep beat task.
- **Collector daemon** (`agent/looking-glass/`, multi-arch GoBGP) — bootstrap→JWT→cache (non-negotiable #5), receive-only render, per-neighbor `adj-in` poller, agent-side import-filter scope, heartbeat, bounded-backoff sync loop; Dockerfile + CI workflow + standalone compose.
- **Chart / supervisor** — `looking-glass` role with per-role node label `spatium.io/role-looking-glass` (non-negotiable #16), capability gate, DaemonSet (hostNetwork + hostPath cache), nftables `tcp/179`, bake-images, `NOTICE` (GoBGP).
- **Frontend** — Looking Glass page (Sessions + Routes tabs), `lookingGlassApi`, sidebar + route, FleetTab role entry.

## Review + fixes
Ran an xhigh-recall code review (15 findings) and fixed **all 15** in this branch, with 6 new regression tests — the correctness/security highlights: duplicate-`(prefix,next_hop)` push crash, plaintext MD5 config file now `chmod 0600`, fresh no-peers collector now goes `Ready`, adj-in (not Loc-RIB) so multi-path comparison works, `import_filter` scope actually enforced (agent-side, after proving gobgpd can't do it via policy), Fernet-decrypt-failure never ships a silently-unauthenticated session, and `collector.enabled` / peer-disable now take real effect.

## Verification
- Backend: **ruff ✓ · black ✓ · mypy (665 files) ✓**; **14 looking-glass tests** + #527 hijack suite + AI-tools + supervisor firewall all pass.
- Migration up + down + drift-clean + lint-baselined.
- Frontend `npm run build` + eslint + prettier ✓.
- Collector daemon verified against live gobgpd v4.5.0 (adj-in multi-path, scope filter, receive-only leak test).

## Note / open decision
On HA appliances the collector peers from each labeled node's **real host IP** (DaemonSet + hostNetwork), not the MetalLB VIP — so there's no VIP-based BGP-session failover. Left as a design decision; a stable-source enhancement can be scoped separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
