### PR TITLE
fix(appliance): build + retag looking-glass:dev in `make build` (#573)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,13 @@ build: build-supervisor
 	docker build -t spatiumddi-dns-bind9:dev -f agent/dns/images/bind9/Dockerfile .
 	docker build -t spatiumddi-dns-powerdns:dev -f agent/dns/images/powerdns/Dockerfile .
 	docker build -t spatiumddi-dhcp-kea:dev -f agent/dhcp/images/kea/Dockerfile .
+	# #573 — the BGP Looking Glass collector (#566) is in bake-images.sh's
+	# IMAGES set but the PROD compose pins its ``image:`` with no ``build:``,
+	# so — exactly like the DNS/DHCP agents above — it needs an explicit
+	# build here or ``make build`` leaves ``spatiumddi-looking-glass:dev``
+	# stale and the baked ISO ships an old collector (or trips the #272 >24h
+	# stale-source guard when nothing rebuilt it recently).
+	docker build -t spatiumddi-looking-glass:dev -f agent/looking-glass/images/gobgp/Dockerfile .
 	# #272 Phase 1 — retag compose-built images under the canonical
 	# ``ghcr.io/spatiumddi/<name>:dev`` form so
 	# ``appliance/scripts/bake-images.sh``'s resolve_source_tag picks
@@ -118,7 +125,8 @@ build: build-supervisor
 	    "frontend:spatiumddi-frontend" \
 	    "dns-bind9:dns-bind9" \
 	    "dns-powerdns:dns-powerdns" \
-	    "dhcp-kea:dhcp-kea"; do \
+	    "dhcp-kea:dhcp-kea" \
+	    "looking-glass:looking-glass"; do \
 	  compose="$${pair%%:*}"; target="$${pair##*:}"; \
 	  if docker image inspect "spatiumddi-$$compose:dev" >/dev/null 2>&1; then \
 	    docker tag "spatiumddi-$$compose:dev" "ghcr.io/spatiumddi/$$target:dev"; \


### PR DESCRIPTION
## Problem

`appliance/scripts/bake-images.sh` bakes `ghcr.io/spatiumddi/looking-glass` into every appliance slot (added with the #566 BGP Looking Glass feature), but the Makefile `build` target never built or retagged it:

- the explicit `docker build … :dev` block covered `dns-bind9` / `dns-powerdns` / `dhcp-kea` — not `looking-glass`;
- the `ghcr.io/spatiumddi/<name>:dev` retag pair-list covered `api` / `frontend` / `dns-*` / `dhcp-kea` — not `looking-glass`.

The PROD compose pins the LG `image:` with no `build:` (identical to the DNS/DHCP agents), so `docker compose build` didn't cover it either. Net effect: `make build` refreshed every baked image **except** the Looking Glass collector, so `make appliance-baked-iso` could bake a stale collector or trip the #272 >24h stale-source guard.

## Fix

Mirror the DNS/DHCP wiring in the `build` target: add the explicit `docker build -t spatiumddi-looking-glass:dev …` line and the `looking-glass:looking-glass` retag pair. Verified end-to-end — a fresh `make build && make appliance-baked-iso` now builds, retags, and bakes `ghcr.io/spatiumddi/looking-glass:<ver> → looking-glass.tar.zst`.

Same audit-gap class as the #550–557 host-script sweep: a new baked component must be wired into **every** build/bake path, not just the bake IMAGES list.

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)