### PR TITLE
fix(dns): exclude reverse zones from GSLB pool zone picker + reject server-side (#571)

### DIFF
--- a/backend/app/api/v1/dns/pool_router.py
+++ b/backend/app/api/v1/dns/pool_router.py
@@ -371,6 +371,12 @@ async def create_pool(
         raise HTTPException(status_code=404, detail="Zone not found")
     if zone.zone_type == "forward":
         raise HTTPException(status_code=400, detail="Pools are not supported on forward zones")
+    # Pools render A/AAAA records, which only belong in a forward zone.
+    # Reverse (in-addr.arpa / ip6.arpa) zones hold PTR records, so a pool
+    # there could never render a valid record — reject it defensively
+    # rather than relying on the UI picker filter alone (issue #571).
+    if zone.kind == "reverse":
+        raise HTTPException(status_code=400, detail="Pools are not supported on reverse zones")
     clash = await db.execute(
         select(DNSPool).where(DNSPool.zone_id == zone_id, DNSPool.record_name == body.record_name)
     )

--- a/backend/tests/test_dns_pool_reverse_zone.py
+++ b/backend/tests/test_dns_pool_reverse_zone.py
@@ -1,0 +1,91 @@
+"""#571 — DNS GSLB pools must not be creatable on reverse zones.
+
+Pools render A / AAAA records, which only make sense in a forward zone.
+Reverse (in-addr.arpa / ip6.arpa) zones hold PTR records, so a pool there
+could never render a valid record. The UI picker filters them out; this
+covers the API-first defensive rejection so a direct API client can't
+create an unrenderable pool either.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import DNSServerGroup, DNSZone
+
+
+async def _token(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="T",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _group_and_zone(
+    db: AsyncSession, *, kind: str, name: str
+) -> tuple[DNSServerGroup, DNSZone]:
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name=name,
+        zone_type="primary",
+        kind=kind,
+        primary_ns="ns1.example.com.",
+        admin_email="admin.example.com.",
+    )
+    db.add(zone)
+    await db.flush()
+    return grp, zone
+
+
+def _pool_body() -> dict:
+    return {"name": "web", "record_name": "www", "record_type": "A"}
+
+
+@pytest.mark.asyncio
+async def test_pool_create_rejected_on_reverse_zone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _token(db_session)
+    grp, zone = await _group_and_zone(db_session, kind="reverse", name="10.in-addr.arpa.")
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/pools",
+        headers=h,
+        json=_pool_body(),
+    )
+    assert r.status_code == 400, r.text
+    assert "reverse" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_pool_create_allowed_on_forward_zone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _token(db_session)
+    grp, zone = await _group_and_zone(db_session, kind="forward", name="example.com.")
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{grp.id}/zones/{zone.id}/pools",
+        headers=h,
+        json=_pool_body(),
+    )
+    assert r.status_code == 201, r.text

--- a/backend/tests/test_dns_pool_reverse_zone.py
+++ b/backend/tests/test_dns_pool_reverse_zone.py
@@ -75,7 +75,7 @@ async def test_pool_create_rejected_on_reverse_zone(
 
 
 @pytest.mark.asyncio
-async def test_pool_create_allowed_on_forward_zone(
+async def test_pool_create_allowed_on_forward_lookup_zone(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:
     token = await _token(db_session)

--- a/frontend/src/pages/dns/DNSPoolsPage.tsx
+++ b/frontend/src/pages/dns/DNSPoolsPage.tsx
@@ -304,11 +304,16 @@ function PickGroupZoneModal({
     enabled: !!groupId,
   });
 
-  // Pools render regular A/AAAA records — only primary / secondary
-  // zones can host them. Forward + Tailscale-synthesised zones are
-  // hidden from the picker.
+  // Pools render regular A/AAAA records — only forward primary /
+  // secondary zones can host them. Conditional-forwarder zones, reverse
+  // (in-addr.arpa / ip6.arpa) zones — which hold PTR records, not
+  // A/AAAA — and Tailscale-synthesised zones are hidden from the picker
+  // (issue #571).
   const eligibleZones = zones.filter(
-    (z) => z.zone_type !== "forward" && !z.tailscale_tenant_id,
+    (z) =>
+      z.zone_type !== "forward" &&
+      z.kind !== "reverse" &&
+      !z.tailscale_tenant_id,
   );
 
   const group = groups.find((g) => g.id === groupId);
@@ -362,7 +367,8 @@ function PickGroupZoneModal({
           </select>
           {groupId && eligibleZones.length === 0 && (
             <p className="text-[11px] text-muted-foreground">
-              No primary or secondary zones in this group. Forward zones and
+              No eligible forward zones in this group. Conditional-forwarder
+              zones, reverse (in-addr.arpa / ip6.arpa) zones, and
               Tailscale-synthesised zones can&apos;t host pools.
             </p>
           )}

--- a/frontend/src/pages/dns/DNSPoolsPage.tsx
+++ b/frontend/src/pages/dns/DNSPoolsPage.tsx
@@ -304,11 +304,9 @@ function PickGroupZoneModal({
     enabled: !!groupId,
   });
 
-  // Pools render regular A/AAAA records — only forward primary /
-  // secondary zones can host them. Conditional-forwarder zones, reverse
-  // (in-addr.arpa / ip6.arpa) zones — which hold PTR records, not
-  // A/AAAA — and Tailscale-synthesised zones are hidden from the picker
-  // (issue #571).
+// Pools render regular A/AAAA records — they must target a forward-lookup zone.
+// Conditional-forwarder zones (zone_type === "forward"), reverse zones (kind === "reverse"),
+// and Tailscale-synthesised zones are hidden from the picker (issue #571).
   const eligibleZones = zones.filter(
     (z) =>
       z.zone_type !== "forward" &&

--- a/frontend/src/pages/dns/DNSPoolsPage.tsx
+++ b/frontend/src/pages/dns/DNSPoolsPage.tsx
@@ -304,9 +304,9 @@ function PickGroupZoneModal({
     enabled: !!groupId,
   });
 
-// Pools render regular A/AAAA records — they must target a forward-lookup zone.
-// Conditional-forwarder zones (zone_type === "forward"), reverse zones (kind === "reverse"),
-// and Tailscale-synthesised zones are hidden from the picker (issue #571).
+  // Pools render regular A/AAAA records — they must target a forward-lookup zone.
+  // Conditional-forwarder zones (zone_type === "forward"), reverse zones (kind === "reverse"),
+  // and Tailscale-synthesised zones are hidden from the picker (issue #571).
   const eligibleZones = zones.filter(
     (z) =>
       z.zone_type !== "forward" &&


### PR DESCRIPTION
## Problem

Closes #571. The **"New DNS pool — pick zone"** modal listed reverse-lookup zones (e.g. `10.in-addr.arpa (primary)`) alongside forward zones. GSLB pools render **A / AAAA** records, which only belong in a forward zone — reverse zones hold **PTR** records, so a pool targeting one could never render a valid record.

Reverse zones slipped through the existing picker filter because they carry `zone_type === "primary"`; the filter only excluded conditional-forwarder (`forward`) and Tailscale-synthesised zones.

## Fix

- **Frontend** (`DNSPoolsPage.tsx`): filter on the dedicated `kind` field — `z.kind !== "reverse"` — instead of relying on `zone_type`. Empty-state copy updated to mention reverse zones can't host pools.
- **Backend** (`pool_router.py`): reject a reverse-zone target in `create_pool` with a `400` (API-first — the UI filter is not the enforcement layer), mirroring the existing forward-zone guard.

## Tests

New `test_dns_pool_reverse_zone.py`: reverse-zone target → `400`, forward-zone target → `201`. Both pass. `ruff` + `black` + `mypy` clean; frontend `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)