### PR TITLE
ci(dependabot): pin agent images to alpine 3.23 (3.24 breaks agents) (#640)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,8 +81,17 @@ updates:
       - dependency-name: "python"
         update-types:
           ["version-update:semver-minor", "version-update:semver-major"]
-      # Defer base-image majors (node 22→26, alpine 3→4, …); base-image CVEs
-      # are backstopped by the weekly Trivy scan. Minor/patch flow grouped.
+      # Alpine 3.24 bumps the bundled Python 3.12→3.13, which breaks the agent
+      # images: they install spatium_*_agent for 3.12, so on 3.24 the module
+      # lands on the wrong Python path -> "ModuleNotFoundError: No module named
+      # 'spatium_dns_agent'" -> CrashLoopBackOff (caught by agent-e2e on #672).
+      # Pin the agents to alpine 3.23.x until their Dockerfiles are updated for
+      # 3.13; patch bumps (3.23.x) still flow. The 3.24 move is a deliberate task.
+      - dependency-name: "alpine"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-major"]
+      # Defer base-image majors (node 22→26, …); base-image CVEs are backstopped
+      # by the weekly Trivy scan. Minor/patch flow grouped.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 


### PR DESCRIPTION
Dependabot's `alpine 3.23→3.24` base-image bump (#672) surfaced a **real incompatibility**, not a flake. Alpine 3.24 ships **Python 3.13**, but the agent Dockerfiles install `spatium_*_agent` for **3.12**, so on 3.24 the module isn't on the runtime Python's path:

```
ModuleNotFoundError: No module named 'spatium_dns_agent'
dns-bind9-ns1-0        0/1  CrashLoopBackOff
dns-powerdns-pdns1-0   0/1  CrashLoopBackOff
```

(caught by `agent-e2e` — exactly its job.)

Pin the agents to **alpine 3.23.x** (ignore minor+major, like the Python pin) so Dependabot stops re-offering the breaking bump weekly. 3.23.x patch bumps still flow; Trivy backstops base-image CVEs. **Moving the agents to alpine 3.24 / Python 3.13 is a deliberate follow-up** (bump the Dockerfiles' `PYTHON_VERSION` + verify the agents on 3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)