### PR TITLE
docs: convert ASCII diagrams to verified SVG, and gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,36 @@ jobs:
           echo "all 8 backend test shards passed"
 
   # ── Frontend ───────────────────────────────────────────────────────────────
+  # ── Docs ───────────────────────────────────────────────────────────────────
+  # The published docs embed hand-authored SVG diagrams. Their text is placed
+  # by absolute coordinate, so a relabelled box silently spills out of its
+  # container or off the canvas — invisible in a diff, obvious on the site.
+  # This renders each one in headless Chrome and measures real text metrics.
+  docs-diagrams:
+    name: Docs — Diagram Geometry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # ubuntu-latest ships Google Chrome preinstalled, which the script
+      # finds on its own. Install chromium only if that ever stops being
+      # true — apt on a runner without it would otherwise fail the job for
+      # a reason unrelated to the diagrams.
+      - name: Ensure a headless browser is present
+        run: |
+          if ! command -v google-chrome >/dev/null 2>&1 \
+             && ! command -v chromium >/dev/null 2>&1 \
+             && ! command -v chromium-browser >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y chromium
+          fi
+
+      - name: Verify diagram geometry
+        run: python3 scripts/verify_svg_diagrams.py
+
   frontend-lint:
     name: Frontend — Lint & Type Check
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,9 @@ scratchpad-*.md
 
 # Trivy vulnerability-DB cache (make trivy)
 .trivy-cache/
+
+# Jekyll local docs preview (make docs writes inside the container, but a
+# bare `jekyll build` in docs/ would drop these into the tree).
+docs/_site/
+docs/.jekyll-cache/
+docs/.jekyll-metadata

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help up down dev build build-supervisor migrate lint test lint-backend lint-frontend test-backend \
         ci ci-backend-lint ci-frontend-lint ci-frontend-build screenshots \
+        docs docs-down docs-verify \
         trivy \
         appliance appliance-builder appliance-iso appliance-clean \
         appliance-bake-images appliance-clean-baked-images appliance-dev-iso \
@@ -52,6 +53,9 @@ help:
 	@echo "  make test        Run backend tests against a live DB"
 	@echo "  make ci          Run the exact same lint + typecheck + build jobs CI runs"
 	@echo "  make screenshots Re-capture docs/assets/screenshots/ via headless chromium"
+	@echo "  make docs        Serve the documentation site locally on :4000 (Jekyll)"
+	@echo "  make docs-down   Stop the local documentation site"
+	@echo "  make docs-verify Check every docs SVG diagram for overflow / clipping"
 	@echo "  make appliance      Build the OS-appliance qcow2 (Phase 1 — Debian 13 amd64)"
 	@echo "  make appliance-iso  Wrap the Phase 1 raw image as a hybrid USB/CD ISO (Phase 2)"
 	@echo ""
@@ -296,6 +300,24 @@ screenshots:
 	@test -d scripts/screenshots/node_modules || \
 	  (cd scripts/screenshots && npm install --no-audit --no-fund)
 	node scripts/screenshots/capture.mjs $(SCREENSHOT_ARGS)
+
+# ── Docs site ──────────────────────────────────────────────────────────────────
+# Renders docs/ with the same Jekyll plugin set GitHub Pages uses, so a page can
+# be reviewed before it ships. Override the port with DOCS_PORT=8081.
+docs:
+	docker compose -f docker-compose.docs.yml up -d --build
+	@echo "docs site → http://localhost:$${DOCS_PORT:-4000}  (make docs-down to stop)"
+
+docs-down:
+	docker compose -f docker-compose.docs.yml down
+
+# Diagram geometry gate — the same check CI runs. Measures real text metrics in
+# headless Chromium, so a relabelled box that now spills out of its container
+# fails here instead of on the published site.
+docs-verify:
+	@test -x /usr/bin/chromium || command -v google-chrome >/dev/null || \
+	  (echo "chromium missing — apt-get install -y chromium"; exit 1)
+	python3 scripts/verify_svg_diagrams.py
 
 # ── OS Appliance (Phase 1: Debian 13 amd64 qcow2 MVP) ──────────────────────────
 # See appliance/README.md for the full design + prereqs.

--- a/docker-compose.docs.yml
+++ b/docker-compose.docs.yml
@@ -1,0 +1,22 @@
+# Local preview of the documentation site.
+#
+#   docker compose -f docker-compose.docs.yml up      → http://localhost:4000
+#
+# Renders docs/ with the same Jekyll plugin set GitHub Pages uses, so a page
+# can be checked before it ships. Edits to docs/ rebuild automatically.
+#
+# The build output goes to /tmp/_site *inside* the container rather than to
+# docs/_site, so a preview run never drops an untracked build directory into
+# the working tree.
+services:
+  docs:
+    build:
+      context: ./docs
+    image: spatiumddi-docs:local
+    ports:
+      - "${DOCS_PORT:-4000}:4000"
+      # livereload — the browser reconnects here for auto-refresh on save.
+      - "35729:35729"
+    volumes:
+      - ./docs:/srv/jekyll:ro
+    restart: unless-stopped

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,22 +24,9 @@ plane** that is the single source of truth, plus a set of **data-plane
 service containers** (DNS and DHCP daemons) that the control plane
 deploys, configures, and runs.
 
-```
-Clients                Control plane                      Data plane
-┌──────────┐           ┌──────────────────────────┐      ┌─────────────────┐
-│ Browser  │──HTTP────▶│ frontend (nginx + SPA)   │      │ DNS agent       │
-│ (React)  │           ├──────────────────────────┤      │  └ BIND9 /      │
-├──────────┤           │ api (FastAPI/uvicorn)    │◀─────│    PowerDNS     │
-│ CLI /    │──REST────▶│   • REST + OpenAPI       │ long │ DHCP agent      │
-│ API /    │           │   • /api/v1/ai/mcp (MCP) │ poll │  └ Kea          │
-│ MCP      │           ├──────────────────────────┤      │ supervisor      │
-└──────────┘           │ worker (Celery)          │      │  (appliance)    │
-                       │ beat   (Celery schedule) │      └─────────────────┘
-                       ├──────────────────────────┤              ▲
-                       │ PostgreSQL 16  (truth)   │              │
-                       │ Redis 7  (broker + wake) │──────pub/sub──┘
-                       └──────────────────────────┘
-```
+<p align="center">
+  <img src="assets/diagrams/architecture-planes.svg" alt="SpatiumDDI control plane and data plane" width="900"/>
+</p>
 
 Three properties define the design and are enforced everywhere
 (see [`../CLAUDE.md`](../CLAUDE.md) "Absolute Non-Negotiables"):

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -133,12 +133,9 @@ Files: [`ipam.py`](../backend/app/models/ipam.py),
 
 The core hierarchy is a strict containment tree:
 
-```
-IPSpace  (ip_space — a VRF / routing domain; addresses may overlap across spaces)
-  └── IPBlock  (ip_block — aggregate/supernet; nests via parent_block_id)
-        └── Subnet  (subnet — the primary managed unit; routable network)
-              └── IPAddress  (ip_address — individual host IP)
-```
+<p align="center">
+  <img src="assets/diagrams/data-model-ipam.svg" alt="IPAM data model — the address-space containment tree" width="900"/>
+</p>
 
 | Model | Table | Key FKs |
 |---|---|---|
@@ -205,14 +202,9 @@ File: [`dns.py`](../backend/app/models/dns.py). Feature spec:
 The DNS hierarchy is group-centric — configuration lives on the group,
 servers are members, zones and records hang off the group:
 
-```
-DNSServerGroup  (dns_server_group — logical cluster; holds shared config + TSIG)
-  ├── DNSServer  (dns_server — individual BIND9 / PowerDNS / Windows / agentless server)
-  ├── DNSView    (dns_view — split-horizon view)
-  ├── DNSZone    (dns_zone — authoritative / secondary / stub / forward)
-  │     └── DNSRecord  (dns_record — RR within a zone)
-  └── DNSPool    (dns_pool — health-checked A/AAAA set rendered as records)
-```
+<p align="center">
+  <img src="assets/diagrams/data-model-dns.svg" alt="DNS data model — the group-centric hierarchy" width="900"/>
+</p>
 
 | Model | Table | Key FKs |
 |---|---|---|
@@ -258,15 +250,9 @@ on the **group**, not on individual servers (a 2-member Kea group is an
 HA pair). Leases are per-server because each Kea instance owns its own
 memfile.
 
-```
-DHCPServerGroup  (dhcp_server_group — primary config container; HA tuning)
-  ├── DHCPServer  (dhcp_server — Kea instance or Windows DHCP)
-  │     └── DHCPLease  (dhcp_lease — per-server active/historical lease)
-  ├── DHCPScope  (dhcp_scope — one subnet served by the group)
-  │     ├── DHCPPool             (dhcp_pool — dynamic / excluded / reserved range)
-  │     └── DHCPStaticAssignment (dhcp_static_assignment — MAC → IP reservation)
-  └── DHCPClientClass  (dhcp_client_class — conditional option delivery)
-```
+<p align="center">
+  <img src="assets/diagrams/data-model-dhcp.svg" alt="DHCP data model — the group-centric hierarchy" width="900"/>
+</p>
 
 | Model | Table | Key FKs / constraints |
 |---|---|---|
@@ -355,11 +341,9 @@ File: [`auth.py`](../backend/app/models/auth.py),
 [`time_bound_grant.py`](../backend/app/models/time_bound_grant.py).
 Permission grammar: [PERMISSIONS.md](PERMISSIONS.md).
 
-```
-User ──< user_group >── Group ──< group_role >── Role
-                                                  └── permissions (JSONB list of
-                                                      {action, resource_type, resource_id?})
-```
+<p align="center">
+  <img src="assets/diagrams/data-model-rbac.svg" alt="Auth and RBAC — the permission chain" width="900"/>
+</p>
 
 | Model | Table | Notes |
 |---|---|---|

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,45 @@
+# Local docs preview — Jekyll, matched to what GitHub Pages actually runs.
+#
+# The published site is built by GitHub Pages from this directory (see the
+# "Documentation sites" note in CLAUDE.md). This image exists so the same
+# tree can be rendered locally before publishing, because a docs change that
+# only looks right on GitHub is a change nobody reviewed.
+#
+# Pinned to the plugin set declared in _config.yml — no theme, no bundler.
+# Pages enables optional-front-matter and relative-links by default; the
+# config declares them explicitly and so do we, or a local build silently
+# diverges from the published one.
+#
+#   docker compose -f docker-compose.docs.yml up
+#   → http://localhost:4000
+FROM ruby:3.2-slim
+
+# webrick is no longer a default gem on Ruby 3.x and jekyll serve needs it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && gem install --no-document \
+         jekyll:4.3.4 \
+         jekyll-optional-front-matter:0.3.2 \
+         jekyll-relative-links:0.6.1 \
+         webrick:1.8.1 \
+    && apt-get purge -y build-essential \
+    && apt-get autoremove -y
+
+WORKDIR /srv/jekyll
+EXPOSE 4000
+
+# --force_polling: the source is a bind mount, and inotify does not fire
+#   reliably across that boundary on every host, so edits would not trigger a
+#   rebuild. Polling costs a little CPU and always works.
+# --disable-disk-cache: the source is mounted read-only so a preview can never
+#   mutate the working tree, and Jekyll otherwise insists on creating
+#   .jekyll-cache/ next to the sources. Without this it aborts on EROFS.
+CMD ["jekyll", "serve", \
+     "--source", "/srv/jekyll", \
+     "--destination", "/tmp/_site", \
+     "--host", "0.0.0.0", \
+     "--port", "4000", \
+     "--force_polling", \
+     "--disable-disk-cache", \
+     "--livereload"]

--- a/docs/PERFORMANCE_TESTING.md
+++ b/docs/PERFORMANCE_TESTING.md
@@ -606,21 +606,9 @@ exercised as production would.
 
 **Per-device FSM:**
 
-```
-            arrival (diurnal-scheduled)
-                 │
-                 ▼
-   ┌──────► OFFLINE ──boot──► DISCOVERING ──(DORA)──► ONLINE (lease held)
-   │                                                       │ at T1 = 900s
-   │                                                       ▼
-   │                                                  RENEWING ──ACK──► ONLINE
-   │                                                       │ (T1 fails) at T2 = 1800s
-   │                                                       ▼
-   │                                                  REBINDING ──ACK──► ONLINE
-   │                                                       │ (rebind fails / lapse)
-   │                                                       ▼
-   └────────── LEFT ◄──release── DEPARTING ◄── departure (diurnal/dwell-time)
-```
+<p align="center">
+  <img src="assets/diagrams/perf-client-state-machine.svg" alt="Simulated DHCP client — per-device state machine" width="900"/>
+</p>
 
 - **DORA on arrival** → first `dhcp_lease` INSERT + `ip_address` mirror INSERT +
   DDNS publish (A+PTR). Record `(IP, lease_time, T1=900, T2=1800)`.
