### PR TITLE
feat(dns): add Technitium DNS Server as a third DNS driver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,7 @@ updates:
       - "/agent/dhcp/images/kea"
       - "/agent/dns/images/bind9"
       - "/agent/dns/images/powerdns"
+      - "/agent/dns/images/technitium"
       - "/agent/dns/images/dnsdist"
       - "/agent/supervisor/images/supervisor"
       - "/agent/looking-glass/images/gobgp"

--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -1,15 +1,20 @@
 name: Agent E2E (kind)
 
-# Spins up a kind cluster, installs the umbrella Helm chart with both
-# DNS-agent flavors (BIND9 + PowerDNS) enabled side by side, and
-# verifies:
+# Spins up a kind cluster, installs the umbrella Helm chart with all three
+# DNS-agent flavors (BIND9 + PowerDNS + Technitium) enabled side by side,
+# and verifies:
 #   1. Every deployment + statefulset reaches Ready.
 #   2. The API's /health/live returns 200 via a port-forward.
 #   3. The BIND9 agent answers ``dig version.bind CH TXT`` — cheap
 #      "daemon is alive" probe that doesn't need pre-seeded zone data.
 #   4. The PowerDNS agent answers ``dig id.server CH TXT`` — pdns's
 #      CHAOS-class equivalent.
-#   5. Both pods register and stay stable (low restart count).
+#   5. The Technitium agent answers a query for the RFC 6761 reserved
+#      "invalid." TLD — Technitium REFUSES CHAOS-class queries entirely
+#      (confirmed empirically), so it has no id.server/version.bind
+#      equivalent; querying "invalid." is answered locally and instantly
+#      (NXDOMAIN, no recursion) regardless of zone state instead.
+#   6. All three pods register and stay stable (low restart count).
 #
 # Tag selection — control-plane vs agent images publish on different
 # cadences, so they need different tags:
@@ -97,7 +102,7 @@ jobs:
         run: |
           set -euxo pipefail
           docker buildx create --use --name e2e-builder >/dev/null 2>&1 || docker buildx use e2e-builder
-          for flavor in bind9 powerdns; do
+          for flavor in bind9 powerdns technitium; do
             docker buildx build \
               --platform linux/amd64 \
               --file "agent/dns/images/${flavor}/Dockerfile" \
@@ -150,12 +155,12 @@ jobs:
           # deployment operators pre-create an external secret; the
           # inline value here is only safe because the cluster dies
           # with the workflow run.
-          # Both flavors get pinned to the same TAG so the test
+          # All three flavors get pinned to the same TAG so the test
           # exercises a coherent build cohort. Mixed flavor list
-          # makes the chart render two StatefulSets that live in
-          # different DNSServerGroups (e2e-bind9 + e2e-powerdns) —
-          # mirrors the production "split groups by driver" model
-          # the control plane gates rely on.
+          # makes the chart render three StatefulSets that live in
+          # different DNSServerGroups (e2e-bind9 + e2e-powerdns +
+          # e2e-technitium) — mirrors the production "split groups by
+          # driver" model the control plane gates rely on.
           helm install ddi charts/spatiumddi \
             --namespace spatiumddi --create-namespace \
             --wait --timeout 10m \
@@ -170,7 +175,8 @@ jobs:
             --set dnsAgents.agentKey.value=e2e-dns-key \
             --set dnsAgents.image.tag="${AGENT_TAG}" \
             --set dnsAgents.flavors.powerdns.tag="${AGENT_TAG}" \
-            --set-json 'dnsAgents.servers=[{"name":"ns1","flavor":"bind9","role":"primary","group":"e2e-bind9","service":{"type":"ClusterIP"}},{"name":"pdns1","flavor":"powerdns","role":"primary","group":"e2e-powerdns","service":{"type":"ClusterIP"}}]'
+            --set dnsAgents.flavors.technitium.tag="${AGENT_TAG}" \
+            --set-json 'dnsAgents.servers=[{"name":"ns1","flavor":"bind9","role":"primary","group":"e2e-bind9","service":{"type":"ClusterIP"}},{"name":"pdns1","flavor":"powerdns","role":"primary","group":"e2e-powerdns","service":{"type":"ClusterIP"}},{"name":"tdx1","flavor":"technitium","role":"primary","group":"e2e-technitium","service":{"type":"ClusterIP"}}]'
 
       - name: Dump pod state
         if: always()
@@ -277,6 +283,39 @@ jobs:
           kubectl -n spatiumddi logs "$POD" --tail=120
           exit 1
 
