### PR TITLE
fix(ipam,dns): render API validation errors readably instead of raw JSON

### DIFF
--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -7272,7 +7272,7 @@ function BlocklistModal({
       qc.invalidateQueries({ queryKey: ["dns-blocklists"] });
       onClose();
     },
-    onError: (e: ApiError) => setError(e.response?.data?.detail ?? "Failed"),
+    onError: (e: ApiError) => setError(formatApiError(e, "Failed")),
   });
 
   return (

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -3294,10 +3294,10 @@ function AddAddressModal({
         setError(null);
         return;
       }
-      const msg =
-        (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? "Failed to allocate address";
-      setError(typeof msg === "string" ? msg : JSON.stringify(msg));
+      // Use the shared unwrapper so a FastAPI 422 validation body (a
+      // ``detail: [{msg, loc, …}]`` array) renders as its readable message
+      // instead of raw JSON (e.g. a rejected hostname).
+      setError(formatApiError(err, "Failed to allocate address"));
     },
   });
 
@@ -8601,10 +8601,9 @@ function EditAddressModal({
         setError(null);
         return;
       }
-      const msg =
-        (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? "Failed to save";
-      setError(typeof msg === "string" ? msg : JSON.stringify(msg));
+      // Shared unwrapper so a FastAPI 422 body renders its readable message
+      // (e.g. a rejected hostname) instead of raw JSON.
+      setError(formatApiError(err, "Failed to save"));
     },
   });
 


### PR DESCRIPTION
Follow-up to #600 (DNS name validation). Now that malformed hostnames /
record names are rejected server-side with a 422, the frontend needs to
render those 422s readably — the IPAM address modals were dumping the raw
FastAPI validation body as JSON.

## What

- **IPAM allocate + edit address modals** — the `onError` handlers grabbed
  `response.data.detail` (a `[{msg, loc, …}]` array for a 422) and
  `JSON.stringify`'d it, so a rejected hostname surfaced as
  `[{"type":"value_error", …}]` at the bottom of the form. Both now use the
  existing `formatApiError` helper, which unwraps the array into its `msg`.
  The client-side inline validation already blocks submit for a bad
  hostname (red text + disabled button); this fixes the fallback for a 422
  that still reaches the server.

- **DNS `BlocklistModal`** — the last DNS `onError` still using a raw
  `detail` fallback; switched to `formatApiError` for consistency. (Not a
  name-validation path, so #600 doesn't trigger it — tidied while nearby.)

## Not changed (verified already correct)

- **All DHCP modals** (static reservation hostname, scope
  `domain-name`/`domain-search`, option templates, client classes) route
  errors through the shared `errMsg` helper in `dhcp/_shared.tsx`, which
  already unwraps the Pydantic 422 array into readable `field: msg` text.
- **DNS record + zone modals** already use `formatApiError`.

So after this, no IPAM/DNS/DHCP modal renders a raw error body.

The broader `setError(typeof msg === "string" ? msg : JSON.stringify(msg))`
pattern still exists in modals unrelated to this flow (VLANs / Users /
Roles / Groups) — pre-existing, out of scope here.

## Verified

`make ci` green (tsc + eslint + prettier + build); hard-refreshed UI shows
a rejected hostname as a readable inline message, not JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
