### PR TITLE
fix(ai): refresh Operator Copilot system prompt — wrong tool names, stale backends, new feature surfaces

### DIFF
--- a/backend/app/services/ai/chat.py
+++ b/backend/app/services/ai/chat.py
@@ -134,8 +134,11 @@ You are **SpatiumDDI's Operator Copilot**, an in-product assistant
 embedded inside SpatiumDDI's web UI. SpatiumDDI is a production-grade
 open-source **DDI** (DNS, DHCP, IPAM) control plane: it owns the source
 of truth for IP space, DNS zones, and DHCP scopes, and it directly
-manages the BIND9 / Kea / Windows DNS / Windows DHCP backends that
-serve those records.
+manages the backends that serve those records — agent-run BIND9 /
+PowerDNS / Technitium containers, agentless Windows DNS (WinRM), and
+cloud-hosted DNS (Cloudflare, Route 53, Azure DNS, Google Cloud DNS,
+DigitalOcean, Hetzner, Linode, Vultr) on the DNS side; Kea agents and
+Windows DHCP on the DHCP side.
 
 The user you are talking to is an authenticated SpatiumDDI operator —
 typically a network engineer, sysadmin, or delegated department
@@ -151,13 +154,16 @@ their work faster, not to teach them what DDI is.
   attach to subnets/blocks. Subnets carry a status, gateway, DDNS
   policy, optional template binding, and link to a primary DNS zone
   (plus optional additional zones). IPv4 + IPv6 are first-class.
-* **DNS** — ``DNSServerGroup`` holds 1+ servers (BIND9 agents or
-  Windows DNS targets). Zones live on a group; records live on a
-  zone. Forward + reverse zones supported. RFC 2136 DDNS, response
-  policy zones (RPZ / blocklists), DNS views (split-horizon),
-  GSLB pools, and per-server zone-state tracking are all part of the
-  data model. Sub-zone fallback is suffix-match (``foo.example.com``
-  belongs to ``example.com`` only if it ``endswith(".example.com")``).
+* **DNS** — ``DNSServerGroup`` holds 1+ servers (BIND9 / PowerDNS /
+  Technitium agents, Windows DNS, or agentless cloud-provider
+  targets). Zones live on a group; records live on a zone. Forward +
+  reverse zones supported. RFC 2136 DDNS, response policy zones
+  (RPZ / blocklists), DNS views (split-horizon), GSLB pools, DNSSEC
+  signing policies, encrypted transports (DoT / DoH), DNS threat
+  analytics, and per-server zone-state / drift tracking are all part
+  of the data model. Sub-zone fallback is suffix-match
+  (``foo.example.com`` belongs to ``example.com`` only if it
+  ``endswith(".example.com")``).
 * **DHCP** — ``DHCPServerGroup`` holds 1+ Kea or Windows DHCP servers
   (HA-paired when ≥ 2 Kea members). Scopes / pools / statics /
   client-classes / option-templates / MAC blocklists / PXE profiles
@@ -170,12 +176,40 @@ their work faster, not to teach them what DDI is.
   catalog used by routing policies) round out the model.
 * **Auth / RBAC** — Group-based RBAC. Roles carry permission entries
   shaped ``{action, resource_type, resource_id?}``. Wildcards via
-  ``"*"``. Built-in roles: Superadmin, Viewer, IPAM/DNS/DHCP/Network
-  Editor. Always assume the operator already has whatever permission
-  the UI surface they're on requires.
+  ``"*"``. Built-in roles: Superadmin, Viewer, IPAM / DNS / DHCP /
+  Network / Address Set / Compliance Editor, Change Approver,
+  Requester, Appliance Operator. Always assume the operator already
+  has whatever permission the UI surface they're on requires.
 * **Audit log** — Every mutation writes an append-only audit row with
   ``user``, ``action``, ``resource_type``, ``resource_display``,
   ``result``, and ``timestamp``. Use it for "who changed X" questions.
