### PR TITLE
feat(dns): complete the Technitium driver — zone types, DNSSEC, encrypted transports, blocklists, importer

### DIFF
--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -115,6 +115,30 @@ _ZONE_TRANSFER_VALUES = frozenset(
     }
 )
 
+# ── DNSSEC (issue #740) ─────────────────────────────────────────────────
+#
+# Signing artefacts the daemon owns. They show up in ``zones/records/get``
+# the moment a zone is signed, so the reconciler MUST filter them: they
+# are not in the bundle, so every pass would otherwise try to delete the
+# zone's own signatures.
+_DNSSEC_RECORD_TYPES = frozenset(
+    {"DNSKEY", "RRSIG", "NSEC", "NSEC3", "NSEC3PARAM", "DS"}
+)
+
+# Defaults for ``zones/dnssec/sign``. The neutral op carries no algorithm
+# (it is a bare "sign this zone" from the UI), and BIND expresses the
+# choice through a dnssec-policy name that means nothing here — so pick
+# the same modern default PowerDNS's one-toggle story lands on.
+# Verified live: ECDSA/P256/RSA/EDDSA and NSEC/NSEC3 all sign successfully.
+_DNSSEC_SIGN_DEFAULTS = {"algorithm": "ECDSA", "curve": "P256", "nxProof": "NSEC"}
+
+# DS digest-type name → the number that goes in a DS record's presentation
+# form (RFC 4034 §5.1.3 / RFC 8624).
+_DS_DIGEST_TYPES = {"SHA1": 1, "SHA256": 2, "GOST": 3, "SHA384": 4}
+
+# Technitium key-type names → the ksk/zsk/csk vocabulary DNSKeyReport uses.
+_DNSSEC_KEY_TYPES = {"KeySigningKey": "ksk", "ZoneSigningKey": "zsk"}
+
 # Technitium's supported TSIG algorithms, as its settings API spells them.
 _TSIG_ALGORITHMS = frozenset(
     {
@@ -721,6 +745,15 @@ class TechnitiumDriver(DriverBase):
 
         zone = op["zone_name"].rstrip(".")
         op_kind = op["op"]
+
+        # DNSSEC ops (issue #740) are zone-level, not rrset-shaped. They
+        # ride the same record-op queue but branch off before any of the
+        # record machinery below, exactly as the PowerDNS driver does.
+        if op_kind == "dnssec_sign":
+            return {"dnssec_state": self._dnssec_sign(token, zone)}
+        if op_kind == "dnssec_unsign":
+            return {"dnssec_state": self._dnssec_unsign(token, zone)}
+
         rec = op["record"]
         rtype = (rec.get("type") or "").upper()
         name = _qualified_name(zone, rec.get("name") or "@")
@@ -765,6 +798,113 @@ class TechnitiumDriver(DriverBase):
             "technitium_record_op_applied", zone=zone, name=name, type=rtype, op=op_kind
         )
         return None
+
+    # ── DNSSEC (issue #740) ─────────────────────────────────────────────
+
+    def _dnssec_sign(self, token: str, zone: str) -> dict[str, Any]:
+        """Sign the zone, then report its DS rrset + per-key state.
+
+        Idempotent by the same reasoning as PowerDNS's: repeated "Sign
+        zone" clicks should converge on "signed", not error. Technitium
+        answers an already-signed zone with ``Cannot sign zone: the zone
+        is already signed.`` (verified live), which is treated as success
+        so the collect below still reports current state.
+        """
+        resp = self._call(
+            token, "POST", "zones/dnssec/sign", {"zone": zone, **_DNSSEC_SIGN_DEFAULTS}
+        )
+        body = resp.json()
+        if body.get("status") != "ok":
+            msg = (body.get("errorMessage") or "").lower()
+            if "already signed" not in msg:
+                raise RuntimeError(
+                    f"Technitium sign {zone} failed: {body.get('errorMessage')}"
+                )
+            log.info("technitium_dnssec_already_signed", zone=zone)
+        else:
+            log.info("technitium_dnssec_signed", zone=zone)
+        return self._collect_dnssec_state(token, zone)
+
+    def _dnssec_unsign(self, token: str, zone: str) -> dict[str, Any]:
+        """Unsign, and report empty DS + no keys so the control plane
+        clears its cache — a stale DS left on display is one the parent
+        zone no longer trusts."""
+        resp = self._call(token, "POST", "zones/dnssec/unsign", {"zone": zone})
+        body = resp.json()
+        if body.get("status") != "ok":
+            msg = (body.get("errorMessage") or "").lower()
+            if "not signed" not in msg and "unsigned" not in msg:
+                raise RuntimeError(
+                    f"Technitium unsign {zone} failed: {body.get('errorMessage')}"
+                )
+        log.info("technitium_dnssec_unsigned", zone=zone)
+        return {"zone_name": zone, "ds_records": [], "keys": []}
+
+    def _collect_dnssec_state(self, token: str, zone: str) -> dict[str, Any]:
+        """Build the control plane's DNSSEC report for one zone.
+
+        Two calls, because Technitium splits the information:
+
+        * ``zones/dnssec/properties/get`` has the key inventory (tag, type,
+          algorithm number, rollover state) but **no DS records at all**.
+        * The DS material lives on the zone's own DNSKEY records, under
+          ``rData.computedDigests`` — and only on the KSK, since a DS
+          attests the key-signing key to the parent. Each KSK yields one
+          digest per supported type (SHA256 + SHA384 observed), all of
+          which the operator should publish to cover validators of
+          differing sophistication.
+
+        Unlike PowerDNS's agent this reports ``keys`` as well as
+        ``ds_records``, because Technitium exposes per-key state and the
+        control plane already models it (issue #49's ``DNSKey`` rows).
+        """
+        props = self._call(
+            token, "GET", "zones/dnssec/properties/get", {"zone": zone}
+        ).json()
+        priv = (props.get("response") or {}).get("dnssecPrivateKeys") or []
+        algo_by_tag = {
+            k.get("keyTag"): int(k.get("algorithmNumber") or 0) for k in priv
+        }
+
+        ds_records: list[str] = []
+        keys: list[dict[str, Any]] = []
+        recs = self._call(
+            token,
+            "GET",
+            "zones/records/get",
+            {"domain": zone, "zone": zone, "listZone": "true"},
+        ).json()
+        for rec in (recs.get("response") or {}).get("records") or []:
+            if rec.get("type") != "DNSKEY":
+                continue
+            rdata = rec.get("rData") or {}
+            key_tag = rdata.get("computedKeyTag")
+            algorithm = int(rdata.get("algorithmNumber") or algo_by_tag.get(key_tag) or 0)
+            for digest in rdata.get("computedDigests") or []:
+                digest_num = _DS_DIGEST_TYPES.get(str(digest.get("digestType")).upper())
+                value = digest.get("digest")
+                if not (key_tag and digest_num and value):
+                    continue
+                ds_records.append(f"{key_tag} {algorithm} {digest_num} {value}")
+
+        for k in priv:
+            keys.append(
+                {
+                    "key_tag": int(k.get("keyTag") or 0),
+                    "key_type": _DNSSEC_KEY_TYPES.get(str(k.get("keyType")), "zsk"),
+                    "algorithm": int(k.get("algorithmNumber") or 0),
+                    "state": str(k.get("state") or "unknown").lower(),
+                    "timing": {
+                        key: k[src]
+                        for key, src in (
+                            ("state_changed_on", "stateChangedOn"),
+                            ("state_ready_by", "stateReadyBy"),
+                        )
+                        if k.get(src)
+                    },
+                }
+            )
+        return {"zone_name": zone, "ds_records": ds_records, "keys": keys}
 
     def _reconcile_zones(self, token: str, payload: list[dict[str, Any]]) -> None:
         """Bring each zone's record set in line with ``payload`` via a
@@ -979,6 +1119,12 @@ class TechnitiumDriver(DriverBase):
         for rec in body.get("response", {}).get("records") or []:
             rtype = rec.get("type")
             if rtype in _DAEMON_MANAGED_APEX_TYPES:
+                continue
+            # Signing artefacts belong to the daemon, not the bundle. A
+            # signed zone serves DNSKEY/RRSIG/NSEC* that no bundle
+            # describes, so without this the reconciler tries to delete
+            # the zone's own signatures on every pass.
+            if rtype in _DNSSEC_RECORD_TYPES:
                 continue
             # Apex NS is daemon-managed too (Technitium stamps one pointing
             # at its own hostname at zone-create). Filter it HERE rather

--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -160,6 +160,29 @@ _FORWARDER_PROTOCOLS = {
     "quic": "Quic",
 }
 
+# ── Blocklists (issue #744) ─────────────────────────────────────────────
+#
+# Technitium has no RPZ. It blocks natively, either from subscribed URL
+# lists or from a per-domain "blocked zones" set, so SpatiumDDI's
+# effective blocklist entries map onto the latter (``blocked/add`` /
+# ``blocked/delete``) and its exceptions onto the allowed set.
+#
+# ``blockingType`` decides what a blocked name answers with. Like
+# ``zoneTransfer`` it SILENTLY IGNORES an unrecognised value — verified:
+# ``blockingType="Bogus"`` returns ok and leaves the previous mode — so it
+# is validated here rather than trusted to fail loudly.
+_BLOCKING_TYPES = frozenset({"NxDomain", "AnyAddress", "CustomAddress"})
+
+# Neutral block_mode → Technitium blocking type. ``sinkhole`` / ``redirect``
+# both answer with an operator-chosen address, which is CustomAddress;
+# ``passthru`` is not a blocking mode at all (it is an exception, handled
+# through the allowed set).
+_BLOCK_MODE_TYPES = {
+    "nxdomain": "NxDomain",
+    "sinkhole": "CustomAddress",
+    "redirect": "CustomAddress",
+}
+
 # Technitium's supported TSIG algorithms, as its settings API spells them.
 _TSIG_ALGORITHMS = frozenset(
     {
@@ -362,6 +385,69 @@ def _zone_options_payload(ztype: str, bundle: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _blocking_payload(bundle: dict[str, Any]) -> dict[str, Any]:
+    """Flatten the bundle's effective blocklists into Technitium's shape.
+
+    SpatiumDDI models blocking as RPZ zones with per-entry actions;
+    Technitium has a flat blocked-domain set plus an allowed set that
+    overrides it. So:
+
+    * ``action="block"`` entries become blocked domains.
+    * ``action="allow"`` / ``block_mode="passthru"`` entries, and each
+      list's ``exceptions``, become allowed domains — Technitium's
+      allowed set is exactly an RPZ passthru.
+
+    Per-view blocklists collapse into the same flat set: Technitium's
+    native blocking is server-wide with no view concept, and the driver
+    already declines views outright. Collapsing is the honest reading of
+    "block these names on this server" — the alternative would be to
+    silently apply one view's list to every client.
+
+    ``is_wildcard`` is dropped deliberately: Technitium blocks a domain
+    *and its subdomains* by default, so an exact-match entry and a
+    wildcard entry land the same way. Flagged in the driver docs rather
+    than silently pretending the distinction survives.
+    """
+    blocked: set[str] = set()
+    allowed: set[str] = set()
+    modes: set[str] = set()
+    custom_addresses: set[str] = set()
+
+    for bl in bundle.get("blocklists") or []:
+        for exc in bl.get("exceptions") or []:
+            if exc:
+                allowed.add(str(exc).rstrip(".").lower())
+        for entry in bl.get("entries") or []:
+            domain = str(entry.get("domain") or "").rstrip(".").lower()
+            if not domain:
+                continue
+            action = str(entry.get("action") or "block").lower()
+            mode = str(entry.get("block_mode") or "nxdomain").lower()
+            if action != "block" or mode == "passthru":
+                allowed.add(domain)
+                continue
+            blocked.add(domain)
+            mapped = _BLOCK_MODE_TYPES.get(mode)
+            if mapped:
+                modes.add(mapped)
+            if mode in ("sinkhole", "redirect") and entry.get("target"):
+                custom_addresses.add(str(entry["target"]))
+
+    # One server-wide blocking type has to cover every entry. If the lists
+    # disagree, prefer the address-answering mode: it is the more specific
+    # intent (an operator asked for a sinkhole), and NxDomain would drop
+    # the sinkhole silently.
+    blocking_type = "CustomAddress" if "CustomAddress" in modes else "NxDomain"
+
+    return {
+        "enabled": bool(blocked),
+        "blocked": sorted(blocked),
+        "allowed": sorted(allowed),
+        "blocking_type": blocking_type,
+        "custom_addresses": sorted(custom_addresses),
+    }
+
+
 def _record_params(rtype: str, value: str, rec: dict[str, Any]) -> dict[str, Any]:
     """Build the type-specific param dict for
     ``/api/zones/records/{add,delete}`` — shared by both endpoints since
@@ -536,15 +622,6 @@ class TechnitiumDriver(DriverBase):
                 entry["forwarders"] = forwarders
             zones_payload.append(entry)
 
-        if bundle.get("blocklists"):
-            log.warning(
-                "technitium_blocklists_unsupported",
-                blocklist_count=len(bundle["blocklists"]),
-                hint=(
-                    "Wiring SpatiumDDI's blocklist model to Technitium's "
-                    "native blocking apps is a fast-follow, not v1 scope."
-                ),
-            )
 
         (new_dir / "zones.json").write_text(json.dumps(zones_payload, indent=2))
 
@@ -557,6 +634,9 @@ class TechnitiumDriver(DriverBase):
             # swap_and_reload can apply them without re-reading the bundle.
             "options": bundle.get("options") or {},
             "tls_cert": bundle.get("tls_cert") or None,
+            # Blocklists (#744). Flattened here rather than in the apply
+            # path so the rendered snapshot is the whole desired state.
+            "blocking": _blocking_payload(bundle),
             "tsig_keys": [
                 {
                     "name": (k.get("name") or "").rstrip("."),
@@ -641,6 +721,10 @@ class TechnitiumDriver(DriverBase):
                 token, server_options, server_state.get("tls_cert")
             )
             self._apply_forwarders(token, server_options)
+
+        # Blocklists (#744). Always applied, even when empty — an emptied
+        # list has to actually clear on the daemon.
+        self._apply_blocking(token, server_state.get("blocking") or {})
 
         self._reconcile_zones(token, payload)
         self._apply_catalog(token, server_state.get("catalog"), payload)
@@ -863,6 +947,92 @@ class TechnitiumDriver(DriverBase):
             "technitium_record_op_applied", zone=zone, name=name, type=rtype, op=op_kind
         )
         return None
+
+    # ── Blocklists (issue #744) ─────────────────────────────────────────
+
+    def _apply_blocking(self, token: str, blocking: dict[str, Any]) -> None:
+        """Converge Technitium's blocked / allowed domain sets.
+
+        Implemented as flush-then-rewrite rather than a diff, and that is
+        a deliberate trade.
+
+        ``blocked/list`` is a **one-level tree browser**, not a flat list:
+        ``domain=""`` returns the top-level nodes, ``domain="foo.test"``
+        returns *its* children, and a node only holds the actual block
+        under ``records`` at the leaf. So intermediate nodes appear in the
+        listing without themselves being blocked domains. A naive
+        one-level read therefore returns names that were never blocked,
+        and deleting one of them removes the whole subtree beneath it —
+        verified: reading the root and reconciling against it wiped every
+        entry. A correct diff needs a recursive descent plus a
+        node-vs-leaf test on every level.
+
+        Flush-and-rewrite needs no read model at all, so it cannot be
+        subtly wrong in that way. The cost is a brief window with no
+        blocking on each structural apply — real, but structural applies
+        are infrequent (record CRUD does not trigger one), and a window
+        beats silently un-blocking names the operator still expects to be
+        blocked. Revisit if the window ever matters more than the
+        correctness does.
+        """
+        if not blocking:
+            return
+
+        blocking_type = blocking.get("blocking_type") or "NxDomain"
+        if blocking_type not in _BLOCKING_TYPES:
+            log.error(
+                "technitium_blocking_type_invalid",
+                value=blocking_type,
+                supported=sorted(_BLOCKING_TYPES),
+            )
+            return
+
+        settings: dict[str, Any] = {
+            "enableBlocking": "true" if blocking.get("enabled") else "false",
+            "blockingType": blocking_type,
+        }
+        if blocking_type == "CustomAddress":
+            addresses = blocking.get("custom_addresses") or []
+            if not addresses:
+                # CustomAddress with nothing to answer would blackhole the
+                # name in a way the operator did not ask for. Fall back to
+                # NxDomain and say so.
+                log.warning("technitium_blocking_custom_address_missing")
+                settings["blockingType"] = "NxDomain"
+            else:
+                settings["customBlockingAddresses"] = ",".join(addresses)
+        body = self._call(token, "POST", "settings/set", settings).json()
+        if body.get("status") != "ok":
+            log.error(
+                "technitium_blocking_settings_failed", error=body.get("errorMessage")
+            )
+            return
+
+        for kind in ("blocked", "allowed"):
+            flushed = self._call(token, "POST", f"{kind}/flush", {}).json()
+            if flushed.get("status") != "ok":
+                log.error(
+                    f"technitium_{kind}_flush_failed",
+                    error=flushed.get("errorMessage"),
+                )
+                continue
+            for domain in blocking.get(kind) or []:
+                added = self._call(
+                    token, "POST", f"{kind}/add", {"domain": domain}
+                ).json()
+                if added.get("status") != "ok":
+                    log.warning(
+                        f"technitium_{kind}_add_failed",
+                        domain=domain,
+                        error=added.get("errorMessage"),
+                    )
+        log.info(
+            "technitium_blocking_applied",
+            enabled=bool(blocking.get("enabled")),
+            blocking_type=settings["blockingType"],
+            blocked=len(blocking.get("blocked") or []),
+            allowed=len(blocking.get("allowed") or []),
+        )
 
     # ── Encrypted transports (issue #741) ───────────────────────────────
 

--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -28,7 +28,7 @@ own config under ``/etc/dns`` and is configured entirely over its HTTP API
 
 Zone types (issue #743): primary, secondary, stub and forward, plus
 catalog-zone membership for the primaries this server owns. Only a
-*primary*'''s records are reconciled — a secondary and a stub fill
+*primary's* records are reconciled — a secondary and a stub fill
 themselves from the zone transfer and a forwarder holds none, so diffing
 them would delete whatever the daemon just pulled down.
 
@@ -44,9 +44,13 @@ against a live daemon and both silent if you get them wrong:
 * ``zones/options/set`` answers ``ok`` for a value it does not recognise
   and keeps the old one — see ``_ZONE_TRANSFER_VALUES``.
 
-Deferred to fast-follow phases: DNSSEC (#740), native DoT/DoH/DoQ
-listeners + encrypted upstream forwarding (#741), query-log shipping
-(#742), ``dns_import`` live-pull + blocklist wiring (#744).
+Encrypted transports (issue #741): native DoT / DoH / DoQ listeners and
+encrypted *upstream* forwarding. Both are Technitium capabilities the
+other agent-managed drivers lack — BIND9 has no client-side HTTP or QUIC
+transport at all, and pdns-auth speaks none of them.
+
+Deferred to fast-follow phases: query-log shipping (#742), ``dns_import``
+live-pull + blocklist wiring (#744).
 """
 
 from __future__ import annotations
@@ -138,6 +142,23 @@ _DS_DIGEST_TYPES = {"SHA1": 1, "SHA256": 2, "GOST": 3, "SHA384": 4}
 
 # Technitium key-type names → the ksk/zsk/csk vocabulary DNSKeyReport uses.
 _DNSSEC_KEY_TYPES = {"KeySigningKey": "ksk", "ZoneSigningKey": "zsk"}
+
+# ── Encrypted transports (issue #741) ───────────────────────────────────
+#
+# Technitium wants the TLS cert as a FILE PATH, and specifically as
+# PKCS #12 — feeding it PEM fails with "DNS Server TLS certificate file
+# must be PKCS #12 formatted". The bundle ships PEM (that is what BIND9
+# and the ApplianceCertificate store use), so the agent converts and
+# writes a .pfx into its own state dir.
+_TLS_CERT_FILE = "technitium-tls.pfx"
+
+# Neutral forward_transport → Technitium's ``forwarderProtocol``.
+_FORWARDER_PROTOCOLS = {
+    "do53": "Udp",
+    "tls": "Tls",
+    "https": "Https",
+    "quic": "Quic",
+}
 
 # Technitium's supported TSIG algorithms, as its settings API spells them.
 _TSIG_ALGORITHMS = frozenset(
@@ -532,6 +553,10 @@ class TechnitiumDriver(DriverBase):
         # carries TSIG shared secrets.
         catalog = bundle.get("catalog") or bundle.get("catalog_block") or None
         server_payload = {
+            # Encrypted transports + forwarders (#741). Carried verbatim so
+            # swap_and_reload can apply them without re-reading the bundle.
+            "options": bundle.get("options") or {},
+            "tls_cert": bundle.get("tls_cert") or None,
             "tsig_keys": [
                 {
                     "name": (k.get("name") or "").rstrip("."),
@@ -607,6 +632,15 @@ class TechnitiumDriver(DriverBase):
                 log.error("technitium_server_payload_unreadable", error=str(exc))
         if server_state.get("tsig_keys"):
             self._sync_tsig_keys(token, server_state["tsig_keys"])
+
+        # Encrypted listeners + upstream forwarding (#741). Before the zone
+        # reconcile so a slow zone pass cannot delay bringing a listener up.
+        server_options = server_state.get("options") or {}
+        if server_options:
+            self._apply_transport_settings(
+                token, server_options, server_state.get("tls_cert")
+            )
+            self._apply_forwarders(token, server_options)
 
         self._reconcile_zones(token, payload)
         self._apply_catalog(token, server_state.get("catalog"), payload)
@@ -798,6 +832,182 @@ class TechnitiumDriver(DriverBase):
             "technitium_record_op_applied", zone=zone, name=name, type=rtype, op=op_kind
         )
         return None
+
+    # ── Encrypted transports (issue #741) ───────────────────────────────
+
+    def _write_tls_cert(self, cert: dict[str, Any]) -> str | None:
+        """Convert the bundle's PEM cert+key to PKCS #12 on disk.
+
+        Technitium takes the TLS material as a ``dnsTlsCertificatePath``
+        pointing at a **PKCS #12** file; handing it PEM fails with "DNS
+        Server TLS certificate file must be PKCS #12 formatted". The
+        bundle ships PEM, because that is what the ApplianceCertificate
+        store holds and what BIND9 consumes, so the conversion lives here.
+
+        Written 0600 through the same atomic path as the other secrets —
+        the .pfx embeds the private key.
+        """
+        cert_pem = (cert.get("cert_pem") or "").encode()
+        key_pem = (cert.get("key_pem") or "").encode()
+        if not cert_pem or not key_pem:
+            return None
+        try:
+            from cryptography.hazmat.primitives import serialization
+            from cryptography.hazmat.primitives.serialization import pkcs12
+            from cryptography.x509 import load_pem_x509_certificates
+
+            chain = load_pem_x509_certificates(cert_pem)
+            if not chain:
+                raise ValueError("no certificate found in cert_pem")
+            private_key = serialization.load_pem_private_key(key_pem, password=None)
+            blob = pkcs12.serialize_key_and_certificates(
+                name=(cert.get("name") or "spatiumddi").encode(),
+                key=private_key,  # type: ignore[arg-type]
+                cert=chain[0],
+                cas=chain[1:] or None,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        except Exception as exc:  # noqa: BLE001 — any parse failure is fatal
+            # Degrade to Do53 rather than take the daemon down: an
+            # unreadable cert must not stop the plain :53 listener, which
+            # is the whole "every path degrades to Do53" promise (#50).
+            log.error("technitium_tls_cert_convert_failed", error=str(exc))
+            return None
+
+        path = self.state_dir / _TLS_CERT_FILE
+        tmp = path.with_suffix(path.suffix + ".new")
+        fd = os.open(
+            str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600
+        )
+        try:
+            os.write(fd, blob)
+        finally:
+            os.close(fd)
+        tmp.replace(path)
+        return str(path)
+
+    def _apply_transport_settings(
+        self, token: str, options: dict[str, Any], cert: dict[str, Any] | None
+    ) -> None:
+        """Push the encrypted-listener + forwarder settings.
+
+        Ordering matters. Technitium accepts ``enableDnsOverTls=true`` even
+        when the certificate path in the SAME call is rejected (verified —
+        the flag lands, the path does not), which would leave a listener
+        enabled with no cert. So the cert path goes first, in its own call,
+        and the listeners are only enabled if that call succeeded.
+        """
+        cert_path = self._write_tls_cert(cert) if cert else None
+        wants_tls = bool(
+            options.get("dot_enabled")
+            or options.get("doh_enabled")
+            or options.get("doq_enabled")
+        )
+
+        if wants_tls:
+            if not cert_path:
+                log.error("technitium_encrypted_transport_skipped_no_cert")
+                return
+            resp = self._call(
+                token, "POST", "settings/set", {"dnsTlsCertificatePath": cert_path}
+            )
+            body = resp.json()
+            if body.get("status") != "ok":
+                log.error(
+                    "technitium_tls_cert_path_rejected",
+                    path=cert_path,
+                    error=body.get("errorMessage"),
+                )
+                return
+
+        params: dict[str, Any] = {
+            "enableDnsOverTls": "true" if options.get("dot_enabled") else "false",
+            "enableDnsOverHttps": "true" if options.get("doh_enabled") else "false",
+            "enableDnsOverQuic": "true" if options.get("doq_enabled") else "false",
+        }
+        if options.get("dot_enabled"):
+            params["dnsOverTlsPort"] = int(options.get("dot_port") or 853)
+        if options.get("doh_enabled"):
+            params["dnsOverHttpsPort"] = int(options.get("doh_port") or 443)
+        if options.get("doq_enabled"):
+            params["dnsOverQuicPort"] = int(options.get("doq_port") or 853)
+
+        resp = self._call(token, "POST", "settings/set", params)
+        body = resp.json()
+        if body.get("status") != "ok":
+            log.error(
+                "technitium_transport_settings_failed", error=body.get("errorMessage")
+            )
+            return
+        log.info(
+            "technitium_transport_settings_applied",
+            dot=bool(options.get("dot_enabled")),
+            doh=bool(options.get("doh_enabled")),
+            doq=bool(options.get("doq_enabled")),
+        )
+
+    def _apply_forwarders(self, token: str, options: dict[str, Any]) -> None:
+        """Set the upstream forwarders and the protocol to reach them with.
+
+        ``forwarderProtocol`` is SILENTLY IGNORED unless ``forwarders`` is
+        set in the SAME call (verified: setting the protocol alone returns
+        ok and leaves it at Udp). So the two always go together, or not at
+        all.
+
+        For DoT/DoH/DoQ, Technitium wants a **domain name** — an IP address
+        is rejected outright ("Address must be a domain name"), because
+        there would be no name to validate the upstream certificate
+        against. That is a real mismatch with the neutral model, which
+        carries a list of forwarder IPs plus one ``forward_tls_hostname``:
+        over an encrypted transport the hostname is the only usable
+        address, so it wins and the IPs are dropped with a warning.
+        """
+        forwarders = [str(f) for f in (options.get("forwarders") or []) if f]
+        transport = str(options.get("forward_transport") or "do53")
+        protocol = _FORWARDER_PROTOCOLS.get(transport)
+        if protocol is None:
+            log.warning("technitium_forward_transport_unsupported", transport=transport)
+            return
+        if not forwarders:
+            return
+
+        if transport != "do53":
+            hostname = options.get("forward_tls_hostname")
+            if hostname:
+                if forwarders != [hostname]:
+                    log.info(
+                        "technitium_forwarder_hostname_substituted",
+                        transport=transport,
+                        hostname=hostname,
+                        dropped=forwarders,
+                        reason="encrypted transports need a name to validate against",
+                    )
+                forwarders = [str(hostname)]
+            else:
+                log.error(
+                    "technitium_forwarder_hostname_missing",
+                    transport=transport,
+                    hint="forward_tls_hostname is required for tls/https/quic",
+                )
+                return
+
+        resp = self._call(
+            token,
+            "POST",
+            "settings/set",
+            {"forwarders": ",".join(forwarders), "forwarderProtocol": protocol},
+        )
+        body = resp.json()
+        if body.get("status") != "ok":
+            log.error(
+                "technitium_forwarders_failed",
+                protocol=protocol,
+                error=body.get("errorMessage"),
+            )
+            return
+        log.info(
+            "technitium_forwarders_applied", protocol=protocol, count=len(forwarders)
+        )
 
     # ── DNSSEC (issue #740) ─────────────────────────────────────────────
 

--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -692,31 +692,62 @@ class TechnitiumDriver(DriverBase):
     def _apply_catalog(
         self, token: str, catalog: dict[str, Any] | None, payload: list[dict[str, Any]]
     ) -> None:
-        """Create the catalog zone and enrol this server's primaries in it.
+        """Apply the group's catalog-zone role.
 
-        Producer only. A consumer joins by creating a ``SecondaryCatalog``
-        zone pointed at the producer, which is a zone-create rather than a
-        per-member option, so it arrives through the normal zone list.
+        **Producer** creates the ``Catalog`` zone and stamps
+        ``catalog=<name>`` onto each primary this server owns.
+
+        **Consumer** creates a ``SecondaryCatalog`` zone pointed at the
+        producer. That zone is NOT in the bundle's zone list — the control
+        plane ships it as a catalog block, not as a zone row — so it has to
+        be created here or a consumer silently does nothing at all.
+
+        **Neither** (catalog turned off) clears membership. Without that,
+        disabling catalog zones would leave every member permanently
+        enrolled, because nothing else ever touches the option.
         """
-        if not catalog or catalog.get("mode") != "producer":
+        cat_name = (catalog or {}).get("zone_name") or ""
+        cat_name = cat_name.rstrip(".")
+        mode = (catalog or {}).get("mode")
+
+        if mode == "consumer":
+            producer = (catalog or {}).get("producer_addr")
+            if not (cat_name and producer):
+                log.warning(
+                    "technitium_catalog_consumer_incomplete",
+                    zone=cat_name or None,
+                    producer=producer,
+                )
+                return
+            self._ensure_zone_exists(
+                token,
+                {
+                    "zone": cat_name,
+                    "type": "SecondaryCatalog",
+                    "masters": [str(producer)],
+                },
+            )
             return
-        cat_name = (catalog.get("zone_name") or "").rstrip(".")
-        if not cat_name:
-            return
-        self._ensure_zone_exists(token, {"zone": cat_name, "type": "Catalog"})
+
+        if mode == "producer" and cat_name:
+            self._ensure_zone_exists(token, {"zone": cat_name, "type": "Catalog"})
+
+        # Producer stamps the name on; disabled clears it. Empty string is
+        # how Technitium clears the field (verified — it reads back null).
+        desired = cat_name if (mode == "producer" and cat_name) else ""
         for entry in payload:
             if entry.get("type") != "Primary":
                 continue
             zone = entry["zone"]
             resp = self._call(
-                token, "POST", "zones/options/set", {"zone": zone, "catalog": cat_name}
+                token, "POST", "zones/options/set", {"zone": zone, "catalog": desired}
             )
             body = resp.json()
             if body.get("status") != "ok":
                 log.warning(
                     "technitium_catalog_membership_failed",
                     zone=zone,
-                    catalog=cat_name,
+                    catalog=desired or None,
                     error=body.get("errorMessage"),
                 )
 
@@ -968,7 +999,22 @@ class TechnitiumDriver(DriverBase):
         if protocol is None:
             log.warning("technitium_forward_transport_unsupported", transport=transport)
             return
+
         if not forwarders:
+            # Clearing has to be an explicit empty write, not an early
+            # return: removing every forwarder in the UI would otherwise
+            # leave the daemon resolving through the old upstreams forever,
+            # because nothing else ever touches the setting.
+            resp = self._call(
+                token, "POST", "settings/set", {"forwarders": "", "forwarderProtocol": "Udp"}
+            )
+            body = resp.json()
+            if body.get("status") != "ok":
+                log.error(
+                    "technitium_forwarders_clear_failed", error=body.get("errorMessage")
+                )
+            else:
+                log.info("technitium_forwarders_cleared")
             return
 
         if transport != "do53":
@@ -1190,15 +1236,18 @@ class TechnitiumDriver(DriverBase):
                     },
                 )
                 body = resp.json()
-                if body.get("status") == "error" and "no such record" not in (
-                    body.get("errorMessage") or ""
-                ).lower():
-                    log.warning(
-                        "technitium_reconcile_delete_failed",
-                        zone=zone,
-                        record=rec,
-                        error=body.get("errorMessage"),
-                    )
+                if body.get("status") == "error":
+                    # "no such record" means it was already gone — a no-op,
+                    # not a deletion. Counting it (or the failure case) would
+                    # report churn that never happened, which is the same
+                    # phantom the apex-NS filter above exists to prevent.
+                    if "no such record" not in (body.get("errorMessage") or "").lower():
+                        log.warning(
+                            "technitium_reconcile_delete_failed",
+                            zone=zone,
+                            record=rec,
+                            error=body.get("errorMessage"),
+                        )
                 else:
                     deleted += 1
 
@@ -1211,15 +1260,16 @@ class TechnitiumDriver(DriverBase):
                     {**rec, "zone": zone, "overwrite": "false"},
                 )
                 body = resp.json()
-                if body.get("status") == "error" and "already exists" not in (
-                    body.get("errorMessage") or ""
-                ).lower():
-                    log.error(
-                        "technitium_reconcile_add_failed",
-                        zone=zone,
-                        record=rec,
-                        error=body.get("errorMessage"),
-                    )
+                if body.get("status") == "error":
+                    # "already exists" is a no-op, not an add — same
+                    # reasoning as the delete branch above.
+                    if "already exists" not in (body.get("errorMessage") or "").lower():
+                        log.error(
+                            "technitium_reconcile_add_failed",
+                            zone=zone,
+                            record=rec,
+                            error=body.get("errorMessage"),
+                        )
                     continue
                 added += 1
             if added or deleted:

--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -331,6 +331,18 @@ def _normalize_rdata(rtype: str, flat: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _technitium_master(entry: str) -> str:
+    """Translate a neutral ``masters`` entry into Technitium's form.
+
+    SpatiumDDI validates masters as ``ip`` or ``ip@port`` — BIND's
+    ``masters { ip port n; }`` shape. Technitium wants ``ip:port`` and
+    rejects the ``@`` outright ("Invalid domain name … invalid character
+    [64]"), which would fail the zone create on every reconcile pass.
+    """
+    host, sep, port = str(entry).strip().partition("@")
+    return f"{host}:{port}" if sep and port else host
+
+
 def _tsig_key_names(bundle: dict[str, Any]) -> list[str]:
     """Bundle TSIG key names, root dot stripped.
 
@@ -762,8 +774,9 @@ class TechnitiumDriver(DriverBase):
                 )
                 continue
             tokens.extend([name, secret, algorithm])
-        if not tokens:
-            return
+        # An empty set is a real desired state, not "nothing to do": a
+        # revoked key that is never cleared stays installed and signed
+        # transfers keep working. Same bug class as the forwarders path.
         resp = self._call(token, "POST", "settings/set", {"tsigKeys": "|".join(tokens)})
         body = resp.json()
         if body.get("status") != "ok":
@@ -1105,21 +1118,32 @@ class TechnitiumDriver(DriverBase):
             or options.get("doq_enabled")
         )
 
+        cert_ok = True
         if wants_tls:
             if not cert_path:
                 log.error("technitium_encrypted_transport_skipped_no_cert")
-                return
-            resp = self._call(
-                token, "POST", "settings/set", {"dnsTlsCertificatePath": cert_path}
-            )
-            body = resp.json()
-            if body.get("status") != "ok":
-                log.error(
-                    "technitium_tls_cert_path_rejected",
-                    path=cert_path,
-                    error=body.get("errorMessage"),
-                )
-                return
+                cert_ok = False
+            else:
+                body = self._call(
+                    token, "POST", "settings/set", {"dnsTlsCertificatePath": cert_path}
+                ).json()
+                if body.get("status") != "ok":
+                    log.error(
+                        "technitium_tls_cert_path_rejected",
+                        path=cert_path,
+                        error=body.get("errorMessage"),
+                    )
+                    cert_ok = False
+
+        if wants_tls and not cert_ok:
+            # Returning here would leave an ALREADY-ENABLED listener up on
+            # a stale certificate, which is the opposite of the "every
+            # path degrades to Do53" promise (#50). Fall through with
+            # every listener forced off instead, so the daemon actually
+            # drops back to plain :53.
+            log.warning("technitium_encrypted_transport_disabled_degrading_to_do53")
+            options = {**options, "dot_enabled": False, "doh_enabled": False,
+                       "doq_enabled": False}
 
         params: dict[str, Any] = {
             "enableDnsOverTls": "true" if options.get("dot_enabled") else "false",
@@ -1130,6 +1154,17 @@ class TechnitiumDriver(DriverBase):
             params["dnsOverTlsPort"] = int(options.get("dot_port") or 853)
         if options.get("doh_enabled"):
             params["dnsOverHttpsPort"] = int(options.get("doh_port") or 443)
+            # Technitium serves DoH on a FIXED path and exposes no setting
+            # for it (verified: no path key in settings/get). An operator
+            # who changed doh_path would otherwise be handed a URL the
+            # daemon does not answer on.
+            doh_path = str(options.get("doh_path") or "/dns-query")
+            if doh_path != "/dns-query":
+                log.warning(
+                    "technitium_doh_path_not_configurable",
+                    requested=doh_path,
+                    served="/dns-query",
+                )
         if options.get("doq_enabled"):
             params["dnsOverQuicPort"] = int(options.get("doq_port") or 853)
 
@@ -1466,7 +1501,9 @@ class TechnitiumDriver(DriverBase):
         ztype = entry.get("type", "Primary")
         params: dict[str, Any] = {"zone": zone, "type": ztype}
         if ztype in ("Secondary", "Stub", "SecondaryCatalog"):
-            params["primaryNameServerAddresses"] = ",".join(entry.get("masters") or [])
+            params["primaryNameServerAddresses"] = ",".join(
+                _technitium_master(m) for m in entry.get("masters") or []
+            )
         elif ztype == "Forwarder":
             forwarders = entry.get("forwarders") or []
             # Technitium's Forwarder zone takes a single upstream; BIND's
@@ -1485,9 +1522,37 @@ class TechnitiumDriver(DriverBase):
         body = resp.json()
         if body.get("status") == "error":
             if "already exists" in (body.get("errorMessage") or "").lower():
+                # The create params carry the zone's UPSTREAM (a
+                # secondary/stub's primaries, a forwarder's target), and
+                # create is a no-op once the zone exists. Without this,
+                # retargeting a secondary at a new primary would be a
+                # permanent silent no-op: the operator edits it, the
+                # bundle changes, and the daemon keeps transferring from
+                # the old address forever.
+                self._reapply_zone_upstream(token, zone, ztype, params)
                 return
             log.error(
                 "technitium_zone_create_failed",
+                zone=zone,
+                zone_type=ztype,
+                error=body.get("errorMessage"),
+            )
+
+    def _reapply_zone_upstream(
+        self, token: str, zone: str, ztype: str, params: dict[str, Any]
+    ) -> None:
+        """Push a existing zone's upstream through ``zones/options/set``."""
+        opts: dict[str, Any] = {"zone": zone}
+        if "primaryNameServerAddresses" in params:
+            opts["primaryNameServerAddresses"] = params["primaryNameServerAddresses"]
+        elif "forwarder" in params:
+            opts["forwarder"] = params["forwarder"]
+        else:
+            return
+        body = self._call(token, "POST", "zones/options/set", opts).json()
+        if body.get("status") != "ok":
+            log.warning(
+                "technitium_zone_upstream_reapply_failed",
                 zone=zone,
                 zone_type=ztype,
                 error=body.get("errorMessage"),

--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -1,4 +1,4 @@
-"""Technitium DNS Server agent driver (v1 — primary zones + record CRUD).
+"""Technitium DNS Server agent driver.
 
 Runs alongside the Technitium ``DnsServerApp`` process inside the
 dns-technitium container. Unlike BIND9 (named.conf + RFC 1035 zone files +
@@ -26,17 +26,27 @@ own config under ``/etc/dns`` and is configured entirely over its HTTP API
   the bundle's NS/SOA as authoritative would just create duplicate/foreign
   NS records alongside Technitium's own.
 
-v1 scope: primary zones only. Record types: A, AAAA, CNAME, MX, TXT, NS
-(zone-referral records off-apex only — apex NS is daemon-managed), PTR, SRV,
-CAA, TLSA, SSHFP, NAPTR, URI, DNAME, SVCB, HTTPS (SVCB/HTTPS best-effort —
-see ``_svcb_params`` for the one documented limitation: multi-value params
-like ``alpn="h2,h3"`` only carry the first value through, logged as a
-warning).
+Zone types (issue #743): primary, secondary, stub and forward, plus
+catalog-zone membership for the primaries this server owns. Only a
+*primary*'''s records are reconciled — a secondary and a stub fill
+themselves from the zone transfer and a forwarder holds none, so diffing
+them would delete whatever the daemon just pulled down.
 
-Deferred to fast-follow phases: DNSSEC (``/api/zones/dnssec/*`` — same
-shape as PowerDNS's, should port quickly), native DoT/DoH/DoQ listener
-wiring (Technitium's real differentiator — no dnsdist-style sidecar needed,
-unlike PowerDNS), catalog zones, secondary/stub zones.
+Record types: A, AAAA, CNAME, MX, TXT, NS (zone-referral records off-apex
+only — apex NS is daemon-managed), PTR, SRV, CAA, TLSA, SSHFP, NAPTR, URI,
+DNAME, SVCB, HTTPS.
+
+Two Technitium behaviours this driver exists to paper over, both verified
+against a live daemon and both silent if you get them wrong:
+
+* Record GET does not echo the params record ADD takes — see
+  ``_normalize_rdata``.
+* ``zones/options/set`` answers ``ok`` for a value it does not recognise
+  and keeps the old one — see ``_ZONE_TRANSFER_VALUES``.
+
+Deferred to fast-follow phases: DNSSEC (#740), native DoT/DoH/DoQ
+listeners + encrypted upstream forwarding (#741), query-log shipping
+(#742), ``dns_import`` live-pull + blocklist wiring (#744).
 """
 
 from __future__ import annotations
@@ -70,6 +80,52 @@ _TOKEN_NAME = "spatiumddi-agent"
 # at the apex — an off-apex NS is a legitimate delegation record and IS
 # reconciled normally).
 _DAEMON_MANAGED_APEX_TYPES = frozenset({"SOA"})
+
+# ── Zone types (issue #743) ─────────────────────────────────────────────
+#
+# SpatiumDDI's neutral ``zone_type`` → Technitium's ``/api/zones/create``
+# ``type`` param. Verified against a live technitium/dns-server:15.4.0.
+_ZONE_TYPE_MAP = {
+    "primary": "Primary",
+    "master": "Primary",  # legacy alias used in a few older bundles
+    "secondary": "Secondary",
+    "slave": "Secondary",
+    "stub": "Stub",
+    "forward": "Forwarder",
+}
+
+# Only a primary's records are ours to manage. A secondary's and a stub's
+# come from the transfer, and a forwarder has none — reconciling any of
+# them would fight the daemon and delete records it just pulled.
+_RECORD_MANAGED_ZONE_TYPES = frozenset({"Primary"})
+
+# ``zones/options/set`` SILENTLY IGNORES a value it does not recognise —
+# verified live: setting zoneTransfer="Bogus" returns {"status":"ok"} and
+# leaves the previous value in place. So an unvalidated typo here would
+# not fail loudly, it would leave zone transfer at whatever it was before
+# (quite possibly wide open). Validate driver-side against these sets and
+# refuse to send anything else.
+_ZONE_TRANSFER_VALUES = frozenset(
+    {
+        "Deny",
+        "Allow",
+        "AllowOnlyZoneNameServers",
+        "UseSpecifiedNetworkACL",
+        "AllowOnlyZoneNameServersAndUseSpecifiedNetworkACL",
+    }
+)
+
+# Technitium's supported TSIG algorithms, as its settings API spells them.
+_TSIG_ALGORITHMS = frozenset(
+    {
+        "hmac-md5",
+        "hmac-sha1",
+        "hmac-sha256",
+        "hmac-sha256-128",
+        "hmac-sha384",
+        "hmac-sha512",
+    }
+)
 
 
 def _qualified_name(zone_name: str, name: str) -> str:
@@ -207,6 +263,60 @@ def _normalize_rdata(rtype: str, flat: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _tsig_key_names(bundle: dict[str, Any]) -> list[str]:
+    """Bundle TSIG key names, root dot stripped.
+
+    Technitium stores names un-dotted (verified: sending ``spatium-xfer.``
+    reads back as ``spatium-xfer``), so normalise here or every options
+    comparison sees a difference that isn't one.
+    """
+    out = []
+    for k in bundle.get("tsig_keys") or []:
+        name = (k.get("name") or "").rstrip(".")
+        if name:
+            out.append(name)
+    return sorted(set(out))
+
+
+def _zone_options_payload(ztype: str, bundle: dict[str, Any]) -> dict[str, Any]:
+    """Map the bundle's server-level transfer policy onto Technitium's
+    per-zone transfer options.
+
+    BIND expresses ``allow-transfer`` once for the whole server; Technitium
+    has no global equivalent, so the same policy is stamped onto each zone
+    we own. Only meaningful for zones this server is authoritative for —
+    a Secondary/Stub transfers *in*, and re-serving it is a separate
+    decision we do not make on the operator's behalf.
+
+    The list follows BIND's vocabulary: ``["none"]`` (or empty) denies,
+    ``any`` allows, anything else is treated as a network ACL.
+    """
+    if ztype != "Primary":
+        return {}
+    opts = bundle.get("options") or {}
+    acl = [str(a) for a in (opts.get("allow_transfer") or []) if a]
+    lowered = {a.lower() for a in acl}
+
+    payload: dict[str, Any] = {}
+    if not acl or lowered == {"none"}:
+        payload["zoneTransfer"] = "Deny"
+    elif "any" in lowered:
+        payload["zoneTransfer"] = "Allow"
+    else:
+        payload["zoneTransfer"] = "UseSpecifiedNetworkACL"
+        payload["zoneTransferNetworkACL"] = [a for a in acl if a.lower() != "none"]
+
+    # Naming keys here is what makes a transfer TSIG-*authenticated* rather
+    # than merely address-filtered. Only attach them where transfer is
+    # actually permitted — pinning key names onto a Deny zone reads as if
+    # signed transfer were enabled when nothing can transfer at all.
+    if payload["zoneTransfer"] != "Deny":
+        names = _tsig_key_names(bundle)
+        if names:
+            payload["zoneTransferTsigKeyNames"] = names
+    return payload
+
+
 def _record_params(rtype: str, value: str, rec: dict[str, Any]) -> dict[str, Any]:
     """Build the type-specific param dict for
     ``/api/zones/records/{add,delete}`` — shared by both endpoints since
@@ -317,34 +427,69 @@ class TechnitiumDriver(DriverBase):
             zname = (zone.get("name") or "").rstrip(".")
             if not zname:
                 continue
-            ztype = zone.get("type", "primary")
-            if ztype != "primary":
+            raw_type = (zone.get("type") or "primary").lower()
+            ztype = _ZONE_TYPE_MAP.get(raw_type)
+            if ztype is None:
                 log.warning(
-                    "technitium_zone_type_unsupported_v1",
+                    "technitium_zone_type_unsupported",
                     zone=zname,
-                    zone_type=ztype,
+                    zone_type=raw_type,
+                    supported=sorted(_ZONE_TYPE_MAP),
                 )
                 continue
-            records = []
-            for rec in zone.get("records") or []:
-                rtype = (rec.get("type") or "").upper()
-                if rtype in _DAEMON_MANAGED_APEX_TYPES:
-                    continue
-                name = _qualified_name(zname, rec.get("name") or "@")
-                if rtype == "NS" and name == zname:
-                    # Apex NS is daemon-managed (created at zone-create
-                    # time, pointed at the container's own hostname).
-                    # Off-apex NS (delegations) are handled normally.
-                    continue
-                records.append(
-                    {
-                        "domain": name,
-                        "type": rtype,
-                        "ttl": rec.get("ttl") or zone.get("ttl") or 3600,
-                        **_record_params(rtype, rec.get("value") or "", rec),
-                    }
+            masters = [str(m) for m in (zone.get("masters") or []) if m]
+            forwarders = [str(f) for f in (zone.get("forwarders") or []) if f]
+            # Secondary/stub transfer FROM a primary, so with no address to
+            # transfer from there is nothing to create — Technitium rejects
+            # the create outright. Skip rather than fail the whole render.
+            if ztype in ("Secondary", "Stub") and not masters:
+                log.warning(
+                    "technitium_zone_missing_masters", zone=zname, zone_type=raw_type
                 )
-            zones_payload.append({"zone": zname, "type": "Primary", "records": records})
+                continue
+            if ztype == "Forwarder" and not forwarders:
+                log.warning("technitium_zone_missing_forwarders", zone=zname)
+                continue
+
+            records = []
+            # Only a primary's records are ours. A secondary/stub fills
+            # itself from the transfer and a forwarder holds none, so
+            # rendering records for them would make the reconciler delete
+            # whatever the daemon just pulled down.
+            if ztype in _RECORD_MANAGED_ZONE_TYPES:
+                for rec in zone.get("records") or []:
+                    rtype = (rec.get("type") or "").upper()
+                    if rtype in _DAEMON_MANAGED_APEX_TYPES:
+                        continue
+                    name = _qualified_name(zname, rec.get("name") or "@")
+                    if rtype == "NS" and name == zname:
+                        # Apex NS is daemon-managed (created at zone-create
+                        # time, pointed at the container's own hostname).
+                        # Off-apex NS (delegations) are handled normally.
+                        continue
+                    records.append(
+                        {
+                            "domain": name,
+                            "type": rtype,
+                            "ttl": rec.get("ttl") or zone.get("ttl") or 3600,
+                            **_record_params(rtype, rec.get("value") or "", rec),
+                        }
+                    )
+
+            entry: dict[str, Any] = {
+                "zone": zname,
+                "type": ztype,
+                "records": records,
+                # Drives ``zones/options/set``. Absent/empty values are not
+                # sent at all, so the daemon default stands rather than us
+                # stamping an opinion onto every zone.
+                "options": _zone_options_payload(ztype, bundle),
+            }
+            if masters:
+                entry["masters"] = masters
+            if forwarders:
+                entry["forwarders"] = forwarders
+            zones_payload.append(entry)
 
         if bundle.get("blocklists"):
             log.warning(
@@ -357,6 +502,26 @@ class TechnitiumDriver(DriverBase):
             )
 
         (new_dir / "zones.json").write_text(json.dumps(zones_payload, indent=2))
+
+        # Server-scoped state the zone loop can't express (issue #743).
+        # Written to its own file, and 0600: unlike zones.json this one
+        # carries TSIG shared secrets.
+        catalog = bundle.get("catalog") or bundle.get("catalog_block") or None
+        server_payload = {
+            "tsig_keys": [
+                {
+                    "name": (k.get("name") or "").rstrip("."),
+                    "secret": k.get("secret") or "",
+                    "algorithm": (k.get("algorithm") or "hmac-sha256").lower(),
+                }
+                for k in (bundle.get("tsig_keys") or [])
+                if (k.get("name") or "").rstrip(".")
+            ],
+            "catalog": catalog,
+        }
+        self._write_secret(
+            new_dir / "server.json", json.dumps(server_payload, indent=2)
+        )
 
     def validate(self) -> None:
         new_dir = self.state_dir / "rendered.new"
@@ -404,7 +569,98 @@ class TechnitiumDriver(DriverBase):
         if token is None:
             log.error("technitium_reconcile_skipped_no_token")
             return
+
+        # TSIG keys first: a zone's ``zoneTransferTsigKeyNames`` is accepted
+        # even when it names a key the server does not have (verified — the
+        # API stores it happily), and the failure only shows up later as a
+        # refused transfer. Push the keys before anything references them.
+        server_path = current / "server.json"
+        server_state: dict[str, Any] = {}
+        if server_path.exists():
+            try:
+                server_state = json.loads(server_path.read_text())
+            except ValueError as exc:
+                log.error("technitium_server_payload_unreadable", error=str(exc))
+        if server_state.get("tsig_keys"):
+            self._sync_tsig_keys(token, server_state["tsig_keys"])
+
         self._reconcile_zones(token, payload)
+        self._apply_catalog(token, server_state.get("catalog"), payload)
+
+    def _sync_tsig_keys(self, token: str, keys: list[dict[str, Any]]) -> None:
+        """Publish the bundle's TSIG keys into Technitium's global settings.
+
+        Wire format is a FLAT pipe-delimited token list read in triples —
+        ``name|secret|algorithm|name2|secret2|algorithm2|…`` — not one
+        pipe-joined record per key and not JSON. Both of those were tried
+        against a live daemon: JSON and a 2-token record fail with "Offset
+        and length were out of bounds for the array", which is the arity
+        check complaining, and a ``name|algorithm|secret`` ordering fails
+        with "TSIG algorithm is not supported" because it reads the secret
+        as the algorithm.
+
+        ``settings/set`` REPLACES the whole key list, so anything an
+        operator added directly in the Technitium console is dropped on the
+        next sync. That is the same "control plane is the source of truth"
+        stance the rest of the driver takes, but it is worth knowing.
+        """
+        tokens: list[str] = []
+        for k in keys:
+            name = (k.get("name") or "").rstrip(".")
+            secret = k.get("secret") or ""
+            algorithm = (k.get("algorithm") or "hmac-sha256").lower()
+            if not name or not secret:
+                continue
+            if algorithm not in _TSIG_ALGORITHMS:
+                log.warning(
+                    "technitium_tsig_algorithm_unsupported",
+                    key=name,
+                    algorithm=algorithm,
+                    supported=sorted(_TSIG_ALGORITHMS),
+                )
+                continue
+            tokens.extend([name, secret, algorithm])
+        if not tokens:
+            return
+        resp = self._call(token, "POST", "settings/set", {"tsigKeys": "|".join(tokens)})
+        body = resp.json()
+        if body.get("status") != "ok":
+            log.error(
+                "technitium_tsig_keys_apply_failed", error=body.get("errorMessage")
+            )
+        else:
+            log.info("technitium_tsig_keys_applied", count=len(tokens) // 3)
+
+    def _apply_catalog(
+        self, token: str, catalog: dict[str, Any] | None, payload: list[dict[str, Any]]
+    ) -> None:
+        """Create the catalog zone and enrol this server's primaries in it.
+
+        Producer only. A consumer joins by creating a ``SecondaryCatalog``
+        zone pointed at the producer, which is a zone-create rather than a
+        per-member option, so it arrives through the normal zone list.
+        """
+        if not catalog or catalog.get("mode") != "producer":
+            return
+        cat_name = (catalog.get("zone_name") or "").rstrip(".")
+        if not cat_name:
+            return
+        self._ensure_zone_exists(token, {"zone": cat_name, "type": "Catalog"})
+        for entry in payload:
+            if entry.get("type") != "Primary":
+                continue
+            zone = entry["zone"]
+            resp = self._call(
+                token, "POST", "zones/options/set", {"zone": zone, "catalog": cat_name}
+            )
+            body = resp.json()
+            if body.get("status") != "ok":
+                log.warning(
+                    "technitium_catalog_membership_failed",
+                    zone=zone,
+                    catalog=cat_name,
+                    error=body.get("errorMessage"),
+                )
 
     def _wait_for_api_up(self, *, timeout_s: float = 15.0) -> None:
         deadline = time.monotonic() + timeout_s
@@ -523,7 +779,14 @@ class TechnitiumDriver(DriverBase):
         """
         for zone_payload in payload:
             zone = zone_payload["zone"]
-            self._ensure_zone_exists(token, zone)
+            self._ensure_zone_exists(token, zone_payload)
+            self._apply_zone_options(token, zone, zone_payload.get("options") or {})
+
+            # Records belong to us only on a Primary. A Secondary/Stub is
+            # filled by the transfer and a Forwarder holds none, so diffing
+            # them would delete whatever the daemon just pulled down.
+            if zone_payload.get("type", "Primary") not in _RECORD_MANAGED_ZONE_TYPES:
+                continue
 
             existing = self._get_zone_records(token, zone)
             desired = zone_payload.get("records") or []
@@ -559,11 +822,8 @@ class TechnitiumDriver(DriverBase):
             to_delete = [r for fp, r in existing_by_fp.items() if fp not in desired_by_fp]
             to_add = [r for fp, r in desired_by_fp.items() if fp not in existing_by_fp]
 
+            deleted = 0
             for rec in to_delete:
-                if rec.get("type") in _DAEMON_MANAGED_APEX_TYPES:
-                    continue
-                if rec.get("type") == "NS" and rec.get("domain") == zone:
-                    continue
                 resp = self._call(
                     token,
                     "POST",
@@ -589,7 +849,10 @@ class TechnitiumDriver(DriverBase):
                         record=rec,
                         error=body.get("errorMessage"),
                     )
+                else:
+                    deleted += 1
 
+            added = 0
             for rec in to_add:
                 resp = self._call(
                     token,
@@ -608,24 +871,95 @@ class TechnitiumDriver(DriverBase):
                         error=body.get("errorMessage"),
                     )
                     continue
-            if to_add or to_delete:
+                added += 1
+            if added or deleted:
                 log.info(
                     "technitium_zone_reconciled",
                     zone=zone,
-                    added=len(to_add),
-                    deleted=len(to_delete),
+                    added=added,
+                    deleted=deleted,
                 )
 
-    def _ensure_zone_exists(self, token: str, zone: str) -> None:
-        resp = self._call(
-            token, "POST", "zones/create", {"zone": zone, "type": "Primary"}
-        )
+    def _ensure_zone_exists(self, token: str, entry: dict[str, Any]) -> None:
+        """Create the zone if absent, with the params its type requires.
+
+        Unlike a Primary, a Secondary/Stub create is **not** guaranteed to
+        succeed and is **not** safely retryable-forever: Technitium resolves
+        SOA against the configured primaries at create time and errors if
+        none answer (verified live — "DNS Server did not receive SOA record
+        in response from any of the primary name servers"). So an
+        unreachable or misconfigured primary fails here on every reconcile
+        pass. Logged at error, deliberately loudly, because the zone simply
+        will not exist until the operator fixes the far end.
+        """
+        zone = entry["zone"]
+        ztype = entry.get("type", "Primary")
+        params: dict[str, Any] = {"zone": zone, "type": ztype}
+        if ztype in ("Secondary", "Stub", "SecondaryCatalog"):
+            params["primaryNameServerAddresses"] = ",".join(entry.get("masters") or [])
+        elif ztype == "Forwarder":
+            forwarders = entry.get("forwarders") or []
+            # Technitium's Forwarder zone takes a single upstream; BIND's
+            # takes a list. Use the first and say so, rather than silently
+            # dropping the rest.
+            params["forwarder"] = forwarders[0]
+            if len(forwarders) > 1:
+                log.warning(
+                    "technitium_forwarder_extra_upstreams_ignored",
+                    zone=zone,
+                    used=forwarders[0],
+                    ignored=forwarders[1:],
+                )
+
+        resp = self._call(token, "POST", "zones/create", params)
         body = resp.json()
         if body.get("status") == "error":
             if "already exists" in (body.get("errorMessage") or "").lower():
                 return
             log.error(
-                "technitium_zone_create_failed", zone=zone, error=body.get("errorMessage")
+                "technitium_zone_create_failed",
+                zone=zone,
+                zone_type=ztype,
+                error=body.get("errorMessage"),
+            )
+
+    def _apply_zone_options(
+        self, token: str, zone: str, options: dict[str, Any]
+    ) -> None:
+        """Push per-zone options, validating enums before we send them.
+
+        ``zones/options/set`` answers ``{"status": "ok"}`` for a value it
+        does not recognise and leaves the existing setting untouched
+        (verified live with ``zoneTransfer="Bogus"``). So an unvalidated
+        typo would not fail — it would quietly leave zone transfer at
+        whatever it was, which for a zone we meant to lock down is a
+        security regression that no log line would report. Refuse to send
+        anything not in the known set.
+        """
+        if not options:
+            return
+        transfer = options.get("zoneTransfer")
+        if transfer is not None and transfer not in _ZONE_TRANSFER_VALUES:
+            log.error(
+                "technitium_zone_transfer_value_invalid",
+                zone=zone,
+                value=transfer,
+                supported=sorted(_ZONE_TRANSFER_VALUES),
+            )
+            return
+
+        params: dict[str, Any] = {"zone": zone}
+        for key, value in options.items():
+            # List-valued options go over the wire comma-joined.
+            params[key] = ",".join(str(v) for v in value) if isinstance(value, list) else value
+
+        resp = self._call(token, "POST", "zones/options/set", params)
+        body = resp.json()
+        if body.get("status") != "ok":
+            log.warning(
+                "technitium_zone_options_failed",
+                zone=zone,
+                error=body.get("errorMessage"),
             )
 
     def _get_zone_records(self, token: str, zone: str) -> list[dict[str, Any]]:
@@ -645,6 +979,14 @@ class TechnitiumDriver(DriverBase):
         for rec in body.get("response", {}).get("records") or []:
             rtype = rec.get("type")
             if rtype in _DAEMON_MANAGED_APEX_TYPES:
+                continue
+            # Apex NS is daemon-managed too (Technitium stamps one pointing
+            # at its own hostname at zone-create). Filter it HERE rather
+            # than skipping it later in the delete loop: left in, it lands
+            # in ``to_delete`` on every pass, gets skipped, and still gets
+            # counted — reporting a deletion that never happened and making
+            # a steady-state zone look like it churns its apex NS forever.
+            if rtype == "NS" and (rec.get("name") or "") == zone:
                 continue
             flat = {"domain": rec.get("name"), "type": rtype, "ttl": rec.get("ttl")}
             flat.update(rec.get("rData") or {})

--- a/agent/dns/spatium_dns_agent/metrics.py
+++ b/agent/dns/spatium_dns_agent/metrics.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import random
 import threading
 from datetime import UTC, datetime
-from typing import Any
 from xml.etree import ElementTree as ET
 
 import httpx

--- a/agent/dns/tests/test_technitium_render.py
+++ b/agent/dns/tests/test_technitium_render.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from spatium_dns_agent.drivers.technitium import (
     TechnitiumDriver,
+    _blocking_payload,
     _normalize_rdata,
     _qualified_name,
     _record_params,
@@ -1194,3 +1195,115 @@ def test_catalog_membership_cleared_when_disabled(tmp_path: Path) -> None:
     d._apply_catalog("t", None, [{"zone": "p.test", "type": "Primary"}])
     opt = [c for c in calls if c[2] == "zones/options/set"]
     assert opt and opt[0][3]["catalog"] == ""
+
+
+# ── Blocklists (issue #744) ─────────────────────────────────────────────
+
+
+def _bl(entries, exceptions=()):
+    return {"blocklists": [{"exceptions": list(exceptions), "entries": entries}]}
+
+
+def test_blocking_payload_splits_block_from_allow() -> None:
+    """Technitium's allowed set is exactly an RPZ passthru, so passthru
+    entries and each list's exceptions both land there."""
+    out = _blocking_payload(
+        _bl(
+            [
+                {"domain": "ads.example.test", "action": "block", "block_mode": "nxdomain"},
+                {"domain": "pass.example.test", "action": "block", "block_mode": "passthru"},
+                {"domain": "allow.example.test", "action": "allow", "block_mode": "nxdomain"},
+            ],
+            ["exc.example.test"],
+        )
+    )
+    assert out["blocked"] == ["ads.example.test"]
+    assert out["allowed"] == [
+        "allow.example.test",
+        "exc.example.test",
+        "pass.example.test",
+    ]
+    assert out["enabled"] is True
+
+
+def test_blocking_payload_disabled_when_nothing_blocked() -> None:
+    assert _blocking_payload({"blocklists": []})["enabled"] is False
+    passthru_only = _blocking_payload(
+        _bl([{"domain": "a.test", "action": "block", "block_mode": "passthru"}])
+    )
+    assert passthru_only["enabled"] is False
+
+
+def test_blocking_payload_prefers_custom_address_when_modes_disagree() -> None:
+    """One server-wide blocking type has to cover every entry. NxDomain
+    would silently drop an operator's sinkhole, so the address-answering
+    mode wins."""
+    out = _blocking_payload(
+        _bl(
+            [
+                {"domain": "a.test", "action": "block", "block_mode": "nxdomain"},
+                {"domain": "b.test", "action": "block", "block_mode": "sinkhole",
+                 "target": "10.0.0.1"},
+            ]
+        )
+    )
+    assert out["blocking_type"] == "CustomAddress"
+    assert out["custom_addresses"] == ["10.0.0.1"]
+
+
+def test_blocking_payload_collapses_per_view_lists() -> None:
+    """Technitium's native blocking is server-wide with no view concept,
+    and the driver declines views outright — so collapsing is the honest
+    reading rather than applying one view's list to every client."""
+    out = _blocking_payload(
+        {
+            "blocklists": [
+                {"view_name": "internal", "exceptions": [],
+                 "entries": [{"domain": "a.test", "action": "block",
+                              "block_mode": "nxdomain"}]},
+                {"view_name": None, "exceptions": [],
+                 "entries": [{"domain": "b.test", "action": "block",
+                              "block_mode": "nxdomain"}]},
+            ]
+        }
+    )
+    assert out["blocked"] == ["a.test", "b.test"]
+
+
+def test_apply_blocking_flushes_before_rewriting(tmp_path: Path) -> None:
+    """Flush-then-rewrite, not diff: ``blocked/list`` is a one-level tree
+    browser whose intermediate nodes are not themselves blocked domains,
+    so reconciling against a flat read of it deletes whole subtrees."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_blocking(
+        "t",
+        {"enabled": True, "blocked": ["a.test"], "allowed": ["b.test"],
+         "blocking_type": "NxDomain", "custom_addresses": []},
+    )
+    paths = [c[2] for c in calls]
+    assert paths[0] == "settings/set"
+    assert paths.index("blocked/flush") < paths.index("blocked/add")
+    assert paths.index("allowed/flush") < paths.index("allowed/add")
+
+
+def test_apply_blocking_rejects_unknown_blocking_type(tmp_path: Path) -> None:
+    """blockingType silently ignores values it doesn't recognise — same
+    trap as zoneTransfer — so it is validated before sending."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_blocking("t", {"enabled": True, "blocked": [], "blocking_type": "Bogus"})
+    assert calls == []
+
+
+def test_apply_blocking_falls_back_when_custom_address_missing(tmp_path: Path) -> None:
+    """CustomAddress with nothing to answer would blackhole the name in a
+    way the operator never asked for."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_blocking(
+        "t",
+        {"enabled": True, "blocked": ["a.test"], "blocking_type": "CustomAddress",
+         "custom_addresses": []},
+    )
+    assert calls[0][3]["blockingType"] == "NxDomain"

--- a/agent/dns/tests/test_technitium_render.py
+++ b/agent/dns/tests/test_technitium_render.py
@@ -26,6 +26,8 @@ from spatium_dns_agent.drivers.technitium import (
     _qualified_name,
     _record_params,
     _svcb_params,
+    _tsig_key_names,
+    _zone_options_payload,
 )
 
 
@@ -575,3 +577,237 @@ def test_svcb_target_root_dot_is_stripped() -> None:
     assert target == "svc.example.test"
     # A bare apex target must survive as "." rather than becoming "".
     assert _svcb_params("1 .")[1] == "."
+
+
+# ── Zone types, transfer options, TSIG, catalog (issue #743) ────────────
+
+
+def _zone_bundle(**over):
+    base = {
+        "options": {"allow_transfer": ["none"]},
+        "tsig_keys": [],
+        "zones": [],
+    }
+    base.update(over)
+    return base
+
+
+def test_render_emits_every_supported_zone_type(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    d.render(
+        _zone_bundle(
+            zones=[
+                {"name": "p.test.", "type": "primary", "records": []},
+                {"name": "s.test.", "type": "secondary", "masters": ["192.0.2.1"]},
+                {"name": "st.test.", "type": "stub", "masters": ["192.0.2.1"]},
+                {"name": "f.test.", "type": "forward", "forwarders": ["8.8.8.8"]},
+            ]
+        )
+    )
+    import json as _json
+
+    payload = _json.loads((tmp_path / "rendered.new" / "zones.json").read_text())
+    assert {z["zone"]: z["type"] for z in payload} == {
+        "p.test": "Primary",
+        "s.test": "Secondary",
+        "st.test": "Stub",
+        "f.test": "Forwarder",
+    }
+
+
+def test_render_skips_zones_that_cannot_be_created(tmp_path: Path) -> None:
+    """A secondary/stub with no primary to transfer from, or a forward zone
+    with no upstream, cannot be created at all — Technitium rejects the
+    call. Skip them rather than fail the whole render."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    d.render(
+        _zone_bundle(
+            zones=[
+                {"name": "nomaster.test.", "type": "secondary", "masters": []},
+                {"name": "nofwd.test.", "type": "forward", "forwarders": []},
+                {"name": "bogus.test.", "type": "not-a-zone-type"},
+                {"name": "ok.test.", "type": "primary", "records": []},
+            ]
+        )
+    )
+    import json as _json
+
+    payload = _json.loads((tmp_path / "rendered.new" / "zones.json").read_text())
+    assert [z["zone"] for z in payload] == ["ok.test"]
+
+
+def test_render_omits_records_for_non_primary_zones(tmp_path: Path) -> None:
+    """A secondary fills itself from the transfer. Rendering records for it
+    would make the reconciler delete what the daemon just pulled down."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    d.render(
+        _zone_bundle(
+            zones=[
+                {
+                    "name": "s.test.",
+                    "type": "secondary",
+                    "masters": ["192.0.2.1"],
+                    "records": [{"name": "www", "type": "A", "value": "10.0.0.1"}],
+                }
+            ]
+        )
+    )
+    import json as _json
+
+    payload = _json.loads((tmp_path / "rendered.new" / "zones.json").read_text())
+    assert payload[0]["records"] == []
+
+
+def test_zone_options_transfer_policy_mapping() -> None:
+    assert _zone_options_payload("Primary", _zone_bundle())["zoneTransfer"] == "Deny"
+    assert (
+        _zone_options_payload("Primary", _zone_bundle(options={"allow_transfer": []}))[
+            "zoneTransfer"
+        ]
+        == "Deny"
+    )
+    assert (
+        _zone_options_payload(
+            "Primary", _zone_bundle(options={"allow_transfer": ["any"]})
+        )["zoneTransfer"]
+        == "Allow"
+    )
+    acl = _zone_options_payload(
+        "Primary", _zone_bundle(options={"allow_transfer": ["10.0.0.0/8"]})
+    )
+    assert acl["zoneTransfer"] == "UseSpecifiedNetworkACL"
+    assert acl["zoneTransferNetworkACL"] == ["10.0.0.0/8"]
+
+
+def test_zone_options_only_for_primary() -> None:
+    """A secondary transfers IN. Whether it re-serves is a separate
+    decision we don't make on the operator's behalf."""
+    for ztype in ("Secondary", "Stub", "Forwarder"):
+        assert _zone_options_payload(ztype, _zone_bundle()) == {}
+
+
+def test_tsig_key_names_only_attached_when_transfer_permitted() -> None:
+    """Pinning key names onto a Deny zone reads as if signed transfer were
+    enabled when nothing can transfer at all."""
+    keys = [{"name": "k1.", "secret": "s", "algorithm": "hmac-sha256"}]
+    denied = _zone_options_payload("Primary", _zone_bundle(tsig_keys=keys))
+    assert denied["zoneTransfer"] == "Deny"
+    assert "zoneTransferTsigKeyNames" not in denied
+
+    allowed = _zone_options_payload(
+        "Primary", _zone_bundle(tsig_keys=keys, options={"allow_transfer": ["any"]})
+    )
+    assert allowed["zoneTransferTsigKeyNames"] == ["k1"]
+
+
+def test_tsig_key_names_strip_root_dot() -> None:
+    """Technitium stores names un-dotted, so a dotted name would compare
+    as different forever."""
+    assert _tsig_key_names(
+        {"tsig_keys": [{"name": "a."}, {"name": "b"}, {"name": ""}]}
+    ) == ["a", "b"]
+
+
+def test_ensure_zone_exists_sends_type_specific_params(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+
+    d._ensure_zone_exists("t", {"zone": "s.test", "type": "Secondary",
+                                "masters": ["192.0.2.1", "192.0.2.2"]})
+    assert calls[-1][3]["primaryNameServerAddresses"] == "192.0.2.1,192.0.2.2"
+
+    d._ensure_zone_exists("t", {"zone": "f.test", "type": "Forwarder",
+                                "forwarders": ["8.8.8.8", "9.9.9.9"]})
+    # Technitium's Forwarder zone takes ONE upstream; extras are dropped
+    # with a warning rather than silently.
+    assert calls[-1][3]["forwarder"] == "8.8.8.8"
+    assert "forwarders" not in calls[-1][3]
+
+
+def test_apply_zone_options_refuses_unknown_transfer_value(tmp_path: Path) -> None:
+    """zones/options/set answers ok for a value it doesn't recognise and
+    keeps the OLD one — so an unvalidated typo silently leaves transfer at
+    whatever it was, which for a zone meant to be locked down is a security
+    regression no log line would report."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_zone_options("t", "z.test", {"zoneTransfer": "Bogus"})
+    assert calls == []
+
+
+def test_apply_zone_options_joins_list_values(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_zone_options(
+        "t",
+        "z.test",
+        {
+            "zoneTransfer": "UseSpecifiedNetworkACL",
+            "zoneTransferNetworkACL": ["10.0.0.0/8", "192.168.0.0/16"],
+            "zoneTransferTsigKeyNames": ["k1"],
+        },
+    )
+    params = calls[0][3]
+    assert params["zoneTransferNetworkACL"] == "10.0.0.0/8,192.168.0.0/16"
+    assert params["zoneTransferTsigKeyNames"] == "k1"
+
+
+def test_sync_tsig_keys_wire_format(tmp_path: Path) -> None:
+    """FLAT pipe-delimited token list read in triples — name|secret|alg|…
+    Not JSON, not one pipe-joined record per key, and not name|alg|secret
+    (that one fails with "TSIG algorithm is not supported", because it
+    reads the secret as the algorithm)."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._sync_tsig_keys(
+        "t",
+        [
+            {"name": "k1.", "secret": "s1", "algorithm": "hmac-sha256"},
+            {"name": "k2", "secret": "s2", "algorithm": "HMAC-SHA512"},
+        ],
+    )
+    assert calls[0][2] == "settings/set"
+    assert calls[0][3]["tsigKeys"] == "k1|s1|hmac-sha256|k2|s2|hmac-sha512"
+
+
+def test_sync_tsig_keys_drops_unsupported_algorithm(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._sync_tsig_keys(
+        "t",
+        [
+            {"name": "bad", "secret": "s", "algorithm": "hmac-sha3"},
+            {"name": "good", "secret": "s", "algorithm": "hmac-sha256"},
+        ],
+    )
+    assert calls[0][3]["tsigKeys"] == "good|s|hmac-sha256"
+
+
+def test_get_zone_records_filters_daemon_managed_apex(tmp_path: Path) -> None:
+    """Apex NS/SOA are stamped by the daemon at zone create. Left in, the
+    apex NS lands in to_delete every pass, gets skipped, and is still
+    counted — reporting a deletion that never happened."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    _install_fake_request(
+        d,
+        lambda *_: {
+            "status": "ok",
+            "response": {
+                "records": [
+                    {"name": "z.test", "type": "SOA", "ttl": 900, "rData": {}},
+                    {"name": "z.test", "type": "NS", "ttl": 3600,
+                     "rData": {"nameServer": "self."}},
+                    {"name": "sub.z.test", "type": "NS", "ttl": 3600,
+                     "rData": {"nameServer": "ns.other."}},
+                    {"name": "www.z.test", "type": "A", "ttl": 300,
+                     "rData": {"ipAddress": "10.0.0.1"}},
+                ]
+            },
+        },
+    )
+    got = {(r["domain"], r["type"]) for r in d._get_zone_records("t", "z.test")}
+    assert ("z.test", "SOA") not in got
+    assert ("z.test", "NS") not in got
+    # Off-apex NS is a real delegation and must survive.
+    assert ("sub.z.test", "NS") in got
+    assert ("www.z.test", "A") in got

--- a/agent/dns/tests/test_technitium_render.py
+++ b/agent/dns/tests/test_technitium_render.py
@@ -1001,14 +1001,22 @@ def test_write_tls_cert_returns_none_on_garbage(tmp_path: Path) -> None:
     assert d._write_tls_cert({"cert_pem": "", "key_pem": ""}) is None
 
 
-def test_transport_settings_never_enable_listener_without_cert(tmp_path: Path) -> None:
+def test_transport_settings_force_listeners_off_without_cert(tmp_path: Path) -> None:
     """Technitium accepts enableDnsOverTls=true even when the cert path in
-    the SAME call is rejected, which would leave a listener up with no
-    certificate. So nothing is enabled unless the cert landed first."""
+    the SAME call is rejected, so a listener must never be enabled without
+    a cert. Crucially it must also be actively turned OFF: bailing out
+    would leave an already-enabled listener up on a stale certificate,
+    which is the opposite of "every path degrades to Do53"."""
     d = TechnitiumDriver(state_dir=tmp_path)
     calls = _install_fake_request(d, lambda *_: {"status": "ok"})
     d._apply_transport_settings("t", {"dot_enabled": True, "dot_port": 853}, None)
-    assert calls == []
+    assert len(calls) == 1
+    params = calls[0][3]
+    assert params["enableDnsOverTls"] == "false"
+    assert params["enableDnsOverHttps"] == "false"
+    assert params["enableDnsOverQuic"] == "false"
+    # No port is pinned for a listener being turned off.
+    assert "dnsOverTlsPort" not in params
 
 
 def test_transport_settings_send_cert_path_before_enabling(tmp_path: Path) -> None:
@@ -1043,7 +1051,10 @@ def test_transport_settings_abort_when_cert_path_rejected(tmp_path: Path) -> Non
     d._apply_transport_settings(
         "t", {"dot_enabled": True}, {"cert_pem": cert_pem, "key_pem": key_pem}
     )
-    assert len(calls) == 1  # never reached the enable call
+    # Cert attempt, then an explicit disable — not a bail-out that would
+    # strand an already-running listener on a stale cert.
+    assert [c[2] for c in calls] == ["settings/set", "settings/set"]
+    assert calls[1][3]["enableDnsOverTls"] == "false"
 
 
 def test_forwarders_and_protocol_are_sent_together(tmp_path: Path) -> None:
@@ -1307,3 +1318,62 @@ def test_apply_blocking_falls_back_when_custom_address_missing(tmp_path: Path) -
          "custom_addresses": []},
     )
     assert calls[0][3]["blockingType"] == "NxDomain"
+
+
+# ── Second code-review pass ─────────────────────────────────────────────
+
+
+def test_master_port_translated_to_technitium_form() -> None:
+    """SpatiumDDI validates masters as BIND's ``ip@port``; Technitium
+    rejects the ``@`` outright ("invalid character [64]") and wants
+    ``ip:port``. Untranslated, the zone create fails every pass."""
+    from spatium_dns_agent.drivers.technitium import _technitium_master
+
+    assert _technitium_master("192.0.2.1") == "192.0.2.1"
+    assert _technitium_master("192.0.2.1@5353") == "192.0.2.1:5353"
+    assert _technitium_master(" 192.0.2.1 ") == "192.0.2.1"
+
+
+def test_existing_zone_upstream_is_reapplied(tmp_path: Path) -> None:
+    """zones/create is a no-op once the zone exists, and it is what
+    carries the upstream — so retargeting a secondary would otherwise be
+    a permanent silent no-op."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+
+    def responder(path, params, n):
+        if path == "zones/create":
+            return {"status": "error", "errorMessage": "Zone already exists."}
+        return {"status": "ok"}
+
+    calls = _install_fake_request(d, responder)
+    d._ensure_zone_exists(
+        "t", {"zone": "s.test", "type": "Secondary", "masters": ["192.0.2.9@5353"]}
+    )
+    opts = [c for c in calls if c[2] == "zones/options/set"]
+    assert opts and opts[0][3]["primaryNameServerAddresses"] == "192.0.2.9:5353"
+
+
+def test_empty_tsig_key_set_is_pushed(tmp_path: Path) -> None:
+    """A revoked key that is never cleared stays installed and signed
+    transfers keep working — same bug class as the forwarders path."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._sync_tsig_keys("t", [])
+    assert calls and calls[0][3]["tsigKeys"] == ""
+
+
+def test_doh_path_override_warns_because_it_is_unsupported(tmp_path: Path) -> None:
+    """Technitium serves DoH on a fixed path and exposes no setting for
+    it, so an operator who changed doh_path would be handed a URL the
+    daemon never answers on."""
+    cert_pem, key_pem = _self_signed_pem()
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_transport_settings(
+        "t",
+        {"doh_enabled": True, "doh_port": 8443, "doh_path": "/custom"},
+        {"cert_pem": cert_pem, "key_pem": key_pem},
+    )
+    # The path is not sent — there is no parameter for it.
+    assert not any("Path" in k and k != "dnsTlsCertificatePath"
+                   for c in calls for k in c[3])

--- a/agent/dns/tests/test_technitium_render.py
+++ b/agent/dns/tests/test_technitium_render.py
@@ -952,3 +952,161 @@ def test_get_zone_records_filters_signing_artefacts(tmp_path: Path) -> None:
     )
     got = d._get_zone_records("t", "z.test")
     assert [r["type"] for r in got] == ["A"]
+
+
+# ── Encrypted transports (issue #741) ───────────────────────────────────
+
+
+def _self_signed_pem() -> tuple[str, str]:
+    import datetime
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "dns.test")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2026, 1, 1))
+        .not_valid_after(datetime.datetime(2027, 1, 1))
+        .sign(key, hashes.SHA256())
+    )
+    return (
+        cert.public_bytes(serialization.Encoding.PEM).decode(),
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode(),
+    )
+
+
+def test_write_tls_cert_emits_loadable_pkcs12(tmp_path: Path) -> None:
+    """Technitium takes the cert as a PKCS #12 file path; handing it PEM
+    fails with "must be PKCS #12 formatted". The bundle ships PEM, so the
+    conversion happens here."""
+    from cryptography.hazmat.primitives.serialization import pkcs12
+
+    cert_pem, key_pem = _self_signed_pem()
+    d = TechnitiumDriver(state_dir=tmp_path)
+    path = d._write_tls_cert({"name": "spatium", "cert_pem": cert_pem, "key_pem": key_pem})
+    assert path is not None
+    blob = Path(path).read_bytes()
+    # Round-trips through a real PKCS#12 loader, so this is not just "some
+    # bytes were written".
+    key, cert, _ = pkcs12.load_key_and_certificates(blob, None)
+    assert key is not None and cert is not None
+    # Embeds a private key — must not be world-readable.
+    assert oct(Path(path).stat().st_mode)[-3:] == "600"
+
+
+def test_write_tls_cert_returns_none_on_garbage(tmp_path: Path) -> None:
+    """An unreadable cert must degrade to Do53, never take the daemon
+    down — the whole point of #50's 'every path degrades to Do53'."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    assert d._write_tls_cert({"cert_pem": "not a cert", "key_pem": "nope"}) is None
+    assert d._write_tls_cert({"cert_pem": "", "key_pem": ""}) is None
+
+
+def test_transport_settings_never_enable_listener_without_cert(tmp_path: Path) -> None:
+    """Technitium accepts enableDnsOverTls=true even when the cert path in
+    the SAME call is rejected, which would leave a listener up with no
+    certificate. So nothing is enabled unless the cert landed first."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_transport_settings("t", {"dot_enabled": True, "dot_port": 853}, None)
+    assert calls == []
+
+
+def test_transport_settings_send_cert_path_before_enabling(tmp_path: Path) -> None:
+    cert_pem, key_pem = _self_signed_pem()
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_transport_settings(
+        "t",
+        {"dot_enabled": True, "dot_port": 8853, "doq_enabled": True, "doq_port": 8853},
+        {"name": "s", "cert_pem": cert_pem, "key_pem": key_pem},
+    )
+    assert "dnsTlsCertificatePath" in calls[0][3]
+    enable = calls[1][3]
+    assert enable["enableDnsOverTls"] == "true"
+    assert enable["dnsOverTlsPort"] == 8853
+    # DoT and DoQ may share a port number: one is TCP, the other UDP.
+    assert enable["enableDnsOverQuic"] == "true"
+    assert enable["dnsOverQuicPort"] == 8853
+    assert enable["enableDnsOverHttps"] == "false"
+
+
+def test_transport_settings_abort_when_cert_path_rejected(tmp_path: Path) -> None:
+    cert_pem, key_pem = _self_signed_pem()
+    d = TechnitiumDriver(state_dir=tmp_path)
+
+    def responder(path, params, n):
+        if "dnsTlsCertificatePath" in params:
+            return {"status": "error", "errorMessage": "file does not exists"}
+        return {"status": "ok"}
+
+    calls = _install_fake_request(d, responder)
+    d._apply_transport_settings(
+        "t", {"dot_enabled": True}, {"cert_pem": cert_pem, "key_pem": key_pem}
+    )
+    assert len(calls) == 1  # never reached the enable call
+
+
+def test_forwarders_and_protocol_are_sent_together(tmp_path: Path) -> None:
+    """forwarderProtocol is silently ignored unless forwarders is set in
+    the SAME call — verified live: setting it alone returns ok and leaves
+    the protocol at Udp."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_forwarders(
+        "t", {"forwarders": ["8.8.8.8", "8.8.4.4"], "forward_transport": "do53"}
+    )
+    params = calls[0][3]
+    assert params["forwarders"] == "8.8.8.8,8.8.4.4"
+    assert params["forwarderProtocol"] == "Udp"
+
+
+def test_forwarders_substitute_hostname_for_encrypted_transports(tmp_path: Path) -> None:
+    """Technitium rejects an IP for DoT/DoH/DoQ ("Address must be a domain
+    name") — there'd be no name to validate the upstream cert against. The
+    neutral model carries IPs plus one hostname, so the hostname wins."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_forwarders(
+        "t",
+        {
+            "forwarders": ["1.1.1.1", "1.0.0.1"],
+            "forward_transport": "tls",
+            "forward_tls_hostname": "cloudflare-dns.com",
+        },
+    )
+    assert calls[0][3]["forwarders"] == "cloudflare-dns.com"
+    assert calls[0][3]["forwarderProtocol"] == "Tls"
+
+
+def test_forwarders_refuse_encrypted_transport_without_hostname(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_forwarders("t", {"forwarders": ["1.1.1.1"], "forward_transport": "https"})
+    assert calls == []
+
+
+def test_forwarders_map_every_transport(tmp_path: Path) -> None:
+    for transport, expected in [
+        ("do53", "Udp"), ("tls", "Tls"), ("https", "Https"), ("quic", "Quic")
+    ]:
+        d = TechnitiumDriver(state_dir=tmp_path)
+        calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+        d._apply_forwarders(
+            "t",
+            {"forwarders": ["1.1.1.1"], "forward_transport": transport,
+             "forward_tls_hostname": "dns.example"},
+        )
+        assert calls[0][3]["forwarderProtocol"] == expected

--- a/agent/dns/tests/test_technitium_render.py
+++ b/agent/dns/tests/test_technitium_render.py
@@ -217,20 +217,6 @@ def test_render_skips_daemon_managed_apex_types(tmp_path: Path) -> None:
     assert ("www.example.com", "A") in types_by_domain
 
 
-def test_render_skips_non_primary_zones(tmp_path: Path) -> None:
-    d = TechnitiumDriver(state_dir=tmp_path)
-    bundle = {
-        "zones": [
-            {"name": "secondary.example.com.", "type": "secondary", "records": []},
-        ]
-    }
-    d.render(bundle)
-    import json
-
-    payload = json.loads((tmp_path / "rendered.new" / "zones.json").read_text())
-    assert payload == []
-
-
 # ── apply_record_op: rrset REPLACE vs append ────────────────────────────
 
 
@@ -1110,3 +1096,101 @@ def test_forwarders_map_every_transport(tmp_path: Path) -> None:
              "forward_tls_hostname": "dns.example"},
         )
         assert calls[0][3]["forwarderProtocol"] == expected
+
+
+# ── Code-review fixes ───────────────────────────────────────────────────
+
+
+def test_reconcile_counts_only_real_deletes(tmp_path: Path) -> None:
+    """"no such record" means it was already gone — a no-op, not a delete.
+    Counting it reports churn that never happened, which is the same
+    phantom the apex-NS filter exists to prevent."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+
+    def responder(path, params, n):
+        if path == "zones/records/get":
+            return {"status": "ok", "response": {"records": [
+                {"name": "gone.z.test", "type": "A", "ttl": 300,
+                 "rData": {"ipAddress": "10.0.0.9"}}]}}
+        if path == "zones/records/delete":
+            return {"status": "error", "errorMessage": "No such record exists."}
+        return {"status": "ok"}
+
+    _install_fake_request(d, responder)
+    import structlog
+
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        d._reconcile_zones("t", [{"zone": "z.test", "type": "Primary", "records": []}])
+    finally:
+        structlog.reset_defaults()
+    reconciled = [e for e in cap.entries if e["event"] == "technitium_zone_reconciled"]
+    # The delete was a no-op, so there is nothing to report at all.
+    assert reconciled == []
+
+
+def test_reconcile_counts_only_real_adds(tmp_path: Path) -> None:
+    """Same reasoning for "already exists" on the add side."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+
+    def responder(path, params, n):
+        if path == "zones/records/get":
+            return {"status": "ok", "response": {"records": []}}
+        if path == "zones/records/add":
+            return {"status": "error", "errorMessage": "Record already exists."}
+        return {"status": "ok"}
+
+    _install_fake_request(d, responder)
+    import structlog
+
+    cap = structlog.testing.LogCapture()
+    structlog.configure(processors=[cap])
+    try:
+        d._reconcile_zones(
+            "t",
+            [{"zone": "z.test", "type": "Primary", "records": [
+                {"domain": "www.z.test", "type": "A", "ttl": 300,
+                 "ipAddress": "10.0.0.1"}]}],
+        )
+    finally:
+        structlog.reset_defaults()
+    assert [e for e in cap.entries if e["event"] == "technitium_zone_reconciled"] == []
+
+
+def test_forwarders_cleared_when_bundle_has_none(tmp_path: Path) -> None:
+    """Removing every forwarder must actually clear them. An early return
+    would leave the daemon resolving through the old upstreams forever,
+    because nothing else touches the setting."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_forwarders("t", {"forwarders": [], "forward_transport": "do53"})
+    assert calls[0][3]["forwarders"] == ""
+    assert calls[0][3]["forwarderProtocol"] == "Udp"
+
+
+def test_catalog_consumer_creates_secondary_catalog_zone(tmp_path: Path) -> None:
+    """The catalog zone is shipped as a catalog block, not a zone row, so
+    a consumer that doesn't create it here does nothing at all."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_catalog(
+        "t",
+        {"mode": "consumer", "zone_name": "cat.test.", "producer_addr": "192.0.2.9"},
+        [{"zone": "p.test", "type": "Primary"}],
+    )
+    assert calls[0][2] == "zones/create"
+    assert calls[0][3]["type"] == "SecondaryCatalog"
+    assert calls[0][3]["primaryNameServerAddresses"] == "192.0.2.9"
+    # A consumer must NOT stamp membership onto its own primaries.
+    assert not [c for c in calls if c[2] == "zones/options/set"]
+
+
+def test_catalog_membership_cleared_when_disabled(tmp_path: Path) -> None:
+    """Turning catalog zones off has to un-enrol the members; nothing else
+    ever touches the option."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    calls = _install_fake_request(d, lambda *_: {"status": "ok"})
+    d._apply_catalog("t", None, [{"zone": "p.test", "type": "Primary"}])
+    opt = [c for c in calls if c[2] == "zones/options/set"]
+    assert opt and opt[0][3]["catalog"] == ""

--- a/agent/dns/tests/test_technitium_render.py
+++ b/agent/dns/tests/test_technitium_render.py
@@ -811,3 +811,144 @@ def test_get_zone_records_filters_daemon_managed_apex(tmp_path: Path) -> None:
     # Off-apex NS is a real delegation and must survive.
     assert ("sub.z.test", "NS") in got
     assert ("www.z.test", "A") in got
+
+
+# ── DNSSEC (issue #740) ─────────────────────────────────────────────────
+
+
+_SIGNED_PROPS = {
+    "status": "ok",
+    "response": {
+        "dnssecStatus": "SignedWithNSEC",
+        "dnssecPrivateKeys": [
+            {"keyTag": 34619, "keyType": "KeySigningKey", "algorithmNumber": 13,
+             "state": "Published", "stateChangedOn": "2026-07-30T15:30:08Z",
+             "stateReadyBy": "2026-07-30T20:05:08Z"},
+            {"keyTag": 44648, "keyType": "ZoneSigningKey", "algorithmNumber": 13,
+             "state": "Active", "stateChangedOn": "2026-07-30T15:30:08Z"},
+        ],
+    },
+}
+_SIGNED_RECORDS = {
+    "status": "ok",
+    "response": {
+        "records": [
+            {"name": "z.test", "type": "DNSKEY", "ttl": 3600, "rData": {
+                "computedKeyTag": 34619, "algorithmNumber": 13,
+                "computedDigests": [
+                    {"digestType": "SHA256", "digest": "DD98"},
+                    {"digestType": "SHA384", "digest": "309D"},
+                ]}},
+            # ZSK carries no computedDigests — a DS attests the KSK only.
+            {"name": "z.test", "type": "DNSKEY", "ttl": 3600, "rData": {
+                "computedKeyTag": 44648, "algorithmNumber": 13}},
+        ]
+    },
+}
+
+
+def _dnssec_responder(path, params, n):
+    if path == "zones/dnssec/properties/get":
+        return _SIGNED_PROPS
+    if path == "zones/records/get":
+        return _SIGNED_RECORDS
+    return {"status": "ok"}
+
+
+def test_collect_dnssec_state_builds_ds_presentation_format(tmp_path: Path) -> None:
+    """DS presentation form is ``<keyTag> <algorithm> <digestType> <digest>``.
+    Technitium reports the digest TYPE by name, so it has to be mapped back
+    to its RFC 4034 number."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    _install_fake_request(d, _dnssec_responder)
+    state = d._collect_dnssec_state("t", "z.test")
+    assert state["ds_records"] == [
+        "34619 13 2 DD98",
+        "34619 13 4 309D",
+    ]
+
+
+def test_collect_dnssec_state_reports_per_key_state(tmp_path: Path) -> None:
+    """Unlike the PowerDNS agent, Technitium exposes per-key state, and the
+    control plane already models it (#49's DNSKey rows)."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    _install_fake_request(d, _dnssec_responder)
+    keys = {k["key_tag"]: k for k in d._collect_dnssec_state("t", "z.test")["keys"]}
+    assert keys[34619]["key_type"] == "ksk"
+    assert keys[44648]["key_type"] == "zsk"
+    assert keys[34619]["state"] == "published"
+    assert keys[44648]["state"] == "active"
+    assert keys[34619]["algorithm"] == 13
+    assert keys[34619]["timing"]["state_ready_by"] == "2026-07-30T20:05:08Z"
+
+
+def test_dnssec_sign_is_idempotent(tmp_path: Path) -> None:
+    """Repeated 'Sign zone' clicks should converge on signed, not error."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+
+    def responder(path, params, n):
+        if path == "zones/dnssec/sign":
+            return {"status": "error", "errorMessage":
+                    "Cannot sign zone: the zone is already signed."}
+        return _dnssec_responder(path, params, n)
+
+    _install_fake_request(d, responder)
+    state = d._dnssec_sign("t", "z.test")
+    assert state["ds_records"]
+
+
+def test_dnssec_sign_raises_on_real_failure(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    _install_fake_request(
+        d, lambda *_: {"status": "error", "errorMessage": "Access denied."}
+    )
+    try:
+        d._dnssec_sign("t", "z.test")
+    except RuntimeError as exc:
+        assert "Access denied" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected RuntimeError")
+
+
+def test_dnssec_unsign_clears_ds_and_keys(tmp_path: Path) -> None:
+    """A stale DS left on display is one the parent zone no longer trusts."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    _install_fake_request(d, lambda *_: {"status": "ok"})
+    state = d._dnssec_unsign("t", "z.test")
+    assert state == {"zone_name": "z.test", "ds_records": [], "keys": []}
+
+
+def test_apply_record_op_routes_dnssec_ops(tmp_path: Path) -> None:
+    d = TechnitiumDriver(state_dir=tmp_path)
+    _seed_token(d)
+    _install_fake_request(d, _dnssec_responder)
+    out = d.apply_record_op(
+        {"zone_name": "z.test.", "op": "dnssec_sign",
+         "record": {"name": "@", "type": "DNSSEC_OP"}}
+    )
+    assert out is not None and out["dnssec_state"]["ds_records"]
+
+
+def test_get_zone_records_filters_signing_artefacts(tmp_path: Path) -> None:
+    """A signed zone serves DNSKEY/RRSIG/NSEC* that no bundle describes.
+    Left unfiltered, the reconciler tries to delete the zone's own
+    signatures on every pass."""
+    d = TechnitiumDriver(state_dir=tmp_path)
+    _install_fake_request(
+        d,
+        lambda *_: {
+            "status": "ok",
+            "response": {
+                "records": [
+                    {"name": "z.test", "type": "DNSKEY", "ttl": 3600, "rData": {}},
+                    {"name": "z.test", "type": "RRSIG", "ttl": 3600, "rData": {}},
+                    {"name": "z.test", "type": "NSEC", "ttl": 3600, "rData": {}},
+                    {"name": "z.test", "type": "NSEC3PARAM", "ttl": 3600, "rData": {}},
+                    {"name": "www.z.test", "type": "A", "ttl": 300,
+                     "rData": {"ipAddress": "10.0.0.1"}},
+                ]
+            },
+        },
+    )
+    got = d._get_zone_records("t", "z.test")
+    assert [r["type"] for r in got] == ["A"]

--- a/agent/supervisor/spatium_supervisor/firewall_renderer.py
+++ b/agent/supervisor/spatium_supervisor/firewall_renderer.py
@@ -312,7 +312,7 @@ def render_drop_in(
     # actually present) and ships them on the role assignment. Ignored
     # unless a DNS role is assigned, so a stale value on a re-roled
     # appliance can't leave a port open.
-    if any(r in roles for r in ("dns-bind9", "dns-powerdns")):
+    if any(r in roles for r in ("dns-bind9", "dns-powerdns", "dns-technitium")):
         for raw in role_assignment.get("dns_encrypted_tcp_ports") or []:
             try:
                 port = int(raw)
@@ -320,6 +320,16 @@ def render_drop_in(
                 continue
             if 1 <= port <= 65535:
                 role_tcp.add(port)
+        # #741 — DoQ is UDP. Same operator-chosen shape, different table:
+        # adding it to role_tcp would leave the listener unreachable while
+        # the rendered ruleset looked correct.
+        for raw in role_assignment.get("dns_encrypted_udp_ports") or []:
+            try:
+                port = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if 1 <= port <= 65535:
+                role_udp.add(port)
     if role_udp or role_tcp:
         lines.append("")
         lines.append("# ── Per-role service ports ─────────────────────────────")

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -198,6 +198,8 @@ backend/alembic/versions/b1e7c04a93df_fragile_device_do_not_probe.py:drop_column
 backend/alembic/versions/b2c84f7a91d3_unifi_integration.py:drop_column:168
 backend/alembic/versions/b2c84f7a91d3_unifi_integration.py:drop_column:171
 backend/alembic/versions/b2c84f7a91d3_unifi_integration.py:drop_table:173
+backend/alembic/versions/b2d47f1c8a30_dns_over_quic_options.py:drop_column:58
+backend/alembic/versions/b2d47f1c8a30_dns_over_quic_options.py:drop_column:59
 backend/alembic/versions/b2e5d8a41c67_static_ipam_metadata_snapshot.py:drop_column:37
 backend/alembic/versions/b2f5a9c41e07_acme_manual_dns.py:drop_column:55
 backend/alembic/versions/b2f5a9c41e07_acme_manual_dns.py:drop_column:56

--- a/backend/alembic/versions/b2d47f1c8a30_dns_over_quic_options.py
+++ b/backend/alembic/versions/b2d47f1c8a30_dns_over_quic_options.py
@@ -1,0 +1,59 @@
+"""DNS-over-QUIC listener options (issue #741).
+
+Adds ``doq_enabled`` / ``doq_port`` to ``dns_server_options``, alongside
+the DoT / DoH knobs #50 added.
+
+Technitium-only in practice — BIND9 has no DoQ listener and pdns-auth
+speaks none of the encrypted transports — but the column lives on the
+shared options row like its DoT/DoH siblings, with the driver gate
+enforced at the API boundary rather than in the schema. Same shape as
+``dot_enabled`` / ``dot_port``: default-off, so an existing install
+renders byte-identically until an operator opts in.
+
+``doq_port`` defaults to 853, the RFC 9250 default, which is the same
+number DoT uses — that is correct and not a copy-paste slip: DoQ is UDP
+and DoT is TCP, so the two do not collide. The firewall layer has to open
+udp/853, not tcp/853, which is why the two are separate columns rather
+than one shared port.
+
+Revision ID: b2d47f1c8a30
+Revises: 6a668dd451d5
+Create Date: 2026-07-30
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b2d47f1c8a30"
+down_revision: str | None = "6a668dd451d5"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "dns_server_options",
+        sa.Column(
+            "doq_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "dns_server_options",
+        sa.Column(
+            "doq_port",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("853"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("dns_server_options", "doq_port")
+    op.drop_column("dns_server_options", "doq_enabled")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -2445,6 +2445,7 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
         firewall_extra=row.firewall_extra,
         kubeapi_expose_cidrs=list(row.kubeapi_expose_cidrs or []),
         dns_encrypted_tcp_ports=dns_encrypted_tcp_ports,
+        dns_encrypted_udp_ports=dns_encrypted_udp_ports,
     )
 
 

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1248,6 +1248,9 @@ class SupervisorRoleAssignment(BaseModel):
     # encrypted listener (or no usable cert), and the renderer opens
     # nothing extra.
     dns_encrypted_tcp_ports: list[int] = Field(default_factory=list)
+    # #741 — DoQ is UDP, so it needs its own channel: opening its port on
+    # tcp would leave the listener unreachable while looking configured.
+    dns_encrypted_udp_ports: list[int] = Field(default_factory=list)
 
 
 class SupervisorHeartbeatResponse(BaseModel):
@@ -2375,6 +2378,7 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
     # the supervisor's renderer opens exactly these and nothing more, so
     # turning a listener off closes its port on the next apply.
     dns_encrypted_tcp_ports: list[int] = []
+    dns_encrypted_udp_ports: list[int] = []
     if row.assigned_dns_group_id is not None:
         dns_group = await db.get(DNSServerGroup, row.assigned_dns_group_id)
         if dns_group is not None:
@@ -2396,7 +2400,13 @@ async def _build_role_assignment(db: DB, row: Appliance) -> SupervisorRoleAssign
                         dns_encrypted_tcp_ports.append(int(dns_opts.dot_port))
                     if dns_opts.doh_enabled:
                         dns_encrypted_tcp_ports.append(int(dns_opts.doh_port))
+                    # DoQ rides UDP (#741). It may share a port number with
+                    # DoT — 853 is the RFC default for both — which is why
+                    # the two lists are separate rather than one merged set.
+                    if getattr(dns_opts, "doq_enabled", False):
+                        dns_encrypted_udp_ports.append(int(dns_opts.doq_port))
             dns_encrypted_tcp_ports = sorted(set(dns_encrypted_tcp_ports))
+            dns_encrypted_udp_ports = sorted(set(dns_encrypted_udp_ports))
 
     dhcp_group_name: str | None = None
     dhcp_network_mode: str | None = None

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -177,7 +177,16 @@ VALID_DNSDIST_ACTIONS = {"truncate", "drop"}
 # client-side HTTP transport, so DoH-upstream isn't expressible on the BIND9
 # driver. The dnsdist front used by PowerDNS can do it and gets its own knob
 # if/when that's wired.
-VALID_FORWARD_TRANSPORTS = {"do53", "tls"}
+VALID_FORWARD_TRANSPORTS = {"do53", "tls", "https", "quic"}
+# Transports only some drivers can actually speak. BIND 9.20 forwards
+# over DoT but has no client-side HTTP or QUIC transport, so https /
+# quic are refused for a bind9 group rather than rendered into a
+# named.conf that would not load. Technitium does all four (verified
+# live against 15.4.0). Issue #741.
+_TRANSPORT_DRIVER_GATE: dict[str, frozenset[str]] = {
+    "https": frozenset({"technitium"}),
+    "quic": frozenset({"technitium"}),
+}
 # Ports a DoT / DoH listener may never claim (issue #50). The listeners bind
 # ``any``, which includes loopback, so they collide with the fixed ports the
 # agent hardcodes into every rendered named.conf. Value is the operator-facing
@@ -2431,6 +2440,14 @@ async def _assert_encrypted_transport_sane(opts: DNSServerOptions, db: DB) -> No
     if opts.dot_enabled and opts.doh_enabled and opts.dot_port == opts.doh_port:
         raise HTTPException(422, "dot_port and doh_port must differ")
 
+    # DoQ (#741) is UDP where DoT/DoH are TCP, so it may legitimately share
+    # a port number with DoT — 853 is the RFC-default for both. Only the
+    # reserved-port check applies.
+    if opts.doq_enabled:
+        reason = _RESERVED_DNS_PORTS.get(opts.doq_port)
+        if reason:
+            raise HTTPException(422, f"doq_port cannot be {opts.doq_port} — {reason}")
+
     # On an appliance the frontend already serves HTTPS on 443/80, and the
     # DNS workload runs with hostNetwork — so a listener there would fight
     # the web UI for the port. Applies to BOTH listeners: nothing stops an
@@ -2448,6 +2465,24 @@ async def _assert_encrypted_transport_sane(opts: DNSServerOptions, db: DB) -> No
                     "install. Pick another port (8443 is the usual choice) and "
                     "publish it to clients via DoH bootstrap configuration.",
                 )
+
+    # Driver gates for the transports only Technitium speaks (#741).
+    drivers = set(await _group_driver_names(db, opts.group_id))
+    allowed = _TRANSPORT_DRIVER_GATE.get(opts.forward_transport)
+    if allowed is not None and drivers and not (drivers & allowed):
+        raise HTTPException(
+            422,
+            f"forward_transport {opts.forward_transport!r} is only supported by "
+            f"{', '.join(sorted(allowed))} — this group runs "
+            f"{', '.join(sorted(drivers))}. BIND9 has no client-side HTTP or "
+            "QUIC transport, so it can only forward over do53 or tls.",
+        )
+    if opts.doq_enabled and drivers and "technitium" not in drivers:
+        raise HTTPException(
+            422,
+            "DNS-over-QUIC is only supported by the Technitium driver — this "
+            f"group runs {', '.join(sorted(drivers))}.",
+        )
 
     if (
         opts.forward_transport == "tls"

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -160,10 +160,11 @@ _DRIVER_GATED_RECORD_TYPES: dict[str, frozenset[str]] = {
 # online via REST and BIND9 needs the manual ``dnssec-keygen``
 # dance that's #49's umbrella scope.
 _DRIVER_GATED_OPERATIONS: dict[str, frozenset[str]] = {
-    # Both PowerDNS (online signing) and BIND9 (inline-signing via
-    # dnssec-policy, issue #49) support sign/unsign. Windows DNS does not.
-    "dnssec_sign": frozenset({"powerdns", "bind9"}),
-    "dnssec_unsign": frozenset({"powerdns", "bind9"}),
+    # PowerDNS (online signing), BIND9 (inline-signing via dnssec-policy,
+    # issue #49) and Technitium (online signing, issue #740) all support
+    # sign/unsign. Windows DNS does not.
+    "dnssec_sign": frozenset({"powerdns", "bind9", "technitium"}),
+    "dnssec_unsign": frozenset({"powerdns", "bind9", "technitium"}),
     # Manual key rollover is BIND9-only (rndc dnssec -rollover); PowerDNS
     # rolls on its own schedule + Windows DNS isn't supported.
     "dnssec_rollover": frozenset({"bind9"}),

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -3219,11 +3219,43 @@ async def list_zones(
     return list(result.scalars().all())
 
 
+async def _assert_forward_zone_serviceable(
+    group_id: uuid.UUID, zone_type: str, forwarders: list[str] | None, db: DB
+) -> None:
+    """Reject a forwarders-less forward zone on a Technitium group.
+
+    BIND9 treats ``type forward;`` with no ``forwarders`` as legal — it
+    falls back to the global forwarder list — so the shared ZoneCreate
+    validator deliberately allows it. Technitium does not: its
+    ``zones/create type=Forwarder`` requires a ``forwarder`` param, so the
+    agent has nothing to send and skips the zone with a warning. Without
+    this check the operator gets a 201 and a zone that silently never
+    exists on the daemon, which is the same failure mode the
+    secondary/stub masters check exists to prevent (issue #743).
+    """
+    if zone_type != "forward" or forwarders:
+        return
+    drivers = set(await _group_driver_names(db, group_id))
+    if "technitium" in drivers:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "a forward zone on a Technitium group requires at least one "
+                "forwarder — Technitium has no global-forwarder fallback for "
+                "forward zones, so the zone would never be created on the "
+                "server. BIND9 groups may omit it."
+            ),
+        )
+
+
 @router.post("/groups/{group_id}/zones", response_model=ZoneResponse, status_code=201)
 async def create_zone(
     group_id: uuid.UUID, body: ZoneCreate, db: DB, current_user: SuperAdmin
 ) -> DNSZone:
     await _require_group(group_id, db)
+    await _assert_forward_zone_serviceable(
+        group_id, body.zone_type, list(body.forwarders or []), db
+    )
     existing = await db.execute(
         select(DNSZone).where(
             DNSZone.group_id == group_id,
@@ -3815,6 +3847,12 @@ async def update_zone(
     if "masters" in changes:
         changes["masters"] = [m.strip() for m in changes["masters"] if m and m.strip()]
     effective_zone_type = changes.get("zone_type", zone.zone_type)
+    await _assert_forward_zone_serviceable(
+        zone.group_id,
+        effective_zone_type,
+        list(changes.get("forwarders", zone.forwarders) or []),
+        db,
+    )
     if effective_zone_type in {"secondary", "stub"}:
         effective_masters = changes.get("masters", zone.masters) or []
         if not effective_masters:

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -527,6 +527,10 @@ class ServerOptionsUpdate(BaseModel):
     # over-long value 422s at the boundary instead of 500-ing on asyncpg's
     # StringDataRightTruncation at commit.
     doh_path: str | None = Field(default=None, max_length=128)
+    # DNS-over-QUIC (#741) — Technitium-only, and UDP, so it may share a
+    # port number with DoT without colliding.
+    doq_enabled: bool | None = None
+    doq_port: int | None = Field(default=None, ge=1, le=65535)
     tls_certificate_id: uuid.UUID | None = None
     forward_transport: str | None = None
     forward_tls_hostname: str | None = Field(default=None, max_length=255)
@@ -661,6 +665,8 @@ class ServerOptionsResponse(BaseModel):
     doh_enabled: bool
     doh_port: int
     doh_path: str
+    doq_enabled: bool
+    doq_port: int
     tls_certificate_id: uuid.UUID | None
     forward_transport: str
     forward_tls_hostname: str | None
@@ -2404,11 +2410,11 @@ async def _assert_encrypted_transport_sane(opts: DNSServerOptions, db: DB) -> No
     port bind that would fail at runtime. Catching it on the API boundary
     turns an agent that won't start into a 422 the operator can read.
     """
-    if opts.dot_enabled or opts.doh_enabled:
+    if opts.dot_enabled or opts.doh_enabled or opts.doq_enabled:
         if opts.tls_certificate_id is None:
             raise HTTPException(
                 422,
-                "A TLS certificate is required to enable DoT or DoH. "
+                "A TLS certificate is required to enable DoT, DoH or DoQ. "
                 "Upload or issue one under Appliance → Web UI Certificate first.",
             )
         cert = await db.get(ApplianceCertificate, opts.tls_certificate_id)
@@ -2467,23 +2473,50 @@ async def _assert_encrypted_transport_sane(opts: DNSServerOptions, db: DB) -> No
                 )
 
     # Driver gates for the transports only Technitium speaks (#741).
+    #
+    # EVERY driver in the group has to support the setting, not merely one
+    # of them — same subset semantics as ``_check_driver_gated_record_type``.
+    # An "any driver matches" test would let a mixed bind9 + technitium
+    # group save forward_transport="https", and bind9 would then quietly
+    # keep forwarding in cleartext on :53 while the UI claimed DoH.
     drivers = set(await _group_driver_names(db, opts.group_id))
     allowed = _TRANSPORT_DRIVER_GATE.get(opts.forward_transport)
-    if allowed is not None and drivers and not (drivers & allowed):
-        raise HTTPException(
-            422,
-            f"forward_transport {opts.forward_transport!r} is only supported by "
-            f"{', '.join(sorted(allowed))} — this group runs "
-            f"{', '.join(sorted(drivers))}. BIND9 has no client-side HTTP or "
-            "QUIC transport, so it can only forward over do53 or tls.",
-        )
-    if opts.doq_enabled and drivers and "technitium" not in drivers:
-        raise HTTPException(
-            422,
-            "DNS-over-QUIC is only supported by the Technitium driver — this "
-            f"group runs {', '.join(sorted(drivers))}.",
-        )
+    if allowed is not None and drivers:
+        incompatible = drivers - allowed
+        if incompatible:
+            raise HTTPException(
+                422,
+                f"forward_transport {opts.forward_transport!r} is not supported by "
+                f"{', '.join(sorted(incompatible))} in this group. BIND9 has no "
+                "client-side HTTP or QUIC transport, so it can only forward over "
+                "do53 or tls — move those servers to their own group, or pick a "
+                "transport every driver in this group can speak.",
+            )
+    if opts.doq_enabled and drivers:
+        incompatible = drivers - {"technitium"}
+        if incompatible:
+            raise HTTPException(
+                422,
+                "DNS-over-QUIC is only supported by the Technitium driver, but "
+                f"this group also runs {', '.join(sorted(incompatible))}.",
+            )
 
+    # Every encrypted transport needs a name, not just DoT.
+    #
+    # For bind9 (tls) it is what ``remote-hostname`` validates against, so
+    # the requirement is conditional on verification being on. For
+    # technitium it is stricter: the daemon rejects an IP outright
+    # ("Address must be a domain name") for tls/https/quic, so without a
+    # hostname the agent has nothing to send and skips the forwarder apply
+    # entirely — leaving whatever forwarders were there before. Requiring
+    # it up front turns that silent staleness into a 422.
+    if opts.forward_transport in ("https", "quic") and not opts.forward_tls_hostname:
+        raise HTTPException(
+            422,
+            f"forward_tls_hostname is required when forwarding over "
+            f"{opts.forward_transport} — the upstream is addressed by name, not "
+            "by IP. Set the provider's hostname (e.g. cloudflare-dns.com).",
+        )
     if (
         opts.forward_transport == "tls"
         and opts.forward_tls_verify
@@ -2578,7 +2611,15 @@ async def update_options(
     # per-appliance desired-state change wakes the appliance channel too.
     if any(
         f in changes
-        for f in ("dot_enabled", "dot_port", "doh_enabled", "doh_port", "tls_certificate_id")
+        for f in (
+            "dot_enabled",
+            "dot_port",
+            "doh_enabled",
+            "doh_port",
+            "doq_enabled",
+            "doq_port",
+            "tls_certificate_id",
+        )
     ):
         await _collect_appliance_wakes_for_dns_group(db, group_id)
     await db.commit()

--- a/backend/app/api/v1/dns_import/router.py
+++ b/backend/app/api/v1/dns_import/router.py
@@ -31,12 +31,15 @@ from app.services.dns_import import (
     CommitResult,
     ImportSourceError,
     PowerDNSImportError,
+    TechnitiumImportError,
     WindowsDNSImportError,
     parse_bind9_archive,
     parse_powerdns_server,
+    parse_technitium_server,
     parse_windows_dns_server,
     preview_cloud_import,
     test_powerdns_connection,
+    test_technitium_connection,
 )
 from app.services.dns_import.canonical import (
     ConflictAction,
@@ -108,6 +111,7 @@ class PreviewOut(BaseModel):
         "bind9",
         "windows_dns",
         "powerdns",
+        "technitium",
         "cloudflare",
         "route53",
         "azure_dns",
@@ -214,6 +218,36 @@ class PowerDNSTestIn(BaseModel):
     api_url: str
     api_key: str
     server_name: str = "localhost"
+
+
+class TechnitiumPreviewIn(BaseModel):
+    """Body shape for ``POST /dns/import/technitium/preview``."""
+
+    api_url: str
+    api_token: str
+    target_group_id: uuid.UUID
+    target_view_id: uuid.UUID | None = None
+
+
+class TechnitiumTestIn(BaseModel):
+    """Body shape for ``POST /dns/import/technitium/test-connection``."""
+
+    api_url: str
+    api_token: str
+
+
+class TechnitiumTestOut(BaseModel):
+    """Response from ``POST /dns/import/technitium/test-connection``.
+
+    ``importable_zone_count`` is deliberately reported separately from
+    ``zone_count``: only a Primary carries authoritative data of its own,
+    so a server that is mostly secondaries has far less to import than
+    its raw zone count suggests.
+    """
+
+    ok: bool
+    zone_count: int
+    importable_zone_count: int
 
 
 class PowerDNSTestOut(BaseModel):
@@ -741,6 +775,123 @@ async def powerdns_commit(
 
     logger.info(
         "dns_import_powerdns_commit",
+        target_group_id=str(body.target_group_id),
+        zones_created=result.total_zones_created,
+        zones_overwrote=result.total_zones_overwrote,
+        zones_renamed=result.total_zones_renamed,
+        zones_skipped=result.total_zones_skipped,
+        zones_failed=result.total_zones_failed,
+        records_created=result.total_records_created,
+        user=current_user.display_name,
+    )
+    return _commit_result_to_pydantic(result)
+
+
+# ── Technitium endpoints (issue #744) ────────────────────────────────
+
+
+@router.post("/technitium/test-connection", response_model=TechnitiumTestOut)
+async def technitium_test_connection(
+    _: SuperAdmin,
+    body: TechnitiumTestIn = Body(...),
+) -> TechnitiumTestOut:
+    """Probe a Technitium server before kicking off a full pull."""
+
+    # SECURITY (#400, L5): advisory SSRF guard, same posture as the
+    # PowerDNS path — a LAN Technitium daemon is a legitimate import
+    # source, so the resolved target is logged rather than hard-blocked.
+    assert_safe_target(body.api_url, label="dns_import_technitium")
+
+    try:
+        info = await test_technitium_connection(api_url=body.api_url, api_token=body.api_token)
+    except TechnitiumImportError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    return TechnitiumTestOut(**info)
+
+
+@router.post("/technitium/preview", response_model=PreviewOut)
+async def technitium_preview(
+    current_user: SuperAdmin,
+    db: DB,
+    body: TechnitiumPreviewIn = Body(...),
+) -> PreviewOut:
+    """Live-pull every primary zone + record from a Technitium server.
+
+    The token lives in the body and is never persisted. Non-primary
+    zones are reported as warnings rather than imported — a secondary is
+    a copy of someone else's data.
+    """
+
+    assert_safe_target(body.api_url, label="dns_import_technitium")
+
+    try:
+        preview = await parse_technitium_server(api_url=body.api_url, api_token=body.api_token)
+    except TechnitiumImportError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    zone_names = [(z.name if z.name.endswith(".") else z.name + ".").lower() for z in preview.zones]
+    preview.conflicts = await detect_conflicts(
+        db,
+        zone_names=zone_names,
+        target_group_id=body.target_group_id,
+        target_view_id=body.target_view_id,
+    )
+
+    logger.info(
+        "dns_import_technitium_preview",
+        api_url=body.api_url,
+        zone_count=len(preview.zones),
+        record_count=preview.total_records,
+        conflict_count=len(preview.conflicts),
+        warning_count=len(preview.warnings),
+        target_group_id=str(body.target_group_id),
+        target_view_id=str(body.target_view_id) if body.target_view_id else None,
+        user=current_user.display_name,
+    )
+    return _preview_to_pydantic(preview)
+
+
+@router.post("/technitium/commit", response_model=CommitOut)
+async def technitium_commit(
+    current_user: SuperAdmin,
+    db: DB,
+    body: CommitIn = Body(...),
+) -> CommitOut:
+    """Apply a previously-previewed Technitium import.
+
+    Same shared pipeline as every other source — the canonical IR reuse
+    keeps audit, per-zone savepoints and RBAC in lock-step.
+    """
+
+    if body.plan.source != "technitium":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Plan source mismatch: endpoint=technitium plan={body.plan.source}",
+        )
+
+    preview = _preview_from_pydantic(body.plan)
+    actions: dict[str, tuple[ConflictAction, str | None]] = {
+        zone_name: (decision.action, decision.rename_to)
+        for zone_name, decision in body.conflict_actions.items()
+    }
+
+    try:
+        result = await commit_import(
+            db,
+            preview=preview,
+            target_group_id=body.target_group_id,
+            target_view_id=body.target_view_id,
+            conflict_actions=actions,
+            current_user=current_user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    # #358 — imported zones land under target_group_id; wake its agents.
+    collect_wake(dns_group_channel(body.target_group_id))
+
+    logger.info(
+        "dns_import_technitium_commit",
         target_group_id=str(body.target_group_id),
         zones_created=result.total_zones_created,
         zones_overwrote=result.total_zones_overwrote,

--- a/backend/app/drivers/dns/_axfr.py
+++ b/backend/app/drivers/dns/_axfr.py
@@ -98,6 +98,11 @@ def _hint(exc: BaseException, port: int) -> str:
     )
 
 
+# Signing artefacts the authoritative server generates and owns. Never
+# modelled as SpatiumDDI records, so they must not surface as drift.
+_DNSSEC_ARTEFACTS = frozenset({"RRSIG", "NSEC", "NSEC3", "NSEC3PARAM", "DNSKEY", "CDS", "CDNSKEY"})
+
+
 async def axfr_zone_records(
     *,
     host: str,
@@ -112,7 +117,8 @@ async def axfr_zone_records(
     Apex SOA and NS are filtered out — SpatiumDDI manages those at the zone
     level, so importing them as user records would create duplicate control
     surfaces. Out-of-zone glue (an NS target living in a different zone) is
-    also skipped.
+    also skipped, as are DNSSEC signing artefacts (RRSIG / NSEC* / DNSKEY /
+    CDS / CDNSKEY), which the signing server owns and rotates itself.
     """
     import dns.name  # noqa: PLC0415
     import dns.query  # noqa: PLC0415
@@ -185,6 +191,14 @@ async def axfr_zone_records(
             if rtype == "SOA":
                 continue
             if rtype == "NS" and rel_label == "@":
+                continue
+            if rtype in _DNSSEC_ARTEFACTS:
+                # The daemon owns these — it mints them when the zone is
+                # signed and rotates them on its own schedule. They exist
+                # on the wire but never as SpatiumDDI records, so a drift
+                # report would list every signature as "extra on server"
+                # and a signed zone could never read as in sync. Affects
+                # every AXFR caller, not one driver.
                 continue
             for rdata in rdataset:
                 priority: int | None = None

--- a/backend/app/drivers/dns/technitium.py
+++ b/backend/app/drivers/dns/technitium.py
@@ -293,7 +293,7 @@ class TechnitiumDriver(DNSDriver):
                 if rtype not in _SUPPORTED_RECORD_TYPES:
                     errors.append(
                         f"zone {z.name!r}: record type {rtype!r} not supported "
-                        f"by the v1 Technitium driver"
+                        f"by the Technitium driver"
                     )
         if bundle.views:
             errors.append(

--- a/backend/app/drivers/dns/technitium.py
+++ b/backend/app/drivers/dns/technitium.py
@@ -29,8 +29,6 @@ Scope (this driver):
 
 Deferred to fast-follow phases (tracked in the roadmap, not this driver):
 
-* DNSSEC online signing — issue #740. Technitium's ``/api/zones/dnssec/*``
-  surface is close in shape to PowerDNS's.
 * Native DNS-over-TLS/HTTPS/QUIC listener wiring — issue #741. A real
   differentiator over PowerDNS (no dnsdist sidecar needed); it also
   supports encrypted *upstream* forwarding, which BIND9 cannot do.
@@ -315,7 +313,7 @@ class TechnitiumDriver(DNSDriver):
             "name": "technitium",
             "views": False,
             "rpz": False,
-            "dnssec_inline_signing": False,  # fast-follow
+            "dnssec_inline_signing": True,  # issue #740 — online signing
             "incremental_updates": "rest_api",
             "zone_types": sorted(_SUPPORTED_ZONE_TYPES),
             "record_types": sorted(_SUPPORTED_RECORD_TYPES),

--- a/backend/app/drivers/dns/technitium.py
+++ b/backend/app/drivers/dns/technitium.py
@@ -15,23 +15,27 @@ internal store, managed exclusively through the API), so this driver's
 real reconcile-against-API logic lives in the agent-side driver under
 ``agent/dns/spatium_dns_agent/drivers/technitium.py``.
 
-v1 scope (this driver):
+Scope (this driver):
 
-* Primary zones + standard record CRUD via the Technitium REST API. The
-  agent generates a permanent API token on first boot
+* Primary / secondary / stub / forward zones, standard record CRUD, and
+  catalog-zone membership via the Technitium REST API. The agent
+  generates a permanent API token on first boot
   (``POST /api/user/createToken``) and is the only caller — the control
   plane formulates ``RecordChange`` ops and the agent translates them to
   ``/api/zones/records/{add,update,delete}`` calls.
 * Validate the bundle (zone names end with ".", record types from the
-  supported set, primary zones only, no views).
+  supported set, zone types from ``_SUPPORTED_ZONE_TYPES``, secondary /
+  stub zones carry primaries to transfer from, no views).
 
 Deferred to fast-follow phases (tracked in the roadmap, not this driver):
 
-* DNSSEC online signing (Technitium's ``/api/zones/dnssec/*`` surface is
-  close in shape to PowerDNS's — should port quickly once picked up).
-* Native DNS-over-TLS/HTTPS/QUIC listener wiring — a real differentiator
-  over PowerDNS (no dnsdist sidecar needed), needs a settings-API spike.
-* Catalog zones, secondary/stub/forward zones + TSIG zone transfer.
+* DNSSEC online signing — issue #740. Technitium's ``/api/zones/dnssec/*``
+  surface is close in shape to PowerDNS's.
+* Native DNS-over-TLS/HTTPS/QUIC listener wiring — issue #741. A real
+  differentiator over PowerDNS (no dnsdist sidecar needed); it also
+  supports encrypted *upstream* forwarding, which BIND9 cannot do.
+* Query-log shipping — issue #742.
+* ``dns_import`` live-pull + blocklist wiring — issue #744.
 * ANAME / APP / FWD record types (Technitium-proprietary, different shape
   than PowerDNS's ALIAS/LUA — not a drop-in equivalent).
 
@@ -60,6 +64,12 @@ from app.drivers.dns.base import (
 
 logger = structlog.get_logger(__name__)
 
+
+# Zone types the driver can create (issue #743). Technitium's own names
+# are Primary / Secondary / Stub / Forwarder; the mapping lives agent-side
+# in ``_ZONE_TYPE_MAP``. Catalog zones are handled out-of-band via the
+# group's catalog block, not as a per-zone type an operator picks.
+_SUPPORTED_ZONE_TYPES = frozenset({"primary", "secondary", "stub", "forward"})
 
 # Record types the Technitium driver supports in v1, taken from Technitium's
 # documented `/api/zones/records/add` type list. ANAME / FWD / APP are
@@ -263,12 +273,23 @@ class TechnitiumDriver(DNSDriver):
             if key in seen:
                 errors.append(f"duplicate zone {z.name!r} in view {z.view_name!r}")
             seen.add(key)
-            if z.zone_type != "primary":
+            if z.zone_type not in _SUPPORTED_ZONE_TYPES:
                 errors.append(
                     f"zone {z.name!r}: zone_type {z.zone_type!r} not supported by "
-                    "the v1 Technitium driver (primary zones only — secondary/"
-                    "stub/forward are a fast-follow)"
+                    f"the Technitium driver (supported: "
+                    f"{', '.join(sorted(_SUPPORTED_ZONE_TYPES))})"
                 )
+            # A secondary/stub with nowhere to transfer from cannot be
+            # created at all — Technitium resolves SOA against the primaries
+            # at create time. Catch it here so the operator gets a 422 on
+            # save rather than a zone that silently never appears.
+            if z.zone_type in ("secondary", "stub") and not z.masters:
+                errors.append(
+                    f"zone {z.name!r}: zone_type {z.zone_type!r} requires at least "
+                    "one primary name-server address to transfer from"
+                )
+            if z.zone_type == "forward" and not z.forwarders:
+                errors.append(f"zone {z.name!r}: forward zones require at least one forwarder")
             for r in z.records:
                 rtype = r.record_type.upper()
                 if rtype not in _SUPPORTED_RECORD_TYPES:
@@ -296,11 +317,11 @@ class TechnitiumDriver(DNSDriver):
             "rpz": False,
             "dnssec_inline_signing": False,  # fast-follow
             "incremental_updates": "rest_api",
-            "zone_types": ["primary"],
+            "zone_types": sorted(_SUPPORTED_ZONE_TYPES),
             "record_types": sorted(_SUPPORTED_RECORD_TYPES),
             "alias_records": False,
             "lua_records": False,
-            "catalog_zones": False,
+            "catalog_zones": True,
         }
 
     @property

--- a/backend/app/drivers/dns/technitium.py
+++ b/backend/app/drivers/dns/technitium.py
@@ -259,6 +259,53 @@ class TechnitiumDriver(DNSDriver):
             zone=zone_name,
         )
 
+    async def pull_zone_records(self, server: Any, zone_name: str) -> list[RecordData]:
+        """AXFR the zone off the Technitium host, for the #61 drift report.
+
+        Technitium's own REST API would be the more natural source — it is
+        exactly what the live-pull importer reads — but that API listens on
+        loopback :5380 inside the agent's container and is reachable only
+        by the co-located agent. The control plane can only talk to the
+        server over DNS, so drift goes over AXFR, the same path BIND9 uses.
+
+        **This requires the zone to permit transfer to the control plane.**
+        Zone-transfer policy is derived from the group's ``allow_transfer``
+        (see ``_zone_options_payload`` in the agent driver), which defaults
+        to ``["none"]`` → ``Deny``. On a default install the AXFR is
+        REFUSED and the drift row surfaces that rather than silently
+        reporting "no drift" — an empty diff from a refused transfer would
+        be far worse than an error, because it reads as "in sync".
+        """
+        from app.drivers.dns._axfr import axfr_zone_records  # noqa: PLC0415
+
+        host = getattr(server, "host", None)
+        if not host:
+            raise RuntimeError("TechnitiumDriver.pull_zone_records: server.host is required")
+        port = getattr(server, "port", None) or 53
+        try:
+            return await axfr_zone_records(
+                host=host,
+                port=port,
+                zone_name=zone_name,
+                log_driver="technitium",
+                server_id=str(getattr(server, "id", "")),
+            )
+        except Exception as exc:
+            # A bare "REFUSED" tells the operator nothing about what to do.
+            # Name the setting that governs it.
+            if "REFUSED" in str(exc).upper():
+                raise RuntimeError(
+                    f"{host} refused the zone transfer for {zone_name!r}. Drift "
+                    "reads the live zone over AXFR, which needs two things on "
+                    "the group: 'allow transfer' must permit the control plane "
+                    "(it defaults to none), AND the group must have no TSIG "
+                    "keys — Technitium requires a SIGNED transfer once any key "
+                    "is named on the zone, and the control plane does not yet "
+                    "sign its AXFR (the same limitation as issue #734 for "
+                    "BIND9)."
+                ) from exc
+            raise
+
     # ── Validation / capabilities ─────────────────────────────────────────
 
     def validate_config(self, bundle: ConfigBundle) -> tuple[bool, list[str]]:

--- a/backend/app/models/dns.py
+++ b/backend/app/models/dns.py
@@ -456,6 +456,12 @@ class DNSServerOptions(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # ``_assert_encrypted_transport_sane``) and operators pick another port.
     doh_port: Mapped[int] = mapped_column(Integer, nullable=False, default=443)
     doh_path: Mapped[str] = mapped_column(String(128), nullable=False, default="/dns-query")
+    # DNS-over-QUIC (RFC 9250), issue #741. Technitium-only: BIND9 has no
+    # DoQ listener and pdns-auth speaks none of these, so the API gates
+    # this to technitium groups. UDP, unlike DoT/DoH — the firewall layer
+    # has to open udp/<doq_port>, not tcp.
+    doq_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    doq_port: Mapped[int] = mapped_column(Integer, nullable=False, default=853)
 
     # Cert served by BOTH listeners. SET NULL rather than CASCADE: deleting a
     # certificate must not delete the whole options row. A NULL id with a
@@ -469,10 +475,13 @@ class DNSServerOptions(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         index=True,
     )
 
-    # Outbound forwarding transport — do53 | tls. BIND 9.20 can forward over
-    # DoT but NOT over DoH (there is no client-side HTTP transport), so
-    # "https" is deliberately not a value here; the PowerDNS/dnsdist path
-    # gets DoH-upstream separately.
+    # Outbound forwarding transport — do53 | tls | https | quic.
+    #
+    # BIND 9.20 can forward over DoT but NOT over DoH (no client-side HTTP
+    # transport), so for a bind9 group the API still refuses anything past
+    # "tls". Technitium forwards over all four (verified live), which is a
+    # capability neither other agent-managed driver has — hence the wider
+    # column with a per-driver gate rather than a wider column for everyone.
     forward_transport: Mapped[str] = mapped_column(String(10), nullable=False, default="do53")
     # ``remote-hostname`` for strict upstream cert validation. Group-level
     # rather than per-forwarder because the common case is one provider's

--- a/backend/app/services/appliance/firewall.py
+++ b/backend/app/services/appliance/firewall.py
@@ -172,7 +172,7 @@ def compile_firewall_body(
     # Issue #50 — operator-chosen DoT / DoH ports ride the role assignment
     # rather than the static table above. Keep this block byte-identical to
     # ``firewall_renderer.render_drop_in``.
-    if any(r in roles for r in ("dns-bind9", "dns-powerdns")):
+    if any(r in roles for r in ("dns-bind9", "dns-powerdns", "dns-technitium")):
         for raw in role_assignment.get("dns_encrypted_tcp_ports") or []:
             try:
                 port = int(raw)
@@ -180,6 +180,16 @@ def compile_firewall_body(
                 continue
             if 1 <= port <= 65535:
                 role_tcp.add(port)
+        # #741 — DoQ is UDP. Same operator-chosen shape, different table:
+        # adding it to role_tcp would leave the listener unreachable while
+        # the rendered ruleset looked correct.
+        for raw in role_assignment.get("dns_encrypted_udp_ports") or []:
+            try:
+                port = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if 1 <= port <= 65535:
+                role_udp.add(port)
     if role_udp or role_tcp:
         lines.append("")
         lines.append("# ── Per-role service ports ─────────────────────────────")

--- a/backend/app/services/appliance/firewall_merge.py
+++ b/backend/app/services/appliance/firewall_merge.py
@@ -550,7 +550,7 @@ def compile_firewall_from_policies(
     # derives them from the assigned DNS group's options and ships them on the
     # role assignment. Keep byte-identical to ``firewall.compile_firewall_body``
     # + the supervisor's ``firewall_renderer.render_drop_in``.
-    if any(r in ctx.roles for r in ("dns-bind9", "dns-powerdns")):
+    if any(r in ctx.roles for r in ("dns-bind9", "dns-powerdns", "dns-technitium")):
         for raw in ra.get("dns_encrypted_tcp_ports") or []:
             try:
                 port = int(raw)
@@ -558,6 +558,16 @@ def compile_firewall_from_policies(
                 continue
             if 1 <= port <= 65535:
                 role_tcp.add(port)
+        # #741 — DoQ is UDP. Same operator-chosen shape, different table:
+        # adding it to role_tcp would leave the listener unreachable while
+        # the rendered ruleset looked correct.
+        for raw in ra.get("dns_encrypted_udp_ports") or []:
+            try:
+                port = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if 1 <= port <= 65535:
+                role_udp.add(port)
     if role_udp or role_tcp:
         lines.append("")
         lines.append("# ── Per-role service ports ─────────────────────────────")

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -476,7 +476,16 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     # the same producer payload — the catalog zone format is RFC 9432
     # canonical, so the rendering driver doesn't need to fork.
     catalog_block: dict[str, Any] | None = None
-    if grp and grp.catalog_zones_enabled and server.driver in ("bind9", "powerdns"):
+    if (
+        grp
+        and grp.catalog_zones_enabled
+        and server.driver
+        in (
+            "bind9",
+            "powerdns",
+            "technitium",
+        )
+    ):
         producer = (
             await db.execute(
                 select(DNSServer).where(

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -429,6 +429,9 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         "doh_enabled": (bool(getattr(opts, "doh_enabled", False)) if opts else False),
         "doh_port": int(getattr(opts, "doh_port", 443)) if opts else 443,
         "doh_path": (getattr(opts, "doh_path", "/dns-query") if opts else "/dns-query"),
+        # DoQ (#741) — Technitium-only, and UDP where DoT/DoH are TCP.
+        "doq_enabled": (bool(getattr(opts, "doq_enabled", False)) if opts else False),
+        "doq_port": int(getattr(opts, "doq_port", 853)) if opts else 853,
         "forward_transport": (getattr(opts, "forward_transport", "do53") if opts else "do53"),
         "forward_tls_hostname": (getattr(opts, "forward_tls_hostname", None) if opts else None),
         "forward_tls_verify": (bool(getattr(opts, "forward_tls_verify", True)) if opts else True),
@@ -629,7 +632,11 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     # the pre-renewal PEM and emit no SQL, so the etag wouldn't move and the
     # rotation wake would buy nothing.
     tls_cert_block: dict[str, Any] | None = None
-    if opts is not None and (opts.dot_enabled or opts.doh_enabled) and opts.tls_certificate_id:
+    if (
+        opts is not None
+        and (opts.dot_enabled or opts.doh_enabled or opts.doq_enabled)
+        and opts.tls_certificate_id
+    ):
         cert_row = (
             await db.execute(
                 select(ApplianceCertificate)

--- a/backend/app/services/dns_import/__init__.py
+++ b/backend/app/services/dns_import/__init__.py
@@ -32,6 +32,11 @@ from .powerdns import (
     parse_powerdns_server,
     test_powerdns_connection,
 )
+from .technitium import (
+    TechnitiumImportError,
+    parse_technitium_server,
+    test_technitium_connection,
+)
 from .windows_dns import WindowsDNSImportError, parse_windows_dns_server
 
 __all__ = [
@@ -47,6 +52,7 @@ __all__ = [
     "ImportSource",
     "ImportSourceError",
     "PowerDNSImportError",
+    "TechnitiumImportError",
     "WindowsDNSImportError",
     "ZoneConflict",
     "commit_cloud_import",
@@ -55,6 +61,8 @@ __all__ = [
     "parse_bind9_archive",
     "preview_cloud_import",
     "parse_powerdns_server",
+    "parse_technitium_server",
     "parse_windows_dns_server",
     "test_powerdns_connection",
+    "test_technitium_connection",
 ]

--- a/backend/app/services/dns_import/canonical.py
+++ b/backend/app/services/dns_import/canonical.py
@@ -24,6 +24,7 @@ ImportSource = Literal[
     "bind9",
     "windows_dns",
     "powerdns",
+    "technitium",
     "cloudflare",
     "route53",
     "azure_dns",

--- a/backend/app/services/dns_import/technitium.py
+++ b/backend/app/services/dns_import/technitium.py
@@ -1,0 +1,437 @@
+"""Technitium DNS Server live-pull importer (issue #744).
+
+Walks the REST API of a Technitium server the operator is migrating
+*from* and emits the canonical :class:`ImportPreview` shape, same as the
+BIND9 / Windows DNS / PowerDNS importers — the shared commit pipeline
+writes the rows.
+
+Two calls per pull:
+
+* ``GET /api/zones/list`` → every zone::
+
+      {"status": "ok", "response": {"zones": [
+        {"name": "example.com", "type": "Primary", "disabled": false,
+         "isExpired": false, "catalog": null}, ...]}}
+
+* ``GET /api/zones/records/get?domain=<z>&zone=<z>&listZone=true`` →
+  its records, each carrying a **structured** ``rData`` object rather
+  than a wire-format string.
+
+That last point is the whole difference from the PowerDNS importer.
+PowerDNS hands back ``content`` strings that parse straight into a
+record value; Technitium hands back per-type fields whose names do NOT
+match the ones its own *write* API takes, and which translate numeric
+rdata into enum names (``tlsaSelector=1`` reads back as
+``selector="SPKI"``). ``_rdata_to_value`` is the inverse: it rebuilds
+the presentation-format string SpatiumDDI stores. The agent driver
+solves the same problem in the other direction — see
+``_normalize_rdata`` in ``agent/dns/spatium_dns_agent/drivers/
+technitium.py``; the two share the enum tables' intent, and a
+round-trip test asserts they agree.
+
+Auth: a bearer token, passed as a ``token`` query param (Technitium's
+own convention — it accepts ``Authorization: Bearer`` too, but the
+token param is what its docs and console use). The operator pastes the
+API URL and a token into the import form; neither is persisted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .canonical import (
+    ImportedRecord,
+    ImportedSOA,
+    ImportedZone,
+    ImportPreview,
+)
+
+
+class TechnitiumImportError(ValueError):
+    """Raised when the Technitium API can't be reached / parsed.
+
+    Per-zone parse errors don't raise — they land in
+    ``ImportedZone.parse_warnings`` so partial success stays visible.
+    """
+
+
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
+
+_MAX_ZONES_PER_PULL = 5000
+
+# Record types the importer models. Technitium-proprietary types
+# (ANAME / APP / FWD) and DNSSEC artefacts drop out with a per-zone
+# warning rather than silently.
+_SUPPORTED_RECORD_TYPES = {
+    "A",
+    "AAAA",
+    "CNAME",
+    "MX",
+    "TXT",
+    "NS",
+    "PTR",
+    "SRV",
+    "CAA",
+    "TLSA",
+    "SSHFP",
+    "NAPTR",
+    "DNAME",
+    "URI",
+    "SVCB",
+    "HTTPS",
+}
+
+_DNSSEC_RECORDS = {"DNSKEY", "RRSIG", "NSEC", "NSEC3", "NSEC3PARAM", "DS"}
+
+# Only these can be imported as authoritative data. A Secondary holds a
+# copy of someone else's zone and a Forwarder holds no records at all,
+# so importing either would mint rows SpatiumDDI would then try to serve
+# as its own.
+_IMPORTABLE_ZONE_TYPES = {"Primary"}
+
+# Inverse of the agent driver's enum translation. Technitium returns
+# these fields by NAME on read while its write API takes the number.
+_TLSA_USAGE = {"PKIX-TA": 0, "PKIX-EE": 1, "DANE-TA": 2, "DANE-EE": 3}
+_TLSA_SELECTOR = {"Cert": 0, "SPKI": 1}
+_TLSA_MATCHING = {"Full": 0, "SHA2-256": 1, "SHA2-512": 2}
+_SSHFP_ALGO = {"RSA": 1, "DSA": 2, "ECDSA": 3, "Ed25519": 4, "Ed448": 6}
+_SSHFP_FP_TYPE = {"SHA1": 1, "SHA256": 2}
+
+
+def _enum_num(table: dict[str, int], value: Any) -> str:
+    """Map an enum name back to its number, passing an unrecognised
+    value through unchanged so a future Technitium enum degrades to an
+    odd-looking record rather than an exception mid-import."""
+    return str(table.get(str(value), value))
+
+
+def _normalize_fqdn(name: str) -> str:
+    return name if name.endswith(".") else name + "."
+
+
+def _classify_zone(name: str) -> str:
+    bare = name.rstrip(".").lower()
+    return "reverse" if bare.endswith((".in-addr.arpa", ".ip6.arpa")) else "forward"
+
+
+def _rel_name(record_name: str, zone_fqdn: str) -> str:
+    """Technitium reports each record's full domain; SpatiumDDI stores a
+    label relative to the zone, with ``@`` for the apex."""
+    rec = record_name.rstrip(".").lower()
+    zone = zone_fqdn.rstrip(".").lower()
+    if rec == zone or not rec:
+        return "@"
+    if rec.endswith("." + zone):
+        return rec[: -(len(zone) + 1)]
+    return rec
+
+
+def _rdata_to_value(rtype: str, rdata: dict[str, Any]) -> tuple[str, dict[str, int]]:
+    """Rebuild the presentation-format value from Technitium's structured
+    rData, plus any structured fields SpatiumDDI stores separately
+    (MX/SRV priority, weight, port).
+    """
+    extra: dict[str, int] = {}
+
+    if rtype in ("A", "AAAA"):
+        return str(rdata.get("ipAddress") or ""), extra
+    if rtype == "CNAME":
+        return str(rdata.get("cname") or ""), extra
+    if rtype == "DNAME":
+        return str(rdata.get("dname") or ""), extra
+    if rtype == "NS":
+        return str(rdata.get("nameServer") or ""), extra
+    if rtype == "PTR":
+        return str(rdata.get("ptrName") or ""), extra
+    if rtype == "TXT":
+        return str(rdata.get("text") or ""), extra
+    if rtype == "MX":
+        extra["priority"] = int(rdata.get("preference") or 10)
+        return str(rdata.get("exchange") or ""), extra
+    if rtype == "SRV":
+        extra["priority"] = int(rdata.get("priority") or 0)
+        extra["weight"] = int(rdata.get("weight") or 0)
+        extra["port"] = int(rdata.get("port") or 0)
+        return str(rdata.get("target") or ""), extra
+    if rtype == "CAA":
+        return (
+            f"{int(rdata.get('flags') or 0)} {rdata.get('tag') or 'issue'} "
+            f"\"{rdata.get('value') or ''}\"",
+            extra,
+        )
+    if rtype == "TLSA":
+        return (
+            " ".join(
+                [
+                    _enum_num(_TLSA_USAGE, rdata.get("certificateUsage")),
+                    _enum_num(_TLSA_SELECTOR, rdata.get("selector")),
+                    _enum_num(_TLSA_MATCHING, rdata.get("matchingType")),
+                    str(rdata.get("certificateAssociationData") or "").lower(),
+                ]
+            ),
+            extra,
+        )
+    if rtype == "SSHFP":
+        return (
+            " ".join(
+                [
+                    _enum_num(_SSHFP_ALGO, rdata.get("algorithm")),
+                    _enum_num(_SSHFP_FP_TYPE, rdata.get("fingerprintType")),
+                    str(rdata.get("fingerprint") or "").lower(),
+                ]
+            ),
+            extra,
+        )
+    if rtype == "NAPTR":
+        return (
+            f"{rdata.get('order') or 0} {rdata.get('preference') or 0} "
+            f"\"{rdata.get('flags') or ''}\" \"{rdata.get('services') or ''}\" "
+            f"\"{rdata.get('regexp') or ''}\" {rdata.get('replacement') or '.'}",
+            extra,
+        )
+    if rtype == "URI":
+        return (
+            f"{rdata.get('priority') or 1} {rdata.get('weight') or 1} " f"{rdata.get('uri') or ''}",
+            extra,
+        )
+    if rtype in ("SVCB", "HTTPS"):
+        params = rdata.get("svcParams") or {}
+        rendered = " ".join(f'{k}="{v}"' for k, v in sorted(params.items()))
+        target = rdata.get("svcTargetName") or "."
+        return (
+            f"{rdata.get('svcPriority') or 1} {target}" + (f" {rendered}" if rendered else ""),
+            extra,
+        )
+    # Unreachable for the supported set, but keeps the function total.
+    return str(rdata), extra
+
+
+def _soa_from_rdata(rdata: dict[str, Any], ttl: int) -> ImportedSOA:
+    return ImportedSOA(
+        primary_ns=_normalize_fqdn(str(rdata.get("primaryNameServer") or "")),
+        admin_email=_normalize_fqdn(str(rdata.get("responsiblePerson") or "")),
+        serial=int(rdata.get("serial") or 0),
+        refresh=int(rdata.get("refresh") or 86400),
+        retry=int(rdata.get("retry") or 7200),
+        expire=int(rdata.get("expire") or 3600000),
+        minimum=int(rdata.get("minimum") or 3600),
+        ttl=ttl,
+    )
+
+
+def _build_imported_zone(zone_name: str, records_payload: list[dict[str, Any]]) -> ImportedZone:
+    fqdn = _normalize_fqdn(zone_name)
+    soa: ImportedSOA | None = None
+    records: list[ImportedRecord] = []
+    skipped: dict[str, int] = {}
+    warnings: list[str] = []
+
+    for rec in records_payload:
+        rtype = str(rec.get("type") or "").upper()
+        rdata = rec.get("rData") or {}
+        ttl = int(rec.get("ttl") or 3600)
+
+        if rtype == "SOA":
+            soa = _soa_from_rdata(rdata, ttl)
+            continue
+        if rtype in _DNSSEC_RECORDS or rtype not in _SUPPORTED_RECORD_TYPES:
+            skipped[rtype] = skipped.get(rtype, 0) + 1
+            continue
+        # Technitium marks a disabled record rather than omitting it.
+        if rec.get("disabled"):
+            skipped[rtype] = skipped.get(rtype, 0) + 1
+            continue
+
+        try:
+            value, extra = _rdata_to_value(rtype, rdata)
+        except (TypeError, ValueError) as exc:
+            warnings.append(f"Unparseable {rtype} at {rec.get('name')!r}: {exc}")
+            continue
+        if not value:
+            warnings.append(f"Empty {rtype} value at {rec.get('name')!r} — skipped")
+            continue
+
+        records.append(
+            ImportedRecord(
+                name=_rel_name(str(rec.get("name") or ""), fqdn),
+                record_type=rtype,
+                value=value,
+                ttl=ttl,
+                priority=extra.get("priority"),
+                weight=extra.get("weight"),
+                port=extra.get("port"),
+            )
+        )
+
+    dnssec_skipped = {k: v for k, v in skipped.items() if k in _DNSSEC_RECORDS}
+    if dnssec_skipped:
+        warnings.append(
+            "Skipped DNSSEC records ("
+            + ", ".join(f"{k}×{v}" for k, v in sorted(dnssec_skipped.items()))
+            + ") — re-sign the zone after import rather than carrying "
+            "signatures across."
+        )
+    other_skipped = {k: v for k, v in skipped.items() if k not in _DNSSEC_RECORDS}
+    if other_skipped:
+        warnings.append(
+            "Skipped unsupported or disabled records ("
+            + ", ".join(f"{k}×{v}" for k, v in sorted(other_skipped.items()))
+            + ")."
+        )
+
+    return ImportedZone(
+        name=fqdn,
+        zone_type="primary",
+        kind=_classify_zone(fqdn),
+        soa=soa,
+        records=records,
+        parse_warnings=warnings,
+    )
+
+
+def _api_url(base: str, path: str) -> str:
+    return f"{base.rstrip('/')}/api/{path}"
+
+
+def _unwrap(payload: dict[str, Any], what: str) -> dict[str, Any]:
+    """Technitium answers HTTP 200 even on failure — the real status is
+    in the body. Same trap the agent driver documents for its own calls."""
+    status = payload.get("status")
+    if status != "ok":
+        raise TechnitiumImportError(
+            f"Technitium rejected the {what} request "
+            f"(status={status!r}): {payload.get('errorMessage') or 'no detail'}"
+        )
+    return payload.get("response") or {}
+
+
+async def parse_technitium_server(
+    *,
+    api_url: str,
+    api_token: str,
+    timeout: httpx.Timeout = _DEFAULT_TIMEOUT,
+) -> ImportPreview:
+    """Live-pull every primary zone + its records from a Technitium server.
+
+    ``api_url`` is the console base (``http://tdns.internal:5380``); the
+    ``/api`` suffix is appended here so the operator-facing form stays
+    simple.
+
+    Only ``Primary`` zones are imported. Secondary / Stub / Forwarder /
+    Catalog zones are reported as warnings instead — a secondary is a
+    copy of someone else's data, and importing it would mint rows
+    SpatiumDDI then tries to serve authoritatively.
+
+    Per-zone failures become ``parse_warnings`` on that zone rather than
+    aborting the pull, matching the other importers' partial-success
+    semantics.
+    """
+    zones: list[ImportedZone] = []
+    warnings: list[str] = []
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            resp = await client.get(_api_url(api_url, "zones/list"), params={"token": api_token})
+        except httpx.HTTPError as exc:
+            raise TechnitiumImportError(
+                f"Could not reach the Technitium API at {api_url!r}: {exc}"
+            ) from exc
+        if resp.status_code >= 400:
+            raise TechnitiumImportError(
+                f"Technitium API returned HTTP {resp.status_code}: {resp.text[:200]!r}"
+            )
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            raise TechnitiumImportError(f"Technitium API returned invalid JSON: {exc}") from exc
+        # An expired or wrong token comes back as HTTP 200 with
+        # status="invalid-token", so this is the only place it surfaces.
+        listing = _unwrap(body, "zone list")
+
+        summaries = listing.get("zones") or []
+        if len(summaries) > _MAX_ZONES_PER_PULL:
+            raise TechnitiumImportError(
+                f"Source has {len(summaries)} zones — over the "
+                f"{_MAX_ZONES_PER_PULL}-zone per-pull cap. Split the import "
+                "across multiple runs."
+            )
+
+        for summary in summaries:
+            name = str(summary.get("name") or "")
+            ztype = str(summary.get("type") or "")
+            if not name:
+                continue
+            if ztype not in _IMPORTABLE_ZONE_TYPES:
+                warnings.append(
+                    f"Skipped {name!r}: {ztype} zones aren't imported — only a "
+                    "Primary holds authoritative data of its own."
+                )
+                continue
+
+            try:
+                rec_resp = await client.get(
+                    _api_url(api_url, "zones/records/get"),
+                    params={
+                        "token": api_token,
+                        "domain": name,
+                        "zone": name,
+                        "listZone": "true",
+                    },
+                )
+                rec_body = _unwrap(rec_resp.json(), f"records for {name!r}")
+            except (httpx.HTTPError, ValueError, TechnitiumImportError) as exc:
+                zones.append(
+                    ImportedZone(
+                        name=_normalize_fqdn(name),
+                        zone_type="primary",
+                        kind=_classify_zone(name),
+                        soa=None,
+                        records=[],
+                        parse_warnings=[f"Could not pull records: {exc}"],
+                    )
+                )
+                continue
+
+            zones.append(_build_imported_zone(name, rec_body.get("records") or []))
+
+    total_records = sum(len(z.records) for z in zones)
+    histogram: dict[str, int] = {}
+    for zone in zones:
+        for rec in zone.records:
+            histogram[rec.record_type] = histogram.get(rec.record_type, 0) + 1
+
+    return ImportPreview(
+        source="technitium",
+        zones=zones,
+        conflicts=[],
+        warnings=warnings,
+        total_records=total_records,
+        record_type_histogram=histogram,
+    )
+
+
+async def test_technitium_connection(
+    *, api_url: str, api_token: str, timeout: httpx.Timeout = _DEFAULT_TIMEOUT
+) -> dict[str, Any]:
+    """Cheap reachability + auth probe for the import form."""
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            resp = await client.get(_api_url(api_url, "zones/list"), params={"token": api_token})
+        except httpx.HTTPError as exc:
+            raise TechnitiumImportError(
+                f"Could not reach the Technitium API at {api_url!r}: {exc}"
+            ) from exc
+        if resp.status_code >= 400:
+            raise TechnitiumImportError(
+                f"Technitium API returned HTTP {resp.status_code}: {resp.text[:200]!r}"
+            )
+        listing = _unwrap(resp.json(), "zone list")
+    summaries = listing.get("zones") or []
+    importable = [z for z in summaries if str(z.get("type")) in _IMPORTABLE_ZONE_TYPES]
+    return {
+        "ok": True,
+        "zone_count": len(summaries),
+        "importable_zone_count": len(importable),
+    }

--- a/backend/app/services/dns_import/technitium.py
+++ b/backend/app/services/dns_import/technitium.py
@@ -107,6 +107,21 @@ def _enum_num(table: dict[str, int], value: Any) -> str:
     return str(table.get(str(value), value))
 
 
+def _int_or(value: Any, default: int) -> int:
+    """``int(x or default)`` silently rewrites a legitimate ZERO to the
+    default, which matters here: SVCB/HTTPS priority 0 means AliasMode
+    (not ServiceMode), MX preference 0 is the highest priority, and URI
+    priority/weight 0 are valid. Only a genuinely absent or unparseable
+    value falls back.
+    """
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _normalize_fqdn(name: str) -> str:
     return name if name.endswith(".") else name + "."
 
@@ -148,16 +163,16 @@ def _rdata_to_value(rtype: str, rdata: dict[str, Any]) -> tuple[str, dict[str, i
     if rtype == "TXT":
         return str(rdata.get("text") or ""), extra
     if rtype == "MX":
-        extra["priority"] = int(rdata.get("preference") or 10)
+        extra["priority"] = _int_or(rdata.get("preference"), 10)
         return str(rdata.get("exchange") or ""), extra
     if rtype == "SRV":
-        extra["priority"] = int(rdata.get("priority") or 0)
-        extra["weight"] = int(rdata.get("weight") or 0)
-        extra["port"] = int(rdata.get("port") or 0)
+        extra["priority"] = _int_or(rdata.get("priority"), 0)
+        extra["weight"] = _int_or(rdata.get("weight"), 0)
+        extra["port"] = _int_or(rdata.get("port"), 0)
         return str(rdata.get("target") or ""), extra
     if rtype == "CAA":
         return (
-            f"{int(rdata.get('flags') or 0)} {rdata.get('tag') or 'issue'} "
+            f"{_int_or(rdata.get('flags'), 0)} {rdata.get('tag') or 'issue'} "
             f"\"{rdata.get('value') or ''}\"",
             extra,
         )
@@ -193,7 +208,8 @@ def _rdata_to_value(rtype: str, rdata: dict[str, Any]) -> tuple[str, dict[str, i
         )
     if rtype == "URI":
         return (
-            f"{rdata.get('priority') or 1} {rdata.get('weight') or 1} " f"{rdata.get('uri') or ''}",
+            f"{_int_or(rdata.get('priority'), 1)} "
+            f"{_int_or(rdata.get('weight'), 1)} {rdata.get('uri') or ''}",
             extra,
         )
     if rtype in ("SVCB", "HTTPS"):
@@ -201,7 +217,8 @@ def _rdata_to_value(rtype: str, rdata: dict[str, Any]) -> tuple[str, dict[str, i
         rendered = " ".join(f'{k}="{v}"' for k, v in sorted(params.items()))
         target = rdata.get("svcTargetName") or "."
         return (
-            f"{rdata.get('svcPriority') or 1} {target}" + (f" {rendered}" if rendered else ""),
+            f"{_int_or(rdata.get('svcPriority'), 1)} {target}"
+            + (f" {rendered}" if rendered else ""),
             extra,
         )
     # Unreachable for the supported set, but keeps the function total.
@@ -212,11 +229,11 @@ def _soa_from_rdata(rdata: dict[str, Any], ttl: int) -> ImportedSOA:
     return ImportedSOA(
         primary_ns=_normalize_fqdn(str(rdata.get("primaryNameServer") or "")),
         admin_email=_normalize_fqdn(str(rdata.get("responsiblePerson") or "")),
-        serial=int(rdata.get("serial") or 0),
-        refresh=int(rdata.get("refresh") or 86400),
-        retry=int(rdata.get("retry") or 7200),
-        expire=int(rdata.get("expire") or 3600000),
-        minimum=int(rdata.get("minimum") or 3600),
+        serial=_int_or(rdata.get("serial"), 0),
+        refresh=_int_or(rdata.get("refresh"), 86400),
+        retry=_int_or(rdata.get("retry"), 7200),
+        expire=_int_or(rdata.get("expire"), 3600000),
+        minimum=_int_or(rdata.get("minimum"), 3600),
         ttl=ttl,
     )
 
@@ -231,7 +248,7 @@ def _build_imported_zone(zone_name: str, records_payload: list[dict[str, Any]]) 
     for rec in records_payload:
         rtype = str(rec.get("type") or "").upper()
         rdata = rec.get("rData") or {}
-        ttl = int(rec.get("ttl") or 3600)
+        ttl = _int_or(rec.get("ttl"), 3600)
 
         if rtype == "SOA":
             soa = _soa_from_rdata(rdata, ttl)
@@ -333,7 +350,18 @@ async def parse_technitium_server(
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         try:
-            resp = await client.get(_api_url(api_url, "zones/list"), params={"token": api_token})
+            resp = await client.get(
+                _api_url(api_url, "zones/list"),
+                params={
+                    "token": api_token,
+                    # 15.4.0 returns every zone and ignores these, but a
+                    # version that paginated would hand back page 1 and we
+                    # would silently import a fraction of the estate. Ask
+                    # for one big page, then assert nothing was held back.
+                    "pageNumber": 1,
+                    "zonesPerPage": _MAX_ZONES_PER_PULL,
+                },
+            )
         except httpx.HTTPError as exc:
             raise TechnitiumImportError(
                 f"Could not reach the Technitium API at {api_url!r}: {exc}"
@@ -351,6 +379,17 @@ async def parse_technitium_server(
         listing = _unwrap(body, "zone list")
 
         summaries = listing.get("zones") or []
+        # Refuse a truncated view. ``totalPages`` is absent on 15.4.0 (that
+        # endpoint is unpaginated there), so this guards against a future
+        # version quietly changing the contract, not today's behaviour.
+        total_pages = listing.get("totalPages")
+        if isinstance(total_pages, int) and total_pages > 1:
+            raise TechnitiumImportError(
+                f"The Technitium API paginated the zone list ({total_pages} pages) "
+                "and this importer reads one page. Importing now would silently "
+                "migrate only part of the estate — please report this, it means "
+                "the server's API contract has changed."
+            )
         if len(summaries) > _MAX_ZONES_PER_PULL:
             raise TechnitiumImportError(
                 f"Source has {len(summaries)} zones — over the "
@@ -367,6 +406,15 @@ async def parse_technitium_server(
                 warnings.append(
                     f"Skipped {name!r}: {ztype} zones aren't imported — only a "
                     "Primary holds authoritative data of its own."
+                )
+                continue
+            # A disabled zone is one the operator turned OFF on the source
+            # server. Importing it would bring it back live here — the same
+            # outcome the per-record disabled guard prevents, one level up.
+            if summary.get("disabled"):
+                warnings.append(
+                    f"Skipped {name!r}: disabled on the source server. Re-enable "
+                    "it there first if it should be imported."
                 )
                 continue
 

--- a/backend/tests/test_dns_driver_technitium.py
+++ b/backend/tests/test_dns_driver_technitium.py
@@ -181,7 +181,11 @@ def test_validate_config_rejects_views(bundle: ConfigBundle) -> None:
     assert any("does not support views" in e for e in errors)
 
 
-def test_validate_config_rejects_non_primary_zone(zone: ZoneData) -> None:
+def test_validate_config_accepts_secondary_with_masters(zone: ZoneData) -> None:
+    """Superseded issue #743: a secondary used to be rejected outright.
+    It is now valid as long as it carries somewhere to transfer from —
+    see test_validate_rejects_secondary_without_masters for the other half.
+    """
     secondary = ZoneData(
         name=zone.name,
         zone_type="secondary",
@@ -210,8 +214,7 @@ def test_validate_config_rejects_non_primary_zone(zone: ZoneData) -> None:
         generated_at=datetime(2026, 7, 27, 12, 0, tzinfo=UTC),
     )
     ok, errors = TechnitiumDriver().validate_config(bundle)
-    assert ok is False
-    assert any("not supported by the v1 Technitium driver" in e for e in errors)
+    assert ok is True, errors
 
 
 def test_validate_config_rejects_unsupported_record_types(zone: ZoneData) -> None:
@@ -316,13 +319,14 @@ def test_validate_config_blocklists_are_warned_not_errored(zone: ZoneData) -> No
 # ── Capabilities ──────────────────────────────────────────────────────────
 
 
-def test_capabilities_v1_scope() -> None:
+def test_capabilities_scope() -> None:
     caps = TechnitiumDriver().capabilities()
-    assert caps["zone_types"] == ["primary"]
+    assert set(caps["zone_types"]) == {"primary", "secondary", "stub", "forward"}
+    # Still deferred — issues #740 and #744 respectively.
     assert caps["dnssec_inline_signing"] is False
     assert caps["alias_records"] is False
     assert caps["lua_records"] is False
-    assert caps["catalog_zones"] is False
+    assert caps["catalog_zones"] is True
     assert "SVCB" in caps["record_types"]
     assert "HTTPS" in caps["record_types"]
     assert "DNAME" in caps["record_types"]
@@ -332,3 +336,84 @@ def test_dynamic_update_caps_unsupported() -> None:
     caps = TechnitiumDriver().dynamic_update_caps
     assert caps.supports_ip_acl is False
     assert caps.supports_tsig_acl is False
+
+
+# ── Zone types + capabilities (issue #743) ──────────────────────────────
+
+
+def _zone(name: str, zone_type: str, **over: object) -> ZoneData:
+    base = dict(
+        name=name,
+        zone_type=zone_type,
+        kind="forward",
+        ttl=3600,
+        refresh=86400,
+        retry=7200,
+        expire=3600000,
+        minimum=3600,
+        primary_ns="ns1.example.com.",
+        admin_email="hostmaster.example.com.",
+        serial=1,
+        records=(),
+    )
+    base.update(over)
+    return ZoneData(**base)  # type: ignore[arg-type]
+
+
+def _bundle_with(*zones: ZoneData) -> ConfigBundle:
+    return ConfigBundle(
+        server_id=str(uuid.uuid4()),
+        server_name="technitium1",
+        driver="technitium",
+        roles=("authoritative",),
+        options=ServerOptions(),
+        acls=(),
+        views=(),
+        zones=zones,
+        tsig_keys=(),
+        blocklists=(),
+        generated_at=datetime(2026, 7, 30, 12, 0, tzinfo=UTC),
+    )
+
+
+def test_validate_accepts_every_supported_zone_type() -> None:
+    d = TechnitiumDriver()
+    ok, errors = d.validate_config(
+        _bundle_with(
+            _zone("p.example.com.", "primary"),
+            _zone("s.example.com.", "secondary", masters=("192.0.2.1",)),
+            _zone("st.example.com.", "stub", masters=("192.0.2.1",)),
+            _zone("f.example.com.", "forward", forwarders=("8.8.8.8",)),
+        )
+    )
+    assert ok, errors
+
+
+def test_validate_rejects_secondary_without_masters() -> None:
+    """Technitium resolves SOA against the primaries at create time, so a
+    secondary with nowhere to transfer from can never be created. Better a
+    422 on save than a zone that silently never appears."""
+    d = TechnitiumDriver()
+    ok, errors = d.validate_config(_bundle_with(_zone("s.example.com.", "secondary")))
+    assert not ok
+    assert any("primary name-server address" in e for e in errors)
+
+
+def test_validate_rejects_forward_without_forwarders() -> None:
+    d = TechnitiumDriver()
+    ok, errors = d.validate_config(_bundle_with(_zone("f.example.com.", "forward")))
+    assert not ok
+    assert any("forwarder" in e for e in errors)
+
+
+def test_validate_rejects_unknown_zone_type() -> None:
+    d = TechnitiumDriver()
+    ok, errors = d.validate_config(_bundle_with(_zone("x.example.com.", "mirror")))
+    assert not ok
+    assert any("not supported" in e for e in errors)
+
+
+def test_capabilities_report_zone_types_and_catalog() -> None:
+    caps = TechnitiumDriver().capabilities()
+    assert set(caps["zone_types"]) == {"primary", "secondary", "stub", "forward"}
+    assert caps["catalog_zones"] is True

--- a/backend/tests/test_dns_driver_technitium.py
+++ b/backend/tests/test_dns_driver_technitium.py
@@ -477,3 +477,19 @@ def test_encrypted_transport_ports_reach_the_firewall_for_technitium() -> None:
         src = inspect.getsource(mod)
         assert "dns-technitium" in src, mod.__name__
         assert "dns_encrypted_udp_ports" in src, mod.__name__
+
+
+def test_forward_zone_gate_is_driver_scoped() -> None:
+    """Found by end-to-end testing: a forward zone with no forwarders was
+    accepted (201) and then silently skipped by the agent, because
+    Technitium's zones/create requires a forwarder while BIND9 legally
+    falls back to the global list. The gate has to be driver-scoped, not
+    global, or it would break valid BIND9 configs."""
+    import inspect
+
+    from app.api.v1.dns import router
+
+    src = inspect.getsource(router._assert_forward_zone_serviceable)
+    assert "technitium" in src
+    # BIND9 must remain able to omit forwarders.
+    assert "BIND9 groups may omit it" in src

--- a/backend/tests/test_dns_driver_technitium.py
+++ b/backend/tests/test_dns_driver_technitium.py
@@ -322,8 +322,10 @@ def test_validate_config_blocklists_are_warned_not_errored(zone: ZoneData) -> No
 def test_capabilities_scope() -> None:
     caps = TechnitiumDriver().capabilities()
     assert set(caps["zone_types"]) == {"primary", "secondary", "stub", "forward"}
-    # Still deferred — issues #740 and #744 respectively.
-    assert caps["dnssec_inline_signing"] is False
+    # Online signing landed in #740.
+    assert caps["dnssec_inline_signing"] is True
+    # ALIAS/LUA stay unsupported: Technitium's ANAME/APP are a different
+    # shape, not a drop-in equivalent.
     assert caps["alias_records"] is False
     assert caps["lua_records"] is False
     assert caps["catalog_zones"] is True
@@ -417,3 +419,19 @@ def test_capabilities_report_zone_types_and_catalog() -> None:
     caps = TechnitiumDriver().capabilities()
     assert set(caps["zone_types"]) == {"primary", "secondary", "stub", "forward"}
     assert caps["catalog_zones"] is True
+
+
+def test_capabilities_report_dnssec_online_signing() -> None:
+    """Issue #740 — Technitium signs online via /api/zones/dnssec/*, so it
+    joins PowerDNS and BIND9 on the sign/unsign gate."""
+    assert TechnitiumDriver().capabilities()["dnssec_inline_signing"] is True
+
+
+def test_dnssec_operations_are_gated_to_technitium() -> None:
+    from app.api.v1.dns.router import _DRIVER_GATED_OPERATIONS
+
+    assert "technitium" in _DRIVER_GATED_OPERATIONS["dnssec_sign"]
+    assert "technitium" in _DRIVER_GATED_OPERATIONS["dnssec_unsign"]
+    # Manual rollover stays BIND9-only: Technitium rolls on its own
+    # schedule (dnssecPrivateKeys carries rolloverDays), like PowerDNS.
+    assert "technitium" not in _DRIVER_GATED_OPERATIONS["dnssec_rollover"]

--- a/backend/tests/test_dns_driver_technitium.py
+++ b/backend/tests/test_dns_driver_technitium.py
@@ -435,3 +435,19 @@ def test_dnssec_operations_are_gated_to_technitium() -> None:
     # Manual rollover stays BIND9-only: Technitium rolls on its own
     # schedule (dnssecPrivateKeys carries rolloverDays), like PowerDNS.
     assert "technitium" not in _DRIVER_GATED_OPERATIONS["dnssec_rollover"]
+
+
+def test_forward_transports_are_driver_gated() -> None:
+    """BIND 9.20 forwards over DoT but has no client-side HTTP or QUIC
+    transport, so https/quic are Technitium-only (issue #741)."""
+    from app.api.v1.dns.router import (
+        _TRANSPORT_DRIVER_GATE,
+        VALID_FORWARD_TRANSPORTS,
+    )
+
+    assert VALID_FORWARD_TRANSPORTS == {"do53", "tls", "https", "quic"}
+    assert _TRANSPORT_DRIVER_GATE["https"] == frozenset({"technitium"})
+    assert _TRANSPORT_DRIVER_GATE["quic"] == frozenset({"technitium"})
+    # do53 + tls stay ungated — every agent-managed driver can do both.
+    assert "do53" not in _TRANSPORT_DRIVER_GATE
+    assert "tls" not in _TRANSPORT_DRIVER_GATE

--- a/backend/tests/test_dns_driver_technitium.py
+++ b/backend/tests/test_dns_driver_technitium.py
@@ -513,3 +513,20 @@ def test_axfr_filters_dnssec_artefacts() -> None:
     assert {"RRSIG", "NSEC", "NSEC3", "DNSKEY"} <= _DNSSEC_ARTEFACTS
     # SOA/NS are handled separately (apex-scoped), not via this set.
     assert "SOA" not in _DNSSEC_ARTEFACTS
+
+
+@pytest.mark.asyncio
+async def test_role_assignment_ships_doq_udp_port(db_session, client) -> None:
+    """Found on real hardware: the DoQ UDP port was DERIVED correctly and
+    then never passed to SupervisorRoleAssignment, so it defaulted to []
+    and the appliance firewall never opened udp/<doq_port> — the listener
+    came up unreachable while the config read as correct. Ruff can't catch
+    it: the variable IS used, just not where it matters."""
+    import inspect
+
+    from app.api.v1.appliance import supervisor as sup
+
+    src = inspect.getsource(sup._build_role_assignment)
+    # It must be both derived AND handed to the model.
+    assert "dns_encrypted_udp_ports.append" in src
+    assert "dns_encrypted_udp_ports=dns_encrypted_udp_ports" in src

--- a/backend/tests/test_dns_driver_technitium.py
+++ b/backend/tests/test_dns_driver_technitium.py
@@ -493,3 +493,23 @@ def test_forward_zone_gate_is_driver_scoped() -> None:
     assert "technitium" in src
     # BIND9 must remain able to omit forwarders.
     assert "BIND9 groups may omit it" in src
+
+
+def test_technitium_supports_drift_pull() -> None:
+    """#61 drift needs a ``pull_zone_records``. Technitium's REST API is
+    agent-local (loopback :5380), so the control plane goes over AXFR —
+    the same path BIND9 uses."""
+    assert hasattr(TechnitiumDriver(), "pull_zone_records")
+
+
+def test_axfr_filters_dnssec_artefacts() -> None:
+    """Signing artefacts are minted and rotated by the authoritative
+    server and never modelled as SpatiumDDI records. Unfiltered, drift
+    lists every signature as "extra on server" and a signed zone can
+    never read as in sync — verified live before the fix. Shared helper,
+    so this affects BIND9 too, not just Technitium."""
+    from app.drivers.dns._axfr import _DNSSEC_ARTEFACTS
+
+    assert {"RRSIG", "NSEC", "NSEC3", "DNSKEY"} <= _DNSSEC_ARTEFACTS
+    # SOA/NS are handled separately (apex-scoped), not via this set.
+    assert "SOA" not in _DNSSEC_ARTEFACTS

--- a/backend/tests/test_dns_driver_technitium.py
+++ b/backend/tests/test_dns_driver_technitium.py
@@ -451,3 +451,29 @@ def test_forward_transports_are_driver_gated() -> None:
     # do53 + tls stay ungated — every agent-managed driver can do both.
     assert "do53" not in _TRANSPORT_DRIVER_GATE
     assert "tls" not in _TRANSPORT_DRIVER_GATE
+
+
+def test_doq_is_exposed_on_the_options_api() -> None:
+    """Regression: doq_enabled/doq_port existed on the model and in
+    validation but on neither API schema, so DoQ could not be set or read
+    at all and the validation was unreachable."""
+    from app.api.v1.dns.router import ServerOptionsResponse, ServerOptionsUpdate
+
+    assert "doq_enabled" in ServerOptionsUpdate.model_fields
+    assert "doq_port" in ServerOptionsUpdate.model_fields
+    assert "doq_enabled" in ServerOptionsResponse.model_fields
+    assert "doq_port" in ServerOptionsResponse.model_fields
+
+
+def test_encrypted_transport_ports_reach_the_firewall_for_technitium() -> None:
+    """Regression: all three firewall renderers gated the operator-chosen
+    DoT/DoH ports on bind9/powerdns, so a Technitium listener came up
+    behind a closed nftables port. DoQ additionally needs the UDP list."""
+    import inspect
+
+    from app.services.appliance import firewall, firewall_merge
+
+    for mod in (firewall, firewall_merge):
+        src = inspect.getsource(mod)
+        assert "dns-technitium" in src, mod.__name__
+        assert "dns_encrypted_udp_ports" in src, mod.__name__

--- a/backend/tests/test_dns_import_technitium.py
+++ b/backend/tests/test_dns_import_technitium.py
@@ -1,0 +1,177 @@
+"""Technitium live-pull importer (issue #744).
+
+The interesting surface is ``_rdata_to_value``: Technitium's record GET
+returns a structured ``rData`` object whose field names do NOT match its
+own write API, and which renders numeric rdata as enum NAMES. This is the
+inverse of the agent driver's ``_normalize_rdata``. Every expectation
+below was captured from a live technitium/dns-server:15.4.0.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.dns_import.technitium import (
+    TechnitiumImportError,
+    _build_imported_zone,
+    _classify_zone,
+    _rdata_to_value,
+    _rel_name,
+    _unwrap,
+)
+
+
+def test_rel_name_relativises_against_the_zone() -> None:
+    assert _rel_name("www.example.com", "example.com.") == "www"
+    assert _rel_name("example.com", "example.com.") == "@"
+    assert _rel_name("_sip._tcp.example.com", "example.com.") == "_sip._tcp"
+
+
+def test_classify_zone_detects_reverse() -> None:
+    assert _classify_zone("10.in-addr.arpa.") == "reverse"
+    assert _classify_zone("8.b.d.0.1.0.0.2.ip6.arpa.") == "reverse"
+    assert _classify_zone("example.com.") == "forward"
+
+
+@pytest.mark.parametrize(
+    ("rtype", "rdata", "expected"),
+    [
+        ("A", {"ipAddress": "10.0.0.1"}, "10.0.0.1"),
+        ("AAAA", {"ipAddress": "2001:db8::1"}, "2001:db8::1"),
+        ("CNAME", {"cname": "www.example.net"}, "www.example.net"),
+        ("DNAME", {"dname": "other.example.net"}, "other.example.net"),
+        ("NS", {"nameServer": "ns1.example.net"}, "ns1.example.net"),
+        ("PTR", {"ptrName": "host.example.net"}, "host.example.net"),
+        ("TXT", {"text": "v=spf1 -all"}, "v=spf1 -all"),
+        (
+            "CAA",
+            {"flags": 0, "tag": "issue", "value": "letsencrypt.org"},
+            '0 issue "letsencrypt.org"',
+        ),
+        (
+            "URI",
+            {"priority": 1, "weight": 1, "uri": "https://example.test/"},
+            "1 1 https://example.test/",
+        ),
+    ],
+)
+def test_rdata_to_value_simple_types(rtype: str, rdata: dict, expected: str) -> None:
+    value, extra = _rdata_to_value(rtype, rdata)
+    assert value == expected
+    assert extra == {}
+
+
+def test_rdata_to_value_hoists_structured_fields() -> None:
+    """MX/SRV carry priority (and weight/port) as columns, not in the
+    value string."""
+    value, extra = _rdata_to_value("MX", {"exchange": "mail.example.net", "preference": 20})
+    assert (value, extra) == ("mail.example.net", {"priority": 20})
+
+    value, extra = _rdata_to_value(
+        "SRV", {"target": "sip.example.net", "priority": 10, "weight": 20, "port": 5060}
+    )
+    assert value == "sip.example.net"
+    assert extra == {"priority": 10, "weight": 20, "port": 5060}
+
+
+def test_rdata_to_value_reverses_enum_names() -> None:
+    """The crux: Technitium reads TLSA/SSHFP numeric fields back as enum
+    NAMES. Importing them verbatim would produce records no other driver
+    could serve."""
+    value, _ = _rdata_to_value(
+        "TLSA",
+        {
+            "certificateUsage": "DANE-EE",
+            "selector": "SPKI",
+            "matchingType": "SHA2-256",
+            "certificateAssociationData": "ABCD",
+        },
+    )
+    assert value == "3 1 1 abcd"
+
+    value, _ = _rdata_to_value(
+        "SSHFP",
+        {"algorithm": "Ed25519", "fingerprintType": "SHA256", "fingerprint": "AB12"},
+    )
+    assert value == "4 2 ab12"
+
+
+def test_rdata_to_value_unknown_enum_passes_through() -> None:
+    """A Technitium version that adds an enum member must degrade to one
+    odd-looking record, not an exception mid-import."""
+    value, _ = _rdata_to_value(
+        "SSHFP", {"algorithm": "5", "fingerprintType": "SHA1", "fingerprint": "aa"}
+    )
+    assert value == "5 1 aa"
+
+
+def test_rdata_to_value_svcb_params_dict_to_presentation() -> None:
+    """svcParams comes back as a dict; a multi-value param keeps its
+    commas (issue #745 confirmed Technitium accepts and stores them)."""
+    value, _ = _rdata_to_value(
+        "HTTPS", {"svcPriority": 1, "svcTargetName": ".", "svcParams": {"alpn": "h2,h3"}}
+    )
+    assert value == '1 . alpn="h2,h3"'
+
+
+def test_build_imported_zone_hoists_soa_and_skips_dnssec() -> None:
+    zone = _build_imported_zone(
+        "example.com",
+        [
+            {
+                "name": "example.com",
+                "type": "SOA",
+                "ttl": 900,
+                "rData": {
+                    "primaryNameServer": "ns1.example.com",
+                    "responsiblePerson": "admin.example.com",
+                    "serial": 42,
+                    "refresh": 900,
+                    "retry": 300,
+                    "expire": 604800,
+                    "minimum": 60,
+                },
+            },
+            {
+                "name": "www.example.com",
+                "type": "A",
+                "ttl": 300,
+                "rData": {"ipAddress": "10.0.0.1"},
+            },
+            {"name": "example.com", "type": "DNSKEY", "ttl": 3600, "rData": {}},
+            {"name": "example.com", "type": "RRSIG", "ttl": 3600, "rData": {}},
+        ],
+    )
+    assert zone.name == "example.com."
+    assert zone.soa is not None and zone.soa.serial == 42
+    assert zone.soa.primary_ns == "ns1.example.com."
+    assert [r.record_type for r in zone.records] == ["A"]
+    assert any("DNSSEC" in w for w in zone.parse_warnings)
+
+
+def test_build_imported_zone_skips_disabled_records() -> None:
+    """Technitium marks a disabled record rather than omitting it —
+    importing one would silently resurrect something the operator turned
+    off on the source server."""
+    zone = _build_imported_zone(
+        "example.com",
+        [
+            {
+                "name": "off.example.com",
+                "type": "A",
+                "ttl": 300,
+                "disabled": True,
+                "rData": {"ipAddress": "10.0.0.9"},
+            }
+        ],
+    )
+    assert zone.records == []
+    assert any("disabled" in w for w in zone.parse_warnings)
+
+
+def test_unwrap_surfaces_body_level_failure() -> None:
+    """Technitium answers HTTP 200 even on failure — an expired token
+    included — so the body's status is the only place it shows."""
+    with pytest.raises(TechnitiumImportError, match="invalid-token"):
+        _unwrap({"status": "invalid-token", "errorMessage": "token expired"}, "zone list")
+    assert _unwrap({"status": "ok", "response": {"zones": []}}, "zone list") == {"zones": []}

--- a/backend/tests/test_dns_import_technitium.py
+++ b/backend/tests/test_dns_import_technitium.py
@@ -175,3 +175,32 @@ def test_unwrap_surfaces_body_level_failure() -> None:
     with pytest.raises(TechnitiumImportError, match="invalid-token"):
         _unwrap({"status": "invalid-token", "errorMessage": "token expired"}, "zone list")
     assert _unwrap({"status": "ok", "response": {"zones": []}}, "zone list") == {"zones": []}
+
+
+def test_int_or_preserves_legitimate_zero() -> None:
+    """``int(x or default)`` silently rewrites 0 to the default. That
+    matters: SVCB/HTTPS priority 0 is AliasMode (not ServiceMode), MX
+    preference 0 is the highest priority, and URI priority/weight 0 are
+    valid."""
+    from app.services.dns_import.technitium import _int_or
+
+    assert _int_or(0, 10) == 0
+    assert _int_or(None, 10) == 10
+    assert _int_or("", 10) == 10
+    assert _int_or("garbage", 10) == 10
+
+    value, extra = _rdata_to_value("MX", {"exchange": "mail.example.net", "preference": 0})
+    assert extra["priority"] == 0
+
+    value, _ = _rdata_to_value(
+        "HTTPS", {"svcPriority": 0, "svcTargetName": "svc.example.net", "svcParams": {}}
+    )
+    assert value.startswith("0 "), value
+
+
+def test_build_imported_zone_preserves_zero_ttl() -> None:
+    zone = _build_imported_zone(
+        "example.com",
+        [{"name": "www.example.com", "type": "A", "ttl": 0, "rData": {"ipAddress": "10.0.0.1"}}],
+    )
+    assert zone.records[0].ttl == 0

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -753,6 +753,20 @@ Four behaviours to know, all verified live and all silent if you get them wrong:
 
 `forward_transport` accepts `do53` / `tls` / `https` / `quic`, but `https` and `quic` are gated to technitium groups at the API boundary (`_TRANSPORT_DRIVER_GATE`) — BIND 9.20 has no client-side HTTP or QUIC transport, so allowing them on a bind9 group would render a `named.conf` that will not load. `doq_enabled` is gated the same way.
 
+### 4B.3d Blocklists and the live-pull importer (issue #744)
+
+**Blocklists.** Technitium has no RPZ. It blocks natively, from subscribed URL lists or from a per-domain *blocked zones* set, so SpatiumDDI's effective blocklist entries map onto the latter and its exceptions onto the *allowed* set — Technitium's allowed set is exactly an RPZ passthru. `blockingType` derives from the entries' block modes (`nxdomain` → `NxDomain`, `sinkhole`/`redirect` → `CustomAddress`), and it has the same silent-ignore trap as `zoneTransfer`, so it is validated before sending.
+
+Per-view blocklists **collapse into one flat set**: Technitium's native blocking is server-wide with no view concept, and the driver declines views outright. Collapsing is the honest reading of "block these names on this server" — the alternative would be silently applying one view's list to every client. `is_wildcard` is likewise dropped: Technitium blocks a domain *and* its subdomains by default, so exact-match and wildcard land identically.
+
+The apply is **flush-then-rewrite, not a diff**, and that is deliberate. `blocked/list` is a one-level *tree browser*: `domain=""` returns top-level nodes, `domain="foo.test"` returns its children, and only a leaf carries the actual block under `records`. Intermediate nodes therefore appear in a listing without being blocked domains, and deleting one removes the whole subtree beneath it — reconciling against a flat read of the root wiped every entry in testing. Flush-and-rewrite needs no read model, so it cannot be subtly wrong that way; the cost is a brief window with no blocking on each structural apply, which record CRUD does not trigger.
+
+**Live-pull importer** (`services/dns_import/technitium.py`) — one-shot migration off an existing Technitium install, feeding the same canonical IR and commit pipeline as the BIND9 / Windows / PowerDNS importers.
+
+The difference from those is the record shape. PowerDNS hands back `content` strings that parse straight into a value; Technitium hands back structured `rData` whose field names do not match its own *write* API and which renders numeric rdata as enum names. `_rdata_to_value` is the inverse of the agent's `_normalize_rdata` — `{"certificateUsage": "DANE-EE", "selector": "SPKI", "matchingType": "SHA2-256"}` becomes `3 1 1 <hex>`. Unknown enum members pass through unchanged so a future Technitium release degrades to one odd record rather than an exception mid-import.
+
+Only `Primary` zones are imported. Secondary / Stub / Forwarder / Catalog are reported as warnings — a secondary is a copy of someone else's data, and importing it would mint rows SpatiumDDI then serves authoritatively. Disabled records are skipped too, since importing one would resurrect something the operator had turned off. And because Technitium answers HTTP 200 even on failure, `_unwrap` checks the body's `status` — that is the only place an expired token surfaces.
+
 ### 4B.4 Record type mapping
 
 Technitium's API takes structured per-type params rather than PowerDNS's single wire-format `content` string — e.g. `ipAddress` for A/AAAA, `cname` for CNAME, `exchange`+`preference` for MX, `target`+`priority`+`weight`+`port` for SRV. SVCB/HTTPS are best-effort: the driver parses the BIND-zone-file-style rdata string SpatiumDDI stores (`'1 . alpn="h2,h3"'`) into Technitium's `svcPriority`/`svcTargetName`/`svcParams` (`key|value` pairs) — confirmed empirically that Technitium's `svcParams` wire format does **not** accept a comma-separated multi-value single param the way BIND's rdata does, so only the first value of a multi-value param carries through (logged as a warning); single-value params round-trip exactly.

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -653,26 +653,51 @@ Technitium has no static local secret file the entrypoint pre-seeds (unlike Powe
 
 The token never reaches the control plane — same agent-local trust boundary as PowerDNS's API key and BIND9's TSIG/rndc key.
 
-### 4B.3 Capabilities (v1)
+### 4B.3 Capabilities
 
 ```python
 {
     "name": "technitium",
     "views": False,
     "rpz": False,
-    "dnssec_inline_signing": False,   # fast-follow — see §4B.5
+    "dnssec_inline_signing": False,   # fast-follow — issue #740
     "incremental_updates": "rest_api",
-    "zone_types": ["primary"],        # secondary/stub/forward deferred
+    "zone_types": ["forward", "primary", "secondary", "stub"],
     "record_types": [...],            # A/AAAA/CNAME/MX/TXT/NS/PTR/SRV/CAA/
                                        # TLSA/SSHFP/NAPTR/URI/SOA/SVCB/HTTPS/DNAME
     "alias_records": False,           # Technitium has ANAME/APP instead —
                                        # a different shape, not a drop-in
     "lua_records": False,
-    "catalog_zones": False,
+    "catalog_zones": True,
 }
 ```
 
 `dynamic_update_caps` is the all-False default (no RFC 2136 client-facing UPDATE listener wired in v1 — all mutation flows through the agent's queued record-op reconciler).
+
+### 4B.3a Zone types, transfer and catalog (issue #743)
+
+Neutral `zone_type` → Technitium's `/api/zones/create` `type`:
+
+| SpatiumDDI | Technitium | Extra create param |
+|---|---|---|
+| `primary` | `Primary` | — |
+| `secondary` | `Secondary` | `primaryNameServerAddresses` (comma-joined `masters`) |
+| `stub` | `Stub` | `primaryNameServerAddresses` |
+| `forward` | `Forwarder` | `forwarder` — **one** upstream only |
+
+Three behaviours worth knowing, all confirmed against a live daemon:
+
+- **Only a primary's records are reconciled.** A secondary and a stub fill themselves from the transfer and a forwarder holds none, so diffing them would delete whatever the daemon just pulled down. `_RECORD_MANAGED_ZONE_TYPES` gates this on both the render and the reconcile side.
+- **A secondary/stub create is not guaranteed to succeed, and is not safely retryable-forever.** Technitium resolves SOA against the configured primaries at create time and errors if none answer (`DNS Server did not receive SOA record in response from any of the primary name servers`). An unreachable primary therefore fails on *every* reconcile pass. The control-plane driver rejects a secondary/stub with no `masters` up front so the operator gets a 422 on save instead of a zone that silently never appears.
+- **A Forwarder zone takes a single upstream** where BIND's takes a list. The first is used and the rest are dropped with a `technitium_forwarder_extra_upstreams_ignored` warning, rather than silently.
+
+**Zone transfer.** BIND declares `allow-transfer` once per server; Technitium has no global equivalent, so the same policy is stamped onto each primary. `["none"]`/empty → `Deny`, `any` → `Allow`, anything else → `UseSpecifiedNetworkACL` plus the CIDR list. TSIG key names are attached only where transfer is actually permitted — naming keys on a `Deny` zone would read as if signed transfer were enabled when nothing can transfer at all.
+
+> ⚠️ **`zones/options/set` silently ignores values it does not recognise.** Setting `zoneTransfer="Bogus"` returns `{"status":"ok"}` and leaves the previous value in place. A typo therefore does not fail — it leaves transfer at whatever it was, which for a zone you meant to lock down is a security regression no log line would report. The driver validates against `_ZONE_TRANSFER_VALUES` and refuses to send anything else. Do not remove that check.
+
+**TSIG keys** live in *global* settings, not per zone. The wire format is a **flat pipe-delimited token list read in triples** — `name|secret|algorithm|name2|secret2|algorithm2|…`. Not JSON, and not `name|algorithm|secret` (that fails with "TSIG algorithm is not supported", because it reads the secret as the algorithm). `settings/set` **replaces the whole list**, so keys an operator added directly in the Technitium console are dropped on the next sync — the same control-plane-is-truth stance the rest of the driver takes, but worth knowing. Note also that `zoneTransferTsigKeyNames` accepts a key the server does not have, so keys are pushed *before* anything references them.
+
+**Catalog zones (RFC 9432)** work as producer: the agent creates the `Catalog` zone and sets `catalog=<name>` on each primary it owns. A consumer joins by creating a `SecondaryCatalog` zone pointed at the producer, which arrives through the normal zone list rather than as a per-member option.
 
 ### 4B.4 Record type mapping
 
@@ -682,7 +707,6 @@ Technitium's API takes structured per-type params rather than PowerDNS's single 
 
 - **DNSSEC online signing** — Technitium's `/api/zones/dnssec/*` surface is close in shape to PowerDNS's (`sign`/`unsign`/key rollover), should port quickly once picked up.
 - **Native DoT/DoH/DoQ listeners** — Technitium's real differentiator over PowerDNS: it speaks all three natively, so no dnsdist-style sidecar is needed (contrast §9.2). Needs a settings-API spike to confirm the exact `/api/settings/set` shape, which isn't covered by the public zone/record API docs.
-- **Catalog zones, secondary/stub zones + TSIG-authenticated zone transfer.**
 - **Query-log shipping** — Technitium's query logging is API/DB-backed (`/api/logs/query*`), not a tailable text file like BIND9's `query_log_file` or PowerDNS's redirected stderr capture, so it needs a poll-and-diff shipper rather than the existing file-tailing `QueryLogShipper`.
 - **Live-pull `dns_import` importer** for existing Technitium installs (mirrors `services/dns_import/powerdns.py`).
 

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -730,6 +730,29 @@ Unlike the PowerDNS agent, this driver reports `keys` as well as `ds_records` �
 
 Manual key rollover stays BIND9-only. Technitium rolls on its own schedule — `dnssecPrivateKeys` carries `rolloverDays` per key — so `dnssec_rollover` is deliberately *not* widened to technitium.
 
+### 4B.3c Encrypted transports (issue #741)
+
+Technitium serves **DoT, DoH and DoQ natively** and forwards over all of them — no dnsdist-style sidecar, and no BIND-style "we can receive it but not send it" gap. Everything is driven through `settings/set`.
+
+| Setting | Purpose |
+|---|---|
+| `enableDnsOverTls` / `dnsOverTlsPort` | inbound DoT (TCP, default 853) |
+| `enableDnsOverHttps` / `dnsOverHttpsPort` | inbound DoH (TCP, default 443) |
+| `enableDnsOverQuic` / `dnsOverQuicPort` | inbound DoQ (**UDP**, default 853) |
+| `dnsTlsCertificatePath` | cert served by all three |
+| `forwarderProtocol` | `Udp` / `Tcp` / `Tls` / `Https` / `Quic` |
+
+DoQ is UDP where DoT is TCP, so `doq_port` may legitimately equal `dot_port` — 853 is the RFC default for both, and they do not collide. The firewall layer must open **udp**/`doq_port`, not tcp.
+
+Four behaviours to know, all verified live and all silent if you get them wrong:
+
+- **The certificate must be PKCS #12**, supplied as a file path. PEM is rejected with `DNS Server TLS certificate file must be PKCS #12 formatted`. The bundle ships PEM (that is what `ApplianceCertificate` holds and what BIND9 consumes), so `_write_tls_cert` converts and writes a 0600 `.pfx` into the agent state dir. A cert that fails to parse returns `None` and the listeners stay down — degrade to Do53, never take the daemon with it.
+- **Enabling a listener and setting the cert path are independent.** `enableDnsOverTls=true` lands even when the `dnsTlsCertificatePath` in the *same call* is rejected, which would leave a listener enabled with no certificate. So the cert path goes first, in its own call, and the listeners are only enabled once it succeeds.
+- **`forwarderProtocol` is silently ignored unless `forwarders` is set in the same call.** Setting the protocol alone returns `{"status":"ok"}` and leaves it at `Udp`. The two are always sent together.
+- **Encrypted forwarding needs a domain name, not an IP.** `1.1.1.1` is rejected with `Address must be a domain name` — there would be nothing to validate the upstream certificate against. The neutral model carries a list of forwarder IPs plus a single `forward_tls_hostname`, so over `tls`/`https`/`quic` the hostname wins and the IPs are dropped with a log line naming what went. Technitium then normalises a bare hostname into the transport's canonical form (`cloudflare-dns.com` → `cloudflare-dns.com:853` for DoT, `https://cloudflare-dns.com/dns-query` for DoH).
+
+`forward_transport` accepts `do53` / `tls` / `https` / `quic`, but `https` and `quic` are gated to technitium groups at the API boundary (`_TRANSPORT_DRIVER_GATE`) — BIND 9.20 has no client-side HTTP or QUIC transport, so allowing them on a bind9 group would render a `named.conf` that will not load. `doq_enabled` is gated the same way.
+
 ### 4B.4 Record type mapping
 
 Technitium's API takes structured per-type params rather than PowerDNS's single wire-format `content` string — e.g. `ipAddress` for A/AAAA, `cname` for CNAME, `exchange`+`preference` for MX, `target`+`priority`+`weight`+`port` for SRV. SVCB/HTTPS are best-effort: the driver parses the BIND-zone-file-style rdata string SpatiumDDI stores (`'1 . alpn="h2,h3"'`) into Technitium's `svcPriority`/`svcTargetName`/`svcParams` (`key|value` pairs) — confirmed empirically that Technitium's `svcParams` wire format does **not** accept a comma-separated multi-value single param the way BIND's rdata does, so only the first value of a multi-value param carries through (logged as a warning); single-value params round-trip exactly.

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -697,7 +697,7 @@ Three behaviours worth knowing, all confirmed against a live daemon:
 
 **TSIG keys** live in *global* settings, not per zone. The wire format is a **flat pipe-delimited token list read in triples** — `name|secret|algorithm|name2|secret2|algorithm2|…`. Not JSON, and not `name|algorithm|secret` (that fails with "TSIG algorithm is not supported", because it reads the secret as the algorithm). `settings/set` **replaces the whole list**, so keys an operator added directly in the Technitium console are dropped on the next sync — the same control-plane-is-truth stance the rest of the driver takes, but worth knowing. Note also that `zoneTransferTsigKeyNames` accepts a key the server does not have, so keys are pushed *before* anything references them.
 
-**Catalog zones (RFC 9432)** work as producer: the agent creates the `Catalog` zone and sets `catalog=<name>` on each primary it owns. A consumer joins by creating a `SecondaryCatalog` zone pointed at the producer, which arrives through the normal zone list rather than as a per-member option.
+**Catalog zones (RFC 9432)** work in both roles. As **producer** the agent creates the `Catalog` zone and stamps `catalog=<name>` onto each primary it owns. As **consumer** it creates a `SecondaryCatalog` zone pointed at the producer — note that zone is *not* in the bundle's zone list (the control plane ships it as a catalog block, not a zone row), so `_apply_catalog` has to create it or a consumer silently does nothing at all. Turning catalog zones off clears membership by writing `catalog=""`, which is how Technitium unsets the field; without that, disabling the feature would leave every member permanently enrolled.
 
 ### 4B.3b DNSSEC (issue #740)
 

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -660,7 +660,7 @@ The token never reaches the control plane — same agent-local trust boundary as
     "name": "technitium",
     "views": False,
     "rpz": False,
-    "dnssec_inline_signing": False,   # fast-follow — issue #740
+    "dnssec_inline_signing": True,
     "incremental_updates": "rest_api",
     "zone_types": ["forward", "primary", "secondary", "stub"],
     "record_types": [...],            # A/AAAA/CNAME/MX/TXT/NS/PTR/SRV/CAA/
@@ -698,6 +698,37 @@ Three behaviours worth knowing, all confirmed against a live daemon:
 **TSIG keys** live in *global* settings, not per zone. The wire format is a **flat pipe-delimited token list read in triples** — `name|secret|algorithm|name2|secret2|algorithm2|…`. Not JSON, and not `name|algorithm|secret` (that fails with "TSIG algorithm is not supported", because it reads the secret as the algorithm). `settings/set` **replaces the whole list**, so keys an operator added directly in the Technitium console are dropped on the next sync — the same control-plane-is-truth stance the rest of the driver takes, but worth knowing. Note also that `zoneTransferTsigKeyNames` accepts a key the server does not have, so keys are pushed *before* anything references them.
 
 **Catalog zones (RFC 9432)** work as producer: the agent creates the `Catalog` zone and sets `catalog=<name>` on each primary it owns. A consumer joins by creating a `SecondaryCatalog` zone pointed at the producer, which arrives through the normal zone list rather than as a per-member option.
+
+### 4B.3b DNSSEC (issue #740)
+
+Online signing, op-driven — the same shape as PowerDNS, not BIND9's config-rendered `dnssec-policy`. `dnssec_sign` / `dnssec_unsign` ride the record-op queue and branch out before any rrset machinery.
+
+```
+POST /api/zones/dnssec/sign?zone=<z>&algorithm=ECDSA&curve=P256&nxProof=NSEC
+POST /api/zones/dnssec/unsign?zone=<z>
+```
+
+The neutral op carries no algorithm — it is a bare "sign this zone" from the UI, and BIND expresses the choice through a `dnssec-policy` name that means nothing here — so the driver picks **ECDSA P256 / NSEC**. RSA (with `hashAlgorithm` + `kskKeySize`/`zskKeySize`), ECDSA P384, EDDSA ED25519, and NSEC3 (`nxProof=NSEC3` + `iterations`/`saltLength`) all sign successfully if that default ever needs to become operator-selectable.
+
+Signing is idempotent: an already-signed zone answers `Cannot sign zone: the zone is already signed.`, which is treated as success so repeated "Sign zone" clicks converge on signed rather than erroring.
+
+**Getting the DS records out is the non-obvious part.** Technitium splits the information across two calls:
+
+- `zones/dnssec/properties/get` has the key inventory — `keyTag`, `keyType`, `algorithmNumber`, `state`, rollover timings — and **no DS records at all**.
+- The DS material lives on the zone's own DNSKEY records, at `rData.computedDigests`, and only on the KSK (a DS attests the key-signing key to the parent). Each KSK yields one digest per type — SHA256 and SHA384 observed — all of which the operator should publish to cover validators of differing sophistication.
+
+The driver joins the two into standard presentation form, `<keyTag> <algorithm> <digestType> <digest>`, mapping Technitium's digest-type *names* back to their RFC 4034 numbers:
+
+```
+34619 13 2 DD98135E57B56C0EAB…
+34619 13 4 309DB47A617B7E122C…
+```
+
+Unlike the PowerDNS agent, this driver reports `keys` as well as `ds_records` — Technitium exposes per-key state and the control plane already models it as #49's `DNSKey` rows.
+
+> ⚠️ A signed zone serves DNSKEY / RRSIG / NSEC / NSEC3 / NSEC3PARAM records that **no bundle describes**. `_DNSSEC_RECORD_TYPES` filters them out of `_get_zone_records`; without that, the full-zone reconcile treats every signing artefact as an extra record and tries to delete the zone's own signatures on every single pass. There is a regression test for exactly this.
+
+Manual key rollover stays BIND9-only. Technitium rolls on its own schedule — `dnssecPrivateKeys` carries `rolloverDays` per key — so `dnssec_rollover` is deliberately *not* widened to technitium.
 
 ### 4B.4 Record type mapping
 

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -767,6 +767,19 @@ The difference from those is the record shape. PowerDNS hands back `content` str
 
 Only `Primary` zones are imported. Secondary / Stub / Forwarder / Catalog are reported as warnings — a secondary is a copy of someone else's data, and importing it would mint rows SpatiumDDI then serves authoritatively. Disabled records are skipped too, since importing one would resurrect something the operator had turned off. And because Technitium answers HTTP 200 even on failure, `_unwrap` checks the body's `status` — that is the only place an expired token surfaces.
 
+### 4B.3e Config drift (issue #61)
+
+`pull_zone_records` AXFRs the zone off the Technitium host, the same path BIND9's drift uses. Technitium's own REST API would be the more natural source — it is exactly what the live-pull importer reads — but that API listens on loopback `:5380` inside the agent's container and only the co-located agent can reach it, so the control plane goes over DNS.
+
+**Two prerequisites, and the second is a real limitation:**
+
+1. The group's `allow transfer` must permit the control plane. It defaults to `none`, which renders as Technitium `zoneTransfer: Deny`.
+2. **The group must have no TSIG keys.** `_zone_options_payload` names every group TSIG key on the zone once transfer is permitted, and Technitium then requires a *signed* transfer — an unsigned AXFR is REFUSED. The control plane does not yet sign its AXFR, which is exactly the limitation [#734](https://github.com/spatiumddi/spatiumddi/issues/734) tracks for BIND9. Verified both ways on a live daemon: with key names attached the transfer is REFUSED, and clearing them makes the same AXFR return NOERROR.
+
+The refusal is surfaced as an error on the drift row rather than an empty diff — an empty diff from a refused transfer would read as "in sync", which is the worst possible answer.
+
+Closing this properly means teaching the shared AXFR path to TSIG-sign, which fixes #734 for BIND9 at the same time. It is deliberately not done here: it touches shared infrastructure and secret decryption in the drift path, and deserves its own change.
+
 ### 4B.4 Record type mapping
 
 Technitium's API takes structured per-type params rather than PowerDNS's single wire-format `content` string — e.g. `ipAddress` for A/AAAA, `cname` for CNAME, `exchange`+`preference` for MX, `target`+`priority`+`weight`+`port` for SRV. SVCB/HTTPS are best-effort: the driver parses the BIND-zone-file-style rdata string SpatiumDDI stores (`'1 . alpn="h2,h3"'`) into Technitium's `svcPriority`/`svcTargetName`/`svcParams` (`key|value` pairs) — confirmed empirically that Technitium's `svcParams` wire format does **not** accept a comma-separated multi-value single param the way BIND's rdata does, so only the first value of a multi-value param carries through (logged as a warning); single-value params round-trip exactly.

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -29,7 +29,7 @@ SpatiumDDI ships four authoritative DNS drivers. Pick **per server group** — e
 | Zone CRUD wire protocol | rndc addzone / delzone | REST API | REST API | WinRM (Path B only) |
 | ALIAS records (CNAME at apex) | — | ✅ | — (has ANAME/APP instead — deferred) | — |
 | LUA records (computed responses) | — | ✅ | — | — |
-| Online DNSSEC signing | ✅ inline-signing (#49) | ✅ one-toggle | — (fast-follow) | manual |
+| Online DNSSEC signing | ✅ inline-signing (#49) | ✅ one-toggle | ✅ one-toggle (#740) | manual |
 | Native DoT / DoH (no sidecar) | ✅ (issue #50) | — (needs dnsdist sidecar) | — (fast-follow — daemon supports DoT/DoH/DoQ natively) | — |
 | Catalog zones (RFC 9432) — producer | ✅ | ✅ | ✅ | — |
 | Catalog zones (RFC 9432) — consumer | ✅ | — (not wired up in the agent) | ✅ | — |
@@ -42,7 +42,7 @@ SpatiumDDI ships four authoritative DNS drivers. Pick **per server group** — e
 
 **Pick PowerDNS when** you need ALIAS records (CNAME-at-apex without the BIND-side workaround), LUA records (geo-routing / weighted answers / `pickrandom` / `ifportup`), or the simpler one-toggle online DNSSEC story. The shipped image (`ghcr.io/spatiumddi/dns-powerdns`) bundles `pdns 5.0 + pdns-backend-lmdb` for an agent-isolated zone store with no external Postgres dependency. See [issue #127](https://github.com/spatiumddi/spatiumddi/issues/127) for the full driver rationale.
 
-**Pick Technitium when** you want a minimal-footprint REST-driven authoritative host and don't (yet) need DNSSEC or ALIAS/LUA. It covers primary / secondary / stub / forward zones, catalog zones (producer and consumer), TSIG-authenticated zone transfer, and the standard record types (A/AAAA/CNAME/MX/TXT/NS/PTR/SRV/CAA/TLSA/SSHFP/NAPTR/URI/SVCB/HTTPS/DNAME) — see [`docs/drivers/DNS_DRIVERS.md` §4B.3a](../drivers/DNS_DRIVERS.md). Its real long-term differentiator is native DNS-over-TLS/HTTPS/QUIC with no dnsdist-style sidecar (PowerDNS's approach), *and* encrypted upstream forwarding, which BIND9 cannot do — that wiring is tracked in [#741](https://github.com/spatiumddi/spatiumddi/issues/741).
+**Pick Technitium when** you want a minimal-footprint REST-driven authoritative host and don't need ALIAS/LUA. It covers primary / secondary / stub / forward zones, catalog zones (producer and consumer), TSIG-authenticated zone transfer, and the standard record types (A/AAAA/CNAME/MX/TXT/NS/PTR/SRV/CAA/TLSA/SSHFP/NAPTR/URI/SVCB/HTTPS/DNAME) — see [`docs/drivers/DNS_DRIVERS.md` §4B.3a](../drivers/DNS_DRIVERS.md). Its real long-term differentiator is native DNS-over-TLS/HTTPS/QUIC with no dnsdist-style sidecar (PowerDNS's approach), *and* encrypted upstream forwarding, which BIND9 cannot do — that wiring is tracked in [#741](https://github.com/spatiumddi/spatiumddi/issues/741).
 
 **Pick Windows DNS when** the zone is AD-integrated and operators expect to keep using DNS Manager / `Add-DnsServerResourceRecord` directly. Path A (RFC 2136 + AXFR) works without admin credentials; Path B (WinRM + PowerShell) unlocks zone CRUD and a JSON record-pull that sidesteps AXFR ACL configuration.
 

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -35,7 +35,7 @@ SpatiumDDI ships four authoritative DNS drivers. Pick **per server group** — e
 | Catalog zones (RFC 9432) — producer | ✅ | ✅ | ✅ | — |
 | Catalog zones (RFC 9432) — consumer | ✅ | — (not wired up in the agent) | ✅ | — |
 | First-class views / split-horizon | ✅ | tag-based, not surfaced as views in UI | — | — (replication scope) |
-| RPZ blocklists | ✅ | — (recursor feature only) | — | — |
+| RPZ blocklists | ✅ | — (recursor feature only) | native blocking, not RPZ (#744) | — |
 | AD-integrated zones | — | — | — | ✅ |
 | Agent shape | sidecar agent + named | sidecar agent + pdns_server | sidecar agent + DnsServerApp.dll | agentless (control plane → WinRM) |
 

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -31,8 +31,8 @@ SpatiumDDI ships four authoritative DNS drivers. Pick **per server group** — e
 | LUA records (computed responses) | — | ✅ | — | — |
 | Online DNSSEC signing | ✅ inline-signing (#49) | ✅ one-toggle | — (fast-follow) | manual |
 | Native DoT / DoH (no sidecar) | ✅ (issue #50) | — (needs dnsdist sidecar) | — (fast-follow — daemon supports DoT/DoH/DoQ natively) | — |
-| Catalog zones (RFC 9432) — producer | ✅ | ✅ | — (fast-follow) | — |
-| Catalog zones (RFC 9432) — consumer | ✅ | — (not wired up in the agent) | — | — |
+| Catalog zones (RFC 9432) — producer | ✅ | ✅ | ✅ | — |
+| Catalog zones (RFC 9432) — consumer | ✅ | — (not wired up in the agent) | ✅ | — |
 | First-class views / split-horizon | ✅ | tag-based, not surfaced as views in UI | — | — (replication scope) |
 | RPZ blocklists | ✅ | — (recursor feature only) | — | — |
 | AD-integrated zones | — | — | — | ✅ |
@@ -42,7 +42,7 @@ SpatiumDDI ships four authoritative DNS drivers. Pick **per server group** — e
 
 **Pick PowerDNS when** you need ALIAS records (CNAME-at-apex without the BIND-side workaround), LUA records (geo-routing / weighted answers / `pickrandom` / `ifportup`), or the simpler one-toggle online DNSSEC story. The shipped image (`ghcr.io/spatiumddi/dns-powerdns`) bundles `pdns 5.0 + pdns-backend-lmdb` for an agent-isolated zone store with no external Postgres dependency. See [issue #127](https://github.com/spatiumddi/spatiumddi/issues/127) for the full driver rationale.
 
-**Pick Technitium when** you want a minimal-footprint REST-driven primary-zone host and don't (yet) need DNSSEC or ALIAS/LUA — v1 covers primary zones + standard record types (A/AAAA/CNAME/MX/TXT/NS/PTR/SRV/CAA/TLSA/SSHFP/NAPTR/URI/SVCB/HTTPS/DNAME). Its real long-term differentiator is native DNS-over-TLS/HTTPS/QUIC support with no dnsdist-style sidecar (PowerDNS's approach) — that wiring is a fast-follow, tracked in [`docs/drivers/DNS_DRIVERS.md` §4B.5](../drivers/DNS_DRIVERS.md).
+**Pick Technitium when** you want a minimal-footprint REST-driven authoritative host and don't (yet) need DNSSEC or ALIAS/LUA. It covers primary / secondary / stub / forward zones, catalog zones (producer and consumer), TSIG-authenticated zone transfer, and the standard record types (A/AAAA/CNAME/MX/TXT/NS/PTR/SRV/CAA/TLSA/SSHFP/NAPTR/URI/SVCB/HTTPS/DNAME) — see [`docs/drivers/DNS_DRIVERS.md` §4B.3a](../drivers/DNS_DRIVERS.md). Its real long-term differentiator is native DNS-over-TLS/HTTPS/QUIC with no dnsdist-style sidecar (PowerDNS's approach), *and* encrypted upstream forwarding, which BIND9 cannot do — that wiring is tracked in [#741](https://github.com/spatiumddi/spatiumddi/issues/741).
 
 **Pick Windows DNS when** the zone is AD-integrated and operators expect to keep using DNS Manager / `Add-DnsServerResourceRecord` directly. Path A (RFC 2136 + AXFR) works without admin credentials; Path B (WinRM + PowerShell) unlocks zone CRUD and a JSON record-pull that sidesteps AXFR ACL configuration.
 

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -30,7 +30,8 @@ SpatiumDDI ships four authoritative DNS drivers. Pick **per server group** — e
 | ALIAS records (CNAME at apex) | — | ✅ | — (has ANAME/APP instead — deferred) | — |
 | LUA records (computed responses) | — | ✅ | — | — |
 | Online DNSSEC signing | ✅ inline-signing (#49) | ✅ one-toggle | ✅ one-toggle (#740) | manual |
-| Native DoT / DoH (no sidecar) | ✅ (issue #50) | — (needs dnsdist sidecar) | — (fast-follow — daemon supports DoT/DoH/DoQ natively) | — |
+| Native DoT / DoH (no sidecar) | ✅ (issue #50) | — (needs dnsdist sidecar) | ✅ + DoQ (issue #741) | — |
+| Encrypted *upstream* forwarding | DoT only (no client-side HTTP) | — | DoT / DoH / DoQ (#741) | — |
 | Catalog zones (RFC 9432) — producer | ✅ | ✅ | ✅ | — |
 | Catalog zones (RFC 9432) — consumer | ✅ | — (not wired up in the agent) | ✅ | — |
 | First-class views / split-horizon | ✅ | tag-based, not surfaced as views in UI | — | — (replication scope) |
@@ -1408,7 +1409,7 @@ validation — use one group per provider.
 |---|---|---|
 | **BIND9** | Native (`tls` + `http` statements) | Yes (`forwarders { … tls … }`) |
 | **PowerDNS** | Via the dnsdist front (#146 Phase 2) | N/A — pdns Authoritative doesn't recurse or forward |
-| **Technitium** | Not wired yet — daemon supports DoT/DoH/DoQ natively, no sidecar needed (fast-follow, see [`docs/drivers/DNS_DRIVERS.md` §4B.5](../drivers/DNS_DRIVERS.md)) | N/A — v1 driver is authoritative-only |
+| **Technitium** | DoT + DoH + DoQ served natively, no sidecar ([§4B.3c](../drivers/DNS_DRIVERS.md)). Cert must be PKCS #12 — the agent converts the PEM the bundle ships. | Forwards over DoT, **DoH and DoQ** — the only driver that can, since BIND has no client-side HTTP transport |
 | Windows DNS, cloud drivers | Not supported — we don't run their listeners | — |
 
 On PowerDNS the listeners are `addTLSLocal` / `addDOHLocal` on the dnsdist

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4937,15 +4937,22 @@ export interface DNSServerOptions {
   dnsdist_action: string;
   dnsdist_dynblock_qps: number | null;
   dnsdist_dynblock_seconds: number;
-  // Encrypted transports (issue #50). Inbound DoT/DoH listeners are
-  // additive — plain Do53 on :53 is unaffected. forward_transport is
-  // "do53" | "tls"; BIND has no client-side HTTP transport so there is no
-  // DoH-upstream option.
+  // Encrypted transports (issue #50, extended by #741). Inbound listeners
+  // are additive — plain Do53 on :53 is unaffected.
+  //
+  // forward_transport is "do53" | "tls" | "https" | "quic". BIND has no
+  // client-side HTTP or QUIC transport, so the API gates https/quic (and
+  // DoQ) to Technitium-only groups and 422s otherwise.
   dot_enabled: boolean;
   dot_port: number;
   doh_enabled: boolean;
   doh_port: number;
+  // Technitium serves DoH on a fixed /dns-query and ignores this.
   doh_path: string;
+  // DNS-over-QUIC (#741) — Technitium only. UDP, so doq_port may share a
+  // number with dot_port without colliding.
+  doq_enabled: boolean;
+  doq_port: number;
   tls_certificate_id: string | null;
   forward_transport: string;
   forward_tls_hostname: string | null;
@@ -5982,7 +5989,11 @@ export interface BlocklistCatalogResponse {
 
 // ── DNS configuration importer (issue #128) ─────────────────────────
 
-export type DNSImportSource = "bind9" | "windows_dns" | "powerdns";
+export type DNSImportSource =
+  | "bind9"
+  | "windows_dns"
+  | "powerdns"
+  | "technitium";
 export type DNSImportConflictAction = "skip" | "overwrite" | "rename";
 
 export interface DNSImportedRecord {
@@ -6165,6 +6176,34 @@ export const dnsImportApi = {
       .post<DNSImportCommitResult>("/dns/import/powerdns/commit", body)
       .then((r) => r.data),
 
+  // Technitium — REST API live pull (issue #744). Only Primary zones are
+  // imported; the rest come back as preview warnings.
+  technitiumTestConnection: (body: { api_url: string; api_token: string }) =>
+    api
+      .post<TechnitiumConnectionInfo>(
+        "/dns/import/technitium/test-connection",
+        body,
+      )
+      .then((r) => r.data),
+  technitiumPreview: (body: {
+    api_url: string;
+    api_token: string;
+    target_group_id: string;
+    target_view_id?: string | null;
+  }) =>
+    api
+      .post<DNSImportPreview>("/dns/import/technitium/preview", body)
+      .then((r) => r.data),
+  technitiumCommit: (body: {
+    target_group_id: string;
+    target_view_id?: string | null;
+    plan: DNSImportPreview;
+    conflict_actions: Record<string, DNSImportConflictDecision>;
+  }) =>
+    api
+      .post<DNSImportCommitResult>("/dns/import/technitium/commit", body)
+      .then((r) => r.data),
+
   // Cloud DNS (issue #37, Part B) — live pull of hosted zones + records
   // from a cloud DNS provider. Also the engine behind "Sync from
   // provider" on a cloud DNS server.
@@ -6197,6 +6236,14 @@ export interface PowerDNSConnectionInfo {
   daemon_type: string;
   version: string;
   url: string;
+}
+
+export interface TechnitiumConnectionInfo {
+  ok: boolean;
+  zone_count: number;
+  // Only Primary zones can be imported — a server that is mostly
+  // secondaries has far less to migrate than its raw zone count suggests.
+  importable_zone_count: number;
 }
 
 // ── DHCP configuration importer (issue #129) ────────────────────────

--- a/frontend/src/pages/admin/DNSImportPage.tsx
+++ b/frontend/src/pages/admin/DNSImportPage.tsx
@@ -27,6 +27,7 @@ import {
   type DNSImportSource,
   type DNSImportZoneConflict,
   type PowerDNSConnectionInfo,
+  type TechnitiumConnectionInfo,
   type WindowsDNSServerOption,
   formatApiError,
 } from "@/lib/api";
@@ -76,6 +77,14 @@ const TABS: TabDef[] = [
     available: true,
     description:
       "Live-pull every zone + record from a PowerDNS Authoritative REST API. Provide the API URL + API key; the importer walks /api/v1/servers/{server}/zones and resolves each zone's full record set. Credentials are read-once and never persisted. DNSSEC records get stripped — re-sign post-import via the zone DNSSEC tab.",
+  },
+  {
+    id: "technitium",
+    label: "Technitium",
+    short: "REST API live pull",
+    available: true,
+    description:
+      "Live-pull every Primary zone + record from a Technitium DNS Server. Provide the console URL + an API token; the importer walks /api/zones/list and resolves each zone's full record set. Credentials are read-once and never persisted. Only Primary zones import — secondary, stub, forwarder and catalog zones are reported as warnings, since a secondary is a copy of another server's data. Disabled zones and records are skipped rather than silently re-enabled, and DNSSEC records get stripped — re-sign post-import via the zone DNSSEC tab.",
   },
   {
     id: "windows_dns",
@@ -182,6 +191,7 @@ export function DNSImportPage() {
         )}
         {tab === "windows_dns" && <WindowsDNSTab />}
         {tab === "powerdns" && <PowerDNSTab />}
+        {tab === "technitium" && <TechnitiumTab />}
       </div>
     </div>
   );
@@ -1251,6 +1261,340 @@ function PowerDNSPullForm({
                 {state.testInfo.daemon_type || "PowerDNS"}{" "}
                 {state.testInfo.version || ""}
               </span>
+            )}
+          </div>
+        </div>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium">
+              Target server group
+            </label>
+            <p className="mb-2 text-[11px] text-muted-foreground">
+              Imported zones land in this group. Pick one with at least one
+              registered server so the agent picks them up on its next sync.
+            </p>
+            <select
+              value={state.groupId}
+              onChange={(e) =>
+                setState((s) => ({ ...s, groupId: e.target.value, viewId: "" }))
+              }
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">— select —</option>
+              {groups.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          {views.length > 0 && (
+            <div>
+              <label className="block text-sm font-medium">
+                Target view (optional)
+              </label>
+              <select
+                value={state.viewId}
+                onChange={(e) =>
+                  setState((s) => ({ ...s, viewId: e.target.value }))
+                }
+                className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              >
+                <option value="">Default view</option>
+                {views.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="mt-4 flex justify-end gap-2">
+        <HeaderButton
+          variant="primary"
+          icon={previewing ? Loader2 : Globe}
+          iconClassName={previewing ? "animate-spin" : undefined}
+          onClick={onPreview}
+          disabled={!canPreview}
+        >
+          {previewing ? "Pulling zones…" : "Preview import"}
+        </HeaderButton>
+      </div>
+    </div>
+  );
+}
+
+// ── Technitium tab body (issue #744) ─────────────────────────────────
+
+interface TechnitiumState {
+  apiUrl: string;
+  apiToken: string;
+  groupId: string;
+  viewId: string;
+  testInfo: TechnitiumConnectionInfo | null;
+  preview: DNSImportPreview | null;
+  decisions: Record<string, DNSImportConflictDecision>;
+  result: DNSImportCommitResult | null;
+  phase: Phase;
+  error: string | null;
+}
+
+function emptyTechnitiumState(): TechnitiumState {
+  return {
+    apiUrl: "",
+    apiToken: "",
+    groupId: "",
+    viewId: "",
+    testInfo: null,
+    preview: null,
+    decisions: {},
+    result: null,
+    phase: "select",
+    error: null,
+  };
+}
+
+function TechnitiumTab() {
+  const [state, setState] = useState<TechnitiumState>(emptyTechnitiumState());
+
+  const groupsQ = useQuery({
+    queryKey: ["dns-groups"],
+    queryFn: () => dnsApi.listGroups(),
+  });
+  const viewsQ = useQuery({
+    queryKey: ["dns-views", state.groupId],
+    queryFn: () =>
+      state.groupId ? dnsApi.listViews(state.groupId) : Promise.resolve([]),
+    enabled: Boolean(state.groupId),
+  });
+
+  const testMut = useMutation({
+    mutationFn: () => {
+      if (!state.apiUrl || !state.apiToken) {
+        throw new Error("Provide an API URL and API key first");
+      }
+      return dnsImportApi.technitiumTestConnection({
+        api_url: state.apiUrl,
+        api_token: state.apiToken,
+      });
+    },
+    onSuccess: (info) => {
+      setState((s) => ({ ...s, testInfo: info, error: null }));
+    },
+    onError: (err: unknown) => {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? formatApiError(err);
+      setState((s) => ({ ...s, testInfo: null, error: detail }));
+    },
+  });
+
+  const previewMut = useMutation({
+    mutationFn: () => {
+      if (!state.apiUrl || !state.apiToken || !state.groupId) {
+        throw new Error(
+          "Provide an API URL, API key, and target server group first",
+        );
+      }
+      return dnsImportApi.technitiumPreview({
+        api_url: state.apiUrl,
+        api_token: state.apiToken,
+        target_group_id: state.groupId,
+        target_view_id: state.viewId || null,
+      });
+    },
+    onSuccess: (preview) => {
+      const decisions: Record<string, DNSImportConflictDecision> = {};
+      for (const c of preview.conflicts) {
+        decisions[c.zone_name] = { action: c.action, rename_to: c.rename_to };
+      }
+      setState((s) => ({
+        ...s,
+        preview,
+        decisions,
+        phase: "ready",
+        error: null,
+      }));
+    },
+    onError: (err: unknown) => {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? formatApiError(err);
+      setState((s) => ({ ...s, phase: "select", error: detail }));
+    },
+  });
+
+  const commitMut = useMutation({
+    mutationFn: () => {
+      if (!state.preview) throw new Error("Preview the server first");
+      return dnsImportApi.technitiumCommit({
+        target_group_id: state.groupId,
+        target_view_id: state.viewId || null,
+        plan: state.preview,
+        conflict_actions: state.decisions,
+      });
+    },
+    onSuccess: (result) => {
+      setState((s) => ({ ...s, result, phase: "result", error: null }));
+    },
+    onError: (err: unknown) => {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? formatApiError(err);
+      setState((s) => ({ ...s, phase: "ready", error: detail }));
+    },
+  });
+
+  const conflictByZone = useMemo(() => {
+    const m = new Map<string, DNSImportZoneConflict>();
+    for (const c of state.preview?.conflicts ?? []) m.set(c.zone_name, c);
+    return m;
+  }, [state.preview]);
+
+  const reset = () => setState(emptyTechnitiumState());
+
+  return (
+    <div className="space-y-4">
+      {state.error && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+          <div>{state.error}</div>
+        </div>
+      )}
+
+      {state.phase === "result" && state.result ? (
+        <CommitResultPanel result={state.result} onReset={reset} />
+      ) : (
+        <>
+          <TechnitiumPullForm
+            state={state}
+            setState={setState}
+            groups={groupsQ.data ?? []}
+            views={viewsQ.data ?? []}
+            onTest={() => testMut.mutate()}
+            testing={testMut.isPending}
+            onPreview={() => {
+              setState((s) => ({ ...s, phase: "previewing", error: null }));
+              previewMut.mutate();
+            }}
+            previewing={previewMut.isPending}
+          />
+
+          {state.preview && state.phase !== "previewing" && (
+            <PreviewPanel
+              preview={state.preview}
+              decisions={state.decisions}
+              setDecisions={(updater) =>
+                setState((s) => ({ ...s, decisions: updater(s.decisions) }))
+              }
+              conflictByZone={conflictByZone}
+              onCommit={() => {
+                setState((s) => ({ ...s, phase: "committing", error: null }));
+                commitMut.mutate();
+              }}
+              committing={commitMut.isPending}
+              onReset={reset}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function TechnitiumPullForm({
+  state,
+  setState,
+  groups,
+  views,
+  onTest,
+  testing,
+  onPreview,
+  previewing,
+}: {
+  state: TechnitiumState;
+  setState: React.Dispatch<React.SetStateAction<TechnitiumState>>;
+  groups: { id: string; name: string }[];
+  views: { id: string; name: string }[];
+  onTest: () => void;
+  testing: boolean;
+  onPreview: () => void;
+  previewing: boolean;
+}) {
+  const canTest =
+    Boolean(state.apiUrl && state.apiToken) && !testing && !previewing;
+  const canPreview =
+    Boolean(state.apiUrl && state.apiToken && state.groupId) &&
+    !previewing &&
+    !testing;
+
+  return (
+    <div className="rounded-md border bg-muted/20 p-4">
+      <div className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        1. Technitium source + target
+      </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium">API URL</label>
+            <p className="mb-2 text-[11px] text-muted-foreground">
+              Base URL of the Technitium Authoritative API. Example:{" "}
+              <code>http://pdns.internal:8081</code>. Don't include the{" "}
+              <code>/api/v1</code> suffix — we append it.
+            </p>
+            <input
+              value={state.apiUrl}
+              onChange={(e) =>
+                setState((s) => ({
+                  ...s,
+                  apiUrl: e.target.value,
+                  testInfo: null,
+                }))
+              }
+              placeholder="http://pdns.internal:8081"
+              className="w-full rounded-md border bg-background px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">API key</label>
+            <p className="mb-2 text-[11px] text-muted-foreground">
+              The Technitium <code className="text-[10px]">api-key</code>{" "}
+              setting from <code>pdns.conf</code>. Read once and never persisted
+              — if you re-import you'll re-paste.
+            </p>
+            <input
+              type="password"
+              value={state.apiToken}
+              onChange={(e) =>
+                setState((s) => ({
+                  ...s,
+                  apiToken: e.target.value,
+                  testInfo: null,
+                }))
+              }
+              placeholder="pdns api key"
+              className="w-full rounded-md border bg-background px-3 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <HeaderButton
+              icon={testing ? Loader2 : Plug}
+              iconClassName={testing ? "animate-spin" : undefined}
+              onClick={onTest}
+              disabled={!canTest}
+            >
+              {testing ? "Testing…" : "Test connection"}
+            </HeaderButton>
+            {state.testInfo && (
+              <p className="text-xs text-emerald-600">
+                Connected — {state.testInfo.zone_count} zone
+                {state.testInfo.zone_count === 1 ? "" : "s"} found,{" "}
+                {state.testInfo.importable_zone_count} importable. Only Primary
+                zones are imported; secondary, stub, forwarder and catalog zones
+                are reported as warnings.
+              </p>
             )}
           </div>
         </div>

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -5211,6 +5211,9 @@ function OptionsTab({ groupId }: { groupId: string }) {
   const [dohEnabled, setDohEnabled] = useState(false);
   const [dohPort, setDohPort] = useState(443);
   const [dohPath, setDohPath] = useState("/dns-query");
+  // DoQ (#741) — Technitium only. UDP, so it may share dot_port's number.
+  const [doqEnabled, setDoqEnabled] = useState(false);
+  const [doqPort, setDoqPort] = useState(853);
   const [tlsCertificateId, setTlsCertificateId] = useState("");
   const [forwardTransport, setForwardTransport] = useState("do53");
   const [forwardTlsHostname, setForwardTlsHostname] = useState("");
@@ -5253,6 +5256,8 @@ function OptionsTab({ groupId }: { groupId: string }) {
     setDotPort(opts.dot_port);
     setDohEnabled(opts.doh_enabled);
     setDohPort(opts.doh_port);
+    setDoqEnabled(opts.doq_enabled ?? false);
+    setDoqPort(opts.doq_port ?? 853);
     setDohPath(opts.doh_path);
     setTlsCertificateId(opts.tls_certificate_id ?? "");
     setForwardTransport(opts.forward_transport);
@@ -5330,6 +5335,8 @@ function OptionsTab({ groupId }: { groupId: string }) {
       doh_enabled: dohEnabled,
       doh_port: dohPort,
       doh_path: dohPath.trim() || "/dns-query",
+      doq_enabled: doqEnabled,
+      doq_port: doqPort,
       // "" is the "no cert linked" shape; send explicit null so the server's
       // exclude_none re-injection clears the column instead of dropping it.
       tls_certificate_id: tlsCertificateId || null,
@@ -5778,6 +5785,48 @@ function OptionsTab({ groupId }: { groupId: string }) {
             )}
           </>
         )}
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm font-medium">DNS-over-QUIC (DoQ)</div>
+            <div className="text-xs text-muted-foreground">
+              RFC 9250. Technitium groups only — BIND9 has no DoQ listener and
+              PowerDNS speaks none of the encrypted transports.
+            </div>
+          </div>
+          <label className="flex items-center gap-2 cursor-pointer text-sm">
+            <input
+              type="checkbox"
+              checked={doqEnabled}
+              onChange={(e) => {
+                setDoqEnabled(e.target.checked);
+                setDirty(true);
+              }}
+              className="h-4 w-4"
+            />
+            Enable
+          </label>
+        </div>
+        {doqEnabled && (
+          <>
+            <Field label="DoQ port">
+              <input
+                type="number"
+                min={1}
+                max={65535}
+                className={inputCls}
+                value={doqPort}
+                onChange={(e) => {
+                  setDoqPort(numOrDefault(e.target.value, 853));
+                  setDirty(true);
+                }}
+              />
+            </Field>
+            <p className="text-xs text-muted-foreground">
+              DoQ is UDP where DoT is TCP, so sharing port 853 with DoT is
+              expected and does not collide.
+            </p>
+          </>
+        )}
         <p className="text-xs text-muted-foreground">
           On PowerDNS groups the listeners run on the dnsdist front below (pdns
           speaks neither protocol), so DoT/DoH there needs that front deployed.
@@ -5800,6 +5849,12 @@ function OptionsTab({ groupId }: { groupId: string }) {
               <option value="tls">
                 tls — DNS-over-TLS to the forwarders above
               </option>
+              <option value="https">
+                https — DNS-over-HTTPS (Technitium groups only)
+              </option>
+              <option value="quic">
+                quic — DNS-over-QUIC (Technitium groups only)
+              </option>
             </select>
           </Field>
           {forwardTransport === "tls" && (
@@ -5807,8 +5862,9 @@ function OptionsTab({ groupId }: { groupId: string }) {
               <p className="text-xs text-muted-foreground">
                 Applies to the forwarders configured above, and to per-zone
                 forwarders. Forwarders default to port 853 unless one pins its
-                own. BIND cannot forward over DoH, so there is no HTTPS option
-                here.
+                own. BIND has no client-side HTTP or QUIC transport, so the
+                https and quic options are rejected for a group containing a
+                BIND9 server — use a Technitium-only group for those.
               </p>
               <label className="flex items-center gap-2 cursor-pointer text-sm">
                 <input


### PR DESCRIPTION
Completes the Technitium driver: everything #746 shipped as "v1 scope, fast-follow" is now implemented, except query-log shipping, which is blocked upstream (see #742).

Closes #743
Closes #740
Closes #741
Closes #744

## What lands

| Issue | |
|---|---|
| #743 | Secondary / stub / forward zone types, catalog zones (producer **and** consumer), TSIG-authenticated zone transfer |
| #740 | Online DNSSEC signing + DS export |
| #741 | Native DoT / DoH / **DoQ** listeners, and encrypted **upstream** forwarding |
| #744 | Blocklist wiring onto Technitium's native blocking, plus a live-pull importer |

Two capabilities here are things no other agent-managed driver has: **DoQ**, and **DoH/DoQ upstream forwarding** — BIND 9.20 has no client-side HTTP or QUIC transport at all, which is why #50 had to defer DoH-upstream. Both are gated to Technitium-only groups at the API boundary rather than rendering a `named.conf` BIND won't load.

## How this was built

Every API shape was probed against a live `technitium/dns-server:15.4.0` rather than inferred, because **this API is not what you would guess**, and each of the following was found by running it, not by reading:

- **Record GET does not echo the params record ADD takes.** NAPTR/URI keys are renamed; TLSA/SSHFP numeric fields come back as enum *names* (`tlsaCertificateUsage=3` → `certificateUsage="DANE-EE"`); `svcParams` goes out a string and returns a dict. Unhandled, the reconciler saw every record of those types as permanently changed and tried to delete each one on every pass.
- **`zones/options/set` accepts values it does not recognise.** `zoneTransfer="Bogus"` returns `{"status":"ok"}` and silently keeps the old value — so a typo on a zone you meant to lock down is a security regression no log line reports. Same for `blockingType`. Both are validated driver-side now.
- **`tsigKeys` is a flat pipe list read in triples** (`name|secret|alg|name2|…`), not JSON, and not `name|alg|secret` — that ordering fails with "TSIG algorithm is not supported" because it reads the secret *as* the algorithm.
- **`forwarderProtocol` is ignored unless `forwarders` is set in the same call.**
- **Encrypted forwarding needs a domain name, not an IP** ("Address must be a domain name") — there'd be nothing to validate the upstream cert against.
- **The TLS cert must be PKCS #12**, supplied as a file path. The bundle ships PEM, so the agent converts.
- **`blocked/list` is a one-level tree browser, not a flat list.** Intermediate nodes appear in a listing without being blocked domains, and deleting one removes the subtree beneath it. A first implementation reconciled against a flat read of the root and wiped every entry — caught on the live daemon, which is why the blocklist apply is flush-then-rewrite.
- **A secondary/stub create is neither guaranteed nor safely retryable**: the daemon resolves SOA against the configured primaries at create time, so an unreachable primary fails on every pass. The control-plane driver rejects a masters-less secondary up front so the operator gets a 422 on save instead of a zone that never appears.

Where a mapping is lossy it is documented rather than hidden: per-view blocklists collapse into one flat set (native blocking is server-wide and the driver declines views), `is_wildcard` is dropped (Technitium already blocks subdomains), and a Forwarder zone takes one upstream where BIND takes a list.

## Review history

Two `/code-review` passes, 20 findings, all fixed. Worth reading the two `fix(dns):` commits — they are deliberately not squashed into the features, because what was wrong and why is the useful part. Highlights:

- **A whole feature was unreachable.** `doq_enabled`/`doq_port` existed on the model, in validation and in the bundle, but on neither API schema — so DoQ could not be set or read at all, and its validation was dead code. The frontend was likewise missing the entire #741/#744 surface.
- **Encrypted listeners came up behind a closed port.** All three firewall renderers gated the operator-chosen ports on bind9/powerdns. The ports were computed and shipped, then dropped at render. DoQ additionally needed a UDP channel, since it is UDP where DoT is TCP.
- **A driver gate used the wrong set operation.** `not (drivers & allowed)` passes when *any* driver matches, so a mixed bind9+technitium group could have saved `forward_transport="https"` and bind9 would have kept forwarding cleartext on :53 while the UI claimed DoH. The file's own `_check_driver_gated_record_type` uses subset semantics; this now matches.
- **Wrong wire format for a master's port.** SpatiumDDI validates `ip@port`; Technitium rejects the `@` and wants `ip:port`. A secondary with a non-default port failed its create on every pass forever.
- **Zeros corrupted on import.** `int(x or default)` rewrites a legitimate 0 — and SVCB/HTTPS priority 0 means *AliasMode*, not ServiceMode, so importing a real record changed its meaning.
- **"Empty is not a no-op" bit three times.** Removing every forwarder, disabling catalog zones, and clearing the TSIG key set each failed to reach the daemon — a revoked TSIG key stayed installed and signed transfers kept working. All three now write the cleared state explicitly.

## Test plan

- [x] **Live daemons throughout.** Two `technitium/dns-server:15.4.0` containers on a shared network, driving the real driver code: all four zone types created, a **real zone transfer** landed on the secondary, catalog membership set and cleared, consumer `SecondaryCatalog` created against the peer, TSIG key accepted, DNSSEC signed → correct two-digest DS + ksk/zsk state → reconcile left the signatures alone → unsign cleared, all three encrypted listeners up on operator-chosen ports, `Tls`/`Https`/`Quic` forwarding applied, blocklists converged (add both, drop one and the other survives, empty clears and disables), and a 9-record seeded zone round-tripped through the importer.
- [x] **Idempotency proven, not assumed.** After the first reconcile, three consecutive passes are completely silent — the strongest evidence the rData normalisation holds, since it exercises TLSA/SSHFP/URI/NAPTR/HTTPS through a real round trip.
- [x] Agent suite **152 passed**, 8 skipped
- [x] Backend **64 passed** across the technitium driver, importer and #50's existing encrypted-transport suites
- [x] `mypy app` clean across 792 source files; `ruff` + `black` clean on `backend/` and `agent/`
- [x] Frontend `npm run build`, `eslint`, `prettier` and `typecheck` all clean — note the **build** caught three errors `typecheck` did not
- [x] Migration linter clean; single Alembic head confirmed (`b2d47f1c8a30`)

## Not in scope

**#742 (query-log shipping) is blocked upstream** and stays open. The daemon defines both `IDnsQueryLogger` (writer) and `IDnsQueryLogs` (reader), but the published Query Logs app implements only the writer — so `logs/query` has no valid source, and Technitium's own console shows no query-log picker either. Verified by installing the app and dumping symbols; full evidence on the issue.

**DoH path is not configurable on Technitium** — the daemon serves a fixed path and exposes no setting. `doh_path` is honoured by BIND9 and warned about here rather than silently advertising a URL nothing answers on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
