### PR TITLE
ci: run agent test suites + weekly Trivy scan across all images (#640)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,90 @@
+# Dependabot — proactive dependency, base-image and Actions version bumps.
+#
+# Complements the scheduled Trivy scan (trivy-scheduled.yml, #640): Trivy flags
+# KNOWN CVEs in already-built images after the fact; Dependabot opens
+# (de-duplicated) PRs to move manifests, Docker base images and GitHub Actions
+# forward *before* they rot — security updates included. Between the two, a
+# vulnerable/outdated package surfaces either as a bump PR (Dependabot) or, if it
+# slips through, as the weekly tracking issue (Trivy).
+#
+# Cadence is weekly/Monday to line up with the Trivy scheduled scan. Minor +
+# patch bumps are grouped into one PR per ecosystem to keep the noise down;
+# majors arrive as individual PRs so they get a proper review.
+#
+# NOTE: the Python manifests (backend + the three agents) use unpinned ``>=``
+# ranges with no lock file, so routine ``pip`` *version* PRs will be sparse —
+# the real value there is Dependabot *security* updates (driven by the
+# dependency graph), which fire regardless of pinning.
+version: 2
+
+updates:
+  # GitHub Actions pinned across every workflow (actions/checkout@v4,
+  # setup-python@v5, github-script@v7, aquasecurity/trivy-action, …).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions:
+        update-types: ["minor", "patch"]
+
+  # ``FROM`` base images in every shipped Dockerfile — the exact rot the #640
+  # scheduled Trivy scan catches after the fact (e.g. #639's stale golang pin);
+  # Dependabot bumps them proactively instead.
+  - package-ecosystem: "docker"
+    directories:
+      - "/backend"
+      - "/frontend"
+      - "/agent/dhcp/images/kea"
+      - "/agent/dns/images/bind9"
+      - "/agent/dns/images/powerdns"
+      - "/agent/dns/images/dnsdist"
+      - "/agent/supervisor/images/supervisor"
+      - "/agent/looking-glass/images/gobgp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      docker-base-images:
+        update-types: ["minor", "patch"]
+
+  # Python — control plane (backend) plus the three standalone agents.
+  - package-ecosystem: "pip"
+    directories:
+      - "/backend"
+      - "/agent/dhcp"
+      - "/agent/dns"
+      - "/agent/supervisor"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python:
+        update-types: ["minor", "patch"]
+
+  # Frontend — React / Vite / TypeScript (package-lock.json present).
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,3 +203,64 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  # ── Agents ───────────────────────────────────────────────────────────────────
+  # The standalone agents (DNS / DHCP / supervisor) each ship their own test
+  # suite under ``agent/<name>/tests`` but were never run in CI — ``ci.yml``
+  # only ever touched ``backend`` + ``frontend`` (issue #640). That let
+  # ``agent/supervisor`` sit RED on main undetected, which in turn hid a real
+  # production bug (the ``PeerResolveWatcher`` ``AttributeError`` on the
+  # bootstrap-from-cache path — see #640). These suites are DB-less and fast
+  # (~1-2 s each), so running them on every PR is nearly free.
+  #
+  # NOTE: agent code is NOT yet lint-checked (Backend Lint scopes to
+  # ``backend/app`` + ``backend/tests``) and carries pre-existing ruff/black
+  # drift, so this job runs *tests only*. Bringing agent code under lint is a
+  # separate, larger cleanup (~30 files of black reformatting) deliberately
+  # left out of #640 to keep this change focused.
+  agent-test-shard:
+    name: Agent — Tests (${{ matrix.agent }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        agent: [dhcp, dns, supervisor]
+    defaults:
+      run:
+        working-directory: agent/${{ matrix.agent }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: agent/${{ matrix.agent }}/pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        # The ``@pytest.mark.e2e`` acceptance tests self-``skip()`` when their
+        # docker/live-daemon prerequisites are absent, so a plain ``pytest``
+        # run stays hermetic (no database, no network) — see each agent's
+        # ``tests/test_acceptance.py``.
+        run: python -m pytest tests -q
+
+  # Required-status-check aggregator: branch protection can gate on the stable
+  # name "Agent — Tests"; this job passes only if all three agent suites did.
+  # Keep this name (and the matrix above) in sync with the required check.
+  agent-test:
+    name: Agent — Tests
+    runs-on: ubuntu-latest
+    needs: [agent-test-shard]
+    if: always()
+    steps:
+      - name: All agent suites passed
+        run: |
+          result="${{ needs.agent-test-shard.result }}"
+          if [ "$result" != "success" ]; then
+            echo "::error::one or more agent test suites failed (result=$result)"
+            exit 1
+          fi
+          echo "all agent test suites passed"

--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -1,0 +1,243 @@
+name: Scheduled Image Vulnerability Scan
+
+# Why this exists (issue #640, Gap 2):
+#
+# The per-image ``build-*-images.yml`` workflows are path-filtered and their
+# Trivy step is PR-only, so an image is scanned ONLY when someone happens to
+# touch its Dockerfile. Between those moments upstream CVEs land and nothing
+# looks — until an unrelated PR trips the Dockerfile path filter and inherits
+# a pre-existing HIGH/CRITICAL it didn't introduce (exactly what happened to
+# #639: an Alpine bump surfaced a months-old ``golang`` stdlib CVE).
+#
+# This job scans EVERY shipped container image on a fixed weekly cadence,
+# independent of path filters, and funnels findings into a single tracking
+# issue so a newly-published CVE surfaces on its own instead of ambushing the
+# next contributor. It uses CI's exact gate — HIGH,CRITICAL + --ignore-unfixed
+# (matching ``make trivy`` and the ``build-*-images.yml`` Trivy steps).
+#
+# Unlike ``make trivy`` (six agent images — the contributor pre-push gate),
+# this superset also covers ``backend/Dockerfile`` + ``frontend/Dockerfile``,
+# which had no Trivy coverage anywhere.
+
+on:
+  schedule:
+    # Mondays 06:17 UTC. Off the top of the hour to avoid the cron stampede
+    # that delays runner scheduling on shared infrastructure.
+    - cron: "17 6 * * 1"
+  workflow_dispatch: {}
+
+concurrency:
+  group: trivy-scheduled
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan:
+    name: Trivy — all shipped images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and scan every image
+        id: scan
+        run: |
+          set -uo pipefail
+
+          # One spec per shipped image: name|dockerfile|context|target
+          # Contexts mirror release.yml: the agent images build from the repo
+          # root, backend from ./backend, frontend from ./frontend. Targets:
+          # backend is pinned to ``runtime`` — the documented production stage
+          # (backend/Dockerfile); its final ``dev`` stage only layers test
+          # tooling on top, which we don't ship-scan. frontend's last stage is
+          # already the nginx ``runtime``, so no target is needed;
+          # ``VITE_APP_VERSION`` defaults to ``dev`` in the Dockerfile and is
+          # irrelevant to a CVE scan.
+          specs=(
+            "kea|agent/dhcp/images/kea/Dockerfile|.|"
+            "bind9|agent/dns/images/bind9/Dockerfile|.|"
+            "powerdns|agent/dns/images/powerdns/Dockerfile|.|"
+            "dnsdist|agent/dns/images/dnsdist/Dockerfile|.|"
+            "supervisor|agent/supervisor/images/supervisor/Dockerfile|.|"
+            "looking-glass|agent/looking-glass/images/gobgp/Dockerfile|.|"
+            "backend|backend/Dockerfile|./backend|runtime"
+            "frontend|frontend/Dockerfile|./frontend|"
+          )
+
+          # Shared Trivy cache so the vuln DB downloads once for the whole
+          # job rather than once per image (8× ghcr pulls risks rate limits).
+          cache="$RUNNER_TEMP/trivy-cache"
+          mkdir -p "$cache"
+
+          report="$RUNNER_TEMP/findings.md"
+          : > "$report"
+          any=0
+
+          for spec in "${specs[@]}"; do
+            IFS='|' read -r name df ctx target <<< "$spec"
+            echo "::group::$name ($df)"
+
+            build=(docker build -q -f "$df" -t "trivy-scan-$name:scan")
+            [ -n "$target" ] && build+=(--target "$target")
+            build+=("$ctx")
+            if ! "${build[@]}"; then
+              echo "❌ build failed"
+              {
+                echo "### \`$name\` — ⚠️ image build FAILED"
+                echo ""
+                echo "The scheduled scan could not build this image (see the run log)."
+                echo ""
+              } >> "$report"
+              any=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            # CI's exact gate: HIGH,CRITICAL + fix-available only. exit-code 1
+            # ⇒ findings, 0 ⇒ clean, ≥2 ⇒ scan error. Table → stdout, logs →
+            # stderr (kept out of the report).
+            docker run --rm \
+              -v /var/run/docker.sock:/var/run/docker.sock \
+              -v "$cache":/root/.cache/ \
+              aquasec/trivy:latest image \
+              --severity HIGH,CRITICAL --ignore-unfixed --scanners vuln \
+              --format table --exit-code 1 -q \
+              "trivy-scan-$name:scan" > "$RUNNER_TEMP/trivy-$name.txt" 2>"$RUNNER_TEMP/trivy-$name.log"
+            rc=$?
+
+            if [ "$rc" -eq 0 ]; then
+              echo "✅ clean"
+            elif [ "$rc" -eq 1 ]; then
+              echo "🚨 findings"
+              any=1
+              {
+                echo "### \`$name\` (\`$df\`)"
+                echo ""
+                echo '```'
+                head -c 12000 "$RUNNER_TEMP/trivy-$name.txt"
+                echo '```'
+                echo ""
+              } >> "$report"
+            else
+              echo "⚠️ trivy scan error (rc=$rc)"
+              any=1
+              {
+                echo "### \`$name\` — ⚠️ Trivy scan error (rc=$rc)"
+                echo ""
+                echo '```'
+                tail -c 4000 "$RUNNER_TEMP/trivy-$name.log"
+                echo '```'
+                echo ""
+              } >> "$report"
+            fi
+            echo "::endgroup::"
+          done
+
+          echo "has_findings=$any" >> "$GITHUB_OUTPUT"
+
+          # Human-readable rollup on the run's summary page regardless of outcome.
+          {
+            echo "## Scheduled Trivy scan"
+            echo ""
+            if [ "$any" -eq 0 ]; then
+              echo "✅ All shipped images clean (HIGH/CRITICAL, fix-available)."
+            else
+              cat "$report"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Never fail the job on findings — the tracking issue is the durable
+          # signal (a red weekly run would just add notification noise). The
+          # job only fails if the scan step itself errors out above.
+          exit 0
+
+      - name: Open, update or close the tracking issue
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          HAS_FINDINGS: ${{ steps.scan.outputs.has_findings }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+
+            // Fail safe: if the scan step was killed (OOM / timeout) before it
+            // wrote its output, ``has_findings`` interpolates to '' here. We do
+            // NOT know the images are clean, so leave the tracking issue exactly
+            // as it is — closing it on an indeterminate result would mask real,
+            // still-unfixed CVEs.
+            const raw = process.env.HAS_FINDINGS;
+            if (raw !== '0' && raw !== '1') {
+              core.warning(
+                `Scan produced no definitive result (has_findings=${JSON.stringify(raw)}); ` +
+                `leaving any tracking issue untouched.`);
+              return;
+            }
+            const hasFindings = raw === '1';
+
+            const label = 'security:trivy';
+            const title = 'Scheduled Trivy scan: HIGH/CRITICAL CVEs in shipped images';
+            const marker = '<!-- trivy-scheduled-scan -->';
+
+            // Ensure the label exists (idempotent).
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              await github.rest.issues.createLabel({
+                owner, repo, name: label, color: 'b60205',
+                description: 'Automated weekly Trivy image scan findings',
+              });
+            }
+
+            // Find our open tracking issue (by label, confirmed via body
+            // marker). listForRepo returns PRs too — they're issues in the REST
+            // API — so drop anything with a ``pull_request`` field before matching.
+            const open = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: label, per_page: 100,
+            })).data.filter(i => !i.pull_request).find(i => (i.body || '').includes(marker));
+
+            if (hasFindings) {
+              let report = '(report file missing — see the run log)';
+              const path = `${process.env.RUNNER_TEMP}/findings.md`;
+              if (fs.existsSync(path)) report = fs.readFileSync(path, 'utf8');
+              let body =
+                `${marker}\n\n` +
+                `The weekly image vulnerability scan found **HIGH/CRITICAL, ` +
+                `fix-available** CVEs (or a scan/build error).\n\n` +
+                `- Scan run: ${runUrl}\n- Last updated: ${today}\n\n` +
+                `${report}\n\n---\n` +
+                `Reproduce the agent images locally with \`make trivy\`. ` +
+                `This issue auto-closes when a later scheduled scan is clean.`;
+              // GitHub caps issue bodies at 65536 chars.
+              if (body.length > 60000) body = body.slice(0, 60000) + '\n\n_…truncated._';
+
+              if (open) {
+                await github.rest.issues.update({ owner, repo, issue_number: open.number, body });
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: open.number,
+                  body: `🔁 Still failing as of ${today} — ${runUrl}`,
+                });
+                core.info(`Updated tracking issue #${open.number}`);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner, repo, title, labels: [label], body,
+                });
+                core.info(`Opened tracking issue #${created.data.number}`);
+              }
+            } else if (open) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: open.number,
+                body: `✅ All shipped images clean as of ${today} — ${runUrl}. Closing.`,
+              });
+              await github.rest.issues.update({
+                owner, repo, issue_number: open.number, state: 'closed',
+              });
+              core.info(`Closed tracking issue #${open.number} (now clean)`);
+            } else {
+              core.info('All images clean; no open tracking issue to close.');
+            }

