### PR TITLE
feat(dns): config-drift report UI + fix the AXFR path it depends on (#61)

### DIFF
--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -3351,6 +3351,9 @@ class ZoneDriftResponse(BaseModel):
     zone_name: str
     db_record_count: int
     servers: list[ServerDriftEntry]
+    # Caveats that make the diff less trustworthy (e.g. split-horizon views);
+    # the UI renders these above the per-server results.
+    warnings: list[str] = []
 
 
 @router.get(
@@ -3377,6 +3380,7 @@ async def get_zone_drift(
         zone_id=report.zone_id,
         zone_name=report.zone_name,
         db_record_count=report.db_record_count,
+        warnings=list(report.warnings),
         servers=[
             ServerDriftEntry(
                 server_id=s.server_id,

--- a/backend/app/drivers/dns/_axfr.py
+++ b/backend/app/drivers/dns/_axfr.py
@@ -68,6 +68,36 @@ def resolve_server_address(host: str, port: int, *, what: str) -> list[str]:
     return addrs
 
 
+def _hint(exc: BaseException, port: int) -> str:
+    """Return a next-step hint matched to *why* the transfer failed.
+
+    An unconditional "check allow-transfer" is worse than no hint at all when
+    the real problem is that the host is unreachable — it sends the operator
+    to the DNS config of a box they can't even open a socket to. Only mention
+    the transfer ACL when the server actually answered and said no.
+    """
+    text = str(exc).upper()
+    if isinstance(exc, TimeoutError) or "TIMED OUT" in text or "TIMEOUT" in text:
+        return (
+            f" The server did not answer in time — check that it is running and that "
+            f"TCP/{port} is open (a transfer needs TCP, not just UDP)."
+        )
+    if isinstance(exc, OSError):
+        # Connection refused / no route / network unreachable: we never got a
+        # DNS-level answer, so the transfer ACL is not what's in the way.
+        return f" The server could not be reached on TCP/{port} — check the address and firewall."
+    if "REFUSED" in text or "NOTAUTH" in text:
+        return (
+            " The server answered but declined the transfer — check that its "
+            "allow-transfer permits the SpatiumDDI control plane, and that it is "
+            "authoritative for this zone."
+        )
+    return (
+        f" Check that the server's allow-transfer permits the SpatiumDDI control "
+        f"plane and that TCP/{port} is reachable."
+    )
+
+
 async def axfr_zone_records(
     *,
     host: str,
@@ -121,9 +151,7 @@ async def axfr_zone_records(
         # both surface this string verbatim.
         detail = str(exc).strip() or type(exc).__name__
         raise RuntimeError(
-            f"{what} from {host}:{port} failed: {detail}. "
-            f"Check that the server's allow-transfer permits the SpatiumDDI "
-            f"control plane and that TCP/{port} is reachable."
+            f"{what} from {host}:{port} failed: {detail}.{_hint(exc, port)}"
         ) from exc
 
     def _absolutize(target: Any) -> str:

--- a/backend/app/drivers/dns/_axfr.py
+++ b/backend/app/drivers/dns/_axfr.py
@@ -4,11 +4,16 @@ Both drivers implement ``pull_zone_records`` by doing a standard AXFR over
 TCP/53 and walking the returned zone. The only thing that differs is the
 driver name in log lines — the wire protocol and the rdata shaping are
 identical. Keep this in one place so they can't drift.
+
+Also home to :func:`resolve_server_address`, shared with the RFC 2136 write
+paths — see its docstring for why every ``dnspython`` call site needs it.
 """
 
 from __future__ import annotations
 
 import asyncio
+import ipaddress
+import socket
 from typing import Any
 
 import structlog
@@ -16,6 +21,51 @@ import structlog
 from app.drivers.dns.base import RecordData
 
 logger = structlog.get_logger(__name__)
+
+
+def resolve_server_address(host: str, port: int, *, what: str) -> list[str]:
+    """Return IP literals for ``host``, in the order to try them.
+
+    Every low-level ``dnspython`` entry point we use — ``dns.query.xfr`` for
+    transfers, ``dns.query.tcp`` for RFC 2136 updates — takes an IP *literal*,
+    not a name. Each calls ``dns.inet.af_for_address(where)`` up front to pick
+    the address family, and that raises a **bare, message-less**
+    ``ValueError()`` for anything that doesn't parse as an address, before a
+    single packet leaves the box.
+
+    So any ``DNSServer.host`` holding a hostname — which is every
+    containerised deployment and most others — failed 100% of the time, and
+    the reason surfaced to the operator was the empty string. Resolve here and
+    hand dnspython an address.
+
+    ``what`` is the operation description used to prefix errors, e.g.
+    ``"AXFR of example.com."``.
+    """
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        return [host]
+
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except OSError as exc:
+        raise RuntimeError(
+            f"{what} from {host}:{port} failed: could not resolve {host!r} ({exc})."
+        ) from exc
+
+    # Preserve getaddrinfo's ordering (RFC 6724 / system policy) but drop
+    # duplicates — a dual-stack host commonly returns the same address for
+    # both SOCK_STREAM and SOCK_DGRAM entries.
+    addrs: list[str] = []
+    for info in infos:
+        addr = str(info[4][0])
+        if addr not in addrs:
+            addrs.append(addr)
+    if not addrs:
+        raise RuntimeError(f"{what} from {host}:{port} failed: {host!r} resolved to no addresses.")
+    return addrs
 
 
 async def axfr_zone_records(
@@ -41,10 +91,40 @@ async def axfr_zone_records(
 
     zone_origin = dns.name.from_text(zone_name)
 
-    def _axfr() -> dns.zone.Zone:
-        return dns.zone.from_xfr(dns.query.xfr(host, zone_origin, port=port, timeout=timeout))
+    what = f"AXFR of {zone_name}"
 
-    z = await asyncio.to_thread(_axfr)
+    def _axfr() -> dns.zone.Zone:
+        # A dual-stack host can resolve to an address that isn't the one
+        # permitted by allow-transfer (or isn't routable from here at all).
+        # An AXFR is a read with no side effects, so walking the candidate
+        # list is safe — try each and report the last failure if none work.
+        addrs = resolve_server_address(host, port, what=what)
+        last: Exception | None = None
+        for addr in addrs:
+            try:
+                return dns.zone.from_xfr(
+                    dns.query.xfr(addr, zone_origin, port=port, timeout=timeout)
+                )
+            except Exception as exc:  # noqa: PERF203 — retry the next address
+                last = exc
+        assert last is not None  # resolve_server_address never returns []
+        raise last
+
+    try:
+        z = await asyncio.to_thread(_axfr)
+    except RuntimeError:
+        raise  # already carries a specific, operator-readable message
+    except Exception as exc:
+        # dnspython also raises message-less exceptions for a refused or
+        # malformed transfer, so ``str(exc)`` is routinely "". Never let a
+        # blank reason reach the operator — drift reports and pull-imports
+        # both surface this string verbatim.
+        detail = str(exc).strip() or type(exc).__name__
+        raise RuntimeError(
+            f"{what} from {host}:{port} failed: {detail}. "
+            f"Check that the server's allow-transfer permits the SpatiumDDI "
+            f"control plane and that TCP/{port} is reachable."
+        ) from exc
 
     def _absolutize(target: Any) -> str:
         """Return ``target`` as its absolute form with trailing dot.

--- a/backend/app/drivers/dns/bind9.py
+++ b/backend/app/drivers/dns/bind9.py
@@ -21,6 +21,7 @@ import structlog
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 
 from app.core.dns_names import strip_control_chars
+from app.drivers.dns._axfr import resolve_server_address
 from app.drivers.dns.base import (
     ConfigBundle,
     DNSDriver,
@@ -322,7 +323,10 @@ class BIND9Driver(DNSDriver):
         # thread executor. The control plane never reaches this code path.
         import asyncio
 
-        await asyncio.to_thread(dns.query.tcp, update, host, port=port, timeout=10)
+        # See the Windows driver's matching call: dns.query.tcp takes an IP
+        # literal, and a write must not be retried across addresses.
+        addr = resolve_server_address(host, port, what=f"RFC 2136 update of {change.zone_name}")[0]
+        await asyncio.to_thread(dns.query.tcp, update, addr, port=port, timeout=10)
 
     async def reload_config(self, server: Any) -> None:
         """Surface for the agent's ``rndc reconfig``. Control plane no-op."""

--- a/backend/app/drivers/dns/windows.py
+++ b/backend/app/drivers/dns/windows.py
@@ -46,6 +46,7 @@ from app.drivers._winrm import (
 from app.drivers._winrm import (
     run_ps as _winrm_run_ps,
 )
+from app.drivers.dns._axfr import resolve_server_address
 from app.drivers.dns.base import (
     ConfigBundle,
     DNSDriver,
@@ -289,7 +290,12 @@ class WindowsDNSDriver(DNSDriver):
             type=rtype,
             signed=keyring is not None,
         )
-        await asyncio.to_thread(dns.query.tcp, update, host, port=port, timeout=10)
+        # Resolve first — dns.query.tcp needs an IP literal and dies on a
+        # hostname with a bare ValueError (see resolve_server_address). Unlike
+        # the AXFR path we take only the first address: this is a WRITE, and
+        # retrying it against a second address risks applying it twice.
+        addr = resolve_server_address(host, port, what=f"RFC 2136 update of {change.zone_name}")[0]
+        await asyncio.to_thread(dns.query.tcp, update, addr, port=port, timeout=10)
 
     async def _apply_record_change_winrm(self, server: Any, change: RecordChange) -> None:
         """Record create/update/delete via ``*-DnsServerResourceRecord``."""

--- a/backend/app/services/dns/drift.py
+++ b/backend/app/services/dns/drift.py
@@ -62,6 +62,9 @@ class ZoneDriftReport:
     zone_name: str
     db_record_count: int
     servers: list[ServerDrift] = field(default_factory=list)
+    # Conditions that make the diff below less trustworthy than it looks.
+    # Rendered verbatim by the UI — keep them operator-readable.
+    warnings: list[str] = field(default_factory=list)
 
 
 def _to_drift_record(r: RecordData | DNSRecord) -> DriftRecord:
@@ -98,6 +101,26 @@ async def compute_zone_drift(
     report = ZoneDriftReport(
         zone_id=str(zone.id), zone_name=zone.name, db_record_count=len(db_rows)
     )
+
+    # Split-horizon caveat. Under views (#24) each view gets its own zone row
+    # and its own rendered zone file, but an AXFR is addressed by zone *name*
+    # — the server answers with whichever view matches the control plane's
+    # source IP, which is not necessarily the view this row belongs to. The
+    # diff would then report the other view's content as drift in both
+    # directions. We can't tell from the wire which view answered, so say so
+    # rather than let an operator "fix" a difference that isn't one.
+    if zone.view_id is not None:
+        report.warnings.append(
+            "This zone belongs to a DNS view. A zone transfer is answered by "
+            "whichever view matches the control plane's source address, so "
+            "differences below may reflect a different view rather than real drift."
+        )
+    elif any(r.view_id is not None for r in db_rows):
+        report.warnings.append(
+            "Some records in this zone are scoped to a specific DNS view and are "
+            "only served to clients matching it. They may appear as missing here "
+            "even when the server is correct."
+        )
 
     async def _drift_for_server(srv: DNSServer) -> ServerDrift:
         entry = ServerDrift(

--- a/backend/tests/test_dns_axfr_helper.py
+++ b/backend/tests/test_dns_axfr_helper.py
@@ -174,3 +174,36 @@ async def test_message_less_exception_never_surfaces_blank(
     assert msg.strip()
     assert "ValueError" in msg
     assert "192.0.2.10" in msg
+
+
+@pytest.mark.parametrize(
+    ("exc", "expect_present", "expect_absent"),
+    [
+        # A routing/connection failure means we never got a DNS answer, so
+        # pointing at the transfer ACL sends the operator to the wrong box.
+        (OSError(113, "No route to host"), "could not be reached", "allow-transfer"),
+        (TimeoutError("timed out"), "did not answer in time", "allow-transfer"),
+        # The server DID answer and said no — now the ACL is the right hint.
+        (ValueError("Zone transfer error: REFUSED"), "allow-transfer", "could not be reached"),
+    ],
+)
+async def test_hint_matches_the_failure_cause(
+    exc: Exception,
+    expect_present: str,
+    expect_absent: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The next-step hint must match why it failed, not be boilerplate."""
+    import dns.query
+
+    def _raise(*_a: Any, **_kw: Any) -> Any:
+        raise exc
+
+    monkeypatch.setattr(dns.query, "xfr", _raise)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await axfr_zone_records(host="192.0.2.10", port=53, zone_name="example.com.")
+
+    msg = str(excinfo.value)
+    assert expect_present in msg
+    assert expect_absent not in msg

--- a/backend/tests/test_dns_axfr_helper.py
+++ b/backend/tests/test_dns_axfr_helper.py
@@ -1,0 +1,176 @@
+"""Regression tests for the shared AXFR helper (``app.drivers.dns._axfr``).
+
+This module had no coverage at all, which is how it shipped a bug that made
+every hostname-addressed AXFR fail 100% of the time: ``dns.query.xfr`` takes
+an IP *literal* and calls ``dns.inet.af_for_address()`` on it up front, so a
+``DNSServer.host`` like ``"dns-bind9"`` raised a bare, message-less
+``ValueError`` before a single packet was sent. The #61 drift report and the
+pull-importer both surfaced that empty string as the failure reason, so the
+symptom was "failed, no reason given" on every BIND9 server.
+
+The tests below pin both halves of the fix: names get resolved before the
+transfer, and no failure path is ever allowed to produce a blank message.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+import pytest
+
+from app.drivers.dns._axfr import axfr_zone_records
+
+
+class _FakeZone:
+    """Minimal stand-in for ``dns.zone.Zone`` — an empty zone."""
+
+    def items(self) -> list[Any]:
+        return []
+
+
+@pytest.fixture
+def captured_xfr(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch out the network so we can assert on what ``xfr`` was handed."""
+    import dns.query
+    import dns.zone
+
+    seen: dict[str, Any] = {}
+
+    def fake_xfr(where: str, origin: Any, **kwargs: Any) -> object:
+        seen["where"] = where
+        seen["port"] = kwargs.get("port")
+        return object()
+
+    monkeypatch.setattr(dns.query, "xfr", fake_xfr)
+    monkeypatch.setattr(dns.zone, "from_xfr", lambda _gen: _FakeZone())
+    return seen
+
+
+async def test_hostname_is_resolved_before_transfer(
+    captured_xfr: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hostname must reach ``dns.query.xfr`` as an IP, never as a name.
+
+    This is the actual shipped bug: passing the name through unresolved is
+    what raised the bare ValueError.
+    """
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.10", 53))],
+    )
+
+    await axfr_zone_records(host="dns-bind9", port=53, zone_name="example.com.")
+
+    assert captured_xfr["where"] == "192.0.2.10"
+
+
+@pytest.mark.parametrize("literal", ["192.0.2.10", "2001:db8::1"])
+async def test_ip_literals_pass_through_unchanged(
+    literal: str, captured_xfr: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An address that already parses must not take the resolver path."""
+
+    def _boom(*_a: Any, **_kw: Any) -> Any:  # pragma: no cover - must not run
+        raise AssertionError("getaddrinfo called for an IP literal")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _boom)
+
+    await axfr_zone_records(host=literal, port=53, zone_name="example.com.")
+
+    assert captured_xfr["where"] == literal
+
+
+async def test_resolution_failure_names_the_host(
+    captured_xfr: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unresolvable host produces an operator-readable error, not OSError."""
+
+    def _fail(*_a: Any, **_kw: Any) -> Any:
+        raise socket.gaierror("Name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _fail)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await axfr_zone_records(host="no-such-host", port=53, zone_name="example.com.")
+
+    msg = str(excinfo.value)
+    assert "no-such-host" in msg
+    assert "example.com." in msg
+    assert "resolve" in msg
+
+
+async def test_all_resolved_addresses_are_tried(
+    captured_xfr: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dual-stack host must fall through to its other addresses.
+
+    The first address a resolver returns isn't necessarily the one
+    allow-transfer permits, or even one that's routable from here.
+    """
+    import dns.query
+
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("2001:db8::1", 53, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.10", 53)),
+        ],
+    )
+
+    tried: list[str] = []
+
+    def flaky_xfr(where: str, origin: Any, **kwargs: Any) -> object:
+        tried.append(where)
+        if where == "2001:db8::1":
+            raise OSError("No route to host")
+        return object()
+
+    monkeypatch.setattr(dns.query, "xfr", flaky_xfr)
+
+    await axfr_zone_records(host="dual.example.", port=53, zone_name="example.com.")
+
+    assert tried == ["2001:db8::1", "192.0.2.10"]
+
+
+def test_resolve_dedupes_repeated_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """getaddrinfo repeats an address per socket type; don't try it twice."""
+    from app.drivers.dns._axfr import resolve_server_address
+
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.0.2.10", 53)),
+            (socket.AF_INET, socket.SOCK_DGRAM, 17, "", ("192.0.2.10", 53)),
+        ],
+    )
+
+    assert resolve_server_address("host.example.", 53, what="AXFR of x") == ["192.0.2.10"]
+
+
+async def test_message_less_exception_never_surfaces_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare ``ValueError()`` must not reach the caller as an empty string.
+
+    Callers (drift report, pull-importer) render this text verbatim, so a
+    blank message means the UI shows "failed" with no reason — the exact
+    thing that made the original bug so hard to diagnose.
+    """
+    import dns.query
+
+    def _bare(*_a: Any, **_kw: Any) -> Any:
+        raise ValueError
+
+    monkeypatch.setattr(dns.query, "xfr", _bare)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await axfr_zone_records(host="192.0.2.10", port=53, zone_name="example.com.")
+
+    msg = str(excinfo.value)
+    assert msg.strip()
+    assert "ValueError" in msg
+    assert "192.0.2.10" in msg

--- a/backend/tests/test_dns_drift.py
+++ b/backend/tests/test_dns_drift.py
@@ -8,7 +8,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.drivers.dns.base import RecordData
-from app.models.dns import DNSRecord, DNSServer, DNSServerGroup, DNSZone
+from app.models.dns import DNSRecord, DNSServer, DNSServerGroup, DNSView, DNSZone
 from app.services.dns import drift as drift_mod
 
 
@@ -92,3 +92,59 @@ async def test_zone_drift_pull_failure_is_surfaced(
     assert s.status == "error"
     assert "AXFR refused" in (s.error or "")
     assert s.drift_count == 0
+
+
+async def test_no_warning_for_a_plain_zone(db_session: AsyncSession, monkeypatch: Any) -> None:
+    """A zone with no views must not carry the split-horizon caveat."""
+    group, _server, zone = await _group_server_zone(
+        db_session, server_name="ns1", zone_name="plain.example.com."
+    )
+    db_session.add(DNSRecord(zone_id=zone.id, name="www", record_type="A", value="10.0.0.1"))
+    await db_session.commit()
+    monkeypatch.setattr(drift_mod, "get_driver", lambda _d: _FakeDriver([]))
+
+    report = await drift_mod.compute_zone_drift(db_session, group_id=group.id, zone=zone)
+    assert report.warnings == []
+
+
+async def test_view_scoped_zone_is_flagged(db_session: AsyncSession, monkeypatch: Any) -> None:
+    """A view-scoped zone warns that the transfer may answer from another view.
+
+    An AXFR is addressed by zone *name*, and under split-horizon several zone
+    rows share one name — so the diff can compare this row against a different
+    view's content. Report that rather than let an operator "fix" it.
+    """
+    group, _server, zone = await _group_server_zone(
+        db_session, server_name="ns1", zone_name="split.example.com."
+    )
+    view = DNSView(group_id=group.id, name="internal", match_clients=["10.0.0.0/8"])
+    db_session.add(view)
+    await db_session.flush()
+    zone.view_id = view.id
+    await db_session.commit()
+    monkeypatch.setattr(drift_mod, "get_driver", lambda _d: _FakeDriver([]))
+
+    report = await drift_mod.compute_zone_drift(db_session, group_id=group.id, zone=zone)
+    assert len(report.warnings) == 1
+    assert "view" in report.warnings[0].lower()
+
+
+async def test_view_scoped_records_are_flagged(db_session: AsyncSession, monkeypatch: Any) -> None:
+    """Records pinned to a view aren't served to every client — say so."""
+    group, _server, zone = await _group_server_zone(
+        db_session, server_name="ns1", zone_name="partial.example.com."
+    )
+    view = DNSView(group_id=group.id, name="internal", match_clients=["10.0.0.0/8"])
+    db_session.add(view)
+    await db_session.flush()
+    db_session.add(
+        DNSRecord(
+            zone_id=zone.id, view_id=view.id, name="secret", record_type="A", value="10.0.0.7"
+        )
+    )
+    await db_session.commit()
+    monkeypatch.setattr(drift_mod, "get_driver", lambda _d: _FakeDriver([]))
+
+    report = await drift_mod.compute_zone_drift(db_session, group_id=group.id, zone=zone)
+    assert len(report.warnings) == 1
+    assert "scoped to a specific DNS view" in report.warnings[0]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4997,6 +4997,52 @@ export interface ZoneServerState {
   in_sync: boolean;
 }
 
+// ── Zone config drift (#61) ──────────────────────────────────────────────────
+//
+// Record-level diff between the DB (source of truth) and what each server in
+// the group is actually serving, obtained by AXFR / driver pull. Strictly
+// read-only — the report never applies anything. Distinct from
+// `ZoneServerState` above, which compares SOA *serials* only: a server can sit
+// on the right serial and still be serving the wrong records if someone edited
+// the host by hand.
+
+export interface ZoneDriftRecord {
+  name: string;
+  record_type: string;
+  value: string;
+  ttl: number | null;
+}
+
+export interface ZoneDriftServer {
+  server_id: string;
+  server_name: string;
+  driver: string;
+  // "ok" — pulled and diffed. "error" — the pull failed (unreachable, paused,
+  // AXFR refused); counts are meaningless. "unsupported" — the driver has no
+  // `pull_zone_records`, so drift can't be computed for it at all.
+  status: "ok" | "error" | "unsupported";
+  error: string | null;
+  in_sync: number;
+  // `extra_on_server.length + missing_on_server.length` — the backend derives
+  // it, so don't recompute it in the UI.
+  drift_count: number;
+  // Served by the host but absent from the DB — typically a manual on-host edit.
+  extra_on_server: ZoneDriftRecord[];
+  // In the DB but not being served — the change never reached this host.
+  missing_on_server: ZoneDriftRecord[];
+}
+
+export interface ZoneDrift {
+  zone_id: string;
+  zone_name: string;
+  db_record_count: number;
+  servers: ZoneDriftServer[];
+  // Caveats that make the diff less trustworthy — chiefly split-horizon
+  // views, where an AXFR is answered by whichever view matches the control
+  // plane's source address rather than the one this zone row belongs to.
+  warnings: string[];
+}
+
 // Pending records the delegation wizard would land in the parent zone.
 // `existing_*` lists are already-present rows the wizard would skip on apply.
 export interface DelegationRecord {
@@ -5496,6 +5542,13 @@ export const dnsApi = {
       .get<ZoneServerState>(
         `/dns/groups/${groupId}/zones/${zoneId}/server-state`,
       )
+      .then((r) => r.data),
+  // #61 — AXFRs every server in the group and diffs it against the DB.
+  // One request fans out to every host, so this is slow and deliberately
+  // NOT auto-fetched; the Drift tab loads it on demand.
+  getZoneDrift: (groupId: string, zoneId: string) =>
+    api
+      .get<ZoneDrift>(`/dns/groups/${groupId}/zones/${zoneId}/drift`)
       .then((r) => r.data),
 
   // DNSSEC — PowerDNS online signing (#127) + BIND9 inline-signing (#49)

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -50,6 +50,7 @@ import { ZoneTemplateModal } from "./ZoneTemplateModal";
 import { ServerDetailModal } from "./ServerDetailModal";
 import { PauseServerModal } from "@/components/ui/pause-server-modal";
 import { PoolsView } from "./PoolsView";
+import { DriftView } from "./DriftView";
 import {
   CertsCompactTable,
   TLSStatePill,
@@ -2775,6 +2776,10 @@ function ZoneSyncPill({ state }: { state: ZoneServerState }) {
   );
 }
 
+// Sub-tabs on the zone detail surface. Mirrored in the ``subtab`` URL param
+// (``records`` is the default and is left out of the URL entirely).
+type ZoneSubtab = "records" | "pools" | "certs" | "drift";
+
 function ZoneDetailView({
   group,
   zone,
@@ -2965,16 +2970,16 @@ function ZoneDetailView({
   // surface; otherwise default to Records.
   const [zoneSearchParams, setZoneSearchParams] = useSearchParams();
   const subtabParam = zoneSearchParams.get("subtab");
-  const initialSubtab: "records" | "pools" | "certs" =
+  const initialSubtab: ZoneSubtab =
     subtabParam === "pools"
       ? "pools"
       : subtabParam === "certs"
         ? "certs"
-        : "records";
-  const [zoneView, _setZoneView] = useState<"records" | "pools" | "certs">(
-    initialSubtab,
-  );
-  const setZoneView = (v: "records" | "pools" | "certs") => {
+        : subtabParam === "drift"
+          ? "drift"
+          : "records";
+  const [zoneView, _setZoneView] = useState<ZoneSubtab>(initialSubtab);
+  const setZoneView = (v: ZoneSubtab) => {
     _setZoneView(v);
     // Keep the URL in sync so a refresh / back-navigation lands on
     // the same tab. ``subtab=records`` is the default state — drop
@@ -3308,12 +3313,33 @@ function ZoneDetailView({
               Certificates ({tlsCerts?.items.length ?? 0})
             </button>
           )}
+          {/* No count — the drift report AXFRs every server in the group, so
+              it's only fetched once the operator opens the tab (#61). */}
+          <button
+            type="button"
+            onClick={() => setZoneView("drift")}
+            title="Compare what each server is actually serving against the database"
+            className={
+              "border-b-2 px-3 py-2 text-xs font-medium transition-colors " +
+              (zoneView === "drift"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground")
+            }
+          >
+            Drift
+          </button>
         </div>
       )}
 
       {/* Pools sub-view */}
       {!isForward && !zone.tailscale_tenant_id && zoneView === "pools" && (
         <PoolsView group={group} zone={zone} />
+      )}
+
+      {/* Drift sub-view (#61) — mounted only while the tab is active so the
+          expensive per-server AXFR fan-out isn't fired on every zone open. */}
+      {!isForward && !zone.tailscale_tenant_id && zoneView === "drift" && (
+        <DriftView group={group} zone={zone} />
       )}
 
       {/* Certificates sub-view */}

--- a/frontend/src/pages/dns/DriftView.tsx
+++ b/frontend/src/pages/dns/DriftView.tsx
@@ -1,0 +1,336 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  MinusCircle,
+  PlusCircle,
+  RefreshCw,
+  ShieldQuestion,
+} from "lucide-react";
+import {
+  dnsApi,
+  type DNSServerGroup,
+  type DNSZone,
+  type ZoneDriftRecord,
+  type ZoneDriftServer,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import {
+  RECORD_TYPE_BADGE,
+  RECORD_TYPE_BADGE_FALLBACK,
+} from "./recordTypeBadge";
+
+/**
+ * Config-drift view (#61) — what each server is *actually serving*
+ * versus what SpatiumDDI has in the database.
+ *
+ * Distinct from the ZoneSyncPill in the zone header, which compares SOA
+ * serials only: a host can sit on exactly the right serial and still serve
+ * the wrong records if someone edited the zone file by hand. This view
+ * AXFRs / driver-pulls the live zone from every server in the group and
+ * diffs it record by record.
+ *
+ * Strictly read-only. The backend never applies anything from this report,
+ * and neither does this view — an operator who wants the server to match
+ * the DB uses the existing Sync path. A changed value shows up as a
+ * missing+extra pair, because the diff key includes the value (matching
+ * the additive-sync semantics).
+ */
+
+// A zone with thousands of records diffed against an empty server produces
+// one row per record. Render a slice and let the operator opt into the rest
+// rather than locking the tab up laying out 5,000 <tr>s nobody scrolls to.
+const ROW_CAP = 50;
+
+function statusChip(server: ZoneDriftServer) {
+  if (server.status === "unsupported")
+    return {
+      cls: "bg-muted text-muted-foreground",
+      icon: ShieldQuestion,
+      label: "Not supported",
+    };
+  if (server.status === "error")
+    return {
+      cls: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
+      icon: AlertTriangle,
+      label: "Pull failed",
+    };
+  if (server.drift_count > 0)
+    return {
+      cls: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+      icon: AlertTriangle,
+      label: `${server.drift_count} drifted`,
+    };
+  return {
+    cls: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+    icon: CheckCircle2,
+    label: "In sync",
+  };
+}
+
+function RecordTable({
+  records,
+  kind,
+}: {
+  records: ZoneDriftRecord[];
+  kind: "extra" | "missing";
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const shown = expanded ? records : records.slice(0, ROW_CAP);
+  const hidden = records.length - shown.length;
+
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium">
+        {kind === "extra" ? (
+          <>
+            <PlusCircle className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+            <span>Extra on server ({records.length})</span>
+            <span className="font-normal text-muted-foreground">
+              — served but not in SpatiumDDI, usually a manual edit on the host
+            </span>
+          </>
+        ) : (
+          <>
+            <MinusCircle className="h-3.5 w-3.5 text-sky-600 dark:text-sky-400" />
+            <span>Missing on server ({records.length})</span>
+            <span className="font-normal text-muted-foreground">
+              — in SpatiumDDI but not being served
+            </span>
+          </>
+        )}
+      </div>
+      <div className="overflow-x-auto rounded border">
+        <table className="w-full min-w-[32rem] text-xs">
+          <thead className="bg-muted/50 text-muted-foreground">
+            <tr>
+              <th className="px-2 py-1 text-left font-medium">Name</th>
+              <th className="px-2 py-1 text-left font-medium">Type</th>
+              <th className="px-2 py-1 text-left font-medium">Value</th>
+              <th className="px-2 py-1 text-right font-medium">TTL</th>
+            </tr>
+          </thead>
+          <tbody>
+            {shown.map((r, i) => (
+              <tr
+                // Records have no id — and a name+type+value triple can
+                // legitimately repeat across TTLs — so the index is part of
+                // the key. The list is read-only and never reordered.
+                key={`${r.name}|${r.record_type}|${r.value}|${i}`}
+                className="border-t"
+              >
+                <td className="px-2 py-1 font-mono">{r.name}</td>
+                <td className="px-2 py-1">
+                  <span
+                    className={cn(
+                      "rounded px-1.5 py-0.5 text-[10px] font-medium",
+                      RECORD_TYPE_BADGE[r.record_type] ??
+                        RECORD_TYPE_BADGE_FALLBACK,
+                    )}
+                  >
+                    {r.record_type}
+                  </span>
+                </td>
+                <td
+                  className="max-w-md truncate px-2 py-1 font-mono"
+                  title={r.value}
+                >
+                  {r.value}
+                </td>
+                <td className="px-2 py-1 text-right text-muted-foreground">
+                  {r.ttl ?? "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {hidden > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="mt-1.5 text-xs text-primary hover:underline"
+        >
+          Show {hidden.toLocaleString()} more
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ServerCard({ server }: { server: ZoneDriftServer }) {
+  const chip = statusChip(server);
+  const ChipIcon = chip.icon;
+
+  return (
+    <div className="rounded-md border bg-card">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-2.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-medium">
+            {server.server_name}
+          </span>
+          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+            {server.driver}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 text-xs">
+          {server.status === "ok" && (
+            <span className="text-muted-foreground">
+              {server.in_sync.toLocaleString()} matching
+            </span>
+          )}
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium",
+              chip.cls,
+            )}
+          >
+            <ChipIcon className="h-3 w-3" />
+            {chip.label}
+          </span>
+        </div>
+      </div>
+
+      <div className="px-4 py-3">
+        {server.status !== "ok" ? (
+          // `error` is `str(exc)` server-side, and some exceptions stringify
+          // to "" — so test for a non-blank string rather than just null,
+          // otherwise the card renders "Pull failed" over an empty body.
+          <p className="text-xs text-muted-foreground">
+            {server.error?.trim() ||
+              (server.status === "unsupported"
+                ? "This driver can't pull live records, so drift can't be computed for it."
+                : "The zone could not be pulled from this server. Check that it's reachable and that AXFR from the control plane is permitted.")}
+          </p>
+        ) : server.drift_count === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            Every record in SpatiumDDI is being served, and nothing extra is
+            present on the host.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {server.extra_on_server.length > 0 && (
+              <RecordTable records={server.extra_on_server} kind="extra" />
+            )}
+            {server.missing_on_server.length > 0 && (
+              <RecordTable records={server.missing_on_server} kind="missing" />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function DriftView({
+  group,
+  zone,
+}: {
+  group: DNSServerGroup;
+  zone: DNSZone;
+}) {
+  // Deliberately NOT auto-refetched: one call fans out an AXFR to every
+  // server in the group, so it runs when the operator opens this tab and
+  // then only when they ask for it again. `retry: false` for the same
+  // reason — silently replaying a slow multi-host pull three times on a
+  // timeout is worse than showing the error.
+  const { data, isFetching, error, refetch } = useQuery({
+    queryKey: ["dns-zone-drift", group.id, zone.id],
+    queryFn: () => dnsApi.getZoneDrift(group.id, zone.id),
+    refetchOnWindowFocus: false,
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  const servers = data?.servers ?? [];
+  const comparable = servers.filter((s) => s.status === "ok");
+  const drifted = comparable.filter((s) => s.drift_count > 0);
+  const failed = servers.filter((s) => s.status === "error");
+
+  return (
+    <div className="flex-1 overflow-auto p-5">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm">
+            Compares what each server is actually serving against the{" "}
+            {(data?.db_record_count ?? 0).toLocaleString()} record
+            {data?.db_record_count === 1 ? "" : "s"} SpatiumDDI holds for this
+            zone.
+          </p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Read-only — nothing here is applied. Use Sync to push the database
+            state to a server that has drifted.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          disabled={isFetching}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+        >
+          <RefreshCw
+            className={cn("h-3.5 w-3.5", isFetching && "animate-spin")}
+          />
+          Refresh
+        </button>
+      </div>
+
+      {isFetching && !data ? (
+        <p className="text-sm text-muted-foreground">
+          Pulling the live zone from every server in the group…
+        </p>
+      ) : error ? (
+        <p className="text-sm text-destructive">
+          Could not build the drift report:{" "}
+          {error instanceof Error ? error.message : String(error)}
+        </p>
+      ) : servers.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          This server group has no servers, so there's nothing to compare
+          against.
+        </p>
+      ) : (
+        <>
+          {(data?.warnings ?? []).map((w) => (
+            <div
+              key={w}
+              className="mb-3 flex items-start gap-2 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300"
+            >
+              <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{w}</span>
+            </div>
+          ))}
+          <div className="mb-4 flex flex-wrap items-center gap-3 text-xs">
+            {drifted.length > 0 ? (
+              <span className="inline-flex items-center gap-1.5 rounded bg-amber-500/15 px-2 py-1 font-medium text-amber-600 dark:text-amber-400">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                {drifted.length} of {comparable.length} comparable server
+                {comparable.length === 1 ? "" : "s"} drifted
+              </span>
+            ) : comparable.length > 0 ? (
+              <span className="inline-flex items-center gap-1.5 rounded bg-emerald-500/15 px-2 py-1 font-medium text-emerald-600 dark:text-emerald-400">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                All {comparable.length} comparable server
+                {comparable.length === 1 ? "" : "s"} match the database
+              </span>
+            ) : null}
+            {failed.length > 0 && (
+              <span className="inline-flex items-center gap-1.5 rounded bg-rose-500/15 px-2 py-1 font-medium text-rose-600 dark:text-rose-400">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                {failed.length} server{failed.length === 1 ? "" : "s"} could not
+                be pulled
+              </span>
+            )}
+          </div>
+          <div className="space-y-3">
+            {servers.map((s) => (
+              <ServerCard key={s.server_id} server={s} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the 🟡 on #61. The backend shipped in `2026.06.11-1` — `GET /dns/groups/{gid}/zones/{zid}/drift` plus the `find_dns_zone_drift` MCP tool — but nothing in the frontend ever called it. This adds the UI, and fixes the reason it was never consumed: **the endpoint could not return data.**

## The UI

New **Drift** tab on the zone detail (`frontend/src/pages/dns/DriftView.tsx`), alongside Records / Pools / Certificates and deep-linkable via `?subtab=drift`. Per-server cards showing in-sync / extra-on-server / missing-on-server, with the record tables behind each. Read-only, matching the endpoint — nothing here applies anything.

Two deliberate behaviours:
- **Fetched on demand.** The component is mounted only while its tab is active, with `retry: false`. One call fans out an AXFR to every server in the group; silently replaying that three times on a timeout is worse than showing the error.
- **Capped rendering.** A zone diffed against an empty server produces one row per record. 50 rows, then "show more".

## Why the endpoint returned nothing

`dns.query.xfr` takes an IP **literal**. It calls `dns.inet.af_for_address()` up front, and that raises a **bare, message-less** `ValueError()` for anything that doesn't parse as an address — before a single packet leaves the box.

So every `DNSServer.host` holding a hostname — every containerised deployment, and most others — failed 100% of the time, and the reason each caller surfaced was the **empty string**:

```json
{"server_name": "dns-bind9", "status": "error", "error": ""}
```

That combination is why this sat undiscovered: the feature was totally broken, and its failure mode was silent.

`resolve_server_address` in `_axfr.py` now resolves before handing dnspython an address. Verified end-to-end against the dev stack — the report went from "failed, no reason" to catching genuine drift:

```json
{"server_name": "dns-bind9", "status": "ok", "in_sync": 5, "drift_count": 1,
 "extra_on_server": [{"name": "ns1", "record_type": "A", "value": "127.0.0.1", "ttl": 3600}]}
```

An `ns1 A 127.0.0.1` being served by the host that isn't in the database — exactly what #61 was filed to surface.

### Same bug, two more call sites

`dns.query.tcp` behaves identically, and both RFC 2136 **write** paths passed a hostname straight in (`windows.py`, `bind9.py`). Confirmed: `dns.query.tcp(update, 'dns-bind9')` → `ValueError('')`. A Windows DNS server registered by FQDN without WinRM credentials (Path A) failed every record write with an empty message.

Those take **only the first** resolved address — a write must not be replayed against a second one. The AXFR path walks all candidates, since a transfer is a side-effect-free read and the first address of a dual-stack host isn't necessarily the one `allow-transfer` permits.

No failure path can now produce a blank message.

## Split-horizon caveat

An AXFR is addressed by zone *name*, but under views (#24) several zone rows share a name and the server answers from whichever view matches the control plane's source address. The diff could then report another view's content as drift in both directions.

The report now carries `warnings[]` for this, rendered above the results. I chose to **surface** the ambiguity rather than silently change the diff semantics — deciding which view a drift report should compare against is a real design call and shouldn't be made as a side effect of a UI PR.

## Test coverage

`_axfr.py` had **no tests at all**, which is how a 100%-failure bug shipped. New `test_dns_axfr_helper.py` pins:
- hostnames are resolved before the transfer (the actual bug)
- IPv4/IPv6 literals skip the resolver
- multi-address fallthrough on an unroutable first address
- `getaddrinfo` duplicate collapsing
- no failure path yields a blank message

`test_dns_drift.py` gains three cases for the view warnings. 12 tests pass; `make ci` green; host `ruff`/`black` clean.

## Known gap — filed separately as #734

With the transfer now actually reaching the server, BIND9 answers `REFUSED`. The agent grants `allow-transfer` only to the group TSIG key and only on dynamic zones, and the control plane doesn't sign. Separately, `DNSServerOptions.allow_transfer` / `DNSZone.allow_transfer` are settable via the API but never rendered into `named.conf` — a silent no-op.

**So this tab works today for Windows Path B and the cloud drivers** (which pull over their own APIs, not AXFR) **but not yet for agent-managed BIND9**, where it shows an accurate, actionable "Zone transfer error: REFUSED".

That fix spans the agent renderer, the config bundle, and transfer-policy posture — it wants its own review, not a corner of a UI PR. Details and a suggested shape in #734.

## Scope note

The issue was scoped as "pure frontend: one client method + a tab". It would have been, if the endpoint worked. I kept the backend changes to what the UI needs to not be decorative — the resolution fix, the no-blank-error guarantee, and the view caveat — and pushed the posture change to #734.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
