### PR TITLE
feat(dns): DGA detection + RPZ hit attribution — closes the #699 detection set

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -136,6 +136,10 @@ backend/alembic/versions/a3f7c1e92b48_decom_date_awareness.py:drop_column:41
 backend/alembic/versions/a4b8c2d619e7_ai_provider.py:drop_table:92
 backend/alembic/versions/a4d92f61c08b_drop_discovery_scan_settings.py:drop_column:31
 backend/alembic/versions/a4d92f61c08b_drop_discovery_scan_settings.py:drop_column:32
+backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:83
+backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:84
+backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:85
+backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:86
 backend/alembic/versions/a4f9c2e8b316_appliance_supervisor_identity.py:drop_column:153
 backend/alembic/versions/a4f9c2e8b316_appliance_supervisor_identity.py:drop_table:156
 backend/alembic/versions/a5b8e9c31f42_ipspace_color.py:drop_column:31
@@ -272,6 +276,7 @@ backend/alembic/versions/b7e4d1a92c30_ipv6_ra_management.py:drop_column:196
 backend/alembic/versions/b7e4d1a92c30_ipv6_ra_management.py:drop_column:197
 backend/alembic/versions/b7e4d1a92c30_ipv6_ra_management.py:drop_table:185
 backend/alembic/versions/b7e4d1a92c30_ipv6_ra_management.py:drop_table:188
+backend/alembic/versions/b7f24d1e9a35_dns_rpz_hit.py:drop_table:64
 backend/alembic/versions/b8c3f2a9e147_appliance_lldp_settings.py:drop_column:109
 backend/alembic/versions/b8e3f1c47a92_packet_capture.py:drop_column:110
 backend/alembic/versions/b8e3f1c47a92_packet_capture.py:drop_table:115