--- a/agent/supervisor/tests/test_register.py
+++ b/agent/supervisor/tests/test_register.py
@@ -34,6 +34,10 @@ def test_register_happy_path(tmp_path: Path) -> None:
                 "appliance_id": "11111111-2222-3333-4444-555555555555",
                 "state": "pending_approval",
                 "public_key_fingerprint": identity.fingerprint,
+                # Register returns a cleartext session token the supervisor
+                # re-presents on every poll/heartbeat until approval lands
+                # the mTLS switch (see RegisterResult.session_token).
+                "session_token": "tok-abc123",
             },
         )
 
@@ -48,6 +52,7 @@ def test_register_happy_path(tmp_path: Path) -> None:
     )
     assert result.appliance_id == "11111111-2222-3333-4444-555555555555"
     assert result.state == "pending_approval"
+    assert result.session_token == "tok-abc123"
     assert (
         captured["url"]
         == "https://ddi.example.com/api/v1/appliance/supervisor/register"
@@ -107,6 +112,7 @@ def test_register_retries_on_5xx_then_succeeds(tmp_path: Path) -> None:
                 "appliance_id": "11111111-2222-3333-4444-555555555555",
                 "state": "pending_approval",
                 "public_key_fingerprint": identity.fingerprint,
+                "session_token": "tok-abc123",
             },
         )
 

