### PR TITLE
fix(deps): patch npm audit highs — brace-expansion + js-yaml (dev, transitive)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1079,9 +1079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1099,9 +1096,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1119,9 +1113,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1139,9 +1130,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1159,9 +1147,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1179,9 +1164,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1661,9 +1643,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1964,9 +1946,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3201,9 +3184,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Clears the three high-severity Dependabot alerts on `main` (#21, #22, #23). All are **npm development-dependency**, **transitive** (in `frontend/package-lock.json`), DoS / CPU-consumption class — build/lint tooling, not production runtime, not RCE.

Fix is `npm audit fix` (no `--force`), **lockfile-only**:

| Alert | Package | Bump | Advisory |
|---|---|---|---|
| #21 | brace-expansion (nested) | 5.0.6 → 5.0.7 | GHSA-3jxr-9vmj-r5cp |
| #22 | brace-expansion (top) | 1.1.14 → 1.1.16 | GHSA-3jxr-9vmj-r5cp |
| #23 | js-yaml | 4.2.0 → 4.3.0 | GHSA-52cp-r559-cp3m |

## Notes

- `frontend/package.json` (direct deps) is **unchanged** — same-major patch bumps of transitive deps only.
- `npm audit` now reports **0 vulnerabilities**; `npm run build` and `npm run lint` both pass locally (matching the Frontend CI jobs).
- Merging removes the vulnerable versions from the default branch, so the three Dependabot alerts auto-dismiss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
