### PR TITLE
fix(dhcp): Windows scope sync strands IPAM mirrors — diff-merge + orphan backstop (#620)

### DIFF
--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -393,6 +393,8 @@ class SyncLeasesResponse(BaseModel):
     scopes_skipped_no_subnet: int = 0
     pools_synced: int = 0
     statics_synced: int = 0
+    pools_removed: int = 0
+    statics_removed: int = 0
     # MAC deny-filter reconciliation against the group's active blocks.
     # Zero when the server isn't in a group or has no blocks configured.
     mac_blocks_added: int = 0
@@ -1047,6 +1049,8 @@ async def sync_leases_now(server_id: uuid.UUID, db: DB, user: SuperAdmin) -> Syn
             "scopes_skipped_no_subnet": result.scopes_skipped_no_subnet,
             "pools_synced": result.pools_synced,
             "statics_synced": result.statics_synced,
+            "pools_removed": result.pools_removed,
+            "statics_removed": result.statics_removed,
             "mac_blocks_added": mac_added,
             "mac_blocks_removed": mac_removed,
             "errors": result.errors[:20],
@@ -1067,6 +1071,8 @@ async def sync_leases_now(server_id: uuid.UUID, db: DB, user: SuperAdmin) -> Syn
         scopes_skipped_no_subnet=result.scopes_skipped_no_subnet,
         pools_synced=result.pools_synced,
         statics_synced=result.statics_synced,
+        pools_removed=result.pools_removed,
+        statics_removed=result.statics_removed,
         mac_blocks_added=mac_added,
         mac_blocks_removed=mac_removed,
         errors=result.errors,

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -18,6 +18,7 @@ celery_app = Celery(
         "app.tasks.dhcp_health",
         "app.tasks.dhcp_lease_cleanup",
         "app.tasks.dhcp_mac_blocks",
+        "app.tasks.dhcp_mirror_sweep",
         "app.tasks.dhcp_pull_leases",
         "app.tasks.alerts",
         "app.tasks.conformity",
@@ -91,6 +92,7 @@ celery_app.conf.update(
         "app.tasks.dhcp_health.*": {"queue": "dhcp"},
         "app.tasks.dhcp_lease_cleanup.*": {"queue": "dhcp"},
         "app.tasks.dhcp_mac_blocks.*": {"queue": "dhcp"},
+        "app.tasks.dhcp_mirror_sweep.*": {"queue": "dhcp"},
         "app.tasks.dhcp_pull_leases.*": {"queue": "dhcp"},
         "app.tasks.alerts.*": {"queue": "default"},
         "app.tasks.heartbeat.*": {"queue": "default"},
@@ -182,6 +184,13 @@ celery_app.conf.update(
         "dhcp-lease-cleanup": {
             "task": "app.tasks.dhcp_lease_cleanup.sweep_expired_leases",
             "schedule": schedule(run_every=300.0),
+        },
+        # Hourly backstop for reservation mirrors no release path freed (#620).
+        # A healthy install frees nothing here, so the cadence only bounds how
+        # long a stranded address stays stuck — it is not on any hot path.
+        "dhcp-mirror-sweep": {
+            "task": "app.tasks.dhcp_mirror_sweep.sweep_orphaned_mirrors",
+            "schedule": schedule(run_every=3600.0),
         },
         # Every 60 s, tick the IPAM↔DNS auto-sync task. The task itself
         # checks ``PlatformSettings.dns_auto_sync_enabled`` and the per-run

--- a/backend/app/drivers/dhcp/windows.py
+++ b/backend/app/drivers/dhcp/windows.py
@@ -143,10 +143,16 @@ foreach ($s in $scopes) {
     # them an empty array is ambiguous, and the scope reconciler — which
     # absence-deletes what the wire no longer reports — would tear down every
     # exclusion / reservation (and their IPAM mirrors) on a transient failure.
+    # ``-ErrorAction Stop`` (NOT SilentlyContinue) on these two: the *_ok flags
+    # are only meaningful if every error category reaches the catch, and
+    # SilentlyContinue suppresses non-terminating errors before it can. Verified
+    # against Windows Server that this does not over-trip — a scope with zero
+    # reservations / exclusions returns an empty set WITHOUT throwing, so "empty"
+    # stays authoritative and only a genuine enumeration failure clears the flag.
     $exclusions = @()
     $exclusionsOk = $true
     try {
-        foreach ($e in (Get-DhcpServerv4ExclusionRange -ScopeId $s.ScopeId -ErrorAction SilentlyContinue)) {
+        foreach ($e in (Get-DhcpServerv4ExclusionRange -ScopeId $s.ScopeId -ErrorAction Stop)) {
             $exclusions += [PSCustomObject]@{
                 start_ip = $e.StartRange.ToString()
                 end_ip   = $e.EndRange.ToString()
@@ -157,7 +163,7 @@ foreach ($s in $scopes) {
     $reservations = @()
     $reservationsOk = $true
     try {
-        foreach ($r in (Get-DhcpServerv4Reservation -ScopeId $s.ScopeId -ErrorAction SilentlyContinue)) {
+        foreach ($r in (Get-DhcpServerv4Reservation -ScopeId $s.ScopeId -ErrorAction Stop)) {
             $reservations += [PSCustomObject]@{
                 ip_address = $r.IPAddress.ToString()
                 client_id  = $r.ClientId

--- a/backend/app/drivers/dhcp/windows.py
+++ b/backend/app/drivers/dhcp/windows.py
@@ -138,7 +138,13 @@ foreach ($s in $scopes) {
         }
     } catch { }
 
+    # #620: the *_ok flags tell the reconciler whether an empty list means
+    # "this scope genuinely has none" or "the enumeration blew up". Without
+    # them an empty array is ambiguous, and the scope reconciler — which
+    # absence-deletes what the wire no longer reports — would tear down every
+    # exclusion / reservation (and their IPAM mirrors) on a transient failure.
     $exclusions = @()
+    $exclusionsOk = $true
     try {
         foreach ($e in (Get-DhcpServerv4ExclusionRange -ScopeId $s.ScopeId -ErrorAction SilentlyContinue)) {
             $exclusions += [PSCustomObject]@{
@@ -146,9 +152,10 @@ foreach ($s in $scopes) {
                 end_ip   = $e.EndRange.ToString()
             }
         }
-    } catch { }
+    } catch { $exclusionsOk = $false }
 
     $reservations = @()
+    $reservationsOk = $true
     try {
         foreach ($r in (Get-DhcpServerv4Reservation -ScopeId $s.ScopeId -ErrorAction SilentlyContinue)) {
             $reservations += [PSCustomObject]@{
@@ -158,7 +165,7 @@ foreach ($s in $scopes) {
                 description= $r.Description
             }
         }
-    } catch { }
+    } catch { $reservationsOk = $false }
 
     $result += [PSCustomObject]@{
         scope_id               = $s.ScopeId.ToString()
@@ -171,7 +178,9 @@ foreach ($s in $scopes) {
         state                  = $s.State.ToString()
         options                = $options
         exclusions             = $exclusions
+        exclusions_ok          = $exclusionsOk
         reservations           = $reservations
+        reservations_ok        = $reservationsOk
     }
 }
 $result | ConvertTo-Json -Compress -Depth 5
@@ -252,12 +261,19 @@ class WindowsDHCPReadOnlyDriver(DHCPDriver):
               "statics":             [
                   {"ip_address", "mac_address", "hostname", "client_id", "description"},
               ],
+              "pools_ok":            True,   # exclusion enumeration succeeded
+              "statics_ok":          True,   # reservation enumeration succeeded
             }
 
         All writes are external — the service layer upserts these into
         ``DHCPScope`` / ``DHCPPool`` / ``DHCPStaticAssignment`` only for
         scopes whose CIDR matches an existing IPAM ``Subnet``. No auto-
         subnet creation.
+
+        ``pools_ok`` / ``statics_ok`` exist because the reconciler treats the
+        wire as ground truth and deletes what it stops reporting: an empty
+        ``statics`` list has to be readable as "this scope has no reservations"
+        and NOT as "``Get-DhcpServerv4Reservation`` threw" (#620).
         """
         creds = _load_credentials(server)
         raw = await asyncio.to_thread(_run_ps, server, creds, _PS_LIST_TOPOLOGY)
@@ -881,6 +897,13 @@ def _parse_scopes(raw: str) -> list[dict[str, Any]]:
                 "options": options,
                 "pools": pools,
                 "statics": statics,
+                # Did the enumeration behind each list actually succeed? (#620)
+                # The reconciler absence-deletes what the wire stops reporting,
+                # so it must not read a blown-up enumeration's empty list as
+                # "the operator removed everything". Absent ⇒ assume success,
+                # so a driver that doesn't report the flag stays authoritative.
+                "pools_ok": bool(item.get("exclusions_ok", True)),
+                "statics_ok": bool(item.get("reservations_ok", True)),
             }
         )
     return out

--- a/backend/app/services/dhcp/normalize.py
+++ b/backend/app/services/dhcp/normalize.py
@@ -1,0 +1,38 @@
+"""Canonical forms for the identity fields DHCP reconcilers compare on.
+
+A MAC read back from a Windows DHCP server (``00-15-5D-01-02-03``) and the
+same MAC as Postgres stores it (``00:15:5d:01:02:03``) are the same address
+written two ways. Any code that diffs wire state against DB state has to fold
+both to one form first, or a cosmetic reformat reads as a change — which for
+``pull_leases._upsert_scope`` means deleting a reservation and re-creating it
+under a new id on every poll.
+
+These started life as ``_norm_mac`` / ``_norm_ip`` inside
+``windows_writethrough`` (#426, for its change-detection). ``pull_leases``
+needs exactly the same semantics, and two definitions that could drift apart
+is the last thing a reconciler wants — so they live here and both import them.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+__all__ = ["norm_ip", "norm_mac"]
+
+
+def norm_mac(mac: str) -> str:
+    """Fold a MAC to bare lowercase hex, so ``00-15-5D-…`` == ``00:15:5d:…``."""
+    return "".join(c for c in mac.lower() if c in "0123456789abcdef")
+
+
+def norm_ip(ip: str) -> str:
+    """Canonicalise an IP for change-detection.
+
+    Falls back to the stripped raw string when it doesn't parse, so a bad
+    value still compares equal to itself rather than collapsing every
+    unparseable value onto one key.
+    """
+    try:
+        return str(ipaddress.ip_address(ip.strip()))
+    except ValueError:
+        return ip.strip()

--- a/backend/app/services/dhcp/pull_leases.py
+++ b/backend/app/services/dhcp/pull_leases.py
@@ -157,7 +157,18 @@ async def pull_leases_from_server(
         # and the merge must not act on it (#620). The WinRM round-trip is
         # seconds long — long enough for a reservation created in the UI mid-poll
         # to be absent from the wire we're holding, and absence means delete.
-        snapshot_at = datetime.now(UTC)
+        #
+        # Read from the DATABASE's clock, not this process's. The guard compares
+        # against ``created_at`` / ``modified_at``, which TimestampMixin fills
+        # with ``func.now()`` — i.e. Postgres's clock. Comparing those to a local
+        # ``datetime.now(UTC)`` is a cross-clock comparison, and on a multi-node
+        # appliance (CNPG on another node, chrony drifting) a DB clock running
+        # ahead by more than the poll interval would make EVERY row look newer
+        # than the snapshot: every reservation skipped, every stale one spared,
+        # the reconciler silently converging on nothing. ``clock_timestamp()``,
+        # not ``now()`` — the latter is transaction-start time and would drift
+        # earlier the longer this transaction runs.
+        snapshot_at = (await db.execute(select(func.clock_timestamp()))).scalar_one()
         try:
             wire_scopes = await driver.get_scopes(server)
         except Exception as exc:  # noqa: BLE001
@@ -639,7 +650,7 @@ async def _upsert_scope(
     if not apply or existing_scope is None:
         return
 
-    await _merge_pools(db, existing_scope, wscope, result)
+    await _merge_pools(db, existing_scope, wscope, result, snapshot_at=snapshot_at)
     await _merge_statics(db, existing_scope, wscope, result, snapshot_at=snapshot_at)
     await db.flush()
 
@@ -689,6 +700,8 @@ async def _merge_pools(
     scope: DHCPScope,
     wscope: dict[str, Any],
     result: PullLeasesResult,
+    *,
+    snapshot_at: datetime,
 ) -> None:
     """Diff-merge the scope's pools against the wire, keyed by (start, end).
 
@@ -726,7 +739,16 @@ async def _merge_pools(
             row.pool_type = pool_type
             result.pools_synced += 1
 
-    stale = [row for key, row in by_range.items() if key not in seen]
+    stale = [
+        row
+        for key, row in by_range.items()
+        # Same snapshot guard the reservations get: a pool an operator added
+        # mid-poll (write-through pushed it to the server, but our wire read
+        # predates it) is absent from a wire that simply never saw it, and
+        # deleting it would take IPAM's dynamic-range protection away for a poll
+        # — the exact hole this function's docstring warns about.
+        if key not in seen and not (row.created_at is not None and row.created_at > snapshot_at)
+    ]
     if not stale:
         return
     if not _absence_delete_ok(
@@ -827,6 +849,11 @@ async def _merge_statics(
 
     await _apply_moves(db, scope, movers, by_mac, result, cidr=cidr)
 
+    # Load every in-place reservation's mirror in ONE query. The steady state is
+    # this loop's whole point — it writes nothing — so a per-reservation
+    # ``db.get`` here would be N round-trips per scope per poll, forever, to
+    # establish that there is nothing to do.
+    mirrors = await _load_mirrors(db, [st for st, _ in in_place])
     for st, wstatic in in_place:
         changed, mirrored = _apply_wire_fields(st, wstatic)
         if changed:
@@ -836,7 +863,7 @@ async def _merge_statics(
         # the old replace-all left behind, so those installs repair themselves on
         # the next poll, with no operator action and no migration. A steady-state
         # poll hits neither, and so writes nothing at all.
-        if mirrored or not await _mirror_is_current(db, scope, st):
+        if mirrored or not _mirror_is_current(scope, st, mirrors.get(st.ip_address_id)):
             await upsert_ipam_for_static(db, scope, st, action="update")
 
     # ``by_mac`` now holds every surviving reservation at its final address, so
@@ -984,16 +1011,24 @@ async def _apply_moves(
         await upsert_ipam_for_static(db, scope, st, action="update")
 
 
-async def _mirror_is_current(db: AsyncSession, scope: DHCPScope, st: DHCPStaticAssignment) -> bool:
+async def _load_mirrors(
+    db: AsyncSession, statics: list[DHCPStaticAssignment]
+) -> dict[Any, IPAddress]:
+    """``{ip_address_id: row}`` for every reservation that claims to have a mirror."""
+    ids = [st.ip_address_id for st in statics if st.ip_address_id is not None]
+    if not ids:
+        return {}
+    rows = (await db.execute(select(IPAddress).where(IPAddress.id.in_(ids)))).scalars().all()
+    return {row.id: row for row in rows}
+
+
+def _mirror_is_current(scope: DHCPScope, st: DHCPStaticAssignment, row: IPAddress | None) -> bool:
     """Is ``st``'s IPAM mirror present and pointing back at ``st``?
 
     False for the rows the pre-#620 replace-all stranded (mirror survives, its
     ``static_assignment_id`` names a reservation that no longer exists), and for
     a reservation whose mirror an operator deleted out from under it.
     """
-    if st.ip_address_id is None:
-        return False
-    row = await db.get(IPAddress, st.ip_address_id)
     if row is None:
         return False
     return (

--- a/backend/app/services/dhcp/pull_leases.py
+++ b/backend/app/services/dhcp/pull_leases.py
@@ -33,6 +33,14 @@ polls, or when lease pull is disabled). The two mechanisms overlap
 harmlessly: expiry sweeps anything the pull missed, pull deletes
 anything the sweep hasn't seen yet.
 
+**Phase 1 — topology**, for drivers that also implement ``get_scopes``
+(only ``windows_dhcp`` today): the server's scopes, pools and
+reservations are reconciled the same way, by diff-merge — see
+``_upsert_scope``. Reservations are matched on MAC so they keep their
+row id across polls, which is what lets an ``ip_address`` mirror
+back-link to one and stay valid (#620). Absence still means deleted,
+under the same floor guards (``_absence_delete_ok``).
+
 Per CLAUDE.md non-negotiable #9, the whole operation is idempotent: a
 second run over the same wire state is a no-op (the dedup key is
 ``(server_id, ip_address)`` and all updates are set-to-observed).
@@ -62,6 +70,8 @@ from app.models.ipam import IPAddress, Subnet
 from app.services.dhcp.ipam_mirror import insert_ipam_mirror_row
 from app.services.dhcp.lease_cleanup import purge_lease
 from app.services.dhcp.lease_history import record_lease_history
+from app.services.dhcp.normalize import norm_ip, norm_mac
+from app.services.dhcp.static_ipam import remove_ipam_for_static, upsert_ipam_for_static
 
 
 def _refresh_lease_owned_row(
@@ -92,8 +102,10 @@ class PullLeasesResult:
     scopes_imported: int = 0  # new DHCPScope rows added
     scopes_refreshed: int = 0  # existing DHCPScope rows updated in place
     scopes_skipped_no_subnet: int = 0  # scope CIDR not tracked in IPAM — skipped
-    pools_synced: int = 0  # DHCPPool rows (re-)created from the import
-    statics_synced: int = 0  # DHCPStaticAssignment rows (re-)created
+    pools_synced: int = 0  # DHCPPool rows created or changed by the import
+    statics_synced: int = 0  # DHCPStaticAssignment rows created or changed
+    pools_removed: int = 0  # DHCPPool rows gone from the wire
+    statics_removed: int = 0  # DHCPStaticAssignment rows gone from the wire
     errors: list[str] = field(default_factory=list)
     # #428 — DNS group ids whose zones received a DDNS record this pull;
     # the caller publishes an agent wake for them AFTER its commit so the
@@ -134,11 +146,18 @@ async def pull_leases_from_server(
 
     # Phase 1 — topology (scopes + pools + reservations). Optional: only
     # runs for drivers that expose ``get_scopes``. For each scope whose
-    # CIDR matches a known IPAM subnet, upsert the scope, then replace
-    # its pools and statics with what Windows reports. Scopes whose CIDR
+    # CIDR matches a known IPAM subnet, upsert the scope, then diff-merge
+    # its pools and statics against what Windows reports. Scopes whose CIDR
     # has no matching IPAM subnet are skipped — we intentionally do not
     # auto-create subnets (that belongs in a separate workflow).
     if hasattr(driver, "get_scopes"):
+        # Stamped BEFORE the wire read: everything the wire tells us is a
+        # snapshot of the server as of (at latest) this instant, so a DB row an
+        # operator created or edited *after* it is newer than our information
+        # and the merge must not act on it (#620). The WinRM round-trip is
+        # seconds long — long enough for a reservation created in the UI mid-poll
+        # to be absent from the wire we're holding, and absence means delete.
+        snapshot_at = datetime.now(UTC)
         try:
             wire_scopes = await driver.get_scopes(server)
         except Exception as exc:  # noqa: BLE001
@@ -151,7 +170,9 @@ async def pull_leases_from_server(
             )
             wire_scopes = []
         for wscope in wire_scopes:
-            await _upsert_scope(db, server, wscope, subnets, result, apply=apply)
+            await _upsert_scope(
+                db, server, wscope, subnets, result, apply=apply, snapshot_at=snapshot_at
+            )
 
     # Phase 2 — leases.
     try:
@@ -525,17 +546,29 @@ async def _upsert_scope(
     result: PullLeasesResult,
     *,
     apply: bool,
+    snapshot_at: datetime,
 ) -> None:
     """Upsert one Windows-reported scope + its pools + its reservations.
 
     Matching: the scope's ``subnet_cidr`` must exactly match an existing
     IPAM ``Subnet.network`` (prefix-length identical). No auto-create.
 
-    For pools + statics we do a **replace-all** per scope: delete
-    everything for this scope_id, then insert what Windows reports.
-    That's safe because windows_dhcp is read-only — there are no manual
-    pools/statics anyone could have added through our UI for a
-    windows_dhcp scope.
+    Pools + statics are **diff-merged** against the wire, not replaced (#620).
+    They used to be replaced: a Core ``DELETE`` of every pool + reservation
+    under the scope, then a re-insert from the wire. That was written when
+    ``windows_dhcp`` was a read-only driver and its rows were pure derived
+    state. It stopped being true once write-through landed — operators create
+    reservations through our UI now, and a reservation owns an ``ip_address``
+    mirror that back-links to it by id. Re-inserting minted a fresh id on every
+    poll, so the mirror was left pointing at a row Postgres had dropped (and a
+    Core ``DELETE`` runs no per-row Python, so nothing released it): the address
+    was neither allocated nor free, and deleting the reservation in the UI never
+    freed it, because the lookup keyed on the *current* id and matched nothing.
+
+    Merging keeps a reservation's id stable across polls, which is what makes
+    the mirror's back-link durable. It also means an unchanged reservation is
+    not written at all — so, unlike a detach/re-attach repair, this fires no DNS
+    record churn on the steady state. Only real changes touch anything.
     """
     cidr = wscope.get("subnet_cidr")
     if not cidr:
@@ -606,45 +639,369 @@ async def _upsert_scope(
     if not apply or existing_scope is None:
         return
 
-    # Replace-all: drop old pools + statics for this scope, re-insert.
-    # Cheap on scopes with tens of entries; avoids diff-merge complexity.
-    await db.execute(DHCPPool.__table__.delete().where(DHCPPool.scope_id == existing_scope.id))
-    await db.execute(
-        DHCPStaticAssignment.__table__.delete().where(
-            DHCPStaticAssignment.scope_id == existing_scope.id
+    await _merge_pools(db, existing_scope, wscope, result)
+    await _merge_statics(db, existing_scope, wscope, result, snapshot_at=snapshot_at)
+    await db.flush()
+
+
+def _absence_delete_ok(
+    *,
+    kind: str,
+    cidr: str,
+    wire_count: int,
+    tracked_count: int,
+    enumeration_ok: bool,
+    result: PullLeasesResult,
+) -> bool:
+    """May we treat "absent from the wire" as "deleted on the server"?
+
+    Two ways an empty/short wire list lies, and both end in us deleting rows an
+    operator still has (for reservations: their IPAM mirror and DNS records too):
+
+    * the driver told us the enumeration failed (``*_ok`` false) — see #620's
+      note on ``_PS_LIST_TOPOLOGY``, whose per-list ``try/catch`` can hand back
+      an empty array for a scope that is full of reservations;
+    * the enumeration *claims* success but came back wholly empty while we track
+      rows — the same ambiguity the lease path's zero-wire floor guard (#482)
+      refuses to resolve in favour of deletion.
+
+    Erring toward divergence over data loss: a stale row an operator can delete
+    in the UI beats a reservation (and its A record) we tore down on a hiccup.
+    """
+    if not enumeration_ok:
+        result.errors.append(
+            f"scope {cidr}: the server's {kind} enumeration failed — keeping the "
+            f"{tracked_count} tracked {kind} and skipping the absence-delete this pass"
         )
+        return False
+    if wire_count == 0 and tracked_count > 0:
+        result.errors.append(
+            f"scope {cidr}: wire reported 0 {kind} while {tracked_count} are tracked — "
+            f"skipping the absence-delete this pass (#482). If they really were removed "
+            f"on the server, delete them here to converge."
+        )
+        return False
+    return True
+
+
+async def _merge_pools(
+    db: AsyncSession,
+    scope: DHCPScope,
+    wscope: dict[str, Any],
+    result: PullLeasesResult,
+) -> None:
+    """Diff-merge the scope's pools against the wire, keyed by (start, end).
+
+    Pools carry no IPAM mirror, so churning them strands nothing — but IPAM
+    *reads* them (a manual allocation inside a dynamic range is refused), so a
+    pool that blinks out of existence between polls briefly opens a hole for an
+    operator to allocate an address the DHCP server hands out dynamically.
+    """
+    wire = [p for p in (wscope.get("pools") or []) if p.get("start_ip") and p.get("end_ip")]
+    existing = list(
+        (await db.execute(select(DHCPPool).where(DHCPPool.scope_id == scope.id))).scalars().all()
     )
+    by_range = {(norm_ip(str(p.start_ip)), norm_ip(str(p.end_ip))): p for p in existing}
 
-    for pool in wscope.get("pools") or []:
-        if not pool.get("start_ip") or not pool.get("end_ip"):
+    seen: set[tuple[str, str]] = set()
+    for wpool in wire:
+        key = (norm_ip(str(wpool["start_ip"])), norm_ip(str(wpool["end_ip"])))
+        if key in seen:
             continue
-        db.add(
-            DHCPPool(
-                scope_id=existing_scope.id,
-                start_ip=pool["start_ip"],
-                end_ip=pool["end_ip"],
-                pool_type=pool.get("pool_type") or "dynamic",
-                name="",
+        seen.add(key)
+        pool_type = wpool.get("pool_type") or "dynamic"
+        row = by_range.get(key)
+        if row is None:
+            db.add(
+                DHCPPool(
+                    scope_id=scope.id,
+                    start_ip=wpool["start_ip"],
+                    end_ip=wpool["end_ip"],
+                    pool_type=pool_type,
+                    name="",
+                )
+            )
+            result.pools_synced += 1
+        elif row.pool_type != pool_type:
+            row.pool_type = pool_type
+            result.pools_synced += 1
+
+    stale = [row for key, row in by_range.items() if key not in seen]
+    if not stale:
+        return
+    if not _absence_delete_ok(
+        kind="pools",
+        cidr=str(wscope.get("subnet_cidr") or ""),
+        wire_count=len(wire),
+        tracked_count=len(existing),
+        enumeration_ok=bool(wscope.get("pools_ok", True)),
+        result=result,
+    ):
+        return
+    for row in stale:
+        await db.delete(row)
+        result.pools_removed += 1
+
+
+async def _merge_statics(
+    db: AsyncSession,
+    scope: DHCPScope,
+    wscope: dict[str, Any],
+    result: PullLeasesResult,
+    *,
+    snapshot_at: datetime,
+) -> None:
+    """Diff-merge the scope's reservations against the wire, keyed by MAC.
+
+    MAC is the key because it is what Windows keys a reservation on and what
+    survives an IP change; matching on it lets a relocated reservation keep its
+    id — and therefore its IPAM mirror, and therefore its DNS records.
+
+    Every reservation on the wire gets an IPAM mirror, not just the ones created
+    through our UI (#620). A reservation is an allocation whoever made it, and
+    IPAM that doesn't show it is IPAM that will hand the address out twice.
+    ``upsert_ipam_for_static`` is the same helper the UI create path uses, so
+    both kinds of reservation produce the same row — but we only call it when
+    something actually changed (or the mirror is missing/stale), because it
+    re-syncs DNS, and this runs on the beat.
+    """
+    wire = _dedupe_wire_statics(wscope.get("statics") or [])
+    existing = list(
+        (
+            await db.execute(
+                select(DHCPStaticAssignment).where(DHCPStaticAssignment.scope_id == scope.id)
             )
         )
-        result.pools_synced += 1
+        .scalars()
+        .all()
+    )
+    by_mac = {norm_mac(str(st.mac_address)): st for st in existing}
+    cidr = str(wscope.get("subnet_cidr") or "")
 
-    for static in wscope.get("statics") or []:
-        if not static.get("ip_address") or not static.get("mac_address"):
+    # ── 1. absence-delete, first — it frees addresses the wire may be reusing ──
+    stale = [
+        st
+        for mac_key, st in by_mac.items()
+        # A reservation created after the snapshot cannot be judged by it: the
+        # wire we are holding predates it, so its absence proves nothing.
+        if mac_key not in wire and not (st.created_at is not None and st.created_at > snapshot_at)
+    ]
+    if stale and _absence_delete_ok(
+        kind="reservations",
+        cidr=cidr,
+        wire_count=len(wire),
+        tracked_count=len(existing),
+        enumeration_ok=bool(wscope.get("statics_ok", True)),
+        result=result,
+    ):
+        for st in stale:
+            # Gone from the server ⇒ the address is not reserved for anyone.
+            # Delete the mirror rather than freeing it to ``available``: this is
+            # a machine reconcile, and a persisted freed row still renders as a
+            # line in the subnet table and still counts toward utilization
+            # (#618). Tears the reservation's DNS records down first.
+            await remove_ipam_for_static(db, st)
+            await db.delete(st)
+            by_mac.pop(norm_mac(str(st.mac_address)), None)
+            result.statics_removed += 1
+        await db.flush()
+
+    # ── 2. classify what the wire wants against what survived ──
+    creates: list[dict[str, Any]] = []
+    movers: list[tuple[DHCPStaticAssignment, dict[str, Any]]] = []
+    in_place: list[tuple[DHCPStaticAssignment, dict[str, Any]]] = []
+    for mac_key, wstatic in wire.items():
+        st = by_mac.get(mac_key)
+        if st is None:
+            creates.append(wstatic)
+        # Never overwrite a row an operator touched after we took the wire
+        # snapshot — our information is the older of the two. The write-through
+        # already pushed their edit to the server, so the next poll reads it back
+        # and converges on it.
+        elif st.modified_at is not None and st.modified_at > snapshot_at:
             continue
-        db.add(
-            DHCPStaticAssignment(
-                scope_id=existing_scope.id,
-                ip_address=static["ip_address"],
-                mac_address=static["mac_address"],
-                client_id=static.get("client_id"),
-                hostname=sanitize_hostname(static.get("hostname")),
-                description=static.get("description") or "",
+        elif norm_ip(str(st.ip_address)) != norm_ip(str(wstatic["ip_address"])):
+            movers.append((st, wstatic))
+        else:
+            in_place.append((st, wstatic))
+
+    await _apply_moves(db, scope, movers, by_mac, result, cidr=cidr)
+
+    for st, wstatic in in_place:
+        changed, mirrored = _apply_wire_fields(st, wstatic)
+        if changed:
+            result.statics_synced += 1
+        # Re-mirror on a change the mirror reflects (the hostname), or when the
+        # mirror is missing / points at a dead id — which is exactly the residue
+        # the old replace-all left behind, so those installs repair themselves on
+        # the next poll, with no operator action and no migration. A steady-state
+        # poll hits neither, and so writes nothing at all.
+        if mirrored or not await _mirror_is_current(db, scope, st):
+            await upsert_ipam_for_static(db, scope, st, action="update")
+
+    # ``by_mac`` now holds every surviving reservation at its final address, so
+    # it is the occupancy map a new one has to fit into. A new reservation can
+    # only be blocked by a row the absence-delete floor guard declined to remove
+    # — same story as a blocked move, and the same answer: report it rather than
+    # violate the index and abort the poll.
+    occupied = {norm_ip(str(st.ip_address)): st for st in by_mac.values()}
+    for wstatic in creates:
+        ip_key = norm_ip(str(wstatic["ip_address"]))
+        blocker = occupied.get(ip_key)
+        if blocker is not None:
+            result.errors.append(
+                f"scope {cidr}: reservation {wstatic['mac_address']} cannot be added at "
+                f"{wstatic['ip_address']} — {blocker.mac_address} still holds that address "
+                f"here; retrying next poll"
             )
+            continue
+        st = DHCPStaticAssignment(
+            scope_id=scope.id,
+            ip_address=str(wstatic["ip_address"]),
+            mac_address=str(wstatic["mac_address"]),
+            client_id=wstatic.get("client_id"),
+            hostname=sanitize_hostname(wstatic.get("hostname")) or "",
+            description=wstatic.get("description") or "",
         )
+        db.add(st)
+        await db.flush()
+        await upsert_ipam_for_static(db, scope, st, action="create")
+        occupied[ip_key] = st
         result.statics_synced += 1
 
+
+def _dedupe_wire_statics(raw: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """``{normalised mac: wire static}``, dropping unusable and duplicate rows.
+
+    Both keys a reservation is unique on per scope — MAC and address — are
+    de-duplicated, because the merge writes against unique indexes on both and a
+    wire that claimed the same address twice would abort the poll.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    ips: set[str] = set()
+    for wstatic in raw:
+        if not wstatic.get("ip_address") or not wstatic.get("mac_address"):
+            continue
+        mac_key = norm_mac(str(wstatic["mac_address"]))
+        ip_key = norm_ip(str(wstatic["ip_address"]))
+        if not mac_key or mac_key in out or ip_key in ips:
+            continue
+        out[mac_key] = wstatic
+        ips.add(ip_key)
+    return out
+
+
+def _apply_wire_fields(st: DHCPStaticAssignment, wstatic: dict[str, Any]) -> tuple[bool, bool]:
+    """Copy the wire's non-address fields onto ``st``.
+
+    Returns ``(changed, mirrored)`` — the second flag says whether the change is
+    one the IPAM mirror (and the DNS records published off it) reflects. Only
+    the hostname is: a description or client_id the wire taught us does not move
+    a record anywhere, and ``upsert_ipam_for_static`` re-syncs DNS every time it
+    runs, on a path that runs on the beat.
+
+    Deliberately excludes the address — re-addressing has to be sequenced against
+    the ``(scope, address)`` unique index (see ``_apply_moves``) — but note an
+    address change is mirrored too, and its caller always upserts.
+    """
+    changed = mirrored = False
+    hostname = sanitize_hostname(wstatic.get("hostname")) or ""
+    if (st.hostname or "") != hostname:
+        st.hostname = hostname
+        changed = mirrored = True
+    for attr, value in (
+        ("description", wstatic.get("description") or ""),
+        ("client_id", wstatic.get("client_id")),
+    ):
+        if (getattr(st, attr) or "") != (value or ""):
+            setattr(st, attr, value)
+            changed = True
+    return changed, mirrored
+
+
+async def _apply_moves(
+    db: AsyncSession,
+    scope: DHCPScope,
+    movers: list[tuple[DHCPStaticAssignment, dict[str, Any]]],
+    by_mac: dict[str, DHCPStaticAssignment],
+    result: PullLeasesResult,
+    *,
+    cidr: str,
+) -> None:
+    """Re-address the reservations the wire says have moved.
+
+    Writing the new addresses one row at a time is not safe: renumbering a scope
+    on the server (``A`` takes ``B``'s address, ``B`` takes ``C``'s) hands us a
+    wire whose end state is legal but whose every intermediate state is not, and
+    the first row to land on an address a not-yet-moved reservation still holds
+    violates ``uq_dhcp_static_scope_ip``. That aborts the poll — and the wire
+    keeps reporting the same thing, so it aborts every poll after it, forever.
+
+    That index is partial (``WHERE deleted_at IS NULL``), so lift every mover out
+    of it, flush, then write the new addresses and put the rows back. The
+    interim state lives and dies inside the caller's transaction; no other
+    session can observe it, and a mid-flight failure rolls the whole thing back.
+    """
+    if not movers:
+        return
+
+    # A mover whose destination is held by a reservation that is NOT itself
+    # moving cannot land, lift or no lift. That means a reservation we chose to
+    # keep — the absence-delete floor guard declined to remove it — is sitting on
+    # the address. Say so and leave it for a poll with better information.
+    moving = {id(st) for st, _ in movers}
+    held = {norm_ip(str(st.ip_address)): st for st in by_mac.values()}
+    landable: list[tuple[DHCPStaticAssignment, dict[str, Any]]] = []
+    for st, wstatic in movers:
+        blocker = held.get(norm_ip(str(wstatic["ip_address"])))
+        if blocker is not None and blocker is not st and id(blocker) not in moving:
+            result.errors.append(
+                f"scope {cidr}: reservation {st.mac_address} cannot move to "
+                f"{wstatic['ip_address']} — {blocker.mac_address} still holds that "
+                f"address here; retrying next poll"
+            )
+            continue
+        landable.append((st, wstatic))
+    if not landable:
+        return
+
+    lifted_at = datetime.now(UTC)
+    for st, _ in landable:
+        st.deleted_at = lifted_at
     await db.flush()
+
+    for st, wstatic in landable:
+        st.deleted_at = None
+        st.ip_address = str(wstatic["ip_address"])
+        _apply_wire_fields(st, wstatic)  # the address already counts as a change
+        result.statics_synced += 1
+    await db.flush()
+
+    # Mirrors last, once every row is back in the index at its final address:
+    # upsert_ipam_for_static re-points the mirror and re-syncs DNS, which is
+    # right for a move — the record really did change address.
+    for st, _ in landable:
+        await upsert_ipam_for_static(db, scope, st, action="update")
+
+
+async def _mirror_is_current(db: AsyncSession, scope: DHCPScope, st: DHCPStaticAssignment) -> bool:
+    """Is ``st``'s IPAM mirror present and pointing back at ``st``?
+
+    False for the rows the pre-#620 replace-all stranded (mirror survives, its
+    ``static_assignment_id`` names a reservation that no longer exists), and for
+    a reservation whose mirror an operator deleted out from under it.
+    """
+    if st.ip_address_id is None:
+        return False
+    row = await db.get(IPAddress, st.ip_address_id)
+    if row is None:
+        return False
+    return (
+        row.subnet_id == scope.subnet_id
+        and norm_ip(str(row.address)) == norm_ip(str(st.ip_address))
+        and row.status == "static_dhcp"
+        and row.static_assignment_id == str(st.id)
+    )
 
 
 __all__ = ["PullLeasesResult", "pull_leases_from_server"]

--- a/backend/app/services/dhcp/static_ipam.py
+++ b/backend/app/services/dhcp/static_ipam.py
@@ -40,7 +40,7 @@ import uuid
 from datetime import date, datetime
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import String, cast, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.dhcp import DHCPScope, DHCPStaticAssignment
@@ -52,6 +52,7 @@ __all__ = [
     "remirror_scope_statics",
     "remove_ipam_for_scope_statics",
     "remove_ipam_for_static",
+    "sweep_orphaned_static_mirrors",
     "upsert_ipam_for_static",
 ]
 
@@ -223,30 +224,132 @@ async def remove_ipam_for_static(db: AsyncSession, st: DHCPStaticAssignment) -> 
     the wholesale reservation-removal paths (scope / group / import / purge).
     Returns the number of rows removed.
     """
-    from app.api.v1.ipam.router import _sync_dns_record  # noqa: PLC0415
-
     res = await db.execute(select(IPAddress).where(IPAddress.static_assignment_id == str(st.id)))
     removed = 0
     for row in res.scalars().all():
+        await _delete_mirror_row(db, row, st)
+        removed += 1
+    return removed
+
+
+async def _delete_mirror_row(
+    db: AsyncSession, row: IPAddress, st: DHCPStaticAssignment | None
+) -> None:
+    """Tear down a mirror row's DNS and delete it.
+
+    ``st`` is the reservation the row mirrors, when we still have it — the
+    orphan sweep calls this for rows whose reservation is *gone*, so it passes
+    ``None`` and simply skips the parts that need one.
+    """
+    from app.api.v1.ipam.router import _sync_dns_record  # noqa: PLC0415
+
+    if st is not None:
         # Snapshot operator-authored columns onto the (soft-deleted, retained)
         # reservation before we hard-delete the mirror, so a Trash restore is
         # lossless (#630). The last mirror row wins — there is realistically one.
         snapshot = _snapshot_operator_fields(row)
         if snapshot is not None:
             st.ipam_metadata_snapshot = snapshot
-        subnet_row = await db.get(Subnet, row.subnet_id)
-        if subnet_row is not None:
-            try:
-                await _sync_dns_record(db, row, subnet_row, action="delete")
-            except Exception:  # noqa: BLE001 — DNS sync is best-effort
-                pass
-        # Clear the forward FK before the delete so the ORM's in-memory
-        # ``st`` doesn't hang onto a stale id (the DB FK is ON DELETE SET NULL).
+        # Clear the forward FK before the delete so the ORM's in-memory ``st``
+        # doesn't hang onto a stale id (the DB FK is ON DELETE SET NULL).
         if st.ip_address_id == row.id:
             st.ip_address_id = None
-        await db.delete(row)
-        removed += 1
-    return removed
+
+    subnet_row = await db.get(Subnet, row.subnet_id)
+    if subnet_row is not None:
+        try:
+            await _sync_dns_record(db, row, subnet_row, action="delete")
+        except Exception:  # noqa: BLE001 — DNS sync is best-effort
+            pass
+    await db.delete(row)
+
+
+async def sweep_orphaned_static_mirrors(db: AsyncSession, *, limit: int = 500) -> int:
+    """Free ``ip_address`` rows stuck at ``static_dhcp`` with no live reservation.
+
+    The safety net under every path that destroys a reservation. Those paths are
+    all supposed to release the mirror first (#618 wired the ones that didn't,
+    #620 fixed the Windows reconciler that re-created reservations under new ids
+    and orphaned theirs). But the failure mode is nasty and silent — the address
+    is left neither allocated nor free nor reclaimable by any sweeper, and no
+    amount of clicking in the UI frees it, because every release path looks the
+    mirror up by the *current* reservation id and matches nothing — so it is
+    worth being able to recover from without an operator noticing first, and
+    without another one-shot repair migration (``d7b3f2a9c15e`` was the last
+    one). This is that migration's step 1, made recurring.
+
+    Deliberately narrow. Only rows carrying a **non-NULL** back-link that
+    resolves to no live reservation are touched: that state is unreachable by
+    any legitimate flow, so it is provably residue. A ``static_dhcp`` row with a
+    NULL back-link is left alone — an operator can set that status by hand, and
+    a sweeper that deletes hand-made rows is worse than the bug it fixes.
+
+    "Live" excludes soft-deleted reservations, matching ``d7b3f2a9c15e``: a
+    scope in the Trash has already had its mirrors removed (#618) and gets them
+    re-created on restore, so a mirror still pointing at a soft-deleted
+    reservation is residue too — and when that reservation is still around to
+    hold it, the operator's columns are snapshotted onto it first, so the
+    restore stays lossless.
+
+    Returns the number of mirror rows freed.
+    """
+    # Query the reservation table through its Core ``__table__`` so the ORM's
+    # soft-delete filter doesn't silently inject a second ``deleted_at IS NULL``
+    # — the liveness predicate here is explicit and needs to stay that way.
+    sa_tbl = DHCPStaticAssignment.__table__
+    live_reservation = (
+        select(sa_tbl.c.id)
+        .where(
+            cast(sa_tbl.c.id, String) == IPAddress.static_assignment_id,
+            sa_tbl.c.deleted_at.is_(None),
+        )
+        .exists()
+    )
+    rows = (
+        (
+            await db.execute(
+                select(IPAddress)
+                .where(
+                    IPAddress.status == "static_dhcp",
+                    IPAddress.static_assignment_id.is_not(None),
+                    ~live_reservation,
+                )
+                .limit(limit)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    freed = 0
+    for row in rows:
+        await _delete_mirror_row(db, row, await _load_reservation_any(db, row.static_assignment_id))
+        freed += 1
+    return freed
+
+
+async def _load_reservation_any(
+    db: AsyncSession, raw_id: str | None
+) -> DHCPStaticAssignment | None:
+    """Load a reservation by its back-link string, soft-deleted ones included.
+
+    Returns ``None`` when the id doesn't parse or names no row at all — which is
+    the common case for the sweep, whose whole subject is back-links pointing at
+    reservations that no longer exist.
+    """
+    if not raw_id:
+        return None
+    try:
+        static_id = uuid.UUID(raw_id)
+    except (ValueError, TypeError):
+        return None
+    return (
+        await db.execute(
+            select(DHCPStaticAssignment)
+            .where(DHCPStaticAssignment.id == static_id)
+            .execution_options(include_deleted=True)
+        )
+    ).scalar_one_or_none()
 
 
 async def remove_ipam_for_scope_statics(db: AsyncSession, scope_id: uuid.UUID) -> int:

--- a/backend/app/services/dhcp/static_ipam.py
+++ b/backend/app/services/dhcp/static_ipam.py
@@ -22,13 +22,16 @@ Wired in as of #618:
 * DHCP server-group delete (``ai.operations_risky._apply_delete_group``)
 * DHCP-import ``overwrite`` (``services.dhcp_import.commit``)
 
-KNOWN GAP — ``services.dhcp.pull_leases._upsert_scope`` still Core-DELETEs a
-Windows scope's reservations and re-inserts them from the wire without going
-through here, so a UI-created reservation's mirror is stranded on the next
-Windows scope sync. It is deliberately NOT fixed with a plain detach: that
-reconciler runs on a schedule, and a detach would tear down and recreate the
-forward A record on every pass for reservations that never changed. It needs a
-re-point-by-IP reconcile instead. Tracked separately.
+``services.dhcp.pull_leases._upsert_scope`` — the Windows scope reconciler —
+used to be the one path that destroyed reservations without coming through
+here: it Core-DELETEd every reservation under a scope and re-inserted them from
+the wire, stranding the mirror of any reservation an operator had created in
+the UI. #620 fixed it by making that reconciler diff-merge instead of replace,
+so a reservation keeps its id across polls and its mirror's back-link stays
+valid. It calls ``upsert_ipam_for_static`` only for reservations that actually
+changed (a schedule-driven detach/re-attach would have torn down and recreated
+the forward A record on every pass), and ``remove_ipam_for_static`` for the ones
+that genuinely vanished from the server.
 """
 
 from __future__ import annotations

--- a/backend/app/services/dhcp/static_ipam.py
+++ b/backend/app/services/dhcp/static_ipam.py
@@ -40,7 +40,7 @@ import uuid
 from datetime import date, datetime
 from typing import Any
 
-from sqlalchemy import String, cast, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.dhcp import DHCPScope, DHCPStaticAssignment
@@ -128,14 +128,27 @@ async def upsert_ipam_for_static(
     subnet view shows the reservation alongside regular addresses.
     """
     ip_str = str(st.ip_address)
-    # Detach any previous IPAM row that was pointing at this static (IP change).
+    # Release any previous IPAM row this static was pointing at (its address
+    # changed). Freeing the row it left behind — rather than downgrading it to
+    # ``allocated``, which is what this did before #620 — because an
+    # ``allocated`` row with no owner is reclaimed by NOTHING: the orphan sweep
+    # only looks at ``static_dhcp`` rows, and the lease-mirror path skips rows it
+    # doesn't own. Every reservation re-address leaked its old address into a
+    # permanently-allocated ghost, and the Windows reconciler now re-addresses
+    # reservations on its own, so a renumber on the server would leak one address
+    # per reservation. Deleting the row also snapshots the operator's columns
+    # onto the reservation, which the restore below re-applies at the new
+    # address — so a move carries them across instead of stranding them.
     prior = await db.execute(select(IPAddress).where(IPAddress.static_assignment_id == str(st.id)))
     for row in prior.scalars().all():
         if str(row.address) == ip_str:
             continue
-        row.static_assignment_id = None
         if row.status == "static_dhcp":
-            row.status = "allocated"
+            await _delete_mirror_row(db, row, st)
+        else:
+            # Not ours to delete — an operator re-purposed the row's status. Just
+            # drop the back-link so it can't dangle.
+            row.static_assignment_id = None
     # Find or create the IPAM row for this IP within the scope's subnet.
     res = await db.execute(
         select(IPAddress).where(IPAddress.subnet_id == scope.subnet_id, IPAddress.address == ip_str)
@@ -150,7 +163,12 @@ async def upsert_ipam_for_static(
         # uq_ip_address_subnet_address.
         candidate = IPAddress(subnet_id=scope.subnet_id, address=ip_str, status="static_dhcp")
         row, _created = await insert_ipam_mirror_row(db, candidate)
-    row.hostname = st.hostname or row.hostname
+    # Assigned outright, not ``st.hostname or row.hostname``: the reservation is
+    # the source of truth for the hostname (as it already is for the MAC, right
+    # below), and the ``or`` made an empty one unrepresentable — clearing a
+    # reservation's name left the mirror on the old name and re-published the
+    # stale A record off it, with no number of polls able to converge them.
+    row.hostname = st.hostname
     row.mac_address = str(st.mac_address)
     row.status = "static_dhcp"
     row.static_assignment_id = str(st.id)
@@ -293,26 +311,20 @@ async def sweep_orphaned_static_mirrors(db: AsyncSession, *, limit: int = 500) -
 
     Returns the number of mirror rows freed.
     """
-    # Query the reservation table through its Core ``__table__`` so the ORM's
-    # soft-delete filter doesn't silently inject a second ``deleted_at IS NULL``
-    # — the liveness predicate here is explicit and needs to stay that way.
-    sa_tbl = DHCPStaticAssignment.__table__
-    live_reservation = (
-        select(sa_tbl.c.id)
-        .where(
-            cast(sa_tbl.c.id, String) == IPAddress.static_assignment_id,
-            sa_tbl.c.deleted_at.is_(None),
-        )
-        .exists()
-    )
-    rows = (
+    # Two indexed queries rather than one correlated NOT EXISTS. The obvious
+    # anti-join has to compare a uuid column against a varchar one, and the
+    # ``cast(reservation.id AS text)`` that makes that typecheck also makes the
+    # reservation table's primary-key index unusable — so Postgres re-scans it
+    # for every candidate row, on a task that runs hourly forever and finds
+    # nothing on a healthy install. Resolving the back-links in a second query
+    # keyed on the uuid column keeps the PK index in play.
+    candidates = (
         (
             await db.execute(
                 select(IPAddress)
                 .where(
                     IPAddress.status == "static_dhcp",
                     IPAddress.static_assignment_id.is_not(None),
-                    ~live_reservation,
                 )
                 .limit(limit)
             )
@@ -320,12 +332,51 @@ async def sweep_orphaned_static_mirrors(db: AsyncSession, *, limit: int = 500) -
         .scalars()
         .all()
     )
+    if not candidates:
+        return 0
+
+    # A back-link that doesn't parse as a uuid can name no reservation at all, so
+    # it is residue by definition — keep it in the candidate set (mapped to None)
+    # rather than letting it slip through the liveness check unexamined.
+    parsed: list[tuple[IPAddress, uuid.UUID | None]] = [
+        (row, _parse_uuid(row.static_assignment_id)) for row in candidates
+    ]
+    wanted = {static_id for _row, static_id in parsed if static_id is not None}
+
+    # Core ``__table__`` so the ORM's soft-delete filter doesn't silently inject a
+    # second ``deleted_at IS NULL`` — the liveness predicate is explicit here and
+    # needs to stay that way.
+    sa_tbl = DHCPStaticAssignment.__table__
+    live: set[uuid.UUID] = set()
+    if wanted:
+        live = {
+            row_id
+            for (row_id,) in (
+                await db.execute(
+                    select(sa_tbl.c.id).where(
+                        sa_tbl.c.id.in_(wanted),
+                        sa_tbl.c.deleted_at.is_(None),
+                    )
+                )
+            ).all()
+        }
 
     freed = 0
-    for row in rows:
+    for row, static_id in parsed:
+        if static_id is not None and static_id in live:
+            continue
         await _delete_mirror_row(db, row, await _load_reservation_any(db, row.static_assignment_id))
         freed += 1
     return freed
+
+
+def _parse_uuid(raw: str | None) -> uuid.UUID | None:
+    if not raw:
+        return None
+    try:
+        return uuid.UUID(raw)
+    except (ValueError, TypeError):
+        return None
 
 
 async def _load_reservation_any(
@@ -337,11 +388,8 @@ async def _load_reservation_any(
     the common case for the sweep, whose whole subject is back-links pointing at
     reservations that no longer exist.
     """
-    if not raw_id:
-        return None
-    try:
-        static_id = uuid.UUID(raw_id)
-    except (ValueError, TypeError):
+    static_id = _parse_uuid(raw_id)
+    if static_id is None:
         return None
     return (
         await db.execute(

--- a/backend/app/services/dhcp/windows_writethrough.py
+++ b/backend/app/services/dhcp/windows_writethrough.py
@@ -53,24 +53,16 @@ from app.services.dhcp.cloud_writethrough import (
     push_cloud_scope_delete,
     push_cloud_scope_upsert,
 )
+from app.services.dhcp.normalize import norm_ip, norm_mac
 
 logger = structlog.get_logger(__name__)
 
 
-def _norm_mac(mac: str) -> str:
-    """Canonicalise a MAC to bare lowercase hex so a cosmetic reformat
-    (case / ':' vs '-' separators) doesn't read as a change (#426)."""
-    return "".join(c for c in mac.lower() if c in "0123456789abcdef")
-
-
-def _norm_ip(ip: str) -> str:
-    """Canonicalise an IP for change-detection; falls back to the raw
-    string if it doesn't parse (so a bad value still compares equal to
-    itself)."""
-    try:
-        return str(ipaddress.ip_address(ip.strip()))
-    except ValueError:
-        return ip.strip()
+# Change-detection normalisers (#426). They live in ``services.dhcp.normalize``
+# because ``pull_leases`` diffs the same wire state against the same rows and
+# has to agree byte-for-byte on what counts as a change (#620).
+_norm_mac = norm_mac
+_norm_ip = norm_ip
 
 
 class WindowsPushError(HTTPException):

--- a/backend/app/tasks/dhcp_mirror_sweep.py
+++ b/backend/app/tasks/dhcp_mirror_sweep.py
@@ -1,0 +1,85 @@
+"""Recurring repair for stranded DHCP-reservation IPAM mirrors (#620).
+
+A reservation owns an ``ip_address`` row (``status="static_dhcp"``, back-linked
+by ``static_assignment_id``). Every path that destroys a reservation is supposed
+to release that mirror first — #618 wired up the ones that didn't, and #620
+fixed the Windows scope reconciler, which used to Core-DELETE every reservation
+under a scope and re-insert it under a fresh id on every poll, orphaning the
+mirror of anything an operator had created in the UI.
+
+So why sweep at all, if the paths are fixed? Because of how this fails. A
+stranded mirror is silent and unrecoverable from the UI: the address sits at
+``static_dhcp`` pointing at a reservation Postgres has dropped, so it is neither
+allocated nor free, nothing hands it out, and no amount of clicking frees it —
+every release path looks the mirror up by the reservation's *current* id and
+matches nothing. The last one took a one-shot repair migration
+(``d7b3f2a9c15e``) to clean up. This is that migration's step 1 made recurring,
+so the next one — from a path nobody has thought of yet — costs an operator
+nothing and heals within the hour.
+
+Cheap by construction: the predicate matches only provable residue, so on a
+healthy install it finds nothing and writes nothing (not even an audit row).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import structlog
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.celery_app import celery_app
+from app.db import task_session
+from app.models.audit import AuditLog
+from app.services.dhcp.static_ipam import sweep_orphaned_static_mirrors
+
+logger = structlog.get_logger(__name__)
+
+# Cap per run so a pathological install (a repair migration that never ran, say)
+# can't turn one tick into an hour-long transaction holding locks on ip_address.
+# Whatever is left over is picked up on the next tick — the sweep is idempotent.
+_MAX_PER_RUN = 500
+
+
+async def _sweep() -> int:
+    async with task_session() as db:
+        freed = await sweep_orphaned_static_mirrors(db, limit=_MAX_PER_RUN)
+        if freed:
+            # Only audit when we actually changed something — a row per hour
+            # saying "found nothing" would bury the one that matters. Freeing an
+            # address IS a mutation, and mutations are audited (non-negotiable
+            # #4); it is also a signal worth reading, because a non-zero count
+            # here means some path is still stranding mirrors.
+            db.add(
+                AuditLog(
+                    user_display_name="<system>",
+                    auth_source="system",
+                    action="dhcp-mirror-sweep",
+                    resource_type="platform",
+                    resource_id="dhcp-mirror-sweep",
+                    resource_display="orphaned reservation mirrors",
+                    result="success",
+                    new_value={"mirrors_freed": freed, "capped": freed >= _MAX_PER_RUN},
+                )
+            )
+        await db.commit()
+        return freed
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.dhcp_mirror_sweep.sweep_orphaned_mirrors",
+    autoretry_for=(SQLAlchemyError, ConnectionError, OSError),
+    retry_backoff=True,
+    retry_backoff_max=600,
+    retry_kwargs={"max_retries": 3},
+)
+def sweep_orphaned_mirrors(self: Any) -> dict[str, int]:  # noqa: ARG001
+    freed = asyncio.run(_sweep())
+    if freed:
+        # Warning, not info: a healthy install frees nothing, so a hit means a
+        # reservation-destroying path skipped its mirror release and wants
+        # finding — the sweep is the backstop, not the fix.
+        logger.warning("dhcp_mirror_sweep_freed_orphans", mirrors_freed=freed)
+    return {"mirrors_freed": freed}

--- a/backend/app/tasks/dhcp_pull_leases.py
+++ b/backend/app/tasks/dhcp_pull_leases.py
@@ -98,6 +98,8 @@ async def _run_pull() -> dict[str, Any]:
             total_scopes_skipped = 0
             total_pools_synced = 0
             total_statics_synced = 0
+            total_pools_removed = 0
+            total_statics_removed = 0
             errors: list[str] = []
             wake_group_ids: set[str] = set()  # #428 — DNS groups to wake post-commit
 
@@ -131,6 +133,8 @@ async def _run_pull() -> dict[str, Any]:
                 total_scopes_skipped += result.scopes_skipped_no_subnet
                 total_pools_synced += result.pools_synced
                 total_statics_synced += result.statics_synced
+                total_pools_removed += result.pools_removed
+                total_statics_removed += result.statics_removed
                 wake_group_ids.update(result.dns_wake_group_ids)
                 errors.extend(f"{server.name}: {e}" for e in result.errors)
 
@@ -142,6 +146,13 @@ async def _run_pull() -> dict[str, Any]:
                 or total_removed
                 or total_ipam_created
                 or total_ipam_revoked
+                # Destructive topology work counts too (#620). Without these, a
+                # poll whose only effect was absence-deleting reservations — and
+                # their IPAM mirrors, and their DNS records — wrote NO audit row
+                # at all, because every counter above tracks leases, not statics.
+                or total_statics_synced
+                or total_statics_removed
+                or total_pools_removed
                 or errors
             ):
                 db.add(
@@ -168,6 +179,8 @@ async def _run_pull() -> dict[str, Any]:
                             "scopes_skipped_no_subnet": total_scopes_skipped,
                             "pools_synced": total_pools_synced,
                             "statics_synced": total_statics_synced,
+                            "pools_removed": total_pools_removed,
+                            "statics_removed": total_statics_removed,
                             "errors": errors[:20],
                         },
                     )

--- a/backend/tests/test_dhcp_mirror_sweep.py
+++ b/backend/tests/test_dhcp_mirror_sweep.py
@@ -1,0 +1,190 @@
+"""#620 — the orphaned-reservation-mirror sweep.
+
+A reservation owns an ``ip_address`` row at ``status="static_dhcp"``, back-linked
+by id. When a path destroys the reservation without releasing that mirror, the
+address is left neither allocated nor free nor reclaimable — and invisibly so:
+every release path looks the mirror up by the reservation's *current* id and
+matches nothing, so no amount of clicking in the UI frees it. The paths are
+fixed (#618, #620), but the failure mode is bad enough to be worth a backstop.
+
+The sweep therefore has to be sharp in both directions: it must free provable
+residue, and it must not touch anything an operator could have made by hand.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp import DHCPScope, DHCPServerGroup, DHCPStaticAssignment
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.dhcp.static_ipam import sweep_orphaned_static_mirrors, upsert_ipam_for_static
+
+
+async def _fixture(db: AsyncSession) -> tuple[DHCPScope, Subnet]:
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    db.add(grp)
+    await db.flush()
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.30.0.0/16", name="blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.30.0.0/24", name="sn")
+    db.add(subnet)
+    await db.flush()
+    scope = DHCPScope(group_id=grp.id, subnet_id=subnet.id, is_active=True)
+    db.add(scope)
+    await db.flush()
+    return scope, subnet
+
+
+async def _reservation(
+    db: AsyncSession, scope: DHCPScope, *, ip: str = "10.30.0.10"
+) -> DHCPStaticAssignment:
+    st = DHCPStaticAssignment(
+        scope_id=scope.id,
+        ip_address=ip,
+        mac_address="aa:bb:cc:00:00:01",
+        hostname="printer",
+        description="",
+    )
+    db.add(st)
+    await db.flush()
+    await upsert_ipam_for_static(db, scope, st)
+    await db.flush()
+    return st
+
+
+async def _mirror(db: AsyncSession, subnet: Subnet, ip: str) -> IPAddress | None:
+    return (
+        await db.execute(
+            select(IPAddress).where(IPAddress.subnet_id == subnet.id, IPAddress.address == ip)
+        )
+    ).scalar_one_or_none()
+
+
+@pytest.mark.asyncio
+async def test_sweep_frees_a_mirror_whose_reservation_vanished(
+    db_session: AsyncSession,
+) -> None:
+    """The residue: reservation gone from the table, mirror still holding the
+    address at static_dhcp. Exactly what the pre-#620 Core-DELETE left behind."""
+    scope, subnet = await _fixture(db_session)
+    st = await _reservation(db_session, scope)
+    # Destroy the reservation the way a Core DELETE does — no per-row Python, so
+    # nothing releases the mirror.
+    await db_session.execute(
+        DHCPStaticAssignment.__table__.delete().where(DHCPStaticAssignment.id == st.id)
+    )
+    await db_session.flush()
+
+    stranded = await _mirror(db_session, subnet, "10.30.0.10")
+    assert stranded is not None
+    assert stranded.status == "static_dhcp"  # stuck: not allocated, not free
+
+    freed = await sweep_orphaned_static_mirrors(db_session)
+    await db_session.commit()
+
+    assert freed == 1
+    # Deleted outright, not left at "available": a persisted freed row still
+    # renders as a line in the subnet table and still counts toward utilization
+    # (#618). The address folds back into a free gap.
+    assert await _mirror(db_session, subnet, "10.30.0.10") is None
+
+
+@pytest.mark.asyncio
+async def test_sweep_leaves_a_live_reservations_mirror_alone(
+    db_session: AsyncSession,
+) -> None:
+    """The thing the sweep must never do."""
+    scope, subnet = await _fixture(db_session)
+    st = await _reservation(db_session, scope)
+    await db_session.commit()
+
+    freed = await sweep_orphaned_static_mirrors(db_session)
+    await db_session.commit()
+
+    assert freed == 0
+    mirror = await _mirror(db_session, subnet, "10.30.0.10")
+    assert mirror is not None
+    assert mirror.status == "static_dhcp"
+    assert mirror.static_assignment_id == str(st.id)
+
+
+@pytest.mark.asyncio
+async def test_sweep_ignores_a_hand_made_static_dhcp_row(
+    db_session: AsyncSession,
+) -> None:
+    """A ``static_dhcp`` row with a NULL back-link is reachable by hand — an
+    operator can set that status themselves. A sweeper that deletes hand-made
+    rows would be worse than the bug it fixes, so the predicate requires a
+    non-NULL back-link that resolves to nothing: provable residue, nothing else."""
+    _scope, subnet = await _fixture(db_session)
+    db_session.add(
+        IPAddress(
+            subnet_id=subnet.id,
+            address="10.30.0.99",
+            status="static_dhcp",
+            description="set by hand",
+        )
+    )
+    await db_session.commit()
+
+    freed = await sweep_orphaned_static_mirrors(db_session)
+    await db_session.commit()
+
+    assert freed == 0
+    survivor = await _mirror(db_session, subnet, "10.30.0.99")
+    assert survivor is not None
+    assert survivor.description == "set by hand"
+
+
+@pytest.mark.asyncio
+async def test_sweep_frees_a_mirror_of_a_soft_deleted_reservation_losslessly(
+    db_session: AsyncSession,
+) -> None:
+    """A reservation in the Trash has already had its mirror removed (#618) and
+    gets it re-created on restore, so a mirror still pointing at a soft-deleted
+    one is residue too. But the reservation is still around to hold the
+    operator's columns — snapshot them onto it, so the restore stays lossless."""
+    from datetime import UTC, datetime
+
+    scope, subnet = await _fixture(db_session)
+    st = await _reservation(db_session, scope)
+    mirror = await _mirror(db_session, subnet, "10.30.0.10")
+    assert mirror is not None
+    mirror.description = "rack 4, port 12"
+    mirror.tags = {"owner": "lab"}
+    st.deleted_at = datetime.now(UTC)  # scope batch soft-delete, mirror left behind
+    await db_session.commit()
+
+    freed = await sweep_orphaned_static_mirrors(db_session)
+    await db_session.commit()
+
+    assert freed == 1
+    assert await _mirror(db_session, subnet, "10.30.0.10") is None
+    # The operator's columns rode onto the retained reservation, so restoring the
+    # scope brings them back rather than resurrecting a blank row.
+    await db_session.refresh(st)
+    assert st.ipam_metadata_snapshot == {"description": "rack 4, port 12", "tags": {"owner": "lab"}}
+
+
+@pytest.mark.asyncio
+async def test_sweep_is_idempotent(db_session: AsyncSession) -> None:
+    """It runs hourly on every install forever; a second pass must be a no-op."""
+    scope, subnet = await _fixture(db_session)
+    st = await _reservation(db_session, scope)
+    await db_session.execute(
+        DHCPStaticAssignment.__table__.delete().where(DHCPStaticAssignment.id == st.id)
+    )
+    await db_session.flush()
+
+    assert await sweep_orphaned_static_mirrors(db_session) == 1
+    await db_session.commit()
+    assert await sweep_orphaned_static_mirrors(db_session) == 0
+    await db_session.commit()

--- a/backend/tests/test_dhcp_windows_scope_sync.py
+++ b/backend/tests/test_dhcp_windows_scope_sync.py
@@ -1,0 +1,700 @@
+"""#620 — the Windows scope reconciler (``pull_leases._upsert_scope``).
+
+Phase 1 of ``pull_leases_from_server`` — the ``get_scopes`` topology pass that
+reconciles a Windows DHCP server's scopes, pools and reservations — had zero
+test coverage, which is how it shipped Core-DELETEing every reservation under a
+scope and re-inserting it from the wire on every beat tick. Reservations got a
+fresh id each poll, so the ``ip_address`` mirror that back-links to one by id
+was left pointing at a row Postgres had dropped, within minutes of an operator
+creating it: the address was neither allocated nor free, and deleting the
+reservation in the UI never freed it.
+
+The fix is a diff-merge (ids stay stable), so these tests are mostly about
+*what does not happen*: no id churn, no DNS writes on an unchanged poll, no
+absence-delete on a wire we can't trust.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp import DHCPPool, DHCPScope, DHCPServer, DHCPServerGroup, DHCPStaticAssignment
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.dhcp.static_ipam import upsert_ipam_for_static
+
+SUBNET = "10.20.0.0/24"
+MAC_A = "aa:bb:cc:00:00:01"
+MAC_B = "aa:bb:cc:00:00:02"
+
+
+def wire_scope(
+    *,
+    statics: list[dict[str, Any]] | None = None,
+    pools: list[dict[str, Any]] | None = None,
+    statics_ok: bool = True,
+    pools_ok: bool = True,
+) -> dict[str, Any]:
+    """One neutral scope dict, shaped exactly as ``windows._parse_scopes`` emits."""
+    return {
+        "scope_id": "10.20.0.0",
+        "subnet_cidr": SUBNET,
+        "name": "office",
+        "description": "",
+        "lease_time": 86400,
+        "is_active": True,
+        "options": {},
+        "pools": (
+            [{"start_ip": "10.20.0.100", "end_ip": "10.20.0.200", "pool_type": "dynamic"}]
+            if pools is None
+            else pools
+        ),
+        "statics": statics or [],
+        "pools_ok": pools_ok,
+        "statics_ok": statics_ok,
+    }
+
+
+def wire_static(
+    mac: str = MAC_A,
+    ip: str = "10.20.0.10",
+    hostname: str = "printer",
+    description: str = "",
+) -> dict[str, Any]:
+    return {
+        "ip_address": ip,
+        "mac_address": mac,
+        "hostname": hostname,
+        "client_id": mac.replace(":", "-"),
+        "description": description,
+    }
+
+
+class _StubDriver:
+    """A Windows-shaped driver: implements ``get_scopes`` (which is what gates
+    Phase 1) plus the ``get_leases`` every agentless driver must have."""
+
+    def __init__(self, scopes: list[dict[str, Any]]) -> None:
+        self.scopes = scopes
+
+    async def get_scopes(self, _server: DHCPServer) -> list[dict[str, Any]]:
+        return self.scopes
+
+    async def get_leases(self, _server: DHCPServer) -> list[dict[str, Any]]:
+        return []
+
+
+@dataclass
+class _DNSSpy:
+    """Records every ``_sync_dns_record`` call the reconcile makes.
+
+    The whole point of merging rather than detach/re-attaching is that a steady
+    poll writes no DNS at all, so "how many times was DNS touched" is the
+    assertion that actually pins the behaviour down.
+    """
+
+    calls: list[str] = field(default_factory=list)
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, scopes: list[dict[str, Any]]) -> _DNSSpy:
+    from app.services.dhcp import pull_leases as pl
+
+    monkeypatch.setattr(pl, "get_driver", lambda _drv: _StubDriver(scopes))
+    monkeypatch.setattr(pl, "is_agentless", lambda _drv: True)
+
+    spy = _DNSSpy()
+
+    # Both static_ipam helpers import _sync_dns_record from the router lazily,
+    # so patching it on the router module catches every call site.
+    import app.api.v1.ipam.router as ipam_router
+
+    async def _spy(_db: Any, row: Any, _subnet: Any, action: str = "create", **_kw: Any) -> None:
+        spy.calls.append(f"{action}:{row.address}")
+
+    monkeypatch.setattr(ipam_router, "_sync_dns_record", _spy)
+    return spy
+
+
+async def _fixture(db: AsyncSession) -> tuple[DHCPServer, DHCPScope, Subnet]:
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    db.add(grp)
+    await db.flush()
+    srv = DHCPServer(
+        name=f"s-{uuid.uuid4().hex[:6]}",
+        driver="windows_dhcp",
+        host="127.0.0.1",
+        port=67,
+        server_group_id=grp.id,
+    )
+    db.add(srv)
+    await db.flush()
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.20.0.0/16", name="blk")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=SUBNET, name="office")
+    db.add(subnet)
+    await db.flush()
+    scope = DHCPScope(group_id=grp.id, subnet_id=subnet.id, is_active=True)
+    db.add(scope)
+    await db.flush()
+    return srv, scope, subnet
+
+
+async def _make_ui_reservation(
+    db: AsyncSession,
+    scope: DHCPScope,
+    *,
+    mac: str = MAC_A,
+    ip: str = "10.20.0.10",
+    client_id: str | None = "wire",
+) -> DHCPStaticAssignment:
+    """A reservation created the way the UI creates one — mirror and all.
+
+    ``client_id`` defaults to the form the wire reports, so a fixture is already
+    in the steady state the reconciler should leave alone. Pass ``None`` for a
+    genuinely UI-created reservation, which has no client_id until a poll learns
+    one from the server.
+    """
+    st = DHCPStaticAssignment(
+        scope_id=scope.id,
+        ip_address=ip,
+        mac_address=mac,
+        hostname="printer",
+        description="",
+        client_id=mac.replace(":", "-") if client_id == "wire" else client_id,
+    )
+    db.add(st)
+    await db.flush()
+    await upsert_ipam_for_static(db, scope, st)
+    await db.flush()
+    return st
+
+
+async def _mirror(db: AsyncSession, subnet: Subnet, ip: str) -> IPAddress | None:
+    return (
+        await db.execute(
+            select(IPAddress).where(IPAddress.subnet_id == subnet.id, IPAddress.address == ip)
+        )
+    ).scalar_one_or_none()
+
+
+# ── the bug ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_keeps_a_ui_reservations_mirror_linked(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reported bug: an operator creates a reservation in the UI, the next
+    Windows scope sync reads it back off the wire, and the reservation must come
+    through with the same id — otherwise its IPAM mirror is left pointing at a
+    dead row (not allocated, not free, not reclaimable)."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    st = await _make_ui_reservation(db_session, scope)
+    original_id = st.id
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(statics=[wire_static()])])
+    await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    statics = list(
+        (
+            await db_session.execute(
+                select(DHCPStaticAssignment).where(DHCPStaticAssignment.scope_id == scope.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(statics) == 1
+    assert statics[0].id == original_id, "reservation was re-created — its mirror is now stranded"
+
+    mirror = await _mirror(db_session, subnet, "10.20.0.10")
+    assert mirror is not None
+    assert mirror.status == "static_dhcp"
+    assert mirror.static_assignment_id == str(original_id)
+
+
+@pytest.mark.asyncio
+async def test_repeat_sync_writes_no_dns(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A poll that finds nothing changed must not touch DNS. This runs on the
+    beat, so a detach/re-attach repair would tear down and recreate the forward
+    A record for every reservation, forever."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    await _make_ui_reservation(db_session, scope)
+    await db_session.commit()
+
+    spy = _patch(monkeypatch, [wire_scope(statics=[wire_static()])])
+    for _ in range(3):
+        result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+        await db_session.commit()
+
+    assert spy.calls == [], f"steady-state poll churned DNS: {spy.calls}"
+    assert result.statics_synced == 0
+    assert result.statics_removed == 0
+
+
+@pytest.mark.asyncio
+async def test_learning_client_id_from_the_wire_is_not_a_dns_event(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A UI-created reservation has no client_id; Windows reports one, so the
+    first poll after it is created legitimately writes to the row. That is not a
+    reason to re-sync DNS — the record's name and address haven't moved."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, _subnet = await _fixture(db_session)
+    st = await _make_ui_reservation(db_session, scope, client_id=None)
+    await db_session.commit()
+
+    spy = _patch(monkeypatch, [wire_scope(statics=[wire_static()])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    await db_session.refresh(st)
+    assert st.client_id == MAC_A.replace(":", "-")
+    assert result.statics_synced == 1
+    assert spy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_sync_repairs_a_stranded_mirror(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Installs carrying mirrors the old replace-all stranded (back-link naming a
+    reservation that no longer exists) re-link themselves on the next poll — no
+    operator action, no migration."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    st = await _make_ui_reservation(db_session, scope)
+    mirror = await _mirror(db_session, subnet, "10.20.0.10")
+    assert mirror is not None
+    # Strand it exactly as the pre-fix reconciler did: mirror survives, its
+    # back-link names a reservation id that is gone.
+    mirror.static_assignment_id = str(uuid.uuid4())
+    st.ip_address_id = None
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(statics=[wire_static()])])
+    await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    await db_session.refresh(mirror)
+    assert mirror.static_assignment_id == str(st.id)
+    assert mirror.status == "static_dhcp"
+
+
+# ── mirroring Windows-side reservations ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_windows_side_reservation_gets_an_ipam_mirror(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reservation that only ever existed on the Windows box is still an
+    allocation. IPAM has to show it, or it will hand the address out twice."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(statics=[wire_static(ip="10.20.0.11")])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.statics_synced == 1
+    mirror = await _mirror(db_session, subnet, "10.20.0.11")
+    assert mirror is not None
+    assert mirror.status == "static_dhcp"
+    assert str(mirror.mac_address) == MAC_A
+
+
+@pytest.mark.asyncio
+async def test_relocated_reservation_keeps_its_id_and_moves_its_mirror(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reservations are matched on MAC, so moving one to a new IP updates it in
+    place — the row id (and therefore the mirror's back-link) survives."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    st = await _make_ui_reservation(db_session, scope)
+    original_id = st.id
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(statics=[wire_static(ip="10.20.0.77")])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    await db_session.refresh(st)
+    assert st.id == original_id
+    assert str(st.ip_address) == "10.20.0.77"
+    assert result.statics_synced == 1
+
+    moved = await _mirror(db_session, subnet, "10.20.0.77")
+    assert moved is not None
+    assert moved.static_assignment_id == str(original_id)
+    # The old address is no longer reserved.
+    old = await _mirror(db_session, subnet, "10.20.0.10")
+    assert old is None or old.status != "static_dhcp"
+
+
+@pytest.mark.asyncio
+async def test_cosmetic_mac_reformat_is_not_a_change(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows hands MACs back as ``AA-BB-CC-…``; Postgres stores ``aa:bb:cc:…``.
+    Comparing them raw would delete and re-create the reservation on every poll."""
+    from app.services.dhcp import pull_leases as pl
+
+    wire_mac = MAC_A.upper().replace(":", "-")
+
+    srv, scope, subnet = await _fixture(db_session)
+    st = await _make_ui_reservation(db_session, scope, client_id=wire_mac)
+    original_id = st.id
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(statics=[wire_static(mac=wire_mac)])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.statics_synced == 0
+    assert result.statics_removed == 0
+    statics = list(
+        (
+            await db_session.execute(
+                select(DHCPStaticAssignment).where(DHCPStaticAssignment.scope_id == scope.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [s.id for s in statics] == [original_id]
+
+
+# ── absence-delete + its floor guards ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reservation_removed_on_the_server_is_removed_here(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wire that still reports *other* reservations is trustworthy, so one that
+    stopped being reported really was deleted on the server: drop it, delete its
+    mirror (a freed row still renders and still counts toward utilization) and
+    tear its DNS down."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    gone = await _make_ui_reservation(db_session, scope, mac=MAC_A, ip="10.20.0.10")
+    await _make_ui_reservation(db_session, scope, mac=MAC_B, ip="10.20.0.11")
+    await db_session.commit()
+
+    spy = _patch(monkeypatch, [wire_scope(statics=[wire_static(mac=MAC_B, ip="10.20.0.11")])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.statics_removed == 1
+    assert await db_session.get(DHCPStaticAssignment, gone.id) is None
+    assert await _mirror(db_session, subnet, "10.20.0.10") is None
+    assert spy.calls == ["delete:10.20.0.10"]
+    # The surviving reservation was untouched.
+    assert await _mirror(db_session, subnet, "10.20.0.11") is not None
+
+
+@pytest.mark.asyncio
+async def test_empty_reservation_list_does_not_absence_delete(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty list from a scope we know has reservations is more likely a
+    hiccup than a mass deletion (#482's reasoning, applied per scope). Keep the
+    rows and tell the operator why — a stale reservation they can delete beats a
+    reservation and its A record we tore down on a blip."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    st = await _make_ui_reservation(db_session, scope)
+    await db_session.commit()
+
+    spy = _patch(monkeypatch, [wire_scope(statics=[])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.statics_removed == 0
+    assert await db_session.get(DHCPStaticAssignment, st.id) is not None
+    assert await _mirror(db_session, subnet, "10.20.0.10") is not None
+    assert spy.calls == []
+    assert any("0 reservations" in e for e in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_failed_enumeration_does_not_absence_delete(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``statics_ok=False`` is the driver saying its reservation enumeration blew
+    up. The list it handed back is meaningless — never delete against it."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    st = await _make_ui_reservation(db_session, scope)
+    await db_session.commit()
+
+    _patch(
+        monkeypatch,
+        [wire_scope(statics=[wire_static(mac=MAC_B, ip="10.20.0.99")], statics_ok=False)],
+    )
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.statics_removed == 0
+    assert await db_session.get(DHCPStaticAssignment, st.id) is not None
+    assert any("enumeration failed" in e for e in result.errors)
+
+
+@pytest.mark.asyncio
+async def test_reservation_created_mid_poll_is_not_absence_deleted(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The wire is a snapshot. A reservation created after we took it cannot be
+    absent from it in any meaningful sense — deleting it would destroy a
+    reservation the operator just made (and that write-through already pushed to
+    the server)."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    # Reported on the wire, so the absence-delete is armed for this scope.
+    await _make_ui_reservation(db_session, scope, mac=MAC_B, ip="10.20.0.11")
+    fresh = await _make_ui_reservation(db_session, scope, mac=MAC_A, ip="10.20.0.10")
+    # Stamp it into the future: created after the snapshot the poll is about to take.
+    fresh.created_at = datetime.now(UTC) + timedelta(minutes=5)
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(statics=[wire_static(mac=MAC_B, ip="10.20.0.11")])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.statics_removed == 0
+    assert await db_session.get(DHCPStaticAssignment, fresh.id) is not None
+    assert await _mirror(db_session, subnet, "10.20.0.10") is not None
+
+
+@pytest.mark.asyncio
+async def test_operator_edit_mid_poll_is_not_reverted(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same reasoning for an edit: the wire we're holding predates it, so writing
+    the wire's value back would revert the operator (and bounce the DNS record)."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    st = await _make_ui_reservation(db_session, scope)
+    st.ip_address = "10.20.0.55"
+    st.modified_at = datetime.now(UTC) + timedelta(minutes=5)
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(statics=[wire_static(ip="10.20.0.10")])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    await db_session.refresh(st)
+    assert str(st.ip_address) == "10.20.0.55"
+    assert result.statics_synced == 0
+
+
+# ── pools ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pools_merge_in_place_and_absence_delete(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pools carry no mirror, but IPAM reads them — a manual allocation inside a
+    dynamic range is refused — so they must not blink out of existence between
+    polls either. Merge by range; delete only what the wire dropped."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, _subnet = await _fixture(db_session)
+    keep = DHCPPool(
+        scope_id=scope.id,
+        start_ip="10.20.0.100",
+        end_ip="10.20.0.200",
+        pool_type="dynamic",
+        name="",
+    )
+    drop = DHCPPool(
+        scope_id=scope.id, start_ip="10.20.0.5", end_ip="10.20.0.6", pool_type="excluded", name=""
+    )
+    db_session.add_all([keep, drop])
+    await db_session.flush()
+    keep_id = keep.id
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope()])  # only the dynamic pool
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    pools = list(
+        (await db_session.execute(select(DHCPPool).where(DHCPPool.scope_id == scope.id)))
+        .scalars()
+        .all()
+    )
+    assert [p.id for p in pools] == [keep_id], "the unchanged pool was re-created"
+    assert result.pools_removed == 1
+    assert result.pools_synced == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_pool_list_does_not_absence_delete(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, _subnet = await _fixture(db_session)
+    db_session.add(
+        DHCPPool(
+            scope_id=scope.id,
+            start_ip="10.20.0.100",
+            end_ip="10.20.0.200",
+            pool_type="dynamic",
+            name="",
+        )
+    )
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(pools=[])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.pools_removed == 0
+    pools = list(
+        (await db_session.execute(select(DHCPPool).where(DHCPPool.scope_id == scope.id)))
+        .scalars()
+        .all()
+    )
+    assert len(pools) == 1
+    assert any("0 pools" in e for e in result.errors)
+
+
+# ── re-addressing (the (scope, address) unique index) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_reservations_can_swap_addresses(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two reservations trading addresses on the server is a wire whose end state
+    is legal but whose every intermediate state violates uq_dhcp_static_scope_ip.
+    Applying it row-by-row aborts the poll — and the wire keeps reporting the
+    same thing, so it would abort every poll after it, forever."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    a = await _make_ui_reservation(db_session, scope, mac=MAC_A, ip="10.20.0.10")
+    b = await _make_ui_reservation(db_session, scope, mac=MAC_B, ip="10.20.0.11")
+    a_id, b_id = a.id, b.id
+    await db_session.commit()
+
+    _patch(
+        monkeypatch,
+        [
+            wire_scope(
+                statics=[
+                    wire_static(mac=MAC_A, ip="10.20.0.11"),
+                    wire_static(mac=MAC_B, ip="10.20.0.10"),
+                ]
+            )
+        ],
+    )
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    await db_session.refresh(a)
+    await db_session.refresh(b)
+    assert (a.id, str(a.ip_address)) == (a_id, "10.20.0.11")
+    assert (b.id, str(b.ip_address)) == (b_id, "10.20.0.10")
+    assert result.statics_removed == 0
+    assert not result.errors
+
+    # Both mirrors followed their reservation to its new address.
+    at_10 = await _mirror(db_session, subnet, "10.20.0.10")
+    at_11 = await _mirror(db_session, subnet, "10.20.0.11")
+    assert at_10 is not None and at_10.static_assignment_id == str(b_id)
+    assert at_11 is not None and at_11.static_assignment_id == str(a_id)
+
+
+@pytest.mark.asyncio
+async def test_reservation_renumber_chain(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The same hazard without a cycle: A moves onto the address B is vacating.
+    Whether it aborts depends on the order the wire happens to list them in, so
+    it must not depend on order at all."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    a = await _make_ui_reservation(db_session, scope, mac=MAC_A, ip="10.20.0.10")
+    b = await _make_ui_reservation(db_session, scope, mac=MAC_B, ip="10.20.0.11")
+    await db_session.commit()
+
+    _patch(
+        monkeypatch,
+        [
+            wire_scope(
+                statics=[
+                    wire_static(mac=MAC_A, ip="10.20.0.11"),  # onto B's address…
+                    wire_static(mac=MAC_B, ip="10.20.0.12"),  # …which B is leaving
+                ]
+            )
+        ],
+    )
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    await db_session.refresh(a)
+    await db_session.refresh(b)
+    assert str(a.ip_address) == "10.20.0.11"
+    assert str(b.ip_address) == "10.20.0.12"
+    assert not result.errors
+    assert await _mirror(db_session, subnet, "10.20.0.12") is not None
+
+
+@pytest.mark.asyncio
+async def test_hostname_change_on_the_wire_follows_into_ipam(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A renamed reservation keeps its address, so it is not a 'mover' — but the
+    hostname IS mirrored, and the A record is published off the mirror. Updating
+    the reservation and leaving the mirror on the old name would put IPAM and DNS
+    quietly out of step with the DHCP server."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    await _make_ui_reservation(db_session, scope)
+    await db_session.commit()
+
+    spy = _patch(monkeypatch, [wire_scope(statics=[wire_static(hostname="plotter")])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.statics_synced == 1
+    mirror = await _mirror(db_session, subnet, "10.20.0.10")
+    assert mirror is not None
+    assert mirror.hostname == "plotter"
+    assert spy.calls == ["update:10.20.0.10"]

--- a/backend/tests/test_dhcp_windows_scope_sync.py
+++ b/backend/tests/test_dhcp_windows_scope_sync.py
@@ -351,9 +351,12 @@ async def test_relocated_reservation_keeps_its_id_and_moves_its_mirror(
     moved = await _mirror(db_session, subnet, "10.20.0.77")
     assert moved is not None
     assert moved.static_assignment_id == str(original_id)
-    # The old address is no longer reserved.
-    old = await _mirror(db_session, subnet, "10.20.0.10")
-    assert old is None or old.status != "static_dhcp"
+    # The address it left is FREE — the row is gone, not merely downgraded to
+    # `allocated`. An allocated row with no owner is reclaimed by nothing (the
+    # orphan sweep only looks at `static_dhcp`, the lease mirror skips rows it
+    # doesn't own), so every renumber would leak one address. Asserting "not
+    # static_dhcp" here is what let that through the first time.
+    assert await _mirror(db_session, subnet, "10.20.0.10") is None
 
 
 @pytest.mark.asyncio
@@ -698,3 +701,91 @@ async def test_hostname_change_on_the_wire_follows_into_ipam(
     assert mirror is not None
     assert mirror.hostname == "plotter"
     assert spy.calls == ["update:10.20.0.10"]
+
+
+# ── regressions caught in review of the fix itself ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_carries_operator_columns_to_the_new_address(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Freeing the old address must not throw the operator's work away with it:
+    the columns they authored ride onto the reservation and are re-applied at the
+    new address."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    await _make_ui_reservation(db_session, scope)
+    mirror = await _mirror(db_session, subnet, "10.20.0.10")
+    assert mirror is not None
+    mirror.description = "rack 4, port 12"
+    mirror.tags = {"owner": "lab"}
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(statics=[wire_static(ip="10.20.0.77")])])
+    await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    moved = await _mirror(db_session, subnet, "10.20.0.77")
+    assert moved is not None
+    assert moved.description == "rack 4, port 12"
+    assert moved.tags == {"owner": "lab"}
+
+
+@pytest.mark.asyncio
+async def test_hostname_cleared_on_the_wire_clears_in_ipam(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator clearing a reservation's Name on the server has to converge.
+    `row.hostname = st.hostname or row.hostname` made an empty name
+    unrepresentable — the mirror kept the old one and re-published its A record,
+    forever."""
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, subnet = await _fixture(db_session)
+    await _make_ui_reservation(db_session, scope)
+    await db_session.commit()
+
+    _patch(monkeypatch, [wire_scope(statics=[wire_static(hostname="")])])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.statics_synced == 1
+    mirror = await _mirror(db_session, subnet, "10.20.0.10")
+    assert mirror is not None
+    assert mirror.hostname in (None, "")
+
+
+@pytest.mark.asyncio
+async def test_pool_created_mid_poll_is_not_absence_deleted(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same snapshot reasoning as reservations. A pool an operator added while the
+    poll was in flight is absent from a wire that never saw it — deleting it takes
+    IPAM's dynamic-range protection away, so an operator can allocate an address
+    the DHCP server is actively handing out."""
+    from datetime import UTC, datetime, timedelta
+
+    from app.services.dhcp import pull_leases as pl
+
+    srv, scope, _subnet = await _fixture(db_session)
+    fresh = DHCPPool(
+        scope_id=scope.id,
+        start_ip="10.20.0.5",
+        end_ip="10.20.0.6",
+        pool_type="excluded",
+        name="",
+    )
+    db_session.add(fresh)
+    await db_session.flush()
+    fresh.created_at = datetime.now(UTC) + timedelta(minutes=5)
+    await db_session.commit()
+
+    # Wire reports only the dynamic pool — the new exclusion isn't on it yet.
+    _patch(monkeypatch, [wire_scope()])
+    result = await pl.pull_leases_from_server(db_session, srv, apply=True)
+    await db_session.commit()
+
+    assert result.pools_removed == 0
+    assert await db_session.get(DHCPPool, fresh.id) is not None

--- a/docs/drivers/DHCP_DRIVERS.md
+++ b/docs/drivers/DHCP_DRIVERS.md
@@ -249,6 +249,22 @@ Per poll cycle:
 5. **Absence-delete** — any active `DHCPLease` row for this server whose IP didn't come back in the wire response is deleted along with its `auto_from_lease=True` IPAM mirror. The driver's `get_leases()` returns only currently-active leases, so absence means the server deleted it (admin purged / client released / etc.). `PullLeasesResult` gains `removed` + `ipam_revoked` counters; both flow into the scheduled-task audit row and the manual sync response. See [features/DHCP.md §15.3](../features/DHCP.md) for the rationale.
 6. The time-based `dhcp_lease_cleanup` sweep still handles leases that drift past `expires_at` between polls. The two mechanisms overlap harmlessly.
 
+### Scope reconcile (topology)
+
+The same beat task runs a **topology** phase ahead of the lease phase, for any driver that implements `get_scopes` — which today means Windows DHCP alone. For each wire scope whose CIDR exactly matches an IPAM `Subnet.network` (no auto-create), the scope row is upserted and its pools + reservations are **diff-merged** against the wire. Reservations are keyed on MAC, pools on `(start, end)`; a MAC / range that is already tracked is updated in place, so **a reservation keeps its row id across polls**.
+
+That id stability is load-bearing (#620). A reservation owns an `ip_address` mirror that back-links to it by id, so anything that re-creates the row (the pre-#620 reconciler Core-DELETEd and re-inserted every reservation, every poll) leaves the mirror pointing at a row Postgres has dropped — an address that is neither allocated nor free, and that deleting the reservation in the UI never frees, because the lookup keys on the *current* id. Merging also means an unchanged reservation is not written at all, which is what keeps the reconciler from re-publishing its DNS records on every tick.
+
+Reservations found on the server are mirrored into IPAM exactly like UI-created ones (`status="static_dhcp"`), via the same `upsert_ipam_for_static` helper — a reservation is an allocation whoever made it, and an IPAM that doesn't show it is an IPAM that will hand the address out twice. The mirror upsert (and therefore the DNS re-sync it performs) fires only when the reservation's address or hostname actually moved, or when its mirror is missing or stale.
+
+Three things the merge deliberately refuses to do:
+
+* **Absence-delete against a wire it can't trust.** Absence normally means "deleted on the server" — the reservation is dropped, its mirror deleted and its DNS torn down. But `_PS_LIST_TOPOLOGY` enumerates options / exclusions / reservations inside per-list `try/catch` blocks, so a failure hands back an *empty array*, not an error. The driver therefore reports `pools_ok` / `statics_ok` alongside each list, and the reconciler also declines to delete when a wholly-empty list arrives while it tracks rows (the same call the lease path's zero-wire floor guard makes, #482). Both cases record a soft error on the sync result. The trade is deliberate: a stale reservation an operator can delete beats a reservation and its A record torn down on a blip.
+* **Act on rows newer than its own information.** The wire is a snapshot taken before a multi-second WinRM round-trip. A reservation created or edited *after* that snapshot is judged against stale data, so it is skipped — otherwise a reservation created in the UI mid-poll is "absent from the wire" and gets deleted out from under the operator.
+* **Write an address change row-by-row.** Renumbering reservations on the server (`A` takes `B`'s address) produces a wire whose end state is legal but whose intermediate states violate `uq_dhcp_static_scope_ip` — which would abort the poll, and keep aborting it, since the wire keeps reporting the same state. Movers are lifted out of that partial index (it is `WHERE deleted_at IS NULL`) inside the transaction, re-addressed, and put back.
+
+`PullLeasesResult` reports `scopes_imported` / `scopes_refreshed` / `scopes_skipped_no_subnet` plus `pools_synced` / `statics_synced` (created **or changed**) and `pools_removed` / `statics_removed`. Because the merge is a diff, a steady-state poll reports zeros.
+
 ### Batched WinRM writes
 
 Per-object writes against Windows DHCP used to round-trip WinRM **per reservation / exclusion** — a bulk delete of 200 reservations took minutes. The driver now groups writes into a single PowerShell script per `(server, scope)` chunk.

--- a/docs/drivers/DHCP_DRIVERS.md
+++ b/docs/drivers/DHCP_DRIVERS.md
@@ -265,6 +265,14 @@ Three things the merge deliberately refuses to do:
 
 `PullLeasesResult` reports `scopes_imported` / `scopes_refreshed` / `scopes_skipped_no_subnet` plus `pools_synced` / `statics_synced` (created **or changed**) and `pools_removed` / `statics_removed`. Because the merge is a diff, a steady-state poll reports zeros.
 
+### The orphaned-mirror backstop
+
+A reservation owns its `ip_address` mirror by id, and every path that destroys a reservation is responsible for releasing that mirror first. When one doesn't, the result is nasty out of proportion to the mistake: the address sits at `status="static_dhcp"` pointing at a row Postgres has dropped, so it is neither allocated nor free, nothing hands it out, and *no amount of clicking in the UI frees it* — every release path looks the mirror up by the reservation's current id and matches nothing. It took a one-shot repair migration (`d7b3f2a9c15e`) to clear the last batch.
+
+So there is a recurring backstop: `app.tasks.dhcp_mirror_sweep.sweep_orphaned_mirrors`, hourly, which is that migration's step 1 made permanent. It frees any `static_dhcp` row whose **non-NULL** back-link resolves to no live reservation, deleting the row (a freed-but-persisted row still renders in the subnet table and still counts toward utilization) after tearing down its DNS. If the reservation is merely soft-deleted, the operator-authored columns are snapshotted onto it first so a Trash restore stays lossless.
+
+The predicate is deliberately narrow: a `static_dhcp` row with a **NULL** back-link is left alone, because an operator can set that status by hand and a sweep that deletes hand-made rows is worse than the bug it fixes. On a healthy install it matches nothing and writes nothing — so a non-zero `mirrors_freed` (logged at WARNING, and audited) is itself the signal that some path is still skipping its mirror release.
+
 ### Batched WinRM writes
 
 Per-object writes against Windows DHCP used to round-trip WinRM **per reservation / exclusion** — a bulk delete of 200 reservations took minutes. The driver now groups writes into a single PowerShell script per `(server, scope)` chunk.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6625,6 +6625,8 @@ export interface DHCPLeaseSyncResult {
   scopes_skipped_no_subnet: number;
   pools_synced: number;
   statics_synced: number;
+  pools_removed?: number;
+  statics_removed?: number;
   mac_blocks_added?: number;
   mac_blocks_removed?: number;
   errors: string[];

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -2599,9 +2599,16 @@ function ServerDetailView({
           scopeBits.push(
             `${result.scopes_skipped_no_subnet} skipped (no matching IPAM subnet)`,
           );
-        if (result.pools_synced) scopeBits.push(`${result.pools_synced} pools`);
+        // Counts are changes, not totals: the scope reconciler diff-merges, so
+        // an unchanged pool / reservation is not touched and not counted.
+        if (result.pools_synced)
+          scopeBits.push(`${result.pools_synced} pools changed`);
+        if (result.pools_removed)
+          scopeBits.push(`${result.pools_removed} pools removed`);
         if (result.statics_synced)
-          scopeBits.push(`${result.statics_synced} reservations`);
+          scopeBits.push(`${result.statics_synced} reservations changed`);
+        if (result.statics_removed)
+          scopeBits.push(`${result.statics_removed} reservations removed`);
         parts.push(scopeBits.join(" / "));
       }
       parts.push(`${result.server_leases} leases on wire`);


### PR DESCRIPTION
Closes part 1 of #620. **Part 2 (the `varchar → uuid` FK) is deliberately not here** — see the note at the bottom and the [comment on #620](https://github.com/spatiumddi/spatiumddi/issues/620). The issue stays open.

## The bug

`pull_leases._upsert_scope` reconciled a Windows scope by Core-DELETEing every pool + reservation under it and re-inserting them from the wire. That was written when `windows_dhcp` was read-only and its rows were pure derived state. It stopped being true once write-through landed: operators create reservations through the UI now, and a reservation owns an `ip_address` mirror that back-links to it **by id**.

So every poll minted a fresh reservation id and left the mirror pointing at a row Postgres had dropped. A Core `DELETE` runs no per-row Python, so nothing released it — the address was left neither allocated nor free, and **deleting the reservation in the UI never freed it**, because every release path looks the mirror up by the *current* id and matches nothing. This runs from the beat task, so it stranded a mirror within minutes of an operator creating one.

## The fix — merge, don't replace

Reservations match on MAC (what Windows keys them on, and what survives an address change), pools on `(start, end)`. A row keeps its id across polls, which is what makes the mirror's back-link durable. An unchanged reservation isn't written at all — so unlike the detach/re-attach repair the issue sketched, the steady state fires **no DNS churn**. Mirrors the old code stranded re-link themselves on the next poll; no migration needed.

Reservations found on the server now get an IPAM mirror too, not just UI-created ones. A reservation is an allocation whoever made it, and an IPAM that doesn't show it is one that will hand the address out twice.

### Three hazards the merge has to survive

* **A failed enumeration is indistinguishable from an empty one.** `_PS_LIST_TOPOLOGY` wraps each list in a `try/catch`, so a failure hands back an *empty array*, not an error — which a diff reads as "the operator deleted everything". The driver now reports `pools_ok` / `statics_ok`, and the reconciler additionally refuses to delete against a wholly-empty list while it tracks rows (the same call #482's zero-wire floor guard makes for leases). A stale reservation an operator can delete beats one we tore down, with its A record, on a blip.
* **The wire is a stale snapshot.** It's taken before a multi-second WinRM round-trip, so a reservation created or edited *after* it is judged on old data. Rows newer than the snapshot are skipped — otherwise a reservation created in the UI mid-poll reads as absent and gets deleted out from under the operator.
* **An address renumber can't be written row-by-row.** If A takes B's address, the end state is legal but every intermediate state violates `uq_dhcp_static_scope_ip` — aborting the poll, and every poll after it, since the wire keeps reporting the same thing. That index is partial on `deleted_at IS NULL`, so movers are lifted out of it inside the transaction, re-addressed, and put back.

## The backstop (second commit)

A stranded mirror is silent and unreachable from the UI, and clearing the last batch took a one-shot repair migration (`d7b3f2a9c15e`). An hourly sweep makes that migration's step 1 recurring, so the *next* occurrence — from a path nobody has thought of yet — costs an operator nothing.

Deliberately narrow: only rows whose **non-NULL** back-link resolves to no live reservation are touched — a state no legitimate flow produces. A `static_dhcp` row with a NULL back-link is left alone, because an operator can set that status by hand, and a sweep that deletes hand-made rows is worse than the bug it fixes. A healthy install matches nothing and writes nothing, so a non-zero `mirrors_freed` is itself the signal that some path is still skipping its release (logged at WARNING, and audited).

## Validation

Driven end-to-end against a **real Windows Server DHCP box**, not just tests:

| Scenario | Result |
|---|---|
| New PowerShell on real hardware | `pools_ok` / `statics_ok` both `true`; `Get-DhcpServerv4Reservation` returns `[]` without throwing on an empty scope |
| Steady-state re-sync | `pools_synced 0`, `statics_synced 0` — no churn (was a replace-all every tick) |
| **UI-created reservation survives a sync** | id stable, mirror still back-linked — *the reported bug* |
| **Deleting it frees the IP in IPAM** | Row → `available`, back-link cleared — *the operator-visible symptom* |
| Reservation deleted on the Windows box | Absence-deleted, mirror removed, others untouched |
| Wire returns zero reservations | Floor guard refuses to delete, surfaces the reason |
| Two reservations swap addresses | Converged in one sync, ids stable, mirrors followed |

Plus 22 new tests. Phase 1 of `pull_leases_from_server` previously had **zero** coverage — `grep -rn get_scopes backend/tests/` returned nothing, which is how this shipped.

## Why part 2 isn't here

The issue proposes retyping `ip_address.static_assignment_id` to a real uuid FK. Two things came out of costing it:

1. **`ON DELETE SET NULL` nulls the pointer but leaves `status='static_dhcp'` untouched** — so the address stays stranded either way. The FK buys referential hygiene, not the fix. What actually frees the address is the code paths (#618, and this PR).
2. **It's three releases, not two.** `STRICT_SCHEMA_CHECK` defaults off, so old Celery workers keep executing tasks against the new schema mid-rollout: expand → switch reads → drop, with the varchar surviving until nothing references it.

The FK is still worth doing as hygiene — it just isn't what makes a stranded address reclaimable, and the sweeper is. #620 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)