--- a/agent/supervisor/tests/test_smoke.py
+++ b/agent/supervisor/tests/test_smoke.py
@@ -36,7 +36,10 @@ def test_config_defaults_from_empty_env(monkeypatch) -> None:
     assert cfg.control_plane_url == ""
     assert cfg.state_dir == Path("/var/lib/spatium-supervisor")
     assert cfg.bootstrap_pairing_code == ""
-    assert cfg.heartbeat_interval_seconds == 60
+    # 30s default cadence — operator feedback that 60s felt sluggish on
+    # role-swap (reconcile_node_labels only fires per heartbeat). See the
+    # comment on SupervisorConfig.from_env.
+    assert cfg.heartbeat_interval_seconds == 30
     assert cfg.hostname  # gethostname() always returns something
 
 
@@ -94,4 +97,11 @@ def test_entrypoint_drops_to_unprivileged_user() -> None:
     # The supervisor must not run as root in the container — only the
     # bind-mounted sockets/dirs we mount in get root-capable access,
     # not the Python entrypoint.
-    assert "su-exec spatium:spatium" in text
+    assert "su-exec spatium /usr/local/bin/spatium-supervisor" in text
+    # Must NOT pin an explicit ``:group``. ``su-exec spatium:spatium``
+    # clears supplementary groups, which locks the unprivileged user out
+    # of the host docker.sock (owned root:<docker-gid>); the entrypoint
+    # instead adds spatium to a matching docker group and drops the
+    # ``:group`` so initgroups() keeps it. Regressing this silently
+    # re-breaks docker access — hence the negative assertion.
+    assert "su-exec spatium:spatium" not in text


