### PR TITLE
fix(dhcp): restore DNS Servers + PXE profile on the scope edit form (#583)

### DIFF
--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -57,11 +57,21 @@ _CODE_TO_NAME: dict[int, str] = {
 }
 
 
+# Legacy / alternate option names that collapse onto a canonical name.
+# The frontend historically sent option 6 as the IANA name
+# ``domain-name-servers`` while the canonical stored vocabulary (and the
+# Kea driver's option-name map) is ``dns-servers`` (#583). Normalise on
+# write so new rows store canonically, and recognise the alias on read so
+# already-persisted rows still resolve to code 6 in ``_scope_to_response``
+# rather than falling through to code 0 / the custom-options bucket.
+_OPTION_NAME_ALIASES: dict[str, str] = {"domain-name-servers": "dns-servers"}
+
+
 def _normalize_options(raw: Any) -> dict[str, Any]:
     if raw is None:
         return {}
     if isinstance(raw, dict):
-        return raw
+        return {_OPTION_NAME_ALIASES.get(str(k), str(k)): v for k, v in raw.items()}
     if isinstance(raw, list):
         out: dict[str, Any] = {}
         for entry in raw:
@@ -73,6 +83,7 @@ def _normalize_options(raw: Any) -> dict[str, Any]:
                 name = f"option-{code}" if code else None
             if not name:
                 continue
+            name = _OPTION_NAME_ALIASES.get(name, name)
             out[name] = entry.get("value")
         return out
     return {}
@@ -264,6 +275,11 @@ class ScopeUpdate(BaseModel):
 
 
 _NAME_TO_CODE = {v: k for k, v in _CODE_TO_NAME.items()}
+# Existing rows may still be stored under the legacy alias (#583); map it
+# to code 6 on readback so the DNS Servers field populates on edit.
+for _alias, _canon in _OPTION_NAME_ALIASES.items():
+    if _canon in _NAME_TO_CODE:
+        _NAME_TO_CODE[_alias] = _NAME_TO_CODE[_canon]
 
 
 class ScopeResponse(BaseModel):
@@ -295,6 +311,10 @@ class ScopeResponse(BaseModel):
     ra_prefix_autonomous: bool = True
     ra_interface: str = ""
     relay_addresses: list[str] = Field(default_factory=list)
+    # PXE / iPXE profile binding (issue #51). Echoed so the scope edit
+    # form can pre-select the bound profile — without it the picker always
+    # reset to "(none)" and a save silently detached the profile (#583).
+    pxe_profile_id: uuid.UUID | None = None
     last_pushed_at: datetime | None
     tags: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
@@ -338,6 +358,7 @@ def _scope_to_response(scope: DHCPScope) -> ScopeResponse:
         ra_prefix_autonomous=getattr(scope, "ra_prefix_autonomous", True),
         ra_interface=getattr(scope, "ra_interface", "") or "",
         relay_addresses=list(getattr(scope, "relay_addresses", None) or []),
+        pxe_profile_id=scope.pxe_profile_id,
         last_pushed_at=scope.last_pushed_at,
         tags=scope.tags or {},
         created_at=scope.created_at,

--- a/backend/tests/test_dhcp_scope_options_roundtrip.py
+++ b/backend/tests/test_dhcp_scope_options_roundtrip.py
@@ -1,0 +1,162 @@
+"""#583 — DHCP scope edit form dropped DNS Servers + PXE profile.
+
+Two independent round-trip bugs surfaced when editing an existing scope:
+
+* Option 6 (DNS Servers) was sent by the frontend under the IANA name
+  ``domain-name-servers`` while the canonical stored vocabulary is
+  ``dns-servers``. The response serializer's name→code table only knew
+  ``dns-servers``, so a legacy row read back as code 0 and fell into the
+  hidden custom-options bucket — the DNS Servers field rendered empty and
+  a save wiped it.
+* ``pxe_profile_id`` was missing from ``ScopeResponse`` entirely, so the
+  PXE picker always reset to "(none)" and a save silently detached the
+  bound profile.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPPXEProfile, DHCPScope, DHCPServerGroup
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+CIDR = "192.0.2.0/24"
+
+
+async def _make_token(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="T",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _subnet_and_group(db: AsyncSession) -> tuple[Subnet, DHCPServerGroup]:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=CIDR, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=CIDR, name="s")
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, grp])
+    await db.flush()
+    return subnet, grp
+
+
+async def _create(
+    client: AsyncClient, h: dict, subnet: Subnet, grp: DHCPServerGroup, **extra
+) -> dict:
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet.id}/dhcp-scopes",
+        headers=h,
+        json={"group_id": str(grp.id), "name": "s", **extra},
+    )
+    assert r.status_code in (200, 201), r.text
+    return r.json()
+
+
+def _dns_option(body: dict) -> dict | None:
+    return next((o for o in body["options"] if o["code"] == 6), None)
+
+
+@pytest.mark.asyncio
+async def test_dns_servers_canonical_name_round_trips(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    body = await _create(
+        client,
+        h,
+        subnet,
+        grp,
+        options=[{"code": 6, "name": "dns-servers", "value": ["10.0.0.1", "10.0.0.2"]}],
+    )
+    # Comes back as code 6 (not 0) so the DNS Servers field renders on edit.
+    opt = _dns_option(body)
+    assert opt is not None, body["options"]
+    assert opt["value"] == ["10.0.0.1", "10.0.0.2"]
+
+
+@pytest.mark.asyncio
+async def test_dns_servers_legacy_iana_name_still_maps_to_code_6(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # Older clients (and already-persisted rows) used the IANA name; it must
+    # still resolve to code 6 rather than dropping into custom options (#583).
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    body = await _create(
+        client,
+        h,
+        subnet,
+        grp,
+        options=[{"code": 6, "name": "domain-name-servers", "value": ["10.0.0.9"]}],
+    )
+    opt = _dns_option(body)
+    assert opt is not None, body["options"]
+    assert opt["value"] == ["10.0.0.9"]
+    # Write-side normalisation collapses onto the canonical stored name.
+    scope = await db_session.get(DHCPScope, uuid.UUID(body["id"]))
+    await db_session.refresh(scope)
+    assert "dns-servers" in scope.options
+    assert "domain-name-servers" not in scope.options
+
+
+@pytest.mark.asyncio
+async def test_pxe_profile_id_round_trips(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    profile = DHCPPXEProfile(group_id=grp.id, name="p", next_server="10.0.0.5")
+    db_session.add(profile)
+    await db_session.flush()
+    profile_id = str(profile.id)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    body = await _create(client, h, subnet, grp)
+    # ScopeCreate ignores pxe_profile_id — bind it via update, like the UI.
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{body['id']}",
+        headers=h,
+        json={"pxe_profile_id": profile_id},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["pxe_profile_id"] == profile_id
+
+    # And a fresh GET echoes it so the edit form pre-selects the profile.
+    r = await client.get(f"/api/v1/dhcp/scopes/{body['id']}", headers=h)
+    assert r.status_code == 200, r.text
+    assert r.json()["pxe_profile_id"] == profile_id
+
+
+@pytest.mark.asyncio
+async def test_pxe_profile_id_null_when_unbound(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    body = await _create(client, h, subnet, grp)
+    assert body["pxe_profile_id"] is None

--- a/frontend/src/pages/dhcp/DHCPOptionsEditor.tsx
+++ b/frontend/src/pages/dhcp/DHCPOptionsEditor.tsx
@@ -34,8 +34,13 @@ const STANDARD_OPTIONS: StandardDef[] = [
     hint: "Default gateway(s) for clients on this scope.",
   },
   {
+    // Canonical SpatiumDDI option name is ``dns-servers`` — this is what
+    // the backend stores + what the Kea driver's option-name map keys on
+    // (both v4 → ``domain-name-servers`` and v6 → option 23). Sending the
+    // IANA name ``domain-name-servers`` here bypassed that map and, worse,
+    // read back as code 0 so the field rendered empty on edit (#583).
     code: 6,
-    name: "domain-name-servers",
+    name: "dns-servers",
     label: "DNS Servers (option 6)",
     kind: "ip-list",
     max: 3,


### PR DESCRIPTION
## Problem

Closes #583. Editing an existing DHCP scope showed **blank DNS Servers and PXE profile** fields even when both were configured and correctly propagated to Kea. Saving over the blanks then wiped the real config — a silent data-loss trap. Routers / Domain Name / NTP / TFTP populated fine, which pointed at two field-specific round-trip bugs rather than a general load failure.

## Root causes

1. **DNS Servers (option 6) — option-name mismatch.** The frontend labelled option 6 with the IANA name `domain-name-servers`, but the backend's canonical stored vocabulary (and the Kea driver's option-name map, both v4 → `domain-name-servers` and v6 → option 23) is `dns-servers`. On read-back the serializer's name→code table didn't recognise `domain-name-servers`, so it returned **code 0** and the value dropped into the hidden "Custom options" bucket — the DNS Servers field rendered empty.

2. **PXE profile — never serialized.** `pxe_profile_id` exists on the model and the frontend type, but was **missing from `ScopeResponse`** entirely, so the picker always reset to "(none)" and a save silently detached the bound profile.

## Fix

- **Frontend** (`DHCPOptionsEditor.tsx`): align option 6 to the canonical name `dns-servers`.
- **Backend** (`scopes.py`):
  - Add `_OPTION_NAME_ALIASES` (`domain-name-servers` → `dns-servers`) — normalised on write so new rows store canonically, and recognised on read so **already-persisted rows recover to code 6 without a migration**.
  - Add `pxe_profile_id` to `ScopeResponse` + `_scope_to_response`.

## Tests

New `test_dhcp_scope_options_roundtrip.py` (4 cases): DNS servers canonical round-trip, legacy IANA-name recovery + write-side normalisation, PXE profile round-trip via update + GET, and null-when-unbound. All pass; existing DHCP scope/relay/v6/import suites (41 tests) still green. `ruff` + `black` + `mypy` clean; frontend `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)