### PR TITLE
fix: X-Forwarded-For spoofing hardening (#626) + allow in-pool DHCP reservations (#631)

### DIFF
--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -39,7 +39,6 @@ A minimal bundle looks like::
         "client_classes": [
             {"name": "voip", "test": "substring(option[60].hex,0,12) == 'Cisco-Phone'"}
         ],
-        "reservation_mode": "all",
     }
 
 NTP servers are REQUIRED to be emitted as DHCP option 42 (RFC 2132). Users
@@ -751,9 +750,6 @@ def render(
 
     if rendered_classes:
         dhcp4["client-classes"] = rendered_classes
-
-    if bundle.get("reservation_mode"):
-        dhcp4["reservation-mode"] = bundle["reservation_mode"]
 
     out: dict[str, Any] = {"Dhcp4": dhcp4}
 

--- a/backend/app/api/v1/acme/router.py
+++ b/backend/app/api/v1/acme/router.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import require_permission
+from app.core.request_meta import get_trusted_client_ip
 from app.models.acme import ACMEAccount
 from app.models.audit import AuditLog
 from app.models.dns import DNSZone
@@ -319,17 +320,21 @@ async def _auth_acme(
             detail="X-Api-User and X-Api-Key headers required",
         )
     account = await acme_svc.authenticate(db, x_api_user, x_api_key)
+    # Spoofing-resistant source IP for the account's allowlist gate (#626):
+    # X-Real-IP is the nginx-set peer the client can't forge, unlike the
+    # X-Forwarded-For-derived request.client.host.
+    trusted_ip = get_trusted_client_ip(request)
     if account is None:
         logger.warning(
             "acme_auth_failed",
             user=x_api_user[:8] + "…",
-            source_ip=request.client.host if request.client else None,
+            source_ip=trusted_ip,
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="invalid credentials",
         )
-    client_ip = request.client.host if request.client else None
+    client_ip = trusted_ip
     if not acme_svc.client_ip_allowed(account, client_ip):
         logger.warning(
             "acme_source_ip_denied",

--- a/backend/app/api/v1/admin/feature_modules.py
+++ b/backend/app/api/v1/admin/feature_modules.py
@@ -30,7 +30,7 @@ from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.auth_throttle import login_rate_limited
 from app.core.demo_mode import DEMO_RESTRICTED_MODULES, is_demo_mode
 from app.core.permissions import is_effective_superadmin
-from app.core.request_meta import client_ip
+from app.core.request_meta import get_trusted_client_ip
 from app.models.audit import AuditLog
 from app.models.feature_module import FeatureModule
 from app.models.settings import PlatformSettings
@@ -385,7 +385,7 @@ async def break_glass(
     # 0. Per-IP rate limit (#4) — same Redis budget /auth/login uses, fails open.
     #    Bounds TOTP-spray + high-sev audit noise from one source even before
     #    we touch the per-account counter.
-    if await login_rate_limited(client_ip(request)):
+    if await login_rate_limited(get_trusted_client_ip(request)):
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many break-glass attempts. Try again shortly.",

--- a/backend/app/api/v1/auth/router.py
+++ b/backend/app/api/v1/auth/router.py
@@ -43,7 +43,7 @@ from app.core.auth.user_sync import (
 from app.core.auth_throttle import login_rate_limited, mfa_challenge_consume
 from app.core.demo_mode import forbid_in_demo_mode
 from app.core.permissions import effective_grants, is_effective_superadmin
-from app.core.request_meta import clean_user_agent
+from app.core.request_meta import clean_user_agent, get_trusted_client_ip
 from app.core.security import (
     create_access_token,
     create_mfa_challenge_token,
@@ -203,7 +203,12 @@ class PasswordPolicyResponse(BaseModel):
 
 
 def _client_ip(request: Request) -> str | None:
-    return request.client.host if request.client else None
+    # Auth-surface source IP: the per-IP login throttle (#4) gates on this,
+    # and it also lands in the login audit rows + ``last_login_ip``. Use the
+    # spoofing-resistant value (X-Real-IP, not the forgeable
+    # X-Forwarded-For-derived peer) so neither the throttle nor the audit
+    # trail can be evaded / poisoned by a client-supplied header (#626).
+    return get_trusted_client_ip(request)
 
 
 # SECURITY (#484 / #400 L1): the refresh token is delivered ONLY as an

--- a/backend/app/api/v1/dhcp/statics.py
+++ b/backend/app/api/v1/dhcp/statics.py
@@ -16,7 +16,7 @@ from app.api.v1.dhcp._audit import write_audit
 from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.dns_names import validate_hostname
 from app.core.permissions import require_resource_permission
-from app.models.dhcp import DHCPPool, DHCPScope, DHCPStaticAssignment
+from app.models.dhcp import DHCPScope, DHCPStaticAssignment
 from app.models.ipam import Subnet
 from app.services.dhcp.static_ipam import detach_ipam_for_static, upsert_ipam_for_static
 from app.services.dhcp.windows_writethrough import push_static_change
@@ -182,19 +182,17 @@ async def _conflict_check(
                 ),
             )
 
-    # IP inside existing pool of this scope — reject if dynamic
-    pools_res = await db.execute(select(DHCPPool).where(DHCPPool.scope_id == scope.id))
-    for p in pools_res.scalars().all():
-        try:
-            start = ipaddress.ip_address(str(p.start_ip))
-            end = ipaddress.ip_address(str(p.end_ip))
-        except ValueError:
-            continue
-        if start <= ip_addr <= end and p.pool_type == "dynamic":
-            raise HTTPException(
-                status_code=409,
-                detail=f"IP {ip} falls inside dynamic pool {p.start_ip}-{p.end_ip}; exclude it first",
-            )
+    # NOTE: a reservation whose IP lands inside a *dynamic* pool is explicitly
+    # allowed. Pinning a MAC inside the range is the standard idiom on every
+    # driver we ship — Kea honours it (default ``reservations-out-of-pool:
+    # false`` runs the in-pool check and won't hand the address to another
+    # client), FortiGate renders ``reserved-address`` independently of
+    # ``ip-range``, and Windows *requires* the reservation to fall inside the
+    # scope's StartRange–EndRange (which is derived from the dynamic pool). The
+    # old in-pool 409 had no driver basis, its "exclude it first" workaround was
+    # a no-op or actively harmful, and it looked like it broke Windows statics
+    # outright (#631). Pool occupancy accounts for these reservations separately
+    # (``services/dhcp/pool_occupancy.py``).
 
 
 @router.get("/scopes/{scope_id}/statics", response_model=list[StaticResponse])

--- a/backend/app/api/v1/firewall_feeds/router.py
+++ b/backend/app/api/v1/firewall_feeds/router.py
@@ -26,6 +26,7 @@ from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.core.crypto import encrypt_str
 from app.core.demo_mode import forbid_in_demo_mode
 from app.core.permissions import require_resource_permission
+from app.core.request_meta import get_trusted_client_ip
 from app.models.audit import AuditLog
 from app.models.firewall_feed import FIREWALL_FEED_KINDS, FirewallFeed
 from app.services.firewall_feeds.service import (
@@ -268,7 +269,9 @@ async def poll_blocklist(
         raise HTTPException(status_code=401, detail="invalid or missing token")
 
     body = await render_blocklist(db, f)
-    source_ip = request.client.host if request.client else None
+    # Provenance IP the operator sees for "who polled this feed" — use the
+    # unspoofable X-Real-IP so a client can't forge last_polled_ip (#626).
+    source_ip = get_trusted_client_ip(request)
     await record_poll(db, f, source_ip)
     await db.commit()
     return PlainTextResponse(content=body, media_type="text/plain")

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -543,6 +543,32 @@ def _collision_http_exc(warnings: list[dict[str, Any]]) -> HTTPException:
     )
 
 
+def _dynamic_pool_warning(
+    address: str, ip_int: int, ranges: list[tuple[int, int]]
+) -> dict[str, Any]:
+    """Build the 'inside a dynamic DHCP pool' soft-collision warning (#631).
+
+    In-pool allocation is allowed but flagged: the DHCP server owns the range
+    and will lease it on ``DISCOVER``, and a bare IPAM row — even
+    ``status="static_dhcp"`` — does not create a ``DHCPStaticAssignment`` (the
+    mirror only flows reservation → IPAM), so nothing tells the server to stop
+    handing the address out. The operator confirms via ``force=True`` and is
+    reminded to also pin a matching static reservation on the scope.
+    """
+    pool_start = pool_end = None
+    for start, end in ranges:
+        if start <= ip_int <= end:
+            pool_start = str(ipaddress.ip_address(start))
+            pool_end = str(ipaddress.ip_address(end))
+            break
+    return {
+        "kind": "dynamic_pool",
+        "address": address,
+        "pool_start": pool_start,
+        "pool_end": pool_end,
+    }
+
+
 async def _check_public_facing_warnings(
     db: AsyncSession,
     *,
@@ -6568,20 +6594,6 @@ async def create_address(
             detail=(f"No write permission on subnet or any address set covering {body.address}"),
         )
 
-    # Refuse allocation inside a dynamic DHCP pool — the DHCP server owns
-    # that range and will hand it out on first ``DISCOVER``. Other pool
-    # types (excluded / reserved) don't conflict with manual allocation.
-    dynamic_ranges = await _load_dynamic_pool_ranges(db, subnet_id)
-    if dynamic_ranges and _ip_int_in_dynamic_pool(int(addr), dynamic_ranges):
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"{body.address} falls inside a dynamic DHCP pool — those IPs "
-                "are managed by the DHCP server. Use a static-DHCP reservation "
-                "or pick an address outside the dynamic range."
-            ),
-        )
-
     # MAC address required for static_dhcp
     if body.status == "static_dhcp" and not body.mac_address:
         raise HTTPException(
@@ -6625,6 +6637,12 @@ async def create_address(
                 extra_zone_ids=body.extra_zone_ids,
             )
         )
+        # Allocating inside a dynamic DHCP pool is allowed but flagged (#631):
+        # soft, force-overridable warning rather than the old hard 422, since a
+        # MAC pinned inside the range is the standard idiom on every driver.
+        dynamic_ranges = await _load_dynamic_pool_ranges(db, subnet_id)
+        if dynamic_ranges and _ip_int_in_dynamic_pool(int(addr), dynamic_ranges):
+            warnings.append(_dynamic_pool_warning(body.address, int(addr), dynamic_ranges))
         if warnings:
             raise _collision_http_exc(warnings)
 

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -33,7 +33,7 @@ from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import CurrentUser, get_db
-from app.core.request_meta import clean_user_agent
+from app.core.request_meta import clean_user_agent, get_trusted_client_ip
 from app.models.audit import AuditLog
 from app.models.auth import User
 
@@ -504,7 +504,7 @@ async def _record_denial(
                 user_id=user.id,
                 user_display_name=user.display_name,
                 auth_source=getattr(user, "auth_source", "local") or "local",
-                source_ip=request.client.host if request.client else None,
+                source_ip=get_trusted_client_ip(request),
                 user_agent=clean_user_agent(request.headers.get("user-agent")),
                 action=action,
                 resource_type=resource_type,

--- a/backend/app/core/request_meta.py
+++ b/backend/app/core/request_meta.py
@@ -9,6 +9,7 @@ break downstream rendering (#9).
 
 from __future__ import annotations
 
+import ipaddress
 import re
 
 from fastapi import Request
@@ -32,4 +33,38 @@ def clean_user_agent(raw: str | None) -> str | None:
 
 
 def client_ip(request: Request) -> str | None:
+    """The raw peer address as uvicorn resolved it.
+
+    ⚠️ Spoofable for security decisions on the shipped nginx topology: the
+    API runs uvicorn with ``--proxy-headers --forwarded-allow-ips *``, so
+    ``request.client.host`` is derived from the client-supplied
+    ``X-Forwarded-For`` chain and can be forged (#626). Fine for coarse
+    observability; use :func:`get_trusted_client_ip` for anything that
+    gates access (rate limits, source-IP allowlists, provenance).
+    """
+    return request.client.host if request.client else None
+
+
+def get_trusted_client_ip(request: Request) -> str | None:
+    """The client source IP to trust for security decisions.
+
+    The shipped nginx configs set ``X-Real-IP: $remote_addr`` as an
+    *overwrite* the client cannot influence (any client-supplied
+    ``X-Real-IP`` is discarded by ``proxy_set_header``), whereas uvicorn's
+    ``--forwarded-allow-ips *`` makes ``request.client.host`` follow the
+    attacker-controlled ``X-Forwarded-For`` chain (#626). So prefer
+    ``X-Real-IP`` and fall back to the peer address only for
+    direct-to-uvicorn (no-nginx) deployments — where there is no untrusted
+    proxy in front and thus nothing to spoof past. A present-but-malformed
+    ``X-Real-IP`` (not a valid IP) also falls back rather than poisoning a
+    downstream allowlist / rate-limit key.
+    """
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        candidate = real_ip.strip()
+        try:
+            ipaddress.ip_address(candidate)
+            return candidate
+        except ValueError:
+            pass  # malformed header — fall through to the peer address
     return request.client.host if request.client else None

--- a/backend/app/services/dhcp/pool_occupancy.py
+++ b/backend/app/services/dhcp/pool_occupancy.py
@@ -4,9 +4,13 @@ Occupancy is computed from the mirrored ``DHCPLease`` rows rather than a
 per-driver statistics call, so it works identically for Kea and Windows
 DHCP (both pull active leases into ``dhcp_lease``) with no agent-protocol
 change. A dynamic pool's *assigned* count is the number of distinct
-active-lease IPs that fall inside ``[start_ip, end_ip]`` for the pool's
-scope (DISTINCT dedupes the two rows an HA pair reports for one lease);
-*total* is the address count of the inclusive range.
+addresses inside ``[start_ip, end_ip]`` that are unavailable to a dynamic
+client: active-lease IPs **union** in-pool static reservations. Reservations
+are counted even when the reserved device is currently offline (no active
+lease) — the address is still withheld from the dynamic set, so counting
+leases alone under-reports exhaustion (#631). The union (not a sum) keeps a
+reserved-and-currently-online device from being double-counted. *Total* is
+the address count of the inclusive range.
 
 This is the data source for both the ``find_dhcp_pool_occupancy`` MCP tool
 and the ``dhcp_pool_exhaustion`` alert evaluator.
@@ -16,13 +20,14 @@ from __future__ import annotations
 
 import ipaddress
 import uuid
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from typing import Any
 
-from sqlalchemy import func, select, text
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.dhcp import DHCPLease, DHCPPool
+from app.models.dhcp import DHCPLease, DHCPPool, DHCPStaticAssignment
 
 
 @dataclass(frozen=True)
@@ -57,34 +62,63 @@ def pool_total_addresses(start_ip: str, end_ip: str) -> int:
     return n if n > 0 else 0
 
 
+def _ints_in_range(ips: Iterable[object], start: int, end: int) -> set[int]:
+    """Distinct integer IPs from ``ips`` that fall inside ``[start, end]``.
+
+    Malformed / wrong-family values are skipped rather than raising, so a bad
+    row can't blow up occupancy.
+    """
+    out: set[int] = set()
+    for ip in ips:
+        try:
+            value = int(ipaddress.ip_address(str(ip)))
+        except (ValueError, TypeError):
+            continue
+        if start <= value <= end:
+            out.add(value)
+    return out
+
+
 async def compute_pool_occupancy(db: AsyncSession, pool: DHCPPool) -> PoolOccupancy:
     """Return live occupancy for one pool.
 
-    Counts distinct active-lease IPs inside the pool range for the pool's
-    scope. ``ip_address`` is INET, so the range comparison is cast
-    explicitly (asyncpg otherwise binds the params as VARCHAR and Postgres
-    rejects the inet operators — same cast the voice-lease alert uses).
+    ``assigned`` is the count of distinct in-range addresses that are
+    unavailable to a dynamic client: active-lease IPs union in-pool static
+    reservations (#631). Reservations are soft-delete-filtered by the global
+    ORM listener. Range membership is checked in Python (ints) rather than via
+    an INET SQL cast so leases + reservations share one comparison path.
     """
     total = pool_total_addresses(pool.start_ip, pool.end_ip)
     if total == 0:
-        # Malformed / inverted / mixed-family range — skip the DB range query
-        # entirely. Running it could match unrelated rows (inet ordering across
-        # families) and hand back a non-zero ``assigned`` for a 0-size pool,
-        # so a bad pool can't make occupancy blow up.
+        # Malformed / inverted / mixed-family range — skip the DB query
+        # entirely so a bad pool can't make occupancy blow up.
         return PoolOccupancy(assigned=0, total=0)
-    assigned = (
-        await db.execute(
-            select(func.count(func.distinct(DHCPLease.ip_address)))
-            .where(DHCPLease.scope_id == pool.scope_id)
-            .where(DHCPLease.state == "active")
-            .where(
-                text(
-                    "ip_address >= CAST(:start AS inet) AND ip_address <= CAST(:end AS inet)"
-                ).bindparams(start=str(pool.start_ip), end=str(pool.end_ip))
+    start = int(ipaddress.ip_address(str(pool.start_ip)))
+    end = int(ipaddress.ip_address(str(pool.end_ip)))
+    lease_ips = (
+        (
+            await db.execute(
+                select(DHCPLease.ip_address)
+                .where(DHCPLease.scope_id == pool.scope_id)
+                .where(DHCPLease.state == "active")
             )
         )
-    ).scalar_one()
-    return PoolOccupancy(assigned=int(assigned or 0), total=total)
+        .scalars()
+        .all()
+    )
+    reservation_ips = (
+        (
+            await db.execute(
+                select(DHCPStaticAssignment.ip_address).where(
+                    DHCPStaticAssignment.scope_id == pool.scope_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    occupied = _ints_in_range(lease_ips, start, end) | _ints_in_range(reservation_ips, start, end)
+    return PoolOccupancy(assigned=len(occupied), total=total)
 
 
 async def compute_pool_occupancy_batch(
@@ -111,7 +145,7 @@ async def compute_pool_occupancy_batch(
         return result
 
     scope_ids = {p.scope_id for p in valid}
-    rows = (
+    lease_rows = (
         await db.execute(
             select(DHCPLease.scope_id, DHCPLease.ip_address)
             .where(DHCPLease.scope_id.in_(scope_ids))
@@ -119,13 +153,28 @@ async def compute_pool_occupancy_batch(
             .distinct()
         )
     ).all()
-    # Bucket distinct lease IPs (as ints) by scope.
-    by_scope: dict[uuid.UUID, list[int]] = {}
-    for scope_id, ip in rows:
-        try:
-            by_scope.setdefault(scope_id, []).append(int(ipaddress.ip_address(str(ip))))
-        except ValueError:
-            continue
+    # In-pool static reservations withhold their address from the dynamic set
+    # too (#631). Soft-delete-filtered by the global ORM listener.
+    reservation_rows = (
+        await db.execute(
+            select(DHCPStaticAssignment.scope_id, DHCPStaticAssignment.ip_address).where(
+                DHCPStaticAssignment.scope_id.in_(scope_ids)
+            )
+        )
+    ).all()
+    # Bucket occupied IPs (as ints) into a per-scope set so a reserved-and-
+    # currently-leased address is counted once, not twice.
+    by_scope: dict[uuid.UUID, set[int]] = {}
+
+    def _bucket(rows: Iterable[Any]) -> None:
+        for scope_id, ip in rows:
+            try:
+                by_scope.setdefault(scope_id, set()).add(int(ipaddress.ip_address(str(ip))))
+            except (ValueError, TypeError):
+                continue
+
+    _bucket(lease_rows)
+    _bucket(reservation_rows)
 
     for pool in valid:
         start = int(ipaddress.ip_address(str(pool.start_ip)))

--- a/backend/tests/test_dhcp_pool_exhaustion.py
+++ b/backend/tests/test_dhcp_pool_exhaustion.py
@@ -15,7 +15,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import hash_password
 from app.models.alerts import AlertEvent, AlertRule
 from app.models.auth import User
-from app.models.dhcp import DHCPLease, DHCPPool, DHCPScope, DHCPServer, DHCPServerGroup
+from app.models.dhcp import (
+    DHCPLease,
+    DHCPPool,
+    DHCPScope,
+    DHCPServer,
+    DHCPServerGroup,
+    DHCPStaticAssignment,
+)
 from app.models.ipam import IPBlock, IPSpace, Subnet
 from app.services.alerts import RULE_TYPE_DHCP_POOL_EXHAUSTION, evaluate_all
 from app.services.dhcp.pool_occupancy import (
@@ -75,6 +82,16 @@ async def _lease(
             ip_address=f"10.60.0.{last_octet}",
             mac_address=f"02:00:00:00:00:{last_octet:02x}",
             state=state,
+        )
+    )
+
+
+async def _static(db: AsyncSession, scope: DHCPScope, last_octet: int) -> None:
+    db.add(
+        DHCPStaticAssignment(
+            scope_id=scope.id,
+            ip_address=f"10.60.0.{last_octet}",
+            mac_address=f"02:00:00:00:0a:{last_octet:02x}",
         )
     )
 
@@ -171,6 +188,66 @@ async def test_compute_pool_occupancy_batch_matches_single(db_session: AsyncSess
     # Batch result matches the per-pool helper exactly.
     single = await compute_pool_occupancy(db_session, pool)
     assert (batch[pool.id].assigned, batch[pool.id].total) == (single.assigned, single.total)
+
+
+async def test_occupancy_counts_offline_in_pool_reservation(
+    db_session: AsyncSession,
+) -> None:
+    # #631: an in-pool static reservation withholds its address from the dynamic
+    # set even with no active lease (device offline). It must count as assigned,
+    # or exhaustion is under-reported.
+    scope, server = await _scope_and_server(db_session)
+    pool = await _pool(db_session, scope)
+    await _lease(db_session, server, scope, 10)  # one live dynamic lease
+    await _static(db_session, scope, 15)  # reserved, device currently offline
+    await _static(db_session, scope, 50)  # reservation OUTSIDE the pool — ignored
+    await db_session.flush()
+
+    occ = await compute_pool_occupancy(db_session, pool)
+    assert occ.assigned == 2  # 1 lease + 1 in-pool reservation
+    assert occ.free == 8
+    # Batch path agrees.
+    batch = await compute_pool_occupancy_batch(db_session, [pool])
+    assert batch[pool.id].assigned == 2
+
+
+async def test_occupancy_dedupes_reservation_and_its_lease(
+    db_session: AsyncSession,
+) -> None:
+    # #631: a reserved device that is ALSO currently leased is one occupied
+    # address, not two — union, not sum. (Would otherwise over-count / go free<0.)
+    scope, server = await _scope_and_server(db_session)
+    pool = await _pool(db_session, scope)
+    await _lease(db_session, server, scope, 12)
+    await _static(db_session, scope, 12)  # same address, reserved + leased
+    await db_session.flush()
+
+    occ = await compute_pool_occupancy(db_session, pool)
+    assert occ.assigned == 1
+    batch = await compute_pool_occupancy_batch(db_session, [pool])
+    assert batch[pool.id].assigned == 1
+
+
+async def test_occupancy_ignores_soft_deleted_reservation(
+    db_session: AsyncSession,
+) -> None:
+    # A soft-deleted reservation is filtered by the global ORM listener, so it
+    # must not keep counting against the pool.
+    from datetime import UTC, datetime
+
+    scope, server = await _scope_and_server(db_session)
+    pool = await _pool(db_session, scope)
+    reservation = DHCPStaticAssignment(
+        scope_id=scope.id,
+        ip_address="10.60.0.15",
+        mac_address="02:00:00:00:0a:15",
+        deleted_at=datetime.now(UTC),
+    )
+    db_session.add(reservation)
+    await db_session.flush()
+
+    occ = await compute_pool_occupancy(db_session, pool)
+    assert occ.assigned == 0
 
 
 # ── Alert evaluator ───────────────────────────────────────────────────────

--- a/backend/tests/test_dhcp_static_in_pool.py
+++ b/backend/tests/test_dhcp_static_in_pool.py
@@ -1,0 +1,156 @@
+"""In-pool static reservations + manual IPAM allocation (#631).
+
+The old rule refused a static reservation (409) or a manual IPAM allocation
+(422) whose IP fell inside a `dynamic` pool. That rule had no driver basis —
+pinning a MAC inside the range is the standard idiom on Kea / FortiGate /
+Windows — so it's gone: reservations are allowed unconditionally, and manual
+IPAM allocation downgrades to a force-overridable soft-collision warning.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPPool, DHCPScope, DHCPServer, DHCPServerGroup
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+NETWORK = "10.70.0.0/24"
+POOL_START = "10.70.0.100"
+POOL_END = "10.70.0.150"
+IN_POOL_IP = "10.70.0.120"
+OUT_OF_POOL_IP = "10.70.0.20"
+
+
+async def _admin(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"ip-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="In-Pool Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _scope_with_dynamic_pool(db: AsyncSession) -> tuple[Subnet, DHCPScope]:
+    space = IPSpace(name=f"ip-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/8", name="root")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=NETWORK, name="lan")
+    group = DHCPServerGroup(name=f"ip-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, group])
+    await db.flush()
+    db.add(
+        DHCPServer(
+            name=f"ip-{uuid.uuid4().hex[:6]}",
+            driver="kea",
+            host="127.0.0.1",
+            server_group_id=group.id,
+        )
+    )
+    scope = DHCPScope(group_id=group.id, subnet_id=subnet.id, name="scope", address_family="ipv4")
+    db.add(scope)
+    await db.flush()
+    db.add(
+        DHCPPool(
+            scope_id=scope.id,
+            name="dyn",
+            start_ip=POOL_START,
+            end_ip=POOL_END,
+            pool_type="dynamic",
+        )
+    )
+    await db.flush()
+    await db.commit()
+    return subnet, scope
+
+
+@pytest.mark.asyncio
+async def test_static_reservation_inside_dynamic_pool_is_allowed(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _admin(db_session)
+    _, scope = await _scope_with_dynamic_pool(db_session)
+
+    resp = await client.post(
+        f"/api/v1/dhcp/scopes/{scope.id}/statics",
+        headers=headers,
+        json={"ip_address": IN_POOL_IP, "mac_address": "aa:bb:cc:dd:ee:01"},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.asyncio
+async def test_static_reservation_outside_subnet_still_rejected(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # The neighbouring subnet-CIDR containment check (#619) must survive — only
+    # the in-pool rule was removed.
+    headers = await _admin(db_session)
+    _, scope = await _scope_with_dynamic_pool(db_session)
+
+    resp = await client.post(
+        f"/api/v1/dhcp/scopes/{scope.id}/statics",
+        headers=headers,
+        json={"ip_address": "10.99.0.5", "mac_address": "aa:bb:cc:dd:ee:02"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "outside the scope's subnet" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_manual_ipam_allocation_in_pool_warns_then_forces(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = await _admin(db_session)
+    subnet, _ = await _scope_with_dynamic_pool(db_session)
+
+    body = {"address": IN_POOL_IP, "hostname": "printer1", "status": "allocated"}
+    # First attempt (force implicit false) → soft collision warning, no write.
+    warn = await client.post(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses", headers=headers, json=body
+    )
+    assert warn.status_code == 409, warn.text
+    detail = warn.json()["detail"]
+    assert detail["requires_confirmation"] is True
+    pool_warnings = [w for w in detail["warnings"] if w.get("kind") == "dynamic_pool"]
+    assert len(pool_warnings) == 1
+    assert pool_warnings[0]["address"] == IN_POOL_IP
+    assert pool_warnings[0]["pool_start"] == POOL_START
+    assert pool_warnings[0]["pool_end"] == POOL_END
+
+    # Re-submit with force=true → the allocation goes through.
+    forced = await client.post(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses",
+        headers=headers,
+        json={**body, "force": True},
+    )
+    assert forced.status_code == 201, forced.text
+    assert forced.json()["address"] == IN_POOL_IP
+
+
+@pytest.mark.asyncio
+async def test_manual_ipam_allocation_outside_pool_has_no_warning(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # Sanity: a normal out-of-pool allocation is unaffected — no warning, 201.
+    headers = await _admin(db_session)
+    subnet, _ = await _scope_with_dynamic_pool(db_session)
+
+    resp = await client.post(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses",
+        headers=headers,
+        json={"address": OUT_OF_POOL_IP, "hostname": "server1", "status": "allocated"},
+    )
+    assert resp.status_code == 201, resp.text

--- a/backend/tests/test_trusted_client_ip.py
+++ b/backend/tests/test_trusted_client_ip.py
@@ -1,0 +1,73 @@
+"""Unit tests for ``get_trusted_client_ip`` (#626).
+
+A client can forge ``X-Forwarded-For`` and, because uvicorn runs with
+``--forwarded-allow-ips *``, that forged value becomes ``request.client.host``.
+The shipped nginx sets ``X-Real-IP: $remote_addr`` as an overwrite the client
+cannot influence, so security decisions must prefer it. These tests pin that
+contract: a spoofed XFF/peer is ignored whenever a valid ``X-Real-IP`` is
+present, and the peer address is used only as a no-nginx fallback.
+"""
+
+from __future__ import annotations
+
+from starlette.requests import Request
+
+from app.core.request_meta import client_ip, get_trusted_client_ip
+
+
+def _make_request(
+    headers: dict[str, str] | None = None,
+    client: tuple[str, int] | None = ("10.0.0.9", 4444),
+) -> Request:
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope: dict = {"type": "http", "headers": raw_headers, "client": client}
+    return Request(scope)
+
+
+def test_prefers_x_real_ip_over_spoofed_peer() -> None:
+    # nginx topology: X-Real-IP is the real peer; the attacker-controlled
+    # X-Forwarded-For has already poisoned request.client.host.
+    req = _make_request(
+        headers={"x-real-ip": "203.0.113.7", "x-forwarded-for": "1.2.3.4"},
+        client=("1.2.3.4", 5555),  # what uvicorn resolved from the forged XFF
+    )
+    assert get_trusted_client_ip(req) == "203.0.113.7"
+    # The raw helper still returns the spoofable value — proving the two differ.
+    assert client_ip(req) == "1.2.3.4"
+
+
+def test_spoofed_x_real_ip_is_overwritten_in_practice() -> None:
+    # A client that sends its own X-Real-IP is irrelevant once nginx overwrites
+    # it; from the app's side we simply trust the single header value present.
+    # This test documents that a lone X-Real-IP wins over the peer regardless.
+    req = _make_request(headers={"x-real-ip": "198.51.100.2"}, client=("10.9.9.9", 1))
+    assert get_trusted_client_ip(req) == "198.51.100.2"
+
+
+def test_falls_back_to_peer_without_x_real_ip() -> None:
+    # Direct-to-uvicorn (no nginx) deployment: no X-Real-IP header, so the peer
+    # address is used — there is no untrusted proxy in front to spoof past.
+    req = _make_request(headers={}, client=("192.0.2.55", 22))
+    assert get_trusted_client_ip(req) == "192.0.2.55"
+
+
+def test_malformed_x_real_ip_falls_back_to_peer() -> None:
+    # A present-but-garbage X-Real-IP must not poison a downstream allowlist /
+    # rate-limit key — fall back to the peer instead.
+    req = _make_request(headers={"x-real-ip": "not-an-ip"}, client=("192.0.2.77", 22))
+    assert get_trusted_client_ip(req) == "192.0.2.77"
+
+
+def test_ipv6_x_real_ip_is_accepted() -> None:
+    req = _make_request(headers={"x-real-ip": "2001:db8::1"}, client=("10.0.0.1", 1))
+    assert get_trusted_client_ip(req) == "2001:db8::1"
+
+
+def test_no_client_and_no_header_is_none() -> None:
+    req = _make_request(headers={}, client=None)
+    assert get_trusted_client_ip(req) is None
+
+
+def test_blank_x_real_ip_falls_back() -> None:
+    req = _make_request(headers={"x-real-ip": "   "}, client=("192.0.2.9", 7))
+    assert get_trusted_client_ip(req) == "192.0.2.9"

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -911,10 +911,15 @@ rule here has been surfaced to an operator, not just silently logged.
   — under the group-centric model every peer in the group serves
   the same reservation so duplicates across scopes in the same
   group are rejected. `409` at `backend/app/api/v1/dhcp/statics.py`.
-- **Static IP inside a dynamic pool.** A static reservation whose IP
-  falls inside a `dynamic` pool is refused; delete or shrink the pool,
-  or convert the pool to `reserved` / `excluded` first. `409` at
-  `backend/app/api/v1/dhcp/statics.py:194`.
+- **Static IP inside a dynamic pool is allowed (#631).** Pinning a
+  reservation whose IP falls inside a `dynamic` pool is the standard
+  idiom on every driver we ship — Kea honours it (default
+  `reservations-out-of-pool: false` won't hand the reserved address to
+  another client), FortiGate renders `reserved-address` independently
+  of `ip-range`, and Windows *requires* the reservation to fall inside
+  the scope's range. No conflict check refuses it. Pool occupancy
+  counts in-pool reservations as assigned so exhaustion isn't
+  under-reported even while the reserved device is offline.
 - **Reservation IP outside the scope's subnet.** `422` at
   `backend/app/api/v1/dhcp/statics.py:177` (issue #619). Kea renders a
   reservation **nested inside** its subnet's `subnet4` stanza and Windows

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -1696,7 +1696,7 @@ range, so the operator sees pool extents as first-class structure.
 
 | Path | Behaviour |
 |---|---|
-| ``POST /subnets/{id}/addresses`` (manual) | **422** if ``body.address`` lands inside a dynamic pool. Excluded / reserved pools are still allowed — they don't race with the DHCP server on lease grants. |
+| ``POST /subnets/{id}/addresses`` (manual) | Allowed inside a dynamic pool, but returns a **force-overridable collision warning** (`409` with `{warnings, requires_confirmation}`, `kind: "dynamic_pool"`) so the operator confirms and knows to also pin a matching static reservation (#631). Excluded / reserved pools raise no warning. |
 | ``POST /subnets/{id}/next`` | ``_pick_next_available_ip`` skips dynamic ranges during its linear search. |
 | ``GET  /subnets/{id}/next-ip-preview?strategy=sequential\|random`` | Read-only peek. Returns ``{address, strategy}``; ``address: null`` means IPv6 (not supported) or exhausted subnet. No lock, no write. |
 
@@ -2005,11 +2005,16 @@ already wires this up for every delete / allocate / create flow.
 
 - **IP must be inside the subnet's CIDR.** `422`. Same
   check applies in the import path.
-- **IP inside a dynamic DHCP pool is refused.** Manual allocation
-  inside an active `dynamic` pool is blocked — DHCP owns those
-  addresses. Move the pool to `reserved` / `excluded` or shrink it
-  first. `422`. `GET /subnets/{id}/next-ip-preview`
-  honours the same skip.
+- **IP inside a dynamic DHCP pool is a soft warning (#631).** Manual
+  allocation inside an active `dynamic` pool is *allowed* — pinning a
+  MAC in-range is the standard idiom on every driver we ship — but
+  returns a force-overridable collision warning (`409`,
+  `kind: "dynamic_pool"`) reminding the operator to also create a
+  matching static reservation on the scope, since a bare IPAM row does
+  not itself stop the DHCP server leasing the address. Re-submit with
+  `force=true` to proceed. Auto-allocation (`next` / `next-ip-preview`
+  / bulk) still *skips* dynamic ranges — only the explicit, typed path
+  opens up.
 - **IP already allocated in the subnet.** Duplicate address in the
   same subnet returns `409`.
 - **Malformed IP.** Non-parseable address in create / import paths

--- a/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
+++ b/frontend/src/pages/dhcp/CreateStaticAssignmentModal.tsx
@@ -39,8 +39,10 @@ export function CreateStaticAssignmentModal({
     queryFn: () => dhcpApi.listPools(scope.id),
   });
 
-  // Reservations may not sit inside a dynamic pool (the backend rejects that in
-  // `_conflict_check`), so only offer reserved-pool ranges as IP hints.
+  // A reservation may sit anywhere in the subnet, including inside a dynamic
+  // pool (#631) — pinning a MAC in-range is the standard idiom on every driver.
+  // `reserved`-type pools are the ranges explicitly carved out for statics, so
+  // surface those as IP suggestions; they're hints, not a restriction.
   const eligiblePools = pools.filter((p) => p.pool_type === "reserved");
 
   const mut = useMutation({
@@ -93,8 +95,8 @@ export function CreateStaticAssignmentModal({
             label="IP Address"
             hint={
               eligiblePools.length > 0
-                ? `Any IP in the subnet outside a dynamic pool; reserved-pool ranges are suggested below.`
-                : "Any IP within the subnet (outside a dynamic pool)."
+                ? `Any IP in the subnet, including inside a dynamic pool; reserved-pool ranges are suggested below.`
+                : "Any IP within the subnet (may be inside a dynamic pool)."
             }
           >
             <input

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -2984,6 +2984,12 @@ type CollisionWarning =
       existing_hostname: string | null;
       existing_subnet: string;
       existing_ip_id: string;
+    }
+  | {
+      kind: "dynamic_pool";
+      address: string;
+      pool_start: string | null;
+      pool_end: string | null;
     };
 
 function parseCollisionWarnings(err: unknown): CollisionWarning[] | null {
@@ -3020,6 +3026,16 @@ function CollisionWarningBanner({
                 FQDN <span className="font-mono">{w.fqdn}</span> is already on{" "}
                 <span className="font-mono">{w.existing_ip}</span> in{" "}
                 <span className="font-mono">{w.existing_subnet}</span>
+              </>
+            ) : w.kind === "dynamic_pool" ? (
+              <>
+                <span className="font-mono">{w.address}</span> is inside dynamic
+                DHCP pool{" "}
+                <span className="font-mono">
+                  {w.pool_start}–{w.pool_end}
+                </span>
+                . The DHCP server may lease it to another client — also add a
+                matching static reservation on the scope.
               </>
             ) : (
               <>
@@ -3110,8 +3126,9 @@ function AddAddressModal({
   }, [needsDhcpScope, dhcpScopes.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Which dynamic pool does the manually-entered IP fall in, if any?
-  // Server-side ``create_address`` will reject with 422 regardless, but
-  // a red inline warning + disabled submit button is friendlier.
+  // In-pool allocation is allowed (#631) — the server returns a soft,
+  // force-overridable collision warning — so this drives an amber advisory,
+  // not a hard block, telling the operator to also pin a static reservation.
   const typedDynamicPool = (() => {
     if (mode !== "manual" || !address) return null;
     const ipInt = ipStringToInt(address);
@@ -3316,7 +3333,7 @@ function AddAddressModal({
   const canSubmit =
     !!hostname.trim() &&
     !hostnameErr &&
-    (mode === "next" ? !!nextPreview?.address : !!address && !typedDynamicPool);
+    (mode === "next" ? !!nextPreview?.address : !!address);
 
   // Compute preview FQDN
   const selectedZone = availableZones.find((z: DNSZone) => z.id === dnsZoneId);
@@ -3422,13 +3439,15 @@ function AddAddressModal({
               autoFocus
             />
             {typedDynamicPool && (
-              <p className="mt-1 rounded-md border border-destructive/40 bg-destructive/10 px-2 py-1 text-xs text-destructive">
+              <p className="mt-1 rounded-md border border-amber-500/50 bg-amber-500/10 px-2 py-1 text-xs text-amber-700 dark:text-amber-400">
                 {address} is inside the dynamic DHCP pool{" "}
                 <span className="font-mono">
                   {typedDynamicPool.start_ip}–{typedDynamicPool.end_ip}
                 </span>
                 {typedDynamicPool.name ? ` (${typedDynamicPool.name})` : ""}.
-                The DHCP server owns this range — pick an address outside it.
+                Allowed, but the DHCP server may also lease it — add a matching
+                static reservation on the scope so it isn't handed to another
+                client.
               </p>
             )}
           </Field>


### PR DESCRIPTION
Two independent fixes on one branch.

## #626 — spoofable `X-Forwarded-For` defeats every source-IP allowlist

A client could forge `X-Forwarded-For` and defeat **every** source-IP check in the product. Root cause is two halves that combine: uvicorn runs with `--forwarded-allow-ips *` (so `request.client.host` follows the client-supplied XFF chain), and the shipped nginx **appends** rather than replaces XFF — so the attacker-controlled left-most value wins. nginx already sets `X-Real-IP $remote_addr` as an overwrite the client cannot influence.

**Fix (the issue's preferred option):** a single `get_trusted_client_ip(request)` helper (prefer validated `X-Real-IP`, fall back to the peer for direct-to-uvicorn) routed through the security-sensitive call sites:

- login rate-limit throttle — `auth/router.py` (via `_client_ip`) + break-glass in `admin/feature_modules.py`
- ACME account source-IP allowlist — `acme/router.py`
- firewall-feed poll provenance (`last_polled_ip`) — `firewall_feeds/router.py`
- auth audit `source_ip` / `last_login_ip` + permission-denied audit `source_ip` (audit-trail hardening — a forgeable audit IP is a defect in its own right)

Direct-to-uvicorn (no nginx) keeps working via the peer fallback; a missing/malformed `X-Real-IP` also falls back. New unit test proves a spoofed XFF/peer is ignored when `X-Real-IP` is present.

## #631 — allow static reservations inside dynamic pool ranges

The in-pool block (409 on reservations, 422 on manual IPAM allocation) had **no driver basis** — in-pool reservations are the standard idiom on Kea / FortiGate / Windows, the rule's own "exclude it first" advice was a no-op or actively harmful on every driver, three internal write paths already bypassed it, and it looked like it **broke Windows statics outright** (Windows requires the reservation to fall inside the scope's range, which is derived from the dynamic pool).

- **Drop** the reservation `409` in `_conflict_check` (keep the #619 subnet-CIDR containment check).
- **Downgrade** the IPAM manual-allocation `422` to a **force-overridable** soft collision warning (`kind="dynamic_pool"`) via the existing collision machinery — a bare `status=static_dhcp` IPAM row does **not** itself create a reservation, so the operator is reminded to also pin one on the scope.
- **Pool-occupancy accounting:** in-pool static reservations now count toward `assigned` (union with active leases, so a reserved+online device isn't double-counted). Offline reservations no longer read as free and under-report exhaustion — feeds the `dhcp_pool_exhaustion` alert + `find_dhcp_pool_occupancy` MCP tool.
- **Frontend:** allow submit for in-pool IPs; amber advisory instead of the red block; render the new `dynamic_pool` warning; relax the reservation-modal hint.
- **Dead code:** delete the pre-1.7 Kea `reservation-mode` render (no producer; Kea 2.x rejects it). Docs updated.

Auto-allocation (`next` / `next-ip-preview` / bulk) still **skips** dynamic ranges — only the explicit, operator-typed path opens up. Scope note: the edit path (`update_address`) never blocked in-pool, so it's left as-is; only the create path (where the original 422 lived) gains the soft warning.

## Verification

- Backend: `ruff` + `black` + `mypy` (729 files) clean; new + adjacent tests green (`test_trusted_client_ip`, `test_dhcp_static_in_pool`, `test_dhcp_pool_exhaustion` incl. reservation-union cases, plus auth / ACME / firewall-feed / permissions / DHCP-scope / IPAM suites — 152+ tests).
- Frontend: `npm run build` + eslint + prettier clean.

Closes #626
Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)