### PR DESCRIPTION
Closes #640

Two CI safety-net holes, both the same shape — *a gate that only fires on some
changes, so rot accumulates silently*.

## Gap 1 — CI never ran the agent test suites

`ci.yml` only ever touched `backend` + `frontend`, so `agent/{dhcp,dns,supervisor}/tests`
were invisible to CI. That let **`agent/supervisor` sit RED on `main`** undetected
(4 failing tests), which is exactly how the class of bug the issue describes hides.

**Added** an `Agent — Tests (<agent>)` matrix job over all three suites (DB-less,
~1–2 s each) plus a stable **`Agent — Tests`** aggregator, mirroring the existing
`Backend — Tests` shard/aggregator pattern.

**Fixed** the 4 stale `agent/supervisor` failures — in each case the *code* was
correct and the *test* had lagged behind an intentional change, so the tests were
brought in line and **regression-guarded**:

| Test | Was asserting | Reality | Fix |
|---|---|---|---|
| `test_register_happy_path`, `…retries_on_5xx…` | register response had no `session_token` | the endpoint returns `session_token` (re-presented on poll/heartbeat until approval) and `RegisterResult` requires it | add `session_token` to the mocks + assert it |
| `test_config_defaults_from_empty_env` | `heartbeat_interval_seconds == 60` | default is **30** (operator feedback — `reconcile_node_labels` fires per heartbeat) | assert `== 30` |
| `test_entrypoint_drops_to_unprivileged_user` | `su-exec spatium:spatium` | entrypoint deliberately dropped the `:group` so `initgroups()` keeps the docker.sock supplementary group | assert `su-exec spatium <bin>` **and** `su-exec spatium:spatium` **not** in text (guards the regression) |

