### PR TITLE
fix(firewall): warn (not debug) when a self-partition refusal fails to persist (#611)

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -2321,7 +2321,17 @@ def record_firewall_refusal(source: str, reason: str) -> None:
         tmp.write_text(json.dumps(payload), encoding="utf-8")
         tmp.replace(_FIREWALL_REFUSAL_SIDECAR)
     except OSError as exc:
-        log.debug("supervisor.firewall.refusal_persist_failed", error=str(exc))
+        # A genuine write failure here (read-only fs / ENOSPC / a missing
+        # release-state mount) is the one way a self-partition refusal can go
+        # silent on the host-side console reader — the #593 "never silent"
+        # goal. The in-pod heartbeat still surfaces it (same-container
+        # read-back), so this stays best-effort, but warn so the failure is
+        # not buried at debug. (#611)
+        log.warning(
+            "supervisor.firewall.refusal_persist_failed",
+            error=str(exc),
+            path=str(_FIREWALL_REFUSAL_SIDECAR),
+        )
 
 
 def clear_firewall_refusal() -> None:

--- a/agent/supervisor/tests/test_firewall_applystate.py
+++ b/agent/supervisor/tests/test_firewall_applystate.py
@@ -58,3 +58,38 @@ def test_collect_off_appliance_emits_none(monkeypatch: pytest.MonkeyPatch) -> No
     assert out["firewall_applied_hash"] is None
     assert out["firewall_applied_status"] is None
     assert out["firewall_base_marker"] is None
+
+
+def test_refusal_round_trip(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    sidecar = tmp_path / "sub" / "firewall-refused"  # parent absent → mkdir path
+    monkeypatch.setattr(appliance_state, "_FIREWALL_REFUSAL_SIDECAR", sidecar)
+    assert appliance_state.read_firewall_state() is None
+    appliance_state.record_firewall_refusal("in-pod", "no etcd peer rule")
+    state = appliance_state.read_firewall_state()
+    assert state == {
+        "state": "refused_self_partition",
+        "source": "in-pod",
+        "reason": "no etcd peer rule",
+    }
+    appliance_state.clear_firewall_refusal()
+    assert appliance_state.read_firewall_state() is None
+
+
+def test_refusal_persist_failure_warns(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """#611 — a genuine write failure is the one way a self-partition refusal
+    can go silent on the host-side reader, so it must warn (not debug)."""
+    # A file where the sidecar's grandparent dir should be makes mkdir raise.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir")
+    monkeypatch.setattr(
+        appliance_state, "_FIREWALL_REFUSAL_SIDECAR", blocker / "deep" / "refused"
+    )
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        appliance_state.log, "warning", lambda event, **kw: calls.append((event, kw))
+    )
+    appliance_state.record_firewall_refusal("in-pod", "boom")  # must not raise
+    assert calls and calls[0][0] == "supervisor.firewall.refusal_persist_failed"
+    assert "error" in calls[0][1] and "path" in calls[0][1]


### PR DESCRIPTION
Closes #611.

## TL;DR — #611 was a misdiagnosis; this is the one real residual, hardened.

#611 (split from #609's secondary finding) claimed the #593 "never silent" surfacing was broken because the supervisor pod doesn't mount `release-state`, so a self-partition refusal never lands on disk. Investigation shows the whole chain was **intact at the shipped `1abb7ff` commit**:

- `release-state` **is** mounted into the supervisor pod, writable, `DirectoryOrCreate` — `charts/spatiumddi-appliance/templates/supervisor.yaml:73-74` + `120-123`
- `record_firewall_refusal` already `mkdir(parents=True, exist_ok=True)`'s before its atomic write — `appliance_state.py`
- the heartbeat ships `firewall_state` every beat — `heartbeat.py`

The refusal *was* recorded and *was* on the heartbeat. The operator never *saw* it because the whole UI/API was unreachable off-box (the primary bug), not because it went unrecorded — **#610 fixed that**. The in-pod heartbeat path is also already robust to a missing mount (write + read are same-container).

## The genuine residual (fixed here)

A real write failure (`read-only fs` / `ENOSPC` / a truly-missing mount) was swallowed at `log.debug` — near-invisible, and the only path by which a refusal can go silent for the host-side console reader. This PR:

- elevates that failure to `log.warning` with the target path, and
- adds a `record → read → clear` round-trip test plus a persist-failure-warns regression.

Full supervisor firewall suite: **88 passed**. ruff + black clean on the touched files (CI backend-lint scopes `backend/` only; `agent/supervisor` isn't black-checked — noted a pre-existing unrelated APT-block drift in that file, left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)