### PR TITLE
feat(security): active firewall/network block sync — OPNsense + UniFi enforcement (#601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,64 @@ the formatter handles the rest.
 
 ---
 
+## 2026.07.10-1 — 2026-07-10
+
+An **active enforcement** release. It closes the half-open
+detect→block loop: SpatiumDDI could already *see* a rogue DHCP
+responder (#370) or an unknown MAC (#459) and starve it of a DHCP
+lease, but a device that self-assigns a static IP walked right past
+the DHCP block. **Active block sync (#601)** adds a narrow, heavily
+guarded write path that pushes a real block at the natural
+enforcement point — an **OPNsense** firewall table alias (by IP) or a
+**UniFi** L2 client quarantine (by MAC) — so the block actually
+sticks. It is the deliberate exception to the read-only-mirror stance:
+off by default, layered behind a feature module, a per-target
+enforcement master switch, distinct write-scoped credentials,
+preview + audit on every push, `manage_block_sync` RBAC, and
+two-person approval.
+
+### Added
+
+- **Active block sync — write-back enforcement (#601).** A new
+  `security.block_sync` feature module (default-off) exposes a
+  SpatiumDDI-owned block set (`network_block`: IP or MAC, with
+  reason / source / optional auto-expiry) that a target-driven,
+  idempotent reconciler converges onto every *armed* OPNsense /
+  UniFi target and lifts when a block is disabled / expired /
+  deleted. Convergence is non-destructive — SpatiumDDI only removes
+  values it added (tracked in `network_block_push`), never alias
+  members / blocked clients it doesn't own.
+  - **OPNsense** enforcement mutates operator-pre-created firewall
+    **table-alias** membership only (`alias_util/add|delete` +
+    `alias/reconfigure`) — never rule CRUD.
+  - **UniFi** enforcement issues the legacy `cmd/stamgr`
+    `block-sta` / `unblock-sta` L2 quarantine (the public
+    Integration v1 API doesn't expose client-block), replaying the
+    captured `X-CSRF-Token` / `X-API-Key`.
+  - REST surface at `/api/v1/block-sync` (blocks CRUD with a
+    per-target preview diff, target arm/creds, force-reconcile,
+    password-confirm credential reveal); a 60 s beat sweep plus an
+    immediate on-create/lift converge.
+  - The New Devices review-queue **Block** action grows an "also
+    quarantine upstream" option that creates a MAC block when a
+    UniFi target is armed.
+  - Guardrails: per-target default-off `block_sync_enabled` master
+    switch (independent of the mirror module), distinct Fernet-
+    encrypted write-scoped creds, `manage_block_sync` permission
+    (granted to Network Editor), full audit + two-person approval
+    (#62) on every create, and `find_network_blocks` /
+    `count_network_blocks` + a default-disabled
+    `propose_create_network_block` Operator Copilot tool.
+
+### Migrations
+
+- `d3b9f42a1c05` — `network_block` + `network_block_push` tables,
+  block-sync enforcement columns on `opnsense_router` /
+  `unifi_controller`, and the seeded (disabled) `security.block_sync`
+  feature-module row.
+
+---
+
 ## 2026.07.09-1 — 2026-07-09
 
 A **BGP visibility + HA-hardening** release. The headline feature is

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -417,6 +417,10 @@ backend/alembic/versions/d1f4b7c92e58_appliance_firewall_state.py:drop_column:43
 backend/alembic/versions/d2a8e417b9f3_backup_target.py:drop_table:112
 backend/alembic/versions/d2f7a91e4c8b_nmap_scans.py:drop_table:96
 backend/alembic/versions/d3a9c5b71e84_subnet_kind.py:drop_column:71
+backend/alembic/versions/d3b9f42a1c05_active_block_sync.py:drop_column:196
+backend/alembic/versions/d3b9f42a1c05_active_block_sync.py:drop_column:205
+backend/alembic/versions/d3b9f42a1c05_active_block_sync.py:drop_table:207
+backend/alembic/versions/d3b9f42a1c05_active_block_sync.py:drop_table:209
 backend/alembic/versions/d3f1ab7c8e02_windows_dns_credentials.py:drop_column:36
 backend/alembic/versions/d3f2a51c8e76_bgp_peering.py:drop_column:98
 backend/alembic/versions/d3f2a51c8e76_bgp_peering.py:drop_constraint_fk:96

--- a/backend/alembic/versions/d3b9f42a1c05_active_block_sync.py
+++ b/backend/alembic/versions/d3b9f42a1c05_active_block_sync.py
@@ -1,0 +1,207 @@
+"""Active block sync (#601) — network_block desired-state + per-target
+push state + OPNsense/UniFi enforcement columns + feature module seed.
+
+Revision ID: d3b9f42a1c05
+Revises: c9a4e1f7b820
+Create Date: 2026-07-10 13:00:00
+
+The enforcement half of the detect→block loop. ``network_block`` is the
+SpatiumDDI-owned block set (IPs / MACs); ``network_block_push`` tracks
+per-(block, target) convergence. Enforcement columns are added to the
+existing read-only mirror rows (``opnsense_router`` / ``unifi_controller``)
+so a target is armed in-place — the mirror itself stays read-only. The
+``security.block_sync`` feature module is seeded disabled-by-default.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d3b9f42a1c05"
+down_revision: str | None = "c9a4e1f7b820"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "network_block",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("kind", sa.String(length=8), nullable=False),
+        sa.Column("value", sa.String(length=64), nullable=False),
+        sa.Column("reason", sa.String(length=32), nullable=False, server_default="quarantine"),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("source", sa.String(length=16), nullable=False, server_default="manual"),
+        sa.Column("source_ref", sa.String(length=255), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_by_user_id",
+            sa.UUID(),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_by_user_id",
+            sa.UUID(),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("kind", "value", name="uq_network_block_kind_value"),
+    )
+    op.create_index("ix_network_block_enabled", "network_block", ["enabled"])
+
+    op.create_table(
+        "network_block_push",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "block_id",
+            sa.UUID(),
+            sa.ForeignKey("network_block.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("target_kind", sa.String(length=16), nullable=False),
+        sa.Column("target_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "push_status", sa.String(length=16), nullable=False, server_default=sa.text("'pending'")
+        ),
+        sa.Column("last_pushed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "block_id", "target_kind", "target_id", name="uq_network_block_push_block_target"
+        ),
+    )
+    op.create_index(
+        "ix_network_block_push_target", "network_block_push", ["target_kind", "target_id"]
+    )
+
+    # OPNsense enforcement columns (firewall alias membership).
+    op.add_column(
+        "opnsense_router",
+        sa.Column(
+            "block_sync_enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+    )
+    op.add_column(
+        "opnsense_router",
+        sa.Column("block_sync_api_key", sa.String(length=255), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "opnsense_router",
+        sa.Column(
+            "block_sync_api_secret_encrypted",
+            sa.LargeBinary(),
+            nullable=False,
+            server_default=sa.text("''::bytea"),
+        ),
+    )
+    op.add_column(
+        "opnsense_router",
+        sa.Column("block_alias_name", sa.String(length=255), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "opnsense_router",
+        sa.Column("last_block_sync_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("opnsense_router", sa.Column("last_block_sync_error", sa.Text(), nullable=True))
+
+    # UniFi enforcement columns (L2 client quarantine).
+    op.add_column(
+        "unifi_controller",
+        sa.Column(
+            "block_sync_enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+    )
+    op.add_column(
+        "unifi_controller",
+        sa.Column(
+            "block_sync_auth_kind",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'api_key'"),
+        ),
+    )
+    for col in (
+        "block_sync_api_key_encrypted",
+        "block_sync_username_encrypted",
+        "block_sync_password_encrypted",
+    ):
+        op.add_column(
+            "unifi_controller",
+            sa.Column(col, sa.LargeBinary(), nullable=False, server_default=sa.text("''::bytea")),
+        )
+    op.add_column(
+        "unifi_controller",
+        sa.Column(
+            "block_sync_site", sa.String(length=64), nullable=False, server_default="default"
+        ),
+    )
+    op.add_column(
+        "unifi_controller",
+        sa.Column("last_block_sync_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("unifi_controller", sa.Column("last_block_sync_error", sa.Text(), nullable=True))
+
+    # Seed the feature module disabled-by-default (idempotent).
+    op.execute(
+        sa.text(
+            "INSERT INTO feature_module (id, enabled) "
+            "VALUES ('security.block_sync', false) ON CONFLICT (id) DO NOTHING"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'security.block_sync'"))
+    for col in (
+        "last_block_sync_error",
+        "last_block_sync_at",
+        "block_sync_site",
+        "block_sync_password_encrypted",
+        "block_sync_username_encrypted",
+        "block_sync_api_key_encrypted",
+        "block_sync_auth_kind",
+        "block_sync_enabled",
+    ):
+        op.drop_column("unifi_controller", col)
+    for col in (
+        "last_block_sync_error",
+        "last_block_sync_at",
+        "block_alias_name",
+        "block_sync_api_secret_encrypted",
+        "block_sync_api_key",
+        "block_sync_enabled",
+    ):
+        op.drop_column("opnsense_router", col)
+    op.drop_index("ix_network_block_push_target", table_name="network_block_push")
+    op.drop_table("network_block_push")
+    op.drop_index("ix_network_block_enabled", table_name="network_block")
+    op.drop_table("network_block")

--- a/backend/app/api/v1/ai/proposals.py
+++ b/backend/app/api/v1/ai/proposals.py
@@ -20,13 +20,15 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel
 from sqlalchemy import select
 
 from app.api.deps import DB, CurrentUser
 from app.models.ai import AIOperationProposal
 from app.services.ai import operations
+from app.services.ai.operations_risky import RISKY_OPERATION_NAMES
+from app.services.approvals.gate import gate_or_execute
 
 logger = structlog.get_logger(__name__)
 router = APIRouter()
@@ -117,7 +119,7 @@ async def get_proposal(
 
 @router.post("/proposals/{proposal_id}/apply", response_model=ApplyResponse)
 async def apply_proposal(
-    proposal_id: uuid.UUID, current_user: CurrentUser, db: DB
+    proposal_id: uuid.UUID, current_user: CurrentUser, db: DB, request: Request
 ) -> ApplyResponse:
     row = await db.get(AIOperationProposal, proposal_id)
     if row is None or row.user_id != current_user.id:
@@ -170,6 +172,30 @@ async def apply_proposal(
             result=None,
             proposal=_to_response(row),
         )
+
+    # Two-person approval (#62): a risky op reached via propose→Apply must
+    # route through the SAME gate the equivalent REST route uses — otherwise
+    # the AI surface would be a bypass around the approval workflow (#601
+    # review). Module-off / no matching policy / superadmin-exempt → the gate
+    # returns None and we apply inline exactly as before.
+    if op.name in RISKY_OPERATION_NAMES:
+        pending = await gate_or_execute(db, current_user, request, operation=op, args=args)
+        if pending is not None:
+            row.applied_at = datetime.now(UTC)
+            row.result = {
+                "queued_for_approval": True,
+                "change_request_id": str(pending.change_request_id),
+                "state": pending.state,
+            }
+            row.error = None
+            await db.commit()
+            await db.refresh(row)
+            return ApplyResponse(
+                ok=True,
+                detail="Queued for two-person approval",
+                result=row.result,
+                proposal=_to_response(row),
+            )
 
     try:
         result = await op.apply(db, current_user, args)

--- a/backend/app/api/v1/block_sync/__init__.py
+++ b/backend/app/api/v1/block_sync/__init__.py
@@ -1,0 +1,5 @@
+"""Active block-sync REST surface (#601)."""
+
+from app.api.v1.block_sync.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/block_sync/router.py
+++ b/backend/app/api/v1/block_sync/router.py
@@ -292,8 +292,8 @@ def _enqueue_lift(targets: list[tuple[str, uuid.UUID]]) -> None:
     for target_kind, target_id in targets:
         try:
             lift_target_now.delay(target_kind, str(target_id))
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception:  # noqa: BLE001 — broker down; the target is disarmed
+            pass  # so no sweep re-pushes; stale device state surfaces on next run
 
 
 # ── Block endpoints ──────────────────────────────────────────────────

--- a/backend/app/api/v1/block_sync/router.py
+++ b/backend/app/api/v1/block_sync/router.py
@@ -1,0 +1,634 @@
+"""Active block-sync — operator REST surface (#601).
+
+The *enforcement* half of the detect→block loop. Manages the
+SpatiumDDI-owned ``network_block`` desired-state (blocked IPs / MACs) and
+arms per-target write-back into OPNsense (firewall alias membership) and
+UniFi (L2 client quarantine).
+
+Guardrails, all enforced here:
+
+* Whole surface gated behind the ``security.block_sync`` feature module
+  (applied at the router include in ``app.api.v1.router``).
+* ``manage_block_sync`` RBAC on every endpoint; superadmin bypasses.
+* Every block create routes through the two-person approval gate (#62)
+  when ``governance.approvals`` is on and a policy matches.
+* No silent writes: ``POST /blocks?preview=true`` returns the exact
+  per-target add/remove diff without persisting or pushing; every real
+  mutation is audited and immediately reconciled.
+* Distinct write-scoped credentials, Fernet-encrypted, never returned
+  (password-confirm reveal, mirroring agent-bootstrap-key reveal).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, field_validator
+from sqlalchemy import select
+
+from app.api.deps import DB
+from app.core.crypto import decrypt_str, encrypt_str
+from app.core.demo_mode import forbid_in_demo_mode
+from app.core.permissions import require_permission
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.block_sync import (
+    BLOCK_SOURCES,
+    NetworkBlock,
+    NetworkBlockPush,
+)
+from app.models.opnsense import OPNsenseRouter
+from app.models.unifi import UnifiController
+from app.services.ai.operations import get_operation
+from app.services.ai.operations_risky import CreateNetworkBlockArgs
+from app.services.approvals.gate import gate_or_execute
+from app.services.block_sync.reconcile import (
+    applicable_targets_for_kind,
+    normalize_block_value,
+    opnsense_config_error,
+    preview_opnsense,
+    preview_unifi,
+    unifi_config_error,
+)
+from app.services.reauth import ReauthOutcome, reverify_operator
+
+PERMISSION = "manage_block_sync"
+
+router = APIRouter(
+    prefix="/block-sync",
+    tags=["block-sync"],
+    dependencies=[Depends(require_permission("admin", PERMISSION))],
+)
+
+ManageUser = Annotated[User, Depends(require_permission("admin", PERMISSION))]
+
+
+# ── Value normalisation ──────────────────────────────────────────────
+
+
+def _normalize_value(kind: str, value: str) -> str:
+    try:
+        return normalize_block_value(kind, value)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+# ── Schemas ──────────────────────────────────────────────────────────
+
+
+class BlockPushOut(BaseModel):
+    target_kind: str
+    target_id: uuid.UUID
+    push_status: str
+    last_pushed_at: datetime | None
+    last_error: str | None
+
+
+class BlockOut(BaseModel):
+    id: uuid.UUID
+    kind: str
+    value: str
+    reason: str
+    description: str
+    source: str
+    source_ref: str | None
+    enabled: bool
+    expires_at: datetime | None
+    created_at: datetime
+    modified_at: datetime
+    pushes: list[BlockPushOut] = []
+
+
+class BlockCreate(BaseModel):
+    kind: Literal["ip", "mac"]
+    value: str
+    reason: str = "quarantine"
+    description: str = ""
+    source: str = "manual"
+    source_ref: str | None = None
+    expires_at: datetime | None = None
+
+    @field_validator("source")
+    @classmethod
+    def _valid_source(cls, v: str) -> str:
+        if v not in BLOCK_SOURCES:
+            raise ValueError(f"source must be one of {BLOCK_SOURCES}")
+        return v
+
+
+class TargetDiffOut(BaseModel):
+    target_kind: str
+    target_id: uuid.UUID
+    target_name: str
+    to_add: list[str]
+    to_remove: list[str]
+    error: str | None = None
+
+
+class TargetOut(BaseModel):
+    target_kind: str
+    target_id: uuid.UUID
+    name: str
+    block_sync_enabled: bool
+    # OPNsense-only
+    block_alias_name: str | None = None
+    # UniFi-only
+    block_sync_site: str | None = None
+    block_sync_auth_kind: str | None = None
+    write_credentials_present: bool
+    last_block_sync_at: datetime | None
+    last_block_sync_error: str | None
+
+
+class OpnsenseArm(BaseModel):
+    block_sync_enabled: bool | None = None
+    block_alias_name: str | None = None
+    block_sync_api_key: str | None = None
+    # Omit / empty keeps the stored secret; non-empty rotates it.
+    block_sync_api_secret: str | None = None
+
+
+class UnifiArm(BaseModel):
+    block_sync_enabled: bool | None = None
+    block_sync_site: str | None = None
+    block_sync_auth_kind: Literal["api_key", "user_password"] | None = None
+    block_sync_api_key: str | None = None
+    block_sync_username: str | None = None
+    block_sync_password: str | None = None
+
+
+class RevealRequest(BaseModel):
+    password: str | None = None
+    totp_code: str | None = None
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _audit(
+    db: DB,
+    *,
+    user: User,
+    action: str,
+    resource_id: str,
+    resource_display: str,
+    new_value: dict | None = None,
+    changed_fields: list[str] | None = None,
+) -> None:
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=user.auth_source,
+            action=action,
+            resource_type="network_block",
+            resource_id=resource_id,
+            resource_display=resource_display,
+            new_value=new_value,
+            changed_fields=changed_fields,
+        )
+    )
+
+
+async def _pushes_for(
+    db: DB, block_ids: list[uuid.UUID]
+) -> dict[uuid.UUID, list[NetworkBlockPush]]:
+    if not block_ids:
+        return {}
+    rows = (
+        (await db.execute(select(NetworkBlockPush).where(NetworkBlockPush.block_id.in_(block_ids))))
+        .scalars()
+        .all()
+    )
+    out: dict[uuid.UUID, list[NetworkBlockPush]] = {}
+    for r in rows:
+        out.setdefault(r.block_id, []).append(r)
+    return out
+
+
+def _block_out(block: NetworkBlock, pushes: list[NetworkBlockPush]) -> BlockOut:
+    return BlockOut(
+        id=block.id,
+        kind=block.kind,
+        value=block.value,
+        reason=block.reason,
+        description=block.description,
+        source=block.source,
+        source_ref=block.source_ref,
+        enabled=block.enabled,
+        expires_at=block.expires_at,
+        created_at=block.created_at,
+        modified_at=block.modified_at,
+        pushes=[
+            BlockPushOut(
+                target_kind=p.target_kind,
+                target_id=p.target_id,
+                push_status=p.push_status,
+                last_pushed_at=p.last_pushed_at,
+                last_error=p.last_error,
+            )
+            for p in pushes
+        ],
+    )
+
+
+def _opnsense_target_out(r: OPNsenseRouter) -> TargetOut:
+    return TargetOut(
+        target_kind="opnsense",
+        target_id=r.id,
+        name=r.name,
+        block_sync_enabled=r.block_sync_enabled,
+        block_alias_name=r.block_alias_name or "",
+        write_credentials_present=bool(r.block_sync_api_key and r.block_sync_api_secret_encrypted),
+        last_block_sync_at=r.last_block_sync_at,
+        last_block_sync_error=r.last_block_sync_error,
+    )
+
+
+def _unifi_target_out(c: UnifiController) -> TargetOut:
+    kind = c.block_sync_auth_kind or "api_key"
+    creds = (
+        bool(c.block_sync_api_key_encrypted)
+        if kind == "api_key"
+        else bool(c.block_sync_username_encrypted and c.block_sync_password_encrypted)
+    )
+    return TargetOut(
+        target_kind="unifi",
+        target_id=c.id,
+        name=c.name,
+        block_sync_enabled=c.block_sync_enabled,
+        block_sync_site=c.block_sync_site or "default",
+        block_sync_auth_kind=kind,
+        write_credentials_present=creds,
+        last_block_sync_at=c.last_block_sync_at,
+        last_block_sync_error=c.last_block_sync_error,
+    )
+
+
+def _enqueue_reconcile(targets: list[tuple[str, uuid.UUID]]) -> None:
+    """Fire an immediate converge on each applicable target so enforcement
+    lands within seconds. Broker-unavailable is non-fatal — the 60 s sweep
+    catches up."""
+    from app.tasks.block_sync import reconcile_target_now  # noqa: PLC0415
+
+    for target_kind, target_id in targets:
+        try:
+            reconcile_target_now.delay(target_kind, str(target_id))
+        except Exception:  # noqa: BLE001 — broker down; sweep converges later
+            pass
+
+
+def _enqueue_lift(targets: list[tuple[str, uuid.UUID]]) -> None:
+    """Fire a disarm-cleanup lift: remove everything SpatiumDDI pushed to a
+    target that is being disarmed. Broker-unavailable is non-fatal (the target
+    is disabled, so no sweep will re-push — but the stale device state stays;
+    surfaced via the target's last_block_sync_error on the next successful run)."""
+    from app.tasks.block_sync import lift_target_now  # noqa: PLC0415
+
+    for target_kind, target_id in targets:
+        try:
+            lift_target_now.delay(target_kind, str(target_id))
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# ── Block endpoints ──────────────────────────────────────────────────
+
+
+@router.get("/blocks", response_model=list[BlockOut])
+async def list_blocks(db: DB, _: ManageUser) -> list[BlockOut]:
+    blocks = (
+        (await db.execute(select(NetworkBlock).order_by(NetworkBlock.created_at.desc())))
+        .scalars()
+        .all()
+    )
+    pushes = await _pushes_for(db, [b.id for b in blocks])
+    return [_block_out(b, pushes.get(b.id, [])) for b in blocks]
+
+
+@router.post("/blocks/preview", response_model=list[TargetDiffOut])
+async def preview_block(body: BlockCreate, db: DB, _: ManageUser) -> list[TargetDiffOut]:
+    """Show which armed targets a new block would land on, and the exact
+    add — WITHOUT persisting or pushing anything (NN#5)."""
+    value = _normalize_value(body.kind, body.value)
+    targets = await applicable_targets_for_kind(db, body.kind)
+    out: list[TargetDiffOut] = []
+    # Target-independent: is this value already actively enforced? (A
+    # disabled/lifted row will be re-enabled + re-pushed by create, so it
+    # still counts as an add — match only currently-enabled rows.)
+    already_active = (
+        await db.execute(
+            select(NetworkBlock.id).where(
+                NetworkBlock.kind == body.kind,
+                NetworkBlock.value == value,
+                NetworkBlock.enabled.is_(True),
+            )
+        )
+    ).scalar_one_or_none() is not None
+    for target_kind, target_id in targets:
+        name = await _target_name(db, target_kind, target_id)
+        out.append(
+            TargetDiffOut(
+                target_kind=target_kind,
+                target_id=target_id,
+                target_name=name or str(target_id),
+                to_add=[] if already_active else [value],
+                to_remove=[],
+            )
+        )
+    return out
+
+
+@router.post("/blocks", status_code=status.HTTP_201_CREATED, response_model=None)
+async def create_block(
+    body: BlockCreate,
+    db: DB,
+    user: ManageUser,
+    request: Request,
+) -> BlockOut | JSONResponse:
+    """Create (or re-arm) a network block and immediately converge it onto
+    every armed target of the matching kind.
+
+    Routes through the two-person approval gate (#62): when
+    ``governance.approvals`` is on and a policy matches ``admin:manage_
+    block_sync``, this returns ``202 Accepted`` with a pending change
+    request instead of writing. Module-off / no policy → executes inline
+    via the operation's ``apply``. The actual persist + audit + push all
+    live in the ``create_network_block`` operation so the inline path and
+    the approve path share one mutation."""
+    forbid_in_demo_mode("Block-sync writes are disabled in demo mode")
+    value = _normalize_value(body.kind, body.value)  # 422 early on bad input
+
+    op = get_operation("create_network_block")
+    assert op is not None  # registered at import
+    args = CreateNetworkBlockArgs(
+        kind=body.kind,
+        value=value,
+        reason=body.reason,
+        description=body.description,
+        source=body.source,
+        source_ref=body.source_ref,
+        expires_at=body.expires_at,
+    )
+    pending = await gate_or_execute(db, user, request, operation=op, args=args)
+    if pending is not None:
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=pending.as_dict())
+
+    result = await op.apply(db, user, args)
+    block = await db.get(NetworkBlock, uuid.UUID(str(result["block_id"])))
+    assert block is not None
+    pushes = await _pushes_for(db, [block.id])
+    return _block_out(block, pushes.get(block.id, []))
+
+
+@router.delete("/blocks/{block_id}", response_model=BlockOut)
+async def lift_block(block_id: uuid.UUID, db: DB, user: ManageUser) -> BlockOut:
+    """Lift a block — disables it and pushes the removal to every target it
+    landed on. The row is kept (disabled) as audit history; re-creating the
+    same value re-enables it."""
+    forbid_in_demo_mode("Block-sync writes are disabled in demo mode")
+    block = await db.get(NetworkBlock, block_id)
+    if block is None:
+        raise HTTPException(status_code=404, detail="block not found")
+    block.enabled = False
+    block.updated_by_user_id = user.id
+    targets = await applicable_targets_for_kind(db, block.kind)
+    _audit(
+        db,
+        user=user,
+        action="lift",
+        resource_id=str(block.id),
+        resource_display=f"{block.kind}:{block.value}",
+    )
+    await db.commit()
+    await db.refresh(block)
+    _enqueue_reconcile(targets)
+    pushes = await _pushes_for(db, [block.id])
+    return _block_out(block, pushes.get(block.id, []))
+
+
+# ── Target endpoints ─────────────────────────────────────────────────
+
+
+async def _target_name(db: DB, target_kind: str, target_id: uuid.UUID) -> str | None:
+    if target_kind == "opnsense":
+        r = await db.get(OPNsenseRouter, target_id)
+        return r.name if r else None
+    c = await db.get(UnifiController, target_id)
+    return c.name if c else None
+
+
+@router.get("/targets", response_model=list[TargetOut])
+async def list_targets(db: DB, _: ManageUser) -> list[TargetOut]:
+    """Every OPNsense router + UniFi controller that CAN be a block-sync
+    target, with its current arming state (armed or not)."""
+    routers = (
+        (await db.execute(select(OPNsenseRouter).order_by(OPNsenseRouter.name))).scalars().all()
+    )
+    controllers = (
+        (await db.execute(select(UnifiController).order_by(UnifiController.name))).scalars().all()
+    )
+    return [_opnsense_target_out(r) for r in routers] + [_unifi_target_out(c) for c in controllers]
+
+
+@router.put("/targets/opnsense/{target_id}", response_model=TargetOut)
+async def arm_opnsense(
+    target_id: uuid.UUID, body: OpnsenseArm, db: DB, user: ManageUser
+) -> TargetOut:
+    forbid_in_demo_mode("Block-sync arming is disabled in demo mode")
+    r = await db.get(OPNsenseRouter, target_id)
+    if r is None:
+        raise HTTPException(status_code=404, detail="OPNsense target not found")
+    was_enabled = r.block_sync_enabled
+    changes = body.model_dump(exclude_unset=True)
+    if "block_sync_enabled" in changes:
+        r.block_sync_enabled = bool(changes["block_sync_enabled"])
+    if "block_alias_name" in changes:
+        r.block_alias_name = (changes["block_alias_name"] or "").strip()
+    if "block_sync_api_key" in changes and changes["block_sync_api_key"] is not None:
+        r.block_sync_api_key = changes["block_sync_api_key"].strip()
+    if changes.get("block_sync_api_secret"):
+        r.block_sync_api_secret_encrypted = encrypt_str(changes["block_sync_api_secret"])
+    if r.block_sync_enabled:
+        # Reuse the reconcile-side validator so arm-time and push-time agree.
+        cfg_err = opnsense_config_error(r)
+        if cfg_err is not None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"cannot arm OPNsense block sync: {cfg_err}",
+            )
+    _audit(
+        db,
+        user=user,
+        action="arm_target",
+        resource_id=str(r.id),
+        resource_display=f"opnsense:{r.name}",
+        changed_fields=[k for k in changes if k != "block_sync_api_secret"],
+        new_value={"block_sync_enabled": r.block_sync_enabled},
+    )
+    await db.commit()
+    await db.refresh(r)
+    if r.block_sync_enabled:
+        _enqueue_reconcile([("opnsense", r.id)])
+    elif was_enabled:
+        # Disarm: lift everything SpatiumDDI pushed to this target so a
+        # disabled firewall doesn't keep blocking IPs with no reconcile path.
+        _enqueue_lift([("opnsense", r.id)])
+    return _opnsense_target_out(r)
+
+
+@router.put("/targets/unifi/{target_id}", response_model=TargetOut)
+async def arm_unifi(target_id: uuid.UUID, body: UnifiArm, db: DB, user: ManageUser) -> TargetOut:
+    forbid_in_demo_mode("Block-sync arming is disabled in demo mode")
+    c = await db.get(UnifiController, target_id)
+    if c is None:
+        raise HTTPException(status_code=404, detail="UniFi target not found")
+    was_enabled = c.block_sync_enabled
+    changes = body.model_dump(exclude_unset=True)
+    if "block_sync_enabled" in changes:
+        c.block_sync_enabled = bool(changes["block_sync_enabled"])
+    if "block_sync_site" in changes:
+        c.block_sync_site = (changes["block_sync_site"] or "default").strip() or "default"
+    if changes.get("block_sync_auth_kind"):
+        c.block_sync_auth_kind = changes["block_sync_auth_kind"]
+    if changes.get("block_sync_api_key"):
+        c.block_sync_api_key_encrypted = encrypt_str(changes["block_sync_api_key"])
+    if changes.get("block_sync_username"):
+        c.block_sync_username_encrypted = encrypt_str(changes["block_sync_username"])
+    if changes.get("block_sync_password"):
+        c.block_sync_password_encrypted = encrypt_str(changes["block_sync_password"])
+    if c.block_sync_enabled:
+        # Reuse the reconcile-side validator so arm-time and push-time agree —
+        # this also rejects the cloud-mode + user_password combo the reconciler
+        # refuses (previously armable but silently inert, #601 review).
+        cfg_err = unifi_config_error(c)
+        if cfg_err is not None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"cannot arm UniFi block sync: {cfg_err}",
+            )
+    _audit(
+        db,
+        user=user,
+        action="arm_target",
+        resource_id=str(c.id),
+        resource_display=f"unifi:{c.name}",
+        changed_fields=[
+            k
+            for k in changes
+            if k not in {"block_sync_api_key", "block_sync_username", "block_sync_password"}
+        ],
+        new_value={"block_sync_enabled": c.block_sync_enabled},
+    )
+    await db.commit()
+    await db.refresh(c)
+    if c.block_sync_enabled:
+        _enqueue_reconcile([("unifi", c.id)])
+    elif was_enabled:
+        _enqueue_lift([("unifi", c.id)])
+    return _unifi_target_out(c)
+
+
+@router.post(
+    "/targets/{target_kind}/{target_id}/reconcile",
+    response_model=TargetDiffOut,
+)
+async def reconcile_target(
+    target_kind: Literal["opnsense", "unifi"],
+    target_id: uuid.UUID,
+    db: DB,
+    user: ManageUser,
+    preview: Annotated[bool, Query()] = False,
+) -> TargetDiffOut:
+    """Force-converge one target. ``?preview=true`` reads the device +
+    returns the diff without pushing; otherwise it enqueues the reconcile."""
+    if target_kind == "opnsense":
+        r = await db.get(OPNsenseRouter, target_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="OPNsense target not found")
+        diff = await preview_opnsense(db, r, read_device=preview)
+    else:
+        c = await db.get(UnifiController, target_id)
+        if c is None:
+            raise HTTPException(status_code=404, detail="UniFi target not found")
+        diff = await preview_unifi(db, c)
+
+    if not preview and diff.error is None:
+        forbid_in_demo_mode("Block-sync writes are disabled in demo mode")
+        _enqueue_reconcile([(target_kind, target_id)])
+    return TargetDiffOut(
+        target_kind=diff.target_kind,
+        target_id=diff.target_id,
+        target_name=diff.target_name,
+        to_add=diff.to_add,
+        to_remove=diff.to_remove,
+        error=diff.error,
+    )
+
+
+@router.post("/targets/{target_kind}/{target_id}/reveal")
+async def reveal_credentials(
+    target_kind: Literal["opnsense", "unifi"],
+    target_id: uuid.UUID,
+    body: RevealRequest,
+    db: DB,
+    user: ManageUser,
+) -> dict[str, str]:
+    """Reveal the stored write-scoped secret after re-confirming the
+    operator (password / TOTP), mirroring the agent-bootstrap-key reveal.
+    Audited. ``manage_block_sync`` holders only (router-level gate)."""
+    outcome = reverify_operator(user, password=body.password, totp_code=body.totp_code)
+    if outcome is not ReauthOutcome.OK:
+        db.add(
+            AuditLog(
+                user_id=user.id,
+                user_display_name=user.display_name,
+                auth_source=user.auth_source,
+                action="block_sync_reveal_denied",
+                resource_type="network_block_target",
+                resource_id=str(target_id),
+                resource_display=f"{target_kind}:{target_id}",
+                result="forbidden",
+            )
+        )
+        await db.commit()
+        raise HTTPException(status_code=403, detail="Password or TOTP code is incorrect")
+
+    revealed: dict[str, str] = {}
+    if target_kind == "opnsense":
+        r = await db.get(OPNsenseRouter, target_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail="OPNsense target not found")
+        if r.block_sync_api_secret_encrypted:
+            revealed["api_secret"] = decrypt_str(r.block_sync_api_secret_encrypted)
+        name = r.name
+    else:
+        c = await db.get(UnifiController, target_id)
+        if c is None:
+            raise HTTPException(status_code=404, detail="UniFi target not found")
+        if c.block_sync_api_key_encrypted:
+            revealed["api_key"] = decrypt_str(c.block_sync_api_key_encrypted)
+        if c.block_sync_password_encrypted:
+            revealed["password"] = decrypt_str(c.block_sync_password_encrypted)
+        name = c.name
+
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=user.auth_source,
+            action="block_sync_reveal",
+            resource_type="network_block_target",
+            resource_id=str(target_id),
+            resource_display=f"{target_kind}:{name}",
+        )
+    )
+    await db.commit()
+    return revealed
+
+
+__all__ = ["router"]

--- a/backend/app/api/v1/change_requests/router.py
+++ b/backend/app/api/v1/change_requests/router.py
@@ -52,7 +52,11 @@ from app.services.ai.operations_control import (
     is_controls_protected,
     maybe_gate_control,
 )
-from app.services.approvals.policy import GATEABLE_ACTIONS, GATEABLE_RESOURCE_TYPES
+from app.services.approvals.policy import (
+    GATEABLE_ACTIONS,
+    GATEABLE_RESOURCE_TYPES,
+    gateable_pairs,
+)
 from app.services.approvals.service import (
     ChangeRequestStateError,
     DecisionError,
@@ -234,6 +238,20 @@ def _validate_gateable(action: str | None, resource_type: str | None) -> None:
                 f"{sorted(GATEABLE_RESOURCE_TYPES)}"
             ),
         )
+    # Both axes may individually be gateable while the PAIR maps to no
+    # registered risky operation (e.g. ('admin','subnet')). Such a policy
+    # would validate but ``match_policy`` could never select it — an
+    # enabled-but-inert fail-open. Reject the pair unless an op declares it.
+    if action is not None and resource_type is not None:
+        if (action, resource_type) not in gateable_pairs():
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"no risky operation gates ({action!r}, {resource_type!r}); a policy for "
+                    f"this pair would never fire — supported pairs: "
+                    f"{sorted(gateable_pairs())}"
+                ),
+            )
 
 
 def _require_read(user: CurrentUser) -> None:

--- a/backend/app/api/v1/new_devices/router.py
+++ b/backend/app/api/v1/new_devices/router.py
@@ -13,7 +13,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, model_validator
 from sqlalchemy import String, and_, cast, func, or_, select
 from sqlalchemy.exc import IntegrityError
@@ -80,12 +80,24 @@ class BlockBody(BaseModel):
     group_id: uuid.UUID | None = None  # None → block in every DHCP server group
     reason: str = "other"
     description: str = ""
+    # #601 — also push an upstream MAC quarantine (UniFi block-sta) via the
+    # active block-sync surface. Only takes effect when the
+    # ``security.block_sync`` module is on, the caller holds
+    # ``manage_block_sync``, and at least one UniFi target is armed —
+    # otherwise it is ignored (the DHCP block still lands). A DHCP block
+    # only starves the device of a lease; a self-assigned static IP walks
+    # right past it, which is exactly the gap this closes.
+    block_upstream: bool = False
 
 
 class BlockResult(BaseModel):
     mac_address: str
     blocked_group_ids: list[uuid.UUID]
     already_blocked_group_ids: list[uuid.UUID]
+    # Set when ``block_upstream`` produced an active network block (or queued
+    # one for two-person approval).
+    upstream_block_created: bool = False
+    upstream_change_request_id: str | None = None
 
 
 class AllowlistOut(BaseModel):
@@ -402,10 +414,14 @@ async def delete_allowlist(allowlist_id: uuid.UUID, db: DB, user: WriteUser) -> 
 
 
 @router.post("/block", response_model=BlockResult)