Verified locally: dhcp `97 passed`, dns `46 passed`, supervisor `252 passed`.

## Gap 2 — Trivy only scanned an image when its own Dockerfile changed

The `build-*-images.yml` Trivy steps are path-filtered + PR-only, so upstream CVEs
accumulate silently until an unrelated PR trips a Dockerfile path filter and inherits
a pre-existing HIGH/CRITICAL it didn't introduce (what happened to #639).

**Added** `.github/workflows/trivy-scheduled.yml` — a weekly (Mon 06:17 UTC) +
`workflow_dispatch` scan across **all eight shipped images**, independent of path
filters, using CI's exact gate (`HIGH,CRITICAL` + `--ignore-unfixed`, matching
`make trivy`):

- six agent images (`kea`, `bind9`, `powerdns`, `dnsdist`, `supervisor`,
  `looking-glass`) **plus `backend` + `frontend`**, which had no Trivy coverage
  anywhere.
- Findings funnel into a **single tracking issue** (label `security:trivy`) that the
  run opens / updates / auto-closes-when-clean, so a new CVE surfaces on its own
  cadence instead of ambushing the next contributor. The weekly run itself stays
  green (the issue is the durable signal — no notification-noise red runs).

## Dependabot (added on request)

Trivy flags *known CVEs in built images after the fact*; it won't proactively
bump a merely-outdated package. Added `.github/dependabot.yml` as the
complementary front half — deduplicated PRs to move dependencies, Docker base
images and Actions forward *before* they rot:

- **github-actions** (`/`), **docker** (all 8 shipped Dockerfiles),
  **pip** (backend + the three agents), **npm** (frontend).
- Weekly/Monday (aligned with the Trivy scan); minor+patch grouped per
  ecosystem to limit noise, majors as individual PRs.
- The Python manifests are unpinned `>=` ranges with no lock file, so `pip`
  value there is mainly Dependabot **security** updates (graph-driven) rather
  than routine version bumps — full routine-bump value lands on docker /
  actions / npm.

Between the two: an outdated/vulnerable package surfaces as a bump PR
(Dependabot) or, if it slips through, as the weekly tracking issue (Trivy).

## Acceptance criteria

- [x] All three agent suites run in CI on every PR; the 4 `agent/supervisor` failures fixed
- [x] A scheduled Trivy scan covers all six agent images regardless of path filters
- [x] `backend/Dockerfile` + `frontend/Dockerfile` are scanned too
- [x] A newly-published CVE in an untouched image surfaces on its own (weekly → tracking issue)

## Notes / deliberate scope decisions

- **Agent lint left out of scope** (the issue flags this as an open decision).
  Agent code carries pre-existing ruff/black drift (~30 files would reformat); this
  PR runs *tests only* to stay focused. Bringing agent code under lint is a separate
  cleanup.
- **New checks aren't required-status yet.** `Agent — Tests` (+ the three matrix legs)
  will run and be visible on every PR immediately, but won't *block* merges until
  added to the `main` branch-protection ruleset — a one-click follow-up for a maintainer.
- **Spotted while here (not fixed — separate concern):** `release.yml` builds the
  backend image with **no `--target`**, so it defaults to the Dockerfile's final
  `dev` stage (which layers in `pytest`/`pytest-xdist`/…), contradicting the
  Dockerfile's "release pipeline stops at `runtime`" comment. The shipped `api` image
  is heavier than intended. The scheduled scan pins `--target runtime` (the documented
  production stage) so it scans the intended image; worth a follow-up to add
  `target: runtime` to the release build.

## Code review

Ran `/code-review` (max effort) on the diff. Two robustness defects in the
`github-script` issue-management step were found and fixed in this PR:

1. **False-close masks CVEs** *(medium)* — if the scan step is killed (OOM/timeout)
   before writing its output, `has_findings` interpolates to `""` and the old code
   took the "clean" branch, **closing an open tracking issue**. Now bails out and
   leaves the issue untouched on any indeterminate result.
2. **PR match** *(low)* — `listForRepo({labels})` returns PRs too; a PR carrying the
   label + marker could be mutated as the tracking issue. Now filters `!pull_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