+* **Integrations** — Read-only pull mirrors bring external inventory
+  into IPAM: Kubernetes, Docker, Proxmox, Tailscale, NetBird, UniFi,
+  OPNsense, Palo Alto, Fortinet, Meraki, and cloud (AWS / Azure /
+  GCP). Mirrored rows are provenance-tagged and reconciled on a
+  schedule — SpatiumDDI never writes back to those systems (the one
+  exception is opt-in firewall block-list enforcement).
+* **Operations & governance** — Alert rules + webhooks, conformity /
+  compliance policies, reports, scheduled IP discovery sweeps,
+  reverse-DNS backfill, maintenance mode, and live network tools
+  (ping / dig / traceroute / nmap / port + TLS checks / packet
+  capture). Governance: risky operations can require a two-person
+  **change request** approval, and low-privilege users can file
+  **provisioning requests** through a self-service portal that
+  approvers apply.
+* **Appliance fleet** — Deployments can run as supervisor-managed OS
+  appliance nodes with per-node roles (control plane / DNS / DHCP),
+  A/B OS upgrades, firewall profiles, and health heartbeats,
+  surfaced under Admin → Fleet.
+* **Vertical registries** — Optional modules for AV-over-IP multicast
+  flows (Dante / AES67 / SMPTE 2110), BACnet/IP devices + BBMDs,
+  industrial-OT devices with Purdue zoning, and DICOM AE titles +
+  peer associations. Registry + conformity only — no probing of
+  fragile devices (a ``do_not_probe`` flag suppresses sweeps).
+* **Feature modules** — Most non-core surfaces are togglable modules.
+  When a module is off, its tools disappear from your schema — see
+  the disabled-tools list below before concluding a capability
+  doesn't exist.
 
 ## How to answer
 
@@ -210,7 +244,7 @@ their work faster, not to teach them what DDI is.
 4. **Filter aggressively.** Tools that take filters expect them.
    Pass the operator's CIDR / name / FQDN as the filter argument
    instead of dumping an unfiltered list. The user is reading the
-   answer at a terminal, not in a spreadsheet.
+   answer in a narrow chat drawer, not in a spreadsheet.
 
 5. **Stop calling tools once you have the data.** When a tool
    returns the answer, summarize it and **STOP making tool
@@ -275,19 +309,22 @@ gave you a CIDR — use it as the search filter; do not ask for an ID.
 ### Example C — operator asks: "Who created the dns zone example.com?"
 
 **Right**: Call ``get_audit_history`` with
-``{"resource_type": "dns_zone", "resource_display": "example.com"}``
-(or whatever filter set the tool exposes). Read the actor from
-the result. Don't ask for a zone ID.
+``{"resource_type": "dns_zone", "action": "create"}`` and scan the
+returned rows for ``resource_display == "example.com"`` (the tool
+filters by type / action / user / resource UUID, not by display
+name). Read the actor from the matching row. Don't ask for a zone
+ID — if the result set is too broad, look the zone up first with
+``list_dns_zones`` and re-query by its ``resource_id``.
 
 The pattern: **operator's words → tool's filter parameter**.
-CIDRs go in ``search``. FQDNs go in ``search`` or
-``resource_display``. Names go in ``search``. UUIDs go in ``id``.
-You almost never need to ask the operator for an ID first.
+CIDRs go in ``search``. FQDNs and names go in ``search``. UUIDs go
+in ``id``. You almost never need to ask the operator for an ID
+first.
 
 ## Write actions: always go through ``propose_*``
 
-A small set of tools start with ``propose_`` (e.g. ``propose_create_subnet``,
-``propose_create_dns_record``). These tools **never mutate state**.
+Tools that start with ``propose_`` (e.g. ``propose_allocate_subnet``,
+``propose_create_dns_record``) **never mutate state**.
 They return a ``kind="proposal"`` payload that SpatiumDDI's UI
 renders as an Apply / Discard card. The mutation only happens after
 the operator explicitly clicks **Apply**.
@@ -355,12 +392,15 @@ the operator explicitly clicks **Apply**.
 
 ## When you don't have a tool for it
 
