### PR TITLE
feat(backup): restore drills — prove backup archives are actually restorable (#702)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -432,6 +432,12 @@ backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_column:207
 backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_table:199
 backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_table:201
 backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_table:203
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:132
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:133
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:134
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:135
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:136
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_table:131
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:292
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:298
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:305

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -432,12 +432,12 @@ backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_column:207
 backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_table:199
 backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_table:201
 backend/alembic/versions/c9f2e1a4d7b6_dnsbl_monitoring.py:drop_table:203
-backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:132
-backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:133
-backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:134
-backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:135
 backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:136
-backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_table:131
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:137
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:138
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:139
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_column:140
+backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_table:135
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:292
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:298
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:305

--- a/backend/alembic/versions/c9f4a71b8e35_restore_drills.py
+++ b/backend/alembic/versions/c9f4a71b8e35_restore_drills.py
@@ -116,8 +116,13 @@ def upgrade() -> None:
         sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("duration_ms", sa.Integer(), nullable=True),
     )
-    op.create_index("ix_restore_drill_target_id", "restore_drill", ["target_id"])
-    # The drilldown query is always "latest runs for this target".
+    # Both real access patterns are per-target-newest-first: the list
+    # endpoint scoped to a target, and the alert matcher's
+    # ``row_number() OVER (PARTITION BY target_id ORDER BY started_at
+    # DESC)``. A separate single-column index on ``target_id`` would be
+    # redundant — Postgres serves ``WHERE target_id = ?`` from this
+    # index's leading column at effectively the same cost, and the
+    # second index would just add a write on every insert.
     op.create_index(
         "ix_restore_drill_target_started",
         "restore_drill",
@@ -127,7 +132,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_index("ix_restore_drill_target_started", table_name="restore_drill")
-    op.drop_index("ix_restore_drill_target_id", table_name="restore_drill")
     op.drop_table("restore_drill")
     op.drop_column("backup_target", "drill_last_at")
     op.drop_column("backup_target", "drill_last_status")

--- a/backend/alembic/versions/c9f4a71b8e35_restore_drills.py
+++ b/backend/alembic/versions/c9f4a71b8e35_restore_drills.py
@@ -1,0 +1,136 @@
+"""restore drills: scheduled test-restore verification of backup archives
+
+Revision ID: c9f4a71b8e35
+Revises: b7e2c40a9d18
+Create Date: 2026-07-24 12:00:00.000000
+
+Issue #702 — the backup system (#117) could write archives to eight
+destination kinds but never proved any of them were restorable. The
+common real-world failure isn't a lost site, it's discovering at
+recovery time that the archives were bad all along.
+
+A drill downloads a target's newest archive, replays it into a
+throwaway scratch database, asserts against the result, and drops the
+scratch database. The live database is never touched.
+
+Two pieces of schema:
+
+* ``backup_target`` gains its own drill cadence — ``drill_enabled`` /
+  ``drill_cron`` / ``drill_next_run_at`` mirror the existing backup
+  schedule columns, deliberately separate because a drill is far more
+  expensive than a backup and wants a slower cron (weekly drills
+  against nightly backups is the expected shape). ``drill_last_status``
+  / ``drill_last_at`` are denormalised rollups so the targets list can
+  render a chip without a per-row subquery.
+* ``restore_drill`` is the history of record — one row per run, with
+  the per-check verdicts in a JSONB ``assertions`` list rather than a
+  column per check, so adding a check later needs no migration.
+
+Every new ``backup_target`` column carries a server default matching
+the model default, so existing rows land with drills off and nothing
+changes until an operator opts in.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "c9f4a71b8e35"
+down_revision = "b7e2c40a9d18"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "backup_target",
+        sa.Column(
+            "drill_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "backup_target",
+        sa.Column("drill_cron", sa.String(length=120), nullable=True),
+    )
+    op.add_column(
+        "backup_target",
+        sa.Column("drill_next_run_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "backup_target",
+        sa.Column(
+            "drill_last_status",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'never'"),
+        ),
+    )
+    op.add_column(
+        "backup_target",
+        sa.Column("drill_last_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "restore_drill",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "target_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("backup_target.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "state",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'running'"),
+        ),
+        sa.Column(
+            "triggered_by",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'manual'"),
+        ),
+        sa.Column("filename", sa.String(length=255), nullable=True),
+        sa.Column("archive_bytes", sa.BigInteger(), nullable=True),
+        sa.Column("manifest", JSONB(), nullable=True),
+        sa.Column("scratch_db", sa.String(length=80), nullable=True),
+        sa.Column(
+            "assertions",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+    )
+    op.create_index("ix_restore_drill_target_id", "restore_drill", ["target_id"])
+    # The drilldown query is always "latest runs for this target".
+    op.create_index(
+        "ix_restore_drill_target_started",
+        "restore_drill",
+        ["target_id", "started_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_restore_drill_target_started", table_name="restore_drill")
+    op.drop_index("ix_restore_drill_target_id", table_name="restore_drill")
+    op.drop_table("restore_drill")
+    op.drop_column("backup_target", "drill_last_at")
+    op.drop_column("backup_target", "drill_last_status")
+    op.drop_column("backup_target", "drill_next_run_at")
+    op.drop_column("backup_target", "drill_cron")
+    op.drop_column("backup_target", "drill_enabled")

--- a/backend/app/api/v1/backup/__init__.py
+++ b/backend/app/api/v1/backup/__init__.py
@@ -1,13 +1,16 @@
 from fastapi import APIRouter
 
+from app.api.v1.backup.drills import router as _drills
 from app.api.v1.backup.router import router as _root
 from app.api.v1.backup.targets import router as _targets
 
-# Mount the targets sub-router under ``/backup/targets``. The
-# parent router stays at ``/backup`` (download / restore /
+# Mount the targets sub-router under ``/backup/targets`` and the
+# restore-drill sub-router under ``/backup/drills``. The parent
+# router stays at ``/backup`` (download / restore /
 # manifest-preview).
 router = APIRouter()
 router.include_router(_root)
 router.include_router(_targets, prefix="/targets")
+router.include_router(_drills, prefix="/drills")
 
 __all__ = ["router"]

--- a/backend/app/api/v1/backup/drills.py
+++ b/backend/app/api/v1/backup/drills.py
@@ -14,7 +14,7 @@ manual "run one now" kick.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query
@@ -24,9 +24,12 @@ from sqlalchemy import desc, select
 from app.api.deps import DB, CurrentUser
 from app.core.demo_mode import forbid_in_demo_mode
 from app.core.permissions import is_effective_superadmin
-from app.models.audit import AuditLog
 from app.models.backup import BackupTarget, RestoreDrill
-from app.services.backup.drill import run_drill_for_target
+from app.services.backup.drill import (
+    compute_drill_readiness,
+    drill_mutex_is_stale,
+    run_drill_for_target,
+)
 
 router = APIRouter()
 
@@ -99,6 +102,28 @@ async def list_drills(
     return [_to_response(row, target_name=name) for row, name in rows]
 
 
+@router.get("/readiness")
+async def get_readiness(db: DB, current_user: CurrentUser) -> dict[str, Any]:
+    """Per-target recovery readiness — "can I restore this, and how do
+    I know?".
+
+    Registered before ``/{drill_id}`` so the literal path isn't
+    swallowed by the UUID route. Shares
+    :func:`compute_drill_readiness` with the Operator Copilot tool, so
+    the UI and the assistant can't disagree about whether a backup is
+    proven.
+    """
+    _require_superadmin(current_user)
+    rows = await compute_drill_readiness(db)
+    verified = sum(1 for r in rows if r["verified"])
+    return {
+        "targets": rows,
+        "total_targets": len(rows),
+        "verified_targets": verified,
+        "unverified_targets": len(rows) - verified,
+    }
+
+
 @router.get("/{drill_id}", response_model=RestoreDrillResponse)
 async def get_drill(drill_id: uuid.UUID, db: DB, current_user: CurrentUser) -> RestoreDrillResponse:
     _require_superadmin(current_user)
@@ -137,31 +162,24 @@ async def run_drill_now(
     row = await db.get(BackupTarget, target_id)
     if row is None:
         raise HTTPException(status_code=404, detail="backup target not found")
-    if row.drill_last_status == "in_progress":
+    # Same staleness escape the sweep applies. Without it, a mutex
+    # stranded by an api restart or a client disconnect would 409 this
+    # endpoint forever with no operator-reachable way to clear the flag
+    # (``drill_last_status`` isn't writable through the target API).
+    if row.drill_last_status == "in_progress" and not drill_mutex_is_stale(row, datetime.now(UTC)):
         raise HTTPException(
             status_code=409,
             detail="a drill is already running against this target",
         )
 
-    drill = await run_drill_for_target(db, target=row, triggered_by="manual")
-    db.add(
-        AuditLog(
-            action="backup_restore_drill",
-            resource_type="backup_target",
-            resource_id=str(row.id),
-            resource_display=row.name,
-            user_id=current_user.id,
-            user_display_name=current_user.username,
-            result="success" if drill.state == "passed" else "failure",
-            error_detail=drill.error,
-            new_value={
-                "drill_id": str(drill.id),
-                "state": drill.state,
-                "filename": drill.filename,
-                "duration_ms": drill.duration_ms,
-                "assertions": drill.assertions,
-            },
-        )
+    # The runner writes the audit row itself so scheduled drills are
+    # audited on the same path — see ``run_drill_for_target``.
+    drill = await run_drill_for_target(
+        db,
+        target=row,
+        triggered_by="manual",
+        actor_id=current_user.id,
+        actor_display=current_user.username,
     )
     await db.commit()
     await db.refresh(drill)

--- a/backend/app/api/v1/backup/drills.py
+++ b/backend/app/api/v1/backup/drills.py
@@ -1,0 +1,168 @@
+"""Restore-verification drill endpoints (issue #702).
+
+Mounted at ``/backup/drills`` by the parent backup router. All
+gated to superadmin, matching the rest of the backup surface: a
+drill result names the destination and the archive, which is the
+same class of metadata the targets endpoints protect.
+
+Drills are read-mostly — the schedule itself lives on the backup
+target (``drill_enabled`` / ``drill_cron``, set through
+``PATCH /backup/targets/{id}``), so the only mutation here is the
+manual "run one now" kick.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import desc, select
+
+from app.api.deps import DB, CurrentUser
+from app.core.demo_mode import forbid_in_demo_mode
+from app.core.permissions import is_effective_superadmin
+from app.models.audit import AuditLog
+from app.models.backup import BackupTarget, RestoreDrill
+from app.services.backup.drill import run_drill_for_target
+
+router = APIRouter()
+
+
+def _require_superadmin(current_user: CurrentUser) -> None:
+    if not is_effective_superadmin(current_user):
+        raise HTTPException(
+            status_code=403,
+            detail="restore drills are restricted to superadmin users",
+        )
+
+
+class RestoreDrillResponse(BaseModel):
+    id: uuid.UUID
+    target_id: uuid.UUID
+    target_name: str | None = None
+    state: str
+    triggered_by: str
+    filename: str | None
+    archive_bytes: int | None
+    manifest: dict[str, Any] | None
+    scratch_db: str | None
+    assertions: list[dict[str, Any]]
+    error: str | None
+    started_at: datetime
+    finished_at: datetime | None
+    duration_ms: int | None
+
+
+def _to_response(row: RestoreDrill, *, target_name: str | None = None) -> RestoreDrillResponse:
+    return RestoreDrillResponse(
+        id=row.id,
+        target_id=row.target_id,
+        target_name=target_name,
+        state=row.state,
+        triggered_by=row.triggered_by,
+        filename=row.filename,
+        archive_bytes=row.archive_bytes,
+        manifest=row.manifest,
+        scratch_db=row.scratch_db,
+        assertions=row.assertions or [],
+        error=row.error,
+        started_at=row.started_at,
+        finished_at=row.finished_at,
+        duration_ms=row.duration_ms,
+    )
+
+
+@router.get("", response_model=list[RestoreDrillResponse])
+async def list_drills(
+    db: DB,
+    current_user: CurrentUser,
+    target_id: uuid.UUID | None = Query(default=None),
+    state: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+) -> list[RestoreDrillResponse]:
+    """Recent drills, newest first, optionally scoped to one target."""
+    _require_superadmin(current_user)
+    stmt = (
+        select(RestoreDrill, BackupTarget.name)
+        .join(BackupTarget, BackupTarget.id == RestoreDrill.target_id)
+        .order_by(desc(RestoreDrill.started_at))
+        .limit(limit)
+    )
+    if target_id is not None:
+        stmt = stmt.where(RestoreDrill.target_id == target_id)
+    if state is not None:
+        stmt = stmt.where(RestoreDrill.state == state)
+    rows = (await db.execute(stmt)).all()
+    return [_to_response(row, target_name=name) for row, name in rows]
+
+
+@router.get("/{drill_id}", response_model=RestoreDrillResponse)
+async def get_drill(drill_id: uuid.UUID, db: DB, current_user: CurrentUser) -> RestoreDrillResponse:
+    _require_superadmin(current_user)
+    row = await db.get(RestoreDrill, drill_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="restore drill not found")
+    target = await db.get(BackupTarget, row.target_id)
+    return _to_response(row, target_name=target.name if target else None)
+
+
+@router.post("/run/{target_id}", response_model=RestoreDrillResponse)
+async def run_drill_now(
+    target_id: uuid.UUID, db: DB, current_user: CurrentUser
+) -> RestoreDrillResponse:
+    """Run one drill against this target now.
+
+    Synchronous — blocks until the archive is downloaded, replayed
+    into a scratch database, asserted against, and the scratch
+    database dropped. That can take as long as a real restore on a
+    large install; the UI polls the row rather than holding the
+    request open where it matters.
+    """
+    _require_superadmin(current_user)
+    forbid_in_demo_mode("restore drills")
+
+    # A drill replays into a throwaway database and never writes to
+    # the live one, so it is safe alongside most operations — but a
+    # rolling upgrade moves the schema underneath the assertions,
+    # which would produce a confusing false verdict.
+    from app.services.upgrades.safety import (  # noqa: PLC0415
+        assert_no_upgrade_in_flight,
+    )
+
+    await assert_no_upgrade_in_flight(db, operation_hint="restore drill")
+
+    row = await db.get(BackupTarget, target_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="backup target not found")
+    if row.drill_last_status == "in_progress":
+        raise HTTPException(
+            status_code=409,
+            detail="a drill is already running against this target",
+        )
+
+    drill = await run_drill_for_target(db, target=row, triggered_by="manual")
+    db.add(
+        AuditLog(
+            action="backup_restore_drill",
+            resource_type="backup_target",
+            resource_id=str(row.id),
+            resource_display=row.name,
+            user_id=current_user.id,
+            user_display_name=current_user.username,
+            result="success" if drill.state == "passed" else "failure",
+            error_detail=drill.error,
+            new_value={
+                "drill_id": str(drill.id),
+                "state": drill.state,
+                "filename": drill.filename,
+                "duration_ms": drill.duration_ms,
+                "assertions": drill.assertions,
+            },
+        )
+    )
+    await db.commit()
+    await db.refresh(drill)
+    return _to_response(drill, target_name=row.name)

--- a/backend/app/api/v1/backup/targets.py
+++ b/backend/app/api/v1/backup/targets.py
@@ -108,6 +108,8 @@ class BackupTargetUpdate(BaseModel):
     schedule_cron: str | None = None
     retention_keep_last_n: int | None = Field(default=None, ge=0, le=10_000)
     retention_keep_days: int | None = Field(default=None, ge=0, le=10_000)
+    drill_enabled: bool | None = None
+    drill_cron: str | None = None
 
 
 class BackupTargetResponse(BaseModel):
@@ -129,6 +131,11 @@ class BackupTargetResponse(BaseModel):
     last_run_duration_ms: int | None
     last_run_error: str | None
     next_run_at: datetime | None
+    drill_enabled: bool
+    drill_cron: str | None
+    drill_next_run_at: datetime | None
+    drill_last_status: str
+    drill_last_at: datetime | None
     created_at: datetime
     modified_at: datetime
 
@@ -164,6 +171,11 @@ def _to_response(t: BackupTarget) -> BackupTargetResponse:
         last_run_duration_ms=t.last_run_duration_ms,
         last_run_error=t.last_run_error,
         next_run_at=t.next_run_at,
+        drill_enabled=t.drill_enabled,
+        drill_cron=t.drill_cron,
+        drill_next_run_at=t.drill_next_run_at,
+        drill_last_status=t.drill_last_status,
+        drill_last_at=t.drill_last_at,
         created_at=t.created_at,
         modified_at=t.modified_at,
     )
@@ -325,6 +337,24 @@ async def update_target(
                 raise HTTPException(status_code=422, detail=str(exc)) from exc
             row.schedule_cron = payload["schedule_cron"]
 
+    if "drill_cron" in payload:
+        if payload["drill_cron"] is None or payload["drill_cron"] == "":
+            row.drill_cron = None
+            row.drill_next_run_at = None
+        else:
+            try:
+                validate_cron(payload["drill_cron"])
+                row.drill_next_run_at = compute_next_run(payload["drill_cron"])
+            except InvalidCronExpression as exc:
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
+            row.drill_cron = payload["drill_cron"]
+
+    if payload.get("drill_enabled") and not (payload.get("drill_cron") or row.drill_cron):
+        raise HTTPException(
+            status_code=422,
+            detail="drill_enabled requires drill_cron — set a drill schedule first",
+        )
+
     if "passphrase" in payload and payload["passphrase"] is not None:
         row.passphrase_encrypted = encrypt_str(payload["passphrase"])
 
@@ -335,6 +365,7 @@ async def update_target(
         "passphrase_hint",
         "retention_keep_last_n",
         "retention_keep_days",
+        "drill_enabled",
     ):
         if key in payload:
             setattr(row, key, payload[key])

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -25,6 +25,7 @@ celery_app = Celery(
         "app.tasks.heartbeat",
         "app.tasks.oui_update",
         "app.tasks.backup_sweep",
+        "app.tasks.backup_drill",
         "app.tasks.prune_internal_errors",
         "app.tasks.prune_logs",
         "app.tasks.prune_metrics",
@@ -98,6 +99,7 @@ celery_app.conf.update(
         "app.tasks.heartbeat.*": {"queue": "default"},
         "app.tasks.oui_update.*": {"queue": "default"},
         "app.tasks.backup_sweep.*": {"queue": "default"},
+        "app.tasks.backup_drill.*": {"queue": "default"},
         "app.tasks.prune_internal_errors.*": {"queue": "default"},
         "app.tasks.prune_logs.*": {"queue": "default"},
         "app.tasks.prune_metrics.*": {"queue": "default"},
@@ -589,6 +591,16 @@ celery_app.conf.update(
         # next tick.
         "backup-target-sweep": {
             "task": "app.tasks.backup_sweep.sweep_backup_targets",
+            "schedule": schedule(run_every=60.0),
+        },
+        # Every 60 s, fire any restore-verification drill whose
+        # ``drill_next_run_at`` is now in the past (issue #702).
+        # Same sweep + per-target mutex shape as the backup sweep
+        # above; drills carry their own cron because replaying a
+        # full dump into a scratch database costs far more than
+        # taking a backup does.
+        "restore-drill-sweep": {
+            "task": "app.tasks.backup_drill.sweep_restore_drills",
             "schedule": schedule(run_every=60.0),
         },
         # Every 60 s, fire any Scheduled Wake-on-LAN schedule whose

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -523,6 +523,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await seed_ip_blocklisted_alert_rule()
     except Exception as exc:  # noqa: BLE001
         logger.debug("ip_blocklisted_alert_rule_seed_skipped", reason=str(exc))
+    try:
+        from app.services.alerts import seed_restore_drill_failed_alert_rule  # noqa: PLC0415
+
+        await seed_restore_drill_failed_alert_rule()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("restore_drill_alert_rule_seed_skipped", reason=str(exc))
     # Appliance Web UI cert bootstrap (issue #134, Phase 4b.5). On
     # appliance installs without an active row in appliance_certificate,
     # generate a self-signed default + deploy it to /etc/nginx/certs

--- a/backend/app/models/backup.py
+++ b/backend/app/models/backup.py
@@ -1,10 +1,14 @@
-"""SQLAlchemy model for the ``backup_target`` table (issue #117
-Phase 1b).
+"""SQLAlchemy models for the backup subsystem.
 
-One row per operator-configured backup destination — Phase 1b
-ships ``local_volume``; Phase 1c (S3) and 1d (SCP/Azure Blob)
-add new ``kind`` values without schema changes thanks to the
-JSONB ``config`` column.
+``backup_target`` (issue #117 Phase 1b) — one row per
+operator-configured backup destination. Phase 1b shipped
+``local_volume``; Phase 1c (S3) and 1d (SCP/Azure Blob) added new
+``kind`` values without schema changes thanks to the JSONB
+``config`` column.
+
+``restore_drill`` (issue #702) — one row per restore-verification
+drill: a scheduled test-restore of a target's newest archive into
+a throwaway database, proving the archive is actually restorable.
 """
 
 from __future__ import annotations
@@ -17,11 +21,13 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     DateTime,
+    ForeignKey,
     Integer,
     LargeBinary,
     String,
     Text,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -56,6 +62,21 @@ class BackupTarget(Base):
 
     next_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
+    # Restore-verification drills (issue #702). Separate cadence from
+    # ``schedule_cron`` on purpose: a drill replays the *newest* archive
+    # into a throwaway database, so it's worth running far less often
+    # than the backup itself (weekly against nightly is the common
+    # shape). ``drill_last_status`` is denormalised off ``restore_drill``
+    # purely so the targets list can render a chip without a per-row
+    # subquery — ``restore_drill`` stays the history of record.
+    drill_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    drill_cron: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    drill_next_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    drill_last_status: Mapped[str] = mapped_column(String(20), nullable=False, default="never")
+    drill_last_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -65,3 +86,56 @@ class BackupTarget(Base):
         onupdate=func.now(),
         nullable=False,
     )
+
+
+class RestoreDrill(Base):
+    """One restore-verification drill run (issue #702).
+
+    A drill downloads a target's newest archive, replays it into a
+    throwaway scratch database, runs a fixed assertion set against
+    the result, and drops the scratch database again. The live
+    database is never written to — the whole point is to prove the
+    archive is restorable *before* an operator needs it to be.
+
+    ``assertions`` is the per-check verdict list
+    (``[{"name": str, "status": "pass"|"fail"|"skip", "detail": str}]``)
+    rather than a column per check, so adding a check later doesn't
+    need a migration. ``state`` is the rollup: ``passed`` when no
+    check failed — a ``skip`` (a check that couldn't be answered,
+    e.g. schema skew) does not count against it.
+    """
+
+    __tablename__ = "restore_drill"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("backup_target.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # "running" → terminal "passed" / "failed" / "error".
+    # ``failed`` means the drill ran and an assertion did not hold —
+    # that's a real finding about the archive. ``error`` means the
+    # drill could not reach a verdict (destination unreachable,
+    # scratch database couldn't be created); operationally distinct,
+    # because only ``failed`` says anything about the backup itself.
+    state: Mapped[str] = mapped_column(String(20), nullable=False, default="running")
+    triggered_by: Mapped[str] = mapped_column(String(20), nullable=False, default="manual")
+
+    filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    archive_bytes: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    manifest: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    scratch_db: Mapped[str | None] = mapped_column(String(80), nullable=True)
+
+    assertions: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=text("'[]'::jsonb")
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/app/models/backup.py
+++ b/backend/app/models/backup.py
@@ -108,11 +108,14 @@ class RestoreDrill(Base):
     __tablename__ = "restore_drill"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # No ``index=True``: the composite ``ix_restore_drill_target_started``
+    # in the migration leads with this column and serves single-column
+    # lookups just as well. A second index here would only cost an extra
+    # write per insert (and autogenerate would keep recreating it).
     target_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("backup_target.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
 
     # "running" → terminal "passed" / "failed" / "error".

--- a/backend/app/services/ai/tools/backup.py
+++ b/backend/app/services/ai/tools/backup.py
@@ -1,7 +1,7 @@
 """Backup + factory-reset read tools for the Operator Copilot
-(issues #117 + #116).
+(issues #117 + #116 + #702).
 
-Three read-only tools, all superadmin-only because the surface
+Five read-only tools, all superadmin-only because the surface
 exposes destination configs (even with secrets redacted, the
 target name + kind + path/bucket/host is sensitive metadata):
 
@@ -18,6 +18,12 @@ target name + kind + path/bucket/host is sensitive metadata):
   audit rows with their per-row counters / sizes / errors.
   Useful for "when did backup last fail?" or "show me last
   week's reset history".
+* ``find_restore_drills`` — restore-verification drill history
+  (#702): did the archive actually survive a test restore, and
+  which checks failed if not.
+* ``get_restore_drill_readiness`` — the rollup that answers "can
+  I restore this install right now, and how do I know?" per
+  target, without reading the whole history.
 
 Deliberately NO ``propose_*`` write tools. The factory-reset and
 restore paths are password-gated + confirm-phrase-gated by design;
@@ -41,7 +47,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.permissions import is_effective_superadmin
 from app.models.audit import AuditLog
 from app.models.auth import User
-from app.models.backup import BackupTarget
+from app.models.backup import BackupTarget, RestoreDrill
 from app.services.ai.tools.base import register_tool
 
 
@@ -309,3 +315,156 @@ async def find_backup_audit_history(
         }
         for r in rows
     ]
+
+
+# ── find_restore_drills ───────────────────────────────────────────────
+
+
+class FindRestoreDrillsArgs(BaseModel):
+    target: str | None = Field(
+        default=None,
+        description="Restrict to one target — id (UUID) or exact name.",
+    )
+    state: Literal["running", "passed", "failed", "error"] | None = Field(
+        default=None,
+        description=(
+            "Filter by verdict. 'failed' means the archive did not "
+            "survive a test restore (a real finding). 'error' means the "
+            "drill could not run at all and says nothing about the "
+            "archive."
+        ),
+    )
+    failed_only: bool = Field(
+        default=False,
+        description="Shorthand for state='failed'. Ignored when state is set.",
+    )
+    since_hours: int | None = Field(
+        default=None, ge=1, le=24 * 365, description="Only drills started within this window."
+    )
+    limit: int = Field(default=50, ge=1, le=500)
+
+
+@register_tool(
+    name="find_restore_drills",
+    description=(
+        "Return restore-verification drill history (superadmin only). "
+        "A drill replays a backup target's newest archive into a "
+        "throwaway database and asserts against the result, proving "
+        "the archive is actually restorable. Each row carries target / "
+        "state / filename / duration / the per-check assertion verdicts "
+        "and any error. Use for 'did my backups pass verification?', "
+        "'which archive failed its drill?', or 'show me the failed "
+        "checks on the corp-vault drill'. Note 'failed' (the archive is "
+        "bad) and 'error' (the drill could not run) mean different "
+        "things and should not be conflated."
+    ),
+    args_model=FindRestoreDrillsArgs,
+    category="admin",
+)
+async def find_restore_drills(
+    db: AsyncSession, user: User, args: FindRestoreDrillsArgs
+) -> list[dict[str, Any]]:
+    gate = _superadmin_gate(user)
+    if gate:
+        return [gate]
+    stmt = select(RestoreDrill, BackupTarget.name).join(
+        BackupTarget, BackupTarget.id == RestoreDrill.target_id
+    )
+    if args.target:
+        as_uuid = _try_uuid(args.target)
+        stmt = stmt.where(
+            RestoreDrill.target_id == as_uuid
+            if as_uuid is not None
+            else BackupTarget.name == args.target
+        )
+    state = args.state or ("failed" if args.failed_only else None)
+    if state:
+        stmt = stmt.where(RestoreDrill.state == state)
+    if args.since_hours is not None:
+        stmt = stmt.where(
+            RestoreDrill.started_at >= datetime.now(UTC) - timedelta(hours=args.since_hours)
+        )
+    stmt = stmt.order_by(desc(RestoreDrill.started_at)).limit(args.limit)
+    rows = (await db.execute(stmt)).all()
+    return [
+        {
+            "id": str(d.id),
+            "target_id": str(d.target_id),
+            "target_name": name,
+            "state": d.state,
+            "triggered_by": d.triggered_by,
+            "filename": d.filename,
+            "archive_bytes": d.archive_bytes,
+            "assertions": d.assertions or [],
+            "error": d.error,
+            "started_at": d.started_at.isoformat() if d.started_at else None,
+            "finished_at": d.finished_at.isoformat() if d.finished_at else None,
+            "duration_ms": d.duration_ms,
+        }
+        for d, name in rows
+    ]
+
+
+# ── get_restore_drill_readiness ───────────────────────────────────────
+
+
+class RestoreDrillReadinessArgs(BaseModel):
+    pass
+
+
+@register_tool(
+    name="get_restore_drill_readiness",
+    description=(
+        "One-shot recovery-readiness rollup across every backup target "
+        "(superadmin only). Per target: whether drills are scheduled, "
+        "the latest verdict, when it last passed, and how stale that "
+        "proof is. Answers the question an operator actually cares "
+        "about — 'can I currently restore this install, and how do I "
+        "know?' — without reading the whole drill history. Targets "
+        "with drills disabled are reported as unverified rather than "
+        "healthy: an untested backup is an unknown, not a pass."
+    ),
+    args_model=RestoreDrillReadinessArgs,
+    category="admin",
+)
+async def get_restore_drill_readiness(
+    db: AsyncSession, user: User, args: RestoreDrillReadinessArgs
+) -> dict[str, Any]:
+    gate = _superadmin_gate(user)
+    if gate:
+        return gate
+    targets = (
+        (await db.execute(select(BackupTarget).order_by(BackupTarget.name.asc()))).scalars().all()
+    )
+    now = datetime.now(UTC)
+    out: list[dict[str, Any]] = []
+    for t in targets:
+        last_pass = await db.scalar(
+            select(RestoreDrill.finished_at)
+            .where(RestoreDrill.target_id == t.id, RestoreDrill.state == "passed")
+            .order_by(desc(RestoreDrill.finished_at))
+            .limit(1)
+        )
+        age_hours = round((now - last_pass).total_seconds() / 3600, 1) if last_pass else None
+        out.append(
+            {
+                "target_id": str(t.id),
+                "target_name": t.name,
+                "kind": t.kind,
+                "enabled": t.enabled,
+                "drills_scheduled": bool(t.drill_enabled and t.drill_cron),
+                "drill_cron": t.drill_cron,
+                "latest_verdict": t.drill_last_status,
+                "latest_drill_at": t.drill_last_at.isoformat() if t.drill_last_at else None,
+                "last_passed_at": last_pass.isoformat() if last_pass else None,
+                "hours_since_last_pass": age_hours,
+                "verified": t.drill_last_status == "passed",
+            }
+        )
+    verified = sum(1 for r in out if r["verified"])
+    return {
+        "targets": out,
+        "total_targets": len(out),
+        "verified_targets": verified,
+        "unverified_targets": len(out) - verified,
+    }

--- a/backend/app/services/ai/tools/backup.py
+++ b/backend/app/services/ai/tools/backup.py
@@ -421,8 +421,11 @@ class RestoreDrillReadinessArgs(BaseModel):
         "proof is. Answers the question an operator actually cares "
         "about — 'can I currently restore this install, and how do I "
         "know?' — without reading the whole drill history. Targets "
-        "with drills disabled are reported as unverified rather than "
-        "healthy: an untested backup is an unknown, not a pass."
+        "that proof is. A target that has never passed a drill is "
+        "reported as unverified rather than healthy — an untested "
+        "backup is an unknown, not a pass — while a target whose most "
+        "recent drill merely errored (destination unreachable) keeps "
+        "its previous verdict, because an error disproves nothing."
     ),
     args_model=RestoreDrillReadinessArgs,
     category="admin",
@@ -433,34 +436,11 @@ async def get_restore_drill_readiness(
     gate = _superadmin_gate(user)
     if gate:
         return gate
-    targets = (
-        (await db.execute(select(BackupTarget).order_by(BackupTarget.name.asc()))).scalars().all()
-    )
-    now = datetime.now(UTC)
-    out: list[dict[str, Any]] = []
-    for t in targets:
-        last_pass = await db.scalar(
-            select(RestoreDrill.finished_at)
-            .where(RestoreDrill.target_id == t.id, RestoreDrill.state == "passed")
-            .order_by(desc(RestoreDrill.finished_at))
-            .limit(1)
-        )
-        age_hours = round((now - last_pass).total_seconds() / 3600, 1) if last_pass else None
-        out.append(
-            {
-                "target_id": str(t.id),
-                "target_name": t.name,
-                "kind": t.kind,
-                "enabled": t.enabled,
-                "drills_scheduled": bool(t.drill_enabled and t.drill_cron),
-                "drill_cron": t.drill_cron,
-                "latest_verdict": t.drill_last_status,
-                "latest_drill_at": t.drill_last_at.isoformat() if t.drill_last_at else None,
-                "last_passed_at": last_pass.isoformat() if last_pass else None,
-                "hours_since_last_pass": age_hours,
-                "verified": t.drill_last_status == "passed",
-            }
-        )
+    # Shared with the REST readiness endpoint and the admin UI so all
+    # three give the same answer to the same question.
+    from app.services.backup.drill import compute_drill_readiness  # noqa: PLC0415
+
+    out = await compute_drill_readiness(db)
     verified = sum(1 for r in out if r["verified"])
     return {
         "targets": out,

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -911,6 +911,15 @@ async def _matching_restore_drill_failed_subjects(
     the previous verdict was standing, which is the honest reading:
     we still don't know any more than we did.
 
+    Restricted to targets that are **enabled with drills scheduled**.
+    The manual run-now endpoint will drill a target whose drills are
+    off, so without this filter a single ad-hoc failure could open a
+    critical event that nothing can ever resolve: the documented
+    resolution is "the target's next drill passes", and a target with
+    no schedule has no next drill. Switching drills (or the target)
+    off now resolves the event on the following tick, which also gives
+    operators a reachable way out.
+
     When the latest finished drill passes, the target stops matching
     and the shared evaluator loop auto-resolves its open event.
     """
@@ -943,7 +952,12 @@ async def _matching_restore_drill_failed_subjects(
                 BackupTarget.name,
             )
             .join(BackupTarget, BackupTarget.id == ranked.c.target_id)
-            .where(ranked.c.rn == 1, ranked.c.state == "failed")
+            .where(
+                ranked.c.rn == 1,
+                ranked.c.state == "failed",
+                BackupTarget.enabled.is_(True),
+                BackupTarget.drill_enabled.is_(True),
+            )
         )
     ).all()
 
@@ -956,12 +970,24 @@ async def _matching_restore_drill_failed_subjects(
         ]
         detail = ", ".join(failed) if failed else "no assertion detail recorded"
         when = finished_at.isoformat() if finished_at is not None else "unknown time"
-        message = (
-            f"Restore drill FAILED for backup target '{target_name}': the newest "
-            f"archive ({filename or 'unknown'}) did not survive a test restore at "
-            f"{when}. Failed checks: {detail}. This archive is not a reliable "
-            f"recovery path — investigate before you need it."
-        )
+        # "the archive didn't survive" is the wrong story when the
+        # failing check is that there IS no archive — the operator
+        # would go hunting for corruption instead of finding an empty
+        # destination. Branch on the actual finding.
+        if "archive_available" in failed:
+            message = (
+                f"Restore drill FAILED for backup target '{target_name}': the "
+                f"destination holds no archives to restore from (checked at "
+                f"{when}). There is currently no recovery path from this "
+                f"target — confirm its backups are running."
+            )
+        else:
+            message = (
+                f"Restore drill FAILED for backup target '{target_name}': the newest "
+                f"archive ({filename or 'unknown'}) did not survive a test restore at "
+                f"{when}. Failed checks: {detail}. This archive is not a reliable "
+                f"recovery path — investigate before you need it."
+            )
         matches.append((str(target_id), target_name, message))
     return matches
 
@@ -4046,9 +4072,9 @@ async def seed_ip_blocklisted_alert_rule() -> None:
 async def seed_restore_drill_failed_alert_rule() -> None:
     """Seed the ``restore_drill_failed`` rule (#702), ENABLED by default.
 
-    The odd one out among the seeds: enabled rather than opt-in. It can
-    only ever fire on a target the operator explicitly turned drills on
-    for, so it is silent on every install that doesn't use the feature —
+    The odd one out among the seeds: enabled rather than opt-in. The
+    matcher only considers enabled targets with drills scheduled, so
+    the rule is silent on every install that doesn't use the feature —
     and an operator who went to the trouble of scheduling drills wants
     to hear the answer. Keyed on ``rule_type``; an operator who disables
     or renames it is never overridden.

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -295,6 +295,17 @@ RULE_TYPE_TLS_CERT_ISSUER_CHANGED = "tls_cert_issuer_changed"
 # public-facing IP is listed on ≥1 enabled blocklist, auto-resolves when the
 # sweep finds it delisted (the shared open/resolve loop handles both).
 RULE_TYPE_IP_BLOCKLISTED = "ip_blocklisted"
+
+# ``restore_drill_failed`` (issue #702) — a restore-verification drill
+# replayed a target's newest archive into a scratch database and an
+# assertion did not hold. Subject is the **backup target**, so a target
+# failing every night holds one open event instead of opening a new one
+# per drill. Deliberately matches only ``state="failed"`` (the archive
+# is not restorable), never ``state="error"`` (the drill couldn't run —
+# says nothing about the backup, and paging on it would train operators
+# to ignore the rule). Auto-resolves when the target's next drill
+# passes.
+RULE_TYPE_RESTORE_DRILL_FAILED = "restore_drill_failed"
 # Unreachable only pages after a couple of consecutive failures so a
 # single transient handshake blip doesn't fire.
 _TLS_CERT_UNREACHABLE_MIN_FAILURES = 2
@@ -349,6 +360,7 @@ RULE_TYPES = frozenset(
         RULE_TYPE_TLS_CERT_CHANGED,
         RULE_TYPE_TLS_CERT_ISSUER_CHANGED,
         RULE_TYPE_IP_BLOCKLISTED,
+        RULE_TYPE_RESTORE_DRILL_FAILED,
     }
 )
 
@@ -879,6 +891,78 @@ async def _matching_rogue_ra_subjects(
             f"router, or acknowledge it if expected."
         )
         matches.append((str(r.id), display, message))
+    return matches
+
+
+async def _matching_restore_drill_failed_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+) -> list[tuple[str, str, str]]:
+    """Backup targets whose most recent finished drill failed.
+
+    Subject is the **target**, not the drill run, so a target failing
+    every night holds one open event rather than opening a fresh one
+    per drill.
+
+    Only the latest *finished* drill counts. ``running`` rows are
+    skipped so a drill in flight neither opens nor resolves anything,
+    and ``error`` rows are skipped so an unreachable destination
+    doesn't masquerade as a bad archive — an ``error`` leaves whatever
+    the previous verdict was standing, which is the honest reading:
+    we still don't know any more than we did.
+
+    When the latest finished drill passes, the target stops matching
+    and the shared evaluator loop auto-resolves its open event.
+    """
+    from app.models.backup import BackupTarget, RestoreDrill  # noqa: PLC0415
+
+    rn = func.row_number().over(
+        partition_by=RestoreDrill.target_id,
+        order_by=RestoreDrill.started_at.desc(),
+    )
+    ranked = (
+        select(
+            RestoreDrill.target_id.label("target_id"),
+            RestoreDrill.state.label("state"),
+            RestoreDrill.filename.label("filename"),
+            RestoreDrill.assertions.label("assertions"),
+            RestoreDrill.finished_at.label("finished_at"),
+            rn.label("rn"),
+        )
+        .where(RestoreDrill.state.in_(("passed", "failed")))
+        .subquery()
+    )
+    rows = (
+        await db.execute(
+            select(
+                ranked.c.target_id,
+                ranked.c.state,
+                ranked.c.filename,
+                ranked.c.assertions,
+                ranked.c.finished_at,
+                BackupTarget.name,
+            )
+            .join(BackupTarget, BackupTarget.id == ranked.c.target_id)
+            .where(ranked.c.rn == 1, ranked.c.state == "failed")
+        )
+    ).all()
+
+    matches: list[tuple[str, str, str]] = []
+    for target_id, _state, filename, assertions, finished_at, target_name in rows:
+        failed = [
+            a.get("name", "?")
+            for a in (assertions or [])
+            if isinstance(a, dict) and a.get("status") == "fail"
+        ]
+        detail = ", ".join(failed) if failed else "no assertion detail recorded"
+        when = finished_at.isoformat() if finished_at is not None else "unknown time"
+        message = (
+            f"Restore drill FAILED for backup target '{target_name}': the newest "
+            f"archive ({filename or 'unknown'}) did not survive a test restore at "
+            f"{when}. Failed checks: {detail}. This archive is not a reliable "
+            f"recovery path — investigate before you need it."
+        )
+        matches.append((str(target_id), target_name, message))
     return matches
 
 
@@ -3959,6 +4043,48 @@ async def seed_ip_blocklisted_alert_rule() -> None:
         await session.commit()
 
 
+async def seed_restore_drill_failed_alert_rule() -> None:
+    """Seed the ``restore_drill_failed`` rule (#702), ENABLED by default.
+
+    The odd one out among the seeds: enabled rather than opt-in. It can
+    only ever fire on a target the operator explicitly turned drills on
+    for, so it is silent on every install that doesn't use the feature —
+    and an operator who went to the trouble of scheduling drills wants
+    to hear the answer. Keyed on ``rule_type``; an operator who disables
+    or renames it is never overridden.
+    """
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+    from app.models.alerts import AlertRule  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as session:
+        existing = await session.scalar(
+            select(AlertRule).where(AlertRule.rule_type == RULE_TYPE_RESTORE_DRILL_FAILED)
+        )
+        if existing is not None:
+            return
+        session.add(
+            AlertRule(
+                name="Backup restore drill failed",
+                description=(
+                    "Fires when a restore-verification drill replays a backup "
+                    "target's newest archive into a scratch database and an "
+                    "assertion does not hold — the archive is not restorable. "
+                    "Drills that could not run at all (destination unreachable) "
+                    "are NOT covered; those are infrastructure faults, not "
+                    "findings about the backup. Auto-resolves when the target's "
+                    "next drill passes."
+                ),
+                rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+                severity="critical",
+                enabled=True,
+                notify_syslog=True,
+                notify_webhook=True,
+                notify_smtp=False,
+            )
+        )
+        await session.commit()
+
+
 async def evaluate_all(db: AsyncSession) -> dict[str, int]:
     """Evaluate every enabled rule; open / resolve events as needed.
 
@@ -4045,6 +4171,10 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 base = await _matching_wol_wake_failed_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]
                 subject_type = "wol_schedule"
+            elif rule.rule_type == RULE_TYPE_RESTORE_DRILL_FAILED:
+                base = await _matching_restore_drill_failed_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "backup_target"
             elif rule.rule_type == RULE_TYPE_NEW_MAC_SEEN:
                 base = await _matching_new_mac_seen_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]

--- a/backend/app/services/backup/drill.py
+++ b/backend/app/services/backup/drill.py
@@ -1,0 +1,696 @@
+"""Restore-verification drills (issue #702).
+
+A drill answers the one question the backup subsystem could not:
+*is the archive we wrote last night actually restorable?* It
+downloads a target's newest archive, replays it into a throwaway
+scratch database, runs a fixed assertion set against the result,
+and drops the scratch database again.
+
+**The live database is never written to.** Every subprocess and
+every session in this module is pointed at a scratch database whose
+name this module generates from a fixed prefix plus random hex —
+never from operator input, and never equal to the live database
+name (:func:`_scratch_db_name` asserts both).
+
+Deliberately *not* built on :func:`app.services.backup.restore.apply_backup_restore`:
+that function takes a pre-restore safety dump against the live
+session and disposes the live engine's connection pool, which is
+correct for an operator-initiated restore and actively wrong for an
+unattended background drill. The replay helpers here are local for
+the same reason — ``restore._run_psql`` terminates every other
+connection to its target database, which must never become
+something a drill can do.
+
+Verdict vocabulary — ``failed`` and ``error`` are operationally
+distinct and worth keeping apart:
+
+* ``failed`` — the drill reached a verdict and the archive did not
+  hold up (malformed, wrong passphrase, replay aborted, an
+  assertion did not pass). This is a real finding about the backup.
+* ``error`` — the drill could not reach a verdict at all
+  (destination unreachable, scratch database couldn't be created).
+  This says nothing about the archive.
+
+Only ``failed`` should page someone about their backups.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import secrets as secrets_mod
+import tempfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.config import settings
+from app.core.crypto import decrypt_str
+from app.models.backup import BackupTarget, RestoreDrill
+from app.services.backup.archive import (
+    BackupArchiveError,
+    _pg_env_from_url,
+    _pg_subprocess_env,
+    extract_archive_members,
+)
+from app.services.backup.crypto import BackupCryptoError, decrypt_secrets
+from app.services.backup.targets import (
+    BackupDestinationError,
+    SecretFieldError,
+    decrypt_config_secrets,
+    get_destination,
+)
+
+logger = structlog.get_logger(__name__)
+
+SCRATCH_DB_PREFIX = "spatiumddi_drill_"
+
+# A drill replays a full dump, so it gets the same envelope the
+# restore path uses. The maintenance statements (CREATE / DROP
+# DATABASE) are fast and get a much tighter bound.
+_REPLAY_TIMEOUT_SECONDS = 30 * 60
+_MAINTENANCE_TIMEOUT_SECONDS = 120
+
+# How long a ``drill_last_status="in_progress"`` mutex is believed
+# before the sweep treats it as stranded. A worker killed mid-drill
+# never gets to stamp a terminal state, and without this the target
+# would silently stop drilling forever. Comfortably above the replay
+# timeout so a genuinely slow drill is never stolen from itself.
+STALE_IN_PROGRESS_SECONDS = _REPLAY_TIMEOUT_SECONDS + 15 * 60
+
+# Assertion verdicts.
+PASS = "pass"
+FAIL = "fail"
+SKIP = "skip"
+
+
+class DrillError(Exception):
+    """Infrastructure failure — the drill could not reach a verdict.
+
+    Distinct from a *failed* drill, which is a real finding about
+    the archive. Raising this maps the run to ``state="error"``.
+    """
+
+
+@dataclass
+class Assertion:
+    name: str
+    status: str
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "status": self.status, "detail": self.detail}
+
+
+@dataclass
+class DrillOutcome:
+    state: str
+    assertions: list[Assertion] = field(default_factory=list)
+    filename: str | None = None
+    archive_bytes: int | None = None
+    manifest: dict[str, Any] | None = None
+    scratch_db: str | None = None
+    error: str | None = None
+
+
+# ── scratch database lifecycle ────────────────────────────────────────
+
+
+def _scratch_db_name(live_dbname: str) -> str:
+    """Generate a throwaway database name.
+
+    Fixed prefix + random hex, never operator-derived. The equality
+    check against the live name is belt-and-braces — the prefix
+    makes a collision essentially impossible — but this is the one
+    place where a bug would replay a backup over production, so it
+    is asserted explicitly rather than reasoned about.
+    """
+    name = f"{SCRATCH_DB_PREFIX}{secrets_mod.token_hex(6)}"
+    if name == live_dbname:
+        raise DrillError("generated scratch database name collided with the live database")
+    return name
+
+
+async def _run_maintenance_sql(sql: str, *, live_db_url: str, timeout: float) -> None:
+    """Run a single statement against the ``postgres`` maintenance
+    database. CREATE / DROP DATABASE cannot run inside a
+    transaction block and cannot run while connected to the
+    database being created or dropped, so these are issued against
+    ``postgres`` rather than either the live or scratch database.
+    """
+    pg_env, _dbname = _pg_env_from_url(live_db_url)
+    pg_env = {**pg_env, "PGDATABASE": "postgres"}
+    proc = await asyncio.create_subprocess_exec(
+        "psql",
+        "--set=ON_ERROR_STOP=1",
+        f"--command={sql}",
+        env=_pg_subprocess_env(pg_env),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError as exc:
+        proc.kill()
+        await proc.wait()
+        raise DrillError(f"maintenance statement exceeded {timeout}s timeout") from exc
+    if proc.returncode != 0:
+        msg = (stderr.decode(errors="replace") or stdout.decode(errors="replace"))[:800]
+        raise DrillError(f"maintenance statement failed (exit {proc.returncode}): {msg}")
+
+
+async def _create_scratch_db(name: str, *, live_db_url: str) -> None:
+    await _run_maintenance_sql(
+        f'CREATE DATABASE "{name}"',
+        live_db_url=live_db_url,
+        timeout=_MAINTENANCE_TIMEOUT_SECONDS,
+    )
+
+
+async def _drop_scratch_db(name: str, *, live_db_url: str) -> None:
+    """Drop the scratch database, best-effort.
+
+    Runs in a ``finally`` — a failure to clean up must not mask the
+    drill's actual verdict, so this logs and returns rather than
+    raising. ``WITH (FORCE)`` kicks any connection we left behind
+    (Postgres 13+); the scratch database is ours alone, so there is
+    nothing else that could legitimately be attached.
+    """
+    if not name.startswith(SCRATCH_DB_PREFIX):
+        logger.error("restore_drill_refusing_drop", dbname=name)
+        return
+    try:
+        await _run_maintenance_sql(
+            f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)',
+            live_db_url=live_db_url,
+            timeout=_MAINTENANCE_TIMEOUT_SECONDS,
+        )
+    except DrillError as exc:
+        # Leaves a stray database behind. Surfaced loudly because it
+        # needs manual cleanup, but never fatal to the drill result.
+        logger.error("restore_drill_scratch_drop_failed", dbname=name, error=str(exc))
+
+
+def _scratch_url(live_db_url: str, scratch_db: str) -> str:
+    """Swap the database name in a SQLAlchemy URL, preserving driver,
+    credentials, and any query string (``?ssl=require`` and friends).
+    """
+    head, sep, query = live_db_url.partition("?")
+    base, _, _old_dbname = head.rpartition("/")
+    if not base:
+        raise DrillError(f"could not derive a scratch URL from {live_db_url!r}")
+    return f"{base}/{scratch_db}{sep}{query}"
+
+
+# ── replay ────────────────────────────────────────────────────────────
+
+
+async def _replay_into_scratch(
+    db_bytes: bytes, *, dump_format: str, scratch_db: str, live_db_url: str
+) -> None:
+    """Replay the archive's dump member into the scratch database.
+
+    Raises :class:`BackupArchiveError` on a non-zero exit — a dump
+    that won't replay is a finding about the archive (``failed``),
+    not an infrastructure error.
+    """
+    pg_env, _live = _pg_env_from_url(live_db_url)
+    pg_env = {**pg_env, "PGDATABASE": scratch_db}
+    env = _pg_subprocess_env(pg_env)
+
+    with tempfile.TemporaryDirectory(prefix="spatium-drill-") as tmpdir:
+        suffix = "sql" if dump_format == "plain" else "dump"
+        dump_path = Path(tmpdir) / f"database.{suffix}"
+        dump_path.write_bytes(db_bytes)
+        os.chmod(dump_path, 0o600)
+
+        if dump_format == "plain":
+            cmd = [
+                "psql",
+                "--set=ON_ERROR_STOP=1",
+                "--single-transaction",
+                f"--file={dump_path}",
+            ]
+        else:
+            cmd = [
+                "pg_restore",
+                "--dbname",
+                scratch_db,
+                "--no-owner",
+                "--no-acl",
+                "--single-transaction",
+                "--exit-on-error",
+                str(dump_path),
+            ]
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=_REPLAY_TIMEOUT_SECONDS
+            )
+        except TimeoutError as exc:
+            proc.kill()
+            await proc.wait()
+            raise BackupArchiveError(f"replay exceeded {_REPLAY_TIMEOUT_SECONDS}s timeout") from exc
+        if proc.returncode != 0:
+            msg = (stderr.decode(errors="replace") or stdout.decode(errors="replace"))[:1500]
+            raise BackupArchiveError(f"replay failed (exit {proc.returncode}): {msg}")
+
+
+# ── assertions ────────────────────────────────────────────────────────
+
+# Tables whose emptiness would make a restore useless. Deliberately
+# short: a drill asserts the archive is *usable*, not that the
+# operator's data looks a particular way.
+_REQUIRED_NONEMPTY = ("user", "alembic_version")
+
+
+async def _assert_against_scratch(scratch_url: str) -> list[Assertion]:
+    """Open a session on the restored scratch database and run the
+    post-replay checks."""
+    out: list[Assertion] = []
+    # NullPool: this engine lives for one drill and is disposed
+    # immediately, and a pooled connection left open would block the
+    # DROP DATABASE in the caller's ``finally``.
+    engine = create_async_engine(scratch_url, poolclass=NullPool)
+    maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    try:
+        async with maker() as session:
+            head = await _assert_alembic_head(session, out)
+            await _assert_required_tables(session, out)
+            await _assert_audit_chain(session, out, restored_head=head)
+    finally:
+        await engine.dispose()
+    return out
+
+
+async def _assert_alembic_head(session: AsyncSession, out: list[Assertion]) -> str | None:
+    """Assert the restored database declares exactly one alembic
+    revision, and report how it relates to the bundled head.
+
+    A restored head *behind* the bundled head is not a failure — the
+    real restore path runs ``alembic upgrade head`` afterwards
+    (``maybe_upgrade_after_restore``). A head the running build has
+    never heard of is a failure: nothing can migrate it forward.
+    """
+    from app.core.schema_check import expected_alembic_head  # noqa: PLC0415
+
+    try:
+        rows = (await session.execute(text("SELECT version_num FROM alembic_version"))).scalars()
+        versions = list(rows)
+    except Exception as exc:  # noqa: BLE001 — any DB error is a finding
+        out.append(
+            Assertion(
+                "alembic_version_present",
+                FAIL,
+                f"could not read alembic_version from the restored database: {exc}",
+            )
+        )
+        return None
+
+    if len(versions) != 1:
+        out.append(
+            Assertion(
+                "alembic_version_present",
+                FAIL,
+                f"expected exactly 1 alembic_version row, found {len(versions)}"
+                + (" (multi-head schema)" if len(versions) > 1 else ""),
+            )
+        )
+        return None
+
+    restored = versions[0]
+    bundled, err = expected_alembic_head()
+    if bundled is None:
+        out.append(
+            Assertion(
+                "alembic_version_present",
+                PASS,
+                f"restored at {restored}; could not compare to the bundled head ({err})",
+            )
+        )
+        return restored
+
+    if restored == bundled:
+        out.append(
+            Assertion("alembic_version_present", PASS, f"restored at bundled head {restored}")
+        )
+        return restored
+
+    if _is_known_revision(restored):
+        out.append(
+            Assertion(
+                "alembic_version_present",
+                PASS,
+                f"restored at {restored}, behind bundled head {bundled} — "
+                f"a real restore would migrate it forward",
+            )
+        )
+        return restored
+
+    out.append(
+        Assertion(
+            "alembic_version_present",
+            FAIL,
+            f"restored at {restored}, which this build does not know — "
+            f"it cannot be migrated to the bundled head {bundled}. The "
+            f"archive was taken by a newer SpatiumDDI than this one.",
+        )
+    )
+    return restored
+
+
+def _is_known_revision(revision: str) -> bool:
+    """True when the bundled alembic scripts contain ``revision``."""
+    try:
+        from alembic.config import Config  # noqa: PLC0415
+        from alembic.script import ScriptDirectory  # noqa: PLC0415
+
+        from app.core.schema_check import _locate_alembic_ini  # noqa: PLC0415
+
+        ini = _locate_alembic_ini()
+        if ini is None:
+            return False
+        script = ScriptDirectory.from_config(Config(str(ini)))
+        return script.get_revision(revision) is not None
+    except Exception:  # noqa: BLE001
+        # Unknown revision id raises; so does a malformed script dir.
+        # Either way we can't vouch for it.
+        return False
+
+
+async def _assert_required_tables(session: AsyncSession, out: list[Assertion]) -> None:
+    """Assert the tables a restore is useless without came back with
+    rows in them."""
+    counts: dict[str, int | None] = {}
+    for table in _REQUIRED_NONEMPTY:
+        try:
+            result = await session.execute(text(f'SELECT count(*) FROM "{table}"'))
+            counts[table] = int(result.scalar_one())
+        except Exception as exc:  # noqa: BLE001 — missing table is a finding
+            out.append(
+                Assertion(
+                    "core_tables_populated",
+                    FAIL,
+                    f'could not count rows in "{table}": {exc}',
+                )
+            )
+            return
+
+    empty = [name for name, n in counts.items() if not n]
+    summary = ", ".join(f"{name}={n}" for name, n in counts.items())
+    if empty:
+        out.append(
+            Assertion(
+                "core_tables_populated",
+                FAIL,
+                f"restored but empty: {', '.join(empty)} — an install restored "
+                f"from this archive would have no way in ({summary})",
+            )
+        )
+        return
+    out.append(Assertion("core_tables_populated", PASS, summary))
+
+
+async def _assert_audit_chain(
+    session: AsyncSession, out: list[Assertion], *, restored_head: str | None
+) -> None:
+    """Verify the restored audit log's tamper-evident hash chain.
+
+    Skipped when the restored schema isn't at the bundled head: the
+    verifier selects through the ORM model, so a column added since
+    the archive was taken would raise ``UndefinedColumn`` and read
+    as tampering when it is really schema skew.
+    """
+    from app.core.schema_check import expected_alembic_head  # noqa: PLC0415
+    from app.services.audit_chain import verify_chain  # noqa: PLC0415
+
+    bundled, _err = expected_alembic_head()
+    if bundled is not None and restored_head is not None and restored_head != bundled:
+        out.append(
+            Assertion(
+                "audit_chain_intact",
+                SKIP,
+                f"restored schema is at {restored_head}, not the bundled head "
+                f"{bundled} — the ORM-based verifier would misread schema skew "
+                f"as tampering",
+            )
+        )
+        return
+
+    try:
+        result = await verify_chain(session)
+    except Exception as exc:  # noqa: BLE001
+        out.append(
+            Assertion("audit_chain_intact", SKIP, f"chain verification could not run: {exc}")
+        )
+        return
+
+    if result.ok:
+        out.append(Assertion("audit_chain_intact", PASS, f"{result.rows_checked} rows verified"))
+        return
+    first = result.breaks[0] if result.breaks else None
+    detail = f"{len(result.breaks)} break(s) across {result.rows_checked} rows" + (
+        f"; first at seq {first.seq} ({first.reason})" if first is not None else ""
+    )
+    out.append(Assertion("audit_chain_intact", FAIL, detail))
+
+
+# ── orchestration ─────────────────────────────────────────────────────
+
+
+async def run_drill_for_target(
+    db: AsyncSession,
+    *,
+    target: BackupTarget,
+    triggered_by: str = "manual",
+) -> RestoreDrill:
+    """Run one restore-verification drill against ``target``.
+
+    Persists a ``running`` row up front so a long drill is visible
+    in the UI while it works, then stamps the terminal state. The
+    caller commits; the row is returned attached to ``db``.
+    """
+    started = datetime.now(UTC)
+    row = RestoreDrill(target_id=target.id, state="running", triggered_by=triggered_by)
+    db.add(row)
+    target.drill_last_status = "in_progress"
+    # While a drill is running this holds its *start* time, which is
+    # what lets the sweep spot a mutex stranded by a killed worker
+    # (see STALE_IN_PROGRESS_SECONDS). It's overwritten with the
+    # finish time below.
+    target.drill_last_at = started
+    await db.commit()
+    await db.refresh(row)
+
+    live_db_url = str(settings.database_url)
+    outcome = await _execute(target, live_db_url=live_db_url)
+
+    finished = datetime.now(UTC)
+    row.state = outcome.state
+    row.assertions = [a.as_dict() for a in outcome.assertions]
+    row.filename = outcome.filename
+    row.archive_bytes = outcome.archive_bytes
+    row.manifest = outcome.manifest
+    row.scratch_db = outcome.scratch_db
+    row.error = outcome.error
+    row.finished_at = finished
+    row.duration_ms = int((finished - started).total_seconds() * 1000)
+
+    target.drill_last_status = outcome.state
+    target.drill_last_at = finished
+    if target.drill_enabled and target.drill_cron:
+        from app.services.backup.schedule import compute_next_run  # noqa: PLC0415
+
+        try:
+            target.drill_next_run_at = compute_next_run(target.drill_cron, after=finished)
+        except Exception as exc:  # noqa: BLE001
+            # A bad cron shouldn't wedge the sweep on this row forever.
+            logger.warning(
+                "restore_drill_next_run_failed",
+                target_id=str(target.id),
+                cron=target.drill_cron,
+                error=str(exc),
+            )
+            target.drill_next_run_at = None
+
+    logger.info(
+        "restore_drill_finished",
+        target_id=str(target.id),
+        state=outcome.state,
+        filename=outcome.filename,
+        duration_ms=row.duration_ms,
+    )
+    return row
+
+
+async def _execute(target: BackupTarget, *, live_db_url: str) -> DrillOutcome:
+    """Do the work, translating every failure mode into a verdict.
+
+    Never raises: the caller always gets a ``DrillOutcome`` to
+    persist.
+    """
+    assertions: list[Assertion] = []
+
+    # 1. Fetch the newest archive from the destination.
+    try:
+        driver = get_destination(target.kind)
+        plain_config = decrypt_config_secrets(driver, target.config)
+        listings = await driver.list_archives(config=plain_config)
+    except (BackupDestinationError, SecretFieldError, ValueError) as exc:
+        return DrillOutcome(state="error", error=f"could not reach the destination: {exc}")
+
+    if not listings:
+        assertions.append(
+            Assertion(
+                "archive_available",
+                FAIL,
+                "the destination holds no archives — there is nothing to restore from",
+            )
+        )
+        return DrillOutcome(state="failed", assertions=assertions)
+
+    newest = max(listings, key=lambda a: a.created_at)
+    assertions.append(
+        Assertion("archive_available", PASS, f"{newest.filename} ({newest.size_bytes} bytes)")
+    )
+
+    try:
+        archive_bytes = await driver.download(config=plain_config, filename=newest.filename)
+    except BackupDestinationError as exc:
+        return DrillOutcome(
+            state="error",
+            filename=newest.filename,
+            assertions=assertions,
+            error=f"download failed: {exc}",
+        )
+    if not archive_bytes:
+        assertions.append(
+            Assertion("archive_readable", FAIL, "archive downloaded empty from the destination")
+        )
+        return DrillOutcome(state="failed", filename=newest.filename, assertions=assertions)
+
+    base = DrillOutcome(
+        state="failed",
+        filename=newest.filename,
+        archive_bytes=len(archive_bytes),
+        assertions=assertions,
+    )
+
+    # 2. Parse it, and prove the stored passphrase opens it.
+    try:
+        manifest, db_bytes, dump_format, secrets_enc = extract_archive_members(archive_bytes)
+    except BackupArchiveError as exc:
+        assertions.append(Assertion("archive_readable", FAIL, str(exc)))
+        return base
+    base.manifest = manifest
+    assertions.append(
+        Assertion(
+            "archive_readable",
+            PASS,
+            f"format_version={manifest.get('format_version')} dump_format={dump_format}",
+        )
+    )
+
+    try:
+        passphrase = decrypt_str(target.passphrase_encrypted)
+    except Exception as exc:  # noqa: BLE001
+        # The stored passphrase itself is unreadable — that's this
+        # install's key management, not the archive.
+        return DrillOutcome(
+            state="error",
+            filename=newest.filename,
+            archive_bytes=len(archive_bytes),
+            manifest=manifest,
+            assertions=assertions,
+            error=f"could not decrypt the target's stored passphrase: {exc}",
+        )
+
+    try:
+        payload = decrypt_secrets(secrets_enc, passphrase=passphrase)
+    except BackupCryptoError as exc:
+        assertions.append(
+            Assertion(
+                "passphrase_opens_secrets",
+                FAIL,
+                f"the passphrase stored on this target does not open the archive's "
+                f"secrets.enc — a restore from it would be impossible ({exc})",
+            )
+        )
+        return base
+    assertions.append(
+        Assertion(
+            "passphrase_opens_secrets",
+            PASS,
+            f"{len(payload)} secret key(s) recovered",
+        )
+    )
+
+    # 3. Replay into a throwaway database and assert against it.
+    try:
+        _pg_env, live_dbname = _pg_env_from_url(live_db_url)
+        scratch_db = _scratch_db_name(live_dbname)
+    except (BackupArchiveError, DrillError) as exc:
+        return DrillOutcome(
+            state="error",
+            filename=newest.filename,
+            archive_bytes=len(archive_bytes),
+            manifest=manifest,
+            assertions=assertions,
+            error=str(exc),
+        )
+    base.scratch_db = scratch_db
+
+    try:
+        await _create_scratch_db(scratch_db, live_db_url=live_db_url)
+    except DrillError as exc:
+        return DrillOutcome(
+            state="error",
+            filename=newest.filename,
+            archive_bytes=len(archive_bytes),
+            manifest=manifest,
+            scratch_db=scratch_db,
+            assertions=assertions,
+            error=f"could not create the scratch database: {exc}",
+        )
+
+    try:
+        try:
+            await _replay_into_scratch(
+                db_bytes,
+                dump_format=dump_format,
+                scratch_db=scratch_db,
+                live_db_url=live_db_url,
+            )
+        except BackupArchiveError as exc:
+            assertions.append(Assertion("dump_replays_cleanly", FAIL, str(exc)))
+            return base
+        assertions.append(Assertion("dump_replays_cleanly", PASS, f"replayed into {scratch_db}"))
+
+        try:
+            assertions.extend(await _assert_against_scratch(_scratch_url(live_db_url, scratch_db)))
+        except Exception as exc:  # noqa: BLE001
+            return DrillOutcome(
+                state="error",
+                filename=newest.filename,
+                archive_bytes=len(archive_bytes),
+                manifest=manifest,
+                scratch_db=scratch_db,
+                assertions=assertions,
+                error=f"post-replay assertions could not run: {exc}",
+            )
+    finally:
+        await _drop_scratch_db(scratch_db, live_db_url=live_db_url)
+
+    base.state = "failed" if any(a.status == FAIL for a in assertions) else "passed"
+    return base

--- a/backend/app/services/backup/drill.py
+++ b/backend/app/services/backup/drill.py
@@ -40,18 +40,20 @@ import asyncio
 import os
 import secrets as secrets_mod
 import tempfile
+import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import structlog
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
 from app.config import settings
 from app.core.crypto import decrypt_str
+from app.models.audit import AuditLog
 from app.models.backup import BackupTarget, RestoreDrill
 from app.services.backup.archive import (
     BackupArchiveError,
@@ -60,6 +62,7 @@ from app.services.backup.archive import (
     extract_archive_members,
 )
 from app.services.backup.crypto import BackupCryptoError, decrypt_secrets
+from app.services.backup.restore import SUPPORTED_FORMAT_VERSIONS
 from app.services.backup.targets import (
     BackupDestinationError,
     SecretFieldError,
@@ -76,18 +79,110 @@ SCRATCH_DB_PREFIX = "spatiumddi_drill_"
 # DATABASE) are fast and get a much tighter bound.
 _REPLAY_TIMEOUT_SECONDS = 30 * 60
 _MAINTENANCE_TIMEOUT_SECONDS = 120
+# Fetching the archive off the destination is unbounded by the driver
+# (an S3 pull over a slow WAN can run long), so the drill bounds it
+# itself. Without this the total runtime has no ceiling and
+# STALE_IN_PROGRESS_SECONDS below would be a fiction.
+_DOWNLOAD_TIMEOUT_SECONDS = 30 * 60
+# The post-replay assertions open a session on the scratch database
+# and walk the audit chain. Bounded for the same reason.
+_ASSERT_TIMEOUT_SECONDS = 10 * 60
 
 # How long a ``drill_last_status="in_progress"`` mutex is believed
 # before the sweep treats it as stranded. A worker killed mid-drill
 # never gets to stamp a terminal state, and without this the target
-# would silently stop drilling forever. Comfortably above the replay
-# timeout so a genuinely slow drill is never stolen from itself.
-STALE_IN_PROGRESS_SECONDS = _REPLAY_TIMEOUT_SECONDS + 15 * 60
+# would silently stop drilling forever.
+#
+# Derived from EVERY bounded phase, not just the replay: download +
+# replay + assertions + slack for the un-timed glue between them. Set
+# it below the real worst case and the sweep would start a second
+# drill against a target that is still legitimately working, giving
+# two concurrent scratch databases and a verdict race.
+STALE_IN_PROGRESS_SECONDS = (
+    _DOWNLOAD_TIMEOUT_SECONDS + _REPLAY_TIMEOUT_SECONDS + _ASSERT_TIMEOUT_SECONDS + 15 * 60
+)
+
+# The audit-chain walk materialises one ORM object per row, and it runs
+# while the archive bytes and the dump bytes are both still referenced.
+# On a multi-million-row audit log that is an OOM-kill mid-drill — which
+# stranding the mutex and leaking the scratch database on the way out.
+# Cap the walk: a break in the first 250k rows is plenty to prove the
+# chain is damaged, and the nightly audit_chain_verify task does the
+# exhaustive pass against the live table.
+_CHAIN_VERIFY_MAX_ROWS = 250_000
+
+# A drill puts a full second copy of the database on the SAME Postgres
+# instance. On the appliance's default 8Gi CNPG volume a 6 GB install
+# would fill the volume and take the production primary down with it —
+# an outage caused by a read-only verification job. There is no portable
+# way to ask Postgres how much free space its data volume has, so the
+# risk is bounded from the other end: refuse to drill when the copy
+# would exceed this size unless the operator raises the ceiling
+# deliberately (``SPATIUM_DRILL_MAX_DB_BYTES``).
+_DEFAULT_MAX_DB_BYTES = 20 * 1024**3
 
 # Assertion verdicts.
 PASS = "pass"
 FAIL = "fail"
 SKIP = "skip"
+
+
+def _human_bytes(n: int) -> str:
+    """Size for an operator-facing message.
+
+    Integer GiB alone renders anything under a gigabyte as "0 GiB",
+    which reads as a bug in the message rather than a small database.
+    """
+    for unit, scale in (("GiB", 1024**3), ("MiB", 1024**2), ("KiB", 1024)):
+        if n >= scale:
+            return f"{n / scale:.1f} {unit}"
+    return f"{n} bytes"
+
+
+def drill_mutex_is_stale(target: BackupTarget, now: datetime) -> bool:
+    """True when an ``in_progress`` drill mutex was stranded rather
+    than being genuinely held.
+
+    A worker killed mid-drill — or an api pod restarted under a
+    synchronous manual run — never stamps a terminal state, and the
+    target would otherwise stop drilling forever and 409 every manual
+    retry. ``drill_last_at`` carries the running drill's start time, so
+    its age is the mutex's age. A NULL means the row was never stamped
+    at all, which is also stale.
+
+    Shared by the beat sweep and the manual run-now endpoint: both need
+    the identical rule, and letting them drift would mean the scheduler
+    recovers a target the operator still can't touch by hand.
+    """
+    if target.drill_last_at is None:
+        return True
+    age = (now - target.drill_last_at).total_seconds()
+    if age < STALE_IN_PROGRESS_SECONDS:
+        return False
+    logger.warning(
+        "restore_drill_stale_mutex_cleared",
+        target_id=str(target.id),
+        age_seconds=int(age),
+    )
+    return True
+
+
+def _max_scratch_db_bytes() -> int:
+    """Ceiling on the live database size a drill will copy.
+
+    Env-overridable rather than a settings column: it is a safety
+    property of the host's disk, not per-target configuration, and an
+    operator raising it is making a deliberate statement about their
+    volume. ``0`` disables the guard.
+    """
+    raw = os.environ.get("SPATIUM_DRILL_MAX_DB_BYTES")
+    if not raw:
+        return _DEFAULT_MAX_DB_BYTES
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("restore_drill_bad_max_db_bytes", value=raw)
+        return _DEFAULT_MAX_DB_BYTES
 
 
 class DrillError(Exception):
@@ -135,6 +230,94 @@ def _scratch_db_name(live_dbname: str) -> str:
     if name == live_dbname:
         raise DrillError("generated scratch database name collided with the live database")
     return name
+
+
+async def _query_scalar(sql: str, *, live_db_url: str, timeout: float) -> str:
+    """Run a single read-only query against the live database and
+    return the first column of the first row as text."""
+    pg_env, _dbname = _pg_env_from_url(live_db_url)
+    proc = await asyncio.create_subprocess_exec(
+        "psql",
+        "--no-align",
+        "--tuples-only",
+        "--set=ON_ERROR_STOP=1",
+        f"--command={sql}",
+        env=_pg_subprocess_env(pg_env),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError as exc:
+        proc.kill()
+        await proc.wait()
+        raise DrillError(f"query exceeded {timeout}s timeout") from exc
+    if proc.returncode != 0:
+        msg = (stderr.decode(errors="replace") or stdout.decode(errors="replace"))[:800]
+        raise DrillError(f"query failed (exit {proc.returncode}): {msg}")
+    return stdout.decode(errors="replace").strip()
+
+
+async def preflight(*, live_db_url: str) -> None:
+    """Prove a drill *can* run before it starts creating things.
+
+    Two gates, both raising :class:`DrillError` (→ ``state="error"``,
+    which correctly says nothing about the archive):
+
+    1. **CREATEDB.** The appliance's permanent Postgres shape is
+       CloudNativePG, whose ``initdb.owner`` is a plain LOGIN role with
+       no CREATEDB and superuser access switched off. Without the
+       privilege every drill dies inside ``CREATE DATABASE`` with a
+       bare "permission denied", which reads as a mysterious
+       infrastructure fault rather than a one-line fix. Checked up
+       front so the message can name the privilege, the role, and the
+       remedy.
+    2. **Size.** The scratch database is a full second copy on the same
+       instance. Postgres exposes no portable free-space query, so the
+       exposure is bounded by refusing to copy a database larger than
+       the operator has agreed to.
+    """
+    role_can_create = await _query_scalar(
+        "SELECT rolcreatedb OR rolsuper FROM pg_roles WHERE rolname = current_user",
+        live_db_url=live_db_url,
+        timeout=_MAINTENANCE_TIMEOUT_SECONDS,
+    )
+    if role_can_create.lower() not in ("t", "true"):
+        _pg_env, dbname = _pg_env_from_url(live_db_url)
+        raise DrillError(
+            "the database role SpatiumDDI connects as lacks CREATEDB, so a "
+            "throwaway database cannot be created. On Kubernetes / appliance "
+            "installs set `postgresql.cnpg.appRoleCreateDb: true` (the chart "
+            "default) and let CloudNativePG reconcile the role; on "
+            "docker-compose grant it directly with "
+            f"`ALTER ROLE <user> CREATEDB;` against {dbname}. Restore drills "
+            "cannot run until then."
+        )
+
+    ceiling = _max_scratch_db_bytes()
+    if ceiling <= 0:
+        return
+    raw_size = await _query_scalar(
+        "SELECT pg_database_size(current_database())",
+        live_db_url=live_db_url,
+        timeout=_MAINTENANCE_TIMEOUT_SECONDS,
+    )
+    try:
+        size = int(raw_size)
+    except ValueError:
+        # Couldn't measure — don't block the drill on a probe failure,
+        # but say so, because the size guard is silently not applying.
+        logger.warning("restore_drill_size_probe_unreadable", value=raw_size[:120])
+        return
+    if size > ceiling:
+        raise DrillError(
+            f"the live database is {_human_bytes(size)} and a drill copies it "
+            f"in full onto the same Postgres instance, which would risk filling "
+            f"the volume the production database is running on. The ceiling is "
+            f"{_human_bytes(ceiling)}. Raise SPATIUM_DRILL_MAX_DB_BYTES "
+            f"(bytes, 0 disables the guard) once you have confirmed the data "
+            f"volume has room for a second copy."
+        )
 
 
 async def _run_maintenance_sql(sql: str, *, live_db_url: str, timeout: float) -> None:
@@ -195,6 +378,49 @@ async def _drop_scratch_db(name: str, *, live_db_url: str) -> None:
         # Leaves a stray database behind. Surfaced loudly because it
         # needs manual cleanup, but never fatal to the drill result.
         logger.error("restore_drill_scratch_drop_failed", dbname=name, error=str(exc))
+
+
+async def reap_orphaned_scratch_dbs(*, live_db_url: str) -> list[str]:
+    """Drop ``spatiumddi_drill_*`` databases left behind by a drill that
+    never reached its ``finally``.
+
+    The in-process cleanup covers every path the drill can *return*
+    through, but not a SIGKILL — a pod eviction, an OOM kill, or a node
+    drain mid-replay leaves a full-size copy of the production database
+    on the instance forever. Nothing else would ever remove it, and the
+    stale-mutex path re-drills under a *fresh* random name, so each
+    killed drill would permanently add another copy until the volume
+    filled. The fixed prefix exists precisely so this sweep is possible.
+
+    Liveness, not age, is the safety signal: a drill holds a connection
+    to its scratch database for the whole replay-and-assert window, so
+    "carries the prefix AND has no backend attached" cannot match a
+    drill that is still working. That avoids having to guess a safe age
+    threshold, and it stays correct however long a legitimate drill
+    runs.
+    """
+    listing = await _query_scalar(
+        "SELECT string_agg(d.datname, ',') FROM pg_database d "
+        "WHERE d.datname LIKE 'spatiumddi\\_drill\\_%' "
+        "AND NOT EXISTS (SELECT 1 FROM pg_stat_activity a WHERE a.datname = d.datname)",
+        live_db_url=live_db_url,
+        timeout=_MAINTENANCE_TIMEOUT_SECONDS,
+    )
+    names = [n.strip() for n in listing.split(",") if n.strip()]
+    reaped: list[str] = []
+    for name in names:
+        if not name.startswith(SCRATCH_DB_PREFIX):
+            continue
+        await _drop_scratch_db(name, live_db_url=live_db_url)
+        reaped.append(name)
+    if reaped:
+        logger.warning(
+            "restore_drill_reaped_orphans",
+            count=len(reaped),
+            databases=reaped,
+            note="left behind by drills that were killed before cleanup",
+        )
+    return reaped
 
 
 def _scratch_url(live_db_url: str, scratch_db: str) -> str:
@@ -449,7 +675,7 @@ async def _assert_audit_chain(
         return
 
     try:
-        result = await verify_chain(session)
+        result = await verify_chain(session, max_rows=_CHAIN_VERIFY_MAX_ROWS)
     except Exception as exc:  # noqa: BLE001
         out.append(
             Assertion("audit_chain_intact", SKIP, f"chain verification could not run: {exc}")
@@ -457,13 +683,83 @@ async def _assert_audit_chain(
         return
 
     if result.ok:
-        out.append(Assertion("audit_chain_intact", PASS, f"{result.rows_checked} rows verified"))
+        capped = (
+            f" (capped at {_CHAIN_VERIFY_MAX_ROWS}; the nightly verify task walks the full table)"
+            if result.rows_checked >= _CHAIN_VERIFY_MAX_ROWS
+            else ""
+        )
+        out.append(
+            Assertion("audit_chain_intact", PASS, f"{result.rows_checked} rows verified{capped}")
+        )
         return
     first = result.breaks[0] if result.breaks else None
     detail = f"{len(result.breaks)} break(s) across {result.rows_checked} rows" + (
         f"; first at seq {first.seq} ({first.reason})" if first is not None else ""
     )
     out.append(Assertion("audit_chain_intact", FAIL, detail))
+
+
+# ── readiness rollup ──────────────────────────────────────────────────
+
+
+async def compute_drill_readiness(db: AsyncSession) -> list[dict[str, Any]]:
+    """Per-target recovery readiness: *can this be restored, and how do
+    we know?*
+
+    Shared by the REST endpoint, the Operator Copilot tool, and the
+    admin UI so all three answer identically — the question is too
+    load-bearing to have three implementations that can drift.
+
+    ``verified`` is deliberately NOT "the last drill passed":
+
+    * A target whose latest drill hit ``error`` (destination briefly
+      unreachable) has not been disproven — the alert path treats an
+      error as leaving the previous verdict standing, and this must
+      agree, or a transient S3 blip would report a backup proven 24 h
+      ago as unverified.
+    * A target that has never passed is unverified regardless of what
+      else it has done. An untested backup is an unknown, not a pass.
+
+    So: verified = has passed at some point AND the most recent
+    *finished* verdict is not a failure. ``hours_since_last_pass``
+    carries the staleness so callers can judge how old the proof is.
+    """
+    targets = (
+        (await db.execute(select(BackupTarget).order_by(BackupTarget.name.asc()))).scalars().all()
+    )
+    now = datetime.now(UTC)
+    out: list[dict[str, Any]] = []
+    for t in targets:
+        last_pass = await db.scalar(
+            select(RestoreDrill.finished_at)
+            .where(RestoreDrill.target_id == t.id, RestoreDrill.state == "passed")
+            .order_by(RestoreDrill.finished_at.desc())
+            .limit(1)
+        )
+        latest_finished = await db.scalar(
+            select(RestoreDrill.state)
+            .where(RestoreDrill.target_id == t.id, RestoreDrill.state.in_(("passed", "failed")))
+            .order_by(RestoreDrill.started_at.desc())
+            .limit(1)
+        )
+        age_hours = round((now - last_pass).total_seconds() / 3600, 1) if last_pass else None
+        out.append(
+            {
+                "target_id": str(t.id),
+                "target_name": t.name,
+                "kind": t.kind,
+                "enabled": t.enabled,
+                "drills_scheduled": bool(t.drill_enabled and t.drill_cron),
+                "drill_cron": t.drill_cron,
+                "latest_verdict": t.drill_last_status,
+                "latest_finished_verdict": latest_finished,
+                "latest_drill_at": t.drill_last_at.isoformat() if t.drill_last_at else None,
+                "last_passed_at": last_pass.isoformat() if last_pass else None,
+                "hours_since_last_pass": age_hours,
+                "verified": last_pass is not None and latest_finished != "failed",
+            }
+        )
+    return out
 
 
 # ── orchestration ─────────────────────────────────────────────────────
@@ -474,12 +770,21 @@ async def run_drill_for_target(
     *,
     target: BackupTarget,
     triggered_by: str = "manual",
+    actor_id: uuid.UUID | None = None,
+    actor_display: str = "system (schedule)",
 ) -> RestoreDrill:
     """Run one restore-verification drill against ``target``.
 
     Persists a ``running`` row up front so a long drill is visible
     in the UI while it works, then stamps the terminal state. The
     caller commits; the row is returned attached to ``db``.
+
+    The audit row is written *here* rather than in the API handler so
+    scheduled drills are audited too — this function mutates
+    ``backup_target`` and inserts a ``restore_drill`` row on every run,
+    and non-negotiable #4 admits no "unless a cron did it" exception.
+    Mirrors ``run_backup_for_target``, which audits from the runner for
+    the same reason.
     """
     started = datetime.now(UTC)
     row = RestoreDrill(target_id=target.id, state="running", triggered_by=triggered_by)
@@ -524,6 +829,27 @@ async def run_drill_for_target(
             )
             target.drill_next_run_at = None
 
+    db.add(
+        AuditLog(
+            action="backup_restore_drill",
+            resource_type="backup_target",
+            resource_id=str(target.id),
+            resource_display=target.name,
+            user_id=actor_id,
+            user_display_name=actor_display,
+            result="success" if outcome.state == "passed" else "failure",
+            error_detail=outcome.error,
+            new_value={
+                "drill_id": str(row.id),
+                "state": outcome.state,
+                "triggered_by": triggered_by,
+                "filename": outcome.filename,
+                "duration_ms": row.duration_ms,
+                "assertions": row.assertions,
+            },
+        )
+    )
+
     logger.info(
         "restore_drill_finished",
         target_id=str(target.id),
@@ -541,6 +867,14 @@ async def _execute(target: BackupTarget, *, live_db_url: str) -> DrillOutcome:
     persist.
     """
     assertions: list[Assertion] = []
+
+    # 0. Prove the drill can run at all before creating anything. Both
+    #    gates are infrastructure facts, so a failure is ``error`` —
+    #    it says nothing about the archive.
+    try:
+        await preflight(live_db_url=live_db_url)
+    except DrillError as exc:
+        return DrillOutcome(state="error", error=str(exc))
 
     # 1. Fetch the newest archive from the destination.
     try:
@@ -566,7 +900,24 @@ async def _execute(target: BackupTarget, *, live_db_url: str) -> DrillOutcome:
     )
 
     try:
-        archive_bytes = await driver.download(config=plain_config, filename=newest.filename)
+        # Bounded explicitly: the destination drivers impose no ceiling
+        # of their own, and an unbounded fetch would make the sweep's
+        # stale-mutex threshold meaningless (see
+        # STALE_IN_PROGRESS_SECONDS).
+        archive_bytes = await asyncio.wait_for(
+            driver.download(config=plain_config, filename=newest.filename),
+            timeout=_DOWNLOAD_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        return DrillOutcome(
+            state="error",
+            filename=newest.filename,
+            assertions=assertions,
+            error=(
+                f"downloading {newest.filename} from the destination exceeded "
+                f"{_DOWNLOAD_TIMEOUT_SECONDS}s"
+            ),
+        )
     except BackupDestinationError as exc:
         return DrillOutcome(
             state="error",
@@ -594,11 +945,28 @@ async def _execute(target: BackupTarget, *, live_db_url: str) -> DrillOutcome:
         assertions.append(Assertion("archive_readable", FAIL, str(exc)))
         return base
     base.manifest = manifest
+    # The real restore path refuses an archive whose format_version this
+    # build doesn't support, so a drill that waved it through would
+    # report "restorable" for something restore would reject outright —
+    # the one failure mode this whole feature exists to catch. Checked
+    # against the same constant restore.apply_backup_restore uses.
+    fmt_version = manifest.get("format_version")
+    if fmt_version not in SUPPORTED_FORMAT_VERSIONS:
+        assertions.append(
+            Assertion(
+                "archive_readable",
+                FAIL,
+                f"unsupported backup format_version {fmt_version!r} — this build "
+                f"restores {sorted(SUPPORTED_FORMAT_VERSIONS)}. The archive was "
+                f"written by a newer SpatiumDDI; a restore would refuse it.",
+            )
+        )
+        return base
     assertions.append(
         Assertion(
             "archive_readable",
             PASS,
-            f"format_version={manifest.get('format_version')} dump_format={dump_format}",
+            f"format_version={fmt_version} dump_format={dump_format}",
         )
     )
 
@@ -678,7 +1046,22 @@ async def _execute(target: BackupTarget, *, live_db_url: str) -> DrillOutcome:
         assertions.append(Assertion("dump_replays_cleanly", PASS, f"replayed into {scratch_db}"))
 
         try:
-            assertions.extend(await _assert_against_scratch(_scratch_url(live_db_url, scratch_db)))
+            assertions.extend(
+                await asyncio.wait_for(
+                    _assert_against_scratch(_scratch_url(live_db_url, scratch_db)),
+                    timeout=_ASSERT_TIMEOUT_SECONDS,
+                )
+            )
+        except TimeoutError:
+            return DrillOutcome(
+                state="error",
+                filename=newest.filename,
+                archive_bytes=len(archive_bytes),
+                manifest=manifest,
+                scratch_db=scratch_db,
+                assertions=assertions,
+                error=f"post-replay assertions exceeded {_ASSERT_TIMEOUT_SECONDS}s",
+            )
         except Exception as exc:  # noqa: BLE001
             return DrillOutcome(
                 state="error",

--- a/backend/app/tasks/backup_drill.py
+++ b/backend/app/tasks/backup_drill.py
@@ -28,40 +28,34 @@ import structlog
 from sqlalchemy import select
 
 from app.celery_app import celery_app
+from app.config import settings
 from app.db import task_session
 from app.models.backup import BackupTarget
-from app.services.backup.drill import STALE_IN_PROGRESS_SECONDS, run_drill_for_target
+from app.services.backup.drill import (
+    DrillError,
+    drill_mutex_is_stale,
+    reap_orphaned_scratch_dbs,
+    run_drill_for_target,
+)
 
 logger = structlog.get_logger(__name__)
-
-
-def _mutex_is_stale(target: BackupTarget, now: datetime) -> bool:
-    """True when an ``in_progress`` drill mutex was stranded rather
-    than being genuinely held.
-
-    A worker killed mid-drill never stamps a terminal state, and the
-    row would otherwise stop drilling forever. ``drill_last_at``
-    carries the running drill's start time, so its age is the mutex's
-    age. A NULL means the row was never stamped at all — also stale.
-    """
-    if target.drill_last_at is None:
-        return True
-    age = (now - target.drill_last_at).total_seconds()
-    if age < STALE_IN_PROGRESS_SECONDS:
-        return False
-    logger.warning(
-        "restore_drill_stale_mutex_cleared",
-        target_id=str(target.id),
-        age_seconds=int(age),
-    )
-    return True
 
 
 async def _sweep() -> dict[str, int]:
     fired = 0
     skipped_in_progress = 0
+    reaped = 0
     async with task_session() as db:
         now = datetime.now(UTC)
+        # Drop scratch databases left behind by drills that were killed
+        # before their cleanup ran. Cheap when there is nothing to do
+        # (one indexed catalogue query), and the only thing standing
+        # between a SIGKILLed drill and a permanent full-size copy of
+        # the production database sitting on the same volume.
+        try:
+            reaped = len(await reap_orphaned_scratch_dbs(live_db_url=str(settings.database_url)))
+        except DrillError as exc:
+            logger.warning("restore_drill_reap_failed", error=str(exc))
         rows = (
             (
                 await db.execute(
@@ -78,7 +72,7 @@ async def _sweep() -> dict[str, int]:
             .all()
         )
         for target in rows:
-            if target.drill_last_status == "in_progress" and not _mutex_is_stale(target, now):
+            if target.drill_last_status == "in_progress" and not drill_mutex_is_stale(target, now):
                 skipped_in_progress += 1
                 continue
             try:
@@ -97,12 +91,16 @@ async def _sweep() -> dict[str, int]:
                     target_id=str(target.id),
                     error=str(exc),
                 )
-    return {"fired": fired, "skipped_in_progress": skipped_in_progress}
+    return {
+        "fired": fired,
+        "skipped_in_progress": skipped_in_progress,
+        "reaped_scratch_dbs": reaped,
+    }
 
 
 @celery_app.task(name="app.tasks.backup_drill.sweep_restore_drills")
 def sweep_restore_drills() -> dict[str, int]:
     result = asyncio.run(_sweep())
-    if result["fired"] or result["skipped_in_progress"]:
+    if any(result.values()):
         logger.info("restore_drill_sweep_tick", **result)
     return result

--- a/backend/app/tasks/backup_drill.py
+++ b/backend/app/tasks/backup_drill.py
@@ -1,0 +1,108 @@
+"""Beat-driven sweep that fires due restore-verification drills
+(issue #702).
+
+Tick cadence: every 60 s, matching the backup-target sweep. Each
+tick walks every enabled target with drills turned on and a
+``drill_next_run_at`` now in the past, and runs one drill for it.
+:func:`run_drill_for_target` re-stamps ``drill_next_run_at`` from
+the cron after the run lands, so a row won't fire twice in the
+same tick.
+
+Per-target dispatch is mutexed by ``drill_last_status =
+"in_progress"``, which the runner stamps on entry — a drill that
+spans several ticks (a large archive can) won't double up.
+
+A drill replays a full dump into a scratch database, so it is
+substantially more expensive than a backup. That cost is the
+reason drills carry their own cron rather than riding
+``schedule_cron``: weekly drills against nightly backups is the
+expected shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select
+
+from app.celery_app import celery_app
+from app.db import task_session
+from app.models.backup import BackupTarget
+from app.services.backup.drill import STALE_IN_PROGRESS_SECONDS, run_drill_for_target
+
+logger = structlog.get_logger(__name__)
+
+
+def _mutex_is_stale(target: BackupTarget, now: datetime) -> bool:
+    """True when an ``in_progress`` drill mutex was stranded rather
+    than being genuinely held.
+
+    A worker killed mid-drill never stamps a terminal state, and the
+    row would otherwise stop drilling forever. ``drill_last_at``
+    carries the running drill's start time, so its age is the mutex's
+    age. A NULL means the row was never stamped at all — also stale.
+    """
+    if target.drill_last_at is None:
+        return True
+    age = (now - target.drill_last_at).total_seconds()
+    if age < STALE_IN_PROGRESS_SECONDS:
+        return False
+    logger.warning(
+        "restore_drill_stale_mutex_cleared",
+        target_id=str(target.id),
+        age_seconds=int(age),
+    )
+    return True
+
+
+async def _sweep() -> dict[str, int]:
+    fired = 0
+    skipped_in_progress = 0
+    async with task_session() as db:
+        now = datetime.now(UTC)
+        rows = (
+            (
+                await db.execute(
+                    select(BackupTarget).where(
+                        BackupTarget.enabled.is_(True),
+                        BackupTarget.drill_enabled.is_(True),
+                        BackupTarget.drill_cron.is_not(None),
+                        BackupTarget.drill_next_run_at.is_not(None),
+                        BackupTarget.drill_next_run_at <= now,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for target in rows:
+            if target.drill_last_status == "in_progress" and not _mutex_is_stale(target, now):
+                skipped_in_progress += 1
+                continue
+            try:
+                await run_drill_for_target(db, target=target, triggered_by="schedule")
+                await db.commit()
+                fired += 1
+            except Exception as exc:  # noqa: BLE001
+                # ``run_drill_for_target`` turns every expected
+                # failure into a persisted verdict, so a bubble-up
+                # here is something deeper (DB lost mid-run). Roll
+                # back and move on so one sick target can't wedge
+                # the sweep for the others.
+                await db.rollback()
+                logger.exception(
+                    "restore_drill_sweep_unexpected",
+                    target_id=str(target.id),
+                    error=str(exc),
+                )
+    return {"fired": fired, "skipped_in_progress": skipped_in_progress}
+
+
+@celery_app.task(name="app.tasks.backup_drill.sweep_restore_drills")
+def sweep_restore_drills() -> dict[str, int]:
+    result = asyncio.run(_sweep())
+    if result["fired"] or result["skipped_in_progress"]:
+        logger.info("restore_drill_sweep_tick", **result)
+    return result

--- a/backend/tests/test_restore_drills.py
+++ b/backend/tests/test_restore_drills.py
@@ -1,0 +1,577 @@
+"""Restore-verification drills (issue #702).
+
+A drill replays a backup target's newest archive into a throwaway
+database and asserts against the result. The tests here cover the
+parts that carry real risk if they regress:
+
+* **scratch-database safety** — the one place a bug would replay a
+  backup over production. Name generation, the live-name collision
+  guard, and the drop-refuses-unprefixed guard;
+* **URL derivation** — swapping the database name without losing
+  driver, credentials, or query string;
+* **verdict rollup** — ``passed`` only when nothing failed; a skip
+  is not a failure;
+* **the alert matcher** — subject is the target (not the run), only
+  the latest *finished* drill counts, and ``error`` deliberately
+  does not mask the previous verdict;
+* **RBAC** — the whole surface is superadmin-only.
+
+Nothing here talks to a real destination or spawns psql: the parts
+that do are thin subprocess wrappers, and the logic worth pinning
+down sits either side of them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import encrypt_str
+from app.core.security import create_access_token, hash_password
+from app.models.alerts import AlertEvent, AlertRule
+from app.models.auth import User
+from app.models.backup import BackupTarget, RestoreDrill
+from app.services.alerts import (
+    RULE_TYPE_RESTORE_DRILL_FAILED,
+    _matching_restore_drill_failed_subjects,
+)
+from app.services.backup.drill import (
+    FAIL,
+    PASS,
+    SCRATCH_DB_PREFIX,
+    SKIP,
+    Assertion,
+    DrillError,
+    _scratch_db_name,
+    _scratch_url,
+)
+
+
+async def _make_user(
+    db: AsyncSession,
+    *,
+    superadmin: bool = True,
+    username: str = "drilladmin",
+) -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        auth_source="local",
+        is_superadmin=superadmin,
+    )
+    user.groups = []  # mark loaded — is_effective_superadmin walks .groups (#351)
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_target(db: AsyncSession, *, name: str = "vault") -> BackupTarget:
+    target = BackupTarget(
+        name=name,
+        description="",
+        kind="local_volume",
+        enabled=True,
+        config={"path": "/var/lib/spatiumddi/backups"},
+        passphrase_encrypted=encrypt_str("hunter2hunter2"),
+    )
+    db.add(target)
+    await db.flush()
+    return target
+
+
+async def _make_drill(
+    db: AsyncSession,
+    target: BackupTarget,
+    *,
+    state: str,
+    started_at: datetime,
+    assertions: list[dict[str, object]] | None = None,
+) -> RestoreDrill:
+    drill = RestoreDrill(
+        target_id=target.id,
+        state=state,
+        triggered_by="schedule",
+        filename="spatiumddi-backup-20260724.zip",
+        assertions=assertions if assertions is not None else [],
+        started_at=started_at,
+        finished_at=started_at + timedelta(seconds=30),
+    )
+    db.add(drill)
+    await db.flush()
+    return drill
+
+
+# ── scratch database safety ───────────────────────────────────────────
+
+
+def test_scratch_db_name_is_prefixed_and_unique() -> None:
+    first = _scratch_db_name("spatiumddi")
+    second = _scratch_db_name("spatiumddi")
+    assert first.startswith(SCRATCH_DB_PREFIX)
+    assert second.startswith(SCRATCH_DB_PREFIX)
+    assert first != second, "scratch names must not collide between drills"
+
+
+def test_scratch_db_name_refuses_to_match_the_live_database(monkeypatch) -> None:
+    """The guard that stops a drill replaying over production.
+
+    The name is random, so the collision has to be forced: pin the
+    token and hand in the live name it would produce. Contrived — the
+    prefix makes a real collision essentially impossible — but this is
+    the one failure whose blast radius is the whole install, so it is
+    asserted rather than assumed.
+    """
+    from app.services.backup import drill as drill_mod
+
+    monkeypatch.setattr(drill_mod.secrets_mod, "token_hex", lambda _n: "deadbeef")
+    colliding_live_name = f"{SCRATCH_DB_PREFIX}deadbeef"
+    with pytest.raises(DrillError, match="collided with the live database"):
+        _scratch_db_name(colliding_live_name)
+    # Sanity: the same pinned token against a normal live name is fine.
+    assert _scratch_db_name("spatiumddi") == colliding_live_name
+
+
+def test_scratch_url_swaps_only_the_database_name() -> None:
+    url = _scratch_url(
+        "postgresql+asyncpg://spatium:pw@db.internal:5432/spatiumddi",
+        "spatiumddi_drill_abc123",
+    )
+    assert url == "postgresql+asyncpg://spatium:pw@db.internal:5432/spatiumddi_drill_abc123"
+
+
+def test_scratch_url_preserves_query_string() -> None:
+    """A TLS-required deployment carries ``?ssl=require``; dropping it
+    would make the drill fail to connect for reasons that have
+    nothing to do with the archive."""
+    url = _scratch_url(
+        "postgresql+asyncpg://spatium:pw@db:5432/spatiumddi?ssl=require",
+        "spatiumddi_drill_deadbe",
+    )
+    assert url.endswith("/spatiumddi_drill_deadbe?ssl=require")
+
+
+@pytest.mark.asyncio
+async def test_drop_scratch_db_refuses_unprefixed_name(monkeypatch) -> None:
+    """``_drop_scratch_db`` must never issue DROP against a name it
+    didn't generate, whatever the caller passes."""
+    from app.services.backup import drill as drill_mod
+
+    issued: list[str] = []
+
+    async def _spy(sql: str, **kwargs: object) -> None:
+        issued.append(sql)
+
+    monkeypatch.setattr(drill_mod, "_run_maintenance_sql", _spy)
+    await drill_mod._drop_scratch_db("spatiumddi", live_db_url="postgresql://x/y")
+    assert issued == [], "refused to drop a database outside the drill prefix"
+
+    await drill_mod._drop_scratch_db(f"{SCRATCH_DB_PREFIX}abc123", live_db_url="postgresql://x/y")
+    assert len(issued) == 1
+    assert SCRATCH_DB_PREFIX in issued[0]
+
+
+# ── verdict rollup ────────────────────────────────────────────────────
+
+
+def test_skip_does_not_fail_the_drill() -> None:
+    """A skipped check (schema skew makes it unanswerable) is not a
+    finding — only an actual ``fail`` is."""
+    assertions = [
+        Assertion("archive_readable", PASS, "ok"),
+        Assertion("audit_chain_intact", SKIP, "schema skew"),
+    ]
+    assert not any(a.status == FAIL for a in assertions)
+
+
+def test_assertion_serialises_for_jsonb() -> None:
+    a = Assertion("core_tables_populated", PASS, "user=3, alembic_version=1")
+    assert a.as_dict() == {
+        "name": "core_tables_populated",
+        "status": "pass",
+        "detail": "user=3, alembic_version=1",
+    }
+
+
+# ── alert matcher ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_alert_matches_target_whose_latest_drill_failed(
+    db_session: AsyncSession,
+) -> None:
+    target = await _make_target(db_session, name="failing-vault")
+    now = datetime.now(UTC)
+    await _make_drill(db_session, target, state="passed", started_at=now - timedelta(days=2))
+    await _make_drill(
+        db_session,
+        target,
+        state="failed",
+        started_at=now,
+        assertions=[{"name": "passphrase_opens_secrets", "status": "fail", "detail": "bad key"}],
+    )
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
+    )
+    matches = await _matching_restore_drill_failed_subjects(db_session, rule)
+    assert len(matches) == 1
+    subject_id, display, message = matches[0]
+    assert subject_id == str(target.id)
+    assert display == "failing-vault"
+    # The failed check name belongs in the message — an operator
+    # paged at 03:00 shouldn't have to open the UI to learn what broke.
+    assert "passphrase_opens_secrets" in message
+
+
+@pytest.mark.asyncio
+async def test_alert_clears_when_latest_drill_passes(db_session: AsyncSession) -> None:
+    target = await _make_target(db_session, name="recovered-vault")
+    now = datetime.now(UTC)
+    await _make_drill(db_session, target, state="failed", started_at=now - timedelta(days=1))
+    await _make_drill(db_session, target, state="passed", started_at=now)
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
+    )
+    assert await _matching_restore_drill_failed_subjects(db_session, rule) == []
+
+
+@pytest.mark.asyncio
+async def test_error_drill_does_not_mask_the_previous_verdict(
+    db_session: AsyncSession,
+) -> None:
+    """An unreachable destination says nothing about the archive.
+
+    A later ``error`` must not resolve an open event opened by an
+    earlier ``failed`` — we know no more than we did before, and
+    silently clearing would be the dangerous reading.
+    """
+    target = await _make_target(db_session, name="flaky-vault")
+    now = datetime.now(UTC)
+    await _make_drill(db_session, target, state="failed", started_at=now - timedelta(hours=2))
+    await _make_drill(db_session, target, state="error", started_at=now)
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
+    )
+    matches = await _matching_restore_drill_failed_subjects(db_session, rule)
+    assert len(matches) == 1, "the earlier failure still stands"
+
+
+@pytest.mark.asyncio
+async def test_running_drill_neither_opens_nor_resolves(db_session: AsyncSession) -> None:
+    target = await _make_target(db_session, name="busy-vault")
+    now = datetime.now(UTC)
+    await _make_drill(db_session, target, state="failed", started_at=now - timedelta(hours=2))
+    await _make_drill(db_session, target, state="running", started_at=now)
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
+    )
+    matches = await _matching_restore_drill_failed_subjects(db_session, rule)
+    assert len(matches) == 1, "an in-flight drill hasn't given a verdict yet"
+
+
+@pytest.mark.asyncio
+async def test_one_subject_per_target_not_per_failed_drill(
+    db_session: AsyncSession,
+) -> None:
+    """A target failing nightly holds one open event, not one per run."""
+    target = await _make_target(db_session, name="nightly-fail")
+    now = datetime.now(UTC)
+    for days in range(4):
+        await _make_drill(db_session, target, state="failed", started_at=now - timedelta(days=days))
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
+    )
+    matches = await _matching_restore_drill_failed_subjects(db_session, rule)
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_target_never_drilled_does_not_match(db_session: AsyncSession) -> None:
+    await _make_target(db_session, name="undrilled")
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
+    )
+    assert await _matching_restore_drill_failed_subjects(db_session, rule) == []
+
+
+# ── API surface ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_drills_requires_superadmin(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_user(db_session, superadmin=False, username="plainuser")
+    res = await client.get("/api/v1/backup/drills", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_drills_returns_target_name(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_user(db_session, username="drilllist")
+    target = await _make_target(db_session, name="listable")
+    await _make_drill(db_session, target, state="passed", started_at=datetime.now(UTC))
+    res = await client.get("/api/v1/backup/drills", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body) == 1
+    assert body[0]["target_name"] == "listable"
+    assert body[0]["state"] == "passed"
+
+
+@pytest.mark.asyncio
+async def test_list_drills_filters_by_state(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_user(db_session, username="drillfilter")
+    target = await _make_target(db_session, name="mixed")
+    now = datetime.now(UTC)
+    await _make_drill(db_session, target, state="passed", started_at=now - timedelta(hours=1))
+    await _make_drill(db_session, target, state="failed", started_at=now)
+    res = await client.get(
+        "/api/v1/backup/drills?state=failed",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert [d["state"] for d in res.json()] == ["failed"]
+
+
+@pytest.mark.asyncio
+async def test_get_missing_drill_404s(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_user(db_session, username="drill404")
+    res = await client.get(
+        f"/api/v1/backup/drills/{uuid.uuid4()}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_run_drill_rejects_when_one_is_already_running(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_user(db_session, username="drillbusy")
+    target = await _make_target(db_session, name="already-busy")
+    target.drill_last_status = "in_progress"
+    await db_session.flush()
+    res = await client.post(
+        f"/api/v1/backup/drills/run/{target.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 409
+
+
+# ── target schedule validation ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enabling_drills_without_a_cron_is_rejected(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``drill_enabled`` with no schedule would never fire — a silent
+    no-op the operator would read as "drills are on"."""
+    _, token = await _make_user(db_session, username="drillcron")
+    target = await _make_target(db_session, name="no-cron")
+    res = await client.patch(
+        f"/api/v1/backup/targets/{target.id}",
+        json={"drill_enabled": True},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 422
+    assert "drill_cron" in res.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_setting_drill_cron_stamps_next_run(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_user(db_session, username="drillsched")
+    target = await _make_target(db_session, name="scheduled")
+    res = await client.patch(
+        f"/api/v1/backup/targets/{target.id}",
+        json={"drill_enabled": True, "drill_cron": "0 5 * * 0"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["drill_enabled"] is True
+    assert body["drill_cron"] == "0 5 * * 0"
+    assert body["drill_next_run_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_clearing_drill_cron_clears_next_run(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_user(db_session, username="drillclear")
+    target = await _make_target(db_session, name="clearable")
+    target.drill_enabled = True
+    target.drill_cron = "0 5 * * 0"
+    target.drill_next_run_at = datetime.now(UTC) + timedelta(days=1)
+    await db_session.flush()
+    res = await client.patch(
+        f"/api/v1/backup/targets/{target.id}",
+        json={"drill_enabled": False, "drill_cron": None},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json()["drill_next_run_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_drill_cron_is_rejected(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_user(db_session, username="drillbadcron")
+    target = await _make_target(db_session, name="bad-cron")
+    res = await client.patch(
+        f"/api/v1/backup/targets/{target.id}",
+        json={"drill_cron": "not a cron"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 422
+
+
+# ── sweep mutex ───────────────────────────────────────────────────────
+
+
+def test_stale_mutex_detection() -> None:
+    """A worker killed mid-drill leaves ``in_progress`` behind; without
+    the staleness escape the target would stop drilling forever."""
+    from app.services.backup.drill import STALE_IN_PROGRESS_SECONDS
+    from app.tasks.backup_drill import _mutex_is_stale
+
+    now = datetime.now(UTC)
+    target = BackupTarget(
+        name="x",
+        kind="local_volume",
+        config={},
+        passphrase_encrypted=b"",
+        drill_last_status="in_progress",
+    )
+
+    target.drill_last_at = now - timedelta(seconds=30)
+    assert _mutex_is_stale(target, now) is False, "a drill running 30s ago is genuinely held"
+
+    target.drill_last_at = now - timedelta(seconds=STALE_IN_PROGRESS_SECONDS + 60)
+    assert _mutex_is_stale(target, now) is True
+
+    target.drill_last_at = None
+    assert _mutex_is_stale(target, now) is True, "never stamped reads as stale"
+
+
+# ── MCP tools ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_find_restore_drills_gated_to_superadmin(db_session: AsyncSession) -> None:
+    from app.services.ai.tools.backup import FindRestoreDrillsArgs, find_restore_drills
+
+    user, _ = await _make_user(db_session, superadmin=False, username="mcpplain")
+    rows = await find_restore_drills(db_session, user, FindRestoreDrillsArgs())
+    assert len(rows) == 1
+    assert "error" in rows[0]
+
+
+@pytest.mark.asyncio
+async def test_readiness_reports_undrilled_target_as_unverified(
+    db_session: AsyncSession,
+) -> None:
+    """Drills off must not read as healthy — an untested backup is an
+    unknown, not a pass."""
+    from app.services.ai.tools.backup import (
+        RestoreDrillReadinessArgs,
+        get_restore_drill_readiness,
+    )
+
+    user, _ = await _make_user(db_session, username="mcpready")
+    await _make_target(db_session, name="never-drilled")
+    out = await get_restore_drill_readiness(db_session, user, RestoreDrillReadinessArgs())
+    assert out["total_targets"] == 1
+    assert out["verified_targets"] == 0
+    assert out["unverified_targets"] == 1
+    row = out["targets"][0]
+    assert row["verified"] is False
+    assert row["drills_scheduled"] is False
+    assert row["last_passed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_readiness_reports_hours_since_last_pass(db_session: AsyncSession) -> None:
+    from app.services.ai.tools.backup import (
+        RestoreDrillReadinessArgs,
+        get_restore_drill_readiness,
+    )
+
+    user, _ = await _make_user(db_session, username="mcpaged")
+    target = await _make_target(db_session, name="aged")
+    target.drill_last_status = "passed"
+    await _make_drill(
+        db_session,
+        target,
+        state="passed",
+        started_at=datetime.now(UTC) - timedelta(hours=48),
+    )
+    out = await get_restore_drill_readiness(db_session, user, RestoreDrillReadinessArgs())
+    row = out["targets"][0]
+    assert row["verified"] is True
+    assert row["hours_since_last_pass"] is not None
+    assert 47 <= row["hours_since_last_pass"] <= 49
+
+
+# ── seed rule ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_seed_rule_is_idempotent(db_session: AsyncSession) -> None:
+    """Seeding twice must not produce two rules — the seeder keys on
+    ``rule_type`` so an operator's rename or disable is never undone."""
+    existing = await db_session.scalar(
+        select(AlertRule).where(AlertRule.rule_type == RULE_TYPE_RESTORE_DRILL_FAILED)
+    )
+    assert existing is None or isinstance(existing, AlertRule)
+
+
+@pytest.mark.asyncio
+async def test_no_alert_event_rows_leak_between_targets(
+    db_session: AsyncSession,
+) -> None:
+    """Two failing targets are two distinct subjects."""
+    now = datetime.now(UTC)
+    a = await _make_target(db_session, name="vault-a")
+    b = await _make_target(db_session, name="vault-b")
+    await _make_drill(db_session, a, state="failed", started_at=now)
+    await _make_drill(db_session, b, state="failed", started_at=now)
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
+    )
+    matches = await _matching_restore_drill_failed_subjects(db_session, rule)
+    assert {m[1] for m in matches} == {"vault-a", "vault-b"}
+    assert await db_session.scalar(select(AlertEvent).limit(1)) is None

--- a/backend/tests/test_restore_drills.py
+++ b/backend/tests/test_restore_drills.py
@@ -9,11 +9,22 @@ parts that carry real risk if they regress:
   guard, and the drop-refuses-unprefixed guard;
 * **URL derivation** — swapping the database name without losing
   driver, credentials, or query string;
-* **verdict rollup** — ``passed`` only when nothing failed; a skip
-  is not a failure;
+* **verdict rollup** — driven through the real ``_execute``: a skip
+  is not a failure, one fail sinks the drill, an unsupported
+  ``format_version`` is caught the way the restore path catches it,
+  and a preflight failure is ``error`` (says nothing about the
+  archive) rather than ``failed``;
 * **the alert matcher** — subject is the target (not the run), only
-  the latest *finished* drill counts, and ``error`` deliberately
-  does not mask the previous verdict;
+  the latest *finished* drill counts, ``error`` deliberately does not
+  mask the previous verdict, targets without scheduled drills never
+  match (or the event could never resolve), and an empty destination
+  gets its own wording;
+* **the readiness rollup** — a transient ``error`` does not erase a
+  prior pass, a later failure supersedes one, and the REST endpoint
+  and the Copilot tool return byte-identical answers;
+* **mutex recovery** — a stranded ``in_progress`` flag must not lock
+  a target out of manual drills forever;
+* **audit** — scheduled drills are audited too, not just manual ones;
 * **RBAC** — the whole surface is superadmin-only.
 
 Nothing here talks to a real destination or spawns psql: the parts
@@ -25,6 +36,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from httpx import AsyncClient
@@ -34,6 +46,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.crypto import encrypt_str
 from app.core.security import create_access_token, hash_password
 from app.models.alerts import AlertEvent, AlertRule
+from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.backup import BackupTarget, RestoreDrill
 from app.services.alerts import (
@@ -72,7 +85,18 @@ async def _make_user(
     return user, create_access_token(str(user.id))
 
 
-async def _make_target(db: AsyncSession, *, name: str = "vault") -> BackupTarget:
+async def _make_target(
+    db: AsyncSession,
+    *,
+    name: str = "vault",
+    drill_enabled: bool = True,
+) -> BackupTarget:
+    """A backup target with drills scheduled by default.
+
+    Scheduled is the case most of these tests are about, and the alert
+    matcher deliberately only considers targets that have drills turned
+    on — pass ``drill_enabled=False`` to exercise that boundary.
+    """
     target = BackupTarget(
         name=name,
         description="",
@@ -80,6 +104,8 @@ async def _make_target(db: AsyncSession, *, name: str = "vault") -> BackupTarget
         enabled=True,
         config={"path": "/var/lib/spatiumddi/backups"},
         passphrase_encrypted=encrypt_str("hunter2hunter2"),
+        drill_enabled=drill_enabled,
+        drill_cron="0 5 * * 0" if drill_enabled else None,
     )
     db.add(target)
     await db.flush()
@@ -180,14 +206,166 @@ async def test_drop_scratch_db_refuses_unprefixed_name(monkeypatch) -> None:
 # ── verdict rollup ────────────────────────────────────────────────────
 
 
-def test_skip_does_not_fail_the_drill() -> None:
+class _FakeDriver:
+    """Stands in for a destination driver. No network, no disk."""
+
+    def __init__(self, *, archives: list[Any] | None = None, payload: bytes = b"zip") -> None:
+        self._archives = archives if archives is not None else [_listing("newest.zip")]
+        self._payload = payload
+
+    async def list_archives(self, *, config: dict[str, Any]) -> list[Any]:
+        return self._archives
+
+    async def download(self, *, config: dict[str, Any], filename: str) -> bytes:
+        return self._payload
+
+
+def _listing(filename: str, *, when: datetime | None = None) -> Any:
+    from app.services.backup.targets.base import ArchiveListing
+
+    return ArchiveListing(
+        filename=filename,
+        size_bytes=1234,
+        created_at=when or datetime.now(UTC),
+    )
+
+
+def _wire_drill(
+    monkeypatch,
+    *,
+    assertions: list[Assertion],
+    driver: _FakeDriver | None = None,
+    manifest: dict[str, Any] | None = None,
+) -> None:
+    """Point ``_execute`` at fakes for everything external.
+
+    Leaves the verdict rollup, the format-version gate and the
+    ordering of phases as the real code — those are what the tests
+    using this actually exercise.
+    """
+    from app.services.backup import drill as drill_mod
+
+    monkeypatch.setattr(drill_mod, "get_destination", lambda kind: driver or _FakeDriver())
+    monkeypatch.setattr(drill_mod, "decrypt_config_secrets", lambda d, c: c)
+    monkeypatch.setattr(drill_mod, "decrypt_str", lambda b: "passphrase")
+    monkeypatch.setattr(drill_mod, "decrypt_secrets", lambda blob, passphrase: {"SECRET_KEY": "x"})
+    monkeypatch.setattr(
+        drill_mod,
+        "extract_archive_members",
+        lambda b: (
+            manifest if manifest is not None else {"format_version": 2},
+            b"dump",
+            "custom",
+            b"enc",
+        ),
+    )
+
+    async def _noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(drill_mod, "preflight", _noop)
+    monkeypatch.setattr(drill_mod, "_create_scratch_db", _noop)
+    monkeypatch.setattr(drill_mod, "_drop_scratch_db", _noop)
+    monkeypatch.setattr(drill_mod, "_replay_into_scratch", _noop)
+
+    async def _assertions(_url: str) -> list[Assertion]:
+        return assertions
+
+    monkeypatch.setattr(drill_mod, "_assert_against_scratch", _assertions)
+
+
+@pytest.mark.asyncio
+async def test_skip_does_not_fail_the_drill(monkeypatch) -> None:
     """A skipped check (schema skew makes it unanswerable) is not a
-    finding — only an actual ``fail`` is."""
-    assertions = [
-        Assertion("archive_readable", PASS, "ok"),
-        Assertion("audit_chain_intact", SKIP, "schema skew"),
-    ]
-    assert not any(a.status == FAIL for a in assertions)
+    finding — only an actual ``fail`` is.
+
+    Exercises the real rollup in ``_execute`` rather than
+    re-implementing the ``any(status == FAIL)`` expression inline: a
+    flipped rollup has to fail this test.
+    """
+    from app.services.backup.drill import _execute
+
+    _wire_drill(
+        monkeypatch,
+        assertions=[Assertion("audit_chain_intact", SKIP, "schema skew")],
+    )
+    target = BackupTarget(name="t", kind="local_volume", config={}, passphrase_encrypted=b"x")
+    outcome = await _execute(target, live_db_url="postgresql+asyncpg://u:p@h:5432/live")
+    assert outcome.state == "passed"
+    assert {a.status for a in outcome.assertions} == {PASS, SKIP}
+
+
+@pytest.mark.asyncio
+async def test_one_failed_check_fails_the_drill(monkeypatch) -> None:
+    from app.services.backup.drill import _execute
+
+    _wire_drill(
+        monkeypatch,
+        assertions=[
+            Assertion("core_tables_populated", PASS, "ok"),
+            Assertion("audit_chain_intact", FAIL, "3 breaks"),
+        ],
+    )
+    target = BackupTarget(name="t", kind="local_volume", config={}, passphrase_encrypted=b"x")
+    outcome = await _execute(target, live_db_url="postgresql+asyncpg://u:p@h:5432/live")
+    assert outcome.state == "failed"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_format_version_fails_the_drill(monkeypatch) -> None:
+    """The real restore path refuses an archive whose format_version it
+    doesn't know. A drill that waved it through would report an
+    unrestorable archive as restorable — the exact failure this
+    feature exists to catch."""
+    from app.services.backup.drill import _execute
+
+    _wire_drill(
+        monkeypatch,
+        assertions=[Assertion("core_tables_populated", PASS, "ok")],
+        manifest={"format_version": 99},
+    )
+    target = BackupTarget(name="t", kind="local_volume", config={}, passphrase_encrypted=b"x")
+    outcome = await _execute(target, live_db_url="postgresql+asyncpg://u:p@h:5432/live")
+    assert outcome.state == "failed"
+    readable = [a for a in outcome.assertions if a.name == "archive_readable"]
+    assert readable and readable[0].status == FAIL
+    assert "99" in readable[0].detail
+
+
+@pytest.mark.asyncio
+async def test_preflight_failure_is_error_not_failed(monkeypatch) -> None:
+    """A missing CREATEDB privilege says nothing about the archive, so
+    it must not read as a failed backup."""
+    from app.services.backup import drill as drill_mod
+    from app.services.backup.drill import DrillError, _execute
+
+    async def _boom(**kwargs: Any) -> None:
+        raise DrillError("role lacks CREATEDB")
+
+    monkeypatch.setattr(drill_mod, "preflight", _boom)
+    target = BackupTarget(name="t", kind="local_volume", config={}, passphrase_encrypted=b"x")
+    outcome = await _execute(target, live_db_url="postgresql+asyncpg://u:p@h:5432/live")
+    assert outcome.state == "error"
+    assert outcome.error is not None and "CREATEDB" in outcome.error
+    assert outcome.assertions == [], "nothing was checked, so nothing should be claimed"
+
+
+@pytest.mark.asyncio
+async def test_newest_archive_is_the_one_drilled(monkeypatch) -> None:
+    now = datetime.now(UTC)
+    driver = _FakeDriver(
+        archives=[
+            _listing("older.zip", when=now - timedelta(days=3)),
+            _listing("newest.zip", when=now),
+            _listing("middle.zip", when=now - timedelta(days=1)),
+        ]
+    )
+    _wire_drill(monkeypatch, assertions=[], driver=driver)
+    from app.services.backup.drill import _execute
+
+    target = BackupTarget(name="t", kind="local_volume", config={}, passphrase_encrypted=b"x")
+    outcome = await _execute(target, live_db_url="postgresql+asyncpg://u:p@h:5432/live")
+    assert outcome.filename == "newest.zip"
 
 
 def test_assertion_serialises_for_jsonb() -> None:
@@ -377,6 +555,9 @@ async def test_run_drill_rejects_when_one_is_already_running(
     _, token = await _make_user(db_session, username="drillbusy")
     target = await _make_target(db_session, name="already-busy")
     target.drill_last_status = "in_progress"
+    # Stamped just now, so the staleness escape correctly does NOT
+    # apply and the 409 stands.
+    target.drill_last_at = datetime.now(UTC)
     await db_session.flush()
     res = await client.post(
         f"/api/v1/backup/drills/run/{target.id}",
@@ -395,7 +576,7 @@ async def test_enabling_drills_without_a_cron_is_rejected(
     """``drill_enabled`` with no schedule would never fire — a silent
     no-op the operator would read as "drills are on"."""
     _, token = await _make_user(db_session, username="drillcron")
-    target = await _make_target(db_session, name="no-cron")
+    target = await _make_target(db_session, name="no-cron", drill_enabled=False)
     res = await client.patch(
         f"/api/v1/backup/targets/{target.id}",
         json={"drill_enabled": True},
@@ -462,8 +643,10 @@ async def test_invalid_drill_cron_is_rejected(
 def test_stale_mutex_detection() -> None:
     """A worker killed mid-drill leaves ``in_progress`` behind; without
     the staleness escape the target would stop drilling forever."""
-    from app.services.backup.drill import STALE_IN_PROGRESS_SECONDS
-    from app.tasks.backup_drill import _mutex_is_stale
+    from app.services.backup.drill import (
+        STALE_IN_PROGRESS_SECONDS,
+        drill_mutex_is_stale,
+    )
 
     now = datetime.now(UTC)
     target = BackupTarget(
@@ -475,13 +658,13 @@ def test_stale_mutex_detection() -> None:
     )
 
     target.drill_last_at = now - timedelta(seconds=30)
-    assert _mutex_is_stale(target, now) is False, "a drill running 30s ago is genuinely held"
+    assert drill_mutex_is_stale(target, now) is False, "a drill running 30s ago is genuinely held"
 
     target.drill_last_at = now - timedelta(seconds=STALE_IN_PROGRESS_SECONDS + 60)
-    assert _mutex_is_stale(target, now) is True
+    assert drill_mutex_is_stale(target, now) is True
 
     target.drill_last_at = None
-    assert _mutex_is_stale(target, now) is True, "never stamped reads as stale"
+    assert drill_mutex_is_stale(target, now) is True, "never stamped reads as stale"
 
 
 # ── MCP tools ─────────────────────────────────────────────────────────
@@ -509,7 +692,7 @@ async def test_readiness_reports_undrilled_target_as_unverified(
     )
 
     user, _ = await _make_user(db_session, username="mcpready")
-    await _make_target(db_session, name="never-drilled")
+    await _make_target(db_session, name="never-drilled", drill_enabled=False)
     out = await get_restore_drill_readiness(db_session, user, RestoreDrillReadinessArgs())
     assert out["total_targets"] == 1
     assert out["verified_targets"] == 0
@@ -547,13 +730,255 @@ async def test_readiness_reports_hours_since_last_pass(db_session: AsyncSession)
 
 
 @pytest.mark.asyncio
-async def test_seed_rule_is_idempotent(db_session: AsyncSession) -> None:
-    """Seeding twice must not produce two rules — the seeder keys on
-    ``rule_type`` so an operator's rename or disable is never undone."""
-    existing = await db_session.scalar(
-        select(AlertRule).where(AlertRule.rule_type == RULE_TYPE_RESTORE_DRILL_FAILED)
+async def test_seed_rule_is_idempotent(monkeypatch) -> None:
+    """Seeding twice must not produce two rules.
+
+    The seeder keys on ``rule_type``, which is what lets an operator
+    rename or disable the rule without a restart undoing it. Uses a
+    stub session because the real seeder opens ``AsyncSessionLocal``
+    against the live database rather than the test session.
+    """
+    from app.services import alerts as alerts_mod
+
+    class _Session:
+        def __init__(self, existing: object | None) -> None:
+            self._existing = existing
+            self.added: list[Any] = []
+            self.committed = False
+
+        async def scalar(self, *args: Any, **kwargs: Any) -> Any:
+            return self._existing
+
+        def add(self, obj: Any) -> None:
+            self.added.append(obj)
+
+        async def commit(self) -> None:
+            self.committed = True
+
+        async def __aenter__(self) -> Any:
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+    first = _Session(existing=None)
+    monkeypatch.setattr("app.db.AsyncSessionLocal", lambda: first)
+    await alerts_mod.seed_restore_drill_failed_alert_rule()
+    assert len(first.added) == 1
+    assert first.committed is True
+    seeded = first.added[0]
+    assert seeded.rule_type == RULE_TYPE_RESTORE_DRILL_FAILED
+    assert seeded.enabled is True
+    assert seeded.severity == "critical"
+
+    # Second call — the rule already exists, so nothing is added and an
+    # operator's edits to it survive the restart.
+    second = _Session(existing=object())
+    monkeypatch.setattr("app.db.AsyncSessionLocal", lambda: second)
+    await alerts_mod.seed_restore_drill_failed_alert_rule()
+    assert second.added == []
+    assert second.committed is False
+
+
+@pytest.mark.asyncio
+async def test_alert_ignores_target_with_drills_disabled(
+    db_session: AsyncSession,
+) -> None:
+    """An ad-hoc drill on an unscheduled target must not open an event
+    that nothing can resolve.
+
+    The manual run-now endpoint drills regardless of ``drill_enabled``,
+    so without this filter one failed ad-hoc drill would open a
+    critical alert whose documented resolution ("the next drill
+    passes") can never happen — there is no next drill.
+    """
+    target = await _make_target(db_session, name="adhoc-only", drill_enabled=False)
+    await _make_drill(db_session, target, state="failed", started_at=datetime.now(UTC))
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
     )
-    assert existing is None or isinstance(existing, AlertRule)
+    assert await _matching_restore_drill_failed_subjects(db_session, rule) == []
+
+
+@pytest.mark.asyncio
+async def test_disabling_the_target_resolves_the_alert(db_session: AsyncSession) -> None:
+    """Turning a target off is an operator-reachable way to clear the
+    event, rather than leaving a critical alert stuck forever."""
+    target = await _make_target(db_session, name="switch-off")
+    await _make_drill(db_session, target, state="failed", started_at=datetime.now(UTC))
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
+    )
+    assert len(await _matching_restore_drill_failed_subjects(db_session, rule)) == 1
+    target.enabled = False
+    await db_session.flush()
+    assert await _matching_restore_drill_failed_subjects(db_session, rule) == []
+
+
+@pytest.mark.asyncio
+async def test_empty_destination_gets_its_own_alert_wording(
+    db_session: AsyncSession,
+) -> None:
+    """ "The archive didn't survive" is the wrong story when there is no
+    archive — it sends the operator hunting for corruption instead of
+    finding an empty destination."""
+    target = await _make_target(db_session, name="empty-dest")
+    await _make_drill(
+        db_session,
+        target,
+        state="failed",
+        started_at=datetime.now(UTC),
+        assertions=[
+            {
+                "name": "archive_available",
+                "status": "fail",
+                "detail": "the destination holds no archives",
+            }
+        ],
+    )
+    rule = AlertRule(
+        name="drill failed",
+        rule_type=RULE_TYPE_RESTORE_DRILL_FAILED,
+        severity="critical",
+        enabled=True,
+    )
+    matches = await _matching_restore_drill_failed_subjects(db_session, rule)
+    assert len(matches) == 1
+    message = matches[0][2]
+    assert "holds no archives" in message
+    assert "did not survive" not in message
+
+
+# ── readiness rollup ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_readiness_error_does_not_erase_a_prior_pass(
+    db_session: AsyncSession,
+) -> None:
+    """A destination that was briefly unreachable disproves nothing.
+
+    The alert path treats ``error`` as leaving the previous verdict
+    standing; the readiness rollup must agree, or a transient S3 blip
+    would report a backup proven yesterday as unverified.
+    """
+    from app.services.backup.drill import compute_drill_readiness
+
+    target = await _make_target(db_session, name="blipped")
+    now = datetime.now(UTC)
+    await _make_drill(db_session, target, state="passed", started_at=now - timedelta(days=1))
+    await _make_drill(db_session, target, state="error", started_at=now)
+    target.drill_last_status = "error"
+    await db_session.flush()
+
+    rows = await compute_drill_readiness(db_session)
+    row = next(r for r in rows if r["target_name"] == "blipped")
+    assert row["verified"] is True
+    assert row["latest_verdict"] == "error"
+    assert row["last_passed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_readiness_failure_supersedes_an_older_pass(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.backup.drill import compute_drill_readiness
+
+    target = await _make_target(db_session, name="regressed")
+    now = datetime.now(UTC)
+    await _make_drill(db_session, target, state="passed", started_at=now - timedelta(days=5))
+    await _make_drill(db_session, target, state="failed", started_at=now)
+    rows = await compute_drill_readiness(db_session)
+    row = next(r for r in rows if r["target_name"] == "regressed")
+    assert row["verified"] is False
+    assert row["last_passed_at"] is not None, "the old pass is still reported, just superseded"
+
+
+@pytest.mark.asyncio
+async def test_readiness_endpoint_matches_the_copilot_tool(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The UI and the assistant must not disagree about whether a
+    backup is proven."""
+    from app.services.ai.tools.backup import (
+        RestoreDrillReadinessArgs,
+        get_restore_drill_readiness,
+    )
+
+    user, token = await _make_user(db_session, username="readyparity")
+    target = await _make_target(db_session, name="parity")
+    await _make_drill(db_session, target, state="passed", started_at=datetime.now(UTC))
+
+    res = await client.get(
+        "/api/v1/backup/drills/readiness", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert res.status_code == 200
+    via_tool = await get_restore_drill_readiness(db_session, user, RestoreDrillReadinessArgs())
+    assert res.json()["targets"] == via_tool["targets"]
+    assert res.json()["verified_targets"] == via_tool["verified_targets"]
+
+
+@pytest.mark.asyncio
+async def test_readiness_requires_superadmin(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_user(db_session, superadmin=False, username="readyplain")
+    res = await client.get(
+        "/api/v1/backup/drills/readiness", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_stale_mutex_does_not_block_a_manual_drill(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+) -> None:
+    """A mutex stranded by an api restart must not 409 the operator
+    forever — there is no other way to clear the flag."""
+    from app.services.backup import drill as drill_mod
+    from app.services.backup.drill import STALE_IN_PROGRESS_SECONDS
+
+    _, token = await _make_user(db_session, username="drillstale")
+    target = await _make_target(db_session, name="stranded")
+    target.drill_last_status = "in_progress"
+    target.drill_last_at = datetime.now(UTC) - timedelta(seconds=STALE_IN_PROGRESS_SECONDS + 120)
+    await db_session.flush()
+
+    async def _fake_execute(_target: Any, *, live_db_url: str) -> Any:
+        return drill_mod.DrillOutcome(state="passed", assertions=[])
+
+    monkeypatch.setattr(drill_mod, "_execute", _fake_execute)
+    res = await client.post(
+        f"/api/v1/backup/drills/run/{target.id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200, "a stranded mutex must not lock out manual drills"
+
+
+@pytest.mark.asyncio
+async def test_scheduled_drill_writes_an_audit_row(db_session: AsyncSession, monkeypatch) -> None:
+    """Non-negotiable #4 admits no 'unless a cron did it' exception —
+    and find_backup_audit_history would otherwise never show a
+    scheduled drill."""
+    from app.services.backup import drill as drill_mod
+
+    target = await _make_target(db_session, name="audited")
+
+    async def _fake_execute(_target: Any, *, live_db_url: str) -> Any:
+        return drill_mod.DrillOutcome(state="passed", assertions=[])
+
+    monkeypatch.setattr(drill_mod, "_execute", _fake_execute)
+    await drill_mod.run_drill_for_target(db_session, target=target, triggered_by="schedule")
+    await db_session.flush()
+
+    row = await db_session.scalar(select(AuditLog).where(AuditLog.action == "backup_restore_drill"))
+    assert row is not None
+    assert row.resource_display == "audited"
+    assert row.new_value["triggered_by"] == "schedule"
 
 
 @pytest.mark.asyncio

--- a/charts/spatiumddi/templates/cnpg-cluster.yaml
+++ b/charts/spatiumddi/templates/cnpg-cluster.yaml
@@ -89,6 +89,29 @@ spec:
       secret:
         name: {{ include "spatiumddi.postgresSecretName" . }}
 
+  {{- if .Values.postgresql.cnpg.appRoleCreateDb }}
+  # Restore-verification drills (#702) create a throwaway
+  # ``spatiumddi_drill_*`` database, replay the newest backup archive
+  # into it, assert, and drop it again. ``initdb.owner`` is a plain
+  # LOGIN role with no CREATEDB and ``enableSuperuserAccess`` is off,
+  # so without this grant every drill dies at "permission denied to
+  # create database" and the feature can never run on an appliance.
+  #
+  # ``managed.roles`` reconciles attributes on EXISTING clusters too
+  # (unlike ``initdb.postInitSQL``, which only fires on first
+  # bootstrap), so this grant reaches installs that predate #702.
+  #
+  # Set ``postgresql.cnpg.appRoleCreateDb: false`` to withhold it —
+  # drills then report a clear "role lacks CREATEDB" error rather
+  # than failing obscurely.
+  managed:
+    roles:
+      - name: {{ .Values.postgresql.auth.username | quote }}
+        ensure: present
+        login: true
+        createdb: true
+  {{- end }}
+
   storage:
     size: {{ .Values.postgresql.persistence.size | quote }}
     {{- with .Values.postgresql.persistence.storageClass }}

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -407,6 +407,14 @@ postgresql:
   affinity: {}
   # CNPG-specific topology (only used when ``kind: cnpg``).
   cnpg:
+    # Grant CREATEDB to the application role (#702). Restore-verification
+    # drills create a throwaway database, replay the newest backup archive
+    # into it, assert against the result, and drop it. The role initdb
+    # creates has no CREATEDB and superuser access is off, so drills cannot
+    # run at all without this. Applied via ``managed.roles`` so it also
+    # reaches clusters created before #702. Set false to withhold the
+    # privilege — drills then report a clear "role lacks CREATEDB" error.
+    appRoleCreateDb: true
     # Replica count. 3 is the smallest etcd-quorum-friendly default
     # (primary + sync replica + async replica). 5 / 7 for larger
     # clusters. CNPG enforces odd counts implicitly via its leader-

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -253,7 +253,7 @@ Dashboard tiles showing platform-wide stats:
 
 ### 2.9 Backup and Restore
 
-The Backup admin page (`/admin/backup`) ships three tabs: **Manual** (build-and-download / restore-from-file), **Destinations** (configured remote targets, scheduling, restore-from-destination), and **Factory Reset** (per-section wipe back to defaults). Everything described here is reachable from the UI; the same surface is exposed via REST under `/api/v1/backup` and `/api/v1/backup/targets` so operators can drive it from automation.
+The Backup admin page (`/admin/backup`) ships four tabs: **Manual** (build-and-download / restore-from-file), **Destinations** (configured remote targets, scheduling, restore-from-destination), **Restore Drills** (scheduled proof that an archive is actually restorable), and **Factory Reset** (per-section wipe back to defaults). Everything described here is reachable from the UI; the same surface is exposed via REST under `/api/v1/backup`, `/api/v1/backup/targets`, and `/api/v1/backup/drills` so operators can drive it from automation.
 
 #### What's in the archive
 
@@ -369,6 +369,28 @@ Same-install restores return `{"same_install": true, ...counters all zero}`. The
 | nmap scan history | Often huge, regenerable. Sectioned as `nmap_history` (volatile). |
 | Metric samples | Volatile, short retention. Sectioned as `metrics` (volatile). |
 | Uploaded asset directory | Phase 2 polish — uploaded files (custom-field attachments, future logo overrides) aren't a separately-tracked path yet. |
+
+#### Restore drills (issue #702)
+
+A backup you have never restored is a hypothesis. The **Restore Drills** tab turns it into a fact: on its own schedule, SpatiumDDI downloads a target's newest archive, replays it into a throwaway database, runs a fixed assertion set against the result, and drops the throwaway database again.
+
+**The live database is never written to.** The scratch database name is generated from a fixed `spatiumddi_drill_` prefix plus random hex — never from operator input — and is checked against the live database name before anything runs. The drill deliberately does not reuse the operator-facing restore path, which takes a safety dump and disposes the live connection pool; those behaviours are right for a real restore and wrong for an unattended background check.
+
+| Check | What a failure means |
+|---|---|
+| `archive_available` | The destination holds no archives — there is nothing to restore from. |
+| `archive_readable` | The zip is malformed, or its `format_version` is newer than this build. |
+| `passphrase_opens_secrets` | The passphrase stored on the target does not open the archive's `secrets.enc`. A restore from it would be impossible. |
+| `dump_replays_cleanly` | `pg_restore` / `psql` aborted — the dump is truncated or corrupt. |
+| `alembic_version_present` | No single schema revision, or one this build has never heard of (the archive came from a newer SpatiumDDI). An archive *behind* the bundled head passes: a real restore migrates it forward. |
+| `core_tables_populated` | The archive restored but came back with no users — an install restored from it would have no way in. |
+| `audit_chain_intact` | The restored audit log's tamper-evident hash chain does not verify. Skipped when the restored schema isn't at the bundled head, because the ORM-based verifier would misread schema skew as tampering. |
+
+**`failed` and `error` mean different things.** `failed` is a verdict about the archive — a real finding. `error` means the drill could not run at all (destination unreachable, scratch database couldn't be created) and says nothing about the backup. Only `failed` opens the `restore_drill_failed` alert; an `error` leaves whatever the previous verdict was standing, which is the honest reading — you know no more than you did before.
+
+Drills carry their own cron (`drill_enabled` / `drill_cron` on the backup target), separate from the backup schedule, because replaying a full dump costs far more than taking a backup. Weekly drills against nightly backups is the expected shape. The `restore_drill_failed` alert keys on the **target**, so a target failing every night holds one open event rather than opening a new one per drill, and auto-resolves when the target's next drill passes.
+
+Two Operator Copilot tools cover the surface: `find_restore_drills` (history, filterable by verdict) and `get_restore_drill_readiness` (the per-target rollup answering "can I restore this install right now, and how do I know?"). A target with drills switched off reports as *unverified* rather than healthy — an untested backup is an unknown, not a pass.
 
 ---
 

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -379,18 +379,27 @@ A backup you have never restored is a hypothesis. The **Restore Drills** tab tur
 | Check | What a failure means |
 |---|---|
 | `archive_available` | The destination holds no archives — there is nothing to restore from. |
-| `archive_readable` | The zip is malformed, or its `format_version` is newer than this build. |
+| `archive_readable` | The zip is malformed, or its `format_version` is one this build cannot restore (checked against the same list the real restore path enforces, so a drill never green-lights an archive a restore would refuse). |
 | `passphrase_opens_secrets` | The passphrase stored on the target does not open the archive's `secrets.enc`. A restore from it would be impossible. |
 | `dump_replays_cleanly` | `pg_restore` / `psql` aborted — the dump is truncated or corrupt. |
 | `alembic_version_present` | No single schema revision, or one this build has never heard of (the archive came from a newer SpatiumDDI). An archive *behind* the bundled head passes: a real restore migrates it forward. |
 | `core_tables_populated` | The archive restored but came back with no users — an install restored from it would have no way in. |
-| `audit_chain_intact` | The restored audit log's tamper-evident hash chain does not verify. Skipped when the restored schema isn't at the bundled head, because the ORM-based verifier would misread schema skew as tampering. |
+| `audit_chain_intact` | The restored audit log's tamper-evident hash chain does not verify. Skipped when the restored schema isn't at the bundled head, because the ORM-based verifier would misread schema skew as tampering. Capped at 250k rows — a break inside that window is plenty to prove damage, and the nightly `audit_chain_verify` task walks the live table exhaustively. |
 
-**`failed` and `error` mean different things.** `failed` is a verdict about the archive — a real finding. `error` means the drill could not run at all (destination unreachable, scratch database couldn't be created) and says nothing about the backup. Only `failed` opens the `restore_drill_failed` alert; an `error` leaves whatever the previous verdict was standing, which is the honest reading — you know no more than you did before.
+#### Requirements and costs
 
-Drills carry their own cron (`drill_enabled` / `drill_cron` on the backup target), separate from the backup schedule, because replaying a full dump costs far more than taking a backup. Weekly drills against nightly backups is the expected shape. The `restore_drill_failed` alert keys on the **target**, so a target failing every night holds one open event rather than opening a new one per drill, and auto-resolves when the target's next drill passes.
+Two things a drill needs that a backup doesn't, both checked up front so a drill that can't run says so plainly instead of failing obscurely (and both report as `error`, not `failed` — see below):
 
-Two Operator Copilot tools cover the surface: `find_restore_drills` (history, filterable by verdict) and `get_restore_drill_readiness` (the per-target rollup answering "can I restore this install right now, and how do I know?"). A target with drills switched off reports as *unverified* rather than healthy — an untested backup is an unknown, not a pass.
+- **`CREATEDB` on the database role.** The scratch database has to be created. On Kubernetes and appliance installs the umbrella chart grants this via CloudNativePG's `managed.roles` (`postgresql.cnpg.appRoleCreateDb`, default `true`), which reconciles onto existing clusters as well as new ones — the role CNPG's `initdb` creates has no `CREATEDB` and superuser access is switched off, so without the grant drills cannot run at all. On docker-compose the default `POSTGRES_USER` is a superuser and nothing is needed; if you run SpatiumDDI as a restricted role, grant it with `ALTER ROLE <user> CREATEDB;`.
+- **Room for a second copy of the database.** The scratch database lands on the *same* Postgres instance, so a drill temporarily doubles the space the database occupies. Postgres offers no portable way to query the free space on its own data volume, so the risk is bounded from the other side: a drill refuses to run when the live database exceeds **20 GiB**. Raise `SPATIUM_DRILL_MAX_DB_BYTES` (bytes; `0` disables the guard) once you have confirmed the volume has room. Sizing this wrong is the one way a read-only verification job can cause a real outage — on the appliance's default 8Gi volume, a 6 GB install would fill it.
+
+Scratch databases are dropped when the drill finishes, whatever the verdict. If a worker is killed outright — pod eviction, OOM, node drain — the drop never runs, so the drill sweep also reaps any `spatiumddi_drill_*` database with no active connections on its next tick.
+
+**`failed` and `error` mean different things.** `failed` is a verdict about the archive — a real finding. `error` means the drill could not run at all (destination unreachable, missing `CREATEDB`, database over the size ceiling) and says nothing about the backup. Only `failed` opens the `restore_drill_failed` alert; an `error` leaves whatever the previous verdict was standing, which is the honest reading — you know no more than you did before.
+
+Drills carry their own cron (`drill_enabled` / `drill_cron` on the backup target), separate from the backup schedule, because replaying a full dump costs far more than taking a backup. Weekly drills against nightly backups is the expected shape. The `restore_drill_failed` alert keys on the **target**, so a target failing every night holds one open event rather than opening a new one per drill, and auto-resolves when the target's next drill passes. It only considers enabled targets with drills scheduled — turning drills (or the target) off resolves an open event on the next tick, which is also the operator's way out if an ad-hoc drill against an unscheduled target ever fires one.
+
+Two Operator Copilot tools cover the surface: `find_restore_drills` (history, filterable by verdict) and `get_restore_drill_readiness` (the per-target rollup answering "can I restore this install right now, and how do I know?"), the latter sharing its computation with the `Restore Drills` tab and `GET /api/v1/backup/drills/readiness` so the UI and the assistant cannot disagree. A target that has never passed a drill reports as *unverified* rather than healthy — an untested backup is an unknown, not a pass — while a target whose most recent drill merely errored keeps its previous verdict, since an error disproves nothing.
 
 ---
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2875,6 +2875,32 @@ export interface RestoreDrill {
   duration_ms: number | null;
 }
 
+/** One target's recovery-readiness row (issue #702). */
+export interface RestoreDrillReadinessTarget {
+  target_id: string;
+  target_name: string;
+  kind: string;
+  enabled: boolean;
+  drills_scheduled: boolean;
+  drill_cron: string | null;
+  /** Raw latest status, including "error" / "in_progress". */
+  latest_verdict: string;
+  /** Latest terminal verdict, i.e. "passed" | "failed" | null. */
+  latest_finished_verdict: string | null;
+  latest_drill_at: string | null;
+  last_passed_at: string | null;
+  hours_since_last_pass: number | null;
+  /** Has passed at some point AND the latest finished verdict isn't a failure. */
+  verified: boolean;
+}
+
+export interface RestoreDrillReadiness {
+  targets: RestoreDrillReadinessTarget[];
+  total_targets: number;
+  verified_targets: number;
+  unverified_targets: number;
+}
+
 export interface BackupArchiveListing {
   filename: string;
   size_bytes: number;
@@ -2936,6 +2962,17 @@ export const backupTargetsApi = {
     limit?: number;
   }) =>
     api.get<RestoreDrill[]>("/backup/drills", { params }).then((r) => r.data),
+  /**
+   * Per-target recovery readiness. Backed by the same server-side
+   * computation the Operator Copilot uses, so the UI and the assistant
+   * can't disagree about whether a backup is proven — and so
+   * "last proven" doesn't depend on how far back the drill history
+   * page happens to reach.
+   */
+  drillReadiness: () =>
+    api
+      .get<RestoreDrillReadiness>("/backup/drills/readiness")
+      .then((r) => r.data),
   deleteArchive: (id: string, filename: string) =>
     api
       .delete<void>(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2813,6 +2813,11 @@ export interface BackupTarget {
   last_run_duration_ms: number | null;
   last_run_error: string | null;
   next_run_at: string | null;
+  drill_enabled: boolean;
+  drill_cron: string | null;
+  drill_next_run_at: string | null;
+  drill_last_status: string;
+  drill_last_at: string | null;
   created_at: string;
   modified_at: string;
 }
@@ -2840,6 +2845,34 @@ export interface BackupTargetUpdate {
   schedule_cron?: string | null;
   retention_keep_last_n?: number | null;
   retention_keep_days?: number | null;
+  drill_enabled?: boolean;
+  drill_cron?: string | null;
+}
+
+/** One check inside a restore drill's verdict (issue #702). */
+export interface RestoreDrillAssertion {
+  name: string;
+  /** "pass" | "fail" | "skip" */
+  status: string;
+  detail: string;
+}
+
+export interface RestoreDrill {
+  id: string;
+  target_id: string;
+  target_name: string | null;
+  /** "running" | "passed" | "failed" | "error" */
+  state: string;
+  triggered_by: string;
+  filename: string | null;
+  archive_bytes: number | null;
+  manifest: Record<string, unknown> | null;
+  scratch_db: string | null;
+  assertions: RestoreDrillAssertion[];
+  error: string | null;
+  started_at: string;
+  finished_at: string | null;
+  duration_ms: number | null;
 }
 
 export interface BackupArchiveListing {
@@ -2889,6 +2922,20 @@ export const backupTargetsApi = {
     api
       .get<BackupArchiveListing[]>(`/backup/targets/${id}/archives`)
       .then((r) => r.data),
+  /**
+   * Restore-verification drills (issue #702) — replay this target's
+   * newest archive into a throwaway database and assert against the
+   * result. Synchronous like ``runNow``; the request is held open
+   * for the whole replay.
+   */
+  runDrill: (id: string) =>
+    api.post<RestoreDrill>(`/backup/drills/run/${id}`).then((r) => r.data),
+  listDrills: (params?: {
+    target_id?: string;
+    state?: string;
+    limit?: number;
+  }) =>
+    api.get<RestoreDrill[]>("/backup/drills", { params }).then((r) => r.data),
   deleteArchive: (id: string, filename: string) =>
     api
       .delete<void>(

--- a/frontend/src/pages/admin/BackupPage.tsx
+++ b/frontend/src/pages/admin/BackupPage.tsx
@@ -19,6 +19,7 @@ import {
 import { BackupSectionsPicker } from "./BackupSectionsPicker";
 import { BackupTargetsSection } from "./BackupTargetsSection";
 import { FactoryResetSection } from "./FactoryResetSection";
+import { RestoreDrillsSection } from "./RestoreDrillsSection";
 
 /**
  * Admin → Platform → Backup (issue #117 Phase 1a).
@@ -39,7 +40,7 @@ import { FactoryResetSection } from "./FactoryResetSection";
  * Phase 1a out-of-scope but coming later: scheduled targets
  * (S3 / SCP / Azure), backup-target rows, selective restore.
  */
-type Tab = "manual" | "destinations" | "factory-reset";
+type Tab = "manual" | "destinations" | "drills" | "factory-reset";
 
 export function BackupPage() {
   const [tab, setTab] = useState<Tab>("manual");
@@ -54,15 +55,17 @@ export function BackupPage() {
           <strong>Manual</strong> — one-off download + restore-from-file.{" "}
           <strong>Destinations</strong> — configure local volumes, S3, SCP,
           Azure Blob. Schedule a recurring backup, view archives at the
-          destination, restore from any archive. <strong>Factory Reset</strong>{" "}
-          — wipe configuration back to defaults per-section or
-          everything-at-once.
+          destination, restore from any archive. <strong>Restore Drills</strong>{" "}
+          — prove an archive is actually restorable by test-restoring it into a
+          throwaway database. <strong>Factory Reset</strong> — wipe
+          configuration back to defaults per-section or everything-at-once.
         </p>
         <div className="-mb-px mt-3 flex gap-1 border-b">
           {(
             [
               ["manual", "Manual"],
               ["destinations", "Destinations"],
+              ["drills", "Restore Drills"],
               ["factory-reset", "Factory Reset"],
             ] as const
           ).map(([key, label]) => (
@@ -101,6 +104,7 @@ export function BackupPage() {
               <SecurityNotes />
             </>
           )}
+          {tab === "drills" && <RestoreDrillsSection />}
           {tab === "factory-reset" && <FactoryResetSection />}
         </div>
       </div>

--- a/frontend/src/pages/admin/RestoreDrillsSection.tsx
+++ b/frontend/src/pages/admin/RestoreDrillsSection.tsx
@@ -1,0 +1,506 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  CircleSlash,
+  Loader2,
+  Play,
+  RefreshCw,
+  ShieldQuestion,
+  XCircle,
+} from "lucide-react";
+
+import {
+  backupTargetsApi,
+  type BackupTarget,
+  type RestoreDrill,
+  type RestoreDrillAssertion,
+} from "@/lib/api";
+import { Modal } from "@/components/ui/modal";
+
+/**
+ * Restore Drills section on the Backup admin page (issue #702).
+ *
+ * A drill replays a target's newest archive into a throwaway
+ * database and asserts against the result. The live database is
+ * never written to — the point is to prove the archive is
+ * restorable *before* an operator needs it to be.
+ *
+ * Two cards:
+ *
+ * 1. **Readiness** — one row per backup target: is a drill
+ *    scheduled, what did the last one say, how long ago did this
+ *    target last *prove* it could be restored. A target with
+ *    drills off reads as "never verified" rather than healthy,
+ *    which is the honest framing: an untested backup is an
+ *    unknown, not a pass.
+ *
+ * 2. **History** — recent drills, expandable to the per-check
+ *    verdicts.
+ *
+ * ``failed`` and ``error`` are shown differently on purpose.
+ * ``failed`` means the archive did not survive the test restore —
+ * a real finding. ``error`` means the drill could not run at all
+ * (destination unreachable), which says nothing about the archive.
+ */
+
+// Slower than the backup presets: a drill replays a whole dump into
+// a scratch database, so it costs far more than taking a backup.
+// Weekly against nightly backups is the shape most installs want.
+const DRILL_CRON_PRESETS: { label: string; value: string }[] = [
+  { label: "Daily 05:00 UTC", value: "0 5 * * *" },
+  { label: "Weekly Sunday 05:00 UTC", value: "0 5 * * 0" },
+  { label: "Weekly Wednesday 05:00 UTC", value: "0 5 * * 3" },
+  { label: "Fortnightly 1st + 15th 05:00 UTC", value: "0 5 1,15 * *" },
+  { label: "Monthly 1st 05:00 UTC", value: "0 5 1 * *" },
+];
+
+function relativeAge(iso: string | null): string {
+  if (!iso) return "never";
+  const then = new Date(iso).getTime();
+  const hours = (Date.now() - then) / 36e5;
+  if (hours < 1) return "under an hour ago";
+  if (hours < 48) return `${Math.round(hours)}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+function StateChip({ state }: { state: string }) {
+  const map: Record<
+    string,
+    { cls: string; icon: typeof CheckCircle2; label: string }
+  > = {
+    passed: {
+      cls: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+      icon: CheckCircle2,
+      label: "Passed",
+    },
+    failed: {
+      cls: "bg-rose-500/10 text-rose-600 dark:text-rose-400",
+      icon: XCircle,
+      label: "Failed",
+    },
+    error: {
+      cls: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+      icon: AlertTriangle,
+      label: "Could not run",
+    },
+    running: {
+      cls: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+      icon: Loader2,
+      label: "Running",
+    },
+    in_progress: {
+      cls: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+      icon: Loader2,
+      label: "Running",
+    },
+    never: {
+      cls: "bg-muted text-muted-foreground",
+      icon: ShieldQuestion,
+      label: "Never verified",
+    },
+  };
+  const e = map[state] ?? map.never;
+  const Icon = e.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium ${e.cls}`}
+    >
+      <Icon
+        className={`h-3 w-3 ${state === "running" || state === "in_progress" ? "animate-spin" : ""}`}
+      />
+      {e.label}
+    </span>
+  );
+}
+
+function AssertionRow({ a }: { a: RestoreDrillAssertion }) {
+  const icon =
+    a.status === "pass" ? (
+      <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+    ) : a.status === "fail" ? (
+      <XCircle className="h-3.5 w-3.5 shrink-0 text-rose-600 dark:text-rose-400" />
+    ) : (
+      <CircleSlash className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+    );
+  return (
+    <li className="flex items-start gap-2 py-1">
+      <span className="mt-0.5">{icon}</span>
+      <span className="min-w-0 flex-1">
+        <span className="font-mono text-xs">{a.name}</span>
+        <span className="ml-2 break-words text-xs text-muted-foreground">
+          {a.detail}
+        </span>
+      </span>
+    </li>
+  );
+}
+
+export function RestoreDrillsSection() {
+  const qc = useQueryClient();
+  const [scheduleFor, setScheduleFor] = useState<BackupTarget | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const targetsQ = useQuery({
+    queryKey: ["backup-targets"],
+    queryFn: () => backupTargetsApi.list(),
+  });
+  const drillsQ = useQuery({
+    queryKey: ["restore-drills"],
+    queryFn: () => backupTargetsApi.listDrills({ limit: 50 }),
+    // A drill is synchronous but slow; poll while one is in flight so
+    // the row flips without the operator hitting Refresh.
+    refetchInterval: (q) =>
+      (q.state.data ?? []).some((d) => d.state === "running") ? 5000 : false,
+  });
+
+  const runDrill = useMutation({
+    mutationFn: (id: string) => backupTargetsApi.runDrill(id),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["restore-drills"] });
+      void qc.invalidateQueries({ queryKey: ["backup-targets"] });
+    },
+  });
+
+  const targets = targetsQ.data ?? [];
+  const drills = drillsQ.data ?? [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="rounded-lg border bg-card">
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold">Recovery readiness</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              A drill replays each target&rsquo;s newest archive into a
+              throwaway database and checks the result. Your live database is
+              never touched.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              void qc.invalidateQueries({ queryKey: ["backup-targets"] });
+              void qc.invalidateQueries({ queryKey: ["restore-drills"] });
+            }}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            <RefreshCw className="h-4 w-4" />
+            Refresh
+          </button>
+        </div>
+
+        {targetsQ.isLoading ? (
+          <div className="px-4 py-6 text-sm text-muted-foreground">
+            Loading targets&hellip;
+          </div>
+        ) : targets.length === 0 ? (
+          <div className="px-4 py-6 text-sm text-muted-foreground">
+            No backup targets configured yet. Add one on the{" "}
+            <strong>Destinations</strong> tab — drills verify the archives a
+            target has already written.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[720px] text-sm">
+              <thead>
+                <tr className="border-b text-left text-xs text-muted-foreground">
+                  <th className="px-4 py-2 font-medium">Target</th>
+                  <th className="px-4 py-2 font-medium">Drill schedule</th>
+                  <th className="px-4 py-2 font-medium">Latest verdict</th>
+                  <th className="px-4 py-2 font-medium">Last proven</th>
+                  <th className="px-4 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {targets.map((t) => {
+                  const lastPass = drills.find(
+                    (d) => d.target_id === t.id && d.state === "passed",
+                  );
+                  const busy =
+                    t.drill_last_status === "in_progress" ||
+                    (runDrill.isPending && runDrill.variables === t.id);
+                  return (
+                    <tr key={t.id} className="border-b last:border-0">
+                      <td className="px-4 py-2">
+                        <div className="font-medium">{t.name}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {t.kind}
+                        </div>
+                      </td>
+                      <td className="px-4 py-2">
+                        {t.drill_enabled && t.drill_cron ? (
+                          <span className="font-mono text-xs">
+                            {t.drill_cron}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            not scheduled
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2">
+                        <StateChip state={t.drill_last_status} />
+                      </td>
+                      <td className="px-4 py-2 text-xs text-muted-foreground">
+                        {lastPass
+                          ? relativeAge(lastPass.finished_at)
+                          : t.drill_last_status === "passed"
+                            ? relativeAge(t.drill_last_at)
+                            : "never"}
+                      </td>
+                      <td className="px-4 py-2">
+                        <div className="flex justify-end gap-1.5">
+                          <button
+                            type="button"
+                            onClick={() => setScheduleFor(t)}
+                            className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs hover:bg-accent"
+                          >
+                            Schedule
+                          </button>
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={() => runDrill.mutate(t.id)}
+                            className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs hover:bg-accent disabled:opacity-50"
+                          >
+                            {busy ? (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                              <Play className="h-3 w-3" />
+                            )}
+                            Run drill
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {runDrill.isError && (
+          <div className="border-t px-4 py-2 text-xs text-rose-600 dark:text-rose-400">
+            {(runDrill.error as Error).message}
+          </div>
+        )}
+        <p className="border-t px-4 py-2 text-xs text-muted-foreground">
+          A drill can take as long as a real restore. It runs synchronously —
+          leave the tab open, or schedule it and check back.
+        </p>
+      </section>
+
+      <section className="rounded-lg border bg-card">
+        <div className="border-b px-4 py-3">
+          <h2 className="text-sm font-semibold">Drill history</h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            <strong>Failed</strong> means the archive did not survive the test
+            restore — that is a finding about your backup.{" "}
+            <strong>Could not run</strong> means the drill itself was blocked
+            (destination unreachable, for instance) and says nothing about the
+            archive.
+          </p>
+        </div>
+        {drillsQ.isLoading ? (
+          <div className="px-4 py-6 text-sm text-muted-foreground">
+            Loading&hellip;
+          </div>
+        ) : drills.length === 0 ? (
+          <div className="px-4 py-6 text-sm text-muted-foreground">
+            No drills have run yet.
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {drills.map((d) => (
+              <DrillRow
+                key={d.id}
+                drill={d}
+                open={expanded.has(d.id)}
+                onToggle={() =>
+                  setExpanded((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(d.id)) next.delete(d.id);
+                    else next.add(d.id);
+                    return next;
+                  })
+                }
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {scheduleFor && (
+        <ScheduleDrillModal
+          target={scheduleFor}
+          onClose={() => setScheduleFor(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function DrillRow({
+  drill,
+  open,
+  onToggle,
+}: {
+  drill: RestoreDrill;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const Chevron = open ? ChevronDown : ChevronRight;
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 px-4 py-2 text-left hover:bg-accent/50"
+      >
+        <Chevron className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <StateChip state={drill.state} />
+        <span className="min-w-0 flex-1 truncate text-sm">
+          {drill.target_name ?? "unknown target"}
+          {drill.filename && (
+            <span className="ml-2 font-mono text-xs text-muted-foreground">
+              {drill.filename}
+            </span>
+          )}
+        </span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {relativeAge(drill.started_at)}
+          {drill.duration_ms != null &&
+            ` · ${(drill.duration_ms / 1000).toFixed(1)}s`}
+        </span>
+      </button>
+      {open && (
+        <div className="border-t bg-muted/30 px-4 py-3">
+          {drill.error && (
+            <p className="mb-2 break-words text-xs text-amber-600 dark:text-amber-400">
+              {drill.error}
+            </p>
+          )}
+          {drill.assertions.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              No checks recorded — the drill stopped before it could run any.
+            </p>
+          ) : (
+            <ul>
+              {drill.assertions.map((a) => (
+                <AssertionRow key={a.name} a={a} />
+              ))}
+            </ul>
+          )}
+          <p className="mt-2 text-xs text-muted-foreground">
+            Triggered {drill.triggered_by}
+            {drill.scratch_db && ` · scratch database ${drill.scratch_db}`}
+          </p>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function ScheduleDrillModal({
+  target,
+  onClose,
+}: {
+  target: BackupTarget;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [enabled, setEnabled] = useState(target.drill_enabled);
+  const [cron, setCron] = useState(target.drill_cron ?? "0 5 * * 0");
+
+  const save = useMutation({
+    mutationFn: () =>
+      backupTargetsApi.update(target.id, {
+        drill_enabled: enabled,
+        drill_cron: cron || null,
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["backup-targets"] });
+      onClose();
+    },
+  });
+
+  return (
+    <Modal title={`Drill schedule — ${target.name}`} onClose={onClose}>
+      <div className="flex flex-col gap-3">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />
+          Run restore-verification drills on a schedule
+        </label>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium">
+            Drill schedule
+          </label>
+          <select
+            value={
+              DRILL_CRON_PRESETS.find((p) => p.value === cron)?.value ??
+              "__custom__"
+            }
+            onChange={(e) => {
+              if (e.target.value !== "__custom__") setCron(e.target.value);
+            }}
+            className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+          >
+            {DRILL_CRON_PRESETS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label} ({p.value})
+              </option>
+            ))}
+            {!DRILL_CRON_PRESETS.some((p) => p.value === cron) && (
+              <option value="__custom__">Custom: {cron}</option>
+            )}
+          </select>
+          <input
+            value={cron}
+            onChange={(e) => setCron(e.target.value)}
+            placeholder="0 5 * * 0"
+            className="mt-2 w-full rounded-md border bg-background px-2 py-1.5 font-mono text-sm"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            5-field UTC cron expression. Drills are far more expensive than
+            backups — weekly against nightly backups is a sensible default.
+          </p>
+        </div>
+
+        {save.isError && (
+          <p className="text-xs text-rose-600 dark:text-rose-400">
+            {(save.error as Error).message}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={save.isPending}
+            onClick={() => save.mutate()}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {save.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            Save
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/admin/RestoreDrillsSection.tsx
+++ b/frontend/src/pages/admin/RestoreDrillsSection.tsx
@@ -33,10 +33,13 @@ import { Modal } from "@/components/ui/modal";
  *
  * 1. **Readiness** — one row per backup target: is a drill
  *    scheduled, what did the last one say, how long ago did this
- *    target last *prove* it could be restored. A target with
- *    drills off reads as "never verified" rather than healthy,
+ *    target last *prove* it could be restored. A target that has
+ *    never passed a drill reads as "never" rather than healthy,
  *    which is the honest framing: an untested backup is an
- *    unknown, not a pass.
+ *    unknown, not a pass. A target whose most recent drill merely
+ *    errored keeps its previous proof — an error disproves
+ *    nothing — but the row flags it as superseded once a real
+ *    failure lands.
  *
  * 2. **History** — recent drills, expandable to the per-check
  *    verdicts.
@@ -262,7 +265,9 @@ export function RestoreDrillsSection() {
                       </td>
                       <td className="px-4 py-2 text-xs">
                         {readinessQ.isLoading ? (
-                          <span className="text-muted-foreground">&hellip;</span>
+                          <span className="text-muted-foreground">
+                            &hellip;
+                          </span>
                         ) : readiness?.last_passed_at ? (
                           <span
                             className={
@@ -272,7 +277,8 @@ export function RestoreDrillsSection() {
                             }
                           >
                             {relativeAge(readiness.last_passed_at)}
-                            {!readiness.verified && " (superseded by a failure)"}
+                            {!readiness.verified &&
+                              " (superseded by a failure)"}
                           </span>
                         ) : (
                           <span className="text-muted-foreground">never</span>

--- a/frontend/src/pages/admin/RestoreDrillsSection.tsx
+++ b/frontend/src/pages/admin/RestoreDrillsSection.tsx
@@ -148,6 +148,16 @@ export function RestoreDrillsSection() {
     queryKey: ["backup-targets"],
     queryFn: () => backupTargetsApi.list(),
   });
+  // "Last proven" must come from a per-target server-side lookup, not
+  // from scanning the drill list: that list is globally capped, so on
+  // an install with several targets a genuine pass scrolls out of the
+  // window and the column would claim "never" for a target that
+  // demonstrably passed — the exact opposite of what this card exists
+  // to tell you.
+  const readinessQ = useQuery({
+    queryKey: ["restore-drill-readiness"],
+    queryFn: () => backupTargetsApi.drillReadiness(),
+  });
   const drillsQ = useQuery({
     queryKey: ["restore-drills"],
     queryFn: () => backupTargetsApi.listDrills({ limit: 50 }),
@@ -162,11 +172,15 @@ export function RestoreDrillsSection() {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["restore-drills"] });
       void qc.invalidateQueries({ queryKey: ["backup-targets"] });
+      void qc.invalidateQueries({ queryKey: ["restore-drill-readiness"] });
     },
   });
 
   const targets = targetsQ.data ?? [];
   const drills = drillsQ.data ?? [];
+  const readinessByTarget = new Map(
+    (readinessQ.data?.targets ?? []).map((r) => [r.target_id, r]),
+  );
 
   return (
     <div className="flex flex-col gap-6">
@@ -185,6 +199,9 @@ export function RestoreDrillsSection() {
             onClick={() => {
               void qc.invalidateQueries({ queryKey: ["backup-targets"] });
               void qc.invalidateQueries({ queryKey: ["restore-drills"] });
+              void qc.invalidateQueries({
+                queryKey: ["restore-drill-readiness"],
+              });
             }}
             className="inline-flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
           >
@@ -217,9 +234,7 @@ export function RestoreDrillsSection() {
               </thead>
               <tbody>
                 {targets.map((t) => {
-                  const lastPass = drills.find(
-                    (d) => d.target_id === t.id && d.state === "passed",
-                  );
+                  const readiness = readinessByTarget.get(t.id);
                   const busy =
                     t.drill_last_status === "in_progress" ||
                     (runDrill.isPending && runDrill.variables === t.id);
@@ -245,12 +260,23 @@ export function RestoreDrillsSection() {
                       <td className="px-4 py-2">
                         <StateChip state={t.drill_last_status} />
                       </td>
-                      <td className="px-4 py-2 text-xs text-muted-foreground">
-                        {lastPass
-                          ? relativeAge(lastPass.finished_at)
-                          : t.drill_last_status === "passed"
-                            ? relativeAge(t.drill_last_at)
-                            : "never"}
+                      <td className="px-4 py-2 text-xs">
+                        {readinessQ.isLoading ? (
+                          <span className="text-muted-foreground">&hellip;</span>
+                        ) : readiness?.last_passed_at ? (
+                          <span
+                            className={
+                              readiness.verified
+                                ? "text-muted-foreground"
+                                : "text-amber-600 dark:text-amber-400"
+                            }
+                          >
+                            {relativeAge(readiness.last_passed_at)}
+                            {!readiness.verified && " (superseded by a failure)"}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">never</span>
+                        )}
                       </td>
                       <td className="px-4 py-2">
                         <div className="flex justify-end gap-1.5">


### PR DESCRIPTION
Closes #702 (the restore-verification-drill half; warm standby is deliberately out of scope — see below).

## Why

The backup subsystem could write archives to eight destination kinds but never proved any of them could be restored. The common real-world failure isn't a lost site — it's discovering at recovery time that the archives were bad all along.

A **drill** downloads a target's newest archive, replays it into a throwaway scratch database, runs a fixed assertion set against the result, and drops the scratch database again.

## Safety

**The live database is never written to.** The scratch name is a fixed `spatiumddi_drill_` prefix plus random hex — never operator input — and is checked against the live database name before anything runs.

This deliberately does **not** build on `apply_backup_restore`: that takes a pre-restore safety dump against the live session and disposes the live engine's connection pool, which is correct for an operator-initiated restore and wrong for an unattended background check. The replay helpers are local for the same reason — `restore._run_psql` terminates every other connection to its target database, and that must never become something a drill can do.

## The checks

| Check | What a failure means |
|---|---|
| `archive_available` | The destination holds no archives — nothing to restore from. |
| `archive_readable` | Malformed zip, or a `format_version` this build can't restore (same constant the real restore path enforces). |
| `passphrase_opens_secrets` | The passphrase stored on the target doesn't open `secrets.enc`. A restore would be impossible. |
| `dump_replays_cleanly` | `pg_restore` / `psql` aborted — truncated or corrupt dump. |
| `alembic_version_present` | No single revision, or one this build has never heard of. A head *behind* the bundled one passes: a real restore migrates it forward. |
| `core_tables_populated` | Restored with no users — an install from this archive would have no way in. |
| `audit_chain_intact` | The restored tamper-evident hash chain doesn't verify. Skipped on schema skew, capped at 250k rows. |

**`failed` and `error` are kept apart.** `failed` is a verdict about the archive — a real finding, and the only thing that opens the alert. `error` means the drill couldn't run at all and leaves the previous verdict standing. Paging on unreachable destinations would train operators to ignore the rule; auto-resolving on them would be worse.

## New operational requirements

Two things a drill needs that a backup doesn't, both preflighted so a drill that can't run says so plainly:

- **`CREATEDB` on the app role.** CNPG's `initdb` owner is a plain LOGIN role with no `CREATEDB` and superuser access off, so drills could not run on an appliance at all. The chart grants it via `managed.roles` (`postgresql.cnpg.appRoleCreateDb`, default `true`), which reconciles onto **existing** clusters, not just fresh bootstraps.
- **Room for a second copy.** The scratch database lands on the same Postgres instance. Postgres has no portable free-space query, so the risk is bounded from the other end: refuse above `SPATIUM_DRILL_MAX_DB_BYTES` (20 GiB default, `0` disables). On the appliance's default 8Gi volume a 6 GB install would otherwise have filled the production primary's volume.

Scratch databases are dropped when a drill finishes. If a worker is SIGKILLed the drop never runs, so the sweep also reaps prefixed databases with **no active connections** — liveness rather than a guessed age threshold, so it can't race a legitimate drill.

## What's included

- `restore_drill` history table + a drill cadence on `backup_target`, migration `c9f4a71b8e35`. Separate cron from the backup schedule, because replaying a full dump costs far more than taking a backup — weekly drills against nightly backups is the expected shape.
- Beat sweep every 60 s, mutexed on `drill_last_status`, with a staleness escape shared by the sweep and the manual run-now endpoint.
- `restore_drill_failed` alert, seeded enabled. Keyed on the **target**, so a nightly failure holds one event rather than one per drill; only considers enabled targets with drills scheduled, so it can't open an event nothing can resolve.
- REST at `/api/v1/backup/drills` (list / get / readiness / run-now), superadmin-gated and audited from the runner so scheduled drills are audited too.
- Two Copilot tools — `find_restore_drills` and `get_restore_drill_readiness` — the latter sharing one computation with the REST readiness endpoint and the UI, so the assistant and the screen can't disagree.
- `Restore Drills` tab on the Backup admin page.

## Scope

Warm-standby / cross-site failover from #702 is **not** here. Drills are the higher-value half and the cheaper one to build: the actual risk operators carry is an untested backup, not a lost site. Warm standby needs WAL streaming, promotion and split-brain avoidance, and belongs in its own change.

## Verification

Live against a dev stack, not just mocked:

- A real 874 KB archive drilled in 5.5 s. Six checks passed; `audit_chain_intact` reported 4 breaks — **verified as a true positive**: `/audit/integrity` reports the identical 4 breaks at the identical sequence numbers against the live database, so the check reproduces real state rather than inventing a failure.
- Reaper drops a planted orphan; scratch database cleaned up; FK cascade on target delete confirmed; exactly one audit row per drill.
- Both preflight gates fire, and the `CREATEDB` probe returns false for a role without it and true for the app role.
- Chart renders the grant and withholds it when toggled off.
- 41 tests in the drill file, 66 across the related regression set. ruff / black / mypy clean over the full backend; `npm run build` clean; migration linter baselined.

The second commit fixes 14 code-review findings against the first — the two most serious being that the feature could never have run under CNPG, and that the scratch copy was unbounded. Both are covered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
