### PR TITLE
Validate hostnames / DNS names against DNS standards across IPAM, DNS, DHCP (#597)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -60,6 +60,7 @@ components. Grouped by role; license + project URL for each.
 - icalendar (Wake-on-LAN calendar gate — .ics parsing) — BSD 2-Clause — https://github.com/collective/icalendar
 - caldav (Wake-on-LAN calendar gate — CalDAV client) — Apache 2.0 — https://github.com/python-caldav/caldav
 - python-dateutil (recurrence RRULE/RDATE expansion) — Apache 2.0 / BSD 3-Clause — https://github.com/dateutil/dateutil
+- idna (IDNA2008 host/record name normalization — issue #597) — BSD 3-Clause — https://github.com/kjd/idna
 - Scapy (passive DHCP fingerprinting) — GPL v2 — https://scapy.net
 - nmap (network scanning) — NPSL (Nmap Public Source License) — https://nmap.org
 - tcpdump / libpcap (packet capture) — BSD 3-Clause — https://www.tcpdump.org

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -17,7 +17,7 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from jose import JWTError
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import select
 
 from app.api.deps import DB
@@ -27,6 +27,7 @@ from app.core.agent_wake import (
     dhcp_wake_channels,
     wake_subscription,
 )
+from app.core.dns_names import sanitize_hostname
 from app.models.dhcp import (
     DHCPConfigOp,
     DHCPLease,
@@ -151,6 +152,18 @@ class LeaseEvent(BaseModel):
     starts_at: datetime | None = None
     ends_at: datetime | None = None
     expires_at: datetime | None = None
+
+    @field_validator("hostname")
+    @classmethod
+    def _sanitize_client_hostname(cls, v: str | None) -> str | None:
+        # The client-supplied DHCP hostname arrives off the wire and flows
+        # into IPAM.hostname + the lease row + DDNS. Fold it to a safe LDH
+        # form at ingress (issue #597) rather than rejecting — a malformed
+        # client hostname must never fail the lease ingest. Empty result →
+        # None ("no usable hostname").
+        if v is None:
+            return None
+        return sanitize_hostname(v) or None
 
 
 class LeaseEventBatch(BaseModel):

--- a/backend/app/api/v1/dhcp/client_classes.py
+++ b/backend/app/api/v1/dhcp/client_classes.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.api.v1.dhcp._audit import write_audit
+from app.api.v1.dhcp.scopes import validate_domain_options
 from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.permissions import require_resource_permission
 from app.models.dhcp import DHCPClientClass, DHCPServerGroup
@@ -72,6 +73,7 @@ async def create_class(
     )
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=409, detail="A client class with that name exists")
+    validate_domain_options(body.options or {})  # #597 — domain-name/domain-search FQDNs
     cc = DHCPClientClass(group_id=group_id, **body.model_dump())
     db.add(cc)
     await db.flush()
@@ -98,6 +100,9 @@ async def update_class(
     if cc is None:
         raise HTTPException(status_code=404, detail="Client class not found")
     changes = body.model_dump(exclude_none=True)
+    if "options" in changes:
+        # Validate only changed domain options (#597) vs the stored value.
+        validate_domain_options(changes["options"], previous=cc.options or {})
     for k, v in changes.items():
         setattr(cc, k, v)
     write_audit(

--- a/backend/app/api/v1/dhcp/option_templates.py
+++ b/backend/app/api/v1/dhcp/option_templates.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.api.v1.dhcp._audit import write_audit
+from app.api.v1.dhcp.scopes import validate_domain_options
 from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.permissions import require_resource_permission
 from app.models.dhcp import (
@@ -146,6 +147,7 @@ async def create_template(
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=409, detail="A template with that name exists")
     options = _normalize_options(body.options)
+    validate_domain_options(options)  # #597 — domain-name/domain-search are FQDNs
     tpl = DHCPOptionTemplate(
         group_id=group_id,
         name=body.name,
@@ -201,6 +203,9 @@ async def update_template(
             raise HTTPException(status_code=409, detail="A template with that name exists")
     if "options" in payload:
         payload["options"] = _normalize_options(payload["options"])
+        # Validate only changed domain options (#597) so a round-tripped
+        # grandfathered value doesn't block an unrelated edit.
+        validate_domain_options(payload["options"], previous=tpl.options or {})
     for k, v in payload.items():
         setattr(tpl, k, v)
     write_audit(

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.api.v1.dhcp._audit import write_audit
 from app.core.agent_wake import collect_wake, dhcp_group_channel
+from app.core.dns_names import validate_fqdn
 from app.core.permissions import require_resource_permission
 from app.models.dhcp import DHCPScope, DHCPServerGroup
 from app.models.ipam import Subnet
@@ -67,11 +68,37 @@ _CODE_TO_NAME: dict[int, str] = {
 _OPTION_NAME_ALIASES: dict[str, str] = {"domain-name-servers": "dns-servers"}
 
 
+def _validate_domain_options(opts: dict[str, Any]) -> dict[str, Any]:
+    """Validate the FQDN-valued DHCP options in place (issue #597).
+
+    ``domain-name`` (option 15) is a single FQDN; ``domain-search``
+    (option 119) is a list of FQDNs. Both render straight into the Kea
+    config, so a malformed value would break the rendered config or ship a
+    bad search suffix. Invalid values raise ``ValueError`` (surfaced as a
+    422). Other options are left untouched.
+    """
+    try:
+        dn = opts.get("domain-name")
+        if isinstance(dn, str) and dn.strip():
+            opts["domain-name"] = validate_fqdn(dn, field="domain-name option")
+        ds = opts.get("domain-search")
+        if isinstance(ds, list):
+            opts["domain-search"] = [
+                validate_fqdn(str(d), field="domain-search option") if str(d).strip() else d
+                for d in ds
+            ]
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return opts
+
+
 def _normalize_options(raw: Any) -> dict[str, Any]:
     if raw is None:
         return {}
     if isinstance(raw, dict):
-        return {_OPTION_NAME_ALIASES.get(str(k), str(k)): v for k, v in raw.items()}
+        return _validate_domain_options(
+            {_OPTION_NAME_ALIASES.get(str(k), str(k)): v for k, v in raw.items()}
+        )
     if isinstance(raw, list):
         out: dict[str, Any] = {}
         for entry in raw:
@@ -85,7 +112,7 @@ def _normalize_options(raw: Any) -> dict[str, Any]:
                 continue
             name = _OPTION_NAME_ALIASES.get(name, name)
             out[name] = entry.get("value")
-        return out
+        return _validate_domain_options(out)
     return {}
 
 

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -68,37 +68,44 @@ _CODE_TO_NAME: dict[int, str] = {
 _OPTION_NAME_ALIASES: dict[str, str] = {"domain-name-servers": "dns-servers"}
 
 
-def _validate_domain_options(opts: dict[str, Any]) -> dict[str, Any]:
-    """Validate the FQDN-valued DHCP options in place (issue #597).
+def validate_domain_options(
+    opts: dict[str, Any], *, previous: dict[str, Any] | None = None
+) -> None:
+    """Validate the FQDN-valued DHCP options (issue #597); raise 422 on a bad one.
 
     ``domain-name`` (option 15) is a single FQDN; ``domain-search``
     (option 119) is a list of FQDNs. Both render straight into the Kea
-    config, so a malformed value would break the rendered config or ship a
-    bad search suffix. Invalid values raise ``ValueError`` (surfaced as a
-    422). Other options are left untouched.
+    config, so a malformed value would break it or ship a bad search suffix.
+    Empty / whitespace-only entries are rejected too (a blank search suffix
+    is meaningless). A value identical to ``previous`` is skipped, so an
+    update that merely round-trips a grandfathered value doesn't block the
+    edit (validate-on-*change*, matching the issue's report-don't-break stance).
     """
+    prev = previous or {}
     try:
         dn = opts.get("domain-name")
-        if isinstance(dn, str) and dn.strip():
-            opts["domain-name"] = validate_fqdn(dn, field="domain-name option")
+        if isinstance(dn, str) and dn != prev.get("domain-name"):
+            if not dn.strip():
+                raise ValueError("domain-name option must not be blank")
+            validate_fqdn(dn, field="domain-name option")
         ds = opts.get("domain-search")
-        if isinstance(ds, list):
-            opts["domain-search"] = [
-                validate_fqdn(str(d), field="domain-search option") if str(d).strip() else d
-                for d in ds
-            ]
+        if isinstance(ds, list) and ds != prev.get("domain-search"):
+            for d in ds:
+                if not str(d).strip():
+                    raise ValueError("domain-search option contains a blank entry")
+                validate_fqdn(str(d), field="domain-search option")
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    return opts
 
 
 def _normalize_options(raw: Any) -> dict[str, Any]:
+    """Normalize option shape (name aliases, list→dict). Does NOT validate —
+    callers run ``validate_domain_options`` so the create/update paths can
+    apply different only-on-change gating."""
     if raw is None:
         return {}
     if isinstance(raw, dict):
-        return _validate_domain_options(
-            {_OPTION_NAME_ALIASES.get(str(k), str(k)): v for k, v in raw.items()}
-        )
+        return {_OPTION_NAME_ALIASES.get(str(k), str(k)): v for k, v in raw.items()}
     if isinstance(raw, list):
         out: dict[str, Any] = {}
         for entry in raw:
@@ -112,7 +119,7 @@ def _normalize_options(raw: Any) -> dict[str, Any]:
                 continue
             name = _OPTION_NAME_ALIASES.get(name, name)
             out[name] = entry.get("value")
-        return _validate_domain_options(out)
+        return out
     return {}
 
 
@@ -466,6 +473,8 @@ async def create_scope(
     except ValueError:
         address_family = "ipv4"
     _validate_relay_family(body.relay_addresses, address_family)
+    _create_options = _normalize_options(body.options)
+    validate_domain_options(_create_options)  # always validate on create (#597)
     scope = DHCPScope(
         subnet_id=subnet_id,
         group_id=group_id,
@@ -475,7 +484,7 @@ async def create_scope(
         lease_time=body.lease_time,
         min_lease_time=body.min_lease_time,
         max_lease_time=body.max_lease_time,
-        options=_normalize_options(body.options),
+        options=_create_options,
         ddns_enabled=body.ddns_enabled,
         ddns_hostname_policy=body.ddns_hostname_policy or "client",
         hostname_to_ipam_sync=sync_mode,
@@ -571,7 +580,13 @@ async def update_scope(
             detail=f"invalid hostname sync mode: {changes['hostname_to_ipam_sync']}",
         )
     if "options" in changes:
-        changes["options"] = _normalize_options(changes["options"])
+        normalized = _normalize_options(changes["options"])
+        # Validate only domain options that CHANGED from the stored value
+        # (issue #597 review) — the scope form round-trips the full options
+        # dict, so re-validating an unchanged grandfathered value would block
+        # an unrelated edit.
+        validate_domain_options(normalized, previous=scope.options or {})
+        changes["options"] = normalized
     # ``clear_pxe_profile=True`` is the explicit detach signal — Pydantic
     # collapses missing + null on ``pxe_profile_id`` so we need a
     # second boolean field to disambiguate. Apply detach first; a

--- a/backend/app/api/v1/dhcp/statics.py
+++ b/backend/app/api/v1/dhcp/statics.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.api.v1.dhcp._audit import write_audit
 from app.core.agent_wake import collect_wake, dhcp_group_channel
+from app.core.dns_names import validate_hostname
 from app.core.permissions import require_resource_permission
 from app.models.dhcp import DHCPPool, DHCPScope, DHCPStaticAssignment
 from app.models.ipam import IPAddress, Subnet
@@ -24,6 +25,17 @@ from app.services.tags import apply_tag_filter
 router = APIRouter(
     tags=["dhcp"], dependencies=[Depends(require_resource_permission("dhcp_static"))]
 )
+
+
+def _validate_optional_hostname(v: str | None) -> str | None:
+    """Reservation hostname is optional; validate the RFC 1123 form when set.
+
+    Operator-entered (not client-supplied), so a malformed value is rejected
+    rather than sanitized (issue #597). ``""`` / ``None`` pass through.
+    """
+    if v is None or v.strip() == "":
+        return v
+    return validate_hostname(v)
 
 
 class StaticCreate(BaseModel):
@@ -39,6 +51,11 @@ class StaticCreate(BaseModel):
     ip_address_id: uuid.UUID | None = None
     tags: dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator("hostname")
+    @classmethod
+    def _hostname(cls, v: str) -> str:
+        return _validate_optional_hostname(v) or ""
+
 
 class StaticUpdate(BaseModel):
     ip_address: str | None = None
@@ -50,6 +67,11 @@ class StaticUpdate(BaseModel):
     options_override: dict[str, Any] | None = None
     ip_address_id: uuid.UUID | None = None
     tags: dict[str, Any] | None = None
+
+    @field_validator("hostname")
+    @classmethod
+    def _hostname(cls, v: str | None) -> str | None:
+        return _validate_optional_hostname(v)
 
 
 class StaticResponse(BaseModel):

--- a/backend/app/api/v1/diagnostics/router.py
+++ b/backend/app/api/v1/diagnostics/router.py
@@ -21,6 +21,7 @@ from app.api.deps import DB, CurrentUser
 from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.models.diagnostics import InternalError
+from app.services.dns_names_report import scan_name_conformance
 
 router = APIRouter()
 
@@ -234,3 +235,19 @@ async def delete_error(
         raise HTTPException(status_code=404, detail="error not found")
     await db.delete(row)
     await db.commit()
+
+
+@router.get("/name-conformance")
+async def name_conformance(
+    db: DB,
+    current_user: CurrentUser,
+) -> dict[str, Any]:
+    """Report existing names that the #597 DNS-name validators would reject.
+
+    Read-only. The validators reject non-conforming names on write, but
+    pre-existing rows are left untouched — this surfaces them (IPAM
+    hostnames, DNS record owners, DNS zone names, DHCP static hostnames)
+    so an operator can fix them deliberately. Nothing is mutated.
+    """
+    _require_superadmin(current_user)
+    return await scan_name_conformance(db)

--- a/backend/app/api/v1/dns/pool_router.py
+++ b/backend/app/api/v1/dns/pool_router.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.agent_wake import collect_wake, dns_group_channel
+from app.core.dns_names import validate_record_owner
 from app.core.permissions import require_resource_permission
 from app.models.audit import AuditLog
 from app.models.dns import DNSPool, DNSPoolMember, DNSZone
@@ -130,6 +131,13 @@ class PoolWrite(BaseModel):
         if v not in VALID_RECORD_TYPES:
             raise ValueError(f"record_type must be one of {sorted(VALID_RECORD_TYPES)}")
         return v
+
+    @field_validator("record_name")
+    @classmethod
+    def _record_name(cls, v: str) -> str:
+        # A GSLB pool renders A/AAAA rows, so its record name is a DNS owner
+        # within the zone — RFC 2181 rule, permitting ``_`` / apex (issue #597).
+        return validate_record_owner(v, field="record name")
 
     @field_validator("hc_type")
     @classmethod

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -22,6 +22,11 @@ from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page, paginate
 from app.core.agent_wake import collect_wake, dns_group_channel, dns_server_channel
 from app.core.crypto import decrypt_dict, encrypt_dict, encrypt_str
+from app.core.dns_names import (
+    contains_control_chars,
+    validate_fqdn,
+    validate_record_owner,
+)
 from app.core.permissions import (
     _token_grants_for,
     require_any_resource_permission,
@@ -771,8 +776,12 @@ class ZoneCreate(BaseModel):
 
     @field_validator("name")
     @classmethod
-    def ensure_trailing_dot(cls, v: str) -> str:
-        return v if v.endswith(".") else v + "."
+    def validate_zone_name(cls, v: str) -> str:
+        # Validate as an FQDN (issue #597) — rejects spaces / control chars /
+        # zone-file-dangerous punctuation, IDNA-normalizes, and lower-cases —
+        # then re-append the trailing root dot the storage convention uses.
+        # ``allow_underscore`` keeps ``_msdcs`` / ``_sip._tcp`` zones legal.
+        return validate_fqdn(v, field="zone name") + "."
 
 
 class ZoneUpdate(BaseModel):
@@ -806,6 +815,15 @@ class ZoneUpdate(BaseModel):
     masters: list[str] | None = None
     customer_id: uuid.UUID | None = None
     tags: dict[str, Any] | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_zone_name(cls, v: str | None) -> str | None:
+        # Optional on update; validate + re-append the trailing dot when set
+        # (issue #597), mirroring ZoneCreate.
+        if v is None:
+            return v
+        return validate_fqdn(v, field="zone name") + "."
 
     @field_validator("zone_type")
     @classmethod
@@ -902,6 +920,15 @@ class RecordCreate(BaseModel):
             raise ValueError(f"record_type must be one of {sorted(VALID_RECORD_TYPES)}")
         return v
 
+    @field_validator("name")
+    @classmethod
+    def validate_owner(cls, v: str) -> str:
+        # RFC 2181 owner label rule (issue #597) — permits ``_`` owners
+        # (``_acme-challenge``, ``_443._tcp``) and a leftmost ``*`` wildcard,
+        # normalizes ``""``/``@`` to the apex sentinel ``@`` the handlers use
+        # (``fqdn = name.zone if name != "@" else zone``).
+        return validate_record_owner(v, field="record name")
+
 
 class RecordUpdate(BaseModel):
     name: str | None = None
@@ -912,6 +939,14 @@ class RecordUpdate(BaseModel):
     port: int | None = None
     view_id: uuid.UUID | None = None
     tags: dict[str, Any] | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_owner(cls, v: str | None) -> str | None:
+        # Optional on update; same RFC 2181 owner rule as RecordCreate.
+        if v is None:
+            return v
+        return validate_record_owner(v, field="record name")
 
 
 class RecordResponse(BaseModel):
@@ -1013,19 +1048,59 @@ def _normalize_record_struct_fields(
     return None, None, None
 
 
+# rdata for these types is a single bare target *name* — validate it as an
+# FQDN (issue #597). MX / SRV are deliberately excluded: their value may
+# carry the priority / weight / port inline (``10 mail.example.com``) on some
+# client + driver paths, so an FQDN check would reject a legitimate value —
+# the control-character guard below still protects them. Also excludes TXT
+# (freeform, quoted at render), the structured types (SVCB / HTTPS / NAPTR /
+# CAA / SSHFP / TLSA / LOC / LUA), and A/AAAA (IP-validated below).
+_HOSTNAME_TARGET_RECORD_TYPES = frozenset({"CNAME", "NS", "PTR", "DNAME", "ALIAS"})
+
+
 def _validate_address_record_value(record_type: str, value: str) -> None:
-    """Reject A / AAAA values that aren't a single valid IP address (#467).
+    """Reject rdata that would break — or inject into — a rendered zone (#467, #597).
 
-    Each ``DNSRecord`` row holds exactly one address, and the BIND9 / PowerDNS
-    drivers render one RR line per row. So a value like ``10.0.0.1, 10.0.0.2``
-    is silently stored verbatim and emitted as malformed rdata that breaks the
-    zone load. To point one hostname at several IPs an operator adds one A
-    record per IP (RFC 1035 round-robin) or uses a DNS Pool for health-checked
-    failover — never a comma-separated list in one record.
+    Three checks, in order of the record's shape:
 
-    Raises ``HTTPException(422)`` with that guidance on a non-single-IP value.
+    * Any value carrying a control character / newline is rejected for every
+      type — that is the one thing that injects a second zone-file record, and
+      no legitimate rdata contains one. (Spaces and quotes are *not* rejected:
+      structured rdata like CAA / LOC / NAPTR / SVCB needs them.)
+    * A / AAAA must be a single valid IP of the matching family (each row is
+      one RR line, so ``10.0.0.1, 10.0.0.2`` is malformed rdata).
+    * A bare-name target type (CNAME / NS / PTR / DNAME / ALIAS) whose value is
+      the pointed-at name must be a syntactically valid FQDN. MX / SRV are
+      excluded — their value may carry the priority inline on some paths.
+
+    Raises ``HTTPException(422)`` with guidance on any failure.
     """
     rtype = record_type.upper()
+
+    # Injection guard for EVERY type: a newline / control character is the
+    # one thing that can inject a second record into a zone-file line, and no
+    # legitimate rdata carries one. Deliberately narrower than
+    # ``contains_zonefile_unsafe`` — spaces and quotes are load-bearing in
+    # structured rdata (CAA ``0 issue "letsencrypt.org"``, LOC / NAPTR /
+    # SVCB / HTTPS), so only control bytes are rejected here. Interior
+    # whitespace in a *name-valued* type is caught by the FQDN check below;
+    # a comma-separated A/AAAA list by the IP parse.
+    if contains_control_chars(value):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{rtype} record value contains a control character or newline, "
+                "which is not allowed in DNS record data."
+            ),
+        )
+
+    if rtype in _HOSTNAME_TARGET_RECORD_TYPES:
+        try:
+            validate_fqdn(value, field=f"{rtype} record target")
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        return
+
     if rtype not in ("A", "AAAA"):
         return
     candidate = value.strip()

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -24,6 +24,7 @@ from app.core.agent_wake import collect_wake, dns_group_channel, dns_server_chan
 from app.core.crypto import decrypt_dict, encrypt_dict, encrypt_str
 from app.core.dns_names import (
     contains_control_chars,
+    contains_zonefile_unsafe,
     validate_fqdn,
     validate_record_owner,
 )
@@ -783,6 +784,11 @@ class ZoneCreate(BaseModel):
         # ``allow_underscore`` keeps ``_msdcs`` / ``_sip._tcp`` zones legal.
         return validate_fqdn(v, field="zone name") + "."
 
+    @field_validator("primary_ns", "admin_email")
+    @classmethod
+    def validate_soa_fields(cls, v: str) -> str:
+        return _validate_soa_field(v)
+
 
 class ZoneUpdate(BaseModel):
     name: str | None = None
@@ -824,6 +830,14 @@ class ZoneUpdate(BaseModel):
         if v is None:
             return v
         return validate_fqdn(v, field="zone name") + "."
+
+    @field_validator("primary_ns", "admin_email")
+    @classmethod
+    def validate_soa_fields(cls, v: str | None) -> str | None:
+        # Optional on update; same injection guard as ZoneCreate (issue #597).
+        if v is None:
+            return v
+        return _validate_soa_field(v)
 
     @field_validator("zone_type")
     @classmethod
@@ -1046,6 +1060,26 @@ def _normalize_record_struct_fields(
             detail=f"{rtype} records do not take {', '.join(extra)}",
         )
     return None, None, None
+
+
+def _validate_soa_field(v: str | None) -> str:
+    """Reject a zone SOA ``primary_ns`` / ``admin_email`` that could inject.
+
+    Both are interpolated raw into the BIND9 SOA line (issue #597 review), so
+    a newline / space / zone-file metacharacter would inject a record the same
+    way an unescaped owner would. These fields are stored in exact SOA form
+    (RNAME with a *significant* trailing dot, e.g. ``admin.example.com.``), so
+    validate WITHOUT mutating — a valid nameserver / RNAME contains none of the
+    ``contains_zonefile_unsafe`` set. Empty ("" default / auto-filled) passes.
+    """
+    if v is None or v == "":
+        return v or ""
+    if contains_zonefile_unsafe(v):
+        raise ValueError(
+            "must be a bare domain name — no whitespace, control characters, "
+            "or zone-file syntax (e.g. ';' '$' '@')"
+        )
+    return v
 
 
 # rdata for these types is a single bare target *name* — validate it as an
@@ -4526,7 +4560,12 @@ async def update_record(
     record.priority, record.weight, record.port = _normalize_record_struct_fields(
         record.record_type, record.priority, record.weight, record.port
     )
-    _validate_address_record_value(record.record_type, record.value)
+    # Only validate the value when it's actually being changed (issue #597
+    # review): re-validating the merged value on an unrelated edit (e.g. TTL
+    # only) would 422 a pre-existing row whose value predates the rule —
+    # blocking edits to legacy data, contrary to the validate-on-write stance.
+    if "value" in changes:
+        _validate_address_record_value(record.record_type, record.value)
     if "name" in changes and zone:
         record.fqdn = f"{record.name}.{zone.name}" if record.name != "@" else zone.name
     target_serial = bump_zone_serial(zone) if zone is not None else None

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -1746,7 +1746,7 @@ class IPSpaceResponse(BaseModel):
     dhcp_server_group_id: uuid.UUID | None = None
     ddns_enabled: bool = False
     ddns_hostname_policy: str = "client_or_generated"
-    ddns_domain_override: DDNSDomainOverride = None
+    ddns_domain_override: str | None = None
     ddns_ttl: int | None = None
     vrf_id: uuid.UUID | None = None
     vrf_name: str | None = None
@@ -1868,7 +1868,7 @@ class IPBlockResponse(BaseModel):
     dhcp_inherit_settings: bool = True
     ddns_enabled: bool = False
     ddns_hostname_policy: str = "client_or_generated"
-    ddns_domain_override: DDNSDomainOverride = None
+    ddns_domain_override: str | None = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool = True
     vrf_id: uuid.UUID | None = None
@@ -2217,7 +2217,7 @@ class SubnetResponse(BaseModel):
     dhcp_inherit_settings: bool = True
     ddns_enabled: bool = False
     ddns_hostname_policy: str = "client_or_generated"
-    ddns_domain_override: DDNSDomainOverride = None
+    ddns_domain_override: str | None = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool = True
     auto_profile_on_dhcp_lease: bool = False

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -9,12 +9,12 @@ import re
 import string
 import uuid
 from datetime import UTC, date, datetime, timedelta
-from typing import Any, cast
+from typing import Annotated, Any, cast
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, Field, field_validator, model_validator
 from sqlalchemy import String, asc, desc, func, or_, select, text
 from sqlalchemy import cast as sa_cast
 from sqlalchemy.exc import IntegrityError
@@ -23,6 +23,7 @@ from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser
 from app.api.v1.ipam.io_router import router as io_router
+from app.core.dns_names import validate_fqdn, validate_hostname
 from app.core.permissions import (
     is_effective_superadmin,
     require_any_resource_or_scoped,
@@ -71,6 +72,22 @@ from app.services.oui import bulk_lookup_vendors, is_voip_phone_vendor, normaliz
 from app.services.tags import apply_tag_filter
 
 logger = structlog.get_logger(__name__)
+
+
+def _validate_opt_ddns_domain(v: Any) -> Any:
+    """Reusable validator for the optional ``ddns_domain_override`` FQDN.
+
+    ``None`` / empty pass through (the field is clearable); a supplied
+    value must be a valid FQDN (issue #597).
+    """
+    if v is None or (isinstance(v, str) and v.strip() == ""):
+        return v
+    return validate_fqdn(str(v), field="ddns_domain_override")
+
+
+# Shared field type so every IPSpace / IPBlock / Subnet create+update schema
+# validates the DDNS domain suffix without repeating a per-class validator.
+DDNSDomainOverride = Annotated[str | None, BeforeValidator(_validate_opt_ddns_domain)]
 
 # Router-level permission gate: GET → `read`, POST/PUT/PATCH → `write`,
 # DELETE → `delete`. Endpoints under /ipam manipulate IPAM resources, so we
@@ -1647,7 +1664,7 @@ class IPSpaceCreate(BaseModel):
     dhcp_server_group_id: uuid.UUID | None = None
     ddns_enabled: bool = False
     ddns_hostname_policy: str = "client_or_generated"
-    ddns_domain_override: str | None = None
+    ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     # VRF / routing annotation. Pure metadata; address allocation
     # ignores these. ``route_targets`` is a list of strings rather
@@ -1692,7 +1709,7 @@ class IPSpaceUpdate(BaseModel):
     dhcp_server_group_id: uuid.UUID | None = None
     ddns_enabled: bool | None = None
     ddns_hostname_policy: str | None = None
-    ddns_domain_override: str | None = None
+    ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     vrf_id: uuid.UUID | None = None
     vrf_name: str | None = None
@@ -1729,7 +1746,7 @@ class IPSpaceResponse(BaseModel):
     dhcp_server_group_id: uuid.UUID | None = None
     ddns_enabled: bool = False
     ddns_hostname_policy: str = "client_or_generated"
-    ddns_domain_override: str | None = None
+    ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     vrf_id: uuid.UUID | None = None
     vrf_name: str | None = None
@@ -1768,7 +1785,7 @@ class IPBlockCreate(BaseModel):
     dhcp_inherit_settings: bool = True
     ddns_enabled: bool = False
     ddns_hostname_policy: str = "client_or_generated"
-    ddns_domain_override: str | None = None
+    ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool = True
     asn_id: uuid.UUID | None = None
@@ -1816,7 +1833,7 @@ class IPBlockUpdate(BaseModel):
     dhcp_inherit_settings: bool | None = None
     ddns_enabled: bool | None = None
     ddns_hostname_policy: str | None = None
-    ddns_domain_override: str | None = None
+    ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool | None = None
     asn_id: uuid.UUID | None = None
@@ -1851,7 +1868,7 @@ class IPBlockResponse(BaseModel):
     dhcp_inherit_settings: bool = True
     ddns_enabled: bool = False
     ddns_hostname_policy: str = "client_or_generated"
-    ddns_domain_override: str | None = None
+    ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool = True
     vrf_id: uuid.UUID | None = None
@@ -1916,7 +1933,7 @@ class SubnetCreate(BaseModel):
     # space) — see services/dns/ddns.resolve_effective_ddns.
     ddns_enabled: bool = False
     ddns_hostname_policy: str = "client_or_generated"
-    ddns_domain_override: str | None = None
+    ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool = True
     # Device profiling — see Subnet model. Default off because nmap is loud.
@@ -2053,7 +2070,7 @@ class SubnetUpdate(BaseModel):
     dhcp_inherit_settings: bool | None = None
     ddns_enabled: bool | None = None
     ddns_hostname_policy: str | None = None
-    ddns_domain_override: str | None = None
+    ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool | None = None
     auto_profile_on_dhcp_lease: bool | None = None
@@ -2200,7 +2217,7 @@ class SubnetResponse(BaseModel):
     dhcp_inherit_settings: bool = True
     ddns_enabled: bool = False
     ddns_hostname_policy: str = "client_or_generated"
-    ddns_domain_override: str | None = None
+    ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool = True
     auto_profile_on_dhcp_lease: bool = False
@@ -2349,11 +2366,11 @@ class IPAddressCreate(BaseModel):
 
     @field_validator("hostname")
     @classmethod
-    def hostname_nonempty(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Hostname is required")
-        return v
+    def hostname_valid(cls, v: str) -> str:
+        # Required + must be a valid RFC 1123 host name. ``validate_hostname``
+        # normalizes to lowercase A-labels and raises on empty (issue #597),
+        # so the old "required" check is subsumed.
+        return validate_hostname(v)
 
     @field_validator("status")
     @classmethod
@@ -2397,6 +2414,19 @@ class IPAddressUpdate(BaseModel):
     decom_date: date | None = None
     # See IPAddressCreate.force.
     force: bool = False
+
+    @field_validator("hostname")
+    @classmethod
+    def hostname_valid(cls, v: str | None) -> str | None:
+        # Update-path hostname is optional. ``None`` (omitted) leaves it
+        # untouched; an empty string clears it. A non-empty value must be a
+        # valid RFC 1123 host name (issue #597 — the update path previously
+        # validated nothing).
+        if v is None:
+            return v
+        if v.strip() == "":
+            return ""
+        return validate_hostname(v)
 
     @field_validator("status")
     @classmethod
@@ -2556,11 +2586,11 @@ class NextIPRequest(BaseModel):
 
     @field_validator("hostname")
     @classmethod
-    def hostname_nonempty(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("Hostname is required")
-        return v
+    def hostname_valid(cls, v: str) -> str:
+        # Required + must be a valid RFC 1123 host name. ``validate_hostname``
+        # normalizes to lowercase A-labels and raises on empty (issue #597),
+        # so the old "required" check is subsumed.
+        return validate_hostname(v)
 
     @field_validator("strategy")
     @classmethod

--- a/backend/app/core/dns_names.py
+++ b/backend/app/core/dns_names.py
@@ -1,0 +1,289 @@
+"""Shared validation + normalization for DNS-shaped names (issue #597).
+
+One module, so the rule for "what is a legal name here" lives in exactly
+one place. The rule is deliberately **per-context** — there is no single
+"valid DNS name" regex, because the correct answer depends on the field's
+role:
+
+* **Host names** (``IPAddress.hostname``, a DHCP reservation hostname, an
+  A/AAAA/PTR owner) follow RFC 952 + RFC 1123 §2.1 — the classic
+  letters-digits-hyphen (LDH) rule: each label 1–63 chars, no leading or
+  trailing hyphen, total ≤ 253. Internationalized input is normalized to
+  its IDNA A-label (``xn--``) form rather than rejected.
+
+* **DNS record owner labels** (``DNSRecord.name``) follow the looser
+  RFC 2181 §11 rule: the DNS protocol permits an underscore, so this is
+  what keeps ``_acme-challenge`` (our own ACME DNS-01 client, #438),
+  ``_dmarc``, ``_443._tcp`` SRV/TLSA owners, and ``*`` wildcards legal.
+  We still reject whitespace, control characters, and the handful of
+  characters that are dangerous in a zone-file master line.
+
+* **FQDNs** (``DNSZone.name``, a ``domain-name`` DHCP option, rdata
+  targets) are a dotted series of RFC 2181 labels.
+
+Every ``validate_*`` helper raises ``ValueError`` with an operator-facing
+message on failure and returns the *normalized* value on success, so a
+Pydantic ``field_validator`` can both reject and canonicalize in one step.
+
+``sanitize_hostname`` is the non-raising counterpart used on the DHCP
+lease path, where a client-supplied hostname arriving off the wire must be
+folded into something safe rather than rejected (a bad hostname must not
+drop a lease).
+"""
+
+from __future__ import annotations
+
+import re
+
+import idna
+
+# RFC 1035 §2.3.4 / RFC 2181 §11 — a label is ≤ 63 octets; a name is ≤ 255
+# octets on the wire including the length prefixes, which works out to a
+# 253-character textual cap for the dotted presentation form.
+MAX_LABEL_LEN = 63
+MAX_NAME_LEN = 253
+
+# RFC 1123 host label: LDH, 1–63 chars, no leading/trailing hyphen. A
+# single-character label is legal (the alternation's optional tail covers
+# the ≥ 2 char case).
+_HOST_LABEL_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+
+# RFC 2181 owner label as we choose to constrain it: LDH plus underscore.
+# Underscore is what the DNS protocol allows and the LDH host rule forbids
+# — it is load-bearing for _acme-challenge / _dmarc / _443._tcp owners.
+# A leading/trailing hyphen is still rejected; a leading underscore is the
+# whole point, so it is allowed.
+_DNS_LABEL_RE = re.compile(r"^(?![-])[A-Za-z0-9_]([A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?$")
+
+# Characters that are unsafe inside a zone-file master-format line
+# (RFC 1035 §5.1): whitespace splits tokens, a newline injects a new
+# record, ``;`` starts a comment, ``$`` starts a directive ($ORIGIN /
+# $TTL), ``()`` group across lines, ``"`` quotes, ``@`` means the origin,
+# ``\`` escapes, and any C0/C1 control byte is never legitimate in a name.
+_ZONEFILE_UNSAFE_RE = re.compile(r'[\s;$()"@\\]|[\x00-\x1f\x7f]')
+
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def contains_control_chars(value: str) -> bool:
+    """True if *value* holds a C0/C1 control byte (incl. newline)."""
+    return bool(_CONTROL_CHARS_RE.search(value))
+
+
+def strip_control_chars(value: str) -> str:
+    """Remove C0/C1 control characters (incl. newlines) from *value*.
+
+    The render-boundary neutralizer (issue #597): a raw newline is the one
+    character that can inject a *second* record into a zone-file line, and no
+    legitimate owner name or rdata ever contains a control byte. Applied to
+    every name + rdata field as it is written into a master-format line, so a
+    value that slipped past the field validators (via an importer or a legacy
+    row) still cannot break out of its own record. Unlike
+    ``contains_zonefile_unsafe`` this leaves spaces and quotes intact, so
+    structured rdata (CAA / LOC / NAPTR / SVCB) renders unharmed.
+    """
+    return _CONTROL_CHARS_RE.sub("", value)
+
+
+def contains_zonefile_unsafe(value: str) -> bool:
+    """True if *value* contains a character unsafe in a zone-file line.
+
+    Defense-in-depth for the render boundary — a name or rdata string that
+    trips this must never be interpolated into a master-format line
+    unescaped, regardless of how it got past the field validators (e.g.
+    via an importer or a future code path).
+    """
+    return bool(_ZONEFILE_UNSAFE_RE.search(value))
+
+
+def _to_ascii_label(label: str) -> str:
+    """Return the ASCII (A-label) form of a single label.
+
+    Pure-ASCII labels pass through untouched so underscore / wildcard
+    labels survive (the strict IDNA2008 codec would reject them). A label
+    carrying non-ASCII is IDNA-encoded to its ``xn--`` form; anything the
+    codec refuses raises ``ValueError``.
+    """
+    if label.isascii():
+        return label
+    try:
+        return idna.encode(label, uts46=True).decode("ascii")
+    except idna.IDNAError as exc:
+        raise ValueError(f"'{label}' is not a valid internationalized label ({exc})") from exc
+
+
+def _strip_root(name: str) -> tuple[str, bool]:
+    """Split a single optional trailing root dot off *name*.
+
+    Returns ``(name_without_root, had_root_dot)``. A bare ``"."`` (the DNS
+    root) yields ``("", True)``.
+    """
+    if name.endswith("."):
+        return name[:-1], True
+    return name, False
+
+
+def validate_host_label(label: str, *, field: str = "hostname") -> str:
+    """Validate a single RFC 1123 host label; return it lower-cased.
+
+    Non-ASCII input is normalized to its IDNA A-label first, so a unicode
+    label is accepted and canonicalized rather than rejected.
+    """
+    if not label:
+        raise ValueError(f"{field} contains an empty label")
+    ascii_label = _to_ascii_label(label)
+    if len(ascii_label) > MAX_LABEL_LEN:
+        raise ValueError(f"{field} label '{ascii_label}' exceeds {MAX_LABEL_LEN} characters")
+    if not _HOST_LABEL_RE.match(ascii_label):
+        raise ValueError(
+            f"{field} label '{ascii_label}' is not a valid host label "
+            "(letters, digits and hyphens only; no leading or trailing hyphen)"
+        )
+    return ascii_label.lower()
+
+
+def validate_hostname(name: str, *, field: str = "hostname") -> str:
+    """Validate a dotted RFC 1123 host name; return the normalized form.
+
+    Accepts a single label (``web01``) or a multi-label host name
+    (``web01.corp.example.com``). Internationalized labels are converted to
+    their ``xn--`` A-label form and the whole name is lower-cased. A single
+    trailing root dot is tolerated on input but stripped from the result.
+    Raises ``ValueError`` on anything that is not a legal host name.
+    """
+    raw = name.strip()
+    if not raw:
+        raise ValueError(f"{field} must not be empty")
+    body, _ = _strip_root(raw)
+    if not body:
+        raise ValueError(f"{field} must not be the root domain")
+    labels = [validate_host_label(lbl, field=field) for lbl in body.split(".")]
+    normalized = ".".join(labels)
+    if len(normalized) > MAX_NAME_LEN:
+        raise ValueError(f"{field} '{normalized}' exceeds {MAX_NAME_LEN} characters")
+    return normalized
+
+
+def validate_dns_label(label: str, *, field: str = "name", allow_wildcard: bool = False) -> str:
+    """Validate a single RFC 2181 owner label (permits ``_``; optional ``*``).
+
+    Used for the label components of a DNS record owner name. A lone ``*``
+    is accepted only when *allow_wildcard* is set (the leftmost label of a
+    wildcard owner). Non-ASCII is IDNA-normalized. The result is
+    lower-cased.
+    """
+    if not label:
+        raise ValueError(f"{field} contains an empty label")
+    if label == "*":
+        if allow_wildcard:
+            return "*"
+        raise ValueError(f"{field}: a '*' wildcard is only valid as the leftmost label")
+    ascii_label = _to_ascii_label(label)
+    if len(ascii_label) > MAX_LABEL_LEN:
+        raise ValueError(f"{field} label '{ascii_label}' exceeds {MAX_LABEL_LEN} characters")
+    if not _DNS_LABEL_RE.match(ascii_label):
+        raise ValueError(
+            f"{field} label '{ascii_label}' is not a valid DNS label "
+            "(letters, digits, hyphen and underscore only; no leading or trailing hyphen)"
+        )
+    return ascii_label.lower()
+
+
+def validate_record_owner(name: str, *, field: str = "record name") -> str:
+    """Validate a DNS record owner name (RFC 2181, keeps ``_`` and ``*``).
+
+    This is the rule for ``DNSRecord.name``. It deliberately permits the
+    cases strict host validation would break — ``_acme-challenge`` and
+    other underscore owners, ``_443._tcp`` SRV/TLSA owners, and a leftmost
+    ``*`` wildcard — while still rejecting whitespace, control characters,
+    and zone-file-dangerous punctuation.
+
+    ``@`` (the zone apex) and the empty string are both accepted as
+    "the apex" and normalized to ``"@"``. A single trailing root dot is
+    tolerated. Returns the normalized, lower-cased owner.
+    """
+    raw = name.strip()
+    if raw in ("", "@"):
+        return "@"
+    body, had_root = _strip_root(raw)
+    if not body:
+        return "@"
+    parts = body.split(".")
+    out: list[str] = []
+    for i, part in enumerate(parts):
+        # A wildcard is only meaningful as the leftmost label.
+        out.append(validate_dns_label(part, field=field, allow_wildcard=(i == 0)))
+    normalized = ".".join(out)
+    if len(normalized) > MAX_NAME_LEN:
+        raise ValueError(f"{field} '{normalized}' exceeds {MAX_NAME_LEN} characters")
+    return normalized + "." if had_root else normalized
+
+
+def validate_fqdn(name: str, *, field: str = "domain", allow_underscore: bool = True) -> str:
+    """Validate a fully-qualified domain name; return the normalized form.
+
+    For zone names, ``domain-name`` DHCP options, and rdata targets. A
+    dotted series of labels, each validated with the RFC 2181 owner rule
+    (``allow_underscore=True``, the default — some zones legitimately carry
+    underscore labels, e.g. ``_msdcs.example.com``) or the strict host rule
+    when *allow_underscore* is False. Wildcards are not permitted in an
+    FQDN. A single trailing root dot is tolerated and stripped.
+    """
+    raw = name.strip()
+    if not raw:
+        raise ValueError(f"{field} must not be empty")
+    body, _ = _strip_root(raw)
+    if not body:
+        raise ValueError(f"{field} must not be the root domain")
+    if allow_underscore:
+        labels = [validate_dns_label(lbl, field=field) for lbl in body.split(".")]
+    else:
+        labels = [validate_host_label(lbl, field=field) for lbl in body.split(".")]
+    normalized = ".".join(labels)
+    if len(normalized) > MAX_NAME_LEN:
+        raise ValueError(f"{field} '{normalized}' exceeds {MAX_NAME_LEN} characters")
+    return normalized
+
+
+# ── Non-raising sanitizer (DHCP lease path) ──────────────────────────────
+# A client-supplied hostname arriving off the wire (a DHCP DISCOVER option
+# 12, a lease event) must be folded into something safe rather than
+# rejected — a malformed hostname must never drop the lease or 500 the
+# ingest. Mirrors services/dns/ddns._sanitise but is multi-label aware so
+# a client that sends "my pc.corp" becomes "my-pc.corp", not "my-pc-corp".
+
+_SANITIZE_LABEL_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def sanitize_host_label(raw: str | None) -> str:
+    """Fold a raw string into a single safe LDH label (``""`` if nothing left)."""
+    if not raw:
+        return ""
+    s = raw.strip().strip('"').lower()
+    s = _SANITIZE_LABEL_RE.sub("-", s)
+    s = s.strip("-")
+    return s[:MAX_LABEL_LEN]
+
+
+def sanitize_hostname(raw: str | None) -> str:
+    """Fold a raw client hostname into a safe LDH host name (``""`` if empty).
+
+    Splits on dots and sanitizes each label independently, dropping labels
+    that reduce to nothing, then caps the whole name at ``MAX_NAME_LEN``.
+    Non-raising by contract — returns ``""`` when there is nothing usable,
+    which callers treat as "no hostname".
+    """
+    if not raw:
+        return ""
+    labels = [lbl for lbl in (sanitize_host_label(p) for p in raw.split(".")) if lbl]
+    if not labels:
+        return ""
+    name = ".".join(labels)
+    if len(name) <= MAX_NAME_LEN:
+        return name
+    # Trim whole trailing labels until it fits, so we never emit a
+    # truncated (and possibly hyphen-tailed) partial label.
+    while labels and len(".".join(labels)) > MAX_NAME_LEN:
+        labels.pop()
+    return ".".join(labels)

--- a/backend/app/core/dns_names.py
+++ b/backend/app/core/dns_names.py
@@ -262,8 +262,11 @@ def sanitize_host_label(raw: str | None) -> str:
         return ""
     s = raw.strip().strip('"').lower()
     s = _SANITIZE_LABEL_RE.sub("-", s)
-    s = s.strip("-")
-    return s[:MAX_LABEL_LEN]
+    # Truncate FIRST, then strip hyphens — truncating at MAX_LABEL_LEN can land
+    # on a hyphen and re-expose a trailing one, which ``validate_host_label``
+    # (correctly) rejects and which breaks a BIND9 zone load. Stripping after
+    # the cut keeps the sanitizer's output a valid label (issue #597 review).
+    return s[:MAX_LABEL_LEN].strip("-")
 
 
 def sanitize_hostname(raw: str | None) -> str:

--- a/backend/app/core/dns_names.py
+++ b/backend/app/core/dns_names.py
@@ -201,12 +201,15 @@ def validate_record_owner(name: str, *, field: str = "record name") -> str:
 
     ``@`` (the zone apex) and the empty string are both accepted as
     "the apex" and normalized to ``"@"``. A single trailing root dot is
-    tolerated. Returns the normalized, lower-cased owner.
+    tolerated on input but *stripped* from the result — ``DNSRecord.name``
+    is a relative owner that the handlers concatenate as ``f"{name}.{zone}"``,
+    so returning ``www.`` would yield the double-dotted ``www..zone``.
+    Returns the normalized, lower-cased owner.
     """
     raw = name.strip()
     if raw in ("", "@"):
         return "@"
-    body, had_root = _strip_root(raw)
+    body, _ = _strip_root(raw)
     if not body:
         return "@"
     parts = body.split(".")
@@ -217,7 +220,7 @@ def validate_record_owner(name: str, *, field: str = "record name") -> str:
     normalized = ".".join(out)
     if len(normalized) > MAX_NAME_LEN:
         raise ValueError(f"{field} '{normalized}' exceeds {MAX_NAME_LEN} characters")
-    return normalized + "." if had_root else normalized
+    return normalized
 
 
 def validate_fqdn(name: str, *, field: str = "domain", allow_underscore: bool = True) -> str:

--- a/backend/app/drivers/dns/bind9.py
+++ b/backend/app/drivers/dns/bind9.py
@@ -19,6 +19,7 @@ from typing import Any
 import structlog
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 
+from app.core.dns_names import strip_control_chars
 from app.drivers.dns.base import (
     ConfigBundle,
     DNSDriver,
@@ -62,7 +63,12 @@ def _render_record(zone: ZoneData, r: RecordData) -> str:
     name = "@" if r.name in ("@", "", zone.name.rstrip(".")) else r.name
     ttl = f"{r.ttl} " if r.ttl is not None else ""
     rtype = r.record_type.upper()
-    value = r.value
+    # Render-boundary neutralizer (issue #597): strip control characters /
+    # newlines from the owner + rdata so a value that slipped past the field
+    # validators (importer, legacy row) can't inject a second record line.
+    # Spaces / quotes survive, so structured rdata renders intact.
+    name = strip_control_chars(name)
+    value = strip_control_chars(r.value)
 
     if rtype == "TXT":
         rdata = _quote_txt(value)
@@ -155,7 +161,9 @@ class BIND9Driver(DNSDriver):
         rendered: list[str] = []
         excluded = {d.lower() for d in blocklist.exceptions}
         for e in blocklist.entries:
-            dom = e.domain.lower().rstrip(".")
+            # Feed-sourced domains are untrusted; neutralize control chars
+            # so a malformed feed entry can't inject a zone-file line (#597).
+            dom = strip_control_chars(e.domain.lower().rstrip("."))
             if dom in excluded:
                 continue
             rpz_name = f"*.{dom}" if e.is_wildcard else dom

--- a/backend/app/drivers/dns/bind9.py
+++ b/backend/app/drivers/dns/bind9.py
@@ -13,6 +13,7 @@ The ``reload_config``/``reload_zone`` methods here are surface for the agent.
 from __future__ import annotations
 
 import base64
+import dataclasses
 from pathlib import Path
 from typing import Any
 
@@ -148,6 +149,16 @@ class BIND9Driver(DNSDriver):
     def render_zone_file(self, zone: ZoneData, records: list[RecordData]) -> str:
         env = _env()
         tmpl = env.get_template("zone.file.j2")
+        # Neutralize control chars in the SOA fields (issue #597 review): the
+        # template interpolates ``primary_ns`` + ``admin_email`` raw into the
+        # SOA line, so a newline in either would inject a record the same way
+        # an unescaped owner/rdata would. ``_render_record`` already guards the
+        # record lines; this closes the SOA line one altitude up.
+        zone = dataclasses.replace(
+            zone,
+            primary_ns=strip_control_chars(zone.primary_ns),
+            admin_email=strip_control_chars(zone.admin_email),
+        )
         return tmpl.render(
             zone=zone,
             records=records,

--- a/backend/app/drivers/dns/powerdns.py
+++ b/backend/app/drivers/dns/powerdns.py
@@ -42,6 +42,7 @@ from typing import Any
 
 import structlog
 
+from app.core.dns_names import strip_control_chars
 from app.drivers.dns.base import (
     ConfigBundle,
     DNSDriver,
@@ -110,17 +111,21 @@ def _record_content(rr: RecordData) -> str:
     columns from the control plane and stitch them together here.
     """
     rtype = rr.record_type.upper()
+    # Strip control chars from the value first (issue #597) — defense in
+    # depth so a legacy/imported row can't push a raw newline into the
+    # PowerDNS API content.
+    value = strip_control_chars(rr.value)
     if rtype == "TXT":
-        return _quote_txt(rr.value)
+        return _quote_txt(value)
     if rtype == "MX":
         prio = rr.priority if rr.priority is not None else 10
-        return f"{prio} {rr.value}"
+        return f"{prio} {value}"
     if rtype == "SRV":
         prio = rr.priority if rr.priority is not None else 0
         weight = rr.weight if rr.weight is not None else 0
         port = rr.port if rr.port is not None else 0
-        return f"{prio} {weight} {port} {rr.value}"
-    return rr.value
+        return f"{prio} {weight} {port} {value}"
+    return value
 
 
 def _qualified_record_name(zone: ZoneData, rr: RecordData) -> str:
@@ -131,9 +136,10 @@ def _qualified_record_name(zone: ZoneData, rr: RecordData) -> str:
     all three resolve to the zone's apex.
     """
     zone_name = zone.name if zone.name.endswith(".") else zone.name + "."
-    if rr.name in ("", "@") or rr.name == zone_name.rstrip("."):
+    name = strip_control_chars(rr.name)
+    if name in ("", "@") or name == zone_name.rstrip("."):
         return zone_name
-    return f"{rr.name}.{zone_name}"
+    return f"{name}.{zone_name}"
 
 
 def render_pdns_conf(

--- a/backend/app/services/ai/tools/diagnostics.py
+++ b/backend/app/services/ai/tools/diagnostics.py
@@ -33,6 +33,7 @@ from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
 from app.models.diagnostics import InternalError
 from app.services.ai.tools.base import register_tool
+from app.services.dns_names_report import scan_name_conformance
 
 
 def _superadmin_gate(user: User) -> dict[str, Any] | None:
@@ -237,3 +238,39 @@ async def get_internal_error(
     summary["acknowledged_by"] = str(row.acknowledged_by) if row.acknowledged_by else None
     summary["suppressed_until"] = row.suppressed_until.isoformat() if row.suppressed_until else None
     return summary
+
+
+# ── find_nonconforming_names ──────────────────────────────────────────
+
+
+class FindNonconformingNamesArgs(BaseModel):
+    pass
+
+
+@register_tool(
+    name="find_nonconforming_names",
+    description=(
+        "Report existing names that violate DNS naming rules "
+        "(issue #597, superadmin only). Scans IPAM hostnames, DNS "
+        "record owners, DNS zone names, and DHCP static reservation "
+        "hostnames for values the write-time validators now reject — "
+        "spaces, control characters, illegal punctuation, "
+        "over-length labels, etc. Returns per-category counts plus "
+        "up to 100 examples each (id + value + reason). Read-only; "
+        "fixes are made by editing the offending rows. Use for 'which "
+        "hostnames aren't valid DNS names?' / 'do we have any records "
+        "that would break a zone file?'."
+    ),
+    args_model=FindNonconformingNamesArgs,
+    category="ops",
+    default_enabled=True,
+)
+async def find_nonconforming_names(
+    db: AsyncSession,
+    user: User,
+    args: FindNonconformingNamesArgs,
+) -> dict[str, Any]:
+    gate = _superadmin_gate(user)
+    if gate:
+        return gate
+    return await scan_name_conformance(db)

--- a/backend/app/services/dhcp/pull_leases.py
+++ b/backend/app/services/dhcp/pull_leases.py
@@ -49,6 +49,7 @@ import structlog
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dns_names import sanitize_hostname
 from app.drivers.dhcp import get_driver, is_agentless
 from app.models.dhcp import (
     DHCPLease,
@@ -165,6 +166,16 @@ async def pull_leases_from_server(
         return result
 
     result.server_leases = len(wire)
+
+    # Fold each client-supplied hostname to a safe LDH form at ingress
+    # (issue #597) so the raw wire value — which flows into IPAM.hostname and
+    # the lease row below — can't carry spaces / control chars / a zone-file
+    # newline. The DDNS path re-sanitizes idempotently. Non-raising by
+    # design: a bad hostname must never abort a lease pull.
+    for _lease in wire:
+        _h = _lease.get("hostname")
+        if _h:
+            _lease["hostname"] = sanitize_hostname(_h) or None
 
     scope_cache = await _load_scope_cache(db, server.server_group_id)
     # Inverse map (scope_id -> subnet_id) so the absence-delete branch can
@@ -621,7 +632,7 @@ async def _upsert_scope(
                 ip_address=static["ip_address"],
                 mac_address=static["mac_address"],
                 client_id=static.get("client_id"),
-                hostname=static.get("hostname") or "",
+                hostname=sanitize_hostname(static.get("hostname")),
                 description=static.get("description") or "",
             )
         )

--- a/backend/app/services/dns/ddns.py
+++ b/backend/app/services/dns/ddns.py
@@ -42,13 +42,13 @@ lazy-import the router function at call time to dodge it.
 from __future__ import annotations
 
 import ipaddress
-import re
 from typing import Any
 
 import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dns_names import sanitize_host_label
 from app.models.dhcp import DHCPScope, DHCPStaticAssignment
 from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
 
@@ -138,25 +138,15 @@ _POLICIES: frozenset[str] = frozenset(
     {"client_provided", "client_or_generated", "always_generate", "disabled"}
 )
 
-# Hostnames are a subset of RFC 1035 labels. We clamp to lower-case
-# alphanumerics + hyphen and strip anything else; empty after strip
-# means "use the generated form instead".
-_HOSTNAME_SAFE_RE = re.compile(r"[^a-z0-9-]+")
-
 
 def _sanitise(raw: str | None) -> str:
     """Fold a raw client hostname into a safe DNS label.
 
-    Strips quotes, lower-cases, collapses runs of unsafe chars to a
-    single hyphen, trims leading/trailing hyphens, truncates at 63
-    (the RFC 1035 label limit).
+    Thin alias for the shared ``sanitize_host_label`` (issue #597) so the
+    LDH-folding rule lives in exactly one place; empty after folding means
+    "use the generated form instead".
     """
-    if not raw:
-        return ""
-    s = raw.strip().strip('"').lower()
-    s = _HOSTNAME_SAFE_RE.sub("-", s)
-    s = s.strip("-")
-    return s[:63]
+    return sanitize_host_label(raw)
 
 
 def _generate_hostname(ip_str: str) -> str:

--- a/backend/app/services/dns_import/commit.py
+++ b/backend/app/services/dns_import/commit.py
@@ -24,6 +24,7 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dns_names import contains_control_chars
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.dns import DNSRecord, DNSServerGroup, DNSView, DNSZone
@@ -152,17 +153,26 @@ async def _build_records_for_zone(
     parsed: ImportedZone,
     source: ImportSource,
     now: datetime,
-) -> int:
-    """Create the DNSRecord rows for one parsed zone. Returns the
-    number of records created.
+) -> tuple[int, list[str]]:
+    """Create the DNSRecord rows for one parsed zone.
 
-    Skips the SOA — SOA fields live as columns on the parent zone,
-    not as a regular record row.
+    Returns ``(records_created, skipped_reasons)``. Skips the SOA (its
+    fields live as columns on the parent zone) and, per issue #597, any
+    record whose owner name or rdata carries a control character / newline
+    — those can't be safely rendered into a zone-file line, so the row is
+    dropped with a reported reason rather than silently imported.
     """
 
     rows: list[DNSRecord] = []
+    skipped: list[str] = []
     for r in parsed.records:
         if r.record_type == "SOA":
+            continue
+        if contains_control_chars(r.name) or contains_control_chars(r.value):
+            skipped.append(
+                f"{r.name or '@'} {r.record_type}: dropped — control character "
+                "in the record name or value"
+            )
             continue
         # FQDN is "<label>.<zone_fqdn>" with the apex label "@"
         # collapsing to just the zone fqdn.
@@ -188,7 +198,7 @@ async def _build_records_for_zone(
         )
     if rows:
         db.add_all(rows)
-    return len(rows)
+    return len(rows), skipped
 
 
 def _zone_kwargs_from_parsed(
@@ -267,7 +277,7 @@ async def _create_zone_at(
     db.add(zone)
     await db.flush()  # populate zone.id for the FK
 
-    records_created = await _build_records_for_zone(
+    records_created, skipped_records = await _build_records_for_zone(
         db,
         zone_id=zone.id,
         zone_fqdn=target_name,
@@ -282,6 +292,8 @@ async def _create_zone_at(
         "records_created": records_created,
         "skipped_record_types": parsed.skipped_record_types,
     }
+    if skipped_records:
+        audit_meta["records_skipped_unsafe"] = skipped_records
     if overwrote_records:
         audit_meta["records_deleted_on_overwrite"] = overwrote_records
     if audit_extra:

--- a/backend/app/services/dns_names_report.py
+++ b/backend/app/services/dns_names_report.py
@@ -14,10 +14,12 @@ the operator knows the real scale.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import Select, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.dns_names import (
@@ -27,7 +29,11 @@ from app.core.dns_names import (
 )
 from app.models.dhcp import DHCPStaticAssignment
 from app.models.dns import DNSRecord, DNSZone
-from app.models.ipam import IPAddress
+from app.models.ipam import IP_STATUSES_INTEGRATION_OWNED, IPAddress
+
+# Yield the event loop every this-many rows so a large scan (CPU-bound regex
+# + IDNA validation) doesn't monopolize the loop and stall other requests.
+_YIELD_EVERY = 2000
 
 # Cap the examples returned per category — the count is always exact, only
 # the ``examples`` list is truncated.
@@ -61,6 +67,34 @@ class _CategoryReport:
         }
 
 
+async def _scan_category(
+    db: AsyncSession,
+    report: _CategoryReport,
+    stmt: Select[Any],
+    check: Callable[[str], Any],
+    *,
+    has_context: bool = False,
+) -> None:
+    """Stream one category's rows through ``check``; flag violations.
+
+    Fetches ``cap + 1`` so ``scanned_capped`` distinguishes "exactly at the
+    cap" (fully scanned) from "truncated" (issue #597 review), and yields the
+    event loop every ``_YIELD_EVERY`` rows so the CPU-bound validation can't
+    stall other requests. ``check`` raises ``ValueError`` on a bad value.
+    """
+    rows = (await db.execute(stmt.limit(_MAX_SCAN_PER_CATEGORY + 1))).all()
+    report.scanned_capped = len(rows) > _MAX_SCAN_PER_CATEGORY
+    for i, row in enumerate(rows[:_MAX_SCAN_PER_CATEGORY]):
+        row_id, value = row[0], row[1]
+        ctx = row[2] if has_context else None
+        try:
+            check(value)
+        except ValueError as exc:
+            report.add(row_id=row_id, value=value, reason=str(exc), context=ctx)
+        if i % _YIELD_EVERY == 0:
+            await asyncio.sleep(0)
+
+
 async def scan_name_conformance(db: AsyncSession) -> dict[str, Any]:
     """Scan existing rows for names the #597 validators would now reject.
 
@@ -72,63 +106,48 @@ async def scan_name_conformance(db: AsyncSession) -> dict[str, Any]:
     zone = _CategoryReport("dns_zone_name")
     static = _CategoryReport("dhcp_static_hostname")
 
-    # IPAM hostnames (host rule).
-    n = 0
-    for row_id, value in (
-        await db.execute(
-            select(IPAddress.id, IPAddress.hostname)
-            .where(IPAddress.hostname.isnot(None), IPAddress.hostname != "")
-            .limit(_MAX_SCAN_PER_CATEGORY)
-        )
-    ).all():
-        n += 1
-        try:
-            validate_hostname(value)
-        except ValueError as exc:
-            ipam.add(row_id=row_id, value=value, reason=str(exc))
-    ipam.scanned_capped = n >= _MAX_SCAN_PER_CATEGORY
+    # IPAM hostnames (host rule). Exclude integration-owned rows: their names
+    # are set by an external mirror (Docker / Proxmox / UniFi / …) the operator
+    # can't fix here, and the render boundary + DDNS re-sanitize already keep
+    # them safe — flagging them would be permanent unfixable noise (#597 review).
+    await _scan_category(
+        db,
+        ipam,
+        select(IPAddress.id, IPAddress.hostname).where(
+            IPAddress.hostname.isnot(None),
+            IPAddress.hostname != "",
+            IPAddress.status.notin_(IP_STATUSES_INTEGRATION_OWNED),
+        ),
+        validate_hostname,
+    )
 
     # DNS record owners (RFC 2181 rule).
-    n = 0
-    for row_id, value, ctx in (
-        await db.execute(
-            select(DNSRecord.id, DNSRecord.name, DNSRecord.fqdn).limit(_MAX_SCAN_PER_CATEGORY)
-        )
-    ).all():
-        n += 1
-        try:
-            validate_record_owner(value or "@")
-        except ValueError as exc:
-            rec.add(row_id=row_id, value=value, reason=str(exc), context=ctx)
-    rec.scanned_capped = n >= _MAX_SCAN_PER_CATEGORY
+    await _scan_category(
+        db,
+        rec,
+        select(DNSRecord.id, DNSRecord.name, DNSRecord.fqdn),
+        lambda v: validate_record_owner(v or "@"),
+        has_context=True,
+    )
 
     # DNS zone names (FQDN rule). Strip the stored trailing dot first.
-    n = 0
-    for row_id, value in (
-        await db.execute(select(DNSZone.id, DNSZone.name).limit(_MAX_SCAN_PER_CATEGORY))
-    ).all():
-        n += 1
-        try:
-            validate_fqdn((value or "").rstrip("."), field="zone name")
-        except ValueError as exc:
-            zone.add(row_id=row_id, value=value, reason=str(exc))
-    zone.scanned_capped = n >= _MAX_SCAN_PER_CATEGORY
+    await _scan_category(
+        db,
+        zone,
+        select(DNSZone.id, DNSZone.name),
+        lambda v: validate_fqdn((v or "").rstrip("."), field="zone name"),
+    )
 
     # DHCP static reservation hostnames (host rule; empty is allowed here).
-    n = 0
-    for row_id, value in (
-        await db.execute(
-            select(DHCPStaticAssignment.id, DHCPStaticAssignment.hostname)
-            .where(DHCPStaticAssignment.hostname.isnot(None), DHCPStaticAssignment.hostname != "")
-            .limit(_MAX_SCAN_PER_CATEGORY)
-        )
-    ).all():
-        n += 1
-        try:
-            validate_hostname(value)
-        except ValueError as exc:
-            static.add(row_id=row_id, value=value, reason=str(exc))
-    static.scanned_capped = n >= _MAX_SCAN_PER_CATEGORY
+    await _scan_category(
+        db,
+        static,
+        select(DHCPStaticAssignment.id, DHCPStaticAssignment.hostname).where(
+            DHCPStaticAssignment.hostname.isnot(None),
+            DHCPStaticAssignment.hostname != "",
+        ),
+        validate_hostname,
+    )
 
     categories = [ipam, rec, zone, static]
     return {

--- a/backend/app/services/dns_names_report.py
+++ b/backend/app/services/dns_names_report.py
@@ -1,0 +1,138 @@
+"""Read-only conformance report for existing DNS-shaped names (issue #597).
+
+The #597 validators reject non-conforming names on *write*, but rows that
+predate them stay in the database untouched (the deliberate "validate +
+report, never auto-mutate" stance). This module scans the existing
+IPAM hostnames, DNS record owners, DNS zone names, and DHCP static
+reservation hostnames and reports which ones would now be rejected, so an
+operator can fix them deliberately. It never mutates anything.
+
+Each category caps the number of returned examples (the full offending
+set on a large install could be huge) but reports the true total count so
+the operator knows the real scale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dns_names import (
+    validate_fqdn,
+    validate_hostname,
+    validate_record_owner,
+)
+from app.models.dhcp import DHCPStaticAssignment
+from app.models.dns import DNSRecord, DNSZone
+from app.models.ipam import IPAddress
+
+# Cap the examples returned per category — the count is always exact, only
+# the ``examples`` list is truncated.
+_EXAMPLES_PER_CATEGORY = 100
+# Hard ceiling on rows scanned per category so the report can't run away on
+# a multi-million-row install; ``scanned_capped`` flags when it bit.
+_MAX_SCAN_PER_CATEGORY = 200_000
+
+
+@dataclass
+class _CategoryReport:
+    category: str
+    total: int = 0
+    scanned_capped: bool = False
+    examples: list[dict[str, Any]] = field(default_factory=list)
+
+    def add(self, *, row_id: Any, value: str, reason: str, context: str | None = None) -> None:
+        self.total += 1
+        if len(self.examples) < _EXAMPLES_PER_CATEGORY:
+            ex: dict[str, Any] = {"id": str(row_id), "value": value, "reason": reason}
+            if context is not None:
+                ex["context"] = context
+            self.examples.append(ex)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "category": self.category,
+            "total": self.total,
+            "scanned_capped": self.scanned_capped,
+            "examples": self.examples,
+        }
+
+
+async def scan_name_conformance(db: AsyncSession) -> dict[str, Any]:
+    """Scan existing rows for names the #597 validators would now reject.
+
+    Returns a dict with one entry per category plus a ``total`` rollup.
+    Read-only — issues plain SELECTs and validates in Python.
+    """
+    ipam = _CategoryReport("ipam_hostname")
+    rec = _CategoryReport("dns_record_name")
+    zone = _CategoryReport("dns_zone_name")
+    static = _CategoryReport("dhcp_static_hostname")
+
+    # IPAM hostnames (host rule).
+    n = 0
+    for row_id, value in (
+        await db.execute(
+            select(IPAddress.id, IPAddress.hostname)
+            .where(IPAddress.hostname.isnot(None), IPAddress.hostname != "")
+            .limit(_MAX_SCAN_PER_CATEGORY)
+        )
+    ).all():
+        n += 1
+        try:
+            validate_hostname(value)
+        except ValueError as exc:
+            ipam.add(row_id=row_id, value=value, reason=str(exc))
+    ipam.scanned_capped = n >= _MAX_SCAN_PER_CATEGORY
+
+    # DNS record owners (RFC 2181 rule).
+    n = 0
+    for row_id, value, ctx in (
+        await db.execute(
+            select(DNSRecord.id, DNSRecord.name, DNSRecord.fqdn).limit(_MAX_SCAN_PER_CATEGORY)
+        )
+    ).all():
+        n += 1
+        try:
+            validate_record_owner(value or "@")
+        except ValueError as exc:
+            rec.add(row_id=row_id, value=value, reason=str(exc), context=ctx)
+    rec.scanned_capped = n >= _MAX_SCAN_PER_CATEGORY
+
+    # DNS zone names (FQDN rule). Strip the stored trailing dot first.
+    n = 0
+    for row_id, value in (
+        await db.execute(select(DNSZone.id, DNSZone.name).limit(_MAX_SCAN_PER_CATEGORY))
+    ).all():
+        n += 1
+        try:
+            validate_fqdn((value or "").rstrip("."), field="zone name")
+        except ValueError as exc:
+            zone.add(row_id=row_id, value=value, reason=str(exc))
+    zone.scanned_capped = n >= _MAX_SCAN_PER_CATEGORY
+
+    # DHCP static reservation hostnames (host rule; empty is allowed here).
+    n = 0
+    for row_id, value in (
+        await db.execute(
+            select(DHCPStaticAssignment.id, DHCPStaticAssignment.hostname)
+            .where(DHCPStaticAssignment.hostname.isnot(None), DHCPStaticAssignment.hostname != "")
+            .limit(_MAX_SCAN_PER_CATEGORY)
+        )
+    ).all():
+        n += 1
+        try:
+            validate_hostname(value)
+        except ValueError as exc:
+            static.add(row_id=row_id, value=value, reason=str(exc))
+    static.scanned_capped = n >= _MAX_SCAN_PER_CATEGORY
+
+    categories = [ipam, rec, zone, static]
+    return {
+        "total_nonconforming": sum(c.total for c in categories),
+        "examples_per_category": _EXAMPLES_PER_CATEGORY,
+        "categories": [c.as_dict() for c in categories],
+    }

--- a/backend/app/services/dns_names_report.py
+++ b/backend/app/services/dns_names_report.py
@@ -91,7 +91,7 @@ async def _scan_category(
             check(value)
         except ValueError as exc:
             report.add(row_id=row_id, value=value, reason=str(exc), context=ctx)
-        if i % _YIELD_EVERY == 0:
+        if i and i % _YIELD_EVERY == 0:
             await asyncio.sleep(0)
 
 

--- a/backend/app/services/ipam_io/importer.py
+++ b/backend/app/services/ipam_io/importer.py
@@ -32,6 +32,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dns_names import validate_hostname
 from app.models.audit import AuditLog
 from app.models.ipam import IP_STATUSES, IPAddress, IPBlock, IPSpace, Subnet
 from app.services.ipam.resize import _total_ips
@@ -695,7 +696,13 @@ def _row_address_fields(
     if (h := row.get("hostname")) is not None:
         h = str(h).strip() or None
         if h:
-            fields["hostname"] = h
+            # Validate as an RFC 1123 host name (issue #597). A malformed
+            # hostname skips just this row with a clear reason, matching the
+            # per-row error contract above (import never hard-fails a batch).
+            try:
+                fields["hostname"] = validate_hostname(h)
+            except ValueError as exc:
+                return None, {}, str(exc)
     if (m := row.get("mac_address")) is not None:
         m = str(m).strip() or None
         if m:

--- a/backend/app/services/netbox_import/commit.py
+++ b/backend/app/services/netbox_import/commit.py
@@ -58,6 +58,7 @@ from typing import Any
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.dns_names import sanitize_hostname
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
@@ -1351,7 +1352,10 @@ async def _commit_address(
             )
         existing.status = imported.status or existing.status
         existing.role = imported.role or existing.role
-        existing.hostname = imported.hostname or existing.hostname
+        # Fold a NetBox device/dns name to a valid LDH host name (#597) — a
+        # migration should keep the IP with a cleaned name rather than store a
+        # non-conforming one; a valid FQDN passes through unchanged.
+        existing.hostname = sanitize_hostname(imported.hostname) or existing.hostname
         existing.fqdn = imported.fqdn or existing.fqdn
         if imported.description:
             existing.description = imported.description
@@ -1382,7 +1386,7 @@ async def _commit_address(
         address=imported.address,
         status=imported.status or "allocated",
         role=imported.role,
-        hostname=imported.hostname,
+        hostname=sanitize_hostname(imported.hostname) or None,
         fqdn=imported.fqdn,
         description=imported.description or "",
         managed_by=managed_by,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -52,6 +52,11 @@ dependencies = [
     "icalendar>=6.0.0",
     "caldav>=1.3.0",
     "python-dateutil>=2.9.0",
+    # IDNA2008 encoding for the shared DNS-name validators (issue #597) —
+    # normalizes internationalized host/record names to their xn-- A-label
+    # form. Already present transitively (httpx / requests); pinned direct
+    # because app.core.dns_names imports it.
+    "idna>=3.7",
     "boto3>=1.35.0",
     "paramiko>=3.4.0",
     "azure-storage-blob>=12.20.0",

--- a/backend/tests/test_dns_names.py
+++ b/backend/tests/test_dns_names.py
@@ -229,10 +229,21 @@ def test_sanitize_hostname(raw: str | None, expected: str) -> None:
 def test_sanitize_hostname_output_is_valid() -> None:
     # Whatever the sanitizer emits (when non-empty) must itself pass strict
     # host validation — otherwise it just moves the problem downstream.
-    for raw in ["my pc", "Weird__Name", "café-01", "a.b.c"]:
+    # Includes truncation-boundary inputs (issue #597 review): a long run of
+    # hyphens truncated at 63 must NOT leave a trailing hyphen.
+    for raw in [
+        "my pc",
+        "Weird__Name",
+        "café-01",
+        "a.b.c",
+        "printer" + "-" * 60 + "lobby",  # 63rd char lands on a hyphen
+        "a" + "-" * 70 + "b",
+        "conference room projector second floor east wing unit annex",
+        "x" * 300,
+    ]:
         out = sanitize_hostname(raw)
         if out:
-            assert validate_hostname(out) == out
+            assert validate_hostname(out) == out, f"{raw!r} -> {out!r} is not a valid hostname"
 
 
 def test_sanitize_hostname_respects_length_cap() -> None:

--- a/backend/tests/test_dns_names.py
+++ b/backend/tests/test_dns_names.py
@@ -138,6 +138,20 @@ def test_validate_record_owner_wildcard_only_leftmost() -> None:
         validate_record_owner("example.*.com")
 
 
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("www.", "www"),
+        ("www.example.com.", "www.example.com"),
+        ("_acme-challenge.", "_acme-challenge"),
+    ],
+)
+def test_validate_record_owner_strips_trailing_dot(raw: str, expected: str) -> None:
+    # A record owner is relative and the handlers build ``f"{name}.{zone}"``,
+    # so a preserved trailing dot would yield a double-dotted FQDN (#597 review).
+    assert validate_record_owner(raw) == expected
+
+
 # ── FQDNs (zone names, domain-name option, rdata targets) ────────────────
 
 

--- a/backend/tests/test_dns_names.py
+++ b/backend/tests/test_dns_names.py
@@ -1,0 +1,241 @@
+"""Unit tests for the shared DNS-name validators (issue #597).
+
+The acceptance criteria are encoded directly here: the eight malformed
+hostnames from the live repro must be rejected, while legitimate DNS
+owners that are *not* valid host names — ``_acme-challenge`` (our own ACME
+DNS-01 client), ``_443._tcp`` SRV owners, ``*`` wildcards — must still
+pass. These two facts pulling in opposite directions are the whole reason
+the rule is per-context.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.dns_names import (
+    MAX_NAME_LEN,
+    contains_control_chars,
+    contains_zonefile_unsafe,
+    sanitize_hostname,
+    validate_fqdn,
+    validate_hostname,
+    validate_record_owner,
+)
+
+# ── Host names (RFC 1123, strict LDH) ────────────────────────────────────
+
+# The eight malformed hostnames that returned HTTP 201 in the live repro.
+MALFORMED_HOSTNAMES = [
+    "has space",
+    "under_score",  # underscore is illegal in a *host* name (fine in a record owner)
+    "-leading-hyphen",
+    "a..b",  # empty label
+    "CAPS Host!",
+    'evil\nMORE IN TXT "pwned"',
+    "x" * 68,  # over the 63-char label limit
+    "trailing-hyphen-",
+]
+
+
+@pytest.mark.parametrize("bad", MALFORMED_HOSTNAMES)
+def test_validate_hostname_rejects_malformed(bad: str) -> None:
+    with pytest.raises(ValueError):
+        validate_hostname(bad)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("web01", "web01"),
+        ("WEB01", "web01"),  # canonicalized to lowercase
+        ("web01.corp.example.com", "web01.corp.example.com"),
+        ("host-name-01", "host-name-01"),
+        ("a", "a"),  # single-char label is legal
+        ("web01.example.com.", "web01.example.com"),  # trailing root dot stripped
+        ("  web01  ", "web01"),  # surrounding whitespace trimmed
+        ("9host", "9host"),  # RFC 1123 relaxed the leading-digit ban
+    ],
+)
+def test_validate_hostname_accepts_and_normalizes(raw: str, expected: str) -> None:
+    assert validate_hostname(raw) == expected
+
+
+def test_validate_hostname_idna_normalizes_unicode() -> None:
+    # A unicode host name is accepted by converting to its A-label form,
+    # which is what actually goes on the wire — not rejected outright.
+    out = validate_hostname("Ünïcödé")
+    assert out.startswith("xn--")
+    assert out.isascii()
+
+
+def test_validate_hostname_rejects_over_253() -> None:
+    long_name = ".".join(["abcdefgh"] * 40)  # 40*8 + 39 dots = 359 chars
+    with pytest.raises(ValueError):
+        validate_hostname(long_name)
+
+
+def test_validate_hostname_empty() -> None:
+    with pytest.raises(ValueError):
+        validate_hostname("   ")
+
+
+# ── DNS record owners (RFC 2181, permits _ and *) ────────────────────────
+
+# The load-bearing acceptance case: these are NOT valid host names but ARE
+# valid DNS record owners and must keep working.
+LEGITIMATE_OWNERS = [
+    "_acme-challenge",
+    "_acme-challenge.www",
+    "_dmarc",
+    "_443._tcp",
+    "_sip._tls.example.com",
+    "*",
+    "*.example.com",
+    "www",
+    "@",  # apex
+    "",  # apex (empty → @)
+]
+
+
+@pytest.mark.parametrize("owner", LEGITIMATE_OWNERS)
+def test_validate_record_owner_accepts_legitimate(owner: str) -> None:
+    # Must not raise; apex forms normalize to "@".
+    out = validate_record_owner(owner)
+    if owner in ("", "@"):
+        assert out == "@"
+    else:
+        assert out == owner.lower()
+
+
+def test_validate_record_owner_underscore_is_a_hostname_failure() -> None:
+    # Same string: illegal as a host name, legal as a record owner. This
+    # divergence is exactly why the rule is per-context.
+    with pytest.raises(ValueError):
+        validate_hostname("_acme-challenge")
+    assert validate_record_owner("_acme-challenge") == "_acme-challenge"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "has space",
+        "evil\nrecord",
+        "semi;colon",  # ; starts a zone-file comment
+        "dollar$sign",
+        'quote"mark',
+        "a..b",  # empty interior label
+        "x" * 64,  # label too long
+    ],
+)
+def test_validate_record_owner_rejects_dangerous(bad: str) -> None:
+    with pytest.raises(ValueError):
+        validate_record_owner(bad)
+
+
+def test_validate_record_owner_wildcard_only_leftmost() -> None:
+    assert validate_record_owner("*.example.com") == "*.example.com"
+    with pytest.raises(ValueError):
+        validate_record_owner("example.*.com")
+
+
+# ── FQDNs (zone names, domain-name option, rdata targets) ────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("example.com", "example.com"),
+        ("EXAMPLE.COM", "example.com"),
+        ("example.com.", "example.com"),
+        ("10.in-addr.arpa", "10.in-addr.arpa"),
+        ("_msdcs.example.com", "_msdcs.example.com"),  # underscore zone label
+    ],
+)
+def test_validate_fqdn_accepts(raw: str, expected: str) -> None:
+    assert validate_fqdn(raw) == expected
+
+
+@pytest.mark.parametrize("bad", ["bad domain", "under_score.com not", "a..b", "*.example.com"])
+def test_validate_fqdn_rejects(bad: str) -> None:
+    with pytest.raises(ValueError):
+        validate_fqdn(bad)
+
+
+def test_validate_fqdn_strict_host_mode_rejects_underscore() -> None:
+    with pytest.raises(ValueError):
+        validate_fqdn("_dmarc.example.com", allow_underscore=False)
+
+
+# ── Zone-file safety guard (render boundary) ─────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "value,unsafe",
+    [
+        ("web01", False),
+        ("_acme-challenge.www", False),
+        ("normal.example.com", False),
+        ("evil\nrecord", True),
+        ("has space", True),
+        ("semi;colon", True),
+        ("dollar$sign", True),
+        ("null\x00byte", True),
+        ("paren(group", True),
+    ],
+)
+def test_contains_zonefile_unsafe(value: str, unsafe: bool) -> None:
+    assert contains_zonefile_unsafe(value) is unsafe
+
+
+@pytest.mark.parametrize(
+    "value,has_ctrl",
+    [
+        # The narrow guard used at the rdata boundary: only control bytes.
+        # Spaces and quotes must NOT trip it, or structured rdata breaks.
+        ("web01", False),
+        ('1 . alpn="h2,h3"', False),  # HTTPS/SVCB rdata — spaces + quotes
+        ('0 issue "letsencrypt.org"', False),  # CAA rdata
+        ("51 30 12.748 N 0 7 39.611 W 2m", False),  # LOC rdata
+        ("evil\nrecord", True),
+        ("tab\there", True),
+        ("null\x00byte", True),
+    ],
+)
+def test_contains_control_chars(value: str, has_ctrl: bool) -> None:
+    assert contains_control_chars(value) is has_ctrl
+
+
+# ── Non-raising sanitizer (DHCP lease path) ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("my pc", "my-pc"),
+        ("MyPC", "mypc"),
+        ("my pc.corp", "my-pc.corp"),  # multi-label aware
+        ("--weird--", "weird"),
+        ('"quoted"', "quoted"),
+        ("", ""),
+        (None, ""),
+        ("!!!", ""),  # nothing usable
+        ("under_score", "under-score"),
+    ],
+)
+def test_sanitize_hostname(raw: str | None, expected: str) -> None:
+    assert sanitize_hostname(raw) == expected
+
+
+def test_sanitize_hostname_output_is_valid() -> None:
+    # Whatever the sanitizer emits (when non-empty) must itself pass strict
+    # host validation — otherwise it just moves the problem downstream.
+    for raw in ["my pc", "Weird__Name", "café-01", "a.b.c"]:
+        out = sanitize_hostname(raw)
+        if out:
+            assert validate_hostname(out) == out
+
+
+def test_sanitize_hostname_respects_length_cap() -> None:
+    out = sanitize_hostname(".".join(["label"] * 60))
+    assert len(out) <= MAX_NAME_LEN
+    assert not out.endswith(".")

--- a/frontend/src/lib/dnsNames.ts
+++ b/frontend/src/lib/dnsNames.ts
@@ -1,0 +1,104 @@
+/**
+ * Client-side mirror of the backend DNS-name validators (issue #597).
+ *
+ * The backend (`app/core/dns_names.py`) is the enforcement layer; these
+ * helpers give instant inline feedback in forms so an operator isn't told
+ * "invalid hostname" only after hitting Save. Keep the rules in step with
+ * the Python module — same per-context split:
+ *
+ *   - hostnames (IPAM / DHCP reservation): RFC 1123 LDH, no `_`
+ *   - DNS record owners: RFC 2181, permits `_` and a leftmost `*`, plus `@`
+ *   - FQDNs (zone names, domain-name option): dotted RFC 2181 labels
+ *
+ * Each returns `null` when valid, or a short human-readable reason string
+ * when not. They do NOT normalize (the server canonicalizes on write); a
+ * unicode label is reported as needing ASCII/punycode rather than being
+ * silently converted, since the browser can't run IDNA reliably.
+ */
+
+export const MAX_LABEL_LEN = 63;
+export const MAX_NAME_LEN = 253;
+
+// RFC 1123 host label: LDH, 1–63, no leading/trailing hyphen.
+const HOST_LABEL_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
+// RFC 2181 owner label as constrained by the backend: LDH + underscore.
+const DNS_LABEL_RE = /^[A-Za-z0-9_](?:[A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?$/;
+// A control character (incl. newline) — never valid in any name.
+// eslint-disable-next-line no-control-regex
+const CONTROL_RE = /[\x00-\x1f\x7f]/;
+
+function isAscii(s: string): boolean {
+  // eslint-disable-next-line no-control-regex
+  return /^[\x00-\x7f]*$/.test(s);
+}
+
+/** Validate a single RFC 1123 host label. Returns an error string or null. */
+export function hostLabelError(label: string): string | null {
+  if (!label) return "contains an empty label";
+  if (!isAscii(label))
+    return `label "${label}" must be ASCII (use its punycode xn-- form)`;
+  if (label.length > MAX_LABEL_LEN)
+    return `label "${label}" exceeds ${MAX_LABEL_LEN} characters`;
+  if (!HOST_LABEL_RE.test(label))
+    return `label "${label}" is not a valid host label (letters, digits and hyphens only; no leading or trailing hyphen)`;
+  return null;
+}
+
+/** Validate a dotted RFC 1123 host name (IPAM / DHCP reservation hostname). */
+export function hostnameError(name: string): string | null {
+  const raw = name.trim();
+  if (!raw) return "must not be empty";
+  const body = raw.endsWith(".") ? raw.slice(0, -1) : raw;
+  if (!body) return "must not be the root domain";
+  for (const label of body.split(".")) {
+    const err = hostLabelError(label);
+    if (err) return err;
+  }
+  if (body.length > MAX_NAME_LEN) return `exceeds ${MAX_NAME_LEN} characters`;
+  return null;
+}
+
+/** Validate a DNS record owner (RFC 2181 — permits `_`, leftmost `*`, and `@`). */
+export function recordOwnerError(name: string): string | null {
+  const raw = name.trim();
+  if (raw === "" || raw === "@") return null; // apex
+  if (CONTROL_RE.test(raw)) return "contains a control character";
+  const body = raw.endsWith(".") ? raw.slice(0, -1) : raw;
+  if (!body) return null;
+  const parts = body.split(".");
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === "*") {
+      if (i === 0) continue; // wildcard only as leftmost label
+      return "a '*' wildcard is only valid as the leftmost label";
+    }
+    if (!part) return "contains an empty label";
+    if (!isAscii(part))
+      return `label "${part}" must be ASCII (use its punycode xn-- form)`;
+    if (part.length > MAX_LABEL_LEN)
+      return `label "${part}" exceeds ${MAX_LABEL_LEN} characters`;
+    if (!DNS_LABEL_RE.test(part))
+      return `label "${part}" is not a valid DNS label (letters, digits, hyphen and underscore only; no leading or trailing hyphen)`;
+  }
+  if (body.length > MAX_NAME_LEN) return `exceeds ${MAX_NAME_LEN} characters`;
+  return null;
+}
+
+/** Validate an FQDN (zone name, domain-name option). Permits `_` labels. */
+export function fqdnError(name: string): string | null {
+  const raw = name.trim();
+  if (!raw) return "must not be empty";
+  const body = raw.endsWith(".") ? raw.slice(0, -1) : raw;
+  if (!body) return "must not be the root domain";
+  for (const label of body.split(".")) {
+    if (!label) return "contains an empty label";
+    if (!isAscii(label))
+      return `label "${label}" must be ASCII (use its punycode xn-- form)`;
+    if (label.length > MAX_LABEL_LEN)
+      return `label "${label}" exceeds ${MAX_LABEL_LEN} characters`;
+    if (!DNS_LABEL_RE.test(label))
+      return `label "${label}" is not a valid domain label`;
+  }
+  if (body.length > MAX_NAME_LEN) return `exceeds ${MAX_NAME_LEN} characters`;
+  return null;
+}

--- a/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
+++ b/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { dhcpApi, type DHCPStaticAssignment, type DHCPScope } from "@/lib/api";
+import { hostnameError } from "@/lib/dnsNames";
 import { Modal, Field, Btns, inputCls, errMsg } from "./_shared";
 
 export function CreateStaticAssignmentModal({
@@ -25,6 +26,8 @@ export function CreateStaticAssignmentModal({
   const isV6 = scope.address_family === "ipv6";
   const [duid, setDuid] = useState(staticAssignment?.duid ?? "");
   const [error, setError] = useState("");
+  // Hostname is optional here — only validate (and block submit) when non-empty.
+  const hostnameErr = hostname.trim() ? hostnameError(hostname) : null;
 
   const { data: pools = [] } = useQuery({
     queryKey: ["dhcp-pools", scope.id],
@@ -113,6 +116,9 @@ export function CreateStaticAssignmentModal({
               value={hostname}
               onChange={(e) => setHostname(e.target.value)}
             />
+            {hostnameErr && (
+              <p className="text-xs text-destructive">{hostnameErr}</p>
+            )}
           </Field>
           <Field
             label="Client ID"
@@ -150,7 +156,11 @@ export function CreateStaticAssignmentModal({
             {error}
           </p>
         )}
-        <Btns onClose={onClose} pending={mut.isPending} />
+        <Btns
+          onClose={onClose}
+          pending={mut.isPending}
+          disabled={!!hostnameErr}
+        />
       </form>
     </Modal>
   );

--- a/frontend/src/pages/dhcp/_shared.tsx
+++ b/frontend/src/pages/dhcp/_shared.tsx
@@ -30,10 +30,12 @@ export function Btns({
   onClose,
   pending,
   label,
+  disabled,
 }: {
   onClose: () => void;
   pending: boolean;
   label?: string;
+  disabled?: boolean;
 }) {
   return (
     <div className="flex justify-end gap-2 pt-2">
@@ -46,7 +48,7 @@ export function Btns({
       </button>
       <button
         type="submit"
-        disabled={pending}
+        disabled={pending || disabled}
         className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
       >
         {pending ? "Saving…" : (label ?? "Save")}

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -82,6 +82,7 @@ import {
   type DNSGroupSyncResult,
 } from "@/lib/api";
 import { copyToClipboard } from "@/lib/clipboard";
+import { fqdnError, recordOwnerError } from "@/lib/dnsNames";
 import { useTableSort, SortableTh } from "@/lib/useTableSort";
 import { cn, swatchCls, zebraBodyCls } from "@/lib/utils";
 import { SwatchPicker } from "@/components/ui/swatch-picker";
@@ -136,10 +137,12 @@ function Btns({
   onClose,
   pending,
   label,
+  disabled,
 }: {
   onClose: () => void;
   pending: boolean;
   label?: string;
+  disabled?: boolean;
 }) {
   return (
     <div className="flex justify-end gap-2 pt-2">
@@ -152,7 +155,7 @@ function Btns({
       </button>
       <button
         type="submit"
-        disabled={pending}
+        disabled={pending || disabled}
         className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
       >
         {pending ? "Saving…" : (label ?? "Save")}
@@ -2058,6 +2061,8 @@ function ZoneModal({
   const [ttl, setTtl] = useState(String(zone?.ttl ?? 3600));
   const [dnssec, setDnssec] = useState(zone?.dnssec_enabled ?? false);
   const [color, setColor] = useState<string | null>(zone?.color ?? null);
+  // Client-side FQDN check (create only — the name is locked on edit).
+  const nameErr = !zone && name.trim() ? fqdnError(name) : null;
   // Forward-zone config — only shown / submitted when zoneType === "forward".
   const [forwardersText, setForwardersText] = useState(
     (zone?.forwarders ?? []).join(", "),
@@ -2151,10 +2156,14 @@ function ZoneModal({
             autoFocus
             disabled={!!zone}
           />
-          {!zone && (
-            <p className="text-xs text-muted-foreground mt-0.5">
-              Trailing dot added automatically.
-            </p>
+          {nameErr ? (
+            <p className="text-xs text-destructive mt-0.5">{nameErr}</p>
+          ) : (
+            !zone && (
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Trailing dot added automatically.
+              </p>
+            )
           )}
         </Field>
         <div className="grid grid-cols-2 gap-3">
@@ -2339,6 +2348,7 @@ function ZoneModal({
           onClose={onClose}
           pending={mut.isPending}
           label={zone ? "Save" : "Add Zone"}
+          disabled={!!nameErr}
         />
       </form>
     </Modal>
@@ -2421,6 +2431,8 @@ function RecordModal({
   const [port, setPort] = useState(String(record?.port ?? ""));
   const [viewId, setViewId] = useState<string>(record?.view_id ?? "");
   const [error, setError] = useState("");
+  // Owner-name check — permits `_`, a leftmost `*`, and empty/`@` (apex).
+  const nameErr = recordOwnerError(name);
 
   const { data: views = [] } = useQuery({
     queryKey: ["dns-views", groupId],
@@ -2481,6 +2493,7 @@ function RecordModal({
               required
               autoFocus
             />
+            {nameErr && <p className="text-xs text-destructive">{nameErr}</p>}
           </Field>
           <Field label="Type">
             <select
@@ -2700,6 +2713,7 @@ function RecordModal({
           onClose={onClose}
           pending={mut.isPending}
           label={record ? "Save" : "Add Record"}
+          disabled={!!nameErr}
         />
       </form>
     </Modal>

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -95,6 +95,7 @@ import {
   handleApprovalQueued,
 } from "@/lib/approvalQueue";
 import { copyToClipboard } from "@/lib/clipboard";
+import { hostnameError } from "@/lib/dnsNames";
 import { cn, swatchTintCls, zebraBodyCls } from "@/lib/utils";
 import { StatusTag } from "@/components/ui/status-tag";
 import { SwatchPicker } from "@/components/ui/swatch-picker";
@@ -3307,8 +3308,13 @@ function AddAddressModal({
     setPendingWarnings(null);
   }, [hostname, mac, dnsZoneId, address]);
 
+  // Hostname is required here; only surface the inline reason once the
+  // operator has typed something (empty is already blocked by canSubmit).
+  const hostnameErr = hostname.trim() ? hostnameError(hostname) : null;
+
   const canSubmit =
     !!hostname.trim() &&
+    !hostnameErr &&
     (mode === "next" ? !!nextPreview?.address : !!address && !typedDynamicPool);
 
   // Compute preview FQDN
@@ -3434,6 +3440,9 @@ function AddAddressModal({
             placeholder="Required"
             autoFocus={mode === "next"}
           />
+          {hostnameErr && (
+            <p className="mt-1 text-xs text-destructive">{hostnameErr}</p>
+          )}
         </Field>
         {/* DNS zone selector — only shown when zones are available */}
         {availableZones.length > 0 && (
@@ -8604,6 +8613,10 @@ function EditAddressModal({
     setPendingWarnings(null);
   }, [hostname, macAddress, dnsZoneId]);
 
+  // Hostname is optional on edit (clearing it is allowed) — only validate
+  // when non-empty.
+  const hostnameErr = hostname.trim() ? hostnameError(hostname) : null;
+
   // ── Tabs ────────────────────────────────────────────────────────────
   // EditAddressModal is also the "IP detail panel" surface — the
   // network-discovery feature mounts a second tab here that surfaces
@@ -8676,6 +8689,9 @@ function EditAddressModal({
             placeholder="Optional"
             autoFocus
           />
+          {hostnameErr && (
+            <p className="mt-1 text-xs text-destructive">{hostnameErr}</p>
+          )}
         </Field>
         {/* DNS zone — only shown when zones are available */}
         {availableZones.length > 0 && (
@@ -8891,7 +8907,7 @@ function EditAddressModal({
               setError(null);
               mutation.mutate(pendingWarnings != null);
             }}
-            disabled={mutation.isPending}
+            disabled={mutation.isPending || !!hostnameErr}
             className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
           >
             {mutation.isPending


### PR DESCRIPTION
Closes #597.

## What

Adds server- and client-side validation of DNS-shaped names (hostnames,
DNS record owners, zone names, FQDNs) across IPAM, DNS, and DHCP. Before
this, every user-supplied name field accepted arbitrary strings up to its
column length — spaces, uppercase, unicode, leading/trailing hyphens,
consecutive dots, `;{}`, even embedded newlines all persisted verbatim
(verified live: eight malformed hostnames all returned HTTP 201).

The rule is deliberately **per-context** — there is no single "valid DNS
name" regex, because the correct answer depends on the field:

- **Host names** (IPAM hostname, DHCP reservation hostname) → RFC 1123 LDH
- **DNS record owners** → RFC 2181 (permits `_` and `*`, so `_acme-challenge`,
  `_443._tcp`, and `*.example.com` stay legal — the load-bearing constraint,
  since a naive RFC 1123 check would break our own ACME DNS-01 client + SRV/TLSA)
- **FQDNs** (zone name, `domain-name` option) → dotted RFC 2181 labels

## How

- **`backend/app/core/dns_names.py`** — one shared module (unit-tested).
  Validators raise `ValueError` with an operator-facing message and return the
  normalized value (lowercased, IDNA `xn--` A-label for unicode). Plus
  `sanitize_hostname` (non-raising, for the DHCP lease path) and
  `strip_control_chars` / `contains_control_chars` (render-boundary guard).
- **Schema wiring** — `field_validator`s on the IPAM address (create + update +
  next-ip), DNS zone + record (create + update), GSLB pool, and DHCP static
  reservation schemas; the `domain-name` / `domain-search` DHCP options (scopes,
  option templates, and client classes); and `ddns_domain_override` across the
  IPSpace/Block/Subnet **create + update** schemas (not Response models).
- **DHCP client hostname** — sanitized to LDH at ingress (`/lease-events`
  schema + `pull_leases` wire loop) **before** it reaches `IPAM.hostname`.
- **Render boundary** — BIND9 + PowerDNS drivers strip control chars from every
  name + rdata field **and the SOA `primary_ns` / `admin_email`**, so a value
  that slips past the validators can't inject a second zone-file record. Narrow
  by design: only control bytes, so structured rdata (CAA / LOC / NAPTR / SVCB)
  keeps its legitimate spaces and quotes.
- **Import paths** — IPAM CSV/JSON/XLSX validates hostname per-row (skip +
  reason); the NetBox importer folds names to LDH; DNS import drops records
  with control chars in name/value.
- **Back-compat: validate + report, never break reads or block legacy edits.**
  Existing non-conforming rows are untouched and remain readable; updates only
  validate values that actually change. A read-only
  `GET /diagnostics/name-conformance` (superadmin) + `find_nonconforming_names`
  MCP tool surface pre-existing violations (integration-owned mirror rows
  excluded, since the operator can't fix those here).
- **Frontend** — `frontend/src/lib/dnsNames.ts` mirrors the rules for instant
  inline feedback + disabled submit on the IPAM address, DNS zone/record, and
  DHCP static forms. The backend stays the enforcement layer.

## Standards

There is a written standard — several, and they differ, which is why the rule
is per-context: RFC 952 / RFC 1123 §2.1 (host LDH), RFC 2181 §11 (the looser
DNS label that permits `_`), RFC 5890/5891 IDNA2008 (unicode → `xn--`), and
RFC 1035 §5.1 zone-file master format (the injection surface).

## Two commits

1. **feat** — the validators + wiring + frontend.
2. **fix** — ten findings from a high-effort self-review of commit 1, most
   caught real behavior bugs: the biggest were an accidental validator on the
   IPAM **Response** models (would 500 on reading a legacy row) and the SOA
   `primary_ns`/`admin_email` render path (an injection vector missed one
   altitude up from records). Also: a sanitizer that could emit a trailing-hyphen
   label, DHCP domain-option coverage + legacy-edit gating, and a report perf
   pass. Details in the commit message.

## Verified

- The eight malformed hostnames from the issue now 422 on create **and**
  update — except unicode `Ünïcödé`, which is IDNA-normalized to
  `xn--ncd-dma1a7bzb` (correct — that's what goes on the wire), not rejected.
- `_acme-challenge`, `_dmarc`, `_443._tcp` SRV, `*`, `*.example.com`, apex `@`,
  and CAA / HTTPS records with legitimate spaces + quotes all still create.
- CNAME rdata with a newline / interior space is rejected; a legacy row with a
  bad `ddns_domain_override` reads at 200 (not 500); a legacy scope's unrelated
  edit is not blocked; a SOA newline is rejected and stripped.
- `make ci` green; mypy/ruff/black clean; unit tests + 196 targeted regression
  tests + a full live acceptance pass.

## Deferred follow-ups (documented, out of scope here)

- Unifying the bulk-allocate label regex (front + back) with the shared strict
  rule — would change that feature's semantics (lowercasing + trailing-hyphen
  rejection); front/back are internally consistent today.
- Full rdata-target validation for MX/SRV (their value may carry the priority
  inline on some driver paths); the control-char guard still covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
