### PR TITLE
fix(looking-glass): stop early-SIGHUP gobgpd crashloop on the k3s appliance (#576)

### DIFF
--- a/agent/looking-glass/spatium_lg_agent/gobgp.py
+++ b/agent/looking-glass/spatium_lg_agent/gobgp.py
@@ -66,6 +66,7 @@ import signal
 import socket
 import subprocess
 import threading
+import time
 from typing import Any
 
 import structlog
@@ -378,6 +379,46 @@ def start_daemon(cfg: AgentConfig) -> subprocess.Popen[bytes]:
     )
     log.info("gobgpd_started", pid=proc.pid)
     return proc
+
+
+def wait_until_ready(
+    cfg: AgentConfig,
+    proc: subprocess.Popen[bytes] | None = None,
+    timeout: float = 30.0,
+    interval: float = 0.25,
+) -> bool:
+    """Block until gobgpd's gRPC API answers a real request.
+
+    Gates the sync thread's first ``apply_config`` (→ :func:`reload` → SIGHUP)
+    on gobgpd being fully up. gobgpd installs its ``signal.Notify(SIGHUP)``
+    reload handler partway through startup; a SIGHUP that lands *before* then
+    hits the default disposition — **terminate** — and kills the daemon. The
+    bootstrap-from-cache apply fires within a few ms of :func:`start_daemon`,
+    so on a slow host that SIGHUP beats the handler and gobgpd dies with no
+    output ~1s in (issue #576 — reproduced on the k3s appliance; Docker won the
+    race locally, which is why this only surfaced in the field). A successful
+    ``gobgp neighbor`` call proves the gRPC server is serving requests, by which
+    point the signal handler is installed and any SIGHUP is safe.
+
+    Returns ``True`` once ready. Returns ``False`` if gobgpd exits during
+    startup (a genuine config/bind failure — surfaced immediately) or the
+    timeout elapses; the caller proceeds regardless — ``--config-auto-reload``
+    still delivers the config via gobgpd's own file watch, and the supervisor's
+    ``daemon_running`` check catches a truly dead daemon on its next tick.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc is not None and proc.poll() is not None:
+            log.error("gobgpd_exited_during_startup", returncode=proc.returncode)
+            return False
+        try:
+            run_gobgp_cli(cfg, "neighbor", timeout=5.0)
+            log.info("gobgpd_ready")
+            return True
+        except GoBGPCliError:
+            time.sleep(interval)
+    log.warning("gobgpd_ready_timeout", timeout=timeout)
+    return False
 
 
 def daemon_running(proc: subprocess.Popen[bytes] | None) -> bool:

--- a/agent/looking-glass/spatium_lg_agent/supervisor.py
+++ b/agent/looking-glass/spatium_lg_agent/supervisor.py
@@ -36,6 +36,13 @@ def run(cfg: AgentConfig) -> int:
 
     proc = gobgp.start_daemon(cfg)
 
+    # Wait for gobgpd's gRPC to answer before the sync thread fires its first
+    # apply_config() (→ reload() → SIGHUP). A SIGHUP that lands during gobgpd's
+    # startup window — before it installs its SIGHUP handler — hits the default
+    # disposition (terminate) and kills the daemon, which then surfaces ~1s
+    # later as a bogus lg_gobgpd_exited crashloop (issue #576).
+    gobgp.wait_until_ready(cfg, proc)
+
     heartbeat = HeartbeatClient(cfg, token_ref)
     rib = RibPoller(cfg, token_ref, heartbeat)
     syncer = SyncLoop(cfg, token_ref, heartbeat, rib, proc)

--- a/agent/looking-glass/spatium_lg_agent/supervisor.py
+++ b/agent/looking-glass/spatium_lg_agent/supervisor.py
@@ -41,7 +41,18 @@ def run(cfg: AgentConfig) -> int:
     # startup window — before it installs its SIGHUP handler — hits the default
     # disposition (terminate) and kills the daemon, which then surfaces ~1s
     # later as a bogus lg_gobgpd_exited crashloop (issue #576).
-    gobgp.wait_until_ready(cfg, proc)
+    ready = gobgp.wait_until_ready(cfg, proc)
+    if not ready and not gobgp.daemon_running(proc):
+        # gobgpd exited during startup — a genuine config/bind failure, already
+        # logged by wait_until_ready. Don't start the worker threads against a
+        # dead daemon (avoidable secondary error logs) or wait a full poll tick
+        # to notice: exit now so the container restarts + re-bootstraps from the
+        # cached PSK (non-negotiable #5). A False return with gobgpd still alive
+        # means it was merely slow to answer gRPC within the timeout — proceed,
+        # since --config-auto-reload delivers the config via gobgpd's own file
+        # watch and the 1s daemon_running poll below still guards it.
+        log.error("lg_gobgpd_exited")
+        return 2
 
     heartbeat = HeartbeatClient(cfg, token_ref)
     rib = RibPoller(cfg, token_ref, heartbeat)

--- a/charts/spatiumddi-appliance/templates/looking-glass.yaml
+++ b/charts/spatiumddi-appliance/templates/looking-glass.yaml
@@ -66,6 +66,18 @@ spec:
         - name: looking-glass
           image: {{ include "spatiumddi-appliance.imageRef" (dict "global" .Values.global "repository" .Values.lookingGlass.image.repository) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          # gobgpd binds the privileged BGP port :179 as the non-root
+          # ``spatium`` user via a file capability (``setcap
+          # cap_net_bind_service`` on the binary). Under k8s that file cap is
+          # only honoured with NET_BIND_SERVICE in the container's capability
+          # set and ``no_new_privs`` off; the empty default securityContext
+          # left it fragile across runtimes (issue #576). Grant it explicitly
+          # — the k8s-native way to let a non-root process bind a well-known
+          # port, matching the Dockerfile's documented intent.
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
           env:
             # spatium_lg_agent.config.AgentConfig.from_env() contract
             # (agent/looking-glass/): CONTROL_PLANE_URL + LG_AGENT_KEY.


### PR DESCRIPTION
Field-testing the #566 BGP Looking Glass on a real k3s appliance surfaced a `CrashLoopBackOff`. Full diagnosis in #576; this PR fixes the actual crash (Bug 2) plus a defensive hardening.

## The bug (startup race)

`supervisor.run()` starts gobgpd, then immediately starts the sync thread. The sync thread's first act — bootstrap-from-cache → `apply_config()` → `reload()` — sends **SIGHUP ~4 ms after spawn**. gobgpd (Go) installs its `signal.Notify(SIGHUP)` reload handler partway through startup; a SIGHUP that lands *before* then hits the default disposition — **terminate** — and kills gobgpd before it prints a line. The supervisor's 1 s `daemon_running` poll then reports a bogus `lg_gobgpd_exited` and the container restarts, forever.

It won the race under Docker locally but reliably lost on the slower k3s appliance.

### Why it's specifically the race (evidence from #576)

In a sleep-overridden pod, gobgpd v4.7.0:
- runs 6 s cleanly with the **exact** agent args (`-t json -l info --config-auto-reload --pprof-disable`),
- with both the image idle config **and** the agent-rendered config,
- binds `:179`, and
- **survives a SIGHUP sent at 20 ms** (even logs "Reload the config file").

It only dies when the SIGHUP arrives inside the ~ms handler-install window — matching the agent's ~4 ms timing and the "zero gobgpd output + death detected at the 1 s poll" symptom.

## Fix

`gobgp.wait_until_ready()` — after `start_daemon()` and **before** the sync/rib/heartbeat threads start, poll the gobgpd gRPC listener (a `gobgp neighbor` call). Once gRPC serves a request the signal handler is installed, so the first apply's SIGHUP is safe.

- Bounded 30 s timeout.
- Bails early (returns False, logged) if gobgpd exits during startup — a genuine config/bind failure surfaces immediately instead of after 30 s.
- Falls through on timeout: `--config-auto-reload` delivers the config via gobgpd's own file watch regardless, and `daemon_running()` still catches a truly dead daemon on the next tick.

## Defensive hardening

The `looking-glass` DaemonSet had **no securityContext** — it relied on `setcap cap_net_bind_service` on the gobgpd binary to bind privileged `:179` as non-root `spatium`. That file cap is fragile under k8s (bounding set / `no_new_privs`). This PR grants `securityContext.capabilities.add: [NET_BIND_SERVICE]` explicitly, matching the Dockerfile's documented intent.

## Scope / not in this PR

Bug 1 from #576 — the appliance doesn't wire `LG_AGENT_KEY` (the api has no `LG_AGENT_KEY` env and `lookingGlass.agentKey` is never populated, unlike DNS/DHCP) — is a separate appliance-integration piece (installer/supervisor key generation + injection) and stays tracked in #576. It was worked around live (`kubectl set env`) to validate this fix.

## Testing

- `ruff` / `black` / `mypy` clean on the agent; `helm lint` + render verified for the chart.
- Field verification (rebuild the looking-glass image + redeploy to the appliance with `LG_AGENT_KEY` set) to follow.

Refs #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)