### PR TITLE
fix(ci): pin the backend release build to the runtime stage (#732)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile
+          # #732 — MUST be pinned. ``dev`` is the LAST stage in
+          # backend/Dockerfile, so an unpinned build silently publishes an api
+          # image carrying pytest + pytest-xdist + coverage (installed as root),
+          # and diverges from what trivy-scheduled.yml scans.
+          target: runtime
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -141,8 +141,16 @@ CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--worker
 # Adds the ``[dev]`` extras (pytest + pytest-asyncio + pytest-xdist +
 # pytest-cov) on top of the runtime stage so ``make test`` can run pytest
 # inside the api container without bloating the production image. The dev
-# compose's ``build.target: dev`` selects this stage; the release pipeline
-# stops at ``runtime``.
+# compose's ``build.target: dev`` selects this stage.
+#
+# ⚠️  This is the LAST stage, so ``docker build`` with no ``--target`` lands
+# HERE, not on ``runtime``. Nothing in this file can prevent that — every
+# ship path must pin the stage explicitly, and all of them do:
+# ``.github/workflows/release.yml`` (``target: runtime``), the appliance bake
+# in ``Makefile`` (``--target runtime``), and ``trivy-scheduled.yml``. That
+# was not always true: until #732 release.yml had no ``target:``, so every
+# published api image shipped the test tooling below. If you append a stage
+# after this one, you inherit the same trap.
 #
 # We install as root (the runtime stage's USER app would block site-packages
 # writes), then switch back to ``app`` so the runtime CMD stays unchanged.


### PR DESCRIPTION
## Summary

`.github/workflows/release.yml`'s `build-api` job passed no `target:`, so Docker built the **last** stage in `backend/Dockerfile` — `FROM runtime AS dev` — and every published `ghcr.io/spatiumddi/spatiumddi-api:<version>` / `:latest` image shipped the test tooling that stage installs, as `root`, onto the production layer.

This adds `target: runtime` and corrects the Dockerfile comment that hid the bug.

## What was actually being shipped

Built both stages from `main` (`ad06c1fb`) and compared:

| Package | unpinned build (shipped today) | `--target runtime` |
|---|---|---|
| `pytest` 9.1.1 | ✅ | — |
| `pytest-asyncio` 1.4.0 | ✅ | — |
| `pytest-cov` 7.1.0 | ✅ | — |
| `pytest-xdist` 3.8.0 | ✅ | — |
| `coverage` 7.15.2 | ✅ | — |
| `execnet` 2.1.2 | ✅ | — |
| `iniconfig` 2.3.0 | ✅ | — |
| `pluggy` 1.6.0 | ✅ | — |

Every resolved version is **above** the `>=` floor in the `dev` stage (`pytest>=8.3.0` → 9.1.1) — they're unpinned, so the production image's contents were re-resolving against upstream PyPI on each release build.

## Why this matters — and why size isn't the reason

Measured size delta is **~30 MB (1.04 GB → 1.01 GB, ~3%)**. Real, and paid twice across `linux/amd64` + `linux/arm64`, but that is not the argument. The two that hold up:

1. **`execnet` is importable in the production container.** Its entire purpose is spawning and communicating with remote Python interpreters.
2. **The published artifact was not the artifact we scan.** `trivy-scheduled.yml:65` pins `runtime` and documents that it deliberately does *not* ship-scan the extra `dev` layer. So a CVE in any of the 8 packages above was invisible to our own scheduled scan **by construction** — the one job whose job it is to catch this was structurally looking at a different image.

Third, minor: those packages are `pip install`ed as `root` before the stage switches back to `app`.

## `release.yml` was the sole outlier

Every other build path in the repo already pinned the stage correctly, which is what makes this an oversight rather than a decision:

| Build path | Stage |
|---|---|
| Appliance bake (`Makefile:94`) | `--target runtime` |
| Scheduled Trivy (`trivy-scheduled.yml:65`) | `runtime` |
| Dev compose (`docker-compose.dev.yml:74`) | `dev` — correct, that's the point |
| **`release.yml` `build-api`** | **unpinned → `dev`** |

I also checked the last `FROM` in every other shipped Dockerfile — frontend, bind9, powerdns, dnsdist, kea, supervisor, looking-glass — and all seven already end on their `runtime` stage. **Backend was the only affected image; no other build step needs a `target:`.**

## The comment change is the more important half

`backend/Dockerfile` asserted, immediately above the offending stage:

> The dev compose's `build.target: dev` selects this stage; **the release pipeline stops at `runtime`**.

It didn't. That sentence is why this survived: anyone checking "do we ship pytest?" found a confident denial sitting next to the code causing it. Replaced with the actual invariant — this is the last stage, nothing in the Dockerfile can enforce anything, every ship path must pin explicitly (and now all of them do), and appending a stage after this one inherits the same trap.

## Verification

```
$ docker build --target runtime -t verify-runtime ./backend
$ docker build                  -t verify-default ./backend   # current release behaviour
$ docker run --rm --entrypoint pip verify-default list | grep -icE '^(pytest|coverage|execnet)'
6
$ docker run --rm --entrypoint pip verify-runtime list | grep -icE '^(pytest|coverage|execnet)'
0
```

Both stages build clean. `release.yml` re-parsed as YAML to confirm `build-api` now resolves `target: runtime` and no other job changed.

## Note on timing

This only takes effect on the **next publish**, so it's worth landing before the next release tag rather than after.

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)
