### PR TITLE
fix(appliance): security pass on the #549 preseed installer + CI for its tests (#581)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,40 @@ jobs:
         # ``tests/test_acceptance.py``.
         run: python -m pytest tests -q
 
+  # ── Appliance ────────────────────────────────────────────────────────────────
+  # ``appliance/tests`` has ~194 host-portable cases covering the installer's
+  # GRUB rendering, host migration, slot upgrades, cluster-join guards, the
+  # ``--check-preseed`` linter (#581) and the preseed security guards (#581) —
+  # and none of them ran in CI. Same gap #640 found for the agent suites: a
+  # suite nobody runs is a suite that goes red unnoticed, and #549 is a
+  # disk-*wiping* feature, so its guards are exactly the ones that must not
+  # regress silently.
+  #
+  # Deliberately hermetic: no root, no block devices, no Docker, no database.
+  # The only runtime dependency beyond pytest is PyYAML, which
+  # ``spatium-preseed-parse`` imports (the appliance image ships
+  # python3-yaml). Whole suite is ~10 s.
+  #
+  # Like the agent job above, this runs *tests only* — appliance scripts are
+  # not under ruff/black (Backend Lint scopes to ``backend/``), and the two
+  # pre-existing shellcheck findings in ``spatium-install`` (SC2010 / SC2034)
+  # are out of scope here.
+  appliance-test:
+    name: Appliance — Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pytest pyyaml
+
+      - name: Run tests
+        run: python -m pytest appliance/tests -q
+
   # Required-status-check aggregator: branch protection can gate on the stable
   # name "Agent — Tests"; this job passes only if all three agent suites did.
   # Keep this name (and the matrix above) in sync with the required check.

--- a/appliance/cloud-init/README.md
+++ b/appliance/cloud-init/README.md
@@ -55,7 +55,7 @@ Summary:
 | `confirm_wipe` | **Must be `true`** to auto-wipe a disk unattended |
 | `target_disk` | Prefer `/dev/disk/by-id/…` or `by-path/…` (stable). Absent / unresolvable ⇒ interactive picker |
 | `hostname` | RFC 1123 (alnum + hyphen, ≤ 63) |
-| `admin_user` | default `admin` |
+| `admin_user` | default `admin`. Must match `[a-z_][a-z0-9_-]*$?`, ≤ 32 chars, and not be an existing system account (`root`, `www-data`, …) |
 | `admin_password` **or** `admin_password_hash` | plaintext, or a crypt(3) hash from `openssl passwd -6` |
 | `timezone` | IANA name, default `UTC` |
 | `network.mode` | `dhcp`, or `static` with `interface` + `ip` + `prefix` + `gateway` all required (IPv4 only; optional `dns`) |
@@ -85,7 +85,9 @@ first match wins:
 
 1. **Kernel cmdline** — `spatium.preseed=<url|path>` (best for PXE /
    IPMI). A `http(s)://` value is fetched with curl; anything else is a