@@ -1447,21 +1435,9 @@ against the live API during provisioning (response schemas in
 
 ### 7.1 Runner architecture + the setpoint bus
 
-```
-       load-gen boxes                                SUT (clean appliance)
- ┌───────────────────────────────┐           ┌──────────────────────────────┐
- │ spddi-perf CONTROLLER (lg-0)   │           │ k3s AIO node IP              │
- │  ├ Phase engine (diurnal)      │           │  :67 kea (hostNetwork)       │
- │  ├ Setpoint bus (rate targets) │  L2/relay │  :53 bind9 (hostNetwork)     │
- │  ├ Watchdog (health + abort)   │ ────────► │  :443 frontend→api           │
- │  ├ Checkpointer (state/events) │   API     │  CNPG 1 / Redis 1 / worker 1 │
- │  └ Collector (artifacts)       │ ────────► │                              │
- │ WORKERS:                       │           └──────────────────────────────┘
- │  • perfdhcp shards (lg-1)      │
- │  • dnsperf/flamethrower (lg-1) │           WAR-ROOM POLLER (lg-0, read-only):
- │  • orchestrator shards (lg-2)  │            /health/platform, /admin/*, /metrics/*
- └───────────────────────────────┘            + direct psql for pg_locks/deadlocks
-```
+<p align="center">
+  <img src="assets/diagrams/perf-lab-topology.svg" alt="Perf lab topology — runner architecture and the setpoint bus" width="900"/>
+</p>
 
 **Setpoint bus.** The diurnal curve is sampled on a **60s tick** (matched to the
 appliance's native 60s metric buckets), publishing a setpoint record to

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1384" viewBox="0 0 1400 1384"
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1404" viewBox="0 0 1400 1404"
      preserveAspectRatio="xMidYMid meet"
      font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
   <defs>
@@ -106,39 +106,39 @@
   <rect x="52" y="266" width="560" height="212" rx="10" class="subband"/>
   <text x="64" y="286" class="lane-label">Core — all deployments</text>
   <g>
-    <rect x="66" y="298" width="152" height="172" rx="9" class="card" fill="url(#g-api)"/>
-    <text x="142" y="324" text-anchor="middle" class="card-title">API</text>
-    <text x="142" y="344" text-anchor="middle" class="card-sub">FastAPI · Python 3.12</text>
-    <text x="142" y="362" text-anchor="middle" class="card-sub">async · JWT + RBAC</text>
-    <text x="142" y="380" text-anchor="middle" class="card-sub">audit log · REST/OpenAPI</text>
-    <text x="142" y="402" text-anchor="middle" class="card-sub-dim">long-poll /config (agents)</text>
-    <text x="142" y="420" text-anchor="middle" class="card-sub-dim">WinRM / RFC 2136 (agentless)</text>
-    <text x="142" y="438" text-anchor="middle" class="card-sub-dim">REST/SDK (cloud DNS)</text>
-    <text x="142" y="458" text-anchor="middle" class="card-sub-dim">/api/docs · /api/redoc</text>
+    <rect x="66" y="298" width="164" height="172" rx="9" class="card" fill="url(#g-api)"/>
+    <text x="148" y="324" text-anchor="middle" class="card-title">API</text>
+    <text x="148" y="344" text-anchor="middle" class="card-sub">FastAPI · Python 3.12</text>
+    <text x="148" y="362" text-anchor="middle" class="card-sub">async · JWT + RBAC</text>
+    <text x="148" y="380" text-anchor="middle" class="card-sub">audit log · REST/OpenAPI</text>
+    <text x="148" y="402" text-anchor="middle" class="card-sub-dim">long-poll /config (agents)</text>
+    <text x="148" y="420" text-anchor="middle" class="card-sub-dim">WinRM / RFC 2136 (agentless)</text>
+    <text x="148" y="438" text-anchor="middle" class="card-sub-dim">REST/SDK (cloud DNS)</text>
+    <text x="148" y="458" text-anchor="middle" class="card-sub-dim">/api/docs · /api/redoc</text>
   </g>
   <g>
-    <rect x="232" y="298" width="160" height="82" rx="9" class="card" fill="url(#g-worker)"/>
-    <text x="312" y="326" text-anchor="middle" class="card-title">Worker</text>
-    <text x="312" y="346" text-anchor="middle" class="card-sub">Celery · ipam / dns / dhcp</text>
-    <text x="312" y="364" text-anchor="middle" class="card-sub-dim">integrations · alerts</text>
+    <rect x="244" y="298" width="160" height="82" rx="9" class="card" fill="url(#g-worker)"/>
+    <text x="324" y="326" text-anchor="middle" class="card-title">Worker</text>
+    <text x="324" y="346" text-anchor="middle" class="card-sub">Celery · ipam / dns / dhcp</text>
+    <text x="324" y="364" text-anchor="middle" class="card-sub-dim">integrations · alerts</text>
   </g>
   <g>
-    <rect x="232" y="388" width="160" height="82" rx="9" class="card" fill="url(#g-worker)" fill-opacity="0.85"/>
-    <text x="312" y="416" text-anchor="middle" class="card-title">Beat</text>
-    <text x="312" y="436" text-anchor="middle" class="card-sub">scheduled: sync · health</text>
-    <text x="312" y="454" text-anchor="middle" class="card-sub-dim">cleanup · reconcile</text>
+    <rect x="244" y="388" width="160" height="82" rx="9" class="card" fill="url(#g-worker)" fill-opacity="0.85"/>
+    <text x="324" y="416" text-anchor="middle" class="card-title">Beat</text>
+    <text x="324" y="436" text-anchor="middle" class="card-sub">scheduled: sync · health</text>
+    <text x="324" y="454" text-anchor="middle" class="card-sub-dim">cleanup · reconcile</text>
   </g>
   <g>
-    <rect x="406" y="298" width="190" height="82" rx="9" class="card" fill="url(#g-store)"/>
-    <text x="501" y="326" text-anchor="middle" class="card-title">PostgreSQL 16</text>
-    <text x="501" y="346" text-anchor="middle" class="card-sub">IPAM · DNS · DHCP</text>
-    <text x="501" y="364" text-anchor="middle" class="card-sub-dim">Network · Audit · Auth</text>
+    <rect x="418" y="298" width="178" height="82" rx="9" class="card" fill="url(#g-store)"/>
+    <text x="507" y="326" text-anchor="middle" class="card-title">PostgreSQL 16</text>
+    <text x="507" y="346" text-anchor="middle" class="card-sub">IPAM · DNS · DHCP</text>
+    <text x="507" y="364" text-anchor="middle" class="card-sub-dim">Network · Audit · Auth</text>
   </g>
   <g>
-    <rect x="406" y="388" width="190" height="82" rx="9" class="card" fill="url(#g-store)" fill-opacity="0.85"/>
-    <text x="501" y="416" text-anchor="middle" class="card-title">Redis 7</text>
-    <text x="501" y="436" text-anchor="middle" class="card-sub">cache · Celery broker</text>
-    <text x="501" y="454" text-anchor="middle" class="card-sub-dim">pub/sub agent wake</text>
+    <rect x="418" y="388" width="178" height="82" rx="9" class="card" fill="url(#g-store)" fill-opacity="0.85"/>
+    <text x="507" y="416" text-anchor="middle" class="card-title">Redis 7</text>
+    <text x="507" y="436" text-anchor="middle" class="card-sub">cache · Celery broker</text>
+    <text x="507" y="454" text-anchor="middle" class="card-sub-dim">pub/sub agent wake</text>
   </g>
 
   <!-- HA add-ons -->
@@ -224,9 +224,9 @@
 
   <!-- ───── Data Plane ───── -->
   <text x="40" y="712" class="layer-label">Data plane — independent shapes, mix freely</text>
-  <rect x="36" y="718" width="1328" height="322" rx="12" class="band"/>
-  <line x1="476" y1="730" x2="476" y2="1028" class="lane-div"/>
-  <line x1="916" y1="730" x2="916" y2="1028" class="lane-div"/>
+  <rect x="36" y="718" width="1328" height="342" rx="12" class="band"/>
+  <line x1="476" y1="730" x2="476" y2="1048" class="lane-div"/>
+  <line x1="916" y1="730" x2="916" y2="1048" class="lane-div"/>
 
   <!-- Lane A: Agented on-prem -->
   <text x="52" y="740" class="lane-label">Agented (on-prem) — built-in containers, auto-register</text>
@@ -248,7 +248,8 @@
     <text x="258" y="975" text-anchor="middle" class="card-sub-dim">ghcr.io/spatiumddi/dhcp-kea</text>
     <text x="258" y="995" text-anchor="middle" class="card-sub">spatium-dhcp-agent · kea-dhcp4/6 · 67/udp · HA hook</text>
   </g>
-  <text x="258" y="1024" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">PSK/pairing→JWT · long-poll ETag · last-known-good cache · DNS engine mutually exclusive</text>
+  <text x="258" y="1024" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">PSK/pairing→JWT · long-poll ETag</text>
+  <text x="258" y="1040" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">last-known-good cache · DNS engine mutually exclusive</text>
 
   <!-- Lane B: Agentless on-prem (Windows) -->
   <text x="488" y="740" class="lane-label">Agentless (on-prem) — Windows Server, nothing installed</text>
@@ -269,7 +270,8 @@
     <text x="698" y="956" text-anchor="middle" class="pill-text">read-only WinRM polling → IPAM mirror</text>
     <text x="698" y="984" text-anchor="middle" class="card-sub-dim">5985/5986 · status=dhcp · Path B (CRUD) roadmap</text>
   </g>
-  <text x="698" y="1024" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">no software on the DC · credentials Fernet-encrypted on the server row</text>
+  <text x="698" y="1024" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">no software on the DC</text>
+  <text x="698" y="1040" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">credentials Fernet-encrypted on the server row</text>
 
   <!-- Lane C: Agentless cloud DNS -->
   <text x="924" y="740" class="lane-label">Agentless (cloud DNS) — provider API, no agent</text>
@@ -298,43 +300,44 @@
     <text x="1134" y="938" text-anchor="middle" class="card-title">DigitalOcean · Hetzner · Linode · Vultr</text>
     <text x="1134" y="956" text-anchor="middle" class="card-sub-dim">single API-token REST</text>
   </g>
-  <text x="1134" y="1024" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">control plane calls REST/SDK directly · import-existing-zones</text>
+  <text x="1134" y="1024" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">control plane calls REST/SDK directly</text>
+  <text x="1134" y="1040" text-anchor="middle" class="lane-label" font-size="10.5px" fill="#64748b">import-existing-zones</text>
 
   <!-- ───── Integration mirrors ───── -->
-  <text x="40" y="1062" class="layer-label">Integration mirrors — scheduled pull → IPAM (read-only; block-sync push is the one opt-in exception)</text>
-  <rect x="36" y="1068" width="1328" height="260" rx="12" class="band"/>
-  <rect x="52" y="1082" width="1292" height="232" rx="10" class="card" fill="url(#g-integrations)"/>
+  <text x="40" y="1082" class="layer-label">Integration mirrors — scheduled pull → IPAM (read-only; block-sync push is the one opt-in exception)</text>
+  <rect x="36" y="1088" width="1328" height="260" rx="12" class="band"/>
+  <rect x="52" y="1102" width="1292" height="232" rx="10" class="card" fill="url(#g-integrations)"/>
 
-  <text x="212" y="1116" text-anchor="middle" class="card-title-sm">Kubernetes</text>
-  <text x="212" y="1134" text-anchor="middle" class="card-sub-dim">CIDRs · nodes · LB VIPs · Ingress→DNS</text>
-  <text x="532" y="1116" text-anchor="middle" class="card-title-sm">Docker</text>
-  <text x="532" y="1134" text-anchor="middle" class="card-sub-dim">networks · container IPs</text>
-  <text x="852" y="1116" text-anchor="middle" class="card-title-sm">Proxmox VE</text>
-  <text x="852" y="1134" text-anchor="middle" class="card-sub-dim">bridges · SDN VNets · VM/LXC NICs</text>
-  <text x="1180" y="1116" text-anchor="middle" class="card-title-sm">Cloud (AWS / Azure / GCP)</text>
-  <text x="1180" y="1134" text-anchor="middle" class="card-sub-dim">VPCs→blocks · subnets · NIC/LB IPs</text>
+  <text x="212" y="1136" text-anchor="middle" class="card-title-sm">Kubernetes</text>
+  <text x="212" y="1154" text-anchor="middle" class="card-sub-dim">CIDRs · nodes · LB VIPs · Ingress→DNS</text>
+  <text x="532" y="1136" text-anchor="middle" class="card-title-sm">Docker</text>
+  <text x="532" y="1154" text-anchor="middle" class="card-sub-dim">networks · container IPs</text>
+  <text x="852" y="1136" text-anchor="middle" class="card-title-sm">Proxmox VE</text>
+  <text x="852" y="1154" text-anchor="middle" class="card-sub-dim">bridges · SDN VNets · VM/LXC NICs</text>
+  <text x="1180" y="1136" text-anchor="middle" class="card-title-sm">Cloud (AWS / Azure / GCP)</text>
+  <text x="1180" y="1154" text-anchor="middle" class="card-sub-dim">VPCs→blocks · subnets · NIC/LB IPs</text>
 
-  <line x1="76" y1="1158" x2="1320" y2="1158" class="divider"/>
+  <line x1="76" y1="1178" x2="1320" y2="1178" class="divider"/>
 
-  <text x="212" y="1190" text-anchor="middle" class="card-title-sm">Tailscale</text>
-  <text x="212" y="1208" text-anchor="middle" class="card-sub-dim">devices · synthetic *.ts.net zone</text>
-  <text x="532" y="1190" text-anchor="middle" class="card-title-sm">UniFi Network</text>
-  <text x="532" y="1208" text-anchor="middle" class="card-sub-dim">sites · VLANs · clients (host+MAC)</text>
-  <text x="852" y="1190" text-anchor="middle" class="card-title-sm">OPNsense</text>
-  <text x="852" y="1208" text-anchor="middle" class="card-sub-dim">interfaces · DHCP leases + reservations</text>
-  <text x="1180" y="1190" text-anchor="middle" class="card-title-sm">NetBird</text>
-  <text x="1180" y="1208" text-anchor="middle" class="card-sub-dim">peers · synthetic DNS zone · overlay CIDR</text>
+  <text x="212" y="1210" text-anchor="middle" class="card-title-sm">Tailscale</text>
+  <text x="212" y="1228" text-anchor="middle" class="card-sub-dim">devices · synthetic *.ts.net zone</text>
+  <text x="532" y="1210" text-anchor="middle" class="card-title-sm">UniFi Network</text>
+  <text x="532" y="1228" text-anchor="middle" class="card-sub-dim">sites · VLANs · clients (host+MAC)</text>
+  <text x="852" y="1210" text-anchor="middle" class="card-title-sm">OPNsense</text>
+  <text x="852" y="1228" text-anchor="middle" class="card-sub-dim">interfaces · DHCP leases + reservations</text>
+  <text x="1180" y="1210" text-anchor="middle" class="card-title-sm">NetBird</text>
+  <text x="1180" y="1228" text-anchor="middle" class="card-sub-dim">peers · synthetic DNS zone · overlay CIDR</text>
 
-  <line x1="76" y1="1232" x2="1320" y2="1232" class="divider"/>
+  <line x1="76" y1="1252" x2="1320" y2="1252" class="divider"/>
 
-  <text x="212" y="1264" text-anchor="middle" class="card-title-sm">Palo Alto PAN-OS</text>
-  <text x="212" y="1282" text-anchor="middle" class="card-sub-dim">address objects · NAT rules · zones</text>
-  <text x="532" y="1264" text-anchor="middle" class="card-title-sm">Fortinet FortiGate</text>
-  <text x="532" y="1282" text-anchor="middle" class="card-sub-dim">address objects · VIPs → NAT mappings</text>
-  <text x="852" y="1264" text-anchor="middle" class="card-title-sm">Cisco Meraki MX</text>
-  <text x="852" y="1282" text-anchor="middle" class="card-sub-dim">VLANs · reservations · policy objects</text>
-  <text x="1180" y="1270" text-anchor="middle" class="card-sub">Fernet-encrypted creds · 30 s sync</text>
-  <text x="1180" y="1288" text-anchor="middle" class="card-sub-dim">shape-guarded absence-delete</text>
+  <text x="212" y="1284" text-anchor="middle" class="card-title-sm">Palo Alto PAN-OS</text>
+  <text x="212" y="1302" text-anchor="middle" class="card-sub-dim">address objects · NAT rules · zones</text>
+  <text x="532" y="1284" text-anchor="middle" class="card-title-sm">Fortinet FortiGate</text>
+  <text x="532" y="1302" text-anchor="middle" class="card-sub-dim">address objects · VIPs → NAT mappings</text>
+  <text x="852" y="1284" text-anchor="middle" class="card-title-sm">Cisco Meraki MX</text>
+  <text x="852" y="1302" text-anchor="middle" class="card-sub-dim">VLANs · reservations · policy objects</text>
+  <text x="1180" y="1290" text-anchor="middle" class="card-sub">Fernet-encrypted creds · 30 s sync</text>
+  <text x="1180" y="1308" text-anchor="middle" class="card-sub-dim">shape-guarded absence-delete</text>
 
   <!-- ───── Edges ───── -->
   <!-- Clients → control plane -->
@@ -360,6 +363,6 @@
   <path d="M 120 750 L 120 690 L 14 690 L 14 426 L 66 426" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
 
   <!-- Beat → integration mirrors (right spine) -->
-  <path d="M 1344 470 L 1378 470 L 1378 1080 L 1344 1080" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
-  <text x="1150" y="1062" class="edge-label" text-anchor="end">Beat: scheduled pull → IPAM ↘</text>
+  <path d="M 1344 470 L 1378 470 L 1378 1100 L 1344 1100" class="edge-dashed" marker-end="url(#arrow-dashed)"/>
+  <text x="1150" y="1082" class="edge-label" text-anchor="end">Beat: scheduled pull → IPAM ↘</text>
 </svg>

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -681,6 +681,28 @@ a.card:hover {
   height: auto;
 }
 
+/* Architecture diagrams are authored on a light surface. Left bare on the
+   dark theme they read as a bright slab dropped into the page, so give them
+   a rounded plate that matches the code-block and figure treatment. Scoped
+   to .svg because screenshots (PNG) carry their own chrome already. */
+.doc-body img[src$=".svg"] {
+  display: block;
+  margin: 1.25em auto;
+  border-radius: 12px;
+}
+:root[data-theme="dark"] .doc-body img[src$=".svg"] {
+  background: #f8fafc;
+  padding: 12px;
+  border: 1px solid var(--border);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .doc-body img[src$=".svg"] {
+    background: #f8fafc;
+    padding: 12px;
+    border: 1px solid var(--border);
+  }
+}
+
 .doc-body pre {
   background: var(--bg-code);
   border: 1px solid var(--border);

--- a/docs/assets/diagrams/appliance-k3s-layout.svg
+++ b/docs/assets/diagrams/appliance-k3s-layout.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="898" viewBox="0 0 920 898"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>Single-node k3s appliance layout</title>
+  <desc>What mkosi bakes into the appliance slot rootfs, and how firstboot's HelmChart manifest turns into the supervisor, role and control-plane pods.</desc>
+  <defs>
+    <linearGradient id="appk-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="appk-control" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="appk-worker" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="appk-agent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="appk-accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <marker id="appk-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <!-- outer appliance panel -->
+  <rect x="20" y="20" width="880" height="858" rx="16"
+        fill="url(#appk-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <text x="44" y="52" font-size="18" font-weight="600" fill="#0f172a">appliance — single-node k3s</text>
+  <text x="44" y="74" font-size="12" fill="#475569">Debian 13 slot rootfs · every binary, image and chart baked in for an air-gapped first boot</text>
+
+  <!-- ================= on-disk layout ================= -->
+  <rect x="40" y="92" width="840" height="282" rx="12"
+        fill="#ffffff" stroke="#cbd5e1" stroke-dasharray="4 4" stroke-width="1.5"/>
+  <text x="60" y="116" font-size="13" font-weight="600" fill="#334155">on-disk layout — baked into the slot rootfs by mkosi</text>
+
+  <!-- row 1: k3s binary -->
+  <rect x="52" y="126" width="520" height="40" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="68" y="144" font-size="12" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">/usr/local/bin/k3s</text>
+  <text x="68" y="160" font-size="11" fill="#475569">static binary, pinned via K3S_VERSION</text>
+
+  <!-- row 2: airgap images -->
+  <rect x="52" y="174" width="520" height="40" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="68" y="199" font-size="12" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">/var/lib/rancher/k3s/agent/images/*.tar.zst</text>
+  <rect x="610" y="181" width="140" height="26" rx="6"
+        fill="#ffffff" stroke="#94a3b8" stroke-dasharray="4 4" stroke-width="1"/>
+  <text x="624" y="198" font-size="11" fill="#475569">air-gap-preloaded</text>
+  <path d="M 606 194 H 578" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#appk-arrow)"/>
+
+  <!-- row 3: appliance chart -->
+  <rect x="52" y="222" width="520" height="40" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="68" y="247" font-size="12" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">/usr/lib/spatiumddi/charts/spatiumddi-appliance.tgz</text>
+  <rect x="610" y="229" width="130" height="26" rx="6"
+        fill="#ffffff" stroke="#94a3b8" stroke-dasharray="4 4" stroke-width="1"/>
+  <text x="624" y="246" font-size="11" fill="#475569">appliance chart</text>
+  <path d="M 606 242 H 578" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#appk-arrow)"/>
+
+  <!-- row 4: umbrella chart -->
+  <rect x="52" y="270" width="520" height="40" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="68" y="295" font-size="12" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">/usr/lib/spatiumddi/charts/spatiumddi.tgz</text>
+  <rect x="610" y="277" width="215" height="26" rx="6"
+        fill="#ffffff" stroke="#94a3b8" stroke-dasharray="4 4" stroke-width="1"/>
+  <text x="624" y="294" font-size="11" fill="#475569">umbrella chart (Control plane)</text>
+  <path d="M 606 290 H 578" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#appk-arrow)"/>
+
+  <!-- row 5: bootstrap manifest -->
+  <rect x="52" y="318" width="520" height="40" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.5"/>
+  <text x="68" y="343" font-size="12" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">/var/lib/rancher/k3s/server/manifests/spatium-bootstrap.yaml</text>
+
+  <!-- manifest → helm-controller -->
+  <path d="M 200 374 V 454" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#appk-arrow)"/>
+  <text x="214" y="402" font-size="11" fill="#475569">firstboot writes on every boot — content depends on install role</text>
+
+  <!-- ================= boot sequence ================= -->
+  <rect x="40" y="422" width="840" height="440" rx="12"
+        fill="#ffffff" stroke="#cbd5e1" stroke-dasharray="4 4" stroke-width="1.5"/>
+  <text x="60" y="446" font-size="13" font-weight="600" fill="#334155">boot sequence — helm-controller reconciles the bootstrap release</text>
+
+  <!-- helm-controller -->
+  <rect x="52" y="458" width="520" height="46" rx="8" fill="#64748b"/>
+  <text x="68" y="478" font-size="13" font-weight="600" fill="#ffffff">helm-controller reconciles</text>
+  <text x="68" y="494" font-size="11" fill="#cbd5e1">→ installs the spatium-bootstrap release</text>
+
+  <path d="M 200 504 V 536" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#appk-arrow)"/>
+
+  <!-- supervisor -->
+  <rect x="52" y="540" width="520" height="50" rx="8" fill="url(#appk-worker)"/>
+  <text x="68" y="562" font-size="13" font-weight="600" fill="#ffffff">spatium-supervisor pod</text>
+  <text x="68" y="580" font-size="11" fill="#ddd6fe">DaemonSet · privileged · hostNetwork: false</text>
+  <rect x="610" y="552" width="95" height="26" rx="6"
+        fill="#ffffff" stroke="#94a3b8" stroke-dasharray="4 4" stroke-width="1"/>
+  <text x="624" y="569" font-size="11" fill="#475569">all roles</text>
+  <path d="M 606 565 H 578" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#appk-arrow)"/>
+
+  <path d="M 200 590 V 628" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#appk-arrow)"/>
+  <text x="214" y="606" font-size="11" fill="#475569">registers + heartbeats to control plane</text>
+  <text x="214" y="624" font-size="11" fill="#475569">on role assignment: labels node → DaemonSet schedules</text>
+
+  <!-- role pods -->
+  <rect x="52" y="632" width="520" height="50" rx="8" fill="url(#appk-agent)"/>
+  <text x="68" y="654" font-size="13" font-weight="600" fill="#ffffff">role pods — hostNetwork: true</text>
+  <text x="68" y="672" font-size="11" fill="#fed7aa">dns-bind9 · dns-powerdns · dns-technitium · dhcp-kea</text>
+
+  <text x="60" y="710" font-size="13" font-weight="600" fill="#334155">also owned by the spatium-bootstrap release</text>
+
+  <!-- agent-landing -->
+  <rect x="52" y="722" width="520" height="46" rx="8" fill="url(#appk-accent)"/>
+  <text x="68" y="742" font-size="13" font-weight="600" fill="#ffffff">agent-landing nginx — :80</text>
+  <text x="68" y="758" font-size="11" fill="#cffafe">always-on</text>
+  <rect x="610" y="732" width="125" height="26" rx="6"
+        fill="#ffffff" stroke="#94a3b8" stroke-dasharray="4 4" stroke-width="1"/>
+  <text x="624" y="749" font-size="11" fill="#475569">Appliance only</text>
+  <path d="M 606 745 H 578" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#appk-arrow)"/>
+
+  <!-- control plane pods -->
+  <rect x="52" y="784" width="520" height="64" rx="8" fill="url(#appk-control)"/>
+  <text x="68" y="806" font-size="13" font-weight="600" fill="#ffffff">control plane pods</text>
+  <text x="68" y="822" font-size="11" fill="#ddd6fe">api · frontend · db · redis · worker · beat · migrate</text>
+  <text x="68" y="838" font-size="11" fill="#ddd6fe">frontend on hostNetwork :80 + :443</text>
+  <rect x="610" y="803" width="120" height="26" rx="6"
+        fill="#ffffff" stroke="#94a3b8" stroke-dasharray="4 4" stroke-width="1"/>
+  <text x="624" y="820" font-size="11" fill="#475569">Control plane</text>
+  <path d="M 606 816 H 578" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#appk-arrow)"/>
+</svg>

--- a/docs/assets/diagrams/architecture-planes.svg
+++ b/docs/assets/diagrams/architecture-planes.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="560" viewBox="0 0 920 560"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>SpatiumDDI clients, control plane and data plane</title>
+  <desc>Browsers and CLI/MCP clients call the control plane over HTTP and REST; the data-plane agents long-poll the api for config bundles, and Redis publishes wake events to the appliance supervisor.</desc>
+  <defs>
+    <linearGradient id="arch-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="arch-cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="arch-worker" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="arch-store" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="arch-agent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="arch-client" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <marker id="arch-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="40" font-size="18" font-weight="600" fill="#0f172a">Control plane and data plane</text>
+  <text x="40" y="62" font-size="12" fill="#475569">One control plane is the source of truth; the data-plane containers are projections of it.</text>
+
+  <text x="40" y="94" font-size="13" font-weight="600" fill="#334155">Clients</text>
+  <text x="300" y="94" font-size="13" font-weight="600" fill="#334155">Control plane</text>
+  <text x="720" y="94" font-size="13" font-weight="600" fill="#334155">Data plane</text>
+
+  <!-- Clients -->
+  <rect x="40" y="110" width="180" height="180" rx="16"
+        fill="url(#arch-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <rect x="58" y="140" width="144" height="56" rx="8" fill="url(#arch-client)"/>
+  <text x="130" y="164" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Browser</text>
+  <text x="130" y="182" text-anchor="middle" font-size="11" fill="#cffafe">React SPA</text>
+  <rect x="58" y="216" width="144" height="56" rx="8" fill="url(#arch-client)"/>
+  <text x="130" y="240" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">CLI / API / MCP</text>
+  <text x="130" y="258" text-anchor="middle" font-size="11" fill="#cffafe">REST + MCP clients</text>
+
+  <!-- Control plane -->
+  <rect x="300" y="110" width="340" height="422" rx="16"
+        fill="url(#arch-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <rect x="318" y="140" width="304" height="56" rx="8" fill="url(#arch-cp)"/>
+  <text x="470" y="164" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">frontend</text>
+  <text x="470" y="182" text-anchor="middle" font-size="11" fill="#ddd6fe">nginx + SPA</text>
+
+  <rect x="318" y="212" width="304" height="84" rx="8" fill="url(#arch-cp)"/>
+  <text x="470" y="236" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">api — FastAPI / uvicorn</text>
+  <text x="470" y="258" text-anchor="middle" font-size="11" fill="#ddd6fe">REST + OpenAPI</text>
+  <text x="470" y="276" text-anchor="middle" font-size="11" fill="#ddd6fe">/api/v1/ai/mcp — MCP surface</text>
+
+  <rect x="318" y="312" width="146" height="56" rx="8" fill="url(#arch-worker)"/>
+  <text x="391" y="336" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">worker</text>
+  <text x="391" y="354" text-anchor="middle" font-size="11" fill="#ddd6fe">Celery</text>
+  <rect x="476" y="312" width="146" height="56" rx="8" fill="url(#arch-worker)"/>
+  <text x="549" y="336" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">beat</text>
+  <text x="549" y="354" text-anchor="middle" font-size="11" fill="#ddd6fe">Celery schedule</text>
+
+  <rect x="318" y="384" width="304" height="56" rx="8" fill="url(#arch-store)"/>
+  <text x="470" y="408" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">PostgreSQL 16</text>
+  <text x="470" y="426" text-anchor="middle" font-size="11" fill="#a7f3d0">the source of truth</text>
+  <rect x="318" y="456" width="304" height="56" rx="8" fill="url(#arch-store)"/>
+  <text x="470" y="480" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Redis 7</text>
+  <text x="470" y="498" text-anchor="middle" font-size="11" fill="#a7f3d0">broker + wake pub/sub</text>
+
+  <!-- Data plane -->
+  <rect x="720" y="110" width="176" height="288" rx="16"
+        fill="url(#arch-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <rect x="738" y="140" width="140" height="68" rx="8" fill="url(#arch-agent)"/>
+  <text x="808" y="166" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DNS agent</text>
+  <text x="808" y="184" text-anchor="middle" font-size="11" fill="#fed7aa">BIND9 / PowerDNS</text>
+  <rect x="738" y="224" width="140" height="68" rx="8" fill="url(#arch-agent)"/>
+  <text x="808" y="250" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCP agent</text>
+  <text x="808" y="268" text-anchor="middle" font-size="11" fill="#fed7aa">Kea</text>
+  <rect x="738" y="308" width="140" height="68" rx="8" fill="url(#arch-agent)"/>
+  <text x="808" y="334" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">supervisor</text>
+  <text x="808" y="352" text-anchor="middle" font-size="11" fill="#fed7aa">appliance host</text>
+
+  <!-- Client traffic -->
+  <path d="M 202 168 H 312" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arch-arrow)"/>
+  <text x="257" y="160" text-anchor="middle" font-size="11" fill="#475569">HTTP</text>
+  <path d="M 202 244 H 312" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arch-arrow)"/>
+  <text x="257" y="236" text-anchor="middle" font-size="11" fill="#475569">REST</text>
+
+  <!-- Agents long-poll the api -->
+  <path d="M 714 254 H 628" stroke="#ea580c" stroke-width="2" stroke-dasharray="6 4"
+        fill="none" marker-end="url(#arch-arrow)"/>
+  <text x="671" y="246" text-anchor="middle" font-size="11" fill="#475569">long poll</text>
+  <text x="671" y="272" text-anchor="middle" font-size="11" fill="#475569">(ETag)</text>
+
+  <!-- Redis wake bus -->
+  <path d="M 626 484 H 808 V 404" stroke="#059669" stroke-width="2" stroke-dasharray="6 4"
+        fill="none" marker-end="url(#arch-arrow)"/>
+  <text x="798" y="476" text-anchor="end" font-size="11" fill="#475569">pub/sub</text>
+</svg>

--- a/docs/assets/diagrams/auth-login-flow.svg
+++ b/docs/assets/diagrams/auth-login-flow.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="470" viewBox="0 0 920 470"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>SpatiumDDI login flow</title>
+  <desc>A browser posts to /auth/login, which branches into local password, LDAP/RADIUS/TACACS+ and OIDC/SAML redirect paths that all converge on sync_external_user before access and refresh tokens return to the browser.</desc>
+  <defs>
+    <linearGradient id="auth-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="auth-cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="auth-worker" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <marker id="auth-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="42" font-size="18" font-weight="600" fill="#0f172a">Login flow</text>
+  <text x="40" y="64" font-size="12" fill="#475569">One entry point, three authentication paths, one unified identity sync.</text>
+
+  <!-- Browser -->
+  <rect x="40" y="112" width="160" height="88" rx="8" fill="#1e293b"/>
+  <text x="120" y="162" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">browser</text>
+
+  <!-- /auth/login panel -->
+  <rect x="340" y="88" width="290" height="200" rx="12"
+        fill="url(#auth-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <text x="360" y="115" font-size="14" font-weight="600" fill="#0f172a">/auth/login</text>
+
+  <rect x="360" y="126" width="250" height="44" rx="8" fill="url(#auth-cp)"/>
+  <text x="485" y="153" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">local password</text>
+
+  <rect x="360" y="178" width="250" height="44" rx="8" fill="url(#auth-cp)"/>
+  <text x="485" y="205" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">LDAP / RADIUS / TACACS+</text>
+
+  <rect x="360" y="230" width="250" height="44" rx="8" fill="url(#auth-worker)"/>
+  <text x="485" y="257" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">OIDC / SAML: 302</text>
+
+  <!-- Handlers -->
+  <rect x="670" y="126" width="210" height="44" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
+  <text x="775" y="153" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">verify_password</text>
+
+  <rect x="670" y="178" width="210" height="44" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
+  <text x="775" y="205" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">authenticate_*</text>
+
+  <rect x="670" y="230" width="210" height="44" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
+  <text x="775" y="257" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">redirect to IdP</text>
+
+  <path d="M 610 148 H 668" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#auth-arrow)"/>
+  <path d="M 610 200 H 668" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#auth-arrow)"/>
+  <path d="M 610 252 H 668" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#auth-arrow)"/>
+
+  <!-- Browser to login and back -->
+  <path d="M 200 146 H 338" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#auth-arrow)"/>
+  <text x="270" y="138" text-anchor="middle" font-size="11" fill="#475569">1. login</text>
+
+  <path d="M 340 196 H 202" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#auth-arrow)"/>
+  <text x="270" y="188" text-anchor="middle" font-size="11" fill="#475569">2. access + refresh</text>
+
+  <!-- Converge on sync_external_user -->
+  <path d="M 485 288 V 328" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#auth-arrow)"/>
+
+  <rect x="310" y="330" width="350" height="112" rx="8" fill="url(#auth-worker)"/>
+  <text x="485" y="358" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">sync_external_user</text>
+  <path d="M 326 376 l 8 4 l -8 4 z" fill="#ddd6fe"/>
+  <text x="342" y="384" font-size="11" fill="#ddd6fe">upsert User</text>
+  <path d="M 326 396 l 8 4 l -8 4 z" fill="#ddd6fe"/>
+  <text x="342" y="404" font-size="11" fill="#ddd6fe">replace group membership</text>
+  <path d="M 326 416 l 8 4 l -8 4 z" fill="#fecaca"/>
+  <text x="342" y="424" font-size="11" fill="#fecaca">reject if no mapping match</text>
+</svg>

--- a/docs/assets/diagrams/data-model-dhcp.svg
+++ b/docs/assets/diagrams/data-model-dhcp.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="584" viewBox="0 0 920 584"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>DHCP data model — the group-centric hierarchy</title>
+  <desc>DHCPServerGroup owns DHCPServer, DHCPScope and DHCPClientClass rows; leases hang off a server, while pools and static assignments hang off a scope.</desc>
+  <defs>
+    <linearGradient id="dmh-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="dmh-group" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="dmh-server" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="dmh-lease" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="dmh-scope" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="dmh-leaf" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+
+  <text x="40" y="42" font-size="18" font-weight="600" fill="#0f172a">DHCP — the group-centric hierarchy</text>
+  <text x="40" y="64" font-size="12" fill="#475569">Scopes, pools, statics and classes live on the group; leases are per-server, because each Kea instance owns its own memfile.</text>
+
+  <!-- Group panel -->
+  <rect x="40" y="88" width="840" height="468" rx="16"
+        fill="url(#dmh-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <rect x="64" y="104" width="210" height="36" rx="8" fill="url(#dmh-group)"/>
+  <text x="169" y="127" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPServerGroup</text>
+  <text x="296" y="118" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dhcp_server_group</text>
+  <text x="296" y="136" font-size="12" fill="#475569">the primary config container — holds the HA tuning</text>
+
+  <!-- Tree spine -->
+  <path d="M 76 148 V 510" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 76 186 H 100" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 76 318 H 100" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 76 510 H 100" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+
+  <!-- DHCPServer (contains DHCPLease) -->
+  <rect x="100" y="160" width="756" height="120" rx="10"
+        fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="120" y="170" width="210" height="32" rx="8" fill="url(#dmh-server)"/>
+  <text x="225" y="191" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPServer</text>
+  <text x="352" y="182" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dhcp_server</text>
+  <text x="352" y="200" font-size="12" fill="#475569">a Kea instance or a Windows DHCP server</text>
+
+  <path d="M 118 208 V 242" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 118 242 H 136" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <rect x="136" y="216" width="700" height="52" rx="10"
+        fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="156" y="226" width="210" height="32" rx="8" fill="url(#dmh-lease)"/>
+  <text x="261" y="247" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPLease</text>
+  <text x="388" y="238" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dhcp_lease</text>
+  <text x="388" y="256" font-size="12" fill="#475569">a per-server active or historical lease</text>
+
+  <!-- DHCPScope (contains DHCPPool + DHCPStaticAssignment) -->
+  <rect x="100" y="292" width="756" height="180" rx="10"
+        fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="120" y="302" width="210" height="32" rx="8" fill="url(#dmh-scope)"/>
+  <text x="225" y="323" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPScope</text>
+  <text x="352" y="314" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dhcp_scope</text>
+  <text x="352" y="332" font-size="12" fill="#475569">one subnet served by the group</text>
+
+  <path d="M 118 340 V 434" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 118 374 H 136" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 118 434 H 136" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+
+  <rect x="136" y="348" width="700" height="52" rx="10"
+        fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="156" y="358" width="210" height="32" rx="8" fill="url(#dmh-leaf)"/>
+  <text x="261" y="379" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPPool</text>
+  <text x="388" y="370" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dhcp_pool</text>
+  <text x="388" y="388" font-size="12" fill="#475569">a dynamic / excluded / reserved range</text>
+
+  <rect x="136" y="408" width="700" height="52" rx="10"
+        fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="156" y="418" width="210" height="32" rx="8" fill="url(#dmh-leaf)"/>
+  <text x="261" y="439" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPStaticAssignment</text>
+  <text x="388" y="430" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dhcp_static_assignment</text>
+  <text x="388" y="448" font-size="12" fill="#475569">a MAC → IP reservation</text>
+
+  <!-- DHCPClientClass -->
+  <rect x="100" y="484" width="756" height="52" rx="10"
+        fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="120" y="494" width="210" height="32" rx="8" fill="url(#dmh-leaf)"/>
+  <text x="225" y="515" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPClientClass</text>
+  <text x="352" y="506" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dhcp_client_class</text>
+  <text x="352" y="524" font-size="12" fill="#475569">conditional option delivery</text>
+</svg>

--- a/docs/assets/diagrams/data-model-dns.svg
+++ b/docs/assets/diagrams/data-model-dns.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="520" viewBox="0 0 920 520"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>DNS data model — the group-centric hierarchy</title>
+  <desc>DNSServerGroup owns DNSServer, DNSView, DNSZone and DNSPool rows; DNSRecord rows hang off a zone.</desc>
+  <defs>
+    <linearGradient id="dmd-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="dmd-group" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="dmd-server" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="dmd-view" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="dmd-zone" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="dmd-record" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+  </defs>
+
+  <text x="40" y="42" font-size="18" font-weight="600" fill="#0f172a">DNS — the group-centric hierarchy</text>
+  <text x="40" y="64" font-size="12" fill="#475569">Configuration lives on the group; servers are members, and zones and records hang off the group.</text>
+
+  <!-- Group panel -->
+  <rect x="40" y="88" width="840" height="404" rx="16"
+        fill="url(#dmd-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <rect x="64" y="104" width="200" height="36" rx="8" fill="url(#dmd-group)"/>
+  <text x="164" y="127" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DNSServerGroup</text>
+  <text x="288" y="118" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dns_server_group</text>
+  <text x="288" y="136" font-size="12" fill="#475569">logical cluster — holds the shared config and TSIG key</text>
+
+  <!-- Tree spine -->
+  <path d="M 76 148 V 446" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 76 186 H 100" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 76 250 H 100" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 76 314 H 100" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 76 446 H 100" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+
+  <!-- DNSServer -->
+  <rect x="100" y="160" width="756" height="52" rx="10"
+        fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="120" y="170" width="150" height="32" rx="8" fill="url(#dmd-server)"/>
+  <text x="195" y="191" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DNSServer</text>
+  <text x="290" y="182" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dns_server</text>
+  <text x="290" y="200" font-size="12" fill="#475569">an individual BIND9 / PowerDNS / Windows / agentless server</text>
+
+  <!-- DNSView -->
+  <rect x="100" y="224" width="756" height="52" rx="10"
+        fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="120" y="234" width="150" height="32" rx="8" fill="url(#dmd-view)"/>
+  <text x="195" y="255" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DNSView</text>
+  <text x="290" y="246" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dns_view</text>
+  <text x="290" y="264" font-size="12" fill="#475569">a split-horizon view</text>
+
+  <!-- DNSZone (contains DNSRecord) -->
+  <rect x="100" y="288" width="756" height="120" rx="10"
+        fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="120" y="298" width="150" height="32" rx="8" fill="url(#dmd-zone)"/>
+  <text x="195" y="319" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DNSZone</text>
+  <text x="290" y="310" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dns_zone</text>
+  <text x="290" y="328" font-size="12" fill="#475569">authoritative / secondary / stub / forward</text>
+
+  <path d="M 118 336 V 370" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <path d="M 118 370 H 136" stroke="#cbd5e1" stroke-width="2" fill="none"/>
+  <rect x="136" y="344" width="700" height="52" rx="10"
+        fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="156" y="354" width="150" height="32" rx="8" fill="url(#dmd-record)"/>
+  <text x="231" y="375" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DNSRecord</text>
+  <text x="326" y="366" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dns_record</text>
+  <text x="326" y="384" font-size="12" fill="#475569">a resource record within a zone</text>
+
+  <!-- DNSPool -->
+  <rect x="100" y="420" width="756" height="52" rx="10"
+        fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+  <rect x="120" y="430" width="150" height="32" rx="8" fill="url(#dmd-view)"/>
+  <text x="195" y="451" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DNSPool</text>
+  <text x="290" y="442" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">dns_pool</text>
+  <text x="290" y="460" font-size="12" fill="#475569">health-checked A / AAAA set rendered as records</text>
+</svg>

--- a/docs/assets/diagrams/data-model-ipam.svg
+++ b/docs/assets/diagrams/data-model-ipam.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="480" viewBox="0 0 920 480"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>IPAM containment hierarchy</title>
+  <desc>IPSpace contains IPBlock, which contains Subnet, which contains IPAddress — a strict four-level containment tree with the backing table name at each level.</desc>
+  <defs>
+    <linearGradient id="dmi-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="dmi-space" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="dmi-block" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="dmi-subnet" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="dmi-addr" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <marker id="dmi-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="42" font-size="18" font-weight="600" fill="#0f172a">IPAM — the address-space tree</text>
+  <text x="40" y="64" font-size="12" fill="#475569">A strict containment tree — each level nests inside the one above it.</text>
+
+  <!-- Level 1 — IPSpace -->
+  <rect x="40" y="88" width="840" height="360" rx="16"
+        fill="url(#dmi-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <rect x="64" y="104" width="150" height="34" rx="8" fill="url(#dmi-space)"/>
+  <text x="139" y="127" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">IPSpace</text>
+  <text x="234" y="116" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">ip_space</text>
+  <text x="234" y="134" font-size="12" fill="#475569">a VRF / routing domain — addresses may overlap across spaces</text>
+  <path d="M 139 138 V 156" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#dmi-arrow)"/>
+
+  <!-- Level 2 — IPBlock -->
+  <rect x="76" y="160" width="768" height="264" rx="12"
+        fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <rect x="100" y="176" width="150" height="34" rx="8" fill="url(#dmi-block)"/>
+  <text x="175" y="199" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">IPBlock</text>
+  <text x="270" y="188" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">ip_block</text>
+  <text x="270" y="206" font-size="12" fill="#475569">aggregate / supernet — nests into itself via parent_block_id</text>
+  <path d="M 175 210 V 228" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#dmi-arrow)"/>
+
+  <!-- Level 3 — Subnet -->
+  <rect x="112" y="232" width="696" height="168" rx="12"
+        fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.5"/>
+  <rect x="136" y="248" width="150" height="34" rx="8" fill="url(#dmi-subnet)"/>
+  <text x="211" y="271" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Subnet</text>
+  <text x="306" y="260" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">subnet</text>
+  <text x="306" y="278" font-size="12" fill="#475569">the primary managed unit — a routable network</text>
+  <path d="M 211 282 V 300" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#dmi-arrow)"/>
+
+  <!-- Level 4 — IPAddress -->
+  <rect x="148" y="304" width="624" height="72" rx="12"
+        fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <rect x="172" y="320" width="150" height="34" rx="8" fill="url(#dmi-addr)"/>
+  <text x="247" y="343" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">IPAddress</text>
+  <text x="342" y="332" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">ip_address</text>
+  <text x="342" y="350" font-size="12" fill="#475569">an individual host IP</text>
+</svg>

--- a/docs/assets/diagrams/data-model-rbac.svg
+++ b/docs/assets/diagrams/data-model-rbac.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="470" viewBox="0 0 920 470"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>Auth and RBAC — the permission chain</title>
+  <desc>User links to Group through the user_group association table and Group links to Role through group_role; a Role carries its permissions as a JSONB list of action, resource_type and optional resource_id.</desc>
+  <defs>
+    <linearGradient id="dmr-user" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="dmr-group" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="dmr-role" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <marker id="dmr-crow" viewBox="0 0 12 12" refX="0" refY="6"
+            markerWidth="12" markerHeight="12" markerUnits="userSpaceOnUse" orient="auto">
+      <path d="M 0 6 L 12 0 M 0 6 L 12 6 M 0 6 L 12 12"
+            stroke="#64748b" stroke-width="1.6" fill="none"/>
+    </marker>
+    <marker id="dmr-one" viewBox="0 0 8 12" refX="4" refY="6"
+            markerWidth="8" markerHeight="12" markerUnits="userSpaceOnUse" orient="auto">
+      <path d="M 4 1 V 11" stroke="#64748b" stroke-width="1.6" fill="none"/>
+    </marker>
+    <marker id="dmr-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="44" font-size="18" font-weight="600" fill="#0f172a">Auth + RBAC — the permission chain</text>
+  <text x="40" y="68" font-size="12" fill="#475569">User and Group are linked many-to-many through user_group; Group and Role through group_role.</text>
+  <text x="40" y="86" font-size="12" fill="#475569">Both association tables carry composite primary keys and CASCADE on both sides.</text>
+
+  <!-- User -->
+  <rect x="26" y="150" width="160" height="84" rx="8" fill="url(#dmr-user)"/>
+  <text x="106" y="180" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">User</text>
+  <text x="106" y="200" text-anchor="middle" font-size="11" fill="#ddd6fe"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">user</text>
+  <text x="106" y="218" text-anchor="middle" font-size="11" fill="#ddd6fe">unique username / email</text>
+
+  <!-- user_group -->
+  <rect x="218" y="162" width="130" height="60" rx="8"
+        fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5" stroke-dasharray="4 4"/>
+  <text x="283" y="188" text-anchor="middle" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">user_group</text>
+  <text x="283" y="206" text-anchor="middle" font-size="11" fill="#475569">composite PK</text>
+
+  <!-- Group -->
+  <rect x="380" y="150" width="160" height="84" rx="8" fill="url(#dmr-group)"/>
+  <text x="460" y="180" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Group</text>
+  <text x="460" y="200" text-anchor="middle" font-size="11" fill="#ddd6fe"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">group</text>
+  <text x="460" y="218" text-anchor="middle" font-size="11" fill="#ddd6fe">membership container</text>
+
+  <!-- group_role -->
+  <rect x="572" y="162" width="130" height="60" rx="8"
+        fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1.5" stroke-dasharray="4 4"/>
+  <text x="637" y="188" text-anchor="middle" font-size="12" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">group_role</text>
+  <text x="637" y="206" text-anchor="middle" font-size="11" fill="#475569">composite PK</text>
+
+  <!-- Role -->
+  <rect x="734" y="150" width="160" height="84" rx="8" fill="url(#dmr-role)"/>
+  <text x="814" y="180" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Role</text>
+  <text x="814" y="200" text-anchor="middle" font-size="11" fill="#a7f3d0"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">role</text>
+  <text x="814" y="218" text-anchor="middle" font-size="11" fill="#a7f3d0">is_builtin flag</text>
+
+  <!-- Relationships -->
+  <path d="M 186 192 H 214" stroke="#64748b" stroke-width="2" fill="none"
+        marker-start="url(#dmr-one)" marker-end="url(#dmr-crow)"/>
+  <path d="M 380 192 H 352" stroke="#64748b" stroke-width="2" fill="none"
+        marker-start="url(#dmr-one)" marker-end="url(#dmr-crow)"/>
+  <path d="M 540 192 H 568" stroke="#64748b" stroke-width="2" fill="none"
+        marker-start="url(#dmr-one)" marker-end="url(#dmr-crow)"/>
+  <path d="M 734 192 H 706" stroke="#64748b" stroke-width="2" fill="none"
+        marker-start="url(#dmr-one)" marker-end="url(#dmr-crow)"/>
+
+  <!-- Role → permissions -->
+  <path d="M 814 234 V 296" stroke="#64748b" stroke-width="2" fill="none"
+        marker-end="url(#dmr-arrow)"/>
+
+  <rect x="414" y="300" width="480" height="120" rx="12"
+        fill="#ffffff" stroke="#94a3b8" stroke-width="2"/>
+  <text x="438" y="332" font-size="13" font-weight="600" fill="#0f172a">permissions — a JSONB list on Role</text>
+  <text x="438" y="358" font-size="12" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">{ action, resource_type, resource_id? }</text>
+  <text x="438" y="382" font-size="11" fill="#475569">wildcard * is accepted for action and resource_type</text>
+  <text x="438" y="400" font-size="11" fill="#475569">resource_id scopes a permission to a single resource</text>
+
+  <!-- Legend -->
+  <path d="M 40 438 H 62" stroke="#64748b" stroke-width="2" fill="none"
+        marker-start="url(#dmr-one)" marker-end="url(#dmr-crow)"/>
+  <text x="82" y="442" font-size="11" fill="#475569">The crow's foot marks the many side; the tick marks the one side.</text>
+</svg>

--- a/docs/assets/diagrams/dhcp-driver-shapes.svg
+++ b/docs/assets/diagrams/dhcp-driver-shapes.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="400" viewBox="0 0 920 400"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>DHCP driver shapes</title>
+  <desc>The three shapes today's DHCP drivers take: agented and write-capable (Kea), agentless and read-only (Windows DHCP Path A), and agentless but write-capable over a cloud REST API (FortiGate).</desc>
+  <defs>
+    <linearGradient id="dhcpd-agent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="dhcpd-accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="dhcpd-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+  </defs>
+
+  <text x="460" y="36" text-anchor="middle" font-size="18" font-weight="600" fill="#0f172a">DHCP driver shapes</text>
+  <text x="460" y="58" text-anchor="middle" font-size="12" fill="#475569">the registry classifies every driver on two axes — agented vs agentless, read-only vs write-capable</text>
+
+  <!-- Card 1 — Agented + write (Kea) -->
+  <g>
+    <rect x="40" y="84" width="264" height="286" rx="12" fill="url(#dhcpd-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+    <rect x="54" y="98" width="236" height="54" rx="8" fill="url(#dhcpd-agent)"/>
+    <text x="172" y="122" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Agented + write</text>
+    <text x="172" y="141" text-anchor="middle" font-size="11" fill="#fed7aa">Kea</text>
+
+    <text x="58" y="180" font-size="13" font-weight="600" fill="#0f172a">Control plane</text>
+    <text x="58" y="202" font-size="11" fill="#334155">render_config()</text>
+    <text x="58" y="220" font-size="11" fill="#334155">ETag long-poll → ConfigBundle</text>
+
+    <rect x="54" y="252" width="236" height="100" rx="8" fill="#fff7ed" stroke="#fed7aa" stroke-width="1.5"/>
+    <text x="68" y="276" font-size="13" font-weight="600" fill="#9a3412">Agent (sidecar)</text>
+    <text x="68" y="298" font-size="11" fill="#9a3412">fetch bundle</text>
+    <text x="68" y="316" font-size="11" fill="#9a3412">apply_config()</text>
+    <text x="68" y="334" font-size="11" fill="#9a3412">reload / restart</text>
+  </g>
+
+  <!-- Card 2 — Agentless + read-only (Windows DHCP, Path A) -->
+  <g>
+    <rect x="328" y="84" width="264" height="286" rx="12" fill="url(#dhcpd-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+    <rect x="342" y="98" width="236" height="54" rx="8" fill="url(#dhcpd-accent)"/>
+    <text x="460" y="122" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Agentless + read-only</text>
+    <text x="460" y="141" text-anchor="middle" font-size="11" fill="#cffafe">Windows DHCP — Path A</text>
+
+    <text x="346" y="180" font-size="13" font-weight="600" fill="#0f172a">Control plane</text>
+    <text x="346" y="202" font-size="11" fill="#334155">get_leases()  WinRM</text>
+    <text x="346" y="220" font-size="11" fill="#334155">get_scopes()  WinRM</text>
+
+    <rect x="342" y="252" width="236" height="100" rx="8" fill="#fef2f2" stroke="#fecaca" stroke-width="1.5"/>
+    <text x="356" y="276" font-size="13" font-weight="600" fill="#b91c1c">No agent</text>
+    <text x="356" y="298" font-size="11" fill="#b91c1c">writes raise</text>
+    <text x="356" y="316" font-size="11" fill="#b91c1c">NotImplementedError</text>
+  </g>
+
+  <!-- Card 3 — Agentless + write (FortiGate, cloud) -->
+  <g>
+    <rect x="616" y="84" width="264" height="286" rx="12" fill="url(#dhcpd-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+    <rect x="630" y="98" width="236" height="54" rx="8" fill="url(#dhcpd-accent)"/>
+    <text x="748" y="122" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Agentless + write</text>
+    <text x="748" y="141" text-anchor="middle" font-size="11" fill="#cffafe">FortiGate — cloud</text>
+
+    <text x="634" y="180" font-size="13" font-weight="600" fill="#0f172a">Control plane</text>
+    <text x="634" y="202" font-size="11" fill="#334155">apply_scope_full()</text>
+    <text x="634" y="220" font-size="11" fill="#334155">   → REST PUT / POST</text>
+    <text x="634" y="238" font-size="11" fill="#334155">get_leases()  REST</text>
+
+    <rect x="630" y="252" width="236" height="100" rx="8" fill="#ecfeff" stroke="#a5f3fc" stroke-width="1.5"/>
+    <text x="644" y="276" font-size="13" font-weight="600" fill="#0e7490">No agent</text>
+    <text x="644" y="298" font-size="11" fill="#0e7490">whole-scope push,</text>
+    <text x="644" y="316" font-size="11" fill="#0e7490">synchronous,</text>
+    <text x="644" y="334" font-size="11" fill="#0e7490">before-commit.</text>
+  </g>
+</svg>

--- a/docs/assets/diagrams/dhcp-host-internals.svg
+++ b/docs/assets/diagrams/dhcp-host-internals.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="490" viewBox="0 0 920 490"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>DHCP server host internals</title>
+  <desc>Inside the DHCP server host a SpatiumDDI agent keeps a local config cache on disk, applies config to the Kea or ISC daemon, and pulls config from and pushes lease events to the SpatiumDDI control plane API.</desc>
+  <defs>
+    <linearGradient id="dhcph-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="dhcph-agentbox" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="dhcph-accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="dhcph-cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <marker id="dhcph-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="42" font-size="18" font-weight="600" fill="#0f172a">DHCP agent host internals</text>
+  <text x="40" y="64" font-size="12" fill="#475569">The agent caches the last-known-good config on local disk and keeps serving when the control plane is unreachable.</text>
+
+  <!-- Host boundary -->
+  <rect x="140" y="92" width="640" height="232" rx="16"
+        fill="url(#dhcph-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <text x="170" y="124" font-size="15" font-weight="600" fill="#0f172a">DHCP Server Host / Container</text>
+
+  <!-- DHCP daemon -->
+  <rect x="170" y="160" width="190" height="76" rx="8" fill="url(#dhcph-agentbox)"/>
+  <text x="265" y="190" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCP daemon</text>
+  <text x="265" y="212" text-anchor="middle" font-size="11" fill="#fed7aa">Kea / ISC</text>
+
+  <!-- Agent -->
+  <rect x="460" y="146" width="290" height="156" rx="12" fill="#475569"/>
+  <text x="605" y="176" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">SpatiumDDI Agent</text>
+  <text x="605" y="196" text-anchor="middle" font-size="11" fill="#cbd5e1">polls /config every 30s</text>
+
+  <rect x="486" y="212" width="238" height="72" rx="8" fill="url(#dhcph-accent)"/>
+  <text x="605" y="242" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">config cache</text>
+  <text x="605" y="262" text-anchor="middle" font-size="11" fill="#cffafe">local disk</text>
+
+  <!-- Agent applies config to the daemon -->
+  <path d="M 458 198 H 364" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#dhcph-arrow)"/>
+  <text x="411" y="186" text-anchor="middle" font-size="11" fill="#475569">apply config</text>
+
+  <!-- Agent to control plane -->
+  <path d="M 605 304 V 384" stroke="#64748b" stroke-width="2" fill="none"
+        marker-start="url(#dhcph-arrow)" marker-end="url(#dhcph-arrow)"/>
+  <text x="619" y="336" font-size="11" fill="#475569">pull / push</text>
+  <text x="619" y="354" font-size="11" fill="#475569">config in, lease events out</text>
+
+  <!-- Control plane -->
+  <rect x="485" y="386" width="240" height="76" rx="8" fill="url(#dhcph-cp)"/>
+  <text x="605" y="416" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">SpatiumDDI API</text>
+  <text x="605" y="438" text-anchor="middle" font-size="11" fill="#ddd6fe">control plane</text>
+</svg>

--- a/docs/assets/diagrams/dhcp-scope-containment.svg
+++ b/docs/assets/diagrams/dhcp-scope-containment.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="260" viewBox="0 0 920 260"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>DHCP scope containment hierarchy</title>
+  <desc>A subnet holds one DHCPScope per DHCP server group, and each scope holds one or more DHCPPools plus zero or many DHCPStaticAssignments.</desc>
+  <defs>
+    <linearGradient id="dhcpc-store" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="dhcpc-cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="dhcpc-agent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="dhcpc-accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <marker id="dhcpc-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <text x="40" y="36" font-size="18" font-weight="600" fill="#0f172a">DHCP scope hierarchy</text>
+
+  <!-- Subnet -->
+  <rect x="52" y="118" width="168" height="64" rx="8" fill="url(#dhcpc-store)"/>
+  <text x="136" y="156" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Subnet</text>
+
+  <path d="M 220 150 H 296" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#dhcpc-arrow)"/>
+
+  <!-- DHCPScope -->
+  <rect x="298" y="112" width="222" height="78" rx="8" fill="url(#dhcpc-cp)"/>
+  <text x="409" y="139" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPScope</text>
+  <text x="409" y="159" text-anchor="middle" font-size="11" fill="#ddd6fe">one per subnet per</text>
+  <text x="409" y="175" text-anchor="middle" font-size="11" fill="#ddd6fe">DHCP server group</text>
+
+  <!-- Branch to pool + static assignment -->
+  <path d="M 520 150 H 570 V 106 H 616" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#dhcpc-arrow)"/>
+  <path d="M 520 150 H 570 V 194 H 616" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#dhcpc-arrow)"/>
+
+  <rect x="618" y="70" width="250" height="72" rx="8" fill="url(#dhcpc-agent)"/>
+  <text x="743" y="100" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPPool</text>
+  <text x="743" y="122" text-anchor="middle" font-size="11" fill="#fed7aa">one or more dynamic ranges</text>
+
+  <rect x="618" y="158" width="250" height="72" rx="8" fill="url(#dhcpc-accent)"/>
+  <text x="743" y="188" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPStaticAssignment</text>
+  <text x="743" y="210" text-anchor="middle" font-size="11" fill="#cffafe">zero or many</text>
+</svg>

--- a/docs/assets/diagrams/dns-agent-bootstrap.svg
+++ b/docs/assets/diagrams/dns-agent-bootstrap.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="670" viewBox="0 0 920 670"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>DNS agent bootstrap handshake</title>
+  <desc>A fresh DNS container exchanges its pre-shared DNS_AGENT_KEY for a rotating JWT at the control plane, persists the token to disk, and then heartbeats every 30 seconds with a bearer token.</desc>
+  <defs>
+    <linearGradient id="dnsb-agent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="dnsb-cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="dnsb-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <marker id="dnsb-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <text x="460" y="38" text-anchor="middle" font-size="18" font-weight="600" fill="#0f172a">DNS agent bootstrap — PSK exchanged for a rotating JWT</text>
+
+  <!-- Lifelines -->
+  <line x1="210" y1="120" x2="210" y2="636" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="4 4"/>
+  <line x1="710" y1="120" x2="710" y2="636" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="4 4"/>
+
+  <!-- Actors -->
+  <g>
+    <rect x="100" y="64" width="220" height="56" rx="8" fill="url(#dnsb-agent)"/>
+    <text x="210" y="90" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DNS container</text>
+    <text x="210" y="110" text-anchor="middle" font-size="11" fill="#fed7aa">fresh boot</text>
+  </g>
+  <g>
+    <rect x="600" y="64" width="220" height="56" rx="8" fill="url(#dnsb-cp)"/>
+    <text x="710" y="90" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Control plane</text>
+    <text x="710" y="110" text-anchor="middle" font-size="11" fill="#ddd6fe">FastAPI</text>
+  </g>
+
+  <!-- 1. Read env -->
+  <g>
+    <rect x="48" y="146" width="330" height="76" rx="8" fill="url(#dnsb-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="66" y="170" font-size="12" font-weight="600" fill="#0f172a">1 · Read env</text>
+    <text x="66" y="190" font-size="11" fill="#475569">CONTROL_PLANE_URL · DNS_AGENT_KEY</text>
+    <text x="66" y="208" font-size="11" fill="#475569">AGENT_ID — persisted in /var/lib</text>
+  </g>
+
+  <!-- 2. Bootstrap register -->
+  <text x="460" y="246" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">2 · POST /dns/agents/register</text>
+  <text x="460" y="266" text-anchor="middle" font-size="11" fill="#475569">header  X-DNS-Agent-Key: &lt;bootstrap PSK&gt;</text>
+  <text x="460" y="284" text-anchor="middle" font-size="11" fill="#475569">body  {hostname, driver, roles, version, group_name, fingerprint}</text>
+  <path d="M 212 298 H 708" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#dnsb-arrow)"/>
+  <text x="460" y="316" text-anchor="middle" font-size="11" font-style="italic" fill="#64748b">sent only when no cached agent_token.jwt exists</text>
+
+  <!-- 3. Validate + mint -->
+  <g>
+    <rect x="560" y="336" width="330" height="114" rx="8" fill="url(#dnsb-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="578" y="360" font-size="12" font-weight="600" fill="#0f172a">3 · Validate PSK</text>
+    <text x="578" y="380" font-size="11" fill="#475569">create / update DNSServer row</text>
+    <text x="578" y="398" font-size="11" fill="#475569">pending_approval = true if</text>
+    <text x="578" y="416" font-size="11" fill="#475569">settings.require_agent_approval</text>
+    <text x="578" y="434" font-size="11" fill="#475569">mint agent_token (JWT, 24 h)</text>
+  </g>
+
+  <!-- Response -->
+  <text x="460" y="472" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">200 {server_id, agent_token, config_etag, …}</text>
+  <path d="M 708 486 H 212" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#dnsb-arrow)"/>
+
+  <!-- 4. Persist token -->
+  <g>
+    <rect x="48" y="510" width="330" height="76" rx="8" fill="url(#dnsb-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="66" y="534" font-size="12" font-weight="600" fill="#0f172a">4 · Persist token</text>
+    <text x="66" y="554" font-size="11" fill="#475569">/var/lib/spatium-dns-agent/agent_token.jwt</text>
+    <text x="66" y="572" font-size="11" fill="#475569">mode 0600, owned by the agent user</text>
+  </g>
+
+  <!-- 5. Steady state -->
+  <text x="460" y="616" text-anchor="middle" font-size="12" font-weight="600" fill="#334155">5 · Heartbeat every 30 s — Authorization: Bearer &lt;agent_token&gt;</text>
+  <path d="M 212 630 H 708" stroke="#64748b" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#dnsb-arrow)"/>
+  <text x="460" y="650" text-anchor="middle" font-size="11" font-style="italic" fill="#64748b">token rotated on the 12 h rotation window via the heartbeat response</text>
+</svg>

--- a/docs/assets/diagrams/dns-ddns-lease-flow.svg
+++ b/docs/assets/diagrams/dns-ddns-lease-flow.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="616" viewBox="0 0 920 616"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>DDNS — DHCP lease to DNS record</title>
+  <desc>A lease arriving from the agentless Windows DHCP pull or a Kea agent lease event upserts a DHCPLease row and mirrors it into IPAM, then apply_ddns_for_lease resolves a hostname and calls _sync_dns_record to publish A, AAAA and PTR records.</desc>
+
+  <defs>
+    <linearGradient id="ddns-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="ddns-source" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="ddns-cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="ddns-worker" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <marker id="ddns-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <text x="24" y="36" font-size="18" font-weight="600" fill="#0f172a">DDNS — DHCP lease to DNS record</text>
+  <text x="24" y="58" font-size="12" fill="#475569">Either lease source upserts DHCPLease and mirrors it into IPAM; DDNS then publishes A/AAAA + PTR through the static-allocation path.</text>
+
+  <rect x="24" y="68" width="872" height="522" rx="16" fill="url(#ddns-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+
+  <!-- Stage 1 — lease source -->
+  <rect x="48" y="84" width="330" height="124" rx="8" fill="url(#ddns-source)"/>
+  <text x="66" y="110" font-size="14" font-weight="600" fill="#ffffff">Lease source</text>
+  <path d="M 66 122 H 360" stroke="#fed7aa" stroke-width="1" opacity="0.6"/>
+  <rect x="66" y="145" width="8" height="2" rx="1" fill="#fed7aa"/>
+  <text x="80" y="150" font-size="13" font-weight="600" fill="#ffffff">agentless pull</text>
+  <text x="193" y="150" font-size="11" fill="#fed7aa">(Windows DHCP)</text>
+  <rect x="66" y="181" width="8" height="2" rx="1" fill="#fed7aa"/>
+  <text x="80" y="186" font-size="13" font-weight="600" fill="#ffffff">agent lease event</text>
+  <text x="222" y="186" font-size="11" fill="#fed7aa">(Kea)</text>
+
+  <path d="M 386 150 H 426" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#ddns-arrow)"/>
+  <text x="436" y="144" font-size="12" fill="#475569">upserts DHCPLease + mirrors into IPAM</text>
+  <text x="436" y="160" font-size="12" fill="#475569"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">as auto_from_lease=True</text>
+
+  <path d="M 386 186 H 426" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#ddns-arrow)"/>
+  <text x="436" y="190" font-size="12" fill="#475569">Kea (POST /agents/lease-events)</text>
+
+  <!-- 1 -> 2 -->
+  <path d="M 213 208 V 246" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#ddns-arrow)"/>
+  <text x="224" y="233" font-size="11" font-weight="600" fill="#475569"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">ipam_row</text>
+
+  <!-- Stage 2 — ddns resolver -->
+  <rect x="48" y="250" width="330" height="80" rx="8" fill="url(#ddns-cp)"/>
+  <text x="66" y="282" font-size="14" font-weight="600" fill="#ffffff"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">services/dns/ddns.py</text>
+  <text x="66" y="302" font-size="12" fill="#ddd6fe"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">apply_ddns_for_lease()</text>
+
+  <path d="M 386 290 H 426" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#ddns-arrow)"/>
+  <text x="436" y="274" font-size="12" fill="#475569">resolves hostname per subnet policy,</text>
+  <text x="436" y="292" font-size="12" fill="#475569">writes it onto ipam_row.hostname,</text>
+  <text x="436" y="310" font-size="12" fill="#475569">calls _sync_dns_record(..., "create")</text>
+
+  <!-- 2 -> 3 -->
+  <path d="M 213 330 V 380" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#ddns-arrow)"/>
+
+  <!-- Stage 3 — record sync -->
+  <rect x="48" y="384" width="330" height="80" rx="8" fill="url(#ddns-worker)"/>
+  <text x="66" y="416" font-size="14" font-weight="600" fill="#ffffff"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">_sync_dns_record</text>
+  <text x="66" y="436" font-size="12" fill="#ddd6fe">(IPAM router)</text>
+
+  <path d="M 386 424 H 426" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#ddns-arrow)"/>
+  <text x="436" y="408" font-size="12" fill="#475569">unchanged — drives A/AAAA + PTR via</text>
+  <text x="436" y="426" font-size="12" fill="#475569">RFC 2136 for BIND9 / Windows Path A,</text>
+  <text x="436" y="444" font-size="12" fill="#475569">or WinRM for Windows Path B</text>
+
+  <!-- expiry footnote -->
+  <rect x="48" y="496" width="824" height="70" rx="12" fill="#ffffff" stroke="#cbd5e1"
+        stroke-width="1.5" stroke-dasharray="4 4"/>
+  <text x="66" y="522" font-size="12" font-weight="600" fill="#0f172a">On lease expiry</text>
+  <text x="66" y="542" font-size="11" fill="#475569">dhcp_lease_cleanup sweeps the DHCPLease row past its grace period; before deleting the mirrored</text>
+  <text x="66" y="558" font-size="11" fill="#475569">auto_from_lease IPAM row it calls revoke_ddns_for_lease, which fires _sync_dns_record(..., action="delete").</text>
+</svg>

--- a/docs/assets/diagrams/dns-namespace-views.svg
+++ b/docs/assets/diagrams/dns-namespace-views.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="616" viewBox="0 0 920 616"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>DNS zone tree — namespace hierarchy with view scoping</title>
+  <desc>Zones are managed as a tree mirroring the DNS namespace, from the root through com. and in-addr.arpa.; split-horizon zones carry a badge showing whether they render into one view or every view.</desc>
+
+  <defs>
+    <linearGradient id="dnsv-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="dnsv-internal" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="dnsv-allviews" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+  </defs>
+
+  <text x="32" y="36" font-size="18" font-weight="600" fill="#0f172a">DNS zone tree — namespace hierarchy with view scoping</text>
+  <text x="32" y="58" font-size="12" fill="#475569">Zones are managed in a tree that mirrors the DNS namespace; split-horizon zones are scoped to a view.</text>
+
+  <rect x="32" y="72" width="856" height="512" rx="16" fill="url(#dnsv-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+
+  <!-- connectors -->
+  <g stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round">
+    <!-- root -> com. / net. / in-addr.arpa. -->
+    <path d="M 72 132 V 368"/>
+    <path d="M 72 158 H 94"/>
+    <path d="M 72 326 H 94"/>
+    <path d="M 72 368 H 94"/>
+    <!-- com. -> example. -->
+    <path d="M 110 174 V 200"/>
+    <path d="M 110 200 H 132"/>
+    <!-- example. -> two view-scoped zones -->
+    <path d="M 148 216 V 284"/>
+    <path d="M 148 242 H 170"/>
+    <path d="M 148 284 H 170"/>
+    <!-- in-addr.arpa. -> 10. / 192. -->
+    <path d="M 110 384 V 494"/>
+    <path d="M 110 410 H 132"/>
+    <path d="M 110 494 H 132"/>
+    <!-- 10.in-addr.arpa. -> 1.10.in-addr.arpa. -->
+    <path d="M 148 426 V 452"/>
+    <path d="M 148 452 H 170"/>
+  </g>
+
+  <!-- root -->
+  <rect x="56" y="100" width="100" height="32" rx="8" fill="#1e293b"/>
+  <text x="70" y="121" font-size="13" font-weight="600" fill="#ffffff"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">. (root)</text>
+
+  <!-- com. -->
+  <rect x="94" y="142" width="90" height="32" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="108" y="163" font-size="13" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">com.</text>
+
+  <!-- example. -->
+  <rect x="132" y="184" width="92" height="32" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="146" y="205" font-size="13" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">example.</text>
+
+  <!-- internal.example.com. — internal view only -->
+  <rect x="170" y="226" width="344" height="32" rx="8" fill="#ecfeff" stroke="#67e8f9" stroke-width="1.5"/>
+  <text x="184" y="247" font-size="13" font-weight="600" fill="#155e75"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">internal.example.com.</text>
+  <rect x="364" y="232" width="136" height="20" rx="10" fill="url(#dnsv-internal)"/>
+  <text x="432" y="246" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">internal view only</text>
+
+  <!-- example.com. — all views -->
+  <rect x="170" y="268" width="216" height="32" rx="8" fill="#ecfdf5" stroke="#6ee7b7" stroke-width="1.5"/>
+  <text x="184" y="289" font-size="13" font-weight="600" fill="#065f46"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">example.com.</text>
+  <rect x="294" y="274" width="78" height="20" rx="10" fill="url(#dnsv-allviews)"/>
+  <text x="333" y="288" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">all views</text>
+
+  <!-- net. -->
+  <rect x="94" y="310" width="90" height="32" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="108" y="331" font-size="13" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">net.</text>
+
+  <!-- in-addr.arpa. -->
+  <rect x="94" y="352" width="130" height="32" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="108" y="373" font-size="13" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">in-addr.arpa.</text>
+
+  <!-- 10.in-addr.arpa. -->
+  <rect x="132" y="394" width="154" height="32" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="146" y="415" font-size="13" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.in-addr.arpa.</text>
+
+  <!-- 1.10.in-addr.arpa. -->
+  <rect x="170" y="436" width="170" height="32" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="184" y="457" font-size="13" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">1.10.in-addr.arpa.</text>
+
+  <!-- 192.in-addr.arpa. -->
+  <rect x="132" y="478" width="162" height="32" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="146" y="499" font-size="13" font-weight="600" fill="#334155"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">192.in-addr.arpa.</text>
+
+  <!-- legend -->
+  <path d="M 56 524 H 864" stroke="#cbd5e1" stroke-width="1.5"/>
+  <rect x="56" y="530" width="136" height="20" rx="10" fill="url(#dnsv-internal)"/>
+  <text x="124" y="544" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">internal view only</text>
+  <text x="204" y="544" font-size="11" fill="#475569">— the zone is rendered only into the internal view's zone file</text>
+
+  <rect x="56" y="556" width="78" height="20" rx="10" fill="url(#dnsv-allviews)"/>
+  <text x="95" y="570" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">all views</text>
+  <text x="204" y="570" font-size="11" fill="#475569">— view_id is NULL, so the zone renders into every view</text>
+</svg>

--- a/docs/assets/diagrams/dns-record-propagation.svg
+++ b/docs/assets/diagrams/dns-record-propagation.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="840" viewBox="0 0 920 840"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>DNS record change — end-to-end propagation</title>
+  <desc>A record mutation is validated and written in the service layer, enqueued as RecordOp rows, returned to the caller, released to agents holding a config long-poll, applied over loopback nsupdate on BIND9, and acknowledged on the next heartbeat.</desc>
+  <defs>
+    <linearGradient id="dnsp-cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="dnsp-worker" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="dnsp-store" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="dnsp-accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="dnsp-agent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="dnsp-danger" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f87171"/>
+      <stop offset="100%" stop-color="#dc2626"/>
+    </linearGradient>
+    <linearGradient id="dnsp-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <marker id="dnsp-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <text x="460" y="38" text-anchor="middle" font-size="18" font-weight="600" fill="#0f172a">DNS record change — end-to-end propagation</text>
+
+  <!-- 1. UI / API mutation -->
+  <g>
+    <rect x="180" y="66" width="560" height="62" rx="8" fill="url(#dnsp-cp)"/>
+    <text x="460" y="92" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">UI / API mutation</text>
+    <text x="460" y="112" text-anchor="middle" font-size="11" fill="#ddd6fe">e.g. POST /dns/zones/{id}/records</text>
+  </g>
+  <path d="M 460 128 V 156" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#dnsp-arrow)"/>
+
+  <!-- 2. Service layer -->
+  <g>
+    <rect x="180" y="156" width="560" height="62" rx="8" fill="url(#dnsp-worker)"/>
+    <text x="460" y="182" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Service layer</text>
+    <text x="460" y="202" text-anchor="middle" font-size="11" fill="#ddd6fe">validate · write DNSRecord row · compute delta</text>
+  </g>
+  <path d="M 460 218 V 246" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#dnsp-arrow)"/>
+
+  <!-- 3. Enqueue RecordOp rows -->
+  <g>
+    <rect x="180" y="246" width="560" height="104" rx="8" fill="url(#dnsp-store)"/>
+    <text x="460" y="272" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Enqueue RecordOp rows</text>
+    <text x="204" y="296" font-size="11" fill="#a7f3d0">{ id, server_id, zone_name, op: create | update | delete,</text>
+    <text x="204" y="314" font-size="11" fill="#a7f3d0">  record: {…}, serial_strategy: bump, created_at,</text>
+    <text x="204" y="332" font-size="11" fill="#a7f3d0">  state: pending }</text>
+  </g>
+  <path d="M 460 350 V 378" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#dnsp-arrow)"/>
+
+  <!-- 4. Response to caller -->
+  <g>
+    <rect x="180" y="378" width="560" height="58" rx="8" fill="url(#dnsp-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+    <text x="460" y="402" text-anchor="middle" font-size="13" font-weight="600" fill="#0f172a">Response returned to caller (HTTP 2xx)</text>
+    <text x="460" y="422" text-anchor="middle" font-size="11" fill="#475569">the write is already durable in Postgres</text>
+  </g>
+  <path d="M 460 436 V 464" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#dnsp-arrow)"/>
+
+  <!-- 5. Long-poll released -->
+  <g>
+    <rect x="180" y="464" width="560" height="68" rx="8" fill="url(#dnsp-accent)"/>
+    <text x="460" y="490" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Agents holding a long-poll on /config are released</text>
+    <text x="460" y="512" text-anchor="middle" font-size="11" fill="#cffafe">or the next long-poll picks it up within ≤ 30 s — idempotent by op_id</text>
+  </g>
+  <path d="M 460 532 V 560" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#dnsp-arrow)"/>
+
+  <!-- 6. Agent applies -->
+  <g>
+    <rect x="180" y="560" width="560" height="68" rx="8" fill="url(#dnsp-agent)"/>
+    <text x="460" y="586" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">Agent executes via loopback</text>
+    <text x="460" y="608" text-anchor="middle" font-size="11" fill="#fed7aa">BIND9 → nsupdate ‹signed with the local TSIG key›</text>
+  </g>
+  <path d="M 460 628 V 656" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#dnsp-arrow)"/>
+
+  <!-- 7. ACK -->
+  <g>
+    <rect x="180" y="656" width="560" height="50" rx="8" fill="#475569"/>
+    <text x="460" y="686" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">Agent ACKs on the next heartbeat</text>
+  </g>
+  <path d="M 310 706 V 736" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#dnsp-arrow)"/>
+  <path d="M 600 706 V 736" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#dnsp-arrow)"/>
+
+  <!-- Outcomes -->
+  <g>
+    <rect x="180" y="736" width="260" height="76" rx="8" fill="url(#dnsp-store)"/>
+    <text x="310" y="762" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">RecordOp.state = applied</text>
+    <text x="310" y="782" text-anchor="middle" font-size="11" fill="#a7f3d0">op complete on this server</text>
+  </g>
+  <g>
+    <rect x="460" y="736" width="280" height="76" rx="8" fill="url(#dnsp-danger)"/>
+    <text x="600" y="758" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">state = failed → alert</text>
+    <text x="600" y="777" text-anchor="middle" font-size="11" fill="#fee2e2">after N retries</text>
+    <text x="600" y="794" text-anchor="middle" font-size="11" fill="#fee2e2">(default 5, expo-backoff)</text>
+  </g>
+</svg>

--- a/docs/assets/diagrams/ipam-containment.svg
+++ b/docs/assets/diagrams/ipam-containment.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="528" viewBox="0 0 920 528"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>IPAM hierarchy — containment model</title>
+  <desc>An IPSpace contains IPBlocks, which nest inside one another and contain Subnets; a Subnet is the primary managed unit and holds individual IPAddresses plus a DHCPScope with its pools.</desc>
+
+  <defs>
+    <linearGradient id="ipamc-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="ipamc-space" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="ipamc-block" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="ipamc-subnet" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <linearGradient id="ipamc-addr" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="ipamc-dhcp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <marker id="ipamc-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <text x="32" y="36" font-size="18" font-weight="600" fill="#0f172a">IP hierarchy — containment model</text>
+  <text x="32" y="58" font-size="12" fill="#475569">Each level contains the one below it; a subnet is the primary unit of management and the only level IP addresses attach to.</text>
+
+  <rect x="32" y="72" width="856" height="420" rx="16" fill="url(#ipamc-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+
+  <!-- connectors -->
+  <g stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round">
+    <path d="M 76 140 V 180"/>
+    <path d="M 76 180 H 100"/>
+    <path d="M 120 204 V 244"/>
+    <path d="M 120 244 H 144"/>
+    <path d="M 164 268 V 308"/>
+    <path d="M 164 308 H 188"/>
+    <path d="M 208 332 V 436"/>
+    <path d="M 208 372 H 232"/>
+    <path d="M 208 436 H 232"/>
+  </g>
+
+  <!-- IPSpace -->
+  <rect x="56" y="92" width="280" height="48" rx="8" fill="url(#ipamc-space)"/>
+  <text x="70" y="113" font-size="14" font-weight="600" fill="#ffffff">IPSpace</text>
+  <text x="70" y="129" font-size="11" fill="#ddd6fe">VRF / routing domain</text>
+
+  <!-- IPBlock (aggregate) -->
+  <rect x="100" y="156" width="280" height="48" rx="8" fill="url(#ipamc-block)"/>
+  <text x="114" y="177" font-size="14" font-weight="600" fill="#ffffff">IPBlock</text>
+  <text x="114" y="193" font-size="11" fill="#ddd6fe">aggregate / supernet</text>
+  <rect x="274" y="164" width="92" height="24" rx="6" fill="#ffffff" fill-opacity="0.18"/>
+  <text x="320" y="181" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.0.0/8</text>
+
+  <!-- IPBlock (nested) -->
+  <rect x="144" y="220" width="280" height="48" rx="8" fill="url(#ipamc-block)"/>
+  <text x="158" y="241" font-size="14" font-weight="600" fill="#ffffff">IPBlock</text>
+  <text x="158" y="257" font-size="11" fill="#ddd6fe">nested inside the /8</text>
+  <rect x="310" y="228" width="100" height="24" rx="6" fill="#ffffff" fill-opacity="0.18"/>
+  <text x="360" y="245" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.1.0.0/16</text>
+
+  <!-- Subnet -->
+  <rect x="188" y="284" width="280" height="48" rx="8" fill="url(#ipamc-subnet)" stroke="#0e7490" stroke-width="2"/>
+  <text x="202" y="305" font-size="14" font-weight="600" fill="#ffffff">Subnet</text>
+  <text x="202" y="321" font-size="11" fill="#cffafe">routable network</text>
+  <rect x="354" y="292" width="100" height="24" rx="6" fill="#ffffff" fill-opacity="0.22"/>
+  <text x="404" y="309" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.1.2.0/24</text>
+
+  <path d="M 560 308 H 478" stroke="#0e7490" stroke-width="2" fill="none" marker-end="url(#ipamc-arrow)"/>
+  <text x="570" y="312" font-size="12" font-weight="600" fill="#0e7490">primary managed unit</text>
+
+  <!-- IPAddress -->
+  <rect x="232" y="348" width="280" height="48" rx="8" fill="url(#ipamc-addr)"/>
+  <text x="246" y="369" font-size="14" font-weight="600" fill="#ffffff">IPAddress</text>
+  <text x="246" y="385" font-size="11" fill="#a7f3d0">individual host IP</text>
+
+  <!-- DHCPScope -> DHCPPool(s) -->
+  <rect x="232" y="414" width="150" height="44" rx="8" fill="url(#ipamc-dhcp)"/>
+  <text x="307" y="441" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPScope</text>
+  <path d="M 390 436 H 414" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#ipamc-arrow)"/>
+  <rect x="422" y="414" width="150" height="44" rx="8" fill="url(#ipamc-dhcp)"/>
+  <text x="497" y="441" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DHCPPool(s)</text>
+</svg>

--- a/docs/assets/diagrams/ipam-example-tree.svg
+++ b/docs/assets/diagrams/ipam-example-tree.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="588" viewBox="0 0 920 588"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>IPAM block and subnet tree — worked example</title>
+  <desc>The Corporate IP space holds a 10.0.0.0/8 block at 42 percent utilization, which nests HQ and Branch Office /16 blocks with their VLAN-tagged subnets, alongside a separate 10.128.0.0/9 DMZ block.</desc>
+
+  <defs>
+    <linearGradient id="ipame-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+  </defs>
+
+  <text x="32" y="36" font-size="18" font-weight="600" fill="#0f172a">IPAM tree — worked example</text>
+  <text x="32" y="58" font-size="12" fill="#475569">Blocks nest inside blocks; subnets are the leaves. Blocks carry a rolled-up utilization bar, subnets carry their VLAN.</text>
+
+  <rect x="32" y="72" width="856" height="480" rx="16" fill="url(#ipame-surface)" stroke="#94a3b8" stroke-width="1.5"/>
+
+  <!-- connectors -->
+  <g stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round">
+    <path d="M 68 127 V 432"/>
+    <path d="M 68 152 H 88"/>
+    <path d="M 68 432 H 88"/>
+    <path d="M 104 167 V 352"/>
+    <path d="M 104 192 H 124"/>
+    <path d="M 104 352 H 124"/>
+    <path d="M 140 207 V 312"/>
+    <path d="M 140 232 H 160"/>
+    <path d="M 140 272 H 160"/>
+    <path d="M 140 312 H 160"/>
+    <path d="M 140 367 V 392"/>
+    <path d="M 140 392 H 160"/>
+    <path d="M 104 447 V 472"/>
+    <path d="M 104 472 H 124"/>
+  </g>
+
+  <!-- Corporate (IPSpace) -->
+  <rect x="52" y="97" width="208" height="30" rx="8" fill="#1e293b"/>
+  <text x="64" y="116" font-size="13" font-weight="600" fill="#ffffff">Corporate</text>
+  <rect x="180" y="103" width="68" height="18" rx="9" fill="#ffffff" fill-opacity="0.2"/>
+  <text x="214" y="116" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">IPSpace</text>
+
+  <!-- 10.0.0.0/8 -->
+  <rect x="88" y="137" width="404" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="100" y="156" font-size="13" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.0.0/8</text>
+  <rect x="216" y="143" width="68" height="18" rx="9" fill="#ede9fe"/>
+  <text x="250" y="156" text-anchor="middle" font-size="11" font-weight="600" fill="#6d28d9">IPBlock</text>
+  <rect x="296" y="148" width="110" height="8" rx="4" fill="#e2e8f0"/>
+  <rect x="296" y="148" width="46" height="8" rx="4" fill="#10b981"/>
+  <text x="418" y="156" font-size="11" font-weight="600" fill="#334155">42% used</text>
+
+  <!-- 10.0.0.0/16 — HQ -->
+  <rect x="124" y="177" width="260" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="136" y="196" font-size="13" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.0.0/16</text>
+  <rect x="252" y="183" width="68" height="18" rx="9" fill="#ede9fe"/>
+  <text x="286" y="196" text-anchor="middle" font-size="11" font-weight="600" fill="#6d28d9">IPBlock</text>
+  <text x="332" y="196" font-size="11" fill="#475569">HQ</text>
+
+  <!-- 10.0.1.0/24 — Servers -->
+  <rect x="160" y="217" width="404" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="172" y="236" font-size="13" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.1.0/24</text>
+  <rect x="288" y="223" width="68" height="18" rx="9" fill="#cffafe"/>
+  <text x="322" y="236" text-anchor="middle" font-size="11" font-weight="600" fill="#0e7490">Subnet</text>
+  <text x="368" y="236" font-size="11" fill="#475569">Servers</text>
+  <rect x="476" y="223" width="76" height="18" rx="9" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="514" y="236" text-anchor="middle" font-size="11" font-weight="600" fill="#475569">VLAN 10</text>
+
+  <!-- 10.0.2.0/24 — Workstations -->
+  <rect x="160" y="257" width="404" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="172" y="276" font-size="13" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.2.0/24</text>
+  <rect x="288" y="263" width="68" height="18" rx="9" fill="#cffafe"/>
+  <text x="322" y="276" text-anchor="middle" font-size="11" font-weight="600" fill="#0e7490">Subnet</text>
+  <text x="368" y="276" font-size="11" fill="#475569">Workstations</text>
+  <rect x="476" y="263" width="76" height="18" rx="9" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="514" y="276" text-anchor="middle" font-size="11" font-weight="600" fill="#475569">VLAN 20</text>
+
+  <!-- 10.0.3.0/24 — VoIP -->
+  <rect x="160" y="297" width="404" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="172" y="316" font-size="13" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.3.0/24</text>
+  <rect x="288" y="303" width="68" height="18" rx="9" fill="#cffafe"/>
+  <text x="322" y="316" text-anchor="middle" font-size="11" font-weight="600" fill="#0e7490">Subnet</text>
+  <text x="368" y="316" font-size="11" fill="#475569">VoIP</text>
+  <rect x="476" y="303" width="76" height="18" rx="9" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="514" y="316" text-anchor="middle" font-size="11" font-weight="600" fill="#475569">VLAN 30</text>
+
+  <!-- 10.1.0.0/16 — Branch Office -->
+  <rect x="124" y="337" width="296" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="136" y="356" font-size="13" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.1.0.0/16</text>
+  <rect x="252" y="343" width="68" height="18" rx="9" fill="#ede9fe"/>
+  <text x="286" y="356" text-anchor="middle" font-size="11" font-weight="600" fill="#6d28d9">IPBlock</text>
+  <text x="332" y="356" font-size="11" fill="#475569">Branch Office</text>
+
+  <!-- 10.1.1.0/24 — Branch LAN -->
+  <rect x="160" y="377" width="404" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="172" y="396" font-size="13" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.1.1.0/24</text>
+  <rect x="288" y="383" width="68" height="18" rx="9" fill="#cffafe"/>
+  <text x="322" y="396" text-anchor="middle" font-size="11" font-weight="600" fill="#0e7490">Subnet</text>
+  <text x="368" y="396" font-size="11" fill="#475569">Branch LAN</text>
+  <rect x="476" y="383" width="76" height="18" rx="9" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="514" y="396" text-anchor="middle" font-size="11" font-weight="600" fill="#475569">VLAN 100</text>
+
+  <!-- 10.128.0.0/9 — DMZ -->
+  <rect x="88" y="417" width="256" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="100" y="436" font-size="13" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.128.0.0/9</text>
+  <rect x="216" y="423" width="68" height="18" rx="9" fill="#ede9fe"/>
+  <text x="250" y="436" text-anchor="middle" font-size="11" font-weight="600" fill="#6d28d9">IPBlock</text>
+  <text x="296" y="436" font-size="11" fill="#475569">DMZ</text>
+
+  <!-- 10.128.0.0/24 — Public Services -->
+  <rect x="124" y="457" width="304" height="30" rx="8" fill="#ffffff" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="136" y="476" font-size="13" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.128.0.0/24</text>
+  <rect x="252" y="463" width="68" height="18" rx="9" fill="#cffafe"/>
+  <text x="286" y="476" text-anchor="middle" font-size="11" font-weight="600" fill="#0e7490">Subnet</text>
+  <text x="332" y="476" font-size="11" fill="#475569">Public Services</text>
+
+  <!-- legend -->
+  <path d="M 52 508 H 868" stroke="#cbd5e1" stroke-width="1.5"/>
+  <text x="52" y="532" font-size="11" fill="#475569">Utilization bar colour:</text>
+  <rect x="184" y="524" width="18" height="8" rx="4" fill="#10b981"/>
+  <text x="210" y="532" font-size="11" fill="#475569">&lt; 70%</text>
+  <rect x="262" y="524" width="18" height="8" rx="4" fill="#f59e0b"/>
+  <text x="288" y="532" font-size="11" fill="#475569">70–90%</text>
+  <rect x="352" y="524" width="18" height="8" rx="4" fill="#ef4444"/>
+  <text x="378" y="532" font-size="11" fill="#475569">&gt; 90%</text>
+</svg>

--- a/docs/assets/diagrams/ipam-tree-ui.svg
+++ b/docs/assets/diagrams/ipam-tree-ui.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="448" viewBox="0 0 920 448"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>Combined IPAM tree navigator</title>
+  <desc>A single left-hand tree lists every IP space, block and subnet — including free-space rows — and clicking a subnet row opens its IP address list panel on the right.</desc>
+
+  <defs>
+    <marker id="ipamu-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6d28d9"/>
+    </marker>
+  </defs>
+
+  <text x="32" y="36" font-size="18" font-weight="600" fill="#0f172a">Combined IPAM tree navigator</text>
+  <text x="32" y="58" font-size="12" fill="#475569">One tree replaces separate “IP Spaces” and “Subnets” pages — every space, block and subnet is a node.</text>
+
+  <!-- sidebar panel -->
+  <rect x="32" y="80" width="488" height="312" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="1.5"/>
+
+  <!-- selected row -->
+  <rect x="36" y="189" width="480" height="30" rx="6" fill="#eef2ff"/>
+  <rect x="36" y="189" width="3" height="30" rx="1.5" fill="#6d28d9"/>
+
+  <!-- indent guides -->
+  <g stroke="#e2e8f0" stroke-width="1.5" fill="none" stroke-linecap="round">
+    <path d="M 53 124 V 300"/>
+    <path d="M 53 140 H 68"/>
+    <path d="M 53 300 H 68"/>
+    <path d="M 75 156 V 268"/>
+    <path d="M 75 172 H 90"/>
+    <path d="M 75 268 H 90"/>
+    <path d="M 97 188 V 236"/>
+    <path d="M 97 204 H 112"/>
+    <path d="M 97 236 H 112"/>
+    <path d="M 75 316 V 332"/>
+    <path d="M 75 332 H 90"/>
+    <path d="M 97 348 V 364"/>
+    <path d="M 97 364 H 112"/>
+  </g>
+
+  <!-- IPAM (root) -->
+  <path d="M 50 105 L 60 105 L 55 112 Z" fill="#64748b"/>
+  <text x="66" y="113" font-size="13" font-weight="600" fill="#0f172a">IPAM</text>
+
+  <!-- Corporate (IPSpace) -->
+  <path d="M 72 137 L 82 137 L 77 144 Z" fill="#64748b"/>
+  <text x="88" y="145" font-size="13" font-weight="600" fill="#0f172a">Corporate</text>
+  <rect x="170" y="131" width="66" height="18" rx="9" fill="#ede9fe"/>
+  <text x="203" y="144" text-anchor="middle" font-size="11" font-weight="600" fill="#6d28d9">IPSpace</text>
+
+  <!-- 10.0.0.0/8 (IPBlock) -->
+  <path d="M 94 169 L 104 169 L 99 176 Z" fill="#64748b"/>
+  <text x="110" y="177" font-size="12" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.0.0/8</text>
+  <rect x="224" y="163" width="66" height="18" rx="9" fill="#ede9fe"/>
+  <text x="257" y="176" text-anchor="middle" font-size="11" font-weight="600" fill="#6d28d9">IPBlock</text>
+
+  <!-- 10.0.1.0/24 (Subnet) — selected -->
+  <rect x="118" y="203" width="6" height="2" rx="1" fill="#94a3b8"/>
+  <text x="132" y="209" font-size="12" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.1.0/24</text>
+  <rect x="246" y="195" width="66" height="18" rx="9" fill="#cffafe"/>
+  <text x="279" y="208" text-anchor="middle" font-size="11" font-weight="600" fill="#0e7490">Subnet</text>
+  <text x="324" y="209" font-size="11" fill="#475569">Servers · VLAN 10</text>
+
+  <!-- 10.0.2.0/24 (Subnet) -->
+  <rect x="118" y="235" width="6" height="2" rx="1" fill="#94a3b8"/>
+  <text x="132" y="241" font-size="12" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.2.0/24</text>
+  <rect x="246" y="227" width="66" height="18" rx="9" fill="#cffafe"/>
+  <text x="279" y="240" text-anchor="middle" font-size="11" font-weight="600" fill="#0e7490">Subnet</text>
+  <text x="324" y="241" font-size="11" fill="#475569">Workstations</text>
+
+  <!-- free space row -->
+  <rect x="96" y="267" width="6" height="2" rx="1" fill="#cbd5e1"/>
+  <text x="110" y="273" font-size="11" font-style="italic" fill="#94a3b8"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">(free: 10.1.0.0/8 – 10.255.0.0/8)</text>
+
+  <!-- OOB (IPSpace) -->
+  <path d="M 72 297 L 82 297 L 77 304 Z" fill="#64748b"/>
+  <text x="88" y="305" font-size="13" font-weight="600" fill="#0f172a">OOB</text>
+  <rect x="170" y="291" width="66" height="18" rx="9" fill="#ede9fe"/>
+  <text x="203" y="304" text-anchor="middle" font-size="11" font-weight="600" fill="#6d28d9">IPSpace</text>
+
+  <!-- 192.168.0.0/16 (IPBlock) -->
+  <path d="M 94 329 L 104 329 L 99 336 Z" fill="#64748b"/>
+  <text x="110" y="337" font-size="12" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">192.168.0.0/16</text>
+  <rect x="224" y="323" width="66" height="18" rx="9" fill="#ede9fe"/>
+  <text x="257" y="336" text-anchor="middle" font-size="11" font-weight="600" fill="#6d28d9">IPBlock</text>
+
+  <!-- 192.168.1.0/24 (Subnet) -->
+  <rect x="118" y="363" width="6" height="2" rx="1" fill="#94a3b8"/>
+  <text x="132" y="369" font-size="12" font-weight="600" fill="#0f172a"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">192.168.1.0/24</text>
+  <rect x="246" y="355" width="66" height="18" rx="9" fill="#cffafe"/>
+  <text x="279" y="368" text-anchor="middle" font-size="11" font-weight="600" fill="#0e7490">Subnet</text>
+
+  <!-- click -> IP list -->
+  <path d="M 528 204 H 570" stroke="#6d28d9" stroke-width="2" fill="none" marker-end="url(#ipamu-arrow)"/>
+  <text x="550" y="196" text-anchor="middle" font-size="11" font-weight="600" fill="#6d28d9">click</text>
+
+  <rect x="580" y="164" width="308" height="80" rx="12" fill="#ffffff" stroke="#cbd5e1"
+        stroke-width="1.5" stroke-dasharray="4 4"/>
+  <text x="600" y="192" font-size="14" font-weight="600" fill="#0f172a">IP address list</text>
+  <text x="600" y="212" font-size="12" font-weight="600" fill="#0e7490"
+        font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', monospace">10.0.1.0/24</text>
+  <text x="600" y="232" font-size="11" fill="#475569">collapsible · auto-collapse above 1000 IPs</text>
+
+  <text x="32" y="418" font-size="12" fill="#475569">Muted rows mark unallocated free space inside a block; clicking a subnet opens its IP address list on the right.</text>
+</svg>

--- a/docs/assets/diagrams/perf-client-state-machine.svg
+++ b/docs/assets/diagrams/perf-client-state-machine.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="640" viewBox="0 0 920 640"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>Simulated DHCP client per-device state machine</title>
+  <desc>Each simulated device walks OFFLINE, DISCOVERING, ONLINE, RENEWING, REBINDING, DEPARTING and LEFT, driven by the diurnal arrival curve and the T1/T2 lease timers.</desc>
+  <defs>
+    <linearGradient id="perfs-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="perfs-control" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="perfs-worker" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="perfs-store" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="perfs-agent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="perfs-accent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+    <marker id="perfs-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <rect x="20" y="20" width="880" height="600" rx="16"
+        fill="url(#perfs-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <text x="44" y="52" font-size="18" font-weight="600" fill="#0f172a">Simulated DHCP client — per-device state machine</text>
+  <text x="44" y="74" font-size="12" fill="#475569">250–300k independent FSMs in the asyncio orchestrator, driven by the diurnal curve</text>
+
+  <!-- entry -->
+  <text x="195" y="98" text-anchor="middle" font-size="12" fill="#475569">arrival (diurnal-scheduled)</text>
+  <circle cx="195" cy="110" r="5" fill="#64748b"/>
+  <path d="M 195 115 V 138" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+
+  <!-- OFFLINE -->
+  <rect x="120" y="142" width="150" height="52" rx="12" fill="#64748b"/>
+  <text x="195" y="173" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">OFFLINE</text>
+
+  <path d="M 270 168 H 336" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="303" y="158" text-anchor="middle" font-size="11" fill="#475569">boot</text>
+
+  <!-- DISCOVERING -->
+  <rect x="340" y="142" width="170" height="52" rx="12" fill="url(#perfs-agent)"/>
+  <text x="425" y="173" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DISCOVERING</text>
+
+  <path d="M 510 168 H 576" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="543" y="158" text-anchor="middle" font-size="11" fill="#475569">(DORA)</text>
+
+  <!-- ONLINE -->
+  <rect x="580" y="142" width="200" height="52" rx="12" fill="url(#perfs-store)"/>
+  <text x="680" y="165" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">ONLINE</text>
+  <text x="680" y="183" text-anchor="middle" font-size="11" fill="#a7f3d0">lease held</text>
+
+  <!-- ONLINE → RENEWING -->
+  <path d="M 640 194 V 270" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="652" y="236" font-size="11" fill="#475569">at T1 = 900s</text>
+
+  <!-- RENEWING -->
+  <rect x="580" y="274" width="200" height="52" rx="12" fill="url(#perfs-control)"/>
+  <text x="680" y="305" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">RENEWING</text>
+
+  <!-- RENEWING → REBINDING -->
+  <path d="M 640 326 V 404" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="652" y="356" font-size="11" fill="#475569">(T1 fails)</text>
+  <text x="652" y="374" font-size="11" fill="#475569">at T2 = 1800s</text>
+
+  <!-- REBINDING -->
+  <rect x="580" y="408" width="200" height="52" rx="12" fill="url(#perfs-worker)"/>
+  <text x="680" y="439" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">REBINDING</text>
+
+  <!-- ACK returns to ONLINE -->
+  <path d="M 780 300 H 820 V 180 H 784" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="826" y="250" font-size="11" fill="#475569">ACK</text>
+  <path d="M 780 434 H 862 V 160 H 784" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="868" y="340" font-size="11" fill="#475569">ACK</text>
+
+  <!-- REBINDING → DEPARTING -->
+  <path d="M 680 460 V 542" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="692" y="500" font-size="11" fill="#475569">(rebind fails / lapse)</text>
+
+  <!-- DEPARTING -->
+  <rect x="620" y="546" width="200" height="52" rx="12" fill="url(#perfs-accent)"/>
+  <text x="720" y="577" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">DEPARTING</text>
+
+  <!-- external departure event -->
+  <circle cx="872" cy="572" r="5" fill="#64748b"/>
+  <path d="M 867 572 H 826" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="896" y="534" text-anchor="end" font-size="11" fill="#475569">departure</text>
+  <text x="896" y="550" text-anchor="end" font-size="11" fill="#475569">(diurnal / dwell-time)</text>
+
+  <!-- DEPARTING → LEFT -->
+  <path d="M 620 572 H 484" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="552" y="562" text-anchor="middle" font-size="11" fill="#475569">release</text>
+
+  <!-- LEFT -->
+  <rect x="330" y="546" width="150" height="52" rx="12" fill="#64748b"/>
+  <text x="405" y="577" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">LEFT</text>
+
+  <!-- LEFT → OFFLINE -->
+  <path d="M 330 572 H 60 V 168 H 116" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perfs-arrow)"/>
+  <text x="72" y="372" font-size="11" fill="#475569">re-arrival</text>
+</svg>

--- a/docs/assets/diagrams/perf-lab-topology.svg
+++ b/docs/assets/diagrams/perf-lab-topology.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="580" viewBox="0 0 920 580"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>Performance lab topology</title>
+  <desc>The spddi-perf controller and its worker generators run on separate load-gen boxes and drive a clean k3s appliance under test, with a read-only war-room poller alongside.</desc>
+  <defs>
+    <linearGradient id="perft-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="perft-control" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="perft-store" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="perft-agent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <marker id="perft-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <text x="36" y="48" font-size="18" font-weight="600" fill="#0f172a">Perf lab topology — runner architecture + the setpoint bus</text>
+  <text x="36" y="70" font-size="12" fill="#475569">Generators never run on the appliance — co-locating them contaminates every criterion</text>
+
+  <text x="40" y="100" font-size="13" font-weight="600" fill="#334155">load-gen boxes</text>
+  <text x="560" y="100" font-size="13" font-weight="600" fill="#334155">SUT — clean appliance</text>
+
+  <!-- ================= load-gen panel ================= -->
+  <rect x="36" y="112" width="400" height="446" rx="16"
+        fill="url(#perft-surface)" stroke="#94a3b8" stroke-width="2"/>
+
+  <rect x="52" y="140" width="368" height="50" rx="8" fill="url(#perft-control)"/>
+  <text x="68" y="162" font-size="14" font-weight="600" fill="#ffffff">spddi-perf CONTROLLER</text>
+  <text x="68" y="180" font-size="11" fill="#ddd6fe">lg-0 · owns the run lifecycle, no protocol I/O</text>
+
+  <rect x="68" y="200" width="336" height="32" rx="6" fill="#ffffff" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="84" y="221" font-size="12" fill="#334155">Phase engine (diurnal)</text>
+
+  <rect x="68" y="240" width="336" height="32" rx="6" fill="#ffffff" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="84" y="261" font-size="12" fill="#334155">Setpoint bus (rate targets)</text>
+
+  <rect x="68" y="280" width="336" height="32" rx="6" fill="#ffffff" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="84" y="301" font-size="12" fill="#334155">Watchdog (health + abort)</text>
+
+  <rect x="68" y="320" width="336" height="32" rx="6" fill="#ffffff" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="84" y="341" font-size="12" fill="#334155">Checkpointer (state / events)</text>
+
+  <rect x="68" y="360" width="336" height="32" rx="6" fill="#ffffff" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="84" y="381" font-size="12" fill="#334155">Collector (artifacts)</text>
+
+  <text x="68" y="420" font-size="13" font-weight="600" fill="#334155">WORKERS</text>
+
+  <rect x="68" y="430" width="336" height="32" rx="6" fill="url(#perft-agent)"/>
+  <text x="84" y="451" font-size="12" fill="#ffffff">perfdhcp shards (lg-1)</text>
+
+  <rect x="68" y="470" width="336" height="32" rx="6" fill="url(#perft-agent)"/>
+  <text x="84" y="491" font-size="12" fill="#ffffff">dnsperf / flamethrower (lg-1)</text>
+
+  <rect x="68" y="510" width="336" height="32" rx="6" fill="url(#perft-agent)"/>
+  <text x="84" y="531" font-size="12" fill="#ffffff">orchestrator shards (lg-2)</text>
+
+  <!-- ================= link arrows ================= -->
+  <path d="M 440 240 H 552" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perft-arrow)"/>
+  <text x="496" y="230" text-anchor="middle" font-size="11" fill="#475569">L2 / relay</text>
+
+  <path d="M 440 300 H 552" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#perft-arrow)"/>
+  <text x="496" y="290" text-anchor="middle" font-size="11" fill="#475569">API</text>
+
+  <!-- ================= SUT panel ================= -->
+  <rect x="556" y="112" width="344" height="240" rx="16"
+        fill="url(#perft-surface)" stroke="#94a3b8" stroke-width="2"/>
+  <text x="572" y="140" font-size="14" font-weight="600" fill="#0f172a">k3s AIO node IP</text>
+
+  <rect x="572" y="152" width="312" height="40" rx="8" fill="url(#perft-agent)"/>
+  <text x="588" y="177" font-size="12" fill="#ffffff">:67 kea (hostNetwork)</text>
+
+  <rect x="572" y="200" width="312" height="40" rx="8" fill="url(#perft-agent)"/>
+  <text x="588" y="225" font-size="12" fill="#ffffff">:53 bind9 (hostNetwork)</text>
+
+  <rect x="572" y="248" width="312" height="40" rx="8" fill="url(#perft-control)"/>
+  <text x="588" y="273" font-size="12" fill="#ffffff">:443 frontend → api</text>
+
+  <rect x="572" y="296" width="312" height="40" rx="8" fill="url(#perft-store)"/>
+  <text x="588" y="321" font-size="12" fill="#ffffff">CNPG 1 / Redis 1 / worker 1</text>
+
+  <!-- ================= war-room poller ================= -->
+  <path d="M 728 400 V 358" stroke="#64748b" stroke-width="1.5" stroke-dasharray="5 4"
+        fill="none" marker-end="url(#perft-arrow)"/>
+  <rect x="556" y="400" width="344" height="100" rx="12"
+        fill="#ffffff" stroke="#cbd5e1" stroke-dasharray="4 4" stroke-width="1.5"/>
+  <text x="572" y="428" font-size="13" font-weight="600" fill="#334155">WAR-ROOM POLLER — lg-0, read-only</text>
+  <text x="572" y="452" font-size="11" fill="#475569">/health/platform · /admin/* · /metrics/*</text>
+  <text x="572" y="472" font-size="11" fill="#475569">+ direct psql for pg_locks / deadlocks</text>
+</svg>

--- a/docs/assets/diagrams/system-health-grid.svg
+++ b/docs/assets/diagrams/system-health-grid.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="400" viewBox="0 0 920 400"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>System Health component grid</title>
+  <desc>The health overview page renders one status tile per managed component — API backend, database, Redis, Celery, DHCP servers, DNS servers and the log store — with healthy components marked green and degraded ones flagged amber.</desc>
+
+  <rect x="0" y="0" width="920" height="400" fill="#f8fafc"/>
+
+  <text x="40" y="42" font-size="18" font-weight="600" fill="#0f172a">Component health grid</text>
+
+  <!-- Card -->
+  <rect x="40" y="70" width="840" height="302" rx="12" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+
+  <text x="64" y="104" font-size="12" font-weight="600" fill="#0f172a" letter-spacing="1.2">SYSTEM HEALTH</text>
+  <text x="856" y="104" text-anchor="end" font-size="11" fill="#64748b">Last updated: 2s</text>
+  <path d="M 64 120 H 856" stroke="#e2e8f0" stroke-width="2" fill="none"/>
+
+  <!-- Row 1 -->
+  <rect x="64" y="140" width="186" height="96" rx="8" fill="#fbfdff" stroke="#e2e8f0" stroke-width="2"/>
+  <text x="80" y="166" font-size="12" font-weight="600" fill="#475569">API Backend</text>
+  <circle cx="85" cy="193" r="5" fill="#22c55e"/>
+  <text x="98" y="198" font-size="14" font-weight="600" fill="#0f172a">ONLINE</text>
+  <text x="80" y="220" font-size="11" fill="#64748b">3 replicas</text>
+
+  <rect x="266" y="140" width="186" height="96" rx="8" fill="#fbfdff" stroke="#e2e8f0" stroke-width="2"/>
+  <text x="282" y="166" font-size="12" font-weight="600" fill="#475569">Database</text>
+  <circle cx="287" cy="193" r="5" fill="#22c55e"/>
+  <text x="300" y="198" font-size="14" font-weight="600" fill="#0f172a">PRIMARY</text>
+  <text x="282" y="220" font-size="11" fill="#64748b">+ 2 replicas</text>
+
+  <rect x="468" y="140" width="186" height="96" rx="8" fill="#fbfdff" stroke="#e2e8f0" stroke-width="2"/>
+  <text x="484" y="166" font-size="12" font-weight="600" fill="#475569">Redis</text>
+  <circle cx="489" cy="193" r="5" fill="#22c55e"/>
+  <text x="502" y="198" font-size="14" font-weight="600" fill="#0f172a">ONLINE</text>
+  <text x="484" y="220" font-size="11" fill="#64748b">Sentinel</text>
+  <path d="M 540 217 l 4 4 l 8 -9" stroke="#16a34a" stroke-width="2" fill="none"
+        stroke-linecap="round" stroke-linejoin="round"/>
+
+  <rect x="670" y="140" width="186" height="96" rx="8" fill="#fbfdff" stroke="#e2e8f0" stroke-width="2"/>
+  <text x="686" y="166" font-size="12" font-weight="600" fill="#475569">Celery</text>
+  <circle cx="691" cy="193" r="5" fill="#22c55e"/>
+  <text x="704" y="198" font-size="14" font-weight="600" fill="#0f172a">3 workers</text>
+  <text x="686" y="220" font-size="11" fill="#64748b">0 pending</text>
+
+  <!-- Row 2 -->
+  <rect x="64" y="252" width="186" height="96" rx="8" fill="#fbfdff" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="64" y="252" width="4" height="96" rx="2" fill="#f59e0b"/>
+  <text x="80" y="278" font-size="12" font-weight="600" fill="#475569">DHCP Servers</text>
+  <text x="80" y="310" font-size="14" font-weight="600" fill="#0f172a">2/2 online</text>
+  <path d="M 86 321 L 93 333 L 79 333 Z" fill="#f59e0b"/>
+  <rect x="85" y="325" width="2" height="4" fill="#ffffff"/>
+  <rect x="85" y="330" width="2" height="2" fill="#ffffff"/>
+  <text x="99" y="332" font-size="11" fill="#b45309">kea-02</text>
+
+  <rect x="266" y="252" width="186" height="96" rx="8" fill="#fbfdff" stroke="#e2e8f0" stroke-width="2"/>
+  <rect x="266" y="252" width="4" height="96" rx="2" fill="#f59e0b"/>
+  <text x="282" y="278" font-size="12" font-weight="600" fill="#475569">DNS Servers</text>
+  <text x="282" y="310" font-size="14" font-weight="600" fill="#0f172a">3/4 online</text>
+  <path d="M 288 321 L 295 333 L 281 333 Z" fill="#f59e0b"/>
+  <rect x="287" y="325" width="2" height="4" fill="#ffffff"/>
+  <rect x="287" y="330" width="2" height="2" fill="#ffffff"/>
+  <text x="301" y="332" font-size="11" fill="#b45309">bind-03</text>
+
+  <rect x="468" y="252" width="186" height="96" rx="8" fill="#fbfdff" stroke="#e2e8f0" stroke-width="2"/>
+  <text x="484" y="278" font-size="12" font-weight="600" fill="#475569">Log Store</text>
+  <circle cx="489" cy="305" r="5" fill="#22c55e"/>
+  <text x="502" y="310" font-size="14" font-weight="600" fill="#0f172a">ONLINE</text>
+  <text x="484" y="332" font-size="11" fill="#64748b">12.4 GB used</text>
+
+  <rect x="670" y="252" width="186" height="96" rx="8" fill="#f8fafc"
+        stroke="#e2e8f0" stroke-width="2" stroke-dasharray="4 4"/>
+</svg>

--- a/docs/assets/diagrams/topology-powerdns-group.svg
+++ b/docs/assets/diagrams/topology-powerdns-group.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="550" viewBox="0 0 920 550"
+     preserveAspectRatio="xMidYMid meet"
+     font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
+  <title>PowerDNS-primary with BIND-secondary hybrid</title>
+  <desc>Operators drive the SpatiumDDI control plane, which owns two single-driver server groups: internal-pdns on PowerDNS, whose primary signs DNSSEC, and edge-bind on BIND9, whose members consume the catalog zone by AXFR.</desc>
+  <defs>
+    <linearGradient id="tpd-surface" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f1f5f9"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="tpd-cp" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="tpd-agent" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+    <marker id="tpd-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <!-- Operators -->
+  <g>
+    <rect x="380" y="24" width="160" height="48" rx="24" fill="#1e293b"/>
+    <text x="460" y="54" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">operators</text>
+  </g>
+  <path d="M 460 72 V 104" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#tpd-arrow)"/>
+
+  <!-- Control plane -->
+  <g>
+    <rect x="330" y="104" width="260" height="64" rx="8" fill="url(#tpd-cp)"/>
+    <text x="460" y="132" text-anchor="middle" font-size="14" font-weight="600" fill="#ffffff">SpatiumDDI control plane</text>
+    <text x="460" y="152" text-anchor="middle" font-size="11" fill="#ddd6fe">source of truth for both groups</text>
+  </g>
+  <path d="M 460 168 V 200 H 250 V 230" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#tpd-arrow)"/>
+  <path d="M 460 168 V 200 H 670 V 230" stroke="#475569" stroke-width="2" fill="none" marker-end="url(#tpd-arrow)"/>
+
+  <!-- internal-pdns group -->
+  <g>
+    <rect x="60" y="230" width="380" height="232" rx="12" fill="url(#tpd-surface)" stroke="#94a3b8" stroke-width="2"/>
+    <text x="82" y="258" font-size="14" font-weight="600" fill="#0f172a">DNSServerGroup “internal-pdns”</text>
+    <text x="82" y="278" font-size="11" fill="#475569">driver = powerdns</text>
+
+    <rect x="84" y="296" width="330" height="64" rx="8" fill="url(#tpd-agent)"/>
+    <text x="249" y="322" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">pdns1.corp</text>
+    <text x="249" y="342" text-anchor="middle" font-size="11" fill="#fed7aa">primary · signs DNSSEC</text>
+
+    <rect x="84" y="376" width="330" height="64" rx="8" fill="url(#tpd-agent)"/>
+    <text x="249" y="402" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">pdns2.corp</text>
+    <text x="249" y="422" text-anchor="middle" font-size="11" fill="#fed7aa">secondary</text>
+  </g>
+
+  <!-- edge-bind group -->
+  <g>
+    <rect x="480" y="230" width="380" height="232" rx="12" fill="url(#tpd-surface)" stroke="#94a3b8" stroke-width="2"/>
+    <text x="502" y="258" font-size="14" font-weight="600" fill="#0f172a">DNSServerGroup “edge-bind”</text>
+    <text x="502" y="278" font-size="11" fill="#475569">driver = bind9</text>
+
+    <rect x="504" y="296" width="330" height="64" rx="8" fill="url(#tpd-agent)"/>
+    <text x="669" y="322" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">bind1.edge</text>
+    <text x="669" y="342" text-anchor="middle" font-size="11" fill="#fed7aa">catalog consumer of internal-pdns</text>
+
+    <rect x="504" y="376" width="330" height="64" rx="8" fill="url(#tpd-agent)"/>
+    <text x="669" y="402" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">bind2.edge</text>
+    <text x="669" y="422" text-anchor="middle" font-size="11" fill="#fed7aa">catalog consumer of internal-pdns</text>
+  </g>
+
+  <!-- Catalog-zone AXFR between the groups -->
+  <path d="M 250 462 V 500 H 670 V 464" stroke="#475569" stroke-width="2" stroke-dasharray="6 4" fill="none" marker-end="url(#tpd-arrow)"/>
+  <text x="460" y="522" text-anchor="middle" font-size="11" fill="#475569">catalog-zone-driven AXFR keeps both drivers in sync (NOTIFY → IXFR)</text>
+</svg>

--- a/docs/assets/topologies/topology-4-ha-control-plane.svg
+++ b/docs/assets/topologies/topology-4-ha-control-plane.svg
@@ -30,7 +30,7 @@
   </defs>
 
   <!-- Operators -->
-  <rect x="370" y="20" width="180" height="42" rx="21" fill="#1e293b"/>
+  <rect x="354" y="20" width="212" height="42" rx="21" fill="#1e293b"/>
   <text x="460" y="46" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">operators / API consumers</text>
 
   <!-- LB -->
@@ -61,7 +61,7 @@
   </g>
 
   <!-- Beat singleton -->
-  <rect x="365" y="200" width="190" height="60" rx="8" fill="url(#t4-cp)"/>
+  <rect x="354" y="200" width="212" height="60" rx="8" fill="url(#t4-cp)"/>
   <text x="460" y="226" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">vm-beat (single)</text>
   <text x="460" y="246" text-anchor="middle" font-size="10" fill="#ddd6fe">celery beat — not horizontally scalable</text>
 

--- a/docs/assets/topologies/topology-7-appliance-ha.svg
+++ b/docs/assets/topologies/topology-7-appliance-ha.svg
@@ -30,7 +30,7 @@
   </defs>
 
   <!-- Operators / agents -->
-  <rect x="360" y="16" width="200" height="42" rx="21" fill="#1e293b"/>
+  <rect x="339" y="16" width="242" height="42" rx="21" fill="#1e293b"/>
   <text x="460" y="42" text-anchor="middle" font-size="13" font-weight="600" fill="#ffffff">operators / DNS · DHCP agents</text>
 
   <!-- MetalLB control-plane VIP -->

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -23,24 +23,9 @@ The appliance runs **k3s** as its container orchestrator. Pre-#183 it ran `docke
 
 The historical AIO / Core-only / Application narrative below documents the pre-#272 three-role world; the firstboot dispatch still handles those strings as aliases.
 
-```
-[appliance: single-node k3s]
-   ├─ /usr/local/bin/k3s (static binary, pinned via K3S_VERSION)
-   ├─ /var/lib/rancher/k3s/agent/images/*.tar.zst   ← air-gap-preloaded
-   ├─ /usr/lib/spatiumddi/charts/spatiumddi-appliance.tgz   ← appliance chart
-   ├─ /usr/lib/spatiumddi/charts/spatiumddi.tgz             ← umbrella chart (Control plane)
-   └─ /var/lib/rancher/k3s/server/manifests/spatium-bootstrap.yaml
-        ↓ (firstboot writes on every boot, content depends on variant)
-   helm-controller reconciles → installs `spatium-bootstrap` release
-        ↓
-   spatium-supervisor pod (DaemonSet, privileged, hostNetwork: false)   ← all roles
-        ↓ (registers + heartbeats to control plane)
-        ↓ (on role assignment: labels node → DaemonSet schedules)
-   role pods: dns-bind9 / dns-powerdns / dns-technitium / dhcp-kea (hostNetwork: true)
-   always-on: agent-landing nginx on :80                                 ← Appliance only
-   control plane pods (api / frontend / db / redis / worker / beat /     ← Control plane
-                       migrate, frontend on hostNetwork :80 + :443)
-```
+<p align="center">
+  <img src="../assets/diagrams/appliance-k3s-layout.svg" alt="Appliance — single-node k3s on-disk layout and boot sequence" width="900"/>
+</p>
 
 ### What's bundled in the slot rootfs
 

--- a/docs/deployment/DNS_AGENT.md
+++ b/docs/deployment/DNS_AGENT.md
@@ -127,36 +127,9 @@ pairing-code workflow.
 
 ### Flow
 
-```
-┌────────────────┐                                   ┌──────────────────┐
-│ DNS container  │                                   │  Control plane   │
-│  (fresh boot)  │                                   │   (FastAPI)      │
-└───────┬────────┘                                   └────────┬─────────┘
-        │                                                     │
-        │ 1. Read env: CONTROL_PLANE_URL, DNS_AGENT_KEY,      │
-        │              AGENT_ID (persisted in /var/lib)       │
-        │                                                     │
-        │ 2. If no cached agent_token.jwt → bootstrap:        │
-        │    POST /dns/agents/register                        │
-        │      Headers: X-DNS-Agent-Key: <bootstrap>          │
-        │      Body: {hostname, driver, roles, version,       │
-        │             group_name, fingerprint}                │
-        │───────────────────────────────────────────────────► │
-        │                                                     │ 3. Validate PSK
-        │                                                     │    Create/update DNSServer row
-        │                                                     │    Mark pending_approval=true
-        │                                                     │      if settings.require_agent_approval
-        │                                                     │    Mint agent_token (JWT, 24h)
-        │  ◄────────────────────────────────────────────────  │
-        │    200 {server_id, agent_token, config_etag, ...}   │
-        │                                                     │
-        │ 4. Persist token to /var/lib/spatium-dns-agent/     │
-        │    agent_token.jwt (0600, owned by agent user)      │
-        │                                                     │
-        │ 5. From here on: Authorization: Bearer <agent_token>│
-        │    Heartbeat every 30s — token rotated on rotation  │
-        │    window (every 12h) via heartbeat response.       │
-```
+<p align="center">
+  <img src="../assets/diagrams/dns-agent-bootstrap.svg" alt="DNS agent bootstrap — PSK exchanged for a rotating JWT" width="900"/>
+</p>
 
 ### Identity
 
@@ -298,32 +271,9 @@ ops/
 
 ### Record lifecycle end-to-end
 
-```
-UI / API mutation (e.g. POST /dns/zones/{id}/records)
-        │
-        ▼
-Service layer: validate, write DNSRecord row, compute delta
-        │
-        ▼
-Enqueue RecordOp rows:
-  { id, server_id, zone_name, op: create|update|delete, record: {...},
-    serial_strategy: bump, created_at, state: pending }
-        │
-        ▼
-Response returned to caller (HTTP 2xx) — the write is durable in Postgres.
-        │
-        ▼
-Agents holding a long-poll on /config are released with op list.
-(Or: next long-poll picks it up within ≤30 s; idempotent by op_id.)
-        │
-        ▼
-Agent executes via loopback:
-  BIND9   → nsupdate ‹signed with local TSIG›
-        │
-        ▼
-Agent ACKs on next heartbeat → RecordOp.state = applied
-If failed after N retries (default 5, expo-backoff): state=failed, alert.
-```
+<p align="center">
+  <img src="../assets/diagrams/dns-record-propagation.svg" alt="DNS record change — end-to-end propagation" width="900"/>
+</p>
 
 ### Serial bump responsibility
 

--- a/docs/deployment/TOPOLOGIES.md
+++ b/docs/deployment/TOPOLOGIES.md
@@ -346,17 +346,9 @@ SpatiumDDI ships two authoritative DNS drivers: BIND9 (default) and PowerDNS. Ea
 
 **Shape A — PowerDNS-primary + BIND-secondary on the same zones.** PowerDNS handles writes (online DNSSEC signing, ALIAS records, LUA records); BIND fans the zones out to a battle-tested edge. Catalog-zone-driven AXFR keeps both drivers in sync because the producer-side catalog renderer emits identical wire bytes from either driver (issue #127 Phase 3d).
 
-```
-Operators ─→ SpatiumDDI control plane
-                │
-                ├── DNSServerGroup "internal-pdns" (driver=powerdns)
-                │     ├── pdns1.corp  (primary, signs DNSSEC)
-                │     └── pdns2.corp  (secondary)
-                │
-                └── DNSServerGroup "edge-bind"  (driver=bind9)
-                      ├── bind1.edge  (catalog consumer of internal-pdns)
-                      └── bind2.edge  (catalog consumer of internal-pdns)
-```
+<p align="center">
+  <img src="../assets/diagrams/topology-powerdns-group.svg" alt="PowerDNS and BIND9 server groups under one control plane" width="900"/>
+</p>
 
 Wire it up:
 

--- a/docs/drivers/DHCP_DRIVERS.md
+++ b/docs/drivers/DHCP_DRIVERS.md
@@ -23,21 +23,9 @@ All other drivers (currently just `kea`) are agented: the control plane renders 
 
 Today's drivers split into three shapes:
 
-```
-┌────────────────────────┐  ┌────────────────────────┐  ┌────────────────────────┐
-│  Agented + write       │  │  Agentless + read-only │  │  Agentless + write     │
-│  (Kea)                 │  │  (Windows DHCP—Path A) │  │  (FortiGate — cloud)   │
-│                        │  │                        │  │                        │
-│  Control plane:        │  │  Control plane:        │  │  Control plane:        │
-│    render_config()     │  │    get_leases() WinRM  │  │    apply_scope_full()  │
-│    ETag long-poll      │  │    get_scopes() WinRM  │  │      → REST PUT/POST   │
-│                        │  │                        │  │    get_leases() REST   │
-│  Agent (sidecar):      │  │  No agent.             │  │  No agent.             │
-│    fetch bundle        │  │  Writes raise          │  │  Whole-scope push,     │
-│    apply_config()      │  │    NotImplementedError.│  │    synchronous,        │
-│    reload / restart    │  │                        │  │    before-commit.      │
-└────────────────────────┘  └────────────────────────┘  └────────────────────────┘
-```
+<p align="center">
+  <img src="../assets/diagrams/dhcp-driver-shapes.svg" alt="DHCP driver shapes — agented vs agentless, read-only vs write" width="900"/>
+</p>
 
 The abstract base (`DHCPDriver`) has methods for both halves. Read-only agentless drivers (Windows) implement only the read methods + a stub `apply_config` / `reload` / `restart` / `validate_config` that raises; the API layer consults `READ_ONLY_DRIVERS` before offering write endpoints. Cloud agentless drivers (FortiGate) are write-capable but push the **whole scope object** synchronously over a REST API instead of rendering a daemon config bundle — see §5.
 

--- a/docs/features/AUTH.md
+++ b/docs/features/AUTH.md
@@ -26,23 +26,9 @@ SpatiumDDI's auth stack has three layers:
    role with a matching permission entry. See [PERMISSIONS.md](../PERMISSIONS.md)
    for the grammar.
 
-```
-┌────────────┐  1. login          ┌──────────────────────┐
-│  browser   │──────────────────▶ │   /auth/login        │
-└────────────┘                    │                      │
-      ▲                           │  local password ──▶  │  verify_password
-      │                           │  LDAP / RADIUS /     │──▶ authenticate_*
-      │                           │    TACACS+           │
-      │ 2. access + refresh       │                      │
-      └───────────────────────────│  OIDC / SAML: 302    │──▶ redirect to IdP
-                                   └──────────────────────┘
-                                            │
-                                            ▼
-                                   sync_external_user
-                                   → upsert User
-                                   → replace group membership
-                                   → reject if no mapping match
-```
+<p align="center">
+  <img src="../assets/diagrams/auth-login-flow.svg" alt="Login flow — three authentication paths, one identity sync" width="900"/>
+</p>
 
 ## Local auth
 

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -71,12 +71,9 @@ This is the most granular part of the DHCP model. Within a **subnet**, you can d
 
 ### Hierarchy
 
-```
-Subnet
-  └── DHCPScope (one per subnet per DHCP server group)
-        ├── DHCPPool (one or more dynamic ranges)
-        └── DHCPStaticAssignment (zero or many)
-```
+<p align="center">
+  <img src="../assets/diagrams/dhcp-scope-containment.svg" alt="DHCP scope hierarchy" width="900"/>
+</p>
 
 ### DHCPScope Model
 
@@ -580,25 +577,9 @@ different MAC, or got swept on absence-delete — gives operators a
 
 Each DHCP server is managed by an **SpatiumDDI Agent** — a lightweight sidecar process running on or near the DHCP server.
 
-```
-┌─────────────────────────────────────────┐
-│   DHCP Server Host / Container           │
-│                                         │
-│   ┌─────────────┐    ┌───────────────┐  │
-│   │  DHCP daemon │←── │  SpatiumDDI     │  │
-│   │  (Kea/ISC)  │    │  Agent        │  │
-│   └─────────────┘    │               │  │
-│                       │  config cache │  │
-│                       │  (local disk) │  │
-│                       └──────┬────────┘  │
-│                              │ pull/push │
-└──────────────────────────────┼───────────┘
-                               │
-                      ┌────────▼────────┐
-                      │  SpatiumDDI API   │
-                      │  (control plane)│
-                      └─────────────────┘
-```
+<p align="center">
+  <img src="../assets/diagrams/dhcp-host-internals.svg" alt="DHCP agent host internals" width="900"/>
+</p>
 
 ### Agent Behavior
 

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -407,18 +407,9 @@ The driver is responsible for generating the correct BIND9 config that reflects 
 
 Zones are displayed and managed in a **tree hierarchy** that mirrors the DNS namespace naturally.
 
-```
-. (root)
-├── com.
-│   └── example.
-│       ├── internal.example.com.   [internal view only]
-│       └── example.com.            [all views]
-├── net.
-└── in-addr.arpa.
-    ├── 10.in-addr.arpa.
-    │   └── 1.10.in-addr.arpa.
-    └── 192.in-addr.arpa.
-```
+<p align="center">
+  <img src="../assets/diagrams/dns-namespace-views.svg" alt="DNS zone tree — namespace hierarchy with view scoping" width="900"/>
+</p>
 
 ### Zone Model
 
@@ -518,30 +509,9 @@ async def apply_record_change(
 
 DDNS is a thin layer on top of the IPAM → DNS sync pipeline. The DNS side is identical to what a static allocation produces; the only DDNS-specific logic is picking a hostname from the lease.
 
-```
-┌──────────────────────────┐
-│  Lease source            │
-│  ─ agentless pull        │  → upserts DHCPLease + mirrors into IPAM
-│    (Windows DHCP)         │    as auto_from_lease=True
-│  ─ agent lease event      │  → Kea (POST /agents/lease-events)
-│    (Kea)                  │
-└───────────┬──────────────┘
-            │ ipam_row
-            ▼
-┌──────────────────────────┐
-│  services/dns/ddns.py    │
-│  apply_ddns_for_lease()  │  → resolves hostname per subnet policy,
-│                          │    writes it onto ipam_row.hostname,
-│                          │    calls _sync_dns_record(..., "create")
-└───────────┬──────────────┘
-            │
-            ▼
-┌──────────────────────────┐
-│  _sync_dns_record        │  → unchanged — drives A/AAAA + PTR via
-│  (IPAM router)           │    RFC 2136 for BIND9 / Windows Path A,
-│                          │    or WinRM for Windows Path B
-└──────────────────────────┘
-```
+<p align="center">
+  <img src="../assets/diagrams/dns-ddns-lease-flow.svg" alt="DDNS — DHCP lease to DNS record" width="900"/>
+</p>
 
 On lease expiry, `dhcp_lease_cleanup` sweeps the DHCPLease row past its grace period; before deleting the mirrored `auto_from_lease` IPAM row it calls `revoke_ddns_for_lease`, which fires `_sync_dns_record(..., action="delete")` to tear down the A/AAAA + PTR.
 

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -10,14 +10,9 @@ The IPAM module is the core of SpatiumDDI. It manages the hierarchy of IP space 
 
 ## 1. IP Hierarchy
 
-```
-IPSpace  (VRF / routing domain)
-  └── IPBlock  (aggregate/supernet, e.g., 10.0.0.0/8)
-        └── IPBlock  (nested, e.g., 10.1.0.0/16)
-              └── Subnet  (routable network, e.g., 10.1.2.0/24)  ← primary managed unit
-                    ├── IPAddress  (individual host IP)
-                    └── DHCPScope → DHCPPool(s)
-```
+<p align="center">
+  <img src="../assets/diagrams/ipam-containment.svg" alt="IP hierarchy — containment model" width="900"/>
+</p>
 
 ### IP Space
 - Represents a **VRF** or isolated routing domain (e.g., "Corporate", "Internet", "OOB")
@@ -41,18 +36,9 @@ IPSpace  (VRF / routing domain)
 
 Both IP blocks and subnets are displayed in a **tree view** in the UI, mirroring the network hierarchy.
 
-```
-Corporate (IPSpace)
-├── 10.0.0.0/8  [IPBlock — 42% used]
-│   ├── 10.0.0.0/16  [IPBlock — HQ]
-│   │   ├── 10.0.1.0/24  [Subnet — Servers VLAN 10]
-│   │   ├── 10.0.2.0/24  [Subnet — Workstations VLAN 20]
-│   │   └── 10.0.3.0/24  [Subnet — VoIP VLAN 30]
-│   └── 10.1.0.0/16  [IPBlock — Branch Office]
-│       └── 10.1.1.0/24  [Subnet — Branch LAN VLAN 100]
-└── 10.128.0.0/9  [IPBlock — DMZ]
-    └── 10.128.0.0/24  [Subnet — Public Services]
-```
+<p align="center">
+  <img src="../assets/diagrams/ipam-example-tree.svg" alt="IPAM tree — worked example" width="900"/>
+</p>
 
 ### Tree Features
 - Expand/collapse nodes
@@ -1083,17 +1069,9 @@ Search is implemented via PostgreSQL full-text search + `inet` operators, not a 
 
 The left-side IPAM menu expands into a unified tree view. There are no separate "IP Spaces" and "Subnets" pages — everything is a single hierarchical tree:
 
-```
-IPAM
-├── Corporate (IPSpace)
-│   ├── 10.0.0.0/8  [IPBlock]
-│   │   ├── 10.0.1.0/24  [Subnet — Servers VLAN 10]  ← click → IP list
-│   │   └── 10.0.2.0/24  [Subnet — Workstations]
-│   └── (free: 10.1.0.0/8 – 10.255.0.0/8)
-└── OOB (IPSpace)
-    └── 192.168.0.0/16  [IPBlock]
-        └── 192.168.1.0/24  [Subnet]
-```
+<p align="center">
+  <img src="../assets/diagrams/ipam-tree-ui.svg" alt="Combined IPAM tree navigator" width="900"/>
+</p>
 
 Clicking a subnet opens its IP address list panel on the right. The IP address list is **collapsible** — useful for large subnets (e.g., WiFi /16) where listing every IP is slow. A toggle "Show IP list" defaults based on subnet size (auto-collapse if > 1000 IPs).
 

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -66,19 +66,9 @@ The main **Health Overview** page gives a single-pane-of-glass view of the entir
 
 Each managed component shows a status card:
 
-```
-┌────────────────────────────────────────────────────────────┐
-│ SYSTEM HEALTH                              Last updated: 2s │
-├──────────────┬──────────────┬──────────────┬───────────────┤
-│ API Backend  │  Database    │    Redis     │  Celery       │
-│  ● ONLINE    │  ● PRIMARY   │  ● ONLINE    │  ● 3 workers  │
-│  3 replicas  │  + 2 replicas│  Sentinel ✓  │  0 pending    │
-├──────────────┼──────────────┼──────────────┼───────────────┤
-│ DHCP Servers │ DNS Servers  │  Log Store    │               │
-│  2/2 online  │  3/4 online  │  ● ONLINE     │               │
-│  ⚠ kea-02   │  ⚠ bind-03  │  12.4 GB used │               │
-└──────────────┴──────────────┴──────────────┴───────────────┘
-```
+<p align="center">
+  <img src="../assets/diagrams/system-health-grid.svg" alt="System health — component status grid" width="900"/>
+</p>
 
 ### Per-Component Detail
 

--- a/scripts/verify_svg_diagrams.py
+++ b/scripts/verify_svg_diagrams.py
@@ -57,17 +57,27 @@ MIN_FONT_SIZE = 9.5
 # hairline overhang is invisible; a genuine overflow is several px.
 EDGE_TOLERANCE = 1.0
 
-# The measuring script. Runs inside the page, walks every text node,
-# and reports geometry plus the tightest enclosing rect. Chromium's
-# --dump-dom gives us the post-script DOM, so results come back in a
-# <pre> we can parse.
+# The measuring script. Runs inside the page, walks every text node, and
+# reports geometry plus the tightest enclosing rect. Chromium's --dump-dom
+# gives us the post-script DOM, so results come back in a <pre> we can parse.
+#
+# Every diagram is measured in ONE page load. Launching a browser per file
+# meant ~30 cold starts, which is slow locally and times out on a CI runner
+# whose Chromium starts far slower than a developer's. Batching is safe here
+# because the only cross-document hazard would be duplicate element ids, and
+# these diagrams carry none and use no <use> references — and text metrics
+# depend on font and content, not on which gradient a fill resolved to.
 MEASURE_JS = r"""
 (function () {
-  var out = { texts: [], rects: [], root: null, error: null };
-  try {
-    var svg = document.querySelector('svg');
-    if (!svg) { out.error = 'no <svg> element'; return out; }
+  var all = [];
+  document.querySelectorAll('svg[data-diagram]').forEach(function (svg) {
+    all.push(measureOne(svg, +svg.getAttribute('data-diagram')));
+  });
+  return all;
 
+  function measureOne(svg, idx) {
+  var out = { idx: idx, texts: [], rects: [], root: null, error: null };
+  try {
     var vb = svg.viewBox.baseVal;
     out.root = { x: vb.x, y: vb.y, w: vb.width, h: vb.height };
 
@@ -112,6 +122,7 @@ MEASURE_JS = r"""
     out.error = String(e && e.message || e);
   }
   return out;
+  }
 })()
 """
 
@@ -152,7 +163,10 @@ class Result:
 
 
 def _chromium() -> str:
-    for name in ("chromium", "chromium-browser", "google-chrome", "chrome"):
+    # google-chrome first: it is preinstalled on GitHub's ubuntu runners and
+    # starts noticeably faster there than a Chromium pulled from apt, which
+    # may be a snap wrapper. Falls back to whatever a developer has locally.
+    for name in ("google-chrome", "chromium", "chromium-browser", "chrome"):
         found = shutil.which(name)
         if found:
             return found
@@ -164,55 +178,94 @@ def _chromium() -> str:
     raise SystemExit(2)
 
 
-def measure(svg_path: Path, browser: str) -> dict:
-    """Render one SVG headless and return the measurement payload."""
+def _inline(svg_path: Path, idx: int) -> str:
+    """Prepare one SVG for inlining into the measurement page."""
     svg = svg_path.read_text(encoding="utf-8")
     # Strip the XML prolog — it is invalid partway through an HTML document
     # and Chromium's parser will bail on the rest of the file.
     if svg.lstrip().startswith("<?xml"):
         svg = svg.split("?>", 1)[1]
+    # Tag the root element so the measuring script can attribute results back
+    # to the right file. Only the first <svg> is the root; nested ones (there
+    # are none today) would be measured as part of their parent.
+    return svg.replace("<svg", f'<svg data-diagram="{idx}"', 1)
 
-    html = HTML_TEMPLATE.format(svg=svg, measure=MEASURE_JS)
+
+def measure_all(paths: list[Path], browser: str) -> dict[int, dict]:
+    """Render every SVG in a single headless page and return measurements
+    keyed by index into ``paths``.
+
+    One launch rather than one-per-file: browser startup dominates the
+    runtime, and a CI runner's Chromium is slow enough that per-file launches
+    blow past any sane timeout.
+    """
+    parts, failed = [], {}
+    for i, p in enumerate(paths):
+        try:
+            parts.append(_inline(p, i))
+        except OSError as exc:
+            failed[i] = {"error": f"unreadable: {exc}"}
+
+    html = HTML_TEMPLATE.format(svg="\n".join(parts), measure=MEASURE_JS)
 
     with tempfile.TemporaryDirectory() as tmp:
         page = Path(tmp) / "page.html"
         page.write_text(html, encoding="utf-8")
-        proc = subprocess.run(
-            [
-                browser,
-                "--headless",
-                "--no-sandbox",
-                "--disable-gpu",
-                "--hide-scrollbars",
-                f"--user-data-dir={tmp}/profile",
-                "--virtual-time-budget=5000",
-                "--dump-dom",
-                page.as_uri(),
-            ],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
+        try:
+            proc = subprocess.run(
+                [
+                    browser,
+                    "--headless",
+                    "--no-sandbox",
+                    "--disable-gpu",
+                    "--hide-scrollbars",
+                    f"--user-data-dir={tmp}/profile",
+                    "--virtual-time-budget=8000",
+                    "--dump-dom",
+                    page.as_uri(),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            return {i: {"error": "renderer timed out"} for i in range(len(paths))}
 
     dom = proc.stdout
     marker = '<pre id="__result">'
     start = dom.find(marker)
     if start == -1:
-        return {"error": "renderer produced no measurement block"}
+        return {
+            i: {"error": "renderer produced no measurement block"}
+            for i in range(len(paths))
+        }
     start += len(marker)
-    end = dom.find("</pre>", start)
-    raw = dom[start:end]
+    raw = dom[start : dom.find("</pre>", start)]
     # The DOM dump HTML-escapes the JSON payload.
-    raw = raw.replace("&quot;", '"').replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+    raw = (
+        raw.replace("&quot;", '"')
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+    )
     try:
-        return json.loads(raw)
+        payload = json.loads(raw)
     except json.JSONDecodeError as exc:
-        return {"error": f"unparseable measurement payload: {exc}"}
+        return {
+            i: {"error": f"unparseable measurement payload: {exc}"}
+            for i in range(len(paths))
+        }
+
+    out = dict(failed)
+    for entry in payload:
+        out[entry["idx"]] = entry
+    for i in range(len(paths)):
+        out.setdefault(i, {"error": "diagram did not render"})
+    return out
 
 
-def check(svg_path: Path, browser: str) -> Result:
+def check(svg_path: Path, data: dict) -> Result:
     result = Result(path=svg_path)
-    data = measure(svg_path, browser)
 
     if data.get("error"):
         result.findings.append(Finding("malformed", data["error"]))
@@ -231,7 +284,9 @@ def check(svg_path: Path, browser: str) -> Result:
         short = label if len(label) <= 48 else label[:45] + "..."
 
         if t.get("dropped"):
-            result.findings.append(Finding("malformed", f"renderer dropped text {short!r}"))
+            result.findings.append(
+                Finding("malformed", f"renderer dropped text {short!r}")
+            )
             continue
 
         # 1. Clipped by the canvas.
@@ -324,7 +379,8 @@ def main() -> int:
         print("no SVG diagrams found", file=sys.stderr)
         return 1
 
-    results = [check(p, browser) for p in paths]
+    measurements = measure_all(paths, browser)
+    results = [check(p, measurements[i]) for i, p in enumerate(paths)]
     failed = [r for r in results if not r.ok]
 
     if args.json:
@@ -335,7 +391,9 @@ def main() -> int:
                         "path": str(r.path.relative_to(REPO_ROOT)),
                         "ok": r.ok,
                         "texts": r.text_count,
-                        "findings": [{"kind": f.kind, "detail": f.detail} for f in r.findings],
+                        "findings": [
+                            {"kind": f.kind, "detail": f.detail} for f in r.findings
+                        ],
                     }
                     for r in results
                 ],
@@ -345,7 +403,11 @@ def main() -> int:
         return 1 if failed else 0
 
     for r in results:
-        rel = r.path.relative_to(REPO_ROOT) if r.path.is_relative_to(REPO_ROOT) else r.path
+        rel = (
+            r.path.relative_to(REPO_ROOT)
+            if r.path.is_relative_to(REPO_ROOT)
+            else r.path
+        )
         if r.ok:
             print(f"  ok    {rel}  ({r.text_count} labels)")
         else:

--- a/scripts/verify_svg_diagrams.py
+++ b/scripts/verify_svg_diagrams.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Verify documentation SVG diagrams render cleanly.
+
+ASCII box-drawing diagrams degrade badly in a published docs site, so
+``docs/assets/`` holds hand-authored SVG instead. Hand-authored SVG has
+its own failure mode: text is positioned by absolute coordinate, so a
+label that grew by one word silently spills out of its box or off the
+canvas. Nothing in a diff shows that — it only appears in the rendered
+page, which is exactly where readers see it.
+
+This script measures the real thing. It loads each SVG in headless
+Chromium and reads ``getBBox()`` per text node, so the numbers come
+from the same font stack and shaping engine a browser uses, not from an
+estimate. Five checks run against those measurements:
+
+  overflow    text wider than the ``<rect>`` it is centred in
+  clipped     any element extending past the viewBox
+  collision   two text nodes on the same line whose boxes intersect
+  tiny        font-size below the legibility floor
+  malformed   unparseable SVG, or a text node the renderer dropped
+
+Usage::
+
+    python3 scripts/verify_svg_diagrams.py                # all diagrams
+    python3 scripts/verify_svg_diagrams.py path/to/a.svg  # just one
+    python3 scripts/verify_svg_diagrams.py --json         # machine-readable
+
+Exits non-zero if any diagram fails, so CI can gate on it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIAGRAM_ROOT = REPO_ROOT / "docs" / "assets"
+
+# Logos are artwork, not diagrams — they legitimately use tight custom
+# geometry and their own type treatment, so the box/legibility rules
+# below don't apply to them.
+EXCLUDE_NAMES = {"logo.svg", "logo-icon.svg"}
+
+# Smallest font-size we consider legible in a published diagram. The
+# house style bottoms out at 10px for annotation text; anything under
+# that is a mistake rather than a deliberate choice.
+MIN_FONT_SIZE = 9.5
+
+# Slack allowed when comparing a text box against its container, in user
+# units. Sub-pixel shaping differences between platforms are real, and a
+# hairline overhang is invisible; a genuine overflow is several px.
+EDGE_TOLERANCE = 1.0
+
+# The measuring script. Runs inside the page, walks every text node,
+# and reports geometry plus the tightest enclosing rect. Chromium's
+# --dump-dom gives us the post-script DOM, so results come back in a
+# <pre> we can parse.
+MEASURE_JS = r"""
+(function () {
+  var out = { texts: [], rects: [], root: null, error: null };
+  try {
+    var svg = document.querySelector('svg');
+    if (!svg) { out.error = 'no <svg> element'; return out; }
+
+    var vb = svg.viewBox.baseVal;
+    out.root = { x: vb.x, y: vb.y, w: vb.width, h: vb.height };
+
+    // Collect candidate container rects once. A text label is judged
+    // against the smallest rect that contains its anchor point, which
+    // is how a human reads the diagram: the innermost box wins.
+    var rects = Array.prototype.slice.call(svg.querySelectorAll('rect'));
+    rects.forEach(function (r) {
+      var bb = r.getBBox();
+      out.rects.push({ x: bb.x, y: bb.y, w: bb.width, h: bb.height });
+    });
+
+    var texts = Array.prototype.slice.call(svg.querySelectorAll('text'));
+    texts.forEach(function (t, i) {
+      var bb, len;
+      try { bb = t.getBBox(); len = t.getComputedTextLength(); }
+      catch (e) { out.texts.push({ i: i, dropped: true, content: t.textContent }); return; }
+
+      var cs = window.getComputedStyle(t);
+      var fs = parseFloat(cs.fontSize) || 0;
+
+      // Tightest containing rect by area, tested against the text's own
+      // box rather than its anchor so wide centred labels are caught.
+      var cx = bb.x + bb.width / 2, cy = bb.y + bb.height / 2;
+      var best = null;
+      out.rects.forEach(function (r) {
+        if (cx >= r.x && cx <= r.x + r.w && cy >= r.y && cy <= r.y + r.h) {
+          if (!best || r.w * r.h < best.w * best.h) best = r;
+        }
+      });
+
+      out.texts.push({
+        i: i,
+        content: t.textContent,
+        x: bb.x, y: bb.y, w: bb.width, h: bb.height,
+        len: len,
+        fontSize: fs,
+        box: best
+      });
+    });
+  } catch (e) {
+    out.error = String(e && e.message || e);
+  }
+  return out;
+})()
+"""
+
+HTML_TEMPLATE = """<!doctype html>
+<html><head><meta charset="utf-8">
+<style>html,body{{margin:0;padding:0;background:#fff}}</style>
+</head><body>
+{svg}
+<pre id="__result"></pre>
+<script>
+try {{
+  document.getElementById('__result').textContent =
+    JSON.stringify({measure});
+}} catch (e) {{
+  document.getElementById('__result').textContent =
+    JSON.stringify({{ error: String(e) }});
+}}
+</script>
+</body></html>
+"""
+
+
+@dataclass
+class Finding:
+    kind: str
+    detail: str
+
+
+@dataclass
+class Result:
+    path: Path
+    findings: list[Finding] = field(default_factory=list)
+    text_count: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings
+
+
+def _chromium() -> str:
+    for name in ("chromium", "chromium-browser", "google-chrome", "chrome"):
+        found = shutil.which(name)
+        if found:
+            return found
+    print(
+        "error: no Chromium binary found — install chromium to run the "
+        "geometry checks (apt-get install -y chromium).",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def measure(svg_path: Path, browser: str) -> dict:
+    """Render one SVG headless and return the measurement payload."""
+    svg = svg_path.read_text(encoding="utf-8")
+    # Strip the XML prolog — it is invalid partway through an HTML document
+    # and Chromium's parser will bail on the rest of the file.
+    if svg.lstrip().startswith("<?xml"):
+        svg = svg.split("?>", 1)[1]
+
+    html = HTML_TEMPLATE.format(svg=svg, measure=MEASURE_JS)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        page = Path(tmp) / "page.html"
+        page.write_text(html, encoding="utf-8")
+        proc = subprocess.run(
+            [
+                browser,
+                "--headless",
+                "--no-sandbox",
+                "--disable-gpu",
+                "--hide-scrollbars",
+                f"--user-data-dir={tmp}/profile",
+                "--virtual-time-budget=5000",
+                "--dump-dom",
+                page.as_uri(),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    dom = proc.stdout
+    marker = '<pre id="__result">'
+    start = dom.find(marker)
+    if start == -1:
+        return {"error": "renderer produced no measurement block"}
+    start += len(marker)
+    end = dom.find("</pre>", start)
+    raw = dom[start:end]
+    # The DOM dump HTML-escapes the JSON payload.
+    raw = raw.replace("&quot;", '"').replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {"error": f"unparseable measurement payload: {exc}"}
+
+
+def check(svg_path: Path, browser: str) -> Result:
+    result = Result(path=svg_path)
+    data = measure(svg_path, browser)
+
+    if data.get("error"):
+        result.findings.append(Finding("malformed", data["error"]))
+        return result
+
+    root = data.get("root")
+    if not root or not root.get("w"):
+        result.findings.append(Finding("malformed", "missing or zero-size viewBox"))
+        return result
+
+    texts = [t for t in data.get("texts", []) if t.get("content", "").strip()]
+    result.text_count = len(texts)
+
+    for t in texts:
+        label = t.get("content", "").strip()
+        short = label if len(label) <= 48 else label[:45] + "..."
+
+        if t.get("dropped"):
+            result.findings.append(Finding("malformed", f"renderer dropped text {short!r}"))
+            continue
+
+        # 1. Clipped by the canvas.
+        if (
+            t["x"] < root["x"] - EDGE_TOLERANCE
+            or t["y"] < root["y"] - EDGE_TOLERANCE
+            or t["x"] + t["w"] > root["x"] + root["w"] + EDGE_TOLERANCE
+            or t["y"] + t["h"] > root["y"] + root["h"] + EDGE_TOLERANCE
+        ):
+            result.findings.append(
+                Finding(
+                    "clipped",
+                    f"{short!r} at x={t['x']:.0f},y={t['y']:.0f} "
+                    f"w={t['w']:.0f} extends past viewBox "
+                    f"{root['w']:.0f}x{root['h']:.0f}",
+                )
+            )
+
+        # 2. Overflowing its own container box.
+        box = t.get("box")
+        if box:
+            if (
+                t["x"] < box["x"] - EDGE_TOLERANCE
+                or t["x"] + t["w"] > box["x"] + box["w"] + EDGE_TOLERANCE
+            ):
+                overhang = max(
+                    box["x"] - t["x"],
+                    (t["x"] + t["w"]) - (box["x"] + box["w"]),
+                )
+                result.findings.append(
+                    Finding(
+                        "overflow",
+                        f"{short!r} is {t['w']:.0f}px wide in a "
+                        f"{box['w']:.0f}px box — spills {overhang:.0f}px",
+                    )
+                )
+
+        # 3. Illegibly small.
+        if 0 < t["fontSize"] < MIN_FONT_SIZE:
+            result.findings.append(
+                Finding("tiny", f"{short!r} at font-size {t['fontSize']:.1f}px")
+            )
+
+    # 4. Overlapping labels. Only compare pairs that share vertical space —
+    #    diagrams legitimately stack many labels at the same x.
+    for i, a in enumerate(texts):
+        if a.get("dropped"):
+            continue
+        for b in texts[i + 1 :]:
+            if b.get("dropped"):
+                continue
+            v_overlap = min(a["y"] + a["h"], b["y"] + b["h"]) - max(a["y"], b["y"])
+            h_overlap = min(a["x"] + a["w"], b["x"] + b["w"]) - max(a["x"], b["x"])
+            # Require a substantial intersection in both axes: glyph boxes
+            # routinely share a pixel or two of leading without colliding.
+            if v_overlap > 2.0 and h_overlap > 2.0:
+                result.findings.append(
+                    Finding(
+                        "collision",
+                        f"{a['content'].strip()[:28]!r} overlaps "
+                        f"{b['content'].strip()[:28]!r} "
+                        f"({h_overlap:.0f}x{v_overlap:.0f}px)",
+                    )
+                )
+
+    return result
+
+
+def collect(targets: list[str]) -> list[Path]:
+    if targets:
+        paths: list[Path] = []
+        for t in targets:
+            p = Path(t)
+            if not p.is_absolute():
+                p = (REPO_ROOT / p).resolve() if not p.exists() else p.resolve()
+            paths.append(p)
+        return paths
+    return sorted(p for p in DIAGRAM_ROOT.rglob("*.svg") if p.name not in EXCLUDE_NAMES)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("svg", nargs="*", help="specific SVG files (default: all diagrams)")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable results")
+    args = ap.parse_args()
+
+    browser = _chromium()
+    paths = collect(args.svg)
+    if not paths:
+        print("no SVG diagrams found", file=sys.stderr)
+        return 1
+
+    results = [check(p, browser) for p in paths]
+    failed = [r for r in results if not r.ok]
+
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "path": str(r.path.relative_to(REPO_ROOT)),
+                        "ok": r.ok,
+                        "texts": r.text_count,
+                        "findings": [{"kind": f.kind, "detail": f.detail} for f in r.findings],
+                    }
+                    for r in results
+                ],
+                indent=2,
+            )
+        )
+        return 1 if failed else 0
+
+    for r in results:
+        rel = r.path.relative_to(REPO_ROOT) if r.path.is_relative_to(REPO_ROOT) else r.path
+        if r.ok:
+            print(f"  ok    {rel}  ({r.text_count} labels)")
+        else:
+            print(f"  FAIL  {rel}")
+            for f in r.findings:
+                print(f"          [{f.kind}] {f.detail}")
+
+    print()
+    if failed:
+        total = sum(len(r.findings) for r in failed)
+        print(f"{len(failed)} of {len(results)} diagrams failed ({total} findings)")
+        return 1
+    print(f"all {len(results)} diagrams clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The docs are being showcased, but most diagrams were still box-drawing characters inside fenced code blocks — they wrapped badly on narrow viewports, ignored the dark theme, and looked nothing like the seven hand-authored topology SVGs already in `docs/assets/topologies/`.

## What changed

**21 ASCII diagrams became SVG** in `docs/assets/diagrams/`, across 12 files: the architecture planes, auth login flow, DNS agent bootstrap + record propagation, DHCP driver shapes and host internals, the DDNS lease flow, the system-health dashboard, the perf client state machine and lab topology, the PowerDNS group layout, the k3s appliance layout, and the IPAM / DNS / DHCP / RBAC model hierarchies. The markdown side is +63/−296: each diagram left as text-in-a-fence and came back as one `<img>`, matching the embed pattern already used in `TOPOLOGIES.md`.

**Nine blocks were deliberately left as text.** Python source in `FLEET_FIREWALL.md` and `DNS_DRIVERS.md`, the nftables config, the `runs/` and `/usr/lib` + `/var/lib` directory listings, the k8s object listing, and the perf results table. They match a box-drawing grep but aren't diagrams, and imaging them would cost copy-paste and grep.

## The verification is measured, not eyeballed

`scripts/verify_svg_diagrams.py` renders each SVG in headless Chromium and reads real `getBBox()` metrics, so the numbers come from the same shaping engine a browser uses. It checks five failure modes: text overflowing its container box, anything clipped by the viewBox, colliding labels, sub-9.5px type, and text the renderer dropped. Hand-authored SVG places text by absolute coordinate, so a relabelled box silently spills out and **nothing in the diff shows it** — it only appears on the rendered page. Wired into CI as `Docs — Diagram Geometry`.

**It failed 3 of the 8 diagrams that were already committed**, with 8 real defects:

| File | Defect |
|---|---|
| `architecture.svg` | an annotation rendering at **x=−49** (off the left edge of the canvas), a 615px label spilling its box, three colliding lines |
| `topology-4-ha-control-plane.svg` | two labels overflowing their boxes by 7px and 3px |
| `topology-7-appliance-ha.svg` | a label overflowing by 13px |

Those are repaired here too — by re-laying out the affected bands and nudging coordinates, not by restyling. All 29 diagrams now report clean, and every new one was also rasterised and reviewed by eye; the geometry check tells you a layout is *legal*, not that it's *good*.

## Supporting changes

- **`site.css`** — diagrams are authored on a light surface, so they now get a rounded plate on the dark theme instead of reading as a bright slab.
- **Local preview container** (`docker-compose.docs.yml`, `docs/Dockerfile`, `make docs` / `docs-down` / `docs-verify`). There was previously no way to see the site before publishing, which is precisely how the defects above went unnoticed. Runs the same plugin set Pages uses. The source is mounted read-only so a preview can't mutate the working tree — hence `--disable-disk-cache`, since Jekyll otherwise insists on creating `.jekyll-cache/` next to the sources and aborts on EROFS.

## Testing

- `python3 scripts/verify_svg_diagrams.py` → `all 29 diagrams clean`
- Served the site locally and confirmed all 21 diagrams return 200 and render in place, in both light and dark themes
- Every relative link and image reference across `docs/` resolves; all code fences balanced

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)