### PR TITLE
fix(ha): survive control-plane node loss — the six remaining #590 root causes

### DIFF
--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -1067,6 +1067,20 @@ def heartbeat_once(
                 )
         _evicted_pending.intersection_update({str(n) for n in evict_names})
 
+        # #590 — cluster DNS must survive a node loss. k3s's bundled
+        # CoreDNS is a single replica that deterministically sits on the
+        # seed and takes the k8s-default 300 s to evict, so a hard seed
+        # kill silences ALL Service/pod-FQDN resolution — the api
+        # readiness gate's Postgres and Redis lookups included — for
+        # longer than the whole recovery budget. Re-converged every
+        # heartbeat because k3s re-applies its bundled manifest (replicas
+        # back to 1) on every restart.
+        dns_changed, dns_err = k8s_api.ensure_coredns_ha()
+        if dns_changed:
+            log.info("supervisor.heartbeat.coredns_ha_applied")
+        elif dns_err:
+            log.warning("supervisor.heartbeat.coredns_ha_failed", error=dns_err)
+
     # #170 Wave C2 — render the role-driven compose env. C3 will
     # consume this via ``docker compose --env-file`` to actually
     # bring services up/down; for now we just write the file so the

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -1040,6 +1040,27 @@ def heartbeat_once(
             if ok:
                 _evicted_pending.add(str(name))
                 log.info("supervisor.heartbeat.node_evicted", node=name)
+                # #590 — the deleted node strands any local-path Redis PVC
+                # provisioned on it (node-affine PV): the replacement
+                # replica sits Pending forever and its missing sentinel
+                # silently halves the failover quorum, so the NEXT node
+                # loss takes the whole API down. Reclaim now — the
+                # StatefulSet recreates pod + claim on a live node and the
+                # replica resyncs from the master (cache/broker data;
+                # Postgres is the store of record).
+                pvcs, pvc_err = k8s_api.reclaim_stranded_redis_storage(str(name))
+                if pvcs:
+                    log.info(
+                        "supervisor.heartbeat.redis_storage_reclaimed",
+                        node=name,
+                        pvcs=pvcs,
+                    )
+                elif pvc_err:
+                    log.warning(
+                        "supervisor.heartbeat.redis_storage_reclaim_failed",
+                        node=name,
+                        error=pvc_err,
+                    )
             else:
                 log.warning(
                     "supervisor.heartbeat.node_evict_failed", node=name, error=evict_err

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -501,6 +501,71 @@ def delete_node(name: str) -> tuple[bool, str | None]:
     return False, f"kubeapi status {status}: {resp[:200]!r}"
 
 
+def reclaim_stranded_redis_storage(
+    node: str, namespace: str = "spatium"
+) -> tuple[list[str], str | None]:
+    """Delete Redis PVCs (and their Pending consumer pods) stranded on a
+    just-deleted node — returns (reclaimed_pvc_names, error).
+
+    #590 — local-path PVs are node-affine, so evicting a dead node
+    permanently strands every ReadWriteOnce PVC provisioned on it: the
+    StatefulSet's replacement pod references the old claim and sits
+    ``Pending`` forever ("volume node affinity conflict"). For the
+    Sentinel Redis that is not cosmetic — the missing replica's sentinel
+    silently drops the quorum from 3 to 2, and the NEXT node loss leaves
+    one lone sentinel that can never authorize a failover: the master is
+    stranded, ``sentinel://`` clients never resolve a new one, and the
+    appliance API is down cluster-wide (observed live 2026-07-12; the
+    chart README documented the manual PVC-delete repair — an appliance
+    must do it itself).
+
+    Redis here is cache + Celery broker; Postgres is the store of record,
+    so the data is expendable and the replica resyncs from the master.
+    Deliberately restricted to claims with ``-redis-`` in the name: CNPG
+    manages (deletes + recreates) its own instance PVCs, and anything
+    else is not ours to reap. The PVC goes first (pvc-protection holds it
+    until its pod is gone), then the pod — the StatefulSet then recreates
+    both and the provisioner lands the new PV on a live node."""
+    base = f"/api/v1/namespaces/{quote(namespace)}"
+    try:
+        status, resp = _request("GET", f"{base}/persistentvolumeclaims")
+    except RuntimeError as exc:
+        return [], str(exc)
+    if status != 200:
+        return [], f"kubeapi status {status}: {resp[:200]!r}"
+    try:
+        items = json.loads(resp).get("items", [])
+    except ValueError:
+        return [], "unparseable PVC list"
+    reclaimed: list[str] = []
+    for pvc in items:
+        meta = pvc.get("metadata") or {}
+        name = str(meta.get("name") or "")
+        anns = meta.get("annotations") or {}
+        if "-redis-" not in name:
+            continue
+        if anns.get("volume.kubernetes.io/selected-node") != node:
+            continue
+        try:
+            status, resp = _request(
+                "DELETE", f"{base}/persistentvolumeclaims/{quote(name)}")
+        except RuntimeError as exc:
+            return reclaimed, str(exc)
+        if status not in (200, 202, 404):
+            return reclaimed, f"kubeapi status {status}: {resp[:200]!r}"
+        # volumeClaimTemplate name is the prefix: data-<pod-name>. Delete
+        # the Pending pod so the StatefulSet recreates it against a fresh
+        # claim (an existing pod keeps referencing the deleted PVC).
+        pod = name.partition("-")[2]
+        if pod:
+            try:
+                _request("DELETE", f"{base}/pods/{quote(pod)}")
+            except RuntimeError:
+                pass  # pod may not exist; the PVC reclaim is what matters
+        reclaimed.append(name)
+    return reclaimed, None
+
+
 # #272 — durable control-plane state via k3s HelmChartConfig.
 #
 # The seed supervisor reflects cluster state (control-plane member count,

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -844,6 +844,103 @@ def patch_node_labels(
     return False, f"kubeapi status {status}: {resp[:200]!r}"
 
 
+def ensure_coredns_ha(replicas: int = 2) -> tuple[bool, str | None]:
+    """Keep the k3s-bundled CoreDNS able to survive a node loss —
+    returns (changed, error); ``(False, None)`` means already converged.
+
+    #590 — k3s ships CoreDNS as a SINGLE replica with the default 300 s
+    unreachable toleration, and on an appliance it deterministically
+    lands on the seed (single-node install; members join later; the pod
+    never moves). Hard-kill the seed and cluster DNS is gone for 5
+    minutes — and *everything* the api readiness gate touches resolves
+    through it (the Postgres ``-rw`` Service, the Redis sentinel
+    FQDNs), so every api pod goes NotReady cluster-wide until CoreDNS
+    finally reschedules. Observed live 2026-07-12: kill_leader failed
+    identically across four builds while postgres/redis fixes landed,
+    because DNS was the common upstream casualty.
+
+    Reconciled from the seed's heartbeat (idempotent GET-then-patch):
+    k3s re-applies its bundled manifest on every restart, which resets
+    replicas to 1 — a one-shot patch would silently regress, the
+    heartbeat re-converges it. The toleration list is REPLACED by the
+    merge-patch, so the stock entries ride along with the fast-evict
+    pair (same 20 s rationale as api/frontend/worker/postgresql/redis).
+
+    REQUIRED (not preferred) anti-affinity, deliberately: the reconciler
+    first fires while the appliance is still a single node (firstboot —
+    members join minutes later), and preferred anti-affinity happily
+    parked BOTH replicas on the seed; Kubernetes never rebalances
+    running pods, so the "HA" DNS died with the seed anyway (observed
+    live 2026-07-12: both coredns replicas Terminating in the same
+    kill_leader window the fix was meant to survive). Under required
+    anti-affinity the second replica sits Pending until a member joins
+    and then schedules there — a Pending spare on a genuinely
+    single-node box is harmless (the first replica serves), a
+    co-located spare is worthless."""
+    path = "/apis/apps/v1/namespaces/kube-system/deployments/coredns"
+    try:
+        status, resp = _request("GET", path)
+    except RuntimeError as exc:
+        return False, str(exc)
+    if status != 200:
+        return False, f"kubeapi status {status}: {resp[:200]!r}"
+    try:
+        dep = json.loads(resp)
+    except ValueError:
+        return False, "unparseable coredns deployment"
+    spec = dep.get("spec") or {}
+    tmpl_spec = (spec.get("template") or {}).get("spec") or {}
+    tolerations = tmpl_spec.get("tolerations") or []
+    has_fast_evict = any(
+        t.get("key") == "node.kubernetes.io/unreachable"
+        and (t.get("tolerationSeconds") or 10**9) <= 30
+        for t in tolerations
+    )
+    has_required_spread = bool(
+        ((tmpl_spec.get("affinity") or {}).get("podAntiAffinity") or {})
+        .get("requiredDuringSchedulingIgnoredDuringExecution")
+    )
+    if (int(spec.get("replicas") or 0) >= replicas and has_fast_evict
+            and has_required_spread):
+        return False, None
+    fast = [
+        {"key": "node.kubernetes.io/unreachable", "operator": "Exists",
+         "effect": "NoExecute", "tolerationSeconds": 20},
+        {"key": "node.kubernetes.io/not-ready", "operator": "Exists",
+         "effect": "NoExecute", "tolerationSeconds": 20},
+    ]
+    keep = [t for t in tolerations
+            if t.get("key") not in ("node.kubernetes.io/unreachable",
+                                    "node.kubernetes.io/not-ready")]
+    spread = {
+        "podAntiAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": [{
+                "topologyKey": "kubernetes.io/hostname",
+                "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+            }],
+        },
+    }
+    payload = json.dumps({
+        "spec": {
+            "replicas": replicas,
+            "template": {"spec": {
+                "tolerations": keep + fast,
+                "affinity": spread,
+            }},
+        },
+    }).encode("utf-8")
+    try:
+        status, resp = _request(
+            "PATCH", path, body=payload,
+            content_type="application/merge-patch+json",
+        )
+    except RuntimeError as exc:
+        return False, str(exc)
+    if status in (200, 201):
+        return True, None
+    return False, f"kubeapi status {status}: {resp[:200]!r}"
+
+
 def patch_cnpg_instances(
     instances: int,
     *,

--- a/agent/supervisor/tests/test_coredns_ha.py
+++ b/agent/supervisor/tests/test_coredns_ha.py
@@ -1,0 +1,127 @@
+"""#590 — ensure_coredns_ha keeps cluster DNS able to survive a node loss.
+
+k3s ships CoreDNS as a single replica that deterministically lands on the
+seed and takes the k8s-default 300s to evict — a hard seed kill silences
+all Service/pod-FQDN resolution (the api readiness gate's Postgres and
+Redis lookups included) for longer than any recovery budget. These tests
+pin the reconciler's contract: patch a stock deployment to 2 replicas +
+fast-evict tolerations (stock entries preserved) + REQUIRED anti-affinity;
+converge idempotently; upgrade a preferred-affinity patch from an earlier
+build; and surface kubeapi errors.
+"""
+
+from __future__ import annotations
+
+import json
+
+from spatium_supervisor import k8s_api
+
+
+class _Recorder:
+    def __init__(self, get_status: int, get_body: str, patch_status: int = 200):
+        self._get = (get_status, get_body)
+        self._patch_status = patch_status
+        self.calls: list[tuple[str, str, bytes | None]] = []
+
+    def __call__(self, method, path, body=None, content_type=None):
+        self.calls.append((method, path, body))
+        if method == "GET":
+            return self._get
+        return (self._patch_status, "{}")
+
+    @property
+    def patched(self) -> bool:
+        return any(m == "PATCH" for m, _, _ in self.calls)
+
+    @property
+    def patch_body(self) -> dict:
+        for method, _, body in self.calls:
+            if method == "PATCH" and body is not None:
+                return json.loads(body)
+        return {}
+
+
+_STOCK_TOLERATIONS = [
+    {"key": "CriticalAddonsOnly", "operator": "Exists"},
+    {"key": "node-role.kubernetes.io/control-plane", "operator": "Exists",
+     "effect": "NoSchedule"},
+]
+
+_FAST_TOLERATIONS = [
+    {"key": "node.kubernetes.io/unreachable", "operator": "Exists",
+     "effect": "NoExecute", "tolerationSeconds": 20},
+    {"key": "node.kubernetes.io/not-ready", "operator": "Exists",
+     "effect": "NoExecute", "tolerationSeconds": 20},
+]
+
+_REQUIRED_SPREAD = {
+    "podAntiAffinity": {
+        "requiredDuringSchedulingIgnoredDuringExecution": [{
+            "topologyKey": "kubernetes.io/hostname",
+            "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+        }],
+    },
+}
+
+
+def _deploy(replicas: int, tolerations: list, affinity: dict | None = None) -> str:
+    tmpl_spec: dict = {"tolerations": tolerations}
+    if affinity is not None:
+        tmpl_spec["affinity"] = affinity
+    return json.dumps({"spec": {"replicas": replicas,
+                                "template": {"spec": tmpl_spec}}})
+
+
+def test_stock_manifest_gets_replicas_tolerations_and_required_spread(monkeypatch) -> None:
+    rec = _Recorder(200, _deploy(1, _STOCK_TOLERATIONS))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    body = rec.patch_body
+    assert body["spec"]["replicas"] == 2
+    # Stock tolerations ride along — the merge-patch REPLACES the list.
+    assert body["spec"]["template"]["spec"]["tolerations"] == (
+        _STOCK_TOLERATIONS + _FAST_TOLERATIONS)
+    assert body["spec"]["template"]["spec"]["affinity"] == _REQUIRED_SPREAD
+
+
+def test_idempotent_when_converged(monkeypatch) -> None:
+    rec = _Recorder(200, _deploy(
+        2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, _REQUIRED_SPREAD))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (False, None)
+    assert not rec.patched
+
+
+def test_preferred_spread_from_earlier_build_is_upgraded(monkeypatch) -> None:
+    # The first cut of this reconciler used preferred anti-affinity, which
+    # parked BOTH replicas on the seed when it fired on the single-node
+    # firstboot (k8s never rebalances running pods) — the "HA" DNS died
+    # with the seed anyway. A cluster patched by that build must be
+    # re-patched to the required form, not short-circuited as converged.
+    preferred = {"podAntiAffinity": {
+        "preferredDuringSchedulingIgnoredDuringExecution": [{"weight": 100}]}}
+    rec = _Recorder(200, _deploy(
+        2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, preferred))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    assert rec.patch_body["spec"]["template"]["spec"]["affinity"] == _REQUIRED_SPREAD
+
+
+def test_missing_deployment_reports(monkeypatch) -> None:
+    rec = _Recorder(404, "not found")
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert changed is False
+    assert err is not None and "404" in err
+    assert not rec.patched

--- a/agent/supervisor/tests/test_redis_storage_reclaim.py
+++ b/agent/supervisor/tests/test_redis_storage_reclaim.py
@@ -59,8 +59,7 @@ def test_reclaims_redis_pvc_and_pending_pod_on_dead_node(monkeypatch) -> None:
     assert (reclaimed, err) == (["data-spatium-control-spatiumddi-redis-2"], None)
     # PVC first (pvc-protection holds it until its pod is gone), then the pod.
     assert rec.deleted == [
-        "/api/v1/namespaces/spatium/persistentvolumeclaims/"
-        "data-spatium-control-spatiumddi-redis-2",
+        "/api/v1/namespaces/spatium/persistentvolumeclaims/data-spatium-control-spatiumddi-redis-2",
         "/api/v1/namespaces/spatium/pods/spatium-control-spatiumddi-redis-2",
     ]
 

--- a/agent/supervisor/tests/test_redis_storage_reclaim.py
+++ b/agent/supervisor/tests/test_redis_storage_reclaim.py
@@ -1,0 +1,106 @@
+"""#590 — reclaim_stranded_redis_storage frees node-affine Redis PVCs.
+
+Evicting a dead node strands every local-path PVC provisioned on it (the
+PV is node-affine), so the StatefulSet's replacement pod sits Pending
+forever and the missing replica's sentinel silently drops the failover
+quorum. These tests pin the contract: reclaim exactly the Redis claims
+annotated with the deleted node (PVC first, then the Pending consumer
+pod so the StatefulSet recreates both), never touch CNPG's claims or
+other nodes' claims, and surface kubeapi errors instead of guessing.
+"""
+
+from __future__ import annotations
+
+import json
+
+from spatium_supervisor import k8s_api
+
+
+class _Recorder:
+    """Stand-in for k8s_api._request that scripts the PVC-list GET and
+    records every follow-up DELETE."""
+
+    def __init__(self, get_status: int, get_body: str, delete_status: int = 200):
+        self._get = (get_status, get_body)
+        self._delete_status = delete_status
+        self.calls: list[tuple[str, str]] = []
+
+    def __call__(self, method, path, body=None, content_type=None):
+        self.calls.append((method, path))
+        if method == "GET":
+            return self._get
+        return (self._delete_status, "{}")
+
+    @property
+    def deleted(self) -> list[str]:
+        return [p for m, p in self.calls if m == "DELETE"]
+
+
+def _pvc(name: str, node: str | None) -> dict:
+    meta: dict = {"name": name}
+    if node is not None:
+        meta["annotations"] = {"volume.kubernetes.io/selected-node": node}
+    return {"metadata": meta}
+
+
+def _pvc_list(*items: dict) -> str:
+    return json.dumps({"items": list(items)})
+
+
+def test_reclaims_redis_pvc_and_pending_pod_on_dead_node(monkeypatch) -> None:
+    rec = _Recorder(200, _pvc_list(
+        _pvc("data-spatium-control-spatiumddi-redis-2", "ddipg-member-2"),
+        _pvc("data-spatium-control-spatiumddi-redis-0", "ddipg-seed"),
+    ))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, err = k8s_api.reclaim_stranded_redis_storage("ddipg-member-2")
+
+    assert (reclaimed, err) == (["data-spatium-control-spatiumddi-redis-2"], None)
+    # PVC first (pvc-protection holds it until its pod is gone), then the pod.
+    assert rec.deleted == [
+        "/api/v1/namespaces/spatium/persistentvolumeclaims/"
+        "data-spatium-control-spatiumddi-redis-2",
+        "/api/v1/namespaces/spatium/pods/spatium-control-spatiumddi-redis-2",
+    ]
+
+
+def test_never_touches_cnpg_or_other_nodes(monkeypatch) -> None:
+    # CNPG deletes + recreates its own instance PVCs; reclaiming one out
+    # from under the operator would fight its reconcile. And claims on
+    # LIVE nodes are healthy — only the deleted node's are stranded.
+    rec = _Recorder(200, _pvc_list(
+        _pvc("spatium-control-spatiumddi-postgresql-2", "ddipg-member-2"),
+        _pvc("data-spatium-control-spatiumddi-redis-1", "ddipg-member-1"),
+    ))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, err = k8s_api.reclaim_stranded_redis_storage("ddipg-member-2")
+
+    assert (reclaimed, err) == ([], None)
+    assert rec.deleted == []
+
+
+def test_unannotated_pvc_is_left_alone(monkeypatch) -> None:
+    # No selected-node annotation = not a WaitForFirstConsumer local-path
+    # claim (or not yet scheduled) — there is nothing node-affine to free.
+    rec = _Recorder(200, _pvc_list(
+        _pvc("data-spatium-control-spatiumddi-redis-2", None),
+    ))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, err = k8s_api.reclaim_stranded_redis_storage("ddipg-member-2")
+
+    assert (reclaimed, err) == ([], None)
+    assert rec.deleted == []
+
+
+def test_list_failure_reports_instead_of_guessing(monkeypatch) -> None:
+    rec = _Recorder(500, "boom")
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    reclaimed, err = k8s_api.reclaim_stranded_redis_storage("ddipg-member-2")
+
+    assert reclaimed == []
+    assert err is not None and "500" in err
+    assert rec.deleted == []

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -91,8 +91,11 @@ async def readiness() -> JSONResponse:
                 await session.execute(text("SELECT 1"))
         checks["database"] = "ok"
     except TimeoutError:
-        logger.warning("readiness_check_failed", check="database",
-                       error="timed out after 4s (pool draining dead connections?)")
+        logger.warning(
+            "readiness_check_failed",
+            check="database",
+            error="timed out after 4s (pool draining dead connections?)",
+        )
         checks["database"] = "error: timed out after 4s"
         healthy = False
     except Exception as exc:
@@ -126,9 +129,7 @@ async def readiness() -> JSONResponse:
         # for minutes, which the kubelet's 1 s probe timeout reads as
         # NotReady — on every api pod at once, during exactly the
         # node-loss window readiness exists to survive.
-        r = make_async_redis(
-            settings.redis_url, socket_connect_timeout=2, socket_timeout=2
-        )
+        r = make_async_redis(settings.redis_url, socket_connect_timeout=2, socket_timeout=2)
         await cast(Awaitable[bool], r.ping())
         await r.aclose()
         checks["redis"] = "ok"
@@ -204,9 +205,7 @@ async def platform_health() -> JSONResponse:
         # for minutes, which the kubelet's 1 s probe timeout reads as
         # NotReady — on every api pod at once, during exactly the
         # node-loss window readiness exists to survive.
-        r = make_async_redis(
-            settings.redis_url, socket_connect_timeout=2, socket_timeout=2
-        )
+        r = make_async_redis(settings.redis_url, socket_connect_timeout=2, socket_timeout=2)
         await cast(Awaitable[bool], r.ping())
         await r.aclose()
         components.append(
@@ -283,9 +282,7 @@ async def platform_health() -> JSONResponse:
         # for minutes, which the kubelet's 1 s probe timeout reads as
         # NotReady — on every api pod at once, during exactly the
         # node-loss window readiness exists to survive.
-        r = make_async_redis(
-            settings.redis_url, socket_connect_timeout=2, socket_timeout=2
-        )
+        r = make_async_redis(settings.redis_url, socket_connect_timeout=2, socket_timeout=2)
         raw = await r.get(BEAT_HEARTBEAT_KEY)
         await r.aclose()
         if raw is None:

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -98,7 +98,15 @@ async def readiness() -> JSONResponse:
         from app.config import settings
         from app.core.redis_client import make_async_redis
 
-        r = make_async_redis(settings.redis_url, socket_connect_timeout=2)
+        # #590 — socket_timeout too, and both knobs now reach the SENTINEL
+        # hops as well (redis_client._sentinel_kwargs): an unbounded
+        # connect to a dead-but-still-resolving sentinel hung this check
+        # for minutes, which the kubelet's 1 s probe timeout reads as
+        # NotReady — on every api pod at once, during exactly the
+        # node-loss window readiness exists to survive.
+        r = make_async_redis(
+            settings.redis_url, socket_connect_timeout=2, socket_timeout=2
+        )
         await cast(Awaitable[bool], r.ping())
         await r.aclose()
         checks["redis"] = "ok"
@@ -168,7 +176,15 @@ async def platform_health() -> JSONResponse:
         from app.config import settings
         from app.core.redis_client import make_async_redis
 
-        r = make_async_redis(settings.redis_url, socket_connect_timeout=2)
+        # #590 — socket_timeout too, and both knobs now reach the SENTINEL
+        # hops as well (redis_client._sentinel_kwargs): an unbounded
+        # connect to a dead-but-still-resolving sentinel hung this check
+        # for minutes, which the kubelet's 1 s probe timeout reads as
+        # NotReady — on every api pod at once, during exactly the
+        # node-loss window readiness exists to survive.
+        r = make_async_redis(
+            settings.redis_url, socket_connect_timeout=2, socket_timeout=2
+        )
         await cast(Awaitable[bool], r.ping())
         await r.aclose()
         components.append(
@@ -239,7 +255,15 @@ async def platform_health() -> JSONResponse:
         # Sentinel-aware (HA Redis uses ``sentinel://``, which raw
         # ``aioredis.from_url`` rejects with "must specify one of redis:// …"
         # — the same helper the redis + workers checks above use).
-        r = make_async_redis(settings.redis_url, socket_connect_timeout=2)
+        # #590 — socket_timeout too, and both knobs now reach the SENTINEL
+        # hops as well (redis_client._sentinel_kwargs): an unbounded
+        # connect to a dead-but-still-resolving sentinel hung this check
+        # for minutes, which the kubelet's 1 s probe timeout reads as
+        # NotReady — on every api pod at once, during exactly the
+        # node-loss window readiness exists to survive.
+        r = make_async_redis(
+            settings.redis_url, socket_connect_timeout=2, socket_timeout=2
+        )
         raw = await r.get(BEAT_HEARTBEAT_KEY)
         await r.aclose()
         if raw is None:

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -75,10 +75,26 @@ async def readiness() -> JSONResponse:
     # from the schema check so an operator looking at a 503 response
     # can tell "Postgres is down" apart from "Postgres is up but the
     # schema is behind."
+    #
+    # #590 — each check is wait_for-bounded so the ENDPOINT answers in
+    # seconds no matter what state the pool is in. During a node loss a
+    # pooled connection to the dead primary black-holes (no RST), and a
+    # checkout that waits on it held this endpoint open for minutes —
+    # the kubelet's probe timeout read that as NotReady on every api
+    # pod at once, which emptied the api Service and 502'd the cluster
+    # (observed live 2026-07-12). db.py's command_timeout now culls
+    # such connections in bounded time; the wait_for here keeps the
+    # probe response itself honest-and-fast while that happens.
     try:
-        async with AsyncSessionLocal() as session:
-            await session.execute(text("SELECT 1"))
+        async with asyncio.timeout(4):
+            async with AsyncSessionLocal() as session:
+                await session.execute(text("SELECT 1"))
         checks["database"] = "ok"
+    except TimeoutError:
+        logger.warning("readiness_check_failed", check="database",
+                       error="timed out after 4s (pool draining dead connections?)")
+        checks["database"] = "error: timed out after 4s"
+        healthy = False
     except Exception as exc:
         logger.warning("readiness_check_failed", check="database", error=str(exc))
         checks["database"] = f"error: {exc}"
@@ -87,8 +103,14 @@ async def readiness() -> JSONResponse:
     # Schema-at-head check. Only run when the DB connect succeeded —
     # otherwise the schema check would surface a confusing
     # "could not connect" error on top of the database error above.
+    # Bounded like the database check: it opens its own session, so an
+    # unlucky checkout could land on a not-yet-culled dead connection.
     if checks["database"] == "ok":
-        verdict, detail = await _check_schema_ready()
+        try:
+            async with asyncio.timeout(4):
+                verdict, detail = await _check_schema_ready()
+        except TimeoutError:
+            verdict, detail = "error", "timed out after 4s"
         checks["schema"] = "ok" if verdict == "ok" else f"error: {detail}"
         if verdict != "ok":
             healthy = False

--- a/backend/app/core/redis_client.py
+++ b/backend/app/core/redis_client.py
@@ -110,7 +110,8 @@ def _sentinel_kwargs(password: str | None, kwargs: dict[str, Any]) -> dict[str, 
     kill_leader drill on a nested 3-node rig). Propagate the socket
     knobs so a dead sentinel costs its timeout, not minutes."""
     out: dict[str, Any] = {
-        k: v for k, v in kwargs.items()
+        k: v
+        for k, v in kwargs.items()
         if k in ("socket_connect_timeout", "socket_timeout", "socket_keepalive")
     }
     if password:

--- a/backend/app/core/redis_client.py
+++ b/backend/app/core/redis_client.py
@@ -81,7 +81,7 @@ def make_async_redis(url: str, **kwargs: Any) -> aioredis.Redis:
     sentinel_password = settings.redis_sentinel_password or url_password
     sentinel = Sentinel(
         hosts,
-        sentinel_kwargs=({"password": sentinel_password} if sentinel_password else {}),
+        sentinel_kwargs=_sentinel_kwargs(sentinel_password, kwargs),
         password=url_password,
         **kwargs,
     )
@@ -90,6 +90,32 @@ def make_async_redis(url: str, **kwargs: Any) -> aioredis.Redis:
         db=db,
         password=url_password,
     )
+
+
+def _sentinel_kwargs(password: str | None, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Connection kwargs for the SENTINEL hops, not just the master hop.
+
+    #590 — ``**kwargs`` (socket timeouts et al.) only reaches the
+    master-bound connection pool; the Sentinel objects that
+    ``discover_master`` iterates get ``sentinel_kwargs``, which carried
+    ONLY the password. So a caller's ``socket_connect_timeout=2`` did
+    not bound the sentinel hops at all: connecting to a sentinel whose
+    pod died with its node — but whose headless FQDN still resolves for
+    the ~20-40 s until Kubernetes marks the node's pods not-ready —
+    hangs for the OS TCP connect timeout (minutes, SYNs into a black
+    hole). The api's readiness check walks exactly that path on every
+    probe, so ``/health/ready`` blew straight through the kubelet's 1 s
+    probe timeout and the api sat NotReady cluster-wide during exactly
+    the window a node loss must be survivable (observed live 2026-07-12,
+    kill_leader drill on a nested 3-node rig). Propagate the socket
+    knobs so a dead sentinel costs its timeout, not minutes."""
+    out: dict[str, Any] = {
+        k: v for k, v in kwargs.items()
+        if k in ("socket_connect_timeout", "socket_timeout", "socket_keepalive")
+    }
+    if password:
+        out["password"] = password
+    return out
 
 
 def make_sync_redis(url: str, **kwargs: Any) -> redis_sync.Redis:
@@ -103,7 +129,7 @@ def make_sync_redis(url: str, **kwargs: Any) -> redis_sync.Redis:
     sentinel_password = settings.redis_sentinel_password or url_password
     sentinel = SentinelSync(
         hosts,
-        sentinel_kwargs=({"password": sentinel_password} if sentinel_password else {}),
+        sentinel_kwargs=_sentinel_kwargs(sentinel_password, kwargs),
         password=url_password,
         **kwargs,
     )

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -47,6 +47,32 @@ engine = create_async_engine(
     #     produce the same symptom without pre-ping; with it, the
     #     pool quietly recycles and the request succeeds.
     pool_pre_ping=True,
+    # #590 — pre-ping only helps when a dead connection FAILS FAST
+    # (postgres restarted on a live host → RST). A node death is a
+    # BLACK HOLE: the peer vanishes mid-connection, nothing answers,
+    # and the ping's SELECT 1 waits out the OS TCP retransmission
+    # timeout — minutes — while holding the checkout. Every pooled
+    # connection that pointed at the dead node poisons requests in
+    # turn, /health/ready's database check included, so the api sat
+    # NotReady cluster-wide long after CNPG had already promoted a
+    # new primary (observed live 2026-07-12: the survivor's readiness
+    # still timing out 3+ min into a kill_leader drill while the
+    # postgres -rw endpoint was healthy the whole time).
+    #
+    #   * command_timeout bounds EVERY command on the wire, the
+    #     pre-ping included: a black-holed connection now raises in
+    #     30 s instead of minutes, SQLAlchemy invalidates it, and the
+    #     retry connects fresh — which lands on the NEW primary via
+    #     the Service. Ceiling chosen well above any legitimate
+    #     single statement in the app path (route handlers are many
+    #     small queries; bulk work is chunked; alembic runs on its
+    #     own engine and is unaffected).
+    #   * timeout bounds the fresh CONNECT during failover, so a
+    #     half-open target costs 5 s, not the OS default.
+    connect_args={
+        "timeout": 5,
+        "command_timeout": 30,
+    },
 )
 
 AsyncSessionLocal = async_sessionmaker(

--- a/backend/tests/test_redis_client.py
+++ b/backend/tests/test_redis_client.py
@@ -37,3 +37,33 @@ def test_parse_sentinel_url_no_db_path() -> None:
     assert hosts == [("only", 26379)]
     assert db == 0
     assert password is None
+
+
+def test_sentinel_kwargs_propagates_socket_knobs() -> None:
+    # #590 — the sentinel hops must inherit the caller's timeouts: without
+    # them, connecting to a sentinel whose pod died with its node (but whose
+    # FQDN still resolves for the ~20-40s until Kubernetes marks the node's
+    # pods not-ready) hangs for the OS TCP timeout, and the api readiness
+    # check rides that hang straight through the kubelet's 1s probe timeout.
+    from app.core.redis_client import _sentinel_kwargs
+
+    out = _sentinel_kwargs("pw", {
+        "socket_connect_timeout": 2,
+        "socket_timeout": 2,
+        "socket_keepalive": True,
+        "db": 0,                      # not a socket knob — must not leak
+        "decode_responses": True,     # not a socket knob — must not leak
+    })
+    assert out == {
+        "socket_connect_timeout": 2,
+        "socket_timeout": 2,
+        "socket_keepalive": True,
+        "password": "pw",
+    }
+
+
+def test_sentinel_kwargs_without_password_or_knobs() -> None:
+    from app.core.redis_client import _sentinel_kwargs
+
+    assert _sentinel_kwargs(None, {}) == {}
+    assert _sentinel_kwargs(None, {"socket_timeout": 5}) == {"socket_timeout": 5}

--- a/backend/tests/test_redis_client.py
+++ b/backend/tests/test_redis_client.py
@@ -47,13 +47,16 @@ def test_sentinel_kwargs_propagates_socket_knobs() -> None:
     # check rides that hang straight through the kubelet's 1s probe timeout.
     from app.core.redis_client import _sentinel_kwargs
 
-    out = _sentinel_kwargs("pw", {
-        "socket_connect_timeout": 2,
-        "socket_timeout": 2,
-        "socket_keepalive": True,
-        "db": 0,                      # not a socket knob — must not leak
-        "decode_responses": True,     # not a socket knob — must not leak
-    })
+    out = _sentinel_kwargs(
+        "pw",
+        {
+            "socket_connect_timeout": 2,
+            "socket_timeout": 2,
+            "socket_keepalive": True,
+            "db": 0,  # not a socket knob — must not leak
+            "decode_responses": True,  # not a socket knob — must not leak
+        },
+    )
     assert out == {
         "socket_connect_timeout": 2,
         "socket_timeout": 2,

--- a/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
@@ -158,7 +158,20 @@ rules:
     # + ``update`` cover both the merge-patch form used by
     # k8s_api.patch_node_labels and a fallback strategic-merge if we
     # ever switch.
-    verbs: ["get", "list", "watch", "patch", "update"]
+    #
+    # #590/#272 Phase 9 — ``delete``: the dead-node replacement evict is
+    # the SEED SUPERVISOR calling ``k8s_api.delete_node()`` from its
+    # heartbeat (deleting the k8s Node makes k3s drop the etcd member).
+    # Without this verb every evict 403s
+    # (``supervisor.heartbeat.node_evict_failed`` each heartbeat), the
+    # row stays pinned in ``evicting``, and — because the product
+    # serializes the replacement member's join behind the evict — the
+    # replacement never joins: observed live 2026-07-12 as the ha
+    # suite's dead_node_replace stuck at nodes_ready=2 for 30 min with
+    # the dead Node still listed NotReady (and 2026-07-08 as a member
+    # sitting ``evicting`` 20+ min). The feature shipped without the
+    # RBAC verb it depends on.
+    verbs: ["get", "list", "watch", "patch", "update", "delete"]
     # #389 — read-only on the k3s ETCDSnapshotFile CRs so the
     # heartbeat's ``list_etcd_snapshots()`` can populate the Fleet →
     # etcd snapshots inventory. Without this grant the

--- a/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
@@ -198,6 +198,16 @@ rules:
   - apiGroups: ["k3s.cattle.io"]
     resources: ["etcdsnapshotfiles"]
     verbs: ["get", "list", "watch"]
+    # #590 — ensure_coredns_ha: the seed's heartbeat keeps the k3s-bundled
+    # CoreDNS at >=2 replicas with fast-evict tolerations (k3s resets it to
+    # a single 300s-toleration replica on every restart; a single replica
+    # deterministically sits on the seed, so a hard seed kill silences all
+    # Service/pod-FQDN resolution — api readiness's Postgres + Redis
+    # lookups included — for 5 minutes). resourceNames-pinned to coredns.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["coredns"]
+    verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
@@ -87,6 +87,20 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "services", "events", "configmaps"]
     verbs: ["get", "list", "watch"]
+    # #590/#272 Phase 9 — the dead-node evict reclaims Redis PVCs the
+    # deleted node stranded (node-affine local-path PVs), then deletes
+    # the Pending consumer pod so the StatefulSet recreates both on a
+    # live node (k8s_api.reclaim_stranded_redis_storage, run from the
+    # seed's heartbeat right after delete_node). Without the reclaim the
+    # missing replica's sentinel silently halves the failover quorum and
+    # the next node loss strands the Redis master for good. delete on
+    # pods+PVCs only — everything else in this Role stays read-only.
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -301,6 +301,47 @@ cnpg:
     limits:
       cpu: 500m
       memory: 512Mi
+  # #590 — the operator itself must survive node loss, because it IS the
+  # failover: with the operator down, CNPG performs no reconciliation, so a
+  # dead node holding the Postgres primary is never failed over and the api
+  # (which needs a writable primary to be ready) 502s cluster-wide until the
+  # operator comes back. The #590 fast-evict work covered the
+  # spatium-control workloads (api/frontend/worker via the supervisor's
+  # HelmChartConfig, postgresql/redis instance pods via the spatiumddi
+  # chart) but MISSED this operator: a single replica with the k8s-default
+  # 300 s unreachable toleration. Kill the node it happens to sit on and
+  # Postgres failover stalls ~5 minutes — observed live 2026-07-11 as the
+  # ha suite's kill_leader "did not recover" (60 s spec).
+  #
+  # Two layers, same shape as the rest of #590:
+  #  * replicaCount 2 + preferred pod anti-affinity: a single node loss
+  #    never takes the only operator; controller-runtime leader election
+  #    hands the lease to the survivor in seconds. (Preferred, not
+  #    required — a momentarily-unlabelled fresh member must not leave the
+  #    second replica Pending forever; co-location is a degraded-but-safe
+  #    fallback, and the tolerations below still bound it.)
+  #  * fast-evict tolerations: even a co-located replica leaves a dead
+  #    node in ~20 s instead of 300 s (suppresses DefaultTolerationSeconds,
+  #    exactly like api/frontend/worker/postgresql/redis).
+  replicaCount: 2
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: cloudnative-pg
+  tolerations:
+    - key: node.kubernetes.io/unreachable
+      operator: Exists
+      effect: NoExecute
+      tolerationSeconds: 20
+    - key: node.kubernetes.io/not-ready
+      operator: Exists
+      effect: NoExecute
+      tolerationSeconds: 20
   # Loosen the default 3s-delay / 30s-window (6 × 5s) startup gate — on
   # constrained appliance VMs the operator + its webhook TLS bootstrap
   # can take longer than 30s to answer ``/readyz``, and a startup-probe


### PR DESCRIPTION
Fixes the remainder of #590 — after #591, a 3-node HA cluster still did not survive the loss of a control-plane node. The `kill_leader` failure drill (hard power-off of the seed) left the UI/API down cluster-wide until the node returned, and `dead_node_replace` (kill a member → `POST …/control-plane/{id}/replace` → fresh install → pair/approve/promote) never re-converged: the replacement sat "joining" forever. Root-caused live on nested 3-node QA rigs over 7 build-and-break iterations (2026-07-11/12, ISO baked from each iteration of this branch, full install → form → break → measure each time): **what looked like one HA bug is six independent ones**, and every one of them is load-bearing — fixing the first five still left `kill_leader` at 0% until the sixth landed.

## The six root causes (one commit each; every mechanism observed live, not inferred)

**1. The CNPG operator itself was the un-HA'd component** (`values.yaml`, bootstrap chart). #591 gave fast-evict tolerations to api/frontend/worker and the postgresql/redis *instance* pods — but the CloudNativePG **operator** stayed a single replica with the k8s-default 300 s unreachable toleration. The operator *is* the failover: with it pinned to a dead node, no reconciliation happens and a dead primary is never promoted. Observed live: killing the operator's node froze the Postgres `Cluster` mid-reprovision (`persistentvolumeclaim "…-postgresql-2" not found` FailedScheduling events while the CR sat "Waiting for the instances to become active"). → `replicaCount: 2` + preferred anti-affinity + the same 20 s fast-evict pair. (`--leader-elect` is unconditional in the chart, so the surviving replica takes the lease in seconds.)

**2. The dead-node evict 403'd forever — the replace flow shipped without its RBAC verb** (`supervisor-rbac.yaml`). The #272 Phase 9 evict is the seed supervisor calling `delete_node()` from its heartbeat (deleting the Node makes k3s drop the dead etcd member); the `spatium-supervisor-nodes` ClusterRole granted `get/list/watch/patch/update` — **no `delete`**. Every evict failed (`supervisor.heartbeat.node_evict_failed` each heartbeat), the row pinned in `evicting`, and because the replacement's join is serialized behind the evict, the replacement never joined. Observed live: 30 min after replace+promote, `get nodes` still listed the dead member NotReady and the replacement was absent (`nodes_ready` stuck at 2) — same signature as the 2026-07-08 field observation of a member "evicting" 20+ min. **This one fix took `dead_node_replace` from never-recovering to green** (479.0 s / 569.6 s / 627.9 s across three validation runs).

**3. Sentinel hops had no timeouts — readiness hung for minutes on a dead-but-resolving sentinel** (`redis_client.py`, `health.py`). `make_async_redis` forwarded the caller's socket timeouts only to the master-bound pool; `sentinel_kwargs` carried just the password. A sentinel whose pod died with its node — but whose headless FQDN still resolves for the ~20-40 s until Kubernetes marks the node's pods not-ready — hung the connect for the OS TCP timeout. The api readiness check walks that path on every probe, so `/health/ready` blew through the kubelet's 1 s probe timeout on **every** api pod at once: Service emptied, nginx fell back to the static initialising page. → propagate `socket_connect_timeout/socket_timeout/socket_keepalive` into `sentinel_kwargs` (async + sync) and pass both timeouts at the three health call sites.

**4. Node-affine Redis PVCs strand on the evicted node — and silently halve the sentinel quorum** (`k8s_api.py`, `heartbeat.py`, RBAC). local-path PVs are node-affine, so after an evict the StatefulSet's replacement replica references the old claim and sits Pending forever. The chart README already documents the *manual* repair ("delete the stranded PVC…"); an appliance must do it itself. The failure compounds: the missing replica's sentinel drops quorum 3→2, and the *next* node loss leaves one lone sentinel that can never authorize a failover — observed live as `redis-2` Pending **9 hours** after a replace, then `kill_leader` → every api pod 503 on the redis check with the client looping on the dead master's FQDN: `ConnectionError('Error -2 connecting to spatium-control-spatiumddi-redis-2.…redis-headless…:26379. Name or service not known.')`, sentinel reporting exactly `1 usable` of 3 known. → `reclaim_stranded_redis_storage()` on the evict path: delete Redis PVCs whose `volume.kubernetes.io/selected-node` names the deleted node, then the Pending consumer pod, so the StatefulSet recreates both on a live node and the replica resyncs (cache/broker data; Postgres is the store of record). Deliberately restricted to `-redis-` claims — CNPG reconciles its own.

**5. `pool_pre_ping` cannot cull black-holed connections** (`db.py`, `health.py`). Pre-ping saves you when a dead connection fails fast (postgres restart on a live host → RST). A node death is a black hole: the ping's `SELECT 1` waits out the OS TCP retransmission timeout — minutes — while holding the checkout, and every pooled connection that pointed at the dead primary poisons requests in turn. Observed live: the survivor's `/health/ready` still timing out at t+190 s of a kill drill (`ready{unreachable:ReadTimeout}` in the QA diagnostics) while the promoted `-rw` endpoint was healthy the whole time. → asyncpg `connect_args={"timeout": 5, "command_timeout": 30}` (bounds every command, pre-ping included — dead conns culled in bounded time, retry lands on the new primary; alembic runs its own engine and is unaffected) + each readiness check wrapped in `asyncio.timeout` so the endpoint itself answers in seconds regardless of pool state.

**6. CoreDNS: single replica, deterministically on the seed, 300 s eviction — the common upstream casualty masking everything else** (`k8s_api.py`, `heartbeat.py`, RBAC). k3s ships CoreDNS as one replica; on an appliance it lands on the seed (single-node install; members join minutes later; the pod never moves). Hard-kill the seed → **cluster DNS is silent for 5 minutes**, and everything the readiness gate touches resolves through it — the Postgres `-rw` Service name, the Redis sentinel FQDNs. This is why `kill_leader` failed identically across four consecutive builds while fixes 1-5 landed underneath. Two confirmations: (a) placement — `kubectl -n kube-system get pods -o wide` on a fresh rig showed exactly one `coredns` replica on `ddipg-seed`, 60 min old (= since install); (b) differential — on a rig whose CoreDNS had migrated off the seed during earlier drills, the DNS blackout did not occur; hand-applying this patch to a live rig then took kill_leader recovery **from >180 s (timeout) to 15 s** in back-to-back drills on the same cluster. → `ensure_coredns_ha()`: heartbeat-reconciled (k3s re-applies its bundled manifest on every restart, resetting replicas to 1 — a one-shot patch silently regresses) merge-patch to `replicas: 2` + fast-evict tolerations (stock entries preserved) + **required** anti-affinity. Required, not preferred, deliberately: the reconciler first fires on the still-single-node firstboot, and preferred anti-affinity parked *both* replicas on the seed (k8s never rebalances running pods) — caught when a validation run showed both coredns replicas Terminating inside the same kill window (the second replica now waits Pending until the first member joins; a Pending spare on a genuinely single-node box is harmless, a co-located spare is worthless).

## Validation on real hardware

Nested 3-node HA rigs (libvirt: 8 GiB seed + 2× 6 GiB members), unattended ISO install baked from this branch at each iteration, cluster formed via pair→approve→promote, then the QA failure suite: hard `virsh destroy` of the CNPG-primary/seed (`kill_leader`), NIC link-down + heal (`partition_member`), operator-pod delete (`cnpg_restart_storm`), and the full dead-node replacement flow (`dead_node_replace`). Serving is probed continuously during each fault; recovery = survivor `/health/ready` 200 ∧ cluster health re-converged.

Final run (all six fixes, 2026-07-12T18:23Z):

| drill | before this branch | final run |
|---|---|---|
| `cnpg_restart_storm` | *(not previously runnable)* | **recovered 19.1 s**, serving 100% |
| `kill_leader` | **never recovered** (>180 s timeout, 4/4 consecutive builds) | **recovered 81.0 s** |
| `partition_member` | flaky-failed | **recovered 160.0 s** |
| `dead_node_replace` | **never recovered** (replacement never joined) | **recovered 627.9 s**, serving 100% (3 consecutive green runs: 479.0/569.6/627.9 s) |

Intermediate runs isolate each fix's contribution: with only fix 1, the operator survived but readiness stayed down (fix 3's hang); with 1-2, `dead_node_replace` went green while `kill_leader` still failed; with 1-5, the failure signature narrowed to `ready{unreachable:ReadTimeout}` (fix 5's pool evidence) and finally to the DNS blackout (fix 6). The per-pod readiness bodies (`http://<pod-ip>:8000/health/ready`, bypassing nginx and the Service) were captured live during the drills and name the failing check at each stage — `redis: ConnectionError(…redis-2…Name or service not known)` for the quorum stage, `database`/timeout for the pool stage, everything-at-once for the DNS stage.

The 81 s `kill_leader` recovery sits close to the platform floor: Kubernetes marks an unreachable node's pods not-ready only after `node-monitor-grace-period` (40 s default; 50 s on k8s ≥1.32) + one poll — CloudNativePG's failover documentation quotes the same 40-55 s before promotion can begin (and the baked operator, 1.29.1, includes the upstream node-unreachable failover fix, cloudnative-pg/cloudnative-pg#10448). Sub-60 s recovery from a hard node kill is not reachable without retuning the kubelet/controller-manager detection windows, which trades false-positive evictions on GC/IO pauses.

## Tests

- `test_redis_storage_reclaim.py` (new): reclaims exactly the Redis claims annotated with the deleted node, PVC before pod; never touches CNPG claims, other nodes' claims, or unannotated claims; surfaces kubeapi errors.
- `test_coredns_ha.py` (new): stock manifest → replicas 2 + fast tolerations (stock entries preserved) + required spread; converged → no-op; **preferred-affinity state from an earlier build → re-patched, not short-circuited**; missing deployment reports.
- `test_redis_client.py` (extended): `_sentinel_kwargs` propagates exactly the socket knobs + password, leaks nothing else.
- Full supervisor suite: **248 passed**; the only failures are the same 4 that pre-exist at the base sha (test_register/test_smoke drift, untouched — identical set documented in #610).

## Tradeoffs + known-remaining (documented, out of scope here)

- `command_timeout=30` caps any single statement from the api/worker engine. Route handlers issue many small queries and bulk work is chunked, so the ceiling is generous — but if a migration-sized statement ever moves into the app path it will need a per-call override.
- The CoreDNS reconciler re-patches after every k3s restart (by design, since k3s re-applies its manifest). The brief coredns rollout on each patch is two small pods.
- During the detection+failover window (~40-80 s) the api Service legitimately empties — the UI shows the static fallback until readiness returns. Genuinely hitless node loss for the *API plane* would require decoupling api readiness from DB/redis (#299 made that coupling deliberate). The DHCP/DNS data plane is unaffected throughout (agents serve from cached config).
- Two adjacent findings observed while validating, not addressed here: (a) one occurrence of `POST …/approve` → 500 `ValueError: encrypted value could not be decrypted` immediately after a *failed* restore — post-failure crypto-material integrity is worth its own look; (b) CNPG's reprovision of the killed instance strands on `PVC not found` + required instance anti-affinity until the node returns (2/3 instances serve throughout; the operator reconciles when the node rejoins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
