### PR TITLE
feat(appliance): offline --check-preseed linter + test suite for the #549 headless installer (#581)

### DIFF
--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -23,20 +23,32 @@
 # Uses only shell builtins + utilities present in every Debian
 # rootfs (date, tty, id, cat, command, ls) so the logger itself
 # can't fail in a way the diagnostic forgets to record.
-{
-    printf '[%s] LAUNCH\n'      "$(date -Iseconds 2>/dev/null || echo '?')"
-    printf '  pid=%s ppid=%s\n' "$$" "$PPID"
-    printf '  tty=%s\n'         "$(tty 2>/dev/null || echo '?')"
-    printf '  uid=%s\n'         "$(id -u 2>/dev/null || echo '?')"
-    printf '  bash=%s\n'        "${BASH_VERSION:-?}"
-    printf '  pwd=%s\n'         "$(pwd 2>/dev/null || echo '?')"
-    printf '  cmdline=%s\n'     "$(tr '\n' ' ' </proc/cmdline 2>/dev/null)"
-    printf '  whiptail=%s\n'    "$(command -v whiptail 2>/dev/null || echo MISSING)"
-    printf '  sgdisk=%s\n'      "$(command -v sgdisk 2>/dev/null || echo MISSING)"
-    printf '  rsync=%s\n'       "$(command -v rsync 2>/dev/null || echo MISSING)"
-    printf '  varlog=%s\n'      "$(ls -ld /var/log 2>&1)"
-    printf -- '----\n'
-} >> /var/log/spatium-install-launch.log 2>&1 || true
+#
+# Skipped entirely in the host-portable `--check-preseed` / `--help`
+# modes (issue #581) so the offline lint truly touches nothing — no
+# /var/log write — and can run unprivileged on any dev / CI box. The
+# nested brace + `2>/dev/null` on the real-install path also silences the
+# redirect-open error itself if /var/log is not writable.
+case "${1:-}" in
+    --check-preseed|--help|-h) : ;;
+    *)
+    { {
+        printf '[%s] LAUNCH\n'      "$(date -Iseconds 2>/dev/null || echo '?')"
+        printf '  pid=%s ppid=%s\n' "$$" "$PPID"
+        printf '  tty=%s\n'         "$(tty 2>/dev/null || echo '?')"
+        printf '  uid=%s\n'         "$(id -u 2>/dev/null || echo '?')"
+        printf '  bash=%s\n'        "${BASH_VERSION:-?}"
+        printf '  pwd=%s\n'         "$(pwd 2>/dev/null || echo '?')"
+        printf '  cmdline=%s\n'     "$(tr '\n' ' ' </proc/cmdline 2>/dev/null)"
+        printf '  whiptail=%s\n'    "$(command -v whiptail 2>/dev/null || echo MISSING)"
+        printf '  sgdisk=%s\n'      "$(command -v sgdisk 2>/dev/null || echo MISSING)"
+        printf '  rsync=%s\n'       "$(command -v rsync 2>/dev/null || echo MISSING)"
+        printf '  varlog=%s\n'      "$(ls -ld /var/log 2>&1)"
+        printf -- '----\n'
+    } >> /var/log/spatium-install-launch.log 2>&1
+    } 2>/dev/null || true
+    ;;
+esac
 
 # pipefail + nounset for the wizard, but NOT -e: whiptail returns
 # non-zero on Cancel/Esc and we want to handle that explicitly with
@@ -46,11 +58,17 @@
 set -uo pipefail
 
 BACKTITLE="SpatiumDDI Appliance Installer 0.1.0"
-INSTALL_LOG=/var/log/spatium-install.log
+# The SPATIUM_INSTALL_LOG override + the /dev/null fallback below exist
+# for the host-portable `--check-preseed` linter (issue #581) and its
+# pytest suite, which run this script unprivileged on machines where
+# /var/log isn't writable by the caller.
+INSTALL_LOG="${SPATIUM_INSTALL_LOG:-/var/log/spatium-install.log}"
 MOUNT=/mnt/target
 
-mkdir -p /var/log
-: > "$INSTALL_LOG"
+mkdir -p /var/log 2>/dev/null || true
+if ! : 2>/dev/null > "$INSTALL_LOG"; then
+    INSTALL_LOG=/dev/null
+fi
 # Log to file only — NOT stdout. The do_install brace group below
 # pipes stdout to whiptail's --gauge protocol parser, which expects
 # only "XXX" / percentage / prompt-text lines. If log() tee'd to
@@ -63,8 +81,12 @@ log() { echo "[$(date -Iseconds)] $*" >> "$INSTALL_LOG"; }
 # unexpectedly, this captures every command + variable expansion so
 # we can pinpoint the exact line. Doesn't pollute the user-facing
 # install log.
-TRACE_LOG=/var/log/spatium-install-trace.log
-: > "$TRACE_LOG"
+TRACE_LOG="${SPATIUM_INSTALL_TRACE_LOG:-/var/log/spatium-install-trace.log}"
+if ! : 2>/dev/null > "$TRACE_LOG"; then
+    # Same host-portable fallback as INSTALL_LOG above (issue #581) — a
+    # failed `exec 19>` would kill a non-interactive bash outright.
+    TRACE_LOG=/dev/null
+fi
 exec 19> "$TRACE_LOG"
 # Export so the gauge subshell pipeline below inherits the same
 # trace fd. Without export, the subshell's BASH_XTRACEFD defaults
