### PR TITLE
fix(appliance): wire LG_AGENT_KEY through firstboot so k3s installs run the Looking Glass (#576)

### DIFF
--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -218,20 +218,22 @@ if [ ! -f "$ENV_FILE" ]; then
             ROLE=appliance
             DNS_AGENT_KEY_VAL=""
             DHCP_AGENT_KEY_VAL=""
+            LG_AGENT_KEY_VAL=""
             BOOTSTRAP_PAIRING_CODE_VAL="$INSTALL_BOOTSTRAP_PAIRING_CODE"
             CONTROL_PLANE_URL_VAL="$INSTALL_CONTROL_PLANE_URL"
             AGENT_GROUP_VAL="default"
             ;;
         *)
-            # control-plane (or legacy full-stack / frontend-core). DNS
-            # + DHCP are OFF at install; the operator enables them per
-            # node via the Fleet role toggle. The agent keys are still
-            # generated here so the api can validate agent registrations
-            # once those roles ARE enabled (the api needs the key
-            # server-side, the role pods need it client-side).
+            # control-plane (or legacy full-stack / frontend-core). DNS,
+            # DHCP + Looking Glass are OFF at install; the operator enables
+            # them per node via the Fleet role toggle. The agent keys are
+            # still generated here so the api can validate agent
+            # registrations once those roles ARE enabled (the api needs the
+            # key server-side, the role pods need it client-side).
             ROLE=control-plane
             DNS_AGENT_KEY_VAL=$(gen_hex 24)
             DHCP_AGENT_KEY_VAL=$(gen_hex 24)
+            LG_AGENT_KEY_VAL=$(gen_hex 24)
             # #272 — leave CONTROL_PLANE_URL EMPTY on the control-plane
             # node. Two reasons it must stay empty:
             #   1. The supervisor's self-bootstrap path (mints the seed's
@@ -263,6 +265,7 @@ SECRET_KEY=$(gen_hex 32)
 CREDENTIAL_ENCRYPTION_KEY=$(gen_fernet)
 DNS_AGENT_KEY=${DNS_AGENT_KEY_VAL}
 DHCP_AGENT_KEY=${DHCP_AGENT_KEY_VAL}
+LG_AGENT_KEY=${LG_AGENT_KEY_VAL}
 BOOTSTRAP_PAIRING_CODE=${BOOTSTRAP_PAIRING_CODE_VAL}
 CONTROL_PLANE_URL=${CONTROL_PLANE_URL_VAL}
 AGENT_GROUP=${AGENT_GROUP_VAL}
@@ -409,14 +412,31 @@ APPLIANCE_ROLE_VAL=$(_env_get APPLIANCE_ROLE)
 APPLIANCE_ROLE_VAL="${APPLIANCE_ROLE_VAL:-control-plane}"
 
 # Agent pre-shared keys + in-cluster API service URL for the AIO
-# control-plane node. The DNS + DHCP role pods need them to
-# register against the local control plane, AND the api pod needs
-# them server-side to validate incoming agent registrations
-# (otherwise the api returns 503 "DNS_AGENT_KEY is not configured
-# on the control plane"). Both come from /etc/spatiumddi/.env which
+# control-plane node. The DNS / DHCP / Looking Glass role pods need
+# them to register against the local control plane, AND the api pod
+# needs them server-side to validate incoming agent registrations
+# (otherwise the api returns 503 "<X>_AGENT_KEY is not configured
+# on the control plane"). All come from /etc/spatiumddi/.env which
 # firstboot writes (or carries over) on every boot.
 DNS_AGENT_KEY_VAL=$(_env_get DNS_AGENT_KEY)
 DHCP_AGENT_KEY_VAL=$(_env_get DHCP_AGENT_KEY)
+LG_AGENT_KEY_VAL=$(_env_get LG_AGENT_KEY)
+# Backfill for boxes provisioned before LG_AGENT_KEY existed (issue #576).
+# It's the first agent key added after GA, so an already-installed
+# control-plane appliance that slot-upgrades into a Looking-Glass build has
+# no LG_AGENT_KEY line in its persistent (/var) .env — the first-boot
+# generation block above is skipped because .env already exists, and without
+# this the api would render LG_AGENT_KEY="" and every LG registration 503s.
+# Mint one once and PERSIST it (not just set the var): the api env must be
+# stable across boots or a fresh random key each boot would orphan an
+# already-registered collector. _env_get's ``tail -1`` makes the append
+# authoritative. Control-plane only — data-plane (appliance/application)
+# nodes intentionally keep it empty and receive it from the supervisor at
+# role-assign time.
+if [ -z "$LG_AGENT_KEY_VAL" ] && [ "$APPLIANCE_ROLE_VAL" = "control-plane" ]; then
+    LG_AGENT_KEY_VAL=$(gen_hex 24)
+    printf 'LG_AGENT_KEY=%s\n' "$LG_AGENT_KEY_VAL" >> "$ENV_FILE"
+fi
 # In-cluster service DNS for the api. Matches the umbrella chart's
 # release name (``spatium-control``) + the workload suffix the
 # template ``include "spatiumddi.fullname"`` produces. ClusterFirstWithHostNet
