### PR TITLE
fix(appliance): repoint kube-rbac-proxy off sunset gcr.io/kubebuilder → quay.io/brancz (#575)

### DIFF
--- a/appliance/scripts/bake-images.sh
+++ b/appliance/scripts/bake-images.sh
@@ -128,7 +128,13 @@ OBSERVABILITY_IMAGES=(
 # against charts/frr-k8s/values.yaml inside the vendored
 # metallb-0.15.3.tgz (frr-k8s@0.0.21) — keep in lock-step with the
 # charts/spatiumddi-metallb/values.yaml `metallb.frr-k8s.frrk8s.image` /
-# `.frr.image` pins. ``metallb.speaker.frr.enabled`` stays FALSE (the
+# `.frr.image` pins, and `metallb.frr-k8s.prometheus.rbacProxy.*` for the
+# kube-rbac-proxy sidecar. #575 — kube-rbac-proxy moved off the sunset
+# `gcr.io/kubebuilder` mirror (now 404, which broke this bake + any
+# non-airgap frr-k8s pull) to its upstream home `quay.io/brancz`; the chart
+# override and the bake entry below MUST match so the baked image name is
+# exactly what the frr-k8s pod pulls.
+# ``metallb.speaker.frr.enabled`` stays FALSE (the
 # in-speaker FRR sidecar is mutually exclusive with the frr-k8s backend
 # and unused either way) so no image is baked for that path.
 METALLB_IMAGES=(
@@ -136,7 +142,10 @@ METALLB_IMAGES=(
     "quay.io/metallb/speaker:v0.15.3"
     "quay.io/metallb/frr-k8s:v0.0.21"
     "quay.io/frrouting/frr:10.4.1"
-    "gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0"
+    # #575 — was gcr.io/kubebuilder/kube-rbac-proxy (sunset → 404); same image,
+    # maintained registry. Keep in lock-step with charts/spatiumddi-metallb
+    # values.yaml `metallb.frr-k8s.prometheus.rbacProxy.repository`.
+    "quay.io/brancz/kube-rbac-proxy:v0.12.0"
 )
 
 # CloudNativePG (#272 / #277) — PostgreSQL is CNPG on every appliance

--- a/charts/spatiumddi-metallb/values.yaml
+++ b/charts/spatiumddi-metallb/values.yaml
@@ -133,6 +133,18 @@ metallb:
     # the metallb.io CRDs above — same "no double-owner conflict" reason.
     crds:
       enabled: false
+    # #575 — the frr-k8s controller wires a kube-rbac-proxy sidecar (twice
+    # per pod) whose image defaults to `gcr.io/kubebuilder/kube-rbac-proxy`,
+    # which Google sunset (now 404 — broke the bake + any non-airgap pull).
+    # Repoint to kube-rbac-proxy's maintained upstream home, quay.io/brancz
+    # (same image, same v0.12.0 tag). NOTE `rbacProxy` lives at the frr-k8s
+    # chart's TOP level under `prometheus:` (controller.yaml:397/423 read
+    # `.Values.prometheus.rbacProxy.*`), NOT under the `frrk8s:` block below.
+    # KEEP in lock-step with appliance/scripts/bake-images.sh METALLB_IMAGES.
+    prometheus:
+      rbacProxy:
+        repository: quay.io/brancz/kube-rbac-proxy
+        tag: v0.12.0
     # frr-k8s chart's OWN internal `frrk8s:` key (see the long comment
     # above) — nodeSelector / image / frr-image config all live here,
     # NOT at this block's top level.


### PR DESCRIPTION
`gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0` no longer resolves — Google sunset the `gcr.io/kubebuilder` mirror (`docker manifest inspect` → 404). The frr-k8s controller (MetalLB BGP mode, #566 D1) wires it as a metrics sidecar **twice per pod**, so it broke two paths:

- **The appliance bake** — `appliance/scripts/bake-images.sh` does an unconditional `docker pull` of every third-party image, so the release `build-appliance-iso` job fails at this image. Hit live while baking the #566 test ISO (worked around locally by retagging `quay.io/brancz` as the gcr.io name).
- **Any non-airgap frr-k8s pull** — `ErrImagePull` on the sidecar.

## Fix (lock-step)

Repoint to kube-rbac-proxy's maintained upstream home, `quay.io/brancz` (same image, same `v0.12.0` tag):

- **`bake-images.sh` `METALLB_IMAGES`** → `quay.io/brancz/kube-rbac-proxy:v0.12.0`, so the baked image name is exactly what the frr-k8s pod pulls.
- **`charts/spatiumddi-metallb/values.yaml`** → `metallb.frr-k8s.prometheus.rbacProxy.{repository,tag}`. `rbacProxy` lives at the frr-k8s chart's **top-level `prometheus:`** key (its `controller.yaml` reads `.Values.prometheus.rbacProxy.*` for both sidecars), overridden from the wrapper via the same propagation path as the existing `metallb.frr-k8s.frrk8s.image` pins.

Both must change together: change only the bake and the pod still requests the 404 name; change only the chart and the baked image name won't match.

## Verification

```
# vendored frr-k8s subchart, default:
image: gcr.io/kubebuilder/kube-rbac-proxy:v0.12.0
# with prometheus.rbacProxy override:
image: quay.io/brancz/kube-rbac-proxy:v0.12.0
```

`helm lint charts/spatiumddi-metallb` and `bash -n appliance/scripts/bake-images.sh` both clean.

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)