### PR TITLE
fix(appliance): gate the headless-install Done msgbox on FULLY_UNATTENDED (#549)

### DIFF
--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -1867,6 +1867,24 @@ EOF
     # render Unicode box-drawing chars at all. Plain indented text +
     # the `*** … ***` attention rule scans cleanly on tty1, in serial
     # consoles, and over SSH.
+    #
+    # #549 headless follow-up — GATE this msgbox on FULLY_UNATTENDED, the
+    # same as welcome + the final confirm are gated in main()'s state
+    # machine. A fully-preseeded install has no operator on tty1 to press
+    # OK, so showing it unconditionally hangs the run FOREVER: the disk is
+    # already partitioned, rsynced, grub-installed, answer-injected and
+    # synced, and the media ATA-ejected — but `systemctl reboot` below is
+    # never reached, so the appliance completes its install correctly yet
+    # never boots into it. (Hypervisor-side workarounds can't rescue this:
+    # the install ISO is the live boot medium, so its tray stays LOCKED —
+    # `eject /dev/sr0` above fails and a "tray-open" completion signal can
+    # never fire; and whiptail on tty1 ignores an injected Enter/ACPI on a
+    # headless guest.) The msgbox's "remove the install media" advice is
+    # moot when unattended (the eject already fired; hypervisors honor the
+    # ATA EJECT) and there is no human to read it. Interactive + partial-
+    # preseed installs still show it (an operator was prompted for
+    # something, so give them the review + media reminder).
+    if [ "${FULLY_UNATTENDED:-0}" != "1" ]; then
     whiptail --backtitle "$BACKTITLE" --title "Done" \
         --msgbox "\
 SpatiumDDI is installed on $TARGET_DISK.
@@ -1892,6 +1910,9 @@ the SpatiumDDI container images.
    Login:   admin / admin   (change forced on first login)
 
 Press OK to reboot." 24 72
+    else
+        log "Fully unattended: install complete on $TARGET_DISK — skipping the interactive Done prompt and rebooting straight into the installed system."
+    fi
 
     log "Install complete. Rebooting."
     systemctl reboot

--- a/appliance/tests/test_install_done_gate.py
+++ b/appliance/tests/test_install_done_gate.py
@@ -1,0 +1,96 @@
+"""Host-portable regression test for the headless-install Done-screen gate.
+
+#549 headless follow-up. A fully-preseeded (unattended) install has no
+operator on tty1 to dismiss the final "Press OK to reboot" msgbox, so if
+that dialog is shown unconditionally the install completes on disk but the
+box hangs forever and never reboots — the appliance never comes up on its
+own. `welcome` and the final `confirm` are already gated on
+``FULLY_UNATTENDED``; the Done msgbox must be too.
+
+do_install itself is NOT unit-testable host-side (it partitions a real disk
+as root and rsyncs the live rootfs — the rest of this suite deliberately
+exercises only ``spatium-install --check-preseed``, which touches nothing).
+So this pins the exact regression as a STRUCTURAL invariant on the script:
+
+  1. the ``--title "Done"`` msgbox sits INSIDE an
+     ``if [ ... FULLY_UNATTENDED ... != "1" ]`` gate, and
+  2. ``systemctl reboot`` runs AFTER that gate closes (i.e. unconditionally,
+     on both the attended and the unattended path).
+
+Fails on the pre-fix script (no gate around the msgbox). Tolerant of
+whitespace / comment / wording changes around it.
+
+HOW TO RUN (from the repo root or this directory):
+    python3 -m pytest appliance/tests/test_install_done_gate.py -v
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+INSTALLER = (
+    Path(__file__).parent.parent / "mkosi.extra" / "usr" / "local" / "bin" /
+    "spatium-install"
+)
+
+
+def _lines() -> list[str]:
+    return INSTALLER.read_text(encoding="utf-8").splitlines()
+
+
+def _index(pred, lines, start=0):
+    for i in range(start, len(lines)):
+        if pred(lines[i]):
+            return i
+    return -1
+
+
+def test_done_msgbox_is_gated_on_fully_unattended():
+    lines = _lines()
+
+    done = _index(lambda ln: '--title "Done"' in ln, lines)
+    assert done != -1, 'could not find the `--title "Done"` msgbox in spatium-install'
+
+    # A FULLY_UNATTENDED gate must open BEFORE the Done msgbox, and no `fi`
+    # may intervene between the gate and the msgbox (else the msgbox is not
+    # inside it). Match the guard loosely so re-wording the test/comparison
+    # doesn't break the test: an `if` line mentioning FULLY_UNATTENDED.
+    gate_re = re.compile(r'^\s*if\b.*FULLY_UNATTENDED')
+    gate = -1
+    for i in range(done - 1, -1, -1):
+        if re.match(r'^\s*fi\b', lines[i]):
+            break  # a closed block sits between us and any earlier gate
+        if gate_re.search(lines[i]):
+            gate = i
+            break
+    assert gate != -1, (
+        "the Done msgbox is not wrapped in a FULLY_UNATTENDED gate — a "
+        "fully-preseeded install would hang on it forever (see #549 headless)"
+    )
+
+    # The gate must close (fi) after the msgbox, and `systemctl reboot` must
+    # come AFTER that fi — i.e. the reboot is unconditional, only the dialog
+    # is skipped on the unattended path.
+    fi = _index(lambda ln: re.match(r'^\s*fi\b', ln), lines, start=done)
+    assert fi != -1, "no `fi` closing the Done-msgbox gate after the msgbox"
+
+    reboot = _index(lambda ln: "systemctl reboot" in ln, lines, start=done)
+    assert reboot != -1, "no `systemctl reboot` after the Done msgbox"
+    assert reboot > fi, (
+        "`systemctl reboot` must run AFTER the FULLY_UNATTENDED gate closes "
+        "(unconditionally) — otherwise the unattended path skips the reboot too"
+    )
+
+
+def test_welcome_and_confirm_are_also_unattended_gated():
+    """Guard the sibling invariant the fix mirrors: welcome + the final
+    confirm are skipped on a fully-unattended run. If these ever regress,
+    the 'gate the Done screen the same way' rationale no longer holds."""
+    text = INSTALLER.read_text(encoding="utf-8")
+    # main()'s state machine skips welcome and confirm when FULLY_UNATTENDED.
+    assert re.search(r'FULLY_UNATTENDED"?\s*!=\s*"1".*\n\s*welcome', text) or \
+        re.search(r'if \[ "\$FULLY_UNATTENDED" != "1" \]; then\s*\n\s*welcome', text), \
+        "welcome is no longer gated on FULLY_UNATTENDED"
+    assert 'if [ "$FULLY_UNATTENDED" = "1" ]; then' in text, \
+        "the confirm/do_install unattended gate in main() is gone"


### PR DESCRIPTION
## Bug: fully-unattended preseed install hangs at the Done screen (never reboots)

Found by our automated QA harness driving the #549 headless installer across
releases 2026.06.25-1 … 2026.07.04-1 (the behavior is in current `main` too).
It affects **both** install roles — control-plane and appliance — i.e. every
fully-preseeded install on every current ISO.

### What happens

A **fully-preseeded** install (all fields + `confirm_wipe: true`, delivered via
a NoCloud CIDATA seed) runs exactly as documented — no welcome, no confirm,
partitions, rsyncs the rootfs, installs grub, injects answers, `sync`s, ejects
the media — and then `do_install` shows the final Done msgbox **unconditionally**:

```bash
whiptail --backtitle "$BACKTITLE" --title "Done" --msgbox "\
SpatiumDDI is installed on $TARGET_DISK.
...
Press OK to reboot." 24 72

log "Install complete. Rebooting."
systemctl reboot
```

On a headless box there is no operator on tty1 to press OK, so whiptail waits
forever and `systemctl reboot` is never reached. **The install is complete and
correct on disk — the machine just never comes back up on its own.** The docs'
promise — "runs end-to-end with *zero* console interaction"
(`appliance/cloud-init/README.md`) — holds everywhere except this final screen.

`FULLY_UNATTENDED=1` already gates `welcome` and the final `confirm` in the
wizard state machine. The Done msgbox is the one dialog that wasn't gated.

### Why a hypervisor-side workaround can't rescue it

We first tried to detect completion and power the VM off from the outside. It
doesn't work, and the reason is instructive: **the install ISO is the live boot
medium.** The kernel holds it, so its CD tray is *locked closed* for the entire
install — `eject /dev/sr0` in `do_install` fails silently (the `|| true`
swallows it), and the installer ISO can never present a "tray open" / "no media"
completion signal to the hypervisor. Captured live on the stuck guest:

```
$ virsh qemu-monitor-command <vm> --hmp 'info block'
...-format: /.../spatiumddi-appliance-<tag>.iso (raw, read-only)
    Attached to:      sata0-0-0
    Removable device: locked, tray closed        <-- the live medium; can't eject
...-format: /.../cidata.iso (raw, read-only)
    Attached to:      sata0-0-1
    Removable device: not locked, tray open       <-- only the preseed seed ejects
```

(Only the CIDATA seed — which the installer unmounts after reading the answer
file — ends up ejectable, and it reads `tray open` from very early in the boot,
so it's not a "done" signal either.) And `virsh send-key ... KEY_ENTER` / an
ACPI power button do **not** dismiss the whiptail msgbox on a `--graphics none`
guest. The net effect: every unattended install runs to the Done screen and
then sits until the harness's timeout, on a loop. There is no robust external
signal — the install genuinely needs to reboot itself.

### Fix (PR ready)

Gate the Done msgbox on `FULLY_UNATTENDED`, exactly like `welcome` + `confirm`:

```bash
if [ "${FULLY_UNATTENDED:-0}" != "1" ]; then
    whiptail ... "Press OK to reboot." 24 72
else
    log "Fully unattended: install complete on $TARGET_DISK — skipping the interactive Done prompt and rebooting straight into the installed system."
fi
log "Install complete. Rebooting."
systemctl reboot
```

The eject already fired by then, so the msgbox's "remove the install media"
advice is moot for the headless case (hypervisors honor the ATA EJECT), and
there's no operator to read it. Interactive + partial-preseed installs are
unchanged (an operator was prompted for something, so they still get the review
+ media reminder). Branch `fix/headless-install-done-msgbox-gate` also adds a
host-portable structural regression test (`appliance/tests/test_install_done_gate.py`)
that pins "the Done msgbox stays inside a FULLY_UNATTENDED gate and
`systemctl reboot` runs after it" — it fails on the current script and passes
with the fix.

### Reproduction

1. Build a CIDATA seed with a complete control-plane preseed
   (`spatium-preseed-control-plane.yaml.example` with `confirm_wipe: true` and a
   resolvable `target_disk`), or an appliance preseed with `control_plane_url` +
   `pairing_code`.
2. Boot the release ISO + seed in a headless VM (`--graphics none`, or with a
   framebuffer for observation).
3. Observe: disk writes complete and stop; a framebuffer screenshot
   (`virsh screenshot <vm>`) shows the whiptail **"Done — SpatiumDDI is installed
   on /dev/…  Press OK to reboot"** dialog; the domain stays `running`
   indefinitely and never reboots.

With the fix, the same run reaches `systemctl reboot` on its own; if the domain
is defined with libvirt `<on_reboot>destroy</on_reboot>`, that reboot cleanly
powers the VM off — a real, unambiguous "install done" signal for automation.

Happy to iterate on the PR.
