### PR TITLE
chore(deps): bump react-router-dom from 6.30.4 to 7.18.1 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.1",
         "recharts": "^3.10.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.5.5",
@@ -975,15 +975,6 @@
         "react-redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2191,6 +2182,18 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4949,35 +4952,39 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
-      "license": "MIT",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
-      "license": "MIT",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -5226,6 +5233,11 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.1",
     "recharts": "^3.10.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.5",


### PR DESCRIPTION
Supersedes #708.

## Why not #708

Dependabot opened #708 as a **security** update (which is why it bypassed
the `version-update:semver-major` ignore rule in `.github/dependabot.yml`).
It targets `GHSA-jjmj-jmhj-qwj2` — open redirect → XSS, affecting
`>= 6.30.2, <= 6.30.4` with **no fix on the 6.x line**. So moving off 6.x
is genuinely required.

But Dependabot picks the *minimum* version that clears the specific alert
it is addressing, and that version — 7.0.0 — is ~18 months stale with a
long tail of subsequently-patched advisories. #708 closes 1 advisory and
opens 12:

| | 6.30.4 (main today) | 7.0.0 (#708) | **7.18.1 (this PR)** |
|---|---|---|---|
| High | 0 | 8 | **1** |
| Medium | 3 | 5 | **0** |
| **Total** | **3** | **13** | **1** |

Notable additions at 7.0.0 that this PR avoids: `GHSA-49rj-9fvp-4h2h`
(vendored turbo-stream → unauth RCE) and `GHSA-chx6-hx7r-mcp5`
(unauthenticated DoS via inefficient route matching). At 7.18.1
`turbo-stream` is not in the dependency tree at all.

7.18.1 is the current `latest` dist-tag. Its one remaining advisory,
`GHSA-qwww-vcr4-c8h2` (RSC-mode CSRF bypass), is fixed only in 8.3.0 and
is **unreachable here** — this frontend uses no RSC / framework mode.
7.18.1 also restores npm provenance attestation, which 7.0.0 lacks.

## Why the v7 major is safe for this codebase

The frontend uses **only the declarative router API**, so the v7 breaking
changes are inert:

- `BrowserRouter`, not `createBrowserRouter` / `RouterProvider` — so the
  removal of `defer` / `json` / `AbortedDeferredError`, the
  `fallbackElement` prop, single fetch, partial hydration and
  fetcher-persist are all N/A. No `useFetcher` / `useLoaderData` /
  `useNavigation` / `<Form>` anywhere.
- **No splat routes** across the 94 `<Route>`s in `App.tsx`, so the
  `v7_relativeSplatPath` default change is inert.
- **Nothing suspends** (no `React.lazy` / `Suspense`; React Query suspense
  is off in `lib/queryClient.ts`), so the `v7_startTransition` default
  change has no visible effect.
- No `basename`, no `ScrollRestoration`, no deep/subpath imports — all 52
  consuming files import top-level from `"react-router-dom"`, so the new
  `exports` field changes nothing.

## Verification

Ran the full frontend CI gate locally, all green:

- `npm run lint` (`eslint . --max-warnings 0`)
- `npm run format:check` (`prettier --check src`)
- `npm run typecheck` (`tsc --noEmit`)
- `npm run build` (`tsc -b && vite build`) — 2976 modules transformed

Diff is `frontend/package.json` + `frontend/package-lock.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)