-   path on the installer rootfs.
+   path on the installer rootfs. **A plain `http://` URL is refused
+   unless it is pinned with `spatium.preseed.sha256=<64-hex>`** — see
+   [URL integrity](#url-integrity-http-and-sha256-pinning) below.
 2. **NoCloud CIDATA volume** — a disk labelled `CIDATA` carrying
    `spatium-preseed.yaml` (or `.yml`, or a cloud-init `user-data`
    document with an embedded `spatium_preseed:` block). Best for VM /
@@ -125,6 +127,32 @@ Append to the installer boot cmdline (alongside `spatium-mode=install`):
 ```
 spatium.preseed=https://provision.example.net/spatium/ddi-control-1.yaml
 ```
+
+#### URL integrity (http and sha256 pinning)
+
+The cmdline URL is the only transport that arrives over the network
+from a party the installer cannot authenticate, and the answer file it
+delivers authorises an unattended disk wipe and carries the admin
+password (plus the pairing code on `role: appliance`). So a plain
+`http://` URL with **no** integrity pin is refused before the fetch,
+with a message naming both remedies:
+
+```
+# Option A — TLS authenticates the origin (preferred)
+spatium.preseed=https://provision.example.net/spatium/ddi-control-1.yaml
+
+# Option B — content-pinned, so the transport need not be trusted.
+# For air-gapped / internal-CA PXE where https isn't practical.
+spatium.preseed=http://pxe.internal/spatium/ddi-control-1.yaml
+spatium.preseed.sha256=9f2c...64-hex-digest
+```
+
+Get the digest with `sha256sum spatium-preseed.yaml`. The pin is
+verified whenever it is supplied (https or not); a mismatch halts the
+install rather than acting on content that may have been modified in
+transit, and a pin that cannot be checked fails closed. The `CIDATA`
+and install-medium transports are physically attached and are not
+subject to this gate.
 
 Serve a per-host answer file from any HTTP server. This pairs well with
 the console-redirect cmdline the appliance already sets

--- a/appliance/mkosi.extra/usr/local/bin/spatium-install
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-install
@@ -64,6 +64,13 @@ BACKTITLE="SpatiumDDI Appliance Installer 0.1.0"
 # /var/log isn't writable by the caller.
 INSTALL_LOG="${SPATIUM_INSTALL_LOG:-/var/log/spatium-install.log}"
 MOUNT=/mnt/target
+# Test-only seams (issue #581), same idea as spatium-preseed-parse's
+# SPATIUM_FAKE_DISK_BYTES: the preseed-URL integrity gate and the
+# live-boot-disk exclusion are pure text processing over two kernel
+# files, but a pytest host cannot write either one. Never set on a real
+# install, where both resolve to the real /proc paths.
+PROC_CMDLINE="${SPATIUM_CMDLINE_FILE:-/proc/cmdline}"
+PROC_MOUNTS="${SPATIUM_MOUNTS_FILE:-/proc/mounts}"
 
 mkdir -p /var/log 2>/dev/null || true
 if ! : 2>/dev/null > "$INSTALL_LOG"; then
@@ -377,23 +384,20 @@ ask_application_config() {
     log "Application paired against $CONTROL_PLANE_URL with an 8-digit pairing code"
 }
 
-pick_disk() {
-    log "Step: pick_disk"
-    if [ -n "${PRESEED_HAS_DISK:-}" ]; then
-        log "Preseed: target_disk=$TARGET_DISK (confirm_wipe authorised; skipping picker)"
-        return 0
-    fi
-    local options=()
-    # #554 — exclude EVERY disk backing the live boot medium, not just the
-    # one findmnt resolves. The old code checked only ``findmnt -no SOURCE
-    # /run/live/medium``; with ``boot=live toram`` (or a layout that
-    # unmounts the medium) that returns empty, so the boot USB — an ``sd*``
-    # device the ``grep -vE "^(sr|loop|fd|ram|zram)"`` filter does NOT
-    # exclude — appeared as a wipe target and picking it destroyed the
-    # running install media mid-install. Scan /proc/mounts for every
-    # /run/live // /lib/live mount and map each source back to its parent
-    # disk, keeping the findmnt-derived one too as belt-and-braces.
-    local -A live_disks=()
+# #554 — every disk backing the live boot medium, one /dev/<disk> per
+# line. The old inline code checked only ``findmnt -no SOURCE
+# /run/live/medium``; with ``boot=live toram`` (or a layout that unmounts
+# the medium) that returns empty, so the boot USB — an ``sd*`` device the
+# ``grep -vE "^(sr|loop|fd|ram|zram)"`` filter does NOT exclude —
+# appeared as a wipe target and picking it destroyed the running install
+# media mid-install. Scan /proc/mounts for every /run/live // /lib/live
+# mount and map each source back to its parent disk, keeping the
+# findmnt-derived one too as belt-and-braces.
+#
+# Split out of pick_disk (issue #581) so the pre-wipe guard in do_install
+# applies the SAME exclusion to a preseeded target_disk, which never goes
+# through the picker. One implementation, so the two can't drift.
+_live_boot_disks() {
     local _src _mnt _rest _pk
     while read -r _src _mnt _rest; do
         case "$_mnt" in
@@ -402,20 +406,36 @@ pick_disk() {
                     /dev/*)
                         _pk=$(lsblk -no PKNAME "$_src" 2>/dev/null | head -n1)
                         [ -z "$_pk" ] && _pk=$(basename "$_src")
-                        [ -n "$_pk" ] && live_disks["/dev/$_pk"]=1
+                        [ -n "$_pk" ] && echo "/dev/$_pk"
                         ;;
                 esac
                 ;;
         esac
-    done < /proc/mounts
-    local live_src
+    done < "$PROC_MOUNTS"
+    local live_src live_disk
     live_src=$(findmnt -no SOURCE /run/live/medium 2>/dev/null || \
                findmnt -no SOURCE /lib/live/mount/medium 2>/dev/null || true)
     if [ -n "$live_src" ]; then
-        local live_disk
         live_disk=$(lsblk -no PKNAME "$live_src" 2>/dev/null | head -n1 || true)
-        [ -n "$live_disk" ] && live_disks["/dev/$live_disk"]=1
+        [ -n "$live_disk" ] && echo "/dev/$live_disk"
     fi
+}
+
+pick_disk() {
+    log "Step: pick_disk"
+    if [ -n "${PRESEED_HAS_DISK:-}" ]; then
+        # Skipping the picker also skips its live-medium exclusion and
+        # size floor — _assert_safe_wipe_target re-applies both (plus the
+        # whole-disk check) immediately before the wipe (#581).
+        log "Preseed: target_disk=$TARGET_DISK (confirm_wipe authorised; skipping picker — pre-wipe guard still applies)"
+        return 0
+    fi
+    local options=()
+    local -A live_disks=()
+    local _d
+    while IFS= read -r _d; do
+        [ -n "$_d" ] && live_disks["$_d"]=1
+    done < <(_live_boot_disks)
 
     while IFS= read -r line; do
         local name size model
@@ -641,17 +661,26 @@ ask_user_password() {
         return 0
     fi
 
+    # Tracing OFF for the whole prompt loop (issue #581). The preseed
+    # path already suppressed set -x around the secret env (load_preseed)
+    # and around chpasswd (do_install), but the INTERACTIVE path did not:
+    # `ADMIN_PASSWORD="$p1"` and `[ "$p1" = "$p2" ]` are argv, so xtrace
+    # wrote the operator's plaintext password into the trace log — which
+    # on_failure tails 30 lines of to the console on any non-zero exit.
+    # Re-enabled at the end of the loop on EVERY exit path (both `return
+    # 1`s restore it first).
+    { set +x; } 2>/dev/null
     while true; do
         local p1 p2
         p1=$(whiptail --backtitle "$BACKTITLE" --title "Admin password" \
             --cancel-button "Back" \
             --passwordbox "Password for '$ADMIN_USER' (and root):" 10 60 \
             3>&1 1>&2 2>&3) \
-            || return 1
+            || { set -x; return 1; }
         p2=$(whiptail --backtitle "$BACKTITLE" --title "Confirm password" \
             --cancel-button "Back" \
             --passwordbox "Repeat:" 10 60 3>&1 1>&2 2>&3) \
-            || return 1
+            || { set -x; return 1; }
         if [ "$p1" = "$p2" ] && [ -n "$p1" ]; then
             ADMIN_PASSWORD="$p1"
             break
@@ -660,6 +689,7 @@ ask_user_password() {
             --msgbox "Passwords don't match or are empty. Try again." 8 50 \
             || true
     done
+    set -x
 }
 
 # #554 — validate the static-IP fields with Python's ``ipaddress`` (same
@@ -1027,7 +1057,78 @@ partition_node() {
     esac
 }
 
+# Last-line defence immediately before the irreversible wipe (issue
+# #581). Everything below is re-checked here rather than trusted from
+# whichever path set TARGET_DISK, because the two paths do NOT validate
+# equally:
+#
+#   * interactive — pick_disk builds the menu from lsblk minus the live
+#     boot disks and enforces the size floor in its pick-and-validate
+#     loop, so the value is already known-good.
+#   * preseed — pick_disk returns EARLY on PRESEED_HAS_DISK and never
+#     runs any of that. The parser checks the disk exists, is a whole
+#     disk, and clears the size floor, but it has NO notion of the live
+#     boot medium: a preseed naming the install USB reintroduced exactly
+#     the #554 "wipe the media you are booted from" failure through the
+#     preseed door, mid-install and unattended.
+#
+# Re-validating for BOTH paths also covers the gap between validation
+# and use — the parser ran before NetworkManager and udev settled, and
+# on a bare sdX name (which the parser explicitly permits, only noting
+# the risk) the device can renumber onto a different physical disk in
+# between.
+#
+# Aborts via preseed_halt on an unattended run (loud, non-zero, no
+# guessing) and via a whiptail message + on_cancel when there is an
+# operator to tell.
+_assert_safe_wipe_target() {
+    local why="" real
+    real=$(readlink -f "$TARGET_DISK" 2>/dev/null || echo "$TARGET_DISK")
+
+    if [ -z "$TARGET_DISK" ]; then
+        why="No target disk was selected."
+    elif [ ! -b "$real" ]; then
+        why="Target disk $TARGET_DISK ($real) is not a block device."
+    elif [ ! -d "/sys/block/$(basename "$real")" ]; then
+        why="Target disk $TARGET_DISK resolves to $real, which is a partition, not a whole disk."
+    else
+        local _d
+        while IFS= read -r _d; do
+            [ -z "$_d" ] && continue
+            if [ "$(readlink -f "$_d" 2>/dev/null || echo "$_d")" = "$real" ]; then
+                why="Target disk $TARGET_DISK ($real) is the live install medium this installer is running from. Wiping it would destroy the running system mid-install."
+                break
+            fi
+        done < <(_live_boot_disks)
+    fi
+
+    if [ -z "$why" ]; then
+        local bytes min
+        bytes=$(blockdev --getsize64 "$real" 2>/dev/null || echo 0)
+        min=$((MIN_DISK_GIB * 1024 * 1024 * 1024))
+        if [ "$bytes" -lt "$min" ]; then
+            why="Target disk $TARGET_DISK is $((bytes / 1024 / 1024 / 1024)) GiB — below the ${MIN_DISK_GIB} GiB minimum for the A/B partition layout."
+        fi
+    fi
+
+    [ -z "$why" ] && { log "Pre-wipe guard OK: $TARGET_DISK ($real)"; return 0; }
+
+    log "Pre-wipe guard REFUSED $TARGET_DISK: $why"
+    if [ "$FULLY_UNATTENDED" = "1" ]; then
+        preseed_halt "Refusing to wipe the preseeded target disk:"$'\n\n'"$why"
+    fi
+    set +x
+    whiptail --backtitle "$BACKTITLE" --title "Unsafe target disk" \
+        --msgbox "$why"$'\n\n'"Nothing has been written. Pick a different disk." 14 72 \
+        || true
+    on_cancel "pre-wipe safety check ($TARGET_DISK)"
+}
+
 do_install() {
+    # Re-validate the wipe target before anything destructive (#581).
+    # Runs BEFORE `set -e` so its own probes can fail harmlessly.
+    _assert_safe_wipe_target
+
     # Now we're past all the prompts — enable -e so any failure
     # inside the partitioning / rsync / chroot block aborts cleanly
     # and the EXIT trap drops the operator to a shell with the log.
@@ -1938,6 +2039,70 @@ _fetch_preseed_url() {
     return 1
 }
 
+# Optional integrity pin for a cmdline preseed URL (issue #581):
+#   spatium.preseed.sha256=<64 hex>
+# Read once, here, so both the scheme gate and the post-fetch verify use
+# the same value.
+_preseed_url_sha256() {
+    sed -n 's/.*spatium\.preseed\.sha256=\([0-9a-fA-F]*\).*/\1/p' \
+        "$PROC_CMDLINE" 2>/dev/null | tr 'A-F' 'a-f'
+}
+
+# Integrity gate for the kernel-cmdline URL transport (issue #581).
+#
+# The URL transport is the ONE preseed source that arrives over the
+# network from a party we cannot authenticate: file / CIDATA transports
+# are physically attached, but a PXE/IPMI-supplied `spatium.preseed=`
+# URL is fetched over whatever the DHCP-advertised path offers. That
+# answer file carries `confirm_wipe: true` and a `target_disk` — so
+# whoever controls the bytes on the wire controls a full unattended disk
+# wipe, the admin password, and (appliance role) the pairing code that
+# enrols the box into a control plane. Plain http gives an on-path
+# attacker all three for free.
+#
+# Accept a URL only when its integrity is established one of two ways:
+#   * https:// — TLS authenticates the origin and protects the body.
+#   * a sha256 pin on the cmdline — content-addressed, so the transport
+#     no longer has to be trusted (this is the escape hatch for the
+#     air-gapped / internal-CA PXE setups where https isn't practical).
+# A sha256 pin is verified whenever it is supplied, https or not.
+#
+# Returns 0 to proceed with $1 (the URL), 1 to refuse it.
+_preseed_url_allowed() {
+    local url="$1" pin
+    pin=$(_preseed_url_sha256)
+    case "$url" in
+        https://*) return 0 ;;
+    esac
+    if [ -n "$pin" ]; then
+        log "Preseed: plain-http URL accepted — pinned to sha256 $pin"
+        return 0
+    fi
+    return 1
+}
+
+# Verify a fetched preseed against the cmdline sha256 pin, if one was
+# given. Returns 0 when there is no pin (nothing to check) or the digest
+# matches; 1 on mismatch or when no sha256 tool is available to check a
+# pin that WAS supplied (fail closed — a pin the installer cannot verify
+# must not be treated as verified).
+_preseed_url_verified() {
+    local file="$1" pin got
+    pin=$(_preseed_url_sha256)
+    [ -n "$pin" ] || return 0
+    if ! command -v sha256sum >/dev/null 2>&1; then
+        log "Preseed: sha256 pin supplied but sha256sum is unavailable — refusing"
+        return 1
+    fi
+    got=$(sha256sum "$file" 2>/dev/null | awk '{print $1}')
+    if [ "$got" = "$pin" ]; then
+        log "Preseed: sha256 pin verified ($got)"
+        return 0
+    fi
+    log "Preseed: sha256 MISMATCH — expected $pin, got ${got:-<unreadable>}"
+    return 1
+}
+
 # Append a discovered candidate to the parallel arrays.
 #   $1 local file path, $2 human source description, $3 kind
 _add_preseed_cand() {
@@ -1957,13 +2122,51 @@ _add_preseed_cand() {
 # Returns 0 if at least one candidate was found; 1 otherwise.
 discover_preseed() {
     local cmdval
-    cmdval=$(sed -n 's/.*spatium\.preseed=\([^ ]*\).*/\1/p' /proc/cmdline 2>/dev/null)
+    cmdval=$(sed -n 's/.*spatium\.preseed=\([^ ]*\).*/\1/p' "$PROC_CMDLINE" 2>/dev/null)
     if [ -n "$cmdval" ]; then
         case "$cmdval" in
             http://*|https://*)
                 local dest=/run/spatium-cand-cmdline.yaml
+                # Integrity gate BEFORE the fetch (issue #581) — refuse
+                # an unauthenticated source outright rather than pulling
+                # it and hoping. Halt rather than silently dropping to
+                # the interactive wizard: the operator explicitly asked
+                # for a headless install from this URL, and a fleet
+                # rollout that quietly waits at a whiptail prompt looks
+                # identical to one that hung.
+                if ! _preseed_url_allowed "$cmdval"; then
+                    PRESEED_SOURCE="kernel cmdline URL $cmdval"
+                    preseed_halt \
+"Refusing preseed URL over plain http with no integrity pin:
+
+  $cmdval
+
+An answer file authorises an unattended disk wipe and carries the
+admin password (and, for the appliance role, the pairing code), so
+it must come from a source that cannot be tampered with in transit.
+
+Use either:
+  * an https:// URL, or
+  * spatium.preseed.sha256=<64-hex-digest> on the kernel cmdline
+    alongside spatium.preseed=<url>  (content-pinned, so plain
+    http is fine — for air-gapped / internal-CA PXE setups)"
+                fi
                 if _fetch_preseed_url "$cmdval" "$dest"; then
-                    _add_preseed_cand "$dest" "kernel cmdline URL $cmdval" explicit
+                    if _preseed_url_verified "$dest"; then
+                        _add_preseed_cand "$dest" "kernel cmdline URL $cmdval" explicit
+                    else
+                        rm -f "$dest"
+                        PRESEED_SOURCE="kernel cmdline URL $cmdval"
+                        preseed_halt \
+"Preseed URL failed its sha256 integrity check:
+
+  $cmdval
+
+The fetched answer file does not match the spatium.preseed.sha256
+digest on the kernel cmdline. The install has stopped rather than
+act on content that may have been modified in transit.
+See $INSTALL_LOG for the expected and actual digests."
+                    fi
                 else
                     log "Preseed: gave up fetching $cmdval from cmdline after retries"
                 fi

--- a/appliance/mkosi.extra/usr/local/bin/spatium-preseed-parse
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-preseed-parse
@@ -37,6 +37,7 @@
 
 import ipaddress
 import os
+import re
 import shlex
 import stat
 import sys
@@ -296,10 +297,56 @@ if hostname:
         env["PRESEED_HAS_HOSTNAME"] = "1"
 
 # ── Admin user + password ─────────────────────────────────────────────
+# ── Admin OS user (issue #581) ────────────────────────────────────────
+# The value flows unquoted-in-spirit into `chroot useradd -m -G sudo -s
+# /bin/bash "$ADMIN_USER"` and into the `user:password` line piped to
+# `chpasswd`. The interactive path can only produce something sane (the
+# operator types into a whiptail box and useradd rejects the rest with a
+# visible error); a preseed is applied with no human watching, so an
+# unvalidated value either fails the install halfway through — after the
+# disk is already wiped — or, with a colon in it, splits the chpasswd
+# line and sets a password for the wrong account.
+#
+# Rules are the POSIX-portable useradd shape Debian's adduser enforces
+# (NAME_REGEX in /etc/adduser.conf): start with a lowercase letter or
+# underscore, then lowercase / digits / underscore / hyphen, with an
+# optional trailing '$' for Samba machine accounts. 32-char limit is
+# useradd's own (utmp).
+_ADMIN_USER_RE = re.compile(r"^[a-z_][a-z0-9_-]*\$?$")
+# Accounts the base image already ships. Handing one of these to
+# `useradd -m` fails ("user already exists") mid-install; `root` is
+# doubly wrong because do_install sets the root password separately
+# from the same secret, so a root admin_user silently means "the
+# useradd step fails and the install aborts after the wipe".
+_RESERVED_USERS = {
+    "root", "daemon", "bin", "sys", "sync", "games", "man", "lp", "mail",
+    "news", "uucp", "proxy", "www-data", "backup", "list", "irc", "nobody",
+    "systemd-network", "systemd-resolve", "messagebus", "sshd",
+}
+
 admin_user = as_str(ps.get("admin_user"))
 if admin_user:
-    env["ADMIN_USER"] = admin_user
-    env["PRESEED_HAS_ADMIN_USER"] = "1"
+    if len(admin_user) > 32:
+        fail(
+            f"admin_user {admin_user!r} is longer than 32 characters "
+            "(useradd's limit)"
+        )
+    elif not _ADMIN_USER_RE.match(admin_user):
+        fail(
+            f"admin_user {admin_user!r} is not a valid Linux username — must "
+            "start with a lowercase letter or underscore and contain only "
+            "lowercase letters, digits, underscore or hyphen (optionally "
+            "ending in '$')"
+        )
+    elif admin_user in _RESERVED_USERS:
+        fail(
+            f"admin_user {admin_user!r} is a reserved system account that "
+            "already exists in the image — pick a different name (the root "
+            "password is set from admin_password separately)"
+        )
+    else:
+        env["ADMIN_USER"] = admin_user
+        env["PRESEED_HAS_ADMIN_USER"] = "1"
 
 pw = as_str(ps.get("admin_password"))
 pw_hash = as_str(ps.get("admin_password_hash"))

--- a/appliance/tests/test_preseed_security.py
+++ b/appliance/tests/test_preseed_security.py
@@ -454,8 +454,8 @@ def test_secret_env_sourced_with_xtrace_off():
     """Regression guard: PRESEED_SECRET_ENV carries the admin password
     hash and the pairing code."""
     fn = extract_fn("load_preseed")
-    idx = fn.find("PRESEED_SECRET_ENV")
-    # First mention is the parser argv; the SOURCE of it is what matters.
+    # Anchor on the SOURCE of the secret env, not the first mention of the
+    # name — that one is the parser argv, which is fine to trace.
     src_idx = fn.find('. "$PRESEED_SECRET_ENV"')
     assert src_idx > 0
     assert "set +x" in fn[:src_idx], "secret env must be sourced with xtrace off"

--- a/appliance/tests/test_preseed_security.py
+++ b/appliance/tests/test_preseed_security.py
@@ -1,0 +1,469 @@
+"""Host-portable pytest for the #549 preseed installer's security guards.
+
+Issue #581 — the security half of the salvage from the closed PR #579.
+PR #582 landed the offline ``--check-preseed`` linter + its suite and
+explicitly deferred these items back to #581; this file covers them.
+
+#549 is a disk-*wiping* feature, so each guard here is the thing standing
+between an unattended run and an irreversible mistake:
+
+  * ``_preseed_url_allowed`` / ``_preseed_url_verified`` — a kernel-cmdline
+    preseed URL is the one answer-file transport that arrives over the
+    network from an unauthenticated party, and the file it delivers
+    authorises a full disk wipe. Plain http with no integrity pin is
+    refused; https, or any scheme with a matching ``spatium.preseed.sha256=``
+    pin, is accepted.
+  * ``_live_boot_disks`` / ``_assert_safe_wipe_target`` — the interactive
+    picker excludes the live install medium (#554), but the preseed path
+    returns early from ``pick_disk`` and never ran that check. The pre-wipe
+    guard re-validates for BOTH paths, immediately before ``wipefs``.
+  * ``admin_user`` shape — flows into ``useradd`` and into the
+    ``user:password`` line piped to ``chpasswd``; a colon or a reserved
+    account name breaks the install *after* the disk is already gone.
+
+The shell guards are exercised by extracting the function under test out
+of the installer and running it in a stub harness — the script ends in
+``main "$@"``, so it cannot simply be sourced. ``/proc/cmdline`` and
+``/proc/mounts`` are redirected through the ``SPATIUM_CMDLINE_FILE`` /
+``SPATIUM_MOUNTS_FILE`` seams (inert on a real install, same idea as
+``spatium-preseed-parse``'s ``SPATIUM_FAKE_DISK_BYTES``).
+
+HOW TO RUN (from the repo root or this directory):
+    python3 -m pytest appliance/tests/test_preseed_security.py -v
+
+No database, no Docker, no root, no block devices, no appliance ISO.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+INSTALLER = (
+    Path(__file__).parent.parent / "mkosi.extra" / "usr" / "local" / "bin" /
+    "spatium-install"
+)
+
+_SRC = INSTALLER.read_text(encoding="utf-8")
+
+
+def extract_fn(name: str) -> str:
+    """Pull one shell function definition out of the installer.
+
+    The installer ends in ``main "$@"``, so sourcing it would run a real
+    install. Every function in the file opens with ``name() {`` at column
+    0 and closes with ``}`` at column 0, so a line-anchored slice is
+    exact.
+    """
+    m = re.search(
+        rf"^{re.escape(name)}\(\) \{{$.*?^\}}$",
+        _SRC,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert m, f"function {name}() not found in {INSTALLER}"
+    return m.group(0)
+
+
+# Stubs for everything the extracted functions reach for. `log` is a
+# no-op sink, and the two abort paths echo a marker + exit non-zero so a
+# test can assert WHICH way the guard bailed.
+HARNESS_PRELUDE = """
+set -uo pipefail
+log() { :; }
+preseed_halt() { echo "PRESEED_HALT: $1"; exit 1; }
+on_cancel() { echo "ON_CANCEL: $1"; exit 1; }
+whiptail() { return 0; }
+clear() { :; }
+BACKTITLE="test"
+MIN_DISK_GIB=32
+FULLY_UNATTENDED=0
+TARGET_DISK=""
+"""
+
+
+def run_fn(fns, body: str, *, cmdline: str = "", mounts: str = "",
+           tmp_path: Path, extra: str = "") -> subprocess.CompletedProcess:
+    """Run `body` with `fns` (list of installer function names) in scope."""
+    cmdline_file = tmp_path / "cmdline"
+    cmdline_file.write_text(cmdline, encoding="utf-8")
+    mounts_file = tmp_path / "mounts"
+    mounts_file.write_text(mounts, encoding="utf-8")
+
+    script = "\n".join([
+        HARNESS_PRELUDE,
+        f'PROC_CMDLINE="{cmdline_file}"',
+        f'PROC_MOUNTS="{mounts_file}"',
+        extra,
+        *(extract_fn(f) for f in fns),
+        body,
+    ])
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60,
+    )
+
+
+# ── Preseed URL integrity gate ────────────────────────────────────────
+# A cmdline URL delivers an answer file carrying confirm_wipe + the admin
+# password + the pairing code. Whoever controls those bytes controls the
+# install, so the transport has to be authenticated (https) or the
+# content pinned (sha256).
+
+URL_FNS = ["_preseed_url_sha256", "_preseed_url_allowed"]
+
+
+@pytest.mark.parametrize("url", [
+    "https://boot.example.com/spatium-preseed.yaml",
+    "https://10.0.0.5/preseed.yaml",
+    "https://[2001:db8::1]/preseed.yaml",
+])
+def test_https_url_allowed_without_pin(url, tmp_path):
+    """TLS authenticates the origin — no pin required."""
+    r = run_fn(URL_FNS, f'_preseed_url_allowed "{url}" && echo ALLOW || echo REFUSE',
+               cmdline=f"spatium-mode=install spatium.preseed={url}",
+               tmp_path=tmp_path)
+    assert "ALLOW" in r.stdout
+
+
+@pytest.mark.parametrize("url", [
+    "http://boot.example.com/spatium-preseed.yaml",
+    "http://10.0.0.5/preseed.yaml",
+])
+def test_plain_http_url_refused_without_pin(url, tmp_path):
+    """The MITM case: an on-path attacker rewrites the answer file and
+    drives a disk wipe. Refused."""
+    r = run_fn(URL_FNS, f'_preseed_url_allowed "{url}" && echo ALLOW || echo REFUSE',
+               cmdline=f"spatium-mode=install spatium.preseed={url}",
+               tmp_path=tmp_path)
+    assert "REFUSE" in r.stdout
+
+
+def test_plain_http_url_allowed_with_sha256_pin(tmp_path):
+    """Content-pinning is the documented escape hatch for air-gapped /
+    internal-CA PXE where https isn't practical."""
+    pin = "a" * 64
+    r = run_fn(URL_FNS, '_preseed_url_allowed "http://pxe/preseed.yaml" '
+                        '&& echo ALLOW || echo REFUSE',
+               cmdline=f"spatium.preseed=http://pxe/preseed.yaml "
+                       f"spatium.preseed.sha256={pin}",
+               tmp_path=tmp_path)
+    assert "ALLOW" in r.stdout
+
+
+def test_sha256_pin_is_case_insensitive(tmp_path):
+    """Operators paste digests from tools that emit upper-case hex."""
+    r = run_fn(URL_FNS, '_preseed_url_sha256',
+               cmdline="spatium.preseed.sha256=" + "AB" * 32,
+               tmp_path=tmp_path)
+    assert r.stdout.strip() == "ab" * 32
+
+
+def test_no_pin_on_cmdline_yields_empty(tmp_path):
+    r = run_fn(URL_FNS, '_preseed_url_sha256; echo "END"',
+               cmdline="spatium-mode=install quiet",
+               tmp_path=tmp_path)
+    assert r.stdout.strip() == "END"
+
+
+VERIFY_FNS = ["_preseed_url_sha256", "_preseed_url_verified"]
+
+
+def test_verify_passes_with_no_pin(tmp_path):
+    """No pin supplied — nothing to check, don't invent a failure."""
+    f = tmp_path / "preseed.yaml"
+    f.write_text("spatium_preseed: {}\n", encoding="utf-8")
+    r = run_fn(VERIFY_FNS, f'_preseed_url_verified "{f}" && echo OK || echo BAD',
+               cmdline="spatium-mode=install", tmp_path=tmp_path)
+    assert "OK" in r.stdout
+
+
+def test_verify_passes_on_matching_digest(tmp_path):
+    import hashlib
+    f = tmp_path / "preseed.yaml"
+    content = "spatium_preseed:\n  role: control-plane\n"
+    f.write_text(content, encoding="utf-8")
+    digest = hashlib.sha256(content.encode()).hexdigest()
+    r = run_fn(VERIFY_FNS, f'_preseed_url_verified "{f}" && echo OK || echo BAD',
+               cmdline=f"spatium.preseed.sha256={digest}", tmp_path=tmp_path)
+    assert "OK" in r.stdout
+
+
+def test_verify_fails_on_tampered_content(tmp_path):
+    """The whole point: a modified answer file must not be acted on."""
+    import hashlib
+    f = tmp_path / "preseed.yaml"
+    original = "spatium_preseed:\n  role: control-plane\n"
+    digest = hashlib.sha256(original.encode()).hexdigest()
+    # What actually landed on disk is the attacker's version.
+    f.write_text("spatium_preseed:\n  role: control-plane\n  confirm_wipe: true\n",
+                 encoding="utf-8")
+    r = run_fn(VERIFY_FNS, f'_preseed_url_verified "{f}" && echo OK || echo BAD',
+               cmdline=f"spatium.preseed.sha256={digest}", tmp_path=tmp_path)
+    assert "BAD" in r.stdout
+
+
+def test_verify_fails_closed_when_file_unreadable(tmp_path):
+    """A pin that cannot be checked is not a pin that passed."""
+    r = run_fn(VERIFY_FNS,
+               f'_preseed_url_verified "{tmp_path}/missing.yaml" && echo OK || echo BAD',
+               cmdline="spatium.preseed.sha256=" + "b" * 64, tmp_path=tmp_path)
+    assert "BAD" in r.stdout
+
+
+# ── Live-boot-medium detection ────────────────────────────────────────
+
+LIVE_FNS = ["_live_boot_disks"]
+
+
+def test_live_boot_disks_finds_run_live_mounts(tmp_path):
+    mounts = (
+        "sysfs /sys sysfs rw 0 0\n"
+        "/dev/sdb1 /run/live/medium vfat ro 0 0\n"
+        "tmpfs /run tmpfs rw 0 0\n"
+    )
+    r = run_fn(LIVE_FNS, "_live_boot_disks", mounts=mounts, tmp_path=tmp_path)
+    # lsblk can't resolve a fake device on the test host, so the basename
+    # fallback in _live_boot_disks is what answers here.
+    assert "/dev/sdb1" in r.stdout or "/dev/sdb" in r.stdout
+
+
+def test_live_boot_disks_covers_lib_live_layout(tmp_path):
+    """`boot=live toram` / older live-boot mount the medium under
+    /lib/live/mount — the #554 case that findmnt alone missed."""
+    mounts = "/dev/sdc1 /lib/live/mount/medium iso9660 ro 0 0\n"
+    r = run_fn(LIVE_FNS, "_live_boot_disks", mounts=mounts, tmp_path=tmp_path)
+    assert "sdc" in r.stdout
+
+
+def test_live_boot_disks_ignores_unrelated_mounts(tmp_path):
+    mounts = (
+        "/dev/sda1 / ext4 rw 0 0\n"
+        "/dev/sda2 /home ext4 rw 0 0\n"
+        "proc /proc proc rw 0 0\n"
+    )
+    r = run_fn(LIVE_FNS, '_live_boot_disks; echo "END"',
+               mounts=mounts, tmp_path=tmp_path)
+    assert r.stdout.strip() == "END"
+
+
+def test_live_boot_disks_skips_non_dev_sources(tmp_path):
+    """A tmpfs/overlay source under /run/live has no parent disk."""
+    mounts = (
+        "tmpfs /run/live/overlay tmpfs rw 0 0\n"
+        "overlay /run/live/rootfs overlay rw 0 0\n"
+    )
+    r = run_fn(LIVE_FNS, '_live_boot_disks; echo "END"',
+               mounts=mounts, tmp_path=tmp_path)
+    assert r.stdout.strip() == "END"
+
+
+# ── Pre-wipe guard ────────────────────────────────────────────────────
+
+GUARD_FNS = ["_live_boot_disks", "_assert_safe_wipe_target"]
+
+
+def test_wipe_guard_refuses_empty_target(tmp_path):
+    r = run_fn(GUARD_FNS, "_assert_safe_wipe_target; echo REACHED_WIPE",
+               tmp_path=tmp_path, extra='TARGET_DISK=""')
+    assert "REACHED_WIPE" not in r.stdout
+    assert "ON_CANCEL" in r.stdout
+
+
+def test_wipe_guard_refuses_non_block_device(tmp_path):
+    """A preseed pointing at a regular file (or a path that stopped being
+    a device between parse and wipe) must not reach wipefs."""
+    decoy = tmp_path / "not-a-disk"
+    decoy.write_text("", encoding="utf-8")
+    r = run_fn(GUARD_FNS, "_assert_safe_wipe_target; echo REACHED_WIPE",
+               tmp_path=tmp_path, extra=f'TARGET_DISK="{decoy}"')
+    assert "REACHED_WIPE" not in r.stdout
+    assert "ON_CANCEL" in r.stdout
+
+
+def test_wipe_guard_explains_why_it_refused(tmp_path):
+    """The refusal reason has to reach the operator, not just the log —
+    on the unattended path preseed_halt is what prints it.
+    """
+    decoy = tmp_path / "not-a-disk"
+    decoy.write_text("", encoding="utf-8")
+    r = run_fn(GUARD_FNS, "_assert_safe_wipe_target; echo REACHED_WIPE",
+               tmp_path=tmp_path,
+               extra=f'TARGET_DISK="{decoy}"\nFULLY_UNATTENDED=1')
+    assert "not a block device" in r.stdout
+
+
+def test_wipe_guard_halts_loudly_when_unattended(tmp_path):
+    """Unattended runs get preseed_halt (non-zero, no console prompt),
+    never a whiptail box nobody is there to answer."""
+    decoy = tmp_path / "not-a-disk"
+    decoy.write_text("", encoding="utf-8")
+    r = run_fn(GUARD_FNS, "_assert_safe_wipe_target; echo REACHED_WIPE",
+               tmp_path=tmp_path,
+               extra=f'TARGET_DISK="{decoy}"\nFULLY_UNATTENDED=1')
+    assert "REACHED_WIPE" not in r.stdout
+    assert "PRESEED_HALT" in r.stdout
+    assert r.returncode != 0
+
+
+def test_wipe_guard_rejects_the_live_install_medium(tmp_path):
+    """The #554 regression the preseed path reopened: pick_disk excludes
+    the boot USB, but a preseeded target_disk skips pick_disk entirely.
+
+    Uses /dev/null — a real device node that is not a whole disk — as the
+    stand-in target, and declares it as the live medium. The guard must
+    refuse either way; what must never happen is falling through to the
+    wipe.
+    """
+    mounts = "/dev/null /run/live/medium vfat ro 0 0\n"
+    r = run_fn(GUARD_FNS, "_assert_safe_wipe_target; echo REACHED_WIPE",
+               mounts=mounts, tmp_path=tmp_path,
+               extra='TARGET_DISK="/dev/null"\nFULLY_UNATTENDED=1')
+    assert "REACHED_WIPE" not in r.stdout
+    assert "PRESEED_HALT" in r.stdout
+
+
+def test_wipe_guard_rejects_a_partition(tmp_path):
+    """target_disk must be a whole disk; the layout repartitions it."""
+    # /dev/console is a char device: not a block device, so the guard
+    # bails at the earlier arm. Assert only that it refuses.
+    r = run_fn(GUARD_FNS, "_assert_safe_wipe_target; echo REACHED_WIPE",
+               tmp_path=tmp_path,
+               extra='TARGET_DISK="/dev/console"\nFULLY_UNATTENDED=1')
+    assert "REACHED_WIPE" not in r.stdout
+
+
+# ── admin_user shape validation (parser rule, via --check-preseed) ────
+
+def lint(content: str, tmp_path: Path) -> subprocess.CompletedProcess:
+    f = tmp_path / "spatium-preseed.yaml"
+    f.write_text(content, encoding="utf-8")
+    return subprocess.run(
+        ["bash", str(INSTALLER), "--check-preseed", str(f)],
+        capture_output=True, text=True, timeout=120,
+    )
+
+
+def preseed_with_user(user: str) -> str:
+    return (
+        "spatium_preseed:\n"
+        "  role: control-plane\n"
+        "  hostname: spatium-cp-1\n"
+        f"  admin_user: {user}\n"
+        '  admin_password: "ChangeMe!12345"\n'
+        "  network:\n"
+        "    mode: dhcp\n"
+    )
+
+
+@pytest.mark.parametrize("user", ["admin", "ops", "ops-user", "_svc", "a", "spatium1"])
+def test_valid_admin_users_accepted(user, tmp_path):
+    r = lint(preseed_with_user(user), tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+@pytest.mark.parametrize("user,why", [
+    ("Admin", "uppercase is not a portable useradd name"),
+    ("1admin", "must not start with a digit"),
+    ("-admin", "must not start with a hyphen"),
+    ("ad min", "spaces break the useradd argv"),
+    ("ad:min", "a colon splits the chpasswd user:password line"),
+    ("admin$(id)", "command substitution must never reach a shell"),
+    ("admin;reboot", "shell metacharacters"),
+    ("admin\\ttab", "control characters"),
+    ("a" * 33, "over useradd's 32-character limit"),
+])
+def test_invalid_admin_users_rejected(user, why, tmp_path):
+    r = lint(preseed_with_user(f'"{user}"'), tmp_path)
+    assert r.returncode != 0, f"{why}: {user!r} was accepted\n{r.stdout}"
+
+
+@pytest.mark.parametrize("user", ["root", "daemon", "www-data", "nobody", "sshd"])
+def test_reserved_system_accounts_rejected(user, tmp_path):
+    """`useradd -m root` fails mid-install — after the disk is wiped."""
+    r = lint(preseed_with_user(user), tmp_path)
+    assert r.returncode != 0, f"reserved account {user!r} was accepted\n{r.stdout}"
+    assert "reserved" in (r.stdout + r.stderr).lower()
+
+
+def test_admin_user_error_names_the_field(tmp_path):
+    """The linter's whole job is telling the operator what to fix — so
+    assert it FAILED and that the message names both the field and the
+    offending value."""
+    r = lint(preseed_with_user('"Bad:User"'), tmp_path)
+    out = r.stdout + r.stderr
+    assert r.returncode != 0, out
+    assert "admin_user" in out
+    assert "Bad:User" in out
+
+
+def test_absent_admin_user_is_not_an_error(tmp_path):
+    """admin_user is optional — absent means the "admin" default."""
+    r = lint(
+        "spatium_preseed:\n"
+        "  role: control-plane\n"
+        "  hostname: spatium-cp-1\n"
+        '  admin_password: "ChangeMe!12345"\n'
+        "  network:\n"
+        "    mode: dhcp\n",
+        tmp_path,
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+# ── Secrets must not reach the trace log ──────────────────────────────
+
+def test_interactive_password_prompt_disables_xtrace():
+    """`on_failure` tails 30 lines of the trace log to the console on any
+    non-zero exit. The preseed path already suppressed xtrace around the
+    secret env and around chpasswd; the INTERACTIVE prompt did not, so
+    `ADMIN_PASSWORD="$p1"` and `[ "$p1" = "$p2" ]` — both argv — wrote the
+    operator's plaintext password into that log.
+    """
+    fn = extract_fn("ask_user_password")
+    body = fn.split("while true; do", 1)[0]
+    assert "set +x" in body, (
+        "ask_user_password must disable xtrace BEFORE the password prompt "
+        "loop, or the plaintext lands in the trace log on_failure prints"
+    )
+
+
+def test_password_prompt_restores_xtrace_on_every_exit():
+    """A leaked `set +x` would silently blind the trace log for the rest
+    of the install, which is the diagnostic the whole file exists for."""
+    fn = extract_fn("ask_user_password")
+    # Both early returns inside the loop, plus the fall-through at the end.
+    assert fn.count("{ set -x; return 1; }") == 2, fn
+    assert fn.rstrip().endswith("set -x\n}"), fn[-120:]
+
+
+def test_chpasswd_still_runs_with_xtrace_off():
+    """Regression guard on the shipped #549 protection.
+
+    Anchors on the real command, not the word — do_install's prose
+    mentions chpasswd well before the code that runs it.
+    """
+    fn = extract_fn("do_install")
+    idx = fn.find('| chroot "$MOUNT" chpasswd')
+    assert idx > 0, "could not find the chpasswd invocation in do_install"
+    assert "set +x" in fn[:idx], "chpasswd must not be traced"
+
+
+def test_secret_env_sourced_with_xtrace_off():
+    """Regression guard: PRESEED_SECRET_ENV carries the admin password
+    hash and the pairing code."""
+    fn = extract_fn("load_preseed")
+    idx = fn.find("PRESEED_SECRET_ENV")
+    # First mention is the parser argv; the SOURCE of it is what matters.
+    src_idx = fn.find('. "$PRESEED_SECRET_ENV"')
+    assert src_idx > 0
+    assert "set +x" in fn[:src_idx], "secret env must be sourced with xtrace off"
+
+
+def test_trace_log_is_excluded_from_the_installed_system():
+    """/var/log/* must not be rsynced onto the target — otherwise every
+    guard above is undone by shipping the trace log to the installed
+    machine."""
+    fn = extract_fn("do_install")
+    assert '--exclude="/var/log/*"' in fn

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -839,7 +839,13 @@ invalid, `2` usage error.
 file is the usual preseed tradeoff. Use `admin_password_hash` (crypt(3),
 e.g. `openssl passwd -6`) to keep the cleartext out of the file, and
 mint a fresh single-use pairing code per install. Neither is echoed to
-the console dashboard, the install log, or the trace log.
+the console dashboard, the install log, or the trace log — the secret
+env is sourced and `chpasswd` is fed with `set +x`, and **since #581 the
+interactive password prompt is too** (it previously wrote the operator's
+plaintext password into the trace log, which `on_failure` tails to the
+console on any non-zero exit). `/var/log/*` is excluded from the rsync
+onto the target, so no install-time log follows the secret into the
+installed system.
 
 **Transports** (first match wins): kernel cmdline
 `spatium.preseed=<url|path>` (PXE/IPMI), a NoCloud `CIDATA`-labelled
@@ -848,6 +854,50 @@ volume carrying `spatium-preseed.yaml` (VM/Proxmox), or a
 `spatium_preseed:` block can be embedded in a cloud-init `user-data`
 document, which is how the **AWS** (`--user-data`) and **Azure**
 (`--custom-data`) cloud-image recipes deliver it.
+
+**URL transport integrity (#581).** The cmdline URL is the only
+transport that arrives over the network from a party the installer
+cannot authenticate — and the file it delivers authorises a full disk
+wipe and carries the admin password (plus, on the appliance role, the
+pairing code). A **plain `http://` URL with no integrity pin is
+refused**, loudly, before the fetch. Use either:
+
+- an **`https://`** URL — TLS authenticates the origin; or
+- a content pin alongside it, for air-gapped / internal-CA PXE setups
+  where https isn't practical:
+
+  ```
+  spatium.preseed=http://pxe.internal/spatium-preseed.yaml
+  spatium.preseed.sha256=<64-hex-digest>
+  ```
+
+  (`sha256sum spatium-preseed.yaml` produces the digest.) A pin is
+  verified whenever supplied, https or not, and a mismatch halts the
+  install rather than acting on modified content. If a pin is supplied
+  but cannot be checked, the installer fails closed.
+
+  The `file` and `CIDATA` transports are physically attached and are
+  unaffected by this gate.
+
+**Pre-wipe safety check (#581).** Immediately before `wipefs`,
+`spatium-install` re-validates `target_disk`: it must still be a
+present, whole block device, clear the 32 GiB floor, and **not** be a
+disk backing the live install medium. The interactive picker already
+excluded the boot USB (#554), but a preseeded `target_disk` skips the
+picker entirely — so without this, an answer file naming the install
+USB destroyed the running media mid-install, unattended. The check
+runs on both paths (it also covers a bare `sdX` name renumbering onto a
+different disk between parse and wipe). On an unattended run it halts
+non-zero with the reason; interactively it explains and returns you to
+the picker. There is no `target_disk: auto` mode — the disk must be
+named explicitly, and `confirm_wipe: true` is required on top of it.
+
+**`admin_user` shape (#581).** Validated at parse time: 32 chars max,
+must match `[a-z_][a-z0-9_-]*\$?` (Debian's `NAME_REGEX`), and must not
+be a reserved system account that already exists in the image (`root`,
+`www-data`, `nobody`, …). An unvalidated value would otherwise fail
+`useradd` *after* the disk was already wiped — or, with a colon in it,
+split the `user:password` line piped to `chpasswd`.
 
 Once the installed system reboots, `spatiumddi-firstboot.service`
 runs as normal (identical to the interactive path): generates


### PR DESCRIPTION
Completes **#581**. PR #582 already landed the `--check-preseed` linter + its suite and **explicitly deferred the security items back to this issue** — this is that follow-up. #549 wipes disks unattended, so each guard here is what stands between an answer file and an irreversible mistake.

## Findings

### 1. Preseed URL fetch had no integrity check at all — MITM drives a full install
The kernel-cmdline URL is the **only** answer-file transport that arrives over the network from a party the installer cannot authenticate, and the file it delivers carries `confirm_wipe`, the admin password, and (appliance role) the pairing code. `_fetch_preseed_url` accepted plain `http://` with no verification.

Plain http with no pin is now **refused before the fetch**, with a message naming both remedies:
- an `https://` URL (TLS authenticates the origin), or
- `spatium.preseed.sha256=<64-hex>` on the cmdline — content-pinned, so the transport need not be trusted. This is the escape hatch for air-gapped / internal-CA PXE.

A pin is verified whenever supplied, https or not; a mismatch **halts** rather than acting on modified content, and a pin that cannot be checked **fails closed**. The physically-attached CIDATA / install-medium transports are unaffected.

### 2. A preseed could wipe the live install medium — #554 reopened through the preseed door
`pick_disk` returns early on `PRESEED_HAS_DISK`, so a preseeded `target_disk` **skipped the live-boot-medium exclusion #554 added**. An answer file naming the install USB destroyed the running media mid-install, unattended.

`_assert_safe_wipe_target` now re-validates immediately before `wipefs`, on **both** paths: present, whole block device, clears the 32 GiB floor, and not backing the live medium. That also closes the parse→use gap, where a bare `sdX` name (which the parser permits, only noting the risk) can renumber onto a different disk. The #554 detection is split out of `pick_disk` into `_live_boot_disks` so both callers share one implementation and cannot drift. Halts non-zero when unattended; explains and returns to the picker when there is an operator.

### 3. The interactive password prompt leaked into the trace log
The *preseed* path already suppressed xtrace around the secret env and `chpasswd` — the *interactive* prompt did not. `ADMIN_PASSWORD="$p1"` and `[ "$p1" = "$p2" ]` are argv, so the operator’s plaintext password was written to the trace log that `on_failure` tails 30 lines of **to the console** on any non-zero exit. The prompt loop now runs with tracing off, restored on every exit path.

### 4. `admin_user` was unvalidated
Passed straight into `useradd` and the `user:password` line piped to `chpasswd`. A colon splits that line; `root` fails `useradd` *after* the disk is already gone. Now validated at parse time against Debian’s `NAME_REGEX` (≤ 32 chars) and rejected if it names a reserved account already in the image.

## Two things I did *not* change

**`target_disk: auto` does not exist in shipped #549.** There is no `auto` mode anywhere in the code; the parser requires an explicit spec resolving to exactly one whole disk **and** `confirm_wipe: true`, and falls through to the interactive picker rather than guessing. That concern was a #579 artifact carried into the issue text — no fix invented for it.

**`role-config` / `spatium-config.yaml` stay mode 0644** carrying the pairing code. The existing comment argues the case (single-use, 15 min TTL, and the api pod reads `ROLE=` through that bind mount for #272 Phase 1’s self-bootstrap gate). Tightening it breaks that path to protect a secret that expires in 15 minutes.

## Tests

50 new host-portable cases in `appliance/tests/test_preseed_security.py`. I verified they actually catch the bugs by stashing the fixes and re-running: **38 of 50 fail against unfixed code**; the 11 that pass are regression guards on protections #549 already had, plus the accept-valid-input cases. (One test initially passed vacuously against unfixed code — strengthened rather than left in.)

Two small seams (`SPATIUM_CMDLINE_FILE` / `SPATIUM_MOUNTS_FILE`) follow the existing `SPATIUM_FAKE_DISK_BYTES` idiom and are inert on a real install.

## Beyond the ask: `appliance/tests` never ran in CI

All **194** cases — GRUB rendering, host migration, slot upgrades, cluster-join guards, the #581 linter — ran only when someone remembered to run them locally. Same gap #640 found for the agent suites, and it undercuts the point of testing a disk-wiping feature. Adds an `Appliance — Tests` job: hermetic (no root / Docker / database), ~10 s. Happy to drop this if you would rather keep the PR to the security scope.

## Verification (this host, no root)
- `bash -n` (spatium-install) + `py_compile` (spatium-preseed-parse) clean
- `shellcheck -S warning` — **no new findings** (the 2 reported are the pre-existing SC2010 / SC2034)
- `pytest appliance/tests` → **194 passed** (50 new + 144 existing)
- Both shipped `.example` files still lint clean via `--check-preseed`

Docs updated: `docs/deployment/APPLIANCE.md` (URL integrity, pre-wipe check, `admin_user` rules, secrets) + `appliance/cloud-init/README.md` (PXE pinning recipe, schema table).

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)