### PR TITLE
feat(integrations): NetBird mesh mirror into IPAM + synthetic DNS (#603)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -377,7 +377,10 @@ backend/alembic/versions/c8e3a7f10b54_ai_usage_observability.py:drop_column:78
 backend/alembic/versions/c8e4f7a91d36_session_viewer.py:drop_column:65
 backend/alembic/versions/c8e4f7a91d36_session_viewer.py:drop_column:66
 backend/alembic/versions/c9a1f7e0b234_dns_zone_masters.py:drop_column:43
-backend/alembic/versions/c9a2f61e740b_wol_run_verify_params.py:drop_column:58
+backend/alembic/versions/c9a2f61e740b_wol_run_verify_params.py:drop_column:59
+backend/alembic/versions/c9a4e1f7b820_netbird_integration.py:drop_column:126
+backend/alembic/versions/c9a4e1f7b820_netbird_integration.py:drop_column:129
+backend/alembic/versions/c9a4e1f7b820_netbird_integration.py:drop_table:131
 backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:75
 backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:76
 backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:77

--- a/backend/alembic/versions/c9a4e1f7b820_netbird_integration.py
+++ b/backend/alembic/versions/c9a4e1f7b820_netbird_integration.py
@@ -1,0 +1,131 @@
+"""NetBird integration — instance table + IPAM/DNS provenance + settings toggle.
+
+Revision ID: c9a4e1f7b820
+Revises: e4b8073af215
+Create Date: 2026-07-10 12:00:00
+
+Same shape as the Tailscale + OPNsense integrations (issue #603). One
+row per NetBird deployment. ``netbird_instance_id`` FK on ``ip_address``
++ ``ip_block`` + ``subnet`` (Phase 1 mirror) and ``dns_zone`` +
+``dns_record`` (Phase 2 synthetic DNS), all ON DELETE CASCADE so
+removing an instance sweeps its mirrored rows. Platform-settings toggle
+gates the sidebar entry; the ``integrations.netbird`` feature_module row
+is seeded disabled-by-default.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c9a4e1f7b820"
+down_revision: str | None = "e4b8073af215"
+branch_labels = None
+depends_on = None
+
+_IPAM_TABLES = ("ip_address", "ip_block", "subnet")
+_DNS_TABLES = ("dns_zone", "dns_record")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "netbird_instance",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "api_url",
+            sa.String(length=255),
+            nullable=False,
+            server_default="https://api.netbird.io",
+        ),
+        sa.Column("verify_tls", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "api_key_encrypted",
+            sa.LargeBinary(),
+            nullable=False,
+            server_default=sa.text("''::bytea"),
+        ),
+        sa.Column(
+            "ipam_space_id",
+            sa.UUID(),
+            sa.ForeignKey("ip_space.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "dns_group_id",
+            sa.UUID(),
+            sa.ForeignKey("dns_server_group.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "network_cidr",
+            sa.String(length=32),
+            nullable=False,
+            server_default="100.64.0.0/10",
+        ),
+        sa.Column("skip_expired", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("sync_interval_seconds", sa.Integer(), nullable=False, server_default="60"),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_sync_error", sa.Text(), nullable=True),
+        sa.Column("dns_domain", sa.String(length=255), nullable=True),
+        sa.Column("peer_count", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_netbird_instance_name", "netbird_instance", ["name"], unique=True)
+
+    for table in _IPAM_TABLES + _DNS_TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "netbird_instance_id",
+                sa.UUID(),
+                sa.ForeignKey("netbird_instance.id", ondelete="CASCADE"),
+                nullable=True,
+            ),
+        )
+        op.create_index(f"ix_{table}_netbird_instance_id", table, ["netbird_instance_id"])
+
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "integration_netbird_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    # Seed the feature_module row disabled-by-default. Idempotent — the
+    # catalog's default_enabled=False already resolves to "off" without a
+    # row, but seeding keeps a fresh migrate consistent with the model.
+    op.execute(
+        sa.text(
+            "INSERT INTO feature_module (id, enabled) "
+            "VALUES ('integrations.netbird', false) ON CONFLICT (id) DO NOTHING"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'integrations.netbird'"))
+    op.drop_column("platform_settings", "integration_netbird_enabled")
+    for table in tuple(reversed(_IPAM_TABLES + _DNS_TABLES)):
+        op.drop_index(f"ix_{table}_netbird_instance_id", table_name=table)
+        op.drop_column(table, "netbird_instance_id")
+    op.drop_index("ix_netbird_instance_name", table_name="netbird_instance")
+    op.drop_table("netbird_instance")

--- a/backend/app/api/v1/dashboards/integrations.py
+++ b/backend/app/api/v1/dashboards/integrations.py
@@ -30,6 +30,7 @@ from app.models.audit import AuditLog
 from app.models.cloud import CloudEndpoint
 from app.models.docker import DockerHost
 from app.models.kubernetes import KubernetesCluster
+from app.models.netbird import NetbirdInstance
 from app.models.opnsense import OPNsenseRouter
 from app.models.proxmox import ProxmoxNode
 from app.models.settings import PlatformSettings
@@ -91,6 +92,7 @@ _INTEGRATION_RESOURCE_TYPES = (
     "unifi_controller",
     "cloud_endpoint",
     "opnsense_router",
+    "netbird_instance",
 )
 
 
@@ -170,6 +172,7 @@ async def integrations_summary(
     unifi_targets = list((await db.execute(select(UnifiController))).scalars().all())
     cloud_targets = list((await db.execute(select(CloudEndpoint))).scalars().all())
     opnsense_targets = list((await db.execute(select(OPNsenseRouter))).scalars().all())
+    netbird_targets = list((await db.execute(select(NetbirdInstance))).scalars().all())
 
     panels = [
         _build_panel(
@@ -228,6 +231,14 @@ async def integrations_summary(
             label="OPNsense",
             enabled=getattr(settings, "integration_opnsense_enabled", False),
             targets=opnsense_targets,
+            display_attr="name",
+            now=now,
+        ),
+        _build_panel(
+            kind="netbird",
+            label="NetBird",
+            enabled=getattr(settings, "integration_netbird_enabled", False),
+            targets=netbird_targets,
             display_attr="name",
             now=now,
         ),

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -5564,6 +5564,17 @@ def _reject_if_synthesised_zone(zone: DNSZone, op: str) -> None:
                 f"to release the zone."
             ),
         )
+    if zone.netbird_instance_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Zone {zone.name!r} is synthesised by the NetBird "
+                f"integration and cannot be {op}ed manually. The reconciler "
+                f"will overwrite any changes on the next sync. Unbind the "
+                f"DNS group on the NetBird instance or delete the instance "
+                f"to release the zone."
+            ),
+        )
 
 
 def _reject_if_synthesised_record(record: DNSRecord, op: str) -> None:
@@ -5573,6 +5584,15 @@ def _reject_if_synthesised_record(record: DNSRecord, op: str) -> None:
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=(
                 f"Record {record.fqdn!r} is synthesised by the Tailscale "
+                f"integration and cannot be {op}ed manually. Edits would be "
+                f"overwritten on the next sync."
+            ),
+        )
+    if record.netbird_instance_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Record {record.fqdn!r} is synthesised by the NetBird "
                 f"integration and cannot be {op}ed manually. Edits would be "
                 f"overwritten on the next sync."
             ),

--- a/backend/app/api/v1/netbird/__init__.py
+++ b/backend/app/api/v1/netbird/__init__.py
@@ -1,0 +1,7 @@
+"""NetBird integration API package."""
+
+from __future__ import annotations
+
+from app.api.v1.netbird.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/netbird/router.py
+++ b/backend/app/api/v1/netbird/router.py
@@ -1,0 +1,393 @@
+"""NetBird integration CRUD + probe endpoints.
+
+Parallels ``app/api/v1/tailscale/router.py``. PAT is Fernet-encrypted
+at rest; admin-only surface. Unlike Tailscale (fixed cloud host), the
+management URL is operator-supplied, so the probe runs it through the
+SSRF guard before dialing.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, field_validator
+from sqlalchemy import select
+
+from app.api.deps import DB, CurrentUser, SuperAdmin
+from app.core.crypto import decrypt_str, encrypt_str
+from app.core.demo_mode import forbid_in_demo_mode
+from app.core.permissions import require_resource_permission
+from app.core.ssrf import assert_safe_target
+from app.models.audit import AuditLog
+from app.models.dns import DNSServerGroup
+from app.models.ipam import IPSpace
+from app.models.netbird import NetbirdInstance
+from app.services.netbird.client import (
+    NetbirdClient,
+    NetbirdClientError,
+    derive_netbird_domain,
+)
+
+router = APIRouter(
+    tags=["netbird"],
+    dependencies=[Depends(require_resource_permission("netbird_instance"))],
+)
+
+
+# ── Pydantic schemas ─────────────────────────────────────────────────
+
+
+class InstanceBase(BaseModel):
+    name: str
+    description: str = ""
+    enabled: bool = True
+    api_url: str = "https://api.netbird.io"
+    verify_tls: bool = True
+    ipam_space_id: uuid.UUID
+    dns_group_id: uuid.UUID | None = None
+    network_cidr: str = "100.64.0.0/10"
+    skip_expired: bool = True
+    sync_interval_seconds: int = 60
+
+    @field_validator("api_url")
+    @classmethod
+    def _valid_api_url(cls, v: str) -> str:
+        v = v.strip().rstrip("/")
+        if not v:
+            raise ValueError("api_url is required (e.g. https://api.netbird.io)")
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("api_url must start with http:// or https://")
+        return v
+
+    @field_validator("network_cidr")
+    @classmethod
+    def _valid_cidr(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("network_cidr is required")
+        try:
+            ipaddress.ip_network(v, strict=False)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(f"invalid CIDR: {exc}") from exc
+        return v
+
+    @field_validator("sync_interval_seconds")
+    @classmethod
+    def _floor_interval(cls, v: int) -> int:
+        if v < 30:
+            raise ValueError("sync_interval_seconds must be ≥ 30")
+        return v
+
+
+class InstanceCreate(InstanceBase):
+    api_key: str
+
+    @field_validator("api_key")
+    @classmethod
+    def _valid_api_key(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("api_key is required")
+        return v
+
+
+class InstanceUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    enabled: bool | None = None
+    api_url: str | None = None
+    verify_tls: bool | None = None
+    # Omit / send empty to keep the stored key; non-empty rotates.
+    api_key: str | None = None
+    ipam_space_id: uuid.UUID | None = None
+    dns_group_id: uuid.UUID | None = None
+    network_cidr: str | None = None
+    skip_expired: bool | None = None
+    sync_interval_seconds: int | None = None
+
+
+class InstanceResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str
+    enabled: bool
+    api_url: str
+    verify_tls: bool
+    api_key_present: bool
+    ipam_space_id: uuid.UUID
+    dns_group_id: uuid.UUID | None
+    network_cidr: str
+    skip_expired: bool
+    sync_interval_seconds: int
+    last_synced_at: datetime | None
+    last_sync_error: str | None
+    dns_domain: str | None
+    peer_count: int | None
+    created_at: datetime
+    modified_at: datetime
+
+
+class TestConnectionRequest(BaseModel):
+    instance_id: uuid.UUID | None = None
+    api_url: str | None = None
+    verify_tls: bool = True
+    api_key: str | None = None
+
+
+class TestConnectionResponse(BaseModel):
+    ok: bool
+    message: str
+    dns_domain: str | None = None
+    peer_count: int | None = None
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _to_response(t: NetbirdInstance) -> InstanceResponse:
+    return InstanceResponse(
+        id=t.id,
+        name=t.name,
+        description=t.description,
+        enabled=t.enabled,
+        api_url=t.api_url,
+        verify_tls=t.verify_tls,
+        api_key_present=bool(t.api_key_encrypted),
+        ipam_space_id=t.ipam_space_id,
+        dns_group_id=t.dns_group_id,
+        network_cidr=t.network_cidr,
+        skip_expired=t.skip_expired,
+        sync_interval_seconds=t.sync_interval_seconds,
+        last_synced_at=t.last_synced_at,
+        last_sync_error=t.last_sync_error,
+        dns_domain=t.dns_domain,
+        peer_count=t.peer_count,
+        created_at=t.created_at,
+        modified_at=t.modified_at,
+    )
+
+
+async def _probe(*, api_url: str, verify: bool, api_key: str) -> TestConnectionResponse:
+    """Probe NetBird. Always returns a structured result; never raises."""
+    # SECURITY (#400, L5): api_url is operator-supplied, so unlike the
+    # fixed-host Tailscale probe we run it through the SSRF guard (which
+    # logs + flags loopback / link-local / cloud-metadata targets). It is
+    # advisory (no block=True) because a self-hosted NetBird management
+    # server legitimately lives on a LAN address. See app/core/ssrf.py.
+    assert_safe_target(api_url, label="netbird")
+    try:
+        async with NetbirdClient(
+            api_key=api_key, api_url=api_url, verify=verify, timeout=10.0
+        ) as client:
+            peers = await client.list_peers()
+    except NetbirdClientError as exc:
+        return TestConnectionResponse(ok=False, message=str(exc))
+    except Exception as exc:  # noqa: BLE001
+        return TestConnectionResponse(ok=False, message=str(exc))
+    domain = derive_netbird_domain(peers)
+    return TestConnectionResponse(
+        ok=True,
+        message=f"Connected{' to ' + domain if domain else ''} ({len(peers)} peers)",
+        dns_domain=domain,
+        peer_count=len(peers),
+    )
+
+
+async def _validate_bindings(
+    db: Any, ipam_space_id: uuid.UUID, dns_group_id: uuid.UUID | None
+) -> None:
+    space = await db.get(IPSpace, ipam_space_id)
+    if space is None:
+        raise HTTPException(status_code=422, detail="ipam_space_id not found")
+    if dns_group_id is not None:
+        group = await db.get(DNSServerGroup, dns_group_id)
+        if group is None:
+            raise HTTPException(status_code=422, detail="dns_group_id not found")
+
+
+def _audit(
+    db: Any,
+    *,
+    user: Any,
+    action: str,
+    instance_id: uuid.UUID,
+    instance_name: str,
+    changed_fields: list[str] | None = None,
+    new_value: dict | None = None,
+) -> None:
+    db.add(
+        AuditLog(
+            user_id=user.id if user else None,
+            user_display_name=user.display_name if user else "system",
+            auth_source=user.auth_source if user else "system",
+            action=action,
+            resource_type="netbird_instance",
+            resource_id=str(instance_id),
+            resource_display=instance_name,
+            changed_fields=changed_fields,
+            new_value=new_value,
+        )
+    )
+
+
+# ── Endpoints ────────────────────────────────────────────────────────
+
+
+@router.get("/instances", response_model=list[InstanceResponse])
+async def list_instances(db: DB, _: CurrentUser) -> list[InstanceResponse]:
+    res = await db.execute(select(NetbirdInstance).order_by(NetbirdInstance.name))
+    return [_to_response(t) for t in res.scalars().all()]
+
+
+@router.post(
+    "/instances",
+    response_model=InstanceResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_instance(body: InstanceCreate, db: DB, user: SuperAdmin) -> InstanceResponse:
+    forbid_in_demo_mode("NetBird instance registration is disabled")
+    await _validate_bindings(db, body.ipam_space_id, body.dns_group_id)
+
+    existing = await db.execute(select(NetbirdInstance).where(NetbirdInstance.name == body.name))
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="A NetBird instance with that name exists")
+
+    t = NetbirdInstance(
+        name=body.name,
+        description=body.description,
+        enabled=body.enabled,
+        api_url=body.api_url,
+        verify_tls=body.verify_tls,
+        api_key_encrypted=encrypt_str(body.api_key),
+        ipam_space_id=body.ipam_space_id,
+        dns_group_id=body.dns_group_id,
+        network_cidr=body.network_cidr,
+        skip_expired=body.skip_expired,
+        sync_interval_seconds=body.sync_interval_seconds,
+    )
+    db.add(t)
+    await db.flush()
+    _audit(
+        db,
+        user=user,
+        action="create",
+        instance_id=t.id,
+        instance_name=t.name,
+        new_value=body.model_dump(mode="json", exclude={"api_key"}),
+    )
+    await db.commit()
+    await db.refresh(t)
+    return _to_response(t)
+
+
+@router.put("/instances/{instance_id}", response_model=InstanceResponse)
+async def update_instance(
+    instance_id: uuid.UUID, body: InstanceUpdate, db: DB, user: SuperAdmin
+) -> InstanceResponse:
+    t = await db.get(NetbirdInstance, instance_id)
+    if t is None:
+        raise HTTPException(status_code=404, detail="NetBird instance not found")
+
+    changes = body.model_dump(exclude_unset=True)
+    new_ipam = changes.get("ipam_space_id", t.ipam_space_id)
+    new_dns = changes.get("dns_group_id", t.dns_group_id)
+    if "ipam_space_id" in changes or "dns_group_id" in changes:
+        await _validate_bindings(db, new_ipam, new_dns)
+
+    for k, v in changes.items():
+        if k == "api_key":
+            if v:
+                t.api_key_encrypted = encrypt_str(v)
+        else:
+            setattr(t, k, v)
+
+    _audit(
+        db,
+        user=user,
+        action="update",
+        instance_id=t.id,
+        instance_name=t.name,
+        changed_fields=list(changes.keys()),
+        new_value={k: v for k, v in changes.items() if k != "api_key"},
+    )
+    await db.commit()
+    await db.refresh(t)
+    return _to_response(t)
+
+
+@router.delete("/instances/{instance_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_instance(instance_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
+    t = await db.get(NetbirdInstance, instance_id)
+    if t is None:
+        raise HTTPException(status_code=404, detail="NetBird instance not found")
+    _audit(db, user=user, action="delete", instance_id=t.id, instance_name=t.name)
+    await db.delete(t)
+    await db.commit()
+
+
+@router.post(
+    "/instances/{instance_id}/sync",
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def sync_instance(instance_id: uuid.UUID, db: DB, _: SuperAdmin) -> dict[str, str]:
+    t = await db.get(NetbirdInstance, instance_id)
+    if t is None:
+        raise HTTPException(status_code=404, detail="NetBird instance not found")
+
+    from app.tasks.netbird_sync import sync_instance_now  # noqa: PLC0415
+
+    try:
+        result = sync_instance_now.delay(str(t.id))
+        return {"status": "queued", "task_id": result.id}
+    except Exception:  # noqa: BLE001
+        return {"status": "broker_unavailable", "task_id": ""}
+
+
+@router.post("/instances/test", response_model=TestConnectionResponse)
+async def test_connection(
+    body: TestConnectionRequest, db: DB, _: SuperAdmin
+) -> TestConnectionResponse:
+    api_url = body.api_url
+    verify = body.verify_tls
+    api_key = body.api_key
+
+    if body.instance_id is not None:
+        stored = await db.get(NetbirdInstance, body.instance_id)
+        if stored is None:
+            raise HTTPException(status_code=404, detail="NetBird instance not found")
+        api_url = api_url or stored.api_url
+        if body.api_url is None:
+            verify = stored.verify_tls
+        if not api_key and stored.api_key_encrypted:
+            try:
+                api_key = decrypt_str(stored.api_key_encrypted)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Stored API key could not be decrypted — re-enter it",
+                ) from exc
+
+    if not api_url or not api_key:
+        raise HTTPException(
+            status_code=422,
+            detail="api_url and api_key are required (either in body or via stored instance_id)",
+        )
+
+    result = await _probe(api_url=api_url, verify=verify, api_key=api_key)
+
+    if body.instance_id is not None and result.ok:
+        stored = await db.get(NetbirdInstance, body.instance_id)
+        if stored is not None:
+            stored.dns_domain = result.dns_domain
+            stored.peer_count = result.peer_count
+            stored.last_sync_error = None
+            await db.commit()
+
+    return result
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/netbird/router.py
+++ b/backend/app/api/v1/netbird/router.py
@@ -41,6 +41,32 @@ router = APIRouter(
 # ── Pydantic schemas ─────────────────────────────────────────────────
 
 
+def _normalise_api_url(v: str) -> str:
+    v = v.strip().rstrip("/")
+    if not v:
+        raise ValueError("api_url is required (e.g. https://api.netbird.io)")
+    if not (v.startswith("http://") or v.startswith("https://")):
+        raise ValueError("api_url must start with http:// or https://")
+    return v
+
+
+def _validate_cidr(v: str) -> str:
+    v = v.strip()
+    if not v:
+        raise ValueError("network_cidr is required")
+    try:
+        ipaddress.ip_network(v, strict=False)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"invalid CIDR: {exc}") from exc
+    return v
+
+
+def _floor_sync_interval(v: int) -> int:
+    if v < 30:
+        raise ValueError("sync_interval_seconds must be ≥ 30")
+    return v
+
+
 class InstanceBase(BaseModel):
     name: str
     description: str = ""
@@ -56,31 +82,17 @@ class InstanceBase(BaseModel):
     @field_validator("api_url")
     @classmethod
     def _valid_api_url(cls, v: str) -> str:
-        v = v.strip().rstrip("/")
-        if not v:
-            raise ValueError("api_url is required (e.g. https://api.netbird.io)")
-        if not (v.startswith("http://") or v.startswith("https://")):
-            raise ValueError("api_url must start with http:// or https://")
-        return v
+        return _normalise_api_url(v)
 
     @field_validator("network_cidr")
     @classmethod
     def _valid_cidr(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("network_cidr is required")
-        try:
-            ipaddress.ip_network(v, strict=False)
-        except (ValueError, TypeError) as exc:
-            raise ValueError(f"invalid CIDR: {exc}") from exc
-        return v
+        return _validate_cidr(v)
 
     @field_validator("sync_interval_seconds")
     @classmethod
     def _floor_interval(cls, v: int) -> int:
-        if v < 30:
-            raise ValueError("sync_interval_seconds must be ≥ 30")
-        return v
+        return _floor_sync_interval(v)
 
 
 class InstanceCreate(InstanceBase):
@@ -108,6 +120,24 @@ class InstanceUpdate(BaseModel):
     network_cidr: str | None = None
     skip_expired: bool | None = None
     sync_interval_seconds: int | None = None
+
+    # Validate the same fields as InstanceBase, but only when a value is
+    # actually supplied (partial update) — so a PUT can't persist an
+    # invalid api_url / CIDR / sub-30s interval that later breaks sync.
+    @field_validator("api_url")
+    @classmethod
+    def _valid_api_url(cls, v: str | None) -> str | None:
+        return None if v is None else _normalise_api_url(v)
+
+    @field_validator("network_cidr")
+    @classmethod
+    def _valid_cidr(cls, v: str | None) -> str | None:
+        return None if v is None else _validate_cidr(v)
+
+    @field_validator("sync_interval_seconds")
+    @classmethod
+    def _floor_interval(cls, v: int | None) -> int | None:
+        return None if v is None else _floor_sync_interval(v)
 
 
 class InstanceResponse(BaseModel):

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -49,6 +49,7 @@ from app.api.v1.looking_glass.agents import router as looking_glass_agents_route
 from app.api.v1.looking_glass.router import router as looking_glass_router
 from app.api.v1.metrics import router as metrics_router
 from app.api.v1.multicast import router as multicast_router
+from app.api.v1.netbird import router as netbird_router
 from app.api.v1.netbox_import.router import router as netbox_import_router
 from app.api.v1.network import router as network_router
 from app.api.v1.new_devices import router as new_devices_router
@@ -297,6 +298,12 @@ api_v1_router.include_router(
     prefix="/multicast",
     tags=["multicast"],
     dependencies=[Depends(require_module("network.multicast"))],
+)
+api_v1_router.include_router(
+    netbird_router,
+    prefix="/netbird",
+    tags=["netbird"],
+    dependencies=[Depends(require_module("integrations.netbird"))],
 )
 api_v1_router.include_router(
     netbox_import_router,

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -43,6 +43,7 @@ celery_app = Celery(
         "app.tasks.proxmox_sync",
         "app.tasks.opnsense_sync",
         "app.tasks.tailscale_sync",
+        "app.tasks.netbird_sync",
         "app.tasks.unifi_sync",
         "app.tasks.cloud_sync",
         "app.tasks.snmp_poll",
@@ -109,6 +110,7 @@ celery_app.conf.update(
         "app.tasks.proxmox_sync.*": {"queue": "default"},
         "app.tasks.opnsense_sync.*": {"queue": "default"},
         "app.tasks.tailscale_sync.*": {"queue": "default"},
+        "app.tasks.netbird_sync.*": {"queue": "default"},
         "app.tasks.unifi_sync.*": {"queue": "default"},
         "app.tasks.cloud_sync.*": {"queue": "default"},
         "app.tasks.snmp_poll.*": {"queue": "default"},
@@ -394,6 +396,12 @@ celery_app.conf.update(
         # Gated overall by ``PlatformSettings.integration_tailscale_enabled``.
         "tailscale-sync-sweep": {
             "task": "app.tasks.tailscale_sync.sweep_tailscale_tenants",
+            "schedule": schedule(run_every=30.0),
+        },
+        # NetBird — same 30 s beat, per-instance interval gate.
+        # Gated overall by ``PlatformSettings.integration_netbird_enabled``.
+        "netbird-sync-sweep": {
+            "task": "app.tasks.netbird_sync.sweep_netbird_instances",
             "schedule": schedule(run_every=30.0),
         },
         # UniFi — same 30 s beat, per-controller interval gate.

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -89,6 +89,7 @@ from app.models.multicast import (
     MulticastGroupPort,
     MulticastMembership,
 )
+from app.models.netbird import NetbirdInstance
 from app.models.network import (
     NetworkArpEntry,
     NetworkDevice,
@@ -218,6 +219,7 @@ __all__ = [
     "DockerHost",
     "Domain",
     "KubernetesCluster",
+    "NetbirdInstance",
     "OPNsenseRouter",
     "ProxmoxNode",
     "SystemUpgradeRun",

--- a/backend/app/models/dns.py
+++ b/backend/app/models/dns.py
@@ -644,6 +644,16 @@ class DNSZone(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
         nullable=True,
         index=True,
     )
+    # NetBird synthetic-DNS provenance (issue #603, Phase 2). Set on the
+    # auto-created NetBird DNS-domain zone. While non-null the API blocks
+    # edits / deletes — the reconciler is the only writer. Cascades on
+    # instance delete.
+    netbird_instance_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("netbird_instance.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
     # Optional per-zone color key (from a curated swatch set) shown as a
     # dot/stripe in zone lists + tree nodes. Free-form hex is not accepted
     # so both light and dark themes remain legible. See API validator for
@@ -801,6 +811,15 @@ class DNSRecord(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     tailscale_tenant_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("tailscale_tenant.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    # Set by the NetBird reconciler when the row mirrors a NetBird peer
+    # (Phase 2). The FK cascades on instance delete. API blocks edits /
+    # deletes while non-null.
+    netbird_instance_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("netbird_instance.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
     )

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -50,6 +50,10 @@ IP_STATUSES_INTEGRATION_OWNED: frozenset[str] = frozenset(
         "proxmox-vm",
         "proxmox-lxc",
         "tailscale-node",
+        # NetBird peer mirror (issue #603). One row per NetBird peer's
+        # overlay IP, mirrored from the management API. Read-only — the
+        # reconciler owns the row unless an operator edits it.
+        "netbird-peer",
         # OPNsense ARP-table mirror (issue #31). Opt-in secondary source
         # — a host the firewall has seen on the wire, distinct from a
         # DHCP lease (status="dhcp") or static reservation
@@ -329,6 +333,15 @@ class IPBlock(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     opnsense_router_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("opnsense_router.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    # NetBird provenance (issue #603) — set on the wrapper block the
+    # NetBird reconciler creates for the overlay CIDR. Cascades on
+    # instance delete.
+    netbird_instance_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("netbird_instance.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
     )
@@ -767,6 +780,16 @@ class Subnet(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
         nullable=True,
         index=True,
     )
+    # NetBird provenance (issue #603). Subnet created by the NetBird
+    # reconciler under the auto-created overlay block. Peer IPs are a
+    # routed overlay (no broadcast / gateway), so the whole range is
+    # one flat subnet. Cascades on instance delete.
+    netbird_instance_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("netbird_instance.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
 
     # Computed / cached. ``total_ips`` is BigInteger because IPv6 subnets can
     # be as large as 2^64 addresses (a /64 — the standard LAN size) which
@@ -974,6 +997,14 @@ class IPAddress(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     opnsense_router_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("opnsense_router.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    # NetBird provenance (issue #603) — set on rows mirrored from a
+    # NetBird peer's overlay IP. Cascades on instance delete.
+    netbird_instance_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("netbird_instance.id", ondelete="CASCADE"),
         nullable=True,
         index=True,
     )

--- a/backend/app/models/netbird.py
+++ b/backend/app/models/netbird.py
@@ -1,0 +1,114 @@
+"""NetBird integration — per-instance connection config.
+
+Same shape as ``TailscaleTenant`` / ``ProxmoxNode`` / ``DockerHost``
+but for a NetBird deployment (a management server + a personal-access
+token). NetBird is a managed WireGuard mesh overlay — like Tailscale
+but self-hostable — with a real REST management API, which is what
+lets it be a read-only pull mirror (unlike raw WireGuard, which has
+no API).
+
+Read-only mirror: SpatiumDDI never writes to NetBird. The reconciler
+hits ``GET /api/peers`` on the instance's management server and
+mirrors each peer's overlay ``ip`` into the bound IPAM space. The
+management DNS domain is auto-derived from the first peer's
+``dns_label`` — no separate config field.
+
+Unlike Tailscale (cloud-only, fixed ``api.tailscale.com`` host),
+NetBird is self-hosted by default, so each instance carries its own
+management-server ``api_url`` (operator-supplied) plus a ``verify_tls``
+toggle for private-CA / self-signed deployments. NetBird peers carry a
+single IPv4 overlay address (no IPv6 ULA), so there is one overlay
+CIDR — not the CGNAT + ULA pair Tailscale mirrors.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    String,
+    Text,
+)
+from sqlalchemy import text as sa_text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class NetbirdInstance(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A NetBird deployment SpatiumDDI polls for peer state."""
+
+    __tablename__ = "netbird_instance"
+    __table_args__ = (Index("ix_netbird_instance_name", "name", unique=True),)
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    # ── Connection ──────────────────────────────────────────────────
+    # Management-server base URL. Cloud is ``https://api.netbird.io``;
+    # a self-hosted install is the dashboard/management host (the API
+    # is served under ``/api`` on the same host). Operator-supplied —
+    # the reconciler + probe run it through the SSRF guard before
+    # dialing.
+    api_url: Mapped[str] = mapped_column(
+        String(255), nullable=False, default="https://api.netbird.io"
+    )
+    # Verify the management server's TLS certificate. Off lets a
+    # self-hosted install with a private-CA / self-signed cert connect.
+    verify_tls: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    # Fernet-encrypted personal-access token (``nbp_…``). Empty = unset.
+    api_key_encrypted: Mapped[bytes] = mapped_column(
+        LargeBinary, nullable=False, default=b"", server_default=sa_text("''::bytea")
+    )
+
+    # ── Binding ─────────────────────────────────────────────────────
+    ipam_space_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("ip_space.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    dns_group_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dns_server_group.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # ── Mirror policy ───────────────────────────────────────────────
+    # The overlay range peer IPs live in. NetBird allocates peer
+    # addresses from CGNAT space (``100.64.0.0/10``) by default; the
+    # actual sub-range is management-server config, so keep the
+    # override knob. The whole range is mirrored as one flat subnet —
+    # the mesh is a routed overlay, not a subdivided LAN.
+    network_cidr: Mapped[str] = mapped_column(String(32), nullable=False, default="100.64.0.0/10")
+    # Skip peers whose NetBird login has expired (only when the peer
+    # actually has login-expiration enabled). On by default since an
+    # expired peer can't reach the mesh and just clutters IPAM.
+    skip_expired: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+
+    # ── Cadence ─────────────────────────────────────────────────────
+    # 60 s default; 30 s floor keeps parity with the other mirrors.
+    sync_interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=60)
+
+    # ── Sync state ──────────────────────────────────────────────────
+    last_synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Populated by the test-connection probe + reconciler — shown in
+    # the UI. Derived from the first peer's ``dns_label`` FQDN.
+    dns_domain: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    peer_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+
+__all__ = ["NetbirdInstance"]

--- a/backend/app/models/netbird.py
+++ b/backend/app/models/netbird.py
@@ -56,9 +56,9 @@ class NetbirdInstance(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # ── Connection ──────────────────────────────────────────────────
     # Management-server base URL. Cloud is ``https://api.netbird.io``;
     # a self-hosted install is the dashboard/management host (the API
-    # is served under ``/api`` on the same host). Operator-supplied —
-    # the reconciler + probe run it through the SSRF guard before
-    # dialing.
+    # is served under ``/api`` on the same host). Operator-supplied, so
+    # the test-connection probe runs it through the advisory SSRF guard
+    # at the API boundary (as the other operator-URL integrations do).
     api_url: Mapped[str] = mapped_column(
         String(255), nullable=False, default="https://api.netbird.io"
     )

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -310,6 +310,9 @@ class PlatformSettings(Base):
     integration_opnsense_enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False
     )
+    integration_netbird_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
 
     # Trash retention — high-blast-radius IPAM/DNS/DHCP rows are soft-
     # deleted (``deleted_at`` set) and the nightly purge sweep hard-

--- a/backend/app/services/ai/tools/integrations.py
+++ b/backend/app/services/ai/tools/integrations.py
@@ -31,6 +31,7 @@ from app.models.auth import User
 from app.models.cloud import CloudEndpoint
 from app.models.docker import DockerHost
 from app.models.kubernetes import KubernetesCluster
+from app.models.netbird import NetbirdInstance
 from app.models.opnsense import OPNsenseRouter
 from app.models.proxmox import ProxmoxNode
 from app.models.tailscale import TailscaleTenant
@@ -281,6 +282,63 @@ async def list_tailscale_targets(
     if args.enabled is not None:
         stmt = stmt.where(TailscaleTenant.enabled.is_(args.enabled))
     stmt = stmt.order_by(TailscaleTenant.name.asc()).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        last_synced = getattr(r, "last_synced_at", None)
+        out.append(
+            {
+                "id": str(r.id),
+                "name": r.name,
+                "description": getattr(r, "description", "") or "",
+                "enabled": r.enabled,
+                "ipam_space_id": (
+                    str(r.ipam_space_id) if getattr(r, "ipam_space_id", None) else None
+                ),
+                "sync_interval_seconds": getattr(r, "sync_interval_seconds", None),
+                "last_synced_at": last_synced.isoformat() if last_synced else None,
+            }
+        )
+    return out
+
+
+# ── list_netbird_targets ──────────────────────────────────────────────
+
+
+class ListNetbirdTargetsArgs(BaseModel):
+    search: str | None = _common_target_args()["search"]
+    enabled: bool | None = _common_target_args()["enabled"]
+    limit: int = _common_target_args()["limit"]
+
+
+@register_tool(
+    name="list_netbird_targets",
+    module="integrations.netbird",
+    description=(
+        "List configured NetBird instances (mesh deployments) that "
+        "SpatiumDDI mirrors into IPAM. Each row carries id, name, "
+        "description, enabled flag, ipam_space_id, sync_interval_seconds, "
+        "and last_synced_at. Use for 'which NetBird meshes are connected?' "
+        "or 'is NetBird syncing?'. API tokens never appear."
+    ),
+    args_model=ListNetbirdTargetsArgs,
+    category="integrations",
+)
+async def list_netbird_targets(
+    db: AsyncSession, user: User, args: ListNetbirdTargetsArgs
+) -> list[dict[str, Any]]:
+    stmt = select(NetbirdInstance)
+    if args.search:
+        like = f"%{args.search.lower()}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(NetbirdInstance.name).like(like),
+                func.lower(NetbirdInstance.description).like(like),
+            )
+        )
+    if args.enabled is not None:
+        stmt = stmt.where(NetbirdInstance.enabled.is_(args.enabled))
+    stmt = stmt.order_by(NetbirdInstance.name.asc()).limit(args.limit)
     rows = (await db.execute(stmt)).scalars().all()
     out: list[dict[str, Any]] = []
     for r in rows:

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -316,6 +316,13 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         description="Read-only mirror of OPNsense interfaces + DHCP leases + reservations into IPAM.",
         default_enabled=False,
     ),
+    ModuleSpec(
+        id="integrations.netbird",
+        label="NetBird",
+        group="Integrations",
+        description="Read-only mirror of NetBird mesh peers into IPAM (self-hosted or cloud), with optional synthetic DNS for the mesh domain. Connect instances from the NetBird page once enabled.",
+        default_enabled=False,
+    ),
     # Appliance — the declarative fleet-firewall policy surface (#285
     # Phase 3). Default-enabled for DISCOVERY/STAGING only: turning this
     # module ON exposes the policy editor + preview but applies NOTHING.
@@ -398,6 +405,7 @@ INTEGRATION_SETTINGS_MIRROR: Final[dict[str, str]] = {
     "integrations.unifi": "integration_unifi_enabled",
     "integrations.cloud": "integration_cloud_enabled",
     "integrations.opnsense": "integration_opnsense_enabled",
+    "integrations.netbird": "integration_netbird_enabled",
 }
 
 MODULES_BY_ID: Final[dict[str, ModuleSpec]] = {m.id: m for m in MODULES}

--- a/backend/app/services/netbird/__init__.py
+++ b/backend/app/services/netbird/__init__.py
@@ -1,0 +1,14 @@
+"""NetBird integration — read-only mirror of NetBird peers into IPAM.
+
+NetBird is a managed WireGuard mesh overlay (self-hostable or cloud).
+This package mirrors its peer inventory into the bound IPAM space and,
+optionally (Phase 2), synthesises the mesh's DNS domain as a read-only
+zone. SpatiumDDI never writes to NetBird.
+
+Callers import by full path::
+
+    from app.services.netbird.client import NetbirdClient, NetbirdClientError
+    from app.services.netbird.reconcile import reconcile_instance
+"""
+
+from __future__ import annotations

--- a/backend/app/services/netbird/client.py
+++ b/backend/app/services/netbird/client.py
@@ -1,0 +1,211 @@
+"""Minimal async NetBird REST client.
+
+Endpoints consumed:
+
+* ``GET /api/peers`` — full peer inventory (the only call we need for
+  Phase 1). Returns a bare JSON array of peer objects, each with
+  ``id``, ``name``, ``ip`` (single IPv4 overlay address), ``dns_label``
+  (FQDN, e.g. ``host.netbird.cloud``), ``hostname``, ``os``,
+  ``version``, ``connected``, ``last_seen``, ``login_expired``,
+  ``login_expiration_enabled``, ``groups[]``, ``user_id``,
+  ``ssh_enabled``, ``approval_required``.
+
+Auth is a personal-access token — ``Authorization: Token <api_key>``
+(NetBird's scheme; note it is ``Token``, not ``Bearer``).
+
+Base URL is per-instance and operator-supplied: cloud is
+``https://api.netbird.io``; a self-hosted install is the
+dashboard/management host (API served under ``/api``). Because the URL
+is operator-controlled, callers run it through the SSRF guard
+(``app.core.ssrf``) before we dial it — unlike the fixed-host Tailscale
+client.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import structlog
+
+from app.services._mirror_shape import require_list
+
+logger = structlog.get_logger(__name__)
+
+
+class NetbirdClientError(Exception):
+    """Raised when the NetBird API returns an error we can't recover from."""
+
+
+@dataclass
+class _NetbirdPeer:
+    """Normalised NetBird peer entry.
+
+    Carries only the fields the reconciler uses. The full ``/api/peers``
+    payload has more (geoname_id, city_name, serial_number,
+    accessible_peers_count, …) — drop them here.
+    """
+
+    id: str
+    name: str
+    ip: str  # single IPv4 overlay address
+    dns_label: str = ""  # FQDN (`<host>.<domain>`)
+    hostname: str = ""
+    os: str = ""
+    version: str = ""
+    user_id: str = ""
+    connected: bool = False
+    last_seen: str | None = None  # ISO 8601
+    login_expired: bool = False
+    login_expiration_enabled: bool = False
+    ssh_enabled: bool = False
+    approval_required: bool = False
+    groups: list[str] = field(default_factory=list)  # group names
+
+
+def _normalise_base_url(api_url: str) -> str:
+    """Strip a trailing slash and an accidental trailing ``/api`` so the
+    caller can pass either ``https://host`` or ``https://host/api`` and
+    we always dial ``<host>/api/peers`` exactly once."""
+    base = (api_url or "").strip().rstrip("/")
+    if base.endswith("/api"):
+        base = base[: -len("/api")]
+    return base
+
+
+class NetbirdClient:
+    """Async context-managed REST client.
+
+    ``async with NetbirdClient(api_key=..., api_url=..., verify=True) as c:``
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        api_url: str,
+        verify: bool = True,
+        timeout: float = 15.0,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = _normalise_base_url(api_url)
+        self._verify = verify
+        self._timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    async def __aenter__(self) -> NetbirdClient:
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            headers={
+                "Authorization": f"Token {self._api_key}",
+                "Accept": "application/json",
+            },
+            timeout=self._timeout,
+            verify=self._verify,
+        )
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def _get(self, path: str, **params: Any) -> Any:
+        assert self._client is not None, "NetbirdClient used outside async with"
+        try:
+            r = await self._client.get(path, params=params or None)
+        except httpx.ConnectError as exc:
+            raise NetbirdClientError(f"Could not reach NetBird at {self._base_url}: {exc}") from exc
+        except httpx.TimeoutException as exc:
+            raise NetbirdClientError(f"Request to {path} timed out: {exc}") from exc
+        except httpx.HTTPError as exc:
+            raise NetbirdClientError(f"HTTP error on {path}: {exc}") from exc
+
+        if r.status_code == 401:
+            raise NetbirdClientError(
+                "HTTP 401 — token invalid or revoked. Create a new personal-access "
+                "token under Settings → Users in the NetBird dashboard."
+            )
+        if r.status_code == 403:
+            raise NetbirdClientError(
+                "HTTP 403 — token lacks permission to list peers. "
+                "Use a token for an account admin (or a service user with read access)."
+            )
+        if r.status_code == 404:
+            raise NetbirdClientError(
+                f"HTTP 404 from {path} — check the management URL "
+                f"({self._base_url}); it should be the API base, e.g. "
+                f"https://api.netbird.io or your self-hosted dashboard host."
+            )
+        if r.status_code >= 400:
+            body = (r.text or "")[:200]
+            raise NetbirdClientError(f"HTTP {r.status_code} from {path}: {body}")
+
+        try:
+            return r.json()
+        except ValueError as exc:
+            raise NetbirdClientError(f"Non-JSON response from {path}: {exc}") from exc
+
+    async def list_peers(self) -> list[_NetbirdPeer]:
+        """Fetch every peer in the account (one round-trip).
+
+        ``/api/peers`` returns a bare JSON array — no pagination today.
+        """
+        data = await self._get("/api/peers")
+        # #430 — a 200 that isn't a JSON array (proxy error page, auth
+        # downgrade, envelope change) must raise so the reconciler keeps
+        # existing rows rather than collapsing to [] and mass-deleting.
+        items = require_list(data, make_error=NetbirdClientError, context="list_peers")
+        out: list[_NetbirdPeer] = []
+        for p in items:
+            if not isinstance(p, dict):
+                continue
+            groups = [
+                str(g.get("name") or "")
+                for g in (p.get("groups") or [])
+                if isinstance(g, dict) and g.get("name")
+            ]
+            out.append(
+                _NetbirdPeer(
+                    id=str(p.get("id") or ""),
+                    name=str(p.get("name") or ""),
+                    ip=str(p.get("ip") or ""),
+                    dns_label=str(p.get("dns_label") or ""),
+                    hostname=str(p.get("hostname") or ""),
+                    os=str(p.get("os") or ""),
+                    version=str(p.get("version") or ""),
+                    user_id=str(p.get("user_id") or ""),
+                    connected=bool(p.get("connected", False)),
+                    last_seen=p.get("last_seen") or None,
+                    login_expired=bool(p.get("login_expired", False)),
+                    login_expiration_enabled=bool(p.get("login_expiration_enabled", False)),
+                    ssh_enabled=bool(p.get("ssh_enabled", False)),
+                    approval_required=bool(p.get("approval_required", False)),
+                    groups=groups,
+                )
+            )
+        return out
+
+
+def derive_netbird_domain(peers: list[_NetbirdPeer]) -> str | None:
+    """Pull the management DNS domain off the first peer with an FQDN.
+
+    NetBird peer ``dns_label`` values are ``<host>.<domain>`` (e.g.
+    ``server-1.netbird.cloud``). We strip the leading hostname label and
+    return the rest. Returns ``None`` when no peer carries a usable FQDN.
+    """
+    for p in peers:
+        label = (p.dns_label or "").strip().rstrip(".")
+        if "." not in label:
+            continue
+        return label.split(".", 1)[1]
+    return None
+
+
+__all__ = [
+    "NetbirdClient",
+    "NetbirdClientError",
+    "_NetbirdPeer",
+    "derive_netbird_domain",
+]

--- a/backend/app/services/netbird/client.py
+++ b/backend/app/services/netbird/client.py
@@ -16,9 +16,10 @@ Auth is a personal-access token — ``Authorization: Token <api_key>``
 Base URL is per-instance and operator-supplied: cloud is
 ``https://api.netbird.io``; a self-hosted install is the
 dashboard/management host (API served under ``/api``). Because the URL
-is operator-controlled, callers run it through the SSRF guard
-(``app.core.ssrf``) before we dial it — unlike the fixed-host Tailscale
-client.
+is operator-controlled, the API layer runs it through the advisory
+SSRF guard (``app.core.ssrf``) at the test-connection boundary — the
+same place every operator-URL integration guards — unlike the
+fixed-host Tailscale client, which needs no guard.
 """
 
 from __future__ import annotations
@@ -27,11 +28,8 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
-import structlog
 
 from app.services._mirror_shape import require_list
-
-logger = structlog.get_logger(__name__)
 
 
 class NetbirdClientError(Exception):

--- a/backend/app/services/netbird/reconcile.py
+++ b/backend/app/services/netbird/reconcile.py
@@ -347,8 +347,9 @@ async def _apply_addresses(
                 if (row.description or "") != d.description:
                     row.description = d.description
                     changed = True
-                # Custom fields stay reconciler-owned even on a locked
-                # row — the peer metadata is most useful when fresh.
+                # Peer metadata (last_seen / version / groups) refreshes
+                # alongside the other soft fields on non-locked rows so it
+                # stays current.
                 if (row.custom_fields or {}) != d.custom_fields:
                     row.custom_fields = d.custom_fields
                     changed = True

--- a/backend/app/services/netbird/reconcile.py
+++ b/backend/app/services/netbird/reconcile.py
@@ -1,0 +1,617 @@
+"""Per-instance NetBird reconciler.
+
+For one ``NetbirdInstance`` row:
+
+  1. Fetch peers from the NetBird management API.
+  2. Auto-create the overlay block + subnet under the bound space if
+     they don't already exist (FK-stamped to this instance).
+  3. Compute desired IP rows from each peer's ``ip``. Skip peers whose
+     NetBird login has expired when the instance has
+     ``skip_expired=True``.
+  4. Apply diff: claim pre-existing operator rows, write new rows,
+     update changed soft fields (gated by ``user_modified_at`` lock),
+     un-claim or delete rows that disappeared upstream.
+  5. Phase 2 — synthesise the mesh's DNS domain as a read-only zone in
+     the bound DNS group (A records only; NetBird peers are IPv4).
+  6. Persist ``last_synced_at`` / ``last_sync_error`` / ``dns_domain`` /
+     ``peer_count``.
+
+NetBird overlaps Tailscale on the default CGNAT range (100.64.0.0/10),
+so the cross-integration ownership guard here checks *every* sibling
+integration FK — a peer and a tailnet device could legitimately land on
+the same address.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import decrypt_str
+from app.models.audit import AuditLog
+from app.models.dns import DNSRecord, DNSZone
+from app.models.ipam import IPAddress, IPBlock, Subnet
+from app.models.netbird import NetbirdInstance
+from app.services.netbird.client import (
+    NetbirdClient,
+    NetbirdClientError,
+    _NetbirdPeer,
+    derive_netbird_domain,
+)
+
+logger = structlog.get_logger(__name__)
+
+_BIGINT_MAX = 2**63 - 1
+_STATUS = "netbird-peer"
+
+# Sibling integration provenance columns on IPAddress. A row carrying
+# any of these is owned by another mirror and must not be claimed.
+_OTHER_INTEGRATION_FKS = (
+    "kubernetes_cluster_id",
+    "docker_host_id",
+    "proxmox_node_id",
+    "tailscale_tenant_id",
+    "unifi_controller_id",
+    "cloud_endpoint_id",
+    "opnsense_router_id",
+)
+
+
+@dataclass(frozen=True)
+class _DesiredAddress:
+    address: str
+    hostname: str
+    description: str
+    custom_fields: dict[str, Any]
+
+
+@dataclass
+class ReconcileSummary:
+    ok: bool
+    error: str | None = None
+    dns_domain: str | None = None
+    peer_count: int = 0
+    blocks_created: int = 0
+    subnets_created: int = 0
+    addresses_created: int = 0
+    addresses_updated: int = 0
+    addresses_deleted: int = 0
+    skipped_expired: int = 0
+    skipped_no_subnet: int = 0
+    # Phase 2: synthetic DNS zone + records.
+    dns_zones_created: int = 0
+    dns_records_created: int = 0
+    dns_records_updated: int = 0
+    dns_records_deleted: int = 0
+    dns_skipped: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _parse_net(value: str) -> ipaddress.IPv4Network | ipaddress.IPv6Network | None:
+    try:
+        return ipaddress.ip_network(value, strict=False)
+    except (ValueError, TypeError):
+        return None
+
+
+def _lan_total_ips(net: ipaddress.IPv4Network | ipaddress.IPv6Network) -> int:
+    if isinstance(net, ipaddress.IPv6Network):
+        return min(net.num_addresses, _BIGINT_MAX)
+    # The overlay is a routed mesh — no broadcast, every host usable.
+    return net.num_addresses
+
+
+def _find_subnet_for_ip(subnets: list[Subnet], ip: str) -> Subnet | None:
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return None
+    best: Subnet | None = None
+    best_prefix: int = -1
+    for s in subnets:
+        net = _parse_net(str(s.network))
+        if net is None:
+            continue
+        if addr in net and net.prefixlen > best_prefix:
+            best = s
+            best_prefix = net.prefixlen
+    return best
+
+
+async def _recompute_subnet_utilization(db: AsyncSession, subnet_id: Any) -> None:
+    allocated = (
+        await db.scalar(
+            select(func.count())
+            .select_from(IPAddress)
+            .where(IPAddress.subnet_id == subnet_id)
+            .where(IPAddress.status != "available")
+        )
+        or 0
+    )
+    subnet = await db.get(Subnet, subnet_id)
+    if subnet is None:
+        return
+    subnet.allocated_ips = allocated
+    subnet.utilization_percent = (
+        round(allocated / subnet.total_ips * 100, 2) if subnet.total_ips > 0 else 0.0
+    )
+
+
+def _is_expired(instance: NetbirdInstance, peer: _NetbirdPeer) -> bool:
+    """A peer is filtered only when the instance opts in AND the peer
+    actually has login-expiration enabled AND it has expired. Long-lived
+    setup keys / service peers commonly disable expiration entirely."""
+    return bool(instance.skip_expired and peer.login_expiration_enabled and peer.login_expired)
+
+
+# ── Desired state computation ────────────────────────────────────────
+
+
+def _compute_desired(
+    instance: NetbirdInstance,
+    peers: list[_NetbirdPeer],
+    summary: ReconcileSummary,
+) -> list[_DesiredAddress]:
+    out: list[_DesiredAddress] = []
+    for p in peers:
+        if _is_expired(instance, p):
+            summary.skipped_expired += 1
+            continue
+        if not p.ip:
+            continue
+        os_label = p.os or "unknown"
+        version_label = p.version or ""
+        description = f"{os_label} {version_label}".strip()
+        cf: dict[str, Any] = {
+            "netbird_id": p.id,
+            "os": p.os,
+            "version": p.version,
+            "hostname": p.hostname,
+            "dns_label": p.dns_label,
+            "groups": list(p.groups),
+            "connected": p.connected,
+            "last_seen": p.last_seen,
+            "login_expired": p.login_expired,
+            "ssh_enabled": p.ssh_enabled,
+            "approval_required": p.approval_required,
+            "user_id": p.user_id,
+        }
+        cf = {k: v for k, v in cf.items() if v not in (None, "", [], False)}
+        # The peer's FQDN is the most useful "hostname" for an IPAM row;
+        # fall back to the short hostname / name while onboarding.
+        hostname = p.dns_label or p.hostname or p.name
+        out.append(
+            _DesiredAddress(
+                address=p.ip,
+                hostname=hostname,
+                description=description,
+                custom_fields=cf,
+            )
+        )
+    return out
+
+
+# ── Apply: block + subnet ────────────────────────────────────────────
+
+
+async def _ensure_block_and_subnet(
+    db: AsyncSession,
+    instance: NetbirdInstance,
+    cidr: str,
+    label: str,
+    summary: ReconcileSummary,
+) -> Subnet | None:
+    net = _parse_net(cidr)
+    if net is None:
+        summary.warnings.append(f"unparseable CIDR on instance: {cidr!r}")
+        return None
+    cidr_norm = str(net)
+
+    existing_block = (
+        await db.execute(
+            select(IPBlock).where(
+                IPBlock.netbird_instance_id == instance.id,
+                IPBlock.network == cidr_norm,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing_block is None:
+        existing_block = IPBlock(
+            space_id=instance.ipam_space_id,
+            network=cidr_norm,
+            name=f"{instance.name} {cidr_norm}",
+            description=f"Auto-created for NetBird instance {instance.name} ({label})",
+            netbird_instance_id=instance.id,
+        )
+        db.add(existing_block)
+        await db.flush()
+        summary.blocks_created += 1
+
+    existing_subnet = (
+        await db.execute(
+            select(Subnet).where(
+                Subnet.netbird_instance_id == instance.id,
+                Subnet.network == cidr_norm,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing_subnet is None:
+        existing_subnet = Subnet(
+            space_id=instance.ipam_space_id,
+            block_id=existing_block.id,
+            network=cidr_norm,
+            name=f"netbird:{label}",
+            description=f"NetBird {label} for instance {instance.name}",
+            netbird_instance_id=instance.id,
+            total_ips=_lan_total_ips(net),
+        )
+        db.add(existing_subnet)
+        await db.flush()
+        summary.subnets_created += 1
+    return existing_subnet
+
+
+# ── Apply: addresses ──────────────────────────────────────────────────
+
+
+async def _apply_addresses(
+    db: AsyncSession,
+    instance: NetbirdInstance,
+    desired: list[_DesiredAddress],
+    summary: ReconcileSummary,
+) -> None:
+    subnet_rows = (
+        (await db.execute(select(Subnet).where(Subnet.space_id == instance.ipam_space_id)))
+        .scalars()
+        .all()
+    )
+    subnets = list(subnet_rows)
+
+    desired_map: dict[str, _DesiredAddress] = {}
+    for d in desired:
+        if d.address in desired_map:
+            continue
+        desired_map[d.address] = d
+
+    # Claim pre-existing operator rows at desired addresses.
+    desired_addrs = list(desired_map.keys())
+    if desired_addrs:
+        existing = (
+            (await db.execute(select(IPAddress).where(IPAddress.address.in_(desired_addrs))))
+            .scalars()
+            .all()
+        )
+        for row in existing:
+            if row.netbird_instance_id == instance.id:
+                continue  # already ours
+            if row.netbird_instance_id is not None:
+                summary.warnings.append(
+                    f"address {row.address} owned by another NetBird instance; not claiming"
+                )
+                continue
+            if any(getattr(row, fk) is not None for fk in _OTHER_INTEGRATION_FKS):
+                summary.warnings.append(
+                    f"address {row.address} owned by another integration; not claiming"
+                )
+                continue
+            row.netbird_instance_id = instance.id
+            if row.user_modified_at is None:
+                row.user_modified_at = datetime.now(UTC)
+        await db.flush()
+
+    res = await db.execute(select(IPAddress).where(IPAddress.netbird_instance_id == instance.id))
+    current = {str(a.address): a for a in res.scalars().all()}
+
+    dirty_subnets: set[Any] = {s.id for s in subnets if s.netbird_instance_id == instance.id}
+
+    for addr, row in current.items():
+        if addr not in desired_map:
+            dirty_subnets.add(row.subnet_id)
+            if row.user_modified_at is not None:
+                # Operator invested edits — un-claim, leave as a
+                # manually-managed row rather than deleting their data.
+                row.netbird_instance_id = None
+                summary.addresses_updated += 1
+            else:
+                await db.delete(row)
+                summary.addresses_deleted += 1
+
+    for addr, d in desired_map.items():
+        subnet = _find_subnet_for_ip(subnets, d.address)
+        if subnet is None:
+            summary.skipped_no_subnet += 1
+            continue
+        if addr in current:
+            row = current[addr]
+            changed = False
+            if row.subnet_id != subnet.id:
+                dirty_subnets.add(row.subnet_id)
+                row.subnet_id = subnet.id
+                changed = True
+            if row.user_modified_at is None:
+                if row.status != _STATUS:
+                    row.status = _STATUS
+                    changed = True
+                if (row.hostname or "") != d.hostname:
+                    row.hostname = d.hostname
+                    changed = True
+                if (row.description or "") != d.description:
+                    row.description = d.description
+                    changed = True
+                # Custom fields stay reconciler-owned even on a locked
+                # row — the peer metadata is most useful when fresh.
+                if (row.custom_fields or {}) != d.custom_fields:
+                    row.custom_fields = d.custom_fields
+                    changed = True
+            if changed:
+                dirty_subnets.add(subnet.id)
+                summary.addresses_updated += 1
+        else:
+            db.add(
+                IPAddress(
+                    subnet_id=subnet.id,
+                    address=d.address,
+                    status=_STATUS,
+                    hostname=d.hostname,
+                    description=d.description,
+                    custom_fields=d.custom_fields,
+                    netbird_instance_id=instance.id,
+                )
+            )
+            dirty_subnets.add(subnet.id)
+            summary.addresses_created += 1
+
+    if dirty_subnets:
+        await db.flush()
+        for subnet_id in dirty_subnets:
+            await _recompute_subnet_utilization(db, subnet_id)
+
+
+# ── Phase 2: synthetic DNS zone + records ────────────────────────────
+
+
+_SYNTHESISED_RECORD_TTL = 300
+
+
+def _peer_records(
+    instance: NetbirdInstance,
+    peers: list[_NetbirdPeer],
+    zone_name: str,
+) -> list[tuple[str, str, str]]:
+    """Desired (label, "A", value) tuples — one A record per peer IP.
+
+    Label is the peer's short name (its FQDN minus the zone suffix).
+    Peers with no FQDN, or whose FQDN doesn't end in our zone, are
+    skipped. Expired peers are filtered the same way the IPAM mirror
+    filters them so the two surfaces stay consistent.
+    """
+    suffix = "." + zone_name
+    out: list[tuple[str, str, str]] = []
+    for p in peers:
+        if _is_expired(instance, p):
+            continue
+        name = (p.dns_label or "").strip().rstrip(".")
+        if not name or not name.endswith(suffix):
+            continue
+        label = name[: -len(suffix)] or "@"
+        if not p.ip:
+            continue
+        try:
+            addr = ipaddress.ip_address(p.ip)
+        except ValueError:
+            continue
+        if isinstance(addr, ipaddress.IPv4Address):
+            out.append((label, "A", str(addr)))
+    return out
+
+
+async def _apply_synthetic_dns(
+    db: AsyncSession,
+    instance: NetbirdInstance,
+    peers: list[_NetbirdPeer],
+    summary: ReconcileSummary,
+) -> None:
+    """Materialise the mesh DNS domain zone + per-peer A records.
+
+    Skips silently when the instance has no ``dns_group_id`` bound
+    (Phase 2 is opt-in) or when no peer carries a usable FQDN. Refuses
+    to claim a pre-existing operator-managed zone of the same name in
+    the bound group — surfaced as a warning.
+    """
+    if instance.dns_group_id is None:
+        summary.dns_skipped = True
+        return
+    if not summary.dns_domain:
+        summary.dns_skipped = True
+        return
+
+    zone_name = summary.dns_domain.rstrip(".") + "."
+
+    res = await db.execute(
+        select(DNSZone).where(
+            DNSZone.group_id == instance.dns_group_id,
+            DNSZone.name == zone_name,
+        )
+    )
+    zone = res.scalar_one_or_none()
+    if zone is not None and zone.netbird_instance_id is None:
+        summary.warnings.append(
+            f"DNS zone {zone_name!r} already exists in the bound group and is "
+            f"operator-managed; not synthesising. Delete it or rename to "
+            f"unblock the NetBird Phase 2 surface."
+        )
+        summary.dns_skipped = True
+        return
+    if zone is not None and zone.netbird_instance_id != instance.id:
+        summary.warnings.append(
+            f"DNS zone {zone_name!r} owned by another NetBird instance; not synthesising."
+        )
+        summary.dns_skipped = True
+        return
+
+    if zone is None:
+        zone = DNSZone(
+            group_id=instance.dns_group_id,
+            name=zone_name,
+            zone_type="primary",
+            kind="forward",
+            ttl=_SYNTHESISED_RECORD_TTL,
+            primary_ns=zone_name,
+            admin_email=f"hostmaster.{zone_name}",
+            is_auto_generated=True,
+            netbird_instance_id=instance.id,
+        )
+        db.add(zone)
+        await db.flush()
+        summary.dns_zones_created += 1
+
+    desired = _peer_records(instance, peers, summary.dns_domain)
+    desired_keys: set[tuple[str, str, str]] = set(desired)
+
+    rec_res = await db.execute(
+        select(DNSRecord).where(
+            DNSRecord.zone_id == zone.id,
+            DNSRecord.netbird_instance_id == instance.id,
+        )
+    )
+    current_by_key: dict[tuple[str, str, str], DNSRecord] = {}
+    for r in rec_res.scalars().all():
+        current_by_key.setdefault((r.name, r.record_type, r.value), r)
+
+    for key, row in current_by_key.items():
+        if key in desired_keys:
+            continue
+        await db.delete(row)
+        summary.dns_records_deleted += 1
+
+    for key in desired_keys - current_by_key.keys():
+        label, rtype, value = key
+        fqdn = zone_name.rstrip(".") if label == "@" else f"{label}.{zone_name.rstrip('.')}"
+        db.add(
+            DNSRecord(
+                zone_id=zone.id,
+                name=label,
+                fqdn=fqdn,
+                record_type=rtype,
+                value=value,
+                ttl=_SYNTHESISED_RECORD_TTL,
+                auto_generated=True,
+                netbird_instance_id=instance.id,
+            )
+        )
+        summary.dns_records_created += 1
+
+
+# ── Entry point ───────────────────────────────────────────────────────
+
+
+async def reconcile_instance(db: AsyncSession, instance: NetbirdInstance) -> ReconcileSummary:
+    summary = ReconcileSummary(ok=False)
+
+    api_key = ""
+    if instance.api_key_encrypted:
+        try:
+            api_key = decrypt_str(instance.api_key_encrypted)
+        except ValueError as exc:
+            summary.error = f"api-key decrypt failed: {exc}"
+            instance.last_sync_error = summary.error
+            instance.last_synced_at = datetime.now(UTC)
+            await db.commit()
+            return summary
+    if not api_key:
+        summary.error = "no API key configured"
+        instance.last_sync_error = summary.error
+        instance.last_synced_at = datetime.now(UTC)
+        await db.commit()
+        return summary
+
+    try:
+        async with NetbirdClient(
+            api_key=api_key, api_url=instance.api_url, verify=instance.verify_tls
+        ) as client:
+            peers = await client.list_peers()
+    except NetbirdClientError as exc:
+        summary.error = str(exc)
+        instance.last_sync_error = summary.error
+        instance.last_synced_at = datetime.now(UTC)
+        await db.commit()
+        logger.warning(
+            "netbird_reconcile_fetch_failed", instance=str(instance.id), error=summary.error
+        )
+        return summary
+
+    summary.peer_count = len(peers)
+    summary.dns_domain = derive_netbird_domain(peers)
+
+    await _ensure_block_and_subnet(db, instance, instance.network_cidr, "peers", summary)
+
+    desired = _compute_desired(instance, peers, summary)
+    await _apply_addresses(db, instance, desired, summary)
+
+    # Phase 2 — synthesise the mesh DNS surface in the bound group.
+    # Skipped when no group is bound; an operator-managed same-name zone
+    # is left alone (warning surfaced via summary.warnings).
+    await _apply_synthetic_dns(db, instance, peers, summary)
+
+    instance.last_synced_at = datetime.now(UTC)
+    instance.last_sync_error = None
+    instance.dns_domain = summary.dns_domain
+    instance.peer_count = summary.peer_count
+
+    db.add(
+        AuditLog(
+            user_display_name="system",
+            auth_source="system",
+            action="netbird.reconcile",
+            resource_type="netbird_instance",
+            resource_id=str(instance.id),
+            resource_display=instance.name,
+            new_value={
+                "blocks_created": summary.blocks_created,
+                "subnets_created": summary.subnets_created,
+                "addresses": {
+                    "created": summary.addresses_created,
+                    "updated": summary.addresses_updated,
+                    "deleted": summary.addresses_deleted,
+                    "skipped_expired": summary.skipped_expired,
+                    "skipped_no_subnet": summary.skipped_no_subnet,
+                },
+                "dns": {
+                    "zones_created": summary.dns_zones_created,
+                    "records_created": summary.dns_records_created,
+                    "records_updated": summary.dns_records_updated,
+                    "records_deleted": summary.dns_records_deleted,
+                    "skipped": summary.dns_skipped,
+                },
+            },
+        )
+    )
+    await db.commit()
+    summary.ok = True
+    logger.info(
+        "netbird_reconcile_ok",
+        instance=str(instance.id),
+        dns_domain=summary.dns_domain,
+        peers=summary.peer_count,
+        blocks_created=summary.blocks_created,
+        subnets_created=summary.subnets_created,
+        addresses_created=summary.addresses_created,
+        addresses_updated=summary.addresses_updated,
+        addresses_deleted=summary.addresses_deleted,
+        dns_zones_created=summary.dns_zones_created,
+        dns_records_created=summary.dns_records_created,
+        dns_records_deleted=summary.dns_records_deleted,
+    )
+    return summary
+
+
+__all__ = ["ReconcileSummary", "reconcile_instance"]

--- a/backend/app/services/tailscale/reconcile.py
+++ b/backend/app/services/tailscale/reconcile.py
@@ -331,6 +331,7 @@ async def _apply_addresses(
                 row.proxmox_node_id is not None
                 or row.kubernetes_cluster_id is not None
                 or row.docker_host_id is not None
+                or row.netbird_instance_id is not None
             ):
                 summary.warnings.append(
                     f"address {row.address} owned by another integration; not claiming"

--- a/backend/app/tasks/netbird_sync.py
+++ b/backend/app/tasks/netbird_sync.py
@@ -1,0 +1,136 @@
+"""Periodic NetBird instance reconcile.
+
+Mirrors ``tailscale_sync`` — 30 s beat tick, per-instance interval
+gating, platform-wide kill switch via
+``PlatformSettings.integration_netbird_enabled``. Plus a
+``sync_instance_now`` task for the UI's "Sync Now" button.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.celery_app import celery_app
+from app.config import settings
+from app.models.netbird import NetbirdInstance
+from app.models.settings import PlatformSettings
+
+logger = structlog.get_logger(__name__)
+
+_PLATFORM_SINGLETON_ID = 1
+
+
+async def _run_sweep() -> dict[str, Any]:
+    from app.services.netbird.reconcile import reconcile_instance  # noqa: PLC0415
+
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            ps = await db.get(PlatformSettings, _PLATFORM_SINGLETON_ID)
+            if ps is None or not ps.integration_netbird_enabled:
+                return {"status": "disabled"}
+
+            rows = (
+                (await db.execute(select(NetbirdInstance).where(NetbirdInstance.enabled.is_(True))))
+                .scalars()
+                .all()
+            )
+
+            now = datetime.now(UTC)
+            ran = 0
+            skipped_interval = 0
+            ok_count = 0
+            err_count = 0
+            errors: list[str] = []
+
+            for instance in rows:
+                if instance.last_synced_at is not None:
+                    elapsed = now - instance.last_synced_at
+                    if elapsed < timedelta(seconds=instance.sync_interval_seconds):
+                        skipped_interval += 1
+                        continue
+                try:
+                    summary = await reconcile_instance(db, instance)
+                except Exception as exc:  # noqa: BLE001
+                    err_count += 1
+                    errors.append(f"{instance.name}: {exc}")
+                    logger.warning(
+                        "netbird_reconcile_crash",
+                        instance=str(instance.id),
+                        error=str(exc),
+                    )
+                    continue
+                ran += 1
+                if summary.ok:
+                    ok_count += 1
+                else:
+                    err_count += 1
+                    if summary.error:
+                        errors.append(f"{instance.name}: {summary.error}")
+
+            return {
+                "status": "ok",
+                "ran": ran,
+                "skipped_interval": skipped_interval,
+                "ok": ok_count,
+                "errors": err_count,
+                "error_messages": errors[:20],
+            }
+    finally:
+        await engine.dispose()
+
+
+async def _run_one(instance_id: str) -> dict[str, Any]:
+    import uuid as _uuid  # noqa: PLC0415
+
+    from app.services.netbird.reconcile import reconcile_instance  # noqa: PLC0415
+
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            instance = await db.get(NetbirdInstance, _uuid.UUID(instance_id))
+            if instance is None:
+                return {"status": "not_found"}
+            summary = await reconcile_instance(db, instance)
+            return {
+                "status": "ok" if summary.ok else "error",
+                "error": summary.error,
+                "dns_domain": summary.dns_domain,
+                "peer_count": summary.peer_count,
+                "blocks_created": summary.blocks_created,
+                "subnets_created": summary.subnets_created,
+                "addresses_created": summary.addresses_created,
+                "addresses_updated": summary.addresses_updated,
+                "addresses_deleted": summary.addresses_deleted,
+                "skipped_expired": summary.skipped_expired,
+                "skipped_no_subnet": summary.skipped_no_subnet,
+            }
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(
+    name="app.tasks.netbird_sync.sweep_netbird_instances",
+    bind=True,
+)
+def sweep_netbird_instances(self: Any) -> dict[str, Any]:  # noqa: ARG001
+    return asyncio.run(_run_sweep())
+
+
+@celery_app.task(
+    name="app.tasks.netbird_sync.sync_instance_now",
+    bind=True,
+)
+def sync_instance_now(self: Any, instance_id: str) -> dict[str, Any]:  # noqa: ARG001
+    return asyncio.run(_run_one(instance_id))
+
+
+__all__ = ["sweep_netbird_instances", "sync_instance_now"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { DockerPage } from "@/pages/docker/DockerPage";
 import { ProxmoxPage } from "@/pages/proxmox/ProxmoxPage";
 import { OpnsensePage } from "@/pages/opnsense/OpnsensePage";
 import { CloudPage } from "@/pages/cloud/CloudPage";
+import { NetbirdPage } from "@/pages/netbird/NetbirdPage";
 import { TailscalePage } from "@/pages/tailscale/TailscalePage";
 import { UnifiPage } from "@/pages/unifi/UnifiPage";
 import { UnifiControllerDetailPage } from "@/pages/unifi/UnifiControllerDetailPage";
@@ -174,6 +175,7 @@ export default function App() {
         <Route path="proxmox" element={<ProxmoxPage />} />
         <Route path="opnsense" element={<OpnsensePage />} />
         <Route path="cloud" element={<CloudPage />} />
+        <Route path="netbird" element={<NetbirdPage />} />
         <Route path="tailscale" element={<TailscalePage />} />
         <Route path="unifi" element={<UnifiPage />} />
         <Route path="unifi/:id" element={<UnifiControllerDetailPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -35,6 +35,7 @@ import {
   ShieldQuestion,
   ScrollText,
   BellRing,
+  Bird,
   Sparkles,
   Boxes,
   Cloud,
@@ -621,6 +622,9 @@ export function Sidebar({
       : []),
     ...(moduleEnabled("integrations.opnsense")
       ? [{ label: "OPNsense", icon: ShieldCheck, to: "/opnsense" }]
+      : []),
+    ...(moduleEnabled("integrations.netbird")
+      ? [{ label: "NetBird", icon: Bird, to: "/netbird" }]
       : []),
     ...(moduleEnabled("integrations.proxmox")
       ? [{ label: "Proxmox", icon: HardDrive, to: "/proxmox" }]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3249,6 +3249,7 @@ export interface PlatformSettings {
   integration_unifi_enabled: boolean;
   integration_cloud_enabled: boolean;
   integration_opnsense_enabled: boolean;
+  integration_netbird_enabled: boolean;
   /** Domain WHOIS refresh cadence (hours). Beat ticks hourly; the
    *  task itself reads this on every fire so cadence changes take
    *  effect on the next tick without restarting beat. 1–168 h range
@@ -8278,7 +8279,8 @@ export type IntegrationDashboardKind =
   | "tailscale"
   | "unifi"
   | "cloud"
-  | "opnsense";
+  | "opnsense"
+  | "netbird";
 export interface IntegrationsDashboardTargetRow {
   id: string;
   display: string;
@@ -11618,6 +11620,90 @@ export const tailscaleApi = {
         status: string;
         task_id: string;
       }>(`/tailscale/tenants/${id}/sync`)
+      .then((r) => r.data),
+};
+
+export interface NetbirdInstance {
+  id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  api_url: string;
+  verify_tls: boolean;
+  api_key_present: boolean;
+  ipam_space_id: string;
+  dns_group_id: string | null;
+  network_cidr: string;
+  skip_expired: boolean;
+  sync_interval_seconds: number;
+  last_synced_at: string | null;
+  last_sync_error: string | null;
+  dns_domain: string | null;
+  peer_count: number | null;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface NetbirdInstanceCreate {
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  api_url?: string;
+  verify_tls?: boolean;
+  api_key: string;
+  ipam_space_id: string;
+  dns_group_id?: string | null;
+  network_cidr?: string;
+  skip_expired?: boolean;
+  sync_interval_seconds?: number;
+}
+
+export interface NetbirdInstanceUpdate {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  api_url?: string;
+  verify_tls?: boolean;
+  api_key?: string;
+  ipam_space_id?: string;
+  dns_group_id?: string | null;
+  network_cidr?: string;
+  skip_expired?: boolean;
+  sync_interval_seconds?: number;
+}
+
+export interface NetbirdTestResult {
+  ok: boolean;
+  message: string;
+  dns_domain: string | null;
+  peer_count: number | null;
+}
+
+export const netbirdApi = {
+  listInstances: () =>
+    api.get<NetbirdInstance[]>("/netbird/instances").then((r) => r.data),
+  createInstance: (data: NetbirdInstanceCreate) =>
+    api.post<NetbirdInstance>("/netbird/instances", data).then((r) => r.data),
+  updateInstance: (id: string, data: NetbirdInstanceUpdate) =>
+    api
+      .put<NetbirdInstance>(`/netbird/instances/${id}`, data)
+      .then((r) => r.data),
+  deleteInstance: (id: string) => api.delete(`/netbird/instances/${id}`),
+  testConnection: (body: {
+    instance_id?: string;
+    api_url?: string;
+    verify_tls?: boolean;
+    api_key?: string;
+  }) =>
+    api
+      .post<NetbirdTestResult>("/netbird/instances/test", body)
+      .then((r) => r.data),
+  syncNow: (id: string) =>
+    api
+      .post<{
+        status: string;
+        task_id: string;
+      }>(`/netbird/instances/${id}/sync`)
       .then((r) => r.data),
 };
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -29,6 +29,7 @@ import {
   RefreshCw,
   Route,
   Server,
+  Bird,
   Shield,
   ShieldCheck,
   Waypoints,
@@ -47,6 +48,7 @@ import {
   proxmoxApi,
   opnsenseApi,
   cloudApi,
+  netbirdApi,
   tailscaleApi,
   unifiApi,
   platformHealthApi,
@@ -69,6 +71,7 @@ import {
   type ProxmoxNode,
   type OPNsenseRouter,
   type CloudEndpoint,
+  type NetbirdInstance,
   type TailscaleTenant,
   type UnifiController,
   type PlatformHealthResponse,
@@ -1142,6 +1145,7 @@ export function DashboardPage() {
   const cloudEnabled = settings?.integration_cloud_enabled ?? false;
   const tailscaleEnabled = settings?.integration_tailscale_enabled ?? false;
   const unifiEnabled = settings?.integration_unifi_enabled ?? false;
+  const netbirdEnabled = settings?.integration_netbird_enabled ?? false;
   const { data: k8sClusters = [] } = useQuery<KubernetesCluster[]>({
     queryKey: ["kubernetes-clusters"],
     queryFn: kubernetesApi.listClusters,
@@ -1158,6 +1162,11 @@ export function DashboardPage() {
     queryKey: ["tailscale-tenants"],
     queryFn: tailscaleApi.listTenants,
     enabled: tailscaleEnabled,
+  });
+  const { data: netbirdInstances = [] } = useQuery<NetbirdInstance[]>({
+    queryKey: ["netbird-instances"],
+    queryFn: netbirdApi.listInstances,
+    enabled: netbirdEnabled,
   });
 
   const { data: proxmoxNodes = [] } = useQuery<ProxmoxNode[]>({
@@ -1880,7 +1889,8 @@ export function DashboardPage() {
             opnsenseEnabled ||
             cloudEnabled ||
             tailscaleEnabled ||
-            unifiEnabled) && (
+            unifiEnabled ||
+            netbirdEnabled) && (
             <div className="space-y-1.5">
               {ipamFilterActive && (
                 <p className="px-1 text-[10px] uppercase tracking-wide text-muted-foreground">
@@ -1903,6 +1913,8 @@ export function DashboardPage() {
                 cloudEndpoints={cloudEndpoints}
                 tailscaleTenants={tailscaleTenants}
                 unifiControllers={unifiControllers}
+                netbirdEnabled={netbirdEnabled}
+                netbirdInstances={netbirdInstances}
               />
             </div>
           )}
@@ -2310,6 +2322,8 @@ function IntegrationsPanel({
   cloudEndpoints,
   tailscaleTenants,
   unifiControllers,
+  netbirdEnabled,
+  netbirdInstances,
 }: {
   kubernetesEnabled: boolean;
   dockerEnabled: boolean;
@@ -2325,6 +2339,8 @@ function IntegrationsPanel({
   cloudEndpoints: CloudEndpoint[];
   tailscaleTenants: TailscaleTenant[];
   unifiControllers: UnifiController[];
+  netbirdEnabled: boolean;
+  netbirdInstances: NetbirdInstance[];
 }) {
   const hasK8s = kubernetesEnabled;
   const hasDocker = dockerEnabled;
@@ -2333,6 +2349,7 @@ function IntegrationsPanel({
   const hasCloud = cloudEnabled;
   const hasTailscale = tailscaleEnabled;
   const hasUnifi = unifiEnabled;
+  const hasNetbird = netbirdEnabled;
   const cols = [
     hasK8s,
     hasDocker,
@@ -2341,6 +2358,7 @@ function IntegrationsPanel({
     hasCloud,
     hasTailscale,
     hasUnifi,
+    hasNetbird,
   ].filter(Boolean).length;
   const totalTargets =
     clusters.length +
@@ -2349,7 +2367,8 @@ function IntegrationsPanel({
     opnsenseRouters.length +
     cloudEndpoints.length +
     tailscaleTenants.length +
-    unifiControllers.length;
+    unifiControllers.length +
+    netbirdInstances.length;
   return (
     <div className="rounded-lg border bg-card">
       <div className="flex items-center justify-between border-b px-4 py-2.5">
@@ -2373,6 +2392,7 @@ function IntegrationsPanel({
           cols === 5 && "md:grid-cols-5 md:divide-x md:divide-y-0",
           cols === 6 && "md:grid-cols-6 md:divide-x md:divide-y-0",
           cols === 7 && "md:grid-cols-7 md:divide-x md:divide-y-0",
+          cols === 8 && "md:grid-cols-8 md:divide-x md:divide-y-0",
         )}
       >
         {hasK8s && (
@@ -2671,6 +2691,47 @@ function IntegrationsPanel({
                       lastSyncError={c.last_sync_error}
                       intervalSeconds={c.sync_interval_seconds}
                       enabled={c.enabled}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+        {hasNetbird && (
+          <div className="min-w-0">
+            <Link
+              to="/netbird"
+              className="flex items-center gap-1.5 bg-muted/30 px-4 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:bg-muted/50"
+            >
+              <Bird className="h-3 w-3" />
+              NetBird ({netbirdInstances.length})
+              <span className="ml-auto text-[10px] text-muted-foreground/70">
+                view all →
+              </span>
+            </Link>
+            {netbirdInstances.length === 0 ? (
+              <p className="px-4 py-3 text-[11px] italic text-muted-foreground">
+                No instances registered.
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <div className="min-w-[520px] divide-y">
+                  {netbirdInstances.map((t) => (
+                    <IntegrationRow
+                      key={t.id}
+                      to={`/netbird`}
+                      name={t.name}
+                      subtitle={t.dns_domain ?? t.api_url}
+                      meta={
+                        t.peer_count != null
+                          ? `${t.peer_count} peer${t.peer_count === 1 ? "" : "s"}`
+                          : "—"
+                      }
+                      lastSyncedAt={t.last_synced_at}
+                      lastSyncError={t.last_sync_error}
+                      intervalSeconds={t.sync_interval_seconds}
+                      enabled={t.enabled}
                     />
                   ))}
                 </div>

--- a/frontend/src/pages/netbird/NetbirdPage.tsx
+++ b/frontend/src/pages/netbird/NetbirdPage.tsx
@@ -1,0 +1,760 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Bird,
+  Check,
+  Clipboard,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Trash2,
+  TestTube2,
+  RotateCw,
+} from "lucide-react";
+
+import {
+  netbirdApi,
+  dnsApi,
+  type DNSServerGroup,
+  type NetbirdInstance,
+  type NetbirdInstanceCreate,
+  type NetbirdInstanceUpdate,
+  type NetbirdTestResult,
+} from "@/lib/api";
+import { copyToClipboard } from "@/lib/clipboard";
+import { HeaderButton } from "@/components/ui/header-button";
+import { Modal } from "@/components/ui/modal";
+import { IPSpacePicker } from "@/components/ipam/space-picker";
+
+// ── Setup guide ─────────────────────────────────────────────────────
+// One-shot notes operators follow to mint a read-only NetBird token.
+
+const SETUP_KEY = `# Generate a NetBird API token (personal-access token):
+#
+# 1. Open your NetBird dashboard → Settings → Users
+#    (cloud: https://app.netbird.io/users)
+# 2. Select your user (or create a dedicated service user with a
+#    read-only role) and add an Access Token — give it a name +
+#    expiry.
+# 3. Copy the printed token (starts with "nbp_"). It is shown once.
+#
+# Management URL:
+#   Cloud:        https://api.netbird.io
+#   Self-hosted:  your dashboard/management host,
+#                 e.g. https://netbird.example.com
+#
+# The token reads the peer inventory; SpatiumDDI never writes to
+# NetBird. For a self-hosted install with a private-CA / self-signed
+# certificate, untick "Verify TLS".`;
+
+// ── Page ─────────────────────────────────────────────────────────────
+
+export function NetbirdPage() {
+  const qc = useQueryClient();
+  const { data: instances = [], isFetching } = useQuery({
+    queryKey: ["netbird-instances"],
+    queryFn: netbirdApi.listInstances,
+  });
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [edit, setEdit] = useState<NetbirdInstance | null>(null);
+  const [del, setDel] = useState<NetbirdInstance | null>(null);
+  const [inlineTest, setInlineTest] = useState<
+    Record<string, NetbirdTestResult | undefined>
+  >({});
+
+  const delMut = useMutation({
+    mutationFn: (id: string) => netbirdApi.deleteInstance(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["netbird-instances"] });
+      setDel(null);
+    },
+  });
+
+  const testMut = useMutation({
+    mutationFn: (id: string) => netbirdApi.testConnection({ instance_id: id }),
+    onMutate: (id) => {
+      setInlineTest((prev) => ({ ...prev, [id]: undefined }));
+    },
+    onSuccess: (result, id) => {
+      setInlineTest((prev) => ({ ...prev, [id]: result }));
+      qc.invalidateQueries({ queryKey: ["netbird-instances"] });
+    },
+  });
+
+  const syncMut = useMutation({
+    mutationFn: (id: string) => netbirdApi.syncNow(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["netbird-instances"] });
+      setTimeout(
+        () => qc.invalidateQueries({ queryKey: ["netbird-instances"] }),
+        5000,
+      );
+    },
+  });
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="border-b px-6 py-4 bg-card">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2">
+              <Bird className="h-5 w-5 text-muted-foreground" />
+              <h1 className="text-lg font-semibold">NetBird Instances</h1>
+              <span className="text-xs text-muted-foreground">
+                {instances.length} configured
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground max-w-3xl">
+              Read-only integration. Each instance is polled via the NetBird
+              management API with a personal-access token. The overlay
+              <code className="font-mono"> 100.64.0.0/10</code> block is
+              auto-created under the bound IPAM space, and every mesh
+              peer&apos;s address lands as an IP row with OS, version, groups,
+              and connection state in custom fields. Bind a DNS group to also
+              mirror the mesh&apos;s DNS domain as a read-only zone. SpatiumDDI
+              never writes to NetBird.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <HeaderButton
+              icon={RefreshCw}
+              iconClassName={isFetching ? "animate-spin" : ""}
+              onClick={() =>
+                qc.invalidateQueries({ queryKey: ["netbird-instances"] })
+              }
+            >
+              Refresh
+            </HeaderButton>
+            <HeaderButton
+              variant="primary"
+              icon={Plus}
+              onClick={() => setShowCreate(true)}
+            >
+              Add Instance
+            </HeaderButton>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-auto p-6">
+        <div className="rounded-lg border">
+          {instances.length === 0 ? (
+            <div className="p-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                No NetBird instances configured yet.
+              </p>
+              <button
+                onClick={() => setShowCreate(true)}
+                className="mt-3 inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs hover:bg-accent"
+              >
+                <Plus className="h-3 w-3" /> Add Instance
+              </button>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[1020px] text-xs">
+                <thead>
+                  <tr className="border-b bg-muted/30">
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Name
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Enabled
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Management URL
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Domain
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Peers
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Last sync
+                    </th>
+                    <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                      Test
+                    </th>
+                    <th className="px-3 py-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {instances.map((t) => {
+                    const tr = inlineTest[t.id];
+                    return (
+                      <tr key={t.id} className="border-b last:border-0">
+                        <td className="whitespace-nowrap px-3 py-2 font-medium">
+                          {t.name}
+                          {t.description && (
+                            <div
+                              className="text-[11px] text-muted-foreground max-w-md truncate"
+                              title={t.description}
+                            >
+                              {t.description}
+                            </div>
+                          )}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2">
+                          {t.enabled ? (
+                            <span className="inline-flex rounded bg-emerald-500/10 px-1.5 py-0.5 text-[11px] text-emerald-700 dark:text-emerald-400">
+                              enabled
+                            </span>
+                          ) : (
+                            <span className="inline-flex rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                              disabled
+                            </span>
+                          )}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 font-mono text-[11px]">
+                          {t.api_url}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-muted-foreground font-mono text-[11px]">
+                          {t.dns_domain ?? "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                          {t.peer_count ?? "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                          {t.last_synced_at
+                            ? new Date(t.last_synced_at).toLocaleString()
+                            : "never"}
+                          {t.last_sync_error && (
+                            <div
+                              className="text-[11px] text-destructive max-w-xs truncate"
+                              title={t.last_sync_error}
+                            >
+                              {t.last_sync_error}
+                            </div>
+                          )}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2">
+                          <button
+                            onClick={() => testMut.mutate(t.id)}
+                            disabled={testMut.isPending}
+                            className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] hover:bg-accent disabled:opacity-50"
+                          >
+                            <TestTube2 className="h-3 w-3" />
+                            Test
+                          </button>
+                          {tr && (
+                            <div
+                              className={`mt-1 max-w-xs truncate text-[11px] ${
+                                tr.ok
+                                  ? "text-emerald-600 dark:text-emerald-400"
+                                  : "text-destructive"
+                              }`}
+                              title={tr.message}
+                            >
+                              {tr.ok ? "✓" : "✗"} {tr.message}
+                            </div>
+                          )}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-right">
+                          <button
+                            onClick={() => syncMut.mutate(t.id)}
+                            disabled={
+                              syncMut.isPending && syncMut.variables === t.id
+                            }
+                            className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-50"
+                            title="Sync Now"
+                          >
+                            <RotateCw
+                              className={`h-3.5 w-3.5 ${
+                                syncMut.isPending && syncMut.variables === t.id
+                                  ? "animate-spin"
+                                  : ""
+                              }`}
+                            />
+                          </button>
+                          <button
+                            onClick={() => setEdit(t)}
+                            className="rounded p-1 text-muted-foreground hover:text-foreground"
+                            title="Edit"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            onClick={() => setDel(t)}
+                            className="rounded p-1 text-muted-foreground hover:text-destructive"
+                            title="Delete"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showCreate && <InstanceModal onClose={() => setShowCreate(false)} />}
+      {edit && <InstanceModal instance={edit} onClose={() => setEdit(null)} />}
+      {del && (
+        <DeleteInstanceModal
+          instance={del}
+          onClose={() => setDel(null)}
+          onConfirm={() => delMut.mutate(del.id)}
+          isPending={delMut.isPending}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Create / Edit modal ─────────────────────────────────────────────
+
+function InstanceModal({
+  instance,
+  onClose,
+}: {
+  instance?: NetbirdInstance;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const editing = !!instance;
+
+  const { data: dnsGroups = [] } = useQuery<DNSServerGroup[]>({
+    queryKey: ["dns-groups"],
+    queryFn: () => dnsApi.listGroups(),
+  });
+
+  const [name, setName] = useState(instance?.name ?? "");
+  const [description, setDescription] = useState(instance?.description ?? "");
+  const [enabled, setEnabled] = useState(instance?.enabled ?? true);
+  const [apiUrl, setApiUrl] = useState(
+    instance?.api_url ?? "https://api.netbird.io",
+  );
+  const [verifyTls, setVerifyTls] = useState(instance?.verify_tls ?? true);
+  const [apiKey, setApiKey] = useState("");
+  const [spaceId, setSpaceId] = useState(instance?.ipam_space_id ?? "");
+  const [dnsGroupId, setDnsGroupId] = useState(instance?.dns_group_id ?? "");
+  const [networkCidr, setNetworkCidr] = useState(
+    instance?.network_cidr ?? "100.64.0.0/10",
+  );
+  const [skipExpired, setSkipExpired] = useState(
+    instance?.skip_expired ?? true,
+  );
+  const [syncInterval, setSyncInterval] = useState(
+    instance?.sync_interval_seconds ?? 60,
+  );
+  const [showGuide, setShowGuide] = useState(!editing);
+  const [error, setError] = useState("");
+
+  const [testResult, setTestResult] = useState<NetbirdTestResult | null>(null);
+
+  const testMut = useMutation({
+    mutationFn: () =>
+      netbirdApi.testConnection({
+        instance_id: instance?.id,
+        api_url: apiUrl || undefined,
+        verify_tls: verifyTls,
+        api_key: apiKey || undefined,
+      }),
+    onSuccess: (result) => setTestResult(result),
+    onError: (e) =>
+      setTestResult({
+        ok: false,
+        message: errMsg(e, "Test failed"),
+        dns_domain: null,
+        peer_count: null,
+      }),
+  });
+
+  const saveMut = useMutation({
+    mutationFn: () => {
+      if (editing) {
+        const update: NetbirdInstanceUpdate = {
+          name,
+          description,
+          enabled,
+          api_url: apiUrl,
+          verify_tls: verifyTls,
+          ipam_space_id: spaceId,
+          dns_group_id: dnsGroupId || null,
+          network_cidr: networkCidr,
+          skip_expired: skipExpired,
+          sync_interval_seconds: syncInterval,
+        };
+        if (apiKey) update.api_key = apiKey;
+        return netbirdApi.updateInstance(instance!.id, update);
+      }
+      const create: NetbirdInstanceCreate = {
+        name,
+        description,
+        enabled,
+        api_url: apiUrl,
+        verify_tls: verifyTls,
+        api_key: apiKey,
+        ipam_space_id: spaceId,
+        dns_group_id: dnsGroupId || null,
+        network_cidr: networkCidr,
+        skip_expired: skipExpired,
+        sync_interval_seconds: syncInterval,
+      };
+      return netbirdApi.createInstance(create);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["netbird-instances"] });
+      onClose();
+    },
+    onError: (e) => setError(errMsg(e, "Failed to save instance")),
+  });
+
+  return (
+    <Modal
+      title={editing ? "Edit NetBird Instance" : "Add NetBird Instance"}
+      onClose={onClose}
+      wide
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          saveMut.mutate();
+        }}
+        className="space-y-3"
+      >
+        <div className="rounded-md border bg-muted/30 p-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold">Setup guide</h3>
+            <button
+              type="button"
+              onClick={() => setShowGuide((v) => !v)}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              {showGuide ? "Hide" : "Show"}
+            </button>
+          </div>
+          {showGuide && (
+            <div className="mt-2 space-y-2 text-xs">
+              <p className="text-muted-foreground">
+                Generate a personal-access token in the NetBird dashboard. The
+                token reads the peer inventory; SpatiumDDI only ever reads —
+                never writes — to NetBird.
+              </p>
+              <CopyablePre text={SETUP_KEY} label="NetBird token setup" />
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Name">
+            <input
+              className={inputCls}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </Field>
+          <label className="flex cursor-pointer items-center gap-2 pt-6 text-sm">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => setEnabled(e.target.checked)}
+            />
+            <span>Enabled</span>
+          </label>
+        </div>
+
+        <Field label="Description">
+          <input
+            className={inputCls}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </Field>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field
+            label="Management URL"
+            hint="Cloud: https://api.netbird.io — or your self-hosted dashboard host."
+          >
+            <input
+              className={`${inputCls} font-mono text-[11px]`}
+              value={apiUrl}
+              onChange={(e) => setApiUrl(e.target.value)}
+              placeholder="https://api.netbird.io"
+              required
+            />
+          </Field>
+          <Field label="API token">
+            <input
+              type="password"
+              className={`${inputCls} font-mono text-[11px]`}
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder={
+                editing && instance?.api_key_present
+                  ? "••• stored — enter to replace"
+                  : "nbp_..."
+              }
+              required={!editing}
+            />
+          </Field>
+        </div>
+
+        <label className="flex cursor-pointer items-start gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={verifyTls}
+            onChange={(e) => setVerifyTls(e.target.checked)}
+            className="mt-0.5"
+          />
+          <div>
+            <span>Verify TLS certificate</span>
+            <p className="text-[11px] text-muted-foreground/70">
+              On by default. Untick for a self-hosted management server using a
+              private-CA or self-signed certificate.
+            </p>
+          </div>
+        </label>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => testMut.mutate()}
+            disabled={testMut.isPending || !apiUrl || (!editing && !apiKey)}
+            className="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs hover:bg-accent disabled:opacity-50"
+          >
+            <TestTube2 className="h-3.5 w-3.5" />
+            {testMut.isPending ? "Testing…" : "Test Connection"}
+          </button>
+          {testResult && (
+            <span
+              className={`text-xs ${
+                testResult.ok
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-destructive"
+              }`}
+              title={testResult.message}
+            >
+              {testResult.ok ? "✓" : "✗"} {testResult.message}
+            </span>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 border-t pt-3">
+          <Field label="IPAM space">
+            <IPSpacePicker value={spaceId} onChange={setSpaceId} required />
+          </Field>
+          <Field label="DNS server group (optional)">
+            <select
+              className={inputCls}
+              value={dnsGroupId ?? ""}
+              onChange={(e) => setDnsGroupId(e.target.value)}
+            >
+              <option value="">— none —</option>
+              {dnsGroups.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Field
+            label="Overlay CIDR"
+            hint="NetBird allocates peer IPs from 100.64.0.0/10 by default. Override only if your mesh uses a custom range."
+          >
+            <input
+              className={`${inputCls} font-mono text-[11px]`}
+              value={networkCidr}
+              onChange={(e) => setNetworkCidr(e.target.value)}
+              placeholder="100.64.0.0/10"
+              required
+            />
+          </Field>
+          <Field label="Sync interval (seconds)" hint="Minimum 30 s.">
+            <input
+              type="number"
+              className={inputCls}
+              value={syncInterval}
+              min={30}
+              onChange={(e) => setSyncInterval(parseInt(e.target.value) || 60)}
+            />
+          </Field>
+        </div>
+
+        <div className="space-y-2 border-t pt-2">
+          <label className="flex cursor-pointer items-start gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={skipExpired}
+              onChange={(e) => setSkipExpired(e.target.checked)}
+              className="mt-0.5"
+            />
+            <div>
+              <span>Skip login-expired peers</span>
+              <p className="text-[11px] text-muted-foreground/70">
+                On by default. Peers whose NetBird login has expired can&apos;t
+                reach the mesh. Turn off to surface them in IPAM anyway (useful
+                for capacity-planning views of churned hosts).
+              </p>
+            </div>
+          </label>
+        </div>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saveMut.isPending}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saveMut.isPending ? "Saving…" : editing ? "Save" : "Create"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+function DeleteInstanceModal({
+  instance,
+  onConfirm,
+  onClose,
+  isPending,
+}: {
+  instance: NetbirdInstance;
+  onConfirm: () => void;
+  onClose: () => void;
+  isPending: boolean;
+}) {
+  const [checked, setChecked] = useState(false);
+  return (
+    <Modal title="Delete NetBird Instance" onClose={onClose}>
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Remove the NetBird instance{" "}
+          <span className="font-semibold">{instance.name}</span>? This only
+          affects SpatiumDDI — nothing on the NetBird side changes. All IPAM
+          rows mirrored from this instance (the auto-created overlay block +
+          subnet + every peer IP, plus any synthetic DNS zone) will be removed
+          via the FK cascade.
+        </p>
+        <label className="flex cursor-pointer items-start gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
+            className="mt-0.5"
+          />
+          <span>I understand.</span>
+        </label>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted"
+          >
+            Cancel
+          </button>
+          <button
+            disabled={!checked || isPending}
+            onClick={onConfirm}
+            className="rounded-md bg-destructive px-3 py-1.5 text-sm text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+          >
+            {isPending ? "Deleting…" : "Delete"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ── Helpers (local to this page) ────────────────────────────────────
+
+function CopyablePre({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  async function handle() {
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    }
+  }
+  return (
+    <div className="relative">
+      <pre className="overflow-auto rounded bg-background p-2 pr-20 font-mono text-[11px] leading-tight">
+        {text}
+      </pre>
+      <button
+        type="button"
+        onClick={handle}
+        className="absolute right-1.5 top-1.5 inline-flex items-center gap-1 rounded border bg-background px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
+        aria-label={`Copy ${label}`}
+        title={`Copy ${label}`}
+      >
+        {copied ? (
+          <>
+            <Check className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+            Copied
+          </>
+        ) : (
+          <>
+            <Clipboard className="h-3 w-3" />
+            Copy
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+const inputCls =
+  "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="block text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      {children}
+      {hint && <p className="text-[11px] text-muted-foreground/70">{hint}</p>}
+    </div>
+  );
+}
+
+function errMsg(e: unknown, fallback: string): string {
+  const ae = e as {
+    response?: { data?: { detail?: unknown } };
+    message?: string;
+  };
+  const d = ae?.response?.data?.detail;
+  if (typeof d === "string") return d;
+  if (Array.isArray(d)) {
+    return (
+      (d as Array<{ loc?: (string | number)[]; msg?: string }>)
+        .map((err) => {
+          const field = (err.loc ?? []).filter((p) => p !== "body").join(".");
+          return field ? `${field}: ${err.msg}` : err.msg;
+        })
+        .filter(Boolean)
+        .join("; ") || fallback
+    );
+  }
+  return ae?.message || fallback;
+}


### PR DESCRIPTION
Read-only integration mirror for **NetBird** (managed WireGuard mesh — self-hosted or cloud), cloned from the shipped Tailscale integration shape. NetBird's real REST management API is what makes it a legitimate pull mirror, unlike raw WireGuard (previously shelved as a non-goal for having no API).

## What's included

- **Phase 1 — peer mirror.** `NetbirdInstance` connection model → 30 s beat sweep → reconciler that fetches `GET /api/peers`, auto-creates the overlay block + subnet under the bound IPAM space, and mirrors each peer's IP as a `netbird-peer` IPAddress row (OS / version / groups / connection state in custom fields), using the owned-row + `user_modified_at` lock model.
- **Phase 2 — synthetic DNS (opt-in).** Bind a DNS group and it materializes the mesh's DNS domain as a read-only zone + A records; the DNS `422` write-guards reject operator edits to synthesised zones/records.

## NetBird-specific deltas vs Tailscale

- Per-instance **operator-supplied management URL** + `verify_tls` toggle — and because the host isn't fixed, the probe runs it through the SSRF guard (Tailscale's fixed-host probe doesn't).
- `Authorization: Token` scheme, bare-array `/api/peers`, single IPv4 overlay (no v6 ULA), `login_expired` filter instead of timestamp parsing.
- A **complete cross-integration ownership guard** (checks all sibling integration FKs) plus a one-line symmetry fix on the Tailscale reconciler — both integrations default to `100.64.0.0/10` CGNAT, so a peer and a tailnet device can legitimately collide on an address.

## Full surface (per the non-negotiables)

`integrations.netbird` feature module (default-off) + settings-column mirror · RBAC + demo-mode + Fernet-at-rest · `list_netbird_targets` MCP tool (module-gated, read-only) · management page + route + sidebar nav · **both** dashboard surfaces — the IPAM-tab `IntegrationsPanel` (including the `cols === 8` grid fix, since NetBird is the 8th integration) and the Integrations dashboard tab.

## Verification

- **Static:** ruff + black + `mypy app` (694 files) clean; SQLAlchemy mappers configure (all 5 provenance FKs resolve); full runtime graph imports; migration-shape lint baselined; frontend `tsc -b && vite build` + eslint clean.
- **Runtime (rebuilt dev images against a real DB):** migration applied `e4b8073af215 → c9a4e1f7b820`; schema verified (18-col table + `netbird_instance_id` FK on `ip_address` / `ip_block` / `subnet` / `dns_zone` / `dns_record` + settings flag + feature-module seed); authenticated end-to-end smoke test — gate `404` when disabled → enable → list `200 []` → dashboard panel present → `test-connection` returns a structured error. Worker + beat healthy with the new task.

## Out of scope (noted)

The block-move integration-blocker guard omits NetBird — but it already omits unifi/cloud/opnsense too (a pre-existing stale 4-FK list), so NetBird is consistent with the other shipped integrations. Extending that guard for all of them is a separate cleanup.

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)