-async def block_mac(body: BlockBody, db: DB, user: WriteUser) -> BlockResult:
+async def block_mac(body: BlockBody, db: DB, user: WriteUser, request: Request) -> BlockResult:
     """Block a MAC in one DHCP server group (or all groups when ``group_id`` is
     omitted) — arpwatch with teeth. Creates ``dhcp_mac_block`` rows + wakes the
-    affected agents."""
+    affected agents.
+
+    With ``block_upstream=True`` (#601) it *also* pushes an L2 quarantine to
+    every armed UniFi target through the active block-sync surface — closing
+    the "device self-assigns a static IP and walks past the DHCP block" gap."""
     if body.group_id is not None:
         group_ids = [body.group_id]
         if await db.get(DHCPServerGroup, body.group_id) is None:
@@ -455,11 +471,65 @@ async def block_mac(body: BlockBody, db: DB, user: WriteUser) -> BlockResult:
             new_value={"mac_address": body.mac_address, "blocked_groups": len(blocked)},
         )
     await db.commit()
+
+    upstream_created = False
+    upstream_cr: str | None = None
+    if body.block_upstream:
+        upstream_created, upstream_cr = await _maybe_block_upstream(db, user, request, body)
+
     return BlockResult(
         mac_address=body.mac_address,
         blocked_group_ids=blocked,
         already_blocked_group_ids=list(already),
+        upstream_block_created=upstream_created,
+        upstream_change_request_id=upstream_cr,
     )
+
+
+async def _maybe_block_upstream(
+    db: DB, user: User, request: Request, body: BlockBody
+) -> tuple[bool, str | None]:
+    """Create a MAC-kind ``network_block`` (source=new_device) so armed UniFi
+    targets quarantine the device. Silently no-ops unless the block-sync
+    module is on, the caller holds ``manage_block_sync``, and a target is
+    armed. Routes through the two-person approval gate like the dedicated
+    block-sync surface — returns ``(created, change_request_id)``."""
+    from app.core.permissions import user_has_permission
+    from app.services.ai.operations import get_operation
+    from app.services.ai.operations_risky import CreateNetworkBlockArgs
+    from app.services.approvals.gate import gate_or_execute
+    from app.services.block_sync.reconcile import applicable_targets_for_kind
+    from app.services.feature_modules import is_module_enabled
+
+    # All three gates are "ignore, don't fail" per the BlockBody contract:
+    # the DHCP block has already committed, so a hard error here would report
+    # total failure for a partial success. Missing the manage_block_sync
+    # permission is treated the same as the module being off — the upstream
+    # push is simply skipped (the frontend only offers the checkbox when the
+    # module is on; a caller without the permission just gets no upstream
+    # block, matching the documented "otherwise it is ignored" behaviour).
+    if not await is_module_enabled(db, "security.block_sync"):
+        return False, None
+    if not user_has_permission(user, "admin", "manage_block_sync"):
+        return False, None
+    if not await applicable_targets_for_kind(db, "mac"):
+        return False, None  # nothing armed — DHCP block still applies
+
+    op = get_operation("create_network_block")
+    assert op is not None
+    args = CreateNetworkBlockArgs(
+        kind="mac",
+        value=body.mac_address,
+        reason=body.reason if body.reason != "other" else "quarantine",
+        description=body.description or "Blocked from new-device review (#459/#601)",
+        source="new_device",
+        source_ref=body.mac_address,
+    )
+    pending = await gate_or_execute(db, user, request, operation=op, args=args)
+    if pending is not None:
+        return False, str(pending.change_request_id)
+    await op.apply(db, user, args)
+    return True, None
 
 
 # Keep ``normalize_oui_prefix`` reachable for tests that exercise the parser.

--- a/backend/app/api/v1/opnsense/router.py
+++ b/backend/app/api/v1/opnsense/router.py
@@ -396,6 +396,20 @@ async def delete_router(router_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
     r = await db.get(OPNsenseRouter, router_id)
     if r is None:
         raise HTTPException(status_code=404, detail="OPNsense firewall not found")
+    # #601 — sweep any active block-sync push rows for this target. They have no
+    # FK to opnsense_router (target_id is polymorphic), so nothing cascades.
+    # NOTE: this does NOT lift the blocks off the firewall — disarm the target
+    # first (which lifts) if the device should stop enforcing them.
+    from sqlalchemy import delete as sa_delete  # noqa: PLC0415
+
+    from app.models.block_sync import NetworkBlockPush  # noqa: PLC0415
+
+    await db.execute(
+        sa_delete(NetworkBlockPush).where(
+            NetworkBlockPush.target_kind == "opnsense",
+            NetworkBlockPush.target_id == r.id,
+        )
+    )
     _audit(db, user=user, action="delete", router_id=r.id, router_name=r.name)
     await db.delete(r)
     await db.commit()

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -21,6 +21,7 @@ from app.api.v1.auth.router import router as auth_router
 from app.api.v1.auth_providers.router import router as auth_providers_router
 from app.api.v1.backup import router as backup_router
 from app.api.v1.bgp import router as bgp_router
+from app.api.v1.block_sync import router as block_sync_router
 from app.api.v1.change_requests import router as change_requests_router
 from app.api.v1.circuits import router as circuits_router
 from app.api.v1.cloud import router as cloud_router
@@ -323,6 +324,10 @@ api_v1_router.include_router(
 api_v1_router.include_router(
     new_devices_router,
     dependencies=[Depends(require_module("security.new_device_watch"))],
+)
+api_v1_router.include_router(
+    block_sync_router,
+    dependencies=[Depends(require_module("security.block_sync"))],
 )
 api_v1_router.include_router(
     nmap_router,

--- a/backend/app/api/v1/unifi/router.py
+++ b/backend/app/api/v1/unifi/router.py
@@ -766,6 +766,19 @@ async def delete_controller(controller_id: uuid.UUID, db: DB, user: SuperAdmin) 
     c = await db.get(UnifiController, controller_id)
     if c is None:
         raise HTTPException(status_code=404, detail="UniFi controller not found")
+    # #601 — sweep any active block-sync push rows for this target (polymorphic
+    # target_id, no cascade). Disarm the target first if the controller should
+    # stop quarantining the MACs (disarm lifts them; delete does not).
+    from sqlalchemy import delete as sa_delete  # noqa: PLC0415
+
+    from app.models.block_sync import NetworkBlockPush  # noqa: PLC0415
+
+    await db.execute(
+        sa_delete(NetworkBlockPush).where(
+            NetworkBlockPush.target_kind == "unifi",
+            NetworkBlockPush.target_id == c.id,
+        )
+    )
     _audit(db, user=user, action="delete", controller_id=c.id, controller_name=c.name)
     await db.delete(c)
     await db.commit()

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -45,6 +45,7 @@ celery_app = Celery(
         "app.tasks.tailscale_sync",
         "app.tasks.netbird_sync",
         "app.tasks.unifi_sync",
+        "app.tasks.block_sync",
         "app.tasks.cloud_sync",
         "app.tasks.snmp_poll",
         "app.tasks.nmap",
@@ -109,6 +110,7 @@ celery_app.conf.update(
         "app.tasks.docker_sync.*": {"queue": "default"},
         "app.tasks.proxmox_sync.*": {"queue": "default"},
         "app.tasks.opnsense_sync.*": {"queue": "default"},
+        "app.tasks.block_sync.*": {"queue": "default"},
         "app.tasks.tailscale_sync.*": {"queue": "default"},
         "app.tasks.netbird_sync.*": {"queue": "default"},
         "app.tasks.unifi_sync.*": {"queue": "default"},
@@ -391,6 +393,15 @@ celery_app.conf.update(
         "opnsense-sync-sweep": {
             "task": "app.tasks.opnsense_sync.sweep_opnsense_routers",
             "schedule": schedule(run_every=30.0),
+        },
+        # Active block sync (#601) — converge SpatiumDDI-owned network
+        # blocks onto every armed OPNsense/UniFi target. 60 s cadence
+        # (enforcement, not discovery — the on-create/lift path handles
+        # immediacy). Gated by the ``security.block_sync`` feature module
+        # + each target's own ``block_sync_enabled`` master switch.
+        "block-sync-sweep": {
+            "task": "app.tasks.block_sync.sweep_block_sync",
+            "schedule": schedule(run_every=60.0),
         },
         # Tailscale — same 30 s beat, per-tenant interval gate.
         # Gated overall by ``PlatformSettings.integration_tailscale_enabled``.

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -740,6 +740,7 @@ def require_any_resource_or_scoped(
 # `docs/PERMISSIONS.md` honest as new ones land.
 KNOWN_MANAGE_PERMISSIONS: frozenset[str] = frozenset(
     {
+        "manage_block_sync",
         "manage_dns_pools",
         "manage_domains",
         "manage_network_devices",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -237,6 +237,7 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
             {"action": "admin", "resource_type": "manage_network_devices"},
             {"action": "admin", "resource_type": "manage_nmap_scans"},
             {"action": "admin", "resource_type": "manage_packet_capture"},
+            {"action": "admin", "resource_type": "manage_block_sync"},
             {"action": "admin", "resource_type": "use_network_tools"},
             {"action": "admin", "resource_type": "manage_asns"},
             {"action": "admin", "resource_type": "vrf"},

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -23,6 +23,7 @@ from app.models.backup import BackupTarget
 from app.models.base import Base
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
 from app.models.bgp_monitor import BGPHijackDetection, BGPTrackedPrefix
+from app.models.block_sync import NetworkBlock, NetworkBlockPush
 from app.models.change_request import ApprovalPolicy, ChangeRequest
 from app.models.circuit import Circuit
 from app.models.cloud import CloudEndpoint
@@ -157,6 +158,8 @@ __all__ = [
     "BGPPeering",
     "BGPTrackedPrefix",
     "BGPHijackDetection",
+    "NetworkBlock",
+    "NetworkBlockPush",
     "LookingGlassCollector",
     "BGPLGPeer",
     "BGPLGRoute",

--- a/backend/app/models/block_sync.py
+++ b/backend/app/models/block_sync.py
@@ -1,0 +1,161 @@
+"""Active block-sync — SpatiumDDI-owned network-block desired state (#601).
+
+This is the *enforcement* half of the detection→block loop. Where the
+integration mirrors (OPNsense #31 / UniFi #30) pull ``source → IPAM``
+read-only, this model is the deliberate, guarded exception that pushes
+``decision → source``: a SpatiumDDI-owned set of blocked IPs / MACs that
+a reconciler converges onto each *armed* upstream target (an OPNsense
+firewall table alias, a UniFi client quarantine).
+
+Two tables:
+
+* ``network_block`` — the desired state. One row per blocked value
+  (``kind`` = ``ip`` | ``mac``). ``enabled`` + ``expires_at`` gate
+  whether the value should currently be enforced anywhere.
+* ``network_block_push`` — per-(block, target) convergence state. The
+  reconciler is target-driven: for each armed target it ensures every
+  applicable enabled block is present on the device and every push row
+  whose block is disabled / expired / deleted is removed. The row
+  carries ``push_status`` + ``last_error`` so the UI can show exactly
+  where each block landed.
+
+Guardrails live one layer up (feature module ``security.block_sync``,
+per-target ``block_sync_enabled`` master switch, distinct write-scoped
+credentials, ``manage_block_sync`` RBAC + approval-workflow gating). The
+row itself is pure intent — an out-of-band reconciler does the pushing,
+mirroring the ``dhcp_mac_block`` → Kea-DROP-class shape.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy import text as sa_text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+# ``kind`` values — an L3 address block (OPNsense alias membership) or an
+# L2 MAC quarantine (UniFi block-sta). Firewall targets consume ``ip``;
+# gateway/AP targets consume ``mac``.
+BLOCK_KINDS: tuple[str, ...] = ("ip", "mac")
+
+# Where the block originated. Drives provenance + the one-click wiring
+# from the new-device review queue (#459) / rogue-DHCP detection (#370).
+BLOCK_SOURCES: tuple[str, ...] = ("manual", "new_device", "rogue_dhcp")
+
+# Per-(block, target) push lifecycle.
+#   pending   — queued, not yet confirmed on the device
+#   pushed    — present on the device (converged)
+#   removing  — block was lifted; the IP/MAC still needs removing upstream
+#   error     — last push/remove attempt failed (see ``last_error``)
+PUSH_STATUSES: tuple[str, ...] = ("pending", "pushed", "removing", "error")
+
+# Target kinds a push row can point at. Loose (no cross-table FK) because
+# the target is polymorphic across ``opnsense_router`` / ``unifi_controller``.
+BLOCK_TARGET_KINDS: tuple[str, ...] = ("opnsense", "unifi")
+
+
+class NetworkBlock(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A single blocked IP or MAC — SpatiumDDI's desired-state intent."""
+
+    __tablename__ = "network_block"
+    __table_args__ = (
+        UniqueConstraint("kind", "value", name="uq_network_block_kind_value"),
+        Index("ix_network_block_enabled", "enabled"),
+    )
+
+    # ``ip`` | ``mac`` — validated at the API layer against ``BLOCK_KINDS``.
+    kind: Mapped[str] = mapped_column(String(8), nullable=False)
+    # Normalised value: a bare IP (``10.0.0.5``) for ``kind="ip"`` or a
+    # canonical lowercase colon MAC (``aa:bb:cc:dd:ee:ff``) for ``kind="mac"``.
+    value: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    # Free-text operator reason bucket (rogue / lost_stolen / quarantine /
+    # policy / other) — mirrors ``dhcp_mac_block.reason`` semantics.
+    reason: Mapped[str] = mapped_column(String(32), nullable=False, default="quarantine")
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    # Provenance — where this block came from + an opaque back-reference
+    # (a new-device sighting id, a rogue responder id, …) for audit trails.
+    source: Mapped[str] = mapped_column(String(16), nullable=False, default="manual")
+    source_ref: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Desired-state flags. ``enabled=False`` or an ``expires_at`` in the past
+    # means the reconciler should lift this block from every target it landed
+    # on (it does NOT delete the row — history stays for audit).
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+    updated_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+
+
+class NetworkBlockPush(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """Per-(block, target) convergence state.
+
+    ``target_id`` is the ``opnsense_router.id`` / ``unifi_controller.id``
+    this block was pushed to. No cross-table FK (polymorphic), so nothing
+    cascades from a target delete — instead the OPNsense / UniFi delete
+    handlers explicitly sweep the matching push rows (and an operator is
+    expected to *disarm* a target first, which lifts the blocks off the
+    device via ``lift_all_for_target``; a bare delete removes the rows but
+    leaves the device state).
+
+    ``block_id`` IS ``ON DELETE CASCADE``: a block is normally *lifted*
+    (``enabled=False``, row kept) rather than hard-deleted, and the
+    reconciler removes the device entry before the disabled row is ever
+    reaped — so the cascade only fires once the value is already gone from
+    every device. A raw hard-delete of a still-active block (manual DB /
+    factory reset) is the one path that can strand a device entry; those
+    flows should lift first.
+    """
+
+    __tablename__ = "network_block_push"
+    __table_args__ = (
+        UniqueConstraint(
+            "block_id", "target_kind", "target_id", name="uq_network_block_push_block_target"
+        ),
+        Index("ix_network_block_push_target", "target_kind", "target_id"),
+    )
+
+    block_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("network_block.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    target_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+
+    push_status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="pending", server_default=sa_text("'pending'")
+    )
+    last_pushed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+__all__ = [
+    "BLOCK_KINDS",
+    "BLOCK_SOURCES",
+    "BLOCK_TARGET_KINDS",
+    "PUSH_STATUSES",
+    "NetworkBlock",
+    "NetworkBlockPush",
+]

--- a/backend/app/models/opnsense.py
+++ b/backend/app/models/opnsense.py
@@ -101,6 +101,40 @@ class OPNsenseRouter(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # 30 s beat tick.
     sync_interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=60)
 
+    # ── Active block sync (#601 — enforcement write-back) ────────────
+    # The mirror above stays strictly read-only. This block is a
+    # SEPARATE, opt-in write capability that pushes SpatiumDDI's
+    # ``network_block`` desired-state (IPs) into an operator-pre-created
+    # OPNsense firewall *table alias*. SpatiumDDI only ever mutates alias
+    # membership (add/delete + reconfigure) — never rule CRUD.
+    #
+    # ``block_sync_enabled`` is the per-target master switch — default
+    # OFF, independent of both ``enabled`` (mirror) and the
+    # ``integrations.opnsense`` feature module. Nothing is ever pushed
+    # unless an operator explicitly arms this AND the
+    # ``security.block_sync`` module is on.
+    block_sync_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    # Distinct WRITE-scoped credentials. The read mirror only needs a
+    # read-only API user; enforcement needs a Firewall-privileged user.
+    # When empty, the reconciler refuses to push (it does NOT silently
+    # fall back to the read creds). Same Basic-auth shape as above.
+    block_sync_api_key: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    block_sync_api_secret_encrypted: Mapped[bytes] = mapped_column(
+        LargeBinary, nullable=False, default=b"", server_default=sa_text("''::bytea")
+    )
+    # The OPNsense table alias SpatiumDDI mutates (e.g. ``spatiumddi_blocked``).
+    # The operator pre-creates one block rule referencing this alias; we
+    # add/remove IPs to converge. Empty = not configured (reconcile no-ops).
+    block_alias_name: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+
+    # Block-sync convergence state (surfaced in the UI).
+    last_block_sync_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_block_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # ── Sync state ──────────────────────────────────────────────────
     last_synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/unifi.py
+++ b/backend/app/models/unifi.py
@@ -145,6 +145,47 @@ class UnifiController(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # ``mode="cloud"`` so we don't hammer api.ui.com (it rate-limits).
     sync_interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=60)
 
+    # ── Active block sync (#601 — enforcement write-back) ────────────
+    # The mirror above stays strictly read-only. This block is a
+    # SEPARATE, opt-in write capability that quarantines a device at L2
+    # via the controller's ``cmd/stamgr`` ``block-sta`` / ``unblock-sta``
+    # command (the same call the UniFi UI issues). It consumes MAC-kind
+    # ``network_block`` rows.
+    #
+    # ``block_sync_enabled`` is the per-target master switch — default
+    # OFF, independent of ``enabled`` (mirror) and the
+    # ``integrations.unifi`` feature module.
+    block_sync_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    # Distinct WRITE-scoped credentials — the public Integration v1 API
+    # does NOT expose client-block, so the write path is the legacy
+    # controller API and needs an admin key / admin login. Same auth
+    # shapes as the read creds above but stored separately; the reconciler
+    # refuses to push when the required secret for ``block_sync_auth_kind``
+    # is empty (no fallback to read creds).
+    block_sync_auth_kind: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="api_key", server_default=sa_text("'api_key'")
+    )
+    block_sync_api_key_encrypted: Mapped[bytes] = mapped_column(
+        LargeBinary, nullable=False, default=b"", server_default=sa_text("''::bytea")
+    )
+    block_sync_username_encrypted: Mapped[bytes] = mapped_column(
+        LargeBinary, nullable=False, default=b"", server_default=sa_text("''::bytea")
+    )
+    block_sync_password_encrypted: Mapped[bytes] = mapped_column(
+        LargeBinary, nullable=False, default=b"", server_default=sa_text("''::bytea")
+    )
+    # The site (legacy short id, e.g. ``default``) whose ``stamgr`` command
+    # endpoint receives the block. Empty = ``default``.
+    block_sync_site: Mapped[str] = mapped_column(String(64), nullable=False, default="default")
+
+    # Block-sync convergence state (surfaced in the UI).
+    last_block_sync_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_block_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # ── Sync state ──────────────────────────────────────────────────
     last_synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -1092,8 +1092,8 @@ async def _apply_create_network_block(
         for target_kind, target_id in targets:
             try:
                 reconcile_target_now.delay(target_kind, str(target_id))
-            except Exception:  # noqa: BLE001
-                pass
+            except Exception:  # noqa: BLE001 — broker unavailable; the 60 s
+                pass  # sweep converges this target, so a lost enqueue is safe
     except Exception:  # noqa: BLE001 — task import/broker issues never fail the write
         pass
 

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -50,6 +50,7 @@ row before the commit inside ``apply()``).
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -971,6 +972,146 @@ _OP_DELETE_GROUP = Operation(
 register(_OP_DELETE_GROUP)
 
 
+# ── create_network_block (active block sync #601) ───────────────────────────
+#
+# Unlike the six deletes, this is a *create* — but it is a genuine risky op:
+# a network block, once armed, pushes a real firewall/gateway block that can
+# lock a device (or the operator) out of the network. Gating it through the
+# same two-person workflow is the issue's explicit guardrail #6. The op body
+# does the network_block upsert + audit + immediate reconcile-enqueue; the
+# router delegates to it on the inline path and the approve endpoint replays
+# it under the approver's identity.
+
+
+class CreateNetworkBlockArgs(BaseModel):
+    kind: str
+    value: str
+    reason: str = "quarantine"
+    description: str = ""
+    source: str = "manual"
+    source_ref: str | None = None
+    expires_at: datetime | None = None
+
+
+async def _preview_create_network_block(
+    db: AsyncSession, user: User, args: CreateNetworkBlockArgs
+) -> PreviewResult:
+    from app.models.block_sync import BLOCK_KINDS, BLOCK_SOURCES
+    from app.services.block_sync.reconcile import (
+        applicable_targets_for_kind,
+        normalize_block_value,
+    )
+
+    if args.kind not in BLOCK_KINDS:
+        return PreviewResult(ok=False, detail=f"kind must be one of {BLOCK_KINDS}")
+    if args.source not in BLOCK_SOURCES:
+        return PreviewResult(ok=False, detail=f"source must be one of {BLOCK_SOURCES}")
+    try:
+        value = normalize_block_value(args.kind, args.value)
+    except ValueError as exc:
+        return PreviewResult(ok=False, detail=str(exc))
+    targets = await applicable_targets_for_kind(db, args.kind)
+    names = ", ".join(f"{tk}:{tid}" for tk, tid in targets) or "no armed targets"
+    return PreviewResult(
+        ok=True,
+        detail="ready",
+        preview_text=(
+            f"Block {args.kind} `{value}` and push to {len(targets)} armed " f"target(s) ({names})"
+        ),
+    )
+
+
+async def _apply_create_network_block(
+    db: AsyncSession, user: User, args: CreateNetworkBlockArgs
+) -> dict[str, Any]:
+    from app.models.audit import AuditLog
+    from app.models.block_sync import NetworkBlock
+    from app.services.block_sync.reconcile import (
+        applicable_targets_for_kind,
+        normalize_block_value,
+    )
+
+    value = normalize_block_value(args.kind, args.value)
+    existing = (
+        await db.execute(
+            select(NetworkBlock).where(NetworkBlock.kind == args.kind, NetworkBlock.value == value)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        existing.enabled = True
+        existing.reason = args.reason
+        existing.description = args.description
+        existing.source = args.source
+        existing.source_ref = args.source_ref
+        existing.expires_at = args.expires_at
+        existing.updated_by_user_id = user.id
+        block = existing
+        action = "update"
+    else:
+        block = NetworkBlock(
+            kind=args.kind,
+            value=value,
+            reason=args.reason,
+            description=args.description,
+            source=args.source,
+            source_ref=args.source_ref,
+            enabled=True,
+            expires_at=args.expires_at,
+            created_by_user_id=user.id,
+            updated_by_user_id=user.id,
+        )
+        db.add(block)
+        action = "create"
+    await db.flush()
+
+    targets = await applicable_targets_for_kind(db, args.kind)
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=user.auth_source,
+            action=action,
+            resource_type="network_block",
+            resource_id=str(block.id),
+            resource_display=f"{args.kind}:{value}",
+            new_value={
+                "kind": args.kind,
+                "value": value,
+                "reason": args.reason,
+                "source": args.source,
+                "targets": len(targets),
+            },
+        )
+    )
+    await db.commit()
+
+    # Immediate converge on each armed target (broker-down → 60 s sweep).
+    try:
+        from app.tasks.block_sync import reconcile_target_now  # noqa: PLC0415
+
+        for target_kind, target_id in targets:
+            try:
+                reconcile_target_now.delay(target_kind, str(target_id))
+            except Exception:  # noqa: BLE001
+                pass
+    except Exception:  # noqa: BLE001 — task import/broker issues never fail the write
+        pass
+
+    return {"block_id": str(block.id), "kind": args.kind, "value": value, "mode": action}
+
+
+_OP_CREATE_NETWORK_BLOCK = Operation(
+    name="create_network_block",
+    description="Create/arm a network block (IP or MAC) and push it to armed OPNsense/UniFi targets.",
+    args_model=CreateNetworkBlockArgs,
+    preview=_preview_create_network_block,
+    apply=_apply_create_network_block,
+    category="security",
+    required_permission=("admin", "manage_block_sync"),
+)
+register(_OP_CREATE_NETWORK_BLOCK)
+
+
 # Registry-completeness anchor for the startup assertion (sibling slice):
 # every operation name the seeded policies reference must exist here.
 RISKY_OPERATION_NAMES: frozenset[str] = frozenset(
@@ -981,6 +1122,7 @@ RISKY_OPERATION_NAMES: frozenset[str] = frozenset(
         "delete_zone",
         "delete_scope",
         "delete_group",
+        "create_network_block",
     }
 )
 

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -17,6 +17,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     bgp,
     bgp_lg,
     bgp_monitor,
+    block_sync,
     certificates,
     changes,
     conformity,

--- a/backend/app/services/ai/tools/block_sync.py
+++ b/backend/app/services/ai/tools/block_sync.py
@@ -1,0 +1,230 @@
+"""Operator Copilot tools for active block sync (#601).
+
+All carry ``module="security.block_sync"`` so disabling the (default-off)
+feature module strips them from the AI surface (NN #14).
+
+Reads (default-enabled) — answer "what's blocked?" / "how many blocks are
+pushed vs errored?":
+
+* ``find_network_blocks`` — list SpatiumDDI-owned IP/MAC blocks + per-target
+  push status.
+* ``count_network_blocks`` — counts by kind + enabled state.
+
+Propose write (default-DISABLED per NN #13 — broad blast radius + an
+off-prem firewall/gateway write): the model surfaces a create as a
+propose→Apply card; the tool itself only persists a proposal. The real
+mutation lands only when a human clicks Apply, which routes through the
+same ``create_network_block`` operation the REST endpoint uses (and its
+two-person approval gate when armed).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.block_sync import NetworkBlock, NetworkBlockPush
+from app.services.ai import operations
+from app.services.ai.operations_risky import CreateNetworkBlockArgs
+from app.services.ai.tools.base import register_tool
+
+MODULE = "security.block_sync"
+
+
+# ── find_network_blocks ──────────────────────────────────────────────
+
+
+class FindNetworkBlocksArgs(BaseModel):
+    kind: str | None = Field(
+        default=None, description="Filter to one kind: 'ip' or 'mac'. Omit for both."
+    )
+    enabled_only: bool = Field(
+        default=False, description="When true, only currently-enforced (enabled) blocks."
+    )
+    value_contains: str | None = Field(
+        default=None, description="Substring match on the blocked IP/MAC value."
+    )
+    limit: int = Field(default=50, ge=1, le=200)
+
+
+@register_tool(
+    name="find_network_blocks",
+    description=(
+        "List SpatiumDDI-owned active network blocks (blocked IPs / MACs) "
+        "and where each has been pushed — the enforcement half of the "
+        "detect→block loop (#601). Each row carries kind, value, reason, "
+        "source (manual / new_device / rogue_dhcp), enabled state, optional "
+        "expiry, and the per-target push status (pushed / pending / error) "
+        "on each armed OPNsense firewall / UniFi controller. Use for 'what's "
+        "blocked upstream?' or 'did the block for aa:bb:… land?'. Read-only."
+    ),
+    args_model=FindNetworkBlocksArgs,
+    category="read",
+    default_enabled=True,
+    module=MODULE,
+)
+async def find_network_blocks(
+    db: AsyncSession, user: User, args: FindNetworkBlocksArgs
+) -> dict[str, Any]:
+    stmt = select(NetworkBlock)
+    if args.kind is not None:
+        stmt = stmt.where(NetworkBlock.kind == args.kind)
+    if args.enabled_only:
+        stmt = stmt.where(NetworkBlock.enabled.is_(True))
+    if args.value_contains:
+        stmt = stmt.where(NetworkBlock.value.ilike(f"%{args.value_contains}%"))
+    stmt = stmt.order_by(NetworkBlock.created_at.desc()).limit(args.limit)
+    blocks = list((await db.execute(stmt)).scalars().all())
+
+    pushes: dict[Any, list[NetworkBlockPush]] = {}
+    if blocks:
+        rows = (
+            (
+                await db.execute(
+                    select(NetworkBlockPush).where(
+                        NetworkBlockPush.block_id.in_([b.id for b in blocks])
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for p in rows:
+            pushes.setdefault(p.block_id, []).append(p)
+
+    return {
+        "network_blocks": [
+            {
+                "id": str(b.id),
+                "kind": b.kind,
+                "value": b.value,
+                "reason": b.reason,
+                "description": b.description,
+                "source": b.source,
+                "enabled": b.enabled,
+                "expires_at": b.expires_at.isoformat() if b.expires_at else None,
+                "pushes": [
+                    {
+                        "target_kind": p.target_kind,
+                        "target_id": str(p.target_id),
+                        "push_status": p.push_status,
+                        "last_error": p.last_error,
+                    }
+                    for p in pushes.get(b.id, [])
+                ],
+            }
+            for b in blocks
+        ],
+        "count": len(blocks),
+    }
+
+
+# ── count_network_blocks ─────────────────────────────────────────────
+
+
+class CountNetworkBlocksArgs(BaseModel):
+    pass
+
+
+@register_tool(
+    name="count_network_blocks",
+    description=(
+        "Count active network blocks (#601) grouped by kind (ip / mac) and "
+        "enabled state, plus push-status totals across all armed targets. "
+        "Use to size the enforcement set. Read-only."
+    ),
+    args_model=CountNetworkBlocksArgs,
+    category="read",
+    default_enabled=True,
+    module=MODULE,
+)
+async def count_network_blocks(
+    db: AsyncSession, user: User, args: CountNetworkBlocksArgs
+) -> dict[str, Any]:
+    by_kind: dict[str, int] = {}
+    for kind, n in (
+        await db.execute(
+            select(NetworkBlock.kind, func.count(NetworkBlock.id)).group_by(NetworkBlock.kind)
+        )
+    ).all():
+        by_kind[kind] = int(n)
+    enabled = (
+        await db.execute(select(func.count(NetworkBlock.id)).where(NetworkBlock.enabled.is_(True)))
+    ).scalar_one()
+    by_push: dict[str, int] = {}
+    for st, n in (
+        await db.execute(
+            select(NetworkBlockPush.push_status, func.count(NetworkBlockPush.id)).group_by(
+                NetworkBlockPush.push_status
+            )
+        )
+    ).all():
+        by_push[st] = int(n)
+    return {
+        "total": sum(by_kind.values()),
+        "enabled": int(enabled),
+        "by_kind": by_kind,
+        "by_push_status": by_push,
+    }
+
+
+# ── propose_create_network_block (default-DISABLED) ──────────────────
+
+
+@register_tool(
+    name="propose_create_network_block",
+    description=(
+        "Prepare a proposal to create/arm an active network block (#601) — a "
+        "blocked IP (pushed to armed OPNsense firewall aliases) or MAC "
+        "(pushed as an L2 quarantine on armed UniFi controllers). Pass "
+        "kind ('ip'|'mac'), value, and optional reason / description / "
+        "source. The proposal must be applied by a human operator clicking "
+        "Apply; the real write routes through the create_network_block "
+        "operation (including its two-person approval gate when a policy "
+        "matches). Default-disabled: enabling it lets the copilot stage "
+        "firewall/gateway blocks (broad blast radius + off-prem write). "
+        "Returns a kind='proposal' card."
+    ),
+    args_model=CreateNetworkBlockArgs,
+    writes=False,  # The propose tool is read-only; Apply performs the write.
+    category="ops",
+    default_enabled=False,
+    module=MODULE,
+)
+async def propose_create_network_block(
+    db: AsyncSession, user: User, args: CreateNetworkBlockArgs
+) -> dict[str, Any]:
+    from app.services.ai.tools.proposals import (  # noqa: PLC0415
+        _persist_proposal,
+        _proposal_result,
+    )
+
+    op = operations.get_operation("create_network_block")
+    if op is None:  # pragma: no cover — registered at import
+        return {"error": "Operation 'create_network_block' is not registered"}
+    preview = await op.preview(db, user, args)
+    if not preview.ok:
+        return {
+            "kind": "proposal_rejected",
+            "operation": "create_network_block",
+            "detail": preview.detail,
+        }
+    proposal = await _persist_proposal(
+        db,
+        user=user,
+        operation="create_network_block",
+        args=args.model_dump(mode="json"),
+        preview_text=preview.preview_text,
+    )
+    return _proposal_result(proposal, preview_text=preview.preview_text)
+
+
+__all__ = [
+    "count_network_blocks",
+    "find_network_blocks",
+    "propose_create_network_block",
+]

--- a/backend/app/services/approvals/policy.py
+++ b/backend/app/services/approvals/policy.py
@@ -30,10 +30,43 @@ logger = structlog.get_logger(__name__)
 # that isn't wired yet (the fail-open #2/#4 the seed used to ship). P2 widens
 # both sets as bulk_delete / bulk_edit / bulk_allocate / factory_reset /
 # import_commit ops land their gate threading.
-GATEABLE_ACTIONS: frozenset[str] = frozenset({"delete"})
+GATEABLE_ACTIONS: frozenset[str] = frozenset({"delete", "admin"})
 GATEABLE_RESOURCE_TYPES: frozenset[str] = frozenset(
-    {"subnet", "ip_block", "ip_space", "dns_zone", "dhcp_scope", "dhcp_server_group"}
+    {
+        "subnet",
+        "ip_block",
+        "ip_space",
+        "dns_zone",
+        "dhcp_scope",
+        "dhcp_server_group",
+        # #601 — active block sync: creating/arming a network block pushes a
+        # real firewall/gateway block (broad blast radius), so it is a
+        # two-person-rule candidate. Gated as ``admin:manage_block_sync``.
+        "manage_block_sync",
+    }
 )
+
+
+def gateable_pairs() -> frozenset[tuple[str, str]]:
+    """The ``(action, resource_type)`` pairs an ENABLED policy can actually
+    gate — exactly those declared by a registered risky ``Operation``.
+
+    Validating a policy against these PAIRS (not the two axes independently)
+    is what prevents an enabled-but-inert policy: once ``GATEABLE_ACTIONS`` /
+    ``GATEABLE_RESOURCE_TYPES`` hold more than one value each, their product
+    admits cross pairs like ``(admin, subnet)`` or ``(delete, manage_block_
+    sync)`` that no op declares, so ``match_policy`` could never select them
+    and the operator would get silent, false protection (#601 review).
+    """
+    from app.services.ai.operations import get_operation  # noqa: PLC0415
+    from app.services.ai.operations_risky import RISKY_OPERATION_NAMES  # noqa: PLC0415
+
+    pairs: set[tuple[str, str]] = set()
+    for name in RISKY_OPERATION_NAMES:
+        op = get_operation(name)
+        if op is not None and op.required_permission is not None:
+            pairs.add(op.required_permission)
+    return frozenset(pairs)
 
 
 async def match_policy(
@@ -114,4 +147,4 @@ def _is_stronger(candidate: ApprovalPolicy, current: ApprovalPolicy, resource_ty
     return candidate.min_count < current.min_count
 
 
-__all__ = ["GATEABLE_ACTIONS", "GATEABLE_RESOURCE_TYPES", "match_policy"]
+__all__ = ["GATEABLE_ACTIONS", "GATEABLE_RESOURCE_TYPES", "gateable_pairs", "match_policy"]

--- a/backend/app/services/block_sync/__init__.py
+++ b/backend/app/services/block_sync/__init__.py
@@ -1,0 +1,5 @@
+"""Active block sync (#601) — write-back enforcement service.
+
+Converges SpatiumDDI's ``network_block`` desired-state onto armed
+OPNsense / UniFi targets. See ``reconcile.py`` for the engine.
+"""

--- a/backend/app/services/block_sync/reconcile.py
+++ b/backend/app/services/block_sync/reconcile.py
@@ -31,7 +31,6 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
-import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -43,8 +42,6 @@ from app.models.unifi import UnifiController
 from app.services.opnsense.client import OPNsenseClient, OPNsenseClientError
 from app.services.oui import normalize_mac_key
 from app.services.unifi.client import UnifiClient, UnifiClientConfig, UnifiClientError
-
-logger = structlog.get_logger(__name__)
 
 # How often a UniFi block is re-asserted even when its push row is already
 # "pushed". UniFi has no cheap "list blocked" read, so a MAC an operator

--- a/backend/app/services/block_sync/reconcile.py
+++ b/backend/app/services/block_sync/reconcile.py
@@ -1,0 +1,702 @@
+"""Active block-sync reconciler (#601).
+
+Target-driven convergence: for every *armed* target (an OPNsense router
+or a UniFi controller with ``block_sync_enabled=True``), push the
+applicable ``network_block`` desired-state onto the device and lift any
+block that has been disabled / expired / deleted.
+
+Convergence is non-destructive on the device: SpatiumDDI only removes
+IPs / MACs it added (tracked via ``network_block_push`` rows). It never
+touches alias members / blocked clients it doesn't own. Active blocks
+that are somehow missing from the device (operator removed them by hand)
+are re-pushed — the block set is the source of truth (NN#4/#9).
+
+* OPNsense — kind=``ip`` blocks → firewall table-alias membership. We
+  read the current alias members so we can add only what's missing and
+  reconfigure once.
+* UniFi — kind=``mac`` blocks → ``block-sta`` / ``unblock-sta`` L2
+  quarantine. No cheap "list blocked" read, so convergence is driven
+  purely off push rows + the idempotent block/unblock commands.
+
+Every push path is gated: the caller must ensure the ``security.block_sync``
+feature module is on; the per-target ``block_sync_enabled`` master switch
+is checked here; and a target with no write credentials is skipped with a
+clear error (never a silent fall-back to read creds).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import decrypt_str
+from app.models.audit import AuditLog
+from app.models.block_sync import NetworkBlock, NetworkBlockPush
+from app.models.opnsense import OPNsenseRouter
+from app.models.unifi import UnifiController
+from app.services.opnsense.client import OPNsenseClient, OPNsenseClientError
+from app.services.oui import normalize_mac_key
+from app.services.unifi.client import UnifiClient, UnifiClientConfig, UnifiClientError
+
+logger = structlog.get_logger(__name__)
+
+# How often a UniFi block is re-asserted even when its push row is already
+# "pushed". UniFi has no cheap "list blocked" read, so a MAC an operator
+# manually unblocks on the controller would otherwise never be re-quarantined
+# (the block set is the source of truth — #601 review). Re-issuing block-sta is
+# idempotent; the window trades convergence latency for controller load.
+_UNIFI_REASSERT_SECONDS = 3600.0
+
+
+def _audit_device_push(
+    db: AsyncSession,
+    target_kind: str,
+    target_id: uuid.UUID,
+    target_name: str,
+    added: list[str],
+    removed: list[str],
+) -> None:
+    """Audit the actual device mutation (NN#4). The reconciler runs from the
+    Celery sweep / on-create task with no request user, so the row is attributed
+    to the system with the applied add/remove diff captured in ``new_value``."""
+    if not added and not removed:
+        return
+    db.add(
+        AuditLog(
+            user_id=None,
+            user_display_name="system",
+            auth_source="system",
+            action="block_sync_push",
+            resource_type="network_block_target",
+            resource_id=str(target_id),
+            resource_display=f"{target_kind}:{target_name}",
+            new_value={"added": added, "removed": removed},
+        )
+    )
+
+
+# ── Value + target helpers (shared by the router + the gated operation) ──
+
+
+def normalize_block_value(kind: str, value: str) -> str:
+    """Canonicalise a block value. Raises ``ValueError`` on bad input.
+
+    ``ip`` → the string form of a parsed IP address; ``mac`` → the
+    lowercase colon-separated 12-hex form UniFi + Kea both expect.
+    """
+    value = value.strip()
+    if kind == "ip":
+        return str(ipaddress.ip_address(value))
+    if kind == "mac":
+        key = normalize_mac_key(value)
+        if key is None:
+            raise ValueError(f"invalid MAC address: {value}")
+        return ":".join(key[i : i + 2] for i in range(0, 12, 2))
+    raise ValueError(f"invalid block kind: {kind}")
+
+
+async def applicable_targets_for_kind(db: AsyncSession, kind: str) -> list[tuple[str, uuid.UUID]]:
+    """Armed targets that consume a block of ``kind`` — OPNsense (firewall
+    alias) for IPs, UniFi (L2 quarantine) for MACs."""
+    out: list[tuple[str, uuid.UUID]] = []
+    if kind == "ip":
+        rows = (
+            (
+                await db.execute(
+                    select(OPNsenseRouter.id).where(OPNsenseRouter.block_sync_enabled.is_(True))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        out.extend(("opnsense", rid) for rid in rows)
+    elif kind == "mac":
+        rows = (
+            (
+                await db.execute(
+                    select(UnifiController.id).where(UnifiController.block_sync_enabled.is_(True))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        out.extend(("unifi", cid) for cid in rows)
+    return out
+
+
+# ── Result / diff shapes ─────────────────────────────────────────────
+
+
+@dataclass
+class TargetDiff:
+    """What a reconcile pass *would* change on one target (preview)."""
+
+    target_kind: str  # "opnsense" | "unifi"
+    target_id: uuid.UUID
+    target_name: str
+    to_add: list[str] = field(default_factory=list)  # values to push
+    to_remove: list[str] = field(default_factory=list)  # values to lift
+    # Populated when the target can't be previewed/pushed (creds missing,
+    # not armed, device unreachable). A non-empty error means no changes.
+    error: str | None = None
+
+    def is_noop(self) -> bool:
+        return not self.to_add and not self.to_remove
+
+
+@dataclass
+class BlockSyncSummary:
+    target_kind: str
+    target_id: uuid.UUID
+    target_name: str
+    ok: bool = True
+    error: str | None = None
+    added: int = 0
+    removed: int = 0
+    errors: int = 0
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def block_is_active(block: NetworkBlock, now: datetime) -> bool:
+    """A block should be enforced iff it is enabled and not past its
+    optional ``expires_at``."""
+    if not block.enabled:
+        return False
+    if block.expires_at is not None and block.expires_at <= now:
+        return False
+    return True
+
+
+async def _load_blocks(db: AsyncSession, kind: str) -> list[NetworkBlock]:
+    return list(
+        (await db.execute(select(NetworkBlock).where(NetworkBlock.kind == kind))).scalars().all()
+    )
+
+
+async def _load_pushes(
+    db: AsyncSession, target_kind: str, target_id: uuid.UUID
+) -> dict[uuid.UUID, NetworkBlockPush]:
+    """Existing push rows for this target, keyed by ``block_id``."""
+    rows = (
+        (
+            await db.execute(
+                select(NetworkBlockPush).where(
+                    NetworkBlockPush.target_kind == target_kind,
+                    NetworkBlockPush.target_id == target_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return {r.block_id: r for r in rows}
+
+
+# ── OPNsense ─────────────────────────────────────────────────────────
+
+
+def _opnsense_client(router: OPNsenseRouter) -> OPNsenseClient:
+    secret = decrypt_str(router.block_sync_api_secret_encrypted)
+    return OPNsenseClient(
+        host=router.host,
+        port=router.port,
+        api_key=router.block_sync_api_key,
+        api_secret=secret,
+        verify_tls=router.verify_tls,
+        ca_bundle_pem=router.ca_bundle_pem,
+    )
+
+
+def opnsense_config_error(router: OPNsenseRouter) -> str | None:
+    if not router.block_sync_enabled:
+        return "block sync not armed on this target"
+    if not router.block_alias_name.strip():
+        return "no firewall alias configured (block_alias_name)"
+    if not router.block_sync_api_key.strip() or not router.block_sync_api_secret_encrypted:
+        return "write-scoped credentials not configured"
+    return None
+
+
+async def preview_opnsense(
+    db: AsyncSession, router: OPNsenseRouter, *, read_device: bool = True
+) -> TargetDiff:
+    """Compute the add/remove diff for one OPNsense target without pushing."""
+    diff = TargetDiff(target_kind="opnsense", target_id=router.id, target_name=router.name)
+    cfg_err = opnsense_config_error(router)
+    if cfg_err:
+        diff.error = cfg_err
+        return diff
+
+    now = datetime.now(UTC)
+    blocks = await _load_blocks(db, "ip")
+    active = {b.value for b in blocks if block_is_active(b, now)}
+    pushes = await _load_pushes(db, "opnsense", router.id)
+    block_by_id = {b.id: b for b in blocks}
+
+    # Values we currently own on this target (pushed / pending / error).
+    owned = {block_by_id[bid].value for bid in pushes if bid in block_by_id}
+    # Lift: owned values whose block is no longer active (or deleted).
+    for bid, push in pushes.items():
+        b = block_by_id.get(bid)
+        if b is None or not block_is_active(b, now):
+            diff.to_remove.append(push_value_hint(push, b))
+
+    on_device: set[str] = set()
+    if read_device:
+        try:
+            async with _opnsense_client(router) as client:
+                on_device = set(await client.alias_list_addresses(router.block_alias_name.strip()))
+        except OPNsenseClientError as exc:
+            diff.error = f"cannot read alias: {exc}"
+            return diff
+
+    # Add: active value not yet owned, OR owned-but-missing-from-device.
+    for value in sorted(active):
+        if value not in owned or (read_device and value not in on_device):
+            diff.to_add.append(value)
+
+    return diff
+
+
+def push_value_hint(push: NetworkBlockPush, block: NetworkBlock | None) -> str:
+    """Best-effort value for a to-remove entry (the block row may be gone)."""
+    if block is not None:
+        return block.value
+    return f"<block {push.block_id}>"
+
+
+async def reconcile_opnsense(db: AsyncSession, router: OPNsenseRouter) -> BlockSyncSummary:
+    """Push the OPNsense target to match desired state. Commits push-row
+    changes; the caller commits the target's timestamp fields."""
+    summary = BlockSyncSummary(target_kind="opnsense", target_id=router.id, target_name=router.name)
+    cfg_err = opnsense_config_error(router)
+    if cfg_err:
+        summary.ok = False
+        summary.error = cfg_err
+        router.last_block_sync_error = cfg_err
+        return summary
+
+    now = datetime.now(UTC)
+    alias = router.block_alias_name.strip()
+    blocks = await _load_blocks(db, "ip")
+    block_by_id = {b.id: b for b in blocks}
+    active_blocks = [b for b in blocks if block_is_active(b, now)]
+    pushes = await _load_pushes(db, "opnsense", router.id)
+
+    changed = False
+    added_vals: list[str] = []
+    removed_vals: list[str] = []
+    # Blocks whose membership is (re)asserted this pass but whose push row must
+    # not be marked "pushed" until reconfigure actually loads the ruleset — so a
+    # failed reconfigure never reports a block as converged (#601 review #6).
+    to_confirm: list[tuple[NetworkBlock, NetworkBlockPush | None]] = []
+    try:
+        async with _opnsense_client(router) as client:
+            on_device = set(await client.alias_list_addresses(alias))
+
+            # Lift blocks that are no longer active (or whose row is gone).
+            for bid, push in list(pushes.items()):
+                b = block_by_id.get(bid)
+                if b is not None and block_is_active(b, now):
+                    continue
+                value = b.value if b is not None else None
+                try:
+                    if value and value in on_device:
+                        await client.alias_delete_address(alias, value)
+                        changed = True
+                        removed_vals.append(value)
+                    await db.delete(push)
+                    summary.removed += 1
+                except OPNsenseClientError as exc:
+                    push.push_status = "error"
+                    push.last_error = str(exc)
+                    summary.errors += 1
+
+            # Add / re-assert active blocks.
+            for b in active_blocks:
+                push = pushes.get(b.id)
+                confirmed = push is not None and push.push_status == "pushed"
+                on_dev = b.value in on_device
+                if confirmed and on_dev:
+                    continue  # already converged
+                try:
+                    if not on_dev:
+                        await client.alias_add_address(alias, b.value)
+                        changed = True
+                        added_vals.append(b.value)
+                        summary.added += 1
+                    # Defer marking "pushed" until reconfigure succeeds below.
+                    to_confirm.append((b, push))
+                except OPNsenseClientError as exc:
+                    _upsert_push(
+                        db, push, b.id, "opnsense", router.id, now, status="error", error=str(exc)
+                    )
+                    summary.errors += 1
+
+            # Reconfigure applies both removals and adds. Run it whenever
+            # something changed OR there are memberships awaiting confirmation
+            # (the latter covers retrying a prior pass whose reconfigure failed
+            # while the IP already sits in the alias table).
+            if changed or to_confirm:
+                try:
+                    await client.alias_reconfigure()
+                except OPNsenseClientError as exc:
+                    # The ruleset was NOT reloaded — do not claim these as
+                    # pushed; mark them errored so the next sweep retries.
+                    for b, push in to_confirm:
+                        _upsert_push(
+                            db,
+                            push,
+                            b.id,
+                            "opnsense",
+                            router.id,
+                            now,
+                            status="error",
+                            error=f"reconfigure failed: {exc}",
+                        )
+                    summary.errors += len(to_confirm)
+                    summary.ok = False
+                    summary.error = str(exc)
+                    router.last_block_sync_error = f"reconfigure failed: {exc}"
+                    router.last_block_sync_at = now
+                    return summary
+
+            # Reconfigure succeeded (or nothing to apply) — confirm pushes.
+            for b, push in to_confirm:
+                _upsert_push(db, push, b.id, "opnsense", router.id, now)
+    except OPNsenseClientError as exc:
+        summary.ok = False
+        summary.error = str(exc)
+        router.last_block_sync_error = str(exc)
+        return summary
+
+    router.last_block_sync_at = now
+    router.last_block_sync_error = (
+        None if summary.errors == 0 else f"{summary.errors} push error(s)"
+    )
+    summary.ok = summary.errors == 0
+    _audit_device_push(db, "opnsense", router.id, router.name, added_vals, removed_vals)
+    return summary
+
+
+# ── UniFi ────────────────────────────────────────────────────────────
+
+
+def _unifi_client(controller: UnifiController) -> UnifiClient:
+    kind = controller.block_sync_auth_kind or "api_key"
+    api_key = (
+        decrypt_str(controller.block_sync_api_key_encrypted)
+        if controller.block_sync_api_key_encrypted
+        else ""
+    )
+    username = (
+        decrypt_str(controller.block_sync_username_encrypted)
+        if controller.block_sync_username_encrypted
+        else ""
+    )
+    password = (
+        decrypt_str(controller.block_sync_password_encrypted)
+        if controller.block_sync_password_encrypted
+        else ""
+    )
+    return UnifiClient(
+        UnifiClientConfig(
+            mode=controller.mode,
+            host=controller.host,
+            port=controller.port,
+            cloud_host_id=controller.cloud_host_id,
+            verify_tls=controller.verify_tls,
+            ca_bundle_pem=controller.ca_bundle_pem or "",
+            auth_kind=kind,
+            api_key=api_key,
+            username=username,
+            password=password,
+        )
+    )
+
+
+def unifi_config_error(controller: UnifiController) -> str | None:
+    if not controller.block_sync_enabled:
+        return "block sync not armed on this target"
+    kind = controller.block_sync_auth_kind or "api_key"
+    if kind == "api_key" and not controller.block_sync_api_key_encrypted:
+        return "write-scoped API key not configured"
+    if kind == "user_password" and not (
+        controller.block_sync_username_encrypted and controller.block_sync_password_encrypted
+    ):
+        return "write-scoped admin username/password not configured"
+    if kind == "user_password" and controller.mode == "cloud":
+        return "cloud controllers require an API key for block sync"
+    return None
+
+
+def _unifi_site(controller: UnifiController) -> str:
+    return (controller.block_sync_site or "default").strip() or "default"
+
+
+async def preview_unifi(db: AsyncSession, controller: UnifiController) -> TargetDiff:
+    """Compute the add/remove diff for one UniFi target (push-row driven —
+    the controller has no cheap 'list blocked' read)."""
+    diff = TargetDiff(target_kind="unifi", target_id=controller.id, target_name=controller.name)
+    cfg_err = unifi_config_error(controller)
+    if cfg_err:
+        diff.error = cfg_err
+        return diff
+
+    now = datetime.now(UTC)
+    blocks = await _load_blocks(db, "mac")
+    block_by_id = {b.id: b for b in blocks}
+    pushes = await _load_pushes(db, "unifi", controller.id)
+    owned = {block_by_id[bid].value for bid in pushes if bid in block_by_id}
+
+    for b in blocks:
+        if block_is_active(b, now) and (
+            b.value not in owned or pushes[b.id].push_status != "pushed"
+        ):
+            diff.to_add.append(b.value)
+    for bid, push in pushes.items():
+        b = block_by_id.get(bid)
+        if b is None or not block_is_active(b, now):
+            diff.to_remove.append(push_value_hint(push, b))
+    return diff
+
+
+async def reconcile_unifi(db: AsyncSession, controller: UnifiController) -> BlockSyncSummary:
+    summary = BlockSyncSummary(
+        target_kind="unifi", target_id=controller.id, target_name=controller.name
+    )
+    cfg_err = unifi_config_error(controller)
+    if cfg_err:
+        summary.ok = False
+        summary.error = cfg_err
+        controller.last_block_sync_error = cfg_err
+        return summary
+
+    now = datetime.now(UTC)
+    site = _unifi_site(controller)
+    blocks = await _load_blocks(db, "mac")
+    block_by_id = {b.id: b for b in blocks}
+    active_blocks = [b for b in blocks if block_is_active(b, now)]
+    pushes = await _load_pushes(db, "unifi", controller.id)
+    added_vals: list[str] = []
+    removed_vals: list[str] = []
+
+    try:
+        async with _unifi_client(controller) as client:
+            # Lift.
+            for bid, push in list(pushes.items()):
+                b = block_by_id.get(bid)
+                if b is not None and block_is_active(b, now):
+                    continue
+                try:
+                    if b is not None:
+                        await client.unblock_client(site, b.value)
+                        removed_vals.append(b.value)
+                    await db.delete(push)
+                    summary.removed += 1
+                except UnifiClientError as exc:
+                    push.push_status = "error"
+                    push.last_error = str(exc)
+                    summary.errors += 1
+
+            # (Re)assert active blocks. block-sta is idempotent; because UniFi
+            # has no "list blocked" read, a MAC an operator manually unblocked
+            # on the controller must be periodically re-asserted or it silently
+            # stays un-quarantined while we report converged (#601 review #9).
+            for b in active_blocks:
+                push = pushes.get(b.id)
+                is_pushed = push is not None and push.push_status == "pushed"
+                stale = (
+                    push is None
+                    or push.last_pushed_at is None
+                    or (now - push.last_pushed_at).total_seconds() >= _UNIFI_REASSERT_SECONDS
+                )
+                if is_pushed and not stale:
+                    continue
+                try:
+                    await client.block_client(site, b.value)
+                    _upsert_push(db, push, b.id, "unifi", controller.id, now)
+                    if not is_pushed:
+                        added_vals.append(b.value)
+                        summary.added += 1
+                except UnifiClientError as exc:
+                    _upsert_push(
+                        db, push, b.id, "unifi", controller.id, now, status="error", error=str(exc)
+                    )
+                    summary.errors += 1
+    except UnifiClientError as exc:
+        summary.ok = False
+        summary.error = str(exc)
+        controller.last_block_sync_error = str(exc)
+        return summary
+
+    controller.last_block_sync_at = now
+    controller.last_block_sync_error = (
+        None if summary.errors == 0 else f"{summary.errors} push error(s)"
+    )
+    summary.ok = summary.errors == 0
+    _audit_device_push(db, "unifi", controller.id, controller.name, added_vals, removed_vals)
+    return summary
+
+
+# ── Shared push-row upsert ───────────────────────────────────────────
+
+
+def _upsert_push(
+    db: AsyncSession,
+    push: NetworkBlockPush | None,
+    block_id: uuid.UUID,
+    target_kind: str,
+    target_id: uuid.UUID,
+    now: datetime,
+    *,
+    status: str = "pushed",
+    error: str | None = None,
+) -> None:
+    if push is None:
+        push = NetworkBlockPush(
+            block_id=block_id,
+            target_kind=target_kind,
+            target_id=target_id,
+        )
+        db.add(push)
+    push.push_status = status
+    push.last_error = error
+    if status == "pushed":
+        push.last_pushed_at = now
+
+
+# ── Fan-out ──────────────────────────────────────────────────────────
+
+
+async def armed_targets(
+    db: AsyncSession,
+) -> tuple[list[OPNsenseRouter], list[UnifiController]]:
+    routers = list(
+        (
+            await db.execute(
+                select(OPNsenseRouter).where(OPNsenseRouter.block_sync_enabled.is_(True))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    controllers = list(
+        (
+            await db.execute(
+                select(UnifiController).where(UnifiController.block_sync_enabled.is_(True))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return routers, controllers
+
+
+async def lift_all_for_target(
+    db: AsyncSession, target_kind: str, target: OPNsenseRouter | UnifiController
+) -> BlockSyncSummary:
+    """Remove EVERY value SpatiumDDI pushed to a target and delete its push
+    rows — used when a target is disarmed (block_sync_enabled → False), so a
+    disabled firewall/gateway doesn't keep enforcing blocks with no reconcile
+    path (#601 review #8). Deliberately does NOT gate on block_sync_enabled
+    (the target is being disarmed); it only needs the write creds still present.
+    """
+    summary = BlockSyncSummary(
+        target_kind=target_kind, target_id=target.id, target_name=target.name
+    )
+    pushes = await _load_pushes(db, target_kind, target.id)
+    if not pushes:
+        return summary
+    block_by_id = {b.id: b for b in (await db.execute(select(NetworkBlock))).scalars().all()}
+    removed_vals: list[str] = []
+    try:
+        if target_kind == "opnsense":
+            router = target
+            assert isinstance(router, OPNsenseRouter)
+            if not router.block_alias_name.strip() or not router.block_sync_api_key:
+                return summary  # no creds/alias to work with; leave rows as-is
+            alias = router.block_alias_name.strip()
+            changed = False
+            async with _opnsense_client(router) as client:
+                on_device = set(await client.alias_list_addresses(alias))
+                for bid, push in list(pushes.items()):
+                    b = block_by_id.get(bid)
+                    value = b.value if b is not None else None
+                    if value and value in on_device:
+                        await client.alias_delete_address(alias, value)
+                        changed = True
+                        removed_vals.append(value)
+                    await db.delete(push)
+                    summary.removed += 1
+                if changed:
+                    await client.alias_reconfigure()
+        else:
+            controller = target
+            assert isinstance(controller, UnifiController)
+            kind = controller.block_sync_auth_kind or "api_key"
+            creds_ok = (
+                bool(controller.block_sync_api_key_encrypted)
+                if kind == "api_key"
+                else bool(
+                    controller.block_sync_username_encrypted
+                    and controller.block_sync_password_encrypted
+                )
+            )
+            if not creds_ok:
+                return summary  # no creds to reach the controller; leave rows
+            site = _unifi_site(controller)
+            async with _unifi_client(controller) as client:
+                for bid, push in list(pushes.items()):
+                    b = block_by_id.get(bid)
+                    if b is not None:
+                        await client.unblock_client(site, b.value)
+                        removed_vals.append(b.value)
+                    await db.delete(push)
+                    summary.removed += 1
+    except (OPNsenseClientError, UnifiClientError) as exc:
+        summary.ok = False
+        summary.error = str(exc)
+        target.last_block_sync_error = f"disarm-lift failed: {exc}"
+        return summary
+
+    target.last_block_sync_at = datetime.now(UTC)
+    _audit_device_push(db, target_kind, target.id, target.name, [], removed_vals)
+    return summary
+
+
+async def preview_all(db: AsyncSession, *, read_device: bool = True) -> list[TargetDiff]:
+    """Preview every armed target (used by the reconcile-all preview)."""
+    routers, controllers = await armed_targets(db)
+    diffs: list[TargetDiff] = []
+    for r in routers:
+        diffs.append(await preview_opnsense(db, r, read_device=read_device))
+    for c in controllers:
+        diffs.append(await preview_unifi(db, c))
+    return diffs
+
+
+__all__ = [
+    "BlockSyncSummary",
+    "TargetDiff",
+    "applicable_targets_for_kind",
+    "armed_targets",
+    "block_is_active",
+    "lift_all_for_target",
+    "normalize_block_value",
+    "opnsense_config_error",
+    "preview_all",
+    "preview_opnsense",
+    "preview_unifi",
+    "reconcile_opnsense",
+    "reconcile_unifi",
+    "unifi_config_error",
+]

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -379,6 +379,21 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         description="Alert the moment a previously-unseen MAC address appears on the network (arpwatch-style), across DHCP leases, SNMP ARP/FDB, and an opt-in L2 sniffer. Maintain an allowlist of trusted MACs (or OUI prefixes for VMs/containers), acknowledge or block from a review queue, and fire a real-time device.first_seen event. Default-off: enable, run a baseline import to mark the existing fleet as known, then arm.",
         default_enabled=False,
     ),
+    # Security — active block sync / write-back enforcement (#601). The
+    # deliberate, guarded exception to the read-only-mirror stance: pushes
+    # SpatiumDDI-owned IP/MAC blocks into OPNsense (firewall table alias)
+    # and UniFi (L2 client quarantine). Default-OFF — the whole surface is
+    # dark until an operator opts in, AND every push additionally requires
+    # a per-target ``block_sync_enabled`` master switch + distinct
+    # write-scoped credentials. Turning this module ON exposes the surface
+    # but arms nothing.
+    ModuleSpec(
+        id="security.block_sync",
+        label="Active block sync (firewall enforcement)",
+        group="Security",
+        description="Turn passive rogue-device / new-MAC detection into active enforcement: push a SpatiumDDI-owned block set of IPs / MACs into OPNsense (firewall table-alias membership) and UniFi (L2 client quarantine), so a device that self-assigns a static IP is stopped at the firewall/gateway — not only starved of DHCP. Default-off and heavily guarded: each target has its own default-off enforcement master switch + distinct write-scoped credentials, every push is previewable + audited + RBAC-gated (manage_block_sync) + eligible for two-person approval. Discovery toggle only — enabling this arms nothing on its own.",
+        default_enabled=False,
+    ),
     # Security — DNSBL / RBL reputation monitoring (#528). Default-ENABLED
     # as a DISCOVERY toggle: the catalog + settings UI are visible so
     # operators find the feature, but the module makes ZERO off-prem DNS

--- a/backend/app/services/opnsense/client.py
+++ b/backend/app/services/opnsense/client.py
@@ -159,6 +159,25 @@ def _unwrap_rows(body: Any) -> list[dict[str, Any]]:
     return [r for r in rows if isinstance(r, dict)]
 
 
+def _assert_alias_op_ok(data: Any, label: str) -> None:
+    """Raise ``OPNsenseClientError`` unless an alias_util / reconfigure
+    response reports success.
+
+    OPNsense returns ``{"status": "done"}`` (add/delete/reconfigure) or
+    ``{"result": "saved"}`` on success. A ``{"status": "failed"}`` or a
+    validation envelope means the operation didn't take — surface it so
+    the reconciler marks the push errored instead of falsely converged.
+    """
+    if isinstance(data, dict):
+        status_val = str(data.get("status") or data.get("result") or "").strip().lower()
+        if status_val in {"done", "saved", "ok"}:
+            return
+        # Some firmwares return an empty {} for add-of-already-present.
+        if not status_val and not data.get("validations"):
+            return
+    raise OPNsenseClientError(f"{label}: unexpected response {str(data)[:200]}")
+
+
 def _network_cidr(address: str, prefix: Any) -> str | None:
     """Build the network CIDR (``10.0.0.0/24``) from an interface IP +
     prefix length. Returns ``None`` on parse failure.
@@ -450,6 +469,61 @@ class OPNsenseClient:
                 )
             )
         return out
+
+    # ── Write surface (active block sync #601, opt-in) ───────────────
+    #
+    # Firewall enforcement via *table-alias membership only* — never rule
+    # CRUD. The operator pre-creates one block rule referencing an alias
+    # (e.g. ``spatiumddi_blocked``); SpatiumDDI adds/removes IPs to
+    # converge, then reconfigures to apply. Idempotent + no rule-ordering
+    # state. These require a Firewall-privileged API user (distinct from
+    # the read mirror's read-only user).
+
+    async def alias_list_addresses(self, alias: str) -> list[str]:
+        """Current member IPs of a table alias.
+
+        ``GET /api/firewall/alias_util/list/{alias}`` returns
+        ``{"total": N, "rows": [{"ip": "1.2.3.4"}, ...]}``. Raises
+        (no swallow) so the reconciler can distinguish a real read from a
+        transient failure and never diff against a bad-empty set (#5).
+        """
+        body = await self._get(f"/api/firewall/alias_util/list/{alias}")
+        out: list[str] = []
+        for r in _unwrap_rows(body):
+            ip = str(r.get("ip") or r.get("address") or "").strip()
+            if ip:
+                out.append(ip)
+        return out
+
+    async def alias_add_address(self, alias: str, address: str) -> None:
+        """Add one IP to a table alias.
+
+        ``POST /api/firewall/alias_util/add/{alias}`` with
+        ``{"address": "<ip>"}``. OPNsense returns ``{"status": "done"}``
+        on success; anything else is surfaced as an error.
+        """
+        data = await self._post(f"/api/firewall/alias_util/add/{alias}", json={"address": address})
+        _assert_alias_op_ok(data, f"add {address} to {alias}")
+
+    async def alias_delete_address(self, alias: str, address: str) -> None:
+        """Remove one IP from a table alias.
+
+        ``POST /api/firewall/alias_util/delete/{alias}`` with
+        ``{"address": "<ip>"}``.
+        """
+        data = await self._post(
+            f"/api/firewall/alias_util/delete/{alias}", json={"address": address}
+        )
+        _assert_alias_op_ok(data, f"delete {address} from {alias}")
+
+    async def alias_reconfigure(self) -> None:
+        """Apply pending alias membership changes.
+
+        ``POST /api/firewall/alias/reconfigure`` — cheap, and required for
+        the table update to take effect in the running ruleset.
+        """
+        data = await self._post("/api/firewall/alias/reconfigure")
+        _assert_alias_op_ok(data, "alias reconfigure")
 
     async def list_arp(self) -> list[_OPNArpEntry]:
         """ARP table — secondary population, only fetched when the

--- a/backend/app/services/unifi/client.py
+++ b/backend/app/services/unifi/client.py
@@ -362,6 +362,62 @@ class UnifiClient:
         except ValueError as exc:  # non-JSON body (HTML error page, …)
             raise UnifiClientError(f"{path}: non-JSON body: {resp.text[:200]}") from exc
 
+    async def _post_legacy(self, suffix: str, payload: dict[str, Any]) -> Any:
+        """POST to the legacy controller API, replaying the captured CSRF
+        token (user_password auth) and relying on the ``X-API-Key`` header
+        set at construction (api_key auth).
+
+        The public Integration v1 API deliberately omits client-block, so
+        every write rides this legacy path. Used only by the active
+        block-sync surface (#601) — reads never write.
+        """
+        assert self._client is not None, "use within 'async with'"
+        path = self._legacy_path(suffix)
+        headers: dict[str, str] = {}
+        if self._csrf:
+            headers["X-CSRF-Token"] = self._csrf
+        try:
+            resp = await self._client.post(path, json=payload, headers=headers)
+        except httpx.HTTPError as exc:
+            raise UnifiClientError(f"{path}: {exc}") from exc
+        if resp.status_code == 401:
+            raise UnifiClientError(f"{path}: HTTP 401 — auth invalid / expired")
+        if resp.status_code == 403:
+            raise UnifiClientError(f"{path}: HTTP 403 — token / role denies this write")
+        if resp.status_code >= 400:
+            raise UnifiClientError(f"{path}: HTTP {resp.status_code} {resp.text[:200]}")
+        try:
+            body = resp.json()
+        except ValueError:
+            # Some stamgr responses are empty-bodied 200s — treat as success.
+            return {}
+        # The legacy controller signals command failure in-band: HTTP 200 with
+        # ``{"meta": {"rc": "error", "msg": "api.err.…"}}`` (wrong site, a
+        # key/role without device-block rights, unknown MAC). Without this a
+        # failed block-sta would be recorded as a converged push (#601 review).
+        if isinstance(body, dict):
+            meta = body.get("meta")
+            if isinstance(meta, dict) and str(meta.get("rc", "")).lower() == "error":
+                raise UnifiClientError(
+                    f"{path}: controller rejected command — {meta.get('msg') or 'rc=error'}"
+                )
+        return body
+
+    # ── Write surface (active block sync #601, opt-in) ───────────────
+    #
+    # L2 client quarantine at the AP/switch via the same ``cmd/stamgr``
+    # command the UniFi UI issues. Idempotent-ish: re-blocking a blocked
+    # device is a no-op on the controller. Requires an admin key / admin
+    # login (distinct from the read mirror's creds).
+
+    async def block_client(self, site_name: str, mac: str) -> None:
+        """Quarantine a device by MAC (``block-sta``)."""
+        await self._post_legacy(f"s/{site_name}/cmd/stamgr", {"cmd": "block-sta", "mac": mac})
+
+    async def unblock_client(self, site_name: str, mac: str) -> None:
+        """Lift a device quarantine by MAC (``unblock-sta``)."""
+        await self._post_legacy(f"s/{site_name}/cmd/stamgr", {"cmd": "unblock-sta", "mac": mac})
+
     # ── Public surface ───────────────────────────────────────────────
 
     async def get_version(self) -> _UnifiVersion:

--- a/backend/app/tasks/block_sync.py
+++ b/backend/app/tasks/block_sync.py
@@ -1,0 +1,189 @@
+"""Active block-sync convergence tasks (#601).
+
+* ``sweep_block_sync`` — beat-driven fan-out over every armed OPNsense /
+  UniFi target. Gated on the ``security.block_sync`` feature module (the
+  discovery/master gate) — each target additionally carries its own
+  ``block_sync_enabled`` switch (enforced in the reconciler).
+* ``reconcile_target_now`` — fired immediately after a block is created /
+  lifted / a target is armed, so enforcement converges within seconds
+  instead of waiting for the next sweep tick.
+
+Idempotent (NN#9): re-running converges to the same device state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid as _uuid
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.celery_app import celery_app
+from app.config import settings
+from app.models.opnsense import OPNsenseRouter
+from app.models.unifi import UnifiController
+from app.services.feature_modules import is_module_enabled
+
+logger = structlog.get_logger(__name__)
+
+_MODULE_ID = "security.block_sync"
+
+
+async def _run_sweep() -> dict[str, Any]:
+    from app.services.block_sync.reconcile import (  # noqa: PLC0415
+        armed_targets,
+        reconcile_opnsense,
+        reconcile_unifi,
+    )
+
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            if not await is_module_enabled(db, _MODULE_ID):
+                return {"status": "disabled"}
+
+            routers, controllers = await armed_targets(db)
+            router_ids = [r.id for r in routers]
+            controller_ids = [c.id for c in controllers]
+
+            ran = ok = errors = 0
+            messages: list[str] = []
+
+            for rid in router_ids:
+                router = await db.get(OPNsenseRouter, rid)
+                if router is None:
+                    continue
+                try:
+                    summary = await reconcile_opnsense(db, router)
+                    await db.commit()
+                except Exception as exc:  # noqa: BLE001 — one target can't poison the sweep
+                    await db.rollback()
+                    errors += 1
+                    messages.append(f"{rid}: {exc}")
+                    logger.warning("block_sync_opnsense_crash", target=str(rid), error=str(exc))
+                    continue
+                ran += 1
+                ok += 1 if summary.ok else 0
+                errors += 0 if summary.ok else 1
+                if summary.error:
+                    messages.append(f"opnsense {router.name}: {summary.error}")
+
+            for cid in controller_ids:
+                controller = await db.get(UnifiController, cid)
+                if controller is None:
+                    continue
+                try:
+                    summary = await reconcile_unifi(db, controller)
+                    await db.commit()
+                except Exception as exc:  # noqa: BLE001
+                    await db.rollback()
+                    errors += 1
+                    messages.append(f"{cid}: {exc}")
+                    logger.warning("block_sync_unifi_crash", target=str(cid), error=str(exc))
+                    continue
+                ran += 1
+                ok += 1 if summary.ok else 0
+                errors += 0 if summary.ok else 1
+                if summary.error:
+                    messages.append(f"unifi {controller.name}: {summary.error}")
+
+            return {
+                "status": "ok",
+                "ran": ran,
+                "ok": ok,
+                "errors": errors,
+                "messages": messages[:20],
+            }
+    finally:
+        await engine.dispose()
+
+
+async def _run_one(target_kind: str, target_id: str) -> dict[str, Any]:
+    from app.services.block_sync.reconcile import (  # noqa: PLC0415
+        reconcile_opnsense,
+        reconcile_unifi,
+    )
+
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            if not await is_module_enabled(db, _MODULE_ID):
+                return {"status": "disabled"}
+            tid = _uuid.UUID(target_id)
+            if target_kind == "opnsense":
+                router = await db.get(OPNsenseRouter, tid)
+                if router is None:
+                    return {"status": "not_found"}
+                summary = await reconcile_opnsense(db, router)
+            elif target_kind == "unifi":
+                controller = await db.get(UnifiController, tid)
+                if controller is None:
+                    return {"status": "not_found"}
+                summary = await reconcile_unifi(db, controller)
+            else:
+                return {"status": "bad_target_kind"}
+            await db.commit()
+            return {
+                "status": "ok" if summary.ok else "error",
+                "error": summary.error,
+                "added": summary.added,
+                "removed": summary.removed,
+                "errors": summary.errors,
+            }
+    finally:
+        await engine.dispose()
+
+
+async def _run_lift(target_kind: str, target_id: str) -> dict[str, Any]:
+    """Disarm cleanup — lift everything pushed to a target. NOT gated on the
+    feature module or the per-target switch (the target is being disarmed;
+    leaving its blocks stuck on the device is the bug we're fixing)."""
+    from app.services.block_sync.reconcile import lift_all_for_target  # noqa: PLC0415
+
+    engine = create_async_engine(settings.database_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as db:
+            tid = _uuid.UUID(target_id)
+            target: OPNsenseRouter | UnifiController | None
+            if target_kind == "opnsense":
+                target = await db.get(OPNsenseRouter, tid)
+            elif target_kind == "unifi":
+                target = await db.get(UnifiController, tid)
+            else:
+                return {"status": "bad_target_kind"}
+            if target is None:
+                return {"status": "not_found"}
+            summary = await lift_all_for_target(db, target_kind, target)
+            await db.commit()
+            return {
+                "status": "ok" if summary.ok else "error",
+                "error": summary.error,
+                "removed": summary.removed,
+            }
+    finally:
+        await engine.dispose()
+
+
+@celery_app.task(name="app.tasks.block_sync.sweep_block_sync", bind=True)
+def sweep_block_sync(self: Any) -> dict[str, Any]:  # noqa: ARG001
+    return asyncio.run(_run_sweep())
+
+
+@celery_app.task(name="app.tasks.block_sync.lift_target_now", bind=True)
+def lift_target_now(self: Any, target_kind: str, target_id: str) -> dict[str, Any]:  # noqa: ARG001
+    return asyncio.run(_run_lift(target_kind, target_id))
+
+
+@celery_app.task(name="app.tasks.block_sync.reconcile_target_now", bind=True)
+def reconcile_target_now(
+    self: Any, target_kind: str, target_id: str
+) -> dict[str, Any]:  # noqa: ARG001
+    return asyncio.run(_run_one(target_kind, target_id))
+
+
+__all__ = ["lift_target_now", "reconcile_target_now", "sweep_block_sync"]

--- a/backend/tests/test_block_sync.py
+++ b/backend/tests/test_block_sync.py
@@ -1,0 +1,413 @@
+"""Active block sync (#601) — write-back enforcement.
+
+Covers the pure helpers (value normalisation, active-block gate), the
+per-target config-error guards, the target-driven OPNsense reconciler with
+a mocked client, and the REST surface (module gating, block create/list/
+lift, target arming validation).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import encrypt_str
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.block_sync import NetworkBlock, NetworkBlockPush
+from app.models.feature_module import FeatureModule
+from app.models.ipam import IPSpace
+from app.models.opnsense import OPNsenseRouter
+from app.models.unifi import UnifiController
+from app.services import feature_modules
+from app.services.block_sync import reconcile
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_module_cache():
+    feature_modules.invalidate_cache()
+    yield
+    feature_modules.invalidate_cache()
+
+
+async def _enable_module(db: AsyncSession) -> None:
+    db.add(FeatureModule(id="security.block_sync", enabled=True))
+    await db.flush()
+    feature_modules.invalidate_cache()
+
+
+async def _superadmin(db: AsyncSession) -> tuple[User, str]:
+    u = User(
+        username=f"a-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(u)
+    await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+def _hdr(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _space(db: AsyncSession) -> IPSpace:
+    s = IPSpace(name=f"bs-{uuid.uuid4().hex[:6]}", description="")
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _armed_opnsense(db: AsyncSession, space: IPSpace) -> OPNsenseRouter:
+    r = OPNsenseRouter(
+        name=f"fw-{uuid.uuid4().hex[:6]}",
+        host="10.0.0.1",
+        api_key="ro",
+        api_secret_encrypted=encrypt_str("ro-secret"),
+        ipam_space_id=space.id,
+        block_sync_enabled=True,
+        block_alias_name="spatiumddi_blocked",
+        block_sync_api_key="rw",
+        block_sync_api_secret_encrypted=encrypt_str("rw-secret"),
+    )
+    db.add(r)
+    await db.flush()
+    return r
+
+
+# ── Pure helpers ─────────────────────────────────────────────────────
+
+
+def test_normalize_block_value_ip():
+    assert reconcile.normalize_block_value("ip", " 10.0.0.5 ") == "10.0.0.5"
+
+
+def test_normalize_block_value_mac():
+    assert reconcile.normalize_block_value("mac", "AA-BB-CC-DD-EE-FF") == "aa:bb:cc:dd:ee:ff"
+
+
+@pytest.mark.parametrize("kind,value", [("ip", "not-an-ip"), ("mac", "zz"), ("bogus", "x")])
+def test_normalize_block_value_rejects(kind, value):
+    with pytest.raises(ValueError):
+        reconcile.normalize_block_value(kind, value)
+
+
+def test_block_is_active():
+    now = datetime.now(UTC)
+    b = NetworkBlock(kind="ip", value="10.0.0.1", enabled=True, expires_at=None)
+    assert reconcile.block_is_active(b, now) is True
+    b.enabled = False
+    assert reconcile.block_is_active(b, now) is False
+    b.enabled = True
+    b.expires_at = now - timedelta(minutes=1)
+    assert reconcile.block_is_active(b, now) is False
+    b.expires_at = now + timedelta(minutes=1)
+    assert reconcile.block_is_active(b, now) is True
+
+
+def test_opnsense_config_error_paths():
+    r = OPNsenseRouter(name="x", host="h", api_key="", ipam_space_id=uuid.uuid4())
+    r.block_sync_enabled = False
+    assert reconcile.opnsense_config_error(r) == "block sync not armed on this target"
+    r.block_sync_enabled = True
+    r.block_alias_name = ""
+    assert "alias" in (reconcile.opnsense_config_error(r) or "")
+    r.block_alias_name = "a"
+    r.block_sync_api_key = ""
+    assert "credential" in (reconcile.opnsense_config_error(r) or "")
+
+
+def test_unifi_config_error_paths():
+    c = UnifiController(name="x", ipam_space_id=uuid.uuid4())
+    c.block_sync_enabled = False
+    assert reconcile.unifi_config_error(c) == "block sync not armed on this target"
+    c.block_sync_enabled = True
+    c.block_sync_auth_kind = "api_key"
+    c.block_sync_api_key_encrypted = b""
+    assert "API key" in (reconcile.unifi_config_error(c) or "")
+
+
+# ── Reconciler (mocked OPNsense client) ──────────────────────────────
+
+
+class _FakeOPNClient:
+    def __init__(self, existing: list[str]) -> None:
+        self.members = list(existing)
+        self.added: list[str] = []
+        self.deleted: list[str] = []
+        self.reconfigured = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return None
+
+    async def alias_list_addresses(self, alias: str) -> list[str]:
+        return list(self.members)
+
+    async def alias_add_address(self, alias: str, address: str) -> None:
+        self.added.append(address)
+        self.members.append(address)
+
+    async def alias_delete_address(self, alias: str, address: str) -> None:
+        self.deleted.append(address)
+        if address in self.members:
+            self.members.remove(address)
+
+    async def alias_reconfigure(self) -> None:
+        self.reconfigured += 1
+
+
+class _ReconfigureFailsClient(_FakeOPNClient):
+    async def alias_reconfigure(self) -> None:
+        from app.services.opnsense.client import OPNsenseClientError
+
+        raise OPNsenseClientError("reconfigure boom")
+
+
+async def test_reconcile_opnsense_adds_and_lifts(db_session: AsyncSession, monkeypatch):
+    space = await _space(db_session)
+    router = await _armed_opnsense(db_session, space)
+
+    active = NetworkBlock(kind="ip", value="10.0.0.5", enabled=True)
+    lifted = NetworkBlock(kind="ip", value="10.0.0.9", enabled=False)
+    db_session.add_all([active, lifted])
+    await db_session.flush()
+    # A stale push row for the now-disabled block, present on the device.
+    db_session.add(
+        NetworkBlockPush(
+            block_id=lifted.id,
+            target_kind="opnsense",
+            target_id=router.id,
+            push_status="pushed",
+        )
+    )
+    await db_session.flush()
+
+    fake = _FakeOPNClient(existing=["10.0.0.9"])
+    monkeypatch.setattr(reconcile, "_opnsense_client", lambda r: fake)
+
+    summary = await reconcile.reconcile_opnsense(db_session, router)
+    assert summary.ok is True
+    assert fake.added == ["10.0.0.5"]  # active block pushed
+    assert fake.deleted == ["10.0.0.9"]  # lifted block removed
+    assert fake.reconfigured == 1
+
+    pushes = (await db_session.execute(select(NetworkBlockPush))).scalars().all()
+    # The active block now owns a pushed row; the lifted one's row is gone.
+    assert len(pushes) == 1
+    assert pushes[0].block_id == active.id
+    assert pushes[0].push_status == "pushed"
+
+
+async def test_reconcile_opnsense_reconfigure_failure_not_pushed(
+    db_session: AsyncSession, monkeypatch
+):
+    """A failed reconfigure must NOT mark the block converged, and the next
+    pass must retry the reconfigure (#601 review #6)."""
+    space = await _space(db_session)
+    router = await _armed_opnsense(db_session, space)
+    active = NetworkBlock(kind="ip", value="10.0.0.5", enabled=True)
+    db_session.add(active)
+    await db_session.flush()
+
+    fail = _ReconfigureFailsClient(existing=[])
+    monkeypatch.setattr(reconcile, "_opnsense_client", lambda r: fail)
+    summary = await reconcile.reconcile_opnsense(db_session, router)
+    assert summary.ok is False
+    assert fail.added == ["10.0.0.5"]  # added to the alias table…
+    pushes = (await db_session.execute(select(NetworkBlockPush))).scalars().all()
+    assert len(pushes) == 1
+    assert pushes[0].push_status == "error"  # …but NOT reported converged
+
+    # Next pass with a healthy client retries reconfigure even though the IP is
+    # already in the alias table, and confirms the push.
+    ok = _FakeOPNClient(existing=["10.0.0.5"])
+    monkeypatch.setattr(reconcile, "_opnsense_client", lambda r: ok)
+    summary2 = await reconcile.reconcile_opnsense(db_session, router)
+    assert summary2.ok is True
+    assert ok.reconfigured == 1  # reconfigure retried despite no add
+    pushes2 = (await db_session.execute(select(NetworkBlockPush))).scalars().all()
+    assert pushes2[0].push_status == "pushed"
+
+
+async def test_unifi_post_legacy_rejects_rc_error():
+    """HTTP 200 with meta.rc=error must raise, not be a silent success
+    (#601 review #3)."""
+    import httpx
+
+    from app.services.unifi.client import (
+        UnifiClient,
+        UnifiClientConfig,
+        UnifiClientError,
+    )
+
+    cfg = UnifiClientConfig(
+        mode="local",
+        host="ctrl",
+        port=443,
+        cloud_host_id=None,
+        verify_tls=False,
+        ca_bundle_pem="",
+        auth_kind="api_key",
+        api_key="k",
+        username="",
+        password="",
+    )
+    client = UnifiClient(cfg)
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"meta": {"rc": "error", "msg": "api.err.NoSiteContext"}, "data": []}
+        )
+
+    client._client = httpx.AsyncClient(
+        base_url="https://ctrl", transport=httpx.MockTransport(_handler)
+    )
+    try:
+        with pytest.raises(UnifiClientError):
+            await client.block_client("default", "aa:bb:cc:dd:ee:ff")
+    finally:
+        await client._client.aclose()
+
+
+# ── REST surface ─────────────────────────────────────────────────────
+
+
+async def test_module_gated_404_when_off(client: AsyncClient, db_session: AsyncSession):
+    _u, token = await _superadmin(db_session)
+    await db_session.commit()
+    resp = await client.get("/api/v1/block-sync/blocks", headers=_hdr(token))
+    assert resp.status_code == 404
+
+
+async def test_create_list_lift_block(client: AsyncClient, db_session: AsyncSession, monkeypatch):
+    # No armed targets → the create commits without touching any device.
+    monkeypatch.setattr(
+        "app.tasks.block_sync.reconcile_target_now.delay",
+        lambda *a, **k: None,
+    )
+    await _enable_module(db_session)
+    _u, token = await _superadmin(db_session)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/block-sync/blocks",
+        headers=_hdr(token),
+        json={"kind": "mac", "value": "AA:BB:CC:DD:EE:01", "reason": "quarantine"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["kind"] == "mac"
+    assert body["value"] == "aa:bb:cc:dd:ee:01"
+    assert body["enabled"] is True
+    block_id = body["id"]
+
+    lst = await client.get("/api/v1/block-sync/blocks", headers=_hdr(token))
+    assert lst.status_code == 200
+    assert any(b["id"] == block_id for b in lst.json())
+
+    lifted = await client.delete(f"/api/v1/block-sync/blocks/{block_id}", headers=_hdr(token))
+    assert lifted.status_code == 200
+    assert lifted.json()["enabled"] is False
+
+
+async def test_create_block_rejects_bad_value(client: AsyncClient, db_session: AsyncSession):
+    await _enable_module(db_session)
+    _u, token = await _superadmin(db_session)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/v1/block-sync/blocks",
+        headers=_hdr(token),
+        json={"kind": "ip", "value": "not-an-ip"},
+    )
+    assert resp.status_code == 422
+
+
+async def test_arm_opnsense_requires_creds(client: AsyncClient, db_session: AsyncSession):
+    await _enable_module(db_session)
+    space = await _space(db_session)
+    router = OPNsenseRouter(
+        name="fw1",
+        host="10.0.0.1",
+        api_key="ro",
+        api_secret_encrypted=encrypt_str("s"),
+        ipam_space_id=space.id,
+    )
+    db_session.add(router)
+    await db_session.flush()
+    _u, token = await _superadmin(db_session)
+    await db_session.commit()
+
+    # Arming enabled without alias + write creds → 422.
+    resp = await client.put(
+        f"/api/v1/block-sync/targets/opnsense/{router.id}",
+        headers=_hdr(token),
+        json={"block_sync_enabled": True},
+    )
+    assert resp.status_code == 422
+
+    # With alias + creds → armed.
+    resp = await client.put(
+        f"/api/v1/block-sync/targets/opnsense/{router.id}",
+        headers=_hdr(token),
+        json={
+            "block_sync_enabled": True,
+            "block_alias_name": "spatiumddi_blocked",
+            "block_sync_api_key": "rw",
+            "block_sync_api_secret": "rw-secret",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["block_sync_enabled"] is True
+    assert body["write_credentials_present"] is True
+
+
+async def test_arm_unifi_rejects_cloud_user_password(client: AsyncClient, db_session: AsyncSession):
+    """Cloud-mode UniFi + user_password must be rejected at arm time so a
+    silently-inert target can't be armed (#601 review #7)."""
+    await _enable_module(db_session)
+    space = await _space(db_session)
+    c = UnifiController(name="ctrl1", mode="cloud", cloud_host_id="abc", ipam_space_id=space.id)
+    db_session.add(c)
+    await db_session.flush()
+    _u, token = await _superadmin(db_session)
+    await db_session.commit()
+
+    resp = await client.put(
+        f"/api/v1/block-sync/targets/unifi/{c.id}",
+        headers=_hdr(token),
+        json={
+            "block_sync_enabled": True,
+            "block_sync_auth_kind": "user_password",
+            "block_sync_username": "admin",
+            "block_sync_password": "pw",
+        },
+    )
+    assert resp.status_code == 422
+    assert "cloud" in resp.text.lower()
+
+
+def test_gateable_pairs_excludes_cross_pairs():
+    """Widening GATEABLE_ACTIONS/RESOURCE_TYPES must not admit cross pairs
+    that map to no registered op (#601 review #2)."""
+    from app.services.approvals.policy import gateable_pairs
+
+    pairs = gateable_pairs()
+    assert ("admin", "manage_block_sync") in pairs
+    assert ("delete", "subnet") in pairs
+    # Cross pairs the two independent sets would allow but no op declares:
+    assert ("admin", "subnet") not in pairs
+    assert ("delete", "manage_block_sync") not in pairs

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -76,6 +76,7 @@ Each entry in `Role.permissions` (JSONB) is an object with this shape:
 | `bgp_lg_peer`     | BGP Looking Glass configured peer sessions within a collector (#566) |
 | `conformity`      | Conformity policies + results + auditor PDF export (#106) |
 | `manage_packet_capture` | On-demand packet capture (tcpdump) — start / read / download / delete captures (#59). High-sensitivity (captured bytes can contain plaintext creds/PII); granted to `Network Editor`, not `Viewer`. Download is audited. |
+| `manage_block_sync` | Active block sync / write-back enforcement (#601) — create/lift SpatiumDDI-owned IP/MAC blocks, arm per-target OPNsense/UniFi enforcement + write-scoped creds, reveal + reconcile. High blast-radius (pushes a real firewall/gateway block that can lock devices out); granted to `Network Editor`, not `Viewer`. Every push is audited and eligible for two-person approval (`admin:manage_block_sync`). |
 | `address_set`     | Named IP range within a subnet carrying its own RBAC scope — delegates edit of a slice without subnet-wide write (#103). Creating a set / resizing its range additionally requires write on the parent subnet. |
 | `change_request`  | Queued two-person-approval change requests (#62) — `approve` + `read` for the second-person decision (the underlying operation's permission is *also* required server-side). |
 | `wol_schedule`    | Scheduled Wake-on-LAN jobs + run history (#586) — recurring, tag-targeted, calendar-gated fleet wake |
@@ -140,7 +141,7 @@ on inactive.
 | `IPAM Editor`  | `admin` on `ip_space`, `ip_block`, `subnet`, `ip_address`, `address_set`, `vlan`, `nat_mapping`, `custom_field`, `manage_ipam_templates`, `customer`, `site`, `provider`, `network_service` |
 | `DNS Editor`   | `admin` on `dns_zone`, `dns_record`, `dns_group`, `dns_blocklist`, `manage_dns_pools` |
 | `DHCP Editor`  | `admin` on `dhcp_server`, `dhcp_scope`, `dhcp_pool`, `dhcp_static`, `dhcp_client_class`, `dhcp_option_template`, `dhcp_mac_block` |
-| `Network Editor` | `admin` on `manage_network_devices`, `manage_nmap_scans`, `manage_packet_capture`, `use_network_tools`, `manage_asns`, `vrf`, `circuit`, `multicast`, `network_service`, `overlay_network`, `routing_policy`, `application_category`, `customer`, `site`, `provider`, `tls_cert` |
+| `Network Editor` | `admin` on `manage_network_devices`, `manage_nmap_scans`, `manage_packet_capture`, `manage_block_sync`, `use_network_tools`, `manage_asns`, `vrf`, `circuit`, `multicast`, `network_service`, `overlay_network`, `routing_policy`, `application_category`, `customer`, `site`, `provider`, `tls_cert` |
 | `Auditor`        | `read` on `conformity`, `audit`, `subnet`, `ip_address`, `dns_zone`, `dhcp_scope`, `tls_cert` — external auditor account, can view conformity dashboard + pull the auditor PDF + verify supporting evidence without making changes |
 | `Compliance Editor` | `admin` on `conformity`, `read` on `audit`, `subnet`, `ip_address`, `dns_zone`, `dhcp_scope` — for the team that authors / tunes conformity policies without touching operational config |
 | `Address Set Editor` | `admin` on `address_set` (#103) — delegated edit of a named IP slice within a subnet without subnet-wide write. Grant on a specific address-set id to scope a department admin to just their slice. Creating / resizing a set still requires write on the parent subnet. |

--- a/docs/features/INTEGRATIONS.md
+++ b/docs/features/INTEGRATIONS.md
@@ -421,6 +421,41 @@ Paste `key` into **API Key** and `secret` into **API Secret**. **Test Connection
 
 ---
 
+## Active block sync — write-back enforcement (#601)
+
+> **This is the deliberate exception to the read-only-mirror rule above.** Every other integration in this doc is a one-way `source → IPAM` pull. Active block sync is the opposite direction — `decision → source`, a push reconciler. It exists to close the half-open detect→block loop: rogue-DHCP detection (#370) and new-device watch (#459) can *see* a hostile device, and the DHCP MAC blocklist can starve it of a lease, but a device that **self-assigns a static IP walks right past a DHCP block**. Active block sync pushes a real block at the natural enforcement point instead.
+
+It is off by default and layered behind several independent gates so it can never fire by accident:
+
+1. **Feature module `security.block_sync`** (default-OFF) gates the entire surface (REST router, MCP tools, sidebar entry). Enabling it exposes the UI but **arms nothing**.
+2. **Per-target enforcement master switch** (`block_sync_enabled`, default-OFF) on each OPNsense router / UniFi controller — independent of both the mirror's `enabled` flag and the `integrations.opnsense` / `integrations.unifi` modules. The read-only mirror is never touched; enforcement is a separate armed capability on the same row.
+3. **Distinct write-scoped credentials.** The read mirror uses a read-only API user; enforcement needs a Firewall-privileged OPNsense user / a UniFi admin key. Stored Fernet-encrypted, never returned (password-confirm reveal, audited — mirrors the agent-bootstrap-key reveal).
+4. **RBAC `manage_block_sync`** on every endpoint (Network Editor builtin role; superadmin bypasses).
+5. **Preview + confirm + full audit** on every push — `POST /block-sync/blocks/preview` (and `?preview` on reconcile) returns the exact per-target add/remove diff without writing.
+6. **Two-person approval** — creating/arming a block routes through the approval workflow (#62) as `admin:manage_block_sync` when a policy matches.
+
+### Desired-state model
+
+`network_block` is the SpatiumDDI-owned block set: one row per blocked value (`kind` = `ip` | `mac`), with `reason`, `source` (`manual` / `new_device` / `rogue_dhcp`), `enabled`, and an optional `expires_at` for auto-lift. `network_block_push` tracks per-(block, target) convergence (`push_status` = pending / pushed / removing / error + `last_error`). The reconciler is **target-driven and idempotent** (NN#9): for each armed target it ensures every applicable enabled block is present on the device and lifts every push whose block was disabled / expired / deleted. Convergence is **non-destructive** — SpatiumDDI only removes values it added (tracked via push rows); it never touches alias members / blocked clients it doesn't own. A 60 s beat sweep plus an immediate on-create/lift enqueue keep the device converged.
+
+### OPNsense — firewall table-alias membership
+
+IP-kind blocks push to an operator-**pre-created** OPNsense table alias (e.g. `spatiumddi_blocked`) that the operator references from one block rule. SpatiumDDI only ever mutates alias membership: `POST /api/firewall/alias_util/add|delete/{alias}` then `POST /api/firewall/alias/reconfigure`. No rule CRUD, no rule-ordering state. **Setup:** create a user with Firewall-alias privileges, mint an API key/secret, create the block rule + alias by hand, then arm the target with the alias name + write creds.
+
+### UniFi — L2 client quarantine
+
+MAC-kind blocks push a device quarantine via the legacy controller command `POST /proxy/network/api/s/{site}/cmd/stamgr` `{"cmd": "block-sta", "mac": …}` / `unblock-sta` — the same call the UniFi UI issues (the public Integration v1 API does not expose client-block, so the legacy path + captured `X-CSRF-Token` / `X-API-Key` is mandatory). This is an L2 quarantine at the AP/switch, great for "quarantine this device"; subnet/CIDR firewall rules (`rest/firewallrule`) are out of scope for v1.
+
+### One-click from detection
+
+The New Devices review-queue **Block** action grows an "also quarantine upstream" option: when the module is on, the caller holds `manage_block_sync`, and a UniFi target is armed, blocking a MAC there *also* creates a `network_block` (source=`new_device`) — routed through the same approval gate. Rogue-DHCP responders can be blocked by IP the same way through the dedicated surface (source=`rogue_dhcp`).
+
+### Non-goals (v1)
+
+Full firewall rule authoring / reordering on OPNsense (alias membership only); UniFi subnet/CIDR firewall rules (L2 MAC quarantine only); any write-back other than block/unblock; pfSense enforcement (folds in once the pfSense mirror #32 lands, same shape).
+
+---
+
 ## Dashboard surface
 
 When **any** integration toggle is on, the dashboard renders an **Integrations panel** below the service health strip with:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import { NetworkToolsPage } from "@/pages/tools/NetworkToolsPage";
 import { CidrCalculatorPage } from "@/pages/tools/CidrCalculatorPage";
 import { WakeSchedulesPage } from "@/pages/tools/WakeSchedulesPage";
 import { NewDevicesPage } from "@/pages/security/NewDevicesPage";
+import { BlockSyncPage } from "@/pages/security/BlockSyncPage";
 import { SubnetPlannerListPage } from "@/pages/ipam/SubnetPlannerListPage";
 import { SubnetPlannerEditorPage } from "@/pages/ipam/SubnetPlannerEditorPage";
 import { LogsPage } from "@/pages/LogsPage";
@@ -166,6 +167,7 @@ export default function App() {
         <Route path="tools/cidr" element={<CidrCalculatorPage />} />
         <Route path="tools/wake-schedules" element={<WakeSchedulesPage />} />
         <Route path="security/new-devices" element={<NewDevicesPage />} />
+        <Route path="security/block-sync" element={<BlockSyncPage />} />
         <Route path="dhcp" element={<DHCPPage />} />
         <Route path="dhcp/groups/:groupId/pxe" element={<PXEProfilesPage />} />
         <Route path="logs" element={<LogsPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -32,6 +32,7 @@ import {
   Tags,
   ShieldCheck,
   ShieldAlert,
+  ShieldBan,
   ShieldQuestion,
   ScrollText,
   BellRing,
@@ -219,6 +220,12 @@ const toolsNav = [
     icon: ShieldQuestion,
     to: "/security/new-devices",
     module: "security.new_device_watch",
+  },
+  {
+    label: "Block Sync",
+    icon: ShieldBan,
+    to: "/security/block-sync",
+    module: "security.block_sync",
   },
   { label: "Nmap", icon: Search, to: "/tools/nmap", module: "tools.nmap" },
   {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -213,27 +213,28 @@ const networkInfrastructureNav = [
   },
 ];
 
+// Keep this list alphabetised by label.
 const toolsNav = [
-  { label: "CIDR Calculator", icon: Calculator, to: "/tools/cidr" },
-  {
-    label: "New Devices",
-    icon: ShieldQuestion,
-    to: "/security/new-devices",
-    module: "security.new_device_watch",
-  },
   {
     label: "Block Sync",
     icon: ShieldBan,
     to: "/security/block-sync",
     module: "security.block_sync",
   },
-  { label: "Nmap", icon: Search, to: "/tools/nmap", module: "tools.nmap" },
+  { label: "CIDR Calculator", icon: Calculator, to: "/tools/cidr" },
   {
     label: "Network Tools",
     icon: Wrench,
     to: "/tools/network",
     module: "tools.network",
   },
+  {
+    label: "New Devices",
+    icon: ShieldQuestion,
+    to: "/security/new-devices",
+    module: "security.new_device_watch",
+  },
+  { label: "Nmap", icon: Search, to: "/tools/nmap", module: "tools.nmap" },
   {
     label: "Packet Capture",
     icon: Activity,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,8 @@
-import axios, { AxiosError, type AxiosInstance } from "axios";
+import axios, {
+  AxiosError,
+  type AxiosInstance,
+  type AxiosResponse,
+} from "axios";
 import { getAccessToken, setAccessToken } from "@/lib/authToken";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "/api/v1";
@@ -7224,6 +7228,10 @@ export interface NewDeviceBlockResult {
   mac_address: string;
   blocked_group_ids: string[];
   already_blocked_group_ids: string[];
+  // #601 — set when ``block_upstream`` also pushed an L2 quarantine into
+  // the active block-sync set (or queued it for two-person approval).
+  upstream_block_created: boolean;
+  upstream_change_request_id: string | null;
 }
 
 export const newDeviceApi = {
@@ -7287,6 +7295,9 @@ export const newDeviceApi = {
     group_id?: string;
     reason?: string;
     description?: string;
+    // #601 — also push an L2 quarantine to armed UniFi block-sync targets.
+    // Only meaningful when the ``security.block_sync`` module is enabled.
+    block_upstream?: boolean;
   }) =>
     api
       .post<NewDeviceBlockResult>("/new-devices/block", data)
@@ -15755,5 +15766,157 @@ export const wakeSchedulesApi = {
       .get<
         WolCalendarEvent[]
       >(`/wake-scheduler/calendars/${id}/upcoming-events`, { params })
+      .then((r) => r.data),
+};
+
+// ── Active block sync — firewall / network-block enforcement (#601) ────
+// The enforcement half of the detect→block loop: SpatiumDDI-owned blocked
+// IPs / MACs pushed into armed OPNsense (firewall alias membership) and
+// UniFi (L2 client quarantine) targets. The whole surface is gated by the
+// (default-off) ``security.block_sync`` feature module — every endpoint
+// 404s when the module is off, so callers gate their queries on
+// ``useFeatureModules().enabled("security.block_sync")``. Requires the
+// ``manage_block_sync`` admin permission on every call.
+
+export type BlockKind = "ip" | "mac";
+export type BlockSource = "manual" | "new_device" | "rogue_dhcp";
+export type BlockTargetKind = "opnsense" | "unifi";
+export type BlockPushStatus = "pending" | "pushed" | "removing" | "error";
+export type BlockUnifiAuthKind = "api_key" | "user_password";
+
+export interface BlockPushOut {
+  target_kind: string;
+  target_id: string;
+  push_status: BlockPushStatus;
+  last_pushed_at: string | null;
+  last_error: string | null;
+}
+
+export interface NetworkBlock {
+  id: string;
+  kind: string;
+  value: string;
+  reason: string;
+  description: string;
+  source: string;
+  source_ref: string | null;
+  enabled: boolean;
+  expires_at: string | null;
+  created_at: string;
+  modified_at: string;
+  pushes: BlockPushOut[];
+}
+
+export interface NetworkBlockCreate {
+  kind: BlockKind;
+  value: string;
+  reason?: string;
+  description?: string;
+  source?: BlockSource;
+  source_ref?: string | null;
+  expires_at?: string | null;
+}
+
+export interface BlockTargetDiff {
+  target_kind: string;
+  target_id: string;
+  target_name: string;
+  to_add: string[];
+  to_remove: string[];
+  error: string | null;
+}
+
+export interface BlockTarget {
+  target_kind: BlockTargetKind;
+  target_id: string;
+  name: string;
+  block_sync_enabled: boolean;
+  // OPNsense-only
+  block_alias_name?: string | null;
+  // UniFi-only
+  block_sync_site?: string | null;
+  block_sync_auth_kind?: string | null;
+  write_credentials_present: boolean;
+  last_block_sync_at: string | null;
+  last_block_sync_error: string | null;
+}
+
+export interface BlockOpnsenseArm {
+  block_sync_enabled?: boolean;
+  block_alias_name?: string;
+  block_sync_api_key?: string;
+  // Omit / empty keeps the stored secret; non-empty rotates it.
+  block_sync_api_secret?: string;
+}
+
+export interface BlockUnifiArm {
+  block_sync_enabled?: boolean;
+  block_sync_site?: string;
+  block_sync_auth_kind?: BlockUnifiAuthKind;
+  block_sync_api_key?: string;
+  block_sync_username?: string;
+  block_sync_password?: string;
+}
+
+export interface BlockRevealResult {
+  api_secret?: string;
+  api_key?: string;
+  password?: string;
+}
+
+export const blockSyncApi = {
+  listBlocks: () =>
+    api.get<NetworkBlock[]>("/block-sync/blocks").then((r) => r.data),
+  previewBlock: (data: NetworkBlockCreate) =>
+    api
+      .post<BlockTargetDiff[]>("/block-sync/blocks/preview", data)
+      .then((r) => r.data),
+  // 201 → NetworkBlock, or 202 → ChangeRequestQueued when two-person
+  // approval is armed. Returns the FULL axios response on purpose — do
+  // NOT chain ``.then((r) => r.data)`` here or the 202 status is
+  // invisible. Callers pass the response to ``handleApprovalQueued``.
+  createBlock: (
+    data: NetworkBlockCreate,
+  ): Promise<AxiosResponse<NetworkBlock | ChangeRequestQueued>> =>
+    api.post<NetworkBlock | ChangeRequestQueued>("/block-sync/blocks", data),
+  liftBlock: (id: string) =>
+    api.delete<NetworkBlock>(`/block-sync/blocks/${id}`).then((r) => r.data),
+  listTargets: () =>
+    api.get<BlockTarget[]>("/block-sync/targets").then((r) => r.data),
+  armOpnsense: (id: string, data: BlockOpnsenseArm) =>
+    api
+      .put<BlockTarget>(`/block-sync/targets/opnsense/${id}`, data)
+      .then((r) => r.data),
+  armUnifi: (id: string, data: BlockUnifiArm) =>
+    api
+      .put<BlockTarget>(`/block-sync/targets/unifi/${id}`, data)
+      .then((r) => r.data),
+  // ``preview=true`` reads the device + returns the diff without pushing;
+  // ``preview=false`` enqueues a converge.
+  reconcile: (
+    targetKind: BlockTargetKind,
+    targetId: string,
+    preview: boolean,
+  ) =>
+    api
+      .post<BlockTargetDiff>(
+        `/block-sync/targets/${targetKind}/${targetId}/reconcile`,
+        undefined,
+        { params: { preview } },
+      )
+      .then((r) => r.data),
+  // Password / TOTP re-confirm reveal of the stored write-scoped secret,
+  // mirroring the agent-bootstrap-key reveal. Audited server-side.
+  reveal: (
+    targetKind: BlockTargetKind,
+    targetId: string,
+    password?: string,
+    totpCode?: string,
+  ) =>
+    api
+      .post<BlockRevealResult>(
+        `/block-sync/targets/${targetKind}/${targetId}/reveal`,
+        { password, totp_code: totpCode },
+      )
       .then((r) => r.data),
 };

--- a/frontend/src/pages/security/BlockSyncPage.tsx
+++ b/frontend/src/pages/security/BlockSyncPage.tsx
@@ -1,0 +1,1156 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  RefreshCw,
+  ShieldBan,
+  ShieldCheck,
+  Wifi,
+  Plus,
+  Ban,
+  KeyRound,
+  RotateCw,
+  Eye,
+  EyeOff,
+  Copy,
+} from "lucide-react";
+
+import {
+  blockSyncApi,
+  type BlockTarget,
+  type BlockTargetDiff,
+  type NetworkBlock,
+  type BlockPushOut,
+  type BlockPushStatus,
+  type BlockKind,
+  type BlockRevealResult,
+  type BlockUnifiAuthKind,
+} from "@/lib/api";
+import {
+  handleApprovalQueued,
+  APPROVAL_QUEUED_MESSAGE,
+  CHANGE_REQUEST_QUERY_KEY,
+} from "@/lib/approvalQueue";
+import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { HeaderButton } from "@/components/ui/header-button";
+import { errMsg, inputCls } from "@/pages/dhcp/_shared";
+
+// Relative "time ago" for the sync/pushed columns. Cheap, no dependency.
+function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  return `${days}d ago`;
+}
+
+const PUSH_STATUS_STYLE: Record<BlockPushStatus, string> = {
+  pushed: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  pending: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+  removing: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+  error: "bg-red-500/10 text-red-700 dark:text-red-400",
+};
+
+export function BlockSyncPage() {
+  const qc = useQueryClient();
+
+  const [showArm, setShowArm] = useState<BlockTarget | null>(null);
+  const [showReveal, setShowReveal] = useState<BlockTarget | null>(null);
+  const [showNewBlock, setShowNewBlock] = useState(false);
+  const [reconcilePreview, setReconcilePreview] = useState<{
+    target: BlockTarget;
+    diff: BlockTargetDiff | null;
+  } | null>(null);
+  const [liftTarget, setLiftTarget] = useState<NetworkBlock | null>(null);
+  const [pageError, setPageError] = useState<string | null>(null);
+  const [pageNotice, setPageNotice] = useState<string | null>(null);
+
+  const targetsQ = useQuery({
+    queryKey: ["block-sync", "targets"],
+    queryFn: blockSyncApi.listTargets,
+    refetchInterval: 30_000,
+  });
+  const blocksQ = useQuery({
+    queryKey: ["block-sync", "blocks"],
+    queryFn: blockSyncApi.listBlocks,
+    refetchInterval: 30_000,
+  });
+
+  const targets = targetsQ.data ?? [];
+  const blocks = blocksQ.data ?? [];
+
+  // target_id → display name, for rendering push chips on the Blocks table.
+  const targetNames = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const t of targets) m.set(t.target_id, t.name);
+    return m;
+  }, [targets]);
+
+  function invalidateAll() {
+    qc.invalidateQueries({ queryKey: ["block-sync"] });
+  }
+
+  const reconcileMut = useMutation({
+    mutationFn: ({
+      target,
+      preview,
+    }: {
+      target: BlockTarget;
+      preview: boolean;
+    }) => blockSyncApi.reconcile(target.target_kind, target.target_id, preview),
+    onError: (e) => setPageError(errMsg(e, "Reconcile failed")),
+  });
+
+  function previewReconcile(target: BlockTarget) {
+    setPageError(null);
+    setReconcilePreview({ target, diff: null });
+    reconcileMut.mutate(
+      { target, preview: true },
+      {
+        onSuccess: (diff) => setReconcilePreview({ target, diff }),
+      },
+    );
+  }
+
+  function pushReconcile(target: BlockTarget) {
+    setPageError(null);
+    reconcileMut.mutate(
+      { target, preview: false },
+      {
+        onSuccess: () => {
+          setPageNotice(`Reconcile enqueued for ${target.name}.`);
+          setReconcilePreview(null);
+          invalidateAll();
+        },
+      },
+    );
+  }
+
+  const liftMut = useMutation({
+    mutationFn: (id: string) => blockSyncApi.liftBlock(id),
+    onSuccess: () => {
+      invalidateAll();
+      setLiftTarget(null);
+    },
+    onError: (e) => setPageError(errMsg(e, "Failed to lift block")),
+  });
+
+  return (
+    <div className="space-y-4 p-4 md:p-6">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <h1 className="flex items-center gap-2 text-lg font-semibold">
+            <ShieldBan className="h-5 w-5 flex-shrink-0" />
+            Active block sync
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            SpatiumDDI-owned blocked IPs / MACs, pushed into armed OPNsense
+            firewalls (alias membership) and UniFi controllers (L2 quarantine).
+            Each target is armed separately with distinct write credentials;
+            every push is previewable + audited.
+          </p>
+        </div>
+        <HeaderButton
+          icon={RefreshCw}
+          iconClassName={
+            targetsQ.isFetching || blocksQ.isFetching
+              ? "animate-spin"
+              : undefined
+          }
+          onClick={() => invalidateAll()}
+          disabled={targetsQ.isFetching || blocksQ.isFetching}
+        >
+          Refresh
+        </HeaderButton>
+        <HeaderButton
+          icon={Plus}
+          variant="primary"
+          onClick={() => {
+            setPageError(null);
+            setShowNewBlock(true);
+          }}
+        >
+          New block
+        </HeaderButton>
+      </div>
+
+      {pageError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {pageError}
+        </div>
+      )}
+      {pageNotice && (
+        <div className="flex items-start justify-between gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-400">
+          <span>{pageNotice}</span>
+          <button
+            type="button"
+            onClick={() => setPageNotice(null)}
+            className="text-emerald-700/70 hover:text-emerald-700 dark:text-emerald-400/70"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Targets */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-muted-foreground">Targets</h2>
+        <div className="rounded-lg border">
+          {targets.length === 0 ? (
+            <p className="p-8 text-center text-sm text-muted-foreground">
+              {targetsQ.isLoading
+                ? "Loading…"
+                : "No OPNsense routers or UniFi controllers to arm. Add an OPNsense or UniFi integration first."}
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[880px] text-xs">
+                <thead>
+                  <tr className="border-b bg-muted/30">
+                    <th className="px-3 py-2 text-left font-medium">Name</th>
+                    <th className="px-3 py-2 text-left font-medium">Kind</th>
+                    <th className="px-3 py-2 text-left font-medium">Armed</th>
+                    <th className="px-3 py-2 text-left font-medium">
+                      Alias / Site
+                    </th>
+                    <th className="px-3 py-2 text-left font-medium">
+                      Write creds
+                    </th>
+                    <th className="px-3 py-2 text-left font-medium">
+                      Last sync
+                    </th>
+                    <th className="px-3 py-2 text-right font-medium"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {targets.map((t) => (
+                    <tr
+                      key={`${t.target_kind}:${t.target_id}`}
+                      className="border-b last:border-0"
+                    >
+                      <td className="px-3 py-2 font-medium">{t.name}</td>
+                      <td className="px-3 py-2">
+                        <span className="inline-flex items-center gap-1 text-muted-foreground">
+                          {t.target_kind === "unifi" ? (
+                            <Wifi className="h-3.5 w-3.5" />
+                          ) : (
+                            <ShieldCheck className="h-3.5 w-3.5" />
+                          )}
+                          {t.target_kind === "unifi" ? "UniFi" : "OPNsense"}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        {t.block_sync_enabled ? (
+                          <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-emerald-500/10 text-emerald-700 dark:text-emerald-400">
+                            Armed
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-muted text-muted-foreground">
+                            Off
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {t.target_kind === "opnsense"
+                          ? t.block_alias_name || "—"
+                          : t.block_sync_site || "—"}
+                      </td>
+                      <td className="px-3 py-2">
+                        {t.write_credentials_present ? (
+                          <span className="text-emerald-600 dark:text-emerald-400">
+                            Present
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">Missing</span>
+                        )}
+                      </td>
+                      <td
+                        className="px-3 py-2 text-muted-foreground"
+                        title={
+                          t.last_block_sync_at
+                            ? new Date(t.last_block_sync_at).toLocaleString()
+                            : undefined
+                        }
+                      >
+                        {t.last_block_sync_error ? (
+                          <span
+                            className="text-red-600 dark:text-red-400"
+                            title={t.last_block_sync_error}
+                          >
+                            error
+                          </span>
+                        ) : t.last_block_sync_at ? (
+                          timeAgo(t.last_block_sync_at)
+                        ) : (
+                          "never"
+                        )}
+                      </td>
+                      <td className="px-3 py-2">
+                        <div className="flex items-center justify-end gap-1.5">
+                          <button
+                            type="button"
+                            onClick={() => previewReconcile(t)}
+                            className="inline-flex items-center gap-1 rounded border px-2 py-1 hover:bg-muted disabled:opacity-40"
+                            disabled={!t.block_sync_enabled}
+                            title={
+                              t.block_sync_enabled
+                                ? "Preview + reconcile now"
+                                : "Arm the target first"
+                            }
+                          >
+                            <RotateCw className="h-3 w-3" />
+                            Reconcile
+                          </button>
+                          {t.write_credentials_present && (
+                            <button
+                              type="button"
+                              onClick={() => setShowReveal(t)}
+                              className="inline-flex items-center gap-1 rounded border px-2 py-1 hover:bg-muted"
+                              title="Reveal stored write credentials"
+                            >
+                              <Eye className="h-3 w-3" />
+                              Reveal
+                            </button>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setPageError(null);
+                              setShowArm(t);
+                            }}
+                            className="inline-flex items-center gap-1 rounded border px-2 py-1 hover:bg-muted"
+                          >
+                            <KeyRound className="h-3 w-3" />
+                            Arm / Edit
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Blocks */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-muted-foreground">Blocks</h2>
+        <div className="rounded-lg border">
+          {blocks.length === 0 ? (
+            <p className="p-8 text-center text-sm text-muted-foreground">
+              {blocksQ.isLoading
+                ? "Loading…"
+                : "No network blocks yet. Create one with New block."}
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[900px] text-xs">
+                <thead>
+                  <tr className="border-b bg-muted/30">
+                    <th className="px-3 py-2 text-left font-medium">Kind</th>
+                    <th className="px-3 py-2 text-left font-medium">Value</th>
+                    <th className="px-3 py-2 text-left font-medium">Reason</th>
+                    <th className="px-3 py-2 text-left font-medium">Source</th>
+                    <th className="px-3 py-2 text-left font-medium">State</th>
+                    <th className="px-3 py-2 text-left font-medium">Pushes</th>
+                    <th className="px-3 py-2 text-right font-medium"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {blocks.map((b) => (
+                    <tr
+                      key={b.id}
+                      className={`border-b last:border-0 ${
+                        b.enabled ? "" : "opacity-50"
+                      }`}
+                    >
+                      <td className="px-3 py-2 uppercase text-muted-foreground">
+                        {b.kind}
+                      </td>
+                      <td className="break-all px-3 py-2 font-mono">
+                        {b.value}
+                      </td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {b.reason || "—"}
+                      </td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {b.source}
+                      </td>
+                      <td className="px-3 py-2">
+                        {b.enabled ? (
+                          <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-red-500/10 text-red-700 dark:text-red-400">
+                            Active
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium bg-muted text-muted-foreground">
+                            Lifted
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2">
+                        <PushChips
+                          pushes={b.pushes}
+                          targetNames={targetNames}
+                        />
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        {b.enabled && (
+                          <button
+                            type="button"
+                            onClick={() => setLiftTarget(b)}
+                            className="inline-flex items-center gap-1 rounded border border-destructive/40 px-2 py-1 text-destructive hover:bg-destructive/10"
+                          >
+                            <Ban className="h-3 w-3" />
+                            Lift
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Modals */}
+      {showArm && (
+        <ArmTargetModal
+          target={showArm}
+          onClose={() => setShowArm(null)}
+          onDone={() => {
+            invalidateAll();
+            setShowArm(null);
+          }}
+        />
+      )}
+      {showReveal && (
+        <RevealModal target={showReveal} onClose={() => setShowReveal(null)} />
+      )}
+      {showNewBlock && (
+        <NewBlockModal
+          onClose={() => setShowNewBlock(false)}
+          onDone={(notice) => {
+            invalidateAll();
+            if (notice) setPageNotice(notice);
+            setShowNewBlock(false);
+          }}
+        />
+      )}
+      {reconcilePreview && (
+        <ReconcilePreviewModal
+          target={reconcilePreview.target}
+          diff={reconcilePreview.diff}
+          loading={reconcileMut.isPending}
+          onClose={() => setReconcilePreview(null)}
+          onConfirm={() => pushReconcile(reconcilePreview.target)}
+        />
+      )}
+      <ConfirmModal
+        open={!!liftTarget}
+        title="Lift block"
+        message={
+          <>
+            Lift the block on{" "}
+            <span className="font-mono">{liftTarget?.value}</span>? This
+            disables it and pushes the removal to every target it landed on. The
+            row is kept (disabled) as audit history.
+          </>
+        }
+        tone="destructive"
+        confirmLabel="Lift block"
+        loading={liftMut.isPending}
+        onConfirm={() => liftTarget && liftMut.mutate(liftTarget.id)}
+        onClose={() => setLiftTarget(null)}
+      />
+    </div>
+  );
+}
+
+// ── Per-target push status chips on the Blocks table ─────────────────
+function PushChips({
+  pushes,
+  targetNames,
+}: {
+  pushes: BlockPushOut[];
+  targetNames: Map<string, string>;
+}) {
+  if (pushes.length === 0)
+    return <span className="text-muted-foreground">—</span>;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {pushes.map((p) => {
+        const name = targetNames.get(p.target_id) ?? p.target_kind;
+        const style =
+          PUSH_STATUS_STYLE[p.push_status] ?? "bg-muted text-muted-foreground";
+        return (
+          <span
+            key={`${p.target_kind}:${p.target_id}`}
+            className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${style}`}
+            title={
+              p.last_error
+                ? `${name}: ${p.last_error}`
+                : `${name}: ${p.push_status}${
+                    p.last_pushed_at
+                      ? ` · ${new Date(p.last_pushed_at).toLocaleString()}`
+                      : ""
+                  }`
+            }
+          >
+            {name} · {p.push_status}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Arm / edit a target ───────────────────────────────────────────────
+function ArmTargetModal({
+  target,
+  onClose,
+  onDone,
+}: {
+  target: BlockTarget;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const isUnifi = target.target_kind === "unifi";
+
+  const [enabled, setEnabled] = useState(target.block_sync_enabled);
+  // OPNsense
+  const [alias, setAlias] = useState(target.block_alias_name ?? "");
+  const [apiKey, setApiKey] = useState("");
+  const [apiSecret, setApiSecret] = useState("");
+  // UniFi
+  const [site, setSite] = useState(target.block_sync_site ?? "default");
+  const [authKind, setAuthKind] = useState<BlockUnifiAuthKind>(
+    (target.block_sync_auth_kind as BlockUnifiAuthKind) ?? "api_key",
+  );
+  const [unifiApiKey, setUnifiApiKey] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const [error, setError] = useState<string | null>(null);
+
+  const mut = useMutation({
+    mutationFn: () => {
+      if (isUnifi) {
+        return blockSyncApi.armUnifi(target.target_id, {
+          block_sync_enabled: enabled,
+          block_sync_site: site.trim() || "default",
+          block_sync_auth_kind: authKind,
+          block_sync_api_key:
+            authKind === "api_key" && unifiApiKey.trim()
+              ? unifiApiKey.trim()
+              : undefined,
+          block_sync_username:
+            authKind === "user_password" && username.trim()
+              ? username.trim()
+              : undefined,
+          block_sync_password:
+            authKind === "user_password" && password ? password : undefined,
+        });
+      }
+      return blockSyncApi.armOpnsense(target.target_id, {
+        block_sync_enabled: enabled,
+        block_alias_name: alias.trim(),
+        block_sync_api_key: apiKey.trim() || undefined,
+        block_sync_api_secret: apiSecret || undefined,
+      });
+    },
+    onSuccess: onDone,
+    onError: (e) => setError(errMsg(e, "Failed to save arming config")),
+  });
+
+  const credsHint = target.write_credentials_present
+    ? "Credentials are stored. Leave blank to keep them; type to rotate."
+    : "No credentials stored yet — required to arm.";
+
+  return (
+    <Modal
+      title={`Arm ${isUnifi ? "UniFi" : "OPNsense"} · ${target.name}`}
+      onClose={onClose}
+      wide
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          mut.mutate();
+        }}
+        className="space-y-4"
+      >
+        <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />
+          <span className="font-medium">Arm block sync on this target</span>
+        </label>
+        <p className="text-xs text-muted-foreground">
+          Arming enables pushes to this target. Distinct write-scoped
+          credentials are required — they never leave the server except through
+          the audited Reveal flow.
+        </p>
+
+        {isUnifi ? (
+          <>
+            <Field label="Site">
+              <input
+                className={inputCls}
+                value={site}
+                onChange={(e) => setSite(e.target.value)}
+                placeholder="default"
+              />
+            </Field>
+            <Field label="Auth kind">
+              <select
+                className={inputCls}
+                value={authKind}
+                onChange={(e) =>
+                  setAuthKind(e.target.value as BlockUnifiAuthKind)
+                }
+              >
+                <option value="api_key">API key</option>
+                <option value="user_password">Username / password</option>
+              </select>
+            </Field>
+            {authKind === "api_key" ? (
+              <Field label="API key" hint={credsHint}>
+                <input
+                  className={`${inputCls} font-mono`}
+                  type="password"
+                  autoComplete="new-password"
+                  value={unifiApiKey}
+                  onChange={(e) => setUnifiApiKey(e.target.value)}
+                  placeholder={
+                    target.write_credentials_present ? "•••••• (unchanged)" : ""
+                  }
+                />
+              </Field>
+            ) : (
+              <>
+                <Field label="Username" hint={credsHint}>
+                  <input
+                    className={inputCls}
+                    autoComplete="off"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    placeholder={
+                      target.write_credentials_present
+                        ? "•••••• (unchanged)"
+                        : ""
+                    }
+                  />
+                </Field>
+                <Field label="Password">
+                  <input
+                    className={`${inputCls} font-mono`}
+                    type="password"
+                    autoComplete="new-password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder={
+                      target.write_credentials_present
+                        ? "•••••• (unchanged)"
+                        : ""
+                    }
+                  />
+                </Field>
+              </>
+            )}
+          </>
+        ) : (
+          <>
+            <Field
+              label="Block alias name"
+              hint="The OPNsense firewall alias (table) whose members SpatiumDDI manages. Must already exist and be referenced by a block rule."
+            >
+              <input
+                className={`${inputCls} font-mono`}
+                value={alias}
+                onChange={(e) => setAlias(e.target.value)}
+                placeholder="spatium_blocklist"
+              />
+            </Field>
+            <Field label="API key" hint={credsHint}>
+              <input
+                className={`${inputCls} font-mono`}
+                autoComplete="off"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder={
+                  target.write_credentials_present ? "•••••• (unchanged)" : ""
+                }
+              />
+            </Field>
+            <Field label="API secret">
+              <input
+                className={`${inputCls} font-mono`}
+                type="password"
+                autoComplete="new-password"
+                value={apiSecret}
+                onChange={(e) => setApiSecret(e.target.value)}
+                placeholder={
+                  target.write_credentials_present ? "•••••• (unchanged)" : ""
+                }
+              />
+            </Field>
+          </>
+        )}
+
+        {error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mut.isPending}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {mut.isPending ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+// ── Reveal stored write credentials (password / TOTP re-confirm) ──────
+function RevealModal({
+  target,
+  onClose,
+}: {
+  target: BlockTarget;
+  onClose: () => void;
+}) {
+  const [password, setPassword] = useState("");
+  const [totp, setTotp] = useState("");
+  const [revealed, setRevealed] = useState<BlockRevealResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const mut = useMutation({
+    mutationFn: () =>
+      blockSyncApi.reveal(
+        target.target_kind,
+        target.target_id,
+        password || undefined,
+        totp || undefined,
+      ),
+    onSuccess: (data) => {
+      setRevealed(data);
+      setError(null);
+      setPassword("");
+      setTotp("");
+    },
+    onError: (e) => setError(errMsg(e, "Password or code is incorrect")),
+  });
+
+  const entries = revealed ? Object.entries(revealed) : [];
+
+  return (
+    <Modal title={`Reveal credentials · ${target.name}`} onClose={onClose}>
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Re-confirm your identity to reveal the stored write-scoped secret.
+          Every reveal is audited. SSO accounts: enter an authenticator code
+          instead of a password (enrol under Account → Two-factor).
+        </p>
+
+        {revealed === null ? (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (password || totp) mut.mutate();
+            }}
+            className="space-y-3"
+          >
+            <input
+              type="password"
+              autoComplete="current-password"
+              autoFocus
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password"
+              className={`${inputCls} font-mono`}
+            />
+            <input
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              value={totp}
+              onChange={(e) => setTotp(e.target.value)}
+              placeholder="or 6-digit code"
+              className={`${inputCls} font-mono`}
+            />
+            {error && <p className="text-xs text-destructive">{error}</p>}
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={(!password && !totp) || mut.isPending}
+                className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {mut.isPending ? "Verifying…" : "Reveal"}
+              </button>
+            </div>
+          </form>
+        ) : (
+          <div className="space-y-2">
+            {entries.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No stored secret to reveal for this target.
+              </p>
+            ) : (
+              entries.map(([k, v]) => (
+                <div key={k} className="space-y-1">
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    {k.replace(/_/g, " ")}
+                  </p>
+                  <div className="flex items-center gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 px-2 py-1">
+                    <span className="break-all font-mono text-xs">{v}</span>
+                    <button
+                      type="button"
+                      onClick={() => navigator.clipboard.writeText(v)}
+                      className="ml-auto rounded p-1 hover:bg-accent"
+                      title="Copy to clipboard"
+                    >
+                      <Copy className="h-3 w-3" />
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={() => setRevealed(null)}
+                className="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+              >
+                <EyeOff className="h-3.5 w-3.5" />
+                Hide
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90"
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+// ── New block — preview → create (handles the 202 approval envelope) ──
+function NewBlockModal({
+  onClose,
+  onDone,
+}: {
+  onClose: () => void;
+  onDone: (notice?: string) => void;
+}) {
+  const [kind, setKind] = useState<BlockKind>("ip");
+  const [value, setValue] = useState("");
+  const [reason, setReason] = useState("quarantine");
+  const [description, setDescription] = useState("");
+  const [diff, setDiff] = useState<BlockTargetDiff[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function body() {
+    return {
+      kind,
+      value: value.trim(),
+      reason: reason.trim() || undefined,
+      description: description.trim() || undefined,
+    };
+  }
+
+  const previewMut = useMutation({
+    mutationFn: () => blockSyncApi.previewBlock(body()),
+    onSuccess: (d) => {
+      setDiff(d);
+      setError(null);
+    },
+    onError: (e) => setError(errMsg(e, "Preview failed")),
+  });
+
+  const createMut = useMutation({
+    mutationFn: () => blockSyncApi.createBlock(body()),
+    onSuccess: (resp) => {
+      if (handleApprovalQueued(resp)) {
+        onDone(APPROVAL_QUEUED_MESSAGE);
+        return;
+      }
+      onDone(`Block created for ${value.trim()}.`);
+    },
+    onError: (e) => setError(errMsg(e, "Failed to create block")),
+  });
+
+  // Invalidating the change-request badge on a 202 lives in the parent
+  // via ``invalidateAll``; the approval queue keys refresh here too.
+  const qc = useQueryClient();
+
+  return (
+    <Modal title="New network block" onClose={onClose} wide>
+      <div className="space-y-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <Field label="Kind">
+            <select
+              className={inputCls}
+              value={kind}
+              onChange={(e) => {
+                setKind(e.target.value as BlockKind);
+                setDiff(null);
+              }}
+            >
+              <option value="ip">IP address</option>
+              <option value="mac">MAC address</option>
+            </select>
+          </Field>
+          <Field label="Value" className="sm:col-span-2">
+            <input
+              className={`${inputCls} font-mono`}
+              value={value}
+              onChange={(e) => {
+                setValue(e.target.value);
+                setDiff(null);
+              }}
+              placeholder={kind === "ip" ? "192.0.2.10" : "aa:bb:cc:dd:ee:ff"}
+            />
+          </Field>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label="Reason">
+            <input
+              className={inputCls}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="quarantine"
+            />
+          </Field>
+          <Field label="Description">
+            <input
+              className={inputCls}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="optional note"
+            />
+          </Field>
+        </div>
+
+        {/* Preview */}
+        <div className="rounded-md border">
+          <div className="flex items-center justify-between border-b bg-muted/30 px-3 py-2">
+            <span className="text-xs font-semibold text-muted-foreground">
+              Preview — armed targets this block would land on
+            </span>
+            <button
+              type="button"
+              onClick={() => previewMut.mutate()}
+              disabled={!value.trim() || previewMut.isPending}
+              className="inline-flex items-center gap-1 rounded border px-2 py-1 text-xs hover:bg-muted disabled:opacity-40"
+            >
+              <RotateCw
+                className={`h-3 w-3 ${
+                  previewMut.isPending ? "animate-spin" : ""
+                }`}
+              />
+              Preview
+            </button>
+          </div>
+          <div className="p-3 text-xs">
+            {diff === null ? (
+              <p className="text-muted-foreground">
+                Run a preview to see the exact per-target changes without
+                pushing anything.
+              </p>
+            ) : diff.length === 0 ? (
+              <p className="text-muted-foreground">
+                No armed targets of this kind. Nothing would be pushed.
+              </p>
+            ) : (
+              <ul className="space-y-1">
+                {diff.map((d) => (
+                  <li
+                    key={`${d.target_kind}:${d.target_id}`}
+                    className="flex flex-wrap items-center gap-2"
+                  >
+                    <span className="font-medium">{d.target_name}</span>
+                    {d.error ? (
+                      <span className="text-destructive">{d.error}</span>
+                    ) : d.to_add.length > 0 ? (
+                      <span className="text-emerald-600 dark:text-emerald-400">
+                        + {d.to_add.join(", ")}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">
+                        no change (already blocked)
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              createMut.mutate(undefined, {
+                onSuccess: () =>
+                  qc.invalidateQueries({ queryKey: CHANGE_REQUEST_QUERY_KEY }),
+              });
+            }}
+            disabled={!value.trim() || createMut.isPending}
+            className="rounded-md bg-destructive px-3 py-1.5 text-sm text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+          >
+            {createMut.isPending ? "Creating…" : "Create block"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ── Reconcile-now preview modal ───────────────────────────────────────
+function ReconcilePreviewModal({
+  target,
+  diff,
+  loading,
+  onClose,
+  onConfirm,
+}: {
+  target: BlockTarget;
+  diff: BlockTargetDiff | null;
+  loading: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Modal title={`Reconcile · ${target.name}`} onClose={onClose}>
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Compares the desired block set against what's live on the device, then
+          converges. Review the diff below before pushing.
+        </p>
+        <div className="rounded-md border p-3 text-xs">
+          {diff === null ? (
+            <p className="text-muted-foreground">Reading device…</p>
+          ) : diff.error ? (
+            <p className="text-destructive">{diff.error}</p>
+          ) : diff.to_add.length === 0 && diff.to_remove.length === 0 ? (
+            <p className="text-muted-foreground">
+              Already in sync — nothing to change.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {diff.to_add.length > 0 && (
+                <div>
+                  <p className="font-semibold text-emerald-600 dark:text-emerald-400">
+                    Add ({diff.to_add.length})
+                  </p>
+                  <p className="break-all font-mono text-muted-foreground">
+                    {diff.to_add.join(", ")}
+                  </p>
+                </div>
+              )}
+              {diff.to_remove.length > 0 && (
+                <div>
+                  <p className="font-semibold text-red-600 dark:text-red-400">
+                    Remove ({diff.to_remove.length})
+                  </p>
+                  <p className="break-all font-mono text-muted-foreground">
+                    {diff.to_remove.join(", ")}
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading || diff === null || !!diff?.error}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {loading ? "Working…" : "Reconcile now"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ── Small labelled field ──────────────────────────────────────────────
+function Field({
+  label,
+  hint,
+  className,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`space-y-1 ${className ?? ""}`}>
+      <label className="block text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      {children}
+      {hint && <p className="text-[11px] text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/security/NewDevicesPage.tsx
+++ b/frontend/src/pages/security/NewDevicesPage.tsx
@@ -24,6 +24,7 @@ import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { HeaderButton } from "@/components/ui/header-button";
 import { Pager } from "@/components/ui/pager";
 import { errMsg, inputCls } from "@/pages/dhcp/_shared";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
 
 const PAGE_SIZE = 100;
 
@@ -89,6 +90,12 @@ export function NewDevicesPage() {
   const [showAddAllowlist, setShowAddAllowlist] = useState(false);
   const [showBlock, setShowBlock] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [actionNotice, setActionNotice] = useState<string | null>(null);
+
+  // #601 — the "also quarantine upstream" affordance in the block modal
+  // only makes sense when the active block-sync module is enabled.
+  const { enabled: moduleEnabled } = useFeatureModules();
+  const blockSyncEnabled = moduleEnabled("security.block_sync");
 
   const summaryQ = useQuery({
     queryKey: ["new-devices", "summary"],
@@ -329,6 +336,18 @@ export function NewDevicesPage() {
           {actionError}
         </div>
       )}
+      {actionNotice && (
+        <div className="flex items-start justify-between gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-400">
+          <span>{actionNotice}</span>
+          <button
+            type="button"
+            onClick={() => setActionNotice(null)}
+            className="text-emerald-700/70 hover:text-emerald-700 dark:text-emerald-400/70"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {/* Bulk toolbar — slides in when rows are selected. */}
       {someSelected && (
@@ -498,11 +517,13 @@ export function NewDevicesPage() {
       {showBlock && (
         <BlockSelectedModal
           sightings={selectedRows}
+          blockSyncEnabled={blockSyncEnabled}
           onClose={() => setShowBlock(false)}
-          onDone={() => {
+          onDone={(notice) => {
             invalidateAll();
             setSelected(new Set());
             setShowBlock(false);
+            setActionNotice(notice ?? null);
           }}
           onError={(m) => setActionError(m)}
         />
@@ -819,16 +840,21 @@ function AddSelectedToAllowlistModal({
 // ── Block selected MACs across DHCP server groups ─────────────────────
 function BlockSelectedModal({
   sightings,
+  blockSyncEnabled,
   onClose,
   onDone,
   onError,
 }: {
   sightings: NewDeviceSighting[];
+  blockSyncEnabled: boolean;
   onClose: () => void;
-  onDone: () => void;
+  onDone: (notice?: string) => void;
   onError: (msg: string) => void;
 }) {
   const [reason, setReason] = useState("");
+  // #601 — optionally also push an L2 quarantine to armed UniFi block-sync
+  // targets, not just starve the device of DHCP.
+  const [blockUpstream, setBlockUpstream] = useState(false);
   const mut = useMutation({
     mutationFn: async () => {
       const results = await Promise.allSettled(
@@ -836,14 +862,32 @@ function BlockSelectedModal({
           newDeviceApi.block({
             mac_address: s.mac_address,
             reason: reason.trim() || undefined,
+            block_upstream: blockUpstream || undefined,
           }),
         ),
       );
       const failed = results.filter((r) => r.status === "rejected").length;
       if (failed > 0)
         throw new Error(`${failed} of ${sightings.length} failed to block`);
+      // Summarise the upstream outcome so the operator knows whether the
+      // L2 quarantine landed or is waiting on a second approver.
+      let upstreamCreated = 0;
+      let upstreamQueued = 0;
+      for (const r of results) {
+        if (r.status !== "fulfilled") continue;
+        if (r.value.upstream_block_created) upstreamCreated += 1;
+        if (r.value.upstream_change_request_id) upstreamQueued += 1;
+      }
+      const parts: string[] = [];
+      if (upstreamCreated > 0)
+        parts.push(`${upstreamCreated} upstream quarantine(s) pushed`);
+      if (upstreamQueued > 0)
+        parts.push(
+          `${upstreamQueued} upstream quarantine(s) queued for approval`,
+        );
+      return parts.length > 0 ? parts.join("; ") + "." : undefined;
     },
-    onSuccess: onDone,
+    onSuccess: (notice) => onDone(notice),
     onError: (e) => onError(errMsg(e, "Failed to block")),
   });
 
@@ -874,6 +918,24 @@ function BlockSelectedModal({
           value={reason}
           onChange={(e) => setReason(e.target.value)}
         />
+        {blockSyncEnabled && (
+          <label className="flex cursor-pointer items-start gap-2 text-sm">
+            <input
+              type="checkbox"
+              className="mt-0.5"
+              checked={blockUpstream}
+              onChange={(e) => setBlockUpstream(e.target.checked)}
+            />
+            <span>
+              Also quarantine upstream (UniFi block-sta)
+              <span className="block text-xs text-muted-foreground">
+                Pushes an L2 client quarantine to armed UniFi block-sync
+                targets, not only a DHCP block. May queue for two-person
+                approval.
+              </span>
+            </span>
+          </label>
+        )}
         <div className="flex justify-end gap-2 pt-2">
           <button
             type="button"


### PR DESCRIPTION
Closes #601.

Turns SpatiumDDI's passive detection into **active enforcement**. Today the loop is half-open: rogue-DHCP detection (#370) and new-device watch (#459) can *see* a hostile device and the DHCP MAC blocklist can starve it of a lease, but a device that **self-assigns a static IP walks right past** the DHCP block. This adds a narrow, heavily-guarded write path that pushes a real block at the natural enforcement point — an **OPNsense** firewall table alias (by IP) or a **UniFi** L2 client quarantine (by MAC).

## The guarded exception to read-only mirrors

This is the opposite direction from every other integration (`decision → source`, a push reconciler). It stays off by default behind independent gates:

1. **`security.block_sync` feature module** (default-OFF) gates the whole surface — enabling it arms nothing.
2. **Per-target `block_sync_enabled` master switch** (default-OFF), independent of the mirror module, with **distinct Fernet-encrypted write-scoped credentials**.
3. **`manage_block_sync` RBAC** (Network Editor) on every endpoint.
4. **Two-person approval (#62)** on every create — REST *and* the AI propose→apply path.
5. **Preview + audit on every push** — `POST /blocks/preview` returns the exact per-target diff without writing; the reconciler audits the applied device diff.
6. **Idempotent, non-destructive convergence** — only removes values SpatiumDDI added (tracked in `network_block_push`); never touches alias members / blocked clients it doesn't own.

## What's included

- **Data model** — `network_block` (IP/MAC desired-state) + `network_block_push` (per-(block,target) convergence); enforcement columns on `opnsense_router` / `unifi_controller`. Migration `d3b9f42a1c05`.
- **Clients** — OPNsense alias add/delete/reconfigure; UniFi CSRF-replaying `block-sta`/`unblock-sta`.
- **Reconciler + Celery** — target-driven converge; 60s beat sweep + immediate on-create/lift push; disarm lifts pushed device state.
- **REST** `/api/v1/block-sync` — blocks CRUD w/ preview, target arm/creds, force-reconcile, password-confirm credential reveal.
- **MCP** — `find_network_blocks` / `count_network_blocks` (on) + `propose_create_network_block` (default-disabled).
- **One-click** — New Devices Block modal "also quarantine upstream (UniFi)".
- **Frontend** — `blockSyncApi`, a Block Sync admin page (targets arming/reconcile/reveal + blocks create-with-preview/lift), module-gated nav.
- **Docs** — INTEGRATIONS.md (new "Active block sync" section), PERMISSIONS.md, CHANGELOG.

**Non-goals (v1):** full OPNsense rule authoring (alias membership only), UniFi subnet/CIDR rules (L2 MAC quarantine only), pfSense (folds in with the #32 mirror).

## Hardening from an adversarial self-review

A multi-agent code review of the diff surfaced 10 findings, all fixed before this PR: AI propose→apply now routes risky ops through the approval gate; inert-policy fail-open closed via pair-validation (`gateable_pairs()`); UniFi `meta.rc` error envelope now raises; OPNsense reconfigure-before-confirm ordering + retry; arm-time validation reuses the reconcile-side validators (rejects cloud+user_password); disarm/target-delete lift + orphan-sweep; UniFi periodic re-assert; device pushes audited.

## Verification

- Backend: ruff + black + mypy (701 files) clean; migration-shape lint clean.
- Tests: block-sync 17, approvals 55, AI write-ops 20, new-device block — all pass.
- Frontend: eslint + prettier + typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)