### PR TITLE
ci(dependabot): exclude lint/format toolchain from npm auto-bumps (#640)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -132,3 +132,13 @@ updates:
       # (grouped) + Dependabot security updates still flow.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # The lint/format toolchain reformats or re-lints the WHOLE codebase on a
+      # bump — pure CI churn, not a code change (prettier 3.4→3.9 reflowed every
+      # file; an eslint-plugin-react-refresh bump added new warnings). Bump these
+      # deliberately together with the matching reformat/lint pass, never via a
+      # weekly auto-PR. (These are dev-only tools; security isn't a concern.)
+      - dependency-name: "prettier"
+      - dependency-name: "eslint*"
+      - dependency-name: "@eslint/*"
+      - dependency-name: "typescript-eslint"
+      - dependency-name: "@typescript-eslint/*"


### PR DESCRIPTION
Follow-up to #640/#680. The npm minor/patch group's remaining CI failure was pure dev-tooling churn: **prettier 3.4→3.9** reflows every source file (`format:check` fails on untouched files) and an **eslint-plugin-react-refresh** bump added new warnings. These reformat/re-lint the whole codebase and must be done deliberately with the matching pass — not a weekly auto-PR.

Excludes `prettier` + the `eslint`/`typescript-eslint` toolchain from npm auto-bumps. The npm group stays runtime-only (radix, react-query, axios, recharts, lucide, types, build tooling) and mergeable; the toolchain is bumped deliberately when someone runs the reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)