+      - name: Technitium daemon smoke (dig healthcheck.invalid A)
+        run: |
+          POD=$(kubectl -n spatiumddi get pod \
+            -l app.kubernetes.io/component=dns-agent,spatiumddi.org/dns-flavor=technitium \
+            -o jsonpath='{.items[0].metadata.name}')
+          if [ -z "$POD" ]; then
+            echo "no Technitium agent pod found"
+            kubectl -n spatiumddi get pods --show-labels
+            exit 1
+          fi
+          echo "→ probing DnsServerApp.dll in pod $POD"
+          # Technitium REFUSES CHAOS-class queries entirely (confirmed
+          # empirically — id.server/version.bind both come back REFUSED,
+          # not answered), so there's no BIND/PowerDNS-style CHAOS probe
+          # here. Query the RFC 6761 reserved "invalid." TLD instead —
+          # answered locally and instantly (NXDOMAIN, no recursion)
+          # regardless of zone state, which is exactly the "daemon loaded
+          # and listening on :53" signal this smoke needs. Allow a few
+          # retries for first-boot admin-account + API-token provisioning
+          # (the agent's first apply_config waits on the daemon's web
+          # server before it can even start the config reconcile).
+          for i in 1 2 3 4 5 6; do
+            if kubectl -n spatiumddi exec "$POD" -- dig +time=5 +tries=1 healthcheck.invalid A @127.0.0.1 | grep -q "status: NXDOMAIN"; then
+              echo "Technitium answered on attempt $i"
+              exit 0
+            fi
+            echo "attempt $i: Technitium not ready yet; sleeping…"
+            sleep 5
+          done
+          echo "Technitium dig never succeeded — dumping logs:"
+          kubectl -n spatiumddi logs "$POD" --tail=120
+          exit 1
+
       - name: PowerDNS DNSSEC online signing smoke (Phase 5 / #127)
         # FIXME(#132): The pdnsutil-based smoke path can't observe
         # its own writes through pdns_server even with
@@ -363,12 +402,12 @@ jobs:
           # Without an admin token we can only hit unauthenticated
           # endpoints; the agent register endpoint is open (trusts the
           # PSK). A "server registered" signal is that each agent pod
-          # isn't restarting — crude but useful, and we now check both
-          # flavors so a powerdns-side regression doesn't slip past
-          # because the bind9 pod looks fine.
+          # isn't restarting — crude but useful, and we now check all
+          # three flavors so a driver-side regression doesn't slip past
+          # because the other pods look fine.
           set -u
           fail=0
-          for flavor in bind9 powerdns; do
+          for flavor in bind9 powerdns technitium; do
             RESTARTS=$(kubectl -n spatiumddi get pod \
               -l app.kubernetes.io/component=dns-agent,spatiumddi.org/dns-flavor=${flavor} \
               -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')

--- a/.github/workflows/build-dns-images.yml
+++ b/.github/workflows/build-dns-images.yml
@@ -23,9 +23,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # dnsdist (#146 Phase 2) follows the same image path convention
-        # (agent/dns/images/<flavor>/Dockerfile → ghcr.io/spatiumddi/dns-<flavor>).
-        flavor: [bind9, powerdns, dnsdist]
+        # dnsdist (#146 Phase 2) and technitium follow the same image path
+        # convention (agent/dns/images/<flavor>/Dockerfile →
+        # ghcr.io/spatiumddi/dns-<flavor>).
+        flavor: [bind9, powerdns, technitium, dnsdist]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,36 @@ jobs:
             org.opencontainers.image.revision=${{ needs.meta.outputs.sha_short }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
+  build-dns-technitium:
+    name: Build DNS Technitium agent image
+    runs-on: ubuntu-latest
+    needs: meta
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./agent/dns/images/technitium/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/dns-technitium:${{ needs.meta.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}/dns-technitium:latest
+          labels: |
+            org.opencontainers.image.version=${{ needs.meta.outputs.version }}
+            org.opencontainers.image.revision=${{ needs.meta.outputs.sha_short }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
   build-dns-dnsdist:
     name: Build DNS dnsdist front image
     runs-on: ubuntu-latest
@@ -371,6 +401,7 @@ jobs:
         build-frontend,
         build-dns,
         build-dns-powerdns,
+        build-dns-technitium,
         build-dns-dnsdist,
         build-dhcp,
         build-supervisor,
@@ -592,6 +623,7 @@ jobs:
         build-frontend,
         build-dns,
         build-dns-powerdns,
+        build-dns-technitium,
         build-dns-dnsdist,
         build-dhcp,
         build-supervisor,
@@ -747,6 +779,7 @@ jobs:
             docker pull ghcr.io/${{ github.repository_owner }}/spatiumddi-frontend:${{ needs.meta.outputs.version }}
             docker pull ghcr.io/${{ github.repository_owner }}/dns-bind9:${{ needs.meta.outputs.version }}
             docker pull ghcr.io/${{ github.repository_owner }}/dns-powerdns:${{ needs.meta.outputs.version }}
+            docker pull ghcr.io/${{ github.repository_owner }}/dns-technitium:${{ needs.meta.outputs.version }}
             docker pull ghcr.io/${{ github.repository_owner }}/dhcp-kea:${{ needs.meta.outputs.version }}
             docker pull ghcr.io/${{ github.repository_owner }}/spatium-supervisor:${{ needs.meta.outputs.version }}
             docker pull ghcr.io/${{ github.repository_owner }}/looking-glass:${{ needs.meta.outputs.version }}

--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -59,6 +59,7 @@ jobs:
             "kea|agent/dhcp/images/kea/Dockerfile|.|"
             "bind9|agent/dns/images/bind9/Dockerfile|.|"
             "powerdns|agent/dns/images/powerdns/Dockerfile|.|"
+            "technitium|agent/dns/images/technitium/Dockerfile|.|"
             "dnsdist|agent/dns/images/dnsdist/Dockerfile|.|"
             "supervisor|agent/supervisor/images/supervisor/Dockerfile|.|"
             "looking-glass|agent/looking-glass/images/gobgp/Dockerfile|.|"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ backend/app/            FastAPI app
   api/v1/               HTTP route handlers (ipam/, dns/, dhcp/, auth/, ...)
   models/               SQLAlchemy 2.x async models
   services/             Business logic (dns/, dhcp/, dns_io/, ipam_io/)
-  drivers/dns/          DNS backend abstraction + BIND9 / PowerDNS / Windows DNS impls
+  drivers/dns/          DNS backend abstraction + BIND9 / PowerDNS / Technitium / Windows DNS impls
   drivers/dhcp/         DHCP backend abstraction + Kea impl
   tasks/                Celery tasks (dns_health, dhcp_health, sweep_expired_leases, …)
   core/, db.py, config.py, celery_app.py

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ build: build-supervisor
 	docker build -t spatiumddi-api:dev --target runtime $(BACKEND_DIR)
 	docker build -t spatiumddi-dns-bind9:dev -f agent/dns/images/bind9/Dockerfile .
 	docker build -t spatiumddi-dns-powerdns:dev -f agent/dns/images/powerdns/Dockerfile .
+	docker build -t spatiumddi-dns-technitium:dev -f agent/dns/images/technitium/Dockerfile .
 	docker build -t spatiumddi-dhcp-kea:dev -f agent/dhcp/images/kea/Dockerfile .
 	# #573 — the BGP Looking Glass collector (#566) is in bake-images.sh's
 	# IMAGES set but the PROD compose pins its ``image:`` with no ``build:``,
@@ -126,6 +127,7 @@ build: build-supervisor
 	    "frontend:spatiumddi-frontend" \
 	    "dns-bind9:dns-bind9" \
 	    "dns-powerdns:dns-powerdns" \
+	    "dns-technitium:dns-technitium" \
 	    "dhcp-kea:dhcp-kea" \
 	    "looking-glass:looking-glass"; do \
 	  compose="$${pair%%:*}"; target="$${pair##*:}"; \
@@ -216,12 +218,13 @@ test-one:
 # gobgpd itself and Trivy flags it against the `gobinary` target. No package
 # patch or `apk upgrade` can fix it — only rebuilding on a newer golang base.
 #
-# IMAGE=<name> scans one image; omit to scan all six.
+# IMAGE=<name> scans one image; omit to scan all seven.
 TRIVY_CACHE ?= $(CURDIR)/.trivy-cache
 TRIVY_IMAGES ?= \
 	agent/dhcp/images/kea/Dockerfile:kea \
 	agent/dns/images/bind9/Dockerfile:bind9 \
 	agent/dns/images/powerdns/Dockerfile:powerdns \
+	agent/dns/images/technitium/Dockerfile:technitium \
 	agent/dns/images/dnsdist/Dockerfile:dnsdist \
 	agent/supervisor/images/supervisor/Dockerfile:supervisor \
 	agent/looking-glass/images/gobgp/Dockerfile:looking-glass

--- a/agent/dns/images/technitium/Dockerfile
+++ b/agent/dns/images/technitium/Dockerfile
@@ -1,0 +1,108 @@
+# syntax=docker/dockerfile:1.7
+# SpatiumDDI Technitium DNS Server container — DnsServerApp + spatium-dns-agent.
+# Multi-arch: linux/amd64, linux/arm64 (non-negotiable #11).
+#
+# Unlike bind9/powerdns (Alpine + an apk-packaged daemon binary), Technitium
+# ships no Alpine package and no binary release assets at all (its GitHub
+# releases carry release NOTES only — verified empirically, zero attached
+# assets). The only reproducible, versioned, multi-arch artifact Technitium
+# publishes is its own official Docker image
+# (``docker.io/technitium/dns-server``, Ubuntu 24.04 + .NET 10 aspnet
+# runtime). So this image builds FROM that upstream image and layers the
+# agent on top, rather than trying to fetch+extract a build artifact that
+# doesn't exist. This means the image is glibc/Ubuntu-based, not Alpine —
+# an intentional, documented deviation from the other two DNS images.
+#
+# Pin the exact upstream tag (not :latest) for reproducible builds — bump
+# deliberately, the same way the pdns/bind package versions are pinned.
+ARG TECHNITIUM_VERSION=15.4.0
+ARG PYTHON_VERSION=3.12
+
+# Builder matches the RUNTIME's libc family (glibc/Debian), not Alpine —
+# spatium_dns_agent depends on `cryptography`, which ships compiled wheels;
+# building on Alpine would resolve musllinux wheels that don't load on the
+# Ubuntu-based Technitium runtime.
+FROM python:${PYTHON_VERSION}-slim-bookworm AS agent-build
+WORKDIR /src
+COPY agent/dns/pyproject.toml /src/pyproject.toml
+COPY agent/dns/spatium_dns_agent /src/spatium_dns_agent
+RUN pip install --prefix=/install --no-cache-dir .
+
+FROM technitium/dns-server:${TECHNITIUM_VERSION} AS runtime
+
+# `dig` already ships in the upstream image (dnsutils, installed for
+# troubleshooting) — reused here for the HEALTHCHECK. Add python3 for the
+# agent + su-exec-equivalent (gosu — Debian/Ubuntu's su-exec) to drop
+# privileges, and libcap2-bin for setcap.
+#
+# `aspnetcore-runtime-10.0` (which pulls in `dotnet-runtime-10.0`) is
+# installed explicitly to pick up Ubuntu's patched runtime — the upstream
+# `technitium/dns-server:15.4.0` image ships .NET 10.0.9 (installed via
+# Microsoft's own binary layout under /usr/share/dotnet, not tracked by
+# apt), which carries five HIGH CVEs (CVE-2026-47302/50524/50528/50651/
+# 57108, fixed in 10.0.10 — caught by `make trivy IMAGE=technitium`).
+# Ubuntu's noble-updates/security repo already ships the fixed 10.0.10
+# package (confirmed — no need for the Microsoft apt repo the base image
+# registers for libmsquic). `dotnet` resolves the highest installed
+# runtime satisfying an app's version range at launch, so installing
+# apt's copy alongside the vendored one is sufficient — verified via
+# `dotnet --list-runtimes` before/after. Bump this alongside
+# TECHNITIUM_VERSION and re-run `make trivy IMAGE=technitium`.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      python3 gosu libcap2-bin tini aspnetcore-runtime-10.0 \
+ && apt-get clean -y \
+ && rm -rf /var/lib/apt/lists/* \
+    # The apt package replaces /usr/bin/dotnet's target with its own host
+    # at /usr/lib/dotnet/dotnet (confirmed: `dotnet --list-runtimes`
+    # post-install shows ONLY 10.0.10, from /usr/lib/dotnet/shared/... —
+    # the vendored copy at /usr/share/dotnet is no longer reachable through
+    # the active dotnet binary at all, not merely superseded in a version
+    # search). Remove it outright: leaving the orphaned 10.0.9 files on
+    # disk serves no purpose (they're dead weight, ~200MB) and is exactly
+    # what Trivy's .NET scanner keys on (it reads shared-framework
+    # directories directly, not `dotnet --list-runtimes`) — so the CVEs it
+    # flags stay flagged even though nothing loads those files. Verified
+    # DnsServerApp.dll starts fine post-removal.
+ && rm -rf /usr/share/dotnet \
+    # The upstream image runs `dotnet DnsServerApp.dll` as root (no
+    # unprivileged user is created upstream). Grant CAP_NET_BIND_SERVICE to
+    # the shared dotnet host binary so the unprivileged `spatium` user this
+    # image adds can still bind :53 — this container runs nothing else, so
+    # scoping the capability to `dotnet` system-wide is acceptable here.
+ && setcap cap_net_bind_service=+ep "$(readlink -f "$(command -v dotnet)")" \
+ && groupadd -g 102 spatium \
+ && useradd -u 101 -g spatium -M -s /usr/sbin/nologin spatium \
+ && mkdir -p /var/lib/spatium-dns-agent /etc/dns /var/log/technitium \
+ && chown -R spatium:spatium /var/lib/spatium-dns-agent /etc/dns /var/log/technitium
+
+COPY --from=agent-build /install /usr/local
+COPY agent/dns/images/technitium/entrypoint.sh /usr/local/bin/spatium-dns-entrypoint
+RUN chmod +x /usr/local/bin/spatium-dns-entrypoint
+
+# Override the upstream ENTRYPOINT/CMD entirely — the agent launches
+# DnsServerApp.dll itself as a supervised subprocess (same pattern as the
+# PowerDNS driver launching pdns_server directly), so this image never
+# hits the base image's own entrypoint. tini as PID 1, matching bind9/
+# powerdns, so signals + the dotnet child process reap correctly.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/spatium-dns-entrypoint"]
+CMD []
+
+ENV AGENT_DRIVER=technitium \
+    AGENT_STATE_DIR=/var/lib/spatium-dns-agent \
+    PYTHONPATH=/usr/local/lib/python3.12/site-packages \
+    LOG_LEVEL=INFO
+
+VOLUME ["/var/lib/spatium-dns-agent", "/etc/dns", "/var/log/technitium"]
+EXPOSE 53/udp 53/tcp
+
+# Unlike bind9/powerdns, Technitium REFUSES CHAOS-class queries entirely
+# (confirmed empirically — "id.server CH TXT" / "version.bind CH TXT" both
+# come back REFUSED, not answered) so the usual id.server liveness probe
+# doesn't apply here. Query the RFC 6761 reserved "invalid." TLD instead —
+# Technitium answers it locally and instantly (NXDOMAIN, no recursion
+# attempted) regardless of any configured zone state, which is exactly the
+# "is the daemon actually listening and answering on :53" signal a
+# healthcheck needs.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s \
+  CMD dig @127.0.0.1 -p 53 healthcheck.invalid A +timeout=2 +tries=1 || exit 1

--- a/agent/dns/images/technitium/entrypoint.sh
+++ b/agent/dns/images/technitium/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Container entrypoint — delegates to the Python supervisor. tini is PID 1.
+set -eu
+
+: "${CONTROL_PLANE_URL:?CONTROL_PLANE_URL is required}"
+: "${DNS_AGENT_KEY:?DNS_AGENT_KEY is required (issue #246: pairing-code exchange was removed in #170 Wave A3 — paste the long hex key directly; Application appliances receive it via the supervisor's role-compose.env automatically)}"
+
+# Ensure state + Technitium config dirs are writable by the agent user.
+# Unlike bind9/powerdns there is no pre-seeded secret to generate here —
+# the Python driver manages its own admin-bootstrap-password + API-token
+# files under AGENT_STATE_DIR (see drivers/technitium.py), atomically and
+# lazily on first use, so the entrypoint's only job is ownership.
+# /var/log/technitium is a hardcoded path in DnsServerCore.LogManager,
+# independent of the /etc/dns config dir — the daemon crashes immediately
+# on startup ("UnauthorizedAccessException: Access to the path
+# '/var/log/technitium' is denied") if it can't create it, since the
+# upstream image runs as root and never needed this directory prepared.
+mkdir -p /var/lib/spatium-dns-agent /etc/dns /var/log/technitium
+chown -R spatium:spatium /var/lib/spatium-dns-agent /etc/dns /var/log/technitium || true
+
+# Supervise: agent process manages the DnsServerApp.dll lifecycle.
+#
+# Invoked as `python3 -m spatium_dns_agent` rather than the
+# `spatium-dns-agent` console-script shim: that shim's shebang is baked in
+# by the BUILDER stage's interpreter path (python:3.12-slim-bookworm installs
+# to /usr/local/bin/python3), which does not exist in this runtime stage
+# (apt installs python3 to /usr/bin/python3) — the mismatch fails with a
+# bare "exec failed: no such file or directory" and no other diagnostic.
+# bind9/powerdns don't hit this because both their builder AND runtime
+# stages are Alpine with apk's python3 at the same path.
+exec gosu spatium:spatium python3 -m spatium_dns_agent

--- a/agent/dns/spatium_dns_agent/config.py
+++ b/agent/dns/spatium_dns_agent/config.py
@@ -17,7 +17,7 @@ class AgentConfig:
     # supervisor's ``role-compose.env``.
     dns_agent_key: str
     server_name: str
-    driver: str  # bind9 | powerdns (see supervisor.py for the registry)
+    driver: str  # bind9 | powerdns | technitium (see supervisor.py for the registry)
     roles: list[str]
     group_name: str | None
     tls_ca_path: str | None

--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -1,0 +1,683 @@
+"""Technitium DNS Server agent driver (v1 — primary zones + record CRUD).
+
+Runs alongside the Technitium ``DnsServerApp`` process inside the
+dns-technitium container. Unlike BIND9 (named.conf + RFC 1035 zone files +
+``rndc``) or PowerDNS (``pdns.conf`` + REST reconcile), Technitium has **no
+on-disk config file this driver manages at all** — the daemon persists its
+own config under ``/etc/dns`` and is configured entirely over its HTTP API
+(``http://127.0.0.1:5380/api/...``). So this driver:
+
+* Provisions a permanent API token on first-ever boot. The container image
+  bakes ``DNS_SERVER_ADMIN_PASSWORD`` with a value this driver generates,
+  which Technitium consumes to set the ``admin`` user's password the very
+  first time ``/etc/dns`` is empty. The driver then calls
+  ``/api/user/createToken`` ONCE and persists the resulting bearer token —
+  calling ``createToken`` again would mint a second, orphaned token on the
+  server (confirmed empirically: the endpoint is not idempotent), so the
+  local token file is the source of truth once it exists.
+* Applies zone + record state via the REST API. ``render()``/``validate()``/
+  ``swap_and_reload()`` collapse into: stash the desired-state JSON, then
+  reconcile it against the live API in ``swap_and_reload()`` (same split as
+  PowerDNS, for symmetry with the rest of the codebase, even though there's
+  no config file being swapped here).
+* Zone apex NS/SOA are Technitium-managed (auto-created on
+  ``/api/zones/create``) and are NOT pushed from the bundle — confirmed the
+  daemon renders its own SOA + one NS record at zone creation, so treating
+  the bundle's NS/SOA as authoritative would just create duplicate/foreign
+  NS records alongside Technitium's own.
+
+v1 scope: primary zones only. Record types: A, AAAA, CNAME, MX, TXT, NS
+(zone-referral records off-apex only — apex NS is daemon-managed), PTR, SRV,
+CAA, TLSA, SSHFP, NAPTR, URI, DNAME, SVCB, HTTPS (SVCB/HTTPS best-effort —
+see ``_svcb_params`` for the one documented limitation: multi-value params
+like ``alpn="h2,h3"`` only carry the first value through, logged as a
+warning).
+
+Deferred to fast-follow phases: DNSSEC (``/api/zones/dnssec/*`` — same
+shape as PowerDNS's, should port quickly), native DoT/DoH/DoQ listener
+wiring (Technitium's real differentiator — no dnsdist-style sidecar needed,
+unlike PowerDNS), catalog zones, secondary/stub zones.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import shlex
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+import structlog
+
+from ._process import find_running_daemon, is_zombie
+from .base import DriverBase
+
+log = structlog.get_logger(__name__)
+
+
+_API_BASE = "http://127.0.0.1:5380/api"
+_API_TIMEOUT = 10.0
+_ADMIN_PASSWORD_FILE = "technitium-admin-password"
+_API_TOKEN_FILE = "technitium-api.token"
+_TOKEN_NAME = "spatiumddi-agent"
+
+# Record types whose zone-apex form is daemon-managed (SOA always; NS only
+# at the apex — an off-apex NS is a legitimate delegation record and IS
+# reconciled normally).
+_DAEMON_MANAGED_APEX_TYPES = frozenset({"SOA"})
+
+
+def _qualified_name(zone_name: str, name: str) -> str:
+    """Compose the bare (no trailing dot) FQDN Technitium expects for a
+    record's ``domain`` param."""
+    zone = zone_name.rstrip(".")
+    bare = (name or "@").rstrip(".")
+    if bare in ("", "@") or bare == zone:
+        return zone
+    return f"{bare}.{zone}"
+
+
+def _svcb_params(value: str) -> tuple[int, str, str]:
+    """Parse a BIND-zone-file-style SVCB/HTTPS rdata string into
+    ``(priority, target, svcParams)`` for the Technitium API.
+
+    Input shape (matches what the control-plane driver + BIND9 render,
+    e.g. ``'1 . alpn="h2,h3"'``): priority, target, then space-separated
+    ``key=value`` params with optionally-quoted values.
+
+    Known limitation: Technitium's ``svcParams`` wire format
+    (``key|value`` pairs) does not accept a comma-separated multi-value
+    single param the way BIND's zone-file rdata does (confirmed
+    empirically — ``alpn|h2,h3`` errors). Only the first value of a
+    multi-value param is carried through; the rest are dropped with a
+    warning. Single-value params (the common case) round-trip exactly.
+    """
+    tokens = shlex.split(value)
+    if len(tokens) < 2:
+        return (1, ".", "")
+    priority = int(tokens[0]) if tokens[0].isdigit() else 1
+    target = tokens[1]
+    parts = []
+    for tok in tokens[2:]:
+        if "=" not in tok:
+            continue
+        key, _, raw_val = tok.partition("=")
+        first_val = raw_val.split(",", 1)[0]
+        if "," in raw_val:
+            log.warning(
+                "technitium_svcb_multivalue_param_truncated",
+                key=key,
+                dropped=raw_val.split(",", 1)[1],
+            )
+        parts.append(f"{key}|{first_val}")
+    return (priority, target, ",".join(parts))
+
+
+def _record_params(rtype: str, value: str, rec: dict[str, Any]) -> dict[str, Any]:
+    """Build the type-specific param dict for
+    ``/api/zones/records/{add,delete}`` — shared by both endpoints since
+    ``delete`` requires the exact same value params to identify the record.
+    """
+    value = value.rstrip(".")
+    if rtype in ("A", "AAAA"):
+        return {"ipAddress": value}
+    if rtype == "CNAME":
+        return {"cname": value}
+    if rtype == "DNAME":
+        return {"dname": value}
+    if rtype == "NS":
+        return {"nameServer": value}
+    if rtype == "PTR":
+        return {"ptrName": value}
+    if rtype == "MX":
+        return {"exchange": value, "preference": rec.get("priority") or 10}
+    if rtype == "SRV":
+        return {
+            "target": value,
+            "priority": rec.get("priority") or 0,
+            "weight": rec.get("weight") or 0,
+            "port": rec.get("port") or 0,
+        }
+    if rtype == "TXT":
+        return {"text": value}
+    if rtype == "CAA":
+        # value shape: "<flags> <tag> <target>", e.g. '0 issue "letsencrypt.org"'
+        tokens = shlex.split(value)
+        flags = int(tokens[0]) if tokens and tokens[0].isdigit() else 0
+        tag = tokens[1] if len(tokens) > 1 else "issue"
+        target = tokens[2] if len(tokens) > 2 else ""
+        return {"flags": flags, "tag": tag, "value": target}
+    if rtype == "TLSA":
+        tokens = shlex.split(value)
+        return {
+            "tlsaCertificateUsage": tokens[0] if len(tokens) > 0 else "0",
+            "tlsaSelector": tokens[1] if len(tokens) > 1 else "0",
+            "tlsaMatchingType": tokens[2] if len(tokens) > 2 else "0",
+            "tlsaCertificateAssociationData": tokens[3] if len(tokens) > 3 else "",
+        }
+    if rtype == "SSHFP":
+        tokens = shlex.split(value)
+        return {
+            "sshfpAlgorithm": tokens[0] if len(tokens) > 0 else "0",
+            "sshfpFingerprintType": tokens[1] if len(tokens) > 1 else "0",
+            "sshfpFingerprint": tokens[2] if len(tokens) > 2 else "",
+        }
+    if rtype == "NAPTR":
+        tokens = shlex.split(value)
+        return {
+            "naptrOrder": tokens[0] if len(tokens) > 0 else "0",
+            "naptrPreference": tokens[1] if len(tokens) > 1 else "0",
+            "naptrFlags": tokens[2] if len(tokens) > 2 else "",
+            "naptrServices": tokens[3] if len(tokens) > 3 else "",
+            "naptrRegexp": tokens[4] if len(tokens) > 4 else "",
+            "naptrReplacement": tokens[5] if len(tokens) > 5 else ".",
+        }
+    if rtype == "URI":
+        tokens = shlex.split(value)
+        return {
+            "uriPriority": tokens[0] if len(tokens) > 0 else "1",
+            "uriWeight": tokens[1] if len(tokens) > 1 else "1",
+            "uri": tokens[2] if len(tokens) > 2 else "",
+        }
+    if rtype in ("SVCB", "HTTPS"):
+        priority, target, params = _svcb_params(value)
+        out: dict[str, Any] = {"svcPriority": priority, "svcTargetName": target}
+        if params:
+            out["svcParams"] = params
+        return out
+    # Unrecognised type — pass the raw value through under a best-guess key
+    # so the API's own error message tells us what's missing, rather than
+    # silently dropping the record.
+    return {"value": value}
+
+
+class TechnitiumDriver(DriverBase):
+    """Technitium agent driver — v1."""
+
+    daemon_pid: int | None = None
+
+    # ── Render / validate / swap ────────────────────────────────────────────
+
+    def render(self, bundle: dict[str, Any]) -> None:
+        """Stash the desired-state JSON for the API reconciler.
+
+        There is no config file to write for this driver — Technitium's
+        own on-disk state under ``/etc/dns`` is entirely daemon-managed.
+        The bundle-to-JSON step exists purely so ``swap_and_reload`` has a
+        stable, atomically-swapped snapshot to reconcile against (matches
+        the render → validate → swap_and_reload shape every driver shares).
+        """
+        new_dir = self.state_dir / "rendered.new"
+        if new_dir.exists():
+            shutil.rmtree(new_dir)
+        new_dir.mkdir(parents=True)
+
+        zones_payload = []
+        for zone in bundle.get("zones", []) or []:
+            zname = (zone.get("name") or "").rstrip(".")
+            if not zname:
+                continue
+            ztype = zone.get("type", "primary")
+            if ztype != "primary":
+                log.warning(
+                    "technitium_zone_type_unsupported_v1",
+                    zone=zname,
+                    zone_type=ztype,
+                )
+                continue
+            records = []
+            for rec in zone.get("records") or []:
+                rtype = (rec.get("type") or "").upper()
+                if rtype in _DAEMON_MANAGED_APEX_TYPES:
+                    continue
+                name = _qualified_name(zname, rec.get("name") or "@")
+                if rtype == "NS" and name == zname:
+                    # Apex NS is daemon-managed (created at zone-create
+                    # time, pointed at the container's own hostname).
+                    # Off-apex NS (delegations) are handled normally.
+                    continue
+                records.append(
+                    {
+                        "domain": name,
+                        "type": rtype,
+                        "ttl": rec.get("ttl") or zone.get("ttl") or 3600,
+                        **_record_params(rtype, rec.get("value") or "", rec),
+                    }
+                )
+            zones_payload.append({"zone": zname, "type": "Primary", "records": records})
+
+        if bundle.get("blocklists"):
+            log.warning(
+                "technitium_blocklists_unsupported",
+                blocklist_count=len(bundle["blocklists"]),
+                hint=(
+                    "Wiring SpatiumDDI's blocklist model to Technitium's "
+                    "native blocking apps is a fast-follow, not v1 scope."
+                ),
+            )
+
+        (new_dir / "zones.json").write_text(json.dumps(zones_payload, indent=2))
+
+    def validate(self) -> None:
+        new_dir = self.state_dir / "rendered.new"
+        zones_path = new_dir / "zones.json"
+        if not zones_path.exists():
+            raise RuntimeError("zones.json was not written")
+        try:
+            json.loads(zones_path.read_text())
+        except ValueError as exc:
+            raise RuntimeError(f"zones.json is not valid JSON: {exc}") from exc
+
+    def swap_and_reload(self) -> None:
+        """Promote the new render into place and reconcile via REST.
+
+        Cold-boot ordering mirrors PowerDNS: the supervisor calls
+        ``start_daemon`` before the first ``apply_config``, so on first
+        boot the daemon may still be initializing its web server when we
+        get here. Wait for the API before reconciling — otherwise the
+        first call fails with connection-refused, the reconcile silently
+        gives up, and the structural etag has already advanced so the
+        sync loop never retries.
+        """
+        new_dir = self.state_dir / "rendered.new"
+        current = self.state_dir / "rendered"
+        backup = self.state_dir / "rendered.prev"
+        if current.exists():
+            if backup.exists():
+                shutil.rmtree(backup)
+            current.rename(backup)
+        new_dir.rename(current)
+
+        if not self.daemon_running():
+            log.info("technitium_daemon_starting_after_first_render")
+            self.start_daemon()
+        self._wait_for_api_up()
+
+        zones_path = current / "zones.json"
+        try:
+            payload = json.loads(zones_path.read_text())
+        except Exception as exc:  # noqa: BLE001
+            log.error("technitium_zones_payload_unreadable", error=str(exc))
+            return
+
+        token = self._get_api_token()
+        if token is None:
+            log.error("technitium_reconcile_skipped_no_token")
+            return
+        self._reconcile_zones(token, payload)
+
+    def _wait_for_api_up(self, *, timeout_s: float = 15.0) -> None:
+        deadline = time.monotonic() + timeout_s
+        with httpx.Client(timeout=1.0) as client:
+            while time.monotonic() < deadline:
+                try:
+                    resp = client.get(f"{_API_BASE}/user/session/get")
+                    if resp.status_code < 500:
+                        return
+                except httpx.HTTPError:
+                    pass
+                time.sleep(0.3)
+        log.warning("technitium_api_wait_timeout", timeout_s=timeout_s)
+
+    # ── Record ops (REST calls against loopback API) ────────────────────────
+
+    def apply_record_op(self, op: dict[str, Any]) -> dict[str, Any] | None:
+        """Apply a single record op via the Technitium REST API.
+
+        ``create``/``update`` both map to ``/api/zones/records/add`` with
+        ``overwrite=false`` — Technitium's op payload only carries the NEW
+        value (never the old one), so a genuine value *change* on
+        ``update`` leaves the stale value in place until an explicit
+        delete op fires for it. This is the same documented limitation
+        the PowerDNS driver accepts for the same reason; the full-bundle
+        reconcile path (``swap_and_reload``) is what actually converges
+        a zone to exact desired state via delete-extras + add-missing.
+        """
+        token = self._get_api_token()
+        if token is None:
+            raise RuntimeError("no Technitium API token available")
+
+        zone = op["zone_name"].rstrip(".")
+        op_kind = op["op"]
+        rec = op["record"]
+        rtype = (rec.get("type") or "").upper()
+        name = _qualified_name(zone, rec.get("name") or "@")
+        ttl = rec.get("ttl") or 3600
+        params = {
+            "domain": name,
+            "zone": zone,
+            "type": rtype,
+            **_record_params(rtype, rec.get("value") or "", rec),
+        }
+
+        endpoint = "delete" if op_kind == "delete" else "add"
+        if op_kind != "delete":
+            params["ttl"] = ttl
+            params["overwrite"] = "false"
+
+        resp = self._call(token, "POST", f"zones/records/{endpoint}", params)
+        body = resp.json()
+        if body.get("status") == "error":
+            msg = (body.get("errorMessage") or "").lower()
+            # Idempotent no-ops: retried create of an identical record, or
+            # a delete of a record that's already gone.
+            if "already exists" in msg or "no such record" in msg:
+                log.info(
+                    "technitium_record_op_idempotent_noop",
+                    zone=zone,
+                    name=name,
+                    type=rtype,
+                    op=op_kind,
+                    detail=body.get("errorMessage"),
+                )
+                return None
+            raise RuntimeError(
+                f"Technitium {endpoint} {zone}/{name}/{rtype} failed: "
+                f"{body.get('errorMessage')}"
+            )
+        log.info(
+            "technitium_record_op_applied", zone=zone, name=name, type=rtype, op=op_kind
+        )
+        return None
+
+    def _reconcile_zones(self, token: str, payload: list[dict[str, Any]]) -> None:
+        """Bring each zone's record set in line with ``payload`` via a
+        full per-zone diff: create the zone if missing, then delete
+        records present on the daemon but absent from desired state and
+        add records present in desired state but absent on the daemon.
+
+        Zones present on the daemon but absent from ``payload`` are NOT
+        deleted — same safety stance as the other drivers (operators
+        delete a zone explicitly, it doesn't disappear from a sync
+        glitch).
+        """
+        for zone_payload in payload:
+            zone = zone_payload["zone"]
+            self._ensure_zone_exists(token, zone)
+
+            existing = self._get_zone_records(token, zone)
+            desired = zone_payload.get("records") or []
+
+            def _fingerprint(rec: dict[str, Any]) -> tuple[Any, ...]:
+                extra = tuple(
+                    sorted(
+                        (k, v)
+                        for k, v in rec.items()
+                        if k not in ("domain", "type", "ttl", "zone")
+                    )
+                )
+                return (rec.get("domain"), rec.get("type"), extra)
+
+            existing_by_fp = {_fingerprint(r): r for r in existing}
+            desired_by_fp = {_fingerprint(r): r for r in desired}
+
+            to_delete = [r for fp, r in existing_by_fp.items() if fp not in desired_by_fp]
+            to_add = [r for fp, r in desired_by_fp.items() if fp not in existing_by_fp]
+
+            for rec in to_delete:
+                if rec.get("type") in _DAEMON_MANAGED_APEX_TYPES:
+                    continue
+                if rec.get("type") == "NS" and rec.get("domain") == zone:
+                    continue
+                resp = self._call(
+                    token,
+                    "POST",
+                    "zones/records/delete",
+                    {
+                        "domain": rec["domain"],
+                        "zone": zone,
+                        "type": rec["type"],
+                        **{
+                            k: v
+                            for k, v in rec.items()
+                            if k not in ("domain", "type", "ttl", "zone")
+                        },
+                    },
+                )
+                body = resp.json()
+                if body.get("status") == "error" and "no such record" not in (
+                    body.get("errorMessage") or ""
+                ).lower():
+                    log.warning(
+                        "technitium_reconcile_delete_failed",
+                        zone=zone,
+                        record=rec,
+                        error=body.get("errorMessage"),
+                    )
+
+            for rec in to_add:
+                resp = self._call(
+                    token,
+                    "POST",
+                    "zones/records/add",
+                    {**rec, "zone": zone, "overwrite": "false"},
+                )
+                body = resp.json()
+                if body.get("status") == "error" and "already exists" not in (
+                    body.get("errorMessage") or ""
+                ).lower():
+                    log.error(
+                        "technitium_reconcile_add_failed",
+                        zone=zone,
+                        record=rec,
+                        error=body.get("errorMessage"),
+                    )
+                    continue
+            if to_add or to_delete:
+                log.info(
+                    "technitium_zone_reconciled",
+                    zone=zone,
+                    added=len(to_add),
+                    deleted=len(to_delete),
+                )
+
+    def _ensure_zone_exists(self, token: str, zone: str) -> None:
+        resp = self._call(
+            token, "POST", "zones/create", {"zone": zone, "type": "Primary"}
+        )
+        body = resp.json()
+        if body.get("status") == "error":
+            if "already exists" in (body.get("errorMessage") or "").lower():
+                return
+            log.error(
+                "technitium_zone_create_failed", zone=zone, error=body.get("errorMessage")
+            )
+
+    def _get_zone_records(self, token: str, zone: str) -> list[dict[str, Any]]:
+        resp = self._call(
+            token,
+            "GET",
+            "zones/records/get",
+            {"domain": zone, "zone": zone, "listZone": "true"},
+        )
+        try:
+            body = resp.json()
+        except ValueError:
+            return []
+        if body.get("status") != "ok":
+            return []
+        out = []
+        for rec in body.get("response", {}).get("records") or []:
+            rtype = rec.get("type")
+            if rtype in _DAEMON_MANAGED_APEX_TYPES:
+                continue
+            flat = {"domain": rec.get("name"), "type": rtype, "ttl": rec.get("ttl")}
+            flat.update(rec.get("rData") or {})
+            # Technitium's TXT rData carries extra derived fields
+            # (splitText/characterStrings/characterStringsBase64) that
+            # never round-trip through our add params — drop them so the
+            # fingerprint comparison in ``_reconcile_zones`` doesn't treat
+            # every existing TXT record as "different from desired" on
+            # every single reconcile pass.
+            for extra_key in (
+                "splitText",
+                "characterStrings",
+                "characterStringsBase64",
+                "autoIpv4Hint",
+                "autoIpv6Hint",
+            ):
+                flat.pop(extra_key, None)
+            out.append(flat)
+        return out
+
+    # ── Auth (permanent API token) ──────────────────────────────────────────
+
+    def _admin_password_path(self) -> Path:
+        return self.state_dir / _ADMIN_PASSWORD_FILE
+
+    def _api_token_path(self) -> Path:
+        return self.state_dir / _API_TOKEN_FILE
+
+    def admin_bootstrap_password(self) -> str:
+        """Return the admin password used to initialise the daemon on its
+        very first start (via the ``DNS_SERVER_ADMIN_PASSWORD`` env var
+        passed to the subprocess). Generated once, persisted like the
+        PowerDNS API key (atomic O_NOFOLLOW write, 0600) — needed again
+        any time the local API token is lost and must be re-derived via
+        ``/api/user/createToken``.
+        """
+        return self._read_or_create_secret(self._admin_password_path())
+
+    def _get_api_token(self) -> str | None:
+        path = self._api_token_path()
+        if path.exists():
+            try:
+                return path.read_text().strip()
+            except PermissionError as exc:
+                raise RuntimeError(
+                    f"Technitium API token file at {path} exists but is "
+                    "unreadable by the agent. Fix ownership/permissions "
+                    "(should be spatium:spatium 0600)."
+                ) from exc
+        return self._create_api_token()
+
+    def _create_api_token(self) -> str | None:
+        """Exchange the admin bootstrap password for a permanent API
+        token via ``/api/user/createToken`` — called at most once ever
+        per state dir, since the endpoint mints a NEW token on every
+        call (confirmed empirically: it is not idempotent on
+        ``tokenName``, so retrying here would silently accumulate
+        orphaned tokens on the server).
+        """
+        password = self.admin_bootstrap_password()
+        try:
+            resp = httpx.get(
+                f"{_API_BASE}/user/createToken",
+                params={"user": "admin", "pass": password, "tokenName": _TOKEN_NAME},
+                timeout=_API_TIMEOUT,
+            )
+            body = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            log.error("technitium_create_token_failed", error=str(exc))
+            return None
+        if body.get("status") != "ok" or not body.get("token"):
+            log.error(
+                "technitium_create_token_rejected", error=body.get("errorMessage")
+            )
+            return None
+        token = body["token"]
+        self._write_secret(self._api_token_path(), token)
+        log.info("technitium_api_token_created")
+        return token
+
+    @staticmethod
+    def _write_secret(path: Path, value: str) -> None:
+        tmp = path.with_suffix(path.suffix + ".new")
+        fd = os.open(
+            str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600
+        )
+        try:
+            os.write(fd, (value + "\n").encode())
+        finally:
+            os.close(fd)
+        tmp.replace(path)
+
+    def _read_or_create_secret(self, path: Path) -> str:
+        if path.exists():
+            try:
+                return path.read_text().strip()
+            except PermissionError as exc:
+                raise RuntimeError(
+                    f"Secret file at {path} exists but is unreadable by "
+                    "the agent. Fix ownership/permissions (should be "
+                    "spatium:spatium 0600)."
+                ) from exc
+        value = secrets.token_urlsafe(24)
+        self._write_secret(path, value)
+        return value
+
+    def _call(
+        self, token: str, method: str, path: str, params: dict[str, Any]
+    ) -> httpx.Response:
+        """Issue one API call, auth'd via ``Authorization: Bearer``.
+
+        Technitium returns HTTP 200 even on an invalid/expired token —
+        the failure surfaces only in the JSON body's ``status`` field
+        (confirmed empirically: ``{"status": "invalid-token", ...}`` at
+        HTTP 200). Callers must inspect ``.json()["status"]``, not the
+        HTTP status code, to detect auth failure.
+        """
+        with httpx.Client(timeout=_API_TIMEOUT) as client:
+            if method == "GET":
+                return client.get(f"{_API_BASE}/{path}", params=params, headers=self._auth_header(token))
+            return client.post(f"{_API_BASE}/{path}", data=params, headers=self._auth_header(token))
+
+    @staticmethod
+    def _auth_header(token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}"}
+
+    # ── Lifecycle ───────────────────────────────────────────────────────────
+
+    def start_daemon(self) -> None:
+        """Spawn ``dotnet DnsServerApp.dll /etc/dns``.
+
+        The bootstrap admin password is passed via
+        ``DNS_SERVER_ADMIN_PASSWORD`` on every start — Technitium only
+        consumes it the very first time ``/etc/dns`` is empty (fresh
+        config), so this is a harmless no-op on every subsequent start.
+        """
+        if not shutil.which("dotnet"):
+            log.error("technitium_dotnet_binary_missing")
+            return
+        existing = find_running_daemon("dotnet")
+        if existing is not None:
+            self.daemon_pid = existing
+            log.info(
+                "technitium_already_running_adopted",
+                pid=existing,
+                note="did not spawn a second daemon",
+            )
+            return
+        env = dict(os.environ)
+        env["DNS_SERVER_ADMIN_PASSWORD"] = self.admin_bootstrap_password()
+        log_path = self.state_dir / "technitium.log"
+        log_fh = log_path.open("ab", buffering=0)
+        self.daemon_pid = subprocess.Popen(
+            ["dotnet", "/opt/technitium/dns/DnsServerApp.dll", "/etc/dns"],
+            env=env,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+        ).pid
+        self._daemon_log_path = log_path
+        log.info("technitium_dns_server_started", pid=self.daemon_pid, log_path=str(log_path))
+
+    def daemon_running(self) -> bool:
+        if self.daemon_pid is None:
+            found = find_running_daemon("dotnet")
+            if found is None:
+                return False
+            self.daemon_pid = found
+            return True
+        try:
+            os.kill(self.daemon_pid, 0)
+        except OSError:
+            return False
+        return not is_zombie(str(self.daemon_pid))
+
+
+__all__ = ["TechnitiumDriver"]

--- a/agent/dns/spatium_dns_agent/supervisor.py
+++ b/agent/dns/spatium_dns_agent/supervisor.py
@@ -19,6 +19,7 @@ from .config import AgentConfig
 from .drivers.base import DriverBase
 from .drivers.bind9 import Bind9Driver
 from .drivers.powerdns import PowerDNSDriver
+from .drivers.technitium import TechnitiumDriver
 from .heartbeat import HeartbeatClient
 from .ingest import IngestWorker
 from .metrics import MetricsPoller
@@ -33,6 +34,8 @@ def _select_driver(cfg: AgentConfig) -> DriverBase:
         return Bind9Driver(state_dir=cfg.state_dir)
     if cfg.driver == "powerdns":
         return PowerDNSDriver(state_dir=cfg.state_dir)
+    if cfg.driver == "technitium":
+        return TechnitiumDriver(state_dir=cfg.state_dir)
     raise RuntimeError(f"Unknown driver: {cfg.driver}")
 
 
@@ -94,6 +97,11 @@ def run(cfg: AgentConfig) -> int:
         threads.append(
             threading.Thread(target=query_log.run, name="query-log", daemon=True),
         )
+    # technitium: no query-log thread in v1 — Technitium's query logging is
+    # API/DB-backed (``/api/logs/query*``), not a tailable text file like
+    # BIND9's query_log_file or PowerDNS's redirected stderr capture. Wiring
+    # it needs a poll-and-diff shipper, not the existing file-tailing
+    # QueryLogShipper — deferred to a fast-follow phase.
 
     for t in threads:
         t.start()
@@ -118,10 +126,10 @@ def run(cfg: AgentConfig) -> int:
     signal.signal(signal.SIGINT, _sig)
 
     # Every supported driver in this image manages its own daemon
-    # process (BIND9, PowerDNS). If the daemon dies, we exit non-zero
-    # so the orchestrator restarts the container — agent + daemon are
-    # bound lifecycle-wise.
-    daemon_managed_drivers = {"bind9", "powerdns"}
+    # process (BIND9, PowerDNS, Technitium). If the daemon dies, we exit
+    # non-zero so the orchestrator restarts the container — agent + daemon
+    # are bound lifecycle-wise.
+    daemon_managed_drivers = {"bind9", "powerdns", "technitium"}
     while not stopping.is_set():
         time.sleep(1.0)
         if cfg.driver in daemon_managed_drivers and not driver.daemon_running():

--- a/agent/dns/tests/test_technitium_render.py
+++ b/agent/dns/tests/test_technitium_render.py
@@ -1,0 +1,194 @@
+"""Technitium agent driver — pure helper unit tests (param builders, name
+qualification, SVCB parsing). No live daemon required.
+
+Live-API behavior (auth header shape, idempotent-error detection, zone
+create / record add / delete / reconcile semantics) was verified empirically
+against a real ``technitium/dns-server`` container during development — see
+the driver module's docstring for the confirmed API shapes. Those call
+sites (``_call``, ``_create_api_token``, ``_reconcile_zones``) build a fresh
+``httpx.Client`` per call and are exercised by the docker-compose live test
+in Phase 3 rather than mocked here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from spatium_dns_agent.drivers.technitium import (
+    TechnitiumDriver,
+    _qualified_name,
+    _record_params,
+    _svcb_params,
+)
+
+
+def test_qualified_name_apex() -> None:
+    assert _qualified_name("example.com", "@") == "example.com"
+    assert _qualified_name("example.com", "") == "example.com"
+    assert _qualified_name("example.com.", "example.com.") == "example.com"
+
+
+def test_qualified_name_subdomain() -> None:
+    assert _qualified_name("example.com", "www") == "www.example.com"
+    assert _qualified_name("example.com", "_sip._tcp") == "_sip._tcp.example.com"
+
+
+def test_record_params_a_aaaa() -> None:
+    assert _record_params("A", "10.0.0.1", {}) == {"ipAddress": "10.0.0.1"}
+    assert _record_params("AAAA", "2001:db8::1", {}) == {"ipAddress": "2001:db8::1"}
+
+
+def test_record_params_cname_dname_ns_ptr() -> None:
+    assert _record_params("CNAME", "www.example.com.", {}) == {"cname": "www.example.com"}
+    assert _record_params("DNAME", "other.example.net.", {}) == {"dname": "other.example.net"}
+    assert _record_params("NS", "ns1.example.com.", {}) == {"nameServer": "ns1.example.com"}
+    assert _record_params("PTR", "host.example.com.", {}) == {"ptrName": "host.example.com"}
+
+
+def test_record_params_mx_uses_priority() -> None:
+    rec = {"priority": 20}
+    assert _record_params("MX", "mail.example.com.", rec) == {
+        "exchange": "mail.example.com",
+        "preference": 20,
+    }
+
+
+def test_record_params_mx_default_priority() -> None:
+    assert _record_params("MX", "mail.example.com.", {})["preference"] == 10
+
+
+def test_record_params_srv() -> None:
+    rec = {"priority": 10, "weight": 20, "port": 5060}
+    assert _record_params("SRV", "sip.example.com.", rec) == {
+        "target": "sip.example.com",
+        "priority": 10,
+        "weight": 20,
+        "port": 5060,
+    }
+
+
+def test_record_params_txt() -> None:
+    assert _record_params("TXT", "v=spf1 -all", {}) == {"text": "v=spf1 -all"}
+
+
+def test_record_params_caa() -> None:
+    out = _record_params("CAA", '0 issue "letsencrypt.org"', {})
+    assert out == {"flags": 0, "tag": "issue", "value": "letsencrypt.org"}
+
+
+def test_record_params_tlsa() -> None:
+    out = _record_params("TLSA", "3 1 1 abcd1234", {})
+    assert out == {
+        "tlsaCertificateUsage": "3",
+        "tlsaSelector": "1",
+        "tlsaMatchingType": "1",
+        "tlsaCertificateAssociationData": "abcd1234",
+    }
+
+
+def test_record_params_sshfp() -> None:
+    out = _record_params("SSHFP", "4 2 abcd1234", {})
+    assert out == {
+        "sshfpAlgorithm": "4",
+        "sshfpFingerprintType": "2",
+        "sshfpFingerprint": "abcd1234",
+    }
+
+
+def test_record_params_naptr() -> None:
+    value = '100 10 U "E2U+sip" "!^.*$!sip:info@example.com!" .'
+    out = _record_params("NAPTR", value, {})
+    assert out["naptrOrder"] == "100"
+    assert out["naptrPreference"] == "10"
+    assert out["naptrFlags"] == "U"
+    assert out["naptrServices"] == "E2U+sip"
+    assert out["naptrReplacement"] == "."
+
+
+def test_record_params_uri() -> None:
+    out = _record_params("URI", "1 1 https://example.com", {})
+    assert out == {"uriPriority": "1", "uriWeight": "1", "uri": "https://example.com"}
+
+
+def test_svcb_params_single_value() -> None:
+    priority, target, params = _svcb_params('1 . alpn="h2"')
+    assert priority == 1
+    assert target == "."
+    assert params == "alpn|h2"
+
+
+def test_svcb_params_no_params() -> None:
+    priority, target, params = _svcb_params("1 svc.example.com.")
+    assert priority == 1
+    assert target == "svc.example.com."
+    assert params == ""
+
+
+def test_svcb_params_multivalue_truncates_first() -> None:
+    priority, target, params = _svcb_params('1 . alpn="h2,h3"')
+    assert params == "alpn|h2"
+
+
+def test_record_params_svcb() -> None:
+    out = _record_params("SVCB", '1 . alpn="h2"', {})
+    assert out == {"svcPriority": 1, "svcTargetName": ".", "svcParams": "alpn|h2"}
+
+
+def test_record_params_https_no_params_omits_svcparams() -> None:
+    out = _record_params("HTTPS", "1 .", {})
+    assert out == {"svcPriority": 1, "svcTargetName": "."}
+
+
+def test_admin_bootstrap_password_persists(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    pw1 = d.admin_bootstrap_password()
+    pw2 = d.admin_bootstrap_password()
+    assert pw1 == pw2
+    path = tmp_path / "technitium-admin-password"
+    assert path.exists()
+    assert oct(path.stat().st_mode)[-3:] == "600"
+
+
+def test_render_skips_daemon_managed_apex_types(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    bundle = {
+        "zones": [
+            {
+                "name": "example.com.",
+                "type": "primary",
+                "ttl": 3600,
+                "records": [
+                    {"name": "@", "type": "SOA", "value": "ignored"},
+                    {"name": "@", "type": "NS", "value": "ns1.example.com."},
+                    {"name": "sub", "type": "NS", "value": "ns2.example.com."},
+                    {"name": "www", "type": "A", "value": "10.0.0.1", "ttl": 300},
+                ],
+            }
+        ]
+    }
+    d.render(bundle)
+    import json
+
+    payload = json.loads((tmp_path / "rendered.new" / "zones.json").read_text())
+    zone = payload[0]
+    types_by_domain = {(r["domain"], r["type"]) for r in zone["records"]}
+    # Apex SOA + apex NS are daemon-managed — excluded.
+    assert ("example.com", "SOA") not in types_by_domain
+    assert ("example.com", "NS") not in types_by_domain
+    # Off-apex NS (delegation) and ordinary records pass through.
+    assert ("sub.example.com", "NS") in types_by_domain
+    assert ("www.example.com", "A") in types_by_domain
+
+
+def test_render_skips_non_primary_zones(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    bundle = {
+        "zones": [
+            {"name": "secondary.example.com.", "type": "secondary", "records": []},
+        ]
+    }
+    d.render(bundle)
+    import json
+
+    payload = json.loads((tmp_path / "rendered.new" / "zones.json").read_text())
+    assert payload == []

--- a/agent/supervisor/spatium_supervisor/firewall_renderer.py
+++ b/agent/supervisor/spatium_supervisor/firewall_renderer.py
@@ -153,6 +153,7 @@ class FirewallProfile:
 _ROLE_PORTS_TCP: dict[str, list[int]] = {
     "dns-bind9": [53],
     "dns-powerdns": [53],
+    "dns-technitium": [53],
     # BGP (#566). The collector normally DIALS the router (outbound, allowed
     # by default egress), but opening inbound tcp/179 lets the router initiate
     # the session (passive collector) and keeps firewall drift-detection aware
@@ -162,6 +163,7 @@ _ROLE_PORTS_TCP: dict[str, list[int]] = {
 _ROLE_PORTS_UDP: dict[str, list[int]] = {
     "dns-bind9": [53],
     "dns-powerdns": [53],
+    "dns-technitium": [53],
     "dhcp": [67, 68],
 }
 
@@ -180,7 +182,7 @@ _METALLB_MEMBERLIST = 7946
 
 
 def _profile_name(roles: list[str]) -> str:
-    has_dns = any(r in roles for r in ("dns-bind9", "dns-powerdns"))
+    has_dns = any(r in roles for r in ("dns-bind9", "dns-powerdns", "dns-technitium"))
     has_dhcp = "dhcp" in roles
     if has_dns and has_dhcp:
         return "dns-and-dhcp"

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -151,6 +151,7 @@ def _effective_control_plane_url(cfg: SupervisorConfig) -> str:
 _CAPABILITY_FLAGS = (
     "can_run_dns_bind9",
     "can_run_dns_powerdns",
+    "can_run_dns_technitium",
     "can_run_dhcp",
     "can_run_looking_glass",
 )
@@ -234,7 +235,8 @@ def _capabilities_payload() -> dict[str, Any]:
     capability reporting"):
 
     * ``can_run_dns_bind9`` / ``can_run_dns_powerdns`` /
-      ``can_run_dhcp`` / ``can_run_looking_glass`` — hardcoded
+      ``can_run_dns_technitium`` / ``can_run_dhcp`` /
+      ``can_run_looking_glass`` — hardcoded
       ``True`` post-Phase-7 (looking-glass joins under #566). The
       slot's containerd content store is preloaded with every
       service image; if we're heartbeating, the images are there.

--- a/agent/supervisor/spatium_supervisor/role_orchestrator.py
+++ b/agent/supervisor/spatium_supervisor/role_orchestrator.py
@@ -47,7 +47,7 @@ log = structlog.get_logger(__name__)
 # ``looking-glass`` (#566) joined DNS/DHCP here — the BGP Looking
 # Glass collector is a real service container (GoBGP), not a
 # supervisor-side-only role like observer.
-_SERVICE_ROLES = {"dns-bind9", "dns-powerdns", "dhcp", "looking-glass"}
+_SERVICE_ROLES = {"dns-bind9", "dns-powerdns", "dns-technitium", "dhcp", "looking-glass"}
 
 
 # Issue #237 — values from the heartbeat response land in a docker-
@@ -147,7 +147,7 @@ def compute_target_env(role_assignment: dict[str, Any] | None) -> TargetEnv:
     dns_agent_key = _safe_env_value(
         "dns_agent_key", role_assignment.get("dns_agent_key"), _AGENT_KEY_RE
     )
-    if any(r in roles for r in ("dns-bind9", "dns-powerdns")):
+    if any(r in roles for r in ("dns-bind9", "dns-powerdns", "dns-technitium")):
         if dns_group:
             env_lines.append(f"AGENT_GROUP={dns_group}")
         if dns_engine:

--- a/agent/supervisor/spatium_supervisor/service_lifecycle.py
+++ b/agent/supervisor/spatium_supervisor/service_lifecycle.py
@@ -73,6 +73,7 @@ class LifecycleResult:
 SUPERVISED_SERVICES: tuple[str, ...] = (
     "dns-bind9",
     "dns-powerdns",
+    "dns-technitium",
     "dhcp-kea",
     "looking-glass",
 )
@@ -98,6 +99,7 @@ _TARGET_NAMESPACE = "spatium"
 _PROFILE_TO_HELM_KEY = {
     "dns-bind9": "dnsBind9",
     "dns-powerdns": "dnsPowerdns",
+    "dns-technitium": "dnsTechnitium",
     "dhcp": "dhcpKea",
     "looking-glass": "lookingGlass",
 }
@@ -115,6 +117,7 @@ _PROFILE_TO_HELM_KEY = {
 _ROLE_LABEL_KEYS = {
     "dns-bind9": "spatium.io/role-dns-bind9",
     "dns-powerdns": "spatium.io/role-dns-powerdns",
+    "dns-technitium": "spatium.io/role-dns-technitium",
     "dhcp": "spatium.io/role-dhcp",
     # #566 — BGP Looking Glass collector (GoBGP). Same per-role
     # node-label gating shape as DNS/DHCP (non-negotiable #16).
@@ -238,6 +241,12 @@ def _build_values(profiles: list[str], env_vars: dict[str, str]) -> dict[str, ob
             "serverGroupName": env_vars.get("AGENT_GROUP", ""),
         },
         "dnsPowerdns": {
+            "enabled": True,
+            "controlPlaneUrl": control_plane_url,
+            "agentKey": env_vars.get("DNS_AGENT_KEY", ""),
+            "serverGroupName": env_vars.get("AGENT_GROUP", ""),
+        },
+        "dnsTechnitium": {
             "enabled": True,
             "controlPlaneUrl": control_plane_url,
             "agentKey": env_vars.get("DNS_AGENT_KEY", ""),

--- a/agent/supervisor/spatium_supervisor/watchdog.py
+++ b/agent/supervisor/spatium_supervisor/watchdog.py
@@ -65,6 +65,7 @@ log = structlog.get_logger(__name__)
 _PROFILE_TO_SERVICE: dict[str, str] = {
     "dns-bind9": "dns-bind9",
     "dns-powerdns": "dns-powerdns",
+    "dns-technitium": "dns-technitium",
     "dhcp": "dhcp-kea",
     "looking-glass": "looking-glass",
 }

--- a/appliance/mkosi.extra/usr/local/share/spatiumddi/nginx-appliance.conf
+++ b/appliance/mkosi.extra/usr/local/share/spatiumddi/nginx-appliance.conf
@@ -137,6 +137,26 @@ server {
         proxy_send_timeout       1800s;
     }
 
+    # ── Appliance upgrade-image upload — large body tuning (same as dev).
+    # Sized to the backend's own MAX_UPLOAD_BYTES cap (4 GiB); the 2g
+    # backup limit above isn't enough for a ~1.8-2 GB appliance slot
+    # image. Without this, nginx's default body-size limit 413s the
+    # upload before FastAPI's own size-check ever runs.
+    location /api/v1/appliance/upgrade-images {
+        set $api_upstream http://api:8000;
+        proxy_pass               $api_upstream;
+        proxy_set_header         Host $host;
+        proxy_set_header         X-Real-IP $remote_addr;
+        proxy_set_header         X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header         X-Forwarded-Proto $scheme;
+        proxy_http_version       1.1;
+        proxy_set_header         Connection "";
+        client_max_body_size     4g;
+        proxy_request_buffering  off;
+        proxy_read_timeout       1800s;
+        proxy_send_timeout       1800s;
+    }
+
     location /api/ {
         set $api_upstream http://api:8000;
         proxy_pass         $api_upstream;

--- a/appliance/scripts/bake-images.sh
+++ b/appliance/scripts/bake-images.sh
@@ -51,6 +51,7 @@ IMAGES=(
     "ghcr.io/spatiumddi/spatium-supervisor"
     "ghcr.io/spatiumddi/dns-bind9"
     "ghcr.io/spatiumddi/dns-powerdns"
+    "ghcr.io/spatiumddi/dns-technitium"
     "ghcr.io/spatiumddi/dhcp-kea"
     # Issue #566 — BGP Looking Glass collector (GoBGP). Baked into
     # every slot per decision D3 (can_run_looking_glass hardcodes

--- a/backend/alembic/versions/6a668dd451d5_dns_technitium_firewall_seed.py
+++ b/backend/alembic/versions/6a668dd451d5_dns_technitium_firewall_seed.py
@@ -1,0 +1,92 @@
+"""Technitium DNS driver — builtin firewall policy seed.
+
+Adds the ``dns-technitium`` role policy alongside the existing
+``dns-bind9`` / ``dns-powerdns`` rows seeded by f5b8d2c91a06 — same shape
+(udp/tcp 53), since Technitium binds the standard DNS port like the other
+two drivers. Kept as its own migration (not an edit of f5b8d2c91a06, which
+already shipped) per the append-only migration rule.
+
+Idempotent: guards on NOT EXISTS / ON CONFLICT DO NOTHING, same as the
+parent seed. ``backend/tests/test_firewall_merge.py::
+test_builtin_seed_matches_migration`` keeps this in lock-step with
+``_BUILTIN_SEED`` in ``app/services/appliance/firewall_merge.py``.
+
+Revision ID: 6a668dd451d5
+Revises: e5b2f09c71a4
+Create Date: 2026-07-28
+"""
+
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "6a668dd451d5"
+down_revision: str | None = "e5b2f09c71a4"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_SCOPE_ROLE = "dns-technitium"
+_NAME = "DNS (Technitium)"
+_RULES: list = [
+    (10, "accept", "udp", [53], "any", "both", None, None),
+    (20, "accept", "tcp", [53], "any", "both", None, None),
+]
+# Same (scope_kind, scope_role, name, enabled, rules) shape as
+# f5b8d2c91a06's ``_POLICIES`` — test_builtin_seed_matches_migration
+# concatenates every seed migration's ``_POLICIES`` list uniformly.
+_POLICIES: list = [("role", _SCOPE_ROLE, _NAME, True, _RULES)]
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "INSERT INTO firewall_policy "
+            "(id, name, description, scope_kind, scope_role, enabled, is_builtin, priority, "
+            " created_at, modified_at) "
+            "SELECT gen_random_uuid(), :name, NULL, 'role', :sr, true, true, 100, now(), now() "
+            "WHERE NOT EXISTS "
+            "(SELECT 1 FROM firewall_policy WHERE scope_kind = 'role' AND scope_role = :sr)"
+        ).bindparams(name=_NAME, sr=_SCOPE_ROLE)
+    )
+    for seq, action, proto, ports, skind, fam, comment, guard in _RULES:
+        op.execute(
+            sa.text(
+                "INSERT INTO firewall_rule "
+                "(id, policy_id, seq, action, protocol, ports, source_kind, source_cidrs, "
+                " source_alias, family, comment, render_guard, enabled) "
+                "SELECT gen_random_uuid(), p.id, :seq, :action, :proto, CAST(:ports AS jsonb), "
+                " :skind, '[]'::jsonb, NULL, :fam, :comment, CAST(:guard AS jsonb), true "
+                "FROM firewall_policy p WHERE p.scope_kind = 'role' AND p.scope_role = :sr "
+                "ON CONFLICT (policy_id, seq) DO NOTHING"
+            ).bindparams(
+                sr=_SCOPE_ROLE,
+                seq=seq,
+                action=action,
+                proto=proto,
+                ports=json.dumps(ports),
+                skind=skind,
+                fam=fam,
+                comment=comment,
+                guard=json.dumps(guard) if guard is not None else None,
+            )
+        )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "DELETE FROM firewall_rule WHERE policy_id IN "
+            "(SELECT id FROM firewall_policy WHERE scope_kind = 'role' AND scope_role = :sr "
+            " AND is_builtin)"
+        ).bindparams(sr=_SCOPE_ROLE)
+    )
+    op.execute(
+        sa.text(
+            "DELETE FROM firewall_policy WHERE scope_kind = 'role' AND scope_role = :sr "
+            "AND is_builtin"
+        ).bindparams(sr=_SCOPE_ROLE)
+    )

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -205,6 +205,7 @@ class SupervisorCapabilities(BaseModel):
 
     can_run_dns_bind9: bool = False
     can_run_dns_powerdns: bool = False
+    can_run_dns_technitium: bool = False
     can_run_dhcp: bool = False
     can_run_looking_glass: bool = False
     can_run_observer: bool = False
@@ -1082,7 +1083,7 @@ class SupervisorHeartbeatRequest(BaseModel):
     role_switch_reason: str | None = None
     # #170 Wave E — service-container watchdog. Free-form dict keyed
     # by compose service name (``dns-bind9`` / ``dns-powerdns`` /
-    # ``dhcp-kea``); each value carries ``{role, status, since,
+    # ``dns-technitium`` / ``dhcp-kea``); each value carries ``{role, status, since,
     # container_id}`` where status ∈ {healthy, missing, unhealthy,
     # starting}. The supervisor probes every 5 min and ships the
     # cached verdict on every heartbeat; the Fleet drilldown surfaces
@@ -1303,8 +1304,8 @@ class SupervisorHeartbeatResponse(BaseModel):
     ca_chain_pem: str | None = None
     cert_expires_at: datetime | None = None
     # #170 Wave C2 — assigned roles + group config. The supervisor
-    # uses this to bring up dns-bind9 / dns-powerdns / dhcp-kea
-    # service containers via docker compose. Empty roles list = idle
+    # uses this to bring up dns-bind9 / dns-powerdns / dns-technitium /
+    # dhcp-kea service containers via docker compose. Empty roles list = idle
     # (approved but no service running).
     role_assignment: SupervisorRoleAssignment = Field(default_factory=SupervisorRoleAssignment)
     # #272 Phase 7 — control-plane promote/demote desired state.
@@ -2355,7 +2356,7 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     from app.models.dns import DNSServerGroup, DNSServerOptions
 
     assigned_roles = list(row.assigned_roles or [])
-    dns_role_assigned = "dns-bind9" in assigned_roles or "dns-powerdns" in assigned_roles
+    dns_role_assigned = any(r in assigned_roles for r in _DNS_ROLES)
     dhcp_role_assigned = "dhcp" in assigned_roles
     lg_role_assigned = "looking-glass" in assigned_roles
 
@@ -2364,6 +2365,8 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
         dns_engine = "bind9"
     elif "dns-powerdns" in assigned_roles:
         dns_engine = "powerdns"
+    elif "dns-technitium" in assigned_roles:
+        dns_engine = "technitium"
 
     dns_group_name: str | None = None
     # #50 — DoT / DoH listen on operator-chosen ports, so the firewall can't
@@ -2523,7 +2526,7 @@ class ApplianceRow(BaseModel):
     # #170 Wave E — service-container watchdog. Per-service health
     # the supervisor reports every 5 min via heartbeat. Keys are
     # compose service names (``dns-bind9`` / ``dns-powerdns`` /
-    # ``dhcp-kea``); values carry ``{role, status, since,
+    # ``dns-technitium`` / ``dhcp-kea``); values carry ``{role, status, since,
     # container_id}``.
     role_health: dict[str, dict[str, Any]]
     # #387 — per-plane host-config apply health (snmp / ntp / lldp /
@@ -3324,8 +3327,16 @@ async def rekey_appliance(
 # ── Admin: role assignment + tags (#170 Wave C2) ──────────────────
 
 
-_VALID_ROLES = {"dns-bind9", "dns-powerdns", "dhcp", "looking-glass", "observer", "custom"}
-_DNS_ROLES = {"dns-bind9", "dns-powerdns"}
+_VALID_ROLES = {
+    "dns-bind9",
+    "dns-powerdns",
+    "dns-technitium",
+    "dhcp",
+    "looking-glass",
+    "observer",
+    "custom",
+}
+_DNS_ROLES = {"dns-bind9", "dns-powerdns", "dns-technitium"}
 
 
 class ApplianceRolesUpdate(BaseModel):
@@ -3340,8 +3351,9 @@ class ApplianceRolesUpdate(BaseModel):
     roles: list[str] | None = Field(
         default=None,
         description=(
-            "Subset of dns-bind9 / dns-powerdns / dhcp / looking-glass / "
-            "observer / custom. dns-bind9 and dns-powerdns are mutually exclusive."
+            "Subset of dns-bind9 / dns-powerdns / dns-technitium / dhcp / "
+            "looking-glass / observer / custom. The three dns-* roles are "
+            "mutually exclusive — one engine per appliance."
         ),
     )
     dns_group_id: uuid.UUID | None = None
@@ -3370,8 +3382,9 @@ async def update_appliance_roles(
     """Validate + persist a role assignment. Refuses to assign a role
     the supervisor doesn't advertise the capability for (BIND9 needs
     ``can_run_dns_bind9``, PowerDNS needs ``can_run_dns_powerdns``,
-    DHCP needs ``can_run_dhcp``). Refuses the dns-bind9 + dns-powerdns
-    combo (one engine per box). 422 on validation failure.
+    Technitium needs ``can_run_dns_technitium``, DHCP needs
+    ``can_run_dhcp``). Refuses combining more than one dns-* role (one
+    engine per box). 422 on validation failure.
 
     The supervisor's next heartbeat picks up the change via
     ``role_assignment`` in the response. Service-container lifecycle
@@ -3403,7 +3416,7 @@ async def update_appliance_roles(
         if len(dns_engines) > 1:
             raise HTTPException(
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
-                "dns-bind9 and dns-powerdns are mutually exclusive — one engine per appliance.",
+                f"{sorted(dns_engines)} are mutually exclusive — one DNS engine per appliance.",
             )
         # Capability gate. Each requested role must be backed by the
         # supervisor's advertised cap. Skips for ``observer`` / ``custom``
@@ -3413,6 +3426,7 @@ async def update_appliance_roles(
             cap_key = {
                 "dns-bind9": "can_run_dns_bind9",
                 "dns-powerdns": "can_run_dns_powerdns",
+                "dns-technitium": "can_run_dns_technitium",
                 "dhcp": "can_run_dhcp",
                 "looking-glass": "can_run_looking_glass",
                 "observer": "can_run_observer",

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -147,11 +147,11 @@ _DRIVER_GATED_RECORD_TYPES: dict[str, frozenset[str]] = {
     # SVCB / HTTPS (RFC 9460) + DNAME (RFC 6672) are served natively only by
     # our self-hosted authoritative backends. The hosted-DNS providers vary
     # (and would fail at apply rather than create), so gate to bind9 + pdns
-    # and let a follow-up widen the set once a provider's apply path is
-    # verified. issue #338.
-    "SVCB": frozenset({"bind9", "powerdns"}),
-    "HTTPS": frozenset({"bind9", "powerdns"}),
-    "DNAME": frozenset({"bind9", "powerdns"}),
+    # + technitium and let a follow-up widen the set once a provider's apply
+    # path is verified. issue #338.
+    "SVCB": frozenset({"bind9", "powerdns", "technitium"}),
+    "HTTPS": frozenset({"bind9", "powerdns", "technitium"}),
+    "DNAME": frozenset({"bind9", "powerdns", "technitium"}),
 }
 
 # Zone-level operations only some drivers support. Same shape as

--- a/backend/app/drivers/dns/__init__.py
+++ b/backend/app/drivers/dns/__init__.py
@@ -3,10 +3,10 @@
 Per CLAUDE.md non-negotiable #10, the service layer obtains a driver via
 ``get_driver(server_type)`` and speaks only to the abstract interface.
 
-SpatiumDDI ships three authoritative DNS drivers: BIND9 (default), PowerDNS
-(issue #127, Phase 1 — agent-managed alongside BIND9), and Windows DNS
-(WinRM-driven, agentless). New drivers register here without touching the
-service layer.
+SpatiumDDI ships four authoritative DNS drivers: BIND9 (default), PowerDNS
+(issue #127, Phase 1 — agent-managed alongside BIND9), Technitium
+(agent-managed, REST-API driven), and Windows DNS (WinRM-driven, agentless).
+New drivers register here without touching the service layer.
 """
 
 from __future__ import annotations
@@ -30,12 +30,14 @@ from app.drivers.dns.hetzner import HetznerDNSDriver
 from app.drivers.dns.linode import LinodeDNSDriver
 from app.drivers.dns.powerdns import PowerDNSDriver
 from app.drivers.dns.route53 import Route53DNSDriver
+from app.drivers.dns.technitium import TechnitiumDriver
 from app.drivers.dns.vultr import VultrDNSDriver
 from app.drivers.dns.windows import WindowsDNSDriver
 
 _DRIVERS: dict[str, type[DNSDriver]] = {
     "bind9": BIND9Driver,
     "powerdns": PowerDNSDriver,
+    "technitium": TechnitiumDriver,
     "windows_dns": WindowsDNSDriver,
     # Agentless cloud-hosted DNS providers (issue #37, Part B). The
     # control plane calls the provider REST/SDK API directly — same

--- a/backend/app/drivers/dns/technitium.py
+++ b/backend/app/drivers/dns/technitium.py
@@ -1,0 +1,315 @@
+"""Technitium DNS Server driver.
+
+Technitium is the third authoritative DNS driver SpatiumDDI ships,
+alongside BIND9 and PowerDNS. Each ``DNSServerGroup`` is single-driver;
+mixed installs work via multiple groups (see ``docs/drivers/DNS_DRIVERS.md``
+§5.1).
+
+Technitium is entirely HTTP-API driven (``/api/zones/*``,
+``/api/zones/records/*``) with bearer-token auth — closer in shape to
+PowerDNS than to BIND9's config-file-plus-RFC2136 model, but with an even
+thinner control-plane footprint: Technitium has no equivalent of
+``pdns.conf`` for zone/record state at all (zones live entirely in its own
+internal store, managed exclusively through the API), so this driver's
+``render_zone_config``/``render_zone_file`` produce previews only — the
+real reconcile-against-API logic lives in the agent-side driver under
+``agent/dns/spatium_dns_agent/drivers/technitium.py``.
+
+v1 scope (this driver):
+
+* Primary zones + standard record CRUD via the Technitium REST API. The
+  agent generates a permanent API token on first boot
+  (``POST /api/user/createToken``) and is the only caller — the control
+  plane formulates ``RecordChange`` ops and the agent translates them to
+  ``/api/zones/records/{add,update,delete}`` calls.
+* Validate the bundle (zone names end with ".", record types from the
+  supported set, primary zones only, no views).
+
+Deferred to fast-follow phases (tracked in the roadmap, not this driver):
+
+* DNSSEC online signing (Technitium's ``/api/zones/dnssec/*`` surface is
+  close in shape to PowerDNS's — should port quickly once picked up).
+* Native DNS-over-TLS/HTTPS/QUIC listener wiring — a real differentiator
+  over PowerDNS (no dnsdist sidecar needed), needs a settings-API spike.
+* Catalog zones, secondary/stub/forward zones + TSIG zone transfer.
+* ANAME / APP / FWD record types (Technitium-proprietary, different shape
+  than PowerDNS's ALIAS/LUA — not a drop-in equivalent).
+
+CLAUDE.md non-negotiable #10: this driver speaks only neutral
+``ConfigBundle`` / ``RecordChange`` types. Technitium specifics live inside
+``render_server_config`` / ``apply_record_change`` and the agent-side driver.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from app.core.dns_names import strip_control_chars
+from app.drivers.dns.base import (
+    ConfigBundle,
+    DNSDriver,
+    DynamicUpdateCaps,
+    EffectiveBlocklistData,
+    RecordChange,
+    RecordData,
+    ServerOptions,
+    ZoneData,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+# Record types the Technitium driver supports in v1, taken from Technitium's
+# documented `/api/zones/records/add` type list. ANAME / FWD / APP are
+# Technitium-proprietary and deliberately excluded — they aren't a drop-in
+# equivalent of PowerDNS's ALIAS/LUA and need their own design pass.
+# DNSSEC-adjacent types (DS, DNSKEY, RRSIG, NSEC*) stay out until online
+# signing (fast-follow) lands, except DS which operators may set by hand for
+# manual parent-side delegation independent of signing — held back anyway
+# for v1 simplicity and revisited alongside DNSSEC.
+_SUPPORTED_RECORD_TYPES = frozenset(
+    {
+        "A",
+        "AAAA",
+        "CNAME",
+        "MX",
+        "TXT",
+        "NS",
+        "PTR",
+        "SRV",
+        "CAA",
+        "TLSA",
+        "SSHFP",
+        "NAPTR",
+        "URI",
+        "SOA",
+        "SVCB",
+        "HTTPS",
+        "DNAME",
+    }
+)
+
+
+def _record_payload(zone: ZoneData, rr: RecordData) -> dict[str, Any]:
+    """Compose the neutral JSON projection of one record for the preview /
+    hash-stable rendering. Field names mirror Technitium's
+    ``/api/zones/records/add`` parameters (``ipAddress``, ``cname``,
+    ``exchange``/``preference``, ``priority``/``weight``/``port``/``target``,
+    ``text``) so the agent-side reconciler can consume this shape directly.
+    """
+    rtype = rr.record_type.upper()
+    value = strip_control_chars(rr.value).rstrip(".")
+    payload: dict[str, Any] = {"ttl": rr.ttl or zone.ttl}
+    if rtype in ("A", "AAAA"):
+        payload["ipAddress"] = value
+    elif rtype == "CNAME":
+        payload["cname"] = value
+    elif rtype == "MX":
+        payload["exchange"] = value
+        payload["preference"] = rr.priority if rr.priority is not None else 10
+    elif rtype == "SRV":
+        payload["target"] = value
+        payload["priority"] = rr.priority if rr.priority is not None else 0
+        payload["weight"] = rr.weight if rr.weight is not None else 0
+        payload["port"] = rr.port if rr.port is not None else 0
+    elif rtype == "TXT":
+        payload["text"] = strip_control_chars(rr.value)
+    elif rtype == "NS":
+        payload["nameServer"] = value
+    elif rtype == "PTR":
+        payload["ptrName"] = value
+    else:
+        payload["value"] = strip_control_chars(rr.value)
+    return payload
+
+
+def _qualified_record_name(zone: ZoneData, rr: RecordData) -> str:
+    """Return the FQDN (no trailing dot — Technitium's own convention) for
+    the record's ``domain`` field."""
+    zone_name = zone.name.rstrip(".")
+    name = strip_control_chars(rr.name)
+    if name in ("", "@") or name == zone_name:
+        return zone_name
+    return f"{name}.{zone_name}"
+
+
+class TechnitiumDriver(DNSDriver):
+    """Technitium DNS Server driver (v1 — primary zones + record CRUD).
+
+    Daemon lifecycle + apply runs inside the agent; the control-plane apply
+    path is a no-op (agent-based driver, like BIND9 / PowerDNS).
+    """
+
+    name = "technitium"
+
+    # ── Rendering ─────────────────────────────────────────────────────────
+
+    def render_server_config(
+        self,
+        server: Any,
+        options: ServerOptions,
+        *,
+        bundle: ConfigBundle | None = None,
+    ) -> str:
+        """Render a preview of the settings the agent pushes via
+        ``POST /api/settings/set`` on first boot.
+
+        Technitium has no on-disk config file equivalent to ``named.conf``/
+        ``pdns.conf`` for this driver's v1 scope — the daemon is configured
+        entirely through its API. This preview exists so
+        ``GET /servers/{id}/config`` has something representative to show;
+        the agent's bearer token never reaches the control plane.
+        """
+        import json
+
+        return json.dumps(
+            {
+                "dnsServer": "technitium",
+                "api_token": "<agent-generated>",
+                "recursion": "disabled",
+                "listen_port": 53,
+            },
+            indent=2,
+        )
+
+    def render_zone_config(self, zone: ZoneData) -> str:
+        """Technitium stores zones in its own internal store, not as
+        per-zone config stanzas. Zones are managed via the REST API.
+        Return an empty string so the bundle hash stays stable across
+        drivers.
+        """
+        return ""
+
+    def render_zone_file(self, zone: ZoneData, records: list[RecordData]) -> str:
+        """Render a JSON projection of the zone the agent uses to drive the
+        Technitium REST API (``/api/zones/records/add`` et al.).
+
+        Deliberately not an RFC 1035 zone file — Technitium wants
+        record-by-record API calls. Returns a stable, sorted JSON string so
+        the bundle ETag is deterministic.
+        """
+        import json
+
+        zone_name = zone.name.rstrip(".")
+
+        entries: list[dict[str, Any]] = []
+        for r in records:
+            entries.append(
+                {
+                    "domain": _qualified_record_name(zone, r),
+                    "type": r.record_type.upper(),
+                    **_record_payload(zone, r),
+                }
+            )
+        entries.sort(key=lambda e: (e["domain"], e["type"]))
+
+        return json.dumps(
+            {
+                "zone": zone_name,
+                "type": "Primary",
+                "records": entries,
+            },
+            sort_keys=True,
+            indent=2,
+        )
+
+    def render_rpz_zone(self, blocklist: EffectiveBlocklistData) -> str:
+        """Technitium has its own native blocklist/ad-blocking apps, but
+        wiring SpatiumDDI's blocklist model to them is deferred. Returns an
+        empty string so groups with blocklists still hash deterministically;
+        the agent skips applying blocklist data on Technitium hosts.
+        """
+        return ""
+
+    # ── Runtime (agent-side; control plane only formulates) ──────────────
+
+    async def apply_record_change(self, server: Any, change: RecordChange) -> None:
+        """Control-plane no-op. The agent runs the actual
+        ``/api/zones/records/{add,update,delete}`` call."""
+        logger.info(
+            "technitium.apply_record_change.formulated",
+            server=str(getattr(server, "id", "")),
+            zone=change.zone_name,
+            op=change.op,
+            name=change.record.name,
+            type=change.record.record_type,
+        )
+
+    async def reload_config(self, server: Any) -> None:
+        """Technitium has no global config reload — settings changes apply
+        live via the API. Control-plane no-op."""
+        logger.info("technitium.reload_config", server=str(getattr(server, "id", "")))
+
+    async def reload_zone(self, server: Any, zone_name: str) -> None:
+        """Zone state is always current via the API — no explicit reload
+        step. Control-plane no-op."""
+        logger.info(
+            "technitium.reload_zone",
+            server=str(getattr(server, "id", "")),
+            zone=zone_name,
+        )
+
+    # ── Validation / capabilities ─────────────────────────────────────────
+
+    def validate_config(self, bundle: ConfigBundle) -> tuple[bool, list[str]]:
+        errors: list[str] = []
+        seen: set[tuple[str | None, str]] = set()
+        for z in bundle.zones:
+            if not z.name.endswith("."):
+                errors.append(f"zone {z.name!r}: name must end with '.'")
+            key = (z.view_name, z.name)
+            if key in seen:
+                errors.append(f"duplicate zone {z.name!r} in view {z.view_name!r}")
+            seen.add(key)
+            if z.zone_type != "primary":
+                errors.append(
+                    f"zone {z.name!r}: zone_type {z.zone_type!r} not supported by "
+                    "the v1 Technitium driver (primary zones only — secondary/"
+                    "stub/forward are a fast-follow)"
+                )
+            for r in z.records:
+                rtype = r.record_type.upper()
+                if rtype not in _SUPPORTED_RECORD_TYPES:
+                    errors.append(
+                        f"zone {z.name!r}: record type {rtype!r} not supported "
+                        f"by the v1 Technitium driver"
+                    )
+        if bundle.views:
+            errors.append(
+                "Technitium driver does not support views — create a "
+                "separate group per view (issue #24)"
+            )
+        if bundle.blocklists:
+            # Not an error — just a notice. Agent will skip blocklist apply.
+            logger.info(
+                "technitium.bundle_has_blocklists_skipping",
+                count=len(bundle.blocklists),
+            )
+        return (not errors, errors)
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "name": "technitium",
+            "views": False,
+            "rpz": False,
+            "dnssec_inline_signing": False,  # fast-follow
+            "incremental_updates": "rest_api",
+            "zone_types": ["primary"],
+            "record_types": sorted(_SUPPORTED_RECORD_TYPES),
+            "alias_records": False,
+            "lua_records": False,
+            "catalog_zones": False,
+        }
+
+    @property
+    def dynamic_update_caps(self) -> DynamicUpdateCaps:
+        # v1: no dynamic-update (RFC 2136) surface wired for Technitium —
+        # all record mutation flows through the agent's queued record-op
+        # reconciler, not a client-facing UPDATE listener. Revisit if
+        # Technitium's own RFC 2136 support (it has one) gets wired up.
+        return DynamicUpdateCaps()
+
+
+__all__ = ["TechnitiumDriver"]

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -618,11 +618,11 @@ class Appliance(Base):
     desired_default_slot: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     # Role assignment — #170 Wave C2. Operator picks a subset of
-    # ``dns-bind9`` / ``dns-powerdns`` / ``dhcp`` / ``observer`` /
-    # ``custom``. Mutually-exclusive pairs (one DNS engine per box)
-    # enforced at the role-assignment endpoint, not via a CHECK
-    # constraint (operator intent should be a one-line API error,
-    # not a Postgres exception).
+    # ``dns-bind9`` / ``dns-powerdns`` / ``dns-technitium`` / ``dhcp`` /
+    # ``observer`` / ``custom``. The dns-* roles are mutually exclusive
+    # (one DNS engine per box), enforced at the role-assignment endpoint,
+    # not via a CHECK constraint (operator intent should be a one-line
+    # API error, not a Postgres exception).
     assigned_roles: Mapped[list[str]] = mapped_column(
         JSONB, nullable=False, default=list, server_default=sa.text("'[]'::jsonb")
     )

--- a/backend/app/models/firewall.py
+++ b/backend/app/models/firewall.py
@@ -91,11 +91,20 @@ class FirewallApplyState(Base):
 
 # Allowed scope_role values. NOTE: ``control-plane`` is NOT a node role
 # (the node-label taxonomy is _VALID_ROLES = dns-bind9 / dns-powerdns /
-# dhcp / observer / custom). It is a MERGE-INTERNAL scope key the compiler
-# matches onto a node via the ``is_cp`` predicate (peer/pod/service
-# presence), mirroring the Phase-2 renderer — never via "control-plane in
-# node.roles". Do not add a CHECK tying scope_role to the node-role set.
-_POLICY_ROLES = ("dns-bind9", "dns-powerdns", "dhcp", "observer", "custom", "control-plane")
+# dns-technitium / dhcp / observer / custom). It is a MERGE-INTERNAL scope
+# key the compiler matches onto a node via the ``is_cp`` predicate (peer/
+# pod/service presence), mirroring the Phase-2 renderer — never via
+# "control-plane in node.roles". Do not add a CHECK tying scope_role to
+# the node-role set.
+_POLICY_ROLES = (
+    "dns-bind9",
+    "dns-powerdns",
+    "dns-technitium",
+    "dhcp",
+    "observer",
+    "custom",
+    "control-plane",
+)
 
 
 class FirewallPolicy(UUIDPrimaryKeyMixin, TimestampMixin, Base):

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -2134,7 +2134,7 @@ register(
 # ── create_dns_zone (issue #127 Phase 4e) ─────────────────────────────
 
 
-_DNS_DRIVER_HINTS = {"bind9", "powerdns", "windows_dns"}
+_DNS_DRIVER_HINTS = {"bind9", "powerdns", "technitium", "windows_dns"}
 # DNSSEC online signing + ALIAS + LUA records require the PowerDNS
 # driver — the preview rejects when ``dnssec_enabled=true`` lands in a
 # group whose servers don't include any PowerDNS member, since signing
@@ -3358,16 +3358,23 @@ class AssignApplianceRoleArgs(BaseModel):
     appliance_id: str = Field(description="UUID of the approved appliance row.")
     roles: list[str] = Field(
         description=(
-            "Subset of dns-bind9 / dns-powerdns / dhcp / observer / "
-            "custom. dns-bind9 + dns-powerdns are mutually exclusive."
+            "Subset of dns-bind9 / dns-powerdns / dns-technitium / dhcp / "
+            "observer / custom. The three dns-* roles are mutually exclusive."
         )
     )
     dns_group_id: str | None = None
     dhcp_group_id: str | None = None
 
 
-_APPL_VALID_ROLES = {"dns-bind9", "dns-powerdns", "dhcp", "observer", "custom"}
-_APPL_DNS_ROLES = {"dns-bind9", "dns-powerdns"}
+_APPL_VALID_ROLES = {
+    "dns-bind9",
+    "dns-powerdns",
+    "dns-technitium",
+    "dhcp",
+    "observer",
+    "custom",
+}
+_APPL_DNS_ROLES = {"dns-bind9", "dns-powerdns", "dns-technitium"}
 
 
 async def _preview_assign_appliance_role(
@@ -3397,10 +3404,11 @@ async def _preview_assign_appliance_role(
             return PreviewResult(
                 ok=False, detail=f"Unknown role {r!r}. Valid: {sorted(_APPL_VALID_ROLES)}."
             )
-    if len(_APPL_DNS_ROLES.intersection(args.roles)) > 1:
+    dns_engines = _APPL_DNS_ROLES.intersection(args.roles)
+    if len(dns_engines) > 1:
         return PreviewResult(
             ok=False,
-            detail="dns-bind9 + dns-powerdns are mutually exclusive — one engine per appliance.",
+            detail=f"{sorted(dns_engines)} are mutually exclusive — one DNS engine per appliance.",
         )
     caps = row.capabilities or {}
     for r in args.roles:

--- a/backend/app/services/ai/tools/appliance.py
+++ b/backend/app/services/ai/tools/appliance.py
@@ -150,7 +150,10 @@ class FindApplianceFleetArgs(BaseModel):
         default=None,
         description="Filter by appliance state. Omit for all states.",
     )
-    role: Literal["dns-bind9", "dns-powerdns", "dhcp", "observer", "custom"] | None = Field(
+    role: (
+        Literal["dns-bind9", "dns-powerdns", "dns-technitium", "dhcp", "observer", "custom"]
+        | None
+    ) = Field(
         default=None,
         description=(
             "Filter by an assigned role. Returns rows whose "
@@ -758,9 +761,9 @@ class ProposeAssignRoleArgs(BaseModel):
     appliance_id: str = Field(description="UUID of the approved appliance row.")
     roles: list[str] = Field(
         description=(
-            "Subset of dns-bind9 / dns-powerdns / dhcp / observer / "
-            "custom. dns-bind9 + dns-powerdns are mutually exclusive. "
-            "Empty list = idle (no service containers will run)."
+            "Subset of dns-bind9 / dns-powerdns / dns-technitium / dhcp / "
+            "observer / custom. The three dns-* roles are mutually "
+            "exclusive. Empty list = idle (no service containers will run)."
         )
     )
     dns_group_id: str | None = Field(
@@ -787,9 +790,9 @@ class ProposeAssignRoleArgs(BaseModel):
         "operator clicks Apply for the supervisor to actually start / "
         "stop service containers on the next heartbeat. Server-side "
         "validation rejects roles the supervisor doesn't advertise "
-        "capability for, and rejects the dns-bind9 + dns-powerdns "
-        "combo (one engine per appliance). For tags or firewall "
-        "edits, point the operator at the Fleet tab drilldown."
+        "capability for, and rejects combining more than one dns-* role "
+        "(one engine per appliance). For tags or firewall edits, point "
+        "the operator at the Fleet tab drilldown."
     ),
     args_model=ProposeAssignRoleArgs,
     category="admin",

--- a/backend/app/services/appliance/cluster_health.py
+++ b/backend/app/services/appliance/cluster_health.py
@@ -39,6 +39,7 @@ _COMPONENT_ORDER = [
     "supervisor",
     "dns-bind9",
     "dns-powerdns",
+    "dns-technitium",
     "dhcp-kea",
 ]
 

--- a/backend/app/services/appliance/firewall.py
+++ b/backend/app/services/appliance/firewall.py
@@ -78,10 +78,12 @@ def _split_families(cidrs: list[Any]) -> tuple[list[str], list[str]]:
 _ROLE_PORTS_TCP: dict[str, list[int]] = {
     "dns-bind9": [53],
     "dns-powerdns": [53],
+    "dns-technitium": [53],
 }
 _ROLE_PORTS_UDP: dict[str, list[int]] = {
     "dns-bind9": [53],
     "dns-powerdns": [53],
+    "dns-technitium": [53],
     "dhcp": [67, 68],
 }
 _K3S_ETCD_KUBELET_TCP: tuple[int, ...] = (2379, 2380, 10250)
@@ -90,7 +92,7 @@ _METALLB_MEMBERLIST = 7946
 
 
 def _profile_name(roles: list[str]) -> str:
-    has_dns = any(r in roles for r in ("dns-bind9", "dns-powerdns"))
+    has_dns = any(r in roles for r in ("dns-bind9", "dns-powerdns", "dns-technitium"))
     has_dhcp = "dhcp" in roles
     if has_dns and has_dhcp:
         return "dns-and-dhcp"

--- a/backend/app/services/appliance/firewall_merge.py
+++ b/backend/app/services/appliance/firewall_merge.py
@@ -163,6 +163,21 @@ _BUILTIN_SEED: list[tuple[str, str | None, bool, list[tuple]]] = [
     ),
     ("role", "observer", False, []),
     ("role", "custom", True, []),
+    # dns-technitium ships in its own seed migration (6a668dd451d5) —
+    # f5b8d2c91a06 already shipped before Technitium existed (append-only
+    # migration rule) — so this entry is appended at the END to match the
+    # chronological order the two migrations actually apply in against a
+    # fresh DB. test_builtin_seed_matches_migration compares this list
+    # against the concatenation of every seed migration's ``_POLICIES``.
+    (
+        "role",
+        "dns-technitium",
+        True,
+        [
+            (10, "accept", "udp", (53,), "any", "both", None, None),
+            (20, "accept", "tcp", (53,), "any", "both", None, None),
+        ],
+    ),
 ]
 
 

--- a/backend/tests/test_appliance_supervisor_register.py
+++ b/backend/tests/test_appliance_supervisor_register.py
@@ -229,6 +229,66 @@ async def test_register_happy_path(db_session: AsyncSession, client: AsyncClient
 
 
 @pytest.mark.asyncio
+async def test_register_capabilities_round_trip_every_known_flag(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """Regression test (bug caught live testing the Technitium driver,
+    2026-07): ``SupervisorCapabilities`` is a STRICT Pydantic model, not
+    a passthrough dict — despite the class docstring's "ignores keys it
+    doesn't recognise" framing, Pydantic v2 silently DROPS any field the
+    model doesn't explicitly declare. A capability the supervisor sends
+    but this model doesn't list never reaches the stored
+    ``Appliance.capabilities`` JSONB, which makes the Fleet UI's role
+    picker report "supervisor doesn't advertise can_run_X=true" even
+    though the real supervisor is sending it. Every ``can_run_dns_*``
+    flag must be explicitly declared here — this test locks the full
+    set so adding a fourth DNS driver without updating the model fails
+    loudly instead of silently misreporting capabilities in the field.
+    """
+    await _enable_supervisor_registration(db_session)
+    code_row = await _make_pairing_code(db_session, code="33333333")
+    await db_session.commit()
+
+    _, _, _, pubkey_b64 = _new_keypair()
+
+    resp = await client.post(
+        "/api/v1/appliance/supervisor/register",
+        json={
+            "pairing_code": "33333333",
+            "hostname": "dns-cap-test",
+            "public_key_der_b64": pubkey_b64,
+            "supervisor_version": "2026.07.28-1",
+            "capabilities": {
+                "can_run_dns_bind9": True,
+                "can_run_dns_powerdns": True,
+                "can_run_dns_technitium": True,
+                "can_run_dhcp": True,
+                "can_run_looking_glass": True,
+                "can_run_observer": True,
+                "has_baked_images": True,
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    appliance_id = uuid.UUID(resp.json()["appliance_id"])
+    del code_row
+
+    appliance = await db_session.get(Appliance, appliance_id)
+    assert appliance is not None
+    caps = appliance.capabilities
+    for flag in (
+        "can_run_dns_bind9",
+        "can_run_dns_powerdns",
+        "can_run_dns_technitium",
+        "can_run_dhcp",
+        "can_run_looking_glass",
+        "can_run_observer",
+        "has_baked_images",
+    ):
+        assert caps.get(flag) is True, f"{flag} did not survive SupervisorCapabilities round-trip"
+
+
+@pytest.mark.asyncio
 async def test_register_is_idempotent_for_same_pubkey(
     db_session: AsyncSession, client: AsyncClient
 ) -> None:

--- a/backend/tests/test_dns_driver_technitium.py
+++ b/backend/tests/test_dns_driver_technitium.py
@@ -1,0 +1,334 @@
+"""Unit tests for the Technitium DNS Server driver (v1 — primary zones +
+standard record CRUD)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from app.drivers.dns import get_driver
+from app.drivers.dns.base import (
+    BlocklistEntry,
+    ConfigBundle,
+    EffectiveBlocklistData,
+    RecordData,
+    ServerOptions,
+    ViewData,
+    ZoneData,
+)
+from app.drivers.dns.technitium import TechnitiumDriver
+
+
+@pytest.fixture
+def zone() -> ZoneData:
+    return ZoneData(
+        name="example.com.",
+        zone_type="primary",
+        kind="forward",
+        ttl=3600,
+        refresh=86400,
+        retry=7200,
+        expire=3600000,
+        minimum=3600,
+        primary_ns="ns1.example.com.",
+        admin_email="hostmaster.example.com.",
+        serial=2026072701,
+        records=(),
+    )
+
+
+@pytest.fixture
+def records() -> list[RecordData]:
+    return [
+        RecordData(name="@", record_type="NS", value="ns1.example.com.", ttl=3600),
+        RecordData(name="www", record_type="A", value="10.0.0.1", ttl=300),
+        RecordData(name="ipv6", record_type="AAAA", value="2001:db8::1", ttl=300),
+        RecordData(name="alias", record_type="CNAME", value="www.example.com.", ttl=300),
+        RecordData(name="@", record_type="MX", value="mail.example.com.", ttl=3600, priority=10),
+        RecordData(name="@", record_type="TXT", value="v=spf1 -all", ttl=3600),
+        RecordData(
+            name="_sip._tcp",
+            record_type="SRV",
+            value="sip.example.com.",
+            ttl=3600,
+            priority=10,
+            weight=20,
+            port=5060,
+        ),
+    ]
+
+
+@pytest.fixture
+def bundle(zone: ZoneData) -> ConfigBundle:
+    return ConfigBundle(
+        server_id=str(uuid.uuid4()),
+        server_name="technitium1",
+        driver="technitium",
+        roles=("authoritative",),
+        options=ServerOptions(),
+        acls=(),
+        views=(),
+        zones=(zone,),
+        tsig_keys=(),
+        blocklists=(),
+        generated_at=datetime(2026, 7, 27, 12, 0, tzinfo=UTC),
+    )
+
+
+# ── Registry ──────────────────────────────────────────────────────────────
+
+
+def test_registry_returns_technitium() -> None:
+    drv = get_driver("technitium")
+    assert isinstance(drv, TechnitiumDriver)
+    assert drv.capabilities()["name"] == "technitium"
+
+
+# ── Rendering ─────────────────────────────────────────────────────────────
+
+
+def test_render_server_config_redacts_token() -> None:
+    out = TechnitiumDriver().render_server_config(None, ServerOptions())
+    payload = json.loads(out)
+    assert payload["api_token"] == "<agent-generated>"
+
+
+def test_render_zone_config_returns_empty_string(zone: ZoneData) -> None:
+    # Technitium stores zones in its own internal store, not in per-zone
+    # config stanzas. The driver returns an empty string by design.
+    assert TechnitiumDriver().render_zone_config(zone) == ""
+
+
+def test_render_zone_file_emits_technitium_api_payload(
+    zone: ZoneData, records: list[RecordData]
+) -> None:
+    out = TechnitiumDriver().render_zone_file(zone, records)
+    payload = json.loads(out)
+
+    assert payload["zone"] == "example.com"
+    assert payload["type"] == "Primary"
+
+    by_domain_type = {(r["domain"], r["type"]): r for r in payload["records"]}
+
+    mx = by_domain_type[("example.com", "MX")]
+    assert mx["exchange"] == "mail.example.com"
+    assert mx["preference"] == 10
+
+    srv = by_domain_type[("_sip._tcp.example.com", "SRV")]
+    assert srv["target"] == "sip.example.com"
+    assert srv["priority"] == 10
+    assert srv["weight"] == 20
+    assert srv["port"] == 5060
+
+    txt = by_domain_type[("example.com", "TXT")]
+    assert txt["text"] == "v=spf1 -all"
+
+    a = by_domain_type[("www.example.com", "A")]
+    assert a["ipAddress"] == "10.0.0.1"
+
+    cname = by_domain_type[("alias.example.com", "CNAME")]
+    assert cname["cname"] == "www.example.com"
+
+
+def test_render_zone_file_is_deterministic(zone: ZoneData, records: list[RecordData]) -> None:
+    out1 = TechnitiumDriver().render_zone_file(zone, records)
+    out2 = TechnitiumDriver().render_zone_file(zone, records)
+    assert out1 == out2
+
+
+def test_render_rpz_zone_returns_empty_string() -> None:
+    bl = EffectiveBlocklistData(
+        rpz_zone_name="spatium-blocklist.rpz.",
+        entries=(
+            BlocklistEntry(
+                domain="ads.example.org",
+                action="block",
+                block_mode="nxdomain",
+                sinkhole_ip=None,
+                target=None,
+                is_wildcard=False,
+            ),
+        ),
+        exceptions=frozenset(),
+    )
+    assert TechnitiumDriver().render_rpz_zone(bl) == ""
+
+
+# ── Validation ────────────────────────────────────────────────────────────
+
+
+def test_validate_config_ok(bundle: ConfigBundle) -> None:
+    ok, errors = TechnitiumDriver().validate_config(bundle)
+    assert ok is True
+    assert errors == []
+
+
+def test_validate_config_rejects_views(bundle: ConfigBundle) -> None:
+    bundle.views = (
+        ViewData(
+            name="internal",
+            match_clients=("10.0.0.0/8",),
+            match_destinations=(),
+            recursion=False,
+            order=1,
+        ),
+    )
+    ok, errors = TechnitiumDriver().validate_config(bundle)
+    assert ok is False
+    assert any("does not support views" in e for e in errors)
+
+
+def test_validate_config_rejects_non_primary_zone(zone: ZoneData) -> None:
+    secondary = ZoneData(
+        name=zone.name,
+        zone_type="secondary",
+        kind=zone.kind,
+        ttl=zone.ttl,
+        refresh=zone.refresh,
+        retry=zone.retry,
+        expire=zone.expire,
+        minimum=zone.minimum,
+        primary_ns=zone.primary_ns,
+        admin_email=zone.admin_email,
+        serial=zone.serial,
+        masters=("10.0.0.1",),
+    )
+    bundle = ConfigBundle(
+        server_id=str(uuid.uuid4()),
+        server_name="technitium1",
+        driver="technitium",
+        roles=("authoritative",),
+        options=ServerOptions(),
+        acls=(),
+        views=(),
+        zones=(secondary,),
+        tsig_keys=(),
+        blocklists=(),
+        generated_at=datetime(2026, 7, 27, 12, 0, tzinfo=UTC),
+    )
+    ok, errors = TechnitiumDriver().validate_config(bundle)
+    assert ok is False
+    assert any("not supported by the v1 Technitium driver" in e for e in errors)
+
+
+def test_validate_config_rejects_unsupported_record_types(zone: ZoneData) -> None:
+    bad = ZoneData(
+        name=zone.name,
+        zone_type="primary",
+        kind=zone.kind,
+        ttl=zone.ttl,
+        refresh=zone.refresh,
+        retry=zone.retry,
+        expire=zone.expire,
+        minimum=zone.minimum,
+        primary_ns=zone.primary_ns,
+        admin_email=zone.admin_email,
+        serial=zone.serial,
+        records=(
+            # ALIAS is a PowerDNS-only record type; Technitium has no
+            # equivalent (it has ANAME, a different shape) — stand-in for
+            # "not in our v1 supported set".
+            RecordData(name="@", record_type="ALIAS", value="lb.example.net.", ttl=60),
+        ),
+    )
+    bundle = ConfigBundle(
+        server_id=str(uuid.uuid4()),
+        server_name="technitium1",
+        driver="technitium",
+        roles=("authoritative",),
+        options=ServerOptions(),
+        acls=(),
+        views=(),
+        zones=(bad,),
+        tsig_keys=(),
+        blocklists=(),
+        generated_at=datetime(2026, 7, 27, 12, 0, tzinfo=UTC),
+    )
+    ok, errors = TechnitiumDriver().validate_config(bundle)
+    assert ok is False
+    assert any("ALIAS" in e for e in errors)
+
+
+def test_validate_config_accepts_modern_record_types(zone: ZoneData) -> None:
+    modern = ZoneData(
+        name=zone.name,
+        zone_type="primary",
+        kind=zone.kind,
+        ttl=zone.ttl,
+        refresh=zone.refresh,
+        retry=zone.retry,
+        expire=zone.expire,
+        minimum=zone.minimum,
+        primary_ns=zone.primary_ns,
+        admin_email=zone.admin_email,
+        serial=zone.serial,
+        records=(
+            RecordData(name="_443._tcp", record_type="TLSA", value="3 1 1 abcd", ttl=300),
+            RecordData(name="@", record_type="HTTPS", value="1 . alpn=h2", ttl=300),
+            RecordData(name="@", record_type="SVCB", value="1 target.example.com.", ttl=300),
+        ),
+    )
+    bundle = ConfigBundle(
+        server_id=str(uuid.uuid4()),
+        server_name="technitium1",
+        driver="technitium",
+        roles=("authoritative",),
+        options=ServerOptions(),
+        acls=(),
+        views=(),
+        zones=(modern,),
+        tsig_keys=(),
+        blocklists=(),
+        generated_at=datetime(2026, 7, 27, 12, 0, tzinfo=UTC),
+    )
+    ok, errors = TechnitiumDriver().validate_config(bundle)
+    assert ok is True
+    assert errors == []
+
+
+def test_validate_config_blocklists_are_warned_not_errored(zone: ZoneData) -> None:
+    bl = EffectiveBlocklistData(
+        rpz_zone_name="spatium-blocklist.rpz.",
+        entries=(),
+        exceptions=frozenset(),
+    )
+    bundle = ConfigBundle(
+        server_id=str(uuid.uuid4()),
+        server_name="technitium1",
+        driver="technitium",
+        roles=("authoritative",),
+        options=ServerOptions(),
+        acls=(),
+        views=(),
+        zones=(zone,),
+        tsig_keys=(),
+        blocklists=(bl,),
+        generated_at=datetime(2026, 7, 27, 12, 0, tzinfo=UTC),
+    )
+    ok, errors = TechnitiumDriver().validate_config(bundle)
+    assert ok is True
+    assert errors == []
+
+
+# ── Capabilities ──────────────────────────────────────────────────────────
+
+
+def test_capabilities_v1_scope() -> None:
+    caps = TechnitiumDriver().capabilities()
+    assert caps["zone_types"] == ["primary"]
+    assert caps["dnssec_inline_signing"] is False
+    assert caps["alias_records"] is False
+    assert caps["lua_records"] is False
+    assert caps["catalog_zones"] is False
+    assert "SVCB" in caps["record_types"]
+    assert "HTTPS" in caps["record_types"]
+    assert "DNAME" in caps["record_types"]
+
+
+def test_dynamic_update_caps_unsupported() -> None:
+    caps = TechnitiumDriver().dynamic_update_caps
+    assert caps.supports_ip_acl is False
+    assert caps.supports_tsig_acl is False

--- a/backend/tests/test_firewall_merge.py
+++ b/backend/tests/test_firewall_merge.py
@@ -241,6 +241,7 @@ def test_builtin_set_shape() -> None:
     assert set(ps.roles) == {
         "dns-bind9",
         "dns-powerdns",
+        "dns-technitium",
         "dhcp",
         "control-plane",
         "observer",
@@ -252,24 +253,35 @@ def test_builtin_set_shape() -> None:
     assert cp.rules[2].render_guard == _BUILTIN_GUARD
 
 
-def _load_seed_migration():
-    path = (
-        pathlib.Path(__file__).resolve().parents[1]
-        / "alembic/versions/f5b8d2c91a06_firewall_builtin_seed.py"
-    )
-    spec = importlib.util.spec_from_file_location("_fw_seed_mig", path)
+def _load_migration_module(filename: str):
+    path = pathlib.Path(__file__).resolve().parents[1] / "alembic/versions" / filename
+    spec = importlib.util.spec_from_file_location(f"_fw_seed_mig_{filename}", path)
     assert spec and spec.loader
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
 
 
+# Every migration that seeds a builtin firewall policy row, in the order
+# they apply against a fresh DB. A new DNS driver's role policy lands in
+# its OWN migration (append-only — f5b8d2c91a06 already shipped), so the
+# drift guard below concatenates all of them rather than assuming a single
+# file holds the whole set. Add new migrations here alongside their driver.
+_SEED_MIGRATION_FILES = [
+    "f5b8d2c91a06_firewall_builtin_seed.py",
+    "6a668dd451d5_dns_technitium_firewall_seed.py",
+]
+
+
 def test_builtin_seed_matches_migration() -> None:
     """The in-code canonical builtins (the render source on an unseeded DB)
-    must match the seed migration row-for-row, else a node renders one set
+    must match the seed migrations row-for-row, else a node renders one set
     while the DB holds another."""
-    mig = _load_seed_migration()
-    assert mig._GUARD == _BUILTIN_GUARD
+    migs = [_load_migration_module(f) for f in _SEED_MIGRATION_FILES]
+    for mig in migs:
+        guard = getattr(mig, "_GUARD", None)
+        if guard is not None:
+            assert guard == _BUILTIN_GUARD
 
     def norm_merge(entry):
         sk, sr, enabled, rules = entry
@@ -289,4 +301,5 @@ def test_builtin_seed_matches_migration() -> None:
             [(s, a, p, tuple(po), k, f, c, g) for (s, a, p, po, k, f, c, g) in rules],
         )  # noqa: E501
 
-    assert [norm_merge(e) for e in _BUILTIN_SEED] == [norm_mig(e) for e in mig._POLICIES]
+    mig_policies = [e for mig in migs for e in mig._POLICIES]
+    assert [norm_merge(e) for e in _BUILTIN_SEED] == [norm_mig(e) for e in mig_policies]

--- a/charts/spatiumddi-appliance/README.md
+++ b/charts/spatiumddi-appliance/README.md
@@ -26,6 +26,7 @@ appliance's *local* k3s, deploying the per-role service workloads:
 
 - `dnsBind9` — Deployment + Service. BIND9 authoritative DNS.
 - `dnsPowerdns` — Deployment + Service. PowerDNS alternative.
+- `dnsTechnitium` — Deployment + Service. Technitium alternative.
 - `dhcpKea` — DaemonSet with `hostNetwork: true`. Kea DHCPv4/v6.
 - `lookingGlass` — DaemonSet with `hostNetwork: true`. Receive-only
   BGP collector (GoBGP, issue #566) — see
@@ -33,9 +34,9 @@ appliance's *local* k3s, deploying the per-role service workloads:
 - `supervisor` — DaemonSet, privileged. The reconciler itself.
 
 Each role is gated on a `<role>.enabled` flag. Mutual exclusion
-between DNS engines (bind9 vs powerdns) is enforced upstream by the
-supervisor's CRD reconciler — at the chart level both blocks can
-render side-by-side if values.yaml says so.
+across the three DNS engines (bind9 / powerdns / technitium) is
+enforced upstream by the supervisor's CRD reconciler — at the chart
+level all three blocks can render side-by-side if values.yaml says so.
 
 ## Air-gap defaults
 

--- a/charts/spatiumddi-appliance/templates/dns-technitium.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-technitium.yaml
@@ -1,0 +1,152 @@
+{{- /* Third DNS agent option (alongside BIND9 + PowerDNS).
+       Phase 10 wave 2 — ``.enabled`` is release-ownership scope
+       (bootstrap=false, appliance=true), NOT role-scope. Scheduling
+       is gated by the ``spatium.io/role-dns-technitium=true`` node
+       label. Mutual exclusion across all three DNS engines is enforced
+       supervisor-side: it sets at most one of ``role-dns-bind9`` /
+       ``role-dns-powerdns`` / ``role-dns-technitium`` labels on any
+       heartbeat. */}}
+{{- if .Values.dnsTechnitium.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dns-technitium
+  labels:
+    {{- include "spatiumddi-appliance.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dns-technitium
+spec:
+  # DaemonSet for symmetry with dns-bind9 / dns-powerdns / dhcp-kea —
+  # DESIRED=0 when the node lacks ``spatium.io/role-dns-technitium=true``,
+  # so ``kubectl get pods`` stays silent on unscheduled roles.
+  # #292 — RollingUpdate (not OnDelete): OnDelete strands a pod on its
+  # creation-time spec when CONTROL_PLANE_URL is populated after first
+  # render. See dns-bind9.yaml for the full rationale.
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dns-technitium
+  template:
+    metadata:
+      labels:
+        {{- include "spatiumddi-appliance.labels" . | nindent 8 }}
+        app.kubernetes.io/name: dns-technitium
+        app.kubernetes.io/component: dns-technitium
+    spec:
+      {{- if not .Values.dns.useMetalLBVIP }}
+      # #272 Phase 5 — default path: bind :53 on the node IP. A DNS VIP
+      # drops hostNetwork in favour of the LoadBalancer Service below.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      # #296 Phase A2 — see dns-bind9.yaml for the rationale. The
+      # Technitium daemon flushes in-flight queries on SIGTERM; 30 s
+      # matches BIND9 / PowerDNS.
+      terminationGracePeriodSeconds: 30
+      nodeSelector:
+        {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+        # Phase 10 (#183) — per-role scheduling label.
+        spatium.io/role-dns-technitium: "true"
+      containers:
+        - name: dns-technitium
+          image: {{ include "spatiumddi-appliance.imageRef" (dict "global" .Values.global "repository" .Values.dnsTechnitium.image.repository) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            # #292 / #409 — in-cluster API Service over HTTP by default;
+            # prefer the supervisor-supplied external controlPlaneUrl when
+            # set (Application appliance with its own k3s — no in-cluster
+            # control Service), skipping TLS verify on that self-signed
+            # path. See dns-bind9.yaml for the full rationale.
+            - name: CONTROL_PLANE_URL
+              value: {{ .Values.dnsTechnitium.controlPlaneUrl | default .Values.dnsTechnitium.inClusterApiUrl | default (printf "http://spatium-control-spatiumddi-api.%s.svc:8000" .Release.Namespace) | quote }}
+            {{- if .Values.dnsTechnitium.controlPlaneUrl }}
+            - name: SPATIUM_INSECURE_SKIP_TLS_VERIFY
+              value: "1"
+            {{- end }}
+            - name: DNS_AGENT_KEY
+              value: {{ .Values.dnsTechnitium.agentKey | quote }}
+            - name: AGENT_GROUP
+              value: {{ .Values.dnsTechnitium.serverGroupName | quote }}
+            {{- with .Values.global.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: dns-udp
+              containerPort: 53
+              protocol: UDP
+            - name: dns-tcp
+              containerPort: 53
+              protocol: TCP
+          # #296 Phase A2 — marker + a live query, same shape as bind9/
+          # powerdns's readiness probe. Technitium REFUSES CHAOS-class
+          # queries entirely (confirmed empirically — id.server/
+          # version.bind both come back REFUSED, not answered), so this
+          # queries the RFC 6761 reserved "invalid." TLD instead —
+          # answered locally and instantly (NXDOMAIN, no recursion)
+          # regardless of zone state. See dns-bind9.yaml for the full
+          # rationale on why the marker gate matters for rolling upgrade.
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "test -f /var/lib/spatium-dns-agent/.ready && dig @127.0.0.1 -p 53 healthcheck.invalid A +timeout=2 +tries=1 >/dev/null"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          livenessProbe:
+            tcpSocket:
+              port: 53
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            # #292 — persistent agent config-bundle cache (#5); see
+            # dns-bind9.yaml.
+            - name: agent-state
+              mountPath: /var/lib/spatium-dns-agent
+            - name: data
+              mountPath: /etc/dns
+      # #292 — per-node hostPath (not shared PVC, not emptyDir); see
+      # dns-bind9.yaml for the rationale.
+      volumes:
+        - name: agent-state
+          hostPath:
+            path: /var/lib/spatiumddi/agents/dns-technitium/state
+            type: DirectoryOrCreate
+        - name: data
+          hostPath:
+            path: /var/lib/spatiumddi/agents/dns-technitium/data
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-technitium
+  labels:
+    {{- include "spatiumddi-appliance.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dns-technitium
+  {{- if .Values.dns.useMetalLBVIP }}
+  annotations:
+    # #272 Phase 5 — pin the DNS resolver VIP from the MetalLB pool.
+    metallb.universe.tf/address-pool: {{ .Values.dns.vipPool | quote }}
+    metallb.universe.tf/loadBalancerIPs: {{ .Values.dns.vip | quote }}
+  {{- end }}
+spec:
+  {{- if .Values.dns.useMetalLBVIP }}
+  type: LoadBalancer
+  {{- else }}
+  type: ClusterIP
+  {{- end }}
+  selector:
+    app.kubernetes.io/name: dns-technitium
+  ports:
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+{{- end }}

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -28,10 +28,10 @@ global:
   # operator override).
   extraEnv: []
 
-# DNS — bind9 backend. Exactly one of dnsBind9 / dnsPowerdns runs
-# per appliance; the supervisor enforces mutual-exclusion at the
-# CRD reconciler level so flipping both ``enabled: true`` is a
-# server-side validation error.
+# DNS — bind9 backend. Exactly one of dnsBind9 / dnsPowerdns /
+# dnsTechnitium runs per appliance; the supervisor enforces mutual-
+# exclusion at the CRD reconciler level so flipping more than one
+# ``enabled: true`` is a server-side validation error.
 dnsBind9:
   enabled: false
   image:
@@ -96,6 +96,20 @@ dnsPowerdns:
   # #50 — that same gap means DoT/DoH on the PowerDNS driver is
   # docker-compose-only too: pdns auth speaks neither protocol, so the
   # listeners live on the dnsdist front. BIND9 needs no such sidecar.
+
+# DNS — Technitium backend. Same shape as dnsBind9. v1 supports primary
+# zones + standard record CRUD; DNSSEC and native DoT/DoH/DoQ listener
+# wiring (a real differentiator — Technitium needs no dnsdist-style
+# sidecar, unlike PowerDNS) are fast-follow, so no dotPort/dohPort knobs
+# here yet.
+dnsTechnitium:
+  enabled: false
+  image:
+    repository: ghcr.io/spatiumddi/dns-technitium
+  controlPlaneUrl: ""
+  inClusterApiUrl: ""  # #292 — see dnsBind9.inClusterApiUrl
+  agentKey: ""
+  serverGroupName: ""
 
 # DHCP — Kea backend. DaemonSet (single node) with ``hostNetwork:
 # true`` + ``CAP_NET_BIND_SERVICE`` so Kea sees DHCP-discover

--- a/charts/spatiumddi/README.md
+++ b/charts/spatiumddi/README.md
@@ -142,6 +142,13 @@ dnsAgents:
       role: primary
       group: powerdns-edge
       service: { type: LoadBalancer }
+    # Technitium (third DNS driver — primary zones + standard records in
+    # v1; DNSSEC and native DoT/DoH/DoQ listeners are fast-follow).
+    - name: tdx1
+      flavor: technitium
+      role: primary
+      group: technitium-edge
+      service: { type: LoadBalancer }
 ```
 
 Each server picks its image from `dnsAgents.image` (default,
@@ -226,8 +233,9 @@ subcharts verbatim — any option those charts accept works here. See:
 | `dnsAgents.enabled` | `false` |  |
 | `dnsAgents.image.repository` | `ghcr.io/spatiumddi/dns-bind9` | Default image (BIND9 flavor) |
 | `dnsAgents.flavors.powerdns.repository` | `ghcr.io/spatiumddi/dns-powerdns` | Per-flavor image override (issue #127) |
+| `dnsAgents.flavors.technitium.repository` | `ghcr.io/spatiumddi/dns-technitium` | Per-flavor image override |
 | `dnsAgents.agentKey.existingSecret` | `""` | Carries `DNS_AGENT_KEY` (shared between flavors) |
-| `dnsAgents.servers` | `[]` | One entry → one StatefulSet + Services. `flavor: bind9` (default) or `powerdns` |
+| `dnsAgents.servers` | `[]` | One entry → one StatefulSet + Services. `flavor: bind9` (default), `powerdns`, or `technitium` |
 | `dhcpAgents.enabled` | `false` |  |
 | `dhcpAgents.image.repository` | `ghcr.io/spatiumddi/dhcp-kea` |  |
 | `dhcpAgents.agentKey.existingSecret` | `""` | Carries `SPATIUM_AGENT_KEY` |

--- a/charts/spatiumddi/templates/dns-agent.yaml
+++ b/charts/spatiumddi/templates/dns-agent.yaml
@@ -30,11 +30,16 @@ stringData:
 {{- $imgTag := $flavorImg.tag | default $tag -}}
 {{- /* Volume mount path for the driver's zone-state volume. BIND9 caches
        zone files under /var/cache/bind; PowerDNS LMDB lives at
-       /var/lib/powerdns. The volume claim itself ("dns-state") is the
-       same; only the mount path changes. */ -}}
+       /var/lib/powerdns; Technitium's own config + zone store lives at
+       /etc/dns (its query/error log dir, /var/log/technitium, is NOT
+       persisted here — it's daemon-internal logging, not zone state, and
+       lives fine on the pod's ephemeral writable layer). The volume claim
+       itself ("dns-state") is the same; only the mount path changes. */ -}}
 {{- $dnsStatePath := "/var/cache/bind" -}}
 {{- if eq $flavor "powerdns" -}}
   {{- $dnsStatePath = "/var/lib/powerdns" -}}
+{{- else if eq $flavor "technitium" -}}
+  {{- $dnsStatePath = "/etc/dns" -}}
 {{- end }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/spatiumddi/templates/frontend-tls-config.yaml
+++ b/charts/spatiumddi/templates/frontend-tls-config.yaml
@@ -106,6 +106,26 @@ data:
             proxy_send_timeout       1800s;
         }
 
+        # Appliance upgrade-image upload — sized to the backend's own
+        # MAX_UPLOAD_BYTES cap (4 GiB); the 2g backup limit above isn't
+        # enough for a ~1.8-2 GB appliance slot image. Without this,
+        # nginx's default body-size limit 413s the upload before
+        # FastAPI's own size-check ever runs.
+        location /api/v1/appliance/upgrade-images {
+            set $api_upstream http://${API_UPSTREAM_HOST}:${API_UPSTREAM_PORT};
+            proxy_pass               $api_upstream;
+            proxy_set_header         Host $http_host;
+            proxy_set_header         X-Real-IP $remote_addr;
+            proxy_set_header         X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header         X-Forwarded-Proto $scheme;
+            proxy_http_version       1.1;
+            proxy_set_header         Connection "";
+            client_max_body_size     4g;
+            proxy_request_buffering  off;
+            proxy_read_timeout       1800s;
+            proxy_send_timeout       1800s;
+        }
+
         location /api/ {
             set $api_upstream http://${API_UPSTREAM_HOST}:${API_UPSTREAM_PORT};
             proxy_pass         $api_upstream;

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -606,6 +606,9 @@ dnsAgents:
     powerdns:
       repository: ghcr.io/spatiumddi/dns-powerdns
       tag: ""                    # empty → use Chart.appVersion
+    technitium:
+      repository: ghcr.io/spatiumddi/dns-technitium
+      tag: ""                    # empty → use Chart.appVersion
   # PSK carrying DNS_AGENT_KEY. Prefer `existingSecret`; `value` lives here
   # only to make lab walk-throughs runnable in one command.
   agentKey:
@@ -613,7 +616,7 @@ dnsAgents:
     value: ""
   servers: []
     # - name: ns1
-    #   flavor: bind9            # bind9 (default) | powerdns
+    #   flavor: bind9            # bind9 (default) | powerdns | technitium
     #   role: primary            # primary | secondary
     #   group: internal-resolvers
     #   storage: { agentState: 1Gi, dnsState: 2Gi }

--- a/docker-compose.agent-dns-technitium.yml
+++ b/docker-compose.agent-dns-technitium.yml
@@ -1,0 +1,89 @@
+name: spatiumddi-agent-dns-technitium
+
+# ── Standalone Technitium DNS agent compose file ───────────────────────
+#
+# For running a Technitium DNS Server agent on a machine *without* the
+# SpatiumDDI control plane. Mirror of
+# ``docker-compose.agent-dns-bind9.yml`` / ``docker-compose.agent-dns-
+# powerdns.yml`` for the third authoritative driver — pick whichever
+# image matches the server group's driver in the control plane.
+#
+# Zone + record state lives entirely in Technitium's own store under
+# ``/etc/dns`` inside the container's bound volume — there is no
+# external database dependency (same shape as PowerDNS's embedded LMDB).
+#
+# Quickstart:
+#
+#   export CONTROL_PLANE_URL=https://spatium.example.com
+#   export DNS_AGENT_KEY=$(openssl rand -hex 32)
+#   # Register the key on the control plane first (Settings → Agent
+#   # Keys) so the agent can bootstrap. Create the matching
+#   # DNSServerGroup with driver="technitium" via the UI or REST API.
+#
+#   docker compose -f docker-compose.agent-dns-technitium.yml up -d
+#
+# For multi-server Technitium groups, run this compose file on each
+# additional VM with DNS_HOSTNAME set to a unique server name and the
+# same AGENT_GROUP — the control plane wires them into the same
+# Technitium-driver group automatically.
+#
+# Mixing drivers in one group is rejected by the control plane. To run
+# BIND9 / PowerDNS / Technitium side-by-side, create separate groups.
+#
+# ──────────────────────────────────────────────────────────────────────
+
+services:
+  dns-technitium:
+    image: ghcr.io/spatiumddi/dns-technitium:${SPATIUMDDI_VERSION:-latest}
+    restart: unless-stopped
+    hostname: ${DNS_HOSTNAME:-dns-technitium}
+    networks:
+      - spatiumddi-agent
+    environment:
+      # ── Required ──────────────────────────────────────────────────
+      # URL of the SpatiumDDI control plane API (remote).
+      CONTROL_PLANE_URL: ${CONTROL_PLANE_URL:?CONTROL_PLANE_URL required}
+      # Pre-shared key registered on the control plane first.
+      DNS_AGENT_KEY: ${DNS_AGENT_KEY:?DNS_AGENT_KEY required}
+
+      # ── Registration ──────────────────────────────────────────────
+      # Server name used for auto-registration. MUST be unique across
+      # the deployment.
+      SERVER_NAME: ${DNS_HOSTNAME:-dns-technitium}
+      AGENT_GROUP: ${DNS_AGENT_GROUP:-default}
+      AGENT_ROLES: ${DNS_AGENT_ROLES:-authoritative}
+      # AGENT_DRIVER is baked into the image (technitium); no override.
+
+      # ── TLS ───────────────────────────────────────────────────────
+      SPATIUM_INSECURE_SKIP_TLS_VERIFY: "${SPATIUM_INSECURE_SKIP_TLS_VERIFY:-1}"
+      # TLS_CA_PATH: /etc/ssl/spatium-ca.crt
+    volumes:
+      - dns_technitium_state:/var/lib/spatium-dns-agent
+      # Technitium's own config + zone store. Keep this volume — losing
+      # it means losing every zone the agent has applied, plus the
+      # daemon's admin account (the agent's cached API token would then
+      # point at a re-initialised daemon and need to re-provision).
+      - dns_technitium_config:/etc/dns
+      - dns_technitium_logs:/var/log/technitium
+      # Optional: mount a CA bundle to verify the control plane.
+      # - /etc/ssl/certs:/etc/ssl/certs:ro
+    ports:
+      # DNS — UDP and TCP. The host-port default (1053) is lab-friendly
+      # to avoid colliding with systemd-resolved on 53 *and* avahi-mDNS
+      # on 5353. For a real DNS server use port 53 directly, typically
+      # with ``network_mode: host`` so clients can reach it without
+      # DNAT.
+      - "${DNS_HOST_PORT:-1053}:53/udp"
+      - "${DNS_HOST_PORT:-1053}:53/tcp"
+      # No DoT / DoH / DoQ ports here yet — native encrypted-transport
+      # listener wiring for Technitium (a real differentiator; no
+      # dnsdist-style sidecar needed) is a fast-follow, not v1 scope.
+
+networks:
+  spatiumddi-agent:
+    driver: bridge
+
+volumes:
+  dns_technitium_state:
+  dns_technitium_config:
+  dns_technitium_logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,6 +265,37 @@ services:
       api:
         condition: service_started
 
+  # ── DNS agent (Technitium) ───────────────────────────────────────────
+  # Enable with: docker compose --profile dns-technitium up -d
+  # Third DNS driver, alongside bind9/powerdns. Distinct profile + host
+  # port (6053, avoiding 1053/5453) so all three can run side-by-side in
+  # a dev/migration setup. Technitium's web console + API listen on
+  # loopback :5380 inside the container only — the agent is the only
+  # caller (same trust boundary as PowerDNS's local API key).
+  dns-technitium:
+    profiles: ["dns-technitium"]
+    image: ghcr.io/spatiumddi/dns-technitium:${SPATIUMDDI_VERSION:-latest}
+    restart: unless-stopped
+    networks:
+      - spatiumddi
+    environment:
+      CONTROL_PLANE_URL: http://api:8000
+      DNS_AGENT_KEY: ${DNS_AGENT_KEY:-changeme-dns-agent-key}
+      SERVER_NAME: dns-technitium
+      AGENT_GROUP: default-technitium
+      AGENT_ROLES: authoritative
+      SPATIUM_INSECURE_SKIP_TLS_VERIFY: "1"
+    volumes:
+      - dns_technitium_state:/var/lib/spatium-dns-agent
+      - dns_technitium_config:/etc/dns
+      - dns_technitium_logs:/var/log/technitium
+    ports:
+      - "6053:53/udp"
+      - "6053:53/tcp"
+    depends_on:
+      api:
+        condition: service_started
+
   # ── dnsdist front for PowerDNS (issue #146 Phase 2) ───────────────────
   # Opt-in rate-limit / DDoS front for the authoritative PowerDNS agent
   # (pdns auth has no RRL of its own). A SEPARATE container (its own netns)
@@ -465,6 +496,9 @@ volumes:
   dns_bind9_cache:
   dns_powerdns_state:
   dns_powerdns_lmdb:
+  dns_technitium_state:
+  dns_technitium_config:
+  dns_technitium_logs:
   dhcp_kea_state:
   dhcp_kea_leases:
   dhcp_kea_state_2:

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -19,7 +19,7 @@ The appliance runs **k3s** as its container orchestrator. Pre-#183 it ran `docke
 **#272 — two install roles** (the installer wizard collapsed from the earlier three; the old `full-stack` / `frontend-core` distinction is now a runtime DNS/DHCP role toggle, not an install choice — and legacy variant strings are still accepted from a not-yet-reinstalled box):
 
 - **Control plane** (the default; the required FIRST install) — control plane (api / frontend / worker / beat / migrate / Postgres / Redis) + the supervisor, all on a single-node k3s that is also the etcd seed. **DNS + DHCP are OFF at install** — the operator enables them per node from the `/appliance → Fleet` role toggle (so the data plane is always a deliberate fleet decision). The umbrella chart deploys the control plane; the supervisor owns the per-role node labels. More control-plane nodes are made by **promoting** Appliances in the Fleet UI (#272 Phase 7), not installed as this role.
-- **Appliance** — supervisor + agent-landing nginx. Pairs against a remote control plane via 8-digit pairing code; roles (`dns-bind9` / `dns-powerdns` / `dhcp`) are assigned post-approval from the control plane's `/appliance → Fleet` tab. Can later be promoted to join the control-plane cluster.
+- **Appliance** — supervisor + agent-landing nginx. Pairs against a remote control plane via 8-digit pairing code; roles (`dns-bind9` / `dns-powerdns` / `dns-technitium` / `dhcp`) are assigned post-approval from the control plane's `/appliance → Fleet` tab. Can later be promoted to join the control-plane cluster.
 
 The historical AIO / Core-only / Application narrative below documents the pre-#272 three-role world; the firstboot dispatch still handles those strings as aliases.
 
@@ -36,7 +36,7 @@ The historical AIO / Core-only / Application narrative below documents the pre-#
    spatium-supervisor pod (DaemonSet, privileged, hostNetwork: false)   ← all roles
         ↓ (registers + heartbeats to control plane)
         ↓ (on role assignment: labels node → DaemonSet schedules)
-   role pods: dns-bind9 / dns-powerdns / dhcp-kea (hostNetwork: true)
+   role pods: dns-bind9 / dns-powerdns / dns-technitium / dhcp-kea (hostNetwork: true)
    always-on: agent-landing nginx on :80                                 ← Appliance only
    control plane pods (api / frontend / db / redis / worker / beat /     ← Control plane
                        migrate, frontend on hostNetwork :80 + :443)
@@ -48,7 +48,7 @@ mkosi bakes everything the appliance needs to come up fully air-gapped:
 
 - **k3s static binary** (~70 MB) at `/usr/local/bin/k3s`; `kubectl` / `crictl` / `ctr` symlink to it.
 - **k3s airgap images** (CoreDNS / local-path / pause / metrics-server) as zst-compressed tarballs at `/var/lib/rancher/k3s/agent/images/*.tar.zst`. k3s auto-imports them into containerd at boot.
-- **SpatiumDDI container images** as zst tarballs at `/usr/lib/spatiumddi/images/`. firstboot imports them into k3s containerd via `ctr -n k8s.io images import`. Includes api / frontend / worker / beat / migrate / dns-bind9 / dns-powerdns / dhcp-kea / supervisor / nginx + postgres:16-alpine + redis:8.8-alpine for the Control plane role.
+- **SpatiumDDI container images** as zst tarballs at `/usr/lib/spatiumddi/images/`. firstboot imports them into k3s containerd via `ctr -n k8s.io images import`. Includes api / frontend / worker / beat / migrate / dns-bind9 / dns-powerdns / dns-technitium / dhcp-kea / supervisor / nginx + postgres:16-alpine + redis:8.8-alpine for the Control plane role.
 - **Helm chart tarballs** at `/usr/lib/spatiumddi/charts/`. The appliance chart drives Appliance installs (and the supervisor on the Control plane); the umbrella chart drives the Control plane. Built at release time + signed.
 - **bash-completion + `k` alias** for kubectl — operator SSHing in for triage drops straight into a usable shell.
 
@@ -57,7 +57,7 @@ A fresh appliance boot never reaches out to ghcr.io or any external registry. Th
 ### Two HelmChart CRs
 
 - **`spatium-bootstrap`** — written by `spatiumddi-firstboot` into k3s's auto-deploy directory on every boot. Content depends on install role (Control plane / Appliance). Owns the always-on resources (supervisor on every role; agent-landing on Appliance; control plane pods on Control plane).
-- **`spatiumddi-appliance`** — written by the supervisor on its first successful heartbeat (every role runs a supervisor). Deploys the three role DaemonSets (dns-bind9 / dns-powerdns / dhcp-kea). After #183 Phase 10, this release is installed once and never re-PATCHed for role changes — role swaps happen through node labels (`spatium.io/role-<role>=true`); the DaemonSet's matching-nodes semantics mean an unassigned role produces zero pods rather than a Pending one.
+- **`spatiumddi-appliance`** — written by the supervisor on its first successful heartbeat (every role runs a supervisor). Deploys the role DaemonSets (dns-bind9 / dns-powerdns / dns-technitium / dhcp-kea). After #183 Phase 10, this release is installed once and never re-PATCHed for role changes — role swaps happen through node labels (`spatium.io/role-<role>=true`); the DaemonSet's matching-nodes semantics mean an unassigned role produces zero pods rather than a Pending one.
 
 ### Why k3s
 
@@ -319,7 +319,7 @@ trigger-file → `spatium-firewall-reload` plane. Full design + risk register:
    to it, so flipping the switch never re-fires a node's trigger.
 
 **Policy model.** Three additive scopes merge per node: a **fleet** singleton
-baseline → **per-role** overlays (`dns-bind9` / `dns-powerdns` / `dhcp` /
+baseline → **per-role** overlays (`dns-bind9` / `dns-powerdns` / `dns-technitium` / `dhcp` /
 `observer` / `custom` + the merge-internal `control-plane` key, resolved by the
 `is_cp` predicate, not a node label) → a **per-appliance** override. The merge
 is `explode → deny-wins → source-union`; `source_kind` carries derived scopes
@@ -423,7 +423,7 @@ The fix:
 `/appliance` → **Fleet** tab is the primary management surface. Operators see every Application appliance with state (pending / approved), advertised capabilities, assigned roles, deployment kind, slot info, last-seen. A pending row pins at the top with Approve / Reject. A drilldown modal on each approved row carries:
 
 - Identity (hostname, full cert fingerprint, paired-at + paired-from-ip, last-seen).
-- **Role assignment** — pick a subset of `dns-bind9` / `dns-powerdns` / `dhcp` / `observer`. DNS engines are mutually exclusive; chips for capabilities the supervisor doesn't advertise dim with a tooltip. DNS / DHCP group dropdowns appear conditionally on the selection.
+- **Role assignment** — pick a subset of `dns-bind9` / `dns-powerdns` / `dns-technitium` / `dhcp` / `observer`. DNS engines are mutually exclusive; chips for capabilities the supervisor doesn't advertise dim with a tooltip. DNS / DHCP group dropdowns appear conditionally on the selection.
 - **Firewall preview + operator override** — live preview of the role-driven profile (idle / dns-only / dhcp-only / dns-and-dhcp), always-open + per-role port summary, raw-nft textarea for operator overrides.
 - **OS & lifecycle** — installed appliance version, running + durable-default slots (with trial-boot chip), last upgrade state, Schedule OS upgrade form, Cancel pending upgrade, Reboot host (with a double-confirm modal requiring an "I understand this will go offline" checkbox).
 - **Certificate** — serial, issued/expires timestamps. Re-key + Delete actions on the modal footer.

--- a/docs/deployment/DNS_AGENT.md
+++ b/docs/deployment/DNS_AGENT.md
@@ -79,6 +79,7 @@ The agent images that ship:
 |---|---|---|
 | `ghcr.io/spatiumddi/dns-bind9` | `named` + `spatium-dns-agent` | Authoritative and/or recursive BIND9 |
 | `ghcr.io/spatiumddi/dns-powerdns` | `pdns_server` + `spatium-dns-agent` | Authoritative PowerDNS (LMDB backend) |
+| `ghcr.io/spatiumddi/dns-technitium` | `dotnet DnsServerApp.dll` + `spatium-dns-agent` | Authoritative Technitium DNS Server (v1: primary zones + standard records) |
 
 The **agent is the same Python codebase** (`spatium_dns_agent`) in every image; the DNS daemon differs. The agent abstracts daemon specifics internally (symmetric to the control-plane driver, but on the container side).
 
@@ -398,9 +399,11 @@ them nor manages that transfer.
 
 ### Base
 
-**Alpine 3.23** for every agent image — *except* `dns-powerdns`, which is deliberately held on **Alpine 3.22** (see below). Multi-arch: `linux/amd64`, `linux/arm64/v8` via `docker buildx`.
+**Alpine 3.23** for every agent image — *except* `dns-powerdns`, which is deliberately held on **Alpine 3.22** (see below), and `dns-technitium`, which is **not Alpine at all** (see below). Multi-arch: `linux/amd64`, `linux/arm64/v8` via `docker buildx`.
 
 > **Why `dns-powerdns` is pinned back.** Alpine 3.23 ships pdns 5.0.5 (3.22 ships 4.9.5), and PowerDNS 5.0 performs an automatic, silent, **irreversible** LMDB schema upgrade (v5 → v6) the first time it opens the database — a read is enough, and there is no opt-out. Afterwards pdns 4.9 cannot open the database at all (`Somehow, we are not at schema version 5. Giving up`). Because the LMDB is persisted on `/var` in every deployment shape, and the appliance A/B slot rollback swaps only the *rootfs*, an upgrade-then-rollback would leave pdns crash-looping with DNS down and no automatic recovery. The image stays on 3.22 (a supported branch; `apk upgrade` still pulls its security fixes) until [#638](https://github.com/spatiumddi/spatiumddi/issues/638) lands the pre-upgrade LMDB snapshot + restore path.
+
+> **Why `dns-technitium` is glibc/Ubuntu-based, not Alpine.** Technitium ships no Alpine package and no binary release assets on GitHub at all (its releases carry notes only, zero attached artifacts — confirmed empirically). The only reproducible, versioned, multi-arch artifact it publishes is its own official Docker image (`technitium/dns-server`, Ubuntu 24.04 + .NET 10 aspnet runtime), so `agent/dns/images/technitium/Dockerfile` builds `FROM` that image and layers the `spatium_dns_agent` wheel on top rather than fetching a build artifact that doesn't exist. The builder stage matches (Debian `python:3.12-slim-bookworm`, not Alpine) since `spatium_dns_agent` depends on `cryptography`, which ships compiled wheels — a musllinux wheel built on Alpine wouldn't load on the Ubuntu-based runtime. The image also explicitly upgrades to the distro's patched `aspnetcore-runtime-10.0` package and deletes the vendored `/usr/share/dotnet` copy the upstream image ships, since Trivy's .NET scanner reads shared-framework directories directly (not `dotnet --list-runtimes`) and would otherwise keep flagging CVEs in files nothing loads.
 
 ### `dns-bind9` image
 
@@ -429,6 +432,15 @@ The `dns-powerdns` image follows the same shape — it swaps `bind`/`named`
 for `pdns_server` (LMDB backend) but ships the same `spatium_dns_agent`
 codebase and the same `spatium-dns-entrypoint`, and exposes the same
 `53/udp 53/tcp`.
+
+The `dns-technitium` image follows the same agent/entrypoint shape too,
+but has no config file for the agent to render at all — Technitium is
+configured entirely over its own HTTP API (`http://127.0.0.1:5380`), so
+`render()`/`validate()`/`swap_and_reload()` collapse into "stash the
+desired zone/record state as JSON, then reconcile it against the live
+API." The agent provisions a permanent API bearer token on first-ever
+boot (via `DNS_SERVER_ADMIN_PASSWORD` + `/api/user/createToken`) the same
+way the PowerDNS driver provisions its local API key.
 
 
 ### Volumes

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -573,6 +573,68 @@ Each driver's `capabilities()` returns the same dict shape Windows / PowerDNS us
 
 ---
 
+## 4B. Technitium Driver (v1)
+
+Third authoritative driver, alongside BIND9 and PowerDNS. Same agent-colocated shape as PowerDNS (control-plane driver is a thin/no-op translator; the real work — reconcile, auth, lifecycle — lives in the agent-side driver talking to the daemon over loopback), but even thinner: Technitium has **no config file for zone/record state at all**. The daemon persists its own config under `/etc/dns` and is configured entirely through its HTTP API (`http://127.0.0.1:5380/api/...`).
+
+### 4B.1 Update Strategy: REST API, full-zone diff reconcile
+
+Unlike PowerDNS's rrset-REPLACE PATCH semantics, Technitium's `/api/zones/records/add` **appends** at a given `(name, type)` by default (round-robin A records coexist without a GET-merge-PATCH dance) and only wipes the rrset when `overwrite=true` is passed explicitly. The agent driver exploits this:
+
+- **Bulk reconcile** (`swap_and_reload`, fired on structural config changes): fetch the zone's full record set via `GET /api/zones/records/get?listZone=true`, diff by `(domain, type, params)` fingerprint against the desired bundle state, then `POST` deletes for what's extra and adds for what's missing. No `update` endpoint call needed — a changed value is just delete-old + add-new, computed from the full diff.
+- **Incremental ops** (`apply_record_op`, fired per live edit): `create`/`update` → `add` with `overwrite=false`; `delete` → `delete` with the exact matching value. Same "update leaves a stale value until an explicit delete" caveat PowerDNS's driver documents for the identical reason (the op payload carries only the new value).
+- Zone apex `NS`/`SOA` are **daemon-managed** — Technitium auto-creates its own SOA + one NS pointing at its own hostname on `/api/zones/create`, so the bundle's apex NS/SOA are intentionally excluded from every reconcile pass (pushing them would create duplicate/foreign records). Off-apex `NS` (delegations) reconcile normally.
+
+### 4B.2 Auth — agent-provisioned bearer token
+
+Technitium has no static local secret file the entrypoint pre-seeds (unlike PowerDNS's API key). Instead:
+
+1. The agent generates a random admin bootstrap password once, persisted the same atomic `O_NOFOLLOW`/0600 way as PowerDNS's API key.
+2. `start_daemon()` passes it via the `DNS_SERVER_ADMIN_PASSWORD` env var on every daemon start — Technitium only consumes it the very first time `/etc/dns` is empty, so this is a harmless no-op on every subsequent start.
+3. On first-ever config apply, the driver calls `GET /api/user/createToken?user=admin&pass=<bootstrap-pw>&tokenName=spatiumddi-agent` **exactly once** and persists the resulting bearer token. Confirmed empirically: `createToken` is **not idempotent on tokenName** — calling it again mints a brand-new token and leaves the old one orphaned on the server — so the local token file's mere presence is the "already provisioned" signal, not an API-side check.
+4. All subsequent calls carry `Authorization: Bearer <token>`. **Auth failure surfaces as HTTP 200** with `{"status": "invalid-token", ...}` in the body — confirmed empirically — so every caller must inspect the JSON `status` field, never the HTTP status code alone.
+
+The token never reaches the control plane — same agent-local trust boundary as PowerDNS's API key and BIND9's TSIG/rndc key.
+
+### 4B.3 Capabilities (v1)
+
+```python
+{
+    "name": "technitium",
+    "views": False,
+    "rpz": False,
+    "dnssec_inline_signing": False,   # fast-follow — see §4B.5
+    "incremental_updates": "rest_api",
+    "zone_types": ["primary"],        # secondary/stub/forward deferred
+    "record_types": [...],            # A/AAAA/CNAME/MX/TXT/NS/PTR/SRV/CAA/
+                                       # TLSA/SSHFP/NAPTR/URI/SOA/SVCB/HTTPS/DNAME
+    "alias_records": False,           # Technitium has ANAME/APP instead —
+                                       # a different shape, not a drop-in
+    "lua_records": False,
+    "catalog_zones": False,
+}
+```
+
+`dynamic_update_caps` is the all-False default (no RFC 2136 client-facing UPDATE listener wired in v1 — all mutation flows through the agent's queued record-op reconciler).
+
+### 4B.4 Record type mapping
+
+Technitium's API takes structured per-type params rather than PowerDNS's single wire-format `content` string — e.g. `ipAddress` for A/AAAA, `cname` for CNAME, `exchange`+`preference` for MX, `target`+`priority`+`weight`+`port` for SRV. SVCB/HTTPS are best-effort: the driver parses the BIND-zone-file-style rdata string SpatiumDDI stores (`'1 . alpn="h2,h3"'`) into Technitium's `svcPriority`/`svcTargetName`/`svcParams` (`key|value` pairs) — confirmed empirically that Technitium's `svcParams` wire format does **not** accept a comma-separated multi-value single param the way BIND's rdata does, so only the first value of a multi-value param carries through (logged as a warning); single-value params round-trip exactly.
+
+### 4B.5 Deferred to fast-follow (not v1)
+
+- **DNSSEC online signing** — Technitium's `/api/zones/dnssec/*` surface is close in shape to PowerDNS's (`sign`/`unsign`/key rollover), should port quickly once picked up.
+- **Native DoT/DoH/DoQ listeners** — Technitium's real differentiator over PowerDNS: it speaks all three natively, so no dnsdist-style sidecar is needed (contrast §9.2). Needs a settings-API spike to confirm the exact `/api/settings/set` shape, which isn't covered by the public zone/record API docs.
+- **Catalog zones, secondary/stub zones + TSIG-authenticated zone transfer.**
+- **Query-log shipping** — Technitium's query logging is API/DB-backed (`/api/logs/query*`), not a tailable text file like BIND9's `query_log_file` or PowerDNS's redirected stderr capture, so it needs a poll-and-diff shipper rather than the existing file-tailing `QueryLogShipper`.
+- **Live-pull `dns_import` importer** for existing Technitium installs (mirrors `services/dns_import/powerdns.py`).
+
+### 4B.6 Image
+
+`ghcr.io/spatiumddi/dns-technitium` builds `FROM technitium/dns-server:<pinned>` (Ubuntu 24.04 + .NET 10, **not Alpine** — see `docs/deployment/DNS_AGENT.md` §7 for why) with the `spatium_dns_agent` wheel layered on top. Healthcheck queries the RFC 6761 reserved `invalid.` TLD rather than a CHAOS-class query — confirmed empirically that Technitium REFUSES `id.server`/`version.bind` CH TXT entirely, unlike BIND9/PowerDNS.
+
+---
+
 ## 5. Driver Selection and Registration
 
 Drivers are registered by name and instantiated by the service layer:
@@ -582,6 +644,7 @@ Drivers are registered by name and instantiated by the service layer:
 _DRIVERS: dict[str, type[DNSDriver]] = {
     "bind9": BIND9Driver,
     "powerdns": PowerDNSDriver,
+    "technitium": TechnitiumDriver,
     "windows_dns": WindowsDNSDriver,
     # Agentless cloud-hosted DNS providers (issue #37, Part B).
     "cloudflare": CloudflareDNSDriver,
@@ -615,12 +678,13 @@ def get_driver(server_type: str) -> DNSDriver:
 
 ### 5.1 Per-group driver homogeneity
 
-Each `DNSServerGroup` is **single-driver**. The control plane rejects mixed BIND + PowerDNS within one group because catalog-zone semantics, AXFR/IXFR shape, and the gate logic for PowerDNS-only features (ALIAS / LUA / online DNSSEC) all assume every member of the group runs the same driver.
+Each `DNSServerGroup` is **single-driver**. The control plane rejects mixing drivers within one group because catalog-zone semantics, AXFR/IXFR shape, and the gate logic for driver-only features (PowerDNS's ALIAS / LUA / online DNSSEC) all assume every member of the group runs the same driver.
 
 Mixed installs work via multiple groups:
 
 - "Internal-zones" group runs PowerDNS (LMDB-backed, fast apply, ALIAS records for apex)
 - "External-zones" group runs BIND9 (battle-tested, RPZ for outbound blocklists, well-known operator surface)
+- "Edge-technitium" group runs Technitium (REST-API driven like PowerDNS, native DoT/DoH/DoQ support once wired — see §4B.5)
 
 ### 5.2 Decision tree — when to pick which driver
 
@@ -632,11 +696,13 @@ Mixed installs work via multiple groups:
 | One-toggle online DNSSEC with auto NSEC3 | **PowerDNS** |
 | Manual NSEC3 + KSK / ZSK rollover control | **BIND9** |
 | First-class views / split-horizon (issue #24) | **BIND9** |
-| Catalog zones as **producer** | Either — same wire bytes |
+| Catalog zones as **producer** | BIND9 or PowerDNS — same wire bytes |
 | Catalog zones as **consumer** | **BIND9** today (PowerDNS waits for 4.10+) |
+| Native DoT/DoH/DoQ with no sidecar (once wired, §4B.5) | **Technitium** |
+| Simple REST-driven primary zones, minimal footprint | **PowerDNS** or **Technitium** |
 | Active Directory-integrated DNS | **Windows DNS** (separate path) |
 
-Both BIND9 and PowerDNS drivers are supported indefinitely. PowerDNS landed in issue #127 as a second driver, not a replacement.
+BIND9, PowerDNS, and Technitium drivers are all supported indefinitely. PowerDNS landed in issue #127 as a second driver; Technitium landed as a third, not a replacement for either.
 
 ---
 

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -17,35 +17,38 @@ SpatiumDDI manages DNS servers as first-class resources. It acts as the **author
 
 ---
 
-## 0. Driver choice — BIND9, PowerDNS, or Windows DNS
+## 0. Driver choice — BIND9, PowerDNS, Technitium, or Windows DNS
 
-SpatiumDDI ships three authoritative DNS drivers. Pick **per server group** — every server inside a group runs the same driver, but mixed installs (one group on BIND, another on PowerDNS, a third on Windows) are first-class. The driver registry is in [`drivers/dns/__init__.py`](../../backend/app/drivers/dns/__init__.py); the per-driver internals are in [`docs/drivers/DNS_DRIVERS.md`](../drivers/DNS_DRIVERS.md).
+SpatiumDDI ships four authoritative DNS drivers. Pick **per server group** — every server inside a group runs the same driver, but mixed installs (one group on BIND, another on PowerDNS, a third on Technitium, a fourth on Windows) are first-class. The driver registry is in [`drivers/dns/__init__.py`](../../backend/app/drivers/dns/__init__.py); the per-driver internals are in [`docs/drivers/DNS_DRIVERS.md`](../drivers/DNS_DRIVERS.md).
 
-| Capability | BIND9 | PowerDNS | Windows DNS |
-|---|:---:|:---:|:---:|
-| Authoritative zone serving | ✅ | ✅ | ✅ |
-| Recursive resolver | ✅ | — (recursor is a separate daemon) | ✅ |
-| Record CRUD wire protocol | RFC 2136 + rndc | REST API (PATCH rrsets) | RFC 2136 (Path A) / WinRM (Path B) |
-| Zone CRUD wire protocol | rndc addzone / delzone | REST API | WinRM (Path B only) |
-| ALIAS records (CNAME at apex) | — | ✅ | — |
-| LUA records (computed responses) | — | ✅ | — |
-| Online DNSSEC signing | ✅ inline-signing (#49) | ✅ one-toggle | manual |
-| Catalog zones (RFC 9432) — producer | ✅ | ✅ | — |
-| Catalog zones (RFC 9432) — consumer | ✅ | — (waits for pdns 4.10+) | — |
-| First-class views / split-horizon | ✅ | tag-based, not surfaced as views in UI | — (replication scope) |
-| RPZ blocklists | ✅ | — (recursor feature only) | — |
-| AD-integrated zones | — | — | ✅ |
-| Agent shape | sidecar agent + named | sidecar agent + pdns_server | agentless (control plane → WinRM) |
+| Capability | BIND9 | PowerDNS | Technitium | Windows DNS |
+|---|:---:|:---:|:---:|:---:|
+| Authoritative zone serving | ✅ | ✅ | ✅ | ✅ |
+| Recursive resolver | ✅ | — (recursor is a separate daemon) | ✅ (own daemon, not exposed in v1) | ✅ |
+| Record CRUD wire protocol | RFC 2136 + rndc | REST API (PATCH rrsets) | REST API (per-record add/delete) | RFC 2136 (Path A) / WinRM (Path B) |
+| Zone CRUD wire protocol | rndc addzone / delzone | REST API | REST API | WinRM (Path B only) |
+| ALIAS records (CNAME at apex) | — | ✅ | — (has ANAME/APP instead — deferred) | — |
+| LUA records (computed responses) | — | ✅ | — | — |
+| Online DNSSEC signing | ✅ inline-signing (#49) | ✅ one-toggle | — (fast-follow) | manual |
+| Native DoT/DoH/DoQ (no sidecar) | — | — (needs dnsdist sidecar) | — (fast-follow — daemon supports it natively) | — |
+| Catalog zones (RFC 9432) — producer | ✅ | ✅ | — (fast-follow) | — |
+| Catalog zones (RFC 9432) — consumer | ✅ | — (waits for pdns 4.10+) | — | — |
+| First-class views / split-horizon | ✅ | tag-based, not surfaced as views in UI | — | — (replication scope) |
+| RPZ blocklists | ✅ | — (recursor feature only) | — | — |
+| AD-integrated zones | — | — | — | ✅ |
+| Agent shape | sidecar agent + named | sidecar agent + pdns_server | sidecar agent + DnsServerApp.dll | agentless (control plane → WinRM) |
 
 **Default driver: BIND9.** It is the reference implementation, ubiquitous in operator muscle memory, and runs the catalog-zone consumer + RPZ paths SpatiumDDI ships.
 
 **Pick PowerDNS when** you need ALIAS records (CNAME-at-apex without the BIND-side workaround), LUA records (geo-routing / weighted answers / `pickrandom` / `ifportup`), or the simpler one-toggle online DNSSEC story. The shipped image (`ghcr.io/spatiumddi/dns-powerdns`) bundles `pdns 4.9 + pdns-backend-lmdb` for an agent-isolated zone store with no external Postgres dependency. See [issue #127](https://github.com/spatiumddi/spatiumddi/issues/127) for the full driver rationale.
 
+**Pick Technitium when** you want a minimal-footprint REST-driven primary-zone host and don't (yet) need DNSSEC or ALIAS/LUA — v1 covers primary zones + standard record types (A/AAAA/CNAME/MX/TXT/NS/PTR/SRV/CAA/TLSA/SSHFP/NAPTR/URI/SVCB/HTTPS/DNAME). Its real long-term differentiator is native DNS-over-TLS/HTTPS/QUIC support with no dnsdist-style sidecar (PowerDNS's approach) — that wiring is a fast-follow, tracked in [`docs/drivers/DNS_DRIVERS.md` §4B.5](../drivers/DNS_DRIVERS.md).
+
 **Pick Windows DNS when** the zone is AD-integrated and operators expect to keep using DNS Manager / `Add-DnsServerResourceRecord` directly. Path A (RFC 2136 + AXFR) works without admin credentials; Path B (WinRM + PowerShell) unlocks zone CRUD and a JSON record-pull that sidesteps AXFR ACL configuration.
 
-PowerDNS-only features (ALIAS / LUA / online DNSSEC sign+unsign) are server-side gated by the API's `_DRIVER_GATED_RECORD_TYPES` and `_DRIVER_GATED_OPERATIONS` maps. Calling them against a BIND9 / Windows / mixed group returns 422 with a remediation message — move the zone to a PowerDNS-only group, or add a PowerDNS server to the group, before retrying.
+PowerDNS-only features (ALIAS / LUA / online DNSSEC sign+unsign) are server-side gated by the API's `_DRIVER_GATED_RECORD_TYPES` and `_DRIVER_GATED_OPERATIONS` maps. Calling them against a group without a PowerDNS member returns 422 with a remediation message — move the zone to a PowerDNS-only group, or add a PowerDNS server to the group, before retrying. SVCB / HTTPS / DNAME are gated to BIND9, PowerDNS, and Technitium (all three serve them natively).
 
-The Operator Copilot's `propose_create_dns_zone` tool accepts an explicit `driver_hint` argument (`bind9` / `powerdns` / `windows_dns`) so the LLM can route DNSSEC-required zones to PowerDNS groups without operators having to specify the group UUID by hand. See `app.services.ai.operations.CreateDNSZoneArgs`.
+The Operator Copilot's `propose_create_dns_zone` tool accepts an explicit `driver_hint` argument (`bind9` / `powerdns` / `technitium` / `windows_dns`) so the LLM can route DNSSEC-required zones to PowerDNS groups without operators having to specify the group UUID by hand. See `app.services.ai.operations.CreateDNSZoneArgs`.
 
 ### 0a. Cloud DNS providers — Cloudflare / Route 53 / Azure DNS / Google Cloud DNS (issue #37)
 
@@ -1405,6 +1408,7 @@ validation — use one group per provider.
 |---|---|---|
 | **BIND9** | Native (`tls` + `http` statements) | Yes (`forwarders { … tls … }`) |
 | **PowerDNS** | Via the dnsdist front (#146 Phase 2) | N/A — pdns Authoritative doesn't recurse or forward |
+| **Technitium** | Not wired yet — daemon supports DoT/DoH/DoQ natively, no sidecar needed (fast-follow, see [`docs/drivers/DNS_DRIVERS.md` §4B.5](../drivers/DNS_DRIVERS.md)) | N/A — v1 driver is authoritative-only |
 | Windows DNS, cloud drivers | Not supported — we don't run their listeners | — |
 
 On PowerDNS the listeners are `addTLSLocal` / `addDOHLocal` on the dnsdist

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -203,6 +203,30 @@ server {
         proxy_send_timeout       1800s;
     }
 
+    # Appliance upgrade-image upload (air-gapped slot-image upload, e.g.
+    # dns-technitium / dns-bind9 / dhcp-kea A/B slot images). Same shape
+    # as the backup location above but sized to the backend's own
+    # ``MAX_UPLOAD_BYTES`` cap (4 GiB, app/api/v1/appliance/
+    # upgrade_images.py) — appliance slot images run ~1.8-2 GB, so the
+    # 2g backup limit isn't enough. Without this override the request
+    # falls through to the generic /api/ location below and nginx's
+    # ~1 MB default silently 413s the upload before it ever reaches
+    # FastAPI's own (more informative) size-check error.
+    location /api/v1/appliance/upgrade-images {
+        set $api_upstream http://${API_UPSTREAM_HOST}:${API_UPSTREAM_PORT};
+        proxy_pass               $api_upstream;
+        proxy_set_header         Host $http_host;
+        proxy_set_header         X-Real-IP $remote_addr;
+        proxy_set_header         X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header         X-Forwarded-Proto $scheme;
+        proxy_http_version       1.1;
+        proxy_set_header         Connection "";
+        client_max_body_size     4g;
+        proxy_request_buffering  off;
+        proxy_read_timeout       1800s;
+        proxy_send_timeout       1800s;
+    }
+
     # Proxy API calls to the backend. Using a variable for proxy_pass
     # forces nginx to re-resolve the upstream on each request via the
     # resolver above (instead of binding at config-load time).

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10200,6 +10200,7 @@ export type ApplianceState =
 export interface SupervisorCapabilities {
   can_run_dns_bind9?: boolean;
   can_run_dns_powerdns?: boolean;
+  can_run_dns_technitium?: boolean;
   can_run_dhcp?: boolean;
   can_run_looking_glass?: boolean;
   can_run_observer?: boolean;
@@ -10350,7 +10351,8 @@ export interface ApplianceRow {
   role_switch_reason: string | null;
   // #170 Wave E — supervisor's service-container watchdog. Free-form
   // map keyed by compose service name (``dns-bind9`` / ``dns-powerdns``
-  // / ``dhcp-kea``); each value carries the per-service health verdict.
+  // / ``dns-technitium`` / ``dhcp-kea``); each value carries the
+  // per-service health verdict.
   // Empty when the supervisor hasn't run a watchdog probe yet or the
   // appliance is idle (no roles assigned).
   role_health: Record<

--- a/frontend/src/pages/appliance/FirewallTab.tsx
+++ b/frontend/src/pages/appliance/FirewallTab.tsx
@@ -56,6 +56,7 @@ import { cn } from "@/lib/utils";
 const ROLE_OPTIONS = [
   "dns-bind9",
   "dns-powerdns",
+  "dns-technitium",
   "dhcp",
   "observer",
   "custom",

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -138,6 +138,8 @@ function capabilityChips(caps: SupervisorCapabilities): {
   if (caps.can_run_dns_bind9) out.push({ key: "bind9", label: "BIND9" });
   if (caps.can_run_dns_powerdns)
     out.push({ key: "powerdns", label: "PowerDNS" });
+  if (caps.can_run_dns_technitium)
+    out.push({ key: "technitium", label: "Technitium" });
   if (caps.can_run_dhcp) out.push({ key: "dhcp", label: "DHCP" });
   if (caps.can_run_looking_glass)
     out.push({ key: "looking-glass", label: "Looking Glass" });
@@ -178,6 +180,12 @@ function serviceChips(row: ApplianceRow): {
     out.push({
       key: "dns-powerdns",
       label: "DNS · PowerDNS",
+      status: serviceStatus,
+    });
+  if (roles.includes("dns-technitium"))
+    out.push({
+      key: "dns-technitium",
+      label: "DNS · Technitium",
       status: serviceStatus,
     });
   if (roles.includes("dhcp"))
@@ -2496,6 +2504,10 @@ function ApplianceDrilldownModal({
           <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
             <CapRow label="DNS — BIND9" on={!!caps.can_run_dns_bind9} />
             <CapRow label="DNS — PowerDNS" on={!!caps.can_run_dns_powerdns} />
+            <CapRow
+              label="DNS — Technitium"
+              on={!!caps.can_run_dns_technitium}
+            />
             <CapRow label="DHCP" on={!!caps.can_run_dhcp} />
             <CapRow label="Looking Glass" on={!!caps.can_run_looking_glass} />
             <CapRow label="Observer" on={!!caps.can_run_observer} />
@@ -2713,6 +2725,11 @@ const ROLE_OPTIONS: { value: string; label: string; capKey?: string }[] = [
     label: "DNS · PowerDNS",
     capKey: "can_run_dns_powerdns",
   },
+  {
+    value: "dns-technitium",
+    label: "DNS · Technitium",
+    capKey: "can_run_dns_technitium",
+  },
   { value: "dhcp", label: "DHCP", capKey: "can_run_dhcp" },
   {
     value: "looking-glass",
@@ -2721,6 +2738,12 @@ const ROLE_OPTIONS: { value: string; label: string; capKey?: string }[] = [
   },
   { value: "observer", label: "Observer", capKey: "can_run_observer" },
 ];
+
+// Mutually-exclusive DNS engine roles — at most one may be active at a
+// time (one DNS daemon per appliance). Used by the role toggle handler
+// and every "is a DNS role assigned" check below instead of an
+// enumerated pairwise comparison, so a fourth driver is a one-line add.
+const DNS_ROLES = new Set(["dns-bind9", "dns-powerdns", "dns-technitium"]);
 
 // ── Service-container watchdog section (#170 Wave E) ───────────
 //
@@ -3699,17 +3722,18 @@ function ApplianceRoleAssignmentSection({
       if (next.has(role)) {
         next.delete(role);
       } else {
-        // Mutually-exclusive DNS engines — selecting one clears the
-        // other so the operator can't submit an invalid combo.
-        if (role === "dns-bind9") next.delete("dns-powerdns");
-        if (role === "dns-powerdns") next.delete("dns-bind9");
+        // Mutually-exclusive DNS engines — selecting one clears every
+        // other dns-* role so the operator can't submit an invalid combo.
+        if (DNS_ROLES.has(role)) {
+          for (const r of DNS_ROLES) next.delete(r);
+        }
         next.add(role);
       }
       return next;
     });
   }
 
-  const dnsRoleActive = roles.has("dns-bind9") || roles.has("dns-powerdns");
+  const dnsRoleActive = Array.from(roles).some((r) => DNS_ROLES.has(r));
   const dhcpRoleActive = roles.has("dhcp");
   // ``dirty`` compares the live form state against the latest
   // server-side row (the row prop refreshes after save), not the
@@ -3727,7 +3751,7 @@ function ApplianceRoleAssignmentSection({
   // service ports. Mirrors the supervisor's firewall_renderer.py
   // logic so operators see what will actually land on the host.
   const firewallProfile = (() => {
-    const hasDns = roles.has("dns-bind9") || roles.has("dns-powerdns");
+    const hasDns = Array.from(roles).some((r) => DNS_ROLES.has(r));
     const hasDhcp = roles.has("dhcp");
     if (hasDns && hasDhcp) return "dns-and-dhcp";
     if (hasDns) return "dns-only";
@@ -3735,7 +3759,7 @@ function ApplianceRoleAssignmentSection({
     return "idle";
   })();
   const firewallOpenPorts: string[] = [];
-  if (roles.has("dns-bind9") || roles.has("dns-powerdns")) {
+  if (Array.from(roles).some((r) => DNS_ROLES.has(r))) {
     firewallOpenPorts.push("UDP/53", "TCP/53");
   }
   if (roles.has("dhcp")) {
@@ -5131,6 +5155,7 @@ function UpgradeImageManager() {
 const _ROLE_PORT_KEYS: Record<string, string[]> = {
   "dns-bind9": ["udp_53", "tcp_53"],
   "dns-powerdns": ["udp_53", "tcp_53"],
+  "dns-technitium": ["udp_53", "tcp_53"],
   dhcp: ["udp_67"],
   "looking-glass": ["tcp_179"],
 };

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -1301,6 +1301,7 @@ function ServerModal({
             >
               <option value="bind9">BIND9 (agent-managed)</option>
               <option value="powerdns">PowerDNS (agent-managed)</option>
+              <option value="technitium">Technitium (agent-managed)</option>
               <option value="windows_dns">
                 Windows DNS (agentless, RFC 2136 + optional WinRM)
               </option>
@@ -1336,6 +1337,19 @@ function ServerModal({
             storage; no external DB needed). Records apply via the local
             PowerDNS REST API on port 8081 (loopback only). The agent generates
             and rotates the API key automatically — leave the field below blank.
+          </div>
+        )}
+        {driver === "technitium" && (
+          <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-800 dark:text-emerald-300">
+            <strong>Technitium:</strong> agent-managed. Run the{" "}
+            <code className="rounded bg-emerald-500/20 px-1">
+              ghcr.io/spatiumddi/dns-technitium
+            </code>{" "}
+            container alongside this server. v1 supports primary zones +
+            standard record types; DNSSEC, native DoT/DoH/DoQ listeners, and
+            secondary zones are on the roadmap. The agent provisions and
+            rotates its own API token automatically — leave the field below
+            blank.
           </div>
         )}
         {cloudDriver && (
@@ -1379,13 +1393,15 @@ function ServerModal({
                   placeholder={
                     driver === "powerdns"
                       ? "8081 (PowerDNS REST, loopback)"
-                      : driver === "bind9"
-                        ? "953 (rndc)"
-                        : "953 / 8081"
+                      : driver === "technitium"
+                        ? "5380 (Technitium API, loopback)"
+                        : driver === "bind9"
+                          ? "953 (rndc)"
+                          : "953 / 8081"
                   }
                 />
               </Field>
-              {driver === "powerdns" ? (
+              {driver === "powerdns" || driver === "technitium" ? (
                 <Field label="API Key">
                   <input
                     className={`${inputCls} bg-muted/50 cursor-not-allowed`}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -225,13 +225,13 @@ helm install ddi oci://ghcr.io/spatiumddi/charts/spatiumddi \
 
 Declare each DNS server under `.dnsAgents.servers[]` in `values.yaml`.
 The chart renders a StatefulSet + LoadBalancer Service per entry.
-Set `flavor: powerdns` on a server to pull the
-`ghcr.io/spatiumddi/dns-powerdns` image instead of BIND9 — same
-`DNS_AGENT_KEY` bootstrap, image-baked driver, mount path
-auto-switches to `/var/lib/powerdns` for the LMDB store.
-Mixed-driver groups are rejected by the control plane for the
-PowerDNS-only features (DNSSEC sign/unsign, ALIAS, LUA, catalog
-zones); spin up a separate group per driver.
+Set `flavor: powerdns` or `flavor: technitium` on a server to pull the
+`ghcr.io/spatiumddi/dns-powerdns` / `ghcr.io/spatiumddi/dns-technitium`
+image instead of BIND9 — same `DNS_AGENT_KEY` bootstrap, image-baked
+driver, mount path auto-switches to `/var/lib/powerdns` or `/etc/dns`
+respectively. Mixed-driver groups are rejected by the control plane for
+driver-specific features (PowerDNS: DNSSEC sign/unsign, ALIAS, LUA,
+catalog zones); spin up a separate group per driver.
 
 ### Encrypted transports — DoT / DoH (issue #50)
 


### PR DESCRIPTION
## Summary

Adds Technitium as a fully agent-managed authoritative DNS driver alongside BIND9 and PowerDNS, wired end-to-end through the OS appliance:

- Control-plane driver (`backend/app/drivers/dns/technitium.py`) + agent driver (`agent/dns/spatium_dns_agent/drivers/technitium.py`) reconciling zones/records against Technitium's REST API, with agent-provisioned bearer-token auth (mirrors PowerDNS's local-API-key trust boundary).
- New `ghcr.io/spatiumddi/dns-technitium` container image (Ubuntu/glibc base — Technitium ships no Alpine package or release binaries).
- Docker Compose, CI (build matrix, release jobs, Trivy, kind e2e), and full appliance integration: supervisor role tables, firewall policy layer + seed migration, umbrella + appliance Helm charts, Fleet UI.
- **v1 scope**: primary zones + standard record CRUD. DNSSEC, native DoT/DoH/DoQ, catalog zones, secondary zones, and `dns_import` are tracked as fast-follow (see `docs/drivers/DNS_DRIVERS.md` §4B.5).

Also fixes two pre-existing bugs (not Technitium-specific) surfaced by live appliance testing on real hardware:

- `SupervisorCapabilities` is a strict Pydantic model that silently drops any capability flag it doesn't explicitly declare, despite its docstring's "ignores unknown keys" framing. `can_run_dns_technitium` was added on the supervisor side but never declared here, so the Fleet UI reported "supervisor doesn't advertise" even though the real supervisor was sending it. Added the field plus a regression test locking the full flag set.
- nginx's `client_max_body_size` override for large uploads only covered `/api/v1/backup/`, so the appliance upgrade-image upload endpoint (`/api/v1/appliance/upgrade-images`, backend-capped at 4 GiB) fell through to nginx's ~1MB default and 413'd every real slot-image upload. Added a matching override in all three nginx config copies (docker-compose, appliance ISO, Helm chart).

## Test plan

- [x] Unit tests: control-plane driver (14 tests), agent driver (21 tests), full agent suite (90 tests), full supervisor suite (252 tests) — all passing
- [x] Live docker-compose test against a real control plane: zone/record create/update/delete propagate to a real Technitium daemon and resolve via `dig`; agent cache survives a control-plane outage; recovers cleanly from a full 401/404 rebootstrap cycle
- [x] Real kind cluster e2e for both the umbrella chart and the appliance-specific chart (the exact DaemonSet template the ISO deploys) — real registration, token provisioning, and DNS resolution
- [x] 336 passing backend tests (appliance + firewall suites) after all supervisor/chart/firewall changes; clean frontend typecheck/lint
- [x] Trivy-clean container image (fixed a real vulnerable-runtime issue in the upstream base image along the way)
- [x] Built the actual appliance ISO + A/B slot image with `dns-technitium` baked in for air-gapped installs
- [x] Ran a fully automated, preseeded disk install inside QEMU — real GRUB A/B slot menu, k3s core came up Ready
- [x] Verified the two bug fixes live: role assignment for `dns-technitium` and a real 2.1 GB upgrade-image upload both confirmed working end-to-end on a real installed test appliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)