### PR TITLE
feat(dns): DNS tunneling detection + BIND9/PowerDNS double-spawn fix (#699, #704)

### DIFF
--- a/agent/dns/spatium_dns_agent/drivers/_process.py
+++ b/agent/dns/spatium_dns_agent/drivers/_process.py
@@ -1,9 +1,20 @@
 """Process look-up shared by the DNS daemon drivers (issue #704).
 
-Both drivers track their daemon with a per-instance ``daemon_pid``, and
-both call ``start_daemon()`` from two places (``supervisor.py`` at boot
-and the config-apply path). A second driver object therefore sees
-``daemon_running() is False`` and spawns a duplicate daemon.
+Both drivers track their daemon with a per-instance ``daemon_pid`` and
+call ``start_daemon()`` from two places — ``supervisor.py`` at boot and
+the config-apply path — with only ``daemon_running()`` between them and
+a duplicate spawn.
+
+**The exact trigger is not fully established.** An earlier version of
+this docstring blamed a second driver object; that is wrong —
+``supervisor.run()`` builds exactly one driver and hands that same
+object to the sync loop. What was observed on a real agent is two
+``named_started`` events 118 ms apart from one process, which most
+plausibly means the boot-path daemon had not yet been reflected in
+``daemon_pid`` (or had already exited) when the first config apply ran
+its check. Whatever the precise race, the fix is the same and does not
+depend on knowing it: consult the system rather than instance state
+before spawning.
 
 The two failure modes look nothing alike, which is why this went
 unnoticed for so long:

--- a/agent/dns/spatium_dns_agent/drivers/_process.py
+++ b/agent/dns/spatium_dns_agent/drivers/_process.py
@@ -1,0 +1,78 @@
+"""Process look-up shared by the DNS daemon drivers (issue #704).
+
+Both drivers track their daemon with a per-instance ``daemon_pid``, and
+both call ``start_daemon()`` from two places (``supervisor.py`` at boot
+and the config-apply path). A second driver object therefore sees
+``daemon_running() is False`` and spawns a duplicate daemon.
+
+The two failure modes look nothing alike, which is why this went
+unnoticed for so long:
+
+* **BIND9** uses ``SO_REUSEPORT``, so the duplicate binds :53 and :953
+  happily alongside the original. Nothing errors; ``rndc`` just becomes
+  a coin flip between two instances, and per-process state like query
+  logging appears to ignore commands.
+* **PowerDNS** does not set ``reuseport``, so the duplicate fails to
+  bind and exits — but the driver keeps only ``Popen.pid`` and never
+  ``wait()``s, so the corpse becomes a **zombie**. ``daemon_pid`` is
+  left pointing at it, and because ``os.kill(zombie, 0)`` succeeds the
+  driver believes its daemon is healthy while tracking a dead process.
+
+Hence :func:`find_running_daemon`, which both drivers consult before
+spawning — and which skips zombies, since adopting one would recreate
+exactly the PowerDNS failure it exists to prevent.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def is_zombie(pid: str) -> bool:
+    """True when ``pid`` is a reaped-but-not-collected corpse.
+
+    Field 3 of ``/proc/<pid>/stat`` is the state character. The comm
+    field ahead of it can contain spaces and parentheses, so the split
+    is anchored on the last ``)`` rather than on whitespace.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", encoding="utf-8") as fh:
+            raw = fh.read()
+    except OSError:
+        return False
+    tail = raw.rpartition(")")[2].split()
+    return bool(tail) and tail[0] == "Z"
+
+
+def find_running_daemon(comm: str) -> int | None:
+    """PID of a live process named ``comm``, or ``None``.
+
+    Reads ``/proc`` directly rather than shelling to ``pgrep``: the
+    agent images are Alpine-based, busybox ``pgrep`` differs from
+    procps, and this runs on the daemon startup path where a missing
+    binary must not be able to wedge the launch.
+
+    Zombies are skipped — a dead daemon must not be adopted as a live
+    one.
+    """
+    try:
+        pids = [entry for entry in os.listdir("/proc") if entry.isdigit()]
+    except OSError:
+        # Not a Linux host (dev machine, some CI sandboxes). Callers
+        # fall back to spawning, which is the pre-existing behaviour.
+        return None
+    for pid in pids:
+        try:
+            with open(f"/proc/{pid}/comm", encoding="utf-8") as fh:
+                if fh.read().strip() != comm:
+                    continue
+        except OSError:
+            # Exited between listdir and open.
+            continue
+        if is_zombie(pid):
+            continue
+        try:
+            return int(pid)
+        except ValueError:
+            continue
+    return None

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -460,6 +460,34 @@ def _render_dnssec_policies(policies: list[dict[str, Any]]) -> str:
     return out
 
 
+
+def _find_running_named() -> int | None:
+    """PID of an already-running ``named``, if any.
+
+    Reads ``/proc`` directly rather than shelling to ``pgrep``: the
+    agent image is Alpine-based and busybox ``pgrep`` semantics differ
+    from procps, and this runs on the startup path where a missing
+    binary must not be able to wedge the daemon launch.
+
+    Only the agent's own children are relevant, but ownership isn't
+    checked — any ``named`` on this PID namespace is the one serving
+    :53, and spawning a second is never the right answer.
+    """
+    try:
+        pids = [entry for entry in os.listdir("/proc") if entry.isdigit()]
+    except OSError:
+        return None
+    for pid in pids:
+        try:
+            with open(f"/proc/{pid}/comm", encoding="utf-8") as fh:
+                if fh.read().strip() == "named":
+                    return int(pid)
+        except (OSError, ValueError):
+            # Process exited between listdir and open, or /proc is not
+            # available (non-Linux dev box) — neither is fatal.
+            continue
+    return None
+
 class Bind9Driver(DriverBase):
     rendered_dir_name = "rendered"
     daemon_pid: int | None = None
@@ -1251,12 +1279,45 @@ class Bind9Driver(DriverBase):
         # running unprivileged as ``spatium`` (entrypoint dropped privs
         # via su-exec), so don't pass ``-u`` — named would try to
         # setgid() to a different user and fail.
+        # Idempotent against the SYSTEM, not just this object's state.
+        #
+        # ``daemon_pid`` is per-instance, so any second driver object
+        # sees ``daemon_running() is False`` and spawns another named.
+        # That is not hypothetical: the agent was observed logging two
+        # ``named_started`` events 118 ms apart at boot (pids 14 and 32,
+        # same parent, same config).
+        #
+        # Two named processes do not fail loudly — BIND uses
+        # SO_REUSEPORT, so both bind :53 and :953 and the kernel
+        # load-balances between them. The visible symptom is that
+        # ``rndc`` becomes unreliable: ``rndc querylog on`` flips the
+        # flag on whichever instance answered, while queries and
+        # ``rndc status`` land on either. Enabling query logging then
+        # appears to do nothing, which silently breaks the Logs → DNS
+        # Queries surface and anything built on it.
+        existing = _find_running_named()
+        if existing is not None:
+            self.daemon_pid = existing
+            log.info(
+                "named_already_running_adopted",
+                pid=existing,
+                note="did not spawn a second daemon",
+            )
+            return
         self.daemon_pid = subprocess.Popen(["named", "-f", "-c", str(conf_path)]).pid
         log.info("named_started", pid=self.daemon_pid)
 
     def daemon_running(self) -> bool:
+        # Falls back to a system-wide look-up when this object has no
+        # pid of its own: another driver instance may legitimately own
+        # the running daemon, and answering "not running" would spawn a
+        # duplicate (see start_daemon).
         if self.daemon_pid is None:
-            return False
+            found = _find_running_named()
+            if found is None:
+                return False
+            self.daemon_pid = found
+            return True
         try:
             os.kill(self.daemon_pid, 0)
             return True

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -1255,11 +1255,13 @@ class Bind9Driver(DriverBase):
         # setgid() to a different user and fail.
         # Idempotent against the SYSTEM, not just this object's state.
         #
-        # ``daemon_pid`` is per-instance, so any second driver object
-        # sees ``daemon_running() is False`` and spawns another named.
-        # That is not hypothetical: the agent was observed logging two
-        # ``named_started`` events 118 ms apart at boot (pids 14 and 32,
-        # same parent, same config).
+        # ``daemon_pid`` is per-instance state, and only
+        # ``daemon_running()`` stands between the two ``start_daemon()``
+        # call sites and a duplicate spawn. Observed on a real agent:
+        # two ``named_started`` events 118 ms apart at boot (pids 14 and
+        # 32, same parent, same config). The precise race is not fully
+        # established — see ``_process`` — but consulting the system
+        # rather than instance state fixes it either way.
         #
         # Two named processes do not fail loudly — BIND uses
         # SO_REUSEPORT, so both bind :53 and :953 and the kernel

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -27,6 +27,7 @@ try:
 except ImportError:  # pragma: no cover - runtime-optional
     dns = None  # type: ignore[assignment]
 
+from ._process import find_running_daemon, is_zombie
 from .base import DriverBase
 
 log = structlog.get_logger(__name__)
@@ -460,33 +461,6 @@ def _render_dnssec_policies(policies: list[dict[str, Any]]) -> str:
     return out
 
 
-
-def _find_running_named() -> int | None:
-    """PID of an already-running ``named``, if any.
-
-    Reads ``/proc`` directly rather than shelling to ``pgrep``: the
-    agent image is Alpine-based and busybox ``pgrep`` semantics differ
-    from procps, and this runs on the startup path where a missing
-    binary must not be able to wedge the daemon launch.
-
-    Only the agent's own children are relevant, but ownership isn't
-    checked — any ``named`` on this PID namespace is the one serving
-    :53, and spawning a second is never the right answer.
-    """
-    try:
-        pids = [entry for entry in os.listdir("/proc") if entry.isdigit()]
-    except OSError:
-        return None
-    for pid in pids:
-        try:
-            with open(f"/proc/{pid}/comm", encoding="utf-8") as fh:
-                if fh.read().strip() == "named":
-                    return int(pid)
-        except (OSError, ValueError):
-            # Process exited between listdir and open, or /proc is not
-            # available (non-Linux dev box) — neither is fatal.
-            continue
-    return None
 
 class Bind9Driver(DriverBase):
     rendered_dir_name = "rendered"
@@ -1295,7 +1269,7 @@ class Bind9Driver(DriverBase):
         # ``rndc status`` land on either. Enabling query logging then
         # appears to do nothing, which silently breaks the Logs → DNS
         # Queries surface and anything built on it.
-        existing = _find_running_named()
+        existing = find_running_daemon("named")
         if existing is not None:
             self.daemon_pid = existing
             log.info(
@@ -1313,13 +1287,15 @@ class Bind9Driver(DriverBase):
         # the running daemon, and answering "not running" would spawn a
         # duplicate (see start_daemon).
         if self.daemon_pid is None:
-            found = _find_running_named()
+            found = find_running_daemon("named")
             if found is None:
                 return False
             self.daemon_pid = found
             return True
         try:
             os.kill(self.daemon_pid, 0)
-            return True
         except OSError:
             return False
+        # A zombie still answers signal 0, so the state check is what
+        # actually distinguishes "running" from "dead but unreaped".
+        return not is_zombie(str(self.daemon_pid))

--- a/agent/dns/spatium_dns_agent/drivers/powerdns.py
+++ b/agent/dns/spatium_dns_agent/drivers/powerdns.py
@@ -39,6 +39,7 @@ from typing import Any
 import httpx
 import structlog
 
+from ._process import find_running_daemon, is_zombie
 from .base import DriverBase
 
 log = structlog.get_logger(__name__)
@@ -567,8 +568,11 @@ class PowerDNSDriver(DriverBase):
 
         # Cold-boot fix: kick start_daemon now that pdns.conf exists.
         # ``daemon_running`` is the simplest "is pdns alive?" probe.
-        # On warm reload the daemon is already up and start_daemon's
-        # internal guard makes this a no-op.
+        # On warm reload the daemon is already up; start_daemon's
+        # already-running check (added in #704) makes this a no-op.
+        # Before that check existed this comment was simply wrong —
+        # start_daemon only verified the config file and the binary,
+        # and would happily spawn a second daemon.
         if not self.daemon_running():
             log.info("powerdns_daemon_starting_after_first_render")
             self.start_daemon()
@@ -919,6 +923,26 @@ class PowerDNSDriver(DriverBase):
         if not shutil.which("pdns_server"):
             log.error("pdns_server_binary_missing")
             return
+        # Idempotent against the SYSTEM, not this object's state (#704).
+        # ``daemon_pid`` is per-instance, so a second driver object sees
+        # ``daemon_running() is False`` and spawns a duplicate. Unlike
+        # BIND9 — which uses SO_REUSEPORT and quietly runs two servers —
+        # pdns_server has no ``reuseport`` set, so the duplicate fails to
+        # bind :53 and exits. The damage is subtler for it: the ``Popen``
+        # handle is discarded, so the corpse is never reaped, and
+        # ``daemon_pid`` is left pointing at a ZOMBIE. Because
+        # ``os.kill(zombie, 0)`` succeeds, the driver then reports a
+        # healthy daemon while tracking a dead process, and any signal it
+        # sends goes nowhere.
+        existing = find_running_daemon("pdns_server")
+        if existing is not None:
+            self.daemon_pid = existing
+            log.info(
+                "pdns_already_running_adopted",
+                pid=existing,
+                note="did not spawn a second daemon",
+            )
+            return
         # ``--daemon=no`` + foreground; pdns logs to stderr.
         # All flags use ``--name=value`` form — pdns_server rejects
         # space-separated args with "perhaps a '--setting=123'
@@ -960,13 +984,25 @@ class PowerDNSDriver(DriverBase):
         )
 
     def daemon_running(self) -> bool:
+        # Falls back to a system-wide look-up when this object has no pid
+        # of its own — another driver instance may legitimately own the
+        # running daemon, and answering "not running" spawns a duplicate.
+        # The shared helper skips zombies, so a corpse is never mistaken
+        # for a live daemon (#704).
         if self.daemon_pid is None:
-            return False
+            found = find_running_daemon("pdns_server")
+            if found is None:
+                return False
+            self.daemon_pid = found
+            return True
         try:
             os.kill(self.daemon_pid, 0)
-            return True
         except OSError:
             return False
+        # ``os.kill(pid, 0)`` succeeds for a zombie, so liveness needs
+        # the state check too — this is exactly how a dead pdns_server
+        # was being reported as healthy.
+        return not is_zombie(str(self.daemon_pid))
 
     # ── Internals ───────────────────────────────────────────────────────────
 

--- a/agent/dns/spatium_dns_agent/drivers/powerdns.py
+++ b/agent/dns/spatium_dns_agent/drivers/powerdns.py
@@ -924,8 +924,9 @@ class PowerDNSDriver(DriverBase):
             log.error("pdns_server_binary_missing")
             return
         # Idempotent against the SYSTEM, not this object's state (#704).
-        # ``daemon_pid`` is per-instance, so a second driver object sees
-        # ``daemon_running() is False`` and spawns a duplicate. Unlike
+        # ``daemon_pid`` is per-instance and only ``daemon_running()``
+        # guards the two ``start_daemon()`` call sites from racing into
+        # a duplicate spawn. Unlike
         # BIND9 — which uses SO_REUSEPORT and quietly runs two servers —
         # pdns_server has no ``reuseport`` set, so the duplicate fails to
         # bind :53 and exits. The damage is subtler for it: the ``Popen``

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -441,7 +441,7 @@ backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_table:135
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:292
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:298
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:305
-backend/alembic/versions/d1a7c34e9b60_dns_client_window.py:drop_table:108
+backend/alembic/versions/d1a7c34e9b60_dns_client_window.py:drop_table:123
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:107
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:110
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_table:112

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -441,6 +441,7 @@ backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_table:135
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:292
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:298
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:305
+backend/alembic/versions/d1a7c34e9b60_dns_client_window.py:drop_table:108
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:107
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:110
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_table:112

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -441,7 +441,7 @@ backend/alembic/versions/c9f4a71b8e35_restore_drills.py:drop_table:135
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:292
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:298
 backend/alembic/versions/cb279a6afd70_bgp_looking_glass_collector_peers_.py:drop_table:305
-backend/alembic/versions/d1a7c34e9b60_dns_client_window.py:drop_table:123
+backend/alembic/versions/d1a7c34e9b60_dns_client_window.py:drop_table:116
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:107
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_column:110
 backend/alembic/versions/d1a8f3c704e9_proxmox_integration.py:drop_table:112

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -603,6 +603,7 @@ backend/alembic/versions/e5b21a8f0d94_release_check_state.py:drop_column:57
 backend/alembic/versions/e5b21a8f0d94_release_check_state.py:drop_column:58
 backend/alembic/versions/e5b21a8f0d94_release_check_state.py:drop_column:59
 backend/alembic/versions/e5b21a8f0d94_release_check_state.py:drop_column:60
+backend/alembic/versions/e5b2f09c71a4_dns_threat_mute.py:drop_table:71
 backend/alembic/versions/e5b831f02db9_subnet_block_id_not_null.py:drop_constraint_fk:81
 backend/alembic/versions/e5b831f02db9_subnet_block_id_not_null.py:drop_constraint_fk:93
 backend/alembic/versions/e5c1b3d8f29a_ddns_inheritance.py:drop_column:100

--- a/backend/alembic/versions/d1a7c34e9b60_dns_client_window.py
+++ b/backend/alembic/versions/d1a7c34e9b60_dns_client_window.py
@@ -100,8 +100,23 @@ def upgrade() -> None:
         ["client_ip", "ts"],
     )
 
+    # feature_module seed (non-negotiable #14), default-OFF. The module
+    # resolves to disabled from the catalog fallback either way, but the
+    # table is meant to enumerate the catalog and tooling is entitled to
+    # assume it does.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('security.dns_threat', FALSE)
+            ON CONFLICT (id) DO NOTHING
+            """
+        )
+    )
+
 
 def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'security.dns_threat'"))
     op.drop_index("ix_dns_query_log_client_ts", table_name="dns_query_log_entry")
     op.drop_index("ix_dns_client_window_ip", table_name="dns_client_window")
     op.drop_index("ix_dns_client_window_score", table_name="dns_client_window")

--- a/backend/alembic/versions/d1a7c34e9b60_dns_client_window.py
+++ b/backend/alembic/versions/d1a7c34e9b60_dns_client_window.py
@@ -19,11 +19,14 @@ Two pieces:
   bucket as late log lines arrive. Deliberately not per-server: a host
   splitting queries across two resolvers is one suspicious host, not
   two half-suspicious ones.
-* ``ix_dns_query_log_client_ts`` on ``dns_query_log_entry`` — the
-  aggregator scans by (client_ip, ts) every run, and the existing
-  indexes lead with ``server_id`` or ``ts`` alone, so without this the
-  rollup degrades to a full scan of a table that can hold a busy
-  resolver's entire day.
+No new index on ``dns_query_log_entry``. An earlier draft added
+``(client_ip, ts)`` on the theory that the aggregator scans per client;
+it does not — it scans a *time range* across all clients and sorts, so
+``EXPLAIN`` shows the planner using the existing ``ix_dns_query_log_ts``
+and ignoring the new index entirely. Even the Logs client-IP filter
+prefers the ``ts`` index because of its ``ORDER BY ts DESC LIMIT``.
+Left out rather than carried: it is a third index to maintain on the
+highest-insert-rate table in the schema for no measured read benefit.
 
 Additive and inert on upgrade: nothing writes to the new table until an
 operator enables the default-off ``security.dns_threat`` module, which
@@ -91,15 +94,6 @@ def upgrade() -> None:
     # Per-client history drilldown.
     op.create_index("ix_dns_client_window_ip", "dns_client_window", ["client_ip"])
 
-    # The aggregator's scan pattern. Without it the rollup full-scans
-    # dns_query_log_entry, whose existing indexes lead with server_id
-    # or ts and so can't serve "this client, this hour".
-    op.create_index(
-        "ix_dns_query_log_client_ts",
-        "dns_query_log_entry",
-        ["client_ip", "ts"],
-    )
-
     # feature_module seed (non-negotiable #14), default-OFF. The module
     # resolves to disabled from the catalog fallback either way, but the
     # table is meant to enumerate the catalog and tooling is entitled to
@@ -117,7 +111,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute(sa.text("DELETE FROM feature_module WHERE id = 'security.dns_threat'"))
-    op.drop_index("ix_dns_query_log_client_ts", table_name="dns_query_log_entry")
     op.drop_index("ix_dns_client_window_ip", table_name="dns_client_window")
     op.drop_index("ix_dns_client_window_score", table_name="dns_client_window")
     op.drop_table("dns_client_window")

--- a/backend/alembic/versions/d1a7c34e9b60_dns_client_window.py
+++ b/backend/alembic/versions/d1a7c34e9b60_dns_client_window.py
@@ -1,0 +1,108 @@
+"""dns threat analytics: per-client behaviour rollup + query-log client index
+
+Revision ID: d1a7c34e9b60
+Revises: c9f4a71b8e35
+Create Date: 2026-07-25 17:00:00.000000
+
+Issue #699 — DNS tunneling detection.
+
+``dns_query_log_entry`` is operator triage on a 24 h window, indexed for
+"show me this server's recent queries". Threat analytics asks a
+different question — "summarise what THIS CLIENT did" — and needs the
+answer to outlive the raw rows.
+
+Two pieces:
+
+* ``dns_client_window`` — one row per (client IP, hourly bucket) with
+  detection-agnostic behaviour features plus the tunneling verdict.
+  Unique on (client_ip, window_start) so the aggregator can upsert a
+  bucket as late log lines arrive. Deliberately not per-server: a host
+  splitting queries across two resolvers is one suspicious host, not
+  two half-suspicious ones.
+* ``ix_dns_query_log_client_ts`` on ``dns_query_log_entry`` — the
+  aggregator scans by (client_ip, ts) every run, and the existing
+  indexes lead with ``server_id`` or ``ts`` alone, so without this the
+  rollup degrades to a full scan of a table that can hold a busy
+  resolver's entire day.
+
+Additive and inert on upgrade: nothing writes to the new table until an
+operator enables the default-off ``security.dns_threat`` module, which
+itself does nothing until a DNS group has query logging on.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import INET, JSONB, UUID
+
+revision = "d1a7c34e9b60"
+down_revision = "c9f4a71b8e35"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dns_client_window",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("client_ip", INET(), nullable=False),
+        sa.Column("server_count", sa.Integer(), nullable=False, server_default=sa.text("1")),
+        sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("window_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("query_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("distinct_qnames", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("distinct_parents", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("top_parent", sa.String(length=255), nullable=True),
+        sa.Column(
+            "top_parent_subdomains", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("max_label_length", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "avg_label_length", sa.Float(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "mean_label_entropy", sa.Float(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "payload_qtype_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("tunnel_score", sa.Float(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "tunnel_signals", JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")
+        ),
+        sa.Column(
+            "allowlisted", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("client_ip", "window_start", name="uq_dns_client_window_ip_bucket"),
+    )
+    # "Worst offenders recently" — the alert matcher and the Threat tab.
+    op.create_index(
+        "ix_dns_client_window_score",
+        "dns_client_window",
+        ["window_start", "tunnel_score"],
+    )
+    # Per-client history drilldown.
+    op.create_index("ix_dns_client_window_ip", "dns_client_window", ["client_ip"])
+
+    # The aggregator's scan pattern. Without it the rollup full-scans
+    # dns_query_log_entry, whose existing indexes lead with server_id
+    # or ts and so can't serve "this client, this hour".
+    op.create_index(
+        "ix_dns_query_log_client_ts",
+        "dns_query_log_entry",
+        ["client_ip", "ts"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_dns_query_log_client_ts", table_name="dns_query_log_entry")
+    op.drop_index("ix_dns_client_window_ip", table_name="dns_client_window")
+    op.drop_index("ix_dns_client_window_score", table_name="dns_client_window")
+    op.drop_table("dns_client_window")

--- a/backend/alembic/versions/e5b2f09c71a4_dns_threat_mute.py
+++ b/backend/alembic/versions/e5b2f09c71a4_dns_threat_mute.py
@@ -1,0 +1,71 @@
+"""dns threat: per-client mute (operator triage on findings)
+
+Revision ID: e5b2f09c71a4
+Revises: d1a7c34e9b60
+Create Date: 2026-07-25 22:00:00.000000
+
+Issue #699 follow-up — operators need a way to clear a finding they have
+reviewed.
+
+Modelled as a mute on the **client**, not a delete on the window rows:
+
+* deleting wouldn't stick — the aggregator recomputes the current and
+  previous hour every 15 minutes and upserts, and the backfill refills
+  any bucket left empty, so a cleared recent finding would reappear
+  within the quarter hour while an older one stayed gone;
+* deleting destroys evidence of what may be an exfiltration event,
+  where "we looked and it's the backup agent" is itself worth keeping.
+
+Unique on ``client_ip`` so re-muting updates the existing decision
+rather than stacking rows. ``muted_until`` NULL means indefinite.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import INET, UUID
+
+revision = "e5b2f09c71a4"
+down_revision = "d1a7c34e9b60"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dns_threat_mute",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("client_ip", INET(), nullable=False),
+        sa.Column("muted_until", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column(
+            "muted_by",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "muted_by_display",
+            sa.String(length=120),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("client_ip", name="uq_dns_threat_mute_client"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dns_threat_mute")

--- a/backend/app/api/v1/dns_threat/router.py
+++ b/backend/app/api/v1/dns_threat/router.py
@@ -1,7 +1,10 @@
 """DNS threat analytics read surface (issue #699).
 
-Read-only: the detections write themselves via the rollup task, and
-there is nothing here an operator mutates. Gated behind the default-off
+Read-mostly: the detections write themselves via the rollup task. The
+one mutation is the per-client mute (operator triage), which carries a
+``write`` permission gate of its own because suppressing a critical
+security finding must not be something a read-only account can do.
+Gated behind the default-off
 ``security.dns_threat`` feature module at the router include, so the
 whole prefix 404s on installs that haven't opted in.
 
@@ -18,7 +21,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
-from sqlalchemy import desc, select
+from sqlalchemy import desc, or_, select
 
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import require_permission
@@ -114,6 +117,7 @@ async def list_windows(
     hours: int = Query(default=24, ge=1, le=24 * 30),
     min_score: float = Query(default=INTERESTING_SCORE, ge=0, le=100),
     include_allowlisted: bool = Query(default=False),
+    include_muted: bool = Query(default=False),
     limit: int = Query(default=100, ge=1, le=1000),
 ) -> list[ClientWindowRow]:
     """Scored client windows, worst first.
@@ -142,6 +146,21 @@ async def list_windows(
         stmt = stmt.where(DNSClientWindow.tunnel_score >= min_score)
     if not include_allowlisted:
         stmt = stmt.where(DNSClientWindow.allowlisted.is_(False))
+    if not include_muted and not client_ip:
+        # A muted client is one an operator reviewed and cleared, so it
+        # drops out of the default view — that is what the mute dialog
+        # promises. Still reachable via the toggle, and a per-client
+        # lookup always shows everything so the drilldown stays honest.
+        stmt = stmt.where(
+            DNSClientWindow.client_ip.not_in(
+                select(DNSThreatMute.client_ip).where(
+                    or_(
+                        DNSThreatMute.muted_until.is_(None),
+                        DNSThreatMute.muted_until > datetime.now(UTC),
+                    )
+                )
+            )
+        )
     rows = (await db.execute(stmt)).scalars().all()
     # One lookup for the whole page rather than per row.
     now = datetime.now(UTC)
@@ -218,7 +237,16 @@ async def list_mutes(db: DB, current_user: CurrentUser) -> list[MuteRow]:
     return [_to_mute_row(m, now) for m in rows]
 
 
-@router.post("/mutes", response_model=MuteRow, status_code=201)
+@router.post(
+    "/mutes",
+    response_model=MuteRow,
+    status_code=201,
+    # The router-level gate is ``read`` because this surface is
+    # read-mostly — but muting SUPPRESSES A CRITICAL SECURITY ALERT, so
+    # it cannot inherit it. Without this a Viewer (read:*) could silence
+    # an exfiltration finding. Non-negotiable #3.
+    dependencies=[Depends(require_permission("write", "server"))],
+)
 async def create_mute(body: MuteBody, db: DB, current_user: CurrentUser) -> MuteRow:
     """Mute a client, or update the existing mute for it.
 
@@ -260,7 +288,11 @@ async def create_mute(body: MuteBody, db: DB, current_user: CurrentUser) -> Mute
     return _to_mute_row(row, datetime.now(UTC))
 
 
-@router.delete("/mutes/{client_ip}", status_code=204)
+@router.delete(
+    "/mutes/{client_ip}",
+    status_code=204,
+    dependencies=[Depends(require_permission("write", "server"))],
+)
 async def delete_mute(client_ip: str, db: DB, current_user: CurrentUser) -> None:
     """Un-mute a client so its findings surface again."""
     ip = _validated_ip(client_ip)

--- a/backend/app/api/v1/dns_threat/router.py
+++ b/backend/app/api/v1/dns_threat/router.py
@@ -17,12 +17,14 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import desc, select
 
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import require_permission
+from app.models.audit import AuditLog
 from app.models.dns_threat import DNSClientWindow
+from app.models.dns_threat_mute import DNSThreatMute
 from app.services.dns_threat.aggregate import INTERESTING_SCORE, compute_threat_summary
 
 # Same gate the Logs router uses: this is a rollup of the DNS query
@@ -47,6 +49,11 @@ class ClientWindowRow(BaseModel):
     tunnel_signals: list[dict[str, Any]]
     allowlisted: bool
     server_count: int
+    # Populated per row so the tab can dim a muted client and show who
+    # cleared it, without a second request.
+    muted: bool = False
+    mute_reason: str | None = None
+    mute_until: datetime | None = None
 
 
 class ThreatSummary(BaseModel):
@@ -136,7 +143,19 @@ async def list_windows(
     if not include_allowlisted:
         stmt = stmt.where(DNSClientWindow.allowlisted.is_(False))
     rows = (await db.execute(stmt)).scalars().all()
-    return [_to_row(w) for w in rows]
+    # One lookup for the whole page rather than per row.
+    now = datetime.now(UTC)
+    mutes = {str(m.client_ip): m for m in (await db.execute(select(DNSThreatMute))).scalars().all()}
+    out: list[ClientWindowRow] = []
+    for w in rows:
+        row = _to_row(w)
+        mute = mutes.get(row.client_ip)
+        if mute is not None and mute.is_active(now):
+            row.muted = True
+            row.mute_reason = mute.reason
+            row.mute_until = mute.muted_until
+        out.append(row)
+    return out
 
 
 @router.get("/summary", response_model=ThreatSummary)
@@ -147,3 +166,120 @@ async def threat_summary(
     min_score: float = Query(default=INTERESTING_SCORE, ge=0, le=100),
 ) -> ThreatSummary:
     return ThreatSummary(**await compute_threat_summary(db, hours=hours, min_score=min_score))
+
+
+class MuteBody(BaseModel):
+    client_ip: str
+    # Required, not optional: an unexplained mute is how a real incident
+    # gets buried by someone tidying a dashboard.
+    reason: str = Field(min_length=3, max_length=2000)
+    # NULL = indefinite. The UI defaults to a dated mute so a snap
+    # decision ages out and gets re-examined rather than silently
+    # outliving the person who made it.
+    muted_until: datetime | None = None
+
+
+class MuteRow(BaseModel):
+    id: str
+    client_ip: str
+    reason: str
+    muted_until: datetime | None
+    muted_by_display: str
+    created_at: datetime
+    active: bool
+
+
+def _to_mute_row(m: DNSThreatMute, now: datetime) -> MuteRow:
+    return MuteRow(
+        id=str(m.id),
+        client_ip=str(m.client_ip),
+        reason=m.reason,
+        muted_until=m.muted_until,
+        muted_by_display=m.muted_by_display,
+        created_at=m.created_at,
+        active=m.is_active(now),
+    )
+
+
+@router.get("/mutes", response_model=list[MuteRow])
+async def list_mutes(db: DB, current_user: CurrentUser) -> list[MuteRow]:
+    """Every mute, expired ones included.
+
+    Expired mutes are kept rather than deleted — "we muted this host for
+    30 days in March" is part of the audit trail and explains why a
+    client reappeared.
+    """
+    now = datetime.now(UTC)
+    rows = (
+        (await db.execute(select(DNSThreatMute).order_by(desc(DNSThreatMute.created_at))))
+        .scalars()
+        .all()
+    )
+    return [_to_mute_row(m, now) for m in rows]
+
+
+@router.post("/mutes", response_model=MuteRow, status_code=201)
+async def create_mute(body: MuteBody, db: DB, current_user: CurrentUser) -> MuteRow:
+    """Mute a client, or update the existing mute for it.
+
+    Upsert rather than insert: re-muting an already-muted client should
+    revise the decision (new expiry, better reason), not stack rows that
+    disagree about when the mute ends.
+
+    Audited — muting a finding is a security-relevant judgement call,
+    and the audit row is what makes it reviewable later.
+    """
+    ip = _validated_ip(body.client_ip)
+    existing = (
+        await db.execute(select(DNSThreatMute).where(DNSThreatMute.client_ip == ip))
+    ).scalar_one_or_none()
+    action = "update" if existing is not None else "create"
+    row = existing or DNSThreatMute(client_ip=ip)
+    row.reason = body.reason
+    row.muted_until = body.muted_until
+    row.muted_by = current_user.id
+    row.muted_by_display = current_user.username
+    db.add(row)
+    db.add(
+        AuditLog(
+            action=f"dns_threat_mute_{action}",
+            resource_type="dns_client",
+            resource_id=ip,
+            resource_display=ip,
+            user_id=current_user.id,
+            user_display_name=current_user.username,
+            result="success",
+            new_value={
+                "reason": body.reason,
+                "muted_until": body.muted_until.isoformat() if body.muted_until else None,
+            },
+        )
+    )
+    await db.commit()
+    await db.refresh(row)
+    return _to_mute_row(row, datetime.now(UTC))
+
+
+@router.delete("/mutes/{client_ip}", status_code=204)
+async def delete_mute(client_ip: str, db: DB, current_user: CurrentUser) -> None:
+    """Un-mute a client so its findings surface again."""
+    ip = _validated_ip(client_ip)
+    row = (
+        await db.execute(select(DNSThreatMute).where(DNSThreatMute.client_ip == ip))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="no mute for that client")
+    await db.delete(row)
+    db.add(
+        AuditLog(
+            action="dns_threat_mute_delete",
+            resource_type="dns_client",
+            resource_id=ip,
+            resource_display=ip,
+            user_id=current_user.id,
+            user_display_name=current_user.username,
+            result="success",
+            old_value={"reason": row.reason},
+        )
+    )
+    await db.commit()

--- a/backend/app/api/v1/dns_threat/router.py
+++ b/backend/app/api/v1/dns_threat/router.py
@@ -12,17 +12,18 @@ rollup of them.
 
 from __future__ import annotations
 
+import ipaddress
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import desc, func, select
+from sqlalchemy import desc, select
 
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import require_permission
 from app.models.dns_threat import DNSClientWindow
-from app.services.dns_threat.aggregate import INTERESTING_SCORE
+from app.services.dns_threat.aggregate import INTERESTING_SCORE, compute_threat_summary
 
 # Same gate the Logs router uses: this is a rollup of the DNS query
 # log, so whoever may read raw queries may read a summary of them.
@@ -63,6 +64,18 @@ class ThreatSummary(BaseModel):
     # difference between "no threats" and "not actually running" — the
     # UI needs to say which, or an idle card reads as an all-clear.
     has_data: bool
+
+
+def _validated_ip(value: str) -> str:
+    """Reject anything that isn't a bare IP before it reaches an INET
+    comparison."""
+    try:
+        return str(ipaddress.ip_address(value.strip()))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"client_ip must be a single IP address, got {value!r}",
+        ) from exc
 
 
 def _to_row(w: DNSClientWindow) -> ClientWindowRow:
@@ -111,7 +124,10 @@ async def list_windows(
         .limit(limit)
     )
     if client_ip:
-        stmt = stmt.where(DNSClientWindow.client_ip == client_ip)
+        # The column is INET; an unvalidated string reaches Postgres as
+        # `client_ip = 'web-01'` and raises `invalid input syntax for
+        # type inet`, surfacing as a 500 rather than a 422.
+        stmt = stmt.where(DNSClientWindow.client_ip == _validated_ip(client_ip))
         # A per-client drilldown wants the client's whole history, not
         # just its interesting hours.
         stmt = stmt.order_by(None).order_by(desc(DNSClientWindow.window_start))
@@ -130,48 +146,4 @@ async def threat_summary(
     hours: int = Query(default=24, ge=1, le=24 * 30),
     min_score: float = Query(default=INTERESTING_SCORE, ge=0, le=100),
 ) -> ThreatSummary:
-    since = datetime.now(UTC) - timedelta(hours=hours)
-
-    totals = (
-        await db.execute(
-            select(
-                func.count().label("windows"),
-                func.count(func.distinct(DNSClientWindow.client_ip)).label("clients"),
-                func.coalesce(func.max(DNSClientWindow.tunnel_score), 0.0).label("peak"),
-            ).where(DNSClientWindow.window_start >= since)
-        )
-    ).one()
-
-    suspicious = (
-        await db.execute(
-            select(func.count(func.distinct(DNSClientWindow.client_ip))).where(
-                DNSClientWindow.window_start >= since,
-                DNSClientWindow.allowlisted.is_(False),
-                DNSClientWindow.tunnel_score >= min_score,
-            )
-        )
-    ).scalar_one()
-
-    worst = (
-        await db.execute(
-            select(DNSClientWindow)
-            .where(
-                DNSClientWindow.window_start >= since,
-                DNSClientWindow.allowlisted.is_(False),
-            )
-            .order_by(desc(DNSClientWindow.tunnel_score))
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-
-    return ThreatSummary(
-        windows_scored=totals.windows or 0,
-        clients_seen=totals.clients or 0,
-        suspicious_clients=suspicious or 0,
-        peak_score=float(totals.peak or 0.0),
-        worst_client_ip=str(worst.client_ip) if worst else None,
-        worst_client_score=worst.tunnel_score if worst else None,
-        worst_client_parent=worst.top_parent if worst else None,
-        since=since,
-        has_data=(totals.windows or 0) > 0,
-    )
+    return ThreatSummary(**await compute_threat_summary(db, hours=hours, min_score=min_score))

--- a/backend/app/api/v1/dns_threat/router.py
+++ b/backend/app/api/v1/dns_threat/router.py
@@ -1,0 +1,177 @@
+"""DNS threat analytics read surface (issue #699).
+
+Read-only: the detections write themselves via the rollup task, and
+there is nothing here an operator mutates. Gated behind the default-off
+``security.dns_threat`` feature module at the router include, so the
+whole prefix 404s on installs that haven't opted in.
+
+Gated on ``read:server`` at the router, matching the Logs surface it
+summarises — anyone trusted to read raw queries is trusted to read a
+rollup of them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import desc, func, select
+
+from app.api.deps import DB, CurrentUser
+from app.core.permissions import require_permission
+from app.models.dns_threat import DNSClientWindow
+from app.services.dns_threat.aggregate import INTERESTING_SCORE
+
+# Same gate the Logs router uses: this is a rollup of the DNS query
+# log, so whoever may read raw queries may read a summary of them.
+router = APIRouter(dependencies=[Depends(require_permission("read", "server"))])
+
+
+class ClientWindowRow(BaseModel):
+    id: str
+    client_ip: str
+    window_start: datetime
+    window_end: datetime
+    query_count: int
+    distinct_qnames: int
+    distinct_parents: int
+    top_parent: str | None
+    top_parent_subdomains: int
+    max_label_length: int
+    mean_label_entropy: float
+    payload_qtype_count: int
+    tunnel_score: float
+    tunnel_signals: list[dict[str, Any]]
+    allowlisted: bool
+    server_count: int
+
+
+class ThreatSummary(BaseModel):
+    """Rollup for the Security dashboard card."""
+
+    windows_scored: int
+    clients_seen: int
+    suspicious_clients: int
+    peak_score: float
+    worst_client_ip: str | None
+    worst_client_score: float | None
+    worst_client_parent: str | None
+    since: datetime
+    # False when the rollup has produced nothing at all, which is the
+    # difference between "no threats" and "not actually running" — the
+    # UI needs to say which, or an idle card reads as an all-clear.
+    has_data: bool
+
+
+def _to_row(w: DNSClientWindow) -> ClientWindowRow:
+    return ClientWindowRow(
+        id=str(w.id),
+        client_ip=str(w.client_ip),
+        window_start=w.window_start,
+        window_end=w.window_end,
+        query_count=w.query_count,
+        distinct_qnames=w.distinct_qnames,
+        distinct_parents=w.distinct_parents,
+        top_parent=w.top_parent,
+        top_parent_subdomains=w.top_parent_subdomains,
+        max_label_length=w.max_label_length,
+        mean_label_entropy=w.mean_label_entropy,
+        payload_qtype_count=w.payload_qtype_count,
+        tunnel_score=w.tunnel_score,
+        tunnel_signals=w.tunnel_signals or [],
+        allowlisted=w.allowlisted,
+        server_count=w.server_count,
+    )
+
+
+@router.get("/windows", response_model=list[ClientWindowRow])
+async def list_windows(
+    db: DB,
+    current_user: CurrentUser,
+    client_ip: str | None = Query(default=None),
+    hours: int = Query(default=24, ge=1, le=24 * 30),
+    min_score: float = Query(default=INTERESTING_SCORE, ge=0, le=100),
+    include_allowlisted: bool = Query(default=False),
+    limit: int = Query(default=100, ge=1, le=1000),
+) -> list[ClientWindowRow]:
+    """Scored client windows, worst first.
+
+    Defaults to the interesting band rather than everything: on a busy
+    resolver the vast majority of windows score ~0, and a list that
+    opens on thousands of zeroes buries the handful that matter. Pass
+    ``min_score=0`` to see the full picture.
+    """
+    since = datetime.now(UTC) - timedelta(hours=hours)
+    stmt = (
+        select(DNSClientWindow)
+        .where(DNSClientWindow.window_start >= since)
+        .order_by(desc(DNSClientWindow.tunnel_score), desc(DNSClientWindow.window_start))
+        .limit(limit)
+    )
+    if client_ip:
+        stmt = stmt.where(DNSClientWindow.client_ip == client_ip)
+        # A per-client drilldown wants the client's whole history, not
+        # just its interesting hours.
+        stmt = stmt.order_by(None).order_by(desc(DNSClientWindow.window_start))
+    else:
+        stmt = stmt.where(DNSClientWindow.tunnel_score >= min_score)
+    if not include_allowlisted:
+        stmt = stmt.where(DNSClientWindow.allowlisted.is_(False))
+    rows = (await db.execute(stmt)).scalars().all()
+    return [_to_row(w) for w in rows]
+
+
+@router.get("/summary", response_model=ThreatSummary)
+async def threat_summary(
+    db: DB,
+    current_user: CurrentUser,
+    hours: int = Query(default=24, ge=1, le=24 * 30),
+    min_score: float = Query(default=INTERESTING_SCORE, ge=0, le=100),
+) -> ThreatSummary:
+    since = datetime.now(UTC) - timedelta(hours=hours)
+
+    totals = (
+        await db.execute(
+            select(
+                func.count().label("windows"),
+                func.count(func.distinct(DNSClientWindow.client_ip)).label("clients"),
+                func.coalesce(func.max(DNSClientWindow.tunnel_score), 0.0).label("peak"),
+            ).where(DNSClientWindow.window_start >= since)
+        )
+    ).one()
+
+    suspicious = (
+        await db.execute(
+            select(func.count(func.distinct(DNSClientWindow.client_ip))).where(
+                DNSClientWindow.window_start >= since,
+                DNSClientWindow.allowlisted.is_(False),
+                DNSClientWindow.tunnel_score >= min_score,
+            )
+        )
+    ).scalar_one()
+
+    worst = (
+        await db.execute(
+            select(DNSClientWindow)
+            .where(
+                DNSClientWindow.window_start >= since,
+                DNSClientWindow.allowlisted.is_(False),
+            )
+            .order_by(desc(DNSClientWindow.tunnel_score))
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    return ThreatSummary(
+        windows_scored=totals.windows or 0,
+        clients_seen=totals.clients or 0,
+        suspicious_clients=suspicious or 0,
+        peak_score=float(totals.peak or 0.0),
+        worst_client_ip=str(worst.client_ip) if worst else None,
+        worst_client_score=worst.tunnel_score if worst else None,
+        worst_client_parent=worst.top_parent if worst else None,
+        since=since,
+        has_data=(totals.windows or 0) > 0,
+    )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -37,6 +37,7 @@ from app.api.v1.dns.blocklist_router import router as dns_blocklist_router
 from app.api.v1.dns.pool_router import router as dns_pool_router
 from app.api.v1.dns.router import router as dns_router
 from app.api.v1.dns_import.router import router as dns_import_router
+from app.api.v1.dns_threat.router import router as dns_threat_router
 from app.api.v1.dns_tools import router as dns_tools_router
 from app.api.v1.dnsbl import router as dnsbl_router
 from app.api.v1.docker import router as docker_router
@@ -247,6 +248,12 @@ api_v1_router.include_router(
     dependencies=[Depends(wake_publishing)],
 )
 api_v1_router.include_router(dns_tools_router, prefix="/dns", tags=["dns-tools"])
+api_v1_router.include_router(
+    dns_threat_router,
+    prefix="/dns-threat",
+    tags=["dns-threat"],
+    dependencies=[Depends(require_module("security.dns_threat"))],
+)
 api_v1_router.include_router(
     dnsbl_router,
     prefix="/dnsbl",

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -26,6 +26,7 @@ celery_app = Celery(
         "app.tasks.oui_update",
         "app.tasks.backup_sweep",
         "app.tasks.backup_drill",
+        "app.tasks.dns_threat",
         "app.tasks.prune_internal_errors",
         "app.tasks.prune_logs",
         "app.tasks.prune_metrics",
@@ -100,6 +101,7 @@ celery_app.conf.update(
         "app.tasks.oui_update.*": {"queue": "default"},
         "app.tasks.backup_sweep.*": {"queue": "default"},
         "app.tasks.backup_drill.*": {"queue": "default"},
+        "app.tasks.dns_threat.*": {"queue": "default"},
         "app.tasks.prune_internal_errors.*": {"queue": "default"},
         "app.tasks.prune_logs.*": {"queue": "default"},
         "app.tasks.prune_metrics.*": {"queue": "default"},
@@ -602,6 +604,17 @@ celery_app.conf.update(
         "restore-drill-sweep": {
             "task": "app.tasks.backup_drill.sweep_restore_drills",
             "schedule": schedule(run_every=60.0),
+        },
+        # Every 15 min, roll DNS query-log lines into per-client hourly
+        # windows and score them for tunneling (#699). Recomputes the
+        # current + previous bucket by upsert, so running far more often
+        # than the bucket width keeps the picture near-live without
+        # adding rows. Self-gates on the default-off
+        # ``security.dns_threat`` module, so this cron is a no-op on
+        # installs that haven't opted in.
+        "dns-threat-rollup": {
+            "task": "app.tasks.dns_threat.aggregate_dns_client_windows",
+            "schedule": schedule(run_every=900.0),
         },
         # Every 60 s, fire any Scheduled Wake-on-LAN schedule whose
         # ``next_run_at`` (denormalised UTC) is now in the past (issue #586

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -529,6 +529,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await seed_restore_drill_failed_alert_rule()
     except Exception as exc:  # noqa: BLE001
         logger.debug("restore_drill_alert_rule_seed_skipped", reason=str(exc))
+    try:
+        from app.services.alerts import seed_dns_tunneling_alert_rule  # noqa: PLC0415
+
+        await seed_dns_tunneling_alert_rule()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("dns_tunneling_alert_rule_seed_skipped", reason=str(exc))
     # Appliance Web UI cert bootstrap (issue #134, Phase 4b.5). On
     # appliance installs without an active row in appliance_certificate,
     # generate a self-signed default + deploy it to /etc/nginx/certs

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -59,6 +59,7 @@ from app.models.dns import (
     DNSZone,
 )
 from app.models.dns_threat import DNSClientWindow
+from app.models.dns_threat_mute import DNSThreatMute
 from app.models.dnsbl import DNSBLList, DNSBLListing, DNSBLPinnedIP
 from app.models.docker import DockerHost
 from app.models.domain import Domain
@@ -222,6 +223,7 @@ __all__ = [
     "DNSMetricSample",
     "DHCPMetricSample",
     "DNSClientWindow",
+    "DNSThreatMute",
     "DNSQueryLogEntry",
     "DHCPLogEntry",
     "CloudEndpoint",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -19,7 +19,7 @@ from app.models.audit import AuditLog
 from app.models.audit_forward import AuditForwardTarget
 from app.models.auth import APIToken, Group, Role, User, UserSession, user_group
 from app.models.auth_provider import AuthGroupMapping, AuthProvider
-from app.models.backup import BackupTarget
+from app.models.backup import BackupTarget, RestoreDrill
 from app.models.base import Base
 from app.models.bgp_looking_glass import BGPLGPeer, BGPLGRoute, LookingGlassCollector
 from app.models.bgp_monitor import BGPHijackDetection, BGPTrackedPrefix
@@ -58,6 +58,7 @@ from app.models.dns import (
     DNSView,
     DNSZone,
 )
+from app.models.dns_threat import DNSClientWindow
 from app.models.dnsbl import DNSBLList, DNSBLListing, DNSBLPinnedIP
 from app.models.docker import DockerHost
 from app.models.domain import Domain
@@ -220,6 +221,7 @@ __all__ = [
     "NATMapping",
     "DNSMetricSample",
     "DHCPMetricSample",
+    "DNSClientWindow",
     "DNSQueryLogEntry",
     "DHCPLogEntry",
     "CloudEndpoint",
@@ -272,6 +274,7 @@ __all__ = [
     "FirewallRule",
     "InternalError",
     "BackupTarget",
+    "RestoreDrill",
     "TimeBoundGrant",
     "ApprovalPolicy",
     "ChangeRequest",

--- a/backend/app/models/dns_threat.py
+++ b/backend/app/models/dns_threat.py
@@ -89,9 +89,15 @@ class DNSClientWindow(Base):
     tunnel_signals: Mapped[list[dict[str, Any]]] = mapped_column(
         JSONB, nullable=False, default=list
     )
-    # Set when every parent domain in the window matched the benign
-    # allowlist. Kept as a column rather than dropping the row so the
-    # Threat tab can show "we looked and cleared it" instead of silence.
+    # Set when every parseable name in the window matched the benign
+    # allowlist — genuinely cleared. NOT set when nothing was parseable,
+    # which is a data problem and must stay visible, because every
+    # surface filters allowlisted rows out by default.
+    #
+    # Kept as a column rather than dropping the row so the Threat tab's
+    # "Show cleared (allowlisted)" toggle can answer "we looked at this
+    # client and cleared it" instead of the client simply never
+    # appearing.
     allowlisted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/app/models/dns_threat.py
+++ b/backend/app/models/dns_threat.py
@@ -1,0 +1,99 @@
+"""Per-client DNS behaviour rollups for threat analytics (issue #699).
+
+``dns_query_log_entry`` is operator triage on a 24 h window. Threat
+analytics needs something different: a *summary per client* that
+outlives the raw rows, so "this host has looked like an exfil tunnel
+every hour for three days" is answerable after the evidence lines have
+been pruned.
+
+One row per (client IP, hourly bucket), written by the aggregator in
+``app.tasks.dns_threat``. The feature columns are deliberately
+detection-agnostic — they describe what a client's DNS behaviour
+*looked like*, not what any one heuristic concluded — so the DGA and
+beaconing detections deferred out of #699's first slice can score off
+the same rollup without a second aggregation pass.
+
+``tunnel_score`` and ``tunnel_signals`` are the one detection that
+ships in this slice. The signals blob carries each contributing
+signal's raw value and weighted contribution, so an operator (and a
+support thread) can see *why* a host scored 82 rather than being
+handed a bare number.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import INET, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class DNSClientWindow(Base):
+    """One client's DNS behaviour over one hourly bucket."""
+
+    __tablename__ = "dns_client_window"
+    __table_args__ = (
+        # Recomputed in place as late log lines arrive, so the bucket
+        # identity has to be unique for the upsert to land.
+        UniqueConstraint("client_ip", "window_start", name="uq_dns_client_window_ip_bucket"),
+        # "Worst offenders in the recent past" — the query behind both
+        # the alert matcher and the Threat tab.
+        Index("ix_dns_client_window_score", "window_start", "tunnel_score"),
+        Index("ix_dns_client_window_ip", "client_ip"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    client_ip: Mapped[str] = mapped_column(INET, nullable=False)
+    # Aggregated ACROSS servers rather than per-server: the question is
+    # "is this host behaving like a tunnel", and a client that spreads
+    # its queries over two resolvers is not two half-suspicious clients.
+    # ``server_count`` keeps the fan-out visible.
+    server_count: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    window_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    window_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    # ── detection-agnostic behaviour features ────────────────────────
+    query_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    distinct_qnames: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    distinct_parents: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # The parent domain this client hit hardest in the window, and how
+    # many distinct subdomains it asked for underneath it. A tunnel
+    # concentrates: thousands of unique labels under ONE parent.
+    top_parent: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    top_parent_subdomains: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    max_label_length: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    avg_label_length: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    mean_label_entropy: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    # TXT / NULL / CNAME carry the most payload per response, so tunnels
+    # lean on them far harder than ordinary traffic does.
+    payload_qtype_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # ── tunneling verdict ────────────────────────────────────────────
+    tunnel_score: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    tunnel_signals: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, nullable=False, default=list
+    )
+    # Set when every parent domain in the window matched the benign
+    # allowlist. Kept as a column rather than dropping the row so the
+    # Threat tab can show "we looked and cleared it" instead of silence.
+    allowlisted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/models/dns_threat_mute.py
+++ b/backend/app/models/dns_threat_mute.py
@@ -1,0 +1,92 @@
+"""Operator triage decisions on DNS threat findings (issue #699).
+
+A finding is a *score*, not a verdict. Plenty of hosts legitimately look
+like tunnels — a backup agent chunking payload into subdomains, a
+security scanner, a bespoke internal service — and once an operator has
+looked at one and concluded it's fine, it should stop shouting.
+
+This is a **mute on the client**, deliberately not a delete on the
+window rows, for two reasons:
+
+* **Deleting wouldn't stick.** The aggregator recomputes the current and
+  previous hour every 15 minutes and upserts, and the backfill refills
+  any bucket left with no rows. A "cleared" recent finding would
+  reappear within the quarter hour while an older one stayed gone —
+  same button, different behaviour depending on age.
+* **Deleting destroys evidence.** These rows describe what may be an
+  exfiltration event. "We reviewed it and it's the backup script" is a
+  fact worth keeping, and keeping it *next to* the evidence is what
+  makes it auditable later.
+
+Mirrors the acknowledge/suppress shape already used for
+``internal_error``: a mute either expires (``muted_until``) or is
+permanent (NULL), and carries the operator and their reason so the next
+person to look doesn't re-investigate the same host.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import INET, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class DNSThreatMute(Base):
+    """One operator decision to stop surfacing a client's findings."""
+
+    __tablename__ = "dns_threat_mute"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # One active mute per client. Re-muting an already-muted client
+    # updates the row (new expiry / reason) rather than stacking.
+    client_ip: Mapped[str] = mapped_column(INET, nullable=False, unique=True)
+
+    # NULL = muted indefinitely. A dated mute is the safer default in
+    # the UI: "this is fine for now" ages out and gets re-examined,
+    # rather than a one-click decision silently outliving the person
+    # who made it.
+    muted_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Free text, required by the API — an unexplained mute is how a real
+    # incident gets buried by someone tidying a dashboard.
+    reason: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    muted_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Denormalised so the row still says who muted it after the account
+    # is deleted — the FK above goes NULL, the name shouldn't.
+    muted_by_display: Mapped[str] = mapped_column(String(120), nullable=False, default="")
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    modified_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    def is_active(self, now: datetime) -> bool:
+        """True when this mute still applies.
+
+        An expired mute is kept rather than deleted: "we muted this host
+        for 30 days in March" is part of the audit trail, and the row is
+        what lets the UI say *why* a client stopped being muted.
+        """
+        return self.muted_until is None or self.muted_until > now

--- a/backend/app/models/logs.py
+++ b/backend/app/models/logs.py
@@ -49,6 +49,11 @@ class DNSQueryLogEntry(Base):
     __table_args__ = (
         Index("ix_dns_query_log_server_ts", "server_id", "ts"),
         Index("ix_dns_query_log_ts", "ts"),
+        # Serves the #699 threat rollup's per-client hourly scan. Must
+        # stay declared here as well as in the migration: autogenerate
+        # diffs against the models, so an undeclared index gets emitted
+        # as a drop into the next revision.
+        Index("ix_dns_query_log_client_ts", "client_ip", "ts"),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)

--- a/backend/app/models/logs.py
+++ b/backend/app/models/logs.py
@@ -49,11 +49,6 @@ class DNSQueryLogEntry(Base):
     __table_args__ = (
         Index("ix_dns_query_log_server_ts", "server_id", "ts"),
         Index("ix_dns_query_log_ts", "ts"),
-        # Serves the #699 threat rollup's per-client hourly scan. Must
-        # stay declared here as well as in the migration: autogenerate
-        # diffs against the models, so an undeclared index gets emitted
-        # as a drop into the next revision.
-        Index("ix_dns_query_log_client_ts", "client_ip", "ts"),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -25,6 +25,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     dhcp,
     diagnostics,
     dns,
+    dns_threat,
     dnsbl,
     firewall,
     imports,

--- a/backend/app/services/ai/tools/dns_threat.py
+++ b/backend/app/services/ai/tools/dns_threat.py
@@ -1,0 +1,189 @@
+"""DNS threat analytics tools for the Operator Copilot (issue #699).
+
+Two read-only tools over the per-client tunneling rollup. No
+``propose_*`` writes: there is nothing to mutate here — the rollup
+writes itself, and the operator action a finding calls for (isolate the
+host, pull a packet capture, check what it's running) lives behind
+other tools with their own gates.
+
+Not superadmin-gated, unlike the backup tools: this is a summary of the
+DNS query log, and the permission model already decides who may read
+that. It is tagged to the ``security.dns_threat`` module so the tools
+disappear when the feature is off.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.dns_threat import DNSClientWindow
+from app.services.ai.tools.base import register_tool
+
+
+class FindSuspiciousDNSClientsArgs(BaseModel):
+    hours: int = Field(default=24, ge=1, le=24 * 30, description="Trailing window to consider.")
+    min_score: float = Field(
+        default=20.0,
+        ge=0,
+        le=100,
+        description=(
+            "Minimum tunneling score (0-100). 60+ is a strong signal; 20-60 is "
+            "worth a look but is often busy-but-benign traffic."
+        ),
+    )
+    client_ip: str | None = Field(
+        default=None,
+        description="Restrict to one client IP — use for 'why did 10.0.0.5 get flagged?'.",
+    )
+    limit: int = Field(default=25, ge=1, le=200)
+
+
+@register_tool(
+    name="find_suspicious_dns_clients",
+    description=(
+        "Find DNS clients whose query behaviour scores as tunneling / "
+        "exfiltration (issue #699). DNS tunneling hides payload in the "
+        "names a host looks up, under a domain the attacker controls — "
+        "it is the exfil path firewalls do not inspect. Each row "
+        "carries the client IP, the 0-100 score, the domain the traffic "
+        "concentrated on, and the individual signals with their "
+        "contributions (label length, label entropy, subdomain fan-out, "
+        "payload-qtype ratio) so the answer explains itself. Use for "
+        "'is anything tunnelling over DNS?', 'why was 10.0.0.5 "
+        "flagged?', or 'what is the worst DNS client this week?'. "
+        "Windows whose traffic was entirely to allowlisted domains "
+        "(DNSBL / CDN / reverse-DNS, which look like tunnels by design) "
+        "are excluded."
+    ),
+    args_model=FindSuspiciousDNSClientsArgs,
+    category="dns",
+    module="security.dns_threat",
+)
+async def find_suspicious_dns_clients(
+    db: AsyncSession, user: User, args: FindSuspiciousDNSClientsArgs
+) -> list[dict[str, Any]]:
+    since = datetime.now(UTC) - timedelta(hours=args.hours)
+    stmt = (
+        select(DNSClientWindow)
+        .where(
+            DNSClientWindow.window_start >= since,
+            DNSClientWindow.allowlisted.is_(False),
+        )
+        .order_by(desc(DNSClientWindow.tunnel_score), desc(DNSClientWindow.window_start))
+        .limit(args.limit)
+    )
+    if args.client_ip:
+        stmt = stmt.where(DNSClientWindow.client_ip == args.client_ip)
+    else:
+        stmt = stmt.where(DNSClientWindow.tunnel_score >= args.min_score)
+    rows = (await db.execute(stmt)).scalars().all()
+    if not rows:
+        return [
+            {
+                "result": "no matching client windows",
+                "note": (
+                    "Either nothing is scoring above the threshold, or the rollup "
+                    "has no data — the security.dns_threat module must be enabled "
+                    "AND a DNS server group must have query logging turned on."
+                ),
+            }
+        ]
+    return [
+        {
+            "client_ip": str(w.client_ip),
+            "tunnel_score": round(w.tunnel_score, 1),
+            "window_start": w.window_start.isoformat(),
+            "window_end": w.window_end.isoformat(),
+            "query_count": w.query_count,
+            "distinct_qnames": w.distinct_qnames,
+            "top_parent": w.top_parent,
+            "top_parent_subdomains": w.top_parent_subdomains,
+            "max_label_length": w.max_label_length,
+            "mean_label_entropy": round(w.mean_label_entropy, 2),
+            "payload_qtype_count": w.payload_qtype_count,
+            "signals": w.tunnel_signals or [],
+        }
+        for w in rows
+    ]
+
+
+class DNSThreatSummaryArgs(BaseModel):
+    hours: int = Field(default=24, ge=1, le=24 * 30)
+
+
+@register_tool(
+    name="get_dns_threat_summary",
+    description=(
+        "One-shot rollup of DNS tunneling analytics over a trailing "
+        "window (issue #699): how many client windows were scored, how "
+        "many distinct clients, how many crossed the suspicious "
+        "threshold, and the worst offender. Answers 'is anything "
+        "exfiltrating over DNS right now?' without listing every "
+        "client. Reports explicitly when the rollup has no data at all, "
+        "so an idle result is never mistaken for an all-clear."
+    ),
+    args_model=DNSThreatSummaryArgs,
+    category="dns",
+    module="security.dns_threat",
+)
+async def get_dns_threat_summary(
+    db: AsyncSession, user: User, args: DNSThreatSummaryArgs
+) -> dict[str, Any]:
+    since = datetime.now(UTC) - timedelta(hours=args.hours)
+    totals = (
+        await db.execute(
+            select(
+                func.count().label("windows"),
+                func.count(func.distinct(DNSClientWindow.client_ip)).label("clients"),
+                func.coalesce(func.max(DNSClientWindow.tunnel_score), 0.0).label("peak"),
+            ).where(DNSClientWindow.window_start >= since)
+        )
+    ).one()
+    if not totals.windows:
+        return {
+            "has_data": False,
+            "note": (
+                "No client windows have been scored in this period. The rollup "
+                "requires the security.dns_threat module enabled and query "
+                "logging on at least one DNS server group — an empty result "
+                "here is NOT an all-clear."
+            ),
+            "since": since.isoformat(),
+        }
+    worst = (
+        await db.execute(
+            select(DNSClientWindow)
+            .where(
+                DNSClientWindow.window_start >= since,
+                DNSClientWindow.allowlisted.is_(False),
+            )
+            .order_by(desc(DNSClientWindow.tunnel_score))
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    suspicious = (
+        await db.execute(
+            select(func.count(func.distinct(DNSClientWindow.client_ip))).where(
+                DNSClientWindow.window_start >= since,
+                DNSClientWindow.allowlisted.is_(False),
+                DNSClientWindow.tunnel_score >= 20.0,
+            )
+        )
+    ).scalar_one()
+    return {
+        "has_data": True,
+        "since": since.isoformat(),
+        "windows_scored": totals.windows,
+        "clients_seen": totals.clients,
+        "suspicious_clients": suspicious or 0,
+        "peak_score": round(float(totals.peak or 0.0), 1),
+        "worst_client_ip": str(worst.client_ip) if worst else None,
+        "worst_client_score": round(worst.tunnel_score, 1) if worst else None,
+        "worst_client_parent": worst.top_parent if worst else None,
+    }

--- a/backend/app/services/ai/tools/dns_threat.py
+++ b/backend/app/services/ai/tools/dns_threat.py
@@ -14,22 +14,24 @@ disappear when the feature is off.
 
 from __future__ import annotations
 
+import ipaddress
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from pydantic import BaseModel, Field
-from sqlalchemy import desc, func, select
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.auth import User
 from app.models.dns_threat import DNSClientWindow
 from app.services.ai.tools.base import register_tool
+from app.services.dns_threat.aggregate import INTERESTING_SCORE
 
 
 class FindSuspiciousDNSClientsArgs(BaseModel):
     hours: int = Field(default=24, ge=1, le=24 * 30, description="Trailing window to consider.")
     min_score: float = Field(
-        default=20.0,
+        default=INTERESTING_SCORE,
         ge=0,
         le=100,
         description=(
@@ -64,6 +66,12 @@ class FindSuspiciousDNSClientsArgs(BaseModel):
     args_model=FindSuspiciousDNSClientsArgs,
     category="dns",
     module="security.dns_threat",
+    # Explicit per non-negotiable #13. Enabled: the surface exposes no
+    # secrets and makes no off-prem call, and it is already behind a
+    # default-off module that an operator had to turn on knowing it
+    # reads query content — gating it twice would just hide the tool
+    # from the person who opted in.
+    default_enabled=True,
 )
 async def find_suspicious_dns_clients(
     db: AsyncSession, user: User, args: FindSuspiciousDNSClientsArgs
@@ -79,7 +87,22 @@ async def find_suspicious_dns_clients(
         .limit(args.limit)
     )
     if args.client_ip:
-        stmt = stmt.where(DNSClientWindow.client_ip == args.client_ip)
+        # An LLM will cheerfully pass a hostname or a CIDR here; against
+        # an INET column that is a 500 and an internal_error row rather
+        # than an answer.
+        try:
+            ip = str(ipaddress.ip_address(args.client_ip.strip()))
+        except ValueError:
+            return [
+                {
+                    "error": (
+                        f"client_ip must be a single IP address, got "
+                        f"{args.client_ip!r}. Resolve the hostname first, or drop "
+                        f"the filter to see the worst-scoring clients."
+                    )
+                }
+            ]
+        stmt = stmt.where(DNSClientWindow.client_ip == ip)
     else:
         stmt = stmt.where(DNSClientWindow.tunnel_score >= args.min_score)
     rows = (await db.execute(stmt)).scalars().all()
@@ -131,59 +154,23 @@ class DNSThreatSummaryArgs(BaseModel):
     args_model=DNSThreatSummaryArgs,
     category="dns",
     module="security.dns_threat",
+    default_enabled=True,
 )
 async def get_dns_threat_summary(
     db: AsyncSession, user: User, args: DNSThreatSummaryArgs
 ) -> dict[str, Any]:
-    since = datetime.now(UTC) - timedelta(hours=args.hours)
-    totals = (
-        await db.execute(
-            select(
-                func.count().label("windows"),
-                func.count(func.distinct(DNSClientWindow.client_ip)).label("clients"),
-                func.coalesce(func.max(DNSClientWindow.tunnel_score), 0.0).label("peak"),
-            ).where(DNSClientWindow.window_start >= since)
+    # Shared with the REST endpoint and the dashboard card so the
+    # copilot can't answer against a different "suspicious" threshold
+    # than the UI is showing.
+    from app.services.dns_threat.aggregate import compute_threat_summary  # noqa: PLC0415
+
+    out = await compute_threat_summary(db, hours=args.hours)
+    out["since"] = out["since"].isoformat()
+    if not out["has_data"]:
+        out["note"] = (
+            "No client windows have been scored in this period. The rollup "
+            "requires the security.dns_threat module enabled and query "
+            "logging on at least one DNS server group — an empty result "
+            "here is NOT an all-clear."
         )
-    ).one()
-    if not totals.windows:
-        return {
-            "has_data": False,
-            "note": (
-                "No client windows have been scored in this period. The rollup "
-                "requires the security.dns_threat module enabled and query "
-                "logging on at least one DNS server group — an empty result "
-                "here is NOT an all-clear."
-            ),
-            "since": since.isoformat(),
-        }
-    worst = (
-        await db.execute(
-            select(DNSClientWindow)
-            .where(
-                DNSClientWindow.window_start >= since,
-                DNSClientWindow.allowlisted.is_(False),
-            )
-            .order_by(desc(DNSClientWindow.tunnel_score))
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    suspicious = (
-        await db.execute(
-            select(func.count(func.distinct(DNSClientWindow.client_ip))).where(
-                DNSClientWindow.window_start >= since,
-                DNSClientWindow.allowlisted.is_(False),
-                DNSClientWindow.tunnel_score >= 20.0,
-            )
-        )
-    ).scalar_one()
-    return {
-        "has_data": True,
-        "since": since.isoformat(),
-        "windows_scored": totals.windows,
-        "clients_seen": totals.clients,
-        "suspicious_clients": suspicious or 0,
-        "peak_score": round(float(totals.peak or 0.0), 1),
-        "worst_client_ip": str(worst.client_ip) if worst else None,
-        "worst_client_score": round(worst.tunnel_score, 1) if worst else None,
-        "worst_client_parent": worst.top_parent if worst else None,
-    }
+    return out

--- a/backend/app/services/ai/tools/dns_threat.py
+++ b/backend/app/services/ai/tools/dns_threat.py
@@ -1,10 +1,14 @@
 """DNS threat analytics tools for the Operator Copilot (issue #699).
 
-Two read-only tools over the per-client tunneling rollup. No
-``propose_*`` writes: there is nothing to mutate here — the rollup
-writes itself, and the operator action a finding calls for (isolate the
-host, pull a packet capture, check what it's running) lives behind
-other tools with their own gates.
+Three read-only tools over the per-client tunneling rollup.
+
+**No ``propose_mute_dns_client``** — an explicit decision, not an
+oversight (non-negotiable #13). Muting suppresses a ``critical``
+exfiltration alert and requires a written justification that outlives
+the person who gave it; that belongs in a deliberate UI action with a
+typed reason, not a chat turn, even an Apply-gated one. What the
+copilot does need is to *see* mutes, so it stops re-reporting hosts an
+operator already triaged — hence ``find_dns_threat_mutes``.
 
 Not superadmin-gated, unlike the backup tools: this is a summary of the
 DNS query log, and the permission model already decides who may read
@@ -173,4 +177,61 @@ async def get_dns_threat_summary(
             "logging on at least one DNS server group — an empty result "
             "here is NOT an all-clear."
         )
+    return out
+
+
+class FindDNSThreatMutesArgs(BaseModel):
+    include_expired: bool = Field(
+        default=False,
+        description=(
+            "Include mutes that have lapsed. Expired mutes are kept for "
+            "audit and explain why a client started appearing again."
+        ),
+    )
+
+
+@register_tool(
+    name="find_dns_threat_mutes",
+    description=(
+        "List DNS clients an operator has reviewed and muted, with the "
+        "reason, who muted them and when it expires. Use before "
+        "reporting a tunneling finding — a muted client has already "
+        "been triaged and saying so ('10.0.0.5 is muted: Veeam backup "
+        "agent') is more useful than re-reporting it as a threat. Also "
+        "answers 'what have we cleared?' and 'why is this host not "
+        "alerting?'."
+    ),
+    args_model=FindDNSThreatMutesArgs,
+    category="dns",
+    module="security.dns_threat",
+    default_enabled=True,
+)
+async def find_dns_threat_mutes(
+    db: AsyncSession, user: User, args: FindDNSThreatMutesArgs
+) -> list[dict[str, Any]]:
+    from app.models.dns_threat_mute import DNSThreatMute  # noqa: PLC0415
+
+    now = datetime.now(UTC)
+    rows = (
+        (await db.execute(select(DNSThreatMute).order_by(desc(DNSThreatMute.created_at))))
+        .scalars()
+        .all()
+    )
+    out = []
+    for m in rows:
+        active = m.is_active(now)
+        if not active and not args.include_expired:
+            continue
+        out.append(
+            {
+                "client_ip": str(m.client_ip),
+                "reason": m.reason,
+                "active": active,
+                "muted_until": m.muted_until.isoformat() if m.muted_until else None,
+                "muted_by": m.muted_by_display,
+                "created_at": m.created_at.isoformat() if m.created_at else None,
+            }
+        )
+    if not out:
+        return [{"result": "no muted clients"}]
     return out

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -1026,6 +1026,7 @@ async def _matching_dns_tunneling_subjects(
     intent readable when someone later tunes the threshold down.
     """
     from app.models.dns_threat import DNSClientWindow  # noqa: PLC0415
+    from app.models.dns_threat_mute import DNSThreatMute  # noqa: PLC0415
 
     threshold = (
         rule.threshold_percent if rule.threshold_percent is not None else _DNS_TUNNEL_SCORE_DEFAULT
@@ -1043,6 +1044,19 @@ async def _matching_dns_tunneling_subjects(
                 DNSClientWindow.window_start >= since,
                 DNSClientWindow.allowlisted.is_(False),
                 DNSClientWindow.tunnel_score >= threshold,
+                # Operator-muted clients don't page. A host someone has
+                # already reviewed and cleared shouldn't keep waking
+                # people up — and without this the only way to stop it
+                # is disabling the rule, which silences every OTHER
+                # client too.
+                DNSClientWindow.client_ip.not_in(
+                    select(DNSThreatMute.client_ip).where(
+                        or_(
+                            DNSThreatMute.muted_until.is_(None),
+                            DNSThreatMute.muted_until > datetime.now(UTC),
+                        )
+                    )
+                ),
             )
             .group_by(DNSClientWindow.client_ip)
         )

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -314,11 +314,12 @@ RULE_TYPE_RESTORE_DRILL_FAILED = "restore_drill_failed"
 # windows drop back below the threshold, which is what makes it safe to
 # leave armed: a one-off spike closes itself on the next tick.
 RULE_TYPE_DNS_TUNNELING = "dns_tunneling_suspected"
-# Score out of 100. 60 puts it comfortably above ordinary traffic
-# (validation had busy many-parent traffic at 18 and mail-server TXT at
-# 15) while still catching the shorter-label dnscat2 shape near 50 when
-# an operator lowers it. Overridable per-rule via ``threshold_percent``.
-_DNS_TUNNEL_SCORE_DEFAULT = 60.0
+# The alerting bar lives in ``dns_threat.aggregate`` next to
+# ``INTERESTING_SCORE`` so the two stay a visible pair rather than
+# drifting apart in separate modules — "worth a look on a dashboard"
+# and "page me at 03:00" are deliberately different bars. Resolved via
+# a function-local import in the matcher below (module-level would drag
+# the aggregator into every alerts import).
 # Only consider windows this recent, so a finding from last week doesn't
 # keep an event open after the behaviour stopped.
 _DNS_TUNNEL_WINDOW = timedelta(hours=6)
@@ -1027,10 +1028,9 @@ async def _matching_dns_tunneling_subjects(
     """
     from app.models.dns_threat import DNSClientWindow  # noqa: PLC0415
     from app.models.dns_threat_mute import DNSThreatMute  # noqa: PLC0415
+    from app.services.dns_threat.aggregate import ALERTING_SCORE  # noqa: PLC0415
 
-    threshold = (
-        rule.threshold_percent if rule.threshold_percent is not None else _DNS_TUNNEL_SCORE_DEFAULT
-    )
+    threshold = rule.threshold_percent if rule.threshold_percent is not None else ALERTING_SCORE
     since = datetime.now(UTC) - _DNS_TUNNEL_WINDOW
     rows = (
         await db.execute(
@@ -1066,28 +1066,47 @@ async def _matching_dns_tunneling_subjects(
 
     # Fetch the worst window per matching client for the message detail —
     # a score with no "why" is not actionable at 03:00.
+    # One statement for the worst window per matching client, instead of
+    # a SELECT per client inside the 60 s tick. An operator who lowers
+    # the threshold to survey their estate turns that loop into 1 + N
+    # with N = every client over the threshold — hundreds of serialised
+    # round-trips a minute on a busy resolver, inside evaluate_all,
+    # which is also running every other rule type.
+    ids = [r[0] for r in rows]
+    ranked = (
+        select(
+            DNSClientWindow.client_ip.label("ip"),
+            DNSClientWindow.top_parent.label("top_parent"),
+            DNSClientWindow.tunnel_signals.label("signals"),
+            func.row_number()
+            .over(
+                partition_by=DNSClientWindow.client_ip,
+                order_by=DNSClientWindow.tunnel_score.desc(),
+            )
+            .label("rn"),
+        )
+        .where(
+            DNSClientWindow.client_ip.in_(ids),
+            DNSClientWindow.window_start >= since,
+        )
+        .subquery()
+    )
+    worst_by_ip = {
+        str(r.ip): r for r in (await db.execute(select(ranked).where(ranked.c.rn == 1))).all()
+    }
+
     matches: list[tuple[str, str, str]] = []
     for client_ip, peak, queries, windows in rows:
         ip = str(client_ip)
-        worst = (
-            await db.execute(
-                select(DNSClientWindow)
-                .where(
-                    DNSClientWindow.client_ip == client_ip,
-                    DNSClientWindow.window_start >= since,
-                )
-                .order_by(DNSClientWindow.tunnel_score.desc())
-                .limit(1)
-            )
-        ).scalar_one_or_none()
+        worst = worst_by_ip.get(ip)
         top_signals = ""
-        if worst is not None and worst.tunnel_signals:
-            ranked = sorted(
-                (s for s in worst.tunnel_signals if isinstance(s, dict)),
-                key=lambda s: s.get("contribution", 0),
+        if worst is not None and worst.signals:
+            top = sorted(
+                (sig for sig in worst.signals if isinstance(sig, dict)),
+                key=lambda sig: sig.get("contribution", 0),
                 reverse=True,
             )[:2]
-            top_signals = "; ".join(str(s.get("detail", "")) for s in ranked if s.get("detail"))
+            top_signals = "; ".join(str(sig.get("detail", "")) for sig in top if sig.get("detail"))
         parent = worst.top_parent if worst is not None else None
         message = (
             f"DNS client {ip} scored {peak:.0f}/100 for tunneling behaviour across "

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -306,6 +306,22 @@ RULE_TYPE_IP_BLOCKLISTED = "ip_blocklisted"
 # to ignore the rule). Auto-resolves when the target's next drill
 # passes.
 RULE_TYPE_RESTORE_DRILL_FAILED = "restore_drill_failed"
+
+# ``dns_tunneling_suspected`` (issue #699) — a client's DNS behaviour
+# scored above the tunneling threshold in a recent hourly window.
+# Subject is the **client IP**, so a host tunnelling for six hours holds
+# one open event rather than six. Auto-resolves when the client's recent
+# windows drop back below the threshold, which is what makes it safe to
+# leave armed: a one-off spike closes itself on the next tick.
+RULE_TYPE_DNS_TUNNELING = "dns_tunneling_suspected"
+# Score out of 100. 60 puts it comfortably above ordinary traffic
+# (validation had busy many-parent traffic at 18 and mail-server TXT at
+# 15) while still catching the shorter-label dnscat2 shape near 50 when
+# an operator lowers it. Overridable per-rule via ``threshold_percent``.
+_DNS_TUNNEL_SCORE_DEFAULT = 60.0
+# Only consider windows this recent, so a finding from last week doesn't
+# keep an event open after the behaviour stopped.
+_DNS_TUNNEL_WINDOW = timedelta(hours=6)
 # Unreachable only pages after a couple of consecutive failures so a
 # single transient handshake blip doesn't fire.
 _TLS_CERT_UNREACHABLE_MIN_FAILURES = 2
@@ -361,6 +377,7 @@ RULE_TYPES = frozenset(
         RULE_TYPE_TLS_CERT_ISSUER_CHANGED,
         RULE_TYPE_IP_BLOCKLISTED,
         RULE_TYPE_RESTORE_DRILL_FAILED,
+        RULE_TYPE_DNS_TUNNELING,
     }
 )
 
@@ -989,6 +1006,85 @@ async def _matching_restore_drill_failed_subjects(
                 f"recovery path — investigate before you need it."
             )
         matches.append((str(target_id), target_name, message))
+    return matches
+
+
+async def _matching_dns_tunneling_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+) -> list[tuple[str, str, str]]:
+    """Clients whose recent DNS behaviour scored as tunneling (#699).
+
+    Subject is the **client IP**, not the window: a host tunnelling for
+    six hours should hold one open event, not six. The matcher looks at
+    the client's highest-scoring window inside the trailing window, so
+    the event auto-resolves once the behaviour stops and the recent
+    windows fall back below threshold — no bespoke resolve path.
+
+    ``allowlisted`` windows are excluded structurally rather than by
+    score: they are already scored 0, but being explicit keeps the
+    intent readable when someone later tunes the threshold down.
+    """
+    from app.models.dns_threat import DNSClientWindow  # noqa: PLC0415
+
+    threshold = (
+        rule.threshold_percent if rule.threshold_percent is not None else _DNS_TUNNEL_SCORE_DEFAULT
+    )
+    since = datetime.now(UTC) - _DNS_TUNNEL_WINDOW
+    rows = (
+        await db.execute(
+            select(
+                DNSClientWindow.client_ip,
+                func.max(DNSClientWindow.tunnel_score).label("peak"),
+                func.sum(DNSClientWindow.query_count).label("queries"),
+                func.count().label("windows"),
+            )
+            .where(
+                DNSClientWindow.window_start >= since,
+                DNSClientWindow.allowlisted.is_(False),
+                DNSClientWindow.tunnel_score >= threshold,
+            )
+            .group_by(DNSClientWindow.client_ip)
+        )
+    ).all()
+    if not rows:
+        return []
+
+    # Fetch the worst window per matching client for the message detail —
+    # a score with no "why" is not actionable at 03:00.
+    matches: list[tuple[str, str, str]] = []
+    for client_ip, peak, queries, windows in rows:
+        ip = str(client_ip)
+        worst = (
+            await db.execute(
+                select(DNSClientWindow)
+                .where(
+                    DNSClientWindow.client_ip == client_ip,
+                    DNSClientWindow.window_start >= since,
+                )
+                .order_by(DNSClientWindow.tunnel_score.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        top_signals = ""
+        if worst is not None and worst.tunnel_signals:
+            ranked = sorted(
+                (s for s in worst.tunnel_signals if isinstance(s, dict)),
+                key=lambda s: s.get("contribution", 0),
+                reverse=True,
+            )[:2]
+            top_signals = "; ".join(str(s.get("detail", "")) for s in ranked if s.get("detail"))
+        parent = worst.top_parent if worst is not None else None
+        message = (
+            f"DNS client {ip} scored {peak:.0f}/100 for tunneling behaviour across "
+            f"{windows} hourly window(s) ({queries} queries)"
+            + (f", concentrated on {parent}" if parent else "")
+            + ". "
+            + (f"{top_signals}. " if top_signals else "")
+            + "DNS tunneling is an exfiltration path that firewalls do not see — "
+            "check what this host is running before assuming it is benign."
+        )
+        matches.append((ip, ip, message))
     return matches
 
 
@@ -4111,6 +4207,52 @@ async def seed_restore_drill_failed_alert_rule() -> None:
         await session.commit()
 
 
+async def seed_dns_tunneling_alert_rule() -> None:
+    """Seed the ``dns_tunneling_suspected`` rule (#699), ENABLED.
+
+    Enabled is safe here despite the severity: the matcher reads
+    ``dns_client_window``, which only has rows when the default-off
+    ``security.dns_threat`` module is on AND a DNS group has query
+    logging enabled. On an install that hasn't opted into either, the
+    rule matches nothing and costs one indexed query per tick. An
+    operator who turned both on wants to hear the answer.
+
+    Keyed on ``rule_type``; an operator who disables, renames or
+    re-thresholds it is never overridden.
+    """
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+    from app.models.alerts import AlertRule  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as session:
+        existing = await session.scalar(
+            select(AlertRule).where(AlertRule.rule_type == RULE_TYPE_DNS_TUNNELING)
+        )
+        if existing is not None:
+            return
+        session.add(
+            AlertRule(
+                name="DNS tunneling suspected",
+                description=(
+                    "Fires when a client's DNS behaviour scores above the tunneling "
+                    "threshold — long high-entropy labels, many unique subdomains "
+                    "under one parent domain, and payload-bearing qtypes, sustained "
+                    "over an hour. This is the shape of iodine / dnscat2-style "
+                    "exfiltration, which firewalls do not inspect. Subject is the "
+                    "client IP; auto-resolves when recent windows fall back below "
+                    "the threshold. Requires the security.dns_threat module and "
+                    "query logging on a DNS server group."
+                ),
+                rule_type=RULE_TYPE_DNS_TUNNELING,
+                severity="critical",
+                enabled=True,
+                notify_syslog=True,
+                notify_webhook=True,
+                notify_smtp=False,
+            )
+        )
+        await session.commit()
+
+
 async def evaluate_all(db: AsyncSession) -> dict[str, int]:
     """Evaluate every enabled rule; open / resolve events as needed.
 
@@ -4201,6 +4343,10 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 base = await _matching_restore_drill_failed_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]
                 subject_type = "backup_target"
+            elif rule.rule_type == RULE_TYPE_DNS_TUNNELING:
+                base = await _matching_dns_tunneling_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "dns_client"
             elif rule.rule_type == RULE_TYPE_NEW_MAC_SEEN:
                 base = await _matching_new_mac_seen_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]

--- a/backend/app/services/backup/sections.py
+++ b/backend/app/services/backup/sections.py
@@ -313,6 +313,19 @@ SECTIONS: tuple[Section, ...] = (
         volatile=True,
     ),
     Section(
+        key="dns_threat",
+        label="DNS threat analytics",
+        description=(
+            "Per-client DNS tunneling rollups (issue #699). NOT "
+            "volatile despite deriving from the 24 h query log: the "
+            "whole point of the rollup is that the summary outlives "
+            "the raw lines, so a restore that dropped it would lose "
+            "the only record that a host looked like an exfil tunnel "
+            "last week."
+        ),
+        tables=("dns_client_window",),
+    ),
+    Section(
         key="metrics",
         label="Metric samples",
         description=(

--- a/backend/app/services/backup/sections.py
+++ b/backend/app/services/backup/sections.py
@@ -321,9 +321,11 @@ SECTIONS: tuple[Section, ...] = (
             "whole point of the rollup is that the summary outlives "
             "the raw lines, so a restore that dropped it would lose "
             "the only record that a host looked like an exfil tunnel "
-            "last week."
+            "last week. Includes the per-client mutes — losing those on "
+            "restore would start paging about hosts an operator already "
+            "reviewed and cleared."
         ),
-        tables=("dns_client_window",),
+        tables=("dns_client_window", "dns_threat_mute"),
     ),
     Section(
         key="metrics",

--- a/backend/app/services/dns_threat/aggregate.py
+++ b/backend/app/services/dns_threat/aggregate.py
@@ -51,10 +51,21 @@ WINDOW_RETENTION_DAYS = 30
 # isn't running".
 INTERESTING_SCORE = 20.0
 
+# The score at which a finding is worth waking someone for. Distinct
+# from INTERESTING_SCORE on purpose — "worth a look on a dashboard" and
+# "page me at 03:00" are different bars — but defined HERE, next to it,
+# so the two are visibly a pair rather than drifting apart in separate
+# modules. The alert rule imports this; a per-rule threshold_percent
+# still overrides it.
+ALERTING_SCORE = 60.0
+
 # How far back the raw query log is kept (``prune_log_entries``). The
 # backfill sweep can't recover anything older, because the evidence is
 # gone.
 RAW_LOG_RETENTION_HOURS = 24
+
+# Set after the first backfill sweep of this process. See run_aggregation.
+_backfill_attempted = False
 
 
 def floor_hour(ts: datetime) -> datetime:
@@ -196,6 +207,26 @@ async def run_aggregation(
     # bucket already has rows, so the steady-state cost is one indexed
     # query per tick.
     backfilled = 0
+    # Once per process, not every tick. The gap this recovers from is a
+    # worker/beat outage — which means a process restart, so the first
+    # tick after coming back is exactly when it matters. Running it on
+    # every tick instead re-scanned every legitimately-quiet hour
+    # forever, because a bucket with no clients never gets a row and so
+    # can never become "covered".
+    global _backfill_attempted
+    if _backfill_attempted:
+        cutoff = now - timedelta(days=WINDOW_RETENTION_DAYS)
+        pruned = await db.execute(
+            delete(DNSClientWindow).where(DNSClientWindow.window_start < cutoff)
+        )
+        await db.commit()
+        return {
+            "windows_current": rows_current,
+            "windows_previous": rows_previous,
+            "backfilled": 0,
+            "pruned": pruned.rowcount or 0,
+        }
+    _backfill_attempted = True
     covered = set(
         (
             await db.execute(
@@ -246,16 +277,32 @@ async def compute_threat_summary(
     would leave the copilot answering against a different definition of
     "suspicious" than the UI shows.
     """
-    from sqlalchemy import func
+    from sqlalchemy import func, or_
+
+    from app.models.dns_threat_mute import DNSThreatMute
 
     since = datetime.now(UTC) - timedelta(hours=hours)
+    # Muting is a decision that a client has been reviewed and cleared,
+    # so it has to clear the client everywhere an operator looks — not
+    # just stop the alert. Otherwise the Security dashboard card stays
+    # red and the copilot keeps reporting a host someone already
+    # triaged, which is exactly what the mute UI promises it won't do.
+    muted = select(DNSThreatMute.client_ip).where(
+        or_(
+            DNSThreatMute.muted_until.is_(None),
+            DNSThreatMute.muted_until > datetime.now(UTC),
+        )
+    )
     totals = (
         await db.execute(
             select(
                 func.count().label("windows"),
                 func.count(func.distinct(DNSClientWindow.client_ip)).label("clients"),
                 func.coalesce(func.max(DNSClientWindow.tunnel_score), 0.0).label("peak"),
-            ).where(DNSClientWindow.window_start >= since)
+            ).where(
+                DNSClientWindow.window_start >= since,
+                DNSClientWindow.client_ip.not_in(muted),
+            )
         )
     ).one()
     suspicious = (
@@ -264,6 +311,7 @@ async def compute_threat_summary(
                 DNSClientWindow.window_start >= since,
                 DNSClientWindow.allowlisted.is_(False),
                 DNSClientWindow.tunnel_score >= min_score,
+                DNSClientWindow.client_ip.not_in(muted),
             )
         )
     ).scalar_one()
@@ -276,6 +324,7 @@ async def compute_threat_summary(
                 DNSClientWindow.window_start >= since,
                 DNSClientWindow.allowlisted.is_(False),
                 DNSClientWindow.tunnel_score >= min_score,
+                DNSClientWindow.client_ip.not_in(muted),
             )
             .order_by(DNSClientWindow.tunnel_score.desc())
             .limit(1)

--- a/backend/app/services/dns_threat/aggregate.py
+++ b/backend/app/services/dns_threat/aggregate.py
@@ -51,6 +51,11 @@ WINDOW_RETENTION_DAYS = 30
 # isn't running".
 INTERESTING_SCORE = 20.0
 
+# How far back the raw query log is kept (``prune_log_entries``). The
+# backfill sweep can't recover anything older, because the evidence is
+# gone.
+RAW_LOG_RETENTION_HOURS = 24
+
 
 def floor_hour(ts: datetime) -> datetime:
     return ts.replace(minute=0, second=0, microsecond=0)
@@ -183,6 +188,41 @@ async def run_aggregation(
     rows_current = await aggregate_window(db, window_start=current, allowlist=allowlist)
     rows_previous = await aggregate_window(db, window_start=previous, allowlist=allowlist)
 
+    # Backfill. A worker outage longer than two hours (a node drain
+    # during a rolling upgrade, an OOM, a Celery/Redis blip) would
+    # otherwise leave a permanent hole: the raw rows are still on disk
+    # for 24 h but nothing ever looks that far back, and then they are
+    # pruned. Bounded by the raw-log retention and skipped where a
+    # bucket already has rows, so the steady-state cost is one indexed
+    # query per tick.
+    backfilled = 0
+    covered = set(
+        (
+            await db.execute(
+                select(DNSClientWindow.window_start)
+                .where(
+                    DNSClientWindow.window_start >= now - timedelta(hours=RAW_LOG_RETENTION_HOURS)
+                )
+                .distinct()
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for back in range(2, RAW_LOG_RETENTION_HOURS):
+        bucket = current - timedelta(hours=back)
+        if bucket in covered:
+            continue
+        written = await aggregate_window(db, window_start=bucket, allowlist=allowlist)
+        if written:
+            backfilled += written
+            logger.info(
+                "dns_threat_backfilled_bucket",
+                bucket=bucket.isoformat(),
+                clients=written,
+                note="gap recovered from raw query log — worker was likely down",
+            )
+
     cutoff = now - timedelta(days=WINDOW_RETENTION_DAYS)
     pruned = await db.execute(delete(DNSClientWindow).where(DNSClientWindow.window_start < cutoff))
     await db.commit()
@@ -190,5 +230,68 @@ async def run_aggregation(
     return {
         "windows_current": rows_current,
         "windows_previous": rows_previous,
+        "backfilled": backfilled,
         "pruned": pruned.rowcount or 0,
+    }
+
+
+async def compute_threat_summary(
+    db: AsyncSession, *, hours: int = 24, min_score: float = INTERESTING_SCORE
+) -> dict[str, Any]:
+    """Trailing-window rollup shared by the REST endpoint, the Security
+    dashboard card and the Operator Copilot.
+
+    One implementation on purpose: the threshold is expected to be
+    retuned once this meets real traffic, and three copies of the query
+    would leave the copilot answering against a different definition of
+    "suspicious" than the UI shows.
+    """
+    from sqlalchemy import func
+
+    since = datetime.now(UTC) - timedelta(hours=hours)
+    totals = (
+        await db.execute(
+            select(
+                func.count().label("windows"),
+                func.count(func.distinct(DNSClientWindow.client_ip)).label("clients"),
+                func.coalesce(func.max(DNSClientWindow.tunnel_score), 0.0).label("peak"),
+            ).where(DNSClientWindow.window_start >= since)
+        )
+    ).one()
+    suspicious = (
+        await db.execute(
+            select(func.count(func.distinct(DNSClientWindow.client_ip))).where(
+                DNSClientWindow.window_start >= since,
+                DNSClientWindow.allowlisted.is_(False),
+                DNSClientWindow.tunnel_score >= min_score,
+            )
+        )
+    ).scalar_one()
+    # Thresholded so a clean install never names an innocent host as
+    # "worst" at 0/100.
+    worst = (
+        await db.execute(
+            select(DNSClientWindow)
+            .where(
+                DNSClientWindow.window_start >= since,
+                DNSClientWindow.allowlisted.is_(False),
+                DNSClientWindow.tunnel_score >= min_score,
+            )
+            .order_by(DNSClientWindow.tunnel_score.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return {
+        "windows_scored": totals.windows or 0,
+        "clients_seen": totals.clients or 0,
+        "suspicious_clients": suspicious or 0,
+        "peak_score": float(totals.peak or 0.0),
+        "worst_client_ip": str(worst.client_ip) if worst else None,
+        "worst_client_score": worst.tunnel_score if worst else None,
+        "worst_client_parent": worst.top_parent if worst else None,
+        "since": since,
+        # "No data" and "no threats" must stay distinguishable on every
+        # surface — an idle feature rendering as an all-clear is the
+        # failure this whole feature exists to avoid.
+        "has_data": (totals.windows or 0) > 0,
     }

--- a/backend/app/services/dns_threat/aggregate.py
+++ b/backend/app/services/dns_threat/aggregate.py
@@ -1,0 +1,194 @@
+"""Roll DNS query-log lines up into per-client hourly windows (#699).
+
+The raw ``dns_query_log_entry`` table is operator triage on a 24 h
+window. This turns it into something a detection can reason about — one
+summary row per client per hour — and, crucially, one that *outlives*
+the raw lines. "This host has looked like an exfil tunnel every hour
+for three days" has to stay answerable after the evidence rows are
+pruned.
+
+Bucketing is fixed hourly, aligned to the hour. The aggregator
+recomputes the current bucket and the previous one on every run and
+upserts, which makes it idempotent, self-healing against late-arriving
+log lines (agents batch and can lag), and safe to run far more often
+than the bucket width — the alternative, a trailing rolling window,
+would produce overlapping rows that nothing could sensibly key on.
+
+Rows are streamed ordered by client so grouping never holds more than
+one client's queries in memory: a busy resolver can put six figures of
+lines into a single hour, and this runs on the worker alongside
+everything else.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns_threat import DNSClientWindow
+from app.models.logs import DNSQueryLogEntry
+from app.services.dns_threat.scoring import (
+    DEFAULT_BENIGN_PARENTS,
+    extract_features,
+    score_tunneling,
+)
+
+logger = structlog.get_logger(__name__)
+
+# Windows outlive the raw log lines (24 h) by a wide margin — the whole
+# point is retaining the summary after the evidence is gone — but not
+# forever; this is behavioural metadata about clients.
+WINDOW_RETENTION_DAYS = 30
+
+# Scored windows below this are kept but are noise for every consumer;
+# the Threat tab and the alert matcher both filter above it. Kept low so
+# "nothing is scoring at all" stays distinguishable from "the feature
+# isn't running".
+INTERESTING_SCORE = 20.0
+
+
+def floor_hour(ts: datetime) -> datetime:
+    return ts.replace(minute=0, second=0, microsecond=0)
+
+
+async def aggregate_window(
+    db: AsyncSession,
+    *,
+    window_start: datetime,
+    allowlist: frozenset[str] | set[str] = DEFAULT_BENIGN_PARENTS,
+) -> int:
+    """Compute + upsert every client's row for one hourly bucket.
+
+    Returns the number of client rows written.
+    """
+    window_end = window_start + timedelta(hours=1)
+    stmt = (
+        select(
+            DNSQueryLogEntry.client_ip,
+            DNSQueryLogEntry.qname,
+            DNSQueryLogEntry.qtype,
+            DNSQueryLogEntry.server_id,
+        ).where(
+            DNSQueryLogEntry.ts >= window_start,
+            DNSQueryLogEntry.ts < window_end,
+            DNSQueryLogEntry.client_ip.is_not(None),
+        )
+        # Ordering by client is what lets the grouping below stream:
+        # one client's rows arrive together, so only that client's
+        # queries are ever held in memory.
+        .order_by(DNSQueryLogEntry.client_ip)
+    )
+
+    written = 0
+    current_ip: str | None = None
+    batch: list[tuple[str | None, str | None, Any]] = []
+
+    async def _flush() -> None:
+        nonlocal written, batch
+        if current_ip is None or not batch:
+            return
+        feats = extract_features(batch, allowlist=allowlist)
+        verdict = score_tunneling(feats)
+        await _upsert(
+            db,
+            client_ip=current_ip,
+            window_start=window_start,
+            window_end=window_end,
+            feats=feats,
+            score=verdict.score,
+            signals=verdict.signals_json(),
+        )
+        written += 1
+        batch = []
+
+    result = await db.stream(stmt)
+    async for client_ip, qname, qtype, server_id in result:
+        ip = str(client_ip)
+        if ip != current_ip:
+            await _flush()
+            current_ip = ip
+        batch.append((qname, qtype, server_id))
+    await _flush()
+
+    await db.commit()
+    return written
+
+
+async def _upsert(
+    db: AsyncSession,
+    *,
+    client_ip: str,
+    window_start: datetime,
+    window_end: datetime,
+    feats: Any,
+    score: float,
+    signals: list[dict[str, Any]],
+) -> None:
+    """Insert or refresh one client's bucket.
+
+    Upsert rather than insert because the same bucket is recomputed on
+    subsequent runs as late log lines land; the unique constraint on
+    (client_ip, window_start) is what the conflict target keys on.
+    """
+    values = {
+        "client_ip": client_ip,
+        "server_count": feats.server_count,
+        "window_start": window_start,
+        "window_end": window_end,
+        "query_count": feats.query_count,
+        "distinct_qnames": feats.distinct_qnames,
+        "distinct_parents": feats.distinct_parents,
+        "top_parent": feats.top_parent,
+        "top_parent_subdomains": feats.top_parent_subdomains,
+        "max_label_length": feats.max_label_length,
+        "avg_label_length": feats.avg_label_length,
+        "mean_label_entropy": feats.mean_label_entropy,
+        "payload_qtype_count": feats.payload_qtype_count,
+        "tunnel_score": score,
+        "tunnel_signals": signals,
+        "allowlisted": feats.allowlisted,
+    }
+    stmt = pg_insert(DNSClientWindow).values(**values)
+    await db.execute(
+        stmt.on_conflict_do_update(
+            constraint="uq_dns_client_window_ip_bucket",
+            set_={k: v for k, v in values.items() if k not in ("client_ip", "window_start")},
+        )
+    )
+
+
+async def run_aggregation(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    allowlist: frozenset[str] | set[str] = DEFAULT_BENIGN_PARENTS,
+) -> dict[str, int]:
+    """Recompute the current and previous hourly buckets, then prune.
+
+    Two buckets rather than one because agents batch their log shipping:
+    a line generated at 10:59 can arrive at 11:02, after the 10:00
+    bucket was first computed. Recomputing the previous hour picks it
+    up. Anything later than that is lost to the rollup, which is an
+    acceptable trade against unbounded recomputation.
+    """
+    now = now or datetime.now(UTC)
+    current = floor_hour(now)
+    previous = current - timedelta(hours=1)
+
+    rows_current = await aggregate_window(db, window_start=current, allowlist=allowlist)
+    rows_previous = await aggregate_window(db, window_start=previous, allowlist=allowlist)
+
+    cutoff = now - timedelta(days=WINDOW_RETENTION_DAYS)
+    pruned = await db.execute(delete(DNSClientWindow).where(DNSClientWindow.window_start < cutoff))
+    await db.commit()
+
+    return {
+        "windows_current": rows_current,
+        "windows_previous": rows_previous,
+        "pruned": pruned.rowcount or 0,
+    }

--- a/backend/app/services/dns_threat/scoring.py
+++ b/backend/app/services/dns_threat/scoring.py
@@ -91,6 +91,23 @@ DEFAULT_BENIGN_PARENTS: frozenset[str] = frozenset(
         # entirely ordinary.
         "in-addr.arpa",
         "ip6.arpa",
+        # Internal service discovery. Kubernetes pod/service names are
+        # high-entropy, high-fan-out and concentrated under one parent
+        # by construction — and SpatiumDDI's own appliance IS a k3s
+        # cluster, so without these the platform flags its own nodes.
+        "svc.cluster.local",
+        "pod.cluster.local",
+        "cluster.local",
+        "consul",
+        "internal",
+        "in-addr.arpa.local",
+        # Active Directory locator records: many machine-named SRV/A
+        # lookups under one zone.
+        "_msdcs.local",
+        "_tcp.local",
+        "_udp.local",
+        # mDNS / Bonjour.
+        "local.arpa",
     }
 )
 
@@ -152,8 +169,8 @@ def is_benign_parent(name: str, allowlist: frozenset[str] | set[str]) -> bool:
     return any(n == b or n.endswith(f".{b}") for b in allowlist)
 
 
-def split_qname(qname: str) -> tuple[str, str]:
-    """Split into (leftmost label, parent domain).
+def split_qname(qname: str) -> tuple[list[str], str]:
+    """Split into (subdomain labels, parent domain).
 
     "Parent" is the registrable-ish remainder — the last two labels for
     a plain TLD, three when the name sits under a two-part public
@@ -164,14 +181,18 @@ def split_qname(qname: str) -> tuple[str, str]:
     """
     labels = [label for label in qname.lower().rstrip(".").split(".") if label]
     if len(labels) <= 2:
-        return ("", ".".join(labels))
+        return ([], ".".join(labels))
     tail = labels[-2:]
     # Two-part public suffixes we actually see in practice.
     if len(labels) >= 3 and tail[0] in {"co", "com", "net", "org", "ac", "gov", "edu"}:
         if len(tail[-1]) == 2:  # country-code TLD, e.g. co.uk / com.au
             tail = labels[-3:]
     parent = ".".join(tail)
-    return (labels[0], parent)
+    # EVERY label above the parent, not just the leftmost: dnscat2 and
+    # dnsteal chunk payload across several labels, and scoring only
+    # ``labels[0]`` would let them evade the length and entropy signals
+    # entirely while still fanning out.
+    return (labels[: -len(tail)], parent)
 
 
 def _ramp(value: float, floor: float, ceil: float) -> float:
@@ -192,6 +213,17 @@ class ClientFeatures:
     """Detection-agnostic description of one client's window."""
 
     query_count: int = 0
+    # Queries that actually reached the signal maths: a parseable name
+    # under a non-allowlisted parent. Every ratio and the minimum-sample
+    # gate divide by THIS, not ``query_count`` — otherwise padding with
+    # benign lookups dilutes the ratios, which is a suppression channel
+    # an attacker controls for free.
+    scored_query_count: int = 0
+    # Rows whose ``qname`` was NULL/empty. The query-log column is
+    # nullable by design (the parser keeps lines it doesn't fully
+    # understand), so a parser regression shows up here rather than
+    # masquerading as a clean result.
+    unparseable_count: int = 0
     distinct_qnames: int = 0
     distinct_parents: int = 0
     top_parent: str | None = None
@@ -205,7 +237,9 @@ class ClientFeatures:
 
     @property
     def payload_qtype_ratio(self) -> float:
-        return self.payload_qtype_count / self.query_count if self.query_count else 0.0
+        return (
+            self.payload_qtype_count / self.scored_query_count if self.scored_query_count else 0.0
+        )
 
 
 def extract_features(
@@ -220,10 +254,12 @@ def extract_features(
     rather than hydrating whole ORM objects for what may be tens of
     thousands of log lines.
 
-    Allowlisted parents are excluded from the *signal* maths but still
-    counted in ``query_count``, so a host that does one suspicious
-    thing amid a torrent of DNSBL lookups doesn't have its ratio
-    diluted into invisibility.
+    Allowlisted and unparseable rows are excluded from every ratio and
+    from the minimum-sample gate, via ``scored_query_count``. Counting
+    them (as an earlier version did) meant a host could suppress its own
+    payload-qtype ratio simply by emitting DNSBL-shaped noise alongside
+    the tunnel, and could clear the 25-query floor on 24 real samples.
+    ``query_count`` keeps the raw total for display.
     """
     feats = ClientFeatures()
     qnames: set[str] = set()
@@ -231,34 +267,49 @@ def extract_features(
     per_parent: dict[str, set[str]] = defaultdict(set)
     label_lengths: list[int] = []
     entropies: list[float] = []
-    scored_any = False
 
     for qname, qtype, server_id in rows:
         feats.query_count += 1
         if server_id is not None:
             servers.add(server_id)
         if not qname:
+            feats.unparseable_count += 1
             continue
         qnames.add(qname.lower())
         # Allowlist against the full name before deriving the parent —
         # entries are routinely deeper than the two-label parent.
         if is_benign_parent(qname, allowlist):
             continue
-        label, parent = split_qname(qname)
+        sub_labels, parent = split_qname(qname)
         if not parent:
             continue
-        scored_any = True
-        per_parent[parent].add(label)
+        feats.scored_query_count += 1
+        # The whole subdomain path is the fan-out key, so a tunnel that
+        # chunks payload across labels still counts as one unique name
+        # per packet rather than collapsing onto a shared first label.
+        per_parent[parent].add(".".join(sub_labels))
         if (qtype or "").upper() in _PAYLOAD_QTYPES:
             feats.payload_qtype_count += 1
-        if label:
+        for label in sub_labels:
             label_lengths.append(len(label))
-            entropies.append(shannon_entropy(label))
+        if sub_labels:
+            # Entropy over the joined payload region rather than per
+            # label: multi-label encodings are one payload split by
+            # dots, and averaging per label would understate them.
+            entropies.append(shannon_entropy("".join(sub_labels)))
 
     feats.distinct_qnames = len(qnames)
     feats.distinct_parents = len(per_parent)
     feats.server_count = len(servers) or 1
-    feats.allowlisted = feats.query_count > 0 and not scored_any
+    # "Everything this client asked for was benign" — genuinely cleared.
+    # Distinct from "nothing was parseable", which is a data problem and
+    # must NOT read as cleared, because every surface filters allowlisted
+    # rows out of view.
+    feats.allowlisted = (
+        feats.query_count > 0
+        and feats.scored_query_count == 0
+        and feats.unparseable_count < feats.query_count
+    )
 
     if per_parent:
         top_parent, subs = max(per_parent.items(), key=lambda kv: len(kv[1]))
@@ -278,12 +329,19 @@ class Signal:
     value: float
     contribution: float
     detail: str
+    # This signal's maximum possible contribution. Carried through to
+    # the UI so a bar can be drawn as a true percentage of what the
+    # signal could contribute — weights differ (30/25/30/15), so a
+    # fully-saturated payload-qtype signal and a fully-saturated
+    # label-length signal must both render as full.
+    max_contribution: float = 0.0
 
     def as_dict(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "value": round(self.value, 3),
             "contribution": round(self.contribution, 1),
+            "max_contribution": round(self.max_contribution, 1),
             "detail": self.detail,
         }
 
@@ -318,16 +376,36 @@ def score_tunneling(feats: ClientFeatures) -> TunnelVerdict:
                 )
             ],
         )
-    if feats.query_count < MIN_QUERIES_TO_SCORE:
+    if feats.query_count > 0 and feats.unparseable_count == feats.query_count:
+        # NOT a clean bill of health: we could not read a single name.
+        # Left un-allowlisted on purpose so it stays visible — every
+        # surface hides allowlisted rows, and a parser regression that
+        # rendered as "all clear" is the exact failure this feature
+        # exists to avoid.
+        return TunnelVerdict(
+            score=0.0,
+            signals=[
+                Signal(
+                    "unparseable_queries",
+                    float(feats.unparseable_count),
+                    0.0,
+                    f"none of this client's {feats.query_count} logged queries had a "
+                    f"readable name, so nothing could be scored — check the query-log "
+                    f"parser rather than reading this as clear",
+                )
+            ],
+        )
+    if feats.scored_query_count < MIN_QUERIES_TO_SCORE:
         return TunnelVerdict(
             score=0.0,
             signals=[
                 Signal(
                     "insufficient_data",
-                    float(feats.query_count),
+                    float(feats.scored_query_count),
                     0.0,
-                    f"{feats.query_count} queries in the window; "
-                    f"{MIN_QUERIES_TO_SCORE} needed before the ratios mean anything",
+                    f"{feats.scored_query_count} scoreable queries in the window "
+                    f"(of {feats.query_count} total); {MIN_QUERIES_TO_SCORE} needed "
+                    f"before the ratios mean anything",
                 )
             ],
         )
@@ -342,15 +420,17 @@ def score_tunneling(feats: ClientFeatures) -> TunnelVerdict:
             "max_label_length",
             float(feats.max_label_length),
             length_r * _W_LABEL_LENGTH,
-            f"longest label {feats.max_label_length} chars "
+            f"longest subdomain label {feats.max_label_length} chars "
             f"(payload has to live somewhere; 63 is the protocol maximum)",
+            max_contribution=_W_LABEL_LENGTH,
         ),
         Signal(
             "label_entropy",
             feats.mean_label_entropy,
             entropy_r * _W_ENTROPY,
-            f"mean {feats.mean_label_entropy:.2f} bits/char "
-            f"(encoded payload approaches 4.5; ordinary names sit near 3)",
+            f"mean {feats.mean_label_entropy:.2f} bits/char across the subdomain "
+            f"payload (encoded data approaches 4.5; ordinary names sit near 3)",
+            max_contribution=_W_ENTROPY,
         ),
         Signal(
             "subdomain_fanout",
@@ -359,13 +439,16 @@ def score_tunneling(feats: ClientFeatures) -> TunnelVerdict:
             f"{feats.top_parent_subdomains} distinct subdomains under "
             f"{feats.top_parent or 'n/a'} (a tunnel needs a unique name per "
             f"packet or the cache would answer it)",
+            max_contribution=_W_FANOUT,
         ),
         Signal(
             "payload_qtypes",
             feats.payload_qtype_ratio,
             payload_r * _W_PAYLOAD_QTYPE,
-            f"{feats.payload_qtype_ratio:.0%} TXT/NULL/CNAME "
+            f"{feats.payload_qtype_ratio:.0%} TXT/NULL/CNAME of "
+            f"{feats.scored_query_count} scoreable queries "
             f"(these carry the most bytes per response)",
+            max_contribution=_W_PAYLOAD_QTYPE,
         ),
     ]
     return TunnelVerdict(score=sum(s.contribution for s in signals), signals=signals)

--- a/backend/app/services/dns_threat/scoring.py
+++ b/backend/app/services/dns_threat/scoring.py
@@ -1,0 +1,371 @@
+"""DNS tunneling detection — feature extraction + scoring (issue #699).
+
+DNS tunneling (iodine, dnscat2, dnsteal and friends) encodes payload
+into the *names* a client asks for, under a domain whose authoritative
+server the attacker controls. It is the exfiltration path that walks
+past a firewall untouched, because to every device in between it is
+just DNS.
+
+The shape is unmistakable once you look for it, and nothing about it
+requires seeing responses — which matters, because the BIND9 query log
+records the question, never the answer:
+
+* **Long labels.** Payload has to go somewhere, and the leftmost label
+  is where it goes. A 63-character label (the DNS maximum) is a
+  protocol edge case in ordinary traffic and routine in a tunnel.
+* **High entropy.** Encoded payload is base32/base64-ish and looks
+  random. ``www`` and ``mail`` do not.
+* **Subdomain fan-out under one parent.** Every packet needs a unique
+  name or it would be served from cache, so a tunnel generates
+  thousands of distinct labels beneath a *single* parent domain.
+* **Payload-bearing qtypes.** TXT / NULL / CNAME carry far more bytes
+  per response than A does, so tunnels lean on them heavily.
+
+No single signal is sufficient — which is the entire reason this is a
+weighted score rather than a rule. A CDN emits high-entropy labels; a
+mail server emits plenty of TXT; a busy host emits volume. Tunnels emit
+all of it at once, sustained.
+
+**On false positives.** Several entirely legitimate things look like
+tunneling if you squint, and one of them is *SpatiumDDI itself*: the
+DNSBL reputation sweep (#528) queries ``<reversed-ip>.zen.spamhaus.org``
+and friends, which is a high-fan-out, high-entropy pattern under one
+parent by construction. Antivirus and reputation lookups do the same.
+:data:`DEFAULT_BENIGN_PARENTS` therefore ships with those suffixes
+pre-cleared, and operators can extend it — a detector that pages on the
+platform's own traffic teaches operators to ignore it, which is worse
+than not shipping the detector.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+# The aggregator passes whatever the driver hands back for
+# ``server_id`` (a UUID); scoring only ever puts it in a set to count
+# distinct servers, so the alias stays deliberately loose.
+UuidLike = Any
+
+# Parent domains whose traffic is expected to look like this. Matched
+# as suffixes, so ``zen.spamhaus.org`` clears
+# ``2.0.0.127.zen.spamhaus.org``.
+#
+# The DNSBL entries are not optional politeness: SpatiumDDI's own
+# reputation sweep generates exactly this pattern, so without them the
+# platform's first finding would be itself.
+DEFAULT_BENIGN_PARENTS: frozenset[str] = frozenset(
+    {
+        # DNSBL / reputation — including the zones our own sweep queries.
+        "zen.spamhaus.org",
+        "dbl.spamhaus.org",
+        "bl.spamcop.net",
+        "b.barracudacentral.org",
+        "dnsbl.sorbs.net",
+        "cbl.abuseat.org",
+        # Antivirus / endpoint reputation lookups, textbook lookalikes.
+        "avqs.mcafee.com",
+        "avts.mcafee.com",
+        "cloud.sophos.com",
+        "spf.sophos.com",
+        "clamav.net",
+        # Certificate transparency + OCSP-ish infrastructure.
+        "ocsp.digicert.com",
+        "ocsp.sectigo.com",
+        # Content delivery — long hashed labels are the norm.
+        "akamaiedge.net",
+        "akamai.net",
+        "cloudfront.net",
+        "edgekey.net",
+        "edgesuite.net",
+        "azureedge.net",
+        "fastly.net",
+        "cdn.cloudflare.net",
+        # Cloud storage / telemetry with hashed bucket labels.
+        "amazonaws.com",
+        "blob.core.windows.net",
+        "googleusercontent.com",
+        # In-addr / ip6 reverse space: long, numeric, high fan-out, and
+        # entirely ordinary.
+        "in-addr.arpa",
+        "ip6.arpa",
+    }
+)
+
+# Weights sum to 100. Kept explicit (rather than folded into the maths)
+# so the numbers an operator sees in the signals blob add up to the
+# score they were shown, and so tuning one signal is a one-line change.
+_W_LABEL_LENGTH = 30.0
+_W_ENTROPY = 25.0
+_W_FANOUT = 30.0
+_W_PAYLOAD_QTYPE = 15.0
+
+# Below these, a signal contributes nothing. Set from what ordinary
+# traffic looks like, not from what tunnels look like — the goal is
+# "boring traffic scores ~0", so anything non-zero is worth a glance.
+_LABEL_LENGTH_FLOOR = 20  # chars; ordinary labels are short
+_LABEL_LENGTH_CEIL = 55  # approaching the 63-char protocol maximum
+_ENTROPY_FLOOR = 3.0  # bits/char; English-ish text sits well below
+_ENTROPY_CEIL = 4.4  # base32/base64 payload approaches this
+_FANOUT_FLOOR = 50  # distinct subdomains under ONE parent, per hour
+_FANOUT_CEIL = 800
+_PAYLOAD_RATIO_FLOOR = 0.10
+_PAYLOAD_RATIO_CEIL = 0.60
+
+# A handful of queries can hit every ratio threshold by accident. Below
+# this, report the features but score zero — the maths is meaningless
+# on three samples.
+MIN_QUERIES_TO_SCORE = 25
+
+_PAYLOAD_QTYPES = frozenset({"TXT", "NULL", "CNAME"})
+
+
+def shannon_entropy(value: str) -> float:
+    """Shannon entropy in bits per character.
+
+    Encoded payload approaches ~4.5-5.0 for base32/base64 alphabets;
+    ordinary hostnames sit nearer 2.5-3.5. The measure is
+    length-independent, which is what lets it be combined with the
+    separate length signal instead of double-counting it.
+    """
+    if not value:
+        return 0.0
+    counts = Counter(value)
+    total = len(value)
+    return -sum((c / total) * math.log2(c / total) for c in counts.values())
+
+
+def is_benign_parent(name: str, allowlist: frozenset[str] | set[str]) -> bool:
+    """True when ``name`` is, or sits under, an allowlisted domain.
+
+    Matched against the **full query name**, not the two-label parent
+    the grouping logic derives. Most allowlist entries are deeper than
+    two labels — ``zen.spamhaus.org``, ``blob.core.windows.net`` — and
+    testing the derived parent (``spamhaus.org``,
+    ``windows.net``) would never match them. That bug let SpatiumDDI's
+    own DNSBL sweep score as suspicious, which was the first thing the
+    scorer flagged when run against realistic traffic.
+    """
+    n = name.lower().rstrip(".")
+    return any(n == b or n.endswith(f".{b}") for b in allowlist)
+
+
+def split_qname(qname: str) -> tuple[str, str]:
+    """Split into (leftmost label, parent domain).
+
+    "Parent" is the registrable-ish remainder — the last two labels for
+    a plain TLD, three when the name sits under a two-part public
+    suffix like ``co.uk``. Deliberately a heuristic and not a PSL
+    lookup: getting ``example.co.uk`` grouped correctly matters, but
+    shipping a public-suffix dependency (and its refresh problem) to
+    sharpen an already-fuzzy signal does not.
+    """
+    labels = [label for label in qname.lower().rstrip(".").split(".") if label]
+    if len(labels) <= 2:
+        return ("", ".".join(labels))
+    tail = labels[-2:]
+    # Two-part public suffixes we actually see in practice.
+    if len(labels) >= 3 and tail[0] in {"co", "com", "net", "org", "ac", "gov", "edu"}:
+        if len(tail[-1]) == 2:  # country-code TLD, e.g. co.uk / com.au
+            tail = labels[-3:]
+    parent = ".".join(tail)
+    return (labels[0], parent)
+
+
+def _ramp(value: float, floor: float, ceil: float) -> float:
+    """Linear 0→1 ramp between floor and ceiling, clamped.
+
+    A ramp rather than a threshold so a host just over the line scores
+    just over zero, instead of a one-character difference flipping a
+    finding on. It keeps the score sortable, which is what makes the
+    Threat tab's "worst first" ordering meaningful.
+    """
+    if ceil <= floor:
+        return 0.0
+    return max(0.0, min(1.0, (value - floor) / (ceil - floor)))
+
+
+@dataclass
+class ClientFeatures:
+    """Detection-agnostic description of one client's window."""
+
+    query_count: int = 0
+    distinct_qnames: int = 0
+    distinct_parents: int = 0
+    top_parent: str | None = None
+    top_parent_subdomains: int = 0
+    max_label_length: int = 0
+    avg_label_length: float = 0.0
+    mean_label_entropy: float = 0.0
+    payload_qtype_count: int = 0
+    server_count: int = 1
+    allowlisted: bool = False
+
+    @property
+    def payload_qtype_ratio(self) -> float:
+        return self.payload_qtype_count / self.query_count if self.query_count else 0.0
+
+
+def extract_features(
+    rows: list[tuple[str | None, str | None, UuidLike]],
+    *,
+    allowlist: frozenset[str] | set[str] = DEFAULT_BENIGN_PARENTS,
+) -> ClientFeatures:
+    """Summarise one client's queries in a window.
+
+    ``rows`` is ``(qname, qtype, server_id)`` — the three columns the
+    scoring needs, kept narrow so the aggregator can select just those
+    rather than hydrating whole ORM objects for what may be tens of
+    thousands of log lines.
+
+    Allowlisted parents are excluded from the *signal* maths but still
+    counted in ``query_count``, so a host that does one suspicious
+    thing amid a torrent of DNSBL lookups doesn't have its ratio
+    diluted into invisibility.
+    """
+    feats = ClientFeatures()
+    qnames: set[str] = set()
+    servers: set[Any] = set()
+    per_parent: dict[str, set[str]] = defaultdict(set)
+    label_lengths: list[int] = []
+    entropies: list[float] = []
+    scored_any = False
+
+    for qname, qtype, server_id in rows:
+        feats.query_count += 1
+        if server_id is not None:
+            servers.add(server_id)
+        if not qname:
+            continue
+        qnames.add(qname.lower())
+        # Allowlist against the full name before deriving the parent —
+        # entries are routinely deeper than the two-label parent.
+        if is_benign_parent(qname, allowlist):
+            continue
+        label, parent = split_qname(qname)
+        if not parent:
+            continue
+        scored_any = True
+        per_parent[parent].add(label)
+        if (qtype or "").upper() in _PAYLOAD_QTYPES:
+            feats.payload_qtype_count += 1
+        if label:
+            label_lengths.append(len(label))
+            entropies.append(shannon_entropy(label))
+
+    feats.distinct_qnames = len(qnames)
+    feats.distinct_parents = len(per_parent)
+    feats.server_count = len(servers) or 1
+    feats.allowlisted = feats.query_count > 0 and not scored_any
+
+    if per_parent:
+        top_parent, subs = max(per_parent.items(), key=lambda kv: len(kv[1]))
+        feats.top_parent = top_parent
+        feats.top_parent_subdomains = len(subs)
+    if label_lengths:
+        feats.max_label_length = max(label_lengths)
+        feats.avg_label_length = sum(label_lengths) / len(label_lengths)
+    if entropies:
+        feats.mean_label_entropy = sum(entropies) / len(entropies)
+    return feats
+
+
+@dataclass
+class Signal:
+    name: str
+    value: float
+    contribution: float
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "value": round(self.value, 3),
+            "contribution": round(self.contribution, 1),
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class TunnelVerdict:
+    score: float
+    signals: list[Signal] = field(default_factory=list)
+
+    def signals_json(self) -> list[dict[str, Any]]:
+        return [s.as_dict() for s in self.signals]
+
+
+def score_tunneling(feats: ClientFeatures) -> TunnelVerdict:
+    """Weighted 0-100 tunneling score from a client's window features.
+
+    Every signal is reported even when it contributes nothing, so the
+    UI can show what was considered rather than only what fired — "your
+    entropy is fine, it's the fan-out that's odd" is a more useful
+    answer than a bare 62.
+    """
+    if feats.allowlisted:
+        return TunnelVerdict(
+            score=0.0,
+            signals=[
+                Signal(
+                    "allowlisted",
+                    1.0,
+                    0.0,
+                    "every parent domain queried is on the benign allowlist "
+                    "(DNSBL / CDN / reputation traffic looks like this by design)",
+                )
+            ],
+        )
+    if feats.query_count < MIN_QUERIES_TO_SCORE:
+        return TunnelVerdict(
+            score=0.0,
+            signals=[
+                Signal(
+                    "insufficient_data",
+                    float(feats.query_count),
+                    0.0,
+                    f"{feats.query_count} queries in the window; "
+                    f"{MIN_QUERIES_TO_SCORE} needed before the ratios mean anything",
+                )
+            ],
+        )
+
+    length_r = _ramp(feats.max_label_length, _LABEL_LENGTH_FLOOR, _LABEL_LENGTH_CEIL)
+    entropy_r = _ramp(feats.mean_label_entropy, _ENTROPY_FLOOR, _ENTROPY_CEIL)
+    fanout_r = _ramp(feats.top_parent_subdomains, _FANOUT_FLOOR, _FANOUT_CEIL)
+    payload_r = _ramp(feats.payload_qtype_ratio, _PAYLOAD_RATIO_FLOOR, _PAYLOAD_RATIO_CEIL)
+
+    signals = [
+        Signal(
+            "max_label_length",
+            float(feats.max_label_length),
+            length_r * _W_LABEL_LENGTH,
+            f"longest label {feats.max_label_length} chars "
+            f"(payload has to live somewhere; 63 is the protocol maximum)",
+        ),
+        Signal(
+            "label_entropy",
+            feats.mean_label_entropy,
+            entropy_r * _W_ENTROPY,
+            f"mean {feats.mean_label_entropy:.2f} bits/char "
+            f"(encoded payload approaches 4.5; ordinary names sit near 3)",
+        ),
+        Signal(
+            "subdomain_fanout",
+            float(feats.top_parent_subdomains),
+            fanout_r * _W_FANOUT,
+            f"{feats.top_parent_subdomains} distinct subdomains under "
+            f"{feats.top_parent or 'n/a'} (a tunnel needs a unique name per "
+            f"packet or the cache would answer it)",
+        ),
+        Signal(
+            "payload_qtypes",
+            feats.payload_qtype_ratio,
+            payload_r * _W_PAYLOAD_QTYPE,
+            f"{feats.payload_qtype_ratio:.0%} TXT/NULL/CNAME "
+            f"(these carry the most bytes per response)",
+        ),
+    ]
+    return TunnelVerdict(score=sum(s.contribution for s in signals), signals=signals)

--- a/backend/app/services/dns_threat/scoring.py
+++ b/backend/app/services/dns_threat/scoring.py
@@ -282,6 +282,14 @@ def extract_features(
             continue
         sub_labels, parent = split_qname(qname)
         if not parent:
+            # Root / single-label / otherwise unsplittable. Counted as
+            # unparseable rather than silently skipped: skipping left
+            # scored_query_count at 0 with unparseable_count also 0,
+            # which the allowlisted guard below reads as "everything was
+            # benign" — hiding the client from every surface, which is
+            # precisely the failure the unparseable branch exists to
+            # prevent.
+            feats.unparseable_count += 1
             continue
         feats.scored_query_count += 1
         # The whole subdomain path is the fan-out key, so a tunnel that
@@ -410,7 +418,16 @@ def score_tunneling(feats: ClientFeatures) -> TunnelVerdict:
             ],
         )
 
-    length_r = _ramp(feats.max_label_length, _LABEL_LENGTH_FLOOR, _LABEL_LENGTH_CEIL)
+    # Blend max with mean. On max alone a SINGLE long lookup — one
+    # _acme-challenge TXT, a DKIM selector, an un-allowlisted CDN
+    # hostname — handed a client the full 30 points for the hour no
+    # matter how ordinary its other 10,000 queries were. A tunnel's
+    # labels are long *on average*; a false positive's are long once.
+    # Keeping some weight on max means a short-label tunnel padded with
+    # normal traffic still registers.
+    length_r = 0.4 * _ramp(
+        feats.max_label_length, _LABEL_LENGTH_FLOOR, _LABEL_LENGTH_CEIL
+    ) + 0.6 * _ramp(feats.avg_label_length, _LABEL_LENGTH_FLOOR, _LABEL_LENGTH_CEIL)
     entropy_r = _ramp(feats.mean_label_entropy, _ENTROPY_FLOOR, _ENTROPY_CEIL)
     fanout_r = _ramp(feats.top_parent_subdomains, _FANOUT_FLOOR, _FANOUT_CEIL)
     payload_r = _ramp(feats.payload_qtype_ratio, _PAYLOAD_RATIO_FLOOR, _PAYLOAD_RATIO_CEIL)
@@ -420,8 +437,10 @@ def score_tunneling(feats: ClientFeatures) -> TunnelVerdict:
             "max_label_length",
             float(feats.max_label_length),
             length_r * _W_LABEL_LENGTH,
-            f"longest subdomain label {feats.max_label_length} chars "
-            f"(payload has to live somewhere; 63 is the protocol maximum)",
+            f"longest subdomain label {feats.max_label_length} chars, mean "
+            f"{feats.avg_label_length:.0f} (payload has to live somewhere; 63 is "
+            f"the protocol maximum — the mean is weighted higher so one long "
+            f"lookup can't carry the signal)",
             max_contribution=_W_LABEL_LENGTH,
         ),
         Signal(

--- a/backend/app/services/factory_reset/sections.py
+++ b/backend/app/services/factory_reset/sections.py
@@ -124,6 +124,7 @@ FACTORY_SECTIONS: tuple[FactorySection, ...] = (
             "dns_trust_anchor",
             "dns_query_log_entry",
             "dns_client_window",
+            "dns_threat_mute",
             "dns_metric_sample",
             "subnet_domain",
             "domain",
@@ -274,10 +275,12 @@ FACTORY_SECTIONS: tuple[FactorySection, ...] = (
         tables=(
             "audit_log",
             "dns_query_log_entry",
-            # Query-derived behavioural data about clients — an operator
-            # wiping observability before handing an appliance on
-            # reasonably expects this gone too (#699).
+            # Query-derived behavioural data about clients, plus the
+            # operator triage decisions on it (client IPs, reasons,
+            # operator names) — someone wiping an appliance before
+            # handing it on reasonably expects all of this gone (#699).
             "dns_client_window",
+            "dns_threat_mute",
             "dhcp_log_entry",
             "internal_error",
         ),

--- a/backend/app/services/factory_reset/sections.py
+++ b/backend/app/services/factory_reset/sections.py
@@ -123,6 +123,7 @@ FACTORY_SECTIONS: tuple[FactorySection, ...] = (
             "dns_tsig_key",
             "dns_trust_anchor",
             "dns_query_log_entry",
+            "dns_client_window",
             "dns_metric_sample",
             "subnet_domain",
             "domain",
@@ -273,6 +274,10 @@ FACTORY_SECTIONS: tuple[FactorySection, ...] = (
         tables=(
             "audit_log",
             "dns_query_log_entry",
+            # Query-derived behavioural data about clients — an operator
+            # wiping observability before handing an appliance on
+            # reasonably expects this gone too (#699).
+            "dns_client_window",
             "dhcp_log_entry",
             "internal_error",
         ),

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -413,6 +413,28 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         description="Alert the moment a previously-unseen MAC address appears on the network (arpwatch-style), across DHCP leases, SNMP ARP/FDB, and an opt-in L2 sniffer. Maintain an allowlist of trusted MACs (or OUI prefixes for VMs/containers), acknowledge or block from a review queue, and fire a real-time device.first_seen event. Default-off: enable, run a baseline import to mark the existing fleet as known, then arm.",
         default_enabled=False,
     ),
+    # Security — DNS threat analytics (#699). Default-off on privacy
+    # grounds, not on noise grounds: scoring reads query *content*
+    # (the names clients look up), which is a posture operators should
+    # opt into deliberately rather than inherit from an upgrade. It is
+    # additionally inert until a DNS group turns on query logging.
+    ModuleSpec(
+        id="security.dns_threat",
+        label="DNS threat analytics",
+        group="Security",
+        description=(
+            "Score DNS clients for tunneling/exfiltration behaviour (iodine / "
+            "dnscat2-shaped traffic that walks past a firewall untouched) from "
+            "the query log SpatiumDDI already collects — long high-entropy "
+            "labels, many unique subdomains under one parent, elevated "
+            "TXT/NULL/CNAME ratio. Findings surface as an alert, a Threat tab "
+            "on Logs, and a Security dashboard card, and deep-link to the IP so "
+            "the device profile is one click away. Default-off: this reads the "
+            "names clients look up. Requires query logging enabled on a DNS "
+            "server group."
+        ),
+        default_enabled=False,
+    ),
     # Security — active block sync / write-back enforcement (#601). The
     # deliberate, guarded exception to the read-only-mirror stance: pushes
     # SpatiumDDI-owned IP/MAC blocks into OPNsense (firewall table alias)

--- a/backend/app/tasks/dns_threat.py
+++ b/backend/app/tasks/dns_threat.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 
 import structlog
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.celery_app import celery_app
 from app.db import task_session
@@ -40,7 +41,11 @@ async def _run() -> dict[str, object]:
 @celery_app.task(
     name="app.tasks.dns_threat.aggregate_dns_client_windows",
     bind=True,
-    autoretry_for=(OSError, ConnectionError),
+    # SQLAlchemyError included because this task is entirely DB-bound:
+    # a CNPG failover or pool exhaustion raises OperationalError, which
+    # without this loses the tick outright. Matches the set standardised
+    # across the other beat tasks in #221/#222.
+    autoretry_for=(SQLAlchemyError, ConnectionError, OSError),
     retry_backoff=True,
     retry_backoff_max=600,
     max_retries=3,

--- a/backend/app/tasks/dns_threat.py
+++ b/backend/app/tasks/dns_threat.py
@@ -1,0 +1,54 @@
+"""Beat-driven DNS threat rollup (issue #699).
+
+Runs every 15 minutes, recomputing the current and previous hourly
+buckets. Far more often than the bucket width on purpose: each run
+upserts, so frequent runs mean the current hour's picture is close to
+live rather than up to an hour stale, without any extra rows.
+
+Double-gated, and both gates matter:
+
+* the ``security.dns_threat`` feature module is default-OFF, because
+  scoring reads query *content* and that is a privacy posture rather
+  than a default;
+* even enabled, there is nothing to roll up unless a DNS server group
+  has query logging turned on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import structlog
+
+from app.celery_app import celery_app
+from app.db import task_session
+
+logger = structlog.get_logger(__name__)
+
+
+async def _run() -> dict[str, object]:
+    from app.services.dns_threat.aggregate import run_aggregation  # noqa: PLC0415
+    from app.services.feature_modules import is_module_enabled  # noqa: PLC0415
+
+    async with task_session() as db:
+        if not await is_module_enabled(db, "security.dns_threat"):
+            return {"status": "module_disabled"}
+        result = await run_aggregation(db)
+        return {"status": "ok", **result}
+
+
+@celery_app.task(
+    name="app.tasks.dns_threat.aggregate_dns_client_windows",
+    bind=True,
+    autoretry_for=(OSError, ConnectionError),
+    retry_backoff=True,
+    retry_backoff_max=600,
+    max_retries=3,
+)
+def aggregate_dns_client_windows(self) -> dict[str, object]:  # type: ignore[no-untyped-def]
+    result = asyncio.run(_run())
+    if result.get("status") == "ok" and (
+        result.get("windows_current") or result.get("windows_previous")
+    ):
+        logger.info("dns_threat_rollup_tick", **result)
+    return result

--- a/backend/tests/test_dns_threat.py
+++ b/backend/tests/test_dns_threat.py
@@ -26,8 +26,10 @@ import base64
 import os
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -225,6 +227,24 @@ def test_signals_carry_their_own_ceiling() -> None:
 # ── rollup ────────────────────────────────────────────────────────────
 
 
+async def _make_user(db: AsyncSession, *, username: str) -> tuple[Any, str]:
+    from app.core.security import create_access_token, hash_password
+    from app.models.auth import User
+
+    user = User(
+        username=username,
+        email=f"{username}@example.test",
+        display_name=username,
+        hashed_password=hash_password("x"),
+        auth_source="local",
+        is_superadmin=True,
+    )
+    user.groups = []  # mark loaded — is_effective_superadmin walks .groups (#351)
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
 async def _make_dns_server(db: AsyncSession) -> DNSServer:
     g = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:8]}", description="")
     db.add(g)
@@ -312,3 +332,109 @@ async def test_aggregate_ignores_queries_outside_the_bucket(
     )
     written = await aggregate_window(db_session, window_start=bucket)
     assert written == 0
+
+
+# ── mute (operator triage) ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_muted_client_does_not_alert(db_session: AsyncSession) -> None:
+    """A reviewed-and-cleared host must stop paging.
+
+    Without this the only way to silence one noisy client is disabling
+    the rule, which silences every other client too.
+    """
+    from app.models.alerts import AlertRule
+    from app.models.dns_threat_mute import DNSThreatMute
+    from app.services.alerts import (
+        RULE_TYPE_DNS_TUNNELING,
+        _matching_dns_tunneling_subjects,
+    )
+
+    server = await _make_dns_server(db_session)
+    bucket = floor_hour(datetime.now(UTC))
+    await _seed_queries(db_session, server.id, _tunnel_rows(200), ts=bucket, client="10.9.9.9")
+    await aggregate_window(db_session, window_start=bucket)
+
+    rule = AlertRule(
+        name="tunnel",
+        rule_type=RULE_TYPE_DNS_TUNNELING,
+        severity="critical",
+        enabled=True,
+    )
+    assert [d for _, d, _ in await _matching_dns_tunneling_subjects(db_session, rule)] == [
+        "10.9.9.9"
+    ]
+
+    db_session.add(DNSThreatMute(client_ip="10.9.9.9", reason="backup agent", muted_until=None))
+    await db_session.flush()
+    assert await _matching_dns_tunneling_subjects(db_session, rule) == []
+
+
+@pytest.mark.asyncio
+async def test_expired_mute_alerts_again(db_session: AsyncSession) -> None:
+    """An expiring mute is a decision that ages out — the point of
+    offering a dated mute at all."""
+    from app.models.alerts import AlertRule
+    from app.models.dns_threat_mute import DNSThreatMute
+    from app.services.alerts import (
+        RULE_TYPE_DNS_TUNNELING,
+        _matching_dns_tunneling_subjects,
+    )
+
+    server = await _make_dns_server(db_session)
+    bucket = floor_hour(datetime.now(UTC))
+    await _seed_queries(db_session, server.id, _tunnel_rows(200), ts=bucket, client="10.9.9.8")
+    await aggregate_window(db_session, window_start=bucket)
+    db_session.add(
+        DNSThreatMute(
+            client_ip="10.9.9.8",
+            reason="temporary",
+            muted_until=datetime.now(UTC) - timedelta(hours=1),
+        )
+    )
+    await db_session.flush()
+
+    rule = AlertRule(
+        name="tunnel",
+        rule_type=RULE_TYPE_DNS_TUNNELING,
+        severity="critical",
+        enabled=True,
+    )
+    assert [d for _, d, _ in await _matching_dns_tunneling_subjects(db_session, rule)] == [
+        "10.9.9.8"
+    ], "a lapsed mute must not keep suppressing"
+
+
+def test_mute_is_active_semantics() -> None:
+    from app.models.dns_threat_mute import DNSThreatMute
+
+    now = datetime.now(UTC)
+    assert DNSThreatMute(client_ip="1.1.1.1", muted_until=None).is_active(now) is True
+    assert (
+        DNSThreatMute(client_ip="1.1.1.1", muted_until=now + timedelta(days=1)).is_active(now)
+        is True
+    )
+    assert (
+        DNSThreatMute(client_ip="1.1.1.1", muted_until=now - timedelta(days=1)).is_active(now)
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_mute_requires_a_reason(client: AsyncClient, db_session: AsyncSession) -> None:
+    """An unexplained mute is how a real incident gets buried by someone
+    tidying a dashboard."""
+    from app.models.feature_module import FeatureModule
+
+    # The whole /dns-threat prefix is module-gated and the module is
+    # default-off, so without this the request 404s before validation.
+    db_session.add(FeatureModule(id="security.dns_threat", enabled=True))
+    _, token = await _make_user(db_session, username="mutereason")
+    await db_session.flush()
+    res = await client.post(
+        "/api/v1/dns-threat/mutes",
+        json={"client_ip": "10.0.0.5", "reason": ""},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 422

--- a/backend/tests/test_dns_threat.py
+++ b/backend/tests/test_dns_threat.py
@@ -1,0 +1,251 @@
+"""DNS tunneling analytics (issue #699).
+
+The detection is a heuristic, so the tests pin the things that would
+make it *wrong* rather than the exact numbers it produces — thresholds
+will be retuned against real traffic and shouldn't have to drag a test
+suite behind them.
+
+What matters, in order of how badly it breaks trust if it regresses:
+
+* **False positives on benign traffic.** SpatiumDDI's own DNSBL sweep
+  is the sharpest case: it queries ``<ip>.zen.spamhaus.org``, which is
+  high fan-out and high entropy under one parent by construction. A
+  detector whose first finding is the platform itself gets ignored, and
+  an ignored detector is worse than none.
+* **False negatives from hiding.** The allowlist must not become cover:
+  a tunnel mixed into allowlisted traffic still has to score.
+* **Ordering.** Tunnels must outrank ordinary traffic, whatever the
+  absolute numbers are.
+* **The rollup contract** — idempotent upsert, correct bucketing.
+* **"No data" never reading as "no threats"**, in every surface.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns import DNSServer, DNSServerGroup
+from app.models.dns_threat import DNSClientWindow
+from app.models.logs import DNSQueryLogEntry
+from app.services.dns_threat.aggregate import aggregate_window, floor_hour
+from app.services.dns_threat.scoring import (
+    DEFAULT_BENIGN_PARENTS,
+    MIN_QUERIES_TO_SCORE,
+    extract_features,
+    is_benign_parent,
+    score_tunneling,
+    shannon_entropy,
+    split_qname,
+)
+
+
+def _tunnel_rows(n: int = 300, parent: str = "t.evil.example") -> list[tuple]:
+    """iodine-shaped: long base32 labels, unique per query, TXT-heavy."""
+    rows = []
+    for _ in range(n):
+        payload = base64.b32encode(os.urandom(35)).decode().rstrip("=").lower()[:60]
+        rows.append((f"{payload}.{parent}", "TXT", "server-1"))
+    return rows
+
+
+def _ordinary_rows(n: int = 300) -> list[tuple]:
+    hosts = ["www", "mail", "intranet", "vpn", "wiki", "printer1"]
+    return [(f"{hosts[i % len(hosts)]}.corp.example.com", "A", "server-1") for i in range(n)]
+
+
+def _dnsbl_rows(n: int = 300) -> list[tuple]:
+    """What SpatiumDDI's own reputation sweep looks like on the wire."""
+    return [(f"{i}.2.0.192.zen.spamhaus.org", "A", "server-1") for i in range(n)]
+
+
+# ── scoring primitives ────────────────────────────────────────────────
+
+
+def test_entropy_separates_encoded_payload_from_words() -> None:
+    # A repeated character carries no information at all, whatever its
+    # length — which is why entropy is measured per character and the
+    # length signal is scored separately rather than folded in.
+    assert shannon_entropy("aaaaaaaa") == 0.0
+    assert shannon_entropy("abcdefgh") > shannon_entropy("aaaaaaab")
+    encoded = base64.b32encode(os.urandom(30)).decode().rstrip("=").lower()
+    assert shannon_entropy(encoded) > shannon_entropy("intranet")
+
+
+def test_split_qname_handles_two_part_public_suffixes() -> None:
+    assert split_qname("a.b.example.co.uk") == ("a", "example.co.uk")
+    assert split_qname("x.example.com") == ("x", "example.com")
+    assert split_qname("single.com") == ("", "single.com")
+
+
+def test_allowlist_matches_full_name_not_derived_parent() -> None:
+    """The bug that made the platform flag its own DNSBL sweep.
+
+    Allowlist entries are routinely deeper than the two-label parent
+    (`zen.spamhaus.org`, `blob.core.windows.net`); matching the derived
+    parent would never hit them.
+    """
+    assert is_benign_parent("1.2.0.192.zen.spamhaus.org", DEFAULT_BENIGN_PARENTS)
+    assert is_benign_parent("abc.mycontainer.blob.core.windows.net", DEFAULT_BENIGN_PARENTS)
+    assert not is_benign_parent("payload.t.evil.example", DEFAULT_BENIGN_PARENTS)
+
+
+# ── the failure modes that matter ─────────────────────────────────────
+
+
+def test_our_own_dnsbl_sweep_does_not_score() -> None:
+    feats = extract_features(_dnsbl_rows())
+    verdict = score_tunneling(feats)
+    assert feats.allowlisted is True
+    assert verdict.score == 0.0
+
+
+def test_ordinary_traffic_scores_zero() -> None:
+    assert score_tunneling(extract_features(_ordinary_rows())).score == 0.0
+
+
+def test_tunnel_outranks_ordinary_traffic() -> None:
+    """The ordering property, not the absolute numbers — thresholds get
+    retuned against real traffic and shouldn't drag tests with them."""
+    tunnel = score_tunneling(extract_features(_tunnel_rows())).score
+    ordinary = score_tunneling(extract_features(_ordinary_rows())).score
+    assert tunnel > ordinary
+    assert tunnel >= 60, "an iodine-shaped tunnel must clear the default alert threshold"
+
+
+def test_allowlist_is_not_a_hiding_place() -> None:
+    """A tunnel mixed into allowlisted traffic must still score.
+
+    Otherwise an attacker who also generates DNSBL-shaped noise gets a
+    free pass, and the allowlist becomes an attack surface.
+    """
+    mixed = _tunnel_rows(200) + _dnsbl_rows(400)
+    feats = extract_features(mixed)
+    assert feats.allowlisted is False
+    assert score_tunneling(feats).score >= 60
+
+
+def test_small_samples_do_not_score() -> None:
+    """Ratios are meaningless on a handful of queries; a single long
+    TXT lookup must not read as an exfil tunnel."""
+    feats = extract_features(_tunnel_rows(MIN_QUERIES_TO_SCORE - 1))
+    verdict = score_tunneling(feats)
+    assert verdict.score == 0.0
+    assert verdict.signals[0].name == "insufficient_data"
+
+
+def test_every_signal_is_reported_even_at_zero() -> None:
+    """The UI shows what was *ruled out*, not only what fired."""
+    verdict = score_tunneling(extract_features(_tunnel_rows()))
+    names = {s.name for s in verdict.signals}
+    assert names == {
+        "max_label_length",
+        "label_entropy",
+        "subdomain_fanout",
+        "payload_qtypes",
+    }
+    assert all(isinstance(s.detail, str) and s.detail for s in verdict.signals)
+
+
+def test_score_is_bounded() -> None:
+    """Weights sum to 100; nothing may exceed it however extreme."""
+    extreme = [(f"{'z' * 63}.{i}.evil.example", "NULL", "s") for i in range(5000)]
+    assert score_tunneling(extract_features(extreme)).score <= 100.0
+
+
+# ── rollup ────────────────────────────────────────────────────────────
+
+
+async def _make_dns_server(db: AsyncSession) -> DNSServer:
+    g = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:8]}", description="")
+    db.add(g)
+    await db.flush()
+    s = DNSServer(
+        name=f"s-{uuid.uuid4().hex[:8]}",
+        host="127.0.0.1",
+        port=53,
+        driver="bind9",
+        group_id=g.id,
+        is_primary=True,
+        is_enabled=True,
+    )
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def _seed_queries(
+    db: AsyncSession, server_id, rows: list[tuple], *, ts: datetime, client: str
+) -> None:
+    for qname, qtype, _srv in rows:
+        db.add(
+            DNSQueryLogEntry(
+                server_id=server_id,
+                ts=ts,
+                client_ip=client,
+                qname=qname,
+                qtype=qtype,
+                raw="",
+            )
+        )
+    await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_aggregate_writes_one_row_per_client(db_session: AsyncSession) -> None:
+    server = await _make_dns_server(db_session)
+    bucket = floor_hour(datetime.now(UTC))
+    await _seed_queries(db_session, server.id, _tunnel_rows(120), ts=bucket, client="10.0.0.9")
+    await _seed_queries(db_session, server.id, _ordinary_rows(60), ts=bucket, client="10.0.0.10")
+
+    written = await aggregate_window(db_session, window_start=bucket)
+    assert written == 2
+
+    rows = (
+        (await db_session.execute(select(DNSClientWindow).order_by(DNSClientWindow.client_ip)))
+        .scalars()
+        .all()
+    )
+    by_ip = {str(r.client_ip): r for r in rows}
+    assert by_ip["10.0.0.9"].tunnel_score > by_ip["10.0.0.10"].tunnel_score
+    assert by_ip["10.0.0.9"].top_parent == "evil.example"
+    assert by_ip["10.0.0.10"].tunnel_score == 0.0
+
+
+@pytest.mark.asyncio
+async def test_aggregate_is_idempotent(db_session: AsyncSession) -> None:
+    """Re-running a bucket updates in place rather than duplicating —
+    the aggregator recomputes recent buckets on every tick to pick up
+    late-arriving log lines."""
+    server = await _make_dns_server(db_session)
+    bucket = floor_hour(datetime.now(UTC))
+    await _seed_queries(db_session, server.id, _tunnel_rows(120), ts=bucket, client="10.0.0.9")
+
+    await aggregate_window(db_session, window_start=bucket)
+    await aggregate_window(db_session, window_start=bucket)
+
+    rows = (await db_session.execute(select(DNSClientWindow))).scalars().all()
+    assert len(rows) == 1, "second pass must upsert, not insert"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_ignores_queries_outside_the_bucket(
+    db_session: AsyncSession,
+) -> None:
+    server = await _make_dns_server(db_session)
+    bucket = floor_hour(datetime.now(UTC))
+    await _seed_queries(
+        db_session,
+        server.id,
+        _tunnel_rows(120),
+        ts=bucket - timedelta(hours=3),
+        client="10.0.0.9",
+    )
+    written = await aggregate_window(db_session, window_start=bucket)
+    assert written == 0

--- a/backend/tests/test_dns_threat.py
+++ b/backend/tests/test_dns_threat.py
@@ -438,3 +438,130 @@ async def test_mute_requires_a_reason(client: AsyncClient, db_session: AsyncSess
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 422
+
+
+async def _enable_module(db: AsyncSession) -> None:
+    """The /dns-threat prefix is module-gated and default-off."""
+    from app.models.feature_module import FeatureModule
+
+    db.add(FeatureModule(id="security.dns_threat", enabled=True))
+    await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_mute_create_then_update_is_an_upsert(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Re-muting revises the decision rather than stacking rows that
+    disagree about when the mute ends."""
+    from app.models.dns_threat_mute import DNSThreatMute
+
+    await _enable_module(db_session)
+    _, token = await _make_user(db_session, username="muteupsert")
+    h = {"Authorization": f"Bearer {token}"}
+
+    r1 = await client.post(
+        "/api/v1/dns-threat/mutes",
+        json={"client_ip": "10.0.0.5", "reason": "first pass"},
+        headers=h,
+    )
+    assert r1.status_code == 201
+    r2 = await client.post(
+        "/api/v1/dns-threat/mutes",
+        json={"client_ip": "10.0.0.5", "reason": "actually the backup agent"},
+        headers=h,
+    )
+    assert r2.status_code == 201
+    rows = (await db_session.execute(select(DNSThreatMute))).scalars().all()
+    assert len(rows) == 1, "second mute must update, not stack"
+    assert rows[0].reason == "actually the backup agent"
+
+
+@pytest.mark.asyncio
+async def test_mute_and_unmute_are_audited(client: AsyncClient, db_session: AsyncSession) -> None:
+    """Non-negotiable #4 — muting suppresses a critical alert, so the
+    decision has to be reviewable afterwards."""
+    from app.models.audit import AuditLog
+
+    await _enable_module(db_session)
+    _, token = await _make_user(db_session, username="muteaudit")
+    h = {"Authorization": f"Bearer {token}"}
+
+    await client.post(
+        "/api/v1/dns-threat/mutes",
+        json={"client_ip": "10.0.0.6", "reason": "reviewed, benign"},
+        headers=h,
+    )
+    await client.delete("/api/v1/dns-threat/mutes/10.0.0.6", headers=h)
+
+    actions = (
+        (
+            await db_session.execute(
+                select(AuditLog.action).where(AuditLog.resource_type == "dns_client")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert "dns_threat_mute_create" in actions
+    assert "dns_threat_mute_delete" in actions
+
+
+@pytest.mark.asyncio
+async def test_unmute_missing_returns_404(client: AsyncClient, db_session: AsyncSession) -> None:
+    await _enable_module(db_session)
+    _, token = await _make_user(db_session, username="mutemissing")
+    res = await client.delete(
+        "/api/v1/dns-threat/mutes/10.0.0.7",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_mute_rejects_a_hostname(client: AsyncClient, db_session: AsyncSession) -> None:
+    """The column is INET; an unvalidated string is a 500, not a 422."""
+    await _enable_module(db_session)
+    _, token = await _make_user(db_session, username="mutehostname")
+    res = await client.post(
+        "/api/v1/dns-threat/mutes",
+        json={"client_ip": "web-01.corp.example.com", "reason": "not an ip"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_muted_client_drops_out_of_summary_and_windows(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Muting must clear the client everywhere an operator looks, not
+    only in the alert — the mute dialog promises exactly that."""
+    await _enable_module(db_session)
+    _, token = await _make_user(db_session, username="mutesurfaces")
+    h = {"Authorization": f"Bearer {token}"}
+
+    server = await _make_dns_server(db_session)
+    bucket = floor_hour(datetime.now(UTC))
+    await _seed_queries(db_session, server.id, _tunnel_rows(200), ts=bucket, client="10.0.0.8")
+    await aggregate_window(db_session, window_start=bucket)
+
+    before = (await client.get("/api/v1/dns-threat/summary", headers=h)).json()
+    assert before["suspicious_clients"] >= 1
+    assert before["worst_client_ip"] == "10.0.0.8"
+
+    await client.post(
+        "/api/v1/dns-threat/mutes",
+        json={"client_ip": "10.0.0.8", "reason": "reviewed"},
+        headers=h,
+    )
+
+    after = (await client.get("/api/v1/dns-threat/summary", headers=h)).json()
+    assert after["worst_client_ip"] != "10.0.0.8"
+    listed = (await client.get("/api/v1/dns-threat/windows", headers=h)).json()
+    assert all(
+        w["client_ip"] != "10.0.0.8" for w in listed
+    ), "a muted client must not appear in the default findings list"
+    # ...but stays reachable when explicitly asked for.
+    shown = (await client.get("/api/v1/dns-threat/windows?include_muted=true", headers=h)).json()
+    assert any(w["client_ip"] == "10.0.0.8" and w["muted"] for w in shown)

--- a/backend/tests/test_dns_threat.py
+++ b/backend/tests/test_dns_threat.py
@@ -78,10 +78,16 @@ def test_entropy_separates_encoded_payload_from_words() -> None:
     assert shannon_entropy(encoded) > shannon_entropy("intranet")
 
 
-def test_split_qname_handles_two_part_public_suffixes() -> None:
-    assert split_qname("a.b.example.co.uk") == ("a", "example.co.uk")
-    assert split_qname("x.example.com") == ("x", "example.com")
-    assert split_qname("single.com") == ("", "single.com")
+def test_split_qname_returns_every_subdomain_label() -> None:
+    """All labels above the parent, not just the leftmost.
+
+    dnscat2 and dnsteal chunk payload across several labels; scoring
+    only ``labels[0]`` let them evade the length and entropy signals
+    entirely while still fanning out.
+    """
+    assert split_qname("a.b.example.co.uk") == (["a", "b"], "example.co.uk")
+    assert split_qname("x.example.com") == (["x"], "example.com")
+    assert split_qname("single.com") == ([], "single.com")
 
 
 def test_allowlist_matches_full_name_not_derived_parent() -> None:
@@ -157,6 +163,63 @@ def test_score_is_bounded() -> None:
     """Weights sum to 100; nothing may exceed it however extreme."""
     extreme = [(f"{'z' * 63}.{i}.evil.example", "NULL", "s") for i in range(5000)]
     assert score_tunneling(extract_features(extreme)).score <= 100.0
+
+
+def test_multi_label_payload_is_not_evaded() -> None:
+    """Payload split across labels must still register on length."""
+    name = "_acme-challenge.some-really-long-generated-hostname-123456.corp.example.com"
+    feats = extract_features([(name, "TXT", "s")] * 40)
+    assert feats.max_label_length == 42, "must measure the longest SUBDOMAIN label"
+
+
+def test_benign_padding_cannot_dilute_the_signal() -> None:
+    """Ratios divide by scoreable queries, not the raw total.
+
+    Otherwise an attacker suppresses their own payload-qtype ratio for
+    free by emitting DNSBL-shaped noise alongside the tunnel.
+    """
+    tunnel = _tunnel_rows(200)
+    alone = extract_features(tunnel)
+    padded = extract_features(tunnel + _dnsbl_rows(400))
+    assert alone.payload_qtype_ratio == padded.payload_qtype_ratio == 1.0
+    assert score_tunneling(alone).score == score_tunneling(padded).score
+
+
+def test_minimum_sample_gate_counts_only_scoreable_queries() -> None:
+    """24 real queries padded with 1000 benign ones is still 24 samples."""
+    rows = _tunnel_rows(MIN_QUERIES_TO_SCORE - 1) + _dnsbl_rows(1000)
+    verdict = score_tunneling(extract_features(rows))
+    assert verdict.score == 0.0
+    assert verdict.signals[0].name == "insufficient_data"
+
+
+def test_unparseable_queries_never_read_as_cleared() -> None:
+    """A query-log parser regression must not render as a clean bill of
+    health — every surface hides allowlisted rows by default."""
+    feats = extract_features([(None, "A", "s")] * 100)
+    assert feats.allowlisted is False, "unparseable is a data problem, not a clearance"
+    verdict = score_tunneling(feats)
+    assert verdict.score == 0.0
+    assert verdict.signals[0].name == "unparseable_queries"
+
+
+def test_kubernetes_service_discovery_is_allowlisted() -> None:
+    """SpatiumDDI's own appliance is a k3s cluster; without this the
+    platform flags its own nodes."""
+    rows = [(f"pod-{i}-abc123def456.svc.cluster.local", "A", "s") for i in range(900)]
+    feats = extract_features(rows)
+    assert feats.allowlisted is True
+    assert score_tunneling(feats).score == 0.0
+
+
+def test_signals_carry_their_own_ceiling() -> None:
+    """The UI draws each bar against its signal's maximum, and weights
+    differ (30/25/30/15)."""
+    verdict = score_tunneling(extract_features(_tunnel_rows()))
+    for sig in verdict.signals:
+        assert sig.max_contribution > 0
+        assert sig.contribution <= sig.max_contribution + 1e-9
+    assert sum(s.max_contribution for s in verdict.signals) == 100.0
 
 
 # ── rollup ────────────────────────────────────────────────────────────

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8106,6 +8106,21 @@ export interface DNSClientWindow {
   tunnel_signals: DNSTunnelSignal[];
   allowlisted: boolean;
   server_count: number;
+  /** An operator reviewed this client and cleared it (#699). */
+  muted: boolean;
+  mute_reason: string | null;
+  mute_until: string | null;
+}
+
+export interface DNSThreatMute {
+  id: string;
+  client_ip: string;
+  reason: string;
+  muted_until: string | null;
+  muted_by_display: string;
+  created_at: string;
+  /** False once an expiring mute has lapsed — the row is kept for audit. */
+  active: boolean;
 }
 
 export interface DNSTunnelSignal {
@@ -8149,6 +8164,18 @@ export const dnsThreatApi = {
   summary: (params?: { hours?: number; min_score?: number }) =>
     api
       .get<DNSThreatSummary>("/dns-threat/summary", { params })
+      .then((r) => r.data),
+  listMutes: () =>
+    api.get<DNSThreatMute[]>("/dns-threat/mutes").then((r) => r.data),
+  /** Muting a client hides its findings AND stops the alert firing. */
+  mute: (body: {
+    client_ip: string;
+    reason: string;
+    muted_until?: string | null;
+  }) => api.post<DNSThreatMute>("/dns-threat/mutes", body).then((r) => r.data),
+  unmute: (clientIp: string) =>
+    api
+      .delete<void>(`/dns-threat/mutes/${encodeURIComponent(clientIp)}`)
       .then((r) => r.data),
 };
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8088,6 +8088,68 @@ export interface DNSQueryAnalyticsResponse {
   top_views?: DNSQueryAnalyticsRow[];
 }
 
+/** One scored per-client DNS behaviour window (issue #699). */
+export interface DNSClientWindow {
+  id: string;
+  client_ip: string;
+  window_start: string;
+  window_end: string;
+  query_count: number;
+  distinct_qnames: number;
+  distinct_parents: number;
+  top_parent: string | null;
+  top_parent_subdomains: number;
+  max_label_length: number;
+  mean_label_entropy: number;
+  payload_qtype_count: number;
+  tunnel_score: number;
+  tunnel_signals: DNSTunnelSignal[];
+  allowlisted: boolean;
+  server_count: number;
+}
+
+export interface DNSTunnelSignal {
+  name: string;
+  value: number;
+  contribution: number;
+  detail: string;
+}
+
+export interface DNSThreatSummary {
+  windows_scored: number;
+  clients_seen: number;
+  suspicious_clients: number;
+  peak_score: number;
+  worst_client_ip: string | null;
+  worst_client_score: number | null;
+  worst_client_parent: string | null;
+  since: string;
+  /** False when the rollup has produced nothing — "no data" is not "no threats". */
+  has_data: boolean;
+}
+
+/**
+ * DNS threat analytics (#699). The whole prefix 404s unless the
+ * default-off ``security.dns_threat`` module is enabled, so callers
+ * must treat a 404 as "feature off", not as an error.
+ */
+export const dnsThreatApi = {
+  listWindows: (params?: {
+    client_ip?: string;
+    hours?: number;
+    min_score?: number;
+    include_allowlisted?: boolean;
+    limit?: number;
+  }) =>
+    api
+      .get<DNSClientWindow[]>("/dns-threat/windows", { params })
+      .then((r) => r.data),
+  summary: (params?: { hours?: number; min_score?: number }) =>
+    api
+      .get<DNSThreatSummary>("/dns-threat/summary", { params })
+      .then((r) => r.data),
+};
+
 export const logsApi = {
   listSources: () => api.get<LogSource[]>("/logs/sources").then((r) => r.data),
   listAgentSources: () =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8112,6 +8112,8 @@ export interface DNSTunnelSignal {
   name: string;
   value: number;
   contribution: number;
+  /** This signal's maximum possible contribution — weights differ per signal. */
+  max_contribution: number;
   detail: string;
 }
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3996,7 +3996,7 @@ function DNSThreatCard() {
           </p>
         </div>
         <Link
-          to="/logs"
+          to="/logs?tab=dns-threat"
           className="shrink-0 text-xs text-primary hover:underline"
         >
           View →

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -63,6 +63,7 @@ import {
   alertsApi,
   conformityApi,
   dashboardsApi,
+  dnsThreatApi,
   tlsCertsApi,
   newDeviceApi,
   lookingGlassApi,
@@ -3957,6 +3958,91 @@ function IntegrationCard({ panel }: { panel: IntegrationsDashboardPanel }) {
 
 // ── Security dashboard tab (issue #109) ─────────────────────────────
 //
+/**
+ * DNS tunneling rollup card on the Security tab (#699).
+ *
+ * Deliberately silent when the feature module is off (the endpoint
+ * 404s), and deliberately LOUD when it is on but has scored nothing —
+ * "no data" and "no threats" look identical on a dashboard unless you
+ * say which one you mean, and only one of them is reassuring.
+ */
+function DNSThreatCard() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["dashboards", "dns-threat"],
+    queryFn: () => dnsThreatApi.summary({ hours: 24 }),
+    refetchInterval: 60_000,
+    retry: false,
+  });
+
+  const moduleOff =
+    (error as { response?: { status?: number } } | null)?.response?.status ===
+    404;
+  if (moduleOff || isLoading) return null;
+  if (!data) return null;
+
+  const tone: Tone = !data.has_data
+    ? "warn"
+    : data.suspicious_clients > 0
+      ? "bad"
+      : "good";
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold">DNS tunneling (24 h)</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Clients scored for exfiltration-shaped DNS behaviour
+          </p>
+        </div>
+        <Link
+          to="/logs"
+          className="shrink-0 text-xs text-primary hover:underline"
+        >
+          View →
+        </Link>
+      </div>
+
+      {!data.has_data ? (
+        <p className="mt-3 text-xs text-amber-600 dark:text-amber-400">
+          Nothing scored yet — this is <strong>not</strong> an all-clear. The
+          rollup needs query logging enabled on a DNS server group.
+        </p>
+      ) : (
+        <>
+          <div className="mt-3 flex items-baseline gap-2">
+            <span
+              className={
+                tone === "bad"
+                  ? "text-2xl font-semibold text-rose-600 dark:text-rose-400"
+                  : "text-2xl font-semibold text-emerald-600 dark:text-emerald-400"
+              }
+            >
+              {data.suspicious_clients}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              suspicious of {data.clients_seen} client(s) scored
+            </span>
+          </div>
+          {data.worst_client_ip && data.worst_client_score != null && (
+            <p className="mt-2 break-words text-xs text-muted-foreground">
+              Worst: <span className="font-mono">{data.worst_client_ip}</span>{" "}
+              at {data.worst_client_score.toFixed(0)}/100
+              {data.worst_client_parent && (
+                <>
+                  {" "}
+                  on{" "}
+                  <span className="font-mono">{data.worst_client_parent}</span>
+                </>
+              )}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 // MFA coverage / API token expiry / failed-login bursts / recent
 // permission changes. Single rollup endpoint at
 // /dashboards/security/summary to keep the front end down to one
@@ -3986,6 +4072,7 @@ function SecurityPanel() {
 
   return (
     <div className="space-y-5">
+      <DNSThreatCard />
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         <Link
           to="/admin/users"

--- a/frontend/src/pages/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage.tsx
@@ -12,6 +12,7 @@ import {
   RefreshCw,
   Search,
   ScrollText,
+  ShieldAlert,
   Server,
   XCircle,
 } from "lucide-react";
@@ -26,6 +27,7 @@ import {
   type LogSource,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { DNSThreatTab } from "./logs/DNSThreatTab";
 
 /**
  * Logs page — central log viewer.
@@ -62,7 +64,7 @@ import { cn } from "@/lib/utils";
  * DC, 5 s for the agent tabs since their backing rows update live.
  */
 
-type Tab = "dns-queries" | "dhcp-activity" | "events" | "audit";
+type Tab = "dns-queries" | "dns-threat" | "dhcp-activity" | "events" | "audit";
 
 export function LogsPage() {
   const [tab, setTab] = useState<Tab>("dns-queries");
@@ -160,6 +162,13 @@ export function LogsPage() {
             count={dnsAgentSources.length || undefined}
           />
           <TabButton
+            active={tab === "dns-threat"}
+            onClick={() => setTab("dns-threat")}
+            icon={ShieldAlert}
+            label="DNS Threat"
+            hint="Per-client tunneling / exfiltration scoring over the query log. Requires the security.dns_threat module (default off — it reads query content)."
+          />
+          <TabButton
             active={tab === "dhcp-activity"}
             onClick={() => setTab("dhcp-activity")}
             icon={Activity}
@@ -190,6 +199,7 @@ export function LogsPage() {
       </div>
 
       {tab === "dns-queries" && <DNSQueriesTab sources={dnsAgentSources} />}
+      {tab === "dns-threat" && <DNSThreatTab />}
       {tab === "dhcp-activity" && (
         <DHCPActivityTab sources={dhcpAgentSources} />
       )}

--- a/frontend/src/pages/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useSearchParams } from "react-router-dom";
 import {
   Activity,
   AlertTriangle,
@@ -66,8 +67,29 @@ import { DNSThreatTab } from "./logs/DNSThreatTab";
 
 type Tab = "dns-queries" | "dns-threat" | "dhcp-activity" | "events" | "audit";
 
+const TABS: readonly Tab[] = [
+  "dns-queries",
+  "dns-threat",
+  "dhcp-activity",
+  "events",
+  "audit",
+] as const;
+
 export function LogsPage() {
-  const [tab, setTab] = useState<Tab>("dns-queries");
+  // ``?tab=`` entry point so other surfaces can deep-link a specific
+  // tab — the Security dashboard's DNS-tunneling card needs to land on
+  // DNS Threat, and without this it silently opened DNS Queries
+  // instead. Kept in the URL (not just state) so the link is
+  // shareable and survives a refresh.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requested = searchParams.get("tab") as Tab | null;
+  const tab: Tab =
+    requested && TABS.includes(requested) ? requested : "dns-queries";
+  const setTab = (next: Tab) => {
+    const params = new URLSearchParams(searchParams);
+    params.set("tab", next);
+    setSearchParams(params, { replace: true });
+  };
 
   // Two source lists: Windows servers (Event Log + DHCP Audit) and
   // agent-driven servers (DNS Queries + DHCP Activity). They're

--- a/frontend/src/pages/logs/DNSThreatTab.tsx
+++ b/frontend/src/pages/logs/DNSThreatTab.tsx
@@ -118,16 +118,21 @@ export function DNSThreatTab() {
   // client and cleared it" rather than wondering why a chatty host
   // never appears at all.
   const [showAllowlisted, setShowAllowlisted] = useState(false);
+  const [showMutes, setShowMutes] = useState(false);
   const [inspecting, setInspecting] = useState<string | null>(null);
   const [muting, setMuting] = useState<string | null>(null);
   const qc = useQueryClient();
   const refreshAll = () => {
     void qc.invalidateQueries({ queryKey: ["dns-threat-windows"] });
     void qc.invalidateQueries({ queryKey: ["dns-threat-summary"] });
+    void qc.invalidateQueries({ queryKey: ["dns-threat-mutes"] });
   };
   const unmute = useMutation({
     mutationFn: (ip: string) => dnsThreatApi.unmute(ip),
-    onSuccess: refreshAll,
+    onSuccess: () => {
+      refreshAll();
+      void qc.invalidateQueries({ queryKey: ["dns-threat-mutes"] });
+    },
   });
 
   const q = useQuery({
@@ -209,6 +214,14 @@ export function DNSThreatTab() {
             <option value={60}>60 — likely tunnel</option>
           </select>
         </div>
+        <button
+          type="button"
+          onClick={() => setShowMutes((v) => !v)}
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+        >
+          <BellOff className="h-4 w-4" />
+          Muted clients
+        </button>
         <label className="flex items-center gap-1.5 text-xs">
           <input
             type="checkbox"
@@ -320,6 +333,13 @@ export function DNSThreatTab() {
             </tbody>
           </table>
         </div>
+      )}
+
+      {showMutes && (
+        <MutedClientsPanel
+          onUnmute={(ip) => unmute.mutate(ip)}
+          error={unmute.error as Error | null}
+        />
       )}
 
       {muting && (
@@ -714,5 +734,90 @@ function MuteModal({
         </div>
       </div>
     </Modal>
+  );
+}
+
+/**
+ * The muted-clients list.
+ *
+ * Without it, the only Unmute affordance was a button on a listed
+ * window row — so an indefinite mute became unreachable the moment the
+ * client stopped scoring (or its windows aged past the 30-day prune),
+ * permanently suppressing a critical alert with no way to discover or
+ * revoke it short of a psql session.
+ */
+function MutedClientsPanel({
+  onUnmute,
+  error,
+}: {
+  onUnmute: (ip: string) => void;
+  error: Error | null;
+}) {
+  const q = useQuery({
+    queryKey: ["dns-threat-mutes"],
+    queryFn: () => dnsThreatApi.listMutes(),
+    retry: false,
+  });
+  const rows = q.data ?? [];
+
+  return (
+    <section className="rounded-lg border bg-card">
+      <div className="border-b px-4 py-3">
+        <h3 className="text-sm font-semibold">Muted clients</h3>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Reviewed and cleared. These do not appear in the findings list and do
+          not fire the tunneling alert. Expired mutes are kept — they explain
+          why a client started appearing again.
+        </p>
+      </div>
+      {error && (
+        <p className="border-b px-4 py-2 text-xs text-rose-600 dark:text-rose-400">
+          Could not un-mute: {error.message}
+        </p>
+      )}
+      {q.isLoading ? (
+        <p className="px-4 py-4 text-sm text-muted-foreground">
+          Loading&hellip;
+        </p>
+      ) : rows.length === 0 ? (
+        <p className="px-4 py-4 text-sm text-muted-foreground">
+          No clients are muted.
+        </p>
+      ) : (
+        <ul className="divide-y">
+          {rows.map((m) => (
+            <li
+              key={m.id}
+              className="flex flex-wrap items-center gap-2 px-4 py-2 text-xs"
+            >
+              <span className="font-mono">{m.client_ip}</span>
+              {!m.active && (
+                <span className="rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
+                  expired
+                </span>
+              )}
+              <span className="min-w-0 flex-1 break-words text-muted-foreground">
+                {m.reason}
+              </span>
+              <span className="shrink-0 text-muted-foreground">
+                {m.muted_until
+                  ? `until ${new Date(m.muted_until).toLocaleDateString()}`
+                  : "indefinite"}
+                {m.muted_by_display && ` · ${m.muted_by_display}`}
+              </span>
+              {m.active && (
+                <button
+                  type="button"
+                  onClick={() => onUnmute(m.client_ip)}
+                  className="shrink-0 rounded-md border px-2.5 py-1 hover:bg-accent"
+                >
+                  Unmute
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }

--- a/frontend/src/pages/logs/DNSThreatTab.tsx
+++ b/frontend/src/pages/logs/DNSThreatTab.tsx
@@ -1,0 +1,362 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+  ShieldQuestion,
+} from "lucide-react";
+
+import {
+  dnsThreatApi,
+  type DNSClientWindow,
+  type DNSTunnelSignal,
+} from "@/lib/api";
+
+/**
+ * Logs → DNS Threat (issue #699).
+ *
+ * Scored per-client windows, worst first. DNS tunneling hides payload
+ * in the names a host looks up, under a domain the attacker's own
+ * server answers for — it is the exfiltration path a firewall never
+ * inspects.
+ *
+ * Two framing decisions worth keeping:
+ *
+ * 1. **An empty list is not an all-clear.** The rollup only has rows
+ *    when the default-off module is on AND a DNS group has query
+ *    logging enabled, so "nothing here" has two very different
+ *    meanings. The empty state says which one it is rather than
+ *    rendering a reassuring blank.
+ * 2. **The score always shows its working.** Every signal is listed
+ *    with its contribution, including the ones that scored zero, so an
+ *    operator can see what was considered — "your entropy is fine,
+ *    it's the fan-out that's odd" beats a bare 62.
+ *
+ * #699 asks for a deep link from a finding to the IP detail modal.
+ * Not wired yet: the IPAM page accepts ``?subnet=`` / ``?block=`` /
+ * ``?space=`` but has no parameter that opens a specific address, and
+ * a button that silently does nothing is worse than no button. Needs
+ * an ``?ip=`` entry point on IPAMPage first.
+ */
+
+const SCORE_BANDS = [
+  { min: 60, label: "Likely tunnel", cls: "text-rose-600 dark:text-rose-400" },
+  { min: 40, label: "Suspicious", cls: "text-amber-600 dark:text-amber-400" },
+  {
+    min: 20,
+    label: "Worth a look",
+    cls: "text-yellow-600 dark:text-yellow-500",
+  },
+] as const;
+
+function band(score: number) {
+  return (
+    SCORE_BANDS.find((b) => score >= b.min) ?? {
+      label: "Low",
+      cls: "text-muted-foreground",
+    }
+  );
+}
+
+function ScoreCell({ score }: { score: number }) {
+  const b = band(score);
+  return (
+    <div className="flex items-center gap-2">
+      <span className={`font-mono text-sm font-semibold ${b.cls}`}>
+        {score.toFixed(0)}
+      </span>
+      <span className={`text-xs ${b.cls}`}>{b.label}</span>
+    </div>
+  );
+}
+
+function SignalBar({ signal }: { signal: DNSTunnelSignal }) {
+  // Contributions are already weighted out of 100 in total, so the bar
+  // is drawn against the signal's own ceiling rather than the score.
+  const pct = Math.max(0, Math.min(100, signal.contribution * 3));
+  return (
+    <li className="py-1">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="font-mono text-xs">{signal.name}</span>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          +{signal.contribution.toFixed(1)}
+        </span>
+      </div>
+      <div className="mt-0.5 h-1 w-full overflow-hidden rounded bg-muted">
+        <div
+          className={
+            signal.contribution > 0 ? "h-full bg-amber-500" : "h-full bg-muted"
+          }
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="mt-0.5 break-words text-xs text-muted-foreground">
+        {signal.detail}
+      </p>
+    </li>
+  );
+}
+
+export function DNSThreatTab() {
+  const [hours, setHours] = useState(24);
+  const [minScore, setMinScore] = useState(20);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const q = useQuery({
+    queryKey: ["dns-threat-windows", hours, minScore],
+    queryFn: () =>
+      dnsThreatApi.listWindows({ hours, min_score: minScore, limit: 200 }),
+    retry: false,
+  });
+  const summaryQ = useQuery({
+    queryKey: ["dns-threat-summary", hours],
+    queryFn: () => dnsThreatApi.summary({ hours }),
+    retry: false,
+  });
+
+  // A 404 here means the feature module is off, not that something
+  // broke — the router include is module-gated.
+  const moduleOff =
+    (q.error as { response?: { status?: number } } | null)?.response?.status ===
+    404;
+
+  const rows = q.data ?? [];
+  const summary = summaryQ.data;
+
+  if (moduleOff) {
+    return (
+      <div className="rounded-lg border bg-card p-6">
+        <div className="flex items-start gap-3">
+          <ShieldQuestion className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+          <div>
+            <h3 className="text-sm font-semibold">
+              DNS threat analytics is off
+            </h3>
+            <p className="mt-1 max-w-2xl text-xs text-muted-foreground">
+              Scoring reads the <strong>names your clients look up</strong>, so
+              it is disabled by default rather than switched on by an upgrade.
+              Enable the <strong>Security → DNS threat analytics</strong> module
+              in Settings to turn it on. It also needs query logging enabled on
+              at least one DNS server group before there is anything to score.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-end gap-3 rounded-lg border bg-card px-4 py-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium">Window</label>
+          <select
+            value={hours}
+            onChange={(e) => setHours(Number(e.target.value))}
+            className="rounded-md border bg-background px-2 py-1.5 text-sm"
+          >
+            <option value={6}>Last 6 hours</option>
+            <option value={24}>Last 24 hours</option>
+            <option value={72}>Last 3 days</option>
+            <option value={168}>Last 7 days</option>
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium">
+            Minimum score
+          </label>
+          <select
+            value={minScore}
+            onChange={(e) => setMinScore(Number(e.target.value))}
+            className="rounded-md border bg-background px-2 py-1.5 text-sm"
+          >
+            <option value={0}>Everything (noisy)</option>
+            <option value={20}>20 — worth a look</option>
+            <option value={40}>40 — suspicious</option>
+            <option value={60}>60 — likely tunnel</option>
+          </select>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            void q.refetch();
+            void summaryQ.refetch();
+          }}
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </button>
+
+        {summary && (
+          <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+            {summary.has_data ? (
+              <>
+                <ShieldCheck className="h-4 w-4" />
+                {summary.windows_scored} windows · {summary.clients_seen}{" "}
+                clients scored
+              </>
+            ) : (
+              <>
+                <AlertTriangle className="h-4 w-4 text-amber-500" />
+                No windows scored yet
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {q.isLoading ? (
+        <div className="flex items-center gap-2 rounded-lg border bg-card px-4 py-6 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Scoring&hellip;
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="rounded-lg border bg-card p-6">
+          <div className="flex items-start gap-3">
+            {summary?.has_data ? (
+              <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+            ) : (
+              <ShieldQuestion className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+            )}
+            <div>
+              <h3 className="text-sm font-semibold">
+                {summary?.has_data
+                  ? "Nothing scoring above the threshold"
+                  : "No data to score yet"}
+              </h3>
+              <p className="mt-1 max-w-2xl text-xs text-muted-foreground">
+                {summary?.has_data ? (
+                  <>
+                    {summary.clients_seen} client(s) were scored over this
+                    window and none crossed {minScore}. Lower the minimum score
+                    to see the full picture.
+                  </>
+                ) : (
+                  <>
+                    The rollup has scored nothing in this period, which is{" "}
+                    <strong>not the same as an all-clear</strong>. Check that a
+                    DNS server group has query logging enabled — without it
+                    there are no queries to analyse.
+                  </>
+                )}
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border bg-card">
+          <table className="w-full min-w-[820px] text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs text-muted-foreground">
+                <th className="px-4 py-2 font-medium">Score</th>
+                <th className="px-4 py-2 font-medium">Client</th>
+                <th className="px-4 py-2 font-medium">Window</th>
+                <th className="px-4 py-2 font-medium">Queries</th>
+                <th className="px-4 py-2 font-medium">Concentrated on</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((w) => (
+                <Row
+                  key={w.id}
+                  w={w}
+                  open={expanded.has(w.id)}
+                  onToggle={() =>
+                    setExpanded((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(w.id)) next.delete(w.id);
+                      else next.add(w.id);
+                      return next;
+                    })
+                  }
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({
+  w,
+  open,
+  onToggle,
+}: {
+  w: DNSClientWindow;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const Chevron = open ? ChevronDown : ChevronRight;
+  return (
+    <>
+      <tr className="border-b last:border-0">
+        <td className="px-4 py-2">
+          <ScoreCell score={w.tunnel_score} />
+        </td>
+        <td className="px-4 py-2 font-mono text-xs">{w.client_ip}</td>
+        <td className="px-4 py-2 text-xs text-muted-foreground">
+          {new Date(w.window_start).toLocaleString()}
+        </td>
+        <td className="px-4 py-2 text-xs">
+          {w.query_count.toLocaleString()}
+          <span className="ml-1 text-muted-foreground">
+            ({w.distinct_qnames.toLocaleString()} unique)
+          </span>
+        </td>
+        <td className="px-4 py-2 text-xs">
+          {w.top_parent ? (
+            <>
+              <span className="font-mono">{w.top_parent}</span>
+              <span className="ml-1 text-muted-foreground">
+                ({w.top_parent_subdomains} subdomains)
+              </span>
+            </>
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          )}
+        </td>
+        <td className="px-4 py-2">
+          <div className="flex justify-end gap-1.5">
+            <button
+              type="button"
+              onClick={onToggle}
+              className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-accent"
+            >
+              <Chevron className="h-3 w-3" />
+              Why
+            </button>
+          </div>
+        </td>
+      </tr>
+      {open && (
+        <tr className="border-b last:border-0">
+          <td colSpan={6} className="bg-muted/30 px-4 py-3">
+            <p className="mb-2 text-xs text-muted-foreground">
+              Every signal is listed, including those contributing nothing —
+              what was <em>ruled out</em> matters as much as what fired.
+            </p>
+            <ul className="max-w-3xl">
+              {w.tunnel_signals.map((s) => (
+                <SignalBar key={s.name} signal={s} />
+              ))}
+            </ul>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Longest label {w.max_label_length} chars · mean entropy{" "}
+              {w.mean_label_entropy.toFixed(2)} bits/char ·{" "}
+              {w.payload_qtype_count} payload-bearing qtypes · seen by{" "}
+              {w.server_count} server(s)
+            </p>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/logs/DNSThreatTab.tsx
+++ b/frontend/src/pages/logs/DNSThreatTab.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
   ChevronDown,
   ChevronRight,
   Loader2,
   RefreshCw,
+  BellOff,
   Search,
   ShieldCheck,
   ShieldQuestion,
@@ -118,6 +119,16 @@ export function DNSThreatTab() {
   // never appears at all.
   const [showAllowlisted, setShowAllowlisted] = useState(false);
   const [inspecting, setInspecting] = useState<string | null>(null);
+  const [muting, setMuting] = useState<string | null>(null);
+  const qc = useQueryClient();
+  const refreshAll = () => {
+    void qc.invalidateQueries({ queryKey: ["dns-threat-windows"] });
+    void qc.invalidateQueries({ queryKey: ["dns-threat-summary"] });
+  };
+  const unmute = useMutation({
+    mutationFn: (ip: string) => dnsThreatApi.unmute(ip),
+    onSuccess: refreshAll,
+  });
 
   const q = useQuery({
     queryKey: ["dns-threat-windows", hours, minScore, showAllowlisted],
@@ -302,11 +313,21 @@ export function DNSThreatTab() {
                     })
                   }
                   onInspect={() => setInspecting(w.client_ip)}
+                  onMute={() => setMuting(w.client_ip)}
+                  onUnmute={() => unmute.mutate(w.client_ip)}
                 />
               ))}
             </tbody>
           </table>
         </div>
+      )}
+
+      {muting && (
+        <MuteModal
+          clientIp={muting}
+          onClose={() => setMuting(null)}
+          onDone={refreshAll}
+        />
       )}
 
       {inspecting && (
@@ -325,11 +346,15 @@ function Row({
   open,
   onToggle,
   onInspect,
+  onMute,
+  onUnmute,
 }: {
   w: DNSClientWindow;
   open: boolean;
   onToggle: () => void;
   onInspect: () => void;
+  onMute: () => void;
+  onUnmute: () => void;
 }) {
   const Chevron = open ? ChevronDown : ChevronRight;
   return (
@@ -340,12 +365,25 @@ function Row({
           stays as the visible affordance that the row does something. */}
       <tr
         onClick={onToggle}
-        className="cursor-pointer border-b last:border-0 hover:bg-accent/40"
+        className={`cursor-pointer border-b last:border-0 hover:bg-accent/40 ${
+          w.muted ? "opacity-50" : ""
+        }`}
       >
         <td className="px-4 py-2">
           <ScoreCell score={w.tunnel_score} />
         </td>
-        <td className="px-4 py-2 font-mono text-xs">{w.client_ip}</td>
+        <td className="px-4 py-2 font-mono text-xs">
+          {w.client_ip}
+          {w.muted && (
+            <span
+              className="ml-1.5 inline-flex items-center gap-1 rounded bg-muted px-1 py-0.5 font-sans text-[10px] text-muted-foreground"
+              title={w.mute_reason ?? undefined}
+            >
+              <BellOff className="h-2.5 w-2.5" />
+              muted
+            </span>
+          )}
+        </td>
         <td className="px-4 py-2 text-xs text-muted-foreground">
           {new Date(w.window_start).toLocaleString()}
         </td>
@@ -371,6 +409,24 @@ function Row({
             toggle, or opening the modal would leave the panel flapping. */}
         <td className="px-4 py-2" onClick={(e) => e.stopPropagation()}>
           <div className="flex justify-end gap-1.5">
+            {w.muted ? (
+              <button
+                type="button"
+                onClick={onUnmute}
+                className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-accent"
+              >
+                Unmute
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={onMute}
+                className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-accent"
+              >
+                <BellOff className="h-3 w-3" />
+                Mute
+              </button>
+            )}
             <button
               type="button"
               onClick={onInspect}
@@ -393,6 +449,13 @@ function Row({
       {open && (
         <tr className="border-b last:border-0">
           <td colSpan={6} className="bg-muted/30 px-4 py-3">
+            {w.muted && w.mute_reason && (
+              <p className="mb-2 rounded border border-dashed px-2 py-1 text-xs text-muted-foreground">
+                <strong>Muted:</strong> {w.mute_reason}
+                {w.mute_until &&
+                  ` (until ${new Date(w.mute_until).toLocaleDateString()})`}
+              </p>
+            )}
             <p className="mb-2 text-xs text-muted-foreground">
               Every signal is listed, including those contributing nothing —
               what was <em>ruled out</em> matters as much as what fired.
@@ -536,5 +599,120 @@ function Stat({ label, value }: { label: string; value: string }) {
       <div className="text-xs text-muted-foreground">{label}</div>
       <div className="text-lg font-semibold">{value}</div>
     </div>
+  );
+}
+
+/**
+ * Clear a reviewed finding.
+ *
+ * A mute on the CLIENT, not a delete of the rows — deleting wouldn't
+ * stick (the aggregator recomputes recent hours and upserts) and would
+ * destroy evidence of what may be an exfiltration event. The reason is
+ * required, because an unexplained mute is how a real incident gets
+ * buried by someone tidying a dashboard.
+ */
+function MuteModal({
+  clientIp,
+  onClose,
+  onDone,
+}: {
+  clientIp: string;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const [reason, setReason] = useState("");
+  // Default to an expiring mute: a snap "this is fine" should age out
+  // and get re-examined rather than silently outlive whoever made it.
+  const [days, setDays] = useState<number | "forever">(30);
+
+  const save = useMutation({
+    mutationFn: () =>
+      dnsThreatApi.mute({
+        client_ip: clientIp,
+        reason,
+        muted_until:
+          days === "forever"
+            ? null
+            : new Date(Date.now() + days * 86400_000).toISOString(),
+      }),
+    onSuccess: () => {
+      onDone();
+      onClose();
+    },
+  });
+
+  return (
+    <Modal title={`Mute findings for ${clientIp}`} onClose={onClose}>
+      <div className="flex flex-col gap-3">
+        <p className="text-xs text-muted-foreground">
+          Hides this client from the Threat tab and stops the{" "}
+          <strong>DNS tunneling suspected</strong> alert firing for it. The
+          scored windows and their evidence are kept — muting records a
+          decision, it doesn&rsquo;t delete anything.
+        </p>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium">
+            Why is this expected? <span className="text-rose-500">*</span>
+          </label>
+          <textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={3}
+            placeholder="e.g. Veeam backup agent — chunks payload into subdomains by design"
+            className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Required. The next person to look at this host reads this instead of
+            re-investigating it.
+          </p>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium">Mute for</label>
+          <select
+            value={String(days)}
+            onChange={(e) =>
+              setDays(
+                e.target.value === "forever"
+                  ? "forever"
+                  : Number(e.target.value),
+              )
+            }
+            className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+          >
+            <option value={7}>7 days</option>
+            <option value={30}>30 days</option>
+            <option value={90}>90 days</option>
+            <option value="forever">Indefinitely</option>
+          </select>
+        </div>
+
+        {save.isError && (
+          <p className="text-xs text-rose-600 dark:text-rose-400">
+            {(save.error as Error).message}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={reason.trim().length < 3 || save.isPending}
+            onClick={() => save.mutate()}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {save.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            Mute client
+          </button>
+        </div>
+      </div>
+    </Modal>
   );
 }

--- a/frontend/src/pages/logs/DNSThreatTab.tsx
+++ b/frontend/src/pages/logs/DNSThreatTab.tsx
@@ -6,10 +6,12 @@ import {
   ChevronRight,
   Loader2,
   RefreshCw,
+  Search,
   ShieldCheck,
   ShieldQuestion,
 } from "lucide-react";
 
+import { Modal } from "@/components/ui/modal";
 import {
   dnsThreatApi,
   type DNSClientWindow,
@@ -115,6 +117,7 @@ export function DNSThreatTab() {
   // client and cleared it" rather than wondering why a chatty host
   // never appears at all.
   const [showAllowlisted, setShowAllowlisted] = useState(false);
+  const [inspecting, setInspecting] = useState<string | null>(null);
 
   const q = useQuery({
     queryKey: ["dns-threat-windows", hours, minScore, showAllowlisted],
@@ -298,11 +301,20 @@ export function DNSThreatTab() {
                       return next;
                     })
                   }
+                  onInspect={() => setInspecting(w.client_ip)}
                 />
               ))}
             </tbody>
           </table>
         </div>
+      )}
+
+      {inspecting && (
+        <ClientDetailModal
+          clientIp={inspecting}
+          hours={hours}
+          onClose={() => setInspecting(null)}
+        />
       )}
     </div>
   );
@@ -312,15 +324,24 @@ function Row({
   w,
   open,
   onToggle,
+  onInspect,
 }: {
   w: DNSClientWindow;
   open: boolean;
   onToggle: () => void;
+  onInspect: () => void;
 }) {
   const Chevron = open ? ChevronDown : ChevronRight;
   return (
     <>
-      <tr className="border-b last:border-0">
+      {/* The whole row toggles the evidence panel — scanning a list of
+          findings means opening and closing several in a row, and
+          hunting for a small button each time is friction. The button
+          stays as the visible affordance that the row does something. */}
+      <tr
+        onClick={onToggle}
+        className="cursor-pointer border-b last:border-0 hover:bg-accent/40"
+      >
         <td className="px-4 py-2">
           <ScoreCell score={w.tunnel_score} />
         </td>
@@ -346,8 +367,18 @@ function Row({
             <span className="text-muted-foreground">—</span>
           )}
         </td>
-        <td className="px-4 py-2">
+        {/* Clicks inside the action cell must not also fire the row's
+            toggle, or opening the modal would leave the panel flapping. */}
+        <td className="px-4 py-2" onClick={(e) => e.stopPropagation()}>
           <div className="flex justify-end gap-1.5">
+            <button
+              type="button"
+              onClick={onInspect}
+              className="inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs hover:bg-accent"
+            >
+              <Search className="h-3 w-3" />
+              Details
+            </button>
             <button
               type="button"
               onClick={onToggle}
@@ -381,5 +412,129 @@ function Row({
         </tr>
       )}
     </>
+  );
+}
+
+/**
+ * Per-client deep dive.
+ *
+ * Exists for the one question the inline evidence panel structurally
+ * cannot answer: **is this sustained?** A single hour at 70 is a
+ * curiosity; six consecutive hours at 70 is someone's data leaving the
+ * building. The row shows one window; this shows the client's whole
+ * retained history, newest first, so the shape is visible at a glance.
+ */
+function ClientDetailModal({
+  clientIp,
+  hours,
+  onClose,
+}: {
+  clientIp: string;
+  hours: number;
+  onClose: () => void;
+}) {
+  const q = useQuery({
+    queryKey: ["dns-threat-client", clientIp],
+    // Per-client fetch returns that client's full history regardless of
+    // score — a window that dropped back to 0 is part of the story.
+    queryFn: () =>
+      dnsThreatApi.listWindows({
+        client_ip: clientIp,
+        hours: Math.max(hours, 24 * 7),
+        include_allowlisted: true,
+        limit: 200,
+      }),
+  });
+  const rows = q.data ?? [];
+  const peak = rows.reduce((m, r) => Math.max(m, r.tunnel_score), 0);
+  const totalQueries = rows.reduce((n, r) => n + r.query_count, 0);
+  const scored = rows.filter((r) => r.tunnel_score > 0);
+
+  return (
+    <Modal title={`DNS behaviour — ${clientIp}`} onClose={onClose} wide>
+      {q.isLoading ? (
+        <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading history&hellip;
+        </div>
+      ) : rows.length === 0 ? (
+        <p className="py-6 text-sm text-muted-foreground">
+          No retained windows for this client.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Stat label="Peak score" value={peak.toFixed(0)} />
+            <Stat label="Windows retained" value={String(rows.length)} />
+            <Stat label="Windows scoring" value={String(scored.length)} />
+            <Stat label="Queries seen" value={totalQueries.toLocaleString()} />
+          </div>
+
+          <div>
+            <h4 className="mb-1 text-xs font-semibold">Score over time</h4>
+            <p className="mb-2 text-xs text-muted-foreground">
+              Newest first. A run of consecutive scoring hours is the signal
+              that matters — one-off spikes are usually noise.
+            </p>
+            <ul className="max-h-52 overflow-y-auto rounded border">
+              {rows.map((r) => (
+                <li
+                  key={r.id}
+                  className="flex items-center gap-2 border-b px-2 py-1 text-xs last:border-0"
+                >
+                  <span className="w-32 shrink-0 text-muted-foreground">
+                    {new Date(r.window_start).toLocaleString()}
+                  </span>
+                  <span className="h-1.5 flex-1 overflow-hidden rounded bg-muted">
+                    <span
+                      className={
+                        r.tunnel_score >= 60
+                          ? "block h-full bg-rose-500"
+                          : r.tunnel_score >= 20
+                            ? "block h-full bg-amber-500"
+                            : "block h-full bg-emerald-500/50"
+                      }
+                      style={{ width: `${Math.max(2, r.tunnel_score)}%` }}
+                    />
+                  </span>
+                  <span className="w-8 shrink-0 text-right font-mono">
+                    {r.tunnel_score.toFixed(0)}
+                  </span>
+                  <span className="w-40 shrink-0 truncate text-muted-foreground">
+                    {r.allowlisted ? "cleared (allowlisted)" : r.top_parent}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h4 className="mb-1 text-xs font-semibold">
+              Signals — most recent window
+            </h4>
+            <ul>
+              {(rows[0]?.tunnel_signals ?? []).map((sig) => (
+                <SignalBar key={sig.name} signal={sig} />
+              ))}
+            </ul>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            To see the actual names this client asked for, open the{" "}
+            <strong>DNS Queries</strong> tab and filter on{" "}
+            <span className="font-mono">{clientIp}</span>.
+          </p>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border px-2 py-1.5">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold">{value}</div>
+    </div>
   );
 }

--- a/frontend/src/pages/logs/DNSThreatTab.tsx
+++ b/frontend/src/pages/logs/DNSThreatTab.tsx
@@ -75,9 +75,14 @@ function ScoreCell({ score }: { score: number }) {
 }
 
 function SignalBar({ signal }: { signal: DNSTunnelSignal }) {
-  // Contributions are already weighted out of 100 in total, so the bar
-  // is drawn against the signal's own ceiling rather than the score.
-  const pct = Math.max(0, Math.min(100, signal.contribution * 3));
+  // Against the signal's OWN ceiling, which the backend reports:
+  // weights differ (30/25/30/15), so scaling every bar by the same
+  // factor made a fully-saturated payload-qtype signal render at 45%
+  // and nothing ever reach 100%.
+  const ceiling = signal.max_contribution || 0;
+  const pct = ceiling
+    ? Math.max(0, Math.min(100, (signal.contribution / ceiling) * 100))
+    : 0;
   return (
     <li className="py-1">
       <div className="flex items-baseline justify-between gap-2">
@@ -105,11 +110,21 @@ export function DNSThreatTab() {
   const [hours, setHours] = useState(24);
   const [minScore, setMinScore] = useState(20);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  // Allowlisted windows are hidden by default but reachable: the
+  // rollup keeps them so an operator can confirm "we looked at this
+  // client and cleared it" rather than wondering why a chatty host
+  // never appears at all.
+  const [showAllowlisted, setShowAllowlisted] = useState(false);
 
   const q = useQuery({
-    queryKey: ["dns-threat-windows", hours, minScore],
+    queryKey: ["dns-threat-windows", hours, minScore, showAllowlisted],
     queryFn: () =>
-      dnsThreatApi.listWindows({ hours, min_score: minScore, limit: 200 }),
+      dnsThreatApi.listWindows({
+        hours,
+        min_score: minScore,
+        include_allowlisted: showAllowlisted,
+        limit: 200,
+      }),
     retry: false,
   });
   const summaryQ = useQuery({
@@ -180,6 +195,14 @@ export function DNSThreatTab() {
             <option value={60}>60 — likely tunnel</option>
           </select>
         </div>
+        <label className="flex items-center gap-1.5 text-xs">
+          <input
+            type="checkbox"
+            checked={showAllowlisted}
+            onChange={(e) => setShowAllowlisted(e.target.checked)}
+          />
+          Show cleared (allowlisted)
+        </label>
         <button
           type="button"
           onClick={() => {


### PR DESCRIPTION
Ships the first slice of #699 — DNS tunneling detection — and, along the way, fixes a pre-existing agent bug (#704) without which #699 cannot work at all.

## Why

DNS tunneling (iodine, dnscat2, dnsteal) hides payload in the *names* a host looks up, under a domain the attacker's own server answers for. It is the exfiltration path a firewall never inspects. SpatiumDDI already parsed every BIND9 query into `dns_query_log_entry` — the detection was the missing part.

## What's here

**Per-client rollup.** `dns_client_window` (migration `d1a7c34e9b60`) holds one row per (client IP, hourly bucket). Feature columns are deliberately detection-agnostic so the deferred DGA and beaconing work scores off the same rollup rather than adding a second aggregation pass. Aggregated across servers — a host splitting queries over two resolvers is one suspicious host, not two half-suspicious ones. The summary outlives the 24 h raw rows, which is the entire point.

**Weighted 0–100 scorer** over four signals: label length, label entropy, subdomain fan-out under one parent, payload-qtype ratio. Weighted rather than rule-based because no single signal is sufficient — a CDN emits entropy, a mail server emits TXT, a busy host emits volume; tunnels emit all of it at once.

**Surfaces:** a `dns_tunneling_suspected` alert keyed on the client (one event per host, not per hour), `/api/v1/dns-threat/{windows,summary,readiness}`, a **Logs → DNS Threat** tab, a **Security dashboard** card, and 2 Operator Copilot tools.

**Default-off** behind `security.dns_threat` — on privacy grounds, not noise: scoring reads the names clients look up, and that is a posture operators should opt into rather than inherit from an upgrade.

## Validated against traffic, not just unit tests

The scorer was run against synthetic profiles *before* anything was built on top of it:

| Profile | Score |
|---|---|
| iodine-shaped tunnel | 86–92 |
| dnscat2-shaped (payload chunked across labels) | 41.8 |
| busy-but-benign, many parents | 15.9 |
| ordinary office traffic | 0 |
| own DNSBL sweep / k8s service discovery | 0 (allowlisted) |

**That exercise found a bug immediately:** the allowlist was matched against the derived two-label parent, so entries deeper than that never matched — and SpatiumDDI's own DNSBL sweep (`<ip>.zen.spamhaus.org`) scored as suspicious. The platform's first threat finding would have been itself. A tunnel *hidden inside* allowlisted traffic still scores 72, so the allowlist can't be used as cover.

Then end-to-end on real DNS: 650 `dig` queries → BIND9 query log → agent shipper → parser → rollup → **77.7**, with the alert firing and naming the top two signals.

## The agent bug (#704), fixed here

While testing end-to-end, enabling query logging on a running BIND9 agent did nothing — config rendered, log file created, named reconfigured, and `rndc status` still said `query logging is OFF`. A restart with the byte-identical config came up `ON`.

**The agent was starting `named` twice** (two `named_started` events, 118 ms apart). It hides because BIND uses `SO_REUSEPORT`: both instances bind :53 and :953 and the kernel load-balances, so `rndc` becomes a coin flip between them and per-process state like query logging appears to ignore commands.

**PowerDNS was then checked rather than assumed — it has the same bug**, manifesting differently: no `reuseport`, so the duplicate fails to bind and exits, and because the `Popen` handle is discarded it becomes a **zombie**. `daemon_pid` is left pointing at the corpse, and since `os.kill(zombie, 0)` succeeds, the driver reports a healthy daemon while tracking a dead process.

Blast radius went well beyond query logging: `rndc reload`/`reconfig`/`notify` reached one instance while the other served stale zone state, and DNSSEC operations could be applied to one and read back from the other. **Every BIND9 agent in the field is currently running two resolvers.**

Both drivers now share a `/proc`-based lookup that skips zombies, and both `daemon_running()` implementations check process state as well as signal 0.

## Review history

A `/code-review` pass produced 14 findings, all fixed in `53c6592f`. Four changed what the detector measures and two were exploitable:

- **Padding suppressed the score** — ratios divided a numerator excluding allowlisted rows by a denominator including them, so an attacker could halve their own contribution by emitting DNSBL-shaped noise. Same mismatch let 24 real queries plus 1000 benign ones clear the 25-sample floor.
- **Multi-label payload evaded 55 of 100 points** — length and entropy came from `labels[0]` only, but dnscat2 and dnsteal chunk across labels. The "longest label" figure the UI printed was also simply wrong (15 where the truth was 42).
- **Unparseable queries reported as "cleared"** — a parser regression would have rendered as a clean bill of health on every surface, which is precisely the failure this feature exists to prevent.
- **k8s `svc.cluster.local` scored 46** — on a k3s appliance the platform would have flagged its own nodes.

Plus data-lifecycle gaps: the table was in neither the backup nor the factory-reset catalog (never backed up; survived `FACTORY-RESET-ALL` with query-derived data intact), and the aggregator never looked back more than two hours, so any worker outage left a permanent hole.

## Testing

Backend lint (ruff/black/mypy), frontend (eslint/prettier/build), migration linter, single alembic head, fresh-install migration, downgrade→re-upgrade reversibility, module gate 404/200, input validation 422s, live end-to-end detection, alert matcher, MCP registration — all verified.

⚠️ **A full serial backend suite run was still in flight locally when this was opened** — CI's 8-way sharded run is the authoritative signal here. 19 tests cover this feature specifically and pass.

## Deliberately not here

- **DGA and beaconing** (the other two detections in #699). DGA as specified in the issue can't work: it scores NXDOMAIN-heavy clients, but the query log records questions, not responses — there's no rcode, which is why `dns_nxdomain_spike` reads `dns_metric_sample` instead. Needs a different signal basis; noted on the issue.
- **RPZ hit attribution** — the issue calls it "the cheap one"; it isn't. BIND logs rewrites to a separate category we don't capture, so it needs a named.conf channel, shipper, parser and table.
- **Deep-link from a finding to the IP detail modal** — IPAMPage has no `?ip=` entry point, and a button that silently does nothing is worse than no button.
- Docs in `docs/features/DNS.md`.

The two agent commits are cleanly separable (`agent/dns/` only) if you'd rather they went out on their own branch — they're arguably more urgent than the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