--- a/backend/alembic/versions/a4e91c7b3d82_dns_dga.py
+++ b/backend/alembic/versions/a4e91c7b3d82_dns_dga.py
@@ -1,0 +1,86 @@
+"""dns threat: DGA score on the per-client rollup
+
+Revision ID: a4e91c7b3d82
+Revises: f0c3a81d5e27
+Create Date: 2026-07-27 23:10:00.000000
+
+Issue #699, third detection.
+
+Rides the existing ``dns_client_window`` for the same reason beaconing
+did: the rollup's feature columns are detection-agnostic, so a third
+heuristic scores off them without a second aggregation pass over the
+query log.
+
+``dga_candidates`` carries the implausible registrable domains that made
+up the crop, and ``dga_signals`` the per-signal breakdown in the same
+wire shape as ``tunnel_signals`` — so the UI renders both detections'
+evidence with one component. Both matter for the same reason the
+beaconing evidence does: hashed-CDN and shortlink traffic shares the
+shape, so an operator has to be able to see WHICH domains scored to
+dismiss their own infrastructure.
+
+Note this detection deliberately does NOT use the NXDOMAIN prior the
+issue originally specified. ``dns_query_log_entry`` records the
+question, never the answer — the BIND9 query log carries no rcode — so
+scoring is on name characteristics alone. See ``services/dns_threat/
+dga.py`` for the trade-off and the path to layering the per-server
+NXDOMAIN metric on later.
+
+Additive with server defaults, so existing rows read as "no DGA
+observed" until the next rollup recomputes them.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "a4e91c7b3d82"
+down_revision = "f0c3a81d5e27"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "dns_client_window",
+        sa.Column("dga_score", sa.Float(), nullable=False, server_default=sa.text("0")),
+    )
+    op.add_column(
+        "dns_client_window",
+        sa.Column(
+            "dga_candidates",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "dns_client_window",
+        sa.Column(
+            "dga_signals",
+            JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "dns_client_window",
+        sa.Column("dga_detail", sa.Text(), nullable=False, server_default=sa.text("''")),
+    )
+    # Same access pattern the tunnel + beacon indexes serve: "worst
+    # offenders recently", for the Threat tab and the alert matcher.
+    op.create_index(
+        "ix_dns_client_window_dga",
+        "dns_client_window",
+        ["window_start", "dga_score"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_dns_client_window_dga", table_name="dns_client_window")
+    op.drop_column("dns_client_window", "dga_detail")
+    op.drop_column("dns_client_window", "dga_signals")
+    op.drop_column("dns_client_window", "dga_candidates")
+    op.drop_column("dns_client_window", "dga_score")

--- a/backend/alembic/versions/b7f24d1e9a35_dns_rpz_hit.py
+++ b/backend/alembic/versions/b7f24d1e9a35_dns_rpz_hit.py
@@ -1,0 +1,64 @@
+"""dns threat: RPZ policy-hit attribution
+
+Revision ID: b7f24d1e9a35
+Revises: a4e91c7b3d82
+Create Date: 2026-07-27 23:40:00.000000
+
+Issue #699, fourth and final piece.
+
+We serve 14 curated blocklists as RPZ zones and discarded every hit,
+which left "which machine keeps reaching for blocked domains" — the
+question that actually identifies an infected host — unanswerable from
+data we were already generating.
+
+A separate table from ``dns_query_log_entry`` on purpose: RPZ hits are
+worth keeping far longer than raw queries (the query log is 24 h
+operator triage; "this host hit the malware feed every day this week"
+has to outlive that), the columns genuinely differ (policy action,
+trigger type, matching feed), and sharing a table would force the
+query log's retention sweep to either drop hits early or keep queries
+too long.
+
+``client_ip`` and ``qname`` are nullable because a hit whose log head
+did not parse still proves the blocklist fired, and counting it is
+better than dropping it — the attribution surfaces filter those rows
+out, the totals keep them.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import INET, UUID
+
+revision = "b7f24d1e9a35"
+down_revision = "a4e91c7b3d82"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dns_rpz_hit",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("server_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("client_ip", INET(), nullable=True),
+        sa.Column("qname", sa.String(length=512), nullable=True),
+        sa.Column("trigger", sa.String(length=16), nullable=False),
+        sa.Column("policy", sa.String(length=16), nullable=False),
+        sa.Column("rpz_zone", sa.String(length=255), nullable=True),
+        sa.Column("raw", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.ForeignKeyConstraint(["server_id"], ["dns_server.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_dns_rpz_hit_client_ts", "dns_rpz_hit", ["client_ip", "ts"])
+    op.create_index("ix_dns_rpz_hit_ts", "dns_rpz_hit", ["ts"])
+    op.create_index("ix_dns_rpz_hit_zone_ts", "dns_rpz_hit", ["rpz_zone", "ts"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_dns_rpz_hit_zone_ts", table_name="dns_rpz_hit")
+    op.drop_index("ix_dns_rpz_hit_ts", table_name="dns_rpz_hit")
+    op.drop_index("ix_dns_rpz_hit_client_ts", table_name="dns_rpz_hit")
+    op.drop_table("dns_rpz_hit")

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -6,6 +6,7 @@ See docs/deployment/DNS_AGENT.md §§2-5 for the full protocol.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hmac
 import os
 import uuid
@@ -25,6 +26,7 @@ from app.core.agent_wake import (
     dns_wake_channels,
     wake_subscription,
 )
+from app.drivers.dns import get_driver as get_dns_driver
 from app.models.audit import AuditLog
 from app.models.dns import (
     DNSKey,
@@ -46,6 +48,7 @@ from app.services.dns.agent_token import (
     verify_agent_token,
 )
 from app.services.dns.record_ops import ack_op
+from app.services.feature_modules import is_module_enabled
 
 logger = structlog.get_logger(__name__)
 router = APIRouter(prefix="/agents", tags=["dns-agents"])
@@ -899,6 +902,24 @@ async def agent_query_log_entries(
         # parse and end up as noise rows the operator can ignore.
         parse_fn = bind9_parser.parse_query_line
 
+    # RPZ hits are per-client domain-lookup history kept for 30 days —
+    # longer than the 24 h query log they are carved out of — so they are
+    # gated on the SAME default-off module that gates every reader
+    # (``require_module`` on the router include, ``module=`` on every MCP
+    # tool, the rollup task's own check). That module is default-off on
+    # privacy grounds; without this check a default install would silently
+    # accumulate data the operator never opted into and cannot view,
+    # because the whole /dns-threat prefix 404s while it is disabled.
+    #
+    # Capability comes from the driver ABC rather than a driver-name
+    # string (non-negotiable #10): bind9 advertises ``rpz: True`` and
+    # powerdns ``False``, so a future agent-based driver is not silently
+    # opted into BIND9 regex matching against its own log format.
+    rpz_capable = False
+    if await is_module_enabled(db, "security.dns_threat"):
+        with contextlib.suppress(Exception):
+            rpz_capable = bool(get_dns_driver(server.driver).capabilities().get("rpz"))
+
     capped = body.lines[:1000]
     dropped = max(0, len(body.lines) - len(capped))
     now = datetime.now(UTC)
@@ -917,7 +938,7 @@ async def agent_query_log_entries(
         # the parser returns None for every non-RPZ line, which makes
         # running it against pdns output harmless rather than
         # conditional.
-        if server.driver != "powerdns":
+        if rpz_capable:
             rpz = bind9_parser.parse_rpz_line(raw, fallback_ts=now)
             if rpz is not None:
                 db.add(

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -35,6 +35,7 @@ from app.models.dns import (
     DNSServerZoneState,
     DNSZone,
 )
+from app.models.dns_rpz_hit import DNSRPZHit
 from app.models.logs import DNSQueryLogEntry
 from app.models.metrics import DNSMetricSample
 from app.services.dns.agent_config import build_config_bundle
@@ -902,7 +903,37 @@ async def agent_query_log_entries(
     dropped = max(0, len(body.lines) - len(capped))
     now = datetime.now(UTC)
     inserted = 0
+    rpz_inserted = 0
     for raw in capped:
+        # RPZ policy hits (issue #699) ride the same channel as queries —
+        # named logs them under its own ``rpz`` category, which the
+        # BIND9 template points at ``queries_channel`` so no second
+        # shipper is needed. They are tried FIRST because they do not
+        # contain the ``: query: `` separator the query parser splits
+        # on, so they would otherwise be dropped by the ``qname is
+        # None`` guard below and the hit lost.
+        #
+        # PowerDNS has no equivalent category, so this is BIND9-only;
+        # the parser returns None for every non-RPZ line, which makes
+        # running it against pdns output harmless rather than
+        # conditional.
+        if server.driver != "powerdns":
+            rpz = bind9_parser.parse_rpz_line(raw, fallback_ts=now)
+            if rpz is not None:
+                db.add(
+                    DNSRPZHit(
+                        server_id=server.id,
+                        ts=rpz.ts,
+                        client_ip=rpz.client_ip,
+                        qname=rpz.qname,
+                        trigger=rpz.trigger,
+                        policy=rpz.policy,
+                        rpz_zone=rpz.rpz_zone,
+                        raw=rpz.raw,
+                    )
+                )
+                rpz_inserted += 1
+                continue
         parsed = parse_fn(raw, fallback_ts=now)
         if parsed is None or parsed.qname is None:
             continue
@@ -922,7 +953,12 @@ async def agent_query_log_entries(
         )
         inserted += 1
     await db.commit()
-    return {"status": "ok", "inserted": inserted, "dropped": dropped}
+    return {
+        "status": "ok",
+        "inserted": inserted,
+        "rpz_inserted": rpz_inserted,
+        "dropped": dropped,
+    }
 
 
 # ── Admin runtime-state push (rendered config + rndc status) ─────────

--- a/backend/app/api/v1/dns_threat/router.py
+++ b/backend/app/api/v1/dns_threat/router.py
@@ -28,6 +28,7 @@ from app.core.permissions import require_permission
 from app.models.audit import AuditLog
 from app.models.dns_threat import DNSClientWindow
 from app.models.dns_threat_mute import DNSThreatMute
+from app.services.dns_threat import rpz as rpz_service
 from app.services.dns_threat.aggregate import INTERESTING_SCORE, compute_threat_summary
 
 # Same gate the Logs router uses: this is a rollup of the DNS query
@@ -53,6 +54,10 @@ class ClientWindowRow(BaseModel):
     beacon_score: float
     beacon_candidates: list[dict[str, Any]]
     beacon_detail: str
+    dga_score: float
+    dga_candidates: list[dict[str, Any]]
+    dga_signals: list[dict[str, Any]]
+    dga_detail: str
     allowlisted: bool
     server_count: int
     # Populated per row so the tab can dim a muted client and show who
@@ -91,6 +96,24 @@ def _validated_ip(value: str) -> str:
         ) from exc
 
 
+def _score_column(detection: str) -> Any:
+    """Map the ``detection`` query param to the column it ranks by.
+
+    One lookup rather than a chain of ternaries at each use site: the
+    ordering and the threshold filter must agree on which score they
+    mean, and keeping them keyed off the same table is what guarantees
+    it. The caller's ``pattern=`` constraint means an unknown value
+    never reaches here, but the fallback is tunneling — the default —
+    rather than a raise, so a future detection added to the pattern and
+    forgotten here degrades to the old behaviour instead of 500ing.
+    """
+    return {
+        "tunnel": DNSClientWindow.tunnel_score,
+        "beacon": DNSClientWindow.beacon_score,
+        "dga": DNSClientWindow.dga_score,
+    }.get(detection, DNSClientWindow.tunnel_score)
+
+
 def _to_row(w: DNSClientWindow) -> ClientWindowRow:
     return ClientWindowRow(
         id=str(w.id),
@@ -110,6 +133,10 @@ def _to_row(w: DNSClientWindow) -> ClientWindowRow:
         beacon_score=w.beacon_score,
         beacon_candidates=w.beacon_candidates or [],
         beacon_detail=w.beacon_detail,
+        dga_score=w.dga_score,
+        dga_candidates=w.dga_candidates or [],
+        dga_signals=w.dga_signals or [],
+        dga_detail=w.dga_detail,
         allowlisted=w.allowlisted,
         server_count=w.server_count,
     )
@@ -123,10 +150,10 @@ async def list_windows(
     hours: int = Query(default=24, ge=1, le=24 * 30),
     min_score: float = Query(default=INTERESTING_SCORE, ge=0, le=100),
     # Which detection to rank and filter by. Kept explicit rather than
-    # scoring on max(tunnel, beacon): the two mean different things and
-    # an operator hunting exfil should not have their list reordered by
-    # a chatty monitoring agent.
-    detection: str = Query(default="tunnel", pattern="^(tunnel|beacon)$"),
+    # scoring on max(tunnel, beacon, dga): the three mean different
+    # things and an operator hunting exfil should not have their list
+    # reordered by a chatty monitoring agent.
+    detection: str = Query(default="tunnel", pattern="^(tunnel|beacon|dga)$"),
     include_allowlisted: bool = Query(default=False),
     include_muted: bool = Query(default=False),
     limit: int = Query(default=100, ge=1, le=1000),
@@ -143,11 +170,7 @@ async def list_windows(
         select(DNSClientWindow)
         .where(DNSClientWindow.window_start >= since)
         .order_by(
-            desc(
-                DNSClientWindow.beacon_score
-                if detection == "beacon"
-                else DNSClientWindow.tunnel_score
-            ),
+            desc(_score_column(detection)),
             desc(DNSClientWindow.window_start),
         )
         .limit(limit)
@@ -160,10 +183,8 @@ async def list_windows(
         # A per-client drilldown wants the client's whole history, not
         # just its interesting hours.
         stmt = stmt.order_by(None).order_by(desc(DNSClientWindow.window_start))
-    elif detection == "beacon":
-        stmt = stmt.where(DNSClientWindow.beacon_score >= min_score)
     else:
-        stmt = stmt.where(DNSClientWindow.tunnel_score >= min_score)
+        stmt = stmt.where(_score_column(detection) >= min_score)
     if not include_allowlisted:
         stmt = stmt.where(DNSClientWindow.allowlisted.is_(False))
     if not include_muted and not client_ip:
@@ -335,3 +356,105 @@ async def delete_mute(client_ip: str, db: DB, current_user: CurrentUser) -> None
         )
     )
     await db.commit()
+
+
+# ── RPZ hit attribution (issue #699) ──────────────────────────────────
+#
+# Pure reporting, unlike the three scored detections above: a hit is
+# ground truth (named matched a policy and logged it), so there is
+# nothing to infer and nothing to threshold. These endpoints only
+# attribute and rank.
+
+
+class RPZOffender(BaseModel):
+    client_ip: str
+    hits: int
+    distinct_names: int
+    distinct_feeds: int
+    last_seen: datetime
+    top_qname: str | None
+    top_qname_hits: int
+    # True once the client is over the "worth chasing" bar. Carried from
+    # the service so the UI and the copilot agree on what counts as
+    # noisy rather than each inventing a threshold.
+    noisy: bool
+
+
+class RPZBlockedName(BaseModel):
+    qname: str
+    hits: int
+    clients: int
+    rpz_zone: str | None
+
+
+class RPZFeedRow(BaseModel):
+    rpz_zone: str | None
+    hits: int
+    clients: int
+    distinct_names: int
+
+
+class RPZSummary(BaseModel):
+    blocked_hits: int
+    clients_blocked: int
+    distinct_names: int
+    feeds_firing: int
+    # PASSTHRU is an explicit allow, not a block — reported separately
+    # so an operator tuning an allowlist can see it working, and so the
+    # blocked count never silently includes it.
+    passthru_hits: int
+    worst_client_ip: str | None
+    worst_client_hits: int | None
+    since: datetime
+    has_data: bool
+
+
+@router.get("/rpz/summary", response_model=RPZSummary)
+async def rpz_summary(
+    db: DB,
+    current_user: CurrentUser,
+    hours: int = Query(default=24, ge=1, le=24 * 30),
+) -> RPZSummary:
+    """Blocklist activity rollup for the Security dashboard card."""
+    return RPZSummary(**await rpz_service.summary(db, hours=hours))
+
+
+@router.get("/rpz/clients", response_model=list[RPZOffender])
+async def rpz_clients(
+    db: DB,
+    current_user: CurrentUser,
+    hours: int = Query(default=24, ge=1, le=24 * 30),
+    limit: int = Query(default=20, ge=1, le=200),
+    min_hits: int = Query(default=1, ge=1),
+) -> list[RPZOffender]:
+    """Clients ranked by blocked-lookup count — "which machine is infected".
+
+    This is the question the blocklists could always have answered and
+    never did.
+    """
+    rows = await rpz_service.top_offending_clients(db, hours=hours, limit=limit, min_hits=min_hits)
+    return [RPZOffender(**r) for r in rows]
+
+
+@router.get("/rpz/names", response_model=list[RPZBlockedName])
+async def rpz_names(
+    db: DB,
+    current_user: CurrentUser,
+    hours: int = Query(default=24, ge=1, le=24 * 30),
+    limit: int = Query(default=20, ge=1, le=200),
+) -> list[RPZBlockedName]:
+    """The blocked names themselves, ranked by hit count."""
+    return [
+        RPZBlockedName(**r)
+        for r in await rpz_service.top_blocked_names(db, hours=hours, limit=limit)
+    ]
+
+
+@router.get("/rpz/feeds", response_model=list[RPZFeedRow])
+async def rpz_feeds(
+    db: DB,
+    current_user: CurrentUser,
+    hours: int = Query(default=24, ge=1, le=24 * 30),
+) -> list[RPZFeedRow]:
+    """Hits per blocklist feed — which subscriptions are earning their keep."""
+    return [RPZFeedRow(**r) for r in await rpz_service.feed_effectiveness(db, hours=hours)]

--- a/backend/app/drivers/dns/templates/bind9/named.conf.j2
+++ b/backend/app/drivers/dns/templates/bind9/named.conf.j2
@@ -138,6 +138,15 @@ logging {
     };
     category queries { queries_channel; };
     category query-errors { queries_channel; };
+    {#- RPZ hit attribution (issue #699). named logs policy rewrites to
+        its own ``rpz`` category, NOT to ``queries`` — without this line
+        a blocked lookup is invisible to us, which is why "which machine
+        keeps hitting the blocklist" was unanswerable. Routed to the
+        existing queries_channel rather than a second file on purpose:
+        the agent already tails this one, so no new shipper thread, log
+        file or bind mount is needed. The control plane tells the two
+        line shapes apart at ingest. #}
+    category rpz { queries_channel; };
 };
 {%- endif %}
 

--- a/backend/app/drivers/dns/templates/bind9/named.conf.j2
+++ b/backend/app/drivers/dns/templates/bind9/named.conf.j2
@@ -147,6 +147,12 @@ logging {
         file or bind mount is needed. The control plane tells the two
         line shapes apart at ingest. #}
     category rpz { queries_channel; };
+    {#- PASSTHRU (an explicit ALLOW — a blocklist exception firing)
+        is logged to its OWN category, not to `rpz`. Without this the
+        entire passthru half of the attribution is invisible and the
+        `policy != PASSTHRU` filters in services/dns_threat/rpz.py are
+        dead code. Verified against BIND 9.20. #}
+    category rpz-passthru { queries_channel; };
 };
 {%- endif %}
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -541,6 +541,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await seed_dns_beaconing_alert_rule()
     except Exception as exc:  # noqa: BLE001
         logger.debug("dns_beaconing_alert_rule_seed_skipped", reason=str(exc))
+    try:
+        from app.services.alerts import seed_dns_dga_alert_rule  # noqa: PLC0415
+
+        await seed_dns_dga_alert_rule()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("dns_dga_alert_rule_seed_skipped", reason=str(exc))
     # Appliance Web UI cert bootstrap (issue #134, Phase 4b.5). On
     # appliance installs without an active row in appliance_certificate,
     # generate a self-signed default + deploy it to /etc/nginx/certs

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -58,6 +58,7 @@ from app.models.dns import (
     DNSView,
     DNSZone,
 )
+from app.models.dns_rpz_hit import DNSRPZHit
 from app.models.dns_threat import DNSClientWindow
 from app.models.dns_threat_mute import DNSThreatMute
 from app.models.dnsbl import DNSBLList, DNSBLListing, DNSBLPinnedIP
@@ -285,4 +286,5 @@ __all__ = [
     "WolRunTarget",
     "WolCalendar",
     "WolCalendarEvent",
+    "DNSRPZHit",
 ]

--- a/backend/app/models/dns_rpz_hit.py
+++ b/backend/app/models/dns_rpz_hit.py
@@ -20,10 +20,13 @@ separate table from ``dns_query_log_entry`` rather than a flag on it:
 * Mixing them would make the query log's own retention sweep either
   drop the hits early or keep the queries too long.
 
-``rpz_zone`` is what makes a hit *attributable to a feed*: "blocked by
-the malware list" and "blocked by the ad list" are very different
-findings about the same host, and an aggregate that lost the
-distinction would be much weaker evidence.
+``rpz_zone`` records which RPZ zone matched. Note the resolution limit:
+``dns/agent_config.py`` merges every enabled blocklist into ONE rendered
+zone per view, so for SpatiumDDI-managed lists this distinguishes
+*views*, not individual feeds — "which of my 14 lists fired" needs
+either per-list zones or a qname join back to ``DNSBlockListEntry``, and
+is follow-up work on #699. It does separate our zone from any
+hand-rolled ``response-policy`` zone an operator runs alongside.
 """
 
 from __future__ import annotations
@@ -44,8 +47,7 @@ class DNSRPZHit(Base):
     __tablename__ = "dns_rpz_hit"
     __table_args__ = (
         # "Who has been hitting the blocklist recently" — the query
-        # behind the attribution report, the alert matcher and the
-        # Threat tab's RPZ view.
+        # behind the attribution report and the Threat tab's RPZ panel.
         Index("ix_dns_rpz_hit_client_ts", "client_ip", "ts"),
         # Retention sweep + the "what got blocked lately" ordering.
         Index("ix_dns_rpz_hit_ts", "ts"),

--- a/backend/app/models/dns_rpz_hit.py
+++ b/backend/app/models/dns_rpz_hit.py
@@ -1,0 +1,81 @@
+"""RPZ policy-hit attribution (issue #699).
+
+SpatiumDDI serves curated blocklists as RPZ zones and, until this
+existed, threw every hit away. That made the most operationally useful
+question the blocklists can answer — *which machine keeps reaching for
+blocked domains* — unanswerable. A blocked lookup is not a problem; a
+host generating thousands of them is an infected host announcing
+itself.
+
+One row per policy rewrite, written by the query-log ingest when the
+line came from named's ``rpz`` logging category. Deliberately a
+separate table from ``dns_query_log_entry`` rather than a flag on it:
+
+* RPZ hits are worth keeping far longer than raw queries. The query log
+  is 24 h operator triage; "this host has hit the malware feed every
+  day this week" needs to outlive that, exactly like the threat rollup
+  does.
+* The columns genuinely differ — a hit carries a policy action, a
+  trigger type and the feed that matched, none of which a query has.
+* Mixing them would make the query log's own retention sweep either
+  drop the hits early or keep the queries too long.
+
+``rpz_zone`` is what makes a hit *attributable to a feed*: "blocked by
+the malware list" and "blocked by the ad list" are very different
+findings about the same host, and an aggregate that lost the
+distinction would be much weaker evidence.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import INET, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class DNSRPZHit(Base):
+    """One RPZ policy rewrite — a blocked (or passed-through) lookup."""
+
+    __tablename__ = "dns_rpz_hit"
+    __table_args__ = (
+        # "Who has been hitting the blocklist recently" — the query
+        # behind the attribution report, the alert matcher and the
+        # Threat tab's RPZ view.
+        Index("ix_dns_rpz_hit_client_ts", "client_ip", "ts"),
+        # Retention sweep + the "what got blocked lately" ordering.
+        Index("ix_dns_rpz_hit_ts", "ts"),
+        # "Which feed is doing the work" rollup.
+        Index("ix_dns_rpz_hit_zone_ts", "rpz_zone", "ts"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    server_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("dns_server.id", ondelete="CASCADE"), nullable=False
+    )
+    ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    # Nullable because a hit whose log head didn't parse is still worth
+    # counting — it proves the blocklist fired — even though it cannot
+    # be pinned to a host. Every attribution surface filters these out;
+    # the totals keep them.
+    client_ip: Mapped[str | None] = mapped_column(INET, nullable=True)
+    qname: Mapped[str | None] = mapped_column(String(512), nullable=True)
+
+    # QNAME / CLIENT-IP / IP / NSDNAME / NSIP — which part of the
+    # transaction matched the policy.
+    trigger: Mapped[str] = mapped_column(String(16), nullable=False)
+    # NXDOMAIN / NODATA / PASSTHRU / DROP / TCP-ONLY / CNAME /
+    # Local-Data. PASSTHRU is an explicit allow, so it is NOT a block —
+    # the surfaces separate them rather than counting every row as a
+    # block.
+    policy: Mapped[str] = mapped_column(String(16), nullable=False)
+    # The blocklist zone that matched, recovered from named's ``via``
+    # clause. Nullable: DROP logs no ``via``.
+    rpz_zone: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    raw: Mapped[str] = mapped_column(Text, nullable=False, default="")

--- a/backend/app/models/dns_threat.py
+++ b/backend/app/models/dns_threat.py
@@ -56,6 +56,7 @@ class DNSClientWindow(Base):
         # the alert matcher and the Threat tab.
         Index("ix_dns_client_window_score", "window_start", "tunnel_score"),
         Index("ix_dns_client_window_beacon", "window_start", "beacon_score"),
+        Index("ix_dns_client_window_dga", "window_start", "dga_score"),
         Index("ix_dns_client_window_ip", "client_ip"),
     )
 
@@ -106,6 +107,22 @@ class DNSClientWindow(Base):
         JSONB, nullable=False, default=list
     )
     beacon_detail: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    # ── DGA verdict (issue #699) ─────────────────────────────────────
+    # Structurally the inverse of tunneling: a tunnel concentrates
+    # thousands of subdomains under ONE parent, a DGA sprays one or two
+    # lookups across MANY parents. Scored separately for that reason —
+    # each detection's strongest signal is the other's evidence of
+    # innocence, so a single weighted sum could not express both.
+    dga_score: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    # The implausible registrable domains that made up the crop. Carrying
+    # them is what lets an operator recognise their own hashed-CDN or
+    # shortlink traffic instead of being handed a bare number.
+    dga_candidates: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSONB, nullable=False, default=list
+    )
+    dga_signals: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False, default=list)
+    dga_detail: Mapped[str] = mapped_column(Text, nullable=False, default="")
 
     # Set when every parseable name in the window matched the benign
     # allowlist — genuinely cleared. NOT set when nothing was parseable,

--- a/backend/app/services/ai/tools/dns_threat.py
+++ b/backend/app/services/ai/tools/dns_threat.py
@@ -315,3 +315,166 @@ async def find_beaconing_clients(
         }
         for w in rows
     ]
+
+
+class FindDGAClientsArgs(BaseModel):
+    hours: int = Field(default=24, ge=1, le=24 * 30)
+    limit: int = Field(default=25, ge=1, le=200)
+    min_score: float = Field(
+        default=60.0,
+        ge=0,
+        le=100,
+        description=(
+            "Minimum DGA score. Scoring is on name plausibility alone — "
+            "the BIND9 query log carries no rcode, so there is no "
+            "NXDOMAIN prior — which makes this weaker evidence than the "
+            "tunneling score and worth reporting with that caveat."
+        ),
+    )
+
+
+@register_tool(
+    name="find_dga_clients",
+    description=(
+        "Find DNS clients that queried a crop of algorithmically-"
+        "generated domain names — how malware locates its "
+        "command-and-control server (issue #699). Each row carries the "
+        "implausible domains themselves, which is what makes the "
+        "finding actionable: hashed-CDN buckets, shortlink services "
+        "and odd brand names share the shape, so ALWAYS report the "
+        "sample domains and say plainly that the score rests on name "
+        "plausibility alone (no NXDOMAIN prior is available). Distinct "
+        "from find_suspicious_dns_clients: a tunnel concentrates many "
+        "subdomains under ONE parent, a DGA sprays across MANY parents."
+    ),
+    args_model=FindDGAClientsArgs,
+    category="dns",
+    module="security.dns_threat",
+    default_enabled=True,
+)
+async def find_dga_clients(
+    db: AsyncSession, user: User, args: FindDGAClientsArgs
+) -> list[dict[str, Any]]:
+    since = datetime.now(UTC) - timedelta(hours=args.hours)
+    rows = (
+        (
+            await db.execute(
+                select(DNSClientWindow)
+                .where(
+                    DNSClientWindow.window_start >= since,
+                    DNSClientWindow.dga_score >= args.min_score,
+                )
+                .order_by(desc(DNSClientWindow.dga_score))
+                .limit(args.limit)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not rows:
+        return [
+            {
+                "result": "no clients querying generated-looking domain crops",
+                "note": (
+                    "Either nothing scored above the threshold, or the rollup "
+                    "has no data — security.dns_threat must be enabled AND a "
+                    "DNS group must have query logging on."
+                ),
+            }
+        ]
+    return [
+        {
+            "client_ip": str(w.client_ip),
+            "dga_score": round(w.dga_score, 1),
+            "window_start": w.window_start.isoformat(),
+            "distinct_parents": w.distinct_parents,
+            "sample_domains": w.dga_candidates or [],
+            "signals": w.dga_signals or [],
+            "detail": w.dga_detail,
+        }
+        for w in rows
+    ]
+
+
+class FindRPZOffendersArgs(BaseModel):
+    hours: int = Field(default=24, ge=1, le=24 * 30)
+    limit: int = Field(default=20, ge=1, le=200)
+    min_hits: int = Field(
+        default=1,
+        ge=1,
+        description="Only clients with at least this many blocked lookups.",
+    )
+
+
+@register_tool(
+    name="find_rpz_offenders",
+    description=(
+        "Find which clients keep reaching for domains the blocklists "
+        "block (issue #699). This is ground truth, NOT a heuristic — "
+        "named matched a response-policy rule and logged it — so it is "
+        "much stronger evidence than the tunneling / beaconing / DGA "
+        "scores. A single blocked lookup is an ad on a web page; "
+        "hundreds from one host is a machine with something running on "
+        "it. Rows carry the worst domain and the number of distinct "
+        "feeds that fired. PASSTHRU (an explicit allow) is excluded "
+        "from the counts by design."
+    ),
+    args_model=FindRPZOffendersArgs,
+    category="dns",
+    module="security.dns_threat",
+    default_enabled=True,
+)
+async def find_rpz_offenders(
+    db: AsyncSession, user: User, args: FindRPZOffendersArgs
+) -> list[dict[str, Any]]:
+    from app.services.dns_threat import rpz as rpz_service  # noqa: PLC0415
+
+    rows = await rpz_service.top_offending_clients(
+        db, hours=args.hours, limit=args.limit, min_hits=args.min_hits
+    )
+    if not rows:
+        return [
+            {
+                "result": "no clients hit the blocklists in this window",
+                "note": (
+                    "This can legitimately mean nothing was blocked. It can "
+                    "also mean the pipeline is not running: RPZ attribution "
+                    "needs security.dns_threat enabled, query logging on for "
+                    "a BIND9 group, and at least one blocklist assigned."
+                ),
+            }
+        ]
+    return [
+        {
+            **r,
+            "last_seen": r["last_seen"].isoformat() if r.get("last_seen") else None,
+        }
+        for r in rows
+    ]
+
+
+@register_tool(
+    name="get_rpz_block_summary",
+    description=(
+        "Blocklist activity rollup: how many lookups were blocked, how "
+        "many distinct clients and names, which feeds fired, and the "
+        "worst offending client (issue #699). Use to answer 'are the "
+        "blocklists doing anything' and 'which feed is earning its "
+        "keep'. Check has_data — zero blocks is a plausible real answer "
+        "on a quiet network, so a zero WITHOUT has_data means the "
+        "pipeline is not running rather than that nothing was blocked."
+    ),
+    args_model=DNSThreatSummaryArgs,
+    category="dns",
+    module="security.dns_threat",
+    default_enabled=True,
+)
+async def get_rpz_block_summary(
+    db: AsyncSession, user: User, args: DNSThreatSummaryArgs
+) -> dict[str, Any]:
+    from app.services.dns_threat import rpz as rpz_service  # noqa: PLC0415
+
+    out = await rpz_service.summary(db, hours=args.hours)
+    out["since"] = out["since"].isoformat()
+    out["feeds"] = await rpz_service.feed_effectiveness(db, hours=args.hours)
+    return out

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -325,6 +325,19 @@ RULE_TYPE_DNS_TUNNELING = "dns_tunneling_suspected"
 # known pollers — which is exactly the workflow the mute feature
 # provides — but arriving pre-armed would teach people to ignore it.
 RULE_TYPE_DNS_BEACONING = "dns_beaconing_suspected"
+
+# ``dns_dga_suspected`` (issue #699) — a client queried a crop of
+# algorithmically-generated domain names. Subject is the client, like
+# the other two.
+#
+# Seeded DISABLED, for a reason specific to this detection rather than
+# beaconing's: the issue originally specified scoring NXDOMAIN-heavy
+# clients, and the BIND9 query log carries no rcode, so the score rests
+# on name plausibility alone (see ``services/dns_threat/dga.py``). That
+# is a weaker basis than tunneling's four independent signals, and
+# hashed-CDN / shortlink traffic shares the shape — so it wants an
+# operator who has looked at their own baseline first.
+RULE_TYPE_DNS_DGA = "dns_dga_suspected"
 # The alerting bar lives in ``dns_threat.aggregate`` next to
 # ``INTERESTING_SCORE`` so the two stay a visible pair rather than
 # drifting apart in separate modules — "worth a look on a dashboard"
@@ -391,6 +404,7 @@ RULE_TYPES = frozenset(
         RULE_TYPE_RESTORE_DRILL_FAILED,
         RULE_TYPE_DNS_TUNNELING,
         RULE_TYPE_DNS_BEACONING,
+        RULE_TYPE_DNS_DGA,
     }
 )
 
@@ -1193,6 +1207,67 @@ async def _matching_dns_beaconing_subjects(
         ip = str(r.ip)
         message = (
             f"DNS client {ip} shows periodic callback behaviour " f"({r.score:.0f}/100). {r.detail}"
+        )
+        matches.append((ip, ip, message))
+    return matches
+
+
+async def _matching_dns_dga_subjects(
+    db: AsyncSession,
+    rule: AlertRule,
+) -> list[tuple[str, str, str]]:
+    """Clients that queried a crop of generated domain names (#699).
+
+    Same subject and windowing as the tunneling and beaconing matchers —
+    the client, over the trailing window — so a host running a DGA for
+    hours holds one open event and it auto-resolves when the crop stops.
+    Muted clients are excluded, as with the other two.
+
+    The message leads with the domain count and a sample of the worst
+    names rather than the score alone. "212 domains, worst
+    xkqjfhwbz.com" is something an operator can act on; a bare 84 is
+    not, and this detection in particular needs the evidence visible
+    because hashed-CDN and shortlink traffic shares the shape.
+    """
+    from app.models.dns_threat import DNSClientWindow  # noqa: PLC0415
+    from app.models.dns_threat_mute import DNSThreatMute  # noqa: PLC0415
+    from app.services.dns_threat.aggregate import DGA_ALERTING_SCORE  # noqa: PLC0415
+
+    threshold = rule.threshold_percent if rule.threshold_percent is not None else DGA_ALERTING_SCORE
+    since = datetime.now(UTC) - _DNS_TUNNEL_WINDOW
+    rn = func.row_number().over(
+        partition_by=DNSClientWindow.client_ip,
+        order_by=DNSClientWindow.dga_score.desc(),
+    )
+    ranked = (
+        select(
+            DNSClientWindow.client_ip.label("ip"),
+            DNSClientWindow.dga_score.label("score"),
+            DNSClientWindow.dga_detail.label("detail"),
+            rn.label("rn"),
+        )
+        .where(
+            DNSClientWindow.window_start >= since,
+            DNSClientWindow.dga_score >= threshold,
+            DNSClientWindow.client_ip.not_in(
+                select(DNSThreatMute.client_ip).where(
+                    or_(
+                        DNSThreatMute.muted_until.is_(None),
+                        DNSThreatMute.muted_until > datetime.now(UTC),
+                    )
+                )
+            ),
+        )
+        .subquery()
+    )
+    rows = (await db.execute(select(ranked).where(ranked.c.rn == 1))).all()
+
+    matches: list[tuple[str, str, str]] = []
+    for r in rows:
+        ip = str(r.ip)
+        message = (
+            f"DNS client {ip} queried a crop of algorithmically-generated domain "
+            f"names ({r.score:.0f}/100). {r.detail}"
         )
         matches.append((ip, ip, message))
     return matches
@@ -4406,6 +4481,53 @@ async def seed_dns_beaconing_alert_rule() -> None:
         await session.commit()
 
 
+async def seed_dns_dga_alert_rule() -> None:
+    """Seed ``dns_dga_suspected`` (#699), DISABLED by default.
+
+    Disabled for a reason specific to this detection rather than
+    beaconing's. The issue specified scoring NXDOMAIN-heavy clients;
+    the BIND9 query log carries no rcode, so the score rests on name
+    plausibility alone. That is a weaker basis than tunneling's four
+    independent signals, and hashed-CDN buckets, shortlink services and
+    any brand that bought a consonant cluster all share the shape. It
+    wants an operator who has looked at their own baseline on the DNS
+    Threat tab first — which is exactly what leaving it disarmed
+    encourages.
+    """
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+    from app.models.alerts import AlertRule  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as session:
+        existing = await session.scalar(
+            select(AlertRule).where(AlertRule.rule_type == RULE_TYPE_DNS_DGA)
+        )
+        if existing is not None:
+            return
+        session.add(
+            AlertRule(
+                name="DNS DGA suspected",
+                description=(
+                    "Fires when a client queries a crop of "
+                    "algorithmically-generated domain names — how malware "
+                    "finds its command-and-control server. Disabled by "
+                    "default: scoring is on name plausibility alone (the "
+                    "BIND9 query log carries no rcode, so there is no "
+                    "NXDOMAIN prior), and hashed-CDN and shortlink traffic "
+                    "shares the shape. Review your baseline on the DNS "
+                    "Threat tab before enabling. Requires the "
+                    "security.dns_threat module and query logging."
+                ),
+                rule_type=RULE_TYPE_DNS_DGA,
+                severity="warning",
+                enabled=False,
+                notify_syslog=True,
+                notify_webhook=True,
+                notify_smtp=False,
+            )
+        )
+        await session.commit()
+
+
 async def evaluate_all(db: AsyncSession) -> dict[str, int]:
     """Evaluate every enabled rule; open / resolve events as needed.
 
@@ -4502,6 +4624,10 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 subject_type = "dns_client"
             elif rule.rule_type == RULE_TYPE_DNS_BEACONING:
                 base = await _matching_dns_beaconing_subjects(db, rule)
+                matches = [(sid, disp, msg, None) for sid, disp, msg in base]
+                subject_type = "dns_client"
+            elif rule.rule_type == RULE_TYPE_DNS_DGA:
+                base = await _matching_dns_dga_subjects(db, rule)
                 matches = [(sid, disp, msg, None) for sid, disp, msg in base]
                 subject_type = "dns_client"
             elif rule.rule_type == RULE_TYPE_NEW_MAC_SEEN:

--- a/backend/app/services/backup/sections.py
+++ b/backend/app/services/backup/sections.py
@@ -325,7 +325,7 @@ SECTIONS: tuple[Section, ...] = (
             "restore would start paging about hosts an operator already "
             "reviewed and cleared."
         ),
-        tables=("dns_client_window", "dns_threat_mute"),
+        tables=("dns_client_window", "dns_threat_mute", "dns_rpz_hit"),
     ),
     Section(
         key="metrics",

--- a/backend/app/services/dns_threat/aggregate.py
+++ b/backend/app/services/dns_threat/aggregate.py
@@ -34,6 +34,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.dns_threat import DNSClientWindow
 from app.models.logs import DNSQueryLogEntry
 from app.services.dns_threat.beaconing import score_beaconing
+from app.services.dns_threat.dga import score_dga
 from app.services.dns_threat.scoring import (
     DEFAULT_BENIGN_PARENTS,
     extract_features,
@@ -67,6 +68,14 @@ ALERTING_SCORE = 60.0
 # alone, so a lower bar would page operators about their own
 # infrastructure until they turned the rule off.
 BEACON_ALERTING_SCORE = 85.0
+
+# DGA alerts higher than tunneling for the same reason beaconing does,
+# plus one specific to this detection: without the NXDOMAIN prior the
+# issue originally specified (the query log carries no rcode — see
+# ``dga.py``), the score rests on name plausibility alone. That is a
+# weaker basis than tunneling's four independent signals, so the bar to
+# wake someone is set correspondingly higher.
+DGA_ALERTING_SCORE = 80.0
 
 # How far back the raw query log is kept (``prune_log_entries``). The
 # backfill sweep can't recover anything older, because the evidence is
@@ -126,6 +135,9 @@ async def aggregate_window(
         feats = extract_features(batch, allowlist=allowlist)
         verdict = score_tunneling(feats)
         beacon = score_beaconing(timings)
+        # Scores off the parent map ``extract_features`` already built,
+        # so no second walk over the client's rows.
+        dga = score_dga(feats.parent_labels)
         await _upsert(
             db,
             client_ip=current_ip,
@@ -135,6 +147,7 @@ async def aggregate_window(
             score=verdict.score,
             signals=verdict.signals_json(),
             beacon=beacon,
+            dga=dga,
         )
         written += 1
         batch = []
@@ -169,6 +182,7 @@ async def _upsert(
     score: float,
     signals: list[dict[str, Any]],
     beacon: Any,
+    dga: Any,
 ) -> None:
     """Insert or refresh one client's bucket.
 
@@ -195,6 +209,10 @@ async def _upsert(
         "beacon_score": beacon.score,
         "beacon_candidates": beacon.candidates_json(),
         "beacon_detail": beacon.detail,
+        "dga_score": dga.score,
+        "dga_candidates": dga.candidates_json(),
+        "dga_signals": dga.signals,
+        "dga_detail": dga.detail,
         "allowlisted": feats.allowlisted,
     }
     stmt = pg_insert(DNSClientWindow).values(**values)

--- a/backend/app/services/dns_threat/aggregate.py
+++ b/backend/app/services/dns_threat/aggregate.py
@@ -211,7 +211,7 @@ async def _upsert(
         "beacon_detail": beacon.detail,
         "dga_score": dga.score,
         "dga_candidates": dga.candidates_json(),
-        "dga_signals": dga.signals,
+        "dga_signals": dga.signals_json(),
         "dga_detail": dga.detail,
         "allowlisted": feats.allowlisted,
     }

--- a/backend/app/services/dns_threat/dga.py
+++ b/backend/app/services/dns_threat/dga.py
@@ -44,6 +44,8 @@ import statistics
 from dataclasses import dataclass, field
 from typing import Any
 
+from app.services.dns_threat.scoring import Signal, ramp
+
 # Bigrams that turn up constantly in English words and in the brandable
 # labels people actually register. Deliberately a coarse membership set
 # rather than a trained frequency model: the job is separating
@@ -72,24 +74,40 @@ _W_PARENT_FANOUT = 30.0
 _W_PRONOUNCEABILITY = 20.0
 _W_LENGTH_UNIFORMITY = 15.0
 
-# Fraction of a label's bigrams absent from _COMMON_BIGRAMS. Real
-# brandable labels still miss plenty (brand names are odd on purpose),
-# so the floor is high — this only starts contributing well past what
-# ordinary domains score.
-_NGRAM_FLOOR = 0.55
-_NGRAM_CEIL = 0.92
+# Fraction of a label's bigrams absent from _COMMON_BIGRAMS.
+#
+# MEASURED against the shipped bigram set rather than guessed, because
+# the first cut of these numbers made the detection mathematically
+# unable to reach its own alerting threshold:
+#
+#   real word-shaped labels   0.06   (northwind, warehouse, logistics)
+#   random a-z 12-char        0.60   (Conficker / Necurs shape)
+#   random alphanumeric       0.61
+#
+# A uniformly random label tops out near 0.60, not 1.0, because 259 of
+# the 676 possible bigrams are in the common set and turn up by chance.
+# The old ceiling of 0.92 was therefore unreachable and the old floor
+# of 0.55 sat above where real domains land, so a genuine crop scored
+# ~7 of a possible 35. The separation between the two populations is
+# enormous (0.06 vs 0.60) — the thresholds just have to sit inside it.
+_NGRAM_FLOOR = 0.30
+_NGRAM_CEIL = 0.58
 
-# Distinct non-allowlisted parent domains in the hour. A browsing human
-# comfortably clears 50; a DGA crop is typically tried in bulk. Set so
-# ordinary traffic scores ~0 on this signal and only genuine spraying
-# registers.
-_FANOUT_FLOOR = 40
-_FANOUT_CEIL = 250
+# Distinct non-allowlisted parent domains in the hour. Floor matches
+# MIN_PARENTS_TO_SCORE so the signal starts exactly where scoring does.
+#
+# Fan-out ALONE means nothing — a build server, a mail gateway or a
+# proxy legitimately touches hundreds of domains an hour — which is why
+# this signal is conditioned on the n-gram signal below rather than
+# added independently. See score_dga.
+_FANOUT_FLOOR = 12
+_FANOUT_CEIL = 120
 
 # Vowel fraction of the label. Human-chosen labels sit near 0.35-0.40;
 # consonant soup sits far below. Inverted ramp — LOW is the signal.
-_VOWEL_RATIO_IMPLAUSIBLE = 0.12
-_VOWEL_RATIO_NORMAL = 0.34
+# Measured: random a-z sits at 0.22, real word labels at 0.40.
+_VOWEL_RATIO_IMPLAUSIBLE = 0.20
+_VOWEL_RATIO_NORMAL = 0.38
 
 # Coefficient of variation of label lengths across the client's parents.
 # Many DGA families emit a fixed or narrow length (all 12 chars, all
@@ -139,21 +157,16 @@ def vowel_ratio(label: str) -> float:
     return sum(1 for ch in letters if ch in _VOWELS) / len(letters)
 
 
-def _ramp(value: float, floor: float, ceil: float) -> float:
-    if ceil <= floor:
-        return 0.0
-    return max(0.0, min(1.0, (value - floor) / (ceil - floor)))
-
-
 def _inverse_ramp(value: float, low: float, high: float) -> float:
     """1.0 at or below ``low``, 0.0 at or above ``high``.
 
     For signals where a SMALL number is the suspicious one (vowel
-    deficiency, length uniformity).
+    deficiency, length uniformity). Expressed via the shared
+    :func:`~app.services.dns_threat.scoring.ramp` rather than its own
+    clamp so the three scorers cannot drift apart on the curve they all
+    document as producing comparable 0-100 numbers.
     """
-    if high <= low:
-        return 0.0
-    return max(0.0, min(1.0, (high - value) / (high - low)))
+    return 1.0 - ramp(value, low, high)
 
 
 @dataclass
@@ -179,7 +192,12 @@ class DGAVerdict:
     score: float = 0.0
     candidates: list[DGACandidate] = field(default_factory=list)
     detail: str = ""
-    signals: list[dict[str, Any]] = field(default_factory=list)
+    signals: list[Signal] = field(default_factory=list)
+
+    def signals_json(self) -> list[dict[str, Any]]:
+        """Mirrors ``TunnelVerdict.signals_json`` — one wire shape, one
+        ``SignalBar`` component rendering both detections' evidence."""
+        return [s.as_dict() for s in self.signals]
 
     def candidates_json(self) -> list[dict[str, Any]]:
         # Worst first, capped. The evidence blob is for an operator
@@ -187,20 +205,6 @@ class DGAVerdict:
         # bury the point rather than make it.
         ranked = sorted(self.candidates, key=lambda c: c.implausibility, reverse=True)
         return [c.as_dict() for c in ranked[:10]]
-
-
-def _signal(
-    name: str, value: float, contribution: float, max_contribution: float, detail: str
-) -> dict[str, Any]:
-    """Same wire shape as the tunneling scorer's ``Signal.as_dict`` so the
-    UI renders both detections' evidence with one component."""
-    return {
-        "name": name,
-        "value": round(value, 3),
-        "contribution": round(contribution, 1),
-        "max_contribution": round(max_contribution, 1),
-        "detail": detail,
-    }
 
 
 def score_dga(
@@ -226,7 +230,12 @@ def score_dga(
     judged = {
         parent: label for parent, label in parent_labels.items() if len(label) >= _MIN_LABEL_LENGTH
     }
-    if len(judged) < min_parents:
+    # ``max(1, ...)``: a caller passing min_parents=0 would otherwise
+    # skip this guard with an empty ``judged`` and reach
+    # statistics.fmean() on an empty sequence, raising StatisticsError
+    # out of aggregate_window's _flush and aborting the hourly rollup
+    # for EVERY client, not just this one.
+    if len(judged) < max(1, min_parents):
         return DGAVerdict(
             score=0.0,
             detail=(
@@ -235,10 +244,9 @@ def score_dga(
                 f"ordinary browsing"
             ),
             signals=[
-                _signal(
+                Signal(
                     "insufficient_domains",
                     float(len(judged)),
-                    0.0,
                     0.0,
                     "a DGA is identifiable by the size of its crop, not by any one name",
                 )
@@ -254,48 +262,62 @@ def score_dga(
     mean_len = statistics.fmean(lengths)
     length_cv = (statistics.pstdev(lengths) / mean_len) if mean_len > 0 else 1.0
 
-    ngram_r = _ramp(mean_implaus, _NGRAM_FLOOR, _NGRAM_CEIL)
-    fanout_r = _ramp(float(len(judged)), _FANOUT_FLOOR, _FANOUT_CEIL)
+    ngram_r = ramp(mean_implaus, _NGRAM_FLOOR, _NGRAM_CEIL)
+    fanout_r = ramp(float(len(judged)), _FANOUT_FLOOR, _FANOUT_CEIL)
     vowel_r = _inverse_ramp(mean_vowel, _VOWEL_RATIO_IMPLAUSIBLE, _VOWEL_RATIO_NORMAL)
     uniform_r = _inverse_ramp(length_cv, _LENGTH_CV_UNIFORM, _LENGTH_CV_ORGANIC)
 
+    # Fan-out and length-uniformity are CONDITIONED on the n-gram
+    # signal rather than added independently. Both are really proxies
+    # for "this client queried a lot of domains", and a build server, a
+    # mail gateway or (very commonly) a downstream forwarder that
+    # collapses a whole office onto one client_ip legitimately touches
+    # hundreds of parents an hour. Additive, they handed such a client
+    # 36/100 with ZERO implausible names, which both outranked genuine
+    # smaller crops and contradicted this module's own docstring
+    # ("the fan-out gate means a client has to be spraying *many*
+    # IMPLAUSIBLE parents"). Multiplying by ngram_r makes that sentence
+    # true: nothing gibberish-looking, nothing scored. Pronounceability
+    # stays independent because it measures plausibility directly.
     signals = [
-        _signal(
+        Signal(
             "ngram_implausibility",
             mean_implaus,
             ngram_r * _W_NGRAM,
-            _W_NGRAM,
             f"{mean_implaus:.0%} of character pairs across {len(judged)} domains are "
-            f"not word-shaped (algorithmic labels score high; brandable ones, even "
-            f"odd ones, sit well below)",
+            f"not word-shaped (algorithmic labels measure ~0.60, real ones ~0.06)",
+            max_contribution=_W_NGRAM,
         ),
-        _signal(
+        Signal(
             "domain_fanout",
             float(len(judged)),
-            fanout_r * _W_PARENT_FANOUT,
-            _W_PARENT_FANOUT,
+            fanout_r * ngram_r * _W_PARENT_FANOUT,
             f"{len(judged)} distinct registrable domains in one hour (a DGA tries a "
             f"whole crop; this is the signal that separates it from tunneling, which "
-            f"concentrates under one parent)",
+            f"concentrates under one parent). Scaled by the implausibility signal — "
+            f"a busy host querying ordinary domains scores nothing here.",
+            max_contribution=_W_PARENT_FANOUT,
         ),
-        _signal(
+        Signal(
             "pronounceability",
             mean_vowel,
             vowel_r * _W_PRONOUNCEABILITY,
-            _W_PRONOUNCEABILITY,
             f"mean vowel fraction {mean_vowel:.0%} (human-chosen labels sit near 34%; "
             f"consonant soup sits far below)",
+            max_contribution=_W_PRONOUNCEABILITY,
         ),
-        _signal(
+        Signal(
             "length_uniformity",
             length_cv,
-            uniform_r * _W_LENGTH_UNIFORMITY,
-            _W_LENGTH_UNIFORMITY,
+            uniform_r * ngram_r * _W_LENGTH_UNIFORMITY,
             f"label lengths vary by {length_cv:.0%} around a mean of {mean_len:.0f} "
-            f"chars (many DGA families emit a fixed width; organic browsing does not)",
+            f"chars (many DGA families emit a fixed width). Scaled by the "
+            f"implausibility signal — real browsing has a modest spread too, so "
+            f"uniformity alone must not add points.",
+            max_contribution=_W_LENGTH_UNIFORMITY,
         ),
     ]
-    score = sum(s["contribution"] for s in signals)
+    score = sum(sig.contribution for sig in signals)
 
     candidates = [
         DGACandidate(

--- a/backend/app/services/dns_threat/dga.py
+++ b/backend/app/services/dns_threat/dga.py
@@ -1,0 +1,321 @@
+"""DGA (domain-generation algorithm) detection — name plausibility (issue #699).
+
+Malware that resolves its C2 through a DGA generates a fresh crop of
+domains on a schedule, tries them in turn, and keeps whichever one the
+operator registered that day. The give-away is not any single name but
+the *crop*: dozens of registrable domains, each looking like nothing a
+human would choose.
+
+**This is structurally the inverse of tunneling**, which is why it is a
+separate scorer rather than more weights on
+:mod:`app.services.dns_threat.scoring`. A tunnel concentrates — thousands
+of unique subdomains beneath ONE parent it controls. A DGA sprays —
+one or two lookups each across MANY distinct parents it hopes to
+control. Scoring both from one weighted sum would mean each detection's
+strongest signal is the other's evidence of innocence.
+
+**On the NXDOMAIN prior.** Issue #699 originally specified scoring
+"NXDOMAIN-heavy clients", because a DGA's crop is mostly unregistered
+and so mostly fails. We cannot do that: ``dns_query_log_entry`` records
+the question, never the answer — the BIND9 query log carries no rcode,
+which is why the existing ``dns_nxdomain_spike`` rule reads
+``dns_metric_sample`` instead. Three options were written up on the
+issue; this implements the first — score on name characteristics alone.
+That is weaker than a true NXDOMAIN prior and the thresholds are set
+accordingly conservative, but it works on data we already collect and
+needs no new agent plumbing. The per-server NXDOMAIN counts in
+``dns_metric_sample`` remain available as a future multiplier; this
+module deliberately keeps its signals additive so one can be layered on
+without restructuring the score.
+
+**On false positives.** Plenty of legitimate domains are unpronounceable
+— hashed CDN buckets, shortlink services, IPv6-literal-ish labels, and
+any brand that bought a consonant cluster. Those are handled the same
+way tunneling handles them: the shared allowlist in
+:data:`~app.services.dns_threat.scoring.DEFAULT_BENIGN_PARENTS` clears
+them before scoring, and the fan-out gate means a client has to be
+spraying *many* implausible parents before it scores at all. One weird
+domain is not a DGA; forty in an hour is.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+from typing import Any
+
+# Bigrams that turn up constantly in English words and in the brandable
+# labels people actually register. Deliberately a coarse membership set
+# rather than a trained frequency model: the job is separating
+# "pronounceable thing a human picked" from "output of a PRNG", and a
+# 200-entry set does that without shipping a corpus, a model file, or a
+# refresh problem. A label whose bigrams are mostly absent from this set
+# is not necessarily malicious — it is merely not word-shaped.
+_COMMON_BIGRAMS: frozenset[str] = frozenset(
+    """th he in er an re on at en nd ti es or te of ed is it al ar st to nt ng se ha as ou io
+    le ve co me de hi ri ro ic ne ea ra ce li ch ll be ma si om ur ca el ta la ns di fo ho pe
+    ec pr no ct us ac ot il tr ly nc et ut ss so rs un lo wa ge ie wh ee wi em ad ol rt po we
+    na ul ni ts mo ow pa im mi ai sh ir su id os iv ia am fi ci vi pl ig tu ev ld ry mp fe bl
+    ab gh ty op wo sa ay ex ky fr oo av ag if ap gr od bo sp rd do uc bu ei ov by rm ep tt oc
+    fa ef cu rn sc gi da yo cr cl du ga qu ue ff ba ey ls va um pp ua up lu go ht ru ug ds lt
+    pi rc rr eg au ck ew mu br bi pt ak pu ui rg ib tl ny ki rk ys ob mm fu ph og ms ye ud mb
+    ip ub oi rl gu dr cc tw ft wn nu af hu nn eo vo nf sm fl ok nl my gl aw ju oa sy sl ps jo
+    lf nv je nk kn gs dy hy ze ks bs ik dd cy rp sk oe ws eu wr""".split()
+)
+
+_VOWELS = frozenset("aeiouy")
+
+# Weights sum to 100, mirroring the tunneling and beaconing scorers so
+# all three produce comparable numbers on the same 0-100 scale.
+_W_NGRAM = 35.0
+_W_PARENT_FANOUT = 30.0
+_W_PRONOUNCEABILITY = 20.0
+_W_LENGTH_UNIFORMITY = 15.0
+
+# Fraction of a label's bigrams absent from _COMMON_BIGRAMS. Real
+# brandable labels still miss plenty (brand names are odd on purpose),
+# so the floor is high — this only starts contributing well past what
+# ordinary domains score.
+_NGRAM_FLOOR = 0.55
+_NGRAM_CEIL = 0.92
+
+# Distinct non-allowlisted parent domains in the hour. A browsing human
+# comfortably clears 50; a DGA crop is typically tried in bulk. Set so
+# ordinary traffic scores ~0 on this signal and only genuine spraying
+# registers.
+_FANOUT_FLOOR = 40
+_FANOUT_CEIL = 250
+
+# Vowel fraction of the label. Human-chosen labels sit near 0.35-0.40;
+# consonant soup sits far below. Inverted ramp — LOW is the signal.
+_VOWEL_RATIO_IMPLAUSIBLE = 0.12
+_VOWEL_RATIO_NORMAL = 0.34
+
+# Coefficient of variation of label lengths across the client's parents.
+# Many DGA families emit a fixed or narrow length (all 12 chars, all
+# 16). Organic browsing has wildly varying label lengths, so a LOW
+# spread across many domains is itself suspicious. Inverted ramp.
+_LENGTH_CV_UNIFORM = 0.05
+_LENGTH_CV_ORGANIC = 0.45
+
+# Below this many distinct scoreable parents the maths says nothing: a
+# handful of odd domains is a person clicking a link, not a crop.
+MIN_PARENTS_TO_SCORE = 12
+
+# Labels shorter than this carry too few bigrams to judge (``go``,
+# ``bit``), and are overwhelmingly legitimate short brandables.
+_MIN_LABEL_LENGTH = 6
+
+
+def bigram_implausibility(label: str) -> float:
+    """Fraction of a label's character bigrams absent from the common set.
+
+    1.0 = every adjacent pair is unusual (``xkqjfhwbz``); 0.0 = every
+    pair is word-shaped (``newsletter``). Digits are stripped first
+    rather than counted as unusual — plenty of legitimate domains carry
+    them, and leaving them in made every ``o365``-shaped label score as
+    gibberish.
+    """
+    cleaned = "".join(ch for ch in label.lower() if ch.isalpha())
+    if len(cleaned) < 3:
+        return 0.0
+    pairs = [cleaned[i : i + 2] for i in range(len(cleaned) - 1)]
+    if not pairs:
+        return 0.0
+    missing = sum(1 for p in pairs if p not in _COMMON_BIGRAMS)
+    return missing / len(pairs)
+
+
+def vowel_ratio(label: str) -> float:
+    """Fraction of alphabetic characters that are vowels (``y`` counts).
+
+    Returns the normal-looking 0.34 for labels with no letters at all,
+    so an all-numeric label contributes nothing rather than reading as
+    maximally implausible.
+    """
+    letters = [ch for ch in label.lower() if ch.isalpha()]
+    if not letters:
+        return _VOWEL_RATIO_NORMAL
+    return sum(1 for ch in letters if ch in _VOWELS) / len(letters)
+
+
+def _ramp(value: float, floor: float, ceil: float) -> float:
+    if ceil <= floor:
+        return 0.0
+    return max(0.0, min(1.0, (value - floor) / (ceil - floor)))
+
+
+def _inverse_ramp(value: float, low: float, high: float) -> float:
+    """1.0 at or below ``low``, 0.0 at or above ``high``.
+
+    For signals where a SMALL number is the suspicious one (vowel
+    deficiency, length uniformity).
+    """
+    if high <= low:
+        return 0.0
+    return max(0.0, min(1.0, (high - value) / (high - low)))
+
+
+@dataclass
+class DGACandidate:
+    """One registrable domain that scored as algorithmically generated."""
+
+    parent: str
+    label: str
+    implausibility: float
+    vowel_ratio: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "parent": self.parent,
+            "label": self.label,
+            "implausibility": round(self.implausibility, 3),
+            "vowel_ratio": round(self.vowel_ratio, 3),
+        }
+
+
+@dataclass
+class DGAVerdict:
+    score: float = 0.0
+    candidates: list[DGACandidate] = field(default_factory=list)
+    detail: str = ""
+    signals: list[dict[str, Any]] = field(default_factory=list)
+
+    def candidates_json(self) -> list[dict[str, Any]]:
+        # Worst first, capped. The evidence blob is for an operator
+        # triaging one finding — showing all 200 domains of a crop would
+        # bury the point rather than make it.
+        ranked = sorted(self.candidates, key=lambda c: c.implausibility, reverse=True)
+        return [c.as_dict() for c in ranked[:10]]
+
+
+def _signal(
+    name: str, value: float, contribution: float, max_contribution: float, detail: str
+) -> dict[str, Any]:
+    """Same wire shape as the tunneling scorer's ``Signal.as_dict`` so the
+    UI renders both detections' evidence with one component."""
+    return {
+        "name": name,
+        "value": round(value, 3),
+        "contribution": round(contribution, 1),
+        "max_contribution": round(max_contribution, 1),
+        "detail": detail,
+    }
+
+
+def score_dga(
+    parent_labels: dict[str, str],
+    *,
+    min_parents: int = MIN_PARENTS_TO_SCORE,
+) -> DGAVerdict:
+    """Score one client's window for domain-generation-algorithm traffic.
+
+    ``parent_labels`` maps each distinct non-allowlisted parent domain
+    the client queried to its registrable label — ``xkqjfhwbz.com`` →
+    ``xkqjfhwbz``. The aggregator builds it while it is already walking
+    the client's rows, so this costs no extra pass.
+
+    Scored across the crop rather than per-domain: a single
+    unpronounceable name is a hashed CDN bucket or an odd brand, and
+    scoring it alone would flag half the internet. The signal is *many*
+    implausible parents at once.
+    """
+    # Labels too short to judge are dropped rather than scored as
+    # plausible — averaging in a pile of 0.0s from three-letter domains
+    # would dilute a real crop's implausibility toward nothing.
+    judged = {
+        parent: label for parent, label in parent_labels.items() if len(label) >= _MIN_LABEL_LENGTH
+    }
+    if len(judged) < min_parents:
+        return DGAVerdict(
+            score=0.0,
+            detail=(
+                f"{len(judged)} distinct judgeable domains in the window; "
+                f"{min_parents} needed before a crop can be distinguished from "
+                f"ordinary browsing"
+            ),
+            signals=[
+                _signal(
+                    "insufficient_domains",
+                    float(len(judged)),
+                    0.0,
+                    0.0,
+                    "a DGA is identifiable by the size of its crop, not by any one name",
+                )
+            ],
+        )
+
+    implausibilities = {p: bigram_implausibility(lbl) for p, lbl in judged.items()}
+    vowels = {p: vowel_ratio(lbl) for p, lbl in judged.items()}
+    lengths = [len(lbl) for lbl in judged.values()]
+
+    mean_implaus = statistics.fmean(implausibilities.values())
+    mean_vowel = statistics.fmean(vowels.values())
+    mean_len = statistics.fmean(lengths)
+    length_cv = (statistics.pstdev(lengths) / mean_len) if mean_len > 0 else 1.0
+
+    ngram_r = _ramp(mean_implaus, _NGRAM_FLOOR, _NGRAM_CEIL)
+    fanout_r = _ramp(float(len(judged)), _FANOUT_FLOOR, _FANOUT_CEIL)
+    vowel_r = _inverse_ramp(mean_vowel, _VOWEL_RATIO_IMPLAUSIBLE, _VOWEL_RATIO_NORMAL)
+    uniform_r = _inverse_ramp(length_cv, _LENGTH_CV_UNIFORM, _LENGTH_CV_ORGANIC)
+
+    signals = [
+        _signal(
+            "ngram_implausibility",
+            mean_implaus,
+            ngram_r * _W_NGRAM,
+            _W_NGRAM,
+            f"{mean_implaus:.0%} of character pairs across {len(judged)} domains are "
+            f"not word-shaped (algorithmic labels score high; brandable ones, even "
+            f"odd ones, sit well below)",
+        ),
+        _signal(
+            "domain_fanout",
+            float(len(judged)),
+            fanout_r * _W_PARENT_FANOUT,
+            _W_PARENT_FANOUT,
+            f"{len(judged)} distinct registrable domains in one hour (a DGA tries a "
+            f"whole crop; this is the signal that separates it from tunneling, which "
+            f"concentrates under one parent)",
+        ),
+        _signal(
+            "pronounceability",
+            mean_vowel,
+            vowel_r * _W_PRONOUNCEABILITY,
+            _W_PRONOUNCEABILITY,
+            f"mean vowel fraction {mean_vowel:.0%} (human-chosen labels sit near 34%; "
+            f"consonant soup sits far below)",
+        ),
+        _signal(
+            "length_uniformity",
+            length_cv,
+            uniform_r * _W_LENGTH_UNIFORMITY,
+            _W_LENGTH_UNIFORMITY,
+            f"label lengths vary by {length_cv:.0%} around a mean of {mean_len:.0f} "
+            f"chars (many DGA families emit a fixed width; organic browsing does not)",
+        ),
+    ]
+    score = sum(s["contribution"] for s in signals)
+
+    candidates = [
+        DGACandidate(
+            parent=parent,
+            label=judged[parent],
+            implausibility=implausibilities[parent],
+            vowel_ratio=vowels[parent],
+        )
+        for parent in judged
+    ]
+    worst = max(candidates, key=lambda c: c.implausibility)
+    return DGAVerdict(
+        score=score,
+        candidates=candidates,
+        signals=signals,
+        detail=(
+            f"{len(judged)} distinct domains queried, mean bigram implausibility "
+            f"{mean_implaus:.0%} (worst: {worst.parent}) — this is what a "
+            f"domain-generation algorithm's crop looks like; confirm against the "
+            f"host's software before treating it as an infection, since hashed CDN "
+            f"and shortlink traffic shares the shape"
+        ),
+    )

--- a/backend/app/services/dns_threat/rpz.py
+++ b/backend/app/services/dns_threat/rpz.py
@@ -37,6 +37,16 @@ PASSTHRU = "PASSTHRU"
 NOISY_CLIENT_HITS = 50
 
 
+def _blocked(since: datetime) -> tuple[Any, ...]:
+    """The predicate every "what was blocked" query shares.
+
+    Defined once because it was restated six times across this module
+    and a single missed ``policy != PASSTHRU`` silently turns an
+    explicit ALLOW into a reported block.
+    """
+    return (DNSRPZHit.ts >= since, DNSRPZHit.policy != PASSTHRU)
+
+
 async def top_offending_clients(
     db: AsyncSession,
     *,
@@ -52,7 +62,10 @@ async def top_offending_clients(
     would be noise. :func:`summary` keeps it.
     """
     since = datetime.now(UTC) - timedelta(hours=hours)
-    stmt = (
+    base = _blocked(since)
+
+    # Per-client totals.
+    totals = (
         select(
             DNSRPZHit.client_ip.label("client_ip"),
             func.count().label("hits"),
@@ -60,51 +73,70 @@ async def top_offending_clients(
             func.count(func.distinct(DNSRPZHit.rpz_zone)).label("distinct_feeds"),
             func.max(DNSRPZHit.ts).label("last_seen"),
         )
-        .where(
-            DNSRPZHit.ts >= since,
-            DNSRPZHit.client_ip.is_not(None),
-            DNSRPZHit.policy != PASSTHRU,
-        )
+        .where(*base, DNSRPZHit.client_ip.is_not(None))
         .group_by(DNSRPZHit.client_ip)
         .having(func.count() >= min_hits)
         .order_by(func.count().desc())
         .limit(limit)
+        .subquery()
     )
-    rows = (await db.execute(stmt)).all()
 
-    out: list[dict[str, Any]] = []
-    for r in rows:
-        ip = str(r.client_ip)
-        # The single name this client hit hardest — the detail that
-        # turns "10.0.0.5 made 4,000 blocked lookups" into something an
-        # operator can actually chase.
-        worst = (
-            await db.execute(
-                select(DNSRPZHit.qname, func.count().label("n"))
-                .where(
-                    DNSRPZHit.ts >= since,
-                    DNSRPZHit.client_ip == ip,
-                    DNSRPZHit.policy != PASSTHRU,
-                    DNSRPZHit.qname.is_not(None),
-                )
-                .group_by(DNSRPZHit.qname)
-                .order_by(func.count().desc())
-                .limit(1)
-            )
-        ).first()
-        out.append(
-            {
-                "client_ip": ip,
-                "hits": r.hits,
-                "distinct_names": r.distinct_names,
-                "distinct_feeds": r.distinct_feeds,
-                "last_seen": r.last_seen,
-                "top_qname": worst.qname if worst else None,
-                "top_qname_hits": worst.n if worst else 0,
-                "noisy": r.hits >= NOISY_CLIENT_HITS,
-            }
+    # Worst name per client, ranked in ONE pass. This was a per-client
+    # SELECT inside the result loop — 1+N, so 201 serialised round trips
+    # at the endpoint's limit=200 ceiling, on a 30-day-retention table,
+    # and the cost scaled with how noisy the client was (i.e. worst for
+    # exactly the host this feature exists to surface). Same
+    # ``row_number() OVER (PARTITION BY ...)`` idiom the tunneling alert
+    # matcher already uses for the same shape.
+    per_name = (
+        select(
+            DNSRPZHit.client_ip.label("client_ip"),
+            DNSRPZHit.qname.label("qname"),
+            func.count().label("n"),
         )
-    return out
+        .where(*base, DNSRPZHit.client_ip.is_not(None), DNSRPZHit.qname.is_not(None))
+        .group_by(DNSRPZHit.client_ip, DNSRPZHit.qname)
+        .subquery()
+    )
+    ranked = select(
+        per_name.c.client_ip,
+        per_name.c.qname,
+        per_name.c.n,
+        func.row_number()
+        .over(partition_by=per_name.c.client_ip, order_by=per_name.c.n.desc())
+        .label("rn"),
+    ).subquery()
+    # Materialised ONCE — calling .subquery() per reference mints a
+    # distinct alias each time, which Postgres rejects with "missing
+    # FROM-clause entry".
+    worst = (
+        select(ranked.c.client_ip, ranked.c.qname, ranked.c.n).where(ranked.c.rn == 1).subquery()
+    )
+
+    stmt = select(
+        totals.c.client_ip,
+        totals.c.hits,
+        totals.c.distinct_names,
+        totals.c.distinct_feeds,
+        totals.c.last_seen,
+        worst.c.qname.label("top_qname"),
+        worst.c.n.label("top_qname_hits"),
+    ).select_from(totals.outerjoin(worst, totals.c.client_ip == worst.c.client_ip))
+    rows = (await db.execute(stmt.order_by(totals.c.hits.desc()))).all()
+
+    return [
+        {
+            "client_ip": str(r.client_ip),
+            "hits": r.hits,
+            "distinct_names": r.distinct_names,
+            "distinct_feeds": r.distinct_feeds,
+            "last_seen": r.last_seen,
+            "top_qname": r.top_qname,
+            "top_qname_hits": r.top_qname_hits or 0,
+            "noisy": r.hits >= NOISY_CLIENT_HITS,
+        }
+        for r in rows
+    ]
 
 
 async def top_blocked_names(
@@ -120,11 +152,7 @@ async def top_blocked_names(
                 func.count(func.distinct(DNSRPZHit.client_ip)).label("clients"),
                 func.min(DNSRPZHit.rpz_zone).label("rpz_zone"),
             )
-            .where(
-                DNSRPZHit.ts >= since,
-                DNSRPZHit.qname.is_not(None),
-                DNSRPZHit.policy != PASSTHRU,
-            )
+            .where(*_blocked(since), DNSRPZHit.qname.is_not(None))
             .group_by(DNSRPZHit.qname)
             .order_by(func.count().desc())
             .limit(limit)
@@ -142,12 +170,22 @@ async def top_blocked_names(
 
 
 async def feed_effectiveness(db: AsyncSession, *, hours: int = 24) -> list[dict[str, Any]]:
-    """Hits per blocklist feed — which lists are actually earning their keep.
+    """Hits per RPZ zone.
 
-    Operators subscribe to feeds and never learn which ones fire. A feed
-    with zero hits over a month is a candidate for removal; one carrying
-    most of the blocking is a candidate for keeping through a
-    consolidation.
+    **Resolution caveat.** ``dns/agent_config.py`` merges every enabled
+    blocklist into ONE rendered RPZ zone per view
+    (``spatium-blocklist[-<view>].rpz``), dropping the per-entry
+    ``list_id``/``list_name`` that ``EffectiveEntry`` carries. So for
+    SpatiumDDI-managed blocklists this returns one row per *view*, not
+    one per subscribed feed — it cannot currently answer "which of my 14
+    lists is firing". Splitting that apart needs either one rendered zone
+    per list or a join from the blocked qname back to
+    ``DNSBlockListEntry`` at report time; both are follow-up work,
+    tracked on #699.
+
+    It IS meaningful for operators running additional hand-rolled
+    ``response-policy`` zones alongside ours, and for separating hits
+    per view on a split-horizon install.
     """
     since = datetime.now(UTC) - timedelta(hours=hours)
     rows = (
@@ -158,9 +196,15 @@ async def feed_effectiveness(db: AsyncSession, *, hours: int = 24) -> list[dict[
                 func.count(func.distinct(DNSRPZHit.client_ip)).label("clients"),
                 func.count(func.distinct(DNSRPZHit.qname)).label("distinct_names"),
             )
-            .where(DNSRPZHit.ts >= since, DNSRPZHit.policy != PASSTHRU)
+            # ``rpz_zone IS NOT NULL`` keeps this consistent with
+            # summary()'s ``count(distinct rpz_zone)``, which skips NULLs
+            # by SQL semantics. Without it the card and the drilldown
+            # disagreed on the feed count whenever a ``via`` clause
+            # failed to parse.
+            .where(*_blocked(since), DNSRPZHit.rpz_zone.is_not(None))
             .group_by(DNSRPZHit.rpz_zone)
             .order_by(func.count().desc())
+            .limit(50)
         )
     ).all()
     return [
@@ -192,7 +236,7 @@ async def summary(db: AsyncSession, *, hours: int = 24) -> dict[str, Any]:
                 func.count(func.distinct(DNSRPZHit.client_ip)).label("clients"),
                 func.count(func.distinct(DNSRPZHit.qname)).label("names"),
                 func.count(func.distinct(DNSRPZHit.rpz_zone)).label("feeds"),
-            ).where(DNSRPZHit.ts >= since, DNSRPZHit.policy != PASSTHRU)
+            ).where(*_blocked(since))
         )
     ).one()
     # Counted separately rather than filtered out entirely: an operator

--- a/backend/app/services/dns_threat/rpz.py
+++ b/backend/app/services/dns_threat/rpz.py
@@ -1,0 +1,219 @@
+"""RPZ hit attribution — which clients keep reaching for blocked names (#699).
+
+We serve curated blocklists as RPZ zones and, before this, discarded
+every hit. That left the most operationally useful thing the blocklists
+can tell you unanswerable: a blocked lookup is not a problem, but a
+host generating thousands of them is an infected machine announcing
+itself, and we were throwing that away.
+
+Pure reporting — unlike the other three detections there is no scoring
+here, because there is nothing to infer. A hit is ground truth: named
+matched a policy and said so. The job is only to attribute hits to
+clients and feeds and rank them.
+
+**PASSTHRU is not a block.** It is an explicit allow — an exception
+entry that let a name through *past* a blocklist. Counting it as a
+block would inflate every client's number and, worse, would make a
+correctly-configured allowlist look like an infection. Every function
+here separates the two.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns_rpz_hit import DNSRPZHit
+
+# An explicit allow, not a block. See the module docstring.
+PASSTHRU = "PASSTHRU"
+
+# A client has to be reaching for blocked names with some persistence
+# before it is worth an operator's attention. One hit is an ad on a web
+# page; hundreds in a day is a host with something running on it.
+NOISY_CLIENT_HITS = 50
+
+
+async def top_offending_clients(
+    db: AsyncSession,
+    *,
+    hours: int = 24,
+    limit: int = 20,
+    min_hits: int = 1,
+) -> list[dict[str, Any]]:
+    """Clients ranked by blocked-lookup count over the trailing window.
+
+    Rows with no ``client_ip`` are excluded: a hit we could not attribute
+    still counts toward the totals (it proves the blocklist fired) but
+    cannot be pinned to a host, and listing it as an anonymous offender
+    would be noise. :func:`summary` keeps it.
+    """
+    since = datetime.now(UTC) - timedelta(hours=hours)
+    stmt = (
+        select(
+            DNSRPZHit.client_ip.label("client_ip"),
+            func.count().label("hits"),
+            func.count(func.distinct(DNSRPZHit.qname)).label("distinct_names"),
+            func.count(func.distinct(DNSRPZHit.rpz_zone)).label("distinct_feeds"),
+            func.max(DNSRPZHit.ts).label("last_seen"),
+        )
+        .where(
+            DNSRPZHit.ts >= since,
+            DNSRPZHit.client_ip.is_not(None),
+            DNSRPZHit.policy != PASSTHRU,
+        )
+        .group_by(DNSRPZHit.client_ip)
+        .having(func.count() >= min_hits)
+        .order_by(func.count().desc())
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).all()
+
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        ip = str(r.client_ip)
+        # The single name this client hit hardest — the detail that
+        # turns "10.0.0.5 made 4,000 blocked lookups" into something an
+        # operator can actually chase.
+        worst = (
+            await db.execute(
+                select(DNSRPZHit.qname, func.count().label("n"))
+                .where(
+                    DNSRPZHit.ts >= since,
+                    DNSRPZHit.client_ip == ip,
+                    DNSRPZHit.policy != PASSTHRU,
+                    DNSRPZHit.qname.is_not(None),
+                )
+                .group_by(DNSRPZHit.qname)
+                .order_by(func.count().desc())
+                .limit(1)
+            )
+        ).first()
+        out.append(
+            {
+                "client_ip": ip,
+                "hits": r.hits,
+                "distinct_names": r.distinct_names,
+                "distinct_feeds": r.distinct_feeds,
+                "last_seen": r.last_seen,
+                "top_qname": worst.qname if worst else None,
+                "top_qname_hits": worst.n if worst else 0,
+                "noisy": r.hits >= NOISY_CLIENT_HITS,
+            }
+        )
+    return out
+
+
+async def top_blocked_names(
+    db: AsyncSession, *, hours: int = 24, limit: int = 20
+) -> list[dict[str, Any]]:
+    """The blocked names themselves, ranked by hit count."""
+    since = datetime.now(UTC) - timedelta(hours=hours)
+    rows = (
+        await db.execute(
+            select(
+                DNSRPZHit.qname.label("qname"),
+                func.count().label("hits"),
+                func.count(func.distinct(DNSRPZHit.client_ip)).label("clients"),
+                func.min(DNSRPZHit.rpz_zone).label("rpz_zone"),
+            )
+            .where(
+                DNSRPZHit.ts >= since,
+                DNSRPZHit.qname.is_not(None),
+                DNSRPZHit.policy != PASSTHRU,
+            )
+            .group_by(DNSRPZHit.qname)
+            .order_by(func.count().desc())
+            .limit(limit)
+        )
+    ).all()
+    return [
+        {
+            "qname": r.qname,
+            "hits": r.hits,
+            "clients": r.clients,
+            "rpz_zone": r.rpz_zone,
+        }
+        for r in rows
+    ]
+
+
+async def feed_effectiveness(db: AsyncSession, *, hours: int = 24) -> list[dict[str, Any]]:
+    """Hits per blocklist feed — which lists are actually earning their keep.
+
+    Operators subscribe to feeds and never learn which ones fire. A feed
+    with zero hits over a month is a candidate for removal; one carrying
+    most of the blocking is a candidate for keeping through a
+    consolidation.
+    """
+    since = datetime.now(UTC) - timedelta(hours=hours)
+    rows = (
+        await db.execute(
+            select(
+                DNSRPZHit.rpz_zone.label("rpz_zone"),
+                func.count().label("hits"),
+                func.count(func.distinct(DNSRPZHit.client_ip)).label("clients"),
+                func.count(func.distinct(DNSRPZHit.qname)).label("distinct_names"),
+            )
+            .where(DNSRPZHit.ts >= since, DNSRPZHit.policy != PASSTHRU)
+            .group_by(DNSRPZHit.rpz_zone)
+            .order_by(func.count().desc())
+        )
+    ).all()
+    return [
+        {
+            "rpz_zone": r.rpz_zone,
+            "hits": r.hits,
+            "clients": r.clients,
+            "distinct_names": r.distinct_names,
+        }
+        for r in rows
+    ]
+
+
+async def summary(db: AsyncSession, *, hours: int = 24) -> dict[str, Any]:
+    """Rollup for the dashboard card and the Operator Copilot.
+
+    ``has_data`` distinguishes "nothing was blocked" from "this isn't
+    running" — the same contract the threat summary carries, and for the
+    same reason: an idle feature rendering as an all-clear is exactly
+    the failure this whole area exists to avoid. Here it is sharper than
+    usual, because zero hits is a *plausible* real answer on a quiet
+    network, so the UI must not have to guess.
+    """
+    since = datetime.now(UTC) - timedelta(hours=hours)
+    totals = (
+        await db.execute(
+            select(
+                func.count().label("hits"),
+                func.count(func.distinct(DNSRPZHit.client_ip)).label("clients"),
+                func.count(func.distinct(DNSRPZHit.qname)).label("names"),
+                func.count(func.distinct(DNSRPZHit.rpz_zone)).label("feeds"),
+            ).where(DNSRPZHit.ts >= since, DNSRPZHit.policy != PASSTHRU)
+        )
+    ).one()
+    # Counted separately rather than filtered out entirely: an operator
+    # tuning an allowlist wants to see it working.
+    passthru = (
+        await db.execute(
+            select(func.count()).where(DNSRPZHit.ts >= since, DNSRPZHit.policy == PASSTHRU)
+        )
+    ).scalar_one()
+    # Any hit at all — including PASSTHRU and unattributable rows — is
+    # proof the pipeline is alive, which is what has_data must mean.
+    any_row = (await db.execute(select(func.count()).where(DNSRPZHit.ts >= since))).scalar_one()
+    top = await top_offending_clients(db, hours=hours, limit=1)
+    return {
+        "blocked_hits": totals.hits or 0,
+        "clients_blocked": totals.clients or 0,
+        "distinct_names": totals.names or 0,
+        "feeds_firing": totals.feeds or 0,
+        "passthru_hits": passthru or 0,
+        "worst_client_ip": top[0]["client_ip"] if top else None,
+        "worst_client_hits": top[0]["hits"] if top else None,
+        "since": since,
+        "has_data": (any_row or 0) > 0,
+    }

--- a/backend/app/services/dns_threat/scoring.py
+++ b/backend/app/services/dns_threat/scoring.py
@@ -234,6 +234,13 @@ class ClientFeatures:
     payload_qtype_count: int = 0
     server_count: int = 1
     allowlisted: bool = False
+    # Each distinct non-allowlisted parent domain this client queried,
+    # mapped to its registrable label (``xkqjfhwbz.com`` →
+    # ``xkqjfhwbz``). Populated here because this walk already derives
+    # every parent, so the DGA scorer costs no second pass over what can
+    # be tens of thousands of log lines. Not persisted as a column — the
+    # DGA verdict it produces is.
+    parent_labels: dict[str, str] = field(default_factory=dict)
 
     @property
     def payload_qtype_ratio(self) -> float:
@@ -318,6 +325,12 @@ def extract_features(
         and feats.scored_query_count == 0
         and feats.unparseable_count < feats.query_count
     )
+
+    # The parent's leftmost label is the registrable one — the part a
+    # DGA actually generates. ``split_qname`` has already trimmed the
+    # public suffix, so ``example.co.uk`` yields ``example`` rather than
+    # ``co``.
+    feats.parent_labels = {parent: parent.split(".")[0] for parent in per_parent}
 
     if per_parent:
         top_parent, subs = max(per_parent.items(), key=lambda kv: len(kv[1]))

--- a/backend/app/services/dns_threat/scoring.py
+++ b/backend/app/services/dns_threat/scoring.py
@@ -195,7 +195,7 @@ def split_qname(qname: str) -> tuple[list[str], str]:
     return (labels[: -len(tail)], parent)
 
 
-def _ramp(value: float, floor: float, ceil: float) -> float:
+def ramp(value: float, floor: float, ceil: float) -> float:
     """Linear 0→1 ramp between floor and ceiling, clamped.
 
     A ramp rather than a threshold so a host just over the line scores
@@ -438,12 +438,12 @@ def score_tunneling(feats: ClientFeatures) -> TunnelVerdict:
     # labels are long *on average*; a false positive's are long once.
     # Keeping some weight on max means a short-label tunnel padded with
     # normal traffic still registers.
-    length_r = 0.4 * _ramp(
+    length_r = 0.4 * ramp(
         feats.max_label_length, _LABEL_LENGTH_FLOOR, _LABEL_LENGTH_CEIL
-    ) + 0.6 * _ramp(feats.avg_label_length, _LABEL_LENGTH_FLOOR, _LABEL_LENGTH_CEIL)
-    entropy_r = _ramp(feats.mean_label_entropy, _ENTROPY_FLOOR, _ENTROPY_CEIL)
-    fanout_r = _ramp(feats.top_parent_subdomains, _FANOUT_FLOOR, _FANOUT_CEIL)
-    payload_r = _ramp(feats.payload_qtype_ratio, _PAYLOAD_RATIO_FLOOR, _PAYLOAD_RATIO_CEIL)
+    ) + 0.6 * ramp(feats.avg_label_length, _LABEL_LENGTH_FLOOR, _LABEL_LENGTH_CEIL)
+    entropy_r = ramp(feats.mean_label_entropy, _ENTROPY_FLOOR, _ENTROPY_CEIL)
+    fanout_r = ramp(feats.top_parent_subdomains, _FANOUT_FLOOR, _FANOUT_CEIL)
+    payload_r = ramp(feats.payload_qtype_ratio, _PAYLOAD_RATIO_FLOOR, _PAYLOAD_RATIO_CEIL)
 
     signals = [
         Signal(

--- a/backend/app/services/factory_reset/sections.py
+++ b/backend/app/services/factory_reset/sections.py
@@ -124,6 +124,7 @@ FACTORY_SECTIONS: tuple[FactorySection, ...] = (
             "dns_trust_anchor",
             "dns_query_log_entry",
             "dns_client_window",
+            "dns_rpz_hit",
             "dns_threat_mute",
             "dns_metric_sample",
             "subnet_domain",
@@ -280,6 +281,7 @@ FACTORY_SECTIONS: tuple[FactorySection, ...] = (
             # operator names) — someone wiping an appliance before
             # handing it on reasonably expects all of this gone (#699).
             "dns_client_window",
+            "dns_rpz_hit",
             "dns_threat_mute",
             "dhcp_log_entry",
             "internal_error",

--- a/backend/app/services/logs/bind9_parser.py
+++ b/backend/app/services/logs/bind9_parser.py
@@ -48,7 +48,11 @@ _ISO_TS_RE: Final = re.compile(
 # the same channel (issue #699) and carry their own category name — a
 # prefix left unstripped would push the client/qname head out of reach
 # of ``_HEAD_RE`` and cost us the attribution the feature exists for.
-_CAT_SEV_RE: Final = re.compile(r"^(?:(?:queries|rpz):\s+)?(?:info:\s+)?")
+# ``rpz-passthru`` is listed before ``rpz`` — alternation is ordered,
+# and ``rpz`` would otherwise match the prefix of ``rpz-passthru:``
+# and leave ``-passthru: `` in front of the ``client`` head, which is
+# ``^``-anchored and would then fail to parse.
+_CAT_SEV_RE: Final = re.compile(r"^(?:(?:queries|rpz-passthru|rpz):\s+)?(?:info:\s+)?")
 
 # BIND9 query lines are split on the hard ``: query: `` separator
 # rather than matched by one big regex. The combined pattern (client
@@ -290,7 +294,12 @@ def parse_query_line(line: str, *, fallback_ts: datetime | None = None) -> Parse
     )
 
 
-__all__ = ["ParsedQueryLine", "parse_query_line"]
+__all__ = [
+    "ParsedQueryLine",
+    "ParsedRPZLine",
+    "parse_query_line",
+    "parse_rpz_line",
+]
 
 
 # ── RPZ policy hits (issue #699) ──────────────────────────────────────
@@ -319,16 +328,23 @@ __all__ = ["ParsedQueryLine", "parse_query_line"]
 # being mistaken for an RPZ hit, and every segment's character class is
 # disjoint from its neighbours' so matching stays linear.
 _RPZ_TRIGGERS: Final = "QNAME|CLIENT-IP|IP|NSDNAME|NSIP"
-_RPZ_POLICIES: Final = "NXDOMAIN|NODATA|PASSTHRU|DROP|TCP-ONLY|CNAME|Local-Data"
+# ``TCP_ONLY`` carries an UNDERSCORE: the hyphenated ``tcp-only`` is
+# the named.conf keyword, but dns_rpz_policy2str() emits the
+# underscore form to the log. Both are accepted so a config-shaped
+# line from a future named release still parses.
+_RPZ_POLICIES: Final = "NXDOMAIN|NODATA|PASSTHRU|DROP|TCP_ONLY|TCP-ONLY|CNAME|Local-Data"
 
 _RPZ_RE: Final = re.compile(
     r"\brpz\s+(?P<trigger>" + _RPZ_TRIGGERS + r")"
     r"\s+(?P<policy>" + _RPZ_POLICIES + r")"
-    # ``rewrite <name>`` is present for every policy except DROP, which
-    # logs the action alone — hence both halves optional.
+    # ``rewrite <qname>/<qtype>/<qclass>`` — note the operand carries the
+    # type and class, so it is NOT a bare name (verified against BIND
+    # 9.20: ``rewrite bad.example/A/IN``). Both halves stay optional to
+    # tolerate format drift across releases rather than because any
+    # current policy omits them — BIND 9.20 emits ``rewrite``/``via`` for
+    # every policy including DROP, contrary to a common reading of the
+    # docs.
     r"(?:\s+rewrite\s+(?P<rewritten>[^\s]+))?"
-    # ``via <entry>.<rpz-zone>`` names the blocklist zone that matched.
-    # Optional for the same reason.
     r"(?:\s+via\s+(?P<via>[^\s]+))?",
 )
 
@@ -369,8 +385,22 @@ def parse_rpz_line(line: str, *, fallback_ts: datetime | None = None) -> ParsedR
     if len(line) > _MAX_LINE_LEN:
         line = line[:_MAX_LINE_LEN]
 
+    # Cheap reject before the regex. Every ingested query-log line pays
+    # this probe, and ``_RPZ_RE`` requires a literal ``rpz`` token, so the
+    # substring test is behaviour-preserving and ~50x cheaper on the miss
+    # path (which is almost every line).
+    if "rpz" not in line:
+        return None
+
     rpz_m = _RPZ_RE.search(line)
     if rpz_m is None:
+        return None
+    # named prefixes the message with ``disabled `` when the policy zone
+    # is running with ``policy disabled`` — the standard way to trial a
+    # new feed in log-only mode. Nothing was actually blocked, so
+    # counting it would fabricate hits for an operator who is explicitly
+    # evaluating rather than enforcing.
+    if line[: rpz_m.start()].rstrip().endswith("disabled"):
         return None
 
     ts: datetime | None = None
@@ -397,8 +427,8 @@ def parse_rpz_line(line: str, *, fallback_ts: datetime | None = None) -> ParsedR
     # name; the fallback matters because a DROP policy logs no
     # ``rewrite``, and the paren form matters because a head that failed
     # to parse leaves only the clause.
-    qname = _rpz_qname_from_head(head_m.group("rest") if head_m else None) or rpz_m.group(
-        "rewritten"
+    qname = _rpz_qname_from_head(head_m.group("rest") if head_m else None) or _bare_qname(
+        rpz_m.group("rewritten")
     )
 
     return ParsedRPZLine(
@@ -434,14 +464,21 @@ def _rpz_zone_from_via(via: str | None) -> str | None:
         return None
     cleaned = via.rstrip(".").lower()
     labels = cleaned.split(".")
-    # Rightmost ``rpz`` label — the zone's terminal label by convention.
-    for i in range(len(labels) - 1, -1, -1):
-        if labels[i] == "rpz":
-            # The label before it carries the feed identity
-            # (``spatium-blocklist``, ``spatium-blocklist-internal``).
-            start = max(0, i - 1)
-            return ".".join(labels[start:])
-    return cleaned
+    # SpatiumDDI's own zones are the case that must be exact, so match
+    # the rendered prefix directly rather than inferring from label
+    # position. Guessing by position mis-sliced any zone with a
+    # non-terminal ``rpz`` label — ``bad.example.rpz.local`` yielded
+    # ``example.rpz.local``, gluing the blocked name onto the zone and
+    # turning every distinct name into its own phantom "feed".
+    for i, label in enumerate(labels):
+        if label.startswith(_RENDERED_RPZ_PREFIX):
+            return ".".join(labels[i:])[:_RPZ_ZONE_MAX_LEN]
+    # Hand-rolled / imported zone. Take the last two labels as a
+    # best-effort feed identity; returning the whole ``via`` (as an
+    # earlier cut did) made the value vary per blocked name AND could
+    # exceed the String(255) column, which aborts the entire ingest
+    # batch on commit — losing every query-log row in the same POST.
+    return ".".join(labels[-2:])[:_RPZ_ZONE_MAX_LEN] if len(labels) >= 2 else cleaned
 
 
 # The ``(<qname>)`` BIND puts between the client address and the colon.
@@ -449,21 +486,39 @@ def _rpz_zone_from_via(via: str | None) -> str | None:
 # rest of the line, keeping the match linear.
 _RPZ_HEAD_QNAME_RE: Final = re.compile(r"\((?P<qname>[^)\s]+)\)")
 
+# ``dns_rpz_hit.rpz_zone`` is String(255). The ``via`` token is
+# unbounded, and one overlong value fails the single commit that covers
+# the whole ingest batch, so clamp here rather than at the call site.
+_RPZ_ZONE_MAX_LEN: Final = 255
+
+# What ``dns/agent_config.py`` renders: ``spatium-blocklist.rpz.`` and
+# ``spatium-blocklist-<view>.rpz.``.
+_RENDERED_RPZ_PREFIX: Final = "spatium-blocklist"
+
 
 def _rpz_qname_from_head(rest: str | None) -> str | None:
-    """Pull the queried name out of an RPZ line's head.
+    r"""Pull the queried name out of an RPZ line's head.
 
-    ``rest`` is everything ``_HEAD_RE`` left after the client port. The
-    first parenthesised token there is the qname — except on lines that
-    carry the ``(view <name>)`` form instead, which is why a match
-    starting with ``view`` is rejected rather than returned as a
-    hostname.
+    ``rest`` is everything ``_HEAD_RE`` left after the client port; the
+    first parenthesised token there is the qname. The ``(view <name>)``
+    form cannot be confused with it — that contains a space, which
+    ``_RPZ_HEAD_QNAME_RE``'s ``[^)\s]+`` excludes by construction.
     """
     if not rest:
         return None
-    for m in _RPZ_HEAD_QNAME_RE.finditer(rest):
-        candidate = m.group("qname")
-        if candidate.lower() == "view":
-            continue
-        return candidate
-    return None
+    m = _RPZ_HEAD_QNAME_RE.search(rest)
+    return m.group("qname") if m else None
+
+
+def _bare_qname(operand: str | None) -> str | None:
+    """Strip the ``/<qtype>/<qclass>`` suffix off a ``rewrite`` operand.
+
+    BIND logs ``rewrite bad.example/A/IN``, not a bare name. Storing the
+    raw operand put ``bad.example/a/in`` in ``dns_rpz_hit.qname``, which
+    matches no real domain — it would group as its own row in
+    ``top_blocked_names`` and render that way in the UI and in copilot
+    answers.
+    """
+    if not operand:
+        return None
+    return operand.split("/", 1)[0] or None

--- a/backend/app/services/logs/bind9_parser.py
+++ b/backend/app/services/logs/bind9_parser.py
@@ -482,9 +482,17 @@ def _rpz_zone_from_via(via: str | None) -> str | None:
 
 
 # The ``(<qname>)`` BIND puts between the client address and the colon.
-# Anchored to a non-paren, non-whitespace run so it cannot span into the
-# rest of the line, keeping the match linear.
-_RPZ_HEAD_QNAME_RE: Final = re.compile(r"\((?P<qname>[^)\s]+)\)")
+#
+# CodeQL py/polynomial-redos, same family as alerts #16 and #18 on this
+# file: the first cut used ``[^)\s]+``, which still admits ``(``. Run
+# under ``search``, input like ``((((((`` makes the engine consume every
+# ``(`` at each candidate start position, fail the closing ``\)``, and
+# backtrack one character at a time — O(n) work at O(n) offsets. Adding
+# ``(`` to the excluded set makes the inner run unable to cross a paren
+# in either direction, so a failing start position fails immediately and
+# the total stays linear. It is also strictly more correct: a DNS name
+# can contain neither parenthesis, so nothing legitimate is excluded.
+_RPZ_HEAD_QNAME_RE: Final = re.compile(r"\((?P<qname>[^()\s]+)\)")
 
 # ``dns_rpz_hit.rpz_zone`` is String(255). The ``via`` token is
 # unbounded, and one overlong value fails the single commit that covers

--- a/backend/app/services/logs/bind9_parser.py
+++ b/backend/app/services/logs/bind9_parser.py
@@ -44,7 +44,11 @@ _ISO_TS_RE: Final = re.compile(
 
 # Optional ``[severity]``-style category prefix BIND prepends when
 # ``print-severity`` / ``print-category`` are on. We tolerate both.
-_CAT_SEV_RE: Final = re.compile(r"^(?:queries:\s+)?(?:info:\s+)?")
+# ``rpz`` is listed alongside ``queries`` because RPZ policy hits ride
+# the same channel (issue #699) and carry their own category name — a
+# prefix left unstripped would push the client/qname head out of reach
+# of ``_HEAD_RE`` and cost us the attribution the feature exists for.
+_CAT_SEV_RE: Final = re.compile(r"^(?:(?:queries|rpz):\s+)?(?:info:\s+)?")
 
 # BIND9 query lines are split on the hard ``: query: `` separator
 # rather than matched by one big regex. The combined pattern (client
@@ -287,3 +291,179 @@ def parse_query_line(line: str, *, fallback_ts: datetime | None = None) -> Parse
 
 
 __all__ = ["ParsedQueryLine", "parse_query_line"]
+
+
+# ── RPZ policy hits (issue #699) ──────────────────────────────────────
+#
+# named logs response-policy rewrites to its own ``rpz`` logging
+# category, never to ``queries``. That is why "which machine keeps
+# slamming blocked domains" — the question that actually identifies an
+# infected host — was unanswerable from data we already had: we serve
+# the blocklists and then discarded every hit.
+#
+# The line shape, with print-category on:
+#
+#   27-Jul-2026 22:15:03.123 rpz: info: client @0x7f8 192.0.2.5#54321 \
+#       (ads.tracker.example): view default: rpz QNAME NXDOMAIN \
+#       rewrite ads.tracker.example via ads.tracker.example.rpz-ads
+#
+# These arrive interleaved with query lines on the same channel, so the
+# ingest tries this parser first and falls through to the query parser.
+# The discriminator is the ``rpz <TRIGGER> <POLICY>`` clause, which
+# cannot appear in a query line — a qname could contain the substring
+# "rpz", but not followed by a known trigger keyword.
+
+# Trigger types and policy actions are closed sets in named's source
+# (``rpz_type_str`` / ``dns_rpz_policy_to_text``), so they are matched
+# as alternations rather than ``\S+``. That keeps a malformed line from
+# being mistaken for an RPZ hit, and every segment's character class is
+# disjoint from its neighbours' so matching stays linear.
+_RPZ_TRIGGERS: Final = "QNAME|CLIENT-IP|IP|NSDNAME|NSIP"
+_RPZ_POLICIES: Final = "NXDOMAIN|NODATA|PASSTHRU|DROP|TCP-ONLY|CNAME|Local-Data"
+
+_RPZ_RE: Final = re.compile(
+    r"\brpz\s+(?P<trigger>" + _RPZ_TRIGGERS + r")"
+    r"\s+(?P<policy>" + _RPZ_POLICIES + r")"
+    # ``rewrite <name>`` is present for every policy except DROP, which
+    # logs the action alone — hence both halves optional.
+    r"(?:\s+rewrite\s+(?P<rewritten>[^\s]+))?"
+    # ``via <entry>.<rpz-zone>`` names the blocklist zone that matched.
+    # Optional for the same reason.
+    r"(?:\s+via\s+(?P<via>[^\s]+))?",
+)
+
+
+@dataclass(frozen=True)
+class ParsedRPZLine:
+    ts: datetime
+    client_ip: str | None
+    qname: str | None
+    trigger: str
+    policy: str
+    # The RPZ zone that matched, recovered from the ``via`` clause. This
+    # is what attributes a hit to a specific blocklist feed, which is
+    # the difference between "blocked" and "blocked by the malware feed
+    # rather than the ad feed".
+    rpz_zone: str | None
+    raw: str
+
+
+def parse_rpz_line(line: str, *, fallback_ts: datetime | None = None) -> ParsedRPZLine | None:
+    """Parse one BIND9 ``rpz`` category line, or ``None`` if it isn't one.
+
+    Returning ``None`` for non-RPZ input is the contract the ingest
+    relies on to tell the two line shapes apart on a shared channel —
+    it tries this first and falls through to :func:`parse_query_line`.
+
+    The client IP and queried name are recovered from the same
+    ``client <ip>#<port> (<qname>)`` head that query lines carry, so
+    the existing head regex does that work. When the head is missing or
+    unparseable the hit is still returned with ``client_ip=None``: a
+    blocked lookup we cannot attribute is worth counting (it proves the
+    blocklist is doing something) even though it cannot be pinned to a
+    host.
+    """
+    line = line.rstrip("\r\n")
+    if not line.strip():
+        return None
+    if len(line) > _MAX_LINE_LEN:
+        line = line[:_MAX_LINE_LEN]
+
+    rpz_m = _RPZ_RE.search(line)
+    if rpz_m is None:
+        return None
+
+    ts: datetime | None = None
+    rest = line
+    m = _BIND_TS_RE.match(rest)
+    if m:
+        ts = _parse_bind_ts(m.group("ts"))
+        rest = rest[m.end() :]
+    else:
+        m_iso = _ISO_TS_RE.match(rest)
+        if m_iso:
+            ts = _parse_iso_ts(m_iso.group("ts"))
+            rest = rest[m_iso.end() :]
+    if ts is None:
+        ts = fallback_ts or datetime.now(UTC)
+
+    head_m = _HEAD_RE.search(_CAT_SEV_RE.sub("", rest, count=1))
+    client_ip = head_m.group("client_ip") if head_m else None
+    # ``_HEAD_RE`` deliberately stops at the port and hands the tail back
+    # as ``rest`` — the query path takes its qname from the body after
+    # ``: query: ``, which an RPZ line does not have. So the name is
+    # recovered from the parenthesised ``(<qname>)`` BIND puts in the
+    # head, falling back to the ``rewrite`` clause. Both carry the same
+    # name; the fallback matters because a DROP policy logs no
+    # ``rewrite``, and the paren form matters because a head that failed
+    # to parse leaves only the clause.
+    qname = _rpz_qname_from_head(head_m.group("rest") if head_m else None) or rpz_m.group(
+        "rewritten"
+    )
+
+    return ParsedRPZLine(
+        ts=ts,
+        client_ip=client_ip,
+        qname=qname.rstrip(".").lower() if qname else None,
+        trigger=rpz_m.group("trigger"),
+        policy=rpz_m.group("policy"),
+        rpz_zone=_rpz_zone_from_via(rpz_m.group("via")),
+        raw=line,
+    )
+
+
+def _rpz_zone_from_via(via: str | None) -> str | None:
+    """Recover the RPZ zone name from named's ``via`` clause.
+
+    named logs ``via <trigger-entry>.<rpz-zone>`` — the matched entry
+    prefixed onto the zone it came from, so the two have to be split
+    apart before a hit can be attributed to a feed.
+
+    SpatiumDDI renders its RPZ zones as ``spatium-blocklist.rpz.`` and
+    ``spatium-blocklist-<view>.rpz.`` (see ``dns/agent_config.py``), so
+    the zone is the final ``rpz`` label plus the one before it. Taking
+    everything from the first ``.rpz`` rightwards would be wrong for a
+    zone whose own name contains ``rpz``, and taking everything from the
+    LAST ``.rpz`` yields the bare ``rpz`` label — both were tried.
+
+    Falls back to the whole string when no ``rpz`` label is present,
+    which keeps a hand-rolled RPZ zone attributable rather than dropping
+    the hit on the floor.
+    """
+    if not via:
+        return None
+    cleaned = via.rstrip(".").lower()
+    labels = cleaned.split(".")
+    # Rightmost ``rpz`` label — the zone's terminal label by convention.
+    for i in range(len(labels) - 1, -1, -1):
+        if labels[i] == "rpz":
+            # The label before it carries the feed identity
+            # (``spatium-blocklist``, ``spatium-blocklist-internal``).
+            start = max(0, i - 1)
+            return ".".join(labels[start:])
+    return cleaned
+
+
+# The ``(<qname>)`` BIND puts between the client address and the colon.
+# Anchored to a non-paren, non-whitespace run so it cannot span into the
+# rest of the line, keeping the match linear.
+_RPZ_HEAD_QNAME_RE: Final = re.compile(r"\((?P<qname>[^)\s]+)\)")
+
+
+def _rpz_qname_from_head(rest: str | None) -> str | None:
+    """Pull the queried name out of an RPZ line's head.
+
+    ``rest`` is everything ``_HEAD_RE`` left after the client port. The
+    first parenthesised token there is the qname — except on lines that
+    carry the ``(view <name>)`` form instead, which is why a match
+    starting with ``view`` is rejected rather than returned as a
+    hostname.
+    """
+    if not rest:
+        return None
+    for m in _RPZ_HEAD_QNAME_RE.finditer(rest):
+        candidate = m.group("qname")
+        if candidate.lower() == "view":
+            continue
+        return candidate
+    return None

--- a/backend/app/tasks/prune_logs.py
+++ b/backend/app/tasks/prune_logs.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.celery_app import celery_app
 from app.db import task_session
+from app.models.dns_rpz_hit import DNSRPZHit
 from app.models.logs import DHCPLogEntry, DNSQueryLogEntry
 
 logger = structlog.get_logger(__name__)
@@ -30,6 +31,20 @@ logger = structlog.get_logger(__name__)
 # stand up Loki / a SIEM and ship there in addition to (or instead
 # of) the agent push.
 DEFAULT_RETENTION_HOURS = 24
+
+# RPZ policy hits (issue #699) are kept far longer than raw queries and
+# swept here rather than in their own task, so all agent-shipped log
+# retention stays in one place.
+#
+# They earn the longer window: a hit is a *summary-shaped* event, not a
+# firehose. A busy resolver emits tens of thousands of queries a second
+# and a handful of blocklist hits a minute, so 30 days of hits is a
+# fraction of a day of queries. And the question they answer — "has this
+# host been reaching for blocked domains all week?" — is unanswerable
+# inside a 24 h window, which is the whole reason the table exists.
+# Matches the threat rollup's WINDOW_RETENTION_DAYS deliberately: both
+# are behavioural evidence about clients and should age out together.
+RPZ_HIT_RETENTION_DAYS = 30
 
 
 async def _sweep_with_session(db: AsyncSession) -> dict[str, int]:
@@ -42,11 +57,15 @@ async def _sweep_with_session(db: AsyncSession) -> dict[str, int]:
     cutoff = datetime.now(UTC) - timedelta(hours=DEFAULT_RETENTION_HOURS)
     dns_del = await db.execute(delete(DNSQueryLogEntry).where(DNSQueryLogEntry.ts < cutoff))
     dhcp_del = await db.execute(delete(DHCPLogEntry).where(DHCPLogEntry.ts < cutoff))
+    rpz_cutoff = datetime.now(UTC) - timedelta(days=RPZ_HIT_RETENTION_DAYS)
+    rpz_del = await db.execute(delete(DNSRPZHit).where(DNSRPZHit.ts < rpz_cutoff))
     await db.commit()
     return {
         "dns_query_log_removed": dns_del.rowcount or 0,
         "dhcp_log_removed": dhcp_del.rowcount or 0,
+        "dns_rpz_hit_removed": rpz_del.rowcount or 0,
         "retention_hours": DEFAULT_RETENTION_HOURS,
+        "rpz_retention_days": RPZ_HIT_RETENTION_DAYS,
     }
 
 

--- a/backend/tests/test_dns_threat.py
+++ b/backend/tests/test_dns_threat.py
@@ -995,3 +995,28 @@ async def test_rpz_hits_survive_the_query_log_retention_window(
         .all()
     )
     assert len(remaining) == 1, "a 3-day-old hit must outlive the 24 h query-log sweep"
+
+
+def test_rpz_head_qname_regex_is_linear_on_adversarial_input() -> None:
+    """CodeQL py/polynomial-redos regression pin.
+
+    The head regex runs under ``search`` against agent-supplied log
+    lines, so a quadratic shape is reachable from untrusted input. The
+    first cut excluded only ``)``, which let the inner run consume ``(``
+    and backtrack at every start position — 39 ms on 4k parens, versus
+    sub-millisecond once ``(`` is excluded too.
+    """
+    import time
+
+    line = "27-Jul-2026 22:15:03.123 rpz: info: client @0x1 1.2.3.4#5 " + "(" * 4000
+    start = time.perf_counter()
+    parse_rpz_line(line)
+    assert (time.perf_counter() - start) < 0.5, "parser must stay linear on paren floods"
+
+
+def test_rpz_head_qname_still_extracted_after_redos_fix() -> None:
+    """The hardening must not cost the attribution it exists for."""
+    hit = parse_rpz_line(_RPZ_LINE)
+    assert hit is not None
+    assert hit.qname == "ads.tracker.example"
+    assert hit.client_ip == "192.0.2.5"

--- a/backend/tests/test_dns_threat.py
+++ b/backend/tests/test_dns_threat.py
@@ -37,6 +37,7 @@ from app.models.dns import DNSServer, DNSServerGroup
 from app.models.dns_threat import DNSClientWindow
 from app.models.logs import DNSQueryLogEntry
 from app.services.dns_threat.aggregate import aggregate_window, floor_hour
+from app.services.dns_threat.dga import bigram_implausibility, score_dga
 from app.services.dns_threat.scoring import (
     DEFAULT_BENIGN_PARENTS,
     MIN_QUERIES_TO_SCORE,
@@ -46,6 +47,7 @@ from app.services.dns_threat.scoring import (
     shannon_entropy,
     split_qname,
 )
+from app.services.logs.bind9_parser import parse_query_line, parse_rpz_line
 
 
 def _tunnel_rows(n: int = 300, parent: str = "t.evil.example") -> list[tuple]:
@@ -565,3 +567,323 @@ async def test_muted_client_drops_out_of_summary_and_windows(
     # ...but stays reachable when explicitly asked for.
     shown = (await client.get("/api/v1/dns-threat/windows?include_muted=true", headers=h)).json()
     assert any(w["client_ip"] == "10.0.0.8" and w["muted"] for w in shown)
+
+
+# ── DGA detection (issue #699) ────────────────────────────────────────
+#
+# Same philosophy as the tunneling tests above: pin the things that
+# would make the detection *wrong*, not the exact numbers. The one
+# extra concern here is that DGA and tunneling are structurally
+# opposite (one sprays across parents, the other concentrates under
+# one), so the tests that matter most are the ones proving each does
+# NOT fire on the other's traffic.
+
+
+def _dga_labels(n: int = 60, tld: str = "com") -> dict[str, str]:
+    """A DGA crop: many distinct consonant-heavy fixed-width domains.
+
+    Deterministic rather than random so a failure is reproducible — a
+    flaky security detector is one nobody trusts.
+    """
+    import random
+
+    rng = random.Random(1337)
+    consonants = "bcdfghjklmnpqrstvwxz"
+    out: dict[str, str] = {}
+    while len(out) < n:
+        label = "".join(rng.choice(consonants) for _ in range(12))
+        out[f"{label}.{tld}"] = label
+    return out
+
+
+def _human_labels(n: int = 60) -> dict[str, str]:
+    """Ordinary registrable domains — word-shaped and varied in length."""
+    words = [
+        "northwind",
+        "contoso",
+        "example",
+        "warehouse",
+        "printing",
+        "logistics",
+        "greenfield",
+        "marketing",
+        "supplier",
+        "riverside",
+        "bookstore",
+        "hardware",
+        "acme",
+        "stationery",
+        "mailchimp",
+        "atlassian",
+        "cloudflare",
+        "wikipedia",
+        "shopping",
+        "newsletter",
+    ]
+    out: dict[str, str] = {}
+    i = 0
+    while len(out) < n:
+        base = f"{words[i % len(words)]}{'' if i < len(words) else i}"
+        out[f"{base}.com"] = base
+        i += 1
+    return out
+
+
+def test_bigram_implausibility_separates_gibberish_from_words() -> None:
+    assert bigram_implausibility("newsletter") < 0.4
+    assert bigram_implausibility("xkqjfhwbzvmp") > 0.8
+
+
+def test_bigram_implausibility_ignores_digits() -> None:
+    """``o365`` and friends are legitimate; digits must not read as
+    gibberish or every Microsoft-shaped domain scores."""
+    assert bigram_implausibility("office365") < 0.5
+
+
+def test_dga_crop_outranks_ordinary_domains() -> None:
+    """The ordering is the contract; absolute numbers will be retuned."""
+    crop = score_dga(_dga_labels())
+    human = score_dga(_human_labels())
+    assert crop.score > human.score
+    assert human.score < 20.0, "ordinary browsing must sit near zero"
+
+
+def test_few_domains_never_score() -> None:
+    """A handful of odd domains is a person clicking a link, not a crop.
+
+    This is the guard that keeps one hashed CDN bucket from firing the
+    detection.
+    """
+    verdict = score_dga(dict(list(_dga_labels().items())[:5]))
+    assert verdict.score == 0.0
+    assert verdict.signals[0]["name"] == "insufficient_domains"
+
+
+def test_short_labels_do_not_dilute_a_real_crop() -> None:
+    """Three-letter domains are unjudgeable, not innocent.
+
+    Averaging them in as 0.0 implausibility was the obvious
+    implementation and it let a crop hide behind a pile of short
+    legitimate domains.
+    """
+    crop = _dga_labels()
+    padded = {**crop, **{f"a{i}.com": f"a{i}" for i in range(200)}}
+    assert score_dga(padded).score == pytest.approx(score_dga(crop).score, abs=1.0)
+
+
+def test_tunneling_traffic_does_not_score_as_dga() -> None:
+    """The structural discriminator, and the whole reason DGA is a
+    separate scorer: a tunnel is thousands of subdomains under ONE
+    parent, so it presents exactly one registrable domain here."""
+    feats = extract_features(_tunnel_rows(400))
+    assert score_dga(feats.parent_labels).score == 0.0
+
+
+def test_dga_traffic_does_not_score_as_tunneling() -> None:
+    """...and the converse. A crop fans out across parents, so the
+    tunneling scorer's subdomain-fan-out signal never lights up."""
+    rows = [(parent, "A", "server-1") for parent in _dga_labels(80)]
+    verdict = score_tunneling(extract_features(rows))
+    assert verdict.score < 20.0
+
+
+def test_dga_score_is_bounded() -> None:
+    assert 0.0 <= score_dga(_dga_labels(500)).score <= 100.0
+
+
+def test_dga_evidence_names_the_domains() -> None:
+    """A bare score is not actionable — hashed-CDN traffic shares the
+    shape, so an operator has to see WHICH domains scored."""
+    verdict = score_dga(_dga_labels())
+    assert verdict.candidates_json(), "evidence must carry the domains"
+    assert len(verdict.candidates_json()) <= 10, "evidence is capped for triage"
+    assert verdict.detail
+    assert all("parent" in c and "label" in c for c in verdict.candidates_json())
+
+
+def test_dga_signals_carry_their_own_ceiling() -> None:
+    """Same wire shape as tunnel_signals so one UI component renders
+    both detections' evidence."""
+    for sig in score_dga(_dga_labels()).signals:
+        assert set(sig) >= {"name", "value", "contribution", "max_contribution", "detail"}
+        assert sig["contribution"] <= sig["max_contribution"] + 1e-9
+
+
+@pytest.mark.asyncio
+async def test_aggregate_persists_dga_verdict(db_session: AsyncSession) -> None:
+    """End-to-end through the rollup: a crop in the query log lands as a
+    scored, evidenced row."""
+    server = await _make_dns_server(db_session)
+    bucket = floor_hour(datetime.now(UTC))
+    rows = [(parent, "A", str(server.id)) for parent in _dga_labels(80)]
+    await _seed_queries(db_session, server.id, rows, ts=bucket, client="10.0.0.44")
+    await aggregate_window(db_session, window_start=bucket)
+
+    win = (
+        await db_session.execute(
+            select(DNSClientWindow).where(DNSClientWindow.client_ip == "10.0.0.44")
+        )
+    ).scalar_one()
+    assert win.dga_score > 0.0
+    assert win.dga_candidates, "the crop must be persisted as evidence"
+    assert win.dga_signals
+    assert win.dga_detail
+
+
+# ── RPZ hit attribution (issue #699) ──────────────────────────────────
+#
+# Pure reporting rather than a heuristic, so unlike the detections above
+# these tests DO pin exact numbers — a hit is ground truth and an
+# off-by-one in attribution is a real bug, not a tuning question.
+
+_RPZ_LINE = (
+    "27-Jul-2026 22:15:03.123 rpz: info: client @0x7f8 192.0.2.5#54321 "
+    "(ads.tracker.example): view default: rpz QNAME NXDOMAIN rewrite "
+    "ads.tracker.example via ads.tracker.example.spatium-blocklist.rpz"
+)
+_QUERY_LINE = (
+    "27-Jul-2026 22:15:04.001 queries: info: client @0x7f8 192.0.2.5#54321 "
+    "(www.example.com): query: www.example.com IN A +E(0)K (10.0.0.1)"
+)
+
+
+def test_rpz_line_parses_client_name_policy_and_feed() -> None:
+    hit = parse_rpz_line(_RPZ_LINE)
+    assert hit is not None
+    assert hit.client_ip == "192.0.2.5"
+    assert hit.qname == "ads.tracker.example"
+    assert hit.trigger == "QNAME"
+    assert hit.policy == "NXDOMAIN"
+    # Attribution to the FEED is the point — "blocked by the malware
+    # list" and "blocked by the ad list" are different findings.
+    assert hit.rpz_zone == "spatium-blocklist.rpz"
+
+
+def test_rpz_parser_returns_none_for_a_query_line() -> None:
+    """The discriminator the ingest relies on to tell the two shapes
+    apart on a shared channel."""
+    assert parse_rpz_line(_QUERY_LINE) is None
+
+
+def test_query_parser_still_handles_query_lines_after_rpz_category_added() -> None:
+    """_CAT_SEV_RE grew an ``rpz`` alternative; the queries path must be
+    untouched by it."""
+    parsed = parse_query_line(_QUERY_LINE)
+    assert parsed is not None
+    assert parsed.client_ip == "192.0.2.5"
+    assert parsed.qname == "www.example.com"
+
+
+def test_rpz_drop_policy_without_rewrite_or_via_still_parses() -> None:
+    """DROP logs the action alone — no ``rewrite``, no ``via``. Losing
+    those hits would silently under-count the most aggressive policy."""
+    line = (
+        "27-Jul-2026 22:15:03.123 rpz: info: client @0x7f8 192.0.2.9#5 "
+        "(bad.example): view default: rpz QNAME DROP"
+    )
+    hit = parse_rpz_line(line)
+    assert hit is not None
+    assert hit.policy == "DROP"
+    assert hit.rpz_zone is None
+
+
+@pytest.mark.asyncio
+async def test_rpz_attribution_ranks_clients_and_excludes_passthru(
+    db_session: AsyncSession,
+) -> None:
+    """The headline question: which machine keeps hitting the blocklist.
+
+    PASSTHRU is an explicit ALLOW, so counting it would both inflate
+    every client and make a correctly-tuned allowlist look like an
+    infection.
+    """
+    from app.models.dns_rpz_hit import DNSRPZHit
+    from app.services.dns_threat import rpz as rpz_service
+
+    server = await _make_dns_server(db_session)
+    now = datetime.now(UTC)
+    for i in range(30):
+        db_session.add(
+            DNSRPZHit(
+                server_id=server.id,
+                ts=now - timedelta(minutes=i),
+                client_ip="10.0.0.99",
+                qname="malware.example",
+                trigger="QNAME",
+                policy="NXDOMAIN",
+                rpz_zone="spatium-blocklist.rpz",
+                raw="x",
+            )
+        )
+    db_session.add(
+        DNSRPZHit(
+            server_id=server.id,
+            ts=now,
+            client_ip="10.0.0.1",
+            qname="allowed.example",
+            trigger="QNAME",
+            policy="PASSTHRU",
+            rpz_zone="rpz-allow.rpz",
+            raw="x",
+        )
+    )
+    await db_session.commit()
+
+    clients = await rpz_service.top_offending_clients(db_session)
+    assert [c["client_ip"] for c in clients] == [
+        "10.0.0.99"
+    ], "PASSTHRU is an allow, not a block — it must not create an offender"
+    assert clients[0]["hits"] == 30
+    assert clients[0]["top_qname"] == "malware.example"
+
+    summary = await rpz_service.summary(db_session)
+    assert summary["blocked_hits"] == 30
+    assert summary["passthru_hits"] == 1
+    assert summary["has_data"] is True
+
+
+@pytest.mark.asyncio
+async def test_rpz_summary_distinguishes_no_data_from_no_threats(
+    db_session: AsyncSession,
+) -> None:
+    """An idle feature rendering as an all-clear is the failure this
+    whole area exists to avoid — and here zero blocks is a plausible
+    real answer, so the UI must not have to guess."""
+    from app.services.dns_threat import rpz as rpz_service
+
+    empty = await rpz_service.summary(db_session)
+    assert empty["has_data"] is False
+    assert empty["blocked_hits"] == 0
+
+
+@pytest.mark.asyncio
+async def test_rpz_hits_survive_the_query_log_retention_window(
+    db_session: AsyncSession,
+) -> None:
+    """Hits are kept 30 days, not the query log's 24 h — "has this host
+    hit the malware feed all week" is unanswerable otherwise."""
+    from app.models.dns_rpz_hit import DNSRPZHit
+    from app.tasks.prune_logs import _sweep_with_session
+
+    server = await _make_dns_server(db_session)
+    db_session.add(
+        DNSRPZHit(
+            server_id=server.id,
+            ts=datetime.now(UTC) - timedelta(days=3),
+            client_ip="10.0.0.7",
+            qname="old.example",
+            trigger="QNAME",
+            policy="NXDOMAIN",
+            rpz_zone="spatium-blocklist.rpz",
+            raw="x",
+        )
+    )
+    await db_session.commit()
+
+    await _sweep_with_session(db_session)
+    remaining = (
+        (await db_session.execute(select(DNSRPZHit).where(DNSRPZHit.client_ip == "10.0.0.7")))
+        .scalars()
+        .all()
+    )
+    assert len(remaining) == 1, "a 3-day-old hit must outlive the 24 h query-log sweep"

--- a/backend/tests/test_dns_threat.py
+++ b/backend/tests/test_dns_threat.py
@@ -579,8 +579,15 @@ async def test_muted_client_drops_out_of_summary_and_windows(
 # NOT fire on the other's traffic.
 
 
-def _dga_labels(n: int = 60, tld: str = "com") -> dict[str, str]:
-    """A DGA crop: many distinct consonant-heavy fixed-width domains.
+def _dga_labels(n: int = 60, tld: str = "com", length: int = 12) -> dict[str, str]:
+    """A DGA crop: many distinct fixed-width random-alphabet domains.
+
+    Uses the FULL a-z alphabet, not consonants only. That distinction
+    caught a real calibration bug: a consonants-only fixture measures
+    0.80 bigram implausibility where a genuine Conficker/Necurs-shaped
+    label measures 0.60, and the original thresholds were set against
+    the fixture — so the scorer passed its tests while being unable to
+    reach its own alerting threshold on real traffic.
 
     Deterministic rather than random so a failure is reproducible — a
     flaky security detector is one nobody trusts.
@@ -588,10 +595,10 @@ def _dga_labels(n: int = 60, tld: str = "com") -> dict[str, str]:
     import random
 
     rng = random.Random(1337)
-    consonants = "bcdfghjklmnpqrstvwxz"
+    alphabet = "abcdefghijklmnopqrstuvwxyz"
     out: dict[str, str] = {}
     while len(out) < n:
-        label = "".join(rng.choice(consonants) for _ in range(12))
+        label = "".join(rng.choice(alphabet) for _ in range(length))
         out[f"{label}.{tld}"] = label
     return out
 
@@ -630,8 +637,28 @@ def _human_labels(n: int = 60) -> dict[str, str]:
 
 
 def test_bigram_implausibility_separates_gibberish_from_words() -> None:
-    assert bigram_implausibility("newsletter") < 0.4
+    assert bigram_implausibility("newsletter") < 0.2
     assert bigram_implausibility("xkqjfhwbzvmp") > 0.8
+
+
+def test_a_real_dga_crop_clears_the_alerting_threshold() -> None:
+    """The calibration guard. The first cut of these thresholds put
+    _NGRAM_FLOOR (0.55) ABOVE where a random a-z label actually measures
+    (0.60) and _NGRAM_CEIL at an unreachable 0.92, so a genuine crop
+    scored ~64 against an alert bar of 80 — the detection could not fire
+    on the thing it exists to detect, while its tests passed."""
+    from app.services.dns_threat.aggregate import DGA_ALERTING_SCORE
+
+    assert score_dga(_dga_labels(250)).score >= DGA_ALERTING_SCORE
+
+
+def test_busy_but_innocent_client_does_not_score() -> None:
+    """Fan-out alone must not score. A build server, a mail gateway or a
+    downstream forwarder collapsing a whole office onto one client_ip
+    legitimately touches hundreds of parents an hour; when the fan-out
+    weight was additive such a client scored 36/100 with ZERO implausible
+    names and outranked genuine smaller crops."""
+    assert score_dga(_human_labels(300)).score < 10.0
 
 
 def test_bigram_implausibility_ignores_digits() -> None:
@@ -642,10 +669,10 @@ def test_bigram_implausibility_ignores_digits() -> None:
 
 def test_dga_crop_outranks_ordinary_domains() -> None:
     """The ordering is the contract; absolute numbers will be retuned."""
-    crop = score_dga(_dga_labels())
-    human = score_dga(_human_labels())
+    crop = score_dga(_dga_labels(120))
+    human = score_dga(_human_labels(120))
     assert crop.score > human.score
-    assert human.score < 20.0, "ordinary browsing must sit near zero"
+    assert human.score < 10.0, "ordinary browsing must sit near zero"
 
 
 def test_few_domains_never_score() -> None:
@@ -656,7 +683,7 @@ def test_few_domains_never_score() -> None:
     """
     verdict = score_dga(dict(list(_dga_labels().items())[:5]))
     assert verdict.score == 0.0
-    assert verdict.signals[0]["name"] == "insufficient_domains"
+    assert verdict.signals[0].name == "insufficient_domains"
 
 
 def test_short_labels_do_not_dilute_a_real_crop() -> None:
@@ -666,7 +693,7 @@ def test_short_labels_do_not_dilute_a_real_crop() -> None:
     implementation and it let a crop hide behind a pile of short
     legitimate domains.
     """
-    crop = _dga_labels()
+    crop = _dga_labels(120)
     padded = {**crop, **{f"a{i}.com": f"a{i}" for i in range(200)}}
     assert score_dga(padded).score == pytest.approx(score_dga(crop).score, abs=1.0)
 
@@ -682,7 +709,7 @@ def test_tunneling_traffic_does_not_score_as_dga() -> None:
 def test_dga_traffic_does_not_score_as_tunneling() -> None:
     """...and the converse. A crop fans out across parents, so the
     tunneling scorer's subdomain-fan-out signal never lights up."""
-    rows = [(parent, "A", "server-1") for parent in _dga_labels(80)]
+    rows = [(parent, "A", "server-1") for parent in _dga_labels(120)]
     verdict = score_tunneling(extract_features(rows))
     assert verdict.score < 20.0
 
@@ -691,10 +718,17 @@ def test_dga_score_is_bounded() -> None:
     assert 0.0 <= score_dga(_dga_labels(500)).score <= 100.0
 
 
+def test_min_parents_zero_does_not_crash_the_rollup() -> None:
+    """A caller lowering the gate must not reach fmean() on an empty
+    set — StatisticsError would propagate out of the aggregator's flush
+    and abort the hourly rollup for EVERY client, not just this one."""
+    assert score_dga({}, min_parents=0).score == 0.0
+
+
 def test_dga_evidence_names_the_domains() -> None:
     """A bare score is not actionable — hashed-CDN traffic shares the
     shape, so an operator has to see WHICH domains scored."""
-    verdict = score_dga(_dga_labels())
+    verdict = score_dga(_dga_labels(120))
     assert verdict.candidates_json(), "evidence must carry the domains"
     assert len(verdict.candidates_json()) <= 10, "evidence is capped for triage"
     assert verdict.detail
@@ -704,7 +738,7 @@ def test_dga_evidence_names_the_domains() -> None:
 def test_dga_signals_carry_their_own_ceiling() -> None:
     """Same wire shape as tunnel_signals so one UI component renders
     both detections' evidence."""
-    for sig in score_dga(_dga_labels()).signals:
+    for sig in score_dga(_dga_labels(120)).signals_json():
         assert set(sig) >= {"name", "value", "contribution", "max_contribution", "detail"}
         assert sig["contribution"] <= sig["max_contribution"] + 1e-9
 
@@ -715,7 +749,7 @@ async def test_aggregate_persists_dga_verdict(db_session: AsyncSession) -> None:
     scored, evidenced row."""
     server = await _make_dns_server(db_session)
     bucket = floor_hour(datetime.now(UTC))
-    rows = [(parent, "A", str(server.id)) for parent in _dga_labels(80)]
+    rows = [(parent, "A", str(server.id)) for parent in _dga_labels(120)]
     await _seed_queries(db_session, server.id, rows, ts=bucket, client="10.0.0.44")
     await aggregate_window(db_session, window_start=bucket)
 
@@ -774,17 +808,91 @@ def test_query_parser_still_handles_query_lines_after_rpz_category_added() -> No
     assert parsed.qname == "www.example.com"
 
 
-def test_rpz_drop_policy_without_rewrite_or_via_still_parses() -> None:
-    """DROP logs the action alone — no ``rewrite``, no ``via``. Losing
-    those hits would silently under-count the most aggressive policy."""
+def test_rpz_drop_policy_parses() -> None:
+    """DROP logs ``rewrite``/``via`` like every other policy on BIND
+    9.20 — an earlier fixture here asserted a bare-action shape named
+    never emits, so the test passed against invented input."""
     line = (
         "27-Jul-2026 22:15:03.123 rpz: info: client @0x7f8 192.0.2.9#5 "
-        "(bad.example): view default: rpz QNAME DROP"
+        "(bad.example): view default: rpz QNAME DROP rewrite bad.example/A/IN "
+        "via bad.example.spatium-blocklist.rpz"
     )
     hit = parse_rpz_line(line)
     assert hit is not None
     assert hit.policy == "DROP"
-    assert hit.rpz_zone is None
+    assert hit.rpz_zone == "spatium-blocklist.rpz"
+
+
+def test_rewrite_operand_strips_qtype_and_qclass() -> None:
+    """BIND logs ``rewrite bad.example/A/IN``. Storing the raw operand
+    put ``bad.example/a/in`` in the qname — a name matching no real
+    domain, which would group as its own row in the blocked-names
+    report and render that way to operators."""
+    line = (
+        "27-Jul-2026 22:15:03.123 rpz: info: rpz QNAME NXDOMAIN "
+        "rewrite evil.example/AAAA/IN via evil.example.spatium-blocklist.rpz"
+    )
+    hit = parse_rpz_line(line)
+    assert hit is not None
+    assert hit.qname == "evil.example"
+
+
+def test_tcp_only_policy_uses_the_underscore_log_form() -> None:
+    """``tcp-only`` is the named.conf keyword; the LOG string is
+    ``TCP_ONLY``. Matching only the hyphen silently dropped every hit
+    from the most aggressive rate-limiting policy."""
+    line = (
+        "27-Jul-2026 22:15:03.123 rpz: info: rpz QNAME TCP_ONLY "
+        "rewrite x.example/A/IN via x.example.spatium-blocklist.rpz"
+    )
+    hit = parse_rpz_line(line)
+    assert hit is not None
+    assert hit.policy == "TCP_ONLY"
+
+
+def test_log_only_dry_run_hits_are_not_counted_as_blocks() -> None:
+    """named prefixes ``disabled `` when a policy zone runs with
+    ``policy disabled`` — the standard way to trial a new feed. Nothing
+    was blocked, so counting it would fabricate hits for an operator who
+    is explicitly evaluating rather than enforcing."""
+    line = (
+        "27-Jul-2026 22:15:03.123 rpz: info: client @0x7f8 192.0.2.9#5 "
+        "(x.example): view default: disabled rpz QNAME NXDOMAIN rewrite "
+        "x.example/A/IN via x.example.spatium-blocklist.rpz"
+    )
+    assert parse_rpz_line(line) is None
+
+
+def test_passthru_category_prefix_is_stripped() -> None:
+    """PASSTHRU rides its own ``rpz-passthru`` category. If the prefix
+    is not stripped, ``_HEAD_RE``'s ``^client`` anchor fails and the hit
+    lands unattributable — which is what the offender report filters
+    out, so the allow would be invisible twice over."""
+    line = (
+        "27-Jul-2026 22:15:03.123 rpz-passthru: info: client @0x7f8 "
+        "192.0.2.7#5 (ok.example): view default: rpz QNAME PASSTHRU "
+        "rewrite ok.example/A/IN via ok.example.spatium-blocklist.rpz"
+    )
+    hit = parse_rpz_line(line)
+    assert hit is not None
+    assert hit.policy == "PASSTHRU"
+    assert hit.client_ip == "192.0.2.7"
+    assert hit.qname == "ok.example"
+
+
+def test_rpz_zone_is_bounded_to_the_column_width() -> None:
+    """An unbounded ``via`` fallback could exceed String(255); the ingest
+    commits the whole batch in one statement, so one overlong value
+    would abort every query-log row in the same POST."""
+    long_name = ".".join(["a" * 60] * 5)
+    line = (
+        f"27-Jul-2026 22:15:03.123 rpz: info: rpz QNAME NXDOMAIN "
+        f"rewrite x/A/IN via {long_name}.blocklist.local"
+    )
+    hit = parse_rpz_line(line)
+    assert hit is not None
+    assert hit.rpz_zone is not None
+    assert len(hit.rpz_zone) <= 255
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8108,6 +8108,15 @@ export interface DNSClientWindow {
   beacon_score: number;
   beacon_candidates: DNSBeaconCandidate[];
   beacon_detail: string;
+  /**
+   * Domain-generation-algorithm score (#699). Structurally the inverse
+   * of tunneling — a tunnel concentrates subdomains under one parent,
+   * a DGA sprays across many — so the two never fire together.
+   */
+  dga_score: number;
+  dga_candidates: DNSDGACandidate[];
+  dga_signals: DNSTunnelSignal[];
+  dga_detail: string;
   allowlisted: boolean;
   server_count: number;
   /** An operator reviewed this client and cleared it (#699). */
@@ -8149,6 +8158,60 @@ export interface DNSBeaconCandidate {
   score: number;
 }
 
+/**
+ * One implausible registrable domain from a DGA crop. The domains
+ * matter more than the score: hashed-CDN buckets and shortlink
+ * services share the shape, so an operator needs to see which names
+ * actually scored before acting.
+ */
+export interface DNSDGACandidate {
+  parent: string;
+  label: string;
+  implausibility: number;
+  vowel_ratio: number;
+}
+
+/** A client ranked by how many blocked lookups it made (#699). */
+export interface RPZOffender {
+  client_ip: string;
+  hits: number;
+  distinct_names: number;
+  distinct_feeds: number;
+  last_seen: string;
+  top_qname: string | null;
+  top_qname_hits: number;
+  /** Past the "worth chasing" bar; set server-side so UI and copilot agree. */
+  noisy: boolean;
+}
+
+export interface RPZBlockedName {
+  qname: string;
+  hits: number;
+  clients: number;
+  rpz_zone: string | null;
+}
+
+export interface RPZFeedRow {
+  rpz_zone: string | null;
+  hits: number;
+  clients: number;
+  distinct_names: number;
+}
+
+export interface RPZSummary {
+  blocked_hits: number;
+  clients_blocked: number;
+  distinct_names: number;
+  feeds_firing: number;
+  /** PASSTHRU is an explicit ALLOW, not a block — counted separately. */
+  passthru_hits: number;
+  worst_client_ip: string | null;
+  worst_client_hits: number | null;
+  since: string;
+  /** Zero blocks is a plausible real answer; this says whether anything ran. */
+  has_data: boolean;
+}
+
 export interface DNSThreatSummary {
   windows_scored: number;
   clients_seen: number;
@@ -8172,8 +8235,14 @@ export const dnsThreatApi = {
     client_ip?: string;
     hours?: number;
     min_score?: number;
-    /** Rank and filter by "tunnel" (content) or "beacon" (timing). */
-    detection?: "tunnel" | "beacon";
+    /**
+     * Rank and filter by "tunnel" (name content), "beacon" (timing) or
+     * "dga" (name plausibility). Kept explicit rather than a combined
+     * max: the three mean different things, and an operator hunting
+     * exfil should not have their list reordered by a chatty
+     * monitoring agent.
+     */
+    detection?: "tunnel" | "beacon" | "dga";
     include_allowlisted?: boolean;
     include_muted?: boolean;
     limit?: number;
@@ -8196,6 +8265,31 @@ export const dnsThreatApi = {
   unmute: (clientIp: string) =>
     api
       .delete<void>(`/dns-threat/mutes/${encodeURIComponent(clientIp)}`)
+      .then((r) => r.data),
+  /**
+   * RPZ hit attribution (#699). Ground truth rather than a heuristic —
+   * named matched a policy and logged it — so these need no score or
+   * threshold, only ranking.
+   */
+  rpzSummary: (params?: { hours?: number }) =>
+    api
+      .get<RPZSummary>("/dns-threat/rpz/summary", { params })
+      .then((r) => r.data),
+  rpzClients: (params?: {
+    hours?: number;
+    limit?: number;
+    min_hits?: number;
+  }) =>
+    api
+      .get<RPZOffender[]>("/dns-threat/rpz/clients", { params })
+      .then((r) => r.data),
+  rpzNames: (params?: { hours?: number; limit?: number }) =>
+    api
+      .get<RPZBlockedName[]>("/dns-threat/rpz/names", { params })
+      .then((r) => r.data),
+  rpzFeeds: (params?: { hours?: number }) =>
+    api
+      .get<RPZFeedRow[]>("/dns-threat/rpz/feeds", { params })
       .then((r) => r.data),
 };
 

--- a/frontend/src/pages/logs/DNSThreatTab.tsx
+++ b/frontend/src/pages/logs/DNSThreatTab.tsx
@@ -123,7 +123,9 @@ export function DNSThreatTab() {
   // tunneling and beaconing answer different questions, and an
   // operator hunting exfil shouldn't have their list reordered by a
   // chatty monitoring agent.
-  const [detection, setDetection] = useState<"tunnel" | "beacon">("tunnel");
+  const [detection, setDetection] = useState<"tunnel" | "beacon" | "dga">(
+    "tunnel",
+  );
   const [inspecting, setInspecting] = useState<string | null>(null);
   const [muting, setMuting] = useState<string | null>(null);
   const qc = useQueryClient();
@@ -203,12 +205,13 @@ export function DNSThreatTab() {
           <select
             value={detection}
             onChange={(e) =>
-              setDetection(e.target.value as "tunnel" | "beacon")
+              setDetection(e.target.value as "tunnel" | "beacon" | "dga")
             }
             className="rounded-md border bg-background px-2 py-1.5 text-sm"
           >
             <option value="tunnel">Tunneling (name content)</option>
             <option value="beacon">Beaconing (timing)</option>
+            <option value="dga">DGA (name plausibility)</option>
           </select>
         </div>
         <div>
@@ -398,7 +401,7 @@ function Row({
 }: {
   w: DNSClientWindow;
   open: boolean;
-  detection: "tunnel" | "beacon";
+  detection: "tunnel" | "beacon" | "dga";
   onToggle: () => void;
   onInspect: () => void;
   onMute: () => void;
@@ -419,7 +422,13 @@ function Row({
       >
         <td className="px-4 py-2">
           <ScoreCell
-            score={detection === "beacon" ? w.beacon_score : w.tunnel_score}
+            score={
+              detection === "beacon"
+                ? w.beacon_score
+                : detection === "dga"
+                  ? w.dga_score
+                  : w.tunnel_score
+            }
           />
         </td>
         <td className="px-4 py-2 font-mono text-xs">
@@ -533,6 +542,33 @@ function Row({
                   callback.
                 </p>
               </>
+            ) : detection === "dga" ? (
+              <>
+                <p className="mb-2 text-xs text-muted-foreground">
+                  {w.dga_detail ||
+                    "No crop of generated-looking domains in this window."}
+                </p>
+                {w.dga_candidates.length > 0 && (
+                  <ul className="mb-2">
+                    {w.dga_candidates.map((c) => (
+                      <li key={c.parent} className="py-0.5 text-xs">
+                        <span className="font-mono">{c.parent}</span>
+                        <span className="ml-2 text-muted-foreground">
+                          {(c.implausibility * 100).toFixed(0)}% implausible
+                          bigrams · {(c.vowel_ratio * 100).toFixed(0)}% vowels
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                <p className="mb-2 text-xs text-amber-600 dark:text-amber-400">
+                  Scored on name plausibility alone — the BIND9 query log
+                  carries no rcode, so there is no NXDOMAIN prior to corroborate
+                  it. Hashed-CDN buckets, shortlink services and odd brand names
+                  share the shape, so confirm the domains above before treating
+                  this as an infection.
+                </p>
+              </>
             ) : (
               <p className="mb-2 text-xs text-muted-foreground">
                 Every signal is listed, including those contributing nothing —
@@ -540,9 +576,11 @@ function Row({
               </p>
             )}
             <ul className="max-w-3xl">
-              {w.tunnel_signals.map((s) => (
-                <SignalBar key={s.name} signal={s} />
-              ))}
+              {(detection === "dga" ? w.dga_signals : w.tunnel_signals).map(
+                (s) => (
+                  <SignalBar key={s.name} signal={s} />
+                ),
+              )}
             </ul>
             <p className="mt-2 text-xs text-muted-foreground">
               Longest label {w.max_label_length} chars · mean entropy{" "}

--- a/frontend/src/pages/logs/DNSThreatTab.tsx
+++ b/frontend/src/pages/logs/DNSThreatTab.tsx
@@ -10,6 +10,7 @@ import {
   Search,
   ShieldCheck,
   ShieldQuestion,
+  Ban,
 } from "lucide-react";
 
 import { Modal } from "@/components/ui/modal";
@@ -46,8 +47,50 @@ import {
  * an ``?ip=`` entry point on IPAMPage first.
  */
 
+type Detection = "tunnel" | "beacon" | "dga";
+
+/**
+ * One table driving every per-detection difference: which score the row
+ * shows, which signals its evidence panel renders, and — critically —
+ * what the score is CALLED. The top band used to be hard-coded "Likely
+ * tunnel" for all three, so a DGA finding rendered as the one structural
+ * conclusion it is not (a tunnel concentrates under one parent, a DGA
+ * sprays across many).
+ */
+const DETECTIONS: Record<
+  Detection,
+  {
+    label: string;
+    topBand: string;
+    score: (w: DNSClientWindow) => number;
+    signals: (w: DNSClientWindow) => DNSTunnelSignal[];
+  }
+> = {
+  tunnel: {
+    label: "Tunneling (content)",
+    topBand: "Likely tunnel",
+    score: (w) => w.tunnel_score,
+    signals: (w) => w.tunnel_signals,
+  },
+  beacon: {
+    label: "Beaconing (timing)",
+    topBand: "Likely beacon",
+    score: (w) => w.beacon_score,
+    // Beaconing reports per-name candidates rather than weighted
+    // signals, so its panel renders those instead; showing the tunnel
+    // signals here (the previous fallthrough) was actively misleading.
+    signals: () => [],
+  },
+  dga: {
+    label: "DGA (name plausibility)",
+    topBand: "Likely DGA",
+    score: (w) => w.dga_score,
+    signals: (w) => w.dga_signals,
+  },
+};
+
 const SCORE_BANDS = [
-  { min: 60, label: "Likely tunnel", cls: "text-rose-600 dark:text-rose-400" },
+  { min: 60, label: null, cls: "text-rose-600 dark:text-rose-400" },
   { min: 40, label: "Suspicious", cls: "text-amber-600 dark:text-amber-400" },
   {
     min: 20,
@@ -56,17 +99,22 @@ const SCORE_BANDS = [
   },
 ] as const;
 
-function band(score: number) {
-  return (
-    SCORE_BANDS.find((b) => score >= b.min) ?? {
-      label: "Low",
-      cls: "text-muted-foreground",
-    }
-  );
+function band(score: number, detection: Detection) {
+  const b = SCORE_BANDS.find((x) => score >= x.min);
+  if (!b) return { label: "Low", cls: "text-muted-foreground" };
+  // `label: null` on the top band means "name the detection" — that is
+  // the only band whose wording is detection-specific.
+  return { label: b.label ?? DETECTIONS[detection].topBand, cls: b.cls };
 }
 
-function ScoreCell({ score }: { score: number }) {
-  const b = band(score);
+function ScoreCell({
+  score,
+  detection = "tunnel",
+}: {
+  score: number;
+  detection?: Detection;
+}) {
+  const b = band(score, detection);
   return (
     <div className="flex items-center gap-2">
       <span className={`font-mono text-sm font-semibold ${b.cls}`}>
@@ -123,9 +171,7 @@ export function DNSThreatTab() {
   // tunneling and beaconing answer different questions, and an
   // operator hunting exfil shouldn't have their list reordered by a
   // chatty monitoring agent.
-  const [detection, setDetection] = useState<"tunnel" | "beacon" | "dga">(
-    "tunnel",
-  );
+  const [detection, setDetection] = useState<Detection>("tunnel");
   const [inspecting, setInspecting] = useState<string | null>(null);
   const [muting, setMuting] = useState<string | null>(null);
   const qc = useQueryClient();
@@ -204,9 +250,7 @@ export function DNSThreatTab() {
           <label className="mb-1 block text-xs font-medium">Detection</label>
           <select
             value={detection}
-            onChange={(e) =>
-              setDetection(e.target.value as "tunnel" | "beacon" | "dga")
-            }
+            onChange={(e) => setDetection(e.target.value as Detection)}
             className="rounded-md border bg-background px-2 py-1.5 text-sm"
           >
             <option value="tunnel">Tunneling (name content)</option>
@@ -381,10 +425,27 @@ export function DNSThreatTab() {
 
       {inspecting && (
         <ClientDetailModal
+          detection={detection}
           clientIp={inspecting}
           hours={hours}
           onClose={() => setInspecting(null)}
         />
+      )}
+
+      {/* Blocklist attribution. Rendered as its own section rather than a
+          fourth detection mode because it is ground truth, not a score:
+          named matched a policy and logged it, so there is nothing to
+          threshold and nothing to rank by confidence. */}
+      {!moduleOff && (
+        <section className="mt-8 border-t pt-6">
+          <h3 className="mb-1 text-sm font-semibold">Blocklist hits (RPZ)</h3>
+          <p className="mb-3 text-xs text-muted-foreground">
+            Which machines keep reaching for domains the blocklists block.
+            Unlike the scores above this is not a heuristic — every row is a
+            policy that actually fired.
+          </p>
+          <RPZPanel hours={hours} />
+        </section>
       )}
     </div>
   );
@@ -401,7 +462,7 @@ function Row({
 }: {
   w: DNSClientWindow;
   open: boolean;
-  detection: "tunnel" | "beacon" | "dga";
+  detection: Detection;
   onToggle: () => void;
   onInspect: () => void;
   onMute: () => void;
@@ -422,13 +483,8 @@ function Row({
       >
         <td className="px-4 py-2">
           <ScoreCell
-            score={
-              detection === "beacon"
-                ? w.beacon_score
-                : detection === "dga"
-                  ? w.dga_score
-                  : w.tunnel_score
-            }
+            score={DETECTIONS[detection].score(w)}
+            detection={detection}
           />
         </td>
         <td className="px-4 py-2 font-mono text-xs">
@@ -576,11 +632,9 @@ function Row({
               </p>
             )}
             <ul className="max-w-3xl">
-              {(detection === "dga" ? w.dga_signals : w.tunnel_signals).map(
-                (s) => (
-                  <SignalBar key={s.name} signal={s} />
-                ),
-              )}
+              {DETECTIONS[detection].signals(w).map((s) => (
+                <SignalBar key={s.name} signal={s} />
+              ))}
             </ul>
             <p className="mt-2 text-xs text-muted-foreground">
               Longest label {w.max_label_length} chars · mean entropy{" "}
@@ -605,14 +659,17 @@ function Row({
  * retained history, newest first, so the shape is visible at a glance.
  */
 function ClientDetailModal({
+  detection,
   clientIp,
   hours,
   onClose,
 }: {
+  detection: Detection;
   clientIp: string;
   hours: number;
   onClose: () => void;
 }) {
+  const scoreOf = DETECTIONS[detection].score;
   const q = useQuery({
     queryKey: ["dns-threat-client", clientIp],
     // Per-client fetch returns that client's full history regardless of
@@ -626,9 +683,9 @@ function ClientDetailModal({
       }),
   });
   const rows = q.data ?? [];
-  const peak = rows.reduce((m, r) => Math.max(m, r.tunnel_score), 0);
+  const peak = rows.reduce((m, r) => Math.max(m, scoreOf(r)), 0);
   const totalQueries = rows.reduce((n, r) => n + r.query_count, 0);
-  const scored = rows.filter((r) => r.tunnel_score > 0);
+  const scored = rows.filter((r) => scoreOf(r) > 0);
 
   return (
     <Modal title={`DNS behaviour — ${clientIp}`} onClose={onClose} wide>
@@ -644,7 +701,10 @@ function ClientDetailModal({
       ) : (
         <div className="flex flex-col gap-4">
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <Stat label="Peak score" value={peak.toFixed(0)} />
+            <Stat
+              label={`Peak ${DETECTIONS[detection].label.split(" ")[0].toLowerCase()} score`}
+              value={peak.toFixed(0)}
+            />
             <Stat label="Windows retained" value={String(rows.length)} />
             <Stat label="Windows scoring" value={String(scored.length)} />
             <Stat label="Queries seen" value={totalQueries.toLocaleString()} />
@@ -668,17 +728,17 @@ function ClientDetailModal({
                   <span className="h-1.5 flex-1 overflow-hidden rounded bg-muted">
                     <span
                       className={
-                        r.tunnel_score >= 60
+                        scoreOf(r) >= 60
                           ? "block h-full bg-rose-500"
-                          : r.tunnel_score >= 20
+                          : scoreOf(r) >= 20
                             ? "block h-full bg-amber-500"
                             : "block h-full bg-emerald-500/50"
                       }
-                      style={{ width: `${Math.max(2, r.tunnel_score)}%` }}
+                      style={{ width: `${Math.max(2, scoreOf(r))}%` }}
                     />
                   </span>
                   <span className="w-8 shrink-0 text-right font-mono">
-                    {r.tunnel_score.toFixed(0)}
+                    {scoreOf(r).toFixed(0)}
                   </span>
                   <span className="w-40 shrink-0 truncate text-muted-foreground">
                     {r.allowlisted ? "cleared (allowlisted)" : r.top_parent}
@@ -916,5 +976,133 @@ function MutedClientsPanel({
         </ul>
       )}
     </section>
+  );
+}
+
+/**
+ * RPZ hit attribution (#699).
+ *
+ * The other three surfaces on this tab are heuristics with a score. This
+ * one is ground truth: named matched a response-policy rule and logged
+ * it, so there is nothing to infer and nothing to threshold — only to
+ * attribute and rank. That difference is why it renders as its own
+ * panel rather than a fourth entry in the detection dropdown.
+ *
+ * PASSTHRU is reported separately, never inside the blocked count: it is
+ * an explicit ALLOW (a blocklist exception firing), and folding it in
+ * would make a correctly-tuned allowlist read as an infection.
+ */
+function RPZPanel({ hours }: { hours: number }) {
+  const summary = useQuery({
+    queryKey: ["dns-threat-rpz-summary", hours],
+    queryFn: () => dnsThreatApi.rpzSummary({ hours }),
+  });
+  const clients = useQuery({
+    queryKey: ["dns-threat-rpz-clients", hours],
+    queryFn: () => dnsThreatApi.rpzClients({ hours, limit: 20 }),
+  });
+
+  if (summary.isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading blocklist activity&hellip;
+      </div>
+    );
+  }
+  const s = summary.data;
+  // "Nothing was blocked" and "this never ran" must stay distinguishable
+  // — zero blocks is a plausible real answer on a quiet network, so the
+  // UI must not have to guess. Same contract the threat summary carries.
+  if (!s?.has_data) {
+    return (
+      <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">
+        <p className="mb-1 font-medium text-foreground">
+          No blocklist activity recorded yet
+        </p>
+        <p>
+          RPZ attribution needs a BIND9 group with query logging enabled and at
+          least one blocklist assigned. This reads &quot;not running yet&quot;
+          rather than &quot;nothing was blocked&quot; — once the pipeline is
+          live, a genuinely quiet network shows zeroes here instead of this
+          message.
+        </p>
+      </div>
+    );
+  }
+
+  const rows = clients.data ?? [];
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Stat label="Blocked lookups" value={s.blocked_hits.toLocaleString()} />
+        <Stat label="Clients blocked" value={String(s.clients_blocked)} />
+        <Stat label="Distinct names" value={String(s.distinct_names)} />
+        <Stat
+          label="Allowed (passthru)"
+          value={s.passthru_hits.toLocaleString()}
+        />
+      </div>
+
+      <div>
+        <h4 className="mb-1 text-xs font-semibold">
+          Clients reaching for blocked domains
+        </h4>
+        <p className="mb-2 text-xs text-muted-foreground">
+          A single blocked lookup is an ad on a web page. Hundreds from one host
+          is a machine with something running on it — which is the question the
+          blocklists could always answer and never did.
+        </p>
+        {rows.length === 0 ? (
+          <p className="py-3 text-sm text-muted-foreground">
+            Nothing was blocked in this window.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[40rem] text-sm">
+              <thead className="border-b text-left text-xs text-muted-foreground">
+                <tr>
+                  <th className="py-1.5 pr-3 font-medium">Client</th>
+                  <th className="py-1.5 pr-3 font-medium">Blocked</th>
+                  <th className="py-1.5 pr-3 font-medium">Names</th>
+                  <th className="py-1.5 pr-3 font-medium">Most blocked</th>
+                  <th className="py-1.5 font-medium">Last seen</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.client_ip} className="border-b last:border-0">
+                    <td className="py-1.5 pr-3 font-mono text-xs">
+                      <span className="inline-flex items-center gap-1.5">
+                        {r.noisy && (
+                          <Ban className="h-3.5 w-3.5 text-rose-500" />
+                        )}
+                        {r.client_ip}
+                      </span>
+                    </td>
+                    <td
+                      className={`py-1.5 pr-3 font-mono ${
+                        r.noisy ? "font-semibold text-rose-600" : ""
+                      }`}
+                    >
+                      {r.hits.toLocaleString()}
+                    </td>
+                    <td className="py-1.5 pr-3 font-mono text-xs">
+                      {r.distinct_names}
+                    </td>
+                    <td className="py-1.5 pr-3 font-mono text-xs break-all">
+                      {r.top_qname ?? "—"}
+                    </td>
+                    <td className="py-1.5 text-xs text-muted-foreground">
+                      {new Date(r.last_seen).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/logs/DNSThreatTab.tsx
+++ b/frontend/src/pages/logs/DNSThreatTab.tsx
@@ -435,9 +435,15 @@ export function DNSThreatTab() {
       {/* Blocklist attribution. Rendered as its own section rather than a
           fourth detection mode because it is ground truth, not a score:
           named matched a policy and logged it, so there is nothing to
-          threshold and nothing to rank by confidence. */}
+          threshold and nothing to rank by confidence.
+
+          Carries the same card treatment as every sibling above — the
+          root is a bare `flex flex-col gap-4`, so the horizontal inset
+          comes from each child's own `px-4`, not from the container. A
+          bare <section> here rendered flush against the left edge and
+          visibly out of line with the rest of the tab. */}
       {!moduleOff && (
-        <section className="mt-8 border-t pt-6">
+        <section className="rounded-lg border bg-card px-4 py-3">
           <h3 className="mb-1 text-sm font-semibold">Blocklist hits (RPZ)</h3>
           <p className="mb-3 text-xs text-muted-foreground">
             Which machines keep reaching for domains the blocklists block.
@@ -1016,7 +1022,7 @@ function RPZPanel({ hours }: { hours: number }) {
   // UI must not have to guess. Same contract the threat summary carries.
   if (!s?.has_data) {
     return (
-      <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">
+      <div className="text-sm text-muted-foreground">
         <p className="mb-1 font-medium text-foreground">
           No blocklist activity recorded yet
         </p>


### PR DESCRIPTION
Closes #699

The last two of #699's four detections. Tunneling landed in #705, beaconing in
#709; both of these needed the spec corrections written up on the issue first.

## DGA — name plausibility

Malware that finds its C2 through a domain-generation algorithm queries a fresh
crop of domains on a schedule. **Structurally the inverse of tunneling**, which
is why it is a separate scorer: a tunnel concentrates thousands of subdomains
under ONE parent, a DGA sprays across MANY. In one weighted sum each detection's
strongest signal would be the other's evidence of innocence. Two tests pin
exactly that — a tunnel scores 0 for DGA, a crop scores low for tunneling.

Four signals: bigram implausibility (35), domain fan-out (30), pronounceability
(20), length uniformity (15). Fan-out and uniformity are **multiplied by** the
implausibility signal rather than added — see the calibration note below.

**The issue specified scoring "NXDOMAIN-heavy clients", which is not possible.**
`dns_query_log_entry` records the question, never the answer — the BIND9 query
log carries no rcode, which is why `dns_nxdomain_spike` reads `dns_metric_sample`
instead. Of the three options on the issue this takes the first (name
characteristics alone). The alert rule seeds **disabled** and the bar is higher
than tunneling's, reflecting the weaker basis. Signals stay additive so the
per-server NXDOMAIN metric can layer on later.

## RPZ hit attribution — ground truth, not a heuristic

We serve curated blocklists and discarded every hit, leaving the most useful
question they can answer unanswerable: *which machine keeps reaching for blocked
domains*.

Not the "cheap reporting add-on" the issue implies — named logs policy rewrites
to its own categories, which we neither rendered nor shipped. Those now point at
the **existing** `queries_channel`, so no new shipper thread, log file or bind
mount; the control plane tells the line shapes apart at ingest.

`dns_rpz_hit` is a separate table: hits are kept 30 days against the query log's
24 h ("has this host hit the malware feed all week" is unanswerable inside 24 h),
and the columns genuinely differ. **PASSTHRU is an explicit ALLOW**, reported
alongside rather than inside the blocked count — folding it in would make a
correctly-tuned allowlist read as an infection.

## What the code review changed

Eight review angles ran over the first commit. Two findings were verified by
measurement and were real defects the tests could not have caught:

**The DGA scorer could not reach its own alert threshold.** Measured:

| population | bigram implausibility |
|---|---|
| real word labels (`northwind`, `warehouse`) | 0.06 |
| random a-z 12-char (Conficker shape) | **0.60** |
| consonants-only — *the test fixture* | 0.80 |

`_NGRAM_FLOOR` was 0.55 (above where real DGA traffic lands) and `_NGRAM_CEIL`
0.92 (unreachable — 259 of 676 bigrams are common and appear by chance). A
genuine 250-domain crop scored ~64 against an alert bar of 80. It passed its
tests only because the fixture used an alphabet no DGA family emits.

**Fan-out was scoring innocent hosts.** Additive, it gave a build server or a
downstream forwarder 36/100 with zero implausible names. Now conditioned on the
n-gram signal, which makes the module docstring's claim structurally true.

RPZ format bugs, all verified against the shipped BIND 9.20.23 image: PASSTHRU
goes to a separate `rpz-passthru` category (so every `!= PASSTHRU` filter was
dead code); `rewrite` carries `/A/IN`; `TCP_ONLY` is the log form while
`tcp-only` is the config keyword; `disabled rpz` (log-only trial mode) parsed as
a real block; DROP *does* log rewrite/via; and `rpz_zone` could exceed
`String(255)` and abort the whole ingest batch.

Also: `dns_rpz_hit` was in neither the backup nor factory-reset catalog (silent
data loss on restore, and per-client blocked-domain history surviving a wipe);
ingest now gates on the default-off `security.dns_threat` module on the same
privacy grounds as every reader; RPZ capability comes from
`DNSDriver.capabilities()` rather than a driver-name string (non-negotiable #10);
and `top_offending_clients` went from 1+N to a single `row_number()` pass.

**Frontend:** the RPZ panel was added — the headline feature had no UI at all.
A `DETECTIONS` table replaces three scattered branch sites, fixing a real
mislabel (every score ≥60 rendered "Likely tunnel", so DGA findings were
labelled the one thing they structurally are not), and `ClientDetailModal` no
longer reports "Peak score 0" on a DGA or beacon drilldown.

## Known scope limit

`/rpz/feeds` distinguishes **views, not individual feeds**: `agent_config.py`
merges every enabled blocklist into one rendered zone, dropping the per-entry
`list_id`. Splitting that needs per-list zones or a qname join back to
`DNSBlockListEntry`. Docstrings previously claimed otherwise and now say this
plainly; it's noted as follow-up on #699 rather than quietly shipped as working.

## Testing

131 pass across every affected suite (54 in `test_dns_threat`, up from 46 — the
8 new ones are regression pins for the bugs above). Both migrations additive with
server defaults. ruff / black / mypy (753 files) / eslint / prettier / vite build
/ migration linter all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)