### PR TITLE
feat(network): fragile-device do-not-probe flag + DICOM AE registry (#722, #723)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Always read the relevant spec doc(s) before writing code for a feature area.
 | `docs/features/INTEGRATIONS.md` | Read-only Kubernetes + Docker mirror integrations; setup, semantics, dashboard surface |
 | `docs/features/MIGRATION.md` | One-shot importers — DNS (BIND9 / Windows DNS / PowerDNS) + DHCP (Kea / Windows DHCP / ISC dhcpd.conf) into native rows; preview → commit, provenance, IPAM linkage |
 | `docs/features/LOOKING_GLASS.md` | BGP Looking Glass — receive-only GoBGP collector peering with operator routers; Sessions + Routes grid, IPAM/ASN/VRF linkage at ingest, `bgp_lg_*` alerts, as-path Query tab + collector-vantage tools; distinct from the #527 public-table hijack monitor. The MetalLB BGP-mode VIP advertiser (#566 D1) ships alongside it, opt-in (`bgp.enabled=false`, `frrk8s.enabled=false` by default; enabling pulls in FRRouting / GPL-2.0) |
-| `docs/features/VERTICALS.md` | Vertical network awareness — AV-over-IP (Dante / AES67 / SMPTE 2110) flow descriptors + reserved multicast ranges, BACnet/IP device-instance registry + BBMD conformity, Industrial-OT device inventory + Purdue zoning. Three default-on Network feature modules (`network.av` / `network.bacnet` / `network.ot`); registry + conformity only, no network probing (and why each discovery phase is deferred) |
+| `docs/features/VERTICALS.md` | Vertical network awareness — AV-over-IP (Dante / AES67 / SMPTE 2110) flow descriptors + reserved multicast ranges, BACnet/IP device-instance registry + BBMD conformity, Industrial-OT device inventory + Purdue zoning, DICOM AE Title registry + peer-association map. Four default-on Network feature modules (`network.av` / `network.bacnet` / `network.ot` / `network.dicom`); registry + conformity only, no network probing (and why each discovery phase is deferred). Also the un-gated fragile-device `do_not_probe` flag (#722) that suppresses SpatiumDDI's own active probes |
 | `docs/PERMISSIONS.md` | RBAC permission grammar (`{action, resource_type, resource_id?}`), builtin roles, wildcards |
 | `docs/features/SYSTEM_ADMIN.md` | System config, health dashboard, notifications, backup/restore, service control |
 | `docs/deployment/APPLIANCE.md` | OS appliance build, base OS selection, licensing |
@@ -359,11 +359,14 @@ sub-headings.
 #### Vertical network awareness
 
 Umbrella [#543](https://github.com/spatiumddi/spatiumddi/issues/543) —
-three IP-native domains a generic IPAM doesn't speak, built on the same
+four IP-native domains a generic IPAM doesn't speak, built on the same
 DDI primitives (uniqueness registry + segmentation documentation +
 conformity). See [`docs/features/VERTICALS.md`](docs/features/VERTICALS.md).
-All three children closed 2026-07-28; the umbrella stays open for the
-deferred discovery phases listed per-item below.
+The first three children closed 2026-07-28; the umbrella stays open for
+the deferred discovery phases listed per-item below. The healthcare pass
+concluded there is **no** `network.healthcare` catch-all — it splits into
+separable pieces, of which DICOM (#723) is the anchor and the
+probe-safety fix (#722) is not a vertical at all.
 
 - ✅ [**AV / Audio-Video-over-IP — Dante · AES67 · SMPTE 2110 · NDI**](https://github.com/spatiumddi/spatiumddi/issues/540)
   — Phase 1 + Copilot tools merged to `main` (#714), pending release cut:
@@ -391,6 +394,37 @@ deferred discovery phases listed per-item below.
   permanently out of scope. **Phase 2 (routable probes) deferred** —
   nmap runs NSE but nothing parses `<script>` output. **Phase 3
   (PROFINET DCP) deferred** — raw L2, needs a container capability grant.
+- 🟡 [**DICOM AE Title registry + peer-association map**](https://github.com/spatiumddi/spatiumddi/issues/723)
+  — Phase 1 merged to a branch, pending PR/release: `network.dicom`
+  module, `dicom_ae` with the institution-wide `uq_dicom_ae_title`
+  constraint (the differentiating hook — PS3.15 Annex H specifies a
+  registry for exactly this and nobody deploys one), `dicom_peer`
+  directed AE→AE edges + a renumber-impact view, CSV import of the
+  estate's AE table, 4 conformity checks, 3 MCP tools. `ip_address_id`
+  is **nullable / SET NULL**, deliberately unlike BACnet's CASCADE: an
+  AE Title outlives its host, so decommissioning demotes it to a
+  reservation rather than freeing a name peers still send to. AE-title
+  validation follows PS3.5 exactly — 16 **bytes**, spaces legal as
+  padding, all-space forbidden, no backslash / control chars. **No PHI,
+  ever** — network identity only, or SpatiumDDI becomes a HIPAA
+  Business Associate. **C-ECHO verification probe deferred** to its own
+  issue: it is the one probe in the family that does *not* inherit the
+  agent↔subnet blocker (routable unicast TCP), but it must respect #722.
+- 🟡 [**Fragile-device "do not probe" flag**](https://github.com/spatiumddi/spatiumddi/issues/722)
+  — merged to a branch, pending PR/release. **Not a vertical and not
+  behind a feature module**: a constraint on our own behaviour and a
+  correctness fix to three shipped features (#23 sweeps, `tools.nmap`,
+  `tools.network`), so hiding it behind a default-off module would leave
+  the sites that need it unprotected. `do_not_probe` +
+  `do_not_probe_reason` on `IPSpace` / `IPBlock` / `Subnet` **OR down**
+  the chain with no per-level inherit toggle — deliberately unlike the
+  DDNS fields they mirror, because a descendant must not be able to opt
+  a clinical space back into being swept. One resolver
+  (`services/ipam/probe_policy.py`) that every prober consults; audited
+  superadmin-only per-request override; `fragile_subnet_probed`
+  conformity check working backwards from the `ot_device` / `dicom_ae` /
+  `role="bmc"` registries; `bmc` added to `IP_ROLES`. Migration
+  `b1e7c04a93df`.
 
 #### Reporting & analytics
 

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -193,6 +193,8 @@ backend/alembic/versions/a9b3c7d5e2f1_add_vlans_module.py:drop_table:96
 backend/alembic/versions/ac3e1f0d8b42_acme_account.py:drop_table:104
 backend/alembic/versions/b1d4c9e57f02_appliance_id_fk_on_dns_dhcp_server.py:drop_column:81
 backend/alembic/versions/b1d4c9e57f02_appliance_id_fk_on_dns_dhcp_server.py:drop_column:83
+backend/alembic/versions/b1e7c04a93df_fragile_device_do_not_probe.py:drop_column:88
+backend/alembic/versions/b1e7c04a93df_fragile_device_do_not_probe.py:drop_column:89
 backend/alembic/versions/b2c84f7a91d3_unifi_integration.py:drop_column:168
 backend/alembic/versions/b2c84f7a91d3_unifi_integration.py:drop_column:171
 backend/alembic/versions/b2c84f7a91d3_unifi_integration.py:drop_table:173
@@ -420,6 +422,8 @@ backend/alembic/versions/c9a2f61e740b_wol_run_verify_params.py:drop_column:59
 backend/alembic/versions/c9a4e1f7b820_netbird_integration.py:drop_column:126
 backend/alembic/versions/c9a4e1f7b820_netbird_integration.py:drop_column:129
 backend/alembic/versions/c9a4e1f7b820_netbird_integration.py:drop_table:131
+backend/alembic/versions/c9a4f2e81b56_dicom_ae_registry.py:drop_table:176
+backend/alembic/versions/c9a4f2e81b56_dicom_ae_registry.py:drop_table:181
 backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:75
 backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:76
 backend/alembic/versions/c9d4a1e8b672_appliance_unattended_upgrades_policy.py:drop_column:77

--- a/backend/alembic/versions/b1e7c04a93df_fragile_device_do_not_probe.py
+++ b/backend/alembic/versions/b1e7c04a93df_fragile_device_do_not_probe.py
@@ -1,0 +1,89 @@
+"""Fragile-device "do not probe" flag on the IPAM hierarchy (#722)
+
+Adds ``do_not_probe`` + ``do_not_probe_reason`` to ``ip_space``,
+``ip_block`` and ``subnet``.
+
+The flag suppresses SpatiumDDI's *own* active probes against anything
+inside the marked scope — the #23 discovery ping/ARP sweep, ``tools.nmap``
+(including the per-subnet auto-profile-on-lease trigger) and the
+``tools.network`` reachability tools. Medical- and OT-device vendors
+instruct sites not to scan their VLANs, and fragile IP stacks genuinely
+fault under a sweep; until now there was no way for an operator to say so.
+
+Two deliberate departures from the DDNS columns this otherwise mirrors:
+
+* **No ``*_inherit_settings`` companion column.** DDNS resolves to the
+  first non-inheriting ancestor, which lets a descendant override its
+  parent. A safety constraint must not work that way, so this flag ORs
+  downward: any level saying "do not probe" wins and nothing below it
+  can un-say it. That is a property of the resolver
+  (``app.services.ipam.probe_policy``), not of the schema — which is why
+  the columns themselves are plain and this note exists.
+* **No feature-module gate.** It is a constraint on our own behaviour
+  and a correctness fix to shipped features, so it ships on by default
+  for every install.
+
+Also widens no enum — ``bmc`` joins the ``IP_ROLES`` frozenset in the
+same issue, but that set is validated in the API layer and has no
+database representation, so it needs no migration.
+
+Revision ID: b1e7c04a93df
+Revises: a4f81c26b9e3
+Create Date: 2026-07-29
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b1e7c04a93df"
+down_revision: str | None = "a4f81c26b9e3"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+# The three levels of the IPAM containment chain the flag rides.
+_TABLES: tuple[str, ...] = ("ip_space", "ip_block", "subnet")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.add_column(
+            table,
+            sa.Column(
+                "do_not_probe",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+        )
+        op.add_column(
+            table,
+            sa.Column(
+                "do_not_probe_reason",
+                sa.Text(),
+                nullable=False,
+                server_default=sa.text("''"),
+            ),
+        )
+
+    # Partial index on the subnet level only. The discovery dispatcher and
+    # the conformity check both ask "is this subnet suppressed", and in a
+    # real estate the flagged rows are a small minority — so a partial
+    # index is tiny and turns those into index scans. ip_space / ip_block
+    # are walked by primary key from a known child, never scanned by flag,
+    # so an index there would only cost write throughput.
+    op.create_index(
+        "ix_subnet_do_not_probe",
+        "subnet",
+        ["do_not_probe"],
+        postgresql_where=sa.text("do_not_probe"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_subnet_do_not_probe", table_name="subnet")
+    for table in _TABLES:
+        op.drop_column(table, "do_not_probe_reason")
+        op.drop_column(table, "do_not_probe")

--- a/backend/alembic/versions/c9a4f2e81b56_dicom_ae_registry.py
+++ b/backend/alembic/versions/c9a4f2e81b56_dicom_ae_registry.py
@@ -1,0 +1,181 @@
+"""DICOM AE Title registry + peer-association map (#723, part of #543)
+
+Adds the ``network.dicom`` feature module and its two tables.
+
+* ``dicom_ae`` — one Application Entity. ``uq_dicom_ae_title`` is the
+  point of the whole module: a DICOM AE Title is institution-wide-unique
+  by specification (PS3.15 Annex H defines a registry object whose only
+  job is allocating them), duplicates break C-MOVE / Storage Commitment /
+  Modality Worklist / MPPS, and in practice the namespace lives in a
+  spreadsheet. Enforcing it in the database is what turns a convention
+  into a guarantee.
+* ``dicom_peer`` — a directed AE→AE configured-association edge, so
+  "what breaks if I renumber this host" and an ePHI data-flow map become
+  answerable.
+
+``dicom_ae.ip_address_id`` is **nullable** with ``ON DELETE SET NULL``,
+deliberately unlike ``bacnet_device``'s ``CASCADE``: an AE Title outlives
+the host it runs on because it is burned into peer configuration across
+the estate. Decommissioning the IP must demote the title to a
+reservation, not hand the name to the next commissioning engineer.
+
+CHECK constraints cover the values with a specification-defined range —
+the 16-**byte** AE length ceiling (PS3.5; bytes, not characters, and
+spaces are legal padding) and the port range. The role / device-class
+vocabularies stay unconstrained frozensets validated at the API layer,
+matching the rationale in ``models/multicast.py``: adding a value later
+should not need a migration.
+
+Default-ENABLED per non-negotiable #14 — registry only, no probes, no
+device I/O, no off-prem calls, and an operator cannot turn off what they
+never knew shipped.
+
+Revision ID: c9a4f2e81b56
+Revises: b1e7c04a93df
+Create Date: 2026-07-29
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c9a4f2e81b56"
+down_revision: str | None = "b1e7c04a93df"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_AE_TITLE_MAX_BYTES = 16
+_DEFAULT_PORT = 11112
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dicom_ae",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("ip_address_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("subnet_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("ae_title", sa.String(length=_AE_TITLE_MAX_BYTES), nullable=False),
+        sa.Column(
+            "port", sa.Integer(), nullable=False, server_default=sa.text(str(_DEFAULT_PORT))
+        ),
+        sa.Column(
+            "tls_enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column("role", sa.String(length=8), nullable=False, server_default=sa.text("'both'")),
+        sa.Column(
+            "device_class",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'other'"),
+        ),
+        sa.Column("vendor", sa.String(length=255), nullable=False, server_default=sa.text("''")),
+        sa.Column(
+            "model_name", sa.String(length=255), nullable=False, server_default=sa.text("''")
+        ),
+        sa.Column(
+            "department", sa.String(length=255), nullable=False, server_default=sa.text("''")
+        ),
+        sa.Column(
+            "location", sa.String(length=255), nullable=False, server_default=sa.text("''")
+        ),
+        sa.Column(
+            "seen_via", sa.String(length=16), nullable=False, server_default=sa.text("'manual'")
+        ),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column(
+            "tags", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")
+        ),
+        sa.Column(
+            "custom_fields",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.ForeignKeyConstraint(["ip_address_id"], ["ip_address.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["subnet_id"], ["subnet.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("ae_title", name="uq_dicom_ae_title"),
+        sa.CheckConstraint("port >= 1 AND port <= 65535", name="ck_dicom_ae_port"),
+        sa.CheckConstraint(
+            f"octet_length(ae_title) BETWEEN 1 AND {_AE_TITLE_MAX_BYTES}",
+            name="ck_dicom_ae_title_length",
+        ),
+    )
+    op.create_index("ix_dicom_ae_ip_address_id", "dicom_ae", ["ip_address_id"])
+    op.create_index("ix_dicom_ae_device_class", "dicom_ae", ["device_class"])
+    op.create_index(
+        "ix_dicom_ae_unbound",
+        "dicom_ae",
+        ["ae_title"],
+        postgresql_where=sa.text("ip_address_id IS NULL"),
+    )
+
+    op.create_table(
+        "dicom_peer",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("source_ae_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("target_ae_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "services", postgresql.JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")
+        ),
+        sa.Column("notes", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.ForeignKeyConstraint(["source_ae_id"], ["dicom_ae.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["target_ae_id"], ["dicom_ae.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("source_ae_id", "target_ae_id", name="uq_dicom_peer_pair"),
+        sa.CheckConstraint("source_ae_id <> target_ae_id", name="ck_dicom_peer_not_self"),
+    )
+    op.create_index("ix_dicom_peer_source", "dicom_peer", ["source_ae_id"])
+    op.create_index("ix_dicom_peer_target", "dicom_peer", ["target_ae_id"])
+
+    # ── feature_module seed (non-negotiable #14) ───────────────────────
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('network.dicom', TRUE)
+            ON CONFLICT (id) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'network.dicom'"))
+
+    op.drop_index("ix_dicom_peer_target", table_name="dicom_peer")
+    op.drop_index("ix_dicom_peer_source", table_name="dicom_peer")
+    op.drop_table("dicom_peer")
+
+    op.drop_index("ix_dicom_ae_unbound", table_name="dicom_ae")
+    op.drop_index("ix_dicom_ae_device_class", table_name="dicom_ae")
+    op.drop_index("ix_dicom_ae_ip_address_id", table_name="dicom_ae")
+    op.drop_table("dicom_ae")

--- a/backend/app/api/v1/dicom/__init__.py
+++ b/backend/app/api/v1/dicom/__init__.py
@@ -1,0 +1,3 @@
+from app.api.v1.dicom.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/dicom/router.py
+++ b/backend/app/api/v1/dicom/router.py
@@ -1,0 +1,1135 @@
+"""DICOM AE Title registry CRUD — issue #723 Phase 1.
+
+Endpoints under ``/dicom``:
+
+* ``/aes`` — Application Entity list / create
+* ``/aes/{id}`` — read / patch / delete
+* ``/aes/import/{preview,commit}`` — CSV ingest of the estate's existing
+  AE table, keyed on the title
+* ``/peers`` — the configured AE→AE association edges, list / create
+* ``/peers/{id}`` — delete
+* ``/by-address/{ip_address_id}`` — the AE anchored to an IPAM address.
+  Drives the IP-detail modal's DICOM section, which treats a 404 as
+  "not a DICOM node" and renders nothing.
+* ``/aes/{id}/impact`` — what a renumber or decommission of this AE
+  would break, i.e. its peer edges in both directions. The question
+  every PACS administrator actually asks.
+
+Permissions: every endpoint is gated on ``dicom_ae`` at the router level
+(GET→read, POST/PATCH→write, DELETE→delete; superadmin always passes).
+Each mutation writes an ``audit_log`` row before commit per CLAUDE.md
+non-negotiable #4.
+
+Server-side validation beyond the field bounds mirrored from
+``app.models.dicom``:
+
+* ``ae_title`` goes through the PS3.5 ``AE`` value-representation rules
+  in ``services/dicom/titles`` — 16 **bytes**, spaces legal as padding,
+  all-space forbidden, no backslash, no control characters. Deliberately
+  not alphanumeric-only: rejecting titles real devices use would make
+  the registry record a plan that fails at commissioning.
+* Title uniqueness is pre-checked for a friendly 409 that names the
+  conflicting AE, and the resulting ``IntegrityError`` is re-mapped to
+  the same 409 so a lost race doesn't surface as a 500.
+
+Zero network I/O: this surface never speaks DICOM. Rows arrive from
+operators and the importer; the C-ECHO verification probe is deferred
+(see ``app.services.dicom``).
+
+**No PHI.** ``notes`` is a network-configuration field and is documented
+as such on the wire. Nothing on this surface accepts or returns
+patient-identifiable data.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import ColumnElement, Select, func, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.api.deps import DB, CurrentUser
+from app.api.v1.ownership._audit import write_audit
+from app.core.permissions import require_resource_permission
+from app.models.auth import User
+from app.models.dicom import (
+    DICOM_AE_ROLES,
+    DICOM_AE_SOURCES,
+    DICOM_AE_TITLE_MAX_BYTES,
+    DICOM_DEFAULT_PORT,
+    DICOM_DEVICE_CLASSES,
+    DICOMApplicationEntity,
+    DICOMPeer,
+)
+from app.models.ipam import IPAddress, IPSpace
+from app.services.dicom.importer import (
+    MAX_IMPORT_ROWS,
+    DICOMImportError,
+    PlannedRow,
+    apply_plan,
+    parse_rows,
+    plan_import,
+)
+from app.services.dicom.registry import (
+    AETitleConflict,
+    assert_title_available,
+    sync_subnet_id,
+)
+from app.services.dicom.titles import AETitleError, is_vendor_default, validate_ae_title
+from app.services.tags import apply_tag_filter
+
+router = APIRouter(
+    tags=["dicom"],
+    dependencies=[Depends(require_resource_permission("dicom_ae"))],
+)
+
+DICOMRole = Literal["scp", "scu", "both"]
+DICOMDeviceClass = Literal[
+    "modality",
+    "pacs",
+    "workstation",
+    "archive",
+    "router",
+    "worklist",
+    "printer",
+    "other",
+]
+DICOMAESource = Literal["manual", "import", "echo"]
+ImportAction = Literal["create", "update", "skip", "error"]
+
+# Network-configuration notes. Named in the field description too — an
+# unlabelled free-text box is the surest way to end up storing PHI.
+_NOTES_DESCRIPTION = (
+    "Network-configuration notes. Do NOT record patient-identifiable "
+    "information here — this registry stores network identity only."
+)
+
+
+# ── Schemas ─────────────────────────────────────────────────────────
+
+
+def _validated_title(v: str) -> str:
+    """Shared ``ae_title`` validator body.
+
+    Raises ``ValueError`` (which pydantic renders as a 422 naming the
+    field) rather than an ``HTTPException``, so the message about *which*
+    VR rule was broken reaches the operator attached to the field they
+    typed it in.
+    """
+    try:
+        return validate_ae_title(v)
+    except AETitleError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+class DICOMAECreate(BaseModel):
+    ae_title: str = Field(..., min_length=1, max_length=DICOM_AE_TITLE_MAX_BYTES)
+    # Nullable on purpose: an AE with no address is a *reservation* — a
+    # title still in peer configuration whose host is gone. Registering
+    # those is the point, not an edge case.
+    ip_address_id: uuid.UUID | None = None
+    port: int = Field(default=DICOM_DEFAULT_PORT, ge=1, le=65535)
+    tls_enabled: bool = False
+    role: DICOMRole = "both"
+    device_class: DICOMDeviceClass = "other"
+    vendor: str = Field(default="", max_length=255)
+    model_name: str = Field(default="", max_length=255)
+    department: str = Field(default="", max_length=255)
+    location: str = Field(default="", max_length=255)
+    seen_via: DICOMAESource = "manual"
+    last_seen_at: datetime | None = None
+    notes: str = Field(default="", description=_NOTES_DESCRIPTION)
+    tags: dict[str, Any] = Field(default_factory=dict)
+    custom_fields: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("ae_title")
+    @classmethod
+    def _v_title(cls, v: str) -> str:
+        return _validated_title(v)
+
+    # House belt-and-braces convention (see ``models/multicast.py``).
+    # Pydantic rejects an unknown value against the ``Literal`` alias
+    # before an after-validator runs, so these never fire for bad client
+    # input — they guard the reverse drift, an alias widened past the
+    # model frozenset, keeping the frozenset the single source of truth.
+    @field_validator("role")
+    @classmethod
+    def _v_role(cls, v: str) -> str:
+        if v not in DICOM_AE_ROLES:
+            raise ValueError(f"role must be one of {sorted(DICOM_AE_ROLES)}")
+        return v
+
+    @field_validator("device_class")
+    @classmethod
+    def _v_class(cls, v: str) -> str:
+        if v not in DICOM_DEVICE_CLASSES:
+            raise ValueError(f"device_class must be one of {sorted(DICOM_DEVICE_CLASSES)}")
+        return v
+
+    @field_validator("seen_via")
+    @classmethod
+    def _v_seen_via(cls, v: str) -> str:
+        if v not in DICOM_AE_SOURCES:
+            raise ValueError(f"seen_via must be one of {sorted(DICOM_AE_SOURCES)}")
+        return v
+
+
+class DICOMAEUpdate(BaseModel):
+    """PATCH body — every field optional, ``exclude_unset`` semantics.
+
+    ``ip_address_id`` is re-parentable *and* explicitly clearable: a
+    modality that moves keeps its title and gains a new anchor, and a
+    decommissioned one keeps its title with no anchor at all. Both are
+    normal lifecycle events for an AE Title, which is why the field is
+    handled through ``model_fields_set`` rather than an
+    ``exclude_none`` dump — otherwise clearing it would be indis-
+    tinguishable from not mentioning it.
+    """
+
+    ae_title: str | None = Field(default=None, max_length=DICOM_AE_TITLE_MAX_BYTES)
+    ip_address_id: uuid.UUID | None = None
+    port: int | None = Field(default=None, ge=1, le=65535)
+    tls_enabled: bool | None = None
+    role: DICOMRole | None = None
+    device_class: DICOMDeviceClass | None = None
+    vendor: str | None = Field(default=None, max_length=255)
+    model_name: str | None = Field(default=None, max_length=255)
+    department: str | None = Field(default=None, max_length=255)
+    location: str | None = Field(default=None, max_length=255)
+    seen_via: DICOMAESource | None = None
+    last_seen_at: datetime | None = None
+    notes: str | None = Field(default=None, description=_NOTES_DESCRIPTION)
+    tags: dict[str, Any] | None = None
+    custom_fields: dict[str, Any] | None = None
+
+    @field_validator("ae_title")
+    @classmethod
+    def _v_title(cls, v: str | None) -> str | None:
+        return None if v is None else _validated_title(v)
+
+
+class DICOMAERead(BaseModel):
+    """Wire model for an AE row.
+
+    ``address`` / ``hostname`` are joined in rather than stored, and
+    ``is_vendor_default`` is derived: every operator-facing read of this
+    registry is "which title, on which box, and has anyone actually
+    configured it", and making the caller round-trip per row for that
+    turns a 300-AE list into 301 requests.
+    """
+
+    id: uuid.UUID
+    ae_title: str
+    ip_address_id: uuid.UUID | None
+    subnet_id: uuid.UUID | None
+    address: str | None = None
+    hostname: str | None = None
+    port: int
+    tls_enabled: bool
+    role: str
+    device_class: str
+    vendor: str
+    model_name: str
+    department: str
+    location: str
+    seen_via: str
+    last_seen_at: datetime | None
+    notes: str
+    tags: dict[str, Any]
+    custom_fields: dict[str, Any]
+    # True when the title is still a known vendor default. Advisory —
+    # it is not invalid, it is just the most common cause of the
+    # estate-wide collisions this registry exists to prevent.
+    is_vendor_default: bool = False
+    # True when the title has no IPAM anchor: a reservation held so the
+    # name is not re-issued while peers still send to it.
+    is_reservation: bool = False
+    created_at: datetime
+    modified_at: datetime
+
+
+class DICOMAEListResponse(BaseModel):
+    items: list[DICOMAERead]
+    total: int
+    limit: int
+    offset: int
+
+
+class DICOMPeerCreate(BaseModel):
+    source_ae_id: uuid.UUID
+    target_ae_id: uuid.UUID
+    # Free-text DICOM services this edge carries (C-STORE, C-FIND,
+    # C-MOVE, MPPS, …). Unconstrained because SOP class support is
+    # genuinely open-ended and an operator documenting their estate
+    # should never be blocked on our taxonomy being complete.
+    services: list[str] = Field(default_factory=list)
+    notes: str = Field(default="", description=_NOTES_DESCRIPTION)
+
+
+class DICOMPeerRead(BaseModel):
+    """One configured association, with both endpoints' titles inlined.
+
+    The titles are what a data-flow map is drawn from, so returning ids
+    alone would make every render an N+1.
+    """
+
+    id: uuid.UUID
+    source_ae_id: uuid.UUID
+    source_ae_title: str
+    target_ae_id: uuid.UUID
+    target_ae_title: str
+    services: list[str]
+    notes: str
+    created_at: datetime
+    modified_at: datetime
+
+
+class DICOMImpactResponse(BaseModel):
+    """What a renumber / decommission of one AE would disturb.
+
+    Split by direction because the consequences differ: the AE's
+    *outbound* edges stop sending, its *inbound* edges stop being able to
+    reach it. A PACS administrator planning a host move needs both lists
+    and needs to know which is which.
+    """
+
+    ae_id: uuid.UUID
+    ae_title: str
+    address: str | None
+    outbound: list[DICOMPeerRead]
+    inbound: list[DICOMPeerRead]
+    total_peers: int
+
+
+class DICOMAEImportColumnMap(BaseModel):
+    """Which CSV header feeds which AE field.
+
+    Institutions name their AE-table columns locally ("AET", "AE Title",
+    "Called AE", "Host", "IP", "Port"), so the operator supplies the
+    mapping instead of us guessing. Header matching is case- and
+    separator-insensitive, and a mapped column that isn't in the file is
+    a hard 422 — a typo'd mapping must not look like a successful import
+    that quietly dropped a column.
+
+    Mirrors ``app.services.dicom.importer.IMPORTABLE_FIELDS``.
+    """
+
+    ae_title: str = Field(..., min_length=1, max_length=255)
+    address: str | None = Field(default=None, max_length=255)
+    port: str | None = Field(default=None, max_length=255)
+    tls_enabled: str | None = Field(default=None, max_length=255)
+    role: str | None = Field(default=None, max_length=255)
+    device_class: str | None = Field(default=None, max_length=255)
+    vendor: str | None = Field(default=None, max_length=255)
+    model_name: str | None = Field(default=None, max_length=255)
+    department: str | None = Field(default=None, max_length=255)
+    location: str | None = Field(default=None, max_length=255)
+    notes: str | None = Field(default=None, max_length=255)
+
+
+class DICOMAEImportRequest(BaseModel):
+    """Same body for preview and commit — the server holds no state
+    between the two calls, so there is no preview token to expire and a
+    concurrent change surfaces as a plan difference rather than a stale
+    write."""
+
+    csv_text: str = Field(..., min_length=1)
+    column_map: DICOMAEImportColumnMap
+    delimiter: Literal[",", ";", "\t", "|"] = ","
+    default_port: int = Field(
+        default=DICOM_DEFAULT_PORT,
+        ge=1,
+        le=65535,
+        description=(
+            "Applied to rows whose port cell is blank, or when no port "
+            "column is mapped. 11112 is the IANA-registered ``dicom`` port; "
+            "104 is the historical ``acr-nema`` registration and is still "
+            "widely configured."
+        ),
+    )
+    default_department: str = Field(default="", max_length=255)
+    overwrite_existing: bool = Field(
+        default=False,
+        description=(
+            "When false, an AE Title that is already registered is skipped. "
+            "When true, its mapped fields are overwritten."
+        ),
+    )
+    space_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Restrict address matching to one IPSpace. Needed when the same "
+            "RFC 1918 plan is repeated across sites and an IP would "
+            "otherwise match several IPAM rows."
+        ),
+    )
+
+
+class DICOMAEImportRow(BaseModel):
+    """One planned (preview) or applied (commit) row."""
+
+    line: int
+    ae_title: str
+    action: ImportAction
+    reason: str = ""
+    address: str = ""
+    ip_address_id: uuid.UUID | None = None
+    fields: dict[str, Any] = Field(default_factory=dict)
+
+
+class DICOMAEImportPreviewResponse(BaseModel):
+    rows: list[DICOMAEImportRow]
+    create_count: int
+    update_count: int
+    skip_count: int
+    error_count: int
+    max_rows: int = MAX_IMPORT_ROWS
+
+
+class DICOMAEImportCommitResponse(BaseModel):
+    rows: list[DICOMAEImportRow]
+    created: int
+    updated: int
+    skipped: int
+    errors: int
+    ae_ids: list[uuid.UUID]
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _to_read(ae: DICOMApplicationEntity, ip: IPAddress | None) -> DICOMAERead:
+    return DICOMAERead(
+        id=ae.id,
+        ae_title=ae.ae_title,
+        ip_address_id=ae.ip_address_id,
+        subnet_id=ae.subnet_id,
+        # ``IPAddress.address`` is INET — asyncpg hands back an
+        # ``ipaddress`` object, which Pydantic won't accept as ``str``.
+        address=str(ip.address) if ip is not None else None,
+        hostname=ip.hostname if ip is not None else None,
+        port=ae.port,
+        tls_enabled=ae.tls_enabled,
+        role=ae.role,
+        device_class=ae.device_class,
+        vendor=ae.vendor,
+        model_name=ae.model_name,
+        department=ae.department,
+        location=ae.location,
+        seen_via=ae.seen_via,
+        last_seen_at=ae.last_seen_at,
+        notes=ae.notes,
+        tags=ae.tags,
+        custom_fields=ae.custom_fields,
+        is_vendor_default=is_vendor_default(ae.ae_title),
+        is_reservation=ae.ip_address_id is None,
+        created_at=ae.created_at,
+        modified_at=ae.modified_at,
+    )
+
+
+def _peer_read(peer: DICOMPeer, source_title: str, target_title: str) -> DICOMPeerRead:
+    return DICOMPeerRead(
+        id=peer.id,
+        source_ae_id=peer.source_ae_id,
+        source_ae_title=source_title,
+        target_ae_id=peer.target_ae_id,
+        target_ae_title=target_title,
+        services=[str(s) for s in (peer.services or [])],
+        notes=peer.notes,
+        created_at=peer.created_at,
+        modified_at=peer.modified_at,
+    )
+
+
+def _jsonable(value: Any) -> Any:
+    """JSON-safe copy of a model attribute for the audit row.
+
+    ``old_value`` lands in a JSONB column, so UUID and datetime values
+    have to be stringified; every other column on ``DICOMApplicationEntity``
+    is already a JSON primitive or a JSONB list/dict.
+    """
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _title_conflict(exc: AETitleConflict) -> HTTPException:
+    """409 naming the AE that already holds the title.
+
+    AE Title uniqueness is institution-wide by specification, so the
+    conflicting row is very often in a different department, owned by a
+    different vendor's service engineer — which is exactly why the
+    response has to name it instead of saying "already in use".
+    """
+    return HTTPException(
+        status_code=409,
+        detail=str(exc),
+        headers={"X-Conflicting-Ae-Id": str(exc.existing_id)},
+    )
+
+
+async def _load_ip(db: AsyncSession, ip_address_id: uuid.UUID, user: User) -> IPAddress:
+    """Fetch the anchoring IPAM address, 422 when it doesn't exist.
+
+    Also applies the resource-scoped API-token gate (#374): a token bound
+    to one subnet must not attach AEs to addresses in another just
+    because the router-level ``dicom_ae`` grant passed. Deferred import —
+    ``app.api.v1.ipam.router`` is a large module and importing it at
+    module scope would create a cycle through the shared IPAM helpers.
+    """
+    from app.api.v1.ipam.router import _enforce_subnet_token_scope  # noqa: PLC0415
+
+    ip = await db.get(IPAddress, ip_address_id)
+    if ip is None:
+        raise HTTPException(status_code=422, detail="ip_address_id not found")
+    _enforce_subnet_token_scope(user, ip.subnet_id)
+    return ip
+
+
+async def _load_anchor(
+    db: AsyncSession, ae: DICOMApplicationEntity, user: User
+) -> IPAddress | None:
+    """Load an AE's current IPAM anchor, enforcing the token gate.
+
+    Returns ``None`` for an unbound reservation — the normal state for a
+    title whose host was decommissioned — as well as for the rare case
+    where the anchor row vanished concurrently. Both are "no address to
+    scope against", so a scoped token is not blocked from reading a
+    reservation it can otherwise see through the list.
+    """
+    from app.api.v1.ipam.router import _enforce_subnet_token_scope  # noqa: PLC0415
+
+    if ae.ip_address_id is None:
+        return None
+    ip = await db.get(IPAddress, ae.ip_address_id)
+    if ip is not None:
+        _enforce_subnet_token_scope(user, ip.subnet_id)
+    return ip
+
+
+async def _get_ae(db: AsyncSession, ae_id: uuid.UUID) -> DICOMApplicationEntity:
+    row = await db.get(DICOMApplicationEntity, ae_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="DICOM application entity not found")
+    return row
+
+
+def _token_subnet_scope(user: Any) -> set[uuid.UUID] | None:
+    """Subnets a resource-scoped token may enumerate, or ``None`` for all.
+
+    The list-endpoint counterpart to the per-row gate (#523). An empty
+    set means "scoped to other resource types only" and must yield
+    nothing — hence callers test ``is not None`` rather than truthiness.
+    """
+    from app.api.v1.ipam.router import _token_subnet_scope_uuids  # noqa: PLC0415
+
+    return _token_subnet_scope_uuids(user)
+
+
+def _apply_ae_filters(
+    stmt: Select[Any],
+    *,
+    token_scope: set[uuid.UUID] | None,
+    tag: list[str],
+    subnet_id: uuid.UUID | None,
+    ip_address_id: uuid.UUID | None,
+    device_class: str | None,
+    role: str | None,
+    tls_enabled: bool | None,
+    unbound: bool | None,
+    q: str | None,
+) -> Select[Any]:
+    """Shared WHERE construction for the list page and its count.
+
+    Kept in one place so the ``total`` can never drift from the rows
+    actually returned — the classic pagination bug where a filter is
+    added to one query and not the other. The token scope rides the same
+    helper for the same reason.
+
+    One asymmetry worth naming: a scoped token sees no unbound
+    reservations at all, because a row with ``subnet_id IS NULL`` is not
+    in any subnet the token is bound to. That is the conservative
+    reading, and the alternative — showing every reservation to every
+    scoped token — would leak the institution-wide title namespace to a
+    token deliberately confined to one subnet.
+    """
+    if token_scope is not None:
+        stmt = stmt.where(DICOMApplicationEntity.subnet_id.in_(token_scope))
+    stmt = apply_tag_filter(stmt, DICOMApplicationEntity.tags, tag)
+    if subnet_id is not None:
+        stmt = stmt.where(DICOMApplicationEntity.subnet_id == subnet_id)
+    if ip_address_id is not None:
+        stmt = stmt.where(DICOMApplicationEntity.ip_address_id == ip_address_id)
+    if device_class is not None:
+        stmt = stmt.where(DICOMApplicationEntity.device_class == device_class)
+    if role is not None:
+        stmt = stmt.where(DICOMApplicationEntity.role == role)
+    if tls_enabled is not None:
+        stmt = stmt.where(DICOMApplicationEntity.tls_enabled.is_(tls_enabled))
+    if unbound is not None:
+        stmt = stmt.where(
+            DICOMApplicationEntity.ip_address_id.is_(None)
+            if unbound
+            else DICOMApplicationEntity.ip_address_id.is_not(None)
+        )
+    if q:
+        needle = f"%{q.strip()}%"
+        clauses: list[ColumnElement[bool]] = [
+            DICOMApplicationEntity.ae_title.ilike(needle),
+            DICOMApplicationEntity.vendor.ilike(needle),
+            DICOMApplicationEntity.model_name.ilike(needle),
+            DICOMApplicationEntity.department.ilike(needle),
+            DICOMApplicationEntity.location.ilike(needle),
+        ]
+        stmt = stmt.where(or_(*clauses))
+    return stmt
+
+
+# ── AE endpoints ────────────────────────────────────────────────────
+
+
+@router.get("/aes", response_model=DICOMAEListResponse)
+async def list_aes(
+    db: DB,
+    user: CurrentUser,
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    subnet_id: uuid.UUID | None = Query(default=None),
+    ip_address_id: uuid.UUID | None = Query(
+        default=None,
+        description=(
+            "Every AE anchored to one IPAM address. A single PACS host "
+            "commonly fronts several AE Titles (one per service), so "
+            "this can legitimately return more than one row."
+        ),
+    ),
+    device_class: DICOMDeviceClass | None = Query(default=None),
+    role: DICOMRole | None = Query(default=None),
+    tls_enabled: bool | None = Query(default=None),
+    unbound: bool | None = Query(
+        default=None,
+        description=(
+            "True = only reservations (titles with no IPAM anchor), " "False = only bound AEs."
+        ),
+    ),
+    tag: list[str] = Query(default_factory=list),
+    q: str | None = Query(
+        default=None,
+        description="Case-insensitive substring on title / vendor / model / department / location.",
+    ),
+) -> DICOMAEListResponse:
+    """List AEs in title order, with their IPAM anchor where they have one."""
+    token_scope = _token_subnet_scope(user)
+    filters: dict[str, Any] = {
+        "token_scope": token_scope,
+        "tag": tag,
+        "subnet_id": subnet_id,
+        "ip_address_id": ip_address_id,
+        "device_class": device_class,
+        "role": role,
+        "tls_enabled": tls_enabled,
+        "unbound": unbound,
+        "q": q,
+    }
+    total = (
+        await db.execute(
+            _apply_ae_filters(select(func.count(DICOMApplicationEntity.id)), **filters)
+        )
+    ).scalar_one()
+
+    # OUTER join — an unbound reservation has no address row, and an
+    # inner join would silently hide exactly the rows the registry most
+    # needs to keep visible.
+    stmt = _apply_ae_filters(
+        select(DICOMApplicationEntity, IPAddress).outerjoin(
+            IPAddress, IPAddress.id == DICOMApplicationEntity.ip_address_id
+        ),
+        **filters,
+    )
+    rows = (
+        await db.execute(
+            stmt.order_by(DICOMApplicationEntity.ae_title.asc()).limit(limit).offset(offset)
+        )
+    ).all()
+    return DICOMAEListResponse(
+        items=[_to_read(ae, ip) for ae, ip in rows],
+        total=int(total),
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("/aes", response_model=DICOMAERead, status_code=status.HTTP_201_CREATED)
+async def create_ae(body: DICOMAECreate, db: DB, user: CurrentUser) -> DICOMAERead:
+    """Register an AE Title. 409 when the title is already taken."""
+    ip = await _load_ip(db, body.ip_address_id, user) if body.ip_address_id else None
+    try:
+        await assert_title_available(db, body.ae_title)
+    except AETitleConflict as exc:
+        raise _title_conflict(exc) from exc
+
+    row = DICOMApplicationEntity(
+        ae_title=body.ae_title,
+        ip_address_id=body.ip_address_id,
+        port=body.port,
+        tls_enabled=body.tls_enabled,
+        role=body.role,
+        device_class=body.device_class,
+        vendor=body.vendor,
+        model_name=body.model_name,
+        department=body.department,
+        location=body.location,
+        seen_via=body.seen_via,
+        last_seen_at=body.last_seen_at,
+        notes=body.notes,
+        tags=body.tags or {},
+        custom_fields=body.custom_fields or {},
+    )
+    await sync_subnet_id(db, row)
+    db.add(row)
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        # Lost the race against a concurrent create between the
+        # availability check and the INSERT. ``uq_dicom_ae_title`` is the
+        # real guard; answer with the same 409 the pre-check would have
+        # produced rather than leaking a 500.
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=f"AE Title {body.ae_title!r} is already registered",
+        ) from exc
+
+    write_audit(
+        db,
+        user=user,
+        action="create",
+        resource_type="dicom_ae",
+        resource_id=str(row.id),
+        resource_display=row.ae_title,
+        new_value=body.model_dump(mode="json"),
+    )
+    await db.commit()
+    await db.refresh(row)
+    return _to_read(row, ip)
+
+
+@router.get("/aes/{ae_id:uuid}", response_model=DICOMAERead)
+async def get_ae(ae_id: uuid.UUID, db: DB, user: CurrentUser) -> DICOMAERead:
+    row = await _get_ae(db, ae_id)
+    ip = await _load_anchor(db, row, user)
+    return _to_read(row, ip)
+
+
+@router.patch("/aes/{ae_id:uuid}", response_model=DICOMAERead)
+async def update_ae(
+    ae_id: uuid.UUID, body: DICOMAEUpdate, db: DB, user: CurrentUser
+) -> DICOMAERead:
+    """Patch an AE. 409 when a new title is already taken."""
+    row = await _get_ae(db, ae_id)
+    # Gate on the AE's *current* anchor before touching anything — a
+    # subnet-bound token must not re-parent an AE out of its own scope.
+    ip = await _load_anchor(db, row, user)
+
+    changes = body.model_dump(exclude_unset=True)
+    if not changes:
+        return _to_read(row, ip)
+
+    old_value = {key: _jsonable(getattr(row, key)) for key in changes}
+
+    # ``ip_address_id`` is present in ``changes`` whenever the caller
+    # mentioned it, including as an explicit null — which is how a
+    # decommissioned host demotes its title to a reservation.
+    reparented = "ip_address_id" in changes and changes["ip_address_id"] != row.ip_address_id
+    if reparented:
+        new_anchor = changes["ip_address_id"]
+        ip = await _load_ip(db, new_anchor, user) if new_anchor is not None else None
+    if "ae_title" in changes and changes["ae_title"] != row.ae_title:
+        try:
+            await assert_title_available(db, changes["ae_title"], exclude_id=row.id)
+        except AETitleConflict as exc:
+            raise _title_conflict(exc) from exc
+
+    for key, value in changes.items():
+        setattr(row, key, value)
+
+    if reparented:
+        await sync_subnet_id(db, row)
+
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=f"AE Title {row.ae_title!r} is already registered",
+        ) from exc
+
+    write_audit(
+        db,
+        user=user,
+        action="update",
+        resource_type="dicom_ae",
+        resource_id=str(row.id),
+        resource_display=row.ae_title,
+        changed_fields=list(changes.keys()),
+        old_value=old_value,
+        new_value=body.model_dump(mode="json", exclude_unset=True),
+    )
+    await db.commit()
+    await db.refresh(row)
+    return _to_read(row, ip)
+
+
+@router.delete("/aes/{ae_id:uuid}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_ae(ae_id: uuid.UUID, db: DB, user: CurrentUser) -> None:
+    """Delete the registry row, freeing its title for re-use.
+
+    That is the intended effect, and it is why the response body records
+    the peer count in the audit row: deleting an AE that still has
+    configured peers is exactly the action that re-issues a name other
+    devices are still sending to. Use ``GET /aes/{id}/impact`` first —
+    this endpoint deliberately does not refuse, because the registry
+    tracks what is deployed and an operator decommissioning a modality
+    is right to remove it.
+    """
+    row = await _get_ae(db, ae_id)
+    await _load_anchor(db, row, user)
+    peer_count = (
+        await db.execute(
+            select(func.count(DICOMPeer.id)).where(
+                or_(DICOMPeer.source_ae_id == row.id, DICOMPeer.target_ae_id == row.id)
+            )
+        )
+    ).scalar_one()
+    write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="dicom_ae",
+        resource_id=str(row.id),
+        resource_display=row.ae_title,
+        old_value={
+            "ae_title": row.ae_title,
+            "ip_address_id": str(row.ip_address_id) if row.ip_address_id else None,
+            "device_class": row.device_class,
+            # Recorded because the cascade silently removes these edges
+            # with the row; without the count nothing downstream can tell
+            # how much of the data-flow map went with it.
+            "peer_edges_removed": int(peer_count),
+        },
+    )
+    await db.delete(row)
+    await db.commit()
+
+
+@router.get("/aes/{ae_id:uuid}/impact", response_model=DICOMImpactResponse)
+async def get_ae_impact(ae_id: uuid.UUID, db: DB, user: CurrentUser) -> DICOMImpactResponse:
+    """What a renumber or decommission of this AE would disturb.
+
+    The question a PACS administrator asks before touching anything, and
+    the reason ``dicom_peer`` exists as a directed edge: an AE's outbound
+    associations stop sending, its inbound ones stop being able to reach
+    it, and those are different remediation lists.
+    """
+    row = await _get_ae(db, ae_id)
+    ip = await _load_anchor(db, row, user)
+
+    source = aliased(DICOMApplicationEntity, name="source_ae")
+    target = aliased(DICOMApplicationEntity, name="target_ae")
+    edges = (
+        await db.execute(
+            select(DICOMPeer, source.ae_title, target.ae_title)
+            .join(source, source.id == DICOMPeer.source_ae_id)
+            .join(target, target.id == DICOMPeer.target_ae_id)
+            .where(or_(DICOMPeer.source_ae_id == row.id, DICOMPeer.target_ae_id == row.id))
+            .order_by(source.ae_title.asc(), target.ae_title.asc())
+        )
+    ).all()
+
+    outbound = [
+        _peer_read(peer, src, dst) for peer, src, dst in edges if peer.source_ae_id == row.id
+    ]
+    inbound = [
+        _peer_read(peer, src, dst) for peer, src, dst in edges if peer.target_ae_id == row.id
+    ]
+    return DICOMImpactResponse(
+        ae_id=row.id,
+        ae_title=row.ae_title,
+        address=str(ip.address) if ip is not None else None,
+        outbound=outbound,
+        inbound=inbound,
+        total_peers=len(outbound) + len(inbound),
+    )
+
+
+# ── Per-IPAM-address lookup ─────────────────────────────────────────
+
+
+@router.get("/by-address/{ip_address_id:uuid}", response_model=DICOMAERead)
+async def get_ae_by_address(ip_address_id: uuid.UUID, db: DB, user: CurrentUser) -> DICOMAERead:
+    """The DICOM AE anchored to an IPAM address, or 404.
+
+    Drives the IP-detail modal's DICOM section, which treats the 404 as
+    "this IP isn't a DICOM node" and renders nothing — so a 404 here is a
+    normal answer, not an error condition.
+
+    The same 404 covers "no such address" and "address carries no AE": to
+    the caller those are one answer, and distinguishing them would leak
+    the existence of addresses outside a scoped token's reach.
+
+    A PACS host can front several AE Titles. This returns the
+    lowest-titled one; the full set is ``GET /dicom/aes?ip_address_id=…``.
+    """
+    from app.api.v1.ipam.router import _enforce_subnet_token_scope  # noqa: PLC0415
+
+    ip = await db.get(IPAddress, ip_address_id)
+    if ip is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No DICOM application entity recorded for this IP address",
+        )
+    _enforce_subnet_token_scope(user, ip.subnet_id)
+
+    ae = (
+        (
+            await db.execute(
+                select(DICOMApplicationEntity)
+                .where(DICOMApplicationEntity.ip_address_id == ip_address_id)
+                .order_by(DICOMApplicationEntity.ae_title.asc())
+                .limit(1)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if ae is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No DICOM application entity recorded for this IP address",
+        )
+    return _to_read(ae, ip)
+
+
+# ── Peer edges ──────────────────────────────────────────────────────
+
+
+@router.get("/peers", response_model=list[DICOMPeerRead])
+async def list_peers(
+    db: DB,
+    _: CurrentUser,
+    ae_id: uuid.UUID | None = Query(
+        default=None, description="Restrict to edges touching this AE, in either direction."
+    ),
+) -> list[DICOMPeerRead]:
+    """Every configured AE→AE association, ordered by source then target.
+
+    These are *configured* relationships as documented by the operator or
+    imported from the estate's AE table — never associations inferred
+    from captured traffic, which would mean parsing DICOM that carries
+    PHI.
+    """
+    source = aliased(DICOMApplicationEntity, name="source_ae")
+    target = aliased(DICOMApplicationEntity, name="target_ae")
+    stmt = (
+        select(DICOMPeer, source.ae_title, target.ae_title)
+        .join(source, source.id == DICOMPeer.source_ae_id)
+        .join(target, target.id == DICOMPeer.target_ae_id)
+        .order_by(source.ae_title.asc(), target.ae_title.asc())
+    )
+    if ae_id is not None:
+        stmt = stmt.where(or_(DICOMPeer.source_ae_id == ae_id, DICOMPeer.target_ae_id == ae_id))
+    return [_peer_read(peer, src, dst) for peer, src, dst in (await db.execute(stmt)).all()]
+
+
+@router.post("/peers", response_model=DICOMPeerRead, status_code=status.HTTP_201_CREATED)
+async def create_peer(body: DICOMPeerCreate, db: DB, user: CurrentUser) -> DICOMPeerRead:
+    """Document an association from one AE to another."""
+    if body.source_ae_id == body.target_ae_id:
+        raise HTTPException(
+            status_code=422,
+            detail="An AE cannot be configured as a peer of itself",
+        )
+    source_ae = await _get_ae(db, body.source_ae_id)
+    target_ae = await _get_ae(db, body.target_ae_id)
+    # Snapshot the titles as plain strings *before* the flush. The
+    # conflict path rolls back, which expires every ORM instance in the
+    # session — touching ``source_ae.ae_title`` afterwards would trigger
+    # a lazy refresh from inside the exception handler and raise
+    # MissingGreenlet instead of the 409.
+    source_title, target_title = source_ae.ae_title, target_ae.ae_title
+
+    row = DICOMPeer(
+        source_ae_id=body.source_ae_id,
+        target_ae_id=body.target_ae_id,
+        services=list(body.services),
+        notes=body.notes,
+    )
+    db.add(row)
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        # ``uq_dicom_peer_pair`` — re-documenting the same association is
+        # an update, not a second edge.
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"An association from {source_title!r} to "
+                f"{target_title!r} is already documented"
+            ),
+        ) from exc
+
+    write_audit(
+        db,
+        user=user,
+        action="create",
+        resource_type="dicom_peer",
+        resource_id=str(row.id),
+        resource_display=f"{source_ae.ae_title} → {target_ae.ae_title}",
+        new_value=body.model_dump(mode="json"),
+    )
+    await db.commit()
+    await db.refresh(row)
+    return _peer_read(row, source_title, target_title)
+
+
+@router.delete("/peers/{peer_id:uuid}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_peer(peer_id: uuid.UUID, db: DB, user: CurrentUser) -> None:
+    row = await db.get(DICOMPeer, peer_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="DICOM peer association not found")
+    source_ae = await db.get(DICOMApplicationEntity, row.source_ae_id)
+    target_ae = await db.get(DICOMApplicationEntity, row.target_ae_id)
+    write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="dicom_peer",
+        resource_id=str(row.id),
+        resource_display=(
+            f"{source_ae.ae_title if source_ae else row.source_ae_id} → "
+            f"{target_ae.ae_title if target_ae else row.target_ae_id}"
+        ),
+        old_value={"services": [str(s) for s in (row.services or [])]},
+    )
+    await db.delete(row)
+    await db.commit()
+
+
+# ── AE-table import ─────────────────────────────────────────────────
+#
+# Preview and commit take the same request body. The commit re-parses and
+# re-plans rather than trusting a plan the client hands back, so a client
+# cannot smuggle in an ip_address_id the preview never resolved — the only
+# thing that decides what gets written is the CSV plus the column map,
+# evaluated server-side both times.
+
+
+async def _build_plan(db: AsyncSession, user: Any, body: DICOMAEImportRequest) -> list[PlannedRow]:
+    # A resource-scoped API token (#374) is bound to specific subnets,
+    # but an import addresses rows by AE Title across the whole
+    # institution — there is no honest way to scope it row-by-row without
+    # silently dropping the operator's data. Refuse the whole call
+    # instead; a scoped token can still write AEs one at a time, where
+    # the per-address gate applies.
+    if _token_subnet_scope(user) is not None:
+        raise HTTPException(
+            status_code=403,
+            detail="Bulk DICOM AE import is not available to a resource-scoped API token",
+        )
+    if body.space_id is not None and (await db.get(IPSpace, body.space_id)) is None:
+        raise HTTPException(status_code=422, detail="space_id not found")
+    try:
+        parsed = parse_rows(
+            body.csv_text,
+            column_map=body.column_map.model_dump(exclude_none=True),
+            delimiter=body.delimiter,
+            default_port=body.default_port,
+            default_department=body.default_department,
+        )
+    except DICOMImportError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return await plan_import(
+        db,
+        parsed,
+        overwrite_existing=body.overwrite_existing,
+        space_id=body.space_id,
+    )
+
+
+def _rows_out(plan: list[PlannedRow]) -> list[DICOMAEImportRow]:
+    return [
+        DICOMAEImportRow(
+            line=row.line,
+            ae_title=row.ae_title,
+            action=row.action,  # type: ignore[arg-type]
+            reason=row.reason,
+            address=row.address,
+            ip_address_id=row.ip_address_id,
+            fields=row.fields,
+        )
+        for row in plan
+    ]
+
+
+@router.post("/aes/import/preview", response_model=DICOMAEImportPreviewResponse)
+async def import_preview(
+    body: DICOMAEImportRequest, db: DB, user: CurrentUser
+) -> DICOMAEImportPreviewResponse:
+    """Parse + plan the CSV without writing anything.
+
+    Returns one row per CSV data row: what would be created, what would
+    be updated, what would be skipped, and — per row, with a reason —
+    what is unusable. A duplicate AE Title inside the file is reported
+    rather than resolved by last-write-wins, because that duplicate is
+    the exact collision this registry exists to surface.
+    """
+    plan = await _build_plan(db, user, body)
+    return DICOMAEImportPreviewResponse(
+        rows=_rows_out(plan),
+        create_count=sum(1 for r in plan if r.action == "create"),
+        update_count=sum(1 for r in plan if r.action == "update"),
+        skip_count=sum(1 for r in plan if r.action == "skip"),
+        error_count=sum(1 for r in plan if r.action == "error"),
+    )
+
+
+@router.post(
+    "/aes/import/commit",
+    response_model=DICOMAEImportCommitResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def import_commit(
+    body: DICOMAEImportRequest, db: DB, user: CurrentUser
+) -> DICOMAEImportCommitResponse:
+    """Apply the import. Valid rows land; invalid rows are reported.
+
+    Deliberately not all-or-nothing at the *row* level — an operator
+    migrating an AE table wants the good rows in and the bad ones named.
+    It is all-or-nothing at the *transaction* level: one commit, so a
+    failure part-way leaves nothing half-applied.
+
+    Audit rows are written per created / updated AE by the importer
+    before the commit (non-negotiable #4).
+    """
+    plan = await _build_plan(db, user, body)
+    outcome = await apply_plan(db, plan, user=user)
+    await db.commit()
+    return DICOMAEImportCommitResponse(
+        rows=_rows_out(plan),
+        created=outcome.created,
+        updated=outcome.updated,
+        skipped=outcome.skipped,
+        errors=outcome.errors,
+        ae_ids=outcome.ae_ids,
+    )

--- a/backend/app/api/v1/dicom/router.py
+++ b/backend/app/api/v1/dicom/router.py
@@ -462,6 +462,28 @@ def _jsonable(value: Any) -> Any:
     return value
 
 
+def _integrity_error(exc: IntegrityError, *, ae_title: str) -> HTTPException:
+    """Map a flush failure to the right status, not just to 409.
+
+    ``uq_dicom_ae_title`` is the constraint this surface expects to trip,
+    but it is not the only one on the table — a NOT NULL or a CHECK
+    (port range, AE-title length) can fail here too, and reporting those
+    as "AE Title already registered" sends the operator hunting for a
+    duplicate that does not exist. Match on the constraint name and fall
+    back to a 422 that says what actually happened.
+    """
+    detail = str(getattr(exc, "orig", exc))
+    if "uq_dicom_ae_title" in detail:
+        return HTTPException(
+            status_code=409,
+            detail=f"AE Title {ae_title!r} is already registered",
+        )
+    return HTTPException(
+        status_code=422,
+        detail=f"The application entity could not be saved: {detail}",
+    )
+
+
 def _title_conflict(exc: AETitleConflict) -> HTTPException:
     """409 naming the AE that already holds the title.
 
@@ -704,10 +726,7 @@ async def create_ae(body: DICOMAECreate, db: DB, user: CurrentUser) -> DICOMAERe
         # real guard; answer with the same 409 the pre-check would have
         # produced rather than leaking a 500.
         await db.rollback()
-        raise HTTPException(
-            status_code=409,
-            detail=f"AE Title {body.ae_title!r} is already registered",
-        ) from exc
+        raise _integrity_error(exc, ae_title=body.ae_title) from exc
 
     write_audit(
         db,
@@ -761,6 +780,11 @@ async def update_ae(
 
     for key, value in changes.items():
         setattr(row, key, value)
+    # Snapshot before the flush: the failure path rolls back, which
+    # expires every ORM instance, so reading ``row.ae_title`` inside the
+    # handler would trigger a lazy refresh and raise MissingGreenlet
+    # instead of the intended response.
+    new_title = row.ae_title
 
     if reparented:
         await sync_subnet_id(db, row)
@@ -769,10 +793,7 @@ async def update_ae(
         await db.flush()
     except IntegrityError as exc:
         await db.rollback()
-        raise HTTPException(
-            status_code=409,
-            detail=f"AE Title {row.ae_title!r} is already registered",
-        ) from exc
+        raise _integrity_error(exc, ae_title=new_title) from exc
 
     write_audit(
         db,

--- a/backend/app/api/v1/dicom/router.py
+++ b/backend/app/api/v1/dicom/router.py
@@ -61,7 +61,6 @@ from app.models.auth import User
 from app.models.dicom import (
     DICOM_AE_ROLES,
     DICOM_AE_SOURCES,
-    DICOM_AE_TITLE_MAX_BYTES,
     DICOM_DEFAULT_PORT,
     DICOM_DEVICE_CLASSES,
     DICOMApplicationEntity,
@@ -103,6 +102,14 @@ DICOMDeviceClass = Literal[
 DICOMAESource = Literal["manual", "import", "echo"]
 ImportAction = Literal["create", "update", "skip", "error"]
 
+# Raw-input ceiling for ``ae_title`` before validation. Generous: the
+# real rule is 16 bytes *after* trimming padding, enforced by
+# ``validate_ae_title``. This only stops an unbounded string from
+# reaching it, and is loose enough that a title made entirely of legal
+# pad space still gets the specific "empty or all spaces" message rather
+# than a generic length one.
+_MAX_TITLE_INPUT = 128
+
 # Network-configuration notes. Named in the field description too — an
 # unlabelled free-text box is the surest way to end up storing PHI.
 _NOTES_DESCRIPTION = (
@@ -129,7 +136,15 @@ def _validated_title(v: str) -> str:
 
 
 class DICOMAECreate(BaseModel):
-    ae_title: str = Field(..., min_length=1, max_length=DICOM_AE_TITLE_MAX_BYTES)
+    # Deliberately NO ``max_length``: pydantic's length check counts
+    # *characters* and runs on the *untrimmed* value, so a legal
+    # 16-byte title carrying pad space ("QRSTUVWXYZABCDEF ") would be
+    # rejected before ``_validated_title`` ever trimmed it. Spaces are
+    # non-significant padding per PS3.5, so the ceiling has to be
+    # measured after trimming and in bytes — which is exactly what
+    # ``validate_ae_title`` does. ``_MAX_TITLE_INPUT`` still bounds the
+    # raw input so an unbounded string can't reach the validator.
+    ae_title: str = Field(..., min_length=1, max_length=_MAX_TITLE_INPUT)
     # Nullable on purpose: an AE with no address is a *reservation* — a
     # title still in peer configuration whose host is gone. Registering
     # those is the point, not an edge case.
@@ -192,7 +207,8 @@ class DICOMAEUpdate(BaseModel):
     tinguishable from not mentioning it.
     """
 
-    ae_title: str | None = Field(default=None, max_length=DICOM_AE_TITLE_MAX_BYTES)
+    # See DICOMAECreate.ae_title on why this is not bounded at 16.
+    ae_title: str | None = Field(default=None, max_length=_MAX_TITLE_INPUT)
     ip_address_id: uuid.UUID | None = None
     port: int | None = Field(default=None, ge=1, le=65535)
     tls_enabled: bool | None = None

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -7376,10 +7376,19 @@ async def profile_address(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="IP address not found")
     _enforce_subnet_token_scope(current_user, ip.subnet_id)
 
-    from app.services.profiling.auto_profile import enqueue_now
+    from app.services.profiling.auto_profile import ProbeSuppressed, enqueue_now
 
     try:
         scan = await enqueue_now(db, ipam_row=ip, preset=body.preset)
+    except ProbeSuppressed as exc:
+        # Fragile-device suppression (#722) — a standing refusal, not a
+        # transient one, so 422 rather than the cap's 429. There is
+        # deliberately no override on this endpoint: an operator who
+        # genuinely must scan a suppressed host has the audited
+        # superadmin path on /nmap/scans.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     except ValueError as exc:
         # Concurrency cap reached — surfaced as 429 so the UI can show
         # a "try again in a moment" message rather than treating this

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -68,6 +68,7 @@ from app.services.ipam.address_set_gate import (
 from app.services.ipam.address_set_gate import (
     user_can_write_ip as _user_can_write_ip,
 )
+from app.services.ipam.probe_policy import resolve_probe_policy
 from app.services.oui import bulk_lookup_vendors, is_voip_phone_vendor, normalize_mac_key
 from app.services.tags import apply_tag_filter
 
@@ -1692,6 +1693,11 @@ class IPSpaceCreate(BaseModel):
     ddns_hostname_policy: str = "client_or_generated"
     ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
+    # Fragile-device probe suppression (#722). Set at any level of the
+    # space → block → subnet chain; ORs downward and cannot be
+    # overridden from below.
+    do_not_probe: bool = False
+    do_not_probe_reason: str = ""
     # VRF / routing annotation. Pure metadata; address allocation
     # ignores these. ``route_targets`` is a list of strings rather
     # than a structured object so the inline ``import:A:B; export:C:D``
@@ -1737,6 +1743,8 @@ class IPSpaceUpdate(BaseModel):
     ddns_hostname_policy: str | None = None
     ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
+    do_not_probe: bool | None = None
+    do_not_probe_reason: str | None = None
     vrf_id: uuid.UUID | None = None
     vrf_name: str | None = None
     route_distinguisher: str | None = None
@@ -1774,6 +1782,8 @@ class IPSpaceResponse(BaseModel):
     ddns_hostname_policy: str = "client_or_generated"
     ddns_domain_override: str | None = None
     ddns_ttl: int | None = None
+    do_not_probe: bool = False
+    do_not_probe_reason: str = ""
     vrf_id: uuid.UUID | None = None
     vrf_name: str | None = None
     route_distinguisher: str | None = None
@@ -1814,6 +1824,9 @@ class IPBlockCreate(BaseModel):
     ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool = True
+    # Fragile-device probe suppression (#722) — see IPSpaceCreate.
+    do_not_probe: bool = False
+    do_not_probe_reason: str = ""
     asn_id: uuid.UUID | None = None
     vrf_id: uuid.UUID | None = None
     # Logical ownership (issue #91).
@@ -1862,6 +1875,8 @@ class IPBlockUpdate(BaseModel):
     ddns_domain_override: DDNSDomainOverride = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool | None = None
+    do_not_probe: bool | None = None
+    do_not_probe_reason: str | None = None
     asn_id: uuid.UUID | None = None
     vrf_id: uuid.UUID | None = None
     customer_id: uuid.UUID | None = None
@@ -1897,6 +1912,8 @@ class IPBlockResponse(BaseModel):
     ddns_domain_override: str | None = None
     ddns_ttl: int | None = None
     ddns_inherit_settings: bool = True
+    do_not_probe: bool = False
+    do_not_probe_reason: str = ""
     vrf_id: uuid.UUID | None = None
     # Non-blocking warning when the block's VRF differs from its
     # parent space's VRF — intentional in some hub-and-spoke designs
@@ -1969,6 +1986,11 @@ class SubnetCreate(BaseModel):
     # IP discovery (issue #23) — opt-in scheduled ping/ARP sweep.
     discovery_enabled: bool = False
     discovery_interval_minutes: int = 360
+    # Fragile-device probe suppression (#722). Orthogonal to
+    # ``discovery_enabled``: a subnet can be opted into discovery and
+    # still be suppressed by an ancestor, in which case no sweep runs.
+    do_not_probe: bool = False
+    do_not_probe_reason: str = ""
     ipv6_allocation_policy: str = "random"
     # Compliance / classification flags — see Subnet model.
     pci_scope: bool = False
@@ -2104,6 +2126,8 @@ class SubnetUpdate(BaseModel):
     auto_profile_refresh_days: int | None = None
     discovery_enabled: bool | None = None
     discovery_interval_minutes: int | None = None
+    do_not_probe: bool | None = None
+    do_not_probe_reason: str | None = None
     ipv6_allocation_policy: str | None = None
     pci_scope: bool | None = None
     hipaa_scope: bool | None = None
@@ -2252,6 +2276,13 @@ class SubnetResponse(BaseModel):
     discovery_enabled: bool = False
     discovery_interval_minutes: int = 360
     last_discovery_at: datetime | None = None
+    # The subnet's OWN flag (#722), not the effective verdict — an
+    # ancestor can suppress a subnet whose own flag is False. The
+    # resolved answer is a separate call
+    # (``GET /ipam/subnets/{id}/probe-policy``) because resolving it
+    # per-row would put a hierarchy walk inside every list page.
+    do_not_probe: bool = False
+    do_not_probe_reason: str = ""
     ipv6_allocation_policy: str = "random"
     pci_scope: bool = False
     hipaa_scope: bool = False
@@ -2299,6 +2330,23 @@ class SubnetResponse(BaseModel):
                     },
                 }
         return data
+
+
+class ProbePolicyResponse(BaseModel):
+    """Effective do-not-probe verdict for a subnet (#722).
+
+    ``inherited`` distinguishes "this subnet is flagged" from "an
+    ancestor flagged it", which is what tells the UI whether clearing
+    the subnet's own checkbox would actually re-enable probing.
+    """
+
+    do_not_probe: bool
+    reason: str = ""
+    # ``"subnet:<id>"`` / ``"block:<id>"`` / ``"space:<id>"``; null when
+    # nothing is suppressing.
+    source: str | None = None
+    scope: str | None = None
+    inherited: bool = False
 
 
 class EffectiveDnsResponse(BaseModel):
@@ -4552,6 +4600,35 @@ async def deprecate_stale_ips(
         deprecated_count=deprecated,
         skipped=skipped,
         capped=capped,
+    )
+
+
+@router.get("/subnets/{subnet_id}/probe-policy", response_model=ProbePolicyResponse)
+async def get_subnet_probe_policy(
+    subnet_id: uuid.UUID, current_user: CurrentUser, db: DB
+) -> ProbePolicyResponse:
+    """Resolve the effective do-not-probe verdict for a subnet (#722).
+
+    A separate call rather than a field on ``SubnetResponse`` because
+    resolving it walks the block chain: cheap once, but N walks on a
+    list page for information only the detail view renders.
+
+    ``do_not_probe`` on the subnet row itself answers "did *this* row
+    set the flag"; this answers "will a probe actually be refused",
+    which is the question an operator staring at a greyed-out Discovery
+    toggle is asking.
+    """
+    _ = current_user
+    subnet = await db.get(Subnet, subnet_id)
+    if subnet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subnet not found")
+    verdict = await resolve_probe_policy(db, subnet)
+    return ProbePolicyResponse(
+        do_not_probe=verdict.blocked,
+        reason=verdict.reason,
+        source=verdict.source or None,
+        scope=verdict.scope_label or None,
+        inherited=verdict.blocked and not subnet.do_not_probe,
     )
 
 

--- a/backend/app/api/v1/nmap/router.py
+++ b/backend/app/api/v1/nmap/router.py
@@ -41,6 +41,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import DB, CurrentUser
+from app.api.v1.probe_guard import enforce_probe_target
 from app.core.permissions import require_permission, user_has_permission
 from app.core.security import decode_access_token
 from app.db import get_db
@@ -153,6 +154,19 @@ async def create_scan(body: NmapScanCreate, db: DB, current_user: CurrentUser) -
 
     if not target_ip:
         raise HTTPException(status_code=422, detail="target_ip is required")
+
+    # Fragile-device suppression (#722) — refuse a target inside a
+    # do-not-probe scope before anything is persisted or dispatched.
+    # nmap targets can be a CIDR, so the check covers overlap in both
+    # directions (see services/ipam/probe_policy).
+    await enforce_probe_target(
+        db,
+        target=target_ip,
+        tool="nmap",
+        user=current_user,
+        override=body.override_do_not_probe,
+        action_label="Port scanning",
+    )
 
     # Pre-validate by building the argv now — surfaces NmapArgError
     # before we persist a doomed row.

--- a/backend/app/api/v1/nmap/schemas.py
+++ b/backend/app/api/v1/nmap/schemas.py
@@ -73,6 +73,10 @@ class NmapScanCreate(BaseModel):
     port_spec: str | None = None
     extra_args: str | None = None
     ip_address_id: uuid.UUID | None = None
+    # Proceed against a scope marked do-not-probe (#722). Superadmin
+    # only, audited, and per-request — nothing is remembered, so the
+    # next scan of the same target is refused again.
+    override_do_not_probe: bool = False
 
     @field_validator("port_spec", "extra_args")
     @classmethod

--- a/backend/app/api/v1/probe_guard.py
+++ b/backend/app/api/v1/probe_guard.py
@@ -66,8 +66,16 @@ async def enforce_probe_target(
     suppressed; we are proceeding anyway). Callers that just want the
     guard can ignore the return value.
 
-    Does not commit. The audit row joins whatever transaction the caller
-    already owns, matching every other mutation on these surfaces.
+    **Commits the override audit row itself.** The obvious alternative —
+    leave it in the caller's transaction — silently loses it on the
+    stateless ``/tools/*`` handlers, which run their probe inline and
+    never commit at all (``mtr`` is server-only, so its override would
+    never have been auditable). Committing here also gets the ordering
+    right everywhere else: the auditable event is the *decision to
+    proceed*, so it must be durable before any packet leaves, whatever
+    the probe then does or fails to do. This runs at the top of a
+    handler, before any other mutation, so there is nothing half-written
+    to sweep into the commit.
     """
     verdict = await check_probe_target(db, target)
     if not verdict.blocked:
@@ -107,6 +115,7 @@ async def enforce_probe_target(
             new_value={"tool": tool, "target": target, **verdict.as_dict()},
         )
     )
+    await db.commit()
     return verdict
 
 

--- a/backend/app/api/v1/probe_guard.py
+++ b/backend/app/api/v1/probe_guard.py
@@ -1,0 +1,113 @@
+"""HTTP-layer enforcement of the do-not-probe flag — issue #722.
+
+``app.services.ipam.probe_policy`` decides *whether* a target is
+suppressed. This module is the single place that turns that decision
+into an HTTP outcome, so ``tools.network`` and ``tools.nmap`` refuse in
+exactly the same way, with the same status code, the same message, and
+the same audit trail.
+
+The override
+------------
+
+There is an escape hatch, and it is deliberately narrow. An operator
+sometimes genuinely has to ping a device on a suppressed subnet — during
+a documented maintenance window, or while proving to a vendor that the
+device is unreachable. Refusing absolutely would just get the flag
+turned off estate-wide, which is a worse outcome than a recorded
+exception.
+
+So ``override_do_not_probe=true``:
+
+* requires superadmin. Not a permission grant — ``use_network_tools`` is
+  a routine grant that delegated admins hold, and the point of the flag
+  is that the person clearing it is accountable for the consequences.
+* writes an ``audit_log`` row *before* the probe runs, with the scope,
+  the level that set the flag, and the reason being overridden. The
+  probe is what is auditable; whether it later succeeds is not the
+  authorization decision.
+* is per-request. Nothing is remembered, so the next call is refused
+  again — an override is an exception, not a mode.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import AuditLog
+from app.services.ipam.probe_policy import ProbeVerdict, check_probe_target
+
+# 422 rather than 403. The request is well-formed and the caller is
+# authorized to use the tool — it is the *target* that is unacceptable,
+# which is a semantic problem with the payload. It also keeps the
+# refusal distinguishable from a genuine permission failure in logs.
+_STATUS = status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def _is_superadmin(user: Any) -> bool:
+    return bool(getattr(user, "is_superadmin", False))
+
+
+async def enforce_probe_target(
+    db: AsyncSession,
+    *,
+    target: str,
+    tool: str,
+    user: Any,
+    override: bool = False,
+    action_label: str = "Active probing",
+) -> ProbeVerdict:
+    """Refuse, or record an override, before a probe reaches the wire.
+
+    Returns the resolved verdict so a caller can annotate its own result
+    (the override path returns a blocked verdict — the target *is*
+    suppressed; we are proceeding anyway). Callers that just want the
+    guard can ignore the return value.
+
+    Does not commit. The audit row joins whatever transaction the caller
+    already owns, matching every other mutation on these surfaces.
+    """
+    verdict = await check_probe_target(db, target)
+    if not verdict.blocked:
+        return verdict
+
+    if not override:
+        raise HTTPException(
+            status_code=_STATUS,
+            detail=(
+                f"{verdict.message(action=action_label)}. A superadmin can proceed "
+                "anyway by re-sending with override_do_not_probe=true, which is audited."
+            ),
+        )
+
+    if not _is_superadmin(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Overriding a do-not-probe scope requires superadmin. "
+                f"{verdict.message(action=action_label)}."
+            ),
+        )
+
+    db.add(
+        AuditLog(
+            user_id=getattr(user, "id", None),
+            user_display_name=getattr(user, "display_name", "system"),
+            auth_source=getattr(user, "auth_source", "local") or "local",
+            action="probe.do_not_probe_override",
+            resource_type="subnet",
+            # The verdict names a level, not necessarily a subnet row, so
+            # the source string is the identifier that actually explains
+            # the override. resource_id stays free-form for the same
+            # reason other cross-cutting audit rows do.
+            resource_id=verdict.source,
+            resource_display=verdict.scope_label or verdict.source,
+            new_value={"tool": tool, "target": target, **verdict.as_dict()},
+        )
+    )
+    return verdict
+
+
+__all__ = ["enforce_probe_target"]

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -34,6 +34,7 @@ from app.api.v1.dhcp import router as dhcp_router
 from app.api.v1.dhcp.ra_routers import router as ra_routers_router
 from app.api.v1.dhcp_import.router import router as dhcp_import_router
 from app.api.v1.diagnostics import router as diagnostics_router
+from app.api.v1.dicom import router as dicom_router
 from app.api.v1.dns.agents import router as dns_agents_router
 from app.api.v1.dns.blocklist_router import router as dns_blocklist_router
 from app.api.v1.dns.pool_router import router as dns_pool_router
@@ -242,6 +243,16 @@ api_v1_router.include_router(
     ],
 )
 api_v1_router.include_router(diagnostics_router, prefix="/diagnostics", tags=["diagnostics"])
+# DICOM AE registry (#723) — the healthcare member of the #543 vertical
+# family. No wake_publishing: it enriches IPAM rows and touches neither
+# the DNS nor the DHCP ConfigBundle, so there is no parked agent
+# long-poll to wake (same reasoning as the /av include above).
+api_v1_router.include_router(
+    dicom_router,
+    prefix="/dicom",
+    tags=["dicom"],
+    dependencies=[Depends(require_module("network.dicom"))],
+)
 api_v1_router.include_router(
     dns_router,
     prefix="/dns",

--- a/backend/app/api/v1/tools/router.py
+++ b/backend/app/api/v1/tools/router.py
@@ -48,6 +48,7 @@ from app.api.v1.dns_tools import (
     PropagationCheckResult,
     _query_one,
 )
+from app.api.v1.probe_guard import enforce_probe_target
 from app.api.v1.tools.schemas import (
     CommandResult,
     DigRequest,
@@ -177,9 +178,12 @@ async def _dispatch_to_appliance[ResultT: BaseModel](
         validated = request_model.model_validate(params)
     except ValidationError as exc:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
-    # Strip the routing-only ``target`` before shipping — the supervisor
-    # always runs locally; a nested target would be meaningless there.
-    wire_params = validated.model_dump(mode="json", exclude={"target"})
+    # Strip the routing-only fields before shipping. ``target`` would be
+    # meaningless on a supervisor that always runs locally, and
+    # ``override_do_not_probe`` (#722) is an authorization decision this
+    # layer has already made — re-sending it would invite the agent to
+    # re-evaluate a call it has no data to make.
+    wire_params = validated.model_dump(mode="json", exclude={"target", "override_do_not_probe"})
 
     target_host = str(params.get("host") or params.get("name") or "")
     ready = agent_cmd.appliance_ready(
@@ -356,10 +360,39 @@ def _reject_non_server(tool: str, target: NetToolTarget | None) -> None:
         )
 
 
+async def _guard_probe(
+    db: DB,
+    current_user: CurrentUser,
+    *,
+    body: Any,
+    tool: str,
+    action_label: str,
+) -> None:
+    """Refuse a target inside a do-not-probe scope (#722).
+
+    Applied before the vantage branch, so an appliance-vantage run is
+    gated identically to a server-vantage one — the hazard is packets
+    reaching the device, and which of our hosts emits them is
+    irrelevant. Reads ``host`` because every gated tool here targets a
+    single host; ``dig`` is deliberately not gated (it queries a
+    resolver about a name, it does not probe the name's host), nor are
+    whois / dns-propagation / mac-vendor, which reach nothing on-prem.
+    """
+    await enforce_probe_target(
+        db,
+        target=getattr(body, "host", "") or "",
+        tool=tool,
+        user=current_user,
+        override=bool(getattr(body, "override_do_not_probe", False)),
+        action_label=action_label,
+    )
+
+
 @router.post("/ping", response_model=CommandResult, dependencies=[_RequirePerm])
 async def ping(
     body: HostRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> CommandResult:
+    await _guard_probe(db, current_user, body=body, tool="ping", action_label="Pinging")
     dispatched = await _dispatch_reachability(
         tool="ping",
         body=body,
@@ -380,6 +413,9 @@ async def ping(
 async def traceroute(
     body: HostRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> CommandResult:
+    await _guard_probe(
+        db, current_user, body=body, tool="traceroute", action_label="Tracing a route to"
+    )
     dispatched = await _dispatch_reachability(
         tool="traceroute",
         body=body,
@@ -397,12 +433,15 @@ async def traceroute(
 
 
 @router.post("/mtr", response_model=CommandResult, dependencies=[_RequirePerm])
-async def mtr(body: HostRequest, _rl=RateLimitDefault) -> CommandResult:
+async def mtr(
+    body: HostRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
+) -> CommandResult:
     # mtr is intentionally NOT in the appliance reachability set (it
     # needs CAP_NET_RAW and the per-vantage value is covered by
     # ping/traceroute). Reject a non-server target rather than silently
     # running on the server.
     _reject_non_server("mtr", body.target)
+    await _guard_probe(db, current_user, body=body, tool="mtr", action_label="Running mtr against")
     try:
         return await run_mtr(body.host)
     except NetToolArgError as exc:
@@ -447,6 +486,7 @@ async def whois(body: WhoisRequest, _rl=RateLimitOffprem) -> CommandResult:
 async def port_test(
     body: PortTestRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> PortTestResult:
+    await _guard_probe(db, current_user, body=body, tool="port-test", action_label="Port testing")
     dispatched = await _dispatch_reachability(
         tool="port-test",
         body=body,
@@ -464,6 +504,7 @@ async def port_test(
 async def tls_cert(
     body: TlsCertRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> TlsCertResult:
+    await _guard_probe(db, current_user, body=body, tool="tls-cert", action_label="TLS probing")
     dispatched = await _dispatch_reachability(
         tool="tls-cert",
         body=body,

--- a/backend/app/api/v1/tools/router.py
+++ b/backend/app/api/v1/tools/router.py
@@ -413,9 +413,7 @@ async def ping(
 async def traceroute(
     body: HostRequest, db: DB, current_user: CurrentUser, _rl=RateLimitDefault
 ) -> CommandResult:
-    await _guard_probe(
-        db, current_user, body=body, tool="traceroute", action_label="Tracing a route to"
-    )
+    await _guard_probe(db, current_user, body=body, tool="traceroute", action_label="Route tracing")
     dispatched = await _dispatch_reachability(
         tool="traceroute",
         body=body,
@@ -441,7 +439,7 @@ async def mtr(
     # ping/traceroute). Reject a non-server target rather than silently
     # running on the server.
     _reject_non_server("mtr", body.target)
-    await _guard_probe(db, current_user, body=body, tool="mtr", action_label="Running mtr against")
+    await _guard_probe(db, current_user, body=body, tool="mtr", action_label="Running mtr")
     try:
         return await run_mtr(body.host)
     except NetToolArgError as exc:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -246,7 +246,8 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
         "SD-WAN overlay topology + routing policies + the application "
         "catalog (#95), the customer-deliverable services (#94) those "
         "resources bundle into, the vertical network-awareness registries "
-        "(AV-over-IP flows, BACnet/IP devices, industrial-OT devices), and "
+        "(AV-over-IP flows, BACnet/IP devices, industrial-OT devices, "
+        "DICOM application entities), and "
         "the logical ownership tags (customer / site / provider) those "
         "entities reference.",
         [
@@ -261,6 +262,7 @@ _BUILTIN_ROLES: dict[str, tuple[str, list[dict[str, object]]]] = {
             {"action": "admin", "resource_type": "multicast"},
             {"action": "admin", "resource_type": "av_flow"},
             {"action": "admin", "resource_type": "bacnet_device"},
+            {"action": "admin", "resource_type": "dicom_ae"},
             {"action": "admin", "resource_type": "ot_device"},
             {"action": "admin", "resource_type": "network_service"},
             {"action": "admin", "resource_type": "overlay_network"},

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -45,6 +45,7 @@ from app.models.dhcp import (
 )
 from app.models.dhcp_fingerprint import DHCPFingerprint
 from app.models.diagnostics import InternalError
+from app.models.dicom import DICOMApplicationEntity, DICOMPeer
 from app.models.dns import (
     DNSAcl,
     DNSAclEntry,
@@ -165,6 +166,8 @@ __all__ = [
     "AVFlowProfile",
     "AVReservedRange",
     "BACnetDevice",
+    "DICOMApplicationEntity",
+    "DICOMPeer",
     "OTDevice",
     "OTZone",
     "ASN",

--- a/backend/app/models/dicom.py
+++ b/backend/app/models/dicom.py
@@ -1,0 +1,333 @@
+"""DICOM Application Entity registry — issue #723 (part of #543).
+
+A DICOM Application Entity Title is a flat, **institution-wide-unique**,
+16-byte identifier. Every imaging device, PACS node, workstation and
+archive on a hospital network answers to one, and every peer that wants
+to talk to it must have that exact string configured. Duplicates break
+C-MOVE, Storage Commitment, Modality Worklist and MPPS in ways that are
+famously hard to trace, and the failure mode is documented back to 1997.
+
+DICOM PS3.15 Annex H defines ``dicomUniqueAETitlesRegistryRoot`` — an LDAP
+registry object whose entire purpose is allocating unique AE Titles via a
+compare-and-set against an enforced constraint. It is essentially
+undeployed. In practice the namespace lives in a spreadsheet.
+
+That is the BACnet device-instance argument (#541,
+``uq_bacnet_device_instance``) with better provenance: the standard
+itself says the value must be unique and specifies a registry for it, and
+no incumbent system owns the namespace. So the ``UNIQUE(ae_title)``
+constraint below is the point of this table, not an incidental index.
+
+Two structural decisions worth stating outright:
+
+* ``ip_address_id`` is **nullable** with ``ON DELETE SET NULL``, unlike
+  BACnet's ``CASCADE``. An AE Title outlives the host it currently runs
+  on: it is burned into peer configuration across the estate, so
+  decommissioning an IP must demote the title to a *reservation*, not
+  free a name that a dozen modalities still send to. Cascading would
+  hand that name straight back to the next commissioning engineer.
+* ``DICOMPeer`` is a directed AE→AE edge describing *configured*
+  associations, not observed traffic. It is what makes "what breaks if I
+  renumber this host" and an ePHI data-flow map answerable — the
+  topology-rule analogue of BACnet's BBMD-per-subnet.
+
+**No PHI, ever.** This registry stores network identity only: titles,
+addresses, ports, roles, vendors. It records nothing about patients,
+studies, or images. Storing patient-identifiable data would make
+SpatiumDDI a HIPAA Business Associate, which is permanently out of
+scope. There is deliberately no free-text field documented as safe for
+clinical detail, and ``notes`` is documented in the API as
+network-configuration notes.
+
+Phase 1 (this) is registry + conformity with zero network I/O. The
+C-ECHO verification probe — which would confirm an AE actually answers
+at the recorded host:port — is deferred to its own issue. Unlike every
+other deferred probe in the #543 family it is *not* blocked on the
+agent↔subnet binding (C-ECHO is routable unicast TCP), but it must
+respect the #722 do-not-probe flag, and a probe that reaches a modality
+mid-study is exactly the hazard #722 exists for.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+# The AE Value Representation is 16 **bytes** — not 16 characters, and
+# not an alphanumeric-only repertoire. Per PS3.5:
+#
+#   * maximum length 16 bytes;
+#   * the default character repertoire excluding backslash (0x5C) and
+#     all control characters;
+#   * spaces are LEGAL but non-significant (they are padding), so
+#     leading/trailing space is trimmed on the way in;
+#   * an all-space value is explicitly forbidden.
+#
+# Getting this wrong in the strict direction is not harmless: a registry
+# that rejects a title real devices use records a plan that fails at
+# commissioning, which is the exact failure this table exists to prevent.
+DICOM_AE_TITLE_MAX_BYTES: int = 16
+
+# Vendor default AE Titles, lower-cased for comparison. Devices ship with
+# these and an alarming number stay that way, which is what makes
+# duplicates so common — two vendors' defaults collide across an estate
+# long before anyone runs out of names. Advisory only; the check that
+# reads this warns, it does not block.
+DICOM_DEFAULT_AE_TITLES: frozenset[str] = frozenset(
+    {
+        "ae_title",
+        "aetitle",
+        "any-scp",
+        "anyscp",
+        "changeme",
+        "conquestsrv1",
+        "dcm4chee",
+        "dcmqrscp",
+        "default",
+        "dicom",
+        "horos",
+        "orthanc",
+        "osirix",
+        "pacs",
+        "storescp",
+        "storescu",
+        "test",
+        "workstation",
+    }
+)
+
+# What the AE does in an association. DICOM calls the initiator the
+# Service Class User and the responder the Service Class Provider; most
+# real devices are both (a modality pushes images as an SCU and answers
+# echo/worklist as an SCP), so ``both`` is the common case rather than an
+# escape hatch.
+DICOM_AE_ROLES: frozenset[str] = frozenset({"scp", "scu", "both"})
+
+# Coarse device classification. Deliberately shallow — this is for
+# filtering a list and reading a data-flow map, not for modelling the
+# DICOM conformance statement. ``modality`` covers CT / MR / US / CR and
+# the rest; splitting it per-modality would multiply the vocabulary
+# without changing any question an operator asks of IPAM.
+DICOM_DEVICE_CLASSES: frozenset[str] = frozenset(
+    {
+        "modality",
+        "pacs",
+        "workstation",
+        "archive",
+        "router",
+        "worklist",
+        "printer",
+        "other",
+    }
+)
+
+# How a row got here. ``import`` is the CSV of an estate's existing AE
+# table; ``echo`` is reserved for the deferred C-ECHO verification probe
+# so adding it later needs no data migration.
+DICOM_AE_SOURCES: frozenset[str] = frozenset({"manual", "import", "echo"})
+
+# 104 and 11112 are both conventional. IANA registers **11112 as
+# ``dicom``**; 104 carries the historical name ``acr-nema``, which is
+# why it is listed second and why nothing here calls 104 "the DICOM
+# port". 11112 is the modern default because 104 is privileged.
+DICOM_DEFAULT_PORT: int = 11112
+DICOM_LEGACY_PORT: int = 104
+
+
+class DICOMApplicationEntity(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """One DICOM Application Entity, optionally anchored to an IPAM address.
+
+    ``UNIQUE(ae_title)`` is enforced in the database rather than only
+    validated in the API because the failure it prevents — two devices
+    answering to the same title — is precisely what makes a DICOM estate
+    misbehave in ways that cost days to trace. The uniqueness is
+    institution-wide by specification, so it is deliberately not scoped
+    to a site, subnet or IPSpace.
+    """
+
+    __tablename__ = "dicom_ae"
+    __table_args__ = (
+        # THE constraint. See the class docstring and PS3.15 Annex H.
+        UniqueConstraint("ae_title", name="uq_dicom_ae_title"),
+        Index("ix_dicom_ae_ip_address_id", "ip_address_id"),
+        Index("ix_dicom_ae_device_class", "device_class"),
+        # The "which AEs are unbound reservations" list — rows whose host
+        # was decommissioned out from under a title still in peer config.
+        # Partial, because in a healthy estate almost every row IS bound.
+        Index(
+            "ix_dicom_ae_unbound",
+            "ae_title",
+            postgresql_where=text("ip_address_id IS NULL"),
+        ),
+        CheckConstraint(
+            "port >= 1 AND port <= 65535",
+            name="ck_dicom_ae_port",
+        ),
+        # Length is a specification constant, so it is enforced in the
+        # database. The *repertoire* (no backslash, no control chars, not
+        # all-space) is validated at the API layer, where a rejection can
+        # explain which rule was broken.
+        CheckConstraint(
+            f"octet_length(ae_title) BETWEEN 1 AND {DICOM_AE_TITLE_MAX_BYTES}",
+            name="ck_dicom_ae_title_length",
+        ),
+    )
+
+    # Nullable + SET NULL: an AE Title outlives its host. See the module
+    # docstring — this is the deliberate difference from BACnet's CASCADE.
+    ip_address_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("ip_address.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # Denormalized from the address for per-subnet grouping, mirroring
+    # ``BACnetDevice.subnet_id``. Kept in step by the service layer at
+    # every point the anchor can move.
+    subnet_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("subnet.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # Stored as given (case is significant to peers — an AE configured as
+    # ``CT_ONE`` will not match ``ct_one``), uniqueness is exact-match.
+    ae_title: Mapped[str] = mapped_column(String(DICOM_AE_TITLE_MAX_BYTES), nullable=False)
+
+    port: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=DICOM_DEFAULT_PORT,
+        server_default=str(DICOM_DEFAULT_PORT),
+    )
+    # Plain DICOM carries ePHI in the clear. Recording the answer is what
+    # makes the ``dicom_ae_no_tls`` check possible; we never test it on
+    # the wire.
+    tls_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+
+    # One of ``DICOM_AE_ROLES``.
+    role: Mapped[str] = mapped_column(
+        String(8), nullable=False, default="both", server_default="both"
+    )
+    # One of ``DICOM_DEVICE_CLASSES``.
+    device_class: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="other", server_default="other"
+    )
+
+    vendor: Mapped[str] = mapped_column(String(255), nullable=False, default="", server_default="")
+    model_name: Mapped[str] = mapped_column(
+        String(255), nullable=False, default="", server_default=""
+    )
+    department: Mapped[str] = mapped_column(
+        String(255), nullable=False, default="", server_default=""
+    )
+    location: Mapped[str] = mapped_column(
+        String(255), nullable=False, default="", server_default=""
+    )
+
+    # One of ``DICOM_AE_SOURCES``.
+    seen_via: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="manual", server_default="manual"
+    )
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Network-configuration notes only. NOT a clinical field — see the
+    # module docstring's PHI guardrail; the API description says so too,
+    # because the surest way to end up storing PHI is an unlabelled
+    # free-text box.
+    notes: Mapped[str] = mapped_column(Text, nullable=False, default="", server_default="")
+
+    tags: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default="{}"
+    )
+    custom_fields: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default="{}"
+    )
+
+
+class DICOMPeer(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A configured, directed association from one AE to another.
+
+    Direction is meaningful: "the CT pushes to the archive" and "the
+    archive queries the CT" are different edges with different failure
+    consequences, and collapsing them would lose exactly the information
+    that makes a renumbering blast-radius answerable.
+
+    These are *configured* relationships as documented by the operator or
+    imported from the estate's AE table — not observed traffic. Nothing
+    here is derived from the wire, and this table never grows an
+    ``observed_at``: inferring associations from captured DICOM would
+    mean parsing traffic that carries PHI.
+
+    Both FKs cascade. An edge to or from a deleted AE describes an
+    association that cannot exist, and keeping half an edge would put
+    dangling rows into the data-flow map the table exists to produce.
+    """
+
+    __tablename__ = "dicom_peer"
+    __table_args__ = (
+        # One edge per ordered pair. Re-documenting the same association
+        # is an update, not a second row.
+        UniqueConstraint("source_ae_id", "target_ae_id", name="uq_dicom_peer_pair"),
+        Index("ix_dicom_peer_source", "source_ae_id"),
+        Index("ix_dicom_peer_target", "target_ae_id"),
+        # A self-edge would describe an AE associating with itself, which
+        # is not a thing on the wire and would render as a loop in the
+        # topology view.
+        CheckConstraint("source_ae_id <> target_ae_id", name="ck_dicom_peer_not_self"),
+    )
+
+    source_ae_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dicom_ae.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_ae_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dicom_ae.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # Free-text list of the DICOM services this edge carries (C-STORE,
+    # C-FIND, C-MOVE, MPPS, …). A JSONB list rather than a constrained
+    # vocabulary because SOP class support is genuinely open-ended and an
+    # operator documenting their estate should never be blocked on our
+    # taxonomy being complete.
+    services: Mapped[list[Any]] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]"
+    )
+
+    notes: Mapped[str] = mapped_column(Text, nullable=False, default="", server_default="")
+
+
+__all__ = [
+    "DICOM_AE_ROLES",
+    "DICOM_AE_SOURCES",
+    "DICOM_AE_TITLE_MAX_BYTES",
+    "DICOM_DEFAULT_AE_TITLES",
+    "DICOM_DEFAULT_PORT",
+    "DICOM_DEVICE_CLASSES",
+    "DICOM_LEGACY_PORT",
+    "DICOMApplicationEntity",
+    "DICOMPeer",
+]

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -91,6 +91,13 @@ IP_ROLES: frozenset[str] = frozenset(
         "vrrp",
         "secondary",
         "gateway",
+        # Baseboard management controller — iDRAC / iLO / IPMI / Redfish
+        # (#722). Worth its own role rather than a tag: a BMC is a
+        # management-plane endpoint on a fragile embedded stack, and it
+        # is a routine casualty of ping sweeps and nmap runs. Naming the
+        # class is what lets an operator find every one of them and
+        # decide whether their subnet belongs behind ``do_not_probe``.
+        "bmc",
         # TLS-serving classifications (#118 Phase 2) — an IP in one of these
         # roles is auto-added as a TLS cert probe target by the discovery
         # reconciler (see TLS_SERVING_ROLES).
@@ -167,6 +174,18 @@ class IPSpace(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     )
     ddns_domain_override: Mapped[str | None] = mapped_column(String(255), nullable=True)
     ddns_ttl: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # ── Fragile-device probe suppression (issue #722) ────────────────────
+    # Root of the space → block → subnet chain. See ``Subnet`` for the
+    # full semantics; the short version is that this flag ORs downward
+    # (a space marked do-not-probe suppresses probes on every subnet
+    # under it, and no descendant can un-set it).
+    do_not_probe: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    do_not_probe_reason: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=sa_text("''")
+    )
 
     # ── VRF / routing annotation ─────────────────────────────────────────
     # First-class VRF binding (added by issue #86). The freeform
@@ -415,6 +434,17 @@ class IPBlock(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
         Boolean, nullable=False, default=True, server_default=sa_text("true")
     )
 
+    # ── Fragile-device probe suppression (issue #722) ─────────────────────
+    # Mid-chain link. Deliberately has NO ``*_inherit_settings`` toggle:
+    # unlike DDNS, this is a safety constraint, so it ORs downward rather
+    # than being overridable by a descendant. See ``Subnet``.
+    do_not_probe: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    do_not_probe_reason: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=sa_text("''")
+    )
+
     # ── VRF binding (issue #86) ───────────────────────────────────────────
     # Optional. NULL means "inherit from the parent block (recurse) or
     # ultimately from the IPSpace". Pinning a non-NULL value lets a
@@ -486,6 +516,16 @@ class Subnet(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
             "ix_subnet_bgp_should_advertise",
             "bgp_should_advertise",
             postgresql_where=sa_text("bgp_should_advertise = true"),
+        ),
+        # Fragile-device probe suppression (#722). Partial because the
+        # flagged rows are a small minority in any real estate, so the
+        # index is tiny and turns the discovery dispatcher's per-tick
+        # question into an index scan. Declared here as well as in the
+        # migration so autogenerate sees it and reports no drift.
+        Index(
+            "ix_subnet_do_not_probe",
+            "do_not_probe",
+            postgresql_where=sa_text("do_not_probe"),
         ),
         # Subnets cannot overlap within the same IP space (enforced at application layer)
     )
@@ -651,6 +691,47 @@ class Subnet(UUIDPrimaryKeyMixin, TimestampMixin, SoftDeleteMixin, Base):
     )
     last_discovery_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
+    )
+
+    # ── Fragile-device probe suppression (issue #722) ─────────────────
+    # "Do not send SpatiumDDI's own active probes at anything in here."
+    #
+    # Medical- and OT-device vendors explicitly instruct sites not to
+    # scan their VLANs — Swisslog's pneumatic-tube guide says to omit
+    # ping sweeps and nmap of any range supporting the PTS, and the same
+    # hazard covers patient monitors and the PLC / RTU class ``network.ot``
+    # already registers. Fragile IP stacks fault or drop off the network
+    # under a sweep. Until this flag existed there was no way to say so.
+    #
+    # Three properties of these two columns are load-bearing:
+    #
+    # 1. **It ORs down the space → block → subnet chain, and there is no
+    #    per-level inherit toggle.** DDNS resolves to the first
+    #    non-inheriting ancestor, so a descendant can override its
+    #    parent. That shape is wrong for a safety constraint: a hospital
+    #    that marks the clinical IPSpace do-not-probe must not have a
+    #    single subnet quietly opt back in. Any level saying "do not
+    #    probe" wins, and nothing downstream can un-say it. See
+    #    ``app.services.ipam.probe_policy``.
+    # 2. **It is not gated behind a vertical feature module.** It is a
+    #    constraint on *our* behaviour and a correctness fix to three
+    #    already-shipped features (#23 discovery sweeps, ``tools.nmap``,
+    #    ``tools.network``), so hiding it behind a default-off module
+    #    would leave the sites that need it unprotected by default.
+    # 3. **The reason travels with the flag.** Every refusal quotes it
+    #    back, because "422 — subnet marked do-not-probe" without "these
+    #    are Alaris pumps, per vendor bulletin X" just gets overridden by
+    #    the next operator who hits it.
+    #
+    # The flag suppresses probes; it does not hide the subnet, block
+    # allocation, or affect passive collection (PCAP #59, DHCP
+    # fingerprinting, ARP-table reads) — passive observation was never
+    # the hazard.
+    do_not_probe: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    do_not_probe_reason: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=sa_text("''")
     )
 
     # IPv6 auto-allocation policy (ignored for IPv4 subnets — those use

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -38,6 +38,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.address_set import AddressSet, validate_address_set_shape
 from app.models.auth import User
 from app.models.ipam import IPAddress, IPBlock, Subnet
+from app.services.ipam.probe_policy import check_probe_target
 from app.services.nmap import NmapArgError, build_argv
 from app.services.pcap import (
     PcapArgError,
@@ -439,6 +440,16 @@ async def _apply_run_nmap_scan(
     enforce_operation_permission(user, _OPERATIONS["run_nmap_scan"])
 
     target = args.target_ip.strip()
+    # Fragile-device suppression (#722). The REST route refuses these
+    # targets, so this path has to as well — a proposal the operator
+    # approved is still a scan, and the flag is a statement about the
+    # devices, not about which surface asked. Deliberately no override
+    # here: clearing the flag is a superadmin action taken deliberately
+    # on the tools page, not something to slip through an approval.
+    probe = await check_probe_target(db, target)
+    if probe.blocked:
+        raise ValueError(probe.message(action="Port scanning"))
+
     # Re-validate at apply time too — argv builder gates dangerous flags.
     try:
         build_argv(target, args.preset, args.port_spec, args.extra_args)

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -26,6 +26,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     copilot,
     dhcp,
     diagnostics,
+    dicom,
     dns,
     dns_threat,
     dnsbl,

--- a/backend/app/services/ai/tools/dicom.py
+++ b/backend/app/services/ai/tools/dicom.py
@@ -1,0 +1,235 @@
+"""Operator-Copilot tools for the DICOM AE registry (#723).
+
+Read-only tools over the AE Title namespace and the configured
+association map. All gated on the ``network.dicom`` feature module so
+they stay in lock-step with the feature surface.
+
+No ``propose_*`` write tools. Every write here is plain CRUD an operator
+performs in the UI, and shipping write proposals for a brand-new table
+before anyone has used it would be speculative.
+
+Nothing in this module returns patient data — the registry does not
+store any. See ``app.models.dicom`` for the guardrail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.models.auth import User
+from app.models.dicom import DICOMApplicationEntity, DICOMPeer
+from app.models.ipam import IPAddress
+from app.services.ai.tools.base import register_tool
+from app.services.dicom.titles import is_vendor_default
+
+_MODULE = "network.dicom"
+
+
+class FindDICOMAEsArgs(BaseModel):
+    ae_title: str | None = Field(
+        default=None,
+        description="Exact AE Title (case-sensitive — peers match titles exactly).",
+    )
+    device_class: str | None = Field(
+        default=None,
+        description=(
+            "modality / pacs / workstation / archive / router / worklist / printer / other."
+        ),
+    )
+    subnet_id: UUID | None = Field(default=None, description="Restrict to one subnet.")
+    unbound: bool | None = Field(
+        default=None,
+        description=(
+            "True = only reservations (titles with no host, held so the name is "
+            "not re-issued while peers still send to it)."
+        ),
+    )
+    tls_enabled: bool | None = Field(
+        default=None, description="Filter on whether the AE is recorded as using TLS."
+    )
+    q: str | None = Field(
+        default=None,
+        description="Case-insensitive substring on title, vendor, model, department or location.",
+    )
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+@register_tool(
+    name="find_dicom_aes",
+    description=(
+        "List DICOM Application Entities with their AE Title, host, port, "
+        "role and device class. Use this to answer 'which device holds AE "
+        "Title X', 'what imaging gear is on this subnet', or 'which AE "
+        "Titles are still vendor defaults'. AE Titles are unique "
+        "institution-wide, so an exact title lookup returns at most one row."
+    ),
+    args_model=FindDICOMAEsArgs,
+    category="network",
+    module=_MODULE,
+    # Read-only network inventory. No secrets, no patient data (the
+    # registry stores none), no device access.
+    default_enabled=True,
+)
+async def find_dicom_aes(
+    db: AsyncSession, user: User, args: FindDICOMAEsArgs
+) -> list[dict[str, Any]]:
+    _ = user
+    # OUTER join — an unbound reservation has no address row, and an
+    # inner join would hide exactly the rows most at risk of being
+    # silently re-issued.
+    stmt = select(DICOMApplicationEntity, IPAddress).outerjoin(
+        IPAddress, IPAddress.id == DICOMApplicationEntity.ip_address_id
+    )
+    if args.ae_title:
+        stmt = stmt.where(DICOMApplicationEntity.ae_title == args.ae_title.strip())
+    if args.device_class:
+        stmt = stmt.where(DICOMApplicationEntity.device_class == args.device_class)
+    if args.subnet_id is not None:
+        stmt = stmt.where(DICOMApplicationEntity.subnet_id == args.subnet_id)
+    if args.unbound is not None:
+        stmt = stmt.where(
+            DICOMApplicationEntity.ip_address_id.is_(None)
+            if args.unbound
+            else DICOMApplicationEntity.ip_address_id.is_not(None)
+        )
+    if args.tls_enabled is not None:
+        stmt = stmt.where(DICOMApplicationEntity.tls_enabled.is_(args.tls_enabled))
+    if args.q:
+        needle = f"%{args.q}%"
+        stmt = stmt.where(
+            or_(
+                DICOMApplicationEntity.ae_title.ilike(needle),
+                DICOMApplicationEntity.vendor.ilike(needle),
+                DICOMApplicationEntity.model_name.ilike(needle),
+                DICOMApplicationEntity.department.ilike(needle),
+                DICOMApplicationEntity.location.ilike(needle),
+            )
+        )
+    stmt = stmt.order_by(DICOMApplicationEntity.ae_title).limit(args.limit)
+
+    return [
+        {
+            "id": str(ae.id),
+            "ae_title": ae.ae_title,
+            "address": str(ip.address) if ip is not None else None,
+            "hostname": ip.hostname if ip is not None else None,
+            "port": ae.port,
+            "tls_enabled": ae.tls_enabled,
+            "role": ae.role,
+            "device_class": ae.device_class,
+            "vendor": ae.vendor,
+            "model_name": ae.model_name,
+            "department": ae.department,
+            "location": ae.location,
+            "subnet_id": str(ae.subnet_id) if ae.subnet_id else None,
+            "is_reservation": ae.ip_address_id is None,
+            "is_vendor_default": is_vendor_default(ae.ae_title),
+            "seen_via": ae.seen_via,
+        }
+        for ae, ip in (await db.execute(stmt)).all()
+    ]
+
+
+class CountDICOMAEsArgs(BaseModel):
+    subnet_id: UUID | None = Field(default=None, description="Restrict to one subnet.")
+
+
+@register_tool(
+    name="count_dicom_aes",
+    description=(
+        "Count DICOM Application Entities with a breakdown of unbound "
+        "reservations, plaintext (non-TLS) endpoints, and how many are "
+        "still on a vendor default AE Title. Quick health rollup for an "
+        "imaging estate."
+    ),
+    args_model=CountDICOMAEsArgs,
+    category="network",
+    module=_MODULE,
+    default_enabled=True,
+)
+async def count_dicom_aes(db: AsyncSession, user: User, args: CountDICOMAEsArgs) -> dict[str, Any]:
+    _ = user
+    stmt = select(
+        func.count(DICOMApplicationEntity.id),
+        func.count(DICOMApplicationEntity.id).filter(
+            DICOMApplicationEntity.ip_address_id.is_(None)
+        ),
+        func.count(DICOMApplicationEntity.id).filter(DICOMApplicationEntity.tls_enabled.is_(False)),
+    )
+    if args.subnet_id is not None:
+        stmt = stmt.where(DICOMApplicationEntity.subnet_id == args.subnet_id)
+    total, reservations, plaintext = (await db.execute(stmt)).one()
+
+    # Vendor-default detection is a Python-side set membership, so the
+    # titles come back and are counted here rather than in SQL. The
+    # registry is hundreds of rows, not millions.
+    title_stmt = select(DICOMApplicationEntity.ae_title)
+    if args.subnet_id is not None:
+        title_stmt = title_stmt.where(DICOMApplicationEntity.subnet_id == args.subnet_id)
+    titles = (await db.execute(title_stmt)).scalars().all()
+
+    return {
+        "total": int(total),
+        "reservations": int(reservations),
+        "plaintext": int(plaintext),
+        "vendor_default_titles": sum(1 for t in titles if is_vendor_default(t)),
+    }
+
+
+class FindDICOMPeersArgs(BaseModel):
+    ae_title: str | None = Field(
+        default=None,
+        description=(
+            "Restrict to edges touching this AE Title, in either direction. "
+            "This is the 'what breaks if I renumber it' question."
+        ),
+    )
+    limit: int = Field(default=200, ge=1, le=500)
+
+
+@register_tool(
+    name="find_dicom_peers",
+    description=(
+        "List configured DICOM associations as directed AE→AE edges with "
+        "the services each carries. Use this to answer 'what talks to this "
+        "modality' or 'what would break if this host is renumbered'. These "
+        "are relationships documented by the operator, not observed traffic."
+    ),
+    args_model=FindDICOMPeersArgs,
+    category="network",
+    module=_MODULE,
+    default_enabled=True,
+)
+async def find_dicom_peers(
+    db: AsyncSession, user: User, args: FindDICOMPeersArgs
+) -> list[dict[str, Any]]:
+    _ = user
+    source = aliased(DICOMApplicationEntity, name="source_ae")
+    target = aliased(DICOMApplicationEntity, name="target_ae")
+    stmt = (
+        select(DICOMPeer, source.ae_title, target.ae_title)
+        .join(source, source.id == DICOMPeer.source_ae_id)
+        .join(target, target.id == DICOMPeer.target_ae_id)
+        .order_by(source.ae_title.asc(), target.ae_title.asc())
+        .limit(args.limit)
+    )
+    if args.ae_title:
+        needle = args.ae_title.strip()
+        stmt = stmt.where(or_(source.ae_title == needle, target.ae_title == needle))
+
+    return [
+        {
+            "id": str(peer.id),
+            "source_ae_title": src,
+            "target_ae_title": dst,
+            "services": [str(s) for s in (peer.services or [])],
+            "notes": peer.notes,
+        }
+        for peer, src, dst in (await db.execute(stmt)).all()
+    ]

--- a/backend/app/services/ai/tools/ipam.py
+++ b/backend/app/services/ai/tools/ipam.py
@@ -40,6 +40,7 @@ from app.models.network_service import NetworkService
 from app.models.overlay import OverlayNetwork
 from app.models.vrf import VRF
 from app.services.ai.tools.base import register_tool
+from app.services.ipam.probe_policy import resolve_probe_policy
 from app.services.oui import bulk_lookup_vendors, is_voip_phone_vendor, normalize_mac_key
 from app.services.tags import apply_tag_filter
 
@@ -384,6 +385,11 @@ async def get_subnet_summary(
     )
     counts_rows = (await db.execute(counts_stmt)).all()
     by_status = {row[0]: int(row[1]) for row in counts_rows}
+    # Fragile-device probe suppression (#722). Surfaced here rather than
+    # as its own tool because the flag is a *field*, not a resource
+    # family — and because the copilot most needs it exactly when it is
+    # about to suggest a scan of a subnet it just looked up.
+    probe = await resolve_probe_policy(db, subnet)
     return {
         "id": str(subnet.id),
         "network": str(subnet.network),
@@ -395,6 +401,9 @@ async def get_subnet_summary(
         "total_ips": int(subnet.total_ips or 0),
         "allocated_ips": int(subnet.allocated_ips or 0),
         "by_status": by_status,
+        "do_not_probe": probe.blocked,
+        "do_not_probe_reason": probe.reason,
+        "do_not_probe_source": probe.source or None,
     }
 
 

--- a/backend/app/services/ai/tools/nettools.py
+++ b/backend/app/services/ai/tools/nettools.py
@@ -138,7 +138,7 @@ async def network_traceroute(
     user: User,  # noqa: ARG001
     args: NetworkTracerouteArgs,
 ) -> dict[str, Any]:
-    refusal = await _probe_refusal(db, args.host, action="Tracing a route to")
+    refusal = await _probe_refusal(db, args.host, action="Route tracing")
     if refusal is not None:
         return refusal
     try:

--- a/backend/app/services/ai/tools/nettools.py
+++ b/backend/app/services/ai/tools/nettools.py
@@ -29,6 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.auth import User
 from app.models.settings import PlatformSettings
 from app.services.ai.tools.base import register_tool
+from app.services.ipam.probe_policy import check_probe_target
 from app.services.nettools import (
     inspect_tls_cert,
     run_dig,
@@ -54,6 +55,26 @@ def _trim(text: str) -> str:
     return text[:_STDOUT_CHARS] + f"\n… (truncated, {len(text)} chars total)"
 
 
+async def _probe_refusal(db: AsyncSession, host: str, *, action: str) -> dict[str, Any] | None:
+    """Refusal payload when ``host`` is inside a do-not-probe scope (#722).
+
+    These tools drive the runners directly rather than going through the
+    ``/tools/*`` handlers, so they need the gate applied here or the
+    copilot becomes the one surface that still probes flagged devices.
+
+    Returns a plain error dict rather than raising: every other refusal
+    in this module answers that way, and it puts the operator's own
+    reason in front of the model so it can explain *why* instead of
+    retrying. There is no override — clearing the flag is a deliberate
+    superadmin action on the tools page, not something to talk a copilot
+    into.
+    """
+    verdict = await check_probe_target(db, host)
+    if not verdict.blocked:
+        return None
+    return {"host": host, "error": verdict.message(action=action)}
+
+
 # ── network_ping ────────────────────────────────────────────────────
 
 
@@ -73,10 +94,13 @@ class NetworkPingArgs(BaseModel):
     args_model=NetworkPingArgs,
 )
 async def network_ping(
-    db: AsyncSession,  # noqa: ARG001 — stateless
+    db: AsyncSession,
     user: User,  # noqa: ARG001
     args: NetworkPingArgs,
 ) -> dict[str, Any]:
+    refusal = await _probe_refusal(db, args.host, action="Pinging")
+    if refusal is not None:
+        return refusal
     try:
         res = await run_ping(args.host)
     except NetToolArgError as exc:
@@ -110,10 +134,13 @@ class NetworkTracerouteArgs(BaseModel):
     args_model=NetworkTracerouteArgs,
 )
 async def network_traceroute(
-    db: AsyncSession,  # noqa: ARG001
+    db: AsyncSession,
     user: User,  # noqa: ARG001
     args: NetworkTracerouteArgs,
 ) -> dict[str, Any]:
+    refusal = await _probe_refusal(db, args.host, action="Tracing a route to")
+    if refusal is not None:
+        return refusal
     try:
         res = await run_traceroute(args.host)
     except NetToolArgError as exc:
@@ -208,10 +235,13 @@ class NetworkPortTestArgs(BaseModel):
     args_model=NetworkPortTestArgs,
 )
 async def network_port_test(
-    db: AsyncSession,  # noqa: ARG001
+    db: AsyncSession,
     user: User,  # noqa: ARG001
     args: NetworkPortTestArgs,
 ) -> dict[str, Any]:
+    refusal = await _probe_refusal(db, args.host, action="Port testing")
+    if refusal is not None:
+        return refusal
     proto = args.protocol.strip().lower()
     if proto not in {"tcp", "udp"}:
         return {"error": "protocol must be 'tcp' or 'udp'"}
@@ -248,10 +278,13 @@ class NetworkTlsCertArgs(BaseModel):
     args_model=NetworkTlsCertArgs,
 )
 async def network_tls_cert(
-    db: AsyncSession,  # noqa: ARG001
+    db: AsyncSession,
     user: User,  # noqa: ARG001
     args: NetworkTlsCertArgs,
 ) -> dict[str, Any]:
+    refusal = await _probe_refusal(db, args.host, action="TLS probing")
+    if refusal is not None:
+        return refusal
     res = await inspect_tls_cert(args.host, args.port, args.server_name)
     return {
         "host": res.host,

--- a/backend/app/services/backup/sections.py
+++ b/backend/app/services/backup/sections.py
@@ -174,14 +174,16 @@ SECTIONS: tuple[Section, ...] = (
     ),
     Section(
         key="verticals",
-        label="Vertical network awareness (multicast / AV / BACnet / OT)",
+        label="Vertical network awareness (multicast / AV / BACnet / OT / DICOM)",
         description=(
             "The multicast stream registry (groups + PIM domains + "
             "ports + memberships) and the vertical descriptors layered "
             "on it: AV-over-IP flow profiles + reserved ranges "
             "(Dante / AES67 / SMPTE 2110), BACnet/IP devices with "
             "their internetwork-unique device instance numbers and "
-            "BBMD tables, and industrial-OT devices + Purdue zoning. "
+            "BBMD tables, industrial-OT devices + Purdue zoning, and "
+            "the DICOM AE Title registry with its configured "
+            "peer-association map. "
             "References IPAM (space / subnet / address) and VLANs."
         ),
         tables=(
@@ -194,6 +196,8 @@ SECTIONS: tuple[Section, ...] = (
             "bacnet_device",
             "ot_device",
             "ot_zone",
+            "dicom_ae",
+            "dicom_peer",
         ),
     ),
     Section(

--- a/backend/app/services/conformity/checks.py
+++ b/backend/app/services/conformity/checks.py
@@ -35,6 +35,7 @@ require a target should defensively short-circuit to
 from __future__ import annotations
 
 import ipaddress
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -48,12 +49,15 @@ from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
 from app.models.audit import AuditLog
 from app.models.av import AVFlowProfile, AVReservedRange
 from app.models.bacnet import BACnetDevice
+from app.models.dicom import DICOMApplicationEntity
 from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
 from app.models.multicast import MulticastGroup
 from app.models.nmap import NmapScan
 from app.models.ot import OTDevice, OTZone
 from app.services import alerts as alert_service
 from app.services.av.ranges import check_allocation_conflict
+from app.services.dicom.titles import is_vendor_default
+from app.services.ipam.probe_policy import resolve_probe_policy
 from app.services.ot.zones import (
     effective_zone_for_address,
     purdue_mismatch,
@@ -1150,6 +1154,331 @@ async def check_ot_zone_missing_purdue_level(
     )
 
 
+# ── Check: fragile-device probe safety (#722) ───────────────────────
+
+
+@register("fragile_subnet_probed")
+async def check_fragile_subnet_probed(
+    db: AsyncSession,
+    *,
+    target: object | None,
+    target_kind: str,
+    args: dict[str, Any],
+    now: datetime,
+) -> CheckOutcome:
+    """A subnet full of fragile gear is marked do-not-probe.
+
+    The ``do_not_probe`` flag (#722) is opt-in, which means the failure
+    mode it exists to prevent — SpatiumDDI sweeping a VLAN whose vendor
+    explicitly said not to — survives right up until somebody remembers
+    to set it. This check closes that gap by working backwards from the
+    registries: if an operator has told us a subnet holds OT devices,
+    DICOM modalities, or BMC / IPMI endpoints, they have already told us
+    it is fragile. Being asked "should this be do-not-probe?" beats
+    finding out from a stalled infusion pump.
+
+    Three signals, any one of which makes the subnet in scope:
+
+    * ``ot_device`` rows (#542) — PLCs, RTUs, HMIs. The class that
+      motivated the flag.
+    * ``dicom_ae`` rows (#723) — imaging modalities and PACS nodes. A CT
+      console that drops its network stack mid-study is a clinical
+      incident, not an inconvenience.
+    * ``IPAddress.role == "bmc"`` — management-plane controllers on
+      embedded stacks, and a routine casualty of nmap.
+
+    A subnet with none of those is NOT_APPLICABLE rather than a pass:
+    most subnets in a mixed estate are ordinary, and flagging them all
+    would bury the handful that matter. Suppression inherited from a
+    parent block or space counts — the check asks whether probes are
+    actually withheld, not whether this particular row holds the flag.
+    """
+    _ = args, now, target_kind
+    if target is None or not isinstance(target, Subnet):
+        return CheckOutcome.not_applicable(
+            "Target row missing or wrong kind for fragile_subnet_probed"
+        )
+
+    ot_count = (
+        await db.execute(
+            select(func.count(OTDevice.id))
+            .select_from(OTDevice)
+            .join(IPAddress, IPAddress.id == OTDevice.ip_address_id)
+            .where(IPAddress.subnet_id == target.id)
+        )
+    ).scalar_one()
+    dicom_count = (
+        await db.execute(
+            select(func.count(DICOMApplicationEntity.id))
+            .select_from(DICOMApplicationEntity)
+            .join(IPAddress, IPAddress.id == DICOMApplicationEntity.ip_address_id)
+            .where(IPAddress.subnet_id == target.id)
+        )
+    ).scalar_one()
+    bmc_count = (
+        await db.execute(
+            select(func.count(IPAddress.id)).where(
+                IPAddress.subnet_id == target.id,
+                IPAddress.role == "bmc",
+            )
+        )
+    ).scalar_one()
+
+    signals = {
+        "ot_devices": int(ot_count),
+        "dicom_aes": int(dicom_count),
+        "bmc_addresses": int(bmc_count),
+    }
+    if not any(signals.values()):
+        return CheckOutcome.not_applicable(
+            "Subnet carries no registered fragile devices (OT / DICOM / BMC)"
+        )
+
+    verdict = await resolve_probe_policy(db, target)
+    if verdict.blocked:
+        return CheckOutcome.passed(
+            f"Subnet is marked do-not-probe ({verdict.source})",
+            {**signals, "source": verdict.source, "reason": verdict.reason},
+        )
+
+    present = ", ".join(f"{count} {label}" for label, count in signals.items() if count)
+    return CheckOutcome.fail(
+        detail=(
+            f"Subnet carries fragile devices ({present}) but is not marked "
+            "do-not-probe — discovery sweeps, nmap and the reachability tools "
+            "will target it"
+        ),
+        diagnostic=signals,
+    )
+
+
+# ── Checks: DICOM AE registry (#723) ────────────────────────────────
+
+
+@register("dicom_ae_default_title")
+async def check_dicom_ae_default_title(
+    db: AsyncSession,
+    *,
+    target: object | None,
+    target_kind: str,
+    args: dict[str, Any],
+    now: datetime,
+) -> CheckOutcome:
+    """No AE is still using a vendor default title.
+
+    Platform-level, because the harm is estate-wide: two vendors' factory
+    defaults collide long before an institution runs out of names, and a
+    duplicate AE Title breaks C-MOVE, Storage Commitment and Modality
+    Worklist in ways that take days to trace. ``uq_dicom_ae_title``
+    prevents two rows sharing ``DCM4CHEE``, but it cannot prevent the
+    *devices* from doing so — which is why "has anyone changed this from
+    the box" is a check rather than a constraint.
+
+    Warns rather than fails: a default title is not invalid, and an
+    institution mid-migration may legitimately still have some.
+    """
+    _ = args, now, target, target_kind
+    rows = list(
+        (await db.execute(select(DICOMApplicationEntity.id, DICOMApplicationEntity.ae_title))).all()
+    )
+    if not rows:
+        return CheckOutcome.not_applicable("No DICOM application entities registered")
+
+    offenders = [title for _id, title in rows if is_vendor_default(title)]
+    if not offenders:
+        return CheckOutcome.passed(
+            f"All {len(rows)} AE Titles have been changed from vendor defaults",
+            {"ae_count": len(rows)},
+        )
+    return CheckOutcome.warn(
+        detail=(
+            f"{len(offenders)} AE Title(s) are still vendor defaults "
+            f"({', '.join(sorted(offenders)[:20])}) — defaults are the most "
+            "common cause of institution-wide AE Title collisions"
+        ),
+        diagnostic={"default_titles": sorted(offenders)[:20], "ae_count": len(rows)},
+    )
+
+
+@register("dicom_ae_title_convention")
+async def check_dicom_ae_title_convention(
+    db: AsyncSession,
+    *,
+    target: object | None,
+    target_kind: str,
+    args: dict[str, Any],
+    now: datetime,
+) -> CheckOutcome:
+    """AE Titles match the institution's naming convention.
+
+    The convention arrives as a **check argument** (``pattern``), not as
+    a table. Every institution has a different one — ``SITE_MODALITY_NN``
+    here, ``DEPT-VENDOR-N`` there — and modelling a convention registry
+    would be a schema for a value that is one regular expression per
+    site. Supplying it per-policy also lets an estate run two policies at
+    once during a rename programme, scoped by whatever ``target_filter``
+    the operator sets.
+
+    Not applicable when no pattern is configured — a policy with no
+    convention has nothing to assert, and failing it would just teach
+    operators to disable the check.
+    """
+    _ = now, target, target_kind
+    pattern = str(args.get("pattern") or "").strip()
+    if not pattern:
+        return CheckOutcome.not_applicable(
+            "No naming convention configured — set the 'pattern' check argument"
+        )
+    try:
+        matcher = re.compile(pattern)
+    except re.error as exc:
+        # A bad pattern is a policy configuration error, not an estate
+        # finding. Warn so it surfaces on the dashboard instead of
+        # silently passing every AE.
+        return CheckOutcome.warn(
+            detail=f"AE Title convention pattern is not a valid regular expression: {exc}",
+            diagnostic={"pattern": pattern},
+        )
+
+    titles = list((await db.execute(select(DICOMApplicationEntity.ae_title))).scalars().all())
+    if not titles:
+        return CheckOutcome.not_applicable("No DICOM application entities registered")
+
+    # ``search`` rather than ``fullmatch``: operators write conventions
+    # with their own anchors (``^CT\\d{2}$``), and silently anchoring for
+    # them would make a deliberately-unanchored pattern behave
+    # differently here than everywhere else they test it.
+    offenders = [t for t in titles if not matcher.search(t)]
+    if not offenders:
+        return CheckOutcome.passed(
+            f"All {len(titles)} AE Titles match {pattern!r}",
+            {"pattern": pattern, "ae_count": len(titles)},
+        )
+    return CheckOutcome.fail(
+        detail=(
+            f"{len(offenders)} of {len(titles)} AE Title(s) do not match the "
+            f"convention {pattern!r} ({', '.join(sorted(offenders)[:20])})"
+        ),
+        diagnostic={
+            "pattern": pattern,
+            "non_conforming": sorted(offenders)[:20],
+            "ae_count": len(titles),
+        },
+    )
+
+
+@register("dicom_ae_outside_hipaa_scope")
+async def check_dicom_ae_outside_hipaa_scope(
+    db: AsyncSession,
+    *,
+    target: object | None,
+    target_kind: str,
+    args: dict[str, Any],
+    now: datetime,
+) -> CheckOutcome:
+    """Every bound AE sits in a subnet flagged ``hipaa_scope``.
+
+    DICOM associations carry ePHI. If an imaging device is addressable
+    from a subnet nobody has declared in scope, then either the scope
+    declaration is wrong or the device is somewhere it should not be —
+    both are findings, and neither is visible without cross-referencing
+    the two registries, which is what this does.
+
+    Unbound reservations are excluded rather than counted as failures: a
+    title with no host is not carrying anything. Rows whose subnet is
+    unknown are excluded for the same reason — an unknown is an unknown,
+    and treating it as a violation would flood the report with missing
+    data (the same tri-state discipline as ``purdue_mismatch``).
+    """
+    _ = args, now, target, target_kind
+    rows = list(
+        (
+            await db.execute(
+                select(
+                    DICOMApplicationEntity.ae_title,
+                    Subnet.network,
+                    Subnet.hipaa_scope,
+                ).join(Subnet, Subnet.id == DICOMApplicationEntity.subnet_id)
+            )
+        ).all()
+    )
+    if not rows:
+        return CheckOutcome.not_applicable(
+            "No DICOM application entities are bound to a known subnet"
+        )
+
+    offenders = [
+        {"ae_title": title, "subnet": str(network)}
+        for title, network, in_scope in rows
+        if not in_scope
+    ]
+    if not offenders:
+        return CheckOutcome.passed(
+            f"All {len(rows)} bound AE(s) sit in HIPAA-scope subnets",
+            {"bound_ae_count": len(rows)},
+        )
+    return CheckOutcome.fail(
+        detail=(
+            f"{len(offenders)} AE(s) are bound to subnets not flagged hipaa_scope "
+            f"({', '.join(o['ae_title'] for o in offenders[:20])}) — DICOM "
+            "associations carry ePHI, so either the scope flag or the device "
+            "placement is wrong"
+        ),
+        diagnostic={"out_of_scope": offenders[:20], "bound_ae_count": len(rows)},
+    )
+
+
+@register("dicom_ae_no_tls")
+async def check_dicom_ae_no_tls(
+    db: AsyncSession,
+    *,
+    target: object | None,
+    target_kind: str,
+    args: dict[str, Any],
+    now: datetime,
+) -> CheckOutcome:
+    """AEs are recorded as using TLS.
+
+    Plaintext DICOM puts ePHI on the wire in the clear. This reports what
+    the *registry* records, not what the wire does — nothing here probes
+    an association, and it never will without going through the
+    do-not-probe gate (#722) first. That distinction matters when reading
+    the result: a fail here means "nobody has recorded this AE as
+    encrypted", which in practice is how an un-encrypted estate looks,
+    but the evidence is documentation rather than observation.
+
+    Warns by default because remediating this is a device-by-device
+    project with real clinical downtime, and a hard fail on day one would
+    put every hospital's dashboard permanently red. Operators who have
+    finished that project can raise the policy's severity.
+    """
+    _ = args, now, target, target_kind
+    rows = list(
+        (
+            await db.execute(
+                select(DICOMApplicationEntity.ae_title, DICOMApplicationEntity.tls_enabled)
+            )
+        ).all()
+    )
+    if not rows:
+        return CheckOutcome.not_applicable("No DICOM application entities registered")
+
+    plaintext = [title for title, tls in rows if not tls]
+    if not plaintext:
+        return CheckOutcome.passed(
+            f"All {len(rows)} AE(s) are recorded as TLS-enabled",
+            {"ae_count": len(rows)},
+        )
+    return CheckOutcome.warn(
+        detail=(
+            f"{len(plaintext)} of {len(rows)} AE(s) are not recorded as TLS-enabled "
+            f"({', '.join(sorted(plaintext)[:20])}) — plaintext DICOM carries ePHI "
+            "in the clear"
+        ),
+        diagnostic={"plaintext_aes": sorted(plaintext)[:20], "ae_count": len(rows)},
+    )
+
+
 CHECK_CATALOG: list[dict[str, Any]] = [
     {
         "name": "has_field",
@@ -1302,6 +1631,43 @@ CHECK_CATALOG: list[dict[str, Any]] = [
         "name": "ot_zone_missing_purdue_level",
         "label": "Subnet with OT devices declares an OT zone (advisory)",
         "supports": ["subnet"],
+        "args": [],
+    },
+    {
+        "name": "fragile_subnet_probed",
+        "label": "Subnet with fragile devices is marked do-not-probe",
+        "supports": ["subnet"],
+        "args": [],
+    },
+    {
+        "name": "dicom_ae_default_title",
+        "label": "No DICOM AE is still on a vendor default title",
+        "supports": ["platform"],
+        "args": [],
+    },
+    {
+        "name": "dicom_ae_title_convention",
+        "label": "DICOM AE Titles match the institution naming convention",
+        "supports": ["platform"],
+        "args": [
+            {
+                "name": "pattern",
+                "type": "string",
+                "required": True,
+                "label": "Regular expression every AE Title must match",
+            }
+        ],
+    },
+    {
+        "name": "dicom_ae_outside_hipaa_scope",
+        "label": "DICOM AEs sit in subnets flagged hipaa_scope",
+        "supports": ["platform"],
+        "args": [],
+    },
+    {
+        "name": "dicom_ae_no_tls",
+        "label": "DICOM AEs are recorded as TLS-enabled",
+        "supports": ["platform"],
         "args": [],
     },
 ]

--- a/backend/app/services/conformity/seeder.py
+++ b/backend/app/services/conformity/seeder.py
@@ -332,6 +332,26 @@ _BUILTIN_POLICIES: list[dict[str, object]] = [
         "check_kind": "ot_zone_missing_purdue_level",
         "check_args": {},
     },
+    # ── Fragile-device probe safety (issue #722) ────────────────────
+    {
+        "name": "Subnets with fragile devices are marked do-not-probe",
+        "description": (
+            "Medical- and OT-device vendors instruct sites not to scan their "
+            "VLANs, and fragile IP stacks genuinely fault under a sweep. Fails "
+            "when a subnet carries registered OT devices, DICOM application "
+            "entities, or BMC / IPMI addresses but is not covered by the "
+            "do-not-probe flag — meaning discovery sweeps, nmap and the "
+            "reachability tools will still target it. Suppression inherited "
+            "from a parent block or space counts as covered."
+        ),
+        "framework": "custom",
+        "reference": None,
+        "severity": "warning",
+        "target_kind": "subnet",
+        "target_filter": {},
+        "check_kind": "fragile_subnet_probed",
+        "check_args": {},
+    },
 ]
 
 

--- a/backend/app/services/dicom/__init__.py
+++ b/backend/app/services/dicom/__init__.py
@@ -1,0 +1,37 @@
+"""DICOM AE Title registry service layer — issue #723 (part of #543).
+
+**Safety posture: registry only.** Nothing in this package opens a
+socket. There is no C-ECHO, no C-FIND, no association negotiation of any
+kind — that probe is deferred to its own issue, and when it lands it
+must go through ``services/ipam/probe_policy`` (#722) first, because a
+probe reaching a modality mid-study is exactly the hazard that flag
+exists for.
+
+**No PHI, ever.** These modules move network identity: AE Titles, hosts,
+ports, roles, vendors. Nothing here reads, stores, or infers anything
+about patients, studies or images. Storing patient-identifiable data
+would make SpatiumDDI a HIPAA Business Associate, which is permanently
+out of scope — so the ``dicom_peer`` edges are *configured*
+relationships documented by the operator, never associations inferred
+from captured traffic.
+
+Modules (imported by full path, per the ``services/ot`` layout)::
+
+    from app.services.dicom.titles import validate_ae_title, is_vendor_default
+    from app.services.dicom.registry import assert_title_available, sync_subnet_id
+    from app.services.dicom.importer import parse_rows, plan_import, apply_plan
+
+``titles``    — the PS3.5 ``AE`` value-representation rules. 16 *bytes*,
+                spaces legal as padding, all-space forbidden, no
+                backslash, no control characters. Getting this wrong in
+                the strict direction rejects titles real devices use.
+``registry``  — the invariants behind ``uq_dicom_ae_title``: a friendly
+                conflict that names the other AE, and the denormalised
+                ``subnet_id`` sync.
+``importer``  — CSV ingest of the estate's existing AE table as a
+                preview → commit pair. Keyed on the title, not the
+                address, and a blank address registers an unbound
+                reservation rather than failing.
+"""
+
+from __future__ import annotations

--- a/backend/app/services/dicom/importer.py
+++ b/backend/app/services/dicom/importer.py
@@ -1,0 +1,745 @@
+"""CSV import of an estate's existing AE Title table — issue #723.
+
+Every hospital that runs DICOM already has this table. It is a
+spreadsheet, it is out of date, and it is the only record of which AE
+Titles are taken — which is exactly why PS3.15's registry object exists
+and exactly why nobody deploys it. So the first thing this module has to
+do well is ingest that spreadsheet without arguing with it.
+
+Shape follows the tree's other importers (``services/ot/importer.py``,
+``services/ipam_io``): a **preview** that is pure planning with zero
+writes, then a **commit** that re-plans from the same request body and
+applies it. Re-planning on commit is what keeps the server stateless
+between the two calls — no preview token to expire, and a concurrent
+change lands as a plan difference rather than a stale write.
+
+Two contracts differ from the OT importer, both because an AE Title is
+not an address:
+
+* **The join key is ``ae_title``, not the IP.** That is the identity
+  DICOM cares about, and it is what the unique constraint is on. Two
+  rows in one file sharing a title is a per-row error, because that is
+  the collision the whole registry exists to surface — reporting it at
+  import is strictly better than letting the second row win silently.
+* **The address column is optional.** A blank address is not an error,
+  it is an *unbound reservation*: a title still burned into peer
+  configuration across the estate whose host has been decommissioned.
+  Refusing those would force operators to omit exactly the rows most at
+  risk of being re-issued to someone else. A *supplied* address that
+  IPAM does not know is still an error, matching the OT importer — an
+  export is an enrichment source, not an address-plan source.
+
+Per-row errors never abort the batch: a 400-row table with three bad
+cells imports 397 and reports three.
+
+No network I/O, and no PHI: the columns below are network identity only.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import ipaddress
+import re
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import structlog
+from sqlalchemy import cast, select
+from sqlalchemy.dialects.postgresql import INET
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import AuditLog
+from app.models.dicom import (
+    DICOM_AE_ROLES,
+    DICOM_DEVICE_CLASSES,
+    DICOMApplicationEntity,
+)
+from app.models.ipam import IPAddress, Subnet
+from app.services.dicom.titles import AETitleError, validate_ae_title
+
+logger = structlog.get_logger(__name__)
+
+# Sized for "one institution's AE table". The commit writes one audit row
+# per affected AE inside a single transaction, so an unbounded batch
+# would turn a fat-fingered paste into a multi-minute lock.
+MAX_IMPORT_ROWS = 2000
+
+# Refused before a CSV reader is built over the body, so a multi-megabyte
+# paste fails fast. Generous enough that MAX_IMPORT_ROWS is always the
+# binding constraint for a real table.
+MAX_CSV_CHARS = 2_000_000
+
+# Fields an operator may map a CSV column onto. ``ae_title`` is the join
+# key and is mandatory; everything else is optional. The router's
+# column-map schema mirrors this tuple — keep the two in step.
+IMPORTABLE_FIELDS: tuple[str, ...] = (
+    "ae_title",
+    "address",
+    "port",
+    "tls_enabled",
+    "role",
+    "device_class",
+    "vendor",
+    "model_name",
+    "department",
+    "location",
+    "notes",
+)
+
+# Column widths from the model. Over-long values are reported as row
+# errors rather than silently truncated: a truncated vendor string is
+# worse than a rejected one, because nothing downstream can tell.
+_MAX_FIELD_LEN: dict[str, int] = {
+    "vendor": 255,
+    "model_name": 255,
+    "department": 255,
+    "location": 255,
+}
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+# Spellings that appear in real AE tables, mapped onto our vocabulary.
+# Applied after ``_normalize_token``, so casing / spaces / hyphens are
+# already flattened. Deliberately conservative — a guess that puts the
+# wrong class on a modality is worse than leaving it ``other``.
+_ROLE_ALIASES: dict[str, str] = {
+    "provider": "scp",
+    "server": "scp",
+    "service_class_provider": "scp",
+    "user": "scu",
+    "client": "scu",
+    "service_class_user": "scu",
+    "scu_scp": "both",
+    "scp_scu": "both",
+    "both_scu_and_scp": "both",
+}
+
+_CLASS_ALIASES: dict[str, str] = {
+    "ct": "modality",
+    "mr": "modality",
+    "mri": "modality",
+    "us": "modality",
+    "xr": "modality",
+    "cr": "modality",
+    "dx": "modality",
+    "nm": "modality",
+    "pet": "modality",
+    "scanner": "modality",
+    "pacs_archive": "archive",
+    "vna": "archive",
+    "long_term_archive": "archive",
+    "viewer": "workstation",
+    "reading_station": "workstation",
+    "diagnostic_workstation": "workstation",
+    "mwl": "worklist",
+    "modality_worklist": "worklist",
+    "ris": "worklist",
+    "gateway": "router",
+    "broker": "router",
+    "film_printer": "printer",
+    "dry_camera": "printer",
+}
+
+# Cell values accepted as booleans for ``tls_enabled``. Anything else is
+# a row error rather than a silent False — "was this AE recorded as
+# encrypted" is a question the ``dicom_ae_no_tls`` check reports on, so
+# guessing would put a wrong answer into a compliance report.
+_TRUE_CELLS: frozenset[str] = frozenset({"1", "true", "t", "yes", "y", "on", "tls", "enabled"})
+_FALSE_CELLS: frozenset[str] = frozenset({"0", "false", "f", "no", "n", "off", "", "none"})
+
+
+class DICOMImportError(ValueError):
+    """The import request is unusable as a whole (bad header, over cap).
+
+    Distinct from a per-row error: this aborts before any planning
+    happens and the router turns it into a 422. Per-row problems ride on
+    :class:`PlannedRow` and never stop the batch.
+    """
+
+
+@dataclass
+class ParsedRow:
+    """One CSV data row after column mapping + value validation."""
+
+    line: int
+    raw_title: str
+    ae_title: str | None
+    address: str | None = None
+    fields: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+@dataclass
+class PlannedRow:
+    """What the import would do (preview) or did do (commit) to one row.
+
+    ``action`` is one of ``create`` / ``update`` / ``skip`` / ``error``.
+    The commit path re-plans and mutates ``action`` in place only where
+    reality differed from the plan, so the response always describes what
+    actually happened.
+    """
+
+    line: int
+    ae_title: str
+    action: str
+    reason: str = ""
+    address: str = ""
+    ip_address_id: uuid.UUID | None = None
+    fields: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ImportOutcome:
+    """Counters returned by :func:`apply_plan`."""
+
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0
+    errors: int = 0
+    ae_ids: list[uuid.UUID] = field(default_factory=list)
+
+
+def _normalize_token(value: str) -> str:
+    """Flatten a free-text enum-ish cell to ``lower_snake``."""
+    return _NON_ALNUM.sub("_", value.strip().lower()).strip("_")
+
+
+def _normalize_header(value: str) -> str:
+    """Canonicalise a CSV header so column mapping is case/space blind."""
+    return _normalize_token(value)
+
+
+def _canonical_address(raw: str) -> str | None:
+    """Strip any ``/prefix`` an export tacked on and canonicalise the IP."""
+    text = raw.strip()
+    if "/" in text:
+        text = text.split("/", 1)[0]
+    try:
+        return str(ipaddress.ip_address(text))
+    except ValueError:
+        return None
+
+
+def _resolve_headers(
+    fieldnames: Sequence[str] | None, column_map: Mapping[str, str]
+) -> dict[str, str]:
+    """Map each requested field onto the real header string in the file.
+
+    Raises :class:`DICOMImportError` when a mapped column isn't in the
+    file. Failing loudly beats importing a column of blanks: a mistyped
+    mapping otherwise looks like a successful import that silently
+    dropped the department for every AE.
+    """
+    if not fieldnames:
+        raise DICOMImportError("CSV has no header row")
+    available = {_normalize_header(h): h for h in fieldnames if h}
+    resolved: dict[str, str] = {}
+    missing: list[str] = []
+    for target, wanted in column_map.items():
+        if target not in IMPORTABLE_FIELDS or not wanted:
+            continue
+        actual = available.get(_normalize_header(wanted))
+        if actual is None:
+            missing.append(wanted)
+            continue
+        resolved[target] = actual
+    if missing:
+        raise DICOMImportError(
+            "column(s) not found in the CSV header: "
+            + ", ".join(sorted(missing))
+            + f" (header is: {', '.join(h for h in fieldnames if h)})"
+        )
+    if "ae_title" not in resolved:
+        raise DICOMImportError("column_map.ae_title must name a column present in the CSV header")
+    return resolved
+
+
+def _cell(raw_row: Mapping[str, Any], headers: Mapping[str, str], target: str) -> str:
+    """Read one mapped cell as a stripped string ("" when absent/blank)."""
+    header = headers.get(target)
+    if header is None:
+        return ""
+    value = raw_row.get(header)
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _parse_one(
+    *,
+    line: int,
+    raw_row: Mapping[str, Any],
+    headers: Mapping[str, str],
+    default_port: int,
+    default_department: str,
+) -> ParsedRow:
+    raw_title = _cell(raw_row, headers, "ae_title")
+    if not raw_title:
+        return ParsedRow(line=line, raw_title="", ae_title=None, error="missing AE Title")
+    try:
+        ae_title = validate_ae_title(raw_title)
+    except AETitleError as exc:
+        return ParsedRow(line=line, raw_title=raw_title, ae_title=None, error=str(exc))
+
+    fields: dict[str, Any] = {}
+
+    # A blank address is an unbound reservation, not an error — see the
+    # module docstring. Only a *supplied* value that doesn't parse fails.
+    address_cell = _cell(raw_row, headers, "address")
+    address: str | None = None
+    if address_cell:
+        address = _canonical_address(address_cell)
+        if address is None:
+            return ParsedRow(
+                line=line,
+                raw_title=raw_title,
+                ae_title=ae_title,
+                error=f"{address_cell!r} is not a valid IP address",
+            )
+
+    port_cell = _cell(raw_row, headers, "port")
+    if port_cell:
+        try:
+            port = int(port_cell)
+        except ValueError:
+            return ParsedRow(
+                line=line,
+                raw_title=raw_title,
+                ae_title=ae_title,
+                error=f"port {port_cell!r} is not a number",
+            )
+        if not 1 <= port <= 65535:
+            return ParsedRow(
+                line=line,
+                raw_title=raw_title,
+                ae_title=ae_title,
+                error=f"port {port} is outside 1-65535",
+            )
+        fields["port"] = port
+    else:
+        fields["port"] = default_port
+
+    tls_cell = _normalize_token(_cell(raw_row, headers, "tls_enabled"))
+    if tls_cell in _TRUE_CELLS:
+        fields["tls_enabled"] = True
+    elif tls_cell in _FALSE_CELLS:
+        fields["tls_enabled"] = False
+    else:
+        return ParsedRow(
+            line=line,
+            raw_title=raw_title,
+            ae_title=ae_title,
+            error=(
+                f"tls_enabled {tls_cell!r} is not a yes/no value — "
+                "leave it blank rather than guessing"
+            ),
+        )
+
+    role_cell = _cell(raw_row, headers, "role")
+    if role_cell:
+        role = _normalize_token(role_cell)
+        role = _ROLE_ALIASES.get(role, role)
+        if role not in DICOM_AE_ROLES:
+            return ParsedRow(
+                line=line,
+                raw_title=raw_title,
+                ae_title=ae_title,
+                error=(
+                    f"unknown role {role_cell!r} "
+                    f"(expected one of {', '.join(sorted(DICOM_AE_ROLES))})"
+                ),
+            )
+        fields["role"] = role
+
+    class_cell = _cell(raw_row, headers, "device_class")
+    if class_cell:
+        device_class = _normalize_token(class_cell)
+        device_class = _CLASS_ALIASES.get(device_class, device_class)
+        if device_class not in DICOM_DEVICE_CLASSES:
+            return ParsedRow(
+                line=line,
+                raw_title=raw_title,
+                ae_title=ae_title,
+                error=(
+                    f"unknown device_class {class_cell!r} "
+                    f"(expected one of {', '.join(sorted(DICOM_DEVICE_CLASSES))})"
+                ),
+            )
+        fields["device_class"] = device_class
+
+    for target in ("vendor", "model_name", "department", "location", "notes"):
+        value = _cell(raw_row, headers, target)
+        if not value and target == "department":
+            value = default_department
+        if not value:
+            continue
+        limit = _MAX_FIELD_LEN.get(target)
+        if limit is not None and len(value) > limit:
+            return ParsedRow(
+                line=line,
+                raw_title=raw_title,
+                ae_title=ae_title,
+                error=f"{target} is longer than {limit} characters",
+            )
+        fields[target] = value
+
+    return ParsedRow(
+        line=line,
+        raw_title=raw_title,
+        ae_title=ae_title,
+        address=address,
+        fields=fields,
+    )
+
+
+def parse_rows(
+    csv_text: str,
+    *,
+    column_map: Mapping[str, str],
+    delimiter: str = ",",
+    default_port: int,
+    default_department: str = "",
+) -> list[ParsedRow]:
+    """Parse + validate the pasted CSV into per-row field dicts.
+
+    Only cells the operator mapped *and* filled land in
+    ``ParsedRow.fields`` — a blank cell means "no opinion", not "clear
+    this value", so re-importing a partial export cannot wipe a vendor
+    string someone typed in the UI. ``port`` is the one exception: it
+    always lands, defaulting to the request's ``default_port``, because
+    an AE with no port is not addressable and there is a conventional
+    answer.
+
+    Raises :class:`DICOMImportError` for whole-request problems (empty
+    body, missing mapped column, over the row cap). Per-row problems are
+    reported on the row.
+    """
+    if len(csv_text) > MAX_CSV_CHARS:
+        raise DICOMImportError(f"CSV body exceeds {MAX_CSV_CHARS} characters")
+    # Spreadsheets on Windows prepend a UTF-8 BOM, which would otherwise
+    # become part of the first header name and break its mapping.
+    body = csv_text.lstrip("﻿").strip()
+    if not body:
+        raise DICOMImportError("CSV body is empty")
+
+    reader = csv.DictReader(io.StringIO(body), delimiter=delimiter)
+    headers = _resolve_headers(reader.fieldnames, column_map)
+
+    rows: list[ParsedRow] = []
+    for line, raw_row in enumerate(reader, start=1):
+        if line > MAX_IMPORT_ROWS:
+            raise DICOMImportError(
+                f"CSV has more than {MAX_IMPORT_ROWS} data rows; split the table by department"
+            )
+        if not any((v or "").strip() for v in raw_row.values() if isinstance(v, str)):
+            # Trailing blank lines are normal in exported files.
+            continue
+        rows.append(
+            _parse_one(
+                line=line,
+                raw_row=raw_row,
+                headers=headers,
+                default_port=default_port,
+                default_department=default_department,
+            )
+        )
+    return rows
+
+
+async def _resolve_ipam_addresses(
+    db: AsyncSession, addresses: Sequence[str], *, space_id: uuid.UUID | None
+) -> dict[str, list[uuid.UUID]]:
+    """Bulk-resolve IP literals to IPAM address ids.
+
+    Returns every match per literal, because the same IP can legitimately
+    exist in more than one IPSpace. The caller turns a multi-match into a
+    row error telling the operator to scope the import with ``space_id``
+    rather than guessing which occupant they meant.
+
+    Casting the bind parameters to ``INET`` keeps the
+    ``ix_ip_address_address`` index usable; comparing ``host(address)``
+    as text would not.
+    """
+    if not addresses:
+        return {}
+    stmt = select(IPAddress.id, IPAddress.address).where(
+        IPAddress.address.in_([cast(a, INET) for a in addresses])
+    )
+    if space_id is not None:
+        stmt = stmt.join(Subnet, Subnet.id == IPAddress.subnet_id).where(
+            Subnet.space_id == space_id
+        )
+    found: dict[str, list[uuid.UUID]] = {}
+    for row_id, row_address in (await db.execute(stmt)).all():
+        found.setdefault(str(row_address), []).append(row_id)
+    return found
+
+
+async def plan_import(
+    db: AsyncSession,
+    parsed: Sequence[ParsedRow],
+    *,
+    overwrite_existing: bool = False,
+    space_id: uuid.UUID | None = None,
+) -> list[PlannedRow]:
+    """Turn parsed rows into a create/update/skip/error plan. No writes.
+
+    Failure modes, each reported per row rather than aborting the batch:
+
+    * the same AE Title appears twice in the file — the collision this
+      registry exists to surface, so it is reported rather than resolved
+      by last-write-wins;
+    * a supplied IP isn't in IPAM — the importer enriches inventory, it
+      does not invent it;
+    * a supplied IP exists in several IPSpaces — ambiguous, resolve by
+      passing ``space_id``;
+    * the title is already registered — ``skip`` unless
+      ``overwrite_existing`` flips it to ``update``.
+    """
+    wanted = sorted({r.address for r in parsed if r.address})
+    resolved = await _resolve_ipam_addresses(db, wanted, space_id=space_id)
+
+    titles = [r.ae_title for r in parsed if r.ae_title]
+    existing_titles: set[str] = set()
+    if titles:
+        existing_titles = {
+            title
+            for (title,) in (
+                await db.execute(
+                    select(DICOMApplicationEntity.ae_title).where(
+                        DICOMApplicationEntity.ae_title.in_(titles)
+                    )
+                )
+            ).all()
+        }
+
+    plan: list[PlannedRow] = []
+    seen: set[str] = set()
+    for row in parsed:
+        if row.error or row.ae_title is None:
+            plan.append(
+                PlannedRow(
+                    line=row.line,
+                    ae_title=row.raw_title,
+                    action="error",
+                    reason=row.error or "unusable row",
+                )
+            )
+            continue
+        if row.ae_title in seen:
+            plan.append(
+                PlannedRow(
+                    line=row.line,
+                    ae_title=row.ae_title,
+                    action="error",
+                    reason=(
+                        "duplicate AE Title earlier in this file — AE Titles are "
+                        "unique institution-wide, so this is a real collision to resolve"
+                    ),
+                )
+            )
+            continue
+        seen.add(row.ae_title)
+
+        ip_id: uuid.UUID | None = None
+        if row.address:
+            matches = resolved.get(row.address, [])
+            if not matches:
+                plan.append(
+                    PlannedRow(
+                        line=row.line,
+                        ae_title=row.ae_title,
+                        action="error",
+                        address=row.address,
+                        reason=(
+                            "no IPAM address matches — allocate it in IPAM first, or "
+                            "leave the address blank to register the title as a reservation"
+                        ),
+                    )
+                )
+                continue
+            if len(matches) > 1:
+                plan.append(
+                    PlannedRow(
+                        line=row.line,
+                        ae_title=row.ae_title,
+                        action="error",
+                        address=row.address,
+                        reason=(
+                            f"{len(matches)} IPAM addresses share this IP across spaces; "
+                            "re-run with space_id set to disambiguate"
+                        ),
+                    )
+                )
+                continue
+            ip_id = matches[0]
+
+        if row.ae_title in existing_titles and not overwrite_existing:
+            plan.append(
+                PlannedRow(
+                    line=row.line,
+                    ae_title=row.ae_title,
+                    action="skip",
+                    reason="AE Title already registered; set overwrite_existing to update",
+                    address=row.address or "",
+                    ip_address_id=ip_id,
+                    fields=row.fields,
+                )
+            )
+            continue
+
+        plan.append(
+            PlannedRow(
+                line=row.line,
+                ae_title=row.ae_title,
+                action="update" if row.ae_title in existing_titles else "create",
+                address=row.address or "",
+                ip_address_id=ip_id,
+                fields=row.fields,
+            )
+        )
+    return plan
+
+
+def _audit_row(
+    user: Any,
+    action: str,
+    ae_id: uuid.UUID,
+    display: str,
+    payload: dict[str, Any],
+) -> AuditLog:
+    """Build the per-AE audit row the import writes before commit.
+
+    One row per created/updated AE rather than a batch summary: "who
+    re-pointed the archive's AE Title at a different host" is
+    unanswerable from a summary, and it is exactly the question asked
+    after an imaging outage.
+    """
+    return AuditLog(
+        user_id=getattr(user, "id", None),
+        user_display_name=getattr(user, "display_name", "system"),
+        auth_source=getattr(user, "auth_source", "system"),
+        action=action,
+        resource_type="dicom_ae",
+        resource_id=str(ae_id),
+        resource_display=display,
+        new_value=payload,
+        result="success",
+    )
+
+
+async def apply_plan(
+    db: AsyncSession,
+    plan: Sequence[PlannedRow],
+    *,
+    user: Any,
+) -> ImportOutcome:
+    """Apply a plan produced by :func:`plan_import`. Caller commits.
+
+    Re-reads by title immediately before writing and flips the row's
+    ``action`` when reality moved under the plan — a create whose title
+    was registered in the meantime becomes an ``update`` rather than an
+    ``IntegrityError`` on ``uq_dicom_ae_title``, and an update whose row
+    was deleted becomes a create. The returned plan therefore describes
+    what happened, not what was intended.
+
+    Audit rows are written here (non-negotiable #4); the caller owns the
+    transaction so the whole import lands or none of it does.
+    """
+    outcome = ImportOutcome()
+    actionable = [r for r in plan if r.action in {"create", "update"}]
+    outcome.errors = sum(1 for r in plan if r.action == "error")
+    outcome.skipped = sum(1 for r in plan if r.action == "skip")
+
+    existing: dict[str, DICOMApplicationEntity] = {}
+    if actionable:
+        rows = (
+            (
+                await db.execute(
+                    select(DICOMApplicationEntity).where(
+                        DICOMApplicationEntity.ae_title.in_([r.ae_title for r in actionable])
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        existing = {r.ae_title: r for r in rows}
+
+    # Subnet ids for the anchors we're about to bind, resolved in one
+    # query rather than one per row — ``sync_subnet_id`` is per-row by
+    # design for the CRUD path, but an import is a batch.
+    anchor_ids = [r.ip_address_id for r in actionable if r.ip_address_id is not None]
+    subnet_by_ip: dict[uuid.UUID, uuid.UUID | None] = {}
+    if anchor_ids:
+        subnet_by_ip = {
+            row_id: subnet_id
+            for row_id, subnet_id in (
+                await db.execute(
+                    select(IPAddress.id, IPAddress.subnet_id).where(IPAddress.id.in_(anchor_ids))
+                )
+            ).all()
+        }
+
+    for row in actionable:
+        ae = existing.get(row.ae_title)
+        if ae is None:
+            ae = DICOMApplicationEntity(ae_title=row.ae_title, seen_via="import")
+            _apply_fields(ae, row.fields)
+            ae.ip_address_id = row.ip_address_id
+            ae.subnet_id = subnet_by_ip.get(row.ip_address_id) if row.ip_address_id else None
+            db.add(ae)
+            await db.flush()
+            existing[row.ae_title] = ae
+            row.action = "create"
+            outcome.created += 1
+            db.add(_audit_row(user, "create", ae.id, f"AE {row.ae_title}", dict(row.fields)))
+        else:
+            _apply_fields(ae, row.fields)
+            # Only re-point the anchor when the file actually supplied
+            # one. A table exported without an address column must not
+            # silently demote every AE to an unbound reservation.
+            if row.ip_address_id is not None:
+                ae.ip_address_id = row.ip_address_id
+                ae.subnet_id = subnet_by_ip.get(row.ip_address_id)
+            # The row was just re-stamped from the estate's AE table, so
+            # its provenance is the import even if it started as a manual
+            # entry — ``seen_via`` answers "where did the values currently
+            # in this row come from".
+            ae.seen_via = "import"
+            row.action = "update"
+            outcome.updated += 1
+            db.add(_audit_row(user, "update", ae.id, f"AE {row.ae_title}", dict(row.fields)))
+        outcome.ae_ids.append(ae.id)
+
+    logger.info(
+        "dicom_ae_import_applied",
+        created=outcome.created,
+        updated=outcome.updated,
+        skipped=outcome.skipped,
+        errors=outcome.errors,
+    )
+    return outcome
+
+
+def _apply_fields(ae: DICOMApplicationEntity, fields: Mapping[str, Any]) -> None:
+    """Copy validated cells onto the ORM row."""
+    for key, value in fields.items():
+        setattr(ae, key, value)
+
+
+__all__ = [
+    "IMPORTABLE_FIELDS",
+    "MAX_CSV_CHARS",
+    "MAX_IMPORT_ROWS",
+    "DICOMImportError",
+    "ImportOutcome",
+    "ParsedRow",
+    "PlannedRow",
+    "apply_plan",
+    "parse_rows",
+    "plan_import",
+]

--- a/backend/app/services/dicom/importer.py
+++ b/backend/app/services/dicom/importer.py
@@ -148,7 +148,11 @@ _CLASS_ALIASES: dict[str, str] = {
 # encrypted" is a question the ``dicom_ae_no_tls`` check reports on, so
 # guessing would put a wrong answer into a compliance report.
 _TRUE_CELLS: frozenset[str] = frozenset({"1", "true", "t", "yes", "y", "on", "tls", "enabled"})
-_FALSE_CELLS: frozenset[str] = frozenset({"0", "false", "f", "no", "n", "off", "", "none"})
+_FALSE_CELLS: frozenset[str] = frozenset({"0", "false", "f", "no", "n", "off", "none"})
+# Empty is deliberately NOT in ``_FALSE_CELLS``: "the operator left this
+# blank" and "the operator wrote no" are different statements, and only
+# the second should overwrite a stored ``true``.
+_BLANK_CELLS: frozenset[str] = frozenset({""})
 
 
 class DICOMImportError(ValueError):
@@ -319,12 +323,24 @@ def _parse_one(
                 error=f"port {port} is outside 1-65535",
             )
         fields["port"] = port
-    else:
+    elif "port" in headers:
+        # Column mapped but this row's cell is blank — fall back to the
+        # request default, which is what the default is for.
         fields["port"] = default_port
+    # No port column mapped at all: leave the key out entirely so an
+    # ``overwrite_existing`` re-import cannot silently reset every AE to
+    # 11112. The create path fills it from the model default instead.
 
     tls_cell = _normalize_token(_cell(raw_row, headers, "tls_enabled"))
     if tls_cell in _TRUE_CELLS:
         fields["tls_enabled"] = True
+    elif "tls_enabled" not in headers or tls_cell in _BLANK_CELLS:
+        # Same reasoning as ``port``, and it matters more here: a blank
+        # or absent TLS column re-importing as ``false`` would flip every
+        # encrypted AE to plaintext in the registry and poison
+        # ``dicom_ae_no_tls`` — a compliance report reading worse than
+        # reality is its own kind of wrong answer.
+        pass
     elif tls_cell in _FALSE_CELLS:
         fields["tls_enabled"] = False
     else:
@@ -408,10 +424,11 @@ def parse_rows(
     Only cells the operator mapped *and* filled land in
     ``ParsedRow.fields`` — a blank cell means "no opinion", not "clear
     this value", so re-importing a partial export cannot wipe a vendor
-    string someone typed in the UI. ``port`` is the one exception: it
-    always lands, defaulting to the request's ``default_port``, because
-    an AE with no port is not addressable and there is a conventional
-    answer.
+    string someone typed in the UI. That rule is what makes
+    ``overwrite_existing`` safe to re-run against a table that is missing
+    columns, and it is why ``port`` falls back to ``default_port`` only
+    when a port column was actually mapped, and why a blank
+    ``tls_enabled`` cell is left alone rather than read as ``false``.
 
     Raises :class:`DICOMImportError` for whole-request problems (empty
     body, missing mapped column, over the row cap). Per-row problems are

--- a/backend/app/services/dicom/registry.py
+++ b/backend/app/services/dicom/registry.py
@@ -1,0 +1,101 @@
+"""DICOM AE registry invariants — issue #723 Phase 1.
+
+The same shape as ``services/bacnet/registry.py``, and for the same
+reason: these helpers are about the *registry*, not about a request, and
+they must behave identically whichever surface (REST, CSV importer,
+Copilot proposal) drives them.
+
+* :func:`sync_subnet_id` keeps the denormalised ``subnet_id`` in step
+  with the AE's IPAM anchor.
+* :func:`assert_title_available` turns ``uq_dicom_ae_title`` into a
+  domain error naming the *conflicting* AE. "CT_1 is already used by the
+  Radiology CT" is the answer a PACS administrator needs; a raw
+  ``IntegrityError`` surfacing as a 500 is not.
+
+Zero network I/O: nothing in this package speaks DICOM. The C-ECHO
+verification probe that would confirm an AE answers at its recorded
+host:port is deferred to its own issue, and when it lands it must go
+through ``services/ipam/probe_policy`` (#722) first — a probe that
+reaches a modality mid-study is precisely the hazard that flag exists
+for.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dicom import DICOMApplicationEntity
+from app.models.ipam import IPAddress
+
+
+class AETitleConflict(Exception):
+    """An AE Title is already registered to another row.
+
+    Carries the conflicting AE's identity because "who has it" is the
+    only fact that helps resolve a collision — the caller turns this
+    into a 409 that names the other device rather than restating that
+    the name is taken.
+    """
+
+    def __init__(self, *, ae_title: str, existing_id: uuid.UUID) -> None:
+        self.ae_title = ae_title
+        self.existing_id = existing_id
+        super().__init__(
+            f"AE Title {ae_title!r} is already registered (application entity {existing_id})"
+        )
+
+
+async def sync_subnet_id(db: AsyncSession, ae: DICOMApplicationEntity) -> uuid.UUID | None:
+    """Point ``ae.subnet_id`` at its IPAM address's current subnet.
+
+    Call on create and on any update that changes ``ip_address_id``.
+    Mutates in place (no flush, no commit — the caller owns the
+    transaction) and returns the resolved subnet id.
+
+    ``None`` is a normal state here, not an error, and it means one of
+    two things: the AE is an unbound *reservation* (a title still in peer
+    configuration whose host was decommissioned — the case
+    ``ON DELETE SET NULL`` exists for), or the anchor row vanished
+    concurrently. Either way the AE drops out of per-subnet grouping
+    rather than being counted against the wrong subnet.
+    """
+    if ae.ip_address_id is None:
+        ae.subnet_id = None
+        return None
+    subnet_id = (
+        await db.execute(select(IPAddress.subnet_id).where(IPAddress.id == ae.ip_address_id))
+    ).scalar_one_or_none()
+    ae.subnet_id = subnet_id
+    return subnet_id
+
+
+async def assert_title_available(
+    db: AsyncSession,
+    ae_title: str,
+    *,
+    exclude_id: uuid.UUID | None = None,
+) -> None:
+    """Raise :class:`AETitleConflict` when the title is taken.
+
+    ``exclude_id`` is the row being edited, so re-submitting an AE's own
+    title in a PATCH is not reported as a conflict with itself.
+
+    This is a check-then-act against a uniquely-indexed column, so it is
+    racy by construction under concurrent creates — intentionally.
+    ``uq_dicom_ae_title`` is what guarantees uniqueness, and the caller
+    re-maps the resulting ``IntegrityError`` to the same 409. This
+    function exists to make the common case legible, not to enforce.
+    """
+    stmt = select(DICOMApplicationEntity.id).where(DICOMApplicationEntity.ae_title == ae_title)
+    if exclude_id is not None:
+        stmt = stmt.where(DICOMApplicationEntity.id != exclude_id)
+    existing = (await db.execute(stmt.limit(1))).scalar_one_or_none()
+    if existing is None:
+        return
+    raise AETitleConflict(ae_title=ae_title, existing_id=existing)
+
+
+__all__ = ["AETitleConflict", "assert_title_available", "sync_subnet_id"]

--- a/backend/app/services/dicom/titles.py
+++ b/backend/app/services/dicom/titles.py
@@ -1,0 +1,129 @@
+"""DICOM AE Title validation — issue #723.
+
+The AE Value Representation is defined in PS3.5, and getting it wrong in
+either direction has a real cost:
+
+* Too permissive and the registry accepts a title a device will reject,
+  so the plan fails at commissioning — which is the exact failure this
+  whole registry exists to prevent.
+* Too strict and the registry rejects titles real devices already use,
+  which is worse: it makes the tool unusable at the sites that most need
+  it, and the operator's fix is to stop using the tool.
+
+The rules, verbatim from the specification rather than from folklore:
+
+* maximum length **16 bytes** — bytes, not characters. Titles are
+  overwhelmingly ASCII in practice, but the ceiling is a byte count, so
+  it is measured as one.
+* the default character repertoire, **excluding backslash** (``0x5C``,
+  which is the DICOM multi-value delimiter) and **all control
+  characters**.
+* **spaces are legal.** They are non-significant padding — a title is
+  padded with trailing spaces to an even length on the wire — so leading
+  and trailing space is trimmed on the way in and internal spaces are
+  kept.
+* an **all-space value is forbidden**, which after trimming is the same
+  statement as "must not be empty".
+
+Note what is *not* a rule: there is no alphanumeric-only restriction and
+no case requirement. Titles like ``CT_1``, ``PACS-ARCHIVE`` and
+``MR SCANNER 2`` are all valid, and case is significant to peers — an AE
+configured as ``CT_ONE`` does not answer to ``ct_one``. So titles are
+stored as given and matched exactly; only the *default-title* advisory
+check compares case-insensitively, because that is asking "did anyone
+change this from the box" rather than "do these two match".
+"""
+
+from __future__ import annotations
+
+from app.models.dicom import DICOM_AE_TITLE_MAX_BYTES, DICOM_DEFAULT_AE_TITLES
+
+# 0x5C is the DICOM multi-value delimiter, so it can never appear inside
+# a single value. Control characters are excluded by the VR definition.
+_BACKSLASH = "\\"
+
+
+class AETitleError(ValueError):
+    """An AE Title violates the PS3.5 ``AE`` value representation.
+
+    Carries a message naming the specific rule broken, because "invalid
+    AE title" tells an operator nothing about whether their problem is
+    length, a stray tab pasted out of a spreadsheet, or the backslash a
+    vendor put in their conformance statement by mistake.
+    """
+
+
+def normalize_ae_title(raw: str) -> str:
+    """Trim padding and return the canonical stored form.
+
+    Spaces are non-significant padding per the VR, so trimming them is
+    normalization, not mutation of operator intent. Nothing else is
+    changed — in particular case is preserved, because peers match
+    titles exactly.
+    """
+    return (raw or "").strip()
+
+
+def validate_ae_title(raw: str) -> str:
+    """Return the normalized title, or raise :class:`AETitleError`.
+
+    Checks are ordered so the message names the most specific problem:
+    empty first (which also covers the forbidden all-space value), then
+    the character repertoire, then length. Length is checked last so a
+    title that is both too long *and* contains a backslash reports the
+    backslash — the operator can shorten a name themselves, but a
+    forbidden character usually means the value was mis-transcribed.
+    """
+    title = normalize_ae_title(raw)
+    if not title:
+        # Also the all-space case, which the specification forbids
+        # explicitly: after trimming padding there is nothing left.
+        raise AETitleError("AE Title must not be empty or all spaces")
+
+    if _BACKSLASH in title:
+        raise AETitleError(
+            "AE Title must not contain a backslash — it is the DICOM "
+            "multi-value delimiter and cannot appear inside a single value"
+        )
+
+    control = [ch for ch in title if ord(ch) < 0x20 or ord(ch) == 0x7F]
+    if control:
+        raise AETitleError(
+            "AE Title must not contain control characters "
+            f"(found {', '.join(f'0x{ord(ch):02X}' for ch in sorted(set(control)))}) — "
+            "this usually means the value was pasted out of a spreadsheet cell"
+        )
+
+    encoded = len(title.encode("utf-8"))
+    if encoded > DICOM_AE_TITLE_MAX_BYTES:
+        # Report bytes, not characters, and say so: a 16-character title
+        # with a non-ASCII character in it is over the limit, and an
+        # operator counting characters will not see why.
+        raise AETitleError(
+            f"AE Title must be at most {DICOM_AE_TITLE_MAX_BYTES} bytes " f"(this one is {encoded})"
+        )
+    return title
+
+
+def is_vendor_default(title: str) -> bool:
+    """Is this a known out-of-the-box vendor default?
+
+    Compared case-insensitively on the trimmed value, because the
+    question is "did anyone change this from the box", and a device
+    shipped as ``ANY-SCP`` that someone re-typed as ``Any-SCP`` is
+    equally un-changed.
+
+    Advisory by design: a default title is not invalid, it is just the
+    single most common cause of the estate-wide collisions this registry
+    exists to prevent — two vendors' defaults collide long before anyone
+    runs out of names.
+    """
+    return normalize_ae_title(title).lower() in DICOM_DEFAULT_AE_TITLES
+
+
+__all__ = [
+    "AETitleError",
+    "is_vendor_default",
+    "normalize_ae_title",
+    "validate_ae_title",
+]

--- a/backend/app/services/factory_reset/sections.py
+++ b/backend/app/services/factory_reset/sections.py
@@ -256,7 +256,8 @@ FACTORY_SECTIONS: tuple[FactorySection, ...] = (
             "ports, memberships) and the vertical descriptors layered "
             "on it — AV-over-IP flow profiles + reserved ranges, "
             "BACnet/IP devices + BBMD tables, industrial-OT devices + "
-            "Purdue zoning. The underlying IPAM addresses and subnets "
+            "Purdue zoning, and the DICOM AE Title registry + peer "
+            "map. The underlying IPAM addresses and subnets "
             "are untouched; only the vertical metadata is destroyed."
         ),
         phrase="DESTROY-VERTICALS",
@@ -265,6 +266,8 @@ FACTORY_SECTIONS: tuple[FactorySection, ...] = (
             "av_flow_profile",
             "av_reserved_range",
             "bacnet_device",
+            "dicom_peer",
+            "dicom_ae",
             "ot_device",
             "ot_zone",
             "multicast_membership",

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -144,6 +144,12 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
         description="Building-automation device registry — internetwork-unique device instance numbers, BACnet network numbers, and per-subnet BBMD designation, each attached to an existing IPAM address. Documents the BACnet topology (including the exactly-one-BBMD-per-subnet rule); never reads or writes device objects.",
     ),
     ModuleSpec(
+        id="network.dicom",
+        label="DICOM AE registry",
+        group="Network",
+        description="Medical-imaging Application Entity registry — the institution-wide-unique AE Titles that PS3.15 Annex H specifies a registry for and that in practice live in a spreadsheet, plus the configured AE→AE association map behind 'what breaks if I renumber this host'. Network identity only: no patient data, ever, and no DICOM traffic is read or generated.",
+    ),
+    ModuleSpec(
         id="network.ot",
         label="OT / industrial devices",
         group="Network",

--- a/backend/app/services/ipam/probe_policy.py
+++ b/backend/app/services/ipam/probe_policy.py
@@ -1,0 +1,292 @@
+"""Fragile-device probe suppression — issue #722.
+
+Medical- and OT-device vendors instruct sites *not* to scan their VLANs.
+Swisslog's pneumatic-tube deployment guide says to omit ping sweeps and
+nmap scans of any range supporting the PTS; the same hazard covers
+patient monitors, BMC / IPMI management endpoints, and the PLC / RTU
+class ``network.ot`` already registers. Fragile IP stacks fault or fall
+off the network under a sweep, and SpatiumDDI ships three features that
+actively violate that instruction — the #23 discovery sweep,
+``tools.nmap``, and the ``tools.network`` reachability tools.
+
+This module is the one place that answers *"may we send packets at
+this?"*. Every prober asks it; nothing re-implements the walk.
+
+Resolution semantics
+--------------------
+
+The flag lives on ``IPSpace`` / ``IPBlock`` / ``Subnet`` and **ORs down
+the chain**: a scope is suppressed if it, or *any* of its ancestors, sets
+``do_not_probe``. This is deliberately unlike
+``services.dns.ddns.resolve_effective_ddns``, which walks to the first
+non-inheriting ancestor and lets a descendant override its parent. A
+hospital that marks its clinical IPSpace do-not-probe must not have one
+subnet quietly opt back in, so there is no per-level inherit toggle and
+no way to un-set the flag from below. The *first* level found saying so
+(nearest-first: subnet, then the block chain upward, then the space)
+supplies the reason, because that is the most specific explanation an
+operator wrote down.
+
+Fail-safe direction
+-------------------
+
+Where this module is unsure, it is unsure in the direction of *fewer*
+refusals, not more: a target it cannot map to a subnet is allowed. That
+is the honest behaviour for a guard whose input is an arbitrary operator
+-supplied host string — refusing everything unmappable would make the
+tools page unusable against off-IPAM infrastructure, and the operator
+who did not model a network in IPAM never told us it was fragile. It
+does mean the flag protects what IPAM knows about, which is the same
+scope every other IPAM-derived guard has. :func:`resolve_probe_policy`,
+which takes an already-resolved ``Subnet`` row, has no such ambiguity.
+
+Passive collection is out of scope by design: PCAP (#59), DHCP
+fingerprinting, RA sniffing and ARP-table reads observe traffic that
+already exists. The hazard is packets *we* originate.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import func as sa_func
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+
+# Depth cap for the block walk. ``IPBlock.parent_block_id`` is a
+# self-referential FK with no database-level cycle guard, so a row that
+# somehow became its own ancestor (a bad restore, a hand-written UPDATE)
+# would spin this loop forever inside a request. Real hierarchies are a
+# handful of levels deep; 64 is far past any legitimate design and cheap
+# to bound.
+_MAX_BLOCK_DEPTH = 64
+
+
+@dataclass(frozen=True)
+class ProbeVerdict:
+    """Whether a probe may proceed, and — when not — why.
+
+    ``reason`` is the operator's own note from whichever level set the
+    flag. It is empty when they set the flag without writing one, which
+    is why every caller renders it conditionally rather than assuming a
+    sentence is there. ``source`` identifies the level (``"subnet:<id>"``
+    / ``"block:<id>"`` / ``"space:<id>"``) so an operator chasing an
+    unexpected refusal can find the row that produced it without
+    guessing at the hierarchy.
+    """
+
+    blocked: bool
+    reason: str = ""
+    source: str = ""
+    scope_label: str = ""
+
+    @property
+    def allowed(self) -> bool:
+        return not self.blocked
+
+    def message(self, *, action: str = "Active probing") -> str:
+        """Operator-facing sentence for a refusal.
+
+        Always names the scope and the level that set the flag; appends
+        the operator's reason when there is one. Callers use this for
+        the 422 detail and for the skip note in a run summary, so the
+        same wording shows up wherever the refusal surfaces.
+        """
+        where = self.scope_label or self.source or "this scope"
+        base = f"{action} is suppressed for {where}: it is marked do-not-probe"
+        if self.reason:
+            return f"{base} — {self.reason}"
+        return base
+
+    def as_dict(self) -> dict[str, object]:
+        """JSON-safe form for audit rows and API payloads."""
+        return {
+            "blocked": self.blocked,
+            "reason": self.reason,
+            "source": self.source,
+            "scope": self.scope_label,
+        }
+
+
+ALLOWED = ProbeVerdict(blocked=False)
+
+
+async def resolve_probe_policy(db: AsyncSession, subnet: Subnet) -> ProbeVerdict:
+    """Effective do-not-probe verdict for one subnet.
+
+    Checks the subnet, then walks its block chain upward, then the
+    containing space, stopping at the first level that sets the flag.
+    Nearest-first ordering is what makes the reported reason the most
+    specific one an operator wrote.
+
+    Soft-deleted ancestors are honoured rather than skipped: a block in
+    the trash still describes the gear that is physically there, and
+    resuming probes because someone deleted a container row would be the
+    wrong way for this to fail.
+    """
+    if subnet.do_not_probe:
+        return ProbeVerdict(
+            blocked=True,
+            reason=subnet.do_not_probe_reason or "",
+            source=f"subnet:{subnet.id}",
+            scope_label=str(subnet.network),
+        )
+
+    seen: set[uuid.UUID] = set()
+    current = await db.get(IPBlock, subnet.block_id) if subnet.block_id else None
+    depth = 0
+    while current is not None and depth < _MAX_BLOCK_DEPTH:
+        if current.id in seen:
+            break
+        seen.add(current.id)
+        depth += 1
+        if current.do_not_probe:
+            return ProbeVerdict(
+                blocked=True,
+                reason=current.do_not_probe_reason or "",
+                source=f"block:{current.id}",
+                scope_label=str(current.network),
+            )
+        current = (
+            await db.get(IPBlock, current.parent_block_id) if current.parent_block_id else None
+        )
+
+    space = await db.get(IPSpace, subnet.space_id) if subnet.space_id else None
+    if space is not None and space.do_not_probe:
+        return ProbeVerdict(
+            blocked=True,
+            reason=space.do_not_probe_reason or "",
+            source=f"space:{space.id}",
+            scope_label=space.name,
+        )
+    return ALLOWED
+
+
+async def resolve_probe_policy_for_subnet_id(
+    db: AsyncSession, subnet_id: uuid.UUID
+) -> ProbeVerdict:
+    """:func:`resolve_probe_policy` for a subnet id, allowing on a miss.
+
+    A subnet that vanished between the caller's read and this call is
+    not a fragile subnet — it is no subnet — so it is allowed, and
+    whatever the caller does next will fail on its own missing row.
+    """
+    subnet = await db.get(Subnet, subnet_id)
+    if subnet is None:
+        return ALLOWED
+    return await resolve_probe_policy(db, subnet)
+
+
+async def _subnets_covering_ip(db: AsyncSession, addr: str) -> list[Subnet]:
+    """Every subnet whose network contains ``addr``.
+
+    Plural because IPSpaces are isolated routing domains and may overlap:
+    the same 10.0.0.0/8 address can legitimately exist in three spaces.
+    We have no way to tell which one an operator meant from a bare IP, so
+    the caller treats a flag on *any* of them as suppressing — the safe
+    reading, and the one that matches what the flag is asserting ("this
+    address hosts fragile gear").
+    """
+    stmt = select(Subnet).where(
+        Subnet.deleted_at.is_(None),
+        Subnet.network.op(">>=")(sa_func.inet(addr)),
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def _subnets_overlapping_network(db: AsyncSession, cidr: str) -> list[Subnet]:
+    """Every subnet that contains, or is contained by, ``cidr``.
+
+    Both directions matter for a CIDR target: scanning ``10.1.0.0/16``
+    reaches the hosts of a flagged ``10.1.7.0/24`` inside it, and
+    scanning ``10.1.7.128/25`` reaches hosts of a flagged ``10.1.0.0/16``
+    around it. Either way packets land on suppressed addresses.
+    """
+    stmt = select(Subnet).where(
+        Subnet.deleted_at.is_(None),
+        or_(
+            Subnet.network.op(">>=")(sa_func.cidr(cidr)),
+            Subnet.network.op("<<=")(sa_func.cidr(cidr)),
+        ),
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def _subnets_for_hostname(db: AsyncSession, name: str) -> list[Subnet]:
+    """Subnets of every IPAM address recorded under ``name``.
+
+    A hostname target is matched against ``IPAddress.hostname`` rather
+    than resolved through DNS. Two reasons, both about the guard being
+    trustworthy: a DNS lookup inside an authorization check makes the
+    verdict depend on a network round-trip that can time out or return a
+    different answer than the probe will use (a TOCTOU the operator
+    cannot see), and it lets a hostile record steer the guard. Matching
+    our own inventory is exact, offline, and reflects the same rows the
+    operator flagged.
+
+    Matched case-insensitively on the short label, and also against
+    ``hostname`` as the first label of a supplied FQDN, because
+    operators type both forms into the tools page.
+    """
+    needle = name.strip().rstrip(".").lower()
+    if not needle:
+        return []
+    candidates = {needle, needle.split(".", 1)[0]}
+    stmt = (
+        select(Subnet)
+        .join(IPAddress, IPAddress.subnet_id == Subnet.id)
+        .where(
+            Subnet.deleted_at.is_(None),
+            sa_func.lower(IPAddress.hostname).in_(candidates),
+        )
+        .distinct()
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def check_probe_target(db: AsyncSession, target: str) -> ProbeVerdict:
+    """Verdict for an operator-supplied probe target.
+
+    Accepts what the probing surfaces actually accept: a bare IP, a CIDR
+    (nmap scans ranges), or a hostname. Resolution per form is documented
+    on the three ``_subnets_*`` helpers above.
+
+    Returns the first blocking verdict found across the matched subnets.
+    An unmappable target is allowed — see the module docstring on the
+    fail-safe direction.
+    """
+    raw = (target or "").strip()
+    if not raw:
+        return ALLOWED
+
+    subnets: list[Subnet]
+    try:
+        ipaddress.ip_address(raw)
+    except ValueError:
+        try:
+            ipaddress.ip_network(raw, strict=False)
+        except ValueError:
+            subnets = await _subnets_for_hostname(db, raw)
+        else:
+            subnets = await _subnets_overlapping_network(db, raw)
+    else:
+        subnets = await _subnets_covering_ip(db, raw)
+
+    for subnet in subnets:
+        verdict = await resolve_probe_policy(db, subnet)
+        if verdict.blocked:
+            return verdict
+    return ALLOWED
+
+
+__all__ = [
+    "ALLOWED",
+    "ProbeVerdict",
+    "check_probe_target",
+    "resolve_probe_policy",
+    "resolve_probe_policy_for_subnet_id",
+]

--- a/backend/app/services/ipam/probe_policy.py
+++ b/backend/app/services/ipam/probe_policy.py
@@ -95,6 +95,11 @@ class ProbeVerdict:
         the operator's reason when there is one. Callers use this for
         the 422 detail and for the skip note in a run summary, so the
         same wording shows up wherever the refusal surfaces.
+
+        ``action`` is interpolated as the subject of "… is suppressed
+        for <scope>", so it must be a bare gerund phrase: "Pinging",
+        "Port scanning", "Route tracing". A trailing preposition
+        ("Tracing a route to") strands mid-sentence.
         """
         where = self.scope_label or self.source or "this scope"
         base = f"{action} is suppressed for {where}: it is marked do-not-probe"

--- a/backend/app/services/ipam/probe_policy.py
+++ b/backend/app/services/ipam/probe_policy.py
@@ -115,6 +115,28 @@ class ProbeVerdict:
 ALLOWED = ProbeVerdict(blocked=False)
 
 
+async def _get_including_deleted[RowT](
+    db: AsyncSession, model: type[RowT], row_id: uuid.UUID | None
+) -> RowT | None:
+    """Load one row by primary key, soft-deleted rows included.
+
+    ``app.db._filter_soft_deleted`` injects ``deleted_at IS NULL`` into
+    every SELECT — including the one behind ``db.get()`` — unless the
+    statement opts out with ``include_deleted=True``. For this module
+    that default is backwards: a trashed ancestor would silently
+    disappear from the walk and the guard would fail *open*, which is
+    the one direction a safety flag must never fail.
+    """
+    if row_id is None:
+        return None
+    stmt = (
+        select(model)
+        .where(model.id == row_id)  # type: ignore[attr-defined]
+        .execution_options(include_deleted=True)
+    )
+    return (await db.execute(stmt)).scalars().first()
+
+
 async def resolve_probe_policy(db: AsyncSession, subnet: Subnet) -> ProbeVerdict:
     """Effective do-not-probe verdict for one subnet.
 
@@ -126,7 +148,11 @@ async def resolve_probe_policy(db: AsyncSession, subnet: Subnet) -> ProbeVerdict
     Soft-deleted ancestors are honoured rather than skipped: a block in
     the trash still describes the gear that is physically there, and
     resuming probes because someone deleted a container row would be the
-    wrong way for this to fail.
+    wrong way for this to fail. That is why every load here goes through
+    :func:`_get_including_deleted` — the session-wide ``deleted_at IS
+    NULL`` filter (``app.db._filter_soft_deleted``) applies to
+    ``db.get()`` too, so a plain fetch would return ``None`` for a
+    trashed block, truncate the walk, and fail *open*.
     """
     if subnet.do_not_probe:
         return ProbeVerdict(
@@ -137,7 +163,9 @@ async def resolve_probe_policy(db: AsyncSession, subnet: Subnet) -> ProbeVerdict
         )
 
     seen: set[uuid.UUID] = set()
-    current = await db.get(IPBlock, subnet.block_id) if subnet.block_id else None
+    current = (
+        await _get_including_deleted(db, IPBlock, subnet.block_id) if subnet.block_id else None
+    )
     depth = 0
     while current is not None and depth < _MAX_BLOCK_DEPTH:
         if current.id in seen:
@@ -152,10 +180,12 @@ async def resolve_probe_policy(db: AsyncSession, subnet: Subnet) -> ProbeVerdict
                 scope_label=str(current.network),
             )
         current = (
-            await db.get(IPBlock, current.parent_block_id) if current.parent_block_id else None
+            await _get_including_deleted(db, IPBlock, current.parent_block_id)
+            if current.parent_block_id
+            else None
         )
 
-    space = await db.get(IPSpace, subnet.space_id) if subnet.space_id else None
+    space = await _get_including_deleted(db, IPSpace, subnet.space_id) if subnet.space_id else None
     if space is not None and space.do_not_probe:
         return ProbeVerdict(
             blocked=True,
@@ -191,9 +221,10 @@ async def _subnets_covering_ip(db: AsyncSession, addr: str) -> list[Subnet]:
     reading, and the one that matches what the flag is asserting ("this
     address hosts fragile gear").
     """
-    stmt = select(Subnet).where(
-        Subnet.deleted_at.is_(None),
-        Subnet.network.op(">>=")(sa_func.inet(addr)),
+    stmt = (
+        select(Subnet)
+        .where(Subnet.network.op(">>=")(sa_func.inet(addr)))
+        .execution_options(include_deleted=True)
     )
     return list((await db.execute(stmt)).scalars().all())
 
@@ -205,13 +236,22 @@ async def _subnets_overlapping_network(db: AsyncSession, cidr: str) -> list[Subn
     reaches the hosts of a flagged ``10.1.7.0/24`` inside it, and
     scanning ``10.1.7.128/25`` reaches hosts of a flagged ``10.1.0.0/16``
     around it. Either way packets land on suppressed addresses.
+
+    ``cidr`` must already be masked to its network address — the caller
+    normalises it, because Postgres's ``cidr()`` cast rejects a value
+    with host bits set (``cidr('10.0.0.5/24')`` is an error, not a
+    coercion) and nmap happily accepts one. Raising a DataError out of a
+    guard would turn a mistyped target into a 500.
     """
-    stmt = select(Subnet).where(
-        Subnet.deleted_at.is_(None),
-        or_(
-            Subnet.network.op(">>=")(sa_func.cidr(cidr)),
-            Subnet.network.op("<<=")(sa_func.cidr(cidr)),
-        ),
+    stmt = (
+        select(Subnet)
+        .where(
+            or_(
+                Subnet.network.op(">>=")(sa_func.cidr(cidr)),
+                Subnet.network.op("<<=")(sa_func.cidr(cidr)),
+            )
+        )
+        .execution_options(include_deleted=True)
     )
     return list((await db.execute(stmt)).scalars().all())
 
@@ -239,11 +279,9 @@ async def _subnets_for_hostname(db: AsyncSession, name: str) -> list[Subnet]:
     stmt = (
         select(Subnet)
         .join(IPAddress, IPAddress.subnet_id == Subnet.id)
-        .where(
-            Subnet.deleted_at.is_(None),
-            sa_func.lower(IPAddress.hostname).in_(candidates),
-        )
+        .where(sa_func.lower(IPAddress.hostname).in_(candidates))
         .distinct()
+        .execution_options(include_deleted=True)
     )
     return list((await db.execute(stmt)).scalars().all())
 
@@ -268,11 +306,14 @@ async def check_probe_target(db: AsyncSession, target: str) -> ProbeVerdict:
         ipaddress.ip_address(raw)
     except ValueError:
         try:
-            ipaddress.ip_network(raw, strict=False)
+            # ``strict=False`` because operators type ``10.1.7.5/24``;
+            # the masked ``network`` form is what reaches Postgres, whose
+            # ``cidr()`` cast rejects host bits outright.
+            network = ipaddress.ip_network(raw, strict=False)
         except ValueError:
             subnets = await _subnets_for_hostname(db, raw)
         else:
-            subnets = await _subnets_overlapping_network(db, raw)
+            subnets = await _subnets_overlapping_network(db, str(network))
     else:
         subnets = await _subnets_covering_ip(db, raw)
 

--- a/backend/app/services/nettools/schemas.py
+++ b/backend/app/services/nettools/schemas.py
@@ -227,6 +227,12 @@ class HostRequest(BaseModel):
     # Optional run-from vantage. None ⇒ run on the api container (server),
     # i.e. exactly today's behaviour. See NetToolTarget above.
     target: NetToolTarget | None = None
+    # Proceed against a scope marked do-not-probe (#722). Superadmin
+    # only, audited, per-request. Routing-only like ``target`` — it is
+    # stripped before the params are shipped to an appliance vantage,
+    # because the decision is made here and the supervisor has no
+    # business re-deciding it.
+    override_do_not_probe: bool = False
 
     @field_validator("host")
     @classmethod
@@ -333,6 +339,8 @@ class PortTestRequest(BaseModel):
     timeout_seconds: float = Field(default=5.0, ge=0.5, le=15.0)
     # Optional run-from vantage. None ⇒ server. See NetToolTarget.
     target: NetToolTarget | None = None
+    # See HostRequest.override_do_not_probe (#722).
+    override_do_not_probe: bool = False
 
     @field_validator("host")
     @classmethod
@@ -373,6 +381,8 @@ class TlsCertRequest(BaseModel):
     timeout_seconds: float = Field(default=8.0, ge=0.5, le=15.0)
     # Optional run-from vantage. None ⇒ server. See NetToolTarget.
     target: NetToolTarget | None = None
+    # See HostRequest.override_do_not_probe (#722).
+    override_do_not_probe: bool = False
 
     @field_validator("host")
     @classmethod

--- a/backend/app/services/profiling/auto_profile.py
+++ b/backend/app/services/profiling/auto_profile.py
@@ -33,6 +33,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.ipam import IPAddress, Subnet
 from app.models.nmap import NmapScan
+from app.services.ipam.probe_policy import resolve_probe_policy
 from app.services.nmap.runner import PRESETS
 
 logger = structlog.get_logger(__name__)
@@ -100,6 +101,20 @@ async def maybe_enqueue_for_lease(
     """
     try:
         if not getattr(subnet, "auto_profile_on_dhcp_lease", False):
+            return None
+
+        # Fragile-device suppression (#722). Checked before the refresh
+        # window, not after: this is the one guard that must not be
+        # bypassable by tuning the others, and a suppressed subnet should
+        # never reach the "how recently did we scan" question at all.
+        probe = await resolve_probe_policy(db, subnet)
+        if probe.blocked:
+            logger.info(
+                "auto_profile_skip_do_not_probe",
+                subnet=str(subnet.id),
+                ip=str(ipam_row.address),
+                source=probe.source,
+            )
             return None
 
         if _within_refresh_window(ipam_row.last_profiled_at, subnet.auto_profile_refresh_days):

--- a/backend/app/services/profiling/auto_profile.py
+++ b/backend/app/services/profiling/auto_profile.py
@@ -38,6 +38,17 @@ from app.services.nmap.runner import PRESETS
 
 logger = structlog.get_logger(__name__)
 
+
+class ProbeSuppressed(Exception):
+    """The target subnet is marked do-not-probe (#722).
+
+    Distinct from the concurrency-cap ``ValueError`` because the two
+    mean opposite things to a caller: the cap is transient and worth
+    retrying, this is a deliberate standing refusal. The message is the
+    resolved verdict's, so the operator's own reason reaches the UI.
+    """
+
+
 # Cap on simultaneous active profile scans per subnet. A small number
 # is intentional — these are background scans triggered by lease
 # events, and a renewal storm shouldn't swamp the worker pool.
@@ -204,12 +215,24 @@ async def enqueue_now(
     Caller owns the commit.
 
     Raises ``ValueError`` if the cap is exceeded so the API endpoint
-    can return a 429-style response. Picks the subnet's configured
-    preset by default; an override can be passed for ad-hoc scans.
+    can return a 429-style response, and :class:`ProbeSuppressed` when
+    the subnet is marked do-not-probe (#722) — a distinct type because
+    that one is not a "try again in a moment" condition. Picks the
+    subnet's configured preset by default; an override can be passed for
+    ad-hoc scans.
+
+    "The operator just told us to scan again" is why the refresh window
+    is bypassed, and exactly why the do-not-probe flag is *not*: the
+    operator who clicked Re-profile is usually not the one who wrote the
+    vendor bulletin onto the subnet.
     """
     subnet = await db.get(Subnet, ipam_row.subnet_id)
     if subnet is None:
         raise ValueError(f"subnet {ipam_row.subnet_id} not found")
+
+    probe = await resolve_probe_policy(db, subnet)
+    if probe.blocked:
+        raise ProbeSuppressed(probe.message(action="Profiling"))
 
     in_flight = await _count_in_flight_profiles(db, subnet.id)
     if in_flight >= MAX_CONCURRENT_PROFILES_PER_SUBNET:
@@ -247,6 +270,7 @@ async def enqueue_now(
 
 __all__ = [
     "MAX_CONCURRENT_PROFILES_PER_SUBNET",
+    "ProbeSuppressed",
     "enqueue_now",
     "maybe_enqueue_for_lease",
 ]

--- a/backend/app/services/wol_scheduler/verify.py
+++ b/backend/app/services/wol_scheduler/verify.py
@@ -90,6 +90,7 @@ from app.models.wol_schedule import WolRunTarget
 # Same connect/RST probe + port set the IPAM discovery sweep uses, so a host that
 # reads as alive to a discovery scan reads as alive to a wake verify.
 from app.services.ipam.discovery import _TCP_PROBE_PORTS, _tcp_alive
+from app.services.ipam.probe_policy import check_probe_target
 from app.services.nettools.runner import run_ping
 
 if TYPE_CHECKING:
@@ -391,6 +392,31 @@ async def verify_run_targets(
         )
         return []
 
+    # Fragile-device suppression (#722). Resolved up front, before the
+    # fan-out, because the gather is deliberately DB-free — and it has to
+    # be a *set of addresses* rather than a per-row check for the same
+    # reason. Only the ACTIVE chain is suppressed: the passive path below
+    # reads sightings that already happened, so a suppressed host can
+    # still be verified without a packet being sent at it. Waking a
+    # fragile device is fine; poking it to confirm is not.
+    suppressed_addresses: set[str] = set()
+    if active_chain:
+        for row in probeable:
+            if not row.address:
+                continue
+            address = str(row.address)
+            if address in suppressed_addresses:
+                continue
+            if (await check_probe_target(db, address)).blocked:
+                suppressed_addresses.add(address)
+    if suppressed_addresses:
+        logger.info(
+            "wol_verify_active_suppressed",
+            run_id=str(run.id),
+            attempt=attempt,
+            suppressed=len(suppressed_addresses),
+        )
+
     # Fan out the active probes (network-bound); no DB access inside the gather.
     sem = asyncio.Semaphore(_PROBE_CONCURRENCY)
 
@@ -406,6 +432,11 @@ async def verify_run_targets(
         """
         trail: list[dict[str, Any]] = []
         if not row.address or not active_chain:
+            return row, False, None, trail
+        if str(row.address) in suppressed_addresses:
+            # Not "down" — unprobed. Falls through to the passive read
+            # with an empty trail, which is the honest record: we never
+            # asked, so we have no active evidence either way.
             return row, False, None, trail
         async with sem:
             for m in active_chain:

--- a/backend/app/tasks/ipam_discovery.py
+++ b/backend/app/tasks/ipam_discovery.py
@@ -36,6 +36,7 @@ from app.config import settings
 from app.models.audit import AuditLog
 from app.models.ipam import Subnet
 from app.services.ipam.discovery import reconcile_subnet, sweep_subnet
+from app.services.ipam.probe_policy import resolve_probe_policy
 
 logger = structlog.get_logger(__name__)
 
@@ -74,6 +75,46 @@ async def _run_subnet_discovery_async(subnet_id_str: str) -> dict[str, Any]:
             subnet = await db.get(Subnet, subnet_id)
             if subnet is None or subnet.deleted_at is not None:
                 return {"status": "skipped", "reason": "subnet_missing"}
+
+            # Fragile-device suppression (#722). Checked here rather than
+            # only in the dispatcher because on-demand runs and re-tried
+            # tasks reach this function directly — the sweep must not be
+            # reachable by any path that skipped the gate. Stamp
+            # last_discovery_at so a flagged-but-still-enabled subnet
+            # doesn't get re-queued every 60 s tick, and record the
+            # reason on the audit row so the operator can see the sweep
+            # is being deliberately withheld rather than silently failing.
+            probe = await resolve_probe_policy(db, subnet)
+            if probe.blocked:
+                subnet.last_discovery_at = datetime.now(UTC)
+                db.add(
+                    AuditLog(
+                        user_id=None,
+                        user_display_name="system",
+                        auth_source="system",
+                        action="discover",
+                        resource_type="subnet",
+                        resource_id=str(subnet.id),
+                        resource_display=str(subnet.network),
+                        result="skipped",
+                        new_value={"skipped": "do_not_probe", **probe.as_dict()},
+                    )
+                )
+                await db.commit()
+                logger.info(
+                    "ipam.discovery.skipped_do_not_probe",
+                    subnet_id=subnet_id_str,
+                    network=str(subnet.network),
+                    source=probe.source,
+                )
+                # ``reason`` stays the machine-readable skip code, as on
+                # every other skip path here; the verdict rides in its own
+                # key so its free-text ``reason`` cannot shadow it.
+                return {
+                    "status": "skipped",
+                    "reason": "do_not_probe",
+                    "do_not_probe": probe.as_dict(),
+                }
 
             sweep = await sweep_subnet(str(subnet.network))
             if sweep is None:
@@ -138,6 +179,7 @@ async def _dispatch_due_async() -> int:
     engine = create_async_engine(settings.database_url, future=True)
     factory = async_sessionmaker(engine, expire_on_commit=False)
     queued = 0
+    skipped_do_not_probe = 0
     try:
         async with factory() as db:
             now = datetime.now(UTC)
@@ -160,12 +202,25 @@ async def _dispatch_due_async() -> int:
                 )
                 if not due:
                     continue
+                # Don't even queue a suppressed subnet (#722). The task
+                # re-checks and would bail anyway; skipping here keeps a
+                # flagged estate from generating a worker task per subnet
+                # per interval forever, and leaves last_discovery_at
+                # untouched so nothing looks like it ran.
+                if (await resolve_probe_policy(db, s)).blocked:
+                    skipped_do_not_probe += 1
+                    continue
                 try:
                     run_subnet_discovery.delay(str(s.id))
                     queued += 1
                 except Exception as exc:  # noqa: BLE001 — broker down? give up quietly
                     logger.warning("ipam.discovery.dispatch_enqueue_failed", error=str(exc))
                     break
+        if skipped_do_not_probe:
+            logger.info(
+                "ipam.discovery.dispatch_skipped_do_not_probe",
+                skipped=skipped_do_not_probe,
+            )
         return queued
     finally:
         await engine.dispose()

--- a/backend/app/tasks/snmp_poll.py
+++ b/backend/app/tasks/snmp_poll.py
@@ -36,6 +36,7 @@ from app.models.network import (
     NetworkInterface,
     NetworkNeighbour,
 )
+from app.services.ipam.probe_policy import check_probe_target
 from app.services.snmp import (
     cross_reference_arp,
     test_connection,
@@ -293,6 +294,25 @@ async def _poll_device_async(device_id: str) -> dict[str, Any]:
             ).scalar_one_or_none()
             if row is None:
                 summary["status"] = "locked_or_missing"
+                return summary
+
+            # Fragile-device suppression (#722). An SNMP poll is a
+            # unicast request we originate at the device, so it belongs
+            # under the same flag as ping and nmap — the fact that the
+            # payload is a GET rather than an echo is not what makes a
+            # fragile stack fall over. ``next_poll_at`` is deliberately
+            # NOT advanced: the poll did not happen, so nothing about
+            # its schedule should move.
+            verdict = await check_probe_target(db, str(row.ip_address))
+            if verdict.blocked:
+                logger.info(
+                    "snmp_poll_skipped_do_not_probe",
+                    device_id=device_id,
+                    host=str(row.ip_address),
+                    source=verdict.source,
+                )
+                summary["status"] = "do_not_probe"
+                summary["reason"] = verdict.reason
                 return summary
 
             now = datetime.now(UTC)

--- a/backend/app/tasks/tls_certs.py
+++ b/backend/app/tasks/tls_certs.py
@@ -33,6 +33,7 @@ from app.db import task_session
 from app.models.audit import AuditLog
 from app.models.settings import PlatformSettings
 from app.models.tls_cert import TLSCertProbe, TLSCertTarget
+from app.services.ipam.probe_policy import check_probe_target
 from app.services.tls_cert.discovery import reconcile_discovered_targets
 from app.services.tls_cert.probe import probe_one
 
@@ -82,9 +83,19 @@ async def _probe_due_async() -> dict[str, Any]:
         )
 
         scanned = changed = unreachable = 0
+        suppressed = 0
         errors: list[str] = []
         for t in rows:
             label = t.display_name or t.host
+            # Fragile-device suppression (#722). A TLS handshake is an
+            # active probe like any other, and a BMC / imaging console
+            # that answers 443 is exactly the class the flag protects.
+            # Skipped silently — a scheduled sweep withheld on purpose is
+            # not an error, and logging one per target every 6 h would
+            # bury the real failures.
+            if (await check_probe_target(db, t.host)).blocked:
+                suppressed += 1
+                continue
             try:
                 result = await probe_one(db, t, default_interval_hours=interval, now=now)
                 if not result.ok:
@@ -164,6 +175,7 @@ async def _probe_due_async() -> dict[str, Any]:
             "scanned": scanned,
             "changed": changed,
             "unreachable": unreachable,
+            "suppressed": suppressed,
             "interval_hours": interval,
             "errors": len(errors),
         }
@@ -247,6 +259,11 @@ async def _probe_one_by_id_async(target_id: str) -> dict[str, Any]:
         t = await db.get(TLSCertTarget, uuid.UUID(target_id))
         if t is None:
             return {"status": "missing", "target_id": target_id}
+        # Same gate as the sweep (#722) — this fires on target create, so
+        # without it the very first probe of a flagged host still goes out.
+        verdict = await check_probe_target(db, t.host)
+        if verdict.blocked:
+            return {"status": "suppressed", "reason": verdict.reason, "source": verdict.source}
         ps = await db.get(PlatformSettings, _SINGLETON_ID)
         interval = _clamp_interval(ps.tls_cert_check_interval_hours if ps is not None else None)
         result = await probe_one(db, t, default_interval_hours=interval)

--- a/backend/tests/test_dicom.py
+++ b/backend/tests/test_dicom.py
@@ -1,0 +1,562 @@
+"""DICOM AE Title registry tests — issue #723 (part of #543).
+
+Two load-bearing areas.
+
+**The unique-title constraint.** AE Titles are institution-wide-unique by
+specification (PS3.15 Annex H), and a duplicate breaks C-MOVE, Storage
+Commitment and Modality Worklist in ways that take days to trace. The
+registry has to answer a collision with a 409 naming the AE that already
+holds the title, not a raw ``IntegrityError`` surfacing as a 500.
+
+**The AE value representation.** 16 *bytes*, spaces legal as padding,
+all-space forbidden, no backslash, no control characters. Getting this
+wrong in the strict direction is the failure the registry exists to
+prevent, arriving from our own validator: a title real devices use gets
+rejected, so the recorded plan fails at commissioning.
+
+Also covers the nullable-anchor reservation semantics (the deliberate
+difference from BACnet's CASCADE), the peer/impact surface, the CSV
+importer, and the ``network.dicom`` feature-module gate.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import Group, Role, User
+from app.models.dicom import DICOMApplicationEntity
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services.dicom.titles import (
+    AETitleError,
+    is_vendor_default,
+    validate_ae_title,
+)
+
+
+async def _make_superadmin(db: AsyncSession) -> tuple[User, str]:
+    u = User(
+        username=f"admin-{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(u)
+    await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+async def _make_user_with_perm(db: AsyncSession, perm: dict | None) -> tuple[User, str]:
+    u = User(
+        username=f"user-{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="User",
+        hashed_password=hash_password("x"),
+        is_superadmin=False,
+    )
+    db.add(u)
+    await db.flush()
+    if perm is not None:
+        role = Role(name=f"r-{uuid.uuid4().hex[:6]}", description="", permissions=[perm])
+        db.add(role)
+        await db.flush()
+        group = Group(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+        group.roles = [role]
+        group.users = [u]
+        db.add(group)
+        await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+async def _make_subnet(db: AsyncSession, network: str = "10.30.0.0/24") -> Subnet:
+    space = IPSpace(name=f"dicom-space-{uuid.uuid4().hex[:8]}")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, name="b", network="10.30.0.0/16")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, name="s", network=network)
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _make_ip(db: AsyncSession, subnet: Subnet, addr: str) -> IPAddress:
+    ip = IPAddress(subnet_id=subnet.id, address=addr, status="allocated")
+    db.add(ip)
+    await db.flush()
+    return ip
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── AE Title value representation ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("CT1", "CT1"),
+        # Spaces are legal padding — trimmed, not rejected.
+        ("  PACS_MAIN  ", "PACS_MAIN"),
+        # Internal spaces are legal and significant enough to keep.
+        ("MR SCANNER 2", "MR SCANNER 2"),
+        # Hyphens, underscores, digits and mixed case are all fine: there
+        # is no alphanumeric-only rule in the VR.
+        ("Dept-CT_01", "Dept-CT_01"),
+        # Exactly at the 16-byte ceiling.
+        ("ABCDEFGHIJKLMNOP", "ABCDEFGHIJKLMNOP"),
+    ],
+)
+def test_valid_ae_titles_are_accepted(raw: str, expected: str) -> None:
+    assert validate_ae_title(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,fragment",
+    [
+        ("", "empty"),
+        # All-space is explicitly forbidden by the specification, and
+        # after trimming padding it is the same statement as empty.
+        ("    ", "empty"),
+        # 0x5C is the DICOM multi-value delimiter.
+        ("CT\\1", "backslash"),
+        ("CT\t1", "control characters"),
+        ("ABCDEFGHIJKLMNOPQ", "16 bytes"),
+    ],
+)
+def test_invalid_ae_titles_are_rejected(raw: str, fragment: str) -> None:
+    with pytest.raises(AETitleError) as exc:
+        validate_ae_title(raw)
+    assert fragment in str(exc.value)
+
+
+def test_length_ceiling_is_bytes_not_characters() -> None:
+    """The VR caps at 16 *bytes*. A 16-character title with a non-ASCII
+    character in it is over the limit, and an operator counting
+    characters will not see why unless the message says bytes."""
+    fifteen_chars_seventeen_bytes = "ÄÖÜÄÖÜÄÖÜÄÖÜÄÖÜ"  # 15 chars, 30 bytes
+    with pytest.raises(AETitleError) as exc:
+        validate_ae_title(fifteen_chars_seventeen_bytes)
+    assert "bytes" in str(exc.value)
+
+
+def test_vendor_default_detection_is_case_insensitive() -> None:
+    """ "Did anyone change this from the box" — a device shipped as
+    ANY-SCP and re-typed as Any-SCP is equally un-changed."""
+    assert is_vendor_default("DCM4CHEE") is True
+    assert is_vendor_default("any-scp") is True
+    assert is_vendor_default(" Orthanc ") is True
+    assert is_vendor_default("CT1_RADIOLOGY") is False
+
+
+# ── AE CRUD ───────────────────────────────────────────────────────────
+
+
+async def test_ae_crud_round_trip(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_superadmin(db_session)
+    subnet = await _make_subnet(db_session)
+    ip = await _make_ip(db_session, subnet, "10.30.0.5")
+    await db_session.commit()
+    headers = _auth(token)
+
+    created = await client.post(
+        "/api/v1/dicom/aes",
+        headers=headers,
+        json={
+            "ae_title": "CT1_RAD",
+            "ip_address_id": str(ip.id),
+            "port": 104,
+            "device_class": "modality",
+            "role": "both",
+            "vendor": "Siemens",
+            "model_name": "SOMATOM",
+            "department": "Radiology",
+        },
+    )
+    assert created.status_code == 201, created.text
+    body = created.json()
+    ae_id = body["id"]
+    assert body["ae_title"] == "CT1_RAD"
+    assert body["address"] == "10.30.0.5"
+    # Denormalised copy the per-subnet grouping + conformity read.
+    assert body["subnet_id"] == str(subnet.id)
+    assert body["is_reservation"] is False
+    assert body["is_vendor_default"] is False
+
+    listed = await client.get("/api/v1/dicom/aes", headers=headers)
+    assert listed.status_code == 200, listed.text
+    assert listed.json()["total"] == 1
+
+    patched = await client.patch(
+        f"/api/v1/dicom/aes/{ae_id}",
+        headers=headers,
+        json={"department": "Radiology (main)", "tls_enabled": True},
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["tls_enabled"] is True
+
+    deleted = await client.delete(f"/api/v1/dicom/aes/{ae_id}", headers=headers)
+    assert deleted.status_code == 204, deleted.text
+    assert (await db_session.scalar(select(func.count()).select_from(DICOMApplicationEntity))) == 0
+
+
+async def test_duplicate_ae_title_409_names_the_conflicting_ae(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """THE constraint. The conflicting AE is very often in another
+    department, owned by another vendor's service engineer, so the
+    response has to name it rather than saying "already in use"."""
+    _, token = await _make_superadmin(db_session)
+    subnet = await _make_subnet(db_session)
+    first = await _make_ip(db_session, subnet, "10.30.0.5")
+    second = await _make_ip(db_session, subnet, "10.30.0.6")
+    await db_session.commit()
+    headers = _auth(token)
+
+    a = await client.post(
+        "/api/v1/dicom/aes",
+        headers=headers,
+        json={"ae_title": "PACS_MAIN", "ip_address_id": str(first.id)},
+    )
+    assert a.status_code == 201, a.text
+
+    b = await client.post(
+        "/api/v1/dicom/aes",
+        headers=headers,
+        json={"ae_title": "PACS_MAIN", "ip_address_id": str(second.id)},
+    )
+    assert b.status_code == 409, b.text
+    assert "PACS_MAIN" in b.json()["detail"]
+    assert b.headers["X-Conflicting-Ae-Id"] == a.json()["id"]
+
+
+async def test_invalid_ae_title_is_422_naming_the_rule(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    resp = await client.post(
+        "/api/v1/dicom/aes", headers=_auth(token), json={"ae_title": "BAD\\TITLE"}
+    )
+    assert resp.status_code == 422, resp.text
+    assert "backslash" in resp.text
+
+
+# ── Reservation semantics ────────────────────────────────────────────
+
+
+async def test_ae_can_be_created_without_an_anchor(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An unbound AE is a *reservation*, not an error: a title still
+    burned into peer config across the estate whose host is gone."""
+    _, token = await _make_superadmin(db_session)
+    resp = await client.post(
+        "/api/v1/dicom/aes", headers=_auth(token), json={"ae_title": "OLD_MR1"}
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["is_reservation"] is True
+    assert resp.json()["address"] is None
+
+
+async def test_deleting_the_ip_demotes_the_ae_to_a_reservation(
+    db_session: AsyncSession,
+) -> None:
+    """The deliberate difference from ``bacnet_device``'s CASCADE.
+    Decommissioning a host must not hand its AE Title straight back to
+    the next commissioning engineer."""
+    subnet = await _make_subnet(db_session)
+    ip = await _make_ip(db_session, subnet, "10.30.0.5")
+    ae = DICOMApplicationEntity(ae_title="MR1_MAIN", ip_address_id=ip.id, subnet_id=subnet.id)
+    db_session.add(ae)
+    await db_session.flush()
+    ae_id = ae.id
+
+    # Raw DELETE so the FK's ON DELETE SET NULL is what is exercised,
+    # not any ORM-side cascade configuration.
+    await db_session.execute(text("DELETE FROM ip_address WHERE id = :i"), {"i": str(ip.id)})
+    await db_session.flush()
+    db_session.expire_all()
+
+    survivor = await db_session.get(DICOMApplicationEntity, ae_id)
+    assert survivor is not None, "the AE Title must outlive its host"
+    assert survivor.ip_address_id is None
+
+
+async def test_patch_can_clear_the_anchor(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_superadmin(db_session)
+    subnet = await _make_subnet(db_session)
+    ip = await _make_ip(db_session, subnet, "10.30.0.5")
+    await db_session.commit()
+    headers = _auth(token)
+
+    created = await client.post(
+        "/api/v1/dicom/aes",
+        headers=headers,
+        json={"ae_title": "US1_MAIN", "ip_address_id": str(ip.id)},
+    )
+    assert created.status_code == 201, created.text
+
+    cleared = await client.patch(
+        f"/api/v1/dicom/aes/{created.json()['id']}",
+        headers=headers,
+        json={"ip_address_id": None},
+    )
+    assert cleared.status_code == 200, cleared.text
+    assert cleared.json()["is_reservation"] is True
+    assert cleared.json()["subnet_id"] is None
+
+
+async def test_unbound_filter_lists_only_reservations(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    subnet = await _make_subnet(db_session)
+    ip = await _make_ip(db_session, subnet, "10.30.0.5")
+    db_session.add_all(
+        [
+            DICOMApplicationEntity(ae_title="BOUND1", ip_address_id=ip.id, subnet_id=subnet.id),
+            DICOMApplicationEntity(ae_title="RESERVED1"),
+        ]
+    )
+    await db_session.commit()
+
+    resp = await client.get("/api/v1/dicom/aes", headers=_auth(token), params={"unbound": "true"})
+    assert resp.status_code == 200, resp.text
+    assert [r["ae_title"] for r in resp.json()["items"]] == ["RESERVED1"]
+
+
+# ── Peers + impact ───────────────────────────────────────────────────
+
+
+async def test_peer_round_trip_and_impact_splits_by_direction(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Direction is the point: outbound edges stop sending, inbound ones
+    lose their target — different remediation lists."""
+    _, token = await _make_superadmin(db_session)
+    db_session.add_all(
+        [
+            DICOMApplicationEntity(ae_title="CT1"),
+            DICOMApplicationEntity(ae_title="ARCHIVE"),
+            DICOMApplicationEntity(ae_title="VIEWER"),
+        ]
+    )
+    await db_session.commit()
+    headers = _auth(token)
+
+    ids = {
+        r["ae_title"]: r["id"]
+        for r in (await client.get("/api/v1/dicom/aes", headers=headers)).json()["items"]
+    }
+
+    made = await client.post(
+        "/api/v1/dicom/peers",
+        headers=headers,
+        json={
+            "source_ae_id": ids["CT1"],
+            "target_ae_id": ids["ARCHIVE"],
+            "services": ["C-STORE"],
+        },
+    )
+    assert made.status_code == 201, made.text
+    assert made.json()["source_ae_title"] == "CT1"
+    assert made.json()["target_ae_title"] == "ARCHIVE"
+
+    inbound = await client.post(
+        "/api/v1/dicom/peers",
+        headers=headers,
+        json={"source_ae_id": ids["VIEWER"], "target_ae_id": ids["CT1"]},
+    )
+    assert inbound.status_code == 201, inbound.text
+
+    impact = await client.get(f"/api/v1/dicom/aes/{ids['CT1']}/impact", headers=headers)
+    assert impact.status_code == 200, impact.text
+    body = impact.json()
+    assert body["total_peers"] == 2
+    assert [p["target_ae_title"] for p in body["outbound"]] == ["ARCHIVE"]
+    assert [p["source_ae_title"] for p in body["inbound"]] == ["VIEWER"]
+
+
+async def test_duplicate_peer_pair_is_409(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_superadmin(db_session)
+    db_session.add_all(
+        [DICOMApplicationEntity(ae_title="A1"), DICOMApplicationEntity(ae_title="B1")]
+    )
+    await db_session.commit()
+    headers = _auth(token)
+    ids = {
+        r["ae_title"]: r["id"]
+        for r in (await client.get("/api/v1/dicom/aes", headers=headers)).json()["items"]
+    }
+    payload = {"source_ae_id": ids["A1"], "target_ae_id": ids["B1"]}
+
+    assert (
+        await client.post("/api/v1/dicom/peers", headers=headers, json=payload)
+    ).status_code == 201
+    dupe = await client.post("/api/v1/dicom/peers", headers=headers, json=payload)
+    assert dupe.status_code == 409, dupe.text
+
+
+async def test_self_peer_is_refused(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_superadmin(db_session)
+    db_session.add(DICOMApplicationEntity(ae_title="SOLO"))
+    await db_session.commit()
+    headers = _auth(token)
+    ae_id = (await client.get("/api/v1/dicom/aes", headers=headers)).json()["items"][0]["id"]
+    resp = await client.post(
+        "/api/v1/dicom/peers",
+        headers=headers,
+        json={"source_ae_id": ae_id, "target_ae_id": ae_id},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+# ── Importer ─────────────────────────────────────────────────────────
+
+_CSV = """AE Title,IP,Port,Class,Vendor,Dept
+CT1_RAD,10.30.0.5,104,CT,Siemens,Radiology
+PACS_MAIN,10.30.0.6,11112,PACS Archive,Philips,IT
+OLD_MR,,11112,MR,GE,Radiology
+"""
+
+_COLUMN_MAP = {
+    "ae_title": "AE Title",
+    "address": "IP",
+    "port": "Port",
+    "device_class": "Class",
+    "vendor": "Vendor",
+    "department": "Dept",
+}
+
+
+async def test_import_preview_then_commit(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_superadmin(db_session)
+    subnet = await _make_subnet(db_session)
+    await _make_ip(db_session, subnet, "10.30.0.5")
+    await _make_ip(db_session, subnet, "10.30.0.6")
+    await db_session.commit()
+    headers = _auth(token)
+    body = {"csv_text": _CSV, "column_map": _COLUMN_MAP}
+
+    preview = await client.post("/api/v1/dicom/aes/import/preview", headers=headers, json=body)
+    assert preview.status_code == 200, preview.text
+    # Three creates: two bound, and OLD_MR as an unbound reservation —
+    # a blank address is not an error.
+    assert preview.json()["create_count"] == 3
+    assert preview.json()["error_count"] == 0
+    # Preview writes nothing.
+    assert (await db_session.scalar(select(func.count()).select_from(DICOMApplicationEntity))) == 0
+
+    commit = await client.post("/api/v1/dicom/aes/import/commit", headers=headers, json=body)
+    assert commit.status_code == 201, commit.text
+    assert commit.json()["created"] == 3
+
+    rows = (await client.get("/api/v1/dicom/aes", headers=headers)).json()["items"]
+    by_title = {r["ae_title"]: r for r in rows}
+    assert by_title["CT1_RAD"]["port"] == 104
+    # "CT" and "PACS Archive" are aliased onto the vocabulary rather
+    # than rejected — institutions name their columns locally.
+    assert by_title["CT1_RAD"]["device_class"] == "modality"
+    assert by_title["PACS_MAIN"]["device_class"] == "archive"
+    assert by_title["OLD_MR"]["is_reservation"] is True
+
+
+async def test_import_reports_duplicate_titles_in_the_file(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A duplicate inside the file is the exact collision this registry
+    exists to surface — reported, not resolved by last-write-wins."""
+    _, token = await _make_superadmin(db_session)
+    csv = "AE Title\nCT1\nCT1\n"
+    resp = await client.post(
+        "/api/v1/dicom/aes/import/preview",
+        headers=_auth(token),
+        json={"csv_text": csv, "column_map": {"ae_title": "AE Title"}},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["error_count"] == 1
+    errored = [r for r in resp.json()["rows"] if r["action"] == "error"]
+    assert "duplicate AE Title" in errored[0]["reason"]
+
+
+async def test_import_rejects_a_mapped_column_missing_from_the_header(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A typo'd mapping must not look like a successful import that
+    quietly dropped a column."""
+    _, token = await _make_superadmin(db_session)
+    resp = await client.post(
+        "/api/v1/dicom/aes/import/preview",
+        headers=_auth(token),
+        json={
+            "csv_text": "AE Title\nCT1\n",
+            "column_map": {"ae_title": "AE Title", "vendor": "Manufacturer"},
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "Manufacturer" in resp.json()["detail"]
+
+
+async def test_import_errors_an_unknown_address_but_keeps_good_rows(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    subnet = await _make_subnet(db_session)
+    await _make_ip(db_session, subnet, "10.30.0.5")
+    await db_session.commit()
+    csv = "AE Title,IP\nGOOD1,10.30.0.5\nBAD1,10.99.99.99\n"
+
+    resp = await client.post(
+        "/api/v1/dicom/aes/import/commit",
+        headers=_auth(token),
+        json={"csv_text": csv, "column_map": {"ae_title": "AE Title", "address": "IP"}},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["created"] == 1
+    assert resp.json()["errors"] == 1
+
+
+# ── Permissions + module gate ────────────────────────────────────────
+
+
+async def test_requires_dicom_ae_permission(client: AsyncClient, db_session: AsyncSession) -> None:
+    _, token = await _make_user_with_perm(db_session, None)
+    await db_session.commit()
+    resp = await client.get("/api/v1/dicom/aes", headers=_auth(token))
+    assert resp.status_code == 403, resp.text
+
+
+async def test_module_gate_404s_the_surface_when_disabled(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    from app.services.feature_modules import invalidate_cache
+
+    _, token = await _make_superadmin(db_session)
+    await db_session.execute(
+        text(
+            "INSERT INTO feature_module (id, enabled) VALUES (:id, false) "
+            "ON CONFLICT (id) DO UPDATE SET enabled = false"
+        ).bindparams(id="network.dicom")
+    )
+    await db_session.commit()
+    invalidate_cache()
+    try:
+        resp = await client.get("/api/v1/dicom/aes", headers=_auth(token))
+        assert resp.status_code == 404, resp.text
+    finally:
+        await db_session.execute(
+            text("UPDATE feature_module SET enabled = true WHERE id = :id").bindparams(
+                id="network.dicom"
+            )
+        )
+        await db_session.commit()
+        invalidate_cache()

--- a/backend/tests/test_dicom.py
+++ b/backend/tests/test_dicom.py
@@ -525,6 +525,74 @@ async def test_import_errors_an_unknown_address_but_keeps_good_rows(
     assert resp.json()["errors"] == 1
 
 
+async def test_reimport_without_tls_column_does_not_reset_tls(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An overwrite re-import from a table lacking TLS / port columns
+    must leave those alone. Flipping every encrypted AE to plaintext
+    would poison ``dicom_ae_no_tls`` — a compliance report reading worse
+    than reality is its own wrong answer."""
+    _, token = await _make_superadmin(db_session)
+    db_session.add(DICOMApplicationEntity(ae_title="MR1", port=2762, tls_enabled=True))
+    await db_session.commit()
+    headers = _auth(token)
+
+    resp = await client.post(
+        "/api/v1/dicom/aes/import/commit",
+        headers=headers,
+        json={
+            "csv_text": "AE Title,Vendor\nMR1,Philips\n",
+            "column_map": {"ae_title": "AE Title", "vendor": "Vendor"},
+            "overwrite_existing": True,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["updated"] == 1
+
+    row = (await client.get("/api/v1/dicom/aes", headers=headers)).json()["items"][0]
+    assert row["vendor"] == "Philips"
+    assert row["tls_enabled"] is True, "a missing TLS column must not mean 'false'"
+    assert row["port"] == 2762, "a missing port column must not mean 'the default'"
+
+
+async def test_blank_tls_cell_does_not_clear_a_stored_true(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """ "The operator left this blank" and "the operator wrote no" are
+    different statements; only the second overwrites."""
+    _, token = await _make_superadmin(db_session)
+    db_session.add(DICOMApplicationEntity(ae_title="CT9", tls_enabled=True))
+    await db_session.commit()
+    headers = _auth(token)
+
+    resp = await client.post(
+        "/api/v1/dicom/aes/import/commit",
+        headers=headers,
+        json={
+            "csv_text": "AE Title,TLS\nCT9,\n",
+            "column_map": {"ae_title": "AE Title", "tls_enabled": "TLS"},
+            "overwrite_existing": True,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    row = (await client.get("/api/v1/dicom/aes", headers=headers)).json()["items"][0]
+    assert row["tls_enabled"] is True
+
+    # An explicit "no" *does* overwrite.
+    resp = await client.post(
+        "/api/v1/dicom/aes/import/commit",
+        headers=headers,
+        json={
+            "csv_text": "AE Title,TLS\nCT9,no\n",
+            "column_map": {"ae_title": "AE Title", "tls_enabled": "TLS"},
+            "overwrite_existing": True,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    row = (await client.get("/api/v1/dicom/aes", headers=headers)).json()["items"][0]
+    assert row["tls_enabled"] is False
+
+
 # ── Permissions + module gate ────────────────────────────────────────
 
 

--- a/backend/tests/test_dicom.py
+++ b/backend/tests/test_dicom.py
@@ -139,6 +139,47 @@ def test_invalid_ae_titles_are_rejected(raw: str, fragment: str) -> None:
     assert fragment in str(exc.value)
 
 
+async def test_padded_16_byte_title_is_accepted_over_the_api(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A 16-byte title carrying legal pad space must survive the API.
+
+    Regression: a ``max_length=16`` on the pydantic field counted
+    *characters* on the *untrimmed* value, so ``"QRSTUVWXYZABCDEF "`` —
+    16 significant chars plus one pad space — was rejected before the
+    validator ever trimmed it. Spaces are non-significant padding per
+    PS3.5, so the ceiling has to be applied after trimming, in bytes.
+    That failure is the exact "strict in the wrong direction" mode this
+    registry exists to avoid: a title real devices use, refused.
+    """
+    _, token = await _make_superadmin(db_session)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/v1/dicom/aes",
+        headers=_auth(token),
+        json={"ae_title": "QRSTUVWXYZABCDEF "},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["ae_title"] == "QRSTUVWXYZABCDEF"
+
+
+async def test_over_length_title_reports_bytes_over_the_api(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The refusal has to come from the byte validator, so its message
+    says "bytes" — an operator counting characters on a multi-byte title
+    cannot otherwise see why 15 characters is too long."""
+    _, token = await _make_superadmin(db_session)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/v1/dicom/aes",
+        headers=_auth(token),
+        json={"ae_title": "ÄÖÜÄÖÜÄÖÜÄÖÜÄÖÜ"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "bytes" in resp.text
+
+
 def test_length_ceiling_is_bytes_not_characters() -> None:
     """The VR caps at 16 *bytes*. A 16-character title with a non-ASCII
     character in it is over the limit, and an operator counting

--- a/backend/tests/test_probe_policy.py
+++ b/backend/tests/test_probe_policy.py
@@ -400,6 +400,101 @@ async def test_override_is_per_request_not_a_mode(
     assert second.status_code == 422, second.text
 
 
+async def test_reprofile_now_refuses_flagged_subnet(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """ "Re-profile now" bypasses the refresh window on purpose — it must
+    not bypass this. The operator who clicked it is usually not the one
+    who wrote the vendor bulletin onto the subnet."""
+    _, token = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    subnet.do_not_probe_reason = "CT console"
+    ip = IPAddress(subnet_id=subnet.id, address="10.20.30.11", status="allocated")
+    db_session.add(ip)
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/ipam/addresses/{ip.id}/profile", headers=_auth(token), json={}
+    )
+    assert resp.status_code == 422, resp.text
+    assert "CT console" in resp.json()["detail"]
+    assert (await db_session.scalar(select(func.count()).select_from(NmapScan))) == 0
+
+
+async def test_copilot_nmap_apply_refuses_flagged_target(
+    db_session: AsyncSession,
+) -> None:
+    """The Copilot's apply path is a separate surface from the REST
+    route; a proposal the operator approved is still a scan."""
+    from app.services.ai.operations import RunNmapScanArgs, _apply_run_nmap_scan
+
+    user, _ = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    subnet.do_not_probe_reason = "infusion pumps"
+    await db_session.flush()
+
+    with pytest.raises(ValueError) as exc:
+        await _apply_run_nmap_scan(
+            db_session, user, RunNmapScanArgs(target_ip="10.20.30.7", preset="quick")
+        )
+    assert "infusion pumps" in str(exc.value)
+    assert (await db_session.scalar(select(func.count()).select_from(NmapScan))) == 0
+
+
+async def test_mcp_network_ping_refuses_flagged_target(
+    db_session: AsyncSession,
+) -> None:
+    """MCP tools call the runners directly, so they need the gate too —
+    otherwise the copilot is the one surface that still probes."""
+    from app.services.ai.tools.nettools import NetworkPingArgs, network_ping
+
+    user, _ = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    subnet.do_not_probe_reason = "patient monitors"
+    await db_session.flush()
+
+    result = await network_ping(db_session, user, NetworkPingArgs(host="10.20.30.7"))
+    assert "patient monitors" in (result.get("error") or "")
+    # A refusal, not a probe result — no exit code was ever produced.
+    assert "exit_code" not in result
+
+
+async def test_cidr_target_with_host_bits_does_not_error(
+    db_session: AsyncSession,
+) -> None:
+    """nmap accepts ``10.20.30.5/24``; Postgres's ``cidr()`` cast does
+    not. The guard has to normalise rather than raise a DataError, or a
+    mistyped target becomes a 500."""
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    await db_session.flush()
+
+    verdict = await check_probe_target(db_session, "10.20.30.5/24")
+    assert verdict.blocked is True
+
+
+async def test_soft_deleted_ancestor_still_suppresses(
+    db_session: AsyncSession,
+) -> None:
+    """The session-wide ``deleted_at IS NULL`` filter applies to
+    ``db.get()`` too, so a trashed block would truncate the walk and the
+    guard would fail OPEN — the one direction it must never fail."""
+    from datetime import UTC, datetime
+
+    _, block, subnet = await _make_chain(db_session)
+    block.do_not_probe = True
+    block.do_not_probe_reason = "OT cell"
+    block.deleted_at = datetime.now(UTC)
+    await db_session.flush()
+
+    verdict = await resolve_probe_policy(db_session, subnet)
+    assert verdict.blocked is True
+    assert verdict.source == f"block:{block.id}"
+
+
 # ── Discovery sweep ──────────────────────────────────────────────────
 
 

--- a/backend/tests/test_probe_policy.py
+++ b/backend/tests/test_probe_policy.py
@@ -1,0 +1,495 @@
+"""Fragile-device do-not-probe tests — issue #722.
+
+The load-bearing property is the *direction* of inheritance. Unlike
+DDNS, this flag ORs downward: a suppressed space must suppress every
+subnet under it, and no descendant may un-set it. If that ever inverts,
+a hospital that marked its clinical IPSpace do-not-probe would find one
+subnet quietly opted back in and being swept — which is the exact
+failure the flag exists to prevent, arriving silently.
+
+Also covers: the three shipped probe origins actually refusing (the
+discovery sweep, nmap, the network tools), the superadmin override being
+audited and per-request, non-superadmins being refused the override, and
+CIDR / hostname target resolution.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import Group, Role, User
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.models.nmap import NmapScan
+from app.services.ipam.probe_policy import (
+    check_probe_target,
+    resolve_probe_policy,
+)
+
+
+async def _make_superadmin(db: AsyncSession) -> tuple[User, str]:
+    u = User(
+        username=f"admin-{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(u)
+    await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+async def _make_user_with_perm(db: AsyncSession, perm: dict) -> tuple[User, str]:
+    u = User(
+        username=f"user-{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@x.com",
+        display_name="User",
+        hashed_password=hash_password("x"),
+        is_superadmin=False,
+    )
+    db.add(u)
+    await db.flush()
+    role = Role(name=f"r-{uuid.uuid4().hex[:6]}", description="", permissions=[perm])
+    db.add(role)
+    await db.flush()
+    group = Group(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    group.roles = [role]
+    group.users = [u]
+    db.add(group)
+    await db.flush()
+    return u, create_access_token(str(u.id))
+
+
+async def _make_chain(
+    db: AsyncSession,
+    *,
+    network: str = "10.20.30.0/24",
+    block_network: str = "10.20.0.0/16",
+) -> tuple[IPSpace, IPBlock, Subnet]:
+    space = IPSpace(name=f"probe-space-{uuid.uuid4().hex[:8]}")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, name="b", network=block_network)
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, name="s", network=network)
+    db.add(subnet)
+    await db.flush()
+    return space, block, subnet
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Inheritance semantics ────────────────────────────────────────────
+
+
+async def test_unflagged_chain_allows(db_session: AsyncSession) -> None:
+    _, _, subnet = await _make_chain(db_session)
+    verdict = await resolve_probe_policy(db_session, subnet)
+    assert verdict.blocked is False
+    assert verdict.allowed is True
+
+
+async def test_subnet_flag_blocks_and_carries_reason(db_session: AsyncSession) -> None:
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    subnet.do_not_probe_reason = "Alaris pumps — vendor bulletin VB-2024-11"
+    await db_session.flush()
+
+    verdict = await resolve_probe_policy(db_session, subnet)
+    assert verdict.blocked is True
+    assert verdict.source == f"subnet:{subnet.id}"
+    assert "VB-2024-11" in verdict.reason
+    # The reason has to survive into the operator-facing sentence — a
+    # refusal that just says "marked do-not-probe" gets overridden.
+    assert "VB-2024-11" in verdict.message()
+
+
+async def test_block_flag_suppresses_descendant_subnet(db_session: AsyncSession) -> None:
+    _, block, subnet = await _make_chain(db_session)
+    block.do_not_probe = True
+    block.do_not_probe_reason = "OT cell 4"
+    await db_session.flush()
+
+    verdict = await resolve_probe_policy(db_session, subnet)
+    assert verdict.blocked is True
+    assert verdict.source == f"block:{block.id}"
+    assert verdict.reason == "OT cell 4"
+
+
+async def test_space_flag_suppresses_descendant_subnet(db_session: AsyncSession) -> None:
+    space, _, subnet = await _make_chain(db_session)
+    space.do_not_probe = True
+    space.do_not_probe_reason = "Clinical VRF"
+    await db_session.flush()
+
+    verdict = await resolve_probe_policy(db_session, subnet)
+    assert verdict.blocked is True
+    assert verdict.source == f"space:{space.id}"
+
+
+async def test_descendant_cannot_unset_an_ancestor_flag(db_session: AsyncSession) -> None:
+    """THE inheritance property, and the one that must never invert.
+
+    Unlike DDNS — which resolves to the first *non-inheriting* ancestor
+    and so lets a descendant override its parent — this flag ORs
+    downward. A subnet whose own flag is False, under a suppressed
+    space, is still suppressed; there is deliberately no per-level
+    inherit toggle to turn it back on.
+    """
+    space, _, subnet = await _make_chain(db_session)
+    space.do_not_probe = True
+    subnet.do_not_probe = False
+    await db_session.flush()
+
+    verdict = await resolve_probe_policy(db_session, subnet)
+    assert verdict.blocked is True
+    assert verdict.source == f"space:{space.id}"
+
+
+async def test_nearest_level_supplies_the_reason(db_session: AsyncSession) -> None:
+    """When several levels are flagged, the most specific one explains it."""
+    space, block, subnet = await _make_chain(db_session)
+    space.do_not_probe = True
+    space.do_not_probe_reason = "whole clinical VRF"
+    block.do_not_probe = True
+    block.do_not_probe_reason = "imaging block"
+    subnet.do_not_probe = True
+    subnet.do_not_probe_reason = "CT room VLAN"
+    await db_session.flush()
+
+    verdict = await resolve_probe_policy(db_session, subnet)
+    assert verdict.source == f"subnet:{subnet.id}"
+    assert verdict.reason == "CT room VLAN"
+
+
+async def test_nested_blocks_walk_upward(db_session: AsyncSession) -> None:
+    space, parent_block, _ = await _make_chain(db_session)
+    child_block = IPBlock(
+        space_id=space.id,
+        parent_block_id=parent_block.id,
+        name="child",
+        network="10.20.32.0/20",
+    )
+    db_session.add(child_block)
+    await db_session.flush()
+    subnet = Subnet(space_id=space.id, block_id=child_block.id, name="s2", network="10.20.40.0/24")
+    db_session.add(subnet)
+    parent_block.do_not_probe = True
+    await db_session.flush()
+
+    verdict = await resolve_probe_policy(db_session, subnet)
+    assert verdict.blocked is True
+    assert verdict.source == f"block:{parent_block.id}"
+
+
+# ── Target resolution ────────────────────────────────────────────────
+
+
+async def test_check_probe_target_resolves_a_bare_ip(db_session: AsyncSession) -> None:
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    await db_session.flush()
+
+    assert (await check_probe_target(db_session, "10.20.30.7")).blocked is True
+    assert (await check_probe_target(db_session, "10.99.99.7")).blocked is False
+
+
+async def test_check_probe_target_resolves_a_cidr_in_both_directions(
+    db_session: AsyncSession,
+) -> None:
+    """A CIDR scan reaches suppressed hosts whether it contains the
+    flagged subnet or sits inside it — both are packets on the wire."""
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    await db_session.flush()
+
+    # Supernet of the flagged subnet.
+    assert (await check_probe_target(db_session, "10.20.0.0/16")).blocked is True
+    # Slice inside the flagged subnet.
+    assert (await check_probe_target(db_session, "10.20.30.128/25")).blocked is True
+    # Unrelated range.
+    assert (await check_probe_target(db_session, "192.168.5.0/24")).blocked is False
+
+
+async def test_check_probe_target_matches_a_known_hostname(
+    db_session: AsyncSession,
+) -> None:
+    """Hostnames are matched against IPAM inventory, not resolved
+    through DNS — the guard must not depend on a network round-trip it
+    cannot see the result of."""
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    db_session.add(
+        IPAddress(
+            subnet_id=subnet.id,
+            address="10.20.30.9",
+            status="allocated",
+            hostname="ct-scanner-1",
+        )
+    )
+    await db_session.flush()
+
+    assert (await check_probe_target(db_session, "CT-Scanner-1")).blocked is True
+    # FQDN form: the first label is matched against the stored hostname.
+    assert (await check_probe_target(db_session, "ct-scanner-1.hospital.example.")).blocked is True
+    assert (await check_probe_target(db_session, "unknown-host")).blocked is False
+
+
+async def test_unmappable_target_is_allowed(db_session: AsyncSession) -> None:
+    """Fail-safe direction: what IPAM doesn't know about, nobody flagged."""
+    assert (await check_probe_target(db_session, "203.0.113.1")).blocked is False
+    assert (await check_probe_target(db_session, "")).blocked is False
+
+
+# ── Probe origins refuse ─────────────────────────────────────────────
+
+
+async def test_network_tools_ping_refuses_flagged_target(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    subnet.do_not_probe_reason = "patient monitors"
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/tools/ping", headers=_auth(token), json={"host": "10.20.30.7"}
+    )
+    assert resp.status_code == 422, resp.text
+    assert "patient monitors" in resp.json()["detail"]
+    assert "override_do_not_probe" in resp.json()["detail"]
+
+
+async def test_network_tools_port_test_refuses_flagged_target(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/tools/port-test",
+        headers=_auth(token),
+        json={"host": "10.20.30.7", "port": 443},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_nmap_scan_refuses_flagged_target_and_persists_nothing(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The refusal happens before the row is written — a doomed scan must
+    not leave a queued NmapScan behind."""
+    _, token = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/nmap/scans",
+        headers=_auth(token),
+        json={"target_ip": "10.20.30.7", "preset": "quick"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert (await db_session.scalar(select(func.count()).select_from(NmapScan))) == 0
+
+
+# ── Override ─────────────────────────────────────────────────────────
+
+
+async def test_superadmin_override_is_allowed_and_audited(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    subnet.do_not_probe_reason = "MRI console"
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/nmap/scans",
+        headers=_auth(token),
+        json={
+            "target_ip": "10.20.30.7",
+            "preset": "quick",
+            "override_do_not_probe": True,
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+    rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(AuditLog.action == "probe.do_not_probe_override")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].new_value is not None
+    assert rows[0].new_value["tool"] == "nmap"
+    assert rows[0].new_value["reason"] == "MRI console"
+
+
+async def test_non_superadmin_cannot_override(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The override is not a permission grant. ``use_network_tools`` is a
+    routine grant delegated admins hold; the point of the flag is that
+    whoever clears it is accountable."""
+    _, token = await _make_user_with_perm(
+        db_session, {"action": "admin", "resource_type": "use_network_tools"}
+    )
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/tools/ping",
+        headers=_auth(token),
+        json={"host": "10.20.30.7", "override_do_not_probe": True},
+    )
+    assert resp.status_code == 403, resp.text
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(AuditLog)
+            .where(AuditLog.action == "probe.do_not_probe_override")
+        )
+    ) == 0
+
+
+async def test_override_is_per_request_not_a_mode(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    await db_session.commit()
+
+    first = await client.post(
+        "/api/v1/nmap/scans",
+        headers=_auth(token),
+        json={
+            "target_ip": "10.20.30.7",
+            "preset": "quick",
+            "override_do_not_probe": True,
+        },
+    )
+    assert first.status_code == 202, first.text
+    # Nothing was remembered — the next call is refused again.
+    second = await client.post(
+        "/api/v1/nmap/scans",
+        headers=_auth(token),
+        json={"target_ip": "10.20.30.7", "preset": "quick"},
+    )
+    assert second.status_code == 422, second.text
+
+
+# ── Discovery sweep ──────────────────────────────────────────────────
+
+
+@pytest.mark.usefixtures("db_session")
+async def test_discovery_task_skips_flagged_subnet(db_session: AsyncSession) -> None:
+    """The sweep bails before any packet is sent, stamps the run so the
+    dispatcher stops re-queueing it, and records why."""
+    from app.tasks import ipam_discovery
+
+    _, _, subnet = await _make_chain(db_session)
+    subnet.do_not_probe = True
+    subnet.do_not_probe_reason = "PTS pneumatic tube"
+    subnet.discovery_enabled = True
+    await db_session.commit()
+    subnet_id = str(subnet.id)
+
+    # The task opens its own engine/session, so patch the sweep itself:
+    # if the gate leaks, this raises rather than silently probing.
+    async def _explode(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("sweep_subnet must not run on a do-not-probe subnet")
+
+    with patch.object(ipam_discovery, "sweep_subnet", _explode):
+        result = await ipam_discovery._run_subnet_discovery_async(subnet_id)
+
+    # The task opens its own engine + session, so its commit is not
+    # visible from this test's transaction. What is assertable here is
+    # the contract the dispatcher and the operator both read: the run
+    # bailed with the do-not-probe code, and it carries the reason.
+    assert result["status"] == "skipped"
+    assert result["reason"] == "do_not_probe"
+    assert result["do_not_probe"]["reason"] == "PTS pneumatic tube"
+    assert result["do_not_probe"]["source"] == f"subnet:{subnet_id}"
+
+
+# ── REST surface ─────────────────────────────────────────────────────
+
+
+async def test_probe_policy_endpoint_reports_inheritance(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    space, _, subnet = await _make_chain(db_session)
+    space.do_not_probe = True
+    space.do_not_probe_reason = "clinical"
+    await db_session.commit()
+
+    resp = await client.get(f"/api/v1/ipam/subnets/{subnet.id}/probe-policy", headers=_auth(token))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["do_not_probe"] is True
+    # ``inherited`` is what tells the UI that clearing the subnet's own
+    # checkbox would change nothing.
+    assert body["inherited"] is True
+    assert body["source"] == f"space:{space.id}"
+    assert body["reason"] == "clinical"
+
+
+async def test_subnet_update_round_trips_the_flag(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    await db_session.commit()
+
+    resp = await client.put(
+        f"/api/v1/ipam/subnets/{subnet.id}",
+        headers=_auth(token),
+        json={"do_not_probe": True, "do_not_probe_reason": "ultrasound carts"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["do_not_probe"] is True
+    assert resp.json()["do_not_probe_reason"] == "ultrasound carts"
+
+
+async def test_bmc_is_an_accepted_ip_role(client: AsyncClient, db_session: AsyncSession) -> None:
+    """BMC / IPMI endpoints are the fragile-device class this issue is
+    about, so they get a first-class role rather than a tag."""
+    _, token = await _make_superadmin(db_session)
+    _, _, subnet = await _make_chain(db_session)
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/ipam/subnets/{subnet.id}/addresses",
+        headers=_auth(token),
+        json={
+            "address": "10.20.30.50",
+            "hostname": "idrac-1",
+            "status": "allocated",
+            "role": "bmc",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["role"] == "bmc"

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -85,6 +85,7 @@ Each entry in `Role.permissions` (JSONB) is an object with this shape:
 | `wol_calendar`    | Subscribed iCal / CalDAV calendars whose all-day spans gate scheduled wakes (#586) |
 | `av_flow`         | AV-over-IP flow descriptors + operator-declared reserved multicast ranges (#540) — the Dante / AES67 / SMPTE 2110 layer over the multicast registry |
 | `bacnet_device`   | BACnet/IP device registry (#541) — internetwork-unique device instance numbers, vendor/model metadata, BBMD flag + BDT/FDT snapshots |
+| `dicom_ae`        | DICOM Application Entity registry (#723) — institution-wide-unique AE Titles, their host/port bindings, and the configured AE→AE association map. Network identity only; this permission never grants access to imaging data, which SpatiumDDI does not store |
 | `ot_device`       | Industrial / OT device inventory + Purdue zoning (#542) — read-only identification; this permission never grants control-protocol access, which is out of scope entirely |
 | `*`               | Wildcard — match any resource type                    |
 
@@ -146,7 +147,7 @@ on inactive.
 | `IPAM Editor`  | `admin` on `ip_space`, `ip_block`, `subnet`, `ip_address`, `address_set`, `vlan`, `nat_mapping`, `custom_field`, `manage_ipam_templates`, `customer`, `site`, `provider`, `network_service` |
 | `DNS Editor`   | `admin` on `dns_zone`, `dns_record`, `dns_group`, `dns_blocklist`, `manage_dns_pools` |
 | `DHCP Editor`  | `admin` on `dhcp_server`, `dhcp_scope`, `dhcp_pool`, `dhcp_static`, `dhcp_client_class`, `dhcp_option_template`, `dhcp_mac_block` |
-| `Network Editor` | `admin` on `manage_network_devices`, `manage_nmap_scans`, `manage_packet_capture`, `manage_block_sync`, `use_network_tools`, `manage_asns`, `vrf`, `circuit`, `multicast`, `av_flow`, `bacnet_device`, `ot_device`, `network_service`, `overlay_network`, `routing_policy`, `application_category`, `customer`, `site`, `provider`, `tls_cert` |
+| `Network Editor` | `admin` on `manage_network_devices`, `manage_nmap_scans`, `manage_packet_capture`, `manage_block_sync`, `use_network_tools`, `manage_asns`, `vrf`, `circuit`, `multicast`, `av_flow`, `bacnet_device`, `dicom_ae`, `ot_device`, `network_service`, `overlay_network`, `routing_policy`, `application_category`, `customer`, `site`, `provider`, `tls_cert` |
 | `Auditor`        | `read` on `conformity`, `audit`, `subnet`, `ip_address`, `dns_zone`, `dhcp_scope`, `tls_cert` — external auditor account, can view conformity dashboard + pull the auditor PDF + verify supporting evidence without making changes |
 | `Compliance Editor` | `admin` on `conformity`, `read` on `audit`, `subnet`, `ip_address`, `dns_zone`, `dhcp_scope` — for the team that authors / tunes conformity policies without touching operational config |
 | `Address Set Editor` | `admin` on `address_set` (#103) — delegated edit of a named IP slice within a subnet without subnet-wide write. Grant on a specific address-set id to scope a department admin to just their slice. Creating / resizing a set still requires write on the parent subnet. |

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -865,6 +865,22 @@ range import above. See `docs/features/MIGRATION.md` § "NetBox → IPAM importe
 > because a sweep is only meaningful for subnets the SpatiumDDI worker
 > can actually route to, and unsolicited probes can trip an IDS.
 
+> **Fragile devices: `do_not_probe` (issue #722).** Medical- and
+> OT-device vendors instruct sites *not* to scan their VLANs, and
+> fragile IP stacks genuinely fault under a sweep. Marking a space,
+> block or subnet **Do not probe** (Edit → *Advanced* / *Networking*)
+> suppresses every active probe SpatiumDDI originates against it: this
+> sweep, `tools.nmap` including auto-profile-on-lease, and the
+> ping / traceroute / mtr / port-test / tls-cert tools. The flag **ORs
+> down** the space → block → subnet chain and a descendant cannot
+> un-set it — deliberately unlike the DDNS fields it otherwise mirrors,
+> because a safety constraint must not be overridable from below. A
+> superadmin can proceed per-request with `override_do_not_probe`,
+> which is audited. Passive collection (PCAP, DHCP fingerprinting, ARP
+> reads) is unaffected. Resolve the effective verdict with
+> `GET /api/v1/ipam/subnets/{id}/probe-policy`; the full design is in
+> `docs/features/VERTICALS.md` § "Fragile-device probe suppression".
+
 ### IP Discovery
 
 A per-subnet-opt-in Celery sweep discovers IPs that are live but not

--- a/docs/features/VERTICALS.md
+++ b/docs/features/VERTICALS.md
@@ -3,19 +3,28 @@ layout: default
 title: Vertical network awareness
 ---
 
-# Vertical network awareness — AV · BACnet/IP · Industrial-OT
+# Vertical network awareness — AV · BACnet/IP · Industrial-OT · DICOM
 
 Umbrella issue [#543](https://github.com/spatiumddi/spatiumddi/issues/543), with
-three children: [#540](https://github.com/spatiumddi/spatiumddi/issues/540) AV /
+four children: [#540](https://github.com/spatiumddi/spatiumddi/issues/540) AV /
 Audio-Video-over-IP, [#541](https://github.com/spatiumddi/spatiumddi/issues/541)
-BACnet/IP building automation, and
-[#542](https://github.com/spatiumddi/spatiumddi/issues/542) Industrial / OT.
+BACnet/IP building automation,
+[#542](https://github.com/spatiumddi/spatiumddi/issues/542) Industrial / OT, and
+[#723](https://github.com/spatiumddi/spatiumddi/issues/723) DICOM (healthcare).
 
-Three IP-native domains that a generic IPAM does not speak. They look unrelated
+Four IP-native domains that a generic IPAM does not speak. They look unrelated
 but they are the **same DDI primitives, specialized**: a uniqueness registry, a
 segmentation-documentation layer, and conformity rules over both. Each is a
 togglable feature module in the Network group, default-enabled so operators
-discover them, and switched off by the plants that don't run that vertical.
+discover them, and switched off by the sites that don't run that vertical.
+
+The healthcare research pass concluded there should be **no**
+`network.healthcare` catch-all — the vertical splits into separable pieces, and
+DICOM is the anchor. The probe-safety piece is
+[#722](https://github.com/spatiumddi/spatiumddi/issues/722), which is not a
+vertical at all: it is a constraint on SpatiumDDI's own behaviour and ships
+un-gated for every install. See
+[Fragile-device probe suppression](#fragile-device-probe-suppression-722).
 
 > **Documentation is in progress.** This covers the shipped Phase 1 of each
 > module — the registry, conformity, and UI surfaces. The discovery phases have
@@ -24,20 +33,20 @@ discover them, and switched off by the plants that don't run that vertical.
 
 ---
 
-## The three at a glance
+## The four at a glance
 
-| | AV over IP (#540) | BACnet/IP (#541) | Industrial / OT (#542) |
-|---|---|---|---|
-| Feature module | `network.av` | `network.bacnet` | `network.ot` |
-| Sidebar | Network → AV flows | Network → BACnet devices | Network → OT devices |
-| The differentiating hook | AV descriptor on a multicast group + operator-declared per-protocol ranges | Device instance numbers — a second uniqueness namespace, internetwork-wide | Purdue-level segmentation documented against real subnets |
-| Protocols | Dante · AES67 · SMPTE ST 2110 (video/audio/anc) · NDI · RAVENNA | BACnet/IP (`UDP 47808`) | PROFINET · EtherNet/IP · Modbus TCP · OPC UA · S7comm · DNP3 · IEC 61850 |
-| Tables | `av_flow_profile`, `av_reserved_range` | `bacnet_device` | `ot_device`, `ot_zone` |
-| Anchored to | `multicast_group` (1:1) | `ip_address` (+ denormalized `subnet_id`) | `ip_address` (1:1), `subnet` (1:1 for zones) |
-| Conformity checks | `av_flow_outside_reserved_range`, `av_flow_no_ptp_domain` | `bbmd_one_per_subnet`, `bacnet_duplicate_device_instance`, `bacnet_vendor_id_unknown` | `ot_device_crosses_purdue_boundary`, `ot_zone_missing_purdue_level` |
-| API prefix | `/api/v1/av/…` | `/api/v1/bacnet/…` | `/api/v1/ot/…` |
-| RBAC resource type | `av_flow` | `bacnet_device` | `ot_device` |
-| Copilot tools | `find_av_flows`, `count_av_flows`, `find_av_reserved_ranges` | `find_bacnet_devices`, `count_bacnet_devices`, `find_bbmds` | `find_ot_devices`, `count_ot_devices`, `find_ot_zones` |
+| | AV over IP (#540) | BACnet/IP (#541) | Industrial / OT (#542) | DICOM (#723) |
+|---|---|---|---|---|
+| Feature module | `network.av` | `network.bacnet` | `network.ot` | `network.dicom` |
+| Sidebar | Network → AV flows | Network → BACnet devices | Network → OT devices | Network → DICOM AEs |
+| The differentiating hook | AV descriptor on a multicast group + operator-declared per-protocol ranges | Device instance numbers — a second uniqueness namespace, internetwork-wide | Purdue-level segmentation documented against real subnets | AE Titles — an institution-wide-unique namespace the standard specifies a registry for, and nobody deploys one |
+| Protocols | Dante · AES67 · SMPTE ST 2110 (video/audio/anc) · NDI · RAVENNA | BACnet/IP (`UDP 47808`) | PROFINET · EtherNet/IP · Modbus TCP · OPC UA · S7comm · DNP3 · IEC 61850 | DICOM (`TCP 11112` `dicom`, `TCP 104` `acr-nema`) |
+| Tables | `av_flow_profile`, `av_reserved_range` | `bacnet_device` | `ot_device`, `ot_zone` | `dicom_ae`, `dicom_peer` |
+| Anchored to | `multicast_group` (1:1) | `ip_address` (+ denormalized `subnet_id`) | `ip_address` (1:1), `subnet` (1:1 for zones) | `ip_address` — **nullable**, `SET NULL` (see below) |
+| Conformity checks | `av_flow_outside_reserved_range`, `av_flow_no_ptp_domain` | `bbmd_one_per_subnet`, `bacnet_duplicate_device_instance`, `bacnet_vendor_id_unknown` | `ot_device_crosses_purdue_boundary`, `ot_zone_missing_purdue_level` | `dicom_ae_default_title`, `dicom_ae_title_convention`, `dicom_ae_outside_hipaa_scope`, `dicom_ae_no_tls` |
+| API prefix | `/api/v1/av/…` | `/api/v1/bacnet/…` | `/api/v1/ot/…` | `/api/v1/dicom/…` |
+| RBAC resource type | `av_flow` | `bacnet_device` | `ot_device` | `dicom_ae` |
+| Copilot tools | `find_av_flows`, `count_av_flows`, `find_av_reserved_ranges` | `find_bacnet_devices`, `count_bacnet_devices`, `find_bbmds` | `find_ot_devices`, `count_ot_devices`, `find_ot_zones` | `find_dicom_aes`, `count_dicom_aes`, `find_dicom_peers` |
 
 All rows land via the REST API or the UI. **Nothing in this feature family emits
 a packet.**
@@ -206,6 +215,174 @@ created** — this importer enriches inventory, it does not invent it.
 
 ---
 
+## DICOM — medical imaging (#723)
+
+### AE Titles are the textbook uniqueness registry
+
+A DICOM **Application Entity Title** is a flat, institution-wide-unique,
+16-byte identifier. Every modality, PACS node, workstation and archive answers
+to one, and every peer that wants to talk to it must have that exact string
+configured. Duplicates break C-MOVE, Storage Commitment, Modality Worklist and
+MPPS, and the failure has been documented since 1997 with an unchanged root
+cause: vendor defaults nobody changed.
+
+DICOM PS3.15 Annex H defines `dicomUniqueAETitlesRegistryRoot` — an LDAP
+registry object whose *only* purpose is allocating unique AE Titles via a
+compare-and-set against an enforced constraint. It is essentially undeployed. In
+practice the namespace lives in a spreadsheet.
+
+That is the BACnet device-instance argument with better provenance: the standard
+itself says the value must be unique and specifies a registry for it, and no
+incumbent system owns the namespace. So `uq_dicom_ae_title` is the point of the
+table, not an incidental index — and a collision answers **409 naming the AE
+that already holds the title**, because the conflicting row is usually in
+another department, commissioned by another vendor's engineer.
+
+Contrast with the rest of healthcare, which is why there is no
+`network.healthcare` module: HL7/MLLP port sprawl is real but the interface
+engine owns it; FHIR is HTTPS with path-based discovery; WMTS is not IP at all.
+
+### The anchor is nullable, on purpose
+
+`dicom_ae.ip_address_id` is nullable with `ON DELETE SET NULL` — deliberately
+unlike `bacnet_device`'s `CASCADE`. **An AE Title outlives the host it runs
+on.** It is burned into peer configuration across the estate, so decommissioning
+an IP must demote the title to a *reservation*, not free a name a dozen
+modalities still send to. Cascading would hand it straight to the next
+commissioning engineer.
+
+An unbound AE is therefore a normal, first-class state: the list has a
+"Reservations only" filter, the API a `?unbound=true` query, and the UI a
+`reservation` badge.
+
+### AE Title validation — 16 bytes, and spaces are legal
+
+The `AE` value representation is easy to get wrong in the strict direction, and
+strict is the worse failure: a registry that rejects a title real devices use
+records a plan that fails at commissioning. `services/dicom/titles.py` implements
+PS3.5 verbatim:
+
+- maximum **16 bytes** — bytes, not characters, so a non-ASCII title can be over
+  the limit at 15 characters;
+- **spaces are legal** but non-significant (they are padding), so leading and
+  trailing space is trimmed and internal spaces are kept;
+- an **all-space value is forbidden**, which after trimming is the same
+  statement as "must not be empty";
+- backslash (`0x5C`, the multi-value delimiter) and all control characters are
+  excluded.
+
+There is no alphanumeric-only rule and no case rule. Case *is* significant to
+peers, so titles are stored as given and matched exactly; only the
+vendor-default advisory compares case-insensitively.
+
+### Peers make renumbering answerable
+
+`dicom_peer` is a directed AE→AE edge describing a **configured** association —
+documented by the operator or imported, never inferred from traffic, which would
+mean parsing DICOM that carries PHI. Direction is load-bearing: an AE's
+*outbound* edges stop sending when it moves, its *inbound* edges stop being able
+to reach it, and those are different remediation lists. `GET
+/api/v1/dicom/aes/{id}/impact` returns them split.
+
+### Conformity
+
+| Check | Target | Verdict |
+|---|---|---|
+| `dicom_ae_default_title` | platform | **Warn** when any AE is still on a known vendor default (`DCM4CHEE`, `ANY-SCP`, `ORTHANC`, …). Not invalid — just the most common cause of estate-wide collisions. |
+| `dicom_ae_title_convention` | platform | **Fail** for titles that don't match the institution's naming convention, supplied as a `pattern` check **argument** rather than a table: every site's convention differs, and a convention registry would be a schema for one regular expression. Not-applicable when no pattern is set. |
+| `dicom_ae_outside_hipaa_scope` | platform | **Fail** for a bound AE in a subnet not flagged `hipaa_scope`. DICOM carries ePHI, so either the scope flag or the device placement is wrong. Reservations and unknown-subnet rows are excluded — an unknown is an unknown. |
+| `dicom_ae_no_tls` | platform | **Warn** for AEs not recorded as TLS-enabled. Reports what the *registry* records, not what the wire does; remediation is a device-by-device project with clinical downtime, so a hard fail on day one would put every hospital permanently red. Raise the severity once that project is done. |
+
+### Import
+
+`POST /api/v1/dicom/aes/import/{preview,commit}` ingests the estate's existing
+AE table. Two contracts differ from the OT importer:
+
+- **The join key is `ae_title`, not the IP** — that is the identity DICOM cares
+  about and the one the unique constraint is on. Two rows in one file sharing a
+  title is a per-row error, because that duplicate is the exact collision the
+  registry exists to surface.
+- **The address column is optional.** A blank address registers an unbound
+  reservation rather than failing. A *supplied* address IPAM doesn't know is
+  still an error — an export enriches inventory, it does not invent it.
+
+### Hard guardrail — no PHI, ever
+
+The registry stores **network identity only**: titles, hosts, ports, roles,
+vendors, departments. It records nothing about patients, studies or images.
+Storing patient-identifiable data would make SpatiumDDI a HIPAA Business
+Associate, which is permanently out of scope. `notes` is documented on the wire
+as a network-configuration field, because an unlabelled free-text box is the
+surest way to end up storing PHI by accident.
+
+---
+
+## Fragile-device probe suppression (#722)
+
+Not a vertical, and deliberately **not** behind a feature module: it is a
+constraint on SpatiumDDI's own behaviour and a correctness fix to three shipped
+features, so it is on for every install.
+
+Medical- and OT-device vendors explicitly instruct sites not to scan their
+VLANs — Swisslog's pneumatic-tube deployment guide says to omit ping sweeps and
+nmap of any range supporting the PTS, and the same hazard covers patient
+monitors, BMC / IPMI endpoints, and the PLC / RTU class `network.ot` registers.
+Fragile IP stacks fault or drop off the network under a sweep. Until this flag
+existed there was no way for an operator to say so.
+
+`do_not_probe` + `do_not_probe_reason` live on `IPSpace`, `IPBlock` and
+`Subnet`, and **OR down the chain**. That is deliberately unlike the DDNS fields
+they otherwise mirror, which resolve to the first non-inheriting ancestor and so
+let a descendant override its parent. A hospital that marks its clinical
+IPSpace do-not-probe must not have one subnet quietly opt back in, so there is
+no per-level inherit toggle and nothing downstream can un-set the flag. The
+*nearest* flagged level supplies the reason, because that is the most specific
+explanation an operator wrote.
+
+**Every probe origin consults the same resolver**
+(`app/services/ipam/probe_policy.py`):
+
+| Origin | Behaviour |
+|---|---|
+| #23 discovery sweep | Skipped before any packet, `last_discovery_at` stamped so the dispatcher stops re-queueing, reason recorded on the audit row. The dispatcher also skips flagged subnets so a flagged estate doesn't generate a task per subnet per interval. |
+| `tools.nmap` | 422 before the scan row is persisted. Covers CIDR targets in both directions — a `/16` sweep reaches a flagged `/24` inside it, and a `/25` inside a flagged `/16` is equally covered. |
+| `tools.nmap` auto-profile on DHCP lease | Checked before the refresh window, so it cannot be bypassed by tuning the other guards. |
+| `tools.network` ping / traceroute / mtr / port-test / tls-cert | 422 with the operator's reason quoted back. Gated before the vantage branch, so an appliance-vantage run is refused identically — the hazard is packets reaching the device, not which host emits them. |
+
+`dig`, `whois`, DNS-propagation and mac-vendor are **not** gated: they query a
+resolver or an off-prem service about a name, they do not probe the name's host.
+Passive collection is untouched by design — PCAP (#59), DHCP fingerprinting, RA
+sniffing and ARP-table reads observe traffic that already exists.
+
+**The override.** `override_do_not_probe: true` requires **superadmin** — not a
+permission grant, because `use_network_tools` is a routine grant delegated
+admins hold and the point of the flag is that whoever clears it is accountable.
+It writes a `probe.do_not_probe_override` audit row *before* the probe runs, and
+it is per-request: nothing is remembered, so the next call is refused again. The
+alternative — refusing absolutely — just gets the flag turned off estate-wide,
+which is a worse outcome than a recorded exception.
+
+**Fail-safe direction.** A target the resolver cannot map to a subnet is
+*allowed*. Refusing everything unmappable would make the tools page unusable
+against off-IPAM infrastructure, and an operator who never modelled a network in
+IPAM never told us it was fragile. Hostnames are matched against
+`IPAddress.hostname` rather than resolved through DNS: a lookup inside an
+authorization check makes the verdict depend on a round-trip nobody can see the
+result of, and lets a hostile record steer the guard.
+
+**The conformity check works backwards from the registries.** The flag is
+opt-in, so `fragile_subnet_probed` (target: subnet) **fails** when a subnet
+carries registered `ot_device` rows, `dicom_ae` rows, or `role="bmc"` addresses
+but is not covered by the flag — if an operator has told us a subnet holds that
+gear, they have already told us it is fragile. Suppression inherited from a
+parent counts as covered.
+
+`bmc` also joins the `IP_ROLES` set in the same issue: BMC / IPMI / Redfish
+endpoints are exactly this fragile class, and naming them is what lets an
+operator find every one and decide whether their subnet belongs behind the flag.
+
+---
+
 ## What is deliberately not here
 
 Every discovery phase across all three modules is unshipped, and the reasons are
@@ -226,11 +403,14 @@ today.
 | #541 Phase 2 — `Who-Is` sweep | Needs a UDP broadcast carrying a real BACnet payload. The control plane's only generic UDP prober sends an **empty** datagram, so this needs a new datagram helper plus the same agent↔subnet binding #40 died on. |
 | #542 Phase 2 — EtherNet/IP · Modbus · OPC UA probes | The issue expected this to be nearly free via nmap NSE scripts. It is not: nmap **runs** `--script enip-info,modbus-discover` today, but `_parse_host()` never reads `<script>` / `<hostscript>` elements, so the output dies in `raw_xml`. Real discovery needs an NSE-output parser plus a preset threaded through five separate hardcoded lists. |
 | #542 Phase 3 — PROFINET DCP | Ethertype `0x8892`, raw L2, not routable. No `SOCK_RAW` code exists in the backend and `CAP_NET_RAW` is a file capability on the `nmap`/`tcpdump` binaries only — the Python process does not have it. Needs a container capability grant, i.e. a deployment change. |
+| #723 — C-ECHO verification probe | Filed separately. It is the **one** probe in this family that does *not* inherit the agent↔subnet blocker — C-ECHO is routable unicast TCP, so it could run from the control plane today. It is deferred on its own merits (an association negotiation is a real DICOM client, not a socket poke) and it must go through #722's do-not-probe gate first: a probe reaching a modality mid-study is precisely the hazard that flag exists for. |
 
 Each phase remains worth doing; each is its own piece of work with its own
 prerequisites, and none of them is a metadata phase.
 
-**Also permanently out of scope:** RTP jitter / packet-loss / SDP essence
+**Also permanently out of scope:** patient-identifiable data of any kind (see
+the DICOM PHI guardrail above) and inferring DICOM associations from captured
+traffic; RTP jitter / packet-loss / SDP essence
 analysis and NMOS IS-05 connection control (SpatiumDDI is a registry, not a
 media monitor); running PIM/IGMP or acting as a BBMD (we document the topology,
 we don't participate in it); BACnet object/point-level management (we track the
@@ -241,19 +421,23 @@ aren't IP-addressable.
 
 ## Operational notes
 
-- **Backup / factory reset.** The five tables — plus the four multicast tables
+- **Backup / factory reset.** The seven tables — plus the four multicast tables
   they depend on — are covered by the `verticals` backup section and the
   `DESTROY-VERTICALS` factory-reset section. Resetting the verticals section
   destroys only the vertical metadata; the underlying IPAM addresses and subnets
   are untouched.
 - **RBAC.** The builtin **Network Editor** role grants `admin` on `av_flow`,
-  `bacnet_device`, and `ot_device`. Builtin roles are re-seeded on every boot, so
-  no migration is involved.
-- **Enum vocabularies** (`av_protocol`, `ot_protocol`, `ot_role`, `seen_via`) are
+  `bacnet_device`, `ot_device`, and `dicom_ae`. Builtin roles are re-seeded on
+  every boot, so no migration is involved. `do_not_probe` (#722) is a field on
+  the IPAM rows and needs no resource type of its own — editing it requires
+  write on the space / block / subnet, and *overriding* it requires superadmin.
+- **Enum vocabularies** (`av_protocol`, `ot_protocol`, `ot_role`, `role`,
+  `device_class`, `seen_via`) are
   module-level `frozenset[str]` validated at the API layer rather than Postgres
   enums, matching the multicast registry's convention — adding a protocol later
   must not require a migration. Values with a *specification-defined* range
-  (BACnet's 22-bit instance space, PTP's single octet, Purdue 0–5) do carry
-  database `CHECK` constraints, because those bounds will never move.
+  (BACnet's 22-bit instance space, PTP's single octet, Purdue 0–5, the DICOM
+  16-byte AE length ceiling and its port range) do carry database `CHECK`
+  constraints, because those bounds will never move.
 - **`seen_via`** already accepts the discovery-phase values (`mdns`, `nmos`,
-  `whois`, `enip`, `dcp`, …) so those phases need no data migration.
+  `whois`, `enip`, `dcp`, `echo`, …) so those phases need no data migration.

--- a/docs/features/VERTICALS.md
+++ b/docs/features/VERTICALS.md
@@ -348,6 +348,11 @@ explanation an operator wrote.
 | `tools.nmap` | 422 before the scan row is persisted. Covers CIDR targets in both directions — a `/16` sweep reaches a flagged `/24` inside it, and a `/25` inside a flagged `/16` is equally covered. |
 | `tools.nmap` auto-profile on DHCP lease | Checked before the refresh window, so it cannot be bypassed by tuning the other guards. |
 | `tools.network` ping / traceroute / mtr / port-test / tls-cert | 422 with the operator's reason quoted back. Gated before the vantage branch, so an appliance-vantage run is refused identically — the hazard is packets reaching the device, not which host emits them. |
+| "Re-profile now" on an IP | 422. It bypasses the refresh window on purpose; it does not bypass this, because the operator who clicked it is usually not the one who wrote the vendor bulletin onto the subnet. |
+| Operator Copilot | Both the `run_nmap_scan` apply path and the `network_ping` / `network_traceroute` / `network_port_test` / `network_tls_cert` MCP tools. A proposal the operator approved is still a scan, and the copilot must not be the one surface that still probes. No override on either — clearing the flag is a deliberate superadmin action on the tools page, not something to talk a copilot into. |
+| TLS certificate probes (#118) | The 6-hourly sweep skips flagged targets, and so does the probe dispatched on target create. A TLS handshake is an active probe, and a BMC or imaging console answering 443 is exactly the protected class. |
+| SNMP polling | Skipped, with `next_poll_at` deliberately left where it was — the poll did not happen, so nothing about its schedule should move. A GET is still a packet we originated. |
+| Scheduled Wake-on-LAN verification (#586) | The **active** chain only. Passive verification still runs, so a suppressed host is still verified — from sightings that already happened, without a packet being sent at it. Waking a fragile device is fine; poking it to confirm is not. |
 
 `dig`, `whois`, DNS-propagation and mac-vendor are **not** gated: they query a
 resolver or an off-prem service about a name, they do not probe the name's host.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Open-source DDI platform — unified DNS, DHCP, and IP Address Management.
 - [ACME DNS-01 Provider](features/ACME.md) — acme-dns-compatible surface for LE / public-CA cert issuance against SpatiumDDI-managed zones
 - [Integrations](features/INTEGRATIONS.md) — read-only Kubernetes + Docker + Proxmox VE + Tailscale + Cloud (AWS/Azure/GCP) mirrors into IPAM; per-integration setup, mirror semantics, dashboard surface, roadmap
 - [BGP Looking Glass](features/LOOKING_GLASS.md) — receive-only BGP collector (GoBGP) peering with the operator's routers; Sessions + Routes grid, RPKI status at ingest
-- [Vertical network awareness](features/VERTICALS.md) — AV-over-IP (Dante / AES67 / SMPTE 2110) flow descriptors, BACnet/IP device-instance registry + BBMD conformity, Industrial-OT inventory + Purdue zoning
+- [Vertical network awareness](features/VERTICALS.md) — AV-over-IP (Dante / AES67 / SMPTE 2110) flow descriptors, BACnet/IP device-instance registry + BBMD conformity, Industrial-OT inventory + Purdue zoning, DICOM AE Title registry + peer map, and the fragile-device do-not-probe flag
 - [System Admin](features/SYSTEM_ADMIN.md) — config, health dashboard, backup/restore
 
 ## Deployment

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ import { AsnsPage } from "@/pages/network/AsnsPage";
 import { AsnDetailPage } from "@/pages/network/AsnDetailPage";
 import { AVFlowsPage } from "@/pages/network/AVFlowsPage";
 import { BACnetDevicesPage } from "@/pages/network/BACnetDevicesPage";
+import { DICOMPage } from "@/pages/network/DICOMPage";
 import { OTDevicesPage } from "@/pages/network/OTDevicesPage";
 import { CertificatesPage } from "@/pages/network/CertificatesPage";
 import { CircuitsPage } from "@/pages/network/CircuitsPage";
@@ -150,6 +151,7 @@ export default function App() {
             BACnet/IP (#541), OT / industrial (#542). */}
         <Route path="network/av" element={<AVFlowsPage />} />
         <Route path="network/bacnet" element={<BACnetDevicesPage />} />
+        <Route path="network/dicom" element={<DICOMPage />} />
         <Route path="network/ot" element={<OTDevicesPage />} />
         <Route path="network/certificates" element={<CertificatesPage />} />
         <Route path="network/circuits" element={<CircuitsPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   Activity,
   AudioLines,
   Building2,
+  Scan,
   Factory,
   Power,
   Network,
@@ -201,6 +202,12 @@ const networkInfrastructureNav = [
     icon: Waypoints,
     to: "/network/circuits",
     module: "network.circuit",
+  },
+  {
+    label: "DICOM AEs",
+    icon: Scan,
+    to: "/network/dicom",
+    module: "network.dicom",
   },
   {
     label: "Devices",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -230,6 +230,12 @@ export interface IPSpace {
   ddns_hostname_policy?: DdnsHostnamePolicy;
   ddns_domain_override?: string | null;
   ddns_ttl?: number | null;
+  // Fragile-device probe suppression (#722). ORs down the
+  // space → block → subnet chain — any level setting it suppresses
+  // every level below, and a descendant cannot un-set it. Reason
+  // travels with the flag and is quoted back in every refusal.
+  do_not_probe?: boolean;
+  do_not_probe_reason?: string;
   // VRF / routing annotation — pure metadata; address allocation
   // ignores these. ``route_targets`` is an array of strings so the
   // operator can encode the inline import:A:B; export:C:D convention
@@ -274,6 +280,12 @@ export interface IPBlock {
   ddns_domain_override?: string | null;
   ddns_ttl?: number | null;
   ddns_inherit_settings?: boolean;
+  // Fragile-device probe suppression (#722). ORs down the
+  // space → block → subnet chain — any level setting it suppresses
+  // every level below, and a descendant cannot un-set it. Reason
+  // travels with the flag and is quoted back in every refusal.
+  do_not_probe?: boolean;
+  do_not_probe_reason?: string;
   vrf_id?: string | null;
   asn_id?: string | null;
   customer_id?: string | null;
@@ -398,6 +410,21 @@ export interface PlanApplyResult {
   block_ids: string[];
   subnet_ids: string[];
   applied_at: string;
+}
+
+/** Effective fragile-device probe verdict for a subnet (#722).
+ *
+ * ``inherited`` distinguishes "this subnet is flagged" from "an ancestor
+ * flagged it" — i.e. whether clearing the subnet's own checkbox would
+ * actually re-enable probing. */
+export interface ProbePolicy {
+  do_not_probe: boolean;
+  reason: string;
+  /** ``subnet:<id>`` / ``block:<id>`` / ``space:<id>``; null when
+   *  nothing is suppressing. */
+  source: string | null;
+  scope: string | null;
+  inherited: boolean;
 }
 
 export interface EffectiveDns {
@@ -580,6 +607,12 @@ export interface Subnet {
   discovery_enabled?: boolean;
   discovery_interval_minutes?: number;
   last_discovery_at?: string | null;
+  // Fragile-device probe suppression (#722). This is the subnet's OWN
+  // flag — an ancestor block / space can suppress a subnet whose own
+  // flag is false. Resolve the effective answer with
+  // ``ipamApi.probePolicy(subnetId)``.
+  do_not_probe?: boolean;
+  do_not_probe_reason?: string;
   // Compliance / classification flags. First-class booleans (rather
   // than freeform tags) so auditor queries — "show me every PCI
   // subnet" — are clean indexed predicates. Default false on every
@@ -699,7 +732,8 @@ export type IPRole =
   | "vip"
   | "vrrp"
   | "secondary"
-  | "gateway";
+  | "gateway"
+  | "bmc";
 
 export const IP_ROLE_OPTIONS: IPRole[] = [
   "host",
@@ -709,6 +743,12 @@ export const IP_ROLE_OPTIONS: IPRole[] = [
   "vrrp",
   "secondary",
   "gateway",
+  // Baseboard management controller — iDRAC / iLO / IPMI / Redfish
+  // (#722). A management-plane endpoint on a fragile embedded stack,
+  // and a routine casualty of ping sweeps: naming the class is what
+  // lets an operator find them all and decide whether their subnet
+  // belongs behind the do-not-probe flag.
+  "bmc",
 ];
 
 export const IP_ROLES_SHARED: ReadonlySet<IPRole> = new Set([
@@ -1365,6 +1405,8 @@ export const ipamApi = {
         | "vrf_id"
         | "customer_id"
         | "site_id"
+        | "do_not_probe"
+        | "do_not_probe_reason"
       >
     >,
   ) => api.put<IPBlock>(`/ipam/blocks/${id}`, data).then((r) => r.data),
@@ -1436,6 +1478,13 @@ export const ipamApi = {
     api.post<PlanApplyResult>(`/ipam/plans/${id}/apply`).then((r) => r.data),
   reopenSubnetPlan: (id: string) =>
     api.post<SubnetPlanRead>(`/ipam/plans/${id}/reopen`).then((r) => r.data),
+  // Effective do-not-probe verdict for a subnet (#722). A separate call
+  // rather than a field on the list rows: resolving it walks the block
+  // chain, which is cheap once but N walks on a list page.
+  getSubnetProbePolicy: (subnetId: string) =>
+    api
+      .get<ProbePolicy>(`/ipam/subnets/${subnetId}/probe-policy`)
+      .then((r) => r.data),
   getEffectiveBlockDns: (blockId: string) =>
     api
       .get<EffectiveDns>(`/ipam/blocks/${blockId}/effective-dns`)
@@ -17351,6 +17400,239 @@ export const bacnetApi = {
       .get<BACnetNextInstance>("/bacnet/next-instance", {
         params: start === undefined ? undefined : { start },
       })
+      .then((r) => r.data),
+};
+
+// ── DICOM AE registry (#723) ─────────────────────────────────────────
+
+export type DICOMRole = "scp" | "scu" | "both";
+
+export type DICOMDeviceClass =
+  | "modality"
+  | "pacs"
+  | "workstation"
+  | "archive"
+  | "router"
+  | "worklist"
+  | "printer"
+  | "other";
+
+export type DICOMAESource = "manual" | "import" | "echo";
+
+export interface DICOMApplicationEntity {
+  id: string;
+  /** Unique institution-wide by specification (PS3.15 Annex H). Case is
+   *  significant — peers match titles exactly. */
+  ae_title: string;
+  /** Null for a *reservation*: a title still burned into peer config
+   *  whose host was decommissioned. Not an error state. */
+  ip_address_id: string | null;
+  subnet_id: string | null;
+  address: string | null;
+  hostname: string | null;
+  port: number;
+  tls_enabled: boolean;
+  role: string;
+  device_class: string;
+  vendor: string;
+  model_name: string;
+  department: string;
+  location: string;
+  seen_via: string;
+  last_seen_at: string | null;
+  /** Network-configuration notes. Never patient data — the registry
+   *  stores none. */
+  notes: string;
+  tags: Record<string, unknown>;
+  custom_fields: Record<string, unknown>;
+  /** Still a known vendor default (DCM4CHEE, ANY-SCP, …) — advisory,
+   *  and the most common cause of estate-wide title collisions. */
+  is_vendor_default: boolean;
+  is_reservation: boolean;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface DICOMAECreate {
+  ae_title: string;
+  ip_address_id?: string | null;
+  port?: number;
+  tls_enabled?: boolean;
+  role?: DICOMRole;
+  device_class?: DICOMDeviceClass;
+  vendor?: string;
+  model_name?: string;
+  department?: string;
+  location?: string;
+  seen_via?: DICOMAESource;
+  last_seen_at?: string | null;
+  notes?: string;
+  tags?: Record<string, unknown>;
+  custom_fields?: Record<string, unknown>;
+}
+
+/** PATCH body. ``ip_address_id: null`` explicitly demotes the AE to a
+ *  reservation — the normal lifecycle event when a host is retired. */
+export interface DICOMAEUpdate {
+  ae_title?: string;
+  ip_address_id?: string | null;
+  port?: number;
+  tls_enabled?: boolean;
+  role?: DICOMRole;
+  device_class?: DICOMDeviceClass;
+  vendor?: string;
+  model_name?: string;
+  department?: string;
+  location?: string;
+  seen_via?: DICOMAESource;
+  last_seen_at?: string | null;
+  notes?: string;
+  tags?: Record<string, unknown>;
+  custom_fields?: Record<string, unknown>;
+}
+
+export interface DICOMAEListResponse {
+  items: DICOMApplicationEntity[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface DICOMAEListQuery {
+  limit?: number;
+  offset?: number;
+  subnet_id?: string;
+  ip_address_id?: string;
+  device_class?: DICOMDeviceClass;
+  role?: DICOMRole;
+  tls_enabled?: boolean;
+  unbound?: boolean;
+  q?: string;
+}
+
+/** A configured, directed AE→AE association. Documented by the operator
+ *  or imported — never inferred from traffic, which would carry PHI. */
+export interface DICOMPeer {
+  id: string;
+  source_ae_id: string;
+  source_ae_title: string;
+  target_ae_id: string;
+  target_ae_title: string;
+  services: string[];
+  notes: string;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface DICOMPeerCreate {
+  source_ae_id: string;
+  target_ae_id: string;
+  services?: string[];
+  notes?: string;
+}
+
+/** Blast radius of renumbering or retiring one AE. Split by direction:
+ *  outbound edges stop sending, inbound edges stop being able to reach
+ *  it — different remediation lists. */
+export interface DICOMImpact {
+  ae_id: string;
+  ae_title: string;
+  address: string | null;
+  outbound: DICOMPeer[];
+  inbound: DICOMPeer[];
+  total_peers: number;
+}
+
+export interface DICOMAEImportColumnMap {
+  ae_title: string;
+  address?: string | null;
+  port?: string | null;
+  tls_enabled?: string | null;
+  role?: string | null;
+  device_class?: string | null;
+  vendor?: string | null;
+  model_name?: string | null;
+  department?: string | null;
+  location?: string | null;
+  notes?: string | null;
+}
+
+export interface DICOMAEImportRequest {
+  csv_text: string;
+  column_map: DICOMAEImportColumnMap;
+  delimiter?: "," | ";" | "\t" | "|";
+  default_port?: number;
+  default_department?: string;
+  overwrite_existing?: boolean;
+  space_id?: string | null;
+}
+
+export interface DICOMAEImportRow {
+  line: number;
+  ae_title: string;
+  action: "create" | "update" | "skip" | "error";
+  reason: string;
+  address: string;
+  ip_address_id: string | null;
+  fields: Record<string, unknown>;
+}
+
+export interface DICOMAEImportPreview {
+  rows: DICOMAEImportRow[];
+  create_count: number;
+  update_count: number;
+  skip_count: number;
+  error_count: number;
+  max_rows: number;
+}
+
+export interface DICOMAEImportCommit {
+  rows: DICOMAEImportRow[];
+  created: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+  ae_ids: string[];
+}
+
+export const dicomApi = {
+  listAes: (params?: DICOMAEListQuery) =>
+    api.get<DICOMAEListResponse>("/dicom/aes", { params }).then((r) => r.data),
+  getAe: (id: string) =>
+    api.get<DICOMApplicationEntity>(`/dicom/aes/${id}`).then((r) => r.data),
+  createAe: (data: DICOMAECreate) =>
+    api.post<DICOMApplicationEntity>("/dicom/aes", data).then((r) => r.data),
+  updateAe: (id: string, data: DICOMAEUpdate) =>
+    api
+      .patch<DICOMApplicationEntity>(`/dicom/aes/${id}`, data)
+      .then((r) => r.data),
+  removeAe: (id: string) => api.delete(`/dicom/aes/${id}`),
+  impact: (id: string) =>
+    api.get<DICOMImpact>(`/dicom/aes/${id}/impact`).then((r) => r.data),
+
+  listPeers: (aeId?: string) =>
+    api
+      .get<DICOMPeer[]>("/dicom/peers", {
+        params: aeId ? { ae_id: aeId } : undefined,
+      })
+      .then((r) => r.data),
+  createPeer: (data: DICOMPeerCreate) =>
+    api.post<DICOMPeer>("/dicom/peers", data).then((r) => r.data),
+  removePeer: (id: string) => api.delete(`/dicom/peers/${id}`),
+
+  // 404 = "this IP isn't a DICOM node" — a normal answer, not a failure.
+  byAddress: (ipAddressId: string) =>
+    api
+      .get<DICOMApplicationEntity>(`/dicom/by-address/${ipAddressId}`)
+      .then((r) => r.data),
+
+  importPreview: (data: DICOMAEImportRequest) =>
+    api
+      .post<DICOMAEImportPreview>("/dicom/aes/import/preview", data)
+      .then((r) => r.data),
+  importCommit: (data: DICOMAEImportRequest) =>
+    api
+      .post<DICOMAEImportCommit>("/dicom/aes/import/commit", data)
       .then((r) => r.data),
 };
 

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -11075,6 +11075,8 @@ function EditSpaceModal({
         vrf_id: vrfId,
         asn_id: asnId,
         customer_id: customerId,
+        do_not_probe: doNotProbe,
+        do_not_probe_reason: doNotProbeReason,
       });
     },
     onSuccess: () => {

--- a/frontend/src/pages/ipam/IPAMPage.tsx
+++ b/frontend/src/pages/ipam/IPAMPage.tsx
@@ -29,6 +29,7 @@ import {
   Lock,
   Search,
   Radar,
+  ShieldAlert,
   Wrench,
   Sparkles,
   HelpCircle,
@@ -1690,6 +1691,91 @@ function DiscoverySettingsSection({
 }
 
 /**
+ * Fragile-device probe suppression (issue #722).
+ *
+ * Medical- and OT-device vendors instruct sites not to scan their
+ * VLANs, and fragile IP stacks genuinely fault under a sweep. This
+ * flag is what an operator sets to say so, and it suppresses every
+ * active probe SpatiumDDI can originate against the scope.
+ *
+ * Used at all three levels of the hierarchy (space / block / subnet),
+ * so the copy is deliberately level-agnostic and the caller passes
+ * ``inherited`` when an ancestor is already suppressing — clearing the
+ * local checkbox in that case changes nothing, and the UI has to say
+ * so rather than let an operator think they re-enabled probing.
+ */
+function DoNotProbeSection({
+  enabled,
+  reason,
+  onEnabledChange,
+  onReasonChange,
+  inherited,
+  inheritedFrom,
+}: {
+  enabled: boolean;
+  reason: string;
+  onEnabledChange: (v: boolean) => void;
+  onReasonChange: (v: string) => void;
+  inherited?: boolean;
+  inheritedFrom?: string | null;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <ShieldAlert className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="text-xs font-medium">
+            Do not probe (fragile devices)
+          </span>
+        </div>
+        <label className="flex cursor-pointer select-none items-center gap-1.5 text-xs">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => onEnabledChange(e.target.checked)}
+            className="h-3.5 w-3.5"
+          />
+          Suppress probes
+        </label>
+      </div>
+      {inherited && (
+        <p className="rounded-md border border-amber-500/30 bg-amber-500/5 px-2 py-1.5 text-[11px] text-amber-700 dark:text-amber-400">
+          Already suppressed by {inheritedFrom ?? "a parent scope"}. The flag
+          ORs down the hierarchy, so clearing it here will not re-enable probing
+          — clear it on the parent instead.
+        </p>
+      )}
+      <p className="text-xs italic text-muted-foreground">
+        Suppresses every active probe SpatiumDDI originates against this scope:
+        the scheduled discovery sweep, nmap (including auto-profile on DHCP
+        lease), and the ping / traceroute / port-test tools. Passive collection
+        (packet capture, DHCP fingerprinting, ARP reads) is unaffected — it was
+        never the hazard. A superadmin can override per request, and every
+        override is audited.
+      </p>
+      {enabled && (
+        <label className="block space-y-1 border-l-2 border-muted pl-5 text-xs">
+          <span className="block text-muted-foreground">
+            Reason (quoted back in every refusal)
+          </span>
+          <input
+            value={reason}
+            onChange={(e) => onReasonChange(e.target.value)}
+            placeholder="e.g. Alaris infusion pumps — vendor bulletin VB-2024-11 forbids scanning"
+            className="w-full rounded-md border bg-background px-2 py-1 text-sm"
+          />
+          <span className="block text-[11px] text-muted-foreground">
+            Worth filling in: a refusal that just says &ldquo;marked
+            do-not-probe&rdquo; is the kind an operator overrides without
+            thinking.
+          </span>
+        </label>
+      )}
+    </div>
+  );
+}
+
+/**
  * Compliance classification — first-class boolean flags on the
  * subnet for PCI / HIPAA / internet-facing scope. Used by the
  * Compliance dashboard at /admin/compliance to answer auditor
@@ -2386,6 +2472,13 @@ function CreateSubnetModal({
   // IP discovery (issue #23) — opt-in scheduled ping/ARP sweep.
   const [discoveryEnabled, setDiscoveryEnabled] = useState(false);
   const [discoveryIntervalMinutes, setDiscoveryIntervalMinutes] = useState(360);
+  // Fragile-device probe suppression (issue #722). On create there is
+  // no subnet row to resolve an effective verdict against yet, so the
+  // inherited hint is only shown on edit.
+  const [doNotProbe, setDoNotProbe] = useState(false);
+  const [doNotProbeReason, setDoNotProbeReason] = useState("");
+  const probeInherited = false;
+  const probeInheritedFrom: string | null = null;
   // Compliance / classification flags (issue #75).
   const [pciScope, setPciScope] = useState(false);
   const [hipaaScope, setHipaaScope] = useState(false);
@@ -2511,6 +2604,8 @@ function CreateSubnetModal({
         auto_profile_refresh_days: autoProfileRefreshDays,
         discovery_enabled: discoveryEnabled,
         discovery_interval_minutes: discoveryIntervalMinutes,
+        do_not_probe: doNotProbe,
+        do_not_probe_reason: doNotProbeReason,
         pci_scope: pciScope,
         hipaa_scope: hipaaScope,
         internet_facing: internetFacing,
@@ -2840,6 +2935,16 @@ function CreateSubnetModal({
               intervalMinutes={discoveryIntervalMinutes}
               onEnabledChange={setDiscoveryEnabled}
               onIntervalChange={setDiscoveryIntervalMinutes}
+            />
+          </div>
+          <div className="border-t pt-4">
+            <DoNotProbeSection
+              enabled={doNotProbe}
+              reason={doNotProbeReason}
+              onEnabledChange={setDoNotProbe}
+              onReasonChange={setDoNotProbeReason}
+              inherited={probeInherited}
+              inheritedFrom={probeInheritedFrom}
             />
           </div>
           <div className="border-t pt-4">
@@ -4494,6 +4599,15 @@ function SubnetDetail({
     for (const z of subnetZonesQuery.data ?? []) m[z.id] = z.name;
     return m;
   }, [subnetZonesQuery.data]);
+  // Effective do-not-probe verdict (#722). Resolved server-side because
+  // an ancestor block or space can suppress a subnet whose own flag is
+  // false — the case the badge most needs to catch.
+  const probePolicyQuery = useQuery({
+    queryKey: ["subnet-probe-policy", subnet.id],
+    queryFn: () => ipamApi.getSubnetProbePolicy(subnet.id),
+    staleTime: 30_000,
+  });
+  const probePolicy = probePolicyQuery.data;
   const [showAddModal, setShowAddModal] = useState(false);
   // Optional seed for ``AddAddressModal`` — set when the operator clicks
   // a gap-marker row so the modal opens in manual mode constrained to
@@ -5315,6 +5429,23 @@ function SubnetDetail({
               title="CGNAT space (RFC 6598, 100.64.0.0/10) — carrier-grade NAT, also the range overlays like Tailscale allocate. Not publicly routable; double-check before using for a normal on-prem LAN."
             >
               CGNAT
+            </span>
+          )}
+          {/* Fragile-device probe suppression (#722). Resolved, not the
+              subnet's own flag: a suppressing ancestor is exactly the
+              case an operator would otherwise miss. */}
+          {probePolicy?.do_not_probe && (
+            <span
+              className="inline-flex items-center rounded bg-rose-100 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wider text-rose-700 dark:bg-rose-950/30 dark:text-rose-400"
+              title={
+                (probePolicy.inherited
+                  ? `Probes suppressed by ${probePolicy.scope ?? "a parent scope"}`
+                  : "Probes suppressed on this subnet") +
+                (probePolicy.reason ? ` — ${probePolicy.reason}` : "") +
+                ". Discovery sweeps, nmap and the reachability tools refuse targets in here."
+              }
+            >
+              do not probe
             </span>
           )}
           {subnet.name && (
@@ -7574,6 +7705,20 @@ function EditSubnetModal({
   const [discoveryIntervalMinutes, setDiscoveryIntervalMinutes] = useState(
     subnet.discovery_interval_minutes ?? 360,
   );
+  // Fragile-device probe suppression (issue #722). This is the subnet's
+  // OWN flag; the effective verdict (which an ancestor may be supplying)
+  // comes from the probe-policy query below.
+  const [doNotProbe, setDoNotProbe] = useState(subnet.do_not_probe ?? false);
+  const [doNotProbeReason, setDoNotProbeReason] = useState(
+    subnet.do_not_probe_reason ?? "",
+  );
+  const probePolicyQ = useQuery({
+    queryKey: ["subnet-probe-policy", subnet.id],
+    queryFn: () => ipamApi.getSubnetProbePolicy(subnet.id),
+    staleTime: 30_000,
+  });
+  const probeInherited = probePolicyQ.data?.inherited ?? false;
+  const probeInheritedFrom = probePolicyQ.data?.scope ?? null;
   // Compliance / classification flags (issue #75). First-class
   // booleans rather than freeform tags so the Compliance dashboard
   // queries hit indexed predicates.
@@ -7701,6 +7846,8 @@ function EditSubnetModal({
         auto_profile_refresh_days: autoProfileRefreshDays,
         discovery_enabled: discoveryEnabled,
         discovery_interval_minutes: discoveryIntervalMinutes,
+        do_not_probe: doNotProbe,
+        do_not_probe_reason: doNotProbeReason,
         pci_scope: pciScope,
         hipaa_scope: hipaaScope,
         internet_facing: internetFacing,
@@ -8069,6 +8216,16 @@ function EditSubnetModal({
               intervalMinutes={discoveryIntervalMinutes}
               onEnabledChange={setDiscoveryEnabled}
               onIntervalChange={setDiscoveryIntervalMinutes}
+            />
+          </div>
+          <div className="border-t pt-4">
+            <DoNotProbeSection
+              enabled={doNotProbe}
+              reason={doNotProbeReason}
+              onEnabledChange={setDoNotProbe}
+              onReasonChange={setDoNotProbeReason}
+              inherited={probeInherited}
+              inheritedFrom={probeInheritedFrom}
             />
           </div>
           <div className="border-t pt-4">
@@ -10893,6 +11050,14 @@ function EditSpaceModal({
   const [customerId, setCustomerId] = useState<string | null>(
     space.customer_id ?? null,
   );
+  // Fragile-device probe suppression (issue #722). Set at the space
+  // level it covers every block and subnet underneath, which is the
+  // shape a hospital or plant with a whole clinical/OT routing domain
+  // actually wants.
+  const [doNotProbe, setDoNotProbe] = useState(space.do_not_probe ?? false);
+  const [doNotProbeReason, setDoNotProbeReason] = useState(
+    space.do_not_probe_reason ?? "",
+  );
   const [tab, setTab] = useState<"dns" | "dhcp" | "networking" | "danger">(
     "dns",
   );
@@ -11148,6 +11313,14 @@ function EditSpaceModal({
               onChange={setCustomerId}
             />
           </Field>
+          <div className="border-t pt-4">
+            <DoNotProbeSection
+              enabled={doNotProbe}
+              reason={doNotProbeReason}
+              onEnabledChange={setDoNotProbe}
+              onReasonChange={setDoNotProbeReason}
+            />
+          </div>
         </div>
       )}
 
@@ -11597,6 +11770,12 @@ function EditBlockModal({
     block.customer_id ?? null,
   );
   const [siteId, setSiteId] = useState<string | null>(block.site_id ?? null);
+  // Fragile-device probe suppression (issue #722). Suppresses every
+  // subnet under this block; a descendant cannot un-set it.
+  const [doNotProbe, setDoNotProbe] = useState(block.do_not_probe ?? false);
+  const [doNotProbeReason, setDoNotProbeReason] = useState(
+    block.do_not_probe_reason ?? "",
+  );
   const [tab, setTab] = useState<
     "general" | "dns" | "dhcp" | "networking" | "danger"
   >("general");
@@ -11666,6 +11845,8 @@ function EditBlockModal({
         vrf_id: vrfId,
         customer_id: customerId,
         site_id: siteId,
+        do_not_probe: doNotProbe,
+        do_not_probe_reason: doNotProbeReason,
       }),
     onSuccess: (updated) => {
       qc.invalidateQueries({ queryKey: ["blocks", block.space_id] });
@@ -11888,6 +12069,14 @@ function EditBlockModal({
               onChange={setSiteId}
             />
           </Field>
+          <div className="border-t pt-4">
+            <DoNotProbeSection
+              enabled={doNotProbe}
+              reason={doNotProbeReason}
+              onEnabledChange={setDoNotProbe}
+              onReasonChange={setDoNotProbeReason}
+            />
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/ipam/IPDetailModal.tsx
+++ b/frontend/src/pages/ipam/IPDetailModal.tsx
@@ -13,6 +13,7 @@ import {
   Radio,
   RefreshCw,
   Route as RouteIcon,
+  Scan,
   ShieldAlert,
   ShieldCheck,
   Trash2,
@@ -21,6 +22,7 @@ import {
 
 import {
   bacnetApi,
+  dicomApi,
   dnsblApi,
   ipamApi,
   lookingGlassApi,
@@ -580,11 +582,12 @@ export function IPDetailModal({
               the network.multicast feature module is disabled. */}
           <MulticastMembershipsSection addressId={addr.id} />
 
-          {/* BACnet/IP device (issue #541) + OT descriptor (issue #542).
-              Both self-hide when their module is off or the address
-              carries no such sidecar. */}
+          {/* BACnet/IP device (issue #541), OT descriptor (issue #542)
+              and DICOM AE (issue #723). Each self-hides when its module
+              is off or the address carries no such sidecar. */}
           <BACnetDeviceSection addressId={addr.id} />
           <OTDeviceSection addressId={addr.id} />
+          <DICOMAESection addressId={addr.id} />
 
           {/* Covering BGP route (issue #566 Phase 3). Hidden when the
               network.looking_glass module is off or nothing in the
@@ -872,6 +875,73 @@ function BACnetDeviceSection({ addressId }: { addressId: string }) {
           UDP {device.udp_port}
           {device.network_number !== null &&
             ` · BACnet network ${device.network_number}`}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── DICOM application entity (issue #723) ─────────────────────────
+//
+// The DICOM identity of this address, if it has one. A PACS host can
+// front several AE Titles; this shows the lowest-titled one, which is
+// enough to answer "is this an imaging node" — the full set is on the
+// DICOM page. 404 means "not a DICOM node", a normal answer here.
+//
+// Network identity only: nothing rendered here is patient data, because
+// the registry stores none.
+
+function DICOMAESection({ addressId }: { addressId: string }) {
+  const { enabled, ready } = useFeatureModules();
+  const dicomEnabled = ready && enabled("network.dicom");
+
+  const q = useQuery({
+    queryKey: ["dicom-ae-by-ip", addressId],
+    queryFn: () => dicomApi.byAddress(addressId),
+    enabled: dicomEnabled,
+    staleTime: 30_000,
+    // 404 = "this address has no DICOM AE", the common case.
+    retry: false,
+  });
+
+  if (!dicomEnabled) return null;
+  const ae = q.data;
+  if (!ae) return null;
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        <Scan className="h-3 w-3" /> DICOM application entity
+      </div>
+      <div className="space-y-1 rounded-md border px-3 py-2 text-xs">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[13px] font-semibold">
+            {ae.ae_title}
+          </span>
+          {ae.is_vendor_default && (
+            <span
+              className="inline-flex rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:bg-amber-950/30 dark:text-amber-400"
+              title="Still a vendor default — the most common cause of institution-wide AE Title collisions"
+            >
+              default
+            </span>
+          )}
+          {!ae.tls_enabled && (
+            <span
+              className="inline-flex rounded bg-rose-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-rose-700 dark:bg-rose-950/30 dark:text-rose-400"
+              title="Not recorded as TLS-enabled — plaintext DICOM carries ePHI in the clear"
+            >
+              plaintext
+            </span>
+          )}
+        </div>
+        <div className="text-muted-foreground">
+          {[ae.vendor, ae.model_name, ae.department, ae.location]
+            .filter(Boolean)
+            .join(" · ") || "No vendor / department recorded"}
+        </div>
+        <div className="text-muted-foreground">
+          Port {ae.port} · {ae.role} · {ae.device_class}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/network/DICOMPage.tsx
+++ b/frontend/src/pages/network/DICOMPage.tsx
@@ -1,0 +1,885 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Pencil,
+  Plus,
+  RefreshCw,
+  Scan,
+  ShieldAlert,
+  Trash2,
+  Waypoints,
+} from "lucide-react";
+
+import {
+  dicomApi,
+  formatApiError,
+  ipamApi,
+  type DICOMAECreate,
+  type DICOMAESource,
+  type DICOMAEUpdate,
+  type DICOMApplicationEntity,
+  type DICOMDeviceClass,
+  type DICOMRole,
+} from "@/lib/api";
+import { HeaderButton } from "@/components/ui/header-button";
+import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import { Pager } from "@/components/ui/pager";
+import { IPAddressPicker } from "@/components/IPAddressPicker";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
+import { usePermissions } from "@/hooks/usePermissions";
+
+// DICOM AE Title registry (issue #723, part of #543). Registry only —
+// nothing on this page opens a DICOM association, and nothing here holds
+// patient data.
+
+const PAGE_SIZE = 50;
+
+// IANA registers 11112 as ``dicom``; 104 carries the historical
+// ``acr-nema`` name and is still widely configured. Mirrors
+// app.models.dicom.DICOM_DEFAULT_PORT / DICOM_LEGACY_PORT.
+const DICOM_DEFAULT_PORT = 11112;
+const DICOM_LEGACY_PORT = 104;
+
+const ROLE_LABELS: Record<string, string> = {
+  scp: "SCP (responder)",
+  scu: "SCU (initiator)",
+  both: "Both",
+};
+
+const DEVICE_CLASS_LABELS: Record<string, string> = {
+  modality: "Modality",
+  pacs: "PACS",
+  workstation: "Workstation",
+  archive: "Archive",
+  router: "Router / gateway",
+  worklist: "Worklist / RIS",
+  printer: "Printer",
+  other: "Other",
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  manual: "Manual",
+  import: "Import",
+  echo: "C-ECHO probe",
+};
+
+// ── Page ─────────────────────────────────────────────────────────────
+
+export function DICOMPage() {
+  const qc = useQueryClient();
+  const { enabled, ready } = useFeatureModules();
+  const dicomEnabled = enabled("network.dicom");
+  // ``enabled()`` is optimistic while the module list loads, so data
+  // queries wait for ``ready`` as well — a hard page load must not fire
+  // a request that 404s.
+  const canQuery = ready && dicomEnabled;
+  const perms = usePermissions();
+  const canWrite = perms.can("write", "dicom_ae");
+  const canDelete = perms.can("delete", "dicom_ae");
+
+  const [page, setPage] = useState(1);
+  const [subnetFilter, setSubnetFilter] = useState("");
+  const [classFilter, setClassFilter] = useState("");
+  const [reservationsOnly, setReservationsOnly] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const [modal, setModal] = useState<
+    { mode: "create" } | { mode: "edit"; ae: DICOMApplicationEntity } | null
+  >(null);
+  const [del, setDel] = useState<DICOMApplicationEntity | null>(null);
+  const [impactOf, setImpactOf] = useState<DICOMApplicationEntity | null>(null);
+
+  const subnetsQ = useQuery({
+    queryKey: ["subnets", "all"],
+    queryFn: () => ipamApi.listSubnets(),
+    staleTime: 60_000,
+  });
+  const subnets = subnetsQ.data ?? [];
+
+  const aesQ = useQuery({
+    queryKey: [
+      "dicom-aes",
+      page,
+      subnetFilter,
+      classFilter,
+      reservationsOnly,
+      search,
+    ],
+    queryFn: () =>
+      dicomApi.listAes({
+        limit: PAGE_SIZE,
+        offset: (page - 1) * PAGE_SIZE,
+        subnet_id: subnetFilter || undefined,
+        device_class: (classFilter || undefined) as
+          | DICOMDeviceClass
+          | undefined,
+        unbound: reservationsOnly ? true : undefined,
+        q: search.trim() || undefined,
+      }),
+    enabled: canQuery,
+  });
+  const aes = aesQ.data?.items ?? [];
+  const total = aesQ.data?.total ?? 0;
+
+  const peersQ = useQuery({
+    queryKey: ["dicom-peers"],
+    queryFn: () => dicomApi.listPeers(),
+    enabled: canQuery,
+  });
+  const peers = peersQ.data ?? [];
+
+  const delMut = useMutation({
+    mutationFn: (id: string) => dicomApi.removeAe(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dicom-aes"] });
+      qc.invalidateQueries({ queryKey: ["dicom-peers"] });
+      setDel(null);
+    },
+  });
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="border-b bg-card px-6 py-4">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <Scan className="h-5 w-5 text-muted-foreground" />
+              <h1 className="text-lg font-semibold">
+                DICOM application entities
+              </h1>
+              <span className="text-xs text-muted-foreground">
+                {total} AE{total === 1 ? "" : "s"} · {peers.length} association
+                {peers.length === 1 ? "" : "s"}
+              </span>
+            </div>
+            <p className="mt-1 max-w-3xl text-xs text-muted-foreground">
+              AE Titles are unique across the whole institution by
+              specification, and a duplicate breaks C-MOVE, Storage Commitment
+              and Modality Worklist in ways that take days to trace. This is the
+              registry that namespace usually lives in as a spreadsheet. Network
+              identity only &mdash; no patient data is stored here, and nothing
+              on this page opens a DICOM association.
+            </p>
+          </div>
+          <div className="flex flex-shrink-0 items-center gap-2">
+            <HeaderButton
+              icon={RefreshCw}
+              iconClassName={
+                aesQ.isFetching || peersQ.isFetching ? "animate-spin" : ""
+              }
+              onClick={() => {
+                qc.invalidateQueries({ queryKey: ["dicom-aes"] });
+                qc.invalidateQueries({ queryKey: ["dicom-peers"] });
+              }}
+            >
+              Refresh
+            </HeaderButton>
+            <HeaderButton
+              variant="primary"
+              icon={Plus}
+              disabled={!canWrite}
+              title={
+                canWrite ? undefined : "Requires write permission on DICOM AEs"
+              }
+              onClick={() => setModal({ mode: "create" })}
+            >
+              New AE
+            </HeaderButton>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-6 overflow-auto p-6">
+        <section className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={subnetFilter}
+              onChange={(e) => {
+                setSubnetFilter(e.target.value);
+                setPage(1);
+              }}
+              className={`${filterCls} max-w-[16rem]`}
+              aria-label="Filter by subnet"
+            >
+              <option value="">All subnets</option>
+              {subnets.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.network}
+                  {s.name ? ` — ${s.name}` : ""}
+                </option>
+              ))}
+            </select>
+            <select
+              value={classFilter}
+              onChange={(e) => {
+                setClassFilter(e.target.value);
+                setPage(1);
+              }}
+              className={filterCls}
+              aria-label="Filter by device class"
+            >
+              <option value="">All classes</option>
+              {Object.entries(DEVICE_CLASS_LABELS).map(([id, label]) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            <label className="flex cursor-pointer items-center gap-1.5 text-xs">
+              <input
+                type="checkbox"
+                checked={reservationsOnly}
+                onChange={(e) => {
+                  setReservationsOnly(e.target.checked);
+                  setPage(1);
+                }}
+              />
+              Reservations only
+            </label>
+            <input
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+              placeholder="Search title / vendor / model / department…"
+              className={`${filterCls} w-72`}
+              aria-label="Search DICOM application entities"
+            />
+            <div className="ml-auto">
+              <Pager
+                page={page}
+                total={total}
+                pageSize={PAGE_SIZE}
+                onChange={setPage}
+              />
+            </div>
+          </div>
+
+          <div className="rounded-lg border">
+            {aes.length === 0 ? (
+              <div className="p-8 text-center text-sm text-muted-foreground">
+                {aesQ.isLoading
+                  ? "Loading application entities…"
+                  : "No DICOM application entities recorded."}
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[1000px] text-xs">
+                  <thead>
+                    <tr className="border-b bg-muted/30">
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        AE Title
+                      </th>
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        Host
+                      </th>
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        Class
+                      </th>
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        Role
+                      </th>
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        Vendor / model
+                      </th>
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        Department
+                      </th>
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        Source
+                      </th>
+                      <th className="px-3 py-2"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {aes.map((ae) => (
+                      <tr key={ae.id} className="border-b last:border-0">
+                        <td className="px-3 py-2">
+                          <div className="flex items-center gap-1.5">
+                            {/* The identifier operators search by, and the
+                                one peers must match exactly — mono + bold
+                                so case differences read at a glance. */}
+                            <span className="font-mono text-[13px] font-semibold">
+                              {ae.ae_title}
+                            </span>
+                            {ae.is_vendor_default && <DefaultTitleBadge />}
+                            {ae.is_reservation && <ReservationBadge />}
+                          </div>
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 font-mono">
+                          {ae.address ?? (
+                            <span className="text-muted-foreground">
+                              unbound
+                            </span>
+                          )}
+                          <span className="ml-1 text-[11px] text-muted-foreground">
+                            :{ae.port}
+                          </span>
+                          {!ae.tls_enabled && <PlaintextBadge />}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {DEVICE_CLASS_LABELS[ae.device_class] ??
+                            ae.device_class}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {ROLE_LABELS[ae.role] ?? ae.role}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {[ae.vendor, ae.model_name]
+                            .filter(Boolean)
+                            .join(" ") || "—"}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {ae.department || "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                          {SOURCE_LABELS[ae.seen_via] ?? ae.seen_via}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-right">
+                          <button
+                            type="button"
+                            onClick={() => setImpactOf(ae)}
+                            className="rounded p-1 text-muted-foreground hover:text-foreground"
+                            title="What breaks if this AE moves or goes away"
+                          >
+                            <Waypoints className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            type="button"
+                            disabled={!canWrite}
+                            onClick={() => setModal({ mode: "edit", ae })}
+                            className="rounded p-1 text-muted-foreground hover:text-foreground disabled:opacity-40"
+                            title="Edit application entity"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            type="button"
+                            disabled={!canDelete}
+                            onClick={() => setDel(ae)}
+                            className="rounded p-1 text-muted-foreground hover:text-destructive disabled:opacity-40"
+                            title="Delete application entity"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* ── Configured associations ──────────────────────────────── */}
+        <section className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-sm font-semibold">Configured associations</h2>
+            <p className="min-w-0 flex-1 text-xs text-muted-foreground">
+              Directed AE&rarr;AE edges as documented by the operator, not
+              observed traffic. Direction matters: an outbound edge stops
+              sending when the source moves, an inbound one stops being able to
+              reach the target.
+            </p>
+          </div>
+          <div className="rounded-lg border">
+            {peers.length === 0 ? (
+              <div className="p-8 text-center text-sm text-muted-foreground">
+                {peersQ.isLoading
+                  ? "Loading associations…"
+                  : "No associations documented. Without them, the blast radius of renumbering a host cannot be reported."}
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[700px] text-xs">
+                  <thead>
+                    <tr className="border-b bg-muted/30">
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        Source
+                      </th>
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        Target
+                      </th>
+                      <th className="whitespace-nowrap px-3 py-2 text-left font-medium">
+                        Services
+                      </th>
+                      <th className="px-3 py-2 text-left font-medium">Notes</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {peers.map((p) => (
+                      <tr key={p.id} className="border-b last:border-0">
+                        <td className="whitespace-nowrap px-3 py-2 font-mono">
+                          {p.source_ae_title}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 font-mono">
+                          &rarr; {p.target_ae_title}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {p.services.length ? p.services.join(", ") : "—"}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {p.notes || "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+
+      {modal && (
+        <AEModal
+          mode={modal.mode}
+          ae={modal.mode === "edit" ? modal.ae : null}
+          onClose={() => setModal(null)}
+        />
+      )}
+      {impactOf && (
+        <ImpactModal ae={impactOf} onClose={() => setImpactOf(null)} />
+      )}
+      <ConfirmModal
+        open={del !== null}
+        title="Delete DICOM application entity"
+        message={
+          <>
+            Delete AE Title{" "}
+            <span className="font-mono font-semibold">{del?.ae_title}</span>?
+            The title is freed for re-use immediately &mdash; if peers across
+            the estate still send to it, check the impact view first. The IPAM
+            address itself is untouched.
+          </>
+        }
+        tone="destructive"
+        confirmLabel="Delete"
+        loading={delMut.isPending}
+        onConfirm={() => del && delMut.mutate(del.id)}
+        onClose={() => setDel(null)}
+      />
+    </div>
+  );
+}
+
+function DefaultTitleBadge() {
+  return (
+    <span
+      className="inline-flex rounded bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-400"
+      title="Still a vendor default — the most common cause of institution-wide AE Title collisions"
+    >
+      default
+    </span>
+  );
+}
+
+function ReservationBadge() {
+  return (
+    <span
+      className="inline-flex rounded bg-violet-500/10 px-1.5 py-0.5 text-[11px] font-medium text-violet-700 dark:text-violet-400"
+      title="No host bound — the title is held so it is not re-issued while peers may still send to it"
+    >
+      reservation
+    </span>
+  );
+}
+
+function PlaintextBadge() {
+  return (
+    <span
+      className="ml-1.5 inline-flex items-center gap-0.5 rounded bg-rose-500/10 px-1.5 py-0.5 text-[11px] font-medium text-rose-700 dark:text-rose-400"
+      title="Not recorded as TLS-enabled — plaintext DICOM carries ePHI in the clear"
+    >
+      <ShieldAlert className="h-3 w-3" />
+      plaintext
+    </span>
+  );
+}
+
+// ── Impact ───────────────────────────────────────────────────────────
+
+function ImpactModal({
+  ae,
+  onClose,
+}: {
+  ae: DICOMApplicationEntity;
+  onClose: () => void;
+}) {
+  const impactQ = useQuery({
+    queryKey: ["dicom-impact", ae.id],
+    queryFn: () => dicomApi.impact(ae.id),
+  });
+  const impact = impactQ.data;
+
+  return (
+    <Modal title={`Impact — ${ae.ae_title}`} onClose={onClose} wide>
+      <div className="space-y-4 text-sm">
+        <p className="text-xs text-muted-foreground">
+          What a renumber or decommission of{" "}
+          <span className="font-mono">{ae.ae_title}</span>
+          {impact?.address ? ` (${impact.address})` : ""} would disturb, per the
+          associations documented in this registry.
+        </p>
+        {impactQ.isLoading && (
+          <p className="text-xs text-muted-foreground">Loading…</p>
+        )}
+        {impact && impact.total_peers === 0 && (
+          <p className="text-xs text-muted-foreground">
+            No associations documented for this AE. That means either it is
+            genuinely isolated, or the estate&rsquo;s peer configuration
+            hasn&rsquo;t been recorded here yet — this view can only report what
+            has been documented.
+          </p>
+        )}
+        {impact && impact.outbound.length > 0 && (
+          <div className="space-y-1">
+            <h3 className="text-xs font-semibold">
+              Outbound — these would stop sending
+            </h3>
+            <ul className="space-y-0.5 text-xs">
+              {impact.outbound.map((p) => (
+                <li key={p.id} className="font-mono">
+                  {p.source_ae_title} &rarr; {p.target_ae_title}
+                  {p.services.length > 0 && (
+                    <span className="ml-2 font-sans text-muted-foreground">
+                      {p.services.join(", ")}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {impact && impact.inbound.length > 0 && (
+          <div className="space-y-1">
+            <h3 className="text-xs font-semibold">
+              Inbound — these would lose their target
+            </h3>
+            <ul className="space-y-0.5 text-xs">
+              {impact.inbound.map((p) => (
+                <li key={p.id} className="font-mono">
+                  {p.source_ae_title} &rarr; {p.target_ae_title}
+                  {p.services.length > 0 && (
+                    <span className="ml-2 font-sans text-muted-foreground">
+                      {p.services.join(", ")}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        <div className="flex justify-end pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ── Create / edit ────────────────────────────────────────────────────
+
+function AEModal({
+  mode,
+  ae,
+  onClose,
+}: {
+  mode: "create" | "edit";
+  ae: DICOMApplicationEntity | null;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [aeTitle, setAeTitle] = useState(ae?.ae_title ?? "");
+  const [ipAddressId, setIpAddressId] = useState<string | null>(
+    ae?.ip_address_id ?? null,
+  );
+  const [ipLabel, setIpLabel] = useState<string | null>(ae?.address ?? null);
+  const [port, setPort] = useState(String(ae?.port ?? DICOM_DEFAULT_PORT));
+  const [tlsEnabled, setTlsEnabled] = useState(ae?.tls_enabled ?? false);
+  const [role, setRole] = useState(ae?.role ?? "both");
+  const [deviceClass, setDeviceClass] = useState(ae?.device_class ?? "other");
+  const [vendor, setVendor] = useState(ae?.vendor ?? "");
+  const [modelName, setModelName] = useState(ae?.model_name ?? "");
+  const [department, setDepartment] = useState(ae?.department ?? "");
+  const [location, setLocation] = useState(ae?.location ?? "");
+  const [seenVia, setSeenVia] = useState(ae?.seen_via ?? "manual");
+  const [notes, setNotes] = useState(ae?.notes ?? "");
+  const [error, setError] = useState("");
+
+  const mut = useMutation({
+    mutationFn: () => {
+      const shared = {
+        ae_title: aeTitle.trim(),
+        port: Number(port.trim() || DICOM_DEFAULT_PORT),
+        tls_enabled: tlsEnabled,
+        role: role as DICOMRole,
+        device_class: deviceClass as DICOMDeviceClass,
+        vendor,
+        model_name: modelName,
+        department,
+        location,
+        seen_via: seenVia as DICOMAESource,
+        notes,
+      };
+      if (mode === "edit" && ae) {
+        // Send ip_address_id unconditionally, including as null — that
+        // explicit null is how a retired host demotes its title to a
+        // reservation, and omitting it would make "clear the anchor"
+        // indistinguishable from "don't touch it".
+        const body: DICOMAEUpdate = { ...shared, ip_address_id: ipAddressId };
+        return dicomApi.updateAe(ae.id, body);
+      }
+      const body: DICOMAECreate = { ...shared, ip_address_id: ipAddressId };
+      return dicomApi.createAe(body);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dicom-aes"] });
+      qc.invalidateQueries({ queryKey: ["dicom-peers"] });
+      onClose();
+    },
+    onError: (e) =>
+      setError(formatApiError(e, "Failed to save application entity")),
+  });
+
+  // The AE value representation is capped at 16 *bytes*, and a non-ASCII
+  // character costs more than one — so measure bytes, like the server.
+  const titleBytes = new TextEncoder().encode(aeTitle.trim()).length;
+  const titleValid = titleBytes >= 1 && titleBytes <= 16;
+  const canSubmit = titleValid && !mut.isPending;
+
+  return (
+    <Modal
+      title={
+        mode === "create"
+          ? "New DICOM application entity"
+          : "Edit DICOM application entity"
+      }
+      onClose={onClose}
+      wide
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (canSubmit) mut.mutate();
+        }}
+        className="space-y-3"
+      >
+        <Field label="AE Title">
+          <input
+            className={`${inputCls} font-mono`}
+            value={aeTitle}
+            onChange={(e) => setAeTitle(e.target.value)}
+            placeholder="e.g. CT1_RADIOLOGY"
+            required
+          />
+          <p className="text-[11px] text-muted-foreground">
+            Unique across the whole institution. Up to 16 bytes ({titleBytes}{" "}
+            used); spaces are legal padding, backslash and control characters
+            are not. Case is significant — peers match the title exactly.
+          </p>
+        </Field>
+
+        <Field label="IPAM address">
+          {ipLabel && (
+            <p className="text-[11px] text-muted-foreground">
+              Currently: <span className="font-mono">{ipLabel}</span>
+            </p>
+          )}
+          <IPAddressPicker
+            value={ipAddressId}
+            onChange={(id, label) => {
+              setIpAddressId(id);
+              setIpLabel(label);
+            }}
+          />
+          <p className="text-[11px] text-muted-foreground">
+            Optional. Leave it unset to register the title as a reservation — a
+            name held so it is not re-issued while peers across the estate may
+            still be sending to it.
+          </p>
+          {ipAddressId !== null && (
+            <button
+              type="button"
+              onClick={() => {
+                setIpAddressId(null);
+                setIpLabel(null);
+              }}
+              className="text-[11px] text-muted-foreground underline hover:text-foreground"
+            >
+              Clear address (make this a reservation)
+            </button>
+          )}
+        </Field>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label="Port">
+            <input
+              className={inputCls}
+              inputMode="numeric"
+              value={port}
+              onChange={(e) => setPort(e.target.value)}
+            />
+            <p className="text-[11px] text-muted-foreground">
+              {DICOM_DEFAULT_PORT} is the IANA-registered <code>dicom</code>{" "}
+              port; {DICOM_LEGACY_PORT} is the historical <code>acr-nema</code>{" "}
+              registration and is still common.
+            </p>
+          </Field>
+          <Field label="Device class">
+            <select
+              className={inputCls}
+              value={deviceClass}
+              onChange={(e) => setDeviceClass(e.target.value)}
+            >
+              {Object.entries(DEVICE_CLASS_LABELS).map(([id, label]) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Role">
+            <select
+              className={inputCls}
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+            >
+              {Object.entries(ROLE_LABELS).map(([id, label]) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Source">
+            <select
+              className={inputCls}
+              value={seenVia}
+              onChange={(e) => setSeenVia(e.target.value)}
+            >
+              {Object.entries(SOURCE_LABELS).map(([id, label]) => (
+                <option key={id} value={id}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Vendor">
+            <input
+              className={inputCls}
+              value={vendor}
+              onChange={(e) => setVendor(e.target.value)}
+            />
+          </Field>
+          <Field label="Model">
+            <input
+              className={inputCls}
+              value={modelName}
+              onChange={(e) => setModelName(e.target.value)}
+            />
+          </Field>
+          <Field label="Department">
+            <input
+              className={inputCls}
+              value={department}
+              onChange={(e) => setDepartment(e.target.value)}
+              placeholder="e.g. Radiology"
+            />
+          </Field>
+          <Field label="Location">
+            <input
+              className={inputCls}
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="e.g. Level 2, room 214"
+            />
+          </Field>
+        </div>
+
+        <label className="flex cursor-pointer items-start gap-2 rounded-md border p-3 text-sm">
+          <input
+            type="checkbox"
+            checked={tlsEnabled}
+            onChange={(e) => setTlsEnabled(e.target.checked)}
+            className="mt-0.5"
+          />
+          <span>
+            TLS enabled
+            <span className="block text-[11px] text-muted-foreground">
+              Records what the estate is configured to do. Plaintext DICOM
+              carries ePHI in the clear, which the <code>dicom_ae_no_tls</code>{" "}
+              conformity check reports on. Nothing here is verified on the wire.
+            </span>
+          </span>
+        </label>
+
+        <Field label="Notes">
+          <textarea
+            className={`${inputCls} min-h-[70px]`}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Network configuration notes"
+          />
+          <p className="text-[11px] text-muted-foreground">
+            Network configuration only. Never record patient-identifiable
+            information — this registry stores network identity.
+          </p>
+        </Field>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {mut.isPending ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+// ── Local form primitives ────────────────────────────────────────────
+
+const inputCls =
+  "w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring";
+
+const filterCls =
+  "rounded-md border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-ring";
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="block text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/pages/network/DICOMPage.tsx
+++ b/frontend/src/pages/network/DICOMPage.tsx
@@ -7,6 +7,7 @@ import {
   Scan,
   ShieldAlert,
   Trash2,
+  Upload,
   Waypoints,
 } from "lucide-react";
 
@@ -15,10 +16,15 @@ import {
   formatApiError,
   ipamApi,
   type DICOMAECreate,
+  type DICOMAEImportColumnMap,
+  type DICOMAEImportCommit,
+  type DICOMAEImportPreview,
+  type DICOMAEImportRequest,
   type DICOMAESource,
   type DICOMAEUpdate,
   type DICOMApplicationEntity,
   type DICOMDeviceClass,
+  type DICOMPeer,
   type DICOMRole,
 } from "@/lib/api";
 import { HeaderButton } from "@/components/ui/header-button";
@@ -89,6 +95,9 @@ export function DICOMPage() {
   >(null);
   const [del, setDel] = useState<DICOMApplicationEntity | null>(null);
   const [impactOf, setImpactOf] = useState<DICOMApplicationEntity | null>(null);
+  const [peerModal, setPeerModal] = useState(false);
+  const [delPeer, setDelPeer] = useState<DICOMPeer | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
 
   const subnetsQ = useQuery({
     queryKey: ["subnets", "all"],
@@ -138,6 +147,15 @@ export function DICOMPage() {
     },
   });
 
+  const delPeerMut = useMutation({
+    mutationFn: (id: string) => dicomApi.removePeer(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dicom-peers"] });
+      qc.invalidateQueries({ queryKey: ["dicom-impact"] });
+      setDelPeer(null);
+    },
+  });
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <div className="border-b bg-card px-6 py-4">
@@ -174,6 +192,16 @@ export function DICOMPage() {
               }}
             >
               Refresh
+            </HeaderButton>
+            <HeaderButton
+              icon={Upload}
+              disabled={!canWrite}
+              title={
+                canWrite ? undefined : "Requires write permission on DICOM AEs"
+              }
+              onClick={() => setImportOpen(true)}
+            >
+              Import
             </HeaderButton>
             <HeaderButton
               variant="primary"
@@ -384,6 +412,20 @@ export function DICOMPage() {
               sending when the source moves, an inbound one stops being able to
               reach the target.
             </p>
+            <HeaderButton
+              icon={Plus}
+              disabled={!canWrite || aes.length < 2}
+              title={
+                !canWrite
+                  ? "Requires write permission on DICOM AEs"
+                  : aes.length < 2
+                    ? "Register at least two application entities first"
+                    : undefined
+              }
+              onClick={() => setPeerModal(true)}
+            >
+              Add association
+            </HeaderButton>
           </div>
           <div className="rounded-lg border">
             {peers.length === 0 ? (
@@ -407,6 +449,7 @@ export function DICOMPage() {
                         Services
                       </th>
                       <th className="px-3 py-2 text-left font-medium">Notes</th>
+                      <th className="px-3 py-2"></th>
                     </tr>
                   </thead>
                   <tbody>
@@ -423,6 +466,17 @@ export function DICOMPage() {
                         </td>
                         <td className="px-3 py-2 text-muted-foreground">
                           {p.notes || "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-right">
+                          <button
+                            type="button"
+                            disabled={!canDelete}
+                            onClick={() => setDelPeer(p)}
+                            className="rounded p-1 text-muted-foreground hover:text-destructive disabled:opacity-40"
+                            title="Delete association"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
                         </td>
                       </tr>
                     ))}
@@ -444,6 +498,27 @@ export function DICOMPage() {
       {impactOf && (
         <ImpactModal ae={impactOf} onClose={() => setImpactOf(null)} />
       )}
+      {peerModal && <PeerModal aes={aes} onClose={() => setPeerModal(false)} />}
+      {importOpen && <ImportModal onClose={() => setImportOpen(false)} />}
+      <ConfirmModal
+        open={delPeer !== null}
+        title="Delete association"
+        message={
+          <>
+            Remove the documented association{" "}
+            <span className="font-mono font-semibold">
+              {delPeer?.source_ae_title} &rarr; {delPeer?.target_ae_title}
+            </span>
+            ? Neither application entity is touched — only the record that they
+            talk to each other, which is what the impact view reads.
+          </>
+        }
+        tone="destructive"
+        confirmLabel="Delete"
+        loading={delPeerMut.isPending}
+        onConfirm={() => delPeer && delPeerMut.mutate(delPeer.id)}
+        onClose={() => setDelPeer(null)}
+      />
       <ConfirmModal
         open={del !== null}
         title="Delete DICOM application entity"
@@ -587,6 +662,368 @@ function ImpactModal({
   );
 }
 
+// ── Peer association ─────────────────────────────────────────────────
+
+function PeerModal({
+  aes,
+  onClose,
+}: {
+  aes: DICOMApplicationEntity[];
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [sourceId, setSourceId] = useState(aes[0]?.id ?? "");
+  const [targetId, setTargetId] = useState(aes[1]?.id ?? "");
+  const [services, setServices] = useState("");
+  const [notes, setNotes] = useState("");
+  const [error, setError] = useState("");
+
+  const mut = useMutation({
+    mutationFn: () =>
+      dicomApi.createPeer({
+        source_ae_id: sourceId,
+        target_ae_id: targetId,
+        // Free-form on purpose: SOP class support is open-ended, and an
+        // operator documenting their estate should never be blocked on
+        // our list being complete.
+        services: services
+          .split(",")
+          .map((x) => x.trim())
+          .filter(Boolean),
+        notes,
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dicom-peers"] });
+      qc.invalidateQueries({ queryKey: ["dicom-impact"] });
+      onClose();
+    },
+    onError: (e) => setError(formatApiError(e, "Failed to save association")),
+  });
+
+  const sameEndpoints = sourceId !== "" && sourceId === targetId;
+  const canSubmit =
+    !!sourceId && !!targetId && !sameEndpoints && !mut.isPending;
+
+  return (
+    <Modal title="Document a DICOM association" onClose={onClose} wide>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (canSubmit) mut.mutate();
+        }}
+        className="space-y-3"
+      >
+        <p className="text-xs text-muted-foreground">
+          Direction matters: record which AE <em>initiates</em> the association.
+          The impact view reads outbound and inbound edges separately, because
+          they break in different ways when a host moves.
+        </p>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label="Source AE (initiator)">
+            <select
+              className={`${inputCls} font-mono`}
+              value={sourceId}
+              onChange={(e) => setSourceId(e.target.value)}
+            >
+              {aes.map((ae) => (
+                <option key={ae.id} value={ae.id}>
+                  {ae.ae_title}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Target AE (responder)">
+            <select
+              className={`${inputCls} font-mono`}
+              value={targetId}
+              onChange={(e) => setTargetId(e.target.value)}
+            >
+              {aes.map((ae) => (
+                <option key={ae.id} value={ae.id}>
+                  {ae.ae_title}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+        {sameEndpoints && (
+          <p className="text-xs text-destructive">
+            An AE cannot be configured as a peer of itself.
+          </p>
+        )}
+        <Field label="Services">
+          <input
+            className={inputCls}
+            value={services}
+            onChange={(e) => setServices(e.target.value)}
+            placeholder="C-STORE, C-FIND, C-MOVE, MPPS"
+          />
+          <p className="text-[11px] text-muted-foreground">
+            Comma-separated. Whatever this association actually carries.
+          </p>
+        </Field>
+        <Field label="Notes">
+          <textarea
+            className={`${inputCls} min-h-[60px]`}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Network configuration notes"
+          />
+        </Field>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {mut.isPending ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+// ── AE-table import ──────────────────────────────────────────────────
+
+// Fields an operator can map a CSV column onto. Mirrors
+// app.services.dicom.importer.IMPORTABLE_FIELDS; ae_title is the join
+// key and is the only mandatory one.
+const IMPORT_FIELDS: {
+  key: keyof DICOMAEImportColumnMap;
+  label: string;
+  required?: boolean;
+}[] = [
+  { key: "ae_title", label: "AE Title", required: true },
+  { key: "address", label: "IP address" },
+  { key: "port", label: "Port" },
+  { key: "tls_enabled", label: "TLS enabled" },
+  { key: "role", label: "Role" },
+  { key: "device_class", label: "Device class" },
+  { key: "vendor", label: "Vendor" },
+  { key: "model_name", label: "Model" },
+  { key: "department", label: "Department" },
+  { key: "location", label: "Location" },
+  { key: "notes", label: "Notes" },
+];
+
+const ACTION_CLS: Record<string, string> = {
+  create: "text-emerald-700 dark:text-emerald-400",
+  update: "text-sky-700 dark:text-sky-400",
+  skip: "text-muted-foreground",
+  error: "text-destructive",
+};
+
+function ImportModal({ onClose }: { onClose: () => void }) {
+  const qc = useQueryClient();
+  const [csvText, setCsvText] = useState("");
+  const [columnMap, setColumnMap] = useState<Record<string, string>>({
+    ae_title: "AE Title",
+  });
+  const [overwrite, setOverwrite] = useState(false);
+  const [error, setError] = useState("");
+  const [preview, setPreview] = useState<DICOMAEImportPreview | null>(null);
+  const [committed, setCommitted] = useState<DICOMAEImportCommit | null>(null);
+
+  const body = (): DICOMAEImportRequest => ({
+    csv_text: csvText,
+    column_map: Object.fromEntries(
+      Object.entries(columnMap).filter(([, v]) => v.trim() !== ""),
+    ) as unknown as DICOMAEImportColumnMap,
+    overwrite_existing: overwrite,
+  });
+
+  const previewMut = useMutation({
+    mutationFn: () => dicomApi.importPreview(body()),
+    onSuccess: (res) => {
+      setPreview(res);
+      setCommitted(null);
+      setError("");
+    },
+    onError: (e) => {
+      setPreview(null);
+      setError(formatApiError(e, "Preview failed"));
+    },
+  });
+
+  const commitMut = useMutation({
+    mutationFn: () => dicomApi.importCommit(body()),
+    onSuccess: (res) => {
+      setCommitted(res);
+      setError("");
+      qc.invalidateQueries({ queryKey: ["dicom-aes"] });
+    },
+    onError: (e) => setError(formatApiError(e, "Import failed")),
+  });
+
+  const rows = committed?.rows ?? preview?.rows ?? [];
+
+  return (
+    <Modal title="Import DICOM AE table" onClose={onClose} wide>
+      <div className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Paste the estate&rsquo;s existing AE table. Rows key on the{" "}
+          <strong>AE Title</strong>, not the address — that is the identity
+          DICOM cares about. A blank address registers the title as a
+          reservation rather than failing; a <em>supplied</em> address IPAM does
+          not know is reported as a row error. Nothing is written until you
+          commit.
+        </p>
+
+        <Field label="CSV">
+          <textarea
+            className={`${inputCls} min-h-[140px] font-mono text-xs`}
+            value={csvText}
+            onChange={(e) => setCsvText(e.target.value)}
+            placeholder={"AE Title,IP,Port,Class\nCT1_RAD,10.30.0.5,104,CT"}
+          />
+        </Field>
+
+        <div>
+          <p className="mb-1 text-xs font-medium text-muted-foreground">
+            Column mapping — the header text in your file for each field
+          </p>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+            {IMPORT_FIELDS.map((f) => (
+              <label key={f.key} className="block space-y-1 text-xs">
+                <span className="block text-muted-foreground">
+                  {f.label}
+                  {f.required ? " *" : ""}
+                </span>
+                <input
+                  className="w-full rounded-md border bg-background px-2 py-1 text-sm"
+                  value={columnMap[f.key] ?? ""}
+                  onChange={(e) =>
+                    setColumnMap((m) => ({ ...m, [f.key]: e.target.value }))
+                  }
+                  placeholder={f.required ? "required" : "leave blank to skip"}
+                />
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <label className="flex cursor-pointer items-start gap-2 rounded-md border p-3 text-sm">
+          <input
+            type="checkbox"
+            checked={overwrite}
+            onChange={(e) => setOverwrite(e.target.checked)}
+            className="mt-0.5"
+          />
+          <span>
+            Overwrite existing AE Titles
+            <span className="block text-[11px] text-muted-foreground">
+              Off by default: an already-registered title is skipped. On, its
+              mapped fields are updated — columns your file doesn&rsquo;t have
+              are left alone, so a partial export can&rsquo;t blank them.
+            </span>
+          </span>
+        </label>
+
+        {(preview || committed) && (
+          <div className="rounded-md border">
+            <div className="flex flex-wrap gap-3 border-b px-3 py-2 text-xs">
+              {committed ? (
+                <>
+                  <span className={ACTION_CLS.create}>
+                    {committed.created} created
+                  </span>
+                  <span className={ACTION_CLS.update}>
+                    {committed.updated} updated
+                  </span>
+                  <span className={ACTION_CLS.skip}>
+                    {committed.skipped} skipped
+                  </span>
+                  <span className={ACTION_CLS.error}>
+                    {committed.errors} errors
+                  </span>
+                </>
+              ) : (
+                preview && (
+                  <>
+                    <span className={ACTION_CLS.create}>
+                      {preview.create_count} to create
+                    </span>
+                    <span className={ACTION_CLS.update}>
+                      {preview.update_count} to update
+                    </span>
+                    <span className={ACTION_CLS.skip}>
+                      {preview.skip_count} to skip
+                    </span>
+                    <span className={ACTION_CLS.error}>
+                      {preview.error_count} errors
+                    </span>
+                  </>
+                )
+              )}
+            </div>
+            <div className="max-h-56 overflow-auto">
+              <table className="w-full text-xs">
+                <tbody>
+                  {rows.map((r) => (
+                    <tr key={r.line} className="border-b last:border-0">
+                      <td className="px-3 py-1 text-muted-foreground">
+                        {r.line}
+                      </td>
+                      <td className="px-3 py-1 font-mono">{r.ae_title}</td>
+                      <td className="px-3 py-1 font-mono text-muted-foreground">
+                        {r.address || "—"}
+                      </td>
+                      <td className={`px-3 py-1 ${ACTION_CLS[r.action] ?? ""}`}>
+                        {r.action}
+                      </td>
+                      <td className="px-3 py-1 text-muted-foreground">
+                        {r.reason}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            {committed ? "Close" : "Cancel"}
+          </button>
+          <button
+            type="button"
+            onClick={() => previewMut.mutate()}
+            disabled={!csvText.trim() || previewMut.isPending}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
+          >
+            {previewMut.isPending ? "Previewing…" : "Preview"}
+          </button>
+          <button
+            type="button"
+            onClick={() => commitMut.mutate()}
+            disabled={!preview || !!committed || commitMut.isPending}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            title={preview ? undefined : "Preview first"}
+          >
+            {commitMut.isPending ? "Importing…" : "Import"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
 // ── Create / edit ────────────────────────────────────────────────────
 
 function AEModal({
@@ -620,7 +1057,10 @@ function AEModal({
     mutationFn: () => {
       const shared = {
         ae_title: aeTitle.trim(),
-        port: Number(port.trim() || DICOM_DEFAULT_PORT),
+        // Parse defensively: a non-numeric field would otherwise become
+        // NaN, serialise to null, and hit the column's NOT NULL as an
+        // opaque server error rather than a fixable form message.
+        port: parsedPort ?? DICOM_DEFAULT_PORT,
         tls_enabled: tlsEnabled,
         role: role as DICOMRole,
         device_class: deviceClass as DICOMDeviceClass,
@@ -655,7 +1095,11 @@ function AEModal({
   // character costs more than one — so measure bytes, like the server.
   const titleBytes = new TextEncoder().encode(aeTitle.trim()).length;
   const titleValid = titleBytes >= 1 && titleBytes <= 16;
-  const canSubmit = titleValid && !mut.isPending;
+  const parsedPort = /^\d+$/.test(port.trim()) ? Number(port.trim()) : null;
+  const portValid =
+    port.trim() === "" ||
+    (parsedPort !== null && parsedPort >= 1 && parsedPort <= 65535);
+  const canSubmit = titleValid && portValid && !mut.isPending;
 
   return (
     <Modal


### PR DESCRIPTION
Two items from the healthcare research pass that pair: a safety fix to shipped code, and the vertical module it protects.

## #722 — fragile-device `do_not_probe`

Medical- and OT-device vendors explicitly instruct sites **not** to scan their VLANs — Swisslog's pneumatic-tube guide says to omit ping sweeps and nmap of any supporting range — and fragile IP stacks genuinely fault under a sweep. SpatiumDDI shipped three features that violate that instruction and no way for an operator to say so.

`do_not_probe` + `do_not_probe_reason` now live on `IPSpace` / `IPBlock` / `Subnet`, resolved by one service (`services/ipam/probe_policy.py`) that **every** prober consults:

| Origin | Behaviour |
|---|---|
| #23 discovery sweep | Skipped before any packet; `last_discovery_at` stamped so the dispatcher stops re-queueing; reason on the audit row |
| `tools.nmap` | 422 before the scan row is persisted; CIDR targets covered in both directions |
| Auto-profile on DHCP lease, "Re-profile now" | Checked before the refresh window, so it can't be bypassed by tuning the other guards |
| `tools.network` ping / traceroute / mtr / port-test / tls-cert | 422 with the operator's reason quoted back, gated before the vantage branch |
| Operator Copilot (`run_nmap_scan` apply + 4 `network_*` MCP tools) | Refused — a proposal the operator approved is still a scan |
| TLS-cert probes, SNMP polling, WoL **active** verification | Skipped; WoL's passive path still verifies without sending anything |

**The flag ORs down the chain, with no per-level inherit toggle.** That is deliberately unlike the DDNS fields it otherwise mirrors, which resolve to the first non-inheriting ancestor: a hospital that marks its clinical IPSpace do-not-probe must not have one subnet quietly opt back in. The *nearest* flagged level supplies the reason.

**Not behind a feature module** — it constrains our own behaviour, so hiding it default-off would leave the sites that need it unprotected.

**The override is narrow:** `override_do_not_probe` requires superadmin (not a permission grant — `use_network_tools` is routine), writes an audit row *before* the probe runs, and is per-request. Refusing absolutely would just get the flag turned off estate-wide.

Also: `fragile_subnet_probed` works backwards from the registries, failing a subnet that carries `ot_device` / `dicom_ae` / `role="bmc"` rows but isn't covered; `bmc` joins `IP_ROLES`; `get_subnet_summary` reports the verdict so the copilot doesn't propose scanning what it just looked up.

## #723 — `network.dicom`

An AE Title is institution-wide-unique by specification. PS3.15 Annex H defines a registry object whose only job is allocating them, it is essentially undeployed, and the namespace lives in a spreadsheet — the BACnet device-instance argument with better provenance. So `uq_dicom_ae_title` is the point of the table, and a collision answers **409 naming the AE that holds it**.

- **`ip_address_id` is nullable / `SET NULL`**, deliberately unlike `bacnet_device`'s `CASCADE`: an AE Title outlives its host because it's burned into peer config across the estate, so decommissioning an IP demotes the title to a *reservation* rather than freeing a name a dozen modalities still send to.
- **`dicom_peer`** is a directed AE→AE edge of *configured* associations, making renumber blast-radius answerable in both directions (`/aes/{id}/impact`).
- **AE validation follows PS3.5 exactly** — 16 **bytes** not characters, spaces legal as padding, all-space forbidden, no backslash or control chars. Strict-in-the-wrong-direction is the worse failure: rejecting a title real devices use records a plan that fails at commissioning.
- 4 conformity checks (naming convention arrives as a check *argument*, not a table), 3 Copilot tools, a CSV importer keyed on the title where a blank address registers a reservation, and the list / peer / impact / import UI.

**No PHI, ever** — network identity only, or SpatiumDDI becomes a HIPAA Business Associate. C-ECHO verification is deferred to its own issue: it's the one probe in the #543 family that doesn't inherit the agent↔subnet blocker, but it must respect #722 first.

## Fact-check corrections applied
Per the issue comments: IANA registers **11112** as `dicom`; **104** carries the historical `acr-nema` name (nothing here calls 104 "the DICOM port"). The AE VR is **16 bytes**, and **spaces are legal**.

## Verification
- 155 backend tests pass — 49 new for the two features, 11 more covering each review finding, plus discovery / nettools-MCP / profiling / WoL / TLS-cert / SNMP / verticals regressions
- `make ci` green (ruff, black, mypy on 789 files, eslint, prettier, tsc, vite build)
- Both migrations apply cleanly on a real DB; no autogenerate drift for the new objects
- A `/code-review` pass raised 11 findings, all fixed in the second commit

Closes #722, Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)