@@ -75,7 +97,14 @@ exec 19> "$TRACE_LOG"
 # fights with set -x output.
 export BASH_XTRACEFD=19
 PS4='+ ${BASH_SOURCE##*/}:${LINENO}: ${FUNCNAME[0]:-main}() '
-set -x
+# No bash trace in the host-portable `--check-preseed` / `--help` modes
+# (issue #581): the lint runs unprivileged and its machine-readable
+# output must not be polluted by set -x spew, and on bash < 4.1
+# BASH_XTRACEFD isn't honoured so the trace would go to stderr.
+case "${1:-}" in
+    --check-preseed|--help|-h) ;;
+    *) set -x ;;
+esac
 
 log "===== spatium-install wizard started at $(date -Iseconds) ====="
 
@@ -848,10 +877,13 @@ ask_k3s_cidrs() {
     done
 }
 
-# Helper: validate the two CIDRs typed by ask_k3s_cidrs. Returns 0 on
-# success; on fail, shows a whiptail msgbox describing the problem +
-# returns 1 so the caller re-prompts.
-_validate_k3s_cidrs() {
+# Pure validation core for a pod/service CIDR pair — prints the problem
+# on stdout (empty output = valid), reading NET_MODE/NET_IP/NET_PREFIX to
+# cross-check the operator's static LAN subnet. Split out of
+# _validate_k3s_cidrs (issue #581) so the headless `--check-preseed`
+# linter can reuse the EXACT rule the interactive wizard enforces,
+# without the whiptail dialog.
+_k3s_cidr_error() {
     local pod="$1" svc="$2"
     # Hand off to Python — ``ipaddress`` does parsing, prefix-len
     # checking, and overlap detection in three idiomatic lines. The
@@ -862,8 +894,7 @@ _validate_k3s_cidrs() {
     if [ "$NET_MODE" = "static" ] && [ -n "$NET_IP" ] && [ -n "$NET_PREFIX" ]; then
         static_subnet="$NET_IP/$NET_PREFIX"
     fi
-    local err
-    err=$(python3 - "$pod" "$svc" "$static_subnet" <<'PY' 2>&1
+    python3 - "$pod" "$svc" "$static_subnet" <<'PY' 2>&1
 import ipaddress
 import sys
 pod_s, svc_s, static_s = sys.argv[1], sys.argv[2], sys.argv[3]
@@ -914,7 +945,16 @@ if static_s:
         )
         sys.exit(1)
 PY
-)
+}
+
+# Helper: validate the two CIDRs typed by ask_k3s_cidrs. Returns 0 on
+# success; on fail, shows a whiptail msgbox describing the problem +
+# returns 1 so the caller re-prompts. The check itself lives in
+# _k3s_cidr_error (issue #581) so the `--check-preseed` linter can reuse
+# it without popping a dialog.
+_validate_k3s_cidrs() {
+    local err
+    err=$(_k3s_cidr_error "$1" "$2")
     if [ -z "$err" ]; then
         return 0
     fi
@@ -2008,6 +2048,159 @@ EOF
     exit 1
 }
 
+# ── Offline preseed linter — `--check-preseed` (issue #581) ────────────────────
+#
+# Usage text, printed by `--help` (to stdout) and shared with the usage
+# error path (which prints its own one-liner to stderr).
+usage() {
+    cat <<'EOF'
+spatium-install — SpatiumDDI appliance disk installer
+
+Usage:
+  spatium-install
+      Run the interactive install wizard (must be root). Also picks up a
+      headless preseed answer file automatically when one is present
+      (spatium.preseed= cmdline, a CIDATA seed, or a rootfs-baked
+      spatium-preseed.yaml) — see docs for the format.
+
+  spatium-install --check-preseed <preseed.yaml>
+      Offline-lint a headless preseed answer file (issue #549 format)
+      WITHOUT installing anything. Runs unprivileged, reads only the
+      given file, and touches no disk / whiptail / /run. Reports every
+      problem it finds in one pass. Exit status:
+        0  the preseed is valid (a real headless install would accept it)
+        1  the preseed is invalid (errors printed to stderr)
+        2  usage error (missing / unreadable file)
+      Machine-specific checks (does target_disk exist / clear the size
+      floor on THIS box) are reported as warnings, so the same file lints
+      identically on a dev laptop and the real appliance.
+
+  spatium-install --help
+      Show this help.
+EOF
+}
+
+# Host-portable pre-flight for a #549 preseed answer file. It parses the
+# file with the SAME helper the real headless install uses
+# (spatium-preseed-parse) so the lint can never diverge from what an
+# unattended boot actually accepts, then re-runs the interactive wizard's
+# own rules (_validate_static_net + _k3s_cidr_error) against the resolved
+# values.
+#
+# That second layer matters: the parser's built-in static-network check
+# is looser than _validate_static_net (it does NOT enforce
+# gateway-in-subnet or validate the DNS list). On a real install
+# ask_network re-validates a preseeded static block and halts — but only
+# at install time, after the operator has already committed the boot. The
+# linter surfaces the same problem offline, before any disk is touched,
+# on any machine — which is the whole point of a pre-flight.
+check_preseed() {
+    local file="$1"
+    local -a errors=() warns=()
+    local line
+
+    local parser
+    parser="$(dirname "$0")/spatium-preseed-parse"
+    [ -f "$parser" ] || parser="/usr/local/bin/spatium-preseed-parse"
+    if [ ! -f "$parser" ]; then
+        echo "ERROR: spatium-preseed-parse not found next to $0 or in /usr/local/bin" >&2
+        return 2
+    fi
+
+    # Reuse the real parser. Its two output files (non-secret env + secret
+    # env) go to tempfiles we own and delete; the secret file may carry an
+    # admin password / pairing code, so it's 0600.
+    local tmp_env tmp_secret out rc
+    tmp_env=$(mktemp 2>/dev/null) || { echo "ERROR: cannot create tempfile" >&2; return 2; }
+    tmp_secret=$(mktemp 2>/dev/null) || { rm -f "$tmp_env"; echo "ERROR: cannot create tempfile" >&2; return 2; }
+    chmod 0600 "$tmp_secret" 2>/dev/null || true
+
+    out=$(python3 "$parser" "$file" "$tmp_env" "$tmp_secret" 2>&1)
+    rc=$?
+
+    case "$rc" in
+        0) : ;;  # parsed OK — resolved values are in $tmp_env / $tmp_secret
+        2)
+            # A supplied field failed the parser's own validation. The
+            # parser accumulates + prints EVERY such error already, one
+            # per `  - ` line — lift them verbatim.
+            while IFS= read -r line; do
+                case "$line" in
+                    "  - "*) errors+=("${line#  - }") ;;
+                esac
+            done <<<"$out"
+            [ "${#errors[@]}" -eq 0 ] && errors+=("preseed validation failed: $out")
+            ;;
+        3) errors+=("preseed file is not valid YAML / could not be read: $out") ;;
+        4) errors+=("no spatium preseed content — the file has no spatium_preseed block and no recognised preseed field; is this the right file?") ;;
+        *) errors+=("unexpected spatium-preseed-parse error (rc=$rc): $out") ;;
+    esac
+
+    # Advisory parser NOTES (e.g. an absent target_disk, a bare sdX name)
+    # become WARNINGS — they never fail the lint.
+    while IFS= read -r line; do
+        case "$line" in
+            "NOTE: "*) warns+=("${line#NOTE: }") ;;
+        esac
+    done <<<"$out"
+
+    local role_display="<interactive>" unattended="no"
+    if [ "$rc" -eq 0 ]; then
+        # Load the resolved values + PRESEED_HAS_* markers exactly as
+        # load_preseed would, then apply the interactive wizard's rules on
+        # top. shellcheck can't follow the runtime source.
+        # shellcheck disable=SC1090
+        [ -f "$tmp_env" ] && . "$tmp_env"
+        # shellcheck disable=SC1090
+        [ -f "$tmp_secret" ] && . "$tmp_secret"
+
+        # Static network — reuse the interactive prompt's own helper,
+        # which is stricter than the parser (gateway-in-subnet + DNS).
+        if [ -n "${PRESEED_HAS_NETWORK:-}" ] && [ "${NET_MODE:-}" = "static" ]; then
+            local nerr
+            if ! nerr=$(_validate_static_net); then
+                while IFS= read -r line; do
+                    [ -n "$line" ] && errors+=("network: $line")
+                done <<<"$nerr"
+            fi
+        fi
+
+        # k3s CIDRs — reuse the shared _k3s_cidr_error core (belt-and-
+        # braces: the parser already validates k3s, so this only fires if
+        # the two implementations ever drift).
+        if [ -n "${PRESEED_HAS_K3S:-}" ]; then
+            local kerr
+            kerr=$(_k3s_cidr_error "${K3S_POD_CIDR}" "${K3S_SERVICE_CIDR}")
+            [ -n "$kerr" ] && errors+=("k3s: $kerr")
+        fi
+
+        [ -n "${PRESEED_HAS_ROLE:-}" ] && role_display="$ROLE"
+        compute_unattended
+        [ "$FULLY_UNATTENDED" = "1" ] && unattended="yes"
+    fi
+
+    rm -f "$tmp_env" "$tmp_secret"
+
+    local i
+    for ((i = 0; i < ${#warns[@]}; i++)); do
+        echo "WARN: ${warns[$i]}"
+    done
+
+    if [ "${#errors[@]}" -gt 0 ]; then
+        {
+            echo ""
+            echo "The preseed answer file failed validation:"
+            for ((i = 0; i < ${#errors[@]}; i++)); do
+                echo "  ERROR: ${errors[$i]}"
+            done
+        } >&2
+        return 1
+    fi
+
+    echo "OK: $file is a valid spatium preseed (role=$role_display, fully-unattended=$unattended)."
+    return 0
+}
+
 # Discover + parse a preseed, if present. Tries every discovered
 # candidate in priority order; the first one that carries real preseed
 # content is adopted. A candidate with a spatium block but an invalid
@@ -2098,6 +2291,28 @@ load_preseed() {
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 main() {
+    # Non-install command modes (issue #581). These run BEFORE the root
+    # check so an operator can lint an answer file or read the help on any
+    # workstation. Clear the on_failure EXIT trap first: its drop-to-shell
+    # recovery is for the live installer, not a CLI that intentionally
+    # exits non-zero.
+    case "${1:-}" in
+        -h|--help)
+            trap - EXIT
+            usage
+            exit 0
+            ;;
+        --check-preseed)
+            trap - EXIT
+            if [ -z "${2:-}" ] || [ ! -f "${2:-}" ]; then
+                echo "usage: spatium-install --check-preseed <preseed.yaml>" >&2
+                exit 2
+            fi
+            check_preseed "$2"
+            exit $?
+            ;;
+    esac
+
     if [ "$(id -u)" -ne 0 ]; then
         echo "Run as root." >&2
         exit 1

--- a/appliance/mkosi.extra/usr/local/bin/spatium-preseed-parse
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-preseed-parse
@@ -195,7 +195,17 @@ if "confirm_wipe" in ps:
 # survives re-enumeration; a bare sdX name is accepted but noted, since
 # it can renumber between boots. A supplied-but-unresolvable disk drops
 # to the interactive picker rather than guessing (never a silent wipe).
+# Test-only seam (issue #581): the `spatium-install --check-preseed`
+# linter + its host-portable pytest suite have no spare 32 GiB block
+# device to point the size-floor gate at, so when SPATIUM_FAKE_DISK_BYTES
+# is set we treat target_disk as a present whole disk of exactly that
+# many bytes. Inert on a real install (the env var is never set there).
+_FAKE_DISK_BYTES = os.environ.get("SPATIUM_FAKE_DISK_BYTES")
+
+
 def resolve_disk(spec: str):
+    if _FAKE_DISK_BYTES is not None:
+        return spec, None
     real = os.path.realpath(spec)
     try:
         st = os.stat(real)
@@ -216,6 +226,11 @@ def resolve_disk(spec: str):
 def disk_size_bytes(real: str):
     """Capacity of a whole-disk /dev node via /sys/block/<name>/size
     (512-byte sectors). Returns None if unreadable."""
+    if _FAKE_DISK_BYTES is not None:
+        try:
+            return int(_FAKE_DISK_BYTES)
+        except ValueError:
+            return None
     name = os.path.basename(real)
     try:
         with open(f"/sys/block/{name}/size", encoding="ascii") as fh:

--- a/appliance/tests/test_preseed_lint.py
+++ b/appliance/tests/test_preseed_lint.py
@@ -1,0 +1,590 @@
+"""Host-portable pytest for spatium-install's `--check-preseed` linter.
+
+Issue #581 — salvaged from the closed PR #579 (which built the same
+offline-lint + pytest pattern for a rival answer-file format) and ported
+onto the SHIPPED #549 preseed (`spatium-preseed.yaml` / cloud-init
+`spatium_preseed:` block).
+
+These tests drive the installer via its ``--check-preseed`` mode, which
+parses + validates a preseed answer file exactly like a real headless
+install would — reusing the SAME parser (``spatium-preseed-parse``) and
+the SAME interactive-wizard rules (``_validate_static_net`` /
+``_k3s_cidr_error``) — but touches nothing: no root, no block devices,
+no whiptail, no /var/log. Machine-specific checks (is target_disk
+attached, does it clear the 32 GiB A/B floor) downgrade to warnings so
+the same file lints identically on a dev laptop and the real appliance.
+
+The disk size-floor gate is exercised through the SPATIUM_FAKE_DISK_BYTES
+test seam in ``spatium-preseed-parse`` — CI machines have no spare 32 GiB
+block device to point the real ``/sys/block/<name>/size`` read at.
+
+HOW TO RUN (from the repo root or this directory):
+    python3 -m pytest appliance/tests/test_preseed_lint.py -v
+
+No database, no Docker, no appliance ISO required.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+INSTALLER = (
+    Path(__file__).parent.parent / "mkosi.extra" / "usr" / "local" / "bin" /
+    "spatium-install"
+)
+CLOUD_INIT = Path(__file__).parent.parent / "cloud-init"
+EXAMPLE_CP = CLOUD_INIT / "spatium-preseed-control-plane.yaml.example"
+EXAMPLE_APPLIANCE = CLOUD_INIT / "spatium-preseed-appliance.yaml.example"
+
+# ``timezone: UTC`` in a preseed is a HARD field in #549 — the parser
+# rejects a zone that isn't in /usr/share/zoneinfo. Skip the handful of
+# tests that pin a real zone when tzdata is absent (minimal CI images).
+_HAS_UTC_ZONE = Path("/usr/share/zoneinfo/UTC").exists()
+
+# A minimal VALID control-plane preseed. Deliberately omits target_disk
+# + timezone (both OPTIONAL in #549 — absent means "prompt interactively"
+# / default, not an error), so the happy path doesn't depend on a block
+# device or on tzdata being installed on the linting host.
+VALID_CONTROL_PLANE = """\
+spatium_preseed:
+  role: control-plane
+  hostname: spatium-cp-1
+  admin_password: "ChangeMe!12345"
+  network:
+    mode: dhcp
+"""
+
+# A fully-populated appliance preseed (role appliance needs a
+# control_plane_url + pairing_code). target_disk is a by-id path that
+# won't exist on the linting box → warning, not error.
+VALID_APPLIANCE = """\
+spatium_preseed:
+  role: appliance
+  hostname: spatium-agent-1
+  admin_password: "ChangeMe!12345"
+  network:
+    mode: dhcp
+  control_plane_url: https://spatium-cp-1.example.com/
+  pairing_code: "12345678"
+"""
+
+
+def _check(
+    tmp_path: Path, content: str, extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Run ``spatium-install --check-preseed`` against `content`."""
+    conf = tmp_path / "preseed.yaml"
+    conf.write_text(content, encoding="utf-8")
+    return _check_file(tmp_path, conf, extra_env)
+
+
+def _check_file(
+    tmp_path: Path, conf: Path, extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    env = {
+        # Keep the installer's log plumbing away from the real /var/log.
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "SPATIUM_INSTALL_LOG": str(tmp_path / "install.log"),
+        "SPATIUM_INSTALL_TRACE_LOG": str(tmp_path / "trace.log"),
+        "HOME": str(tmp_path),
+    }
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(INSTALLER), "--check-preseed", str(conf)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+def _out(result: subprocess.CompletedProcess) -> str:
+    return result.stdout + result.stderr
+
+
+def _static(**overrides: str) -> str:
+    """A VALID_CONTROL_PLANE with its dhcp block swapped for a static
+    one, individual fields overridable/removable (value ``None`` drops
+    the line)."""
+    fields = {
+        "interface": "eth0",
+        "ip": "10.3.3.139",
+        "prefix": "24",
+        "gateway": "10.3.3.1",
+        "dns": "1.1.1.1 1.0.0.1",
+        **overrides,
+    }
+    lines = ["    mode: static"]
+    for key, val in fields.items():
+        if val is not None:
+            lines.append(f"    {key}: {val}")
+    block = "\n".join(lines)
+    return VALID_CONTROL_PLANE.replace("    mode: dhcp", block)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. The happy paths.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_valid_control_plane_accepted(tmp_path: Path) -> None:
+    r = _check(tmp_path, VALID_CONTROL_PLANE)
+    assert r.returncode == 0, _out(r)
+    assert "OK:" in r.stdout
+    assert "role=control-plane" in r.stdout
+
+
+def test_valid_appliance_accepted(tmp_path: Path) -> None:
+    r = _check(tmp_path, VALID_APPLIANCE)
+    assert r.returncode == 0, _out(r)
+    assert "role=appliance" in r.stdout
+
+
+def test_valid_static_network_accepted(tmp_path: Path) -> None:
+    r = _check(tmp_path, _static())
+    assert r.returncode == 0, _out(r)
+
+
+def test_absent_disk_is_warning_not_error(tmp_path: Path) -> None:
+    """A target_disk that isn't on the linting box downgrades to a
+    warning — the size floor is (re)checked on the real appliance."""
+    content = VALID_CONTROL_PLANE + "  confirm_wipe: true\n  target_disk: /dev/vdzzz\n"
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+    assert "WARN" in r.stdout
+    assert "does not exist" in r.stdout
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. confirm_wipe — #549 gates target_disk on it (NOT a standalone
+#    required field like PR #579 modelled).
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_confirm_wipe_non_boolean_refused(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE + "  confirm_wipe: maybe\n"
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "confirm_wipe" in _out(r)
+
+
+def test_confirm_wipe_false_disk_falls_through_to_interactive(tmp_path: Path) -> None:
+    """confirm_wipe:false + a present disk is NOT an error — the disk is
+    simply not auto-selected (the console picker runs). Lints clean."""
+    content = VALID_CONTROL_PLANE + "  confirm_wipe: false\n  target_disk: /dev/vda\n"
+    r = _check(
+        tmp_path, content,
+        extra_env={"SPATIUM_FAKE_DISK_BYTES": str(64 * 1024**3)},
+    )
+    assert r.returncode == 0, _out(r)
+    assert "WARN" in r.stdout
+    assert "confirm_wipe" in r.stdout
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Role validation (incl. #549's friendly aliases).
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("role", ["worker", "full-stack", "Control-Plane-typo", "frontend-core"])
+def test_bad_role_refused(tmp_path: Path, role: str) -> None:
+    content = VALID_CONTROL_PLANE.replace("role: control-plane", f"role: {role}")
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "role" in _out(r)
+
+
+@pytest.mark.parametrize("alias", ["first-node", "control", "add-node", "agent", "application"])
+def test_role_aliases_accepted(tmp_path: Path, alias: str) -> None:
+    """#549 maps friendly aliases onto control-plane / appliance."""
+    content = VALID_APPLIANCE.replace("role: appliance", f"role: {alias}")
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+
+
+def test_appliance_missing_url_and_code_is_partial_not_error(tmp_path: Path) -> None:
+    """A role:appliance preseed with no url/code is a PARTIAL preseed —
+    the wizard prompts interactively. Valid, but warned + not unattended."""
+    content = "spatium_preseed:\n  role: appliance\n  hostname: agent-1\n"
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+    assert "control_plane_url" in r.stdout  # a WARN line
+    assert "fully-unattended=no" in r.stdout
+
+
+def test_control_plane_ignores_pairing_fields(tmp_path: Path) -> None:
+    """Pairing fields are appliance-only; a control-plane must not need them."""
+    r = _check(tmp_path, VALID_CONTROL_PLANE)
+    assert r.returncode == 0, _out(r)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Hostname rules (RFC 1123 — mirror of ask_hostname).
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "hostname",
+    ["has space", "has.dot", "under_score", "-leading", "trailing-", "x" * 64],
+    ids=["space", "dot", "underscore", "leading-hyphen", "trailing-hyphen", "too-long"],
+)
+def test_bad_hostname_refused(tmp_path: Path, hostname: str) -> None:
+    content = VALID_CONTROL_PLANE.replace(
+        "hostname: spatium-cp-1", f'hostname: "{hostname}"'
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "hostname" in _out(r)
+
+
+def test_63_char_hostname_accepted(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE.replace(
+        "hostname: spatium-cp-1", f"hostname: {'x' * 63}"
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Credentials.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_password_and_hash_mutually_exclusive(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE + '  admin_password_hash: "$6$salt$hash"\n'
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "admin_password" in _out(r)
+
+
+def test_bad_password_hash_refused(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE.replace(
+        'admin_password: "ChangeMe!12345"', 'admin_password_hash: "not-a-crypt-hash"'
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "admin_password_hash" in _out(r)
+
+
+def test_valid_password_hash_accepted(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE.replace(
+        'admin_password: "ChangeMe!12345"',
+        'admin_password_hash: "$6$rounds=4096$abcdefgh$0123456789abcdef"',
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+
+
+def test_quoted_password_keeps_hash_char(tmp_path: Path) -> None:
+    """A quoted value keeps a '#' verbatim (not a YAML comment)."""
+    content = VALID_CONTROL_PLANE.replace(
+        'admin_password: "ChangeMe!12345"', 'admin_password: "pa#ss word12"'
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Target disk + the A/B 32 GiB floor (via the fake-bytes seam).
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_disk_under_floor_refused(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE + "  confirm_wipe: true\n  target_disk: /dev/vda\n"
+    r = _check(
+        tmp_path, content,
+        extra_env={"SPATIUM_FAKE_DISK_BYTES": str(16 * 1024**3)},
+    )
+    assert r.returncode == 1
+    assert "32 GiB" in _out(r)
+
+
+def test_disk_over_floor_accepted(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE + "  confirm_wipe: true\n  target_disk: /dev/vda\n"
+    r = _check(
+        tmp_path, content,
+        extra_env={"SPATIUM_FAKE_DISK_BYTES": str(64 * 1024**3)},
+    )
+    assert r.returncode == 0, _out(r)
+
+
+def test_partition_style_disk_refused(tmp_path: Path) -> None:
+    """A partition (has a whole-disk parent in /sys/class/block) is not a
+    valid whole-disk target — but only checkable on a box that has the
+    node. This runs on any box with at least one real disk; skip if none."""
+    disks = [p.name for p in Path("/sys/block").iterdir()
+             if not p.name.startswith(("loop", "ram", "sr", "fd", "zram", "dm-"))]
+    if not disks:
+        pytest.skip("no real block device on this host to derive a partition path")
+    # A path we know is NOT a whole disk (a made-up partition of the disk).
+    part = f"/dev/{disks[0]}p999"
+    content = VALID_CONTROL_PLANE + f"  confirm_wipe: true\n  target_disk: {part}\n"
+    r = _check(tmp_path, content)
+    # Absent/partition disks fall through to interactive → WARN, still valid.
+    assert r.returncode == 0, _out(r)
+    assert "WARN" in r.stdout
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Network validation — parser-level AND the stricter linter-level
+#    rules the linter closes over (the whole point of the salvage).
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_bad_network_mode_refused(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE.replace("    mode: dhcp", "    mode: bridged")
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "network.mode" in _out(r)
+
+
+@pytest.mark.parametrize(
+    "field,value,needle",
+    [
+        ("ip", "999.1.1.1", "network.ip"),
+        ("prefix", "abc", "network.prefix"),
+        ("gateway", "not-an-ip", "network.gateway"),
+    ],
+)
+def test_bad_static_field_refused_by_parser(
+    tmp_path: Path, field: str, value: str, needle: str
+) -> None:
+    r = _check(tmp_path, _static(**{field: value}))
+    assert r.returncode == 1, _out(r)
+    assert needle in _out(r)
+
+
+def test_static_missing_interface_refused(tmp_path: Path) -> None:
+    r = _check(tmp_path, _static(interface=None))
+    assert r.returncode == 1
+    assert "network.interface" in _out(r)
+
+
+def test_static_gateway_off_subnet_refused(tmp_path: Path) -> None:
+    """THE GAP the linter closes: a gateway that is a valid IPv4 but not
+    inside the host subnet passes the parser's own check, yet the
+    interactive install's _validate_static_net (which the linter reuses)
+    rejects it. Without the linter this only surfaces at install time."""
+    r = _check(tmp_path, _static(gateway="192.168.99.1"))
+    assert r.returncode == 1
+    assert "network" in _out(r)
+    assert "not inside" in _out(r)
+
+
+def test_static_bad_dns_refused(tmp_path: Path) -> None:
+    """Same gap: the parser does not validate the DNS list; the linter's
+    reuse of _validate_static_net does."""
+    r = _check(tmp_path, _static(dns='"1.1.1.1 not-an-ip"'))
+    assert r.returncode == 1
+    assert "DNS" in _out(r)
+
+
+def test_static_prefix_zero_refused_by_linter(tmp_path: Path) -> None:
+    """Prefix 0 slips past the parser (it allows 0-32) but _validate_static_net
+    requires 1-32 — another rule the linter closes over."""
+    r = _check(tmp_path, _static(prefix="0"))
+    assert r.returncode == 1
+    assert "Prefix" in _out(r)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 8. k3s CIDR validation (shared _k3s_cidr_error helper + the parser).
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_overlapping_cidrs_refused(tmp_path: Path) -> None:
+    content = (
+        VALID_CONTROL_PLANE
+        + "  k3s:\n    pod_cidr: 10.42.0.0/15\n    service_cidr: 10.43.0.0/16\n"
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "overlaps" in _out(r)
+
+
+def test_too_narrow_cidr_refused(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE + "  k3s:\n    pod_cidr: 10.42.0.0/24\n"
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "/22" in _out(r)
+
+
+def test_pod_cidr_overlapping_static_lan_refused(tmp_path: Path) -> None:
+    content = _static(ip="10.42.3.10", prefix="16", gateway="10.42.0.1")
+    content += "  k3s:\n    pod_cidr: 10.42.0.0/16\n    service_cidr: 10.43.0.0/16\n"
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "overlaps" in _out(r)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 9. Pairing code (appliance role).
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("code", ["1234567", "123456789", "abcdefgh"])
+def test_bad_pairing_code_refused(tmp_path: Path, code: str) -> None:
+    content = VALID_APPLIANCE.replace(
+        'pairing_code: "12345678"', f'pairing_code: "{code}"'
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "pairing_code" in _out(r)
+
+
+def test_pairing_code_with_separators_accepted(tmp_path: Path) -> None:
+    """The frontend shows codes as 1234-5678 — separators must strip."""
+    content = VALID_APPLIANCE.replace(
+        'pairing_code: "12345678"', 'pairing_code: "1234-5678"'
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+
+
+def test_bare_scheme_control_plane_url_refused(tmp_path: Path) -> None:
+    content = VALID_APPLIANCE.replace(
+        "control_plane_url: https://spatium-cp-1.example.com/",
+        'control_plane_url: "https://"',
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "control_plane_url" in _out(r)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 10. Timezone (a hard field in #549 — an unknown zone halts).
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_bad_timezone_refused(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE + "  timezone: Not/AZone\n"
+    r = _check(tmp_path, content)
+    assert r.returncode == 1
+    assert "timezone" in _out(r)
+
+
+@pytest.mark.skipif(not _HAS_UTC_ZONE, reason="tzdata (/usr/share/zoneinfo/UTC) not installed")
+def test_good_timezone_accepted(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE + "  timezone: UTC\n"
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 11. Parser behaviours (YAML shape, wrapper vs bare doc).
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_inline_yaml_comments_stripped(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE.replace(
+        "role: control-plane", "role: control-plane   # the first node"
+    ).replace(
+        "hostname: spatium-cp-1", "hostname: spatium-cp-1   # unique name"
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+    assert "role=control-plane" in r.stdout
+
+
+def test_quoted_and_aliased_values(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE.replace(
+        "role: control-plane", 'role: "control_plane"'
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+
+
+def test_bare_document_without_wrapper_accepted(tmp_path: Path) -> None:
+    """The preseed may be the whole doc (no spatium_preseed: wrapper) if
+    it carries a recognised field."""
+    content = (
+        "role: control-plane\n"
+        "hostname: bare-doc-cp\n"
+        'admin_password: "ChangeMe!12345"\n'
+        "network:\n  mode: dhcp\n"
+    )
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+
+
+def test_hyphen_alias_wrapper_accepted(tmp_path: Path) -> None:
+    content = VALID_CONTROL_PLANE.replace("spatium_preseed:", "spatium-preseed:")
+    r = _check(tmp_path, content)
+    assert r.returncode == 0, _out(r)
+
+
+def test_empty_file_refused(tmp_path: Path) -> None:
+    r = _check(tmp_path, "# just a comment\n")
+    assert r.returncode == 1
+
+
+def test_non_preseed_yaml_refused(tmp_path: Path) -> None:
+    """A parseable YAML with no spatium content is not ours → rejected as
+    a lint target (the real install would just fall through, but you asked
+    us to lint THIS file)."""
+    r = _check(tmp_path, "some_other_tool:\n  foo: bar\n")
+    assert r.returncode == 1
+    assert "preseed content" in _out(r)
+
+
+def test_malformed_yaml_refused(tmp_path: Path) -> None:
+    r = _check(tmp_path, "spatium_preseed:\n  role: [unterminated\n")
+    assert r.returncode == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 12. Multi-error reporting — one lint round surfaces every problem.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_multiple_errors_reported_in_one_pass(tmp_path: Path) -> None:
+    content = (
+        "spatium_preseed:\n"
+        "  role: worker\n"
+        "  hostname: bad host\n"
+        "  network:\n    mode: bridged\n"
+        "  k3s:\n    pod_cidr: 10.42.0.0/15\n    service_cidr: 10.43.0.0/16\n"
+    )
+    r = _check(tmp_path, content)
+    err = _out(r)
+    assert r.returncode == 1
+    for needle in ("role", "hostname", "network.mode", "overlaps"):
+        assert needle in err, f"expected an error mentioning {needle!r}\n{err}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 13. CLI surface — usage / help.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_missing_file_is_usage_error(tmp_path: Path) -> None:
+    r = _check_file(tmp_path, tmp_path / "nope.yaml")
+    assert r.returncode == 2
+    assert "usage" in r.stderr
+
+
+def test_help_exits_zero(tmp_path: Path) -> None:
+    r = subprocess.run(
+        ["bash", str(INSTALLER), "--help"],
+        capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+             "SPATIUM_INSTALL_LOG": str(tmp_path / "i.log"),
+             "SPATIUM_INSTALL_TRACE_LOG": str(tmp_path / "t.log"),
+             "HOME": str(tmp_path)},
+        timeout=60,
+    )
+    assert r.returncode == 0
+    assert "--check-preseed" in r.stdout
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 14. The shipped example files stay valid.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _HAS_UTC_ZONE, reason="tzdata not installed (examples pin timezone: UTC)")
+@pytest.mark.skipif(not EXAMPLE_CP.exists(), reason="shipped example not present")
+def test_shipped_control_plane_example_lints_clean(tmp_path: Path) -> None:
+    """Copying the shipped control-plane example verbatim must lint OK —
+    only its by-id target_disk (absent on CI) shows as a warning."""
+    r = _check_file(tmp_path, EXAMPLE_CP)
+    assert r.returncode == 0, _out(r)
+    assert "role=control-plane" in r.stdout
+
+
+@pytest.mark.skipif(not _HAS_UTC_ZONE, reason="tzdata not installed (examples pin timezone: UTC)")
+@pytest.mark.skipif(not EXAMPLE_APPLIANCE.exists(), reason="shipped example not present")
+def test_shipped_appliance_example_lints_clean(tmp_path: Path) -> None:
+    r = _check_file(tmp_path, EXAMPLE_APPLIANCE)
+    assert r.returncode == 0, _out(r)
+    assert "role=appliance" in r.stdout


### PR DESCRIPTION
Salvages the two genuinely-valuable artifacts from the now-closed **#579** (@amoona6, #134) onto the **shipped #549** preseed installer — which had neither. #579 turned out to duplicate #549 (both drive `spatium-install` to the same 6-partition A/B layout), so it was closed as superseded; these are the bits worth keeping.

## What's here

- **`spatium-install --check-preseed <file>`** — an unprivileged, read-only, *touch-nothing* linter that validates a `spatium-preseed.yaml` on **any** machine, **before** you boot the installer. It parses via the **same** helper a real headless install uses (`spatium-preseed-parse`), then re-runs the wizard's **own** rules (`_validate_static_net` + the new `_k3s_cidr_error`) against the resolved values, reporting **every** error in one pass. Machine-specific checks (disk presence / 32 GiB floor) downgrade to `WARN:` so it's host-portable. Exit `0` valid / `1` invalid / `2` usage. (`--help` prints usage.)
- **Shared-rule refactor, no divergence** — the pure-Python core of `_validate_k3s_cidrs` is split into `_k3s_cidr_error`; `_validate_k3s_cidrs` is now a thin whiptail wrapper. The interactive path is unchanged and the linter reuses the **exact same** rule, so the two can't drift.
- **`appliance/tests/test_preseed_lint.py`** — 61 host-portable pytest cases (adapted from #579's suite). **#549 — a disk-*wiping* feature — shipped with zero tests for this path**, which is the recurring "appliance scripts ship untested" pattern from the #550-557 audit.

## Why it's more than convenience

The linter catches, **offline and pre-boot**, the static-network cases that `spatium-preseed-parse` currently accepts but a real install only rejects at the interactive `ask_network` re-check — off-subnet gateway, prefix `0`, unvalidated DNS — i.e. *after* the operator has already committed the boot. (During my review I confirmed preseeded fields **are** validated today, just in the parser, not the `ask_*` short-circuits — so this isn't a general gap, but these specific static-net cases are, and the linter closes them.)

## Verification (this host, no root)
- `bash -n` (spatium-install) + `py_compile` (spatium-preseed-parse) clean
- `shellcheck -S warning` — no new findings (only the 2 pre-existing SC2010/SC2034)
- `pytest appliance/tests/` → **118 passed** (61 new + 57 existing)
- Lint OK on both shipped `.example` files; rejects a bad hostname/gateway/CIDR/pairing with exit 1

## Scope / follow-up
This is the linter + tests. The deeper #549 security items surfaced in review — `target_disk` >1-candidate refusal, https/checksum on the URL fetch, `admin_user` shape validation, secrets-in-trace-log — stay tracked in **#581** for a focused follow-up.

Refs #581. Salvaged from #579 — credit @amoona6 for the linter idea + the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)