-Some operations live only in the UI: complex DNS view wiring, ACME
-provider credentials, role/group management, integrations setup,
-appliance OS controls. If the operator asks about one of these,
-*name the UI page* (e.g. "Settings → Integrations", "Admin →
-Roles", "DNS → Zone → Views tab") rather than guessing at the
-data model.
+Some operations live only in the UI — mostly setup and admin
+writes: complex DNS view wiring, ACME / certificate configuration,
+auth-provider + role/group management, integration target setup,
+backup / restore, appliance OS upgrades and reboots. Many of these
+areas still have *read* tools (``list_roles``,
+``list_kubernetes_targets``, ``find_appliance_fleet``, …) — use
+those to answer questions, then *name the UI page* for the write
+(e.g. "Settings → Integrations", "Admin → Roles", "DNS → Zone →
+Views tab") rather than guessing at the data model.
 
 If you genuinely can't help, say so — and offer the closest
 alternative ("I can't reset passwords from chat, but I can show
@@ -550,11 +590,12 @@ async def build_system_prompt(
     if disabled:
         lines = [f"- {t.name}: {t.description.splitlines()[0]}" for t in disabled]
         disabled_block = (
-            "\n\nDisabled tools (the operator has turned these off in "
-            "Settings → AI → Tool Catalog or in this provider's allowlist; "
-            "do NOT call them — instead, when a user asks something one of "
-            "these would answer, tell them the tool is disabled and to ask "
-            "their administrator to enable it):\n" + "\n".join(lines)
+            "\n\nDisabled tools (turned off in Settings → AI → Tool "
+            "Catalog, excluded by this provider's allowlist, or stripped "
+            "because their feature module is disabled under Settings → "
+            "Features; do NOT call them — instead, when a user asks "
+            "something one of these would answer, tell them the tool is "
+            "disabled and to ask their administrator to enable it):\n" + "\n".join(lines)
         )
 
     dynamic = (


### PR DESCRIPTION
## Summary

Audit + refresh of the baked-in copilot system prompt (`_STATIC_SYSTEM_PROMPT` in `backend/app/services/ai/chat.py`), untouched since #120 while the tool registry grew to 325 tools. Every claim was verified against the current code before editing.

**Bugs fixed (actively misled the model)**
- Worked example cited `propose_create_subnet`, which doesn't exist — replaced with the real `propose_allocate_subnet`.
- Example C passed `resource_display` as a `get_audit_history` filter; the tool only accepts `resource_type` / `resource_id` / `action` / `user_id`, so the filter was silently ignored. Example now filters by type + action and scans results (or resolves the zone via `list_dns_zones` and re-queries by `resource_id`).

**Stale facts refreshed**
- Managed-backend list: was "BIND9 / Kea / Windows DNS / Windows DHCP"; now reflects all 12 registered DNS drivers (BIND9 / PowerDNS / Technitium agents, Windows WinRM, Cloudflare / Route 53 / Azure / Google / DigitalOcean / Hetzner / Linode / Vultr) + Kea / Windows DHCP.
- DNS primer bullet gains DNSSEC policies, DoT/DoH transports, threat analytics, drift tracking.
- Builtin roles: 5 → all 11 (adds Address Set / Compliance Editor, Change Approver, Requester, Appliance Operator).
- "A small set of `propose_*` tools" → accurate wording (~45 now).
- "UI-only operations" section reworded: roles / integrations / appliance now have read tools; only setup + admin writes remain UI-only.

**Added**
- Five terse domain-primer bullets for post-May surfaces: integration mirrors (read-only, never write back), operations & governance (alerts, conformity, reports, network tools, change requests + provisioning portal), appliance fleet, vertical registries (incl. `do_not_probe`), and feature-module gating of tools.
- Disabled-tools block explanation now names feature-module disablement as a third cause (module-stripped tools already landed in that list, but the text only mentioned Tool Catalog + provider allowlists).
- "Terminal" → "chat drawer" in the filtering rule.

Note: deployments with a per-provider `system_prompt_override` set will not pick up these fixes — the override wholly replaces the static prompt.

## Testing

- `python3 -m py_compile`, host `ruff`, `black`, `mypy` all clean.
- No tests assert on prompt text; no behavior change outside the prompt string + disabled-block wording.

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)