@@ -645,15 +665,20 @@ spec:
         - name: APPLIANCE_MODE
           value: "true"
         # Agent pre-shared keys — the api validates incoming
-        # registrations from DNS/DHCP agents against these. Without
-        # them the api returns 503 "DNS_AGENT_KEY is not configured
-        # on the control plane" and the role pods crash-loop.
+        # registrations from DNS / DHCP / Looking Glass agents against
+        # these. Without them the api returns 503 "<X>_AGENT_KEY is not
+        # configured on the control plane" and the role pods crash-loop.
         # Sourced from /etc/spatiumddi/.env which firstboot stamps
-        # on first boot.
+        # on first boot. LG_AGENT_KEY additionally feeds
+        # settings.lg_agent_key, which the supervisor ships in its
+        # heartbeat role-assignment so the running collector DaemonSet
+        # gets the matching client-side key (issue #576).
         - name: DNS_AGENT_KEY
           value: "${DNS_AGENT_KEY_VAL}"
         - name: DHCP_AGENT_KEY
           value: "${DHCP_AGENT_KEY_VAL}"
+        - name: LG_AGENT_KEY
+          value: "${LG_AGENT_KEY_VAL}"
         # #272 HA — stable identity for the self-signed Web UI cert.
         # The api Deployment runs N replicas (one per control-plane
         # node), all sharing one cluster TLS Secret. WITHOUT these the


### PR DESCRIPTION
Closes the last open piece of #576 (Bug 1 — Bug 2, the gobgpd SIGHUP crash, shipped in #577). Found field-testing the #566 Looking Glass on a real k3s appliance: assigning the `looking-glass` role crashlooped the collector because **`LG_AGENT_KEY` was never wired on the appliance**.

## Root cause

The whole supervisor → HelmChart → DaemonSet → pod LG path is *already* in place (`config.lg_agent_key`, heartbeat role-assignment, `role_orchestrator`, `service_lifecycle`, `looking-glass.yaml`). The only missing link: **firstboot** generates + injects `DNS_AGENT_KEY`/`DHCP_AGENT_KEY` but nothing for LG. So `settings.lg_agent_key` stayed `""` → the api 503'd every LG registration (`_require_bootstrap_key`) **and** shipped an empty key to the supervisor, leaving the running collector DaemonSet keyless.

I mapped the (four-HelmChart) appliance key architecture with a parallel investigation to be sure the fix belongs in firstboot and nowhere else — it does; DNS/DHCP are correctly wired and were never broken.

## Fix — all in `spatiumddi-firstboot`, mirroring DNS/DHCP

- **generate** `LG_AGENT_KEY_VAL` (`gen_hex 24` on control-plane; `""` on the data-plane appliance/application role, where the supervisor injects it at role-assign time);
- **persist** `LG_AGENT_KEY` to `/etc/spatiumddi/.env` so the api pod env is stable across reboots / slot swaps;
- **read-back** every boot via `_env_get`;
- **inject** `LG_AGENT_KEY` into the api pod env in `_render_control_helmchart` — the load-bearing bit. The supervisor does **not** read `.env` directly; the key flows api env → `settings.lg_agent_key` → heartbeat role-assignment → `role-compose.env` → `_build_values` → the running `spatiumddi-appliance` HelmChart's `lookingGlass.agentKey`. So the api-env injection both stops the 503 and is what ultimately delivers the client-side key;
- **backfill** — `LG_AGENT_KEY` is the first agent key added *after* GA, so an already-installed control-plane box that slot-upgrades into an LG build has no `LG_AGENT_KEY` in its existing `.env` (first-boot generation is skipped). Mint + persist one once when absent (control-plane only) so **upgrades** work too, not just fresh installs.

## Verification

- **Live on ddi1**: setting the api's `LG_AGENT_KEY` by hand propagated api → heartbeat → supervisor → DaemonSet and the collector came up READY 1/1 — this PR just makes firstboot do it automatically.
- **Backfill** unit-tested in isolation: mint+append on a pre-fix control-plane `.env`, idempotent on reboot, correctly skipped on data-plane, no-op when the key already exists.
- `bash -n` clean. Self-reviewed (code-review pass) — the review surfaced the upgrade-backfill gap and a mechanism-description inaccuracy, both fixed here.

No backend / supervisor / chart change needed.

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)