### PR TITLE
fix(dns): enqueue record ops on import so imported records reach the daemon (#707)

### DIFF
--- a/backend/app/services/dns_import/commit.py
+++ b/backend/app/services/dns_import/commit.py
@@ -28,6 +28,7 @@ from app.core.dns_names import contains_control_chars
 from app.models.audit import AuditLog
 from app.models.auth import User
 from app.models.dns import DNSRecord, DNSServerGroup, DNSView, DNSZone
+from app.services.dns.record_ops import enqueue_record_ops_bulk, record_op_payload
 
 from .canonical import (
     ConflictAction,
@@ -153,10 +154,12 @@ async def _build_records_for_zone(
     parsed: ImportedZone,
     source: ImportSource,
     now: datetime,
-) -> tuple[int, list[str]]:
+) -> tuple[list[DNSRecord], list[str]]:
     """Create the DNSRecord rows for one parsed zone.
 
-    Returns ``(records_created, skipped_reasons)``. Skips the SOA (its
+    Returns ``(created_rows, skipped_reasons)``. The caller needs the rows
+    themselves (not just a count) to enqueue the matching record ops — see
+    :func:`_create_zone_at`. Skips the SOA (its
     fields live as columns on the parent zone) and, per issue #597, any
     record whose owner name or rdata carries a control character / newline
     — those can't be safely rendered into a zone-file line, so the row is
@@ -198,7 +201,7 @@ async def _build_records_for_zone(
         )
     if rows:
         db.add_all(rows)
-    return len(rows), skipped
+    return rows, skipped
 
 
 def _zone_kwargs_from_parsed(
@@ -277,7 +280,7 @@ async def _create_zone_at(
     db.add(zone)
     await db.flush()  # populate zone.id for the FK
 
-    records_created, skipped_records = await _build_records_for_zone(
+    record_rows, skipped_records = await _build_records_for_zone(
         db,
         zone_id=zone.id,
         zone_fqdn=target_name,
@@ -285,6 +288,42 @@ async def _create_zone_at(
         source=source,
         now=now,
     )
+    records_created = len(record_rows)
+
+    # Issue #707 — writing DNSRecord rows is NOT enough to make imported
+    # records resolvable. Records are deliberately excluded from the agent
+    # bundle's ``structural_etag`` (``agent_config.py`` drops the ``records``
+    # key from ``zones_structural`` unless the group has views), so a
+    # record-only change never triggers the agent's re-render/reload path.
+    # The only route from a committed record to the live daemon is a
+    # ``DNSRecordOp`` row, which the agent drains via nsupdate/RFC 2136
+    # (BIND9) or the zone API (PowerDNS).
+    #
+    # This bites hardest on BIND9 overwrites: named already has the zone
+    # loaded with a journal (zones render with ``allow-update``), so the
+    # re-rendered master file is ignored on ``rndc reload`` and the records
+    # stay invisible until an operator edits each one by hand. PowerDNS
+    # recovers on the next unrelated structural reload (``_reconcile_zones``
+    # PATCHes REPLACE rrsets) but is equally stale until then.
+    #
+    # ``target_serial`` is the zone's own serial rather than a bump: the
+    # importer always creates the zone fresh (overwrites delete + recreate),
+    # so ``last_serial`` was just seeded from the parsed SOA and already
+    # describes the state these records belong to.
+    if record_rows:
+        await db.flush()  # populate record PKs before snapshotting payloads
+        await enqueue_record_ops_bulk(
+            db,
+            zone,
+            [
+                {
+                    "op": "create",
+                    "record": record_op_payload(rec),
+                    "target_serial": zone.last_serial or None,
+                }
+                for rec in record_rows
+            ],
+        )
 
     audit_meta: dict[str, Any] = {
         "import_source": source,

--- a/backend/tests/test_dns_import.py
+++ b/backend/tests/test_dns_import.py
@@ -603,3 +603,90 @@ async def test_commit_missing_group_returns_422(
     )
     assert commit_resp.status_code == 422
     assert "does not exist" in commit_resp.json()["detail"]
+
+
+@pytest.mark.parametrize("driver", ["bind9", "powerdns"])
+@pytest.mark.asyncio
+async def test_commit_enqueues_record_ops_for_agent_servers(
+    db_session: AsyncSession, client: AsyncClient, driver: str
+) -> None:
+    """Issue #707 — imported records must reach the RUNNING daemon.
+
+    The commit path writes ``DNSRecord`` rows and stops. For an
+    agent-based group (BIND9 / PowerDNS) that is not enough: records
+    are deliberately excluded from ``structural_etag`` (see
+    ``agent_config.py`` — ``zones_structural`` drops the ``records``
+    key unless the group has views), so a record-only change never
+    triggers the agent's re-render/reload path. The ONLY route from a
+    committed record to the live daemon is a ``DNSRecordOp`` row,
+    which the agent drains via RFC 2136 (BIND9) or the zone API
+    (PowerDNS).
+
+    Import enqueues none, so imported records are invisible on the
+    wire until an operator edits each one by hand — which is exactly
+    the reported symptom.
+
+    Note the pre-existing tests in this module all use ``_make_group``,
+    which creates a group with NO servers; ``enqueue_record_op``
+    no-ops without a primary, so the gap never surfaced.
+    """
+    import uuid as _uuid
+
+    from app.models.dns import DNSRecordOp, DNSServer
+
+    _, token = await _make_admin(db_session)
+    group = await _make_group(db_session)
+    server = DNSServer(
+        name=f"s-{_uuid.uuid4().hex[:8]}",
+        host="127.0.0.1",
+        port=53,
+        driver=driver,
+        group_id=group.id,
+        is_primary=True,
+        is_enabled=True,
+    )
+    db_session.add(server)
+    await db_session.commit()
+
+    archive = _build_tar(
+        [
+            ("etc/named.conf", _BASIC_NAMED),
+            ("var/named/example.com.zone", _BASIC_ZONE),
+        ]
+    )
+    preview_resp = await client.post(
+        "/api/v1/dns/import/bind9/preview",
+        headers={"Authorization": f"Bearer {token}"},
+        files={"file": ("bind.tar.gz", archive, "application/gzip")},
+        data={"target_group_id": str(group.id)},
+    )
+    assert preview_resp.status_code == 200
+    commit_resp = await client.post(
+        "/api/v1/dns/import/bind9/commit",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "target_group_id": str(group.id),
+            "plan": preview_resp.json(),
+            "conflict_actions": {},
+        },
+    )
+    assert commit_resp.status_code == 200, commit_resp.text
+    assert commit_resp.json()["total_records_created"] == 4
+
+    zone = (
+        await db_session.execute(select(DNSZone).where(DNSZone.name == "example.com."))
+    ).scalar_one()
+    records = (
+        (await db_session.execute(select(DNSRecord).where(DNSRecord.zone_id == zone.id)))
+        .scalars()
+        .all()
+    )
+    ops = (
+        (await db_session.execute(select(DNSRecordOp).where(DNSRecordOp.server_id == server.id)))
+        .scalars()
+        .all()
+    )
+    assert len(ops) == len(records), (
+        f"{driver}: import created {len(records)} records but enqueued "
+        f"{len(ops)} record ops — imported records never reach the live daemon"
+    )


### PR DESCRIPTION
Closes #707

## Root cause

The importer wrote `DNSRecord` rows and stopped. That isn't enough to make an
imported record resolvable.

Records are deliberately excluded from the agent bundle's `structural_etag` —
`agent_config.py` drops the `records` key from `zones_structural` unless the
group has views:

```python
"zones_structural": [
    {k: val for k, val in z.items() if (k != "records" or has_views)} for z in zone_payload
],
```

and `sync.py` only re-renders/reloads when that fingerprint shifts. So a
record-only change never triggers the agent's reload path. **The only route
from a committed record to the live daemon is a `DNSRecordOp` row** — drained
by the agent via nsupdate/RFC 2136 (BIND9) or the zone API (PowerDNS) — and the
commit path enqueued none. `dns_import/commit.py` was absent from the caller
list of every enqueue helper.

## Scope: both agent drivers, BIND9 strictly worse

| | Behaviour |
|---|---|
| **BIND9** | **Never recovers.** Zones render with `allow-update` (#641), so named holds a journal and ignores the re-rendered master file on `rndc reload`. The driver has no freeze/thaw. Records stay invisible until an operator edits each one by hand — the reported symptom (rendered to disk, NXDOMAIN on the wire). |
| **PowerDNS** | **Self-heals**, but only by luck. `_reconcile_zones` PATCHes `changetype: REPLACE` with the full rrset list on any structural reload — so an unrelated options/ACL/blocklist/cert change eventually fixes it. Equally stale until then, and harder to notice. |
| **Windows DNS (agentless)** | Unaffected — writes apply immediately from the control plane. |

## Fix

Option 1 from the issue: enqueue a `create` op per imported record through
`enqueue_record_ops_bulk` — the existing seeding/bulk-import fast-path. It
resolves the enabled agent-based server set **once** and inserts all op rows in
a single `add_all`, so a large import doesn't degrade into per-record server
resolution. Driver-agnostic, so BIND9 and PowerDNS are both fixed by the same
call; agentless primaries delegate to the batched driver call instead of
queueing.

Option 2 (freeze/thaw the zone) was rejected: BIND-only, and riskier than
reusing the incremental path every other write already takes.

Supporting details:

- `_build_records_for_zone` now returns the created rows rather than just a
  count — the caller needs them to build op payloads.
- Payloads go through `record_op_payload` rather than a hand-rolled dict, so a
  future field can't be silently dropped (#632).
- `target_serial` is the zone's own serial, not a bump: the importer always
  creates the zone fresh (overwrites delete + recreate), so `last_serial` was
  just seeded from the parsed SOA and already describes the state these records
  belong to.
- The router already carries `Depends(wake_publishing)`, so the `collect_wake`
  inside the bulk helper publishes after commit — agents converge immediately
  rather than on the 12 s safety tick.

## Testing

New regression test parametrized over `bind9` + `powerdns`, asserting one op per
created record. Both cases failed before the change:

```
AssertionError: bind9: import created 4 records but enqueued 0 record ops
assert 0 == 4
```

The gap survived this long because every pre-existing test in the module builds
its group via `_make_group`, which creates a group with **no servers** — and
`enqueue_record_op` no-ops without a primary.

- `tests/test_dns_import.py` — 19 passed
- `test_dns_import_{cloud,powerdns,windows,export}.py` + `test_netbox_import.py` — 46 passed
- `ruff` / `black --check` clean; `mypy app` — no issues in 750 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)