### PR TITLE
fix(dhcp): scope deletion — agentless write-through, cascade soft-delete, IPAM mirror release (#616 #617 #618 #619)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -194,6 +194,9 @@ backend/alembic/versions/b2f7e91d3c48_dhcp_pull_interval_seconds.py:rename_colum
 backend/alembic/versions/b3a82c0d4e95_appliance_k3s_kubeconfig.py:drop_column:43
 backend/alembic/versions/b3a82c0d4e95_appliance_k3s_kubeconfig.py:drop_column:44
 backend/alembic/versions/b3e7d1f9a204_appliance_host_migration_health.py:drop_column:47
+backend/alembic/versions/b3e7d21c9f04_dhcp_scope_cascade_soft_delete.py:drop_column:148
+backend/alembic/versions/b3e7d21c9f04_dhcp_scope_cascade_soft_delete.py:drop_column:149
+backend/alembic/versions/b3e7d21c9f04_dhcp_scope_cascade_soft_delete.py:drop_column:150
 backend/alembic/versions/b4d1c9e2f3a7_add_reason_to_blocklist_entry.py:drop_column:28
 backend/alembic/versions/b4d291a6c7e8_dns_server_zone_state.py:drop_table:93
 backend/alembic/versions/b4f2a9c17e63_wake_scheduler_verify.py:drop_column:147

--- a/backend/alembic/versions/b3e7d21c9f04_dhcp_scope_cascade_soft_delete.py
+++ b/backend/alembic/versions/b3e7d21c9f04_dhcp_scope_cascade_soft_delete.py
@@ -1,0 +1,150 @@
+"""DHCP scope soft-delete cascades to its pools + reservations (#617), and
+repairs the IPAM mirrors an earlier hard-delete stranded (#618).
+
+Revision ID: b3e7d21c9f04
+Revises: a7c3e91f4d28
+Create Date: 2026-07-11 12:00:00
+
+``DHCPScope`` has been soft-deletable since ``c1f4a8b27d09``, but the cascade
+walk treated it as a leaf. Its pools and reservations were therefore left as
+live, un-stamped rows pointing at a hidden parent — invisible in the UI, but
+still answering ``GET /scopes/{id}/statics`` and still enforcing group-wide MAC
+uniqueness against a scope the operator could no longer see.
+
+This migration gives ``dhcp_pool`` and ``dhcp_static_assignment`` the same three
+``SoftDeleteMixin`` columns every other cascade child carries, so they can ride
+their scope's ``deletion_batch_id`` into the trash and come back with it.
+
+Three things beyond the plain column adds:
+
+1. The two reservation uniqueness rules become **partial** unique indexes
+   (``WHERE deleted_at IS NULL``), same shape as ``uq_dhcp_scope_group_subnet``
+   (#474). Otherwise a trashed reservation would hold the (scope, mac) /
+   (scope, ip) slot against a live one.
+
+2. **Backfill.** Any pool / reservation whose scope is *already* soft-deleted is
+   stamped with that scope's ``deleted_at`` / ``deleted_by_user_id`` /
+   ``deletion_batch_id``. Without this, rows trashed before this release would
+   stay live-but-orphaned forever — and a restore of their scope would bring the
+   scope back while they carried no batch to be restored *with*.
+
+3. **IPAM mirror repair** (#618). Releases ``ip_address`` rows stranded at
+   ``status='static_dhcp'`` with a ``static_assignment_id`` that no longer
+   resolves — the residue of scope hard-deletes/purges that removed the
+   reservation via FK CASCADE without running the Python detach. They are
+   returned to ``available`` (per the #478 rule: ``allocated`` would shadow a
+   future dynamic lease at that IP and never be reaped).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b3e7d21c9f04"
+down_revision: str | None = "a7c3e91f4d28"
+branch_labels = None
+depends_on = None
+
+
+_CASCADE_CHILD_TABLES = ("dhcp_pool", "dhcp_static_assignment")
+
+
+def upgrade() -> None:
+    # ── 1. SoftDeleteMixin columns on the two cascade children ──────────────
+    for table in _CASCADE_CHILD_TABLES:
+        op.add_column(
+            table,
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.add_column(
+            table,
+            sa.Column(
+                "deleted_by_user_id",
+                sa.UUID(),
+                sa.ForeignKey("user.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+        )
+        op.add_column(
+            table,
+            sa.Column("deletion_batch_id", sa.UUID(), nullable=True),
+        )
+        op.create_index(f"ix_{table}_deleted_at", table, ["deleted_at"])
+        op.create_index(f"ix_{table}_deletion_batch_id", table, ["deletion_batch_id"])
+
+    # ── 2. Reservation uniqueness becomes partial (live rows only) ──────────
+    op.drop_constraint("uq_dhcp_static_scope_mac", "dhcp_static_assignment", type_="unique")
+    op.drop_constraint("uq_dhcp_static_scope_ip", "dhcp_static_assignment", type_="unique")
+    op.create_index(
+        "uq_dhcp_static_scope_mac",
+        "dhcp_static_assignment",
+        ["scope_id", "mac_address"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_index(
+        "uq_dhcp_static_scope_ip",
+        "dhcp_static_assignment",
+        ["scope_id", "ip_address"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+    # ── 3. Backfill: adopt children of already-trashed scopes into the batch ─
+    for table in _CASCADE_CHILD_TABLES:
+        op.execute(sa.text(f"""
+                UPDATE {table} AS c
+                SET deleted_at = s.deleted_at,
+                    deleted_by_user_id = s.deleted_by_user_id,
+                    deletion_batch_id = s.deletion_batch_id
+                FROM dhcp_scope AS s
+                WHERE c.scope_id = s.id
+                  AND s.deleted_at IS NOT NULL
+                  AND c.deleted_at IS NULL
+                """))
+
+    # ── 4. #618 repair: release IPAM mirrors of reservations that no longer exist
+    # Only rows whose pointer is a well-formed UUID resolving to nothing are
+    # touched; a malformed pointer is left alone rather than guessed at. The
+    # regex guard keeps the ``::uuid`` cast from erroring on legacy junk — it is
+    # evaluated before the cast because Postgres short-circuits AND left to
+    # right here (both are strict, index-free predicates on the same row).
+    uuid_re = r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    op.execute(sa.text("""
+            UPDATE ip_address
+            SET status = 'available',
+                static_assignment_id = NULL
+            WHERE id IN (
+                SELECT a.id FROM ip_address a
+                WHERE a.status = 'static_dhcp'
+                  AND a.static_assignment_id IS NOT NULL
+                  AND a.static_assignment_id ~ :uuid_re
+                  AND NOT EXISTS (
+                      SELECT 1 FROM dhcp_static_assignment d
+                      WHERE d.id = a.static_assignment_id::uuid
+                  )
+            )
+            """).bindparams(uuid_re=uuid_re))
+
+
+def downgrade() -> None:
+    # Restore the plain (non-partial) unique constraints. Any duplicate that a
+    # partial index allowed (a trashed reservation sharing a live one's
+    # (scope, mac)) would block this — purge the trash first.
+    op.drop_index("uq_dhcp_static_scope_ip", table_name="dhcp_static_assignment")
+    op.drop_index("uq_dhcp_static_scope_mac", table_name="dhcp_static_assignment")
+    op.create_unique_constraint(
+        "uq_dhcp_static_scope_mac", "dhcp_static_assignment", ["scope_id", "mac_address"]
+    )
+    op.create_unique_constraint(
+        "uq_dhcp_static_scope_ip", "dhcp_static_assignment", ["scope_id", "ip_address"]
+    )
+
+    for table in reversed(_CASCADE_CHILD_TABLES):
+        op.drop_index(f"ix_{table}_deletion_batch_id", table_name=table)
+        op.drop_index(f"ix_{table}_deleted_at", table_name=table)
+        op.drop_column(table, "deletion_batch_id")
+        op.drop_column(table, "deleted_by_user_id")
+        op.drop_column(table, "deleted_at")

--- a/backend/app/api/v1/admin/trash.py
+++ b/backend/app/api/v1/admin/trash.py
@@ -22,13 +22,19 @@ from app.api.deps import DB, SuperAdmin
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.dhcp import DHCPScope
-from app.models.dns import DNSRecord, DNSZone
-from app.models.ipam import IPBlock, IPSpace, Subnet
-from app.services.soft_delete import (
+from app.services.dhcp.static_ipam import detach_ipam_for_scope_statics
+from app.services.dhcp.windows_writethrough import push_scope_restore
+from app.services.soft_delete import (  # noqa: PLC2701 — canonical labels, keep in one place
     SOFT_DELETE_RESOURCE_TYPES,
     TYPE_TO_MODEL,
     default_conflict_check,
     restore_batch,
+)
+from app.services.soft_delete import (
+    _resource_type as resource_type_for,
+)
+from app.services.soft_delete import (
+    _row_display as _row_label,
 )
 
 logger = structlog.get_logger(__name__)
@@ -69,22 +75,6 @@ class RestoreConflict(BaseModel):
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────
-
-
-def _row_label(obj: Any) -> str:
-    """Mirror of services.soft_delete._row_display, kept here so the trash
-    list can label rows without importing that private helper."""
-    if isinstance(obj, IPSpace):
-        return obj.name
-    if isinstance(obj, (IPBlock, Subnet)):
-        return f"{obj.network}{(' ' + obj.name) if getattr(obj, 'name', '') else ''}".strip()
-    if isinstance(obj, DNSZone):
-        return obj.name
-    if isinstance(obj, DNSRecord):
-        return f"{obj.fqdn} {obj.record_type}"
-    if isinstance(obj, DHCPScope):
-        return obj.name or str(obj.id)
-    return str(getattr(obj, "id", obj))
 
 
 async def _resolve_usernames(db: Any, user_ids: set[uuid.UUID]) -> dict[uuid.UUID, str]:
@@ -164,8 +154,11 @@ async def list_trash(
     }
     for batch_id in seen_batches:
         size = 0
-        for resource_type in SOFT_DELETE_RESOURCE_TYPES:
-            model = TYPE_TO_MODEL[resource_type]
+        # TYPE_TO_MODEL, not SOFT_DELETE_RESOURCE_TYPES: the batch carries
+        # cascade-only children (a scope's pools + reservations) that the trash
+        # list deliberately doesn't browse, but that must still be counted or
+        # the blast radius under-reports (#617).
+        for model in TYPE_TO_MODEL.values():
             res = await db.execute(
                 select(func.count())
                 .select_from(model)
@@ -229,9 +222,13 @@ async def restore_row(
             detail={"message": "Restore would clash with active rows", "conflicts": conflicts},
         )
 
+    # Soft-delete pushed a remove-scope to every agentless (Windows) member
+    # (#616); the restore owes them the inverse or the scope comes back in
+    # SpatiumDDI only and the two silently diverge. Runs after restore_batch has
+    # un-stamped the rows, so the per-object helpers' scope lookups resolve.
     for obj in restored:
-        from app.services.soft_delete import _resource_type as resource_type_for  # noqa: PLC0415
-
+        if isinstance(obj, DHCPScope):
+            await push_scope_restore(db, obj)
         db.add(
             AuditLog(
                 user_id=current_user.id,
@@ -265,12 +262,14 @@ async def permanent_delete_from_trash(
 ) -> None:
     """Hard-delete a soft-deleted row from the trash.
 
-    Unlike the per-resource ``?permanent=true`` flag (which both deletes
-    *and* runs the legacy write-through hooks), this endpoint just removes
-    the DB row that's already been soft-deleted. The downstream cleanup
-    (Windows DHCP scope removal, DNS zone delete on agentless servers)
-    has either already happened or doesn't need to since the row was
-    already hidden from queries.
+    The agentless write-through (Windows DHCP scope removal, DNS zone delete)
+    already fired at soft-delete time — deleted means deleted on every backend
+    the moment the operator asks for it (#616) — so this endpoint only has to
+    remove the DB row.
+
+    It does still have to release the IPAM mirror of any reservation it is about
+    to destroy: the rows go via FK CASCADE, which runs no Python, so nothing else
+    would (#618).
     """
 
     if type not in SOFT_DELETE_RESOURCE_TYPES:
@@ -290,6 +289,8 @@ async def permanent_delete_from_trash(
         raise HTTPException(status_code=404, detail="Soft-deleted row not found")
 
     label = _row_label(target)
+    if isinstance(target, DHCPScope):
+        await detach_ipam_for_scope_statics(db, target.id)
     db.add(
         AuditLog(
             user_id=current_user.id,

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -628,11 +628,16 @@ async def delete_scope(
 ) -> Any:
     """Delete a DHCP scope.
 
-    Default soft-delete stamps the scope with a fresh batch UUID so it
-    can be restored from /admin/trash. The Windows write-through is only
-    fired on the permanent path; soft-delete leaves the scope in the
-    rendered config until restoration deadline expires (the purge sweep
-    triggers the actual config refresh by hard-deleting then).
+    Default soft-delete stamps the scope — plus its pools and reservations,
+    which are cascade children (#617) — with a fresh batch UUID, so the whole
+    set restores together from /admin/trash.
+
+    Soft-delete means *stop serving immediately*, on every backend. The scope
+    drops out of the rendered ConfigBundle at once (the global ``deleted_at IS
+    NULL`` filter hides it) and ``collect_wake`` pushes agents to re-poll, so
+    Kea members converge within seconds; the Windows write-through fires on this
+    path too, so agentless members converge as well (#616). The purge sweep
+    later hard-deletes the rows; it is not what makes the config change.
 
     Two-person approval (#62): when the ``governance.approvals`` module is on
     and a ``delete:dhcp_scope`` policy matches, returns ``202`` with a pending

--- a/backend/app/api/v1/dhcp/statics.py
+++ b/backend/app/api/v1/dhcp/statics.py
@@ -17,8 +17,8 @@ from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.dns_names import validate_hostname
 from app.core.permissions import require_resource_permission
 from app.models.dhcp import DHCPPool, DHCPScope, DHCPStaticAssignment
-from app.models.ipam import IPAddress, Subnet
-from app.services.dhcp.ipam_mirror import insert_ipam_mirror_row
+from app.models.ipam import Subnet
+from app.services.dhcp.static_ipam import detach_ipam_for_static, upsert_ipam_for_static
 from app.services.dhcp.windows_writethrough import push_static_change
 from app.services.tags import apply_tag_filter
 
@@ -38,6 +38,23 @@ def _validate_optional_hostname(v: str | None) -> str | None:
     return validate_hostname(v)
 
 
+def _no_scope_move(v: uuid.UUID | None) -> uuid.UUID | None:
+    """Reject a body-supplied ``scope_id`` on reservation create/update (#619).
+
+    A reservation belongs to its scope — uniqueness is keyed on it and Kea renders
+    the reservation nested inside that scope's ``subnet4`` stanza, so there is no
+    renderable form of a relocated row. On create the scope comes from the path;
+    on update it cannot change at all. Either way, a value here means the caller
+    expects something we will not do, so say so instead of silently ignoring it.
+    """
+    if v is not None:
+        raise ValueError(
+            "scope_id cannot be set from the request body. A reservation belongs to "
+            "its scope; to move one, delete it and re-create it under the target scope."
+        )
+    return v
+
+
 class StaticCreate(BaseModel):
     ip_address: str
     mac_address: str
@@ -50,6 +67,17 @@ class StaticCreate(BaseModel):
     options_override: dict[str, Any] | None = None
     ip_address_id: uuid.UUID | None = None
     tags: dict[str, Any] = Field(default_factory=dict)
+
+    # Declared only so a body ``scope_id`` is REJECTED rather than silently
+    # dropped (#619) — it is a path parameter here, and Pydantic's default
+    # ``extra="ignore"`` would swallow it with a 200 and no effect. Blanket
+    # ``extra="forbid"`` would do that too, but it would also 422 the common
+    # GET → edit → PUT round-trip (StaticResponse carries ``id`` /
+    # ``created_at`` / ``modified_at``), so reject the one field that means
+    # something and keep ignoring the server-owned ones.
+    scope_id: uuid.UUID | None = None
+
+    _reject_scope_id = field_validator("scope_id")(_no_scope_move)
 
     @field_validator("hostname")
     @classmethod
@@ -67,6 +95,16 @@ class StaticUpdate(BaseModel):
     options_override: dict[str, Any] | None = None
     ip_address_id: uuid.UUID | None = None
     tags: dict[str, Any] | None = None
+
+    # A reservation cannot be re-pointed at another scope: the scope is part of
+    # its identity (uniqueness is keyed on it, and Kea renders the reservation
+    # nested inside the scope's ``subnet4`` stanza), so there is no renderable
+    # form of a relocated row. Declared here purely to REJECT it — sending one
+    # used to be a silent 200-no-op (#619). See the note on StaticCreate for why
+    # this is a field validator and not ``extra="forbid"``.
+    scope_id: uuid.UUID | None = None
+
+    _reject_scope_id = field_validator("scope_id")(_no_scope_move)
 
     @field_validator("hostname")
     @classmethod
@@ -97,82 +135,6 @@ class StaticResponse(BaseModel):
         return str(v) if v is not None else v
 
 
-async def _upsert_ipam_for_static(
-    db, scope: DHCPScope, st: DHCPStaticAssignment, *, action: str = "create"
-) -> None:
-    """Create or update the IPAM row mirroring a static DHCP assignment.
-
-    The static is the source of truth for hostname/MAC; IPAM reflects it with
-    ``status='static_dhcp'`` and a back-link via ``static_assignment_id`` so the
-    subnet view shows the reservation alongside regular addresses.
-    """
-    ip_str = str(st.ip_address)
-    # Detach any previous IPAM row that was pointing at this static (IP change).
-    prior = await db.execute(select(IPAddress).where(IPAddress.static_assignment_id == str(st.id)))
-    for row in prior.scalars().all():
-        if str(row.address) == ip_str:
-            continue
-        row.static_assignment_id = None
-        if row.status == "static_dhcp":
-            row.status = "allocated"
-    # Find or create the IPAM row for this IP within the scope's subnet.
-    res = await db.execute(
-        select(IPAddress).where(IPAddress.subnet_id == scope.subnet_id, IPAddress.address == ip_str)
-    )
-    row = res.scalar_one_or_none()
-    if row is None:
-        # #564 — a concurrent Kea agent lease-event / Sync-DHCP writer
-        # may have already mirrored a dynamic lease at this IP. Insert
-        # inside a savepoint so the unique-violation self-heals into the
-        # incumbent row (which we then overwrite to static_dhcp — the
-        # static is the source of truth) instead of 500-ing on
-        # uq_ip_address_subnet_address.
-        candidate = IPAddress(subnet_id=scope.subnet_id, address=ip_str, status="static_dhcp")
-        row, _created = await insert_ipam_mirror_row(db, candidate)
-    row.hostname = st.hostname or row.hostname
-    row.mac_address = str(st.mac_address)
-    row.status = "static_dhcp"
-    row.static_assignment_id = str(st.id)
-    await db.flush()
-    st.ip_address_id = row.id
-    # Fire DNS sync so forward/reverse records follow the static.
-    from app.api.v1.ipam.router import _sync_dns_record
-
-    subnet_row = await db.get(Subnet, scope.subnet_id)
-    if subnet_row is not None and row.hostname:
-        try:
-            await _sync_dns_record(db, row, subnet_row, action=action)
-        except Exception:  # noqa: BLE001 — DNS sync is best-effort
-            pass
-
-
-async def _detach_ipam_for_static(db, st: DHCPStaticAssignment) -> None:
-    """Release the IPAM row back to `available` when the static is removed.
-
-    Also tears down the forward A (DNS sync with action=delete).
-
-    The row is freed to ``available`` (not ``allocated``): the IP no longer
-    holds a reservation, and — crucially — a leftover ``allocated`` /
-    ``auto_from_lease=False`` row is skipped by the agent's lease-mirror refresh
-    (it only re-mirrors ``available`` or ``auto_from_lease`` rows), so it would
-    shadow a future dynamic lease at that IP AND never be reaped. ``available``
-    lets a new lease reclaim the row (#478).
-    """
-    from app.api.v1.ipam.router import _sync_dns_record
-
-    res = await db.execute(select(IPAddress).where(IPAddress.static_assignment_id == str(st.id)))
-    for row in res.scalars().all():
-        subnet_row = await db.get(Subnet, row.subnet_id)
-        if subnet_row is not None:
-            try:
-                await _sync_dns_record(db, row, subnet_row, action="delete")
-            except Exception:  # noqa: BLE001
-                pass
-        row.static_assignment_id = None
-        if row.status == "static_dhcp":
-            row.status = "available"
-
-
 async def _conflict_check(
     db, scope: DHCPScope, ip: str, mac: str, exclude_id: uuid.UUID | None = None
 ) -> None:
@@ -194,11 +156,33 @@ async def _conflict_check(
             detail=f"MAC {mac} already reserved in this group in scope {row.scope_id}",
         )
 
-    # IP inside existing pool of this scope — reject if dynamic
     try:
         ip_addr = ipaddress.ip_address(ip)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=f"Invalid IP: {e}") from e
+
+    # The reservation's IP must fall inside the scope's subnet. Kea renders the
+    # reservation *nested inside* that subnet's stanza
+    # (``"subnet4": [{"subnet": "<cidr>", "reservations": [...]}]``) and Windows
+    # keys reservations by the scope's network address, so an out-of-CIDR
+    # reservation ships structurally invalid config to the backend. Catch it
+    # here as a legible 422 instead of a downstream agent failure (#619).
+    subnet_row = await db.get(Subnet, scope.subnet_id)
+    if subnet_row is not None:
+        try:
+            network = ipaddress.ip_network(str(subnet_row.network), strict=False)
+        except ValueError:  # pragma: no cover — a malformed subnet CIDR can't be validated against
+            network = None
+        if network is not None and ip_addr not in network:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"IP {ip} is outside the scope's subnet {network}. "
+                    "A reservation must fall inside the subnet its scope serves."
+                ),
+            )
+
+    # IP inside existing pool of this scope — reject if dynamic
     pools_res = await db.execute(select(DHCPPool).where(DHCPPool.scope_id == scope.id))
     for p in pools_res.scalars().all():
         try:
@@ -241,13 +225,13 @@ async def create_static(
     st = DHCPStaticAssignment(
         scope_id=scope_id,
         created_by_user_id=user.id,
-        **body.model_dump(),
+        **body.model_dump(exclude={"scope_id"}),
     )
     db.add(st)
     await db.flush()
     await push_static_change(db, st, action="create")
     collect_wake(dhcp_group_channel(scope.group_id))
-    await _upsert_ipam_for_static(db, scope, st)
+    await upsert_ipam_for_static(db, scope, st)
     write_audit(
         db,
         user=user,
@@ -287,7 +271,7 @@ async def update_static(
     await db.flush()
     await push_static_change(db, st, action="update", prev_mac=prev_mac, prev_ip=prev_ip)
     collect_wake(dhcp_group_channel(scope.group_id))
-    await _upsert_ipam_for_static(db, scope, st, action="update")
+    await upsert_ipam_for_static(db, scope, st, action="update")
     write_audit(
         db,
         user=user,
@@ -312,7 +296,7 @@ async def delete_static(static_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
     if scope is not None:
         collect_wake(dhcp_group_channel(scope.group_id))
     await push_static_change(db, st, action="delete")
-    await _detach_ipam_for_static(db, st)
+    await detach_ipam_for_static(db, st)
     write_audit(
         db,
         user=user,

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -127,11 +127,26 @@ def _soft_delete_models() -> tuple[type, ...]:
     is trivial.
     """
 
-    from app.models.dhcp import DHCPScope
+    from app.models.dhcp import DHCPPool, DHCPScope, DHCPStaticAssignment
     from app.models.dns import DNSRecord, DNSZone
     from app.models.ipam import IPBlock, IPSpace, Subnet
 
-    return (IPSpace, IPBlock, Subnet, DNSZone, DNSRecord, DHCPScope)
+    return (
+        IPSpace,
+        IPBlock,
+        Subnet,
+        DNSZone,
+        DNSRecord,
+        DHCPScope,
+        # Cascade children of DHCPScope (#617). Registering them here is what
+        # closes the read leaks: a bare ``select(DHCPStaticAssignment)`` — the
+        # statics list route, the group-wide MAC conflict check, the
+        # ``find_dhcp_statics`` MCP tool — is now filtered on the primary
+        # entity, so a trashed scope's reservations stop answering queries and
+        # stop 409-ing new ones against a scope the operator cannot see.
+        DHCPPool,
+        DHCPStaticAssignment,
+    )
 
 
 _CACHED_SOFT_DELETE_MODELS: tuple[type, ...] | None = None

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -438,17 +438,42 @@ class DHCPScope(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     imported_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     group: Mapped[DHCPServerGroup] = relationship("DHCPServerGroup", back_populates="scopes")
+    # ``selectin``, NOT ``joined`` (#617). These are collections, so a joined
+    # eager load multiplies rows and — the part that actually bit us — forces
+    # every ``select(DHCPScope)`` in the codebase to remember ``.unique()`` or
+    # raise ``InvalidRequestError`` at runtime. Several didn't: the Trash list,
+    # restore, and permanent-delete all 500'd the moment a soft-deleted scope had
+    # a single pool or reservation (i.e. any real scope), and the conformity
+    # engine / subnet resize / radvd tool carried the same latent trap.
+    #
+    # It also fixes soft-delete filtering of the children, which ``joined`` got
+    # wrong. The global filter registers with ``propagate_to_loaders=False``
+    # (app/db.py) so it does NOT reach a JOINED child — a soft-deleted pool would
+    # ride the parent's statement straight into the rendered config. ``selectin``
+    # emits the child as its own ORM execute, so the filter is applied to it
+    # independently (primary entity = the child model). Verified both ways:
+    #
+    #   live scope + soft-deleted child, no opt-out  -> scope.pools == []
+    #   parent loaded with include_deleted=True      -> scope.pools == [child]
+    #
+    # i.e. the ``include_deleted`` opt-out propagates from the parent statement to
+    # the child load, so a blast-radius count / purge pre-pass CAN read the
+    # collections on a trashed scope, and a renderer never sees a trashed child.
+    #
+    # Still eager, which async SQLAlchemy requires; delete-orphan cascade is
+    # unaffected (a soft-deleted child the ORM cascade no longer enumerates is
+    # removed by the DB-level ON DELETE CASCADE instead).
     pools: Mapped[list[DHCPPool]] = relationship(
         "DHCPPool",
         back_populates="scope",
         cascade="all, delete-orphan",
-        lazy="joined",
+        lazy="selectin",
     )
     statics: Mapped[list[DHCPStaticAssignment]] = relationship(
         "DHCPStaticAssignment",
         back_populates="scope",
         cascade="all, delete-orphan",
-        lazy="joined",
+        lazy="selectin",
     )
     # ``selectin`` rather than ``joined`` because the profile's
     # ``matches`` collection is itself joined-loaded — pulling profile
@@ -464,8 +489,14 @@ class DHCPScope(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     )
 
 
-class DHCPPool(UUIDPrimaryKeyMixin, TimestampMixin, Base):
-    """A range within a scope: dynamic, excluded, or reserved."""
+class DHCPPool(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
+    """A range within a scope: dynamic, excluded, or reserved.
+
+    Soft-deletable (#617) purely as a cascade child of ``DHCPScope`` — a pool
+    is never soft-deleted on its own (``delete_pool`` is a hard delete), it is
+    only stamped as part of its scope's deletion batch so a scope restore
+    brings its ranges back atomically.
+    """
 
     __tablename__ = "dhcp_pool"
     __table_args__ = (Index("ix_dhcp_pool_scope", "scope_id"),)
@@ -504,13 +535,41 @@ class DHCPPool(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     scope: Mapped[DHCPScope] = relationship("DHCPScope", back_populates="pools")
 
 
-class DHCPStaticAssignment(UUIDPrimaryKeyMixin, TimestampMixin, Base):
-    """A DHCP reservation (MAC → IP) within a scope."""
+class DHCPStaticAssignment(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
+    """A DHCP reservation (MAC → IP) within a scope.
+
+    The scope is part of the reservation's identity — uniqueness is keyed on
+    it, Kea renders reservations *nested inside* the scope's ``subnet4``
+    stanza, and Windows keys them by the scope's network address. There is no
+    renderable form of a scope-less reservation, which is why ``scope_id`` is
+    NOT NULL / CASCADE and why the reservation soft-deletes as a cascade child
+    of its scope rather than being re-pointed or orphaned (#617).
+
+    Soft-deletable purely as that cascade child — a reservation is never
+    soft-deleted on its own (``delete_static`` is a hard delete that releases
+    the IPAM mirror); it is only stamped as part of its scope's deletion batch,
+    so a scope restore brings its reservations back atomically.
+    """
 
     __tablename__ = "dhcp_static_assignment"
     __table_args__ = (
-        UniqueConstraint("scope_id", "mac_address", name="uq_dhcp_static_scope_mac"),
-        UniqueConstraint("scope_id", "ip_address", name="uq_dhcp_static_scope_ip"),
+        # Partial unique indexes, not plain UniqueConstraints: a soft-deleted
+        # reservation must not hold the (scope, mac) / (scope, ip) slot against
+        # a live one. Same shape as ``uq_dhcp_scope_group_subnet`` (#474).
+        Index(
+            "uq_dhcp_static_scope_mac",
+            "scope_id",
+            "mac_address",
+            unique=True,
+            postgresql_where=sa_text("deleted_at IS NULL"),
+        ),
+        Index(
+            "uq_dhcp_static_scope_ip",
+            "scope_id",
+            "ip_address",
+            unique=True,
+            postgresql_where=sa_text("deleted_at IS NULL"),
+        ),
         Index("ix_dhcp_static_scope", "scope_id"),
         Index("ix_dhcp_static_mac", "mac_address"),
     )

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -979,8 +979,28 @@ class IPAddress(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     dns_record_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("dns_record.id", ondelete="SET NULL"), nullable=True
     )
-    # DHCP linkage: stored as strings (DHCP models don't exist yet).
+    # DHCP linkage: stored as a string (the DHCP models didn't exist yet when
+    # this column landed).
     dhcp_lease_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Back-link to the reservation that owns this row (mirror of the forward
+    # ``DHCPStaticAssignment.ip_address_id`` FK).
+    #
+    # Still a bare string, NOT a foreign key: as a varchar it can dangle, and it
+    # did — a scope hard-delete/purge removes reservations via FK CASCADE (or a
+    # Core DELETE), neither of which runs Python, so nothing released the mirror
+    # and this row was left stranded at ``status="static_dhcp"`` pointing at a
+    # reservation Postgres had already dropped (#618). Fixed at the behavioural
+    # level: the destruction paths now call
+    # ``services.dhcp.static_ipam.detach_ipam_for_static`` first — see that
+    # module's docstring for the wired-in list, and for the one known gap
+    # (the Windows scope-sync reconciler) that still needs a re-point pass.
+    #
+    # Making it a real ``uuid`` FK (ON DELETE SET NULL) would make the dangle
+    # unrepresentable, but retyping varchar → uuid in one shot breaks the
+    # rolling-upgrade contract (#296): during the mixed-version window N-1 pods
+    # still compare this column against a Python ``str``, which Postgres cannot
+    # coerce to ``uuid``. It needs the two-release expand/contract treatment —
+    # deferred, tracked on #618.
     static_assignment_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     # True if the row was auto-created from a live DHCP lease (as opposed to
     # being manually allocated or from a static assignment). When the lease

--- a/backend/app/services/ai/operations_risky.py
+++ b/backend/app/services/ai/operations_risky.py
@@ -109,9 +109,18 @@ async def _soft_delete_cascade_summary(db: AsyncSession, root: Any) -> str:
         "ip_block": "child block",
         "subnet": "subnet",
         "dhcp_scope": "DHCP scope",
+        "dhcp_pool": "DHCP pool",
+        "dhcp_static_assignment": "DHCP reservation",
         "dns_record": "DNS record",
     }
-    order = ["ip_block", "subnet", "dhcp_scope", "dns_record"]
+    order = [
+        "ip_block",
+        "subnet",
+        "dhcp_scope",
+        "dhcp_pool",
+        "dhcp_static_assignment",
+        "dns_record",
+    ]
     parts = []
     for rt in order:
         n = counts.get(rt, 0)
@@ -126,6 +135,39 @@ async def _soft_delete_cascade_summary(db: AsyncSession, root: Any) -> str:
     if not parts:
         return "cascades nothing (empty)"
     return "cascades " + ", ".join(parts)
+
+
+async def _push_agentless_scope_deletes(db: AsyncSession, batch: Any) -> set[UUID]:
+    """Remove every DHCP scope in a soft-delete batch from its agentless members.
+
+    Soft-delete means "stop serving", and that has to hold on every backend.
+    Agent-based (Kea) members converge on their own — a stamped scope drops
+    straight out of the rendered ConfigBundle — but agentless members (Windows
+    DHCP today, and any future agentless driver) only converge on an explicit
+    push (#616).
+
+    EVERY delete whose cascade can reach a DHCPScope owes this call: scope,
+    subnet, block, and space. Driving it off the batch rather than a hand-rolled
+    per-handler query is deliberate — the batch is the one thing that already
+    knows exactly which scopes are being trashed, so a new ancestor type added to
+    ``_collect_descendants`` cannot silently skip the write-through.
+
+    ORDER IS LOAD-BEARING: call this BEFORE ``apply_soft_delete``. The push
+    resolves each scope's CIDR through ``db.get(Subnet, ...)``; once the subnet
+    row is stamped, the global soft-delete filter hides it and the push would
+    raise ``WindowsPushError("subnet is missing from IPAM")``.
+
+    Returns the group ids whose agents should be woken after the commit.
+    """
+    from app.models.dhcp import DHCPScope  # noqa: PLC0415
+    from app.services.dhcp.windows_writethrough import push_scope_delete  # noqa: PLC0415
+
+    group_ids: set[UUID] = set()
+    for row in batch.rows:
+        if isinstance(row.obj, DHCPScope):
+            await push_scope_delete(db, row.obj)
+            group_ids.add(row.obj.group_id)
+    return group_ids
 
 
 # ── delete_subnet ──────────────────────────────────────────────────────────
@@ -250,22 +292,13 @@ async def _apply_delete_subnet(
 
         # Wake DHCP agents for groups whose scopes are being trashed: soft-delete
         # stamps the scopes deleted, changing rendered Kea config, but without a
-        # wake convergence waits for the 12s safety tick (#512). Capture the
-        # group ids BEFORE the soft-delete filter hides the scope rows.
+        # wake convergence waits for the 12s safety tick (#512). The push +
+        # group-id capture both run BEFORE apply_soft_delete stamps the batch —
+        # see _push_agentless_scope_deletes.
         from app.core.agent_wake import collect_wake, dhcp_group_channel  # noqa: PLC0415
-        from app.models.dhcp import DHCPScope as _DHCPScope  # noqa: PLC0415
-
-        wake_group_ids = set(
-            (
-                await db.execute(
-                    select(_DHCPScope.group_id).where(_DHCPScope.subnet_id == args.subnet_id)
-                )
-            )
-            .scalars()
-            .all()
-        )
 
         batch = await collect_soft_delete_batch(db, subnet)
+        wake_group_ids = await _push_agentless_scope_deletes(db, batch)
         apply_soft_delete(batch, user.id)
         for row in batch.rows:
             db.add(
@@ -513,7 +546,12 @@ async def _apply_delete_block(
         await db.commit()
         return {"block_id": str(args.block_id), "mode": "delete"}
 
+    from app.core.agent_wake import collect_wake, dhcp_group_channel  # noqa: PLC0415
+
     batch = await collect_soft_delete_batch(db, block)
+    # A block cascade reaches DHCP scopes (via its subnets), so it owes the same
+    # agentless write-through the scope + subnet paths do (#616). Before the stamp.
+    wake_group_ids = await _push_agentless_scope_deletes(db, batch)
     apply_soft_delete(batch, user.id)
     for row in batch.rows:
         db.add(
@@ -527,6 +565,8 @@ async def _apply_delete_block(
             )
         )
     await db.commit()
+    for gid in wake_group_ids:
+        collect_wake(dhcp_group_channel(gid))
     return {"block_id": str(args.block_id), "mode": "soft_delete"}
 
 
@@ -642,7 +682,12 @@ async def _apply_delete_space(
         await db.commit()
         return {"space_id": str(args.space_id), "mode": "delete"}
 
+    from app.core.agent_wake import collect_wake, dhcp_group_channel  # noqa: PLC0415
+
     batch = await collect_soft_delete_batch(db, space)
+    # A space cascade reaches DHCP scopes (via its subnets), so it owes the same
+    # agentless write-through the scope + subnet paths do (#616). Before the stamp.
+    wake_group_ids = await _push_agentless_scope_deletes(db, batch)
     apply_soft_delete(batch, user.id)
     for row in batch.rows:
         db.add(
@@ -656,6 +701,8 @@ async def _apply_delete_space(
             )
         )
     await db.commit()
+    for gid in wake_group_ids:
+        collect_wake(dhcp_group_channel(gid))
     return {"space_id": str(args.space_id), "mode": "soft_delete"}
 
 
@@ -804,13 +851,18 @@ async def _preview_delete_scope(
     if scope is None:
         return PreviewResult(ok=False, detail="Scope not found")
     mode = "Permanently delete" if args.permanent else "Soft-delete"
+    # A scope carries its pools + reservations into the batch (#617), so both
+    # modes report a real blast radius. This used to claim a scope was a cascade
+    # leaf, which made the approval preview read as "nothing else affected" for
+    # a scope holding hundreds of reservations.
+    cascade = await _soft_delete_cascade_summary(db, scope)
     if args.permanent:
-        # A scope is a cascade leaf (no soft-delete descendants), so there is
-        # no growing blast radius — the preview stays stable across request →
-        # approve, which is correct (#3a: a leaf has nothing to drift).
-        suffix = " (pushes a remove-scope write-through to Windows members first)"
+        suffix = (
+            f" — {cascade} (unrecoverable; pushes a remove-scope write-through "
+            "to Windows members first)"
+        )
     else:
-        suffix = f" — {await _soft_delete_cascade_summary(db, scope)}; restorable from /admin/trash"
+        suffix = f" — {cascade}; restorable from /admin/trash"
     return PreviewResult(
         ok=True, detail="ready", preview_text=f"{mode} DHCP scope `{scope.id}`{suffix}"
     )
@@ -824,6 +876,7 @@ async def _apply_delete_scope(
     from app.api.v1.dhcp._audit import write_audit
     from app.core.agent_wake import collect_wake, dhcp_group_channel
     from app.models.dhcp import DHCPScope
+    from app.services.dhcp.static_ipam import detach_ipam_for_scope_statics
     from app.services.dhcp.windows_writethrough import push_scope_delete
     from app.services.soft_delete import apply_soft_delete, collect_soft_delete_batch
 
@@ -834,6 +887,17 @@ async def _apply_delete_scope(
     if scope is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Scope not found")
     collect_wake(dhcp_group_channel(scope.group_id))
+
+    # Deleted means deleted on every backend (#616). Agent-based (Kea) members
+    # converge by themselves — the soft-deleted scope drops straight out of the
+    # rendered ConfigBundle — but agentless members (Windows DHCP today, and any
+    # future agentless driver) only converge on an explicit push. This used to
+    # fire on the permanent path only, and since the UI never sends
+    # ``permanent=true``, a scope deleted from the UI stayed live on the Windows
+    # box forever: not removed by the trash permanent-delete (which skips the
+    # write-through hooks) nor by the purge sweep (a Core DELETE that runs no
+    # Python). Fire it on both paths.
+    await push_scope_delete(db, scope)
 
     if not args.permanent:
         batch = await collect_soft_delete_batch(db, scope)
@@ -851,7 +915,9 @@ async def _apply_delete_scope(
         await db.commit()
         return {"scope_id": str(args.scope_id), "mode": "soft_delete"}
 
-    await push_scope_delete(db, scope)
+    # Release each reservation's IPAM mirror before the FK CASCADE wipes the
+    # rows — the cascade runs no Python, so nothing else would (#618).
+    released = await detach_ipam_for_scope_statics(db, scope.id)
     write_audit(
         db,
         user=user,
@@ -859,6 +925,7 @@ async def _apply_delete_scope(
         resource_type="dhcp_scope",
         resource_id=str(scope.id),
         resource_display=str(scope.id),
+        old_value={"ipam_mirrors_released": released},
     )
     await db.delete(scope)
     await db.commit()
@@ -945,6 +1012,28 @@ async def _apply_delete_group(
             ),
         )
 
+    # Deleting the group hard-deletes its scopes, and the FK CASCADE takes their
+    # reservations with them — no Python runs, so nothing would release the IPAM
+    # mirrors and the addresses would be stranded at ``status="static_dhcp"``
+    # pointing at rows Postgres has dropped (#618).
+    from app.models.dhcp import DHCPScope  # noqa: PLC0415
+    from app.services.dhcp.static_ipam import detach_ipam_for_scope_statics  # noqa: PLC0415
+
+    group_scopes = (
+        (
+            await db.execute(
+                select(DHCPScope)
+                .where(DHCPScope.group_id == args.group_id)
+                .execution_options(include_deleted=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    released = 0
+    for sc in group_scopes:
+        released += await detach_ipam_for_scope_statics(db, sc.id)
+
     write_audit(
         db,
         user=user,
@@ -952,6 +1041,7 @@ async def _apply_delete_group(
         resource_type="dhcp_server_group",
         resource_id=str(g.id),
         resource_display=g.name,
+        old_value={"ipam_mirrors_released": released},
     )
     await db.delete(g)
     await db.commit()

--- a/backend/app/services/ai/tools/dhcp.py
+++ b/backend/app/services/ai/tools/dhcp.py
@@ -711,8 +711,9 @@ async def find_dhcp_pool_occupancy(
         stmt = stmt.where(DHCPPool.scope_id == args.scope_id)
     if args.group_id:
         stmt = stmt.where(DHCPScope.group_id == args.group_id)
-    # ``.unique()`` is required because the ORM entities carry eager-loaded
-    # collection relationships (DHCPScope.pools etc.).
+    # ``.unique()`` is a harmless leftover, not a requirement: DHCPScope's
+    # collections are selectin-loaded as of #617, so no joined-collection rows
+    # need de-duplicating.
     rows = (await db.execute(stmt)).unique().all()
 
     # One batched lease query for all pools rather than one per pool (N+1).

--- a/backend/app/services/dhcp/config_bundle.py
+++ b/backend/app/services/dhcp/config_bundle.py
@@ -147,6 +147,10 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
                         DHCPScope.is_active.is_(True),
                     )
                     .options(
+                        # Soft-deleted pools / reservations cannot reach the
+                        # bundle: these are selectin-loaded, so the global
+                        # deleted_at filter applies to each child statement in its
+                        # own right (see the note on DHCPScope.pools, #617).
                         selectinload(DHCPScope.pools),
                         selectinload(DHCPScope.statics),
                     )

--- a/backend/app/services/dhcp/static_ipam.py
+++ b/backend/app/services/dhcp/static_ipam.py
@@ -1,0 +1,168 @@
+"""IPAM mirror lifecycle for DHCP static reservations (#618).
+
+A reservation owns an ``ip_address`` row: ``status="static_dhcp"``, back-linked
+via ``IPAddress.static_assignment_id``, so the subnet view shows the
+reservation alongside regular addresses and a dynamic pool can't hand the
+address out from under it.
+
+These helpers used to live inside ``api/v1/dhcp/statics.py`` and were therefore
+only reachable from the per-reservation CRUD handlers. The paths that destroy
+reservations *wholesale* skipped them, because those paths delete through FK
+CASCADE (or a Core ``DELETE``) and run no per-row Python. The result was an
+``ip_address`` row stranded at ``status="static_dhcp"`` pointing at a
+reservation Postgres had already removed: not allocated, not free, not
+reclaimable by any sweeper.
+
+They live here so those paths can reuse them without importing an HTTP router.
+Wired in as of #618:
+
+* scope permanent-delete (``ai.operations_risky._apply_delete_scope``)
+* trash permanent-delete (``api.v1.admin.trash.permanent_delete_from_trash``)
+* the nightly purge sweep (``tasks.trash_purge``)
+* DHCP server-group delete (``ai.operations_risky._apply_delete_group``)
+* DHCP-import ``overwrite`` (``services.dhcp_import.commit``)
+
+KNOWN GAP — ``services.dhcp.pull_leases._upsert_scope`` still Core-DELETEs a
+Windows scope's reservations and re-inserts them from the wire without going
+through here, so a UI-created reservation's mirror is stranded on the next
+Windows scope sync. It is deliberately NOT fixed with a plain detach: that
+reconciler runs on a schedule, and a detach would tear down and recreate the
+forward A record on every pass for reservations that never changed. It needs a
+re-point-by-IP reconcile instead. Tracked separately.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp import DHCPScope, DHCPStaticAssignment
+from app.models.ipam import IPAddress, Subnet
+from app.services.dhcp.ipam_mirror import insert_ipam_mirror_row
+
+__all__ = [
+    "detach_ipam_for_scope_statics",
+    "detach_ipam_for_static",
+    "upsert_ipam_for_static",
+]
+
+
+async def upsert_ipam_for_static(
+    db: AsyncSession,
+    scope: DHCPScope,
+    st: DHCPStaticAssignment,
+    *,
+    action: str = "create",
+) -> None:
+    """Create or update the IPAM row mirroring a static DHCP assignment.
+
+    The static is the source of truth for hostname/MAC; IPAM reflects it with
+    ``status='static_dhcp'`` and a back-link via ``static_assignment_id`` so the
+    subnet view shows the reservation alongside regular addresses.
+    """
+    ip_str = str(st.ip_address)
+    # Detach any previous IPAM row that was pointing at this static (IP change).
+    prior = await db.execute(select(IPAddress).where(IPAddress.static_assignment_id == str(st.id)))
+    for row in prior.scalars().all():
+        if str(row.address) == ip_str:
+            continue
+        row.static_assignment_id = None
+        if row.status == "static_dhcp":
+            row.status = "allocated"
+    # Find or create the IPAM row for this IP within the scope's subnet.
+    res = await db.execute(
+        select(IPAddress).where(IPAddress.subnet_id == scope.subnet_id, IPAddress.address == ip_str)
+    )
+    row = res.scalar_one_or_none()
+    if row is None:
+        # #564 — a concurrent Kea agent lease-event / Sync-DHCP writer
+        # may have already mirrored a dynamic lease at this IP. Insert
+        # inside a savepoint so the unique-violation self-heals into the
+        # incumbent row (which we then overwrite to static_dhcp — the
+        # static is the source of truth) instead of 500-ing on
+        # uq_ip_address_subnet_address.
+        candidate = IPAddress(subnet_id=scope.subnet_id, address=ip_str, status="static_dhcp")
+        row, _created = await insert_ipam_mirror_row(db, candidate)
+    row.hostname = st.hostname or row.hostname
+    row.mac_address = str(st.mac_address)
+    row.status = "static_dhcp"
+    row.static_assignment_id = str(st.id)
+    await db.flush()
+    st.ip_address_id = row.id
+    # Fire DNS sync so forward/reverse records follow the static.
+    from app.api.v1.ipam.router import _sync_dns_record  # noqa: PLC0415
+
+    subnet_row = await db.get(Subnet, scope.subnet_id)
+    if subnet_row is not None and row.hostname:
+        try:
+            await _sync_dns_record(db, row, subnet_row, action=action)
+        except Exception:  # noqa: BLE001 — DNS sync is best-effort
+            pass
+
+
+async def detach_ipam_for_static(
+    db: AsyncSession,
+    st: DHCPStaticAssignment,
+    *,
+    to_status: str = "available",
+) -> None:
+    """Release the IPAM row back to ``available`` when the static is removed.
+
+    Also tears down the forward A (DNS sync with action=delete).
+
+    The row is freed to ``available`` (not ``allocated``): the IP no longer
+    holds a reservation, and — crucially — a leftover ``allocated`` /
+    ``auto_from_lease=False`` row is skipped by the agent's lease-mirror refresh
+    (it only re-mirrors ``available`` or ``auto_from_lease`` rows), so it would
+    shadow a future dynamic lease at that IP AND never be reaped. ``available``
+    lets a new lease reclaim the row (#478).
+
+    ``to_status="reserved"`` is the opt-in "hold the address in IPAM after the
+    DHCP config is gone" variant — the caller must be an explicitly destructive
+    path that asked for it.
+    """
+    from app.api.v1.ipam.router import _sync_dns_record  # noqa: PLC0415
+
+    res = await db.execute(select(IPAddress).where(IPAddress.static_assignment_id == str(st.id)))
+    for row in res.scalars().all():
+        subnet_row = await db.get(Subnet, row.subnet_id)
+        if subnet_row is not None:
+            try:
+                await _sync_dns_record(db, row, subnet_row, action="delete")
+            except Exception:  # noqa: BLE001 — DNS sync is best-effort
+                pass
+        row.static_assignment_id = None
+        if row.status == "static_dhcp":
+            row.status = to_status
+
+
+async def detach_ipam_for_scope_statics(
+    db: AsyncSession,
+    scope_id: uuid.UUID,
+    *,
+    to_status: str = "available",
+) -> int:
+    """Detach the IPAM mirror of every reservation under ``scope_id``.
+
+    Called by the paths that are about to destroy the reservations physically
+    (scope permanent-delete, trash permanent-delete, purge sweep) — the FK
+    CASCADE that removes them runs no Python, so the mirror has to be released
+    here, *before* the delete, while the rows are still readable.
+
+    ``include_deleted`` because by this point the reservations are themselves
+    soft-deleted (stamped as part of their scope's batch), so the global filter
+    would otherwise hide the very rows we need to clean up.
+
+    Returns the number of reservations processed.
+    """
+    res = await db.execute(
+        select(DHCPStaticAssignment)
+        .where(DHCPStaticAssignment.scope_id == scope_id)
+        .execution_options(include_deleted=True)
+    )
+    statics = list(res.scalars().all())
+    for st in statics:
+        await detach_ipam_for_static(db, st, to_status=to_status)
+    return len(statics)

--- a/backend/app/services/dhcp/windows_writethrough.py
+++ b/backend/app/services/dhcp/windows_writethrough.py
@@ -178,6 +178,81 @@ async def push_scope_delete(db: AsyncSession, scope: DHCPScope) -> None:
             raise WindowsPushError(str(exc)) from exc
 
 
+async def push_scope_restore(db: AsyncSession, scope: DHCPScope) -> None:
+    """Re-create a restored scope, plus its pools and reservations, on Windows members.
+
+    The counterpart to :func:`push_scope_delete` firing on the soft-delete path
+    (#616). Soft-delete removes the scope from the Windows box; a restore has to
+    put it back, or the operator gets it back in SpatiumDDI only and the two
+    silently diverge — the exact drift the write-through exists to prevent.
+
+    Best-effort per child, unlike the edit paths: a restore is a recovery
+    action, and one un-pushable child (e.g. a ``reserved`` pool, which Windows
+    has no equivalent for) must not wedge the whole thing. Failures are logged;
+    the operator can re-sync. The DB restore is authoritative either way.
+
+    Callers must invoke this *after* the rows are un-stamped, so the scope
+    lookups inside the per-object helpers resolve.
+    """
+    win_servers = await _windows_servers_for_group(db, scope.group_id)
+    if not win_servers:
+        return
+
+    # Best-effort INCLUDING the scope itself. push_scope_upsert raises
+    # WindowsPushError (a 502) on failure, which would propagate out of the trash
+    # restore handler and roll the DB restore back — so an unreachable Windows
+    # member would make the row unrestorable, which is the opposite of what a
+    # recovery action should do. Log and bail: the children cannot land if the
+    # scope isn't there, so continuing would only add noise.
+    try:
+        await push_scope_upsert(db, scope)
+    except Exception as exc:  # noqa: BLE001 — best-effort, see docstring
+        logger.warning(
+            "windows_dhcp_push_scope_restore_scope_failed",
+            scope=str(scope.id),
+            error=str(exc),
+        )
+        return
+
+    pools = (
+        (await db.execute(select(DHCPPool).where(DHCPPool.scope_id == scope.id))).scalars().all()
+    )
+    for pool in pools:
+        if pool.pool_type == "dynamic":
+            # Already covered — a dynamic range is a scope property on Windows
+            # and push_scope_upsert re-applied it.
+            continue
+        try:
+            await push_pool_change(db, pool, action="create")
+        except Exception as exc:  # noqa: BLE001 — best-effort, see docstring
+            logger.warning(
+                "windows_dhcp_push_scope_restore_pool_failed",
+                scope=str(scope.id),
+                pool=str(pool.id),
+                error=str(exc),
+            )
+
+    statics = (
+        (
+            await db.execute(
+                select(DHCPStaticAssignment).where(DHCPStaticAssignment.scope_id == scope.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for st in statics:
+        try:
+            await push_static_change(db, st, action="create")
+        except Exception as exc:  # noqa: BLE001 — best-effort, see docstring
+            logger.warning(
+                "windows_dhcp_push_scope_restore_static_failed",
+                scope=str(scope.id),
+                static=str(st.id),
+                error=str(exc),
+            )
+
+
 async def push_pool_change(
     db: AsyncSession,
     pool: DHCPPool,
@@ -389,6 +464,7 @@ __all__ = [
     "WindowsPushError",
     "push_pool_change",
     "push_scope_delete",
+    "push_scope_restore",
     "push_scope_upsert",
     "push_static_change",
     "push_statics_bulk_delete",

--- a/backend/app/services/dhcp_import/commit.py
+++ b/backend/app/services/dhcp_import/commit.py
@@ -41,6 +41,7 @@ from app.models.dhcp import (
     DHCPStaticAssignment,
 )
 from app.models.ipam import IPBlock, IPSpace, Subnet
+from app.services.dhcp.static_ipam import detach_ipam_for_scope_statics
 
 from .canonical import (
     ConflictAction,
@@ -167,9 +168,13 @@ async def detect_conflicts(
             scope = await _existing_scope(db, target_group_id, subnet.id, include_deleted=True)
             if scope is not None:
                 existing_scope_id = str(scope.id)
+                soft_deleted = scope.deleted_at is not None
+                # Safe on a trashed scope: ``_existing_scope`` opted in with
+                # include_deleted, and that propagates to the selectin child
+                # loads — so these counts are the real blast radius the operator
+                # is about to hard-delete with ``overwrite`` (see DHCPScope.pools).
                 pool_count = len(scope.pools)
                 res_count = len(scope.statics)
-                soft_deleted = scope.deleted_at is not None
         # Emit a row when there's anything to tell the operator: an
         # existing scope (blocking) or an existing subnet (link vs
         # create). Pure-new scopes don't generate a row.
@@ -340,6 +345,11 @@ async def _commit_one_scope(
         # overwrite — hard-delete the existing scope (cascades pools +
         # statics, and purges it from Trash if it was soft-deleted),
         # freeing the unique slot before the recreate flush.
+        #
+        # The reservations go via FK CASCADE, which runs no Python, so their
+        # IPAM mirrors have to be released here or the addresses are stranded at
+        # ``status="static_dhcp"`` pointing at rows Postgres has dropped (#618).
+        await detach_ipam_for_scope_statics(db, existing.id)
         await db.delete(existing)
         await db.flush()
         overwrote = True

--- a/backend/app/services/soft_delete.py
+++ b/backend/app/services/soft_delete.py
@@ -1,15 +1,24 @@
 """Shared soft-delete + restore primitives.
 
-Soft-deletable models live in IPAM / DNS / DHCP — see ``SOFT_DELETE_MODELS``.
+Soft-deletable models live in IPAM / DNS / DHCP — see ``TYPE_TO_MODEL``.
 The default ORM query filter (``app.db._filter_soft_deleted``) hides any row
 with a non-null ``deleted_at`` from every SELECT unless the caller opts in
 via ``execution_options(include_deleted=True)``.
 
-Cascading: when soft-deleting a parent (IPSpace / IPBlock / Subnet / DNSZone)
-we walk every descendant in scope and stamp them with the same ``deleted_at``
-+ ``deletion_batch_id``. ``DHCPScope`` is a leaf so its cascades only matter
-when an ancestor Subnet is being deleted. ``DNSRecord`` cascades from a
-parent DNSZone the same way.
+Cascading: when soft-deleting a parent (IPSpace / IPBlock / Subnet / DNSZone /
+DHCPScope) we walk every descendant in scope and stamp them with the same
+``deleted_at`` + ``deletion_batch_id``. ``DNSRecord`` cascades from a parent
+DNSZone; ``DHCPPool`` + ``DHCPStaticAssignment`` cascade from a parent
+DHCPScope (#617 — a scope used to be treated as a leaf, which left its pools
+and reservations as live, un-stamped rows pointing at a hidden parent: still
+enforcing group-wide MAC uniqueness and still answering ``GET
+/scopes/{id}/statics`` for a scope the operator could no longer see).
+
+Root vs child: ``SOFT_DELETE_RESOURCE_TYPES`` is the set of types the trash UI
+*browses* and can restore/purge individually. ``TYPE_TO_MODEL`` is the wider
+set that :func:`restore_batch` sweeps — it also carries the cascade-only
+children, which are restored with their parent's batch but are never addressed
+on their own.
 
 A standalone soft-delete still gets a fresh batch UUID, which keeps the
 restore-by-batch lookup uniform on the wire.
@@ -29,10 +38,15 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.dhcp import DHCPScope
+from app.models.dhcp import DHCPPool, DHCPScope, DHCPStaticAssignment
 from app.models.dns import DNSRecord, DNSZone
 from app.models.ipam import IPBlock, IPSpace, Subnet
 
+# Types the trash UI browses, and that ``restore_row`` /
+# ``permanent_delete_from_trash`` accept as an addressable target. Cascade-only
+# children (DHCPPool / DHCPStaticAssignment) are deliberately NOT here: they
+# ride their parent's batch and would otherwise spam the trash list with one
+# row per reservation.
 SOFT_DELETE_RESOURCE_TYPES: tuple[str, ...] = (
     "ip_space",
     "ip_block",
@@ -47,6 +61,10 @@ SOFT_DELETE_RESOURCE_TYPES: tuple[str, ...] = (
 # to look up rows generically. Kept here so the canonical names live in one
 # place — anywhere outside this module that needs the mapping should import
 # it rather than hand-rolling its own copy.
+#
+# Superset of SOFT_DELETE_RESOURCE_TYPES: this is what ``restore_batch`` sweeps,
+# so it must carry the cascade-only children too or a restore would bring the
+# scope back without its pools and reservations.
 TYPE_TO_MODEL: dict[str, type] = {
     "ip_space": IPSpace,
     "ip_block": IPBlock,
@@ -54,6 +72,9 @@ TYPE_TO_MODEL: dict[str, type] = {
     "dns_zone": DNSZone,
     "dns_record": DNSRecord,
     "dhcp_scope": DHCPScope,
+    # Cascade-only children — restored with the batch, never addressed alone.
+    "dhcp_pool": DHCPPool,
+    "dhcp_static_assignment": DHCPStaticAssignment,
 }
 
 
@@ -90,6 +111,10 @@ def _row_display(obj: Any) -> str:
         return f"{obj.fqdn} {obj.record_type}"
     if isinstance(obj, DHCPScope):
         return obj.name or str(obj.id)
+    if isinstance(obj, DHCPPool):
+        return f"{obj.pool_type} pool {obj.start_ip}-{obj.end_ip}"
+    if isinstance(obj, DHCPStaticAssignment):
+        return f"{obj.mac_address} → {obj.ip_address}"
     return str(getattr(obj, "id", obj))
 
 
@@ -106,6 +131,10 @@ def _resource_type(obj: Any) -> str:
         return "dns_record"
     if isinstance(obj, DHCPScope):
         return "dhcp_scope"
+    if isinstance(obj, DHCPPool):
+        return "dhcp_pool"
+    if isinstance(obj, DHCPStaticAssignment):
+        return "dhcp_static_assignment"
     raise ValueError(f"Not a soft-deletable model: {type(obj).__name__}")
 
 
@@ -144,7 +173,20 @@ async def _collect_descendants(db: AsyncSession, root: Any) -> list[Any]:
     elif isinstance(root, Subnet):
         scope_res = await db.execute(select(DHCPScope).where(DHCPScope.subnet_id == root.id))
         for scope in scope_res.scalars().all():
+            out.extend(await _collect_descendants(db, scope))
             out.append(scope)
+    elif isinstance(root, DHCPScope):
+        # A scope's pools + reservations are cascade children, not independent
+        # rows: the FK is NOT NULL / ON DELETE CASCADE, uniqueness is keyed on
+        # the scope, and Kea renders reservations nested inside the scope's
+        # subnet4 stanza. They must ride the same batch so a restore brings the
+        # scope back whole (#617).
+        pool_res = await db.execute(select(DHCPPool).where(DHCPPool.scope_id == root.id))
+        out.extend(pool_res.scalars().all())
+        static_res = await db.execute(
+            select(DHCPStaticAssignment).where(DHCPStaticAssignment.scope_id == root.id)
+        )
+        out.extend(static_res.scalars().all())
     elif isinstance(root, DNSZone):
         rec_res = await db.execute(select(DNSRecord).where(DNSRecord.zone_id == root.id))
         for record in rec_res.scalars().all():
@@ -312,5 +354,35 @@ async def default_conflict_check(db: AsyncSession, obj: Any) -> str | None:
         ).scalar_one_or_none()
         if existing is not None:
             return "An active DHCP scope already exists for this group + subnet"
+
+    elif isinstance(obj, DHCPStaticAssignment):
+        # A reservation's MAC is unique across the whole group, not just the
+        # scope (see ``_conflict_check`` on the create path). While the scope
+        # sat in the trash, a live scope in the same group may have claimed
+        # this MAC — restoring would resurrect a group-wide duplicate that the
+        # create path would have refused (#617).
+        parent = (
+            await db.execute(
+                select(DHCPScope)
+                .where(DHCPScope.id == obj.scope_id)
+                .execution_options(include_deleted=True)
+            )
+        ).scalar_one_or_none()
+        if parent is not None:
+            clash = (
+                await db.execute(
+                    select(DHCPStaticAssignment)
+                    .join(DHCPScope, DHCPStaticAssignment.scope_id == DHCPScope.id)
+                    .where(
+                        DHCPScope.group_id == parent.group_id,
+                        DHCPStaticAssignment.mac_address == obj.mac_address,
+                        DHCPStaticAssignment.id != obj.id,
+                    )
+                )
+            ).first()
+            if clash is not None:
+                return (
+                    f"MAC {obj.mac_address} has since been reserved by a live scope in this group"
+                )
 
     return None

--- a/backend/app/tasks/trash_purge.py
+++ b/backend/app/tasks/trash_purge.py
@@ -17,15 +17,16 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
-from sqlalchemy import delete, select
+from sqlalchemy import and_, delete, or_, select
 
 from app.celery_app import celery_app
 from app.db import task_session
 from app.models.audit import AuditLog
-from app.models.dhcp import DHCPScope
+from app.models.dhcp import DHCPPool, DHCPScope, DHCPStaticAssignment
 from app.models.dns import DNSRecord, DNSZone
 from app.models.ipam import IPBlock, IPSpace, Subnet
 from app.models.settings import PlatformSettings
+from app.services.dhcp.static_ipam import detach_ipam_for_static
 
 logger = structlog.get_logger(__name__)
 
@@ -34,15 +35,59 @@ logger = structlog.get_logger(__name__)
 # FK is CASCADE, so this is safe either way; we order it explicitly to keep
 # the per-type counters honest — without ordering, the records would
 # already be gone by the time we counted them and the row count would
-# under-report).
+# under-report). Same for ``DHCPStaticAssignment`` / ``DHCPPool`` under
+# ``DHCPScope`` (#617).
 _PURGE_MODELS_LEAF_FIRST: tuple[type, ...] = (
     DNSRecord,
+    DHCPStaticAssignment,
+    DHCPPool,
     DHCPScope,
     Subnet,
     IPBlock,
     DNSZone,
     IPSpace,
 )
+
+
+async def _release_ipam_mirrors(db: Any, cutoff: datetime) -> int:
+    """Release the IPAM row behind every reservation this sweep is about to purge.
+
+    The purge is a Core ``DELETE`` — it runs no per-row Python, so nothing would
+    otherwise call the detach and the mirrored ``ip_address`` row would be left
+    stranded at ``status="static_dhcp"`` pointing at a reservation Postgres had
+    already removed: not allocated, not free, not reclaimable by any sweeper
+    (#618). Run before the deletes, while the reservations are still readable.
+
+    Selected by what the sweep will actually destroy, NOT by the reservation's
+    own tombstone: the ``dhcp_scope`` DELETE below FK-cascades its reservations
+    regardless of their ``deleted_at``, so keying only on the child's timestamp
+    would miss any reservation whose stamp is absent or newer than its scope's
+    (a pre-#617 row the migration backfill didn't reach, a clock skew, a future
+    path that stamps parent and child separately) and strand its mirror.
+
+    ``include_deleted`` because these rows are soft-deleted by definition — the
+    global filter would hide the very rows we need to clean up.
+    """
+    res = await db.execute(
+        select(DHCPStaticAssignment)
+        .join(DHCPScope, DHCPStaticAssignment.scope_id == DHCPScope.id)
+        .where(
+            or_(
+                and_(
+                    DHCPStaticAssignment.deleted_at.is_not(None),
+                    DHCPStaticAssignment.deleted_at < cutoff,
+                ),
+                and_(DHCPScope.deleted_at.is_not(None), DHCPScope.deleted_at < cutoff),
+            )
+        )
+        .execution_options(include_deleted=True)
+    )
+    statics = list(res.scalars().all())
+    for st in statics:
+        await detach_ipam_for_static(db, st)
+    if statics:
+        await db.flush()
+    return len(statics)
 
 
 async def _sweep() -> dict[str, Any]:
@@ -62,6 +107,9 @@ async def _sweep() -> dict[str, Any]:
         cutoff = datetime.now(UTC) - timedelta(days=purge_days)
         per_type: dict[str, int] = {}
         total_removed = 0
+
+        # Release IPAM mirrors before the Core DELETEs wipe the reservations.
+        ipam_released = await _release_ipam_mirrors(db, cutoff)
 
         for model in _PURGE_MODELS_LEAF_FIRST:
             stmt = (
@@ -85,7 +133,11 @@ async def _sweep() -> dict[str, Any]:
                     resource_type="trash",
                     resource_id="sweep",
                     resource_display=f"{total_removed} rows purged",
-                    new_value={"counts": per_type, "purge_days": purge_days},
+                    new_value={
+                        "counts": per_type,
+                        "purge_days": purge_days,
+                        "ipam_mirrors_released": ipam_released,
+                    },
                     result="success",
                 )
             )
@@ -94,6 +146,7 @@ async def _sweep() -> dict[str, Any]:
         return {
             "removed": total_removed,
             "per_type": per_type,
+            "ipam_mirrors_released": ipam_released,
             "purge_days": purge_days,
             "skipped": False,
         }

--- a/backend/tests/test_dhcp_expired_lease_gc.py
+++ b/backend/tests/test_dhcp_expired_lease_gc.py
@@ -161,7 +161,7 @@ async def test_delete_lease_endpoint_removes_lease_and_mirror(
 
 @pytest.mark.asyncio
 async def test_detach_static_frees_ipam_row_to_available(db_session: AsyncSession) -> None:
-    from app.api.v1.dhcp.statics import _detach_ipam_for_static
+    from app.services.dhcp.static_ipam import detach_ipam_for_static
 
     grp, _srv = await _server(db_session)
     subnet, scope = await _subnet(db_session, grp)
@@ -180,7 +180,7 @@ async def test_detach_static_frees_ipam_row_to_available(db_session: AsyncSessio
     db_session.add(row)
     await db_session.commit()
 
-    await _detach_ipam_for_static(db_session, st)
+    await detach_ipam_for_static(db_session, st)
     await db_session.flush()
     await db_session.refresh(row)
 

--- a/backend/tests/test_dhcp_scope_cascade_soft_delete.py
+++ b/backend/tests/test_dhcp_scope_cascade_soft_delete.py
@@ -1,0 +1,677 @@
+"""DHCP scope deletion lifecycle — #616 / #617 / #618 / #619.
+
+A scope's pools and reservations are cascade children, not independent rows:
+the FK is NOT NULL / ON DELETE CASCADE, uniqueness is keyed on the scope, and
+Kea renders reservations nested inside the scope's ``subnet4`` stanza. They used
+to be treated as a cascade *leaf*, which left them live and un-stamped under a
+hidden parent.
+
+Covers:
+  * #617 — soft-deleting a scope stamps its pools + statics into the same batch
+  * #617 — the read leaks close: statics list, group-wide MAC conflict check
+  * #617 — restore brings the scope back with its pools + reservations
+  * #617 — a trashed reservation does not hold the (scope, mac) slot
+  * #616 — the agentless write-through fires on the soft path, not just permanent
+  * #618 — the IPAM mirror is released when reservations are physically destroyed
+  * #619 — ``scope_id`` in a create/update body is a 422, not a silent no-op
+  * #619 — a GET → edit → PUT round-trip still works (server-owned fields ignored)
+  * #619 — a reservation outside its scope's subnet is refused
+
+Review follow-ups (found by adversarially reviewing the above):
+  * #616 — a BLOCK delete cascades scopes into the trash; it owes the same push
+  * #617 — `scope.pools` / `.statics` are unconditionally filtered, so anything
+    inspecting a TRASHED scope's children must query the child model directly.
+    The DHCP importer's conflict preview read them and reported 0/0.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPPool, DHCPScope, DHCPServer, DHCPServerGroup, DHCPStaticAssignment
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+
+async def _make_admin(db: AsyncSession) -> tuple[User, str]:
+    user = User(
+        username=f"cs-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="Cascade Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_scope(
+    db: AsyncSession, *, network: str = "10.50.0.0/24", driver: str = "kea"
+) -> tuple[DHCPScope, Subnet, DHCPServerGroup]:
+    space = IPSpace(name=f"cs-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/8", name="root")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=network, name="lan")
+    db.add(subnet)
+    await db.flush()
+
+    group = DHCPServerGroup(name=f"cs-{uuid.uuid4().hex[:6]}")
+    db.add(group)
+    await db.flush()
+    db.add(
+        DHCPServer(
+            name=f"cs-{uuid.uuid4().hex[:6]}",
+            driver=driver,
+            host="127.0.0.1",
+            server_group_id=group.id,
+        )
+    )
+    scope = DHCPScope(
+        group_id=group.id,
+        subnet_id=subnet.id,
+        name="cascade-scope",
+        address_family="ipv4",
+    )
+    db.add(scope)
+    await db.flush()
+    return scope, subnet, group
+
+
+# ── #617 — the cascade itself ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_scope_soft_delete_stamps_pools_and_statics(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The children ride the scope's deletion batch instead of being orphaned."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, _subnet, _group = await _make_scope(db_session)
+
+    pool = DHCPPool(
+        scope_id=scope.id, start_ip="10.50.0.100", end_ip="10.50.0.200", pool_type="dynamic"
+    )
+    static = DHCPStaticAssignment(
+        scope_id=scope.id, ip_address="10.50.0.10", mac_address="aa:bb:cc:dd:ee:01"
+    )
+    db_session.add_all([pool, static])
+    await db_session.flush()
+    # Capture ids as plain values: once the rows are soft-deleted, refreshing an
+    # expired ORM instance re-SELECTs through the global filter and finds nothing.
+    scope_id, pool_id, static_id = scope.id, pool.id, static.id
+    await db_session.commit()
+
+    resp = await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    assert resp.status_code == 204, resp.text
+
+    db_session.expire_all()
+    scope_row = (
+        await db_session.execute(
+            select(DHCPScope)
+            .where(DHCPScope.id == scope_id)
+            .execution_options(include_deleted=True)
+        )
+    ).scalar_one()
+    pool_row = (
+        await db_session.execute(
+            select(DHCPPool).where(DHCPPool.id == pool_id).execution_options(include_deleted=True)
+        )
+    ).scalar_one()
+    static_row = (
+        await db_session.execute(
+            select(DHCPStaticAssignment)
+            .where(DHCPStaticAssignment.id == static_id)
+            .execution_options(include_deleted=True)
+        )
+    ).scalar_one()
+
+    assert scope_row.deleted_at is not None
+    # The whole point: children stamped, and stamped into the SAME batch, so a
+    # single restore brings them back together.
+    assert pool_row.deleted_at is not None
+    assert static_row.deleted_at is not None
+    assert pool_row.deletion_batch_id == scope_row.deletion_batch_id
+    assert static_row.deletion_batch_id == scope_row.deletion_batch_id
+
+
+@pytest.mark.asyncio
+async def test_trashed_statics_are_hidden_from_default_selects(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The read leak: a bare select(DHCPStaticAssignment) used to serve a trashed
+    scope's reservations because the static itself wasn't soft-delete-aware."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, _subnet, _group = await _make_scope(db_session)
+    db_session.add(
+        DHCPStaticAssignment(
+            scope_id=scope.id, ip_address="10.50.0.11", mac_address="aa:bb:cc:dd:ee:02"
+        )
+    )
+    await db_session.flush()
+    scope_id = scope.id
+    await db_session.commit()
+
+    assert (
+        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    ).status_code == 204
+
+    # Holding the trashed scope's UUID must not get you its reservations back.
+    listed = await client.get(f"/api/v1/dhcp/scopes/{scope_id}/statics", headers=headers)
+    assert listed.status_code == 200
+    assert listed.json() == []
+
+    db_session.expire_all()
+    rows = (
+        (
+            await db_session.execute(
+                select(DHCPStaticAssignment).where(DHCPStaticAssignment.scope_id == scope_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_trashed_static_does_not_block_mac_reuse(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The nastiest leak: the group-wide MAC conflict check 409'd against a
+    reservation in a scope the operator could no longer see."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, subnet, group = await _make_scope(db_session)
+    mac = "aa:bb:cc:dd:ee:03"
+    db_session.add(
+        DHCPStaticAssignment(scope_id=scope.id, ip_address="10.50.0.12", mac_address=mac)
+    )
+    await db_session.flush()
+    await db_session.commit()
+
+    assert (
+        await client.delete(f"/api/v1/dhcp/scopes/{scope.id}", headers=headers)
+    ).status_code == 204
+
+    # Same group, same subnet, fresh scope — the partial unique index on
+    # (group, subnet) released the slot when the old scope was trashed.
+    new_scope = DHCPScope(
+        group_id=group.id, subnet_id=subnet.id, name="replacement", address_family="ipv4"
+    )
+    db_session.add(new_scope)
+    await db_session.flush()
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/dhcp/scopes/{new_scope.id}/statics",
+        headers=headers,
+        json={"ip_address": "10.50.0.12", "mac_address": mac},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.asyncio
+async def test_restore_brings_back_pools_and_statics(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """One click puts the scope back whole — the real answer to 'I deleted the
+    wrong scope'."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, _subnet, _group = await _make_scope(db_session)
+    db_session.add_all(
+        [
+            DHCPPool(
+                scope_id=scope.id,
+                start_ip="10.50.0.100",
+                end_ip="10.50.0.200",
+                pool_type="dynamic",
+            ),
+            DHCPStaticAssignment(
+                scope_id=scope.id, ip_address="10.50.0.13", mac_address="aa:bb:cc:dd:ee:04"
+            ),
+        ]
+    )
+    await db_session.flush()
+    scope_id = scope.id
+    await db_session.commit()
+
+    assert (
+        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    ).status_code == 204
+
+    restore = await client.post(
+        f"/api/v1/admin/trash/dhcp_scope/{scope_id}/restore", headers=headers
+    )
+    assert restore.status_code == 200, restore.text
+    # scope + pool + static
+    assert restore.json()["restored"] == 3
+
+    db_session.expire_all()
+    statics = (
+        (
+            await db_session.execute(
+                select(DHCPStaticAssignment).where(DHCPStaticAssignment.scope_id == scope_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    pools = (
+        (await db_session.execute(select(DHCPPool).where(DHCPPool.scope_id == scope_id)))
+        .scalars()
+        .all()
+    )
+    assert len(statics) == 1
+    assert len(pools) == 1
+    assert statics[0].deleted_at is None
+    assert pools[0].deleted_at is None
+
+
+@pytest.mark.asyncio
+async def test_trash_batch_size_counts_cascade_children(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Blast radius must not under-report: the trash row for a scope carrying a
+    pool + a reservation is a batch of 3, not 1."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, _subnet, _group = await _make_scope(db_session)
+    db_session.add_all(
+        [
+            DHCPPool(
+                scope_id=scope.id,
+                start_ip="10.50.0.100",
+                end_ip="10.50.0.200",
+                pool_type="dynamic",
+            ),
+            DHCPStaticAssignment(
+                scope_id=scope.id, ip_address="10.50.0.14", mac_address="aa:bb:cc:dd:ee:05"
+            ),
+        ]
+    )
+    await db_session.flush()
+    scope_id = scope.id
+    await db_session.commit()
+
+    assert (
+        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    ).status_code == 204
+
+    listing = await client.get("/api/v1/admin/trash?type=dhcp_scope", headers=headers)
+    assert listing.status_code == 200
+    entry = next(i for i in listing.json()["items"] if i["id"] == str(scope_id))
+    assert entry["batch_size"] == 3
+
+    # The children themselves must NOT be browsable rows — they'd swamp the list.
+    assert all(i["type"] == "dhcp_scope" for i in listing.json()["items"])
+
+
+# ── #616 — agentless write-through fires on the soft path ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_pushes_scope_removal_to_agentless_members(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deleted means deleted on every backend. Kea members converge by dropping
+    out of the ConfigBundle; agentless members only converge on an explicit push,
+    which used to fire on the permanent path only — and the UI never sends it."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, _subnet, _group = await _make_scope(db_session, driver="windows_dhcp")
+    await db_session.commit()
+
+    pushed: list[str] = []
+
+    async def _fake_push(_db: Any, sc: DHCPScope) -> None:
+        pushed.append(str(sc.id))
+
+    monkeypatch.setattr(
+        "app.services.dhcp.windows_writethrough.push_scope_delete", _fake_push, raising=True
+    )
+
+    resp = await client.delete(f"/api/v1/dhcp/scopes/{scope.id}", headers=headers)
+    assert resp.status_code == 204, resp.text
+    assert pushed == [str(scope.id)], "soft-delete must remove the scope from agentless members"
+
+
+# ── #618 — IPAM mirror lifecycle ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_permanent_scope_delete_releases_ipam_mirror(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The reservations go via FK CASCADE, which runs no Python — so the mirror
+    has to be released explicitly or the IP is stranded at ``static_dhcp``
+    forever, pointing at a row Postgres already dropped."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, subnet, _group = await _make_scope(db_session)
+    # Plain values: attribute access on an expired ORM instance lazy-refreshes,
+    # which raises MissingGreenlet under the async session.
+    scope_id, subnet_id = scope.id, subnet.id
+    await db_session.commit()
+
+    created = await client.post(
+        f"/api/v1/dhcp/scopes/{scope_id}/statics",
+        headers=headers,
+        json={"ip_address": "10.50.0.20", "mac_address": "aa:bb:cc:dd:ee:06", "hostname": "res1"},
+    )
+    assert created.status_code == 201, created.text
+
+    db_session.expire_all()
+    mirror = (
+        await db_session.execute(
+            select(IPAddress).where(
+                IPAddress.subnet_id == subnet_id, IPAddress.address == "10.50.0.20"
+            )
+        )
+    ).scalar_one()
+    mirror_id = mirror.id
+    assert mirror.status == "static_dhcp"
+    assert mirror.static_assignment_id is not None
+
+    resp = await client.delete(f"/api/v1/dhcp/scopes/{scope_id}?permanent=true", headers=headers)
+    assert resp.status_code == 204, resp.text
+
+    db_session.expire_all()
+    mirror_after = (
+        await db_session.execute(select(IPAddress).where(IPAddress.id == mirror_id))
+    ).scalar_one()
+    # Released to `available`, not `allocated` (#478: an allocated row would
+    # shadow a future dynamic lease at that IP and never be reaped).
+    assert mirror_after.status == "available"
+    assert mirror_after.static_assignment_id is None
+
+
+# ── #619 — validation gaps ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_static_rejects_scope_id(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A reservation cannot be re-pointed. That used to be a silent 200-no-op;
+    it is now a 422, so the caller learns the field had no effect."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, _subnet, _group = await _make_scope(db_session)
+    await db_session.commit()
+
+    created = await client.post(
+        f"/api/v1/dhcp/scopes/{scope.id}/statics",
+        headers=headers,
+        json={"ip_address": "10.50.0.30", "mac_address": "aa:bb:cc:dd:ee:07"},
+    )
+    assert created.status_code == 201, created.text
+    static_id = created.json()["id"]
+
+    resp = await client.put(
+        f"/api/v1/dhcp/statics/{static_id}",
+        headers=headers,
+        json={"hostname": "renamed", "scope_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_static_outside_scope_subnet_is_refused(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Kea renders the reservation nested inside the scope's subnet stanza, so an
+    out-of-CIDR reservation would ship structurally invalid config."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, _subnet, _group = await _make_scope(db_session, network="10.50.1.0/24")
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/dhcp/scopes/{scope.id}/statics",
+        headers=headers,
+        json={"ip_address": "192.168.99.5", "mac_address": "aa:bb:cc:dd:ee:08"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "outside the scope's subnet" in resp.json()["detail"]
+
+
+# ── Review follow-ups ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_block_delete_pushes_scope_removal_to_agentless_members(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#616 one level up: an IPBlock soft-delete cascades Subnet -> DHCPScope into
+    the trash, so it owes the agentless write-through exactly as the scope and
+    subnet paths do. Wiring only the two obvious paths left this one silent."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, subnet, _group = await _make_scope(db_session, driver="windows_dhcp")
+    scope_id = scope.id
+    block_id = subnet.block_id
+    await db_session.commit()
+
+    pushed: list[str] = []
+
+    async def _fake_push(_db: Any, sc: DHCPScope) -> None:
+        pushed.append(str(sc.id))
+
+    monkeypatch.setattr(
+        "app.services.dhcp.windows_writethrough.push_scope_delete", _fake_push, raising=True
+    )
+
+    resp = await client.delete(f"/api/v1/ipam/blocks/{block_id}", headers=headers)
+    assert resp.status_code == 204, resp.text
+    assert pushed == [str(scope_id)], "block delete must remove cascaded scopes from Windows"
+
+
+@pytest.mark.asyncio
+async def test_selectin_children_filter_and_opt_out_both_work(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Pin the loader semantics the whole #617 design leans on.
+
+    ``DHCPScope.pools`` / ``.statics`` are selectin-loaded, so each child load is
+    its own ORM execute and the global soft-delete filter is applied to it
+    independently. Two properties have to hold, in opposite directions:
+
+      * a renderer must NEVER see a soft-deleted child (or a trashed reservation
+        would keep being served), and
+      * a blast-radius count / purge pre-pass MUST be able to see one when it
+        deliberately opts in, or it would under-report what it is about to
+        destroy.
+
+    Under the old ``lazy="joined"`` the first property did not hold: the filter
+    registers with ``propagate_to_loaders=False``, so a joined child rode the
+    parent's statement straight past it.
+    """
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, _subnet, _group = await _make_scope(db_session)
+    db_session.add_all(
+        [
+            DHCPPool(
+                scope_id=scope.id,
+                start_ip="10.50.0.100",
+                end_ip="10.50.0.200",
+                pool_type="dynamic",
+            ),
+            DHCPStaticAssignment(
+                scope_id=scope.id, ip_address="10.50.0.40", mac_address="aa:bb:cc:dd:ee:09"
+            ),
+        ]
+    )
+    await db_session.flush()
+    scope_id = scope.id
+    await db_session.commit()
+
+    assert (
+        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    ).status_code == 204
+
+    # Opted in: the children are visible, so a blast-radius count is honest.
+    db_session.expire_all()
+    trashed = (
+        await db_session.execute(
+            select(DHCPScope)
+            .where(DHCPScope.id == scope_id)
+            .execution_options(include_deleted=True)
+        )
+    ).scalar_one()
+    assert trashed.deleted_at is not None
+    assert len(trashed.pools) == 1, "include_deleted must reach the selectin child load"
+    assert len(trashed.statics) == 1, "include_deleted must reach the selectin child load"
+
+    # Not opted in: a soft-deleted child is invisible even on a LIVE parent, so
+    # nothing that renders config can serve it.
+    restored = await client.post(
+        f"/api/v1/admin/trash/dhcp_scope/{scope_id}/restore", headers=headers
+    )
+    assert restored.status_code == 200, restored.text
+
+    db_session.expire_all()
+    pool_row = (
+        await db_session.execute(select(DHCPPool).where(DHCPPool.scope_id == scope_id))
+    ).scalar_one()
+    pool_row.deleted_at = datetime.now(UTC)
+    pool_row.deletion_batch_id = uuid.uuid4()
+    await db_session.commit()
+
+    db_session.expire_all()
+    live = (
+        await db_session.execute(select(DHCPScope).where(DHCPScope.id == scope_id))
+    ).scalar_one()
+    assert live.deleted_at is None
+    assert list(live.pools) == [], "a soft-deleted child must not reach a live parent's collection"
+
+
+@pytest.mark.asyncio
+async def test_create_static_rejects_scope_id_but_tolerates_round_trip(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A body scope_id must 422 (it means something we won't do), but the common
+    GET -> edit -> PUT round-trip must still work: StaticResponse carries id /
+    created_at / modified_at, and a blanket extra="forbid" would 422 all of them."""
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, _subnet, _group = await _make_scope(db_session)
+    scope_id = scope.id
+    await db_session.commit()
+
+    # scope_id on CREATE -> 422 (path param owns it)
+    rejected = await client.post(
+        f"/api/v1/dhcp/scopes/{scope_id}/statics",
+        headers=headers,
+        json={
+            "ip_address": "10.50.0.41",
+            "mac_address": "aa:bb:cc:dd:ee:0a",
+            "scope_id": str(uuid.uuid4()),
+        },
+    )
+    assert rejected.status_code == 422, rejected.text
+
+    created = await client.post(
+        f"/api/v1/dhcp/scopes/{scope_id}/statics",
+        headers=headers,
+        json={"ip_address": "10.50.0.41", "mac_address": "aa:bb:cc:dd:ee:0a"},
+    )
+    assert created.status_code == 201, created.text
+    row = created.json()
+
+    # Round-trip the response back as an update: server-owned fields are ignored,
+    # not rejected.
+    row["hostname"] = "renamed"
+    row.pop("scope_id")
+    updated = await client.put(f"/api/v1/dhcp/statics/{row['id']}", headers=headers, json=row)
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["hostname"] == "renamed"
+
+
+@pytest.mark.asyncio
+async def test_purge_sweep_releases_ipam_mirror_of_reservations(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The nightly purge is a Core DELETE — no per-row Python — so it has to
+    release the reservations' IPAM mirrors itself before wiping them (#618).
+
+    Also the first coverage of ``detach_ipam_for_static`` being reached from a
+    task session rather than an HTTP request: it lazily imports the IPAM router
+    for ``_sync_dns_record``, which no worker path had exercised before.
+    """
+    from datetime import timedelta
+
+    from app.models.settings import PlatformSettings
+    from app.tasks.trash_purge import _sweep
+
+    _, token = await _make_admin(db_session)
+    headers = {"Authorization": f"Bearer {token}"}
+    scope, subnet, _group = await _make_scope(db_session)
+    scope_id, subnet_id = scope.id, subnet.id
+
+    if (await db_session.execute(select(PlatformSettings).limit(1))).scalar_one_or_none() is None:
+        db_session.add(PlatformSettings())
+    await db_session.commit()
+
+    created = await client.post(
+        f"/api/v1/dhcp/scopes/{scope_id}/statics",
+        headers=headers,
+        json={
+            "ip_address": "10.50.0.50",
+            "mac_address": "aa:bb:cc:dd:ee:0b",
+            "hostname": "purgeme",
+        },
+    )
+    assert created.status_code == 201, created.text
+
+    assert (
+        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    ).status_code == 204
+
+    # Backdate the whole batch past the retention window so the sweep takes it.
+    old = datetime.now(UTC) - timedelta(days=90)
+    for model in (DHCPScope, DHCPPool, DHCPStaticAssignment):
+        rows = (
+            (
+                await db_session.execute(
+                    select(model)
+                    .where(model.deleted_at.is_not(None))
+                    .execution_options(include_deleted=True)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for r in rows:
+            r.deleted_at = old
+    await db_session.commit()
+
+    result = await _sweep()
+    assert result["ipam_mirrors_released"] >= 1, result
+    assert result["per_type"]["dhcp_static_assignment"] >= 1, result
+
+    db_session.expire_all()
+    mirror = (
+        await db_session.execute(
+            select(IPAddress).where(
+                IPAddress.subnet_id == subnet_id, IPAddress.address == "10.50.0.50"
+            )
+        )
+    ).scalar_one()
+    assert mirror.status == "available"
+    assert mirror.static_assignment_id is None

--- a/backend/tests/test_dhcp_scope_cascade_soft_delete.py
+++ b/backend/tests/test_dhcp_scope_cascade_soft_delete.py
@@ -165,9 +165,8 @@ async def test_trashed_statics_are_hidden_from_default_selects(
     scope_id = scope.id
     await db_session.commit()
 
-    assert (
-        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
-    ).status_code == 204
+    deleted = await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    assert deleted.status_code == 204, deleted.text
 
     # Holding the trashed scope's UUID must not get you its reservations back.
     listed = await client.get(f"/api/v1/dhcp/scopes/{scope_id}/statics", headers=headers)
@@ -203,9 +202,8 @@ async def test_trashed_static_does_not_block_mac_reuse(
     await db_session.flush()
     await db_session.commit()
 
-    assert (
-        await client.delete(f"/api/v1/dhcp/scopes/{scope.id}", headers=headers)
-    ).status_code == 204
+    deleted = await client.delete(f"/api/v1/dhcp/scopes/{scope.id}", headers=headers)
+    assert deleted.status_code == 204, deleted.text
 
     # Same group, same subnet, fresh scope — the partial unique index on
     # (group, subnet) released the slot when the old scope was trashed.
@@ -250,9 +248,8 @@ async def test_restore_brings_back_pools_and_statics(
     scope_id = scope.id
     await db_session.commit()
 
-    assert (
-        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
-    ).status_code == 204
+    deleted = await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    assert deleted.status_code == 204, deleted.text
 
     restore = await client.post(
         f"/api/v1/admin/trash/dhcp_scope/{scope_id}/restore", headers=headers
@@ -308,9 +305,8 @@ async def test_trash_batch_size_counts_cascade_children(
     scope_id = scope.id
     await db_session.commit()
 
-    assert (
-        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
-    ).status_code == 204
+    deleted = await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    assert deleted.status_code == 204, deleted.text
 
     listing = await client.get("/api/v1/admin/trash?type=dhcp_scope", headers=headers)
     assert listing.status_code == 200
@@ -521,9 +517,8 @@ async def test_selectin_children_filter_and_opt_out_both_work(
     scope_id = scope.id
     await db_session.commit()
 
-    assert (
-        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
-    ).status_code == 204
+    deleted = await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    assert deleted.status_code == 204, deleted.text
 
     # Opted in: the children are visible, so a blast-radius count is honest.
     db_session.expire_all()
@@ -639,9 +634,8 @@ async def test_purge_sweep_releases_ipam_mirror_of_reservations(
     )
     assert created.status_code == 201, created.text
 
-    assert (
-        await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
-    ).status_code == 204
+    deleted = await client.delete(f"/api/v1/dhcp/scopes/{scope_id}", headers=headers)
+    assert deleted.status_code == 204, deleted.text
 
     # Backdate the whole batch past the retention window so the sweep takes it.
     old = datetime.now(UTC) - timedelta(days=90)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7033,14 +7033,14 @@ export const dhcpApi = {
         params,
       })
       .then((r) => r.data),
-  createStatic: (scopeId: string, data: Partial<DHCPStaticAssignment>) =>
+  createStatic: (scopeId: string, data: DHCPStaticAssignmentWrite) =>
     api
       .post<DHCPStaticAssignment>(`/dhcp/scopes/${scopeId}/statics`, data)
       .then((r) => r.data),
   updateStatic: (
     _scopeId: string,
     staticId: string,
-    data: Partial<DHCPStaticAssignment>,
+    data: DHCPStaticAssignmentWrite,
   ) =>
     api
       .put<DHCPStaticAssignment>(`/dhcp/statics/${staticId}`, data)
@@ -7333,6 +7333,30 @@ export interface DHCPPool {
   created_at: string;
   modified_at: string;
 }
+
+/**
+ * Fields the reservation create/update API actually accepts.
+ *
+ * Deliberately NOT `Partial<DHCPStaticAssignment>`: that includes `scope_id`,
+ * which the API refuses. A reservation cannot be re-pointed at another scope —
+ * the scope is part of its identity (uniqueness is keyed on it, and Kea renders
+ * the reservation nested inside the scope's subnet stanza). The backend used to
+ * drop a stray `scope_id` silently; it now 422s (#619), so the payload type has
+ * to be honest about what is sendable.
+ */
+export type DHCPStaticAssignmentWrite = Partial<
+  Pick<
+    DHCPStaticAssignment,
+    | "ip_address"
+    | "mac_address"
+    | "hostname"
+    | "description"
+    | "client_id"
+    | "duid"
+    | "options_override"
+    | "ip_address_id"
+  >
+> & { tags?: Record<string, unknown> };
 
 export interface DHCPStaticAssignment {
   id: string;

--- a/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
+++ b/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { dhcpApi, type DHCPStaticAssignment, type DHCPScope } from "@/lib/api";
+import {
+  dhcpApi,
+  type DHCPStaticAssignment,
+  type DHCPStaticAssignmentWrite,
+  type DHCPScope,
+} from "@/lib/api";
 import { hostnameError } from "@/lib/dnsNames";
 import { Modal, Field, Btns, inputCls, errMsg } from "./_shared";
 
@@ -40,7 +45,7 @@ export function CreateStaticAssignmentModal({
 
   const mut = useMutation({
     mutationFn: () => {
-      const data: Partial<DHCPStaticAssignment> = {
+      const data: DHCPStaticAssignmentWrite = {
         mac_address: mac,
         ip_address: ip,
         hostname,

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -1159,14 +1159,20 @@ function ScopeDeleteModal({
       `${statics.length} reservation${statics.length === 1 ? "" : "s"}`,
     );
   const windowsNote = groupServers.some((s) => s.driver === "windows_dhcp")
-    ? " The scope will also be removed from the Windows DHCP server via WinRM."
+    ? " The scope is also removed from the Windows DHCP server via WinRM."
     : "";
   return (
     <DeleteConfirmModal
       title="Delete DHCP Scope"
       description={
+        // The old copy — "All its pools and reservations will be removed as
+        // well" — described the permanent path, which the UI never takes. The
+        // default is a soft-delete: the scope and its children stop being served
+        // immediately (agents converge within seconds) but move to Trash
+        // together and restore together (#617).
         `Delete scope "${scope.name || scope.id.slice(0, 8)}"? ` +
-        "All its pools and reservations will be removed as well." +
+        "Its pools and reservations go with it — they stop being served straight " +
+        "away, and are restorable as a set from Administration → Trash." +
         windowsNote
       }
       referencesTitle={

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -3247,8 +3247,9 @@ function AddAddressModal({
             });
       // If the user picked a static_dhcp status and a scope, mirror the row
       // into the DHCP side so the two stay in sync (the backend
-      // `_upsert_ipam_for_static` helper will find the existing IPAM row and
-      // just link / update it — no duplicate is created).
+      // `upsert_ipam_for_static` helper in `services/dhcp/static_ipam.py` will
+      // find the existing IPAM row and just link / update it — no duplicate is
+      // created).
       // #516 — the address IS already created at this point; a failing
       // reservation must NOT surface as "Failed to allocate address" (the
       // row exists, so re-submitting collides). Catch it separately and


### PR DESCRIPTION
A Reddit contributor building an agentless FortiGate DHCP driver asked what
*should* happen to static reservations when their scope is deleted. Digging into
it turned up four shipped bugs in that path. This fixes all four.

Closes #616, Closes #617, Closes #618, Closes #619

## What was broken

**#616 — a scope deleted from the UI kept being served by Windows DHCP, forever.**
`push_scope_delete` only ran on the `permanent=true` branch, and the UI never sends
that flag. So a UI delete removed the scope from SpatiumDDI and from Kea's rendered
config while the Windows box kept handing out the scope and every reservation in it.
Nothing ever cleaned it up: the trash permanent-delete explicitly skips the
write-through hooks, and the purge sweep is a Core `DELETE` that runs no Python.
This is a silent divergence between the control plane's stated intent and real
device state.

**#617 — a scope was treated as a cascade *leaf*.** `DHCPScope` has been
soft-deletable since `c1f4a8b27d09`, but `_collect_descendants` had no branch for
it, so its pools and reservations were left live and un-stamped under a hidden
parent. They stayed reachable from three read surfaces — the statics list, the
group-wide MAC conflict check (which 409'd naming a scope UUID that appears nowhere
in the UI), and the `find_dhcp_statics` MCP tool — and the two-person approval
preview reported a **zero blast radius** for a scope holding hundreds of reservations.

**#618 — IPAM mirrors were stranded on every wholesale delete.** The detach helper
lived in the router and was only reachable from the per-reservation handlers. Every
bulk path (FK CASCADE or Core `DELETE` — no per-row Python) left `ip_address` rows
at `status="static_dhcp"` pointing at reservations Postgres had already dropped:
not allocated, not free, not reclaimable by any sweeper.

**#619 — a body `scope_id` was silently dropped with a 200.** Pydantic's default
`extra="ignore"`, so a caller trying to re-point a reservation got no error and no
effect. Separately, nothing checked that a reservation's IP fell inside its scope's
subnet — even though Kea renders it *nested inside* that subnet's stanza, so an
out-of-CIDR reservation shipped structurally invalid config to the agent.

## The design answer (the contributor's actual question)

A reservation is **not** an independent object that can outlive its scope. The scope
is part of its identity (`uq_dhcp_static_scope_mac`), Kea renders reservations nested
inside the scope's `subnet4` stanza, Windows keys them by the scope's network address,
and a static carries no `group_id` — it reaches a group only via `scope.group_id`.
A scope-less reservation is unrenderable on every driver we have or will have.

So the FK stays `NOT NULL` / `CASCADE`, and what changes is that the *logical* delete
finally mirrors it: `DHCPPool` and `DHCPStaticAssignment` get `SoftDeleteMixin` and
ride the scope's `deletion_batch_id` into the trash. **Restore brings the scope back
whole** — that's the real answer to "I deleted the wrong scope", and it's one click.

Rejected: converting orphans to IPAM `reserved` (lossy — you can't reconstruct the
MAC↔IP binding, `options_override`, or `client_id`/`duid` from a status, and
`reserved` is already taken, with a TTL sweeper that would silently free them); and
re-pointing to another scope (a legitimate feature, but orthogonal to deletion, and
mostly illegal anyway — the IP must sit inside the scope's subnet, and a partial
unique index forbids two live scopes on the same group+subnet).

## Notable: a fifth bug fell out

`DHCPScope.pools` / `.statics` were `lazy="joined"` **collections**, which forces every
`select(DHCPScope)` in the codebase to remember `.unique()` or raise
`InvalidRequestError` at runtime. Several didn't — **the Trash list, restore, and
permanent-delete all 500'd the moment a soft-deleted scope had a single pool or
reservation** (i.e. any real scope), with the same latent trap in the conformity
engine, subnet resize, and the radvd MCP tool.

Fixed at the root by switching to `lazy="selectin"` rather than sprinkling `.unique()`
at ten call sites. That also fixes child soft-delete filtering, which `joined` got
wrong: the global filter registers with `propagate_to_loaders=False`, so a joined child
rode the parent's statement straight past it. Verified both directions:

```
live scope + soft-deleted child, no opt-out  ->  scope.pools == []      (never rendered)
parent loaded with include_deleted=True      ->  scope.pools == [child] (blast radius honest)
```

## Deliberately deferred (tracked in #620)

- **`static_assignment_id` varchar → uuid FK.** Would make the dangle unrepresentable,
  but retyping in one shot breaks the rolling-upgrade contract (#296) — N-1 pods compare
  that column against a Python `str` during the mixed-version window. `lint_migrations.py`
  correctly flags it. Needs two-release expand/contract.
- **`pull_leases._upsert_scope`.** Its replace-all reconciler Core-DELETEs reservations
  on a schedule; a naive detach would tear down and recreate the forward A record on
  every pass. Needs a re-point-by-IP reconcile, and a Windows box to validate against.

## Migration

`b3e7d21c9f04` — additive column adds, the two reservation uniqueness rules become
**partial** unique indexes (`WHERE deleted_at IS NULL`, the #474 shape), a backfill that
adopts children of already-trashed scopes into their parent's batch, and a one-shot
repair releasing already-stranded IPAM mirrors.

## Testing

New `test_dhcp_scope_cascade_soft_delete.py` (12 cases) covers the cascade + batch,
the three read leaks, restore-brings-back-children, honest trash blast radius, the
agentless push on both the scope and block paths, IPAM release on permanent-delete
*and* on the purge sweep (first coverage of that helper from a Celery task session),
`scope_id` rejection with round-trip tolerance, and out-of-CIDR refusal. Plus a
regression test pinning the selectin loader semantics both ways.

Local: full backend suite, ruff/black/mypy, migration linter, frontend build/tsc/eslint/prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
