### PR TITLE
feat(ui): keyboard shortcut help overlay behind `?` (#81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,7 +481,7 @@ suggestion, free-space treemap.
 - ✅ [**Built-in network tools page**](https://github.com/spatiumddi/spatiumddi/issues/58) — shipped `2026.06.11-1`: a `/tools` page (ping / traceroute / mtr / dig / whois over sandboxed argv, port-test / TLS-cert over sockets, DNS-propagation, MAC-vendor), permission-gated + Redis rate-limited, with 7 MCP tools.
 - ✅ [**PCAP capture trigger**](https://github.com/spatiumddi/spatiumddi/issues/59) — shipped `2026.06.15-1`: on-demand tcpdump as an RBAC-gated/audited Tools page, both server-container and appliance-host (real-NIC) vantages, keep-partial-on-Stop, `.pcap` download, 4 Operator Copilot tools.
 - ❌ [**ACL / prefix-list generator**](https://github.com/spatiumddi/spatiumddi/issues/60) — **closed as not planned** 2026-06-17, in the same triage pass that closed #40. No rationale was recorded on the issue; re-open it rather than re-filing if the need comes back.
-- 🟡 [**Config-drift report (full record diff)**](https://github.com/spatiumddi/spatiumddi/issues/61) — **backend shipped `2026.06.11-1`**: `GET …/zones/{id}/drift` AXFRs the live zone from every server in the group and diffs it against the DB — extra-on-server (manual host change) / missing-on-server / in-sync, per server, read-only — plus a `find_dns_zone_drift` MCP tool. **UI still ⬜.**
+- ✅ [**Config-drift report (full record diff)**](https://github.com/spatiumddi/spatiumddi/issues/61) — **backend shipped `2026.06.11-1`**: `GET …/zones/{id}/drift` AXFRs the live zone from every server in the group and diffs it against the DB — extra-on-server (manual host change) / missing-on-server / in-sync, per server, read-only — plus a `find_dns_zone_drift` MCP tool. **UI merged to `main` (#735), pending release cut** — a Drift tab on the zone detail, fetched on demand because one call fans out an AXFR to every server in the group. That PR also fixed the reason nothing had ever consumed the endpoint: `dns.query.xfr` takes an IP *literal* and raises a bare, message-less `ValueError` for a hostname before sending a packet, so every hostname-addressed server failed 100% of the time reporting `""` as the error. **Known gap — [#734](https://github.com/spatiumddi/spatiumddi/issues/734):** agent-managed BIND9 now reaches the server and gets `REFUSED`, because the control plane doesn't TSIG-sign its AXFR and the agent grants `allow-transfer` only to the group key on dynamic zones. The tab works today for Windows Path B + the cloud drivers (API pulls, not AXFR), not for BIND9.
 
 #### Workflow & RBAC
 
@@ -511,7 +511,18 @@ suggestion, free-space treemap.
 - ⬜ [**Personal pinned dashboard**](https://github.com/spatiumddi/spatiumddi/issues/78)
 - ⬜ [**Field-level history**](https://github.com/spatiumddi/spatiumddi/issues/79)
 - ⬜ [**Recent items / favourites sidebar**](https://github.com/spatiumddi/spatiumddi/issues/80)
-- ⬜ [**Keyboard shortcut help overlay**](https://github.com/spatiumddi/spatiumddi/issues/81)
+- ✅ [**Keyboard shortcut help overlay**](https://github.com/spatiumddi/spatiumddi/issues/81)
+  — merged to `main` (#737), pending release cut: `?` opens a modal
+  listing every binding, from a new `frontend/src/lib/shortcuts.ts`
+  mounted via `Header`. The map is deliberately **load-bearing rather
+  than a parallel list** — `GlobalSearch`'s Cmd/Ctrl+K listener matches
+  against it and its trigger keycap renders from it, so retuning a combo
+  moves the handler, the keycap and the help together. That coupling
+  reaches exactly two shortcuts today (Cmd/Ctrl+K, `?`); the other ten
+  are flagged `describedOnly` because their handlers live in components
+  that don't consult the map, and are the rows that can still drift.
+  Note for anyone adding a binding: declare it here and match via
+  `matchesShortcut` rather than adding another described-only row.
 - ⬜ [**Print / PDF export for IPAM tree + subnet detail**](https://github.com/spatiumddi/spatiumddi/issues/82) — GitHub auto-closed this on 2026-06-18 in error: PR [#446](https://github.com/spatiumddi/spatiumddi/pull/446) was titled `fix(supervisor): … (CodeQL #82)`, referring to CodeQL *alert* 82, and the `#82` was read as an issue reference. Nothing IPAM-print-related shipped — the only `reportlab` surfaces are the conformity (`/conformity/export.pdf`) and audit-change (`/audit/export.pdf`) reports. **Reopened 2026-07-28**; shares PDF infrastructure with the shipped #48.
 
 #### CLI tool

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -14,6 +14,11 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { searchApi, type SearchResult } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import {
+  formatCombo,
+  matchesShortcut,
+  OPEN_GLOBAL_SEARCH,
+} from "@/lib/shortcuts";
 import { askAI } from "@/components/copilot/askAI";
 import { useAiAvailable } from "@/components/copilot/useAiAvailable";
 
@@ -188,10 +193,12 @@ export function GlobalSearch() {
     setActiveIdx(0);
   }, [debouncedQuery]);
 
-  // Cmd+K / Ctrl+K to open
+  // Cmd+K / Ctrl+K to open. The combo comes from ``lib/shortcuts.ts``
+  // (issue #81) so the help overlay and this listener can't disagree —
+  // retuning the binding there retunes both.
   useEffect(() => {
     function handler(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      if (matchesShortcut(e, OPEN_GLOBAL_SEARCH)) {
         e.preventDefault();
         setOpen((v) => !v);
       }
@@ -289,8 +296,11 @@ export function GlobalSearch() {
       >
         <Search className="h-3.5 w-3.5 flex-shrink-0" />
         <span className="flex-1 text-left">Search IP, zone, record…</span>
+        {/* Rendered from the shortcut definition, not hardcoded — this
+            used to read "⌘K" on every platform, so Linux / Windows
+            operators were shown a key their keyboard doesn't have. */}
         <kbd className="hidden rounded bg-muted px-1 py-0.5 text-[10px] font-mono sm:inline-block flex-shrink-0">
-          ⌘K
+          {formatCombo(OPEN_GLOBAL_SEARCH.combos[0])}
         </kbd>
       </button>
 

--- a/frontend/src/components/KeyboardShortcutsOverlay.tsx
+++ b/frontend/src/components/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Keyboard } from "lucide-react";
+import { Modal } from "@/components/ui/modal";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
+import {
+  formatCombo,
+  isMacPlatform,
+  isTypingTarget,
+  matchesShortcut,
+  SHORTCUT_GROUPS,
+  SHOW_SHORTCUTS,
+  type Shortcut,
+} from "@/lib/shortcuts";
+
+/**
+ * `?` keyboard-shortcut help overlay (issue #81).
+ *
+ * The button and the modal live in one component on purpose: the header
+ * needs an affordance (a keyboard-only route to "what are the keyboard
+ * shortcuts?" is circular — you'd have to already know the shortcut),
+ * and the `?` binding needs a listener. Splitting them would mean
+ * lifting `open` into a context or messaging between the two, for a
+ * single boolean. Mounted in `Header`, which `AppLayout` always renders,
+ * so the binding is live on every page.
+ *
+ * The list of bindings comes from `lib/shortcuts.ts`, not from this
+ * file — see that module for how far the anti-drift guarantee reaches.
+ */
+
+function Keys({ shortcut }: { shortcut: Shortcut }) {
+  const mac = isMacPlatform();
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      {shortcut.combos.map((combo, i) => (
+        <span key={formatCombo(combo, mac)} className="flex items-center gap-1">
+          {i > 0 && (
+            <span className="text-[10px] text-muted-foreground">or</span>
+          )}
+          <kbd className="rounded border border-b-2 bg-muted px-1.5 py-0.5 font-mono text-[11px] font-medium text-foreground">
+            {formatCombo(combo, mac)}
+          </kbd>
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function KeyboardShortcutsHelp() {
+  const [open, setOpen] = useState(false);
+  const close = useCallback(() => setOpen(false), []);
+  const { enabled } = useFeatureModules();
+
+  // The keydown listener is bound once, so it can't close over `open`.
+  // A ref keeps the current value available without re-binding on every
+  // toggle (which would also mean tearing the listener down mid-event).
+  const openRef = useRef(open);
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      // Never steal a printable character from a field being typed in —
+      // "?" is a legitimate thing to put in a description.
+      if (isTypingTarget(e.target)) return;
+      if (!matchesShortcut(e, SHOW_SHORTCUTS)) return;
+      // Don't stack on top of another dialog. Every modal binds Escape
+      // on `window` (`use-draggable-modal`), so an overlay opened over
+      // an edit form would let a single Escape dismiss BOTH — taking
+      // the operator's unsaved input with it. Closing our own overlay
+      // is still fine, hence the `openRef` check first.
+      if (
+        !openRef.current &&
+        document.querySelector('[role="dialog"][aria-modal="true"]')
+      ) {
+        return;
+      }
+      e.preventDefault();
+      setOpen((v) => !v);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Hide groups whose surface is switched off — no point advertising
+  // Copilot bindings when the drawer can't be opened.
+  const groups = SHORTCUT_GROUPS.filter((g) => !g.module || enabled(g.module));
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        title="Keyboard shortcuts (?)"
+        aria-label="Show keyboard shortcuts"
+        // Hidden on touch/narrow viewports: the header is already tight
+        // there (the Sign out label drops below sm) and an overlay of
+        // keyboard bindings is not actionable without a keyboard.
+        className="hidden rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground sm:block"
+      >
+        <Keyboard className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <Modal title="Keyboard shortcuts" onClose={close} wide>
+          <div className="space-y-5">
+            {groups.map((group) => (
+              <section key={group.id}>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  {group.title}
+                  {group.context && (
+                    <span className="ml-1.5 font-normal normal-case tracking-normal">
+                      — {group.context}
+                    </span>
+                  )}
+                </h3>
+                <dl className="space-y-1.5">
+                  {group.shortcuts.map((s) => (
+                    <div
+                      key={s.id}
+                      className="flex items-baseline gap-3 text-sm"
+                    >
+                      <dt className="min-w-0 flex-1 text-muted-foreground">
+                        {s.description}
+                      </dt>
+                      <dd>
+                        <Keys shortcut={s} />
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </section>
+            ))}
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { Link, useNavigate } from "react-router-dom";
 import { Code2, LogOut, Menu, Moon, Sun, UserCircle2 } from "lucide-react";
 import { GlobalSearch } from "@/components/GlobalSearch";
+import { KeyboardShortcutsHelp } from "@/components/KeyboardShortcutsOverlay";
 
 export function Header({ onMobileMenu }: { onMobileMenu?: () => void }) {
   const { logout } = useAuth();
@@ -28,6 +29,10 @@ export function Header({ onMobileMenu }: { onMobileMenu?: () => void }) {
       <div className="flex-1" />
       <GlobalSearch />
       <div className="flex items-center gap-1">
+        {/* Issue #81 — the ``?`` overlay's discoverable affordance. Same
+            reasoning as the API-docs link below: the keyboard route
+            exists, this is how you find out it exists. */}
+        <KeyboardShortcutsHelp />
         {/* Issue #96 — discoverable API docs link for power users.
             Sidebar has the labeled entry; this is the muscle-memory
             shortcut. ReDoc is the primary surface (cleaner browsing);

--- a/frontend/src/lib/shortcuts.ts
+++ b/frontend/src/lib/shortcuts.ts
@@ -1,0 +1,300 @@
+/**
+ * Keyboard shortcuts — the single source of truth (issue #81).
+ *
+ * Every binding the app responds to is declared here once, and both
+ * halves consume this file:
+ *
+ *   * the **handlers** match against it via {@link matchesShortcut}
+ *   * the **help overlay** renders it via {@link formatCombo}
+ *
+ * That coupling is the point: a help page carrying its own hand-written
+ * copy of the bindings goes stale the first time someone retunes a
+ * handler.
+ *
+ * **How far that guarantee currently reaches.** Two shortcuts are
+ * genuinely wired — `Cmd/Ctrl+K` (matched in `GlobalSearch`) and `?`
+ * (matched in `KeyboardShortcutsOverlay`). Retune either here and both
+ * the handler and the overlay follow. Everything else is flagged
+ * {@link Shortcut.describedOnly}: real behaviour, but implemented in a
+ * component that doesn't consult this map — the modal Escape in
+ * `use-draggable-modal`, the arrow keys in `GlobalSearch`,
+ * Enter/Shift+Enter in the Copilot composer, Backspace in
+ * `TagFilterChips` — plus a few that are native browser behaviour.
+ * Those rows are listed because from the operator's side they're
+ * indistinguishable from the ones we own, but they are exactly the ones
+ * that can drift.
+ *
+ * Adding a binding? Declare it here and have the handler match on it
+ * via {@link matchesShortcut}, rather than adding another
+ * described-only row. Adding it straight to a component means it never
+ * shows up in the overlay at all.
+ */
+
+/** A single chord. `key` is matched against `KeyboardEvent.key`. */
+export interface KeyCombo {
+  /** `KeyboardEvent.key` value, compared case-insensitively. */
+  key: string;
+  /**
+   * The primary modifier. **Rendered** per-platform (⌘ on a Mac, Ctrl
+   * elsewhere) but **matched** against either — see
+   * {@link matchesCombo} for why it is deliberately lenient.
+   */
+  mod?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  /** Render override — for keys whose `key` value reads badly ("ArrowUp"). */
+  label?: string;
+}
+
+export interface Shortcut {
+  id: string;
+  combos: KeyCombo[];
+  description: string;
+  /**
+   * True when this entry only *describes* a binding whose handler lives
+   * elsewhere and does not consult this map — either component-local
+   * (the modal Escape in `use-draggable-modal`, the arrow keys in
+   * `GlobalSearch`, Enter/Shift+Enter in the Copilot composer) or
+   * native browser behaviour.
+   *
+   * These are the entries that **can** go stale, because nothing links
+   * them to the code that implements them. Prefer wiring a new binding
+   * (leave this unset and match via {@link matchesShortcut}) over
+   * adding another described-only row.
+   */
+  describedOnly?: boolean;
+}
+
+export interface ShortcutGroup {
+  /** Stable key — filter on this, never on the display title. */
+  id: string;
+  /** Section heading in the overlay. */
+  title: string;
+  /** When the group only applies in a particular context, say so. */
+  context?: string;
+  /**
+   * Feature module this group's surface belongs to. When set, the
+   * overlay hides the group unless that module is enabled — no point
+   * advertising bindings for a drawer the operator can't open.
+   */
+  module?: string;
+  shortcuts: Shortcut[];
+}
+
+/**
+ * True on macOS-like platforms, where the "mod" key renders as ⌘ and is
+ * reported as `metaKey`. Everywhere else it is Ctrl.
+ *
+ * `navigator.platform` is deprecated but is still the most broadly
+ * supported signal; `userAgentData` is Chromium-only, so it is tried
+ * first and this is the fallback. Guarded for non-browser contexts
+ * (tests, SSR) rather than assuming `navigator` exists.
+ */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const uaPlatform = (
+    navigator as Navigator & { userAgentData?: { platform?: string } }
+  ).userAgentData?.platform;
+  const platform = uaPlatform || navigator.platform || "";
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
+/** Render one combo for display, e.g. `⌘K` / `Ctrl+K` / `Shift+Enter`. */
+export function formatCombo(combo: KeyCombo, mac = isMacPlatform()): string {
+  const parts: string[] = [];
+  if (combo.mod) parts.push(mac ? "⌘" : "Ctrl");
+  if (combo.alt) parts.push(mac ? "⌥" : "Alt");
+  if (combo.shift) parts.push(mac ? "⇧" : "Shift");
+  // Letter keys are stored lowercase because that's what we match
+  // against `KeyboardEvent.key`; a keycap reads as "⌘K", not "⌘k".
+  // Only single characters are touched — "Enter" / "Escape" keep their
+  // capitalisation, and an explicit `label` is used verbatim.
+  const key =
+    combo.label ??
+    (combo.key.length === 1 ? combo.key.toUpperCase() : combo.key);
+  parts.push(key);
+  // ⌘ and friends read as one glyph beside the key; the spelled-out
+  // modifiers need a separator or "CtrlK" runs together.
+  return mac ? parts.join("") : parts.join("+");
+}
+
+/**
+ * Does this keyboard event match the combo?
+ *
+ * Modifier matching is strict in both directions — a combo that doesn't
+ * ask for Alt will not match an event with Alt held — so Ctrl+K and
+ * Ctrl+Alt+K can't both fire the same handler.
+ *
+ * `mod` is the one deliberate exception: it accepts **either** Cmd or
+ * Ctrl regardless of platform. It renders per-platform (⌘K on a Mac,
+ * Ctrl+K elsewhere) but matches both, which is exactly what the
+ * pre-#81 `(e.metaKey || e.ctrlKey)` check in `GlobalSearch` did.
+ * Tightening that to the platform's own modifier would quietly stop
+ * Ctrl+K working for Mac users who have it in their fingers, and
+ * retuning existing bindings isn't this change's job.
+ */
+export function matchesCombo(e: KeyboardEvent, combo: KeyCombo): boolean {
+  if (e.key.toLowerCase() !== combo.key.toLowerCase()) return false;
+  const mod = e.metaKey || e.ctrlKey;
+  if (mod !== !!combo.mod) return false;
+  if (e.altKey !== !!combo.alt) return false;
+  // Shift is only compared when the combo cares. Typing "?" needs Shift
+  // on a US layout but not on every layout, so a shortcut keyed on the
+  // resulting *character* must not also demand the modifier that
+  // happened to produce it.
+  if (combo.shift !== undefined && e.shiftKey !== combo.shift) return false;
+  return true;
+}
+
+/** Any-of-the-combos convenience wrapper around {@link matchesCombo}. */
+export function matchesShortcut(e: KeyboardEvent, shortcut: Shortcut): boolean {
+  return shortcut.combos.some((c) => matchesCombo(e, c));
+}
+
+/**
+ * Is the user typing into something?
+ *
+ * Printable-character shortcuts (`?`) must stand down inside form
+ * fields, or the operator can't type a question mark into a
+ * description. Checked against the *event target* rather than
+ * `document.activeElement` so it stays correct inside shadow roots and
+ * portalled dialogs.
+ */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  // Custom widgets that opt into text entry (combobox / searchbox roles).
+  const role = target.getAttribute("role");
+  return role === "textbox" || role === "combobox" || role === "searchbox";
+}
+
+// ── The bindings ────────────────────────────────────────────────────────
+
+/** Open the global search palette. Matched in `GlobalSearch.tsx`. */
+export const OPEN_GLOBAL_SEARCH: Shortcut = {
+  id: "global-search",
+  // `shift: false` is load-bearing. The pre-#81 check was
+  // `e.key === "k"` — case-*sensitive*, so Shift never matched because
+  // it yields `"K"`. `matchesCombo` compares case-insensitively, so
+  // without this the palette would start toggling on Ctrl+Shift+K,
+  // which is the Web Console shortcut in both Firefox and Chrome.
+  combos: [{ key: "k", mod: true, shift: false }],
+  description: "Open global search",
+};
+
+/** Open this help overlay. Matched in `KeyboardShortcutsOverlay.tsx`. */
+export const SHOW_SHORTCUTS: Shortcut = {
+  id: "show-shortcuts",
+  // No `shift` constraint: "?" is Shift+/ on US layouts but a bare key
+  // elsewhere, and demanding Shift would break those keyboards.
+  combos: [{ key: "?" }],
+  description: "Show keyboard shortcuts",
+};
+
+export const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    id: "global",
+    title: "Global",
+    shortcuts: [
+      OPEN_GLOBAL_SEARCH,
+      SHOW_SHORTCUTS,
+      {
+        id: "escape",
+        combos: [{ key: "Escape", label: "Esc" }],
+        description: "Close the open dialog, drawer, or palette",
+        describedOnly: true,
+      },
+    ],
+  },
+  {
+    id: "global-search",
+    title: "Global search",
+    context: "while the search palette is open",
+    shortcuts: [
+      {
+        id: "search-move",
+        combos: [
+          { key: "ArrowUp", label: "↑" },
+          { key: "ArrowDown", label: "↓" },
+        ],
+        description: "Move between results",
+        describedOnly: true,
+      },
+      {
+        id: "search-open",
+        combos: [{ key: "Enter" }],
+        description: "Open the highlighted result",
+        describedOnly: true,
+      },
+    ],
+  },
+  {
+    id: "copilot",
+    title: "Operator Copilot",
+    module: "ai.copilot",
+    context: "while the chat drawer is open",
+    shortcuts: [
+      {
+        id: "copilot-send",
+        combos: [{ key: "Enter", shift: false }],
+        description: "Send the message",
+        describedOnly: true,
+      },
+      {
+        id: "copilot-newline",
+        combos: [{ key: "Enter", shift: true }],
+        description: "Insert a newline instead of sending",
+        describedOnly: true,
+      },
+      {
+        id: "copilot-history",
+        combos: [
+          { key: "ArrowUp", label: "↑" },
+          { key: "ArrowDown", label: "↓" },
+        ],
+        description:
+          "Walk back through messages you've sent — only from an empty composer, so a draft is never overwritten",
+        describedOnly: true,
+      },
+    ],
+  },
+  {
+    id: "tables",
+    title: "Tables and lists",
+    shortcuts: [
+      {
+        id: "range-select",
+        combos: [{ key: "Click", shift: true }],
+        description:
+          "Select every row between the last one you clicked and this one",
+        describedOnly: true,
+      },
+    ],
+  },
+  {
+    id: "inline",
+    title: "Inline editing and filters",
+    shortcuts: [
+      {
+        id: "inline-apply",
+        combos: [{ key: "Enter" }],
+        description: "Apply the value in the focused field",
+        describedOnly: true,
+      },
+      {
+        id: "inline-cancel",
+        combos: [{ key: "Escape", label: "Esc" }],
+        description: "Cancel without saving",
+        describedOnly: true,
+      },
+      {
+        id: "tag-backspace",
+        combos: [{ key: "Backspace" }],
+        description: "Remove the last tag from an empty tag filter",
+        describedOnly: true,
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Summary

`?` opens a modal listing every keyboard binding, rendered from a new `frontend/src/lib/shortcuts.ts` — the single source of truth the issue asked for. Mounted in `Header` (always rendered by `AppLayout`), so the binding is live on every page, with a keyboard icon beside the API-docs link: a keyboard-only route to *"what are the keyboard shortcuts?"* is circular.

## Making the map load-bearing, not decorative

The whole reason to centralise is that a help page carrying its own hand-written copy of the bindings goes stale the first time someone retunes a handler. So the map isn't just data the overlay prints:

- `GlobalSearch`'s Cmd/Ctrl+K listener matches against `OPEN_GLOBAL_SEARCH` via `matchesShortcut`
- its trigger-button keycap renders through `formatCombo`
- the overlay renders the same definitions

Retune the combo in one place and the handler, the keycap and the help all follow.

The module docstring is explicit about how far that reaches: **exactly two shortcuts today** (Cmd/Ctrl+K and `?`). Everything else is flagged `describedOnly` — real behaviour implemented in a component that doesn't consult the map (modal Escape in `use-draggable-modal`, arrow keys in `GlobalSearch`, Enter/Shift+Enter in the Copilot composer, Backspace in `TagFilterChips`). Those rows *can* drift, and the docs say to wire new bindings rather than describe them.

## Correctness details worth calling out

- **`?` stands down inside form fields** — inputs, textareas, selects, contenteditable, and `textbox`/`combobox`/`searchbox` roles. It's a printable character; without this you can't type a question mark into a description.
- **No Shift constraint on `?`** — it's Shift+/ on a US layout but a bare key elsewhere, and demanding the modifier would break those keyboards.
- **`mod` renders per-platform but matches either.** ⌘K on a Mac, Ctrl+K elsewhere, but both are accepted — preserving the pre-#81 `(metaKey || ctrlKey)` behaviour. Tightening it would have silently stopped Ctrl+K working for Mac users who have it in their fingers, and retuning existing bindings isn't this change's job.

## Corrections from review

Six findings, all fixed. One was a regression I introduced:

> The old check was `e.key === "k"` — **case-sensitive**, so Shift never matched because it yields `"K"`. `matchesCombo` compares case-insensitively, which would have started toggling the palette on **Ctrl+Shift+K — the Web Console shortcut in both Firefox and Chrome.** Pinned with `shift: false`.

The rest:

- **`?` no longer opens over an existing dialog.** Every modal binds Escape on `window`, so a stacked overlay let a single Escape dismiss *both* — taking unsaved form input with it.
- **Copilot group gated on `ai.copilot`** instead of always rendering, so we don't document a drawer that can't be opened.
- **The search trigger's hardcoded `⌘K`** showed Mac keys to Linux/Windows operators — the exact drift this change claims to prevent, sitting in the file I was editing. Now rendered from the definition.
- **`documentedOnly` → `describedOnly`.** The old name asserted those bindings were native browser behaviour when several are ours; the flag now says what it means.
- **Header button hidden below `sm`** — the header is already tight there, and the overlay isn't actionable without a keyboard.

## Verification

`shortcuts.ts` is pure logic, so I compiled it with esbuild and exercised it directly — 36 assertions covering Cmd+K / Ctrl+K acceptance, Ctrl+Shift+K and Alt rejection, `?` with and without Shift, per-platform rendering, `isTypingTarget` across every element kind, and structural invariants (unique ids, module gating, `describedOnly` applied to exactly the unwired entries).

**The frontend has no test runner** — no vitest, no testing-library, zero `*.test.tsx` in the tree — so there's nowhere to land those as a committed suite. Adding one is a bigger decision than this issue. Flagging it rather than quietly bolting a framework onto a docs-sized change.

`make ci` green; verified in the running dev stack that the strings ship and no hardcoded `⌘K` remains in